### PR TITLE
feat(code): browser loopback OAuth callback for MCP auth

### DIFF
--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import stat
 import threading
 from collections.abc import Awaitable, Callable
@@ -350,7 +351,6 @@ class FileTokenStorage(TokenStorage):
 RedirectHandler = Callable[[str], Awaitable[None]]
 CallbackHandler = Callable[[], Awaitable[tuple[str, str | None]]]
 _LOOPBACK_HOST = "127.0.0.1"
-_LOOPBACK_REDIRECT_HOST = "localhost"
 _LOOPBACK_CALLBACK_PATH = "/callback"
 _LOOPBACK_CALLBACK_TIMEOUT = 300.0
 
@@ -359,11 +359,46 @@ class _LoopbackCallbackTimeoutError(RuntimeError):
     """Raised when the browser never reaches the local callback server."""
 
 
+class _LoopbackCallbackUnavailableError(RuntimeError):
+    """Raised when the local callback server cannot be started."""
+
+
+def _choose_loopback_port() -> int:
+    """Return a high local TCP port candidate without opening a socket.
+
+    The OAuth redirect URI must be known before the provider starts the
+    handshake, but the actual callback server should not keep a socket open
+    unless a browser redirect is needed.
+
+    Returns:
+        A port number from the dynamic/private port range.
+    """
+    return 49152 + secrets.randbelow(65535 - 49152 + 1)
+
+
 class _LoopbackOAuthCallbackServer:
     """Single-use loopback HTTP server for CLI OAuth callbacks."""
 
-    def __init__(self) -> None:
-        """Bind a local-only HTTP server and prepare its redirect URI."""
+    def __init__(self, *, port: int) -> None:
+        """Prepare a callback server for a previously selected loopback port.
+
+        Args:
+            port: TCP port to bind when `start()` is called.
+        """
+        self._port = port
+        self.redirect_uri = f"http://{_LOOPBACK_HOST}:{port}{_LOOPBACK_CALLBACK_PATH}"
+        self._future: concurrent.futures.Future[tuple[str, str | None]] = (
+            concurrent.futures.Future()
+        )
+        self._server: object | None = None
+        self._started = False
+        self._closed = False
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """Bind and start serving callback requests in a background thread."""
+        if self._started:
+            return
         from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
         parent = self
@@ -379,29 +414,20 @@ class _LoopbackOAuthCallbackServer:
             ) -> None:
                 del format, args
 
-        self._server = ThreadingHTTPServer((_LOOPBACK_HOST, 0), Handler)
-        port = self._server.server_address[1]
-        self.redirect_uri = (
-            f"http://{_LOOPBACK_REDIRECT_HOST}:{port}{_LOOPBACK_CALLBACK_PATH}"
-        )
-        self._future: concurrent.futures.Future[tuple[str, str | None]] = (
-            concurrent.futures.Future()
-        )
-        self._started = False
-        self._closed = False
-        self._thread: threading.Thread | None = None
-
-    def start(self) -> None:
-        """Start serving callback requests in a background thread."""
-        if self._started:
-            return
+        self._server = ThreadingHTTPServer((_LOOPBACK_HOST, self._port), Handler)
         self._started = True
         self._thread = threading.Thread(
-            target=self._server.serve_forever,
+            target=self._serve_forever,
             name="deepagents-mcp-oauth-callback",
             daemon=True,
         )
         self._thread.start()
+
+    def _serve_forever(self) -> None:
+        from http.server import ThreadingHTTPServer
+
+        if isinstance(self._server, ThreadingHTTPServer):
+            self._server.serve_forever()
 
     async def wait(self) -> tuple[str, str | None]:
         """Wait for the authorization callback and return `(code, state)`.
@@ -428,9 +454,12 @@ class _LoopbackOAuthCallbackServer:
         if self._closed:
             return
         self._closed = True
-        if self._started:
-            self._server.shutdown()
-        self._server.server_close()
+        from http.server import ThreadingHTTPServer
+
+        if isinstance(self._server, ThreadingHTTPServer):
+            if self._started:
+                self._server.shutdown()
+            self._server.server_close()
 
     def _handle_get(self, request: object) -> None:
         from http.server import BaseHTTPRequestHandler
@@ -642,7 +671,22 @@ def _make_loopback_handlers(
         import webbrowser
 
         final_url = _append_query_params(auth_url, extras) if extras else auth_url
-        callback_server.start()
+        try:
+            callback_server.start()
+        except OSError as exc:
+            if not callback_server._future.done():
+                msg = "Local OAuth callback server could not be started."
+                callback_server._future.set_exception(
+                    _LoopbackCallbackUnavailableError(msg)
+                )
+            print(  # noqa: T201 - intentional user-facing fallback
+                "\nCould not start the local OAuth callback server. "
+                "Open this URL in a browser, approve access, then paste "
+                "the full callback URL back here:\n"
+                f"\n  {final_url}\n"
+            )
+            del exc
+            return
         opened = await asyncio.to_thread(webbrowser.open, final_url)
         if opened:
             print(  # noqa: T201 - intentional user-facing prompt
@@ -659,7 +703,10 @@ def _make_loopback_handlers(
     async def callback() -> tuple[str, str | None]:
         try:
             return await callback_server.wait()
-        except _LoopbackCallbackTimeoutError as exc:
+        except (
+            _LoopbackCallbackTimeoutError,
+            _LoopbackCallbackUnavailableError,
+        ) as exc:
             print(  # noqa: T201 - intentional user-facing fallback
                 f"{exc}\nPaste the full callback URL instead."
             )
@@ -709,7 +756,9 @@ def build_oauth_provider(
     if interactive:
         if policy.supports_loopback_callback():
             try:
-                callback_server = _LoopbackOAuthCallbackServer()
+                callback_server = _LoopbackOAuthCallbackServer(
+                    port=_choose_loopback_port()
+                )
             except (OSError, RuntimeError):
                 redirect, callback = _make_paste_back_handlers(
                     extra_auth_params=extra_auth_params

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -11,13 +11,16 @@ server X") rather than the token itself.
 
 from __future__ import annotations
 
+import concurrent.futures
 import contextlib
 import hashlib
+import html
 import json
 import logging
 import os
 import re
 import stat
+import threading
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Literal, TypedDict
 from urllib.parse import parse_qs, urlparse
@@ -346,6 +349,195 @@ class FileTokenStorage(TokenStorage):
 
 RedirectHandler = Callable[[str], Awaitable[None]]
 CallbackHandler = Callable[[], Awaitable[tuple[str, str | None]]]
+_LOOPBACK_HOST = "127.0.0.1"
+_LOOPBACK_REDIRECT_HOST = "localhost"
+_LOOPBACK_CALLBACK_PATH = "/callback"
+_LOOPBACK_CALLBACK_TIMEOUT = 300.0
+
+
+class _LoopbackCallbackTimeoutError(RuntimeError):
+    """Raised when the browser never reaches the local callback server."""
+
+
+class _LoopbackOAuthCallbackServer:
+    """Single-use loopback HTTP server for CLI OAuth callbacks."""
+
+    def __init__(self) -> None:
+        """Bind a local-only HTTP server and prepare its redirect URI."""
+        from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+        parent = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                parent._handle_get(self)
+
+            def log_message(  # noqa: PLR6301  # stdlib override
+                self,
+                format: str,  # noqa: A002
+                *args: object,
+            ) -> None:
+                del format, args
+
+        self._server = ThreadingHTTPServer((_LOOPBACK_HOST, 0), Handler)
+        port = self._server.server_address[1]
+        self.redirect_uri = (
+            f"http://{_LOOPBACK_REDIRECT_HOST}:{port}{_LOOPBACK_CALLBACK_PATH}"
+        )
+        self._future: concurrent.futures.Future[tuple[str, str | None]] = (
+            concurrent.futures.Future()
+        )
+        self._started = False
+        self._closed = False
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """Start serving callback requests in a background thread."""
+        if self._started:
+            return
+        self._started = True
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="deepagents-mcp-oauth-callback",
+            daemon=True,
+        )
+        self._thread.start()
+
+    async def wait(self) -> tuple[str, str | None]:
+        """Wait for the authorization callback and return `(code, state)`.
+
+        Returns:
+            The OAuth authorization code and optional state.
+
+        Raises:
+            _LoopbackCallbackTimeoutError: If no callback arrives before the timeout.
+        """
+        import asyncio
+
+        try:
+            return await asyncio.wait_for(
+                asyncio.wrap_future(self._future),
+                timeout=_LOOPBACK_CALLBACK_TIMEOUT,
+            )
+        except TimeoutError as exc:
+            msg = "Browser callback was not received before the timeout."
+            raise _LoopbackCallbackTimeoutError(msg) from exc
+
+    def close(self) -> None:
+        """Stop the local callback server and release its socket."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._started:
+            self._server.shutdown()
+        self._server.server_close()
+
+    def _handle_get(self, request: object) -> None:
+        from http.server import BaseHTTPRequestHandler
+
+        handler = request
+        if not isinstance(handler, BaseHTTPRequestHandler):
+            return
+        parsed = urlparse(handler.path)
+        if parsed.path != _LOOPBACK_CALLBACK_PATH:
+            self._send_html(
+                handler, 404, _oauth_error_html("Callback route not found.")
+            )
+            return
+
+        params = parse_qs(parsed.query)
+        if "error" in params:
+            err_code = params["error"][0]
+            err_desc = (params.get("error_description") or [""])[0]
+            detail = f": {err_desc}" if err_desc else ""
+            msg = f"Authorization denied by provider: {err_code}{detail}"
+            if not self._future.done():
+                self._future.set_exception(RuntimeError(msg))
+            self._send_html(handler, 400, _oauth_error_html(msg))
+            return
+
+        if "code" not in params or not params["code"]:
+            msg = "Callback URL is missing the 'code' parameter."
+            if not self._future.done():
+                self._future.set_exception(RuntimeError(msg))
+            self._send_html(handler, 400, _oauth_error_html(msg))
+            return
+
+        if not self._future.done():
+            self._future.set_result(
+                (params["code"][0], (params.get("state") or [None])[0])
+            )
+        self._send_html(
+            handler,
+            200,
+            _oauth_success_html(
+                "MCP authorization complete. You can close this browser tab."
+            ),
+        )
+
+    @staticmethod
+    def _send_html(handler: object, status: int, body: str) -> None:
+        from http.server import BaseHTTPRequestHandler
+
+        if not isinstance(handler, BaseHTTPRequestHandler):
+            return
+        payload = body.encode("utf-8")
+        handler.send_response(status)
+        handler.send_header("Content-Type", "text/html; charset=utf-8")
+        handler.send_header("Content-Length", str(len(payload)))
+        handler.end_headers()
+        handler.wfile.write(payload)
+
+
+def _oauth_success_html(message: str) -> str:
+    return _oauth_result_html(
+        title="Authorization complete",
+        heading="You're signed in",
+        message=message,
+        status="success",
+    )
+
+
+def _oauth_error_html(message: str) -> str:
+    return _oauth_result_html(
+        title="Authorization failed",
+        heading="Authorization failed",
+        message=message,
+        status="error",
+    )
+
+
+def _oauth_result_html(
+    *, title: str, heading: str, message: str, status: Literal["success", "error"]
+) -> str:
+    accent = "#137333" if status == "success" else "#b3261e"
+    background = "#eef7f0" if status == "success" else "#fceeee"
+    mark = "✓" if status == "success" else "!"
+    escaped_title = html.escape(title)
+    escaped_heading = html.escape(heading)
+    escaped = html.escape(message)
+    return (
+        '<!doctype html><html><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">'
+        f"<title>{escaped_title}</title>"
+        "<style>"
+        "body{margin:0;min-height:100vh;display:grid;place-items:center;"
+        "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;"
+        "background:#f8faf9;color:#1f2328}"
+        ".panel{width:min(480px,calc(100vw - 40px));box-sizing:border-box;"
+        "padding:32px;border:1px solid #d8dee4;border-radius:8px;"
+        "background:#fff;box-shadow:0 18px 45px rgba(31,35,40,.08)}"
+        ".mark{width:44px;height:44px;border-radius:50%;display:grid;"
+        "place-items:center;margin-bottom:20px;font-weight:700}"
+        "h1{font-size:24px;line-height:1.2;margin:0 0 10px}"
+        "p{font-size:15px;line-height:1.5;margin:0;color:#57606a}"
+        "</style></head><body>"
+        '<main class="panel">'
+        f'<div class="mark" style="background:{background};color:{accent}">{mark}</div>'
+        f"<h1>{escaped_heading}</h1><p>{escaped}</p>"
+        "</main>"
+        "</body></html>"
+    )
 
 
 class MCPReauthRequiredError(RuntimeError):
@@ -426,6 +618,58 @@ def _make_paste_back_handlers(
     return redirect, callback
 
 
+def _make_loopback_handlers(
+    *,
+    callback_server: _LoopbackOAuthCallbackServer,
+    extra_auth_params: dict[str, str] | None = None,
+) -> tuple[RedirectHandler, CallbackHandler]:
+    """Create browser loopback redirect and callback handlers for OAuth.
+
+    Args:
+        callback_server: Bound local callback server for this login attempt.
+        extra_auth_params: Extra query params to append to the auth URL.
+
+    Returns:
+        A tuple of `(redirect_handler, callback_handler)`.
+    """
+    extras = dict(extra_auth_params or {})
+    _paste_redirect, paste_callback = _make_paste_back_handlers(
+        extra_auth_params=extra_auth_params
+    )
+
+    async def redirect(auth_url: str) -> None:
+        import asyncio
+        import webbrowser
+
+        final_url = _append_query_params(auth_url, extras) if extras else auth_url
+        callback_server.start()
+        opened = await asyncio.to_thread(webbrowser.open, final_url)
+        if opened:
+            print(  # noqa: T201 - intentional user-facing prompt
+                "\nOpened your browser to approve MCP access. "
+                "If it did not open, visit this URL:\n"
+                f"\n  {final_url}\n"
+            )
+        else:
+            print(  # noqa: T201 - intentional user-facing prompt
+                "\nOpen this URL in a browser to approve MCP access:\n"
+                f"\n  {final_url}\n"
+            )
+
+    async def callback() -> tuple[str, str | None]:
+        try:
+            return await callback_server.wait()
+        except _LoopbackCallbackTimeoutError as exc:
+            print(  # noqa: T201 - intentional user-facing fallback
+                f"{exc}\nPaste the full callback URL instead."
+            )
+            return await paste_callback()
+        finally:
+            callback_server.close()
+
+    return redirect, callback
+
+
 def _append_query_params(url: str, params: dict[str, str]) -> str:
     """Return `url` with `params` replacing any same-named query keys."""
     from urllib.parse import urlencode, urlunparse
@@ -457,16 +701,33 @@ def build_oauth_provider(
     Returns:
         A configured `OAuthClientProvider`.
     """
+    from deepagents_code.mcp_providers import resolve_provider
+
+    policy = resolve_provider(server_url)
+    redirect_uri: str | None = None
+
     if interactive:
-        redirect, callback = _make_paste_back_handlers(
-            extra_auth_params=extra_auth_params
-        )
+        if policy.supports_loopback_callback():
+            try:
+                callback_server = _LoopbackOAuthCallbackServer()
+            except (OSError, RuntimeError):
+                redirect, callback = _make_paste_back_handlers(
+                    extra_auth_params=extra_auth_params
+                )
+            else:
+                redirect_uri = callback_server.redirect_uri
+                redirect, callback = _make_loopback_handlers(
+                    callback_server=callback_server,
+                    extra_auth_params=extra_auth_params,
+                )
+        else:
+            redirect, callback = _make_paste_back_handlers(
+                extra_auth_params=extra_auth_params
+            )
     else:
         redirect, callback = _make_reauth_required_handlers(server_name=server_name)
 
-    from deepagents_code.mcp_providers import resolve_provider
-
-    metadata = resolve_provider(server_url).client_metadata()
+    metadata = policy.client_metadata(redirect_uri=redirect_uri)
 
     return OAuthClientProvider(
         server_url=server_url,

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -377,7 +377,13 @@ def _choose_loopback_port() -> int:
 
 
 class _LoopbackOAuthCallbackServer:
-    """Single-use loopback HTTP server for CLI OAuth callbacks."""
+    """Single-use loopback HTTP server for CLI OAuth callbacks.
+
+    Port selection and socket binding are intentionally separated: the
+    redirect URI is fixed at construction time so it can be registered with
+    the OAuth provider, while the socket is not opened until `start()` is
+    called from the redirect handler.
+    """
 
     def __init__(self, *, port: int) -> None:
         """Prepare a callback server for a previously selected loopback port.
@@ -437,7 +443,10 @@ class _LoopbackOAuthCallbackServer:
 
         Raises:
             _LoopbackCallbackTimeoutError: If no callback arrives before the timeout.
-        """
+            _LoopbackCallbackUnavailableError: If the server could not be started.
+            RuntimeError: If the provider returned an OAuth error or the callback
+                URL lacked a `code` parameter.
+        """  # noqa: DOC502 - _LoopbackCallbackUnavailableError/RuntimeError set on future
         import asyncio
 
         try:
@@ -448,6 +457,15 @@ class _LoopbackOAuthCallbackServer:
         except TimeoutError as exc:
             msg = "Browser callback was not received before the timeout."
             raise _LoopbackCallbackTimeoutError(msg) from exc
+
+    def fail(self, exc: Exception) -> None:
+        """Poison the future so `wait()` raises `exc` immediately.
+
+        Args:
+            exc: Exception to surface to the awaiting coroutine.
+        """
+        if not self._future.done():
+            self._future.set_exception(exc)
 
     def close(self) -> None:
         """Stop the local callback server and release its socket."""
@@ -467,6 +485,20 @@ class _LoopbackOAuthCallbackServer:
         handler = request
         if not isinstance(handler, BaseHTTPRequestHandler):
             return
+
+        if self._future.done():
+            # Duplicate browser request (retry, prefetch, favicon) after the
+            # flow already completed. Respond and return without touching the
+            # future — avoids InvalidStateError from a concurrent set_result.
+            self._send_html(
+                handler,
+                200,
+                _oauth_success_html(
+                    "MCP authorization complete. You can close this browser tab."
+                ),
+            )
+            return
+
         parsed = urlparse(handler.path)
         if parsed.path != _LOOPBACK_CALLBACK_PATH:
             self._send_html(
@@ -480,22 +512,19 @@ class _LoopbackOAuthCallbackServer:
             err_desc = (params.get("error_description") or [""])[0]
             detail = f": {err_desc}" if err_desc else ""
             msg = f"Authorization denied by provider: {err_code}{detail}"
-            if not self._future.done():
-                self._future.set_exception(RuntimeError(msg))
+            self._future.set_exception(RuntimeError(msg))
             self._send_html(handler, 400, _oauth_error_html(msg))
             return
 
         if "code" not in params or not params["code"]:
             msg = "Callback URL is missing the 'code' parameter."
-            if not self._future.done():
-                self._future.set_exception(RuntimeError(msg))
+            self._future.set_exception(RuntimeError(msg))
             self._send_html(handler, 400, _oauth_error_html(msg))
             return
 
-        if not self._future.done():
-            self._future.set_result(
-                (params["code"][0], (params.get("state") or [None])[0])
-            )
+        self._future.set_result(
+            (params["code"][0], (params.get("state") or [None])[0])
+        )
         self._send_html(
             handler,
             200,
@@ -655,7 +684,8 @@ def _make_loopback_handlers(
     """Create browser loopback redirect and callback handlers for OAuth.
 
     Args:
-        callback_server: Bound local callback server for this login attempt.
+        callback_server: Prepared local callback server for this login attempt.
+            The socket is bound when the returned redirect handler is first called.
         extra_auth_params: Extra query params to append to the auth URL.
 
     Returns:
@@ -674,18 +704,19 @@ def _make_loopback_handlers(
         try:
             callback_server.start()
         except OSError as exc:
-            if not callback_server._future.done():
-                msg = "Local OAuth callback server could not be started."
-                callback_server._future.set_exception(
-                    _LoopbackCallbackUnavailableError(msg)
-                )
+            logger.warning(
+                "Could not start loopback OAuth callback server on port %s: %s",
+                callback_server._port,
+                exc,
+            )
+            msg = "Local OAuth callback server could not be started."
+            callback_server.fail(_LoopbackCallbackUnavailableError(msg))
             print(  # noqa: T201 - intentional user-facing fallback
                 "\nCould not start the local OAuth callback server. "
                 "Open this URL in a browser, approve access, then paste "
                 "the full callback URL back here:\n"
                 f"\n  {final_url}\n"
             )
-            del exc
             return
         opened = await asyncio.to_thread(webbrowser.open, final_url)
         if opened:
@@ -695,8 +726,16 @@ def _make_loopback_handlers(
                 f"\n  {final_url}\n"
             )
         else:
-            print(  # noqa: T201 - intentional user-facing prompt
-                "\nOpen this URL in a browser to approve MCP access:\n"
+            # No browser available — poison the future so callback() falls
+            # through to paste_callback() immediately instead of waiting 300s.
+            callback_server.fail(
+                _LoopbackCallbackUnavailableError(
+                    "No browser is available to complete the OAuth flow."
+                )
+            )
+            print(  # noqa: T201 - intentional user-facing fallback
+                "\nOpen this URL in a browser, approve access, then paste the full "
+                "callback URL back here:\n"
                 f"\n  {final_url}\n"
             )
 
@@ -755,20 +794,14 @@ def build_oauth_provider(
 
     if interactive:
         if policy.supports_loopback_callback():
-            try:
-                callback_server = _LoopbackOAuthCallbackServer(
-                    port=_choose_loopback_port()
-                )
-            except (OSError, RuntimeError):
-                redirect, callback = _make_paste_back_handlers(
-                    extra_auth_params=extra_auth_params
-                )
-            else:
-                redirect_uri = callback_server.redirect_uri
-                redirect, callback = _make_loopback_handlers(
-                    callback_server=callback_server,
-                    extra_auth_params=extra_auth_params,
-                )
+            callback_server = _LoopbackOAuthCallbackServer(
+                port=_choose_loopback_port()
+            )
+            redirect_uri = callback_server.redirect_uri
+            redirect, callback = _make_loopback_handlers(
+                callback_server=callback_server,
+                extra_auth_params=extra_auth_params,
+            )
         else:
             redirect, callback = _make_paste_back_handlers(
                 extra_auth_params=extra_auth_params
@@ -776,7 +809,11 @@ def build_oauth_provider(
     else:
         redirect, callback = _make_reauth_required_handlers(server_name=server_name)
 
-    metadata = policy.client_metadata(redirect_uri=redirect_uri)
+    metadata = (
+        policy.client_metadata(redirect_uri=redirect_uri)
+        if redirect_uri is not None
+        else policy.client_metadata()
+    )
 
     return OAuthClientProvider(
         server_url=server_url,

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -522,9 +522,7 @@ class _LoopbackOAuthCallbackServer:
             self._send_html(handler, 400, _oauth_error_html(msg))
             return
 
-        self._future.set_result(
-            (params["code"][0], (params.get("state") or [None])[0])
-        )
+        self._future.set_result((params["code"][0], (params.get("state") or [None])[0]))
         self._send_html(
             handler,
             200,
@@ -795,9 +793,7 @@ def build_oauth_provider(
 
     if interactive:
         if policy.supports_loopback_callback():
-            callback_server = _LoopbackOAuthCallbackServer(
-                port=_choose_loopback_port()
-            )
+            callback_server = _LoopbackOAuthCallbackServer(port=_choose_loopback_port())
             redirect_uri = callback_server.redirect_uri
             redirect, callback = _make_loopback_handlers(
                 callback_server=callback_server,

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -701,6 +701,22 @@ def _make_loopback_handlers(
         import webbrowser
 
         final_url = _append_query_params(auth_url, extras) if extras else auth_url
+        opened = await asyncio.to_thread(webbrowser.open, final_url)
+        if not opened:
+            # No browser available — poison the future so callback() falls
+            # through to paste_callback() immediately instead of waiting 300s.
+            # The socket is never bound because start() is not called.
+            callback_server.fail(
+                _LoopbackCallbackUnavailableError(
+                    "No browser is available to complete the OAuth flow."
+                )
+            )
+            print(  # noqa: T201 - intentional user-facing fallback
+                "\nOpen this URL in a browser, approve access, then paste the full "
+                "callback URL back here:\n"
+                f"\n  {final_url}\n"
+            )
+            return
         try:
             callback_server.start()
         except OSError as exc:
@@ -718,26 +734,11 @@ def _make_loopback_handlers(
                 f"\n  {final_url}\n"
             )
             return
-        opened = await asyncio.to_thread(webbrowser.open, final_url)
-        if opened:
-            print(  # noqa: T201 - intentional user-facing prompt
-                "\nOpened your browser to approve MCP access. "
-                "If it did not open, visit this URL:\n"
-                f"\n  {final_url}\n"
-            )
-        else:
-            # No browser available — poison the future so callback() falls
-            # through to paste_callback() immediately instead of waiting 300s.
-            callback_server.fail(
-                _LoopbackCallbackUnavailableError(
-                    "No browser is available to complete the OAuth flow."
-                )
-            )
-            print(  # noqa: T201 - intentional user-facing fallback
-                "\nOpen this URL in a browser, approve access, then paste the full "
-                "callback URL back here:\n"
-                f"\n  {final_url}\n"
-            )
+        print(  # noqa: T201 - intentional user-facing prompt
+            "\nOpened your browser to approve MCP access. "
+            "If it did not open, visit this URL:\n"
+            f"\n  {final_url}\n"
+        )
 
     async def callback() -> tuple[str, str | None]:
         try:

--- a/libs/code/deepagents_code/mcp_providers/base.py
+++ b/libs/code/deepagents_code/mcp_providers/base.py
@@ -48,6 +48,9 @@ class OAuthProvider(ABC):
     def supports_loopback_callback(self) -> bool:  # noqa: PLR6301  # subclass hook
         """Return whether this provider can use a runtime loopback redirect URI.
 
+        When `False`, `client_metadata()` ignores the `redirect_uri` argument
+        and uses the provider's own pre-registered static URI instead.
+
         Returns:
             `True` when the provider accepts dynamically registered redirect URIs.
         """

--- a/libs/code/deepagents_code/mcp_providers/base.py
+++ b/libs/code/deepagents_code/mcp_providers/base.py
@@ -45,8 +45,21 @@ class OAuthProvider(ABC):
     def matches(self, server_url: str) -> bool:
         """Return `True` when this provider owns `server_url`."""
 
-    def client_metadata(self) -> OAuthClientMetadata:  # noqa: PLR6301  # subclass hook
+    def supports_loopback_callback(self) -> bool:  # noqa: PLR6301  # subclass hook
+        """Return whether this provider can use a runtime loopback redirect URI.
+
+        Returns:
+            `True` when the provider accepts dynamically registered redirect URIs.
+        """
+        return True
+
+    def client_metadata(  # noqa: PLR6301  # subclass hook
+        self, *, redirect_uri: str | None = None
+    ) -> OAuthClientMetadata:
         """Return the `OAuthClientMetadata` used to build the auth provider.
+
+        Args:
+            redirect_uri: Optional runtime redirect URI for CLI loopback auth.
 
         Returns:
             Metadata for the spec-compliant Authorization Code + PKCE +
@@ -54,7 +67,7 @@ class OAuthProvider(ABC):
         """
         return OAuthClientMetadata(
             client_name="deepagents-code",
-            redirect_uris=[AnyUrl("http://localhost/callback")],
+            redirect_uris=[AnyUrl(redirect_uri or "http://localhost/callback")],
             grant_types=["authorization_code", "refresh_token"],
             response_types=["code"],
         )

--- a/libs/code/deepagents_code/mcp_providers/slack.py
+++ b/libs/code/deepagents_code/mcp_providers/slack.py
@@ -91,12 +91,26 @@ class SlackProvider(OAuthProvider):
         """
         return _is_slack_mcp_url(server_url)
 
-    def client_metadata(self) -> OAuthClientMetadata:  # noqa: PLR6301  # subclass hook
+    def supports_loopback_callback(self) -> bool:  # noqa: PLR6301  # subclass hook
+        """Return `False` because Slack uses a fixed pre-registered redirect URI.
+
+        Returns:
+            Always `False`.
+        """
+        return False
+
+    def client_metadata(  # noqa: PLR6301  # subclass hook
+        self, *, redirect_uri: str | None = None
+    ) -> OAuthClientMetadata:
         """Return public-client metadata with the Slack loopback redirect URI.
+
+        Args:
+            redirect_uri: Ignored; Slack requires its pre-registered redirect URI.
 
         Returns:
             Metadata configured for Slack's public OAuth client (no token secret).
         """
+        del redirect_uri
         return OAuthClientMetadata(
             client_name="deepagents-code",
             redirect_uris=[AnyUrl(_SLACK_REDIRECT_URI)],

--- a/libs/code/deepagents_code/mcp_providers/slack.py
+++ b/libs/code/deepagents_code/mcp_providers/slack.py
@@ -1,9 +1,9 @@
 """Slack-hosted MCP OAuth provider.
 
 Slack's hosted MCP endpoint uses the Authorization Code flow with a
-hardcoded public client ID and the loopback redirect URI. The user
-copy-pastes the redirected URL back into the app rather than running a
-local server, and an optional `team` query parameter selects the
+hardcoded public client ID and a static pre-registered redirect URI. The
+user copy-pastes the redirected URL back into the app rather than running
+a local server, and an optional `team` query parameter selects the
 workspace to install the app into.
 """
 
@@ -31,8 +31,9 @@ _SLACK_MCP_CLIENT_ID = "4518649543379.10944517634130"
 """Public OAuth client ID registered with Slack for the hosted MCP endpoint."""
 
 _SLACK_REDIRECT_URI = "https://localhost"
-"""Loopback redirect URI Slack hands the authorization code back to; the user
-copy-pastes the resulting URL into the app rather than running a local server."""
+"""Static pre-registered redirect URI Slack hands the authorization code back
+to; the user copy-pastes the resulting URL into the app rather than running a
+local server."""
 
 
 def _is_slack_mcp_url(url: str) -> bool:
@@ -102,10 +103,10 @@ class SlackProvider(OAuthProvider):
     def client_metadata(  # noqa: PLR6301  # subclass hook
         self, *, redirect_uri: str | None = None
     ) -> OAuthClientMetadata:
-        """Return public-client metadata with the Slack loopback redirect URI.
+        """Return public-client metadata with Slack's static pre-registered redirect URI.
 
         Args:
-            redirect_uri: Ignored; Slack requires its pre-registered redirect URI.
+            redirect_uri: Ignored; Slack requires its static pre-registered URI.
 
         Returns:
             Metadata configured for Slack's public OAuth client (no token secret).

--- a/libs/code/deepagents_code/mcp_providers/slack.py
+++ b/libs/code/deepagents_code/mcp_providers/slack.py
@@ -103,7 +103,7 @@ class SlackProvider(OAuthProvider):
     def client_metadata(  # noqa: PLR6301  # subclass hook
         self, *, redirect_uri: str | None = None
     ) -> OAuthClientMetadata:
-        """Return public-client metadata with Slack's static pre-registered redirect URI.
+        """Return public-client metadata with Slack's static pre-registered URI.
 
         Args:
             redirect_uri: Ignored; Slack requires its static pre-registered URI.

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -330,6 +330,12 @@ class TestBuildOAuthProvider:
         assert _is_slack_mcp_url("https://deep.slack.com/mcp")
         assert not _is_slack_mcp_url("https://mcp.notion.com/mcp")
 
+    def test_slack_provider_does_not_support_loopback(self) -> None:
+        """SlackProvider opts out of loopback so its static redirect URI is used."""
+        from deepagents_code.mcp_providers.slack import SlackProvider
+
+        assert SlackProvider().supports_loopback_callback() is False
+
     def test_slack_branch_sets_public_client_metadata(self) -> None:
         """Slack branch configures a public OAuth client (no token secret)."""
         from deepagents_code.mcp_auth import build_oauth_provider
@@ -440,6 +446,97 @@ class TestLoopbackHandlers:
         assert response.status_code == 400
         with pytest.raises(RuntimeError, match="access_denied"):
             await callback_handler()
+
+    async def test_loopback_callback_missing_code_raises(
+        self, monkeypatch: pytest.MonkeyPatch, socket_enabled: object
+    ) -> None:
+        """A callback URL missing the `code` parameter sends 400 and raises."""
+        import httpx
+
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        del socket_enabled
+        monkeypatch.setattr("webbrowser.open", lambda _url: True)
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=FileTokenStorage("notion"),
+        )
+        metadata = provider.context.client_metadata
+        assert metadata.redirect_uris is not None
+        redirect_uri = str(metadata.redirect_uris[0])
+        redirect_handler = provider.context.redirect_handler
+        callback_handler = provider.context.callback_handler
+        assert redirect_handler is not None
+        assert callback_handler is not None
+
+        await redirect_handler("https://auth.example/authorize")
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(f"{redirect_uri}?state=xyz")
+
+        assert response.status_code == 400
+        with pytest.raises(RuntimeError, match="missing the 'code' parameter"):
+            await callback_handler()
+
+    async def test_loopback_falls_back_when_browser_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the browser cannot open, callback() falls back to paste-back at once."""
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        monkeypatch.setattr("webbrowser.open", lambda _url: False)
+        monkeypatch.setattr(
+            "builtins.input",
+            lambda _: "https://localhost/?code=fallback&state=s",
+        )
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=FileTokenStorage("notion"),
+        )
+        redirect_handler = provider.context.redirect_handler
+        callback_handler = provider.context.callback_handler
+        assert redirect_handler is not None
+        assert callback_handler is not None
+
+        await redirect_handler("https://auth.example/authorize")
+        code, state = await callback_handler()
+        assert code == "fallback"
+        assert state == "s"
+
+    async def test_loopback_falls_back_on_bind_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bind failure in redirect() causes callback() to fall back to paste-back."""
+        from deepagents_code.mcp_auth import (
+            _LoopbackOAuthCallbackServer,
+            build_oauth_provider,
+        )
+
+        monkeypatch.setattr("webbrowser.open", lambda _url: True)
+        monkeypatch.setattr(
+            _LoopbackOAuthCallbackServer,
+            "start",
+            lambda _self: (_ for _ in ()).throw(OSError("Address already in use")),
+        )
+        monkeypatch.setattr(
+            "builtins.input",
+            lambda _: "https://localhost/?code=fallback&state=s",
+        )
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=FileTokenStorage("notion"),
+        )
+        redirect_handler = provider.context.redirect_handler
+        callback_handler = provider.context.callback_handler
+        assert redirect_handler is not None
+        assert callback_handler is not None
+
+        await redirect_handler("https://auth.example/authorize")
+        code, state = await callback_handler()
+        assert code == "fallback"
+        assert state == "s"
 
 
 @pytest.mark.usefixtures("fake_home")

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -344,13 +344,10 @@ class TestBuildOAuthProvider:
         assert metadata.redirect_uris is not None
         assert [str(uri) for uri in metadata.redirect_uris] == ["https://localhost/"]
 
-    def test_generic_branch_uses_loopback_callback(
-        self, socket_enabled: object
-    ) -> None:
+    def test_generic_branch_uses_loopback_callback(self) -> None:
         """Non-Slack URLs use a local callback server redirect."""
         from deepagents_code.mcp_auth import build_oauth_provider
 
-        del socket_enabled
         provider = build_oauth_provider(
             server_name="notion",
             server_url="https://mcp.notion.com/mcp",
@@ -359,7 +356,7 @@ class TestBuildOAuthProvider:
         metadata = provider.context.client_metadata
         assert metadata.redirect_uris is not None
         redirect_uri = str(metadata.redirect_uris[0])
-        assert re.fullmatch(r"http://localhost:\d+/callback", redirect_uri)
+        assert re.fullmatch(r"http://127\.0\.0\.1:\d+/callback", redirect_uri)
         # Generic (non-Slack) providers default to client-secret auth, so the
         # Slack-only `token_endpoint_auth_method="none"` override must not
         # leak into this branch.

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -343,10 +344,13 @@ class TestBuildOAuthProvider:
         assert metadata.redirect_uris is not None
         assert [str(uri) for uri in metadata.redirect_uris] == ["https://localhost/"]
 
-    def test_generic_branch_uses_localhost_callback(self) -> None:
-        """Non-Slack URLs use the generic `http://localhost/callback` redirect."""
+    def test_generic_branch_uses_loopback_callback(
+        self, socket_enabled: object
+    ) -> None:
+        """Non-Slack URLs use a local callback server redirect."""
         from deepagents_code.mcp_auth import build_oauth_provider
 
+        del socket_enabled
         provider = build_oauth_provider(
             server_name="notion",
             server_url="https://mcp.notion.com/mcp",
@@ -354,9 +358,8 @@ class TestBuildOAuthProvider:
         )
         metadata = provider.context.client_metadata
         assert metadata.redirect_uris is not None
-        assert [str(uri) for uri in metadata.redirect_uris] == [
-            "http://localhost/callback"
-        ]
+        redirect_uri = str(metadata.redirect_uris[0])
+        assert re.fullmatch(r"http://localhost:\d+/callback", redirect_uri)
         # Generic (non-Slack) providers default to client-secret auth, so the
         # Slack-only `token_endpoint_auth_method="none"` override must not
         # leak into this branch.
@@ -371,6 +374,75 @@ class TestBuildOAuthProvider:
             await redirect("https://auth.example/")
         with pytest.raises(MCPReauthRequiredError):
             await callback()
+
+
+class TestLoopbackHandlers:
+    """Tests for the local OAuth callback server."""
+
+    async def test_loopback_callback_returns_code_and_state(
+        self, monkeypatch: pytest.MonkeyPatch, socket_enabled: object
+    ) -> None:
+        """A browser callback to the loopback URI completes the handler."""
+        import httpx
+
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        del socket_enabled
+        monkeypatch.setattr("webbrowser.open", lambda _url: True)
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=FileTokenStorage("notion"),
+        )
+        metadata = provider.context.client_metadata
+        assert metadata.redirect_uris is not None
+        redirect_uri = str(metadata.redirect_uris[0])
+        redirect_handler = provider.context.redirect_handler
+        callback_handler = provider.context.callback_handler
+        assert redirect_handler is not None
+        assert callback_handler is not None
+
+        await redirect_handler("https://auth.example/authorize")
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(f"{redirect_uri}?code=abc&state=xyz")
+
+        assert response.status_code == 200
+        code, state = await callback_handler()
+        assert code == "abc"
+        assert state == "xyz"
+
+    async def test_loopback_callback_surfaces_provider_error(
+        self, monkeypatch: pytest.MonkeyPatch, socket_enabled: object
+    ) -> None:
+        """Provider-side callback errors propagate with a useful message."""
+        import httpx
+
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        del socket_enabled
+        monkeypatch.setattr("webbrowser.open", lambda _url: True)
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=FileTokenStorage("notion"),
+        )
+        metadata = provider.context.client_metadata
+        assert metadata.redirect_uris is not None
+        redirect_uri = str(metadata.redirect_uris[0])
+        redirect_handler = provider.context.redirect_handler
+        callback_handler = provider.context.callback_handler
+        assert redirect_handler is not None
+        assert callback_handler is not None
+
+        await redirect_handler("https://auth.example/authorize")
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(
+                f"{redirect_uri}?error=access_denied&error_description=User%20declined"
+            )
+
+        assert response.status_code == 400
+        with pytest.raises(RuntimeError, match="access_denied"):
+            await callback_handler()
 
 
 @pytest.mark.usefixtures("fake_home")

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -250,7 +250,7 @@ class TestInterruptCleanup:
         await _handle_interrupt_cleanup(
             adapter=adapter,
             agent=agent,
-            config={"configurable": {"thread_id": "t-1"}},  # type: ignore[arg-type]
+            config={"configurable": {"thread_id": "t-1"}},
             pending_text_by_namespace={},
             captured_input_tokens=0,
             captured_output_tokens=0,
@@ -293,7 +293,7 @@ class TestInterruptCleanup:
         await _handle_interrupt_cleanup(
             adapter=adapter,
             agent=agent,
-            config={"configurable": {"thread_id": "t-1"}},  # type: ignore[arg-type]
+            config={"configurable": {"thread_id": "t-1"}},
             pending_text_by_namespace={},
             captured_input_tokens=0,
             captured_output_tokens=0,


### PR DESCRIPTION
MCP OAuth logins previously required users to manually copy-paste a redirect URL from the terminal. For providers that accept dynamically registered redirect URIs, the flow can be fully automatic: open the browser, capture the authorization code over a local HTTP callback, and complete sign-in without user intervention.