### PR TITLE
test(evals): add bear-story eval with word count and sentence-structure constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,8 @@ celerybeat.pid
 # Environments
 .env
 .envrc
+env.local
+*.env.local
 .venv
 env/
 venv/

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -122,7 +122,7 @@ file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test
 
 - [`test_tau2_airline`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/tau2_airline/test_tau2_airline.py#L86) — `tests/evals/tau2_airline/test_tau2_airline.py:86`
 - [`test_followup_question_quality`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_followup_quality.py#L96) — `tests/evals/test_followup_quality.py:96`
-- [`test_exact_word_count_and_vowel_starts`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py#L109) — `tests/evals/test_iterative_constraint_satisfaction.py:109`
+- [`test_exact_word_count_and_vowel_starts`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py#L114) — `tests/evals/test_iterative_constraint_satisfaction.py:114`
 
 ## Summarization (`summarization`) (5 evals)
 

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -10,7 +10,7 @@ Categories (for `--eval-category` filtering):
 file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test
 ```
 
-**110 evals** across **7 categories**
+**111 evals** across **7 categories**
 
 ## File Ops (`file_operations`) (13 evals)
 
@@ -118,10 +118,11 @@ file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test
 - [`test_explicit_preference_remembered`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_memory_multiturn.py#L232) — `tests/evals/test_memory_multiturn.py:232`
 - [`test_transient_info_not_persisted`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_memory_multiturn.py#L259) — `tests/evals/test_memory_multiturn.py:259`
 
-## Conversation (`conversation`) (2 evals)
+## Conversation (`conversation`) (3 evals)
 
 - [`test_tau2_airline`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/tau2_airline/test_tau2_airline.py#L86) — `tests/evals/tau2_airline/test_tau2_airline.py:86`
 - [`test_followup_question_quality`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_followup_quality.py#L96) — `tests/evals/test_followup_quality.py:96`
+- [`test_exact_word_count_and_vowel_starts`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py#L109) — `tests/evals/test_iterative_constraint_satisfaction.py:109`
 
 ## Summarization (`summarization`) (5 evals)
 

--- a/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py
+++ b/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py
@@ -1,6 +1,6 @@
 """Eval test for iterative constraint satisfaction.
 
-Asks a deep agent (with whatever model `--model` selects) to produce a
+Asks a deep agent (with whatever `--model` is selected) to produce a
 paragraph under two simultaneous hard constraints: exact word count AND
 every sentence must start with a vowel. The agent has access to planning,
 scratchpad, and the agent loop itself — room to draft, count, and revise

--- a/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py
+++ b/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py
@@ -1,0 +1,126 @@
+"""Eval test for iterative constraint satisfaction.
+
+Asks a deep agent (with whatever model ``--model`` selects) to produce a
+paragraph under two simultaneous hard constraints: exact word count AND
+every sentence must start with a vowel. The agent has access to planning,
+scratchpad, and the agent loop itself — room to draft, count, and revise
+until both constraints are met. The test passes when the final paragraph
+satisfies the rubric.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+from deepagents import create_deep_agent
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+
+from tests.evals.utils import (
+    AgentTrajectory,
+    SuccessAssertion,
+    TrajectoryScorer,
+    run_agent,
+)
+
+pytestmark = [pytest.mark.eval_category("conversation")]
+
+
+_VOWELS = frozenset("aeiouAEIOU")
+_SENTENCE_SPLIT_RE = re.compile(r"[.!?]+")
+_WRAPPER_CHARS = " \t\n\r\"'`*_"
+
+
+def _extract_paragraph(answer: str) -> str:
+    """Strip surrounding markdown / quotes / fences from the final answer.
+
+    Keeps grading robust to minor formatting noise without softening the
+    underlying constraints.
+    """
+    stripped = answer.strip()
+    if stripped.startswith("```"):
+        # Drop a fenced code block: take the inside, ignore an optional language tag.
+        inner = stripped.strip("`")
+        if "\n" in inner:
+            inner = inner.split("\n", 1)[1]
+        stripped = inner.rsplit("```", 1)[0]
+    return stripped.strip(_WRAPPER_CHARS)
+
+
+def _sentences(paragraph: str) -> list[str]:
+    """Split into sentences and drop empty fragments from trailing punctuation."""
+    return [s.strip() for s in _SENTENCE_SPLIT_RE.split(paragraph) if s.strip()]
+
+
+def _grade_text(text: str, target_words: int) -> tuple[bool, list[str]]:
+    """Grade a paragraph against both constraints.
+
+    Returns ``(passed, problems)`` where ``problems`` is a human-readable list
+    of constraint violations (empty when ``passed`` is True).
+    """
+    paragraph = _extract_paragraph(text)
+    word_count = len(paragraph.split())
+    sentences = _sentences(paragraph)
+    non_vowel = [s for s in sentences if not s or s[0] not in _VOWELS]
+
+    problems: list[str] = []
+    if word_count != target_words:
+        problems.append(f"word count {word_count} != {target_words}")
+    if not sentences:
+        problems.append("no sentences detected")
+    if non_vowel:
+        preview = "; ".join(s[:40] for s in non_vowel)
+        problems.append(f"{len(non_vowel)} sentence(s) did not start with a vowel: {preview}")
+    return not problems, problems
+
+
+@dataclass(frozen=True)
+class ExactWordCountAndVowelStarts(SuccessAssertion):
+    """The final paragraph must be exactly ``target_words`` long and every
+    sentence must begin with a vowel.
+    """
+
+    target_words: int
+
+    def check(self, trajectory: AgentTrajectory) -> bool:
+        passed, _ = _grade_text(trajectory.answer, self.target_words)
+        return passed
+
+    def describe_failure(self, trajectory: AgentTrajectory) -> str:
+        _, problems = _grade_text(trajectory.answer, self.target_words)
+        return "constraint violation: " + "; ".join(problems)
+
+TARGET_WORDS = 47
+
+_QUERY = f"""Write a single paragraph about an bear that satisfies BOTH constraints exactly:
+
+1. The paragraph must be exactly {TARGET_WORDS} words.
+2. Every sentence must start with a vowel letter (A, E, I, O, or U).
+
+Be deliberate: draft, then count words and check each sentence's first letter.
+Revise until BOTH constraints are met exactly — not approximately.
+
+Output ONLY the final paragraph. No preamble, no quotes, no markdown fences."""
+
+
+@pytest.mark.eval_tier("hillclimb")
+@pytest.mark.langsmith
+def test_exact_word_count_and_vowel_starts(model: BaseChatModel) -> None:
+    """Deep agent satisfies two interacting hard constraints by iterating.
+
+    The agent has access to planning, scratchpad, and the agent loop, which
+    lets it draft, count, and revise. The test passes when the final
+    paragraph hits the exact word count AND every sentence starts with a
+    vowel.
+    """
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        query=_QUERY,
+        scorer=TrajectoryScorer().success(ExactWordCountAndVowelStarts(target_words=TARGET_WORDS)),
+    )

--- a/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py
+++ b/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py
@@ -68,7 +68,7 @@ def _sentences(paragraph: str) -> list[str]:
 def _grade_text(text: str, target_words: int) -> tuple[bool, list[str]]:
     """Grade a paragraph against both constraints.
 
-    Returns ``(passed, problems)`` where ``problems`` is a human-readable list
+    Returns `(passed, problems)` where `problems` is a human-readable list
     of constraint violations (empty when ``passed`` is True).
     """
     paragraph = _extract_paragraph(text)

--- a/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py
+++ b/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py
@@ -98,9 +98,10 @@ class ExactWordCountAndVowelStarts(SuccessAssertion):
         _, problems = _grade_text(trajectory.answer, self.target_words)
         return "constraint violation: " + "; ".join(problems)
 
+
 TARGET_WORDS = 72
 
-_QUERY = f"""Write a story about a bear that's 72 words and has every sentence starting with a vowel. Output paragraph only."""
+_QUERY = """Write a story about a bear that's 72 words and has every sentence starting with a vowel. Output paragraph only."""
 
 
 @pytest.mark.eval_tier("hillclimb")

--- a/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py
+++ b/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py
@@ -1,6 +1,6 @@
 """Eval test for iterative constraint satisfaction.
 
-Asks a deep agent (with whatever model ``--model`` selects) to produce a
+Asks a deep agent (with whatever model `--model` selects) to produce a
 paragraph under two simultaneous hard constraints: exact word count AND
 every sentence must start with a vowel. The agent has access to planning,
 scratchpad, and the agent loop itself — room to draft, count, and revise
@@ -30,8 +30,13 @@ from tests.evals.utils import (
 pytestmark = [pytest.mark.eval_category("conversation")]
 
 
+# All vowel characters (upper and lowercase) used to check sentence starts.
 _VOWELS = frozenset("aeiouAEIOU")
+
+# Regex that splits text into sentences on any sequence of sentence-ending punctuation - periods, exclamation points, or question marks.
 _SENTENCE_SPLIT_RE = re.compile(r"[.!?]+")
+
+# Characters stripped from the edges of the extracted paragraph (whitespace, quotes, markdown). Done to allow grading to be robust to models that wrap their final answer in quotes, markdown, or code fences.
 _WRAPPER_CHARS = " \t\n\r\"'`*_"
 
 

--- a/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py
+++ b/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py
@@ -36,19 +36,23 @@ _WRAPPER_CHARS = " \t\n\r\"'`*_"
 
 
 def _extract_paragraph(answer: str) -> str:
-    """Strip surrounding markdown / quotes / fences from the final answer.
+    """Extract the last paragraph from the model's reply.
 
-    Keeps grading robust to minor formatting noise without softening the
-    underlying constraints.
+    Splits the answer on blank lines and returns the final non-empty chunk,
+    stripped of surrounding markdown / quotes / fences. This makes grading
+    robust to models that prefix their answer with reasoning, drafts, or
+    summaries — only the trailing paragraph is graded.
     """
     stripped = answer.strip()
-    if stripped.startswith("```"):
+    paragraphs = [p.strip() for p in re.split(r"\n\s*\n", stripped) if p.strip()]
+    last = paragraphs[-1] if paragraphs else stripped
+    if last.startswith("```"):
         # Drop a fenced code block: take the inside, ignore an optional language tag.
-        inner = stripped.strip("`")
+        inner = last.strip("`")
         if "\n" in inner:
             inner = inner.split("\n", 1)[1]
-        stripped = inner.rsplit("```", 1)[0]
-    return stripped.strip(_WRAPPER_CHARS)
+        last = inner.rsplit("```", 1)[0]
+    return last.strip(_WRAPPER_CHARS)
 
 
 def _sentences(paragraph: str) -> list[str]:
@@ -94,17 +98,9 @@ class ExactWordCountAndVowelStarts(SuccessAssertion):
         _, problems = _grade_text(trajectory.answer, self.target_words)
         return "constraint violation: " + "; ".join(problems)
 
-TARGET_WORDS = 47
+TARGET_WORDS = 72
 
-_QUERY = f"""Write a single paragraph about an bear that satisfies BOTH constraints exactly:
-
-1. The paragraph must be exactly {TARGET_WORDS} words.
-2. Every sentence must start with a vowel letter (A, E, I, O, or U).
-
-Be deliberate: draft, then count words and check each sentence's first letter.
-Revise until BOTH constraints are met exactly — not approximately.
-
-Output ONLY the final paragraph. No preamble, no quotes, no markdown fences."""
+_QUERY = f"""Write a story about a bear that's 72 words and has every sentence starting with a vowel. Output paragraph only."""
 
 
 @pytest.mark.eval_tier("hillclimb")

--- a/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py
+++ b/libs/evals/tests/evals/test_iterative_constraint_satisfaction.py
@@ -1,6 +1,6 @@
 """Eval test for iterative constraint satisfaction.
 
-Asks a deep agent (with whatever model ``--model`` selects) to produce a
+Asks a deep agent (with whatever model `--model` selects) to produce a
 paragraph under two simultaneous hard constraints: exact word count AND
 every sentence must start with a vowel. The agent has access to planning,
 scratchpad, and the agent loop itself — room to draft, count, and revise

--- a/libs/evals/tests/unit_tests/test_category_tagging.py
+++ b/libs/evals/tests/unit_tests/test_category_tagging.py
@@ -32,7 +32,11 @@ EXPECTED_CATEGORY_MODULES: dict[str, list[str]] = {
         "test_external_benchmarks",
     ],
     "memory": ["test_memory", "test_memory_multiturn", "test_memory_agent_bench"],
-    "conversation": ["test_followup_quality", "test_tau2_airline"],
+    "conversation": [
+        "test_followup_quality",
+        "test_tau2_airline",
+        "test_iterative_constraint_satisfaction",
+    ],
     "summarization": ["test_summarization"],
     "unit_test": [
         "test_system_prompt",


### PR DESCRIPTION
Fixes #

Adds an eval that tests whether a deep agent can write a paragraph with an exact word count (72 words) where every sentence starts with a vowel.

The prompt has been simplified to a natural one-line query (mimicing a real user's prompt), and the `_extract_paragraph` helper function now splits on blank lines and grades only the trailing paragraph - so preamble or chain-of-thought leaks no longer invalidate runs where the model produced the correct answer last.

Once the Outcomes API is built, a separate grader agent will validate the deep agent's output against both constraints. The goal is to measure whether the Deep Agent Framework's harnesses produce meaningful improvement in a weaker model (Claude Haiku 4.5) compared to a vanilla model call.

**How did you verify your code works?**
Ran the eval locally against `claude-haiku-4-5` and confirmed the grading logic (`_grade_text`) correctly flags word count mismatches and sentences not starting with a vowel. End-to-end improvement can't be verified yet since the Outcomes API hasn't been developed yet.

**Disclaimer:** Parts of this eval file were written with AI assistance.