### PR TITLE
fix(code): token-safe MCP OAuth login error handling and loopback edge cases

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -8208,7 +8208,7 @@ class DeepAgentsApp(App):
             # token would never reach the MCP tool factory.
             self.notify(
                 "Cannot log into MCP servers against a remote server. "
-                "Relaunch deepagents locally to authenticate.",
+                "Relaunch dcode locally to authenticate.",
                 severity="warning",
                 markup=False,
             )
@@ -8332,18 +8332,25 @@ class DeepAgentsApp(App):
         except BaseException:
             # Worker cancelled or app shutdown — unblock the modal and
             # let the cancellation propagate.
-            if not screen._done:
+            if not screen.is_done:
                 screen.finish(success=False, message="Login interrupted.")
             if not outcome_future.done():
                 outcome_future.set_result(None)
             raise
 
         if login_error is not None:
-            logger.warning("MCP login for %r failed", server_name, exc_info=login_error)
-            screen.finish(success=False, message=f"Login failed: {login_error}")
+            from deepagents_code.mcp_auth import format_login_failure
+
+            # Token-safe: never `%r`, `str()`, or `exc_info=` on the raw
+            # exception — its `args`/repr may include an `OAuthToken` from
+            # the MCP SDK. `format_login_failure` unwraps `ExceptionGroup`
+            # roots and degrades to a class-name chain for unknown types.
+            summary = format_login_failure(login_error)
+            logger.warning("MCP login for %r failed: %s", server_name, summary)
+            screen.finish(success=False, message=f"Login failed: {summary}")
             await asyncio.wait_for(outcome_future, timeout=5.0)
             await self._mount_message(
-                ErrorMessage(f"MCP login for {server_name!r} failed: {login_error}"),
+                ErrorMessage(f"MCP login for {server_name!r} failed: {summary}"),
             )
             return
 
@@ -8377,7 +8384,7 @@ class DeepAgentsApp(App):
         if self._server_kwargs is None or server_proc is None:
             self.notify(
                 "Cannot restart the LangGraph server automatically; "
-                "relaunch deepagents to pick up the new MCP token.",
+                "relaunch dcode to pick up the new MCP token.",
                 severity="warning",
                 markup=False,
             )

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -283,14 +283,16 @@ class FileTokenStorage(TokenStorage):
         except (OSError, json.JSONDecodeError) as exc:
             msg = (
                 f"Failed to read MCP token file {path}: {exc}. "
-                f"Delete the file and log in to {self._server_name!r} again."
+                f"Delete the file and run `/mcp login {self._server_name}` "
+                f"in the TUI (or `dcode mcp login {self._server_name}`)."
             )
             raise RuntimeError(msg) from exc
         if data.get("version") != _STORAGE_VERSION:
             msg = (
                 f"MCP token file {path} has unsupported version "
                 f"{data.get('version')!r} (expected {_STORAGE_VERSION}). "
-                f"Delete it and log in to {self._server_name!r} again."
+                f"Delete it and run `/mcp login {self._server_name}` in the "
+                f"TUI (or `dcode mcp login {self._server_name}`)."
             )
             raise RuntimeError(msg)
         return data
@@ -404,6 +406,11 @@ class _LoopbackOAuthCallbackServer:
         self._closed = False
         self._thread: threading.Thread | None = None
 
+    @property
+    def port(self) -> int:
+        """Loopback TCP port this server will bind on `start()`."""
+        return self._port
+
     def start(self) -> None:
         """Bind and start serving callback requests in a background thread."""
         if self._started:
@@ -493,13 +500,25 @@ class _LoopbackOAuthCallbackServer:
             # Duplicate browser request (retry, prefetch, favicon) after the
             # flow already completed. Respond and return without touching the
             # future — avoids InvalidStateError from a concurrent set_result.
-            self._send_html(
-                handler,
-                200,
-                _oauth_success_html(
-                    "MCP authorization complete. You can close this browser tab.",
-                ),
-            )
+            # Branch on the future's terminal state: a previous error must
+            # not be papered over with a success page.
+            if self._future.exception() is None:
+                self._send_html(
+                    handler,
+                    200,
+                    _oauth_success_html(
+                        "MCP authorization complete. You can close this browser tab.",
+                    ),
+                )
+            else:
+                self._send_html(
+                    handler,
+                    400,
+                    _oauth_error_html(
+                        "Authorization did not complete. "
+                        "Return to your terminal for details.",
+                    ),
+                )
             return
 
         parsed = urlparse(handler.path)
@@ -613,7 +632,8 @@ class MCPReauthRequiredError(RuntimeError):
         self.server_name = server_name
         super().__init__(
             f"MCP server {server_name!r} needs re-authentication. "
-            "Log in again to restore access.",
+            f"Run `/mcp login {server_name}` in the TUI, or "
+            f"`dcode mcp login {server_name}` from the shell.",
         )
 
 
@@ -725,11 +745,22 @@ def _make_loopback_handlers(
         import webbrowser
 
         final_url = _append_query_params(auth_url, extras) if extras else auth_url
-        opened = await asyncio.to_thread(webbrowser.open, final_url)
+
+        # Resolve a browser explicitly before opening so headless / SSH
+        # environments fall through to paste-back without burning the
+        # 300s loopback timeout. `webbrowser.open` can return `True` in
+        # those environments even when nothing launches.
+        try:
+            await asyncio.to_thread(webbrowser.get)
+            has_browser = True
+        except webbrowser.Error:
+            has_browser = False
+
+        if has_browser:
+            opened = await asyncio.to_thread(webbrowser.open, final_url)
+        else:
+            opened = False
         if not opened:
-            # No browser available — poison the future so callback() falls
-            # through to paste_callback() immediately instead of waiting 300s.
-            # The socket is never bound because start() is not called.
             callback_server.fail(
                 _LoopbackCallbackUnavailableError(
                     "No browser is available to complete the OAuth flow.",
@@ -742,7 +773,7 @@ def _make_loopback_handlers(
         except OSError as exc:
             logger.warning(
                 "Could not start loopback OAuth callback server on port %s: %s",
-                callback_server._port,
+                callback_server.port,
                 exc,
             )
             msg = "Local OAuth callback server could not be started."
@@ -752,6 +783,9 @@ def _make_loopback_handlers(
             )
             await interaction.show_authorize_url(final_url, opened_in_browser=False)
             return
+        # Communicate the URL regardless of `webbrowser.open` returning
+        # success — headless setups can report success without actually
+        # rendering a browser, and users still need the paste-back URL.
         await interaction.show_authorize_url(final_url, opened_in_browser=True)
 
     async def callback() -> tuple[str, str | None]:
@@ -927,7 +961,15 @@ async def _run_device_flow(
             # before raise_for_status so 400-returning providers work.
             try:
                 body = token_response.json()
-            except ValueError:
+            except ValueError as exc:
+                # Malformed JSON would otherwise cascade into a confusing
+                # OAuthToken.model_validate({}) error below; log the cause
+                # explicitly so debugging is possible.
+                logger.warning(
+                    "Token endpoint %s returned non-JSON body: %s",
+                    token_url,
+                    exc,
+                )
                 body = {}
             err = body.get("error")
             if err == "authorization_pending":
@@ -959,6 +1001,49 @@ async def _run_device_flow(
     raise RuntimeError(msg)
 
 
+def format_login_failure(exc: BaseException) -> str:
+    """Return a token-safe single-line summary of an OAuth-login exception.
+
+    OAuth handshakes commonly surface as `ExceptionGroup` (anyio task
+    groups) or as MCP-SDK errors whose `args`/`repr` may include an
+    `OAuthToken`. Never call `str()`/`repr()` on the raw exception for
+    display or logging — instead, prefer a known-safe nested
+    `MCPReauthRequiredError` message, fall back to the messages of our
+    own loopback-related exception types, and degrade to a class-name
+    chain for anything else.
+
+    Args:
+        exc: Root exception caught from the login worker.
+
+    Returns:
+        A user-displayable string that is safe to log and to render.
+    """
+    reauth = find_reauth_required(exc)
+    if reauth is not None:
+        return str(reauth)
+
+    safe_types = (
+        _LoopbackCallbackTimeoutError,
+        _LoopbackCallbackUnavailableError,
+    )
+    if isinstance(exc, safe_types):
+        return f"{type(exc).__name__}: {exc}"
+
+    parts: list[str] = []
+    current: BaseException | None = exc
+    visited: set[int] = set()
+    while current is not None and id(current) not in visited:
+        visited.add(id(current))
+        parts.append(type(current).__name__)
+        if isinstance(current, BaseExceptionGroup):
+            parts.append(
+                "[" + ", ".join(type(e).__name__ for e in current.exceptions[:5]) + "]"
+            )
+            break
+        current = current.__cause__ or current.__context__
+    return " -> ".join(parts) if parts else type(exc).__name__
+
+
 def find_reauth_required(exc: BaseException) -> MCPReauthRequiredError | None:
     """Find an `MCPReauthRequiredError` anywhere inside `exc`'s tree.
 
@@ -980,9 +1065,8 @@ def find_reauth_required(exc: BaseException) -> MCPReauthRequiredError | None:
         visited.add(id(current))
         if isinstance(current, MCPReauthRequiredError):
             return current
-        sub_exceptions = getattr(current, "exceptions", None)
-        if sub_exceptions:
-            stack.extend(sub_exceptions)
+        if isinstance(current, BaseExceptionGroup):
+            stack.extend(current.exceptions)
         cause = current.__cause__ or current.__context__
         if cause is not None:
             stack.append(cause)

--- a/libs/code/deepagents_code/mcp_commands.py
+++ b/libs/code/deepagents_code/mcp_commands.py
@@ -125,12 +125,25 @@ async def run_mcp_login(*, server: str, config_path: str | None) -> int:
     import httpx
     from pydantic import ValidationError
 
+    from deepagents_code.mcp_auth import format_login_failure
+
     try:
         await login(
             server_name=selection.server_name,
             server_config=selection.server_config,
             ui=CliOAuthInteraction(),
         )
+    except PermissionError as exc:
+        # PermissionError typically means the user's home dir or the
+        # ~/.deepagents/.state/mcp-tokens/ tree isn't writable. Retrying
+        # without a hint sends users in circles.
+        print(  # noqa: T201
+            f"Login failed: cannot write to the MCP tokens store ({exc}). "
+            f"Check permissions on ~/.deepagents/.state/mcp-tokens/ and "
+            f"retry `dcode mcp login {selection.server_name}`.",
+            file=sys.stderr,
+        )
+        return 1
     except (
         ValueError,
         RuntimeError,
@@ -139,7 +152,10 @@ async def run_mcp_login(*, server: str, config_path: str | None) -> int:
         KeyError,
         OSError,
     ) as exc:
-        print(f"Login failed: {exc}", file=sys.stderr)  # noqa: T201
+        print(  # noqa: T201
+            f"Login failed: {format_login_failure(exc)}",
+            file=sys.stderr,
+        )
         return 1
     return 0
 

--- a/libs/code/deepagents_code/mcp_login_service.py
+++ b/libs/code/deepagents_code/mcp_login_service.py
@@ -265,7 +265,7 @@ def format_untrusted_project_notice(paths: tuple[Path, ...]) -> str:
     return (
         "Skipping untrusted project MCP config "
         f"(not yet approved or config changed): {skipped}. "
-        "Approve it by running `deepagents` in this project, or "
+        "Approve it by running `dcode` in this project, or "
         "pass --config <path> to use it explicitly."
     )
 

--- a/libs/code/deepagents_code/mcp_oauth_ui.py
+++ b/libs/code/deepagents_code/mcp_oauth_ui.py
@@ -83,7 +83,10 @@ class OAuthInteraction(Protocol):
         ...
 
     async def show_error(self, message: str) -> None:
-        """Report a terminal error in the flow.
+        """Report a fatal (flow-ending) error.
+
+        "Fatal" rather than "terminal" because this is a TUI codebase
+        where "terminal" reads ambiguously.
 
         Args:
             message: Plain-text error description.

--- a/libs/code/deepagents_code/mcp_providers/slack.py
+++ b/libs/code/deepagents_code/mcp_providers/slack.py
@@ -9,7 +9,7 @@ on that port so the browser redirect completes automatically. An optional
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 from urllib.parse import urlparse
 
 from mcp.shared.auth import (
@@ -23,6 +23,19 @@ from deepagents_code.mcp_providers.base import LoginResult, OAuthProvider
 if TYPE_CHECKING:
     from deepagents_code.mcp_auth import FileTokenStorage
     from deepagents_code.mcp_oauth_ui import OAuthInteraction
+
+
+@runtime_checkable
+class _SupportsSlackTeamPrompt(Protocol):
+    """Optional interaction-surface capability: prompt for a Slack team ID.
+
+    `OAuthInteraction` deliberately omits this method — only the CLI
+    surface implements it. The TUI lets Slack's browser page handle
+    workspace selection. Marked `runtime_checkable` so `isinstance`
+    can replace `getattr`-style structural probes at the call site.
+    """
+
+    async def prompt_slack_team_id(self) -> str | None: ...
 
 
 # Public OAuth client ID — safe to check in. No secret is associated;
@@ -53,20 +66,22 @@ def _is_slack_mcp_url(url: str) -> bool:
 async def _prompt_slack_team(ui: OAuthInteraction) -> str | None:
     """Return a Slack team ID when the interaction surface supports prompting.
 
-    CLI surfaces implement `prompt_slack_team_id` to interactively ask the
-    user which workspace to install into. TUI surfaces omit the method so
-    Slack's browser page handles workspace selection instead.
+    `prompt_slack_team_id` is **not** a member of the `OAuthInteraction`
+    Protocol — only the CLI surface implements it. The TUI omits it so
+    Slack's browser page handles workspace selection instead. Detection
+    uses `isinstance` against the `runtime_checkable`
+    `_SupportsSlackTeamPrompt` capability protocol.
 
     Args:
         ui: Interaction surface to use.
 
     Returns:
-        The entered Slack team ID, or `None` to let Slack's page decide.
+        The entered Slack team ID, or `None` when the surface lacks the
+            optional prompt method or the user declined to specify one.
     """
-    fn = getattr(ui, "prompt_slack_team_id", None)
-    if fn is None:
+    if not isinstance(ui, _SupportsSlackTeamPrompt):
         return None
-    return await fn()
+    return await ui.prompt_slack_team_id()
 
 
 async def _preseed_slack_client_info(storage: FileTokenStorage) -> None:

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import time
@@ -1410,8 +1411,19 @@ async def _handle_interrupt_cleanup(
             await agent.aupdate_state(config, {"messages": [cancellation_msg]})
     except (httpx.TransportError, httpx.TimeoutException) as e:
         logger.warning("Could not save interrupted state (network): %s", e)
-    except Exception:
+    except Exception as exc:  # interrupt cleanup must not propagate
         logger.warning("Failed to save interrupted state", exc_info=True)
+        # Surface via the chat surface — silent file-only warnings have
+        # masked real state-write failures (validation, checkpointer
+        # corruption) in past incidents. The mount is best-effort; the
+        # adapter may already be tearing down.
+        with contextlib.suppress(Exception):
+            await adapter._mount_message(
+                AppMessage(
+                    f"Could not save interrupted state ({type(exc).__name__}). "
+                    "Subsequent turns may see stale state."
+                )
+            )
 
     # Mark tools as rejected AFTER saving state
     for tool_msg in list(adapter._current_tool_messages.values()):
@@ -1441,17 +1453,28 @@ async def _persist_context_tokens(
 ) -> None:
     """Best-effort persist of the context token count into graph state.
 
-    The `aupdate_state` call is wrapped in `tracing_context(enabled=False)` so
-    this purely-internal bookkeeping write does not surface as a separate
-    `UpdateState` run in LangSmith. `_context_tokens` is already marked
-    `PrivateStateAttr`, but `aupdate_state` itself creates its own traced run
-    that would otherwise clutter the project's traces.
+    For local agents, the `aupdate_state` call is wrapped in
+    `tracing_context(enabled=False)` so this purely-internal bookkeeping write
+    does not surface as a separate `UpdateState` run in LangSmith.
+    `_context_tokens` is already marked `PrivateStateAttr`, but `aupdate_state`
+    itself creates its own traced run that would otherwise clutter the project's
+    traces.
+
+    For remote agents (e.g. a `langgraph dev` server), `aupdate_state` goes
+    over HTTP and the server creates its own LangSmith trace that the client
+    cannot suppress with `tracing_context`. Skipping the call is safe because
+    persistence is best-effort — a stale count on resume is acceptable.
 
     Args:
         agent: The LangGraph agent (must support `aupdate_state`).
         config: Runnable config with `thread_id`.
         tokens: Total context tokens to persist.
     """
+    from deepagents_code.remote_client import RemoteAgent
+
+    if isinstance(agent, RemoteAgent):
+        return
+
     from langsmith import tracing_context
 
     try:

--- a/libs/code/deepagents_code/widgets/mcp_login.py
+++ b/libs/code/deepagents_code/widgets/mcp_login.py
@@ -61,7 +61,13 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("escape", "cancel", "Cancel", show=False, priority=True),
     ]
-    """Esc requests cancellation. The login worker still owns shutdown."""
+    """Esc unblocks the worker; the worker performs the actual shutdown.
+
+    Cancellation completes any outstanding input future with
+    `MCPLoginCancelledError`. The worker (`_run_mcp_login_worker`) sees
+    that exception, calls `finish(success=False)`, and tears down the
+    OAuth handshake. Doing the teardown here would race the worker.
+    """
 
     CSS = """
     MCPLoginScreen {
@@ -151,13 +157,23 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
         self._spinner = Spinner()
         self._spinner_timer: Timer | None = None
 
-        # Promise plumbing: each prompt method blocks on a fresh Future
-        # that the input submission resolves. Cancellation completes any
-        # outstanding future with MCPLoginCancelledError so the worker unblocks.
+        # Each prompt method blocks on a fresh Future; cancellation completes
+        # it with MCPLoginCancelledError so the worker unblocks rather than
+        # hanging on a dismissed modal.
         self._pending_input: asyncio.Future[str] | None = None
         self._cancelled = False
         self._done = False
         self._outcome: LoginOutcome | None = None
+
+    @property
+    def is_done(self) -> bool:
+        """`True` once the modal has been told to finish (success or failure).
+
+        Public accessor for callers that need to coordinate teardown from
+        outside the screen, e.g. the worker's `BaseException` branch that
+        unblocks dismiss without re-finishing.
+        """
+        return self._done
 
     def compose(self) -> ComposeResult:
         """Compose the modal body inside a `Vertical` container.
@@ -269,7 +285,7 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
         self._append_history(message)
 
     async def show_error(self, message: str) -> None:
-        """Render a terminal error status line and append it to history."""
+        """Render a fatal (flow-ending) error status line and history entry."""
         self._set_status(message)
         self._append_history(message)
 
@@ -364,6 +380,9 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
     def finish(self, *, success: bool, message: str | None = None) -> None:
         """Close the modal from the worker, reporting the final outcome.
 
+        Dismiss is deferred by 0.6s so the user sees the final status
+        before the modal disappears.
+
         Args:
             success: `True` when login succeeded; drives the dismiss value.
             message: Optional final status line shown before close.
@@ -376,7 +395,6 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
             self._set_status(message)
             self._append_history(message)
         self._stop_spinner_timer()
-        # Mark spinner area with check / cross via status — no widget swap.
         glyphs = get_glyphs()
         marker = glyphs.checkmark if success else glyphs.error
         if self._title_widget is not None:
@@ -387,13 +405,12 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
                     marker=marker,
                 )
             )
-        # Defer dismiss so the user sees the final status briefly.
 
         def _deferred_dismiss() -> None:
-            # Must be a def (not a lambda) — Textual's _invoke auto-awaits any
-            # awaitable return value, and dismiss() returns AwaitComplete; awaiting
-            # it inside _flush_next_callbacks (the screen's own message pump) raises
-            # ScreenError. A None-returning def discards it instead.
+            # Must be a def (not a lambda): Textual's `_invoke` auto-awaits
+            # any awaitable return, and `dismiss()` returns `AwaitComplete`;
+            # awaiting it inside the screen's own message pump raises
+            # `ScreenError`. A `None`-returning def discards the awaitable.
             self.dismiss(self._outcome or "failed")
 
         self.set_timer(0.6, _deferred_dismiss)

--- a/libs/code/deepagents_code/widgets/mcp_viewer.py
+++ b/libs/code/deepagents_code/widgets/mcp_viewer.py
@@ -477,6 +477,11 @@ class MCPServerHeaderItem(Static):
         )
         super().__init__(content, classes=classes)
 
+    @property
+    def server(self) -> MCPServerInfo:
+        """Server metadata this header row is rendering."""
+        return self._server
+
     def set_selected(self, selected: bool) -> None:
         """Apply or remove the selected-row styling and re-render the label.
 
@@ -1004,7 +1009,7 @@ class MCPViewerScreen(ModalScreen[str | None]):
         if isinstance(row, MCPToolItem):
             row.toggle_expand()
             return
-        server = row._server
+        server = row.server
         if server.status == "unauthenticated":
             self.dismiss(server.name)
 

--- a/libs/code/deepagents_code/widgets/welcome.py
+++ b/libs/code/deepagents_code/widgets/welcome.py
@@ -481,14 +481,17 @@ def build_connecting_footer(
 ) -> Content:
     """Build a footer shown while waiting for the server to connect.
 
+    `resuming` wins over the other branches; otherwise `local_server`
+    selects between the local and generic variants, and `reconnecting`
+    swaps the verb only when `local_server` is `True`.
+
     Args:
         resuming: Show `'Resuming...'` instead of any `'Connecting...'` variant.
         local_server: Qualify the server as "local" in the connecting message.
-
-            Ignored when `resuming` is `True`.
+            Honored only when `resuming` is `False`.
         reconnecting: Use `'Reconnecting'` instead of `'Connecting'` for
-            mid-session restarts. Ignored when `resuming` is `True` or
-            `local_server` is `False`.
+            mid-session restarts. Honored only when `local_server` is `True`
+            and `resuming` is `False`.
         dots: Ellipsis string appended to the status text. Pass an animated
             frame (e.g. `"."`, `".."`, `"..."`) to show a cycling indicator.
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -8513,3 +8513,98 @@ class TestMCPLoginCommand:
                 "Unknown" in str(w._content) and "frobnicate" in str(w._content)
                 for w in app.query(AppMessage)
             )
+
+    async def test_mcp_login_worker_surfaces_config_resolution_error(self) -> None:
+        """`_run_mcp_login_worker` exits with ErrorMessage on config-resolve failure."""
+        from deepagents_code.mcp_login_service import (
+            ConfigErrorKind,
+            ConfigResolutionError,
+        )
+
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._mcp_preload_kwargs = {
+                "mcp_config_path": None,
+                "no_mcp": False,
+                "trust_project_mcp": None,
+            }
+            with patch(
+                "deepagents_code.mcp_login_service.resolve_mcp_config",
+                return_value=ConfigResolutionError(
+                    kind=ConfigErrorKind.NO_CONFIG_FOUND,
+                    message="No MCP config file found",
+                ),
+            ):
+                await app._run_mcp_login_worker("notion")
+                await pilot.pause()
+            assert any(
+                "No MCP config file found" in str(w._content)
+                for w in app.query(ErrorMessage)
+            )
+
+    async def test_mcp_login_worker_does_not_leak_unknown_exception_message(
+        self,
+    ) -> None:
+        """Unknown login exceptions are summarized without leaking their str().
+
+        The MCP SDK can raise exceptions whose `args`/`repr` include an
+        `OAuthToken`. The worker uses `format_login_failure` to degrade
+        unrecognized types to a class-name chain so tokens never reach the
+        user-facing `ErrorMessage` or the rotating log files.
+        """
+        from pathlib import Path as _Path
+
+        from deepagents_code.mcp_login_service import (
+            ConfigResolution,
+            ServerSelection,
+        )
+
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._mcp_preload_kwargs = {
+                "mcp_config_path": None,
+                "no_mcp": False,
+                "trust_project_mcp": None,
+            }
+
+            resolution = ConfigResolution(
+                config={"mcpServers": {"notion": {"type": "http", "auth": "oauth"}}},
+                used_paths=(_Path("/tmp/mcp.json"),),
+            )
+            selection = ServerSelection(
+                server_name="notion",
+                server_config={
+                    "type": "http",
+                    "auth": "oauth",
+                    "url": "https://example",
+                },
+            )
+
+            class _FakeMcpError(RuntimeError):
+                pass
+
+            sentinel = "TOKEN_PAYLOAD_MUST_NOT_LEAK"
+
+            async def _failing_login(**_: object) -> None:
+                await asyncio.sleep(0)
+                raise _FakeMcpError(sentinel)
+
+            with (
+                patch(
+                    "deepagents_code.mcp_login_service.resolve_mcp_config",
+                    return_value=resolution,
+                ),
+                patch(
+                    "deepagents_code.mcp_login_service.select_server",
+                    return_value=selection,
+                ),
+                patch("deepagents_code.mcp_auth.login", _failing_login),
+            ):
+                await app._run_mcp_login_worker("notion")
+                await pilot.pause()
+
+            rendered = " ".join(str(w._content) for w in app.query(ErrorMessage))
+            assert sentinel not in rendered
+            assert "_FakeMcpError" in rendered or "FakeMcpError" in rendered

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -15,6 +15,7 @@ from deepagents_code.mcp_auth import (
     FileTokenStorage,
     MCPReauthRequiredError,
     find_reauth_required,
+    format_login_failure,
     resolve_headers,
 )
 
@@ -244,6 +245,68 @@ class TestFindReauthRequired:
         assert find_reauth_required(a) is None
 
 
+class TestFormatLoginFailure:
+    """Tests for the token-safe summary helper used in app + CLI logs."""
+
+    def test_returns_reauth_message_for_nested_reauth_error(self) -> None:
+        """ExceptionGroup wrapping `MCPReauthRequiredError` surfaces its message."""
+        exc = ExceptionGroup(
+            "anyio task group",
+            [RuntimeError("upstream"), MCPReauthRequiredError("notion")],
+        )
+        summary = format_login_failure(exc)
+        assert "notion" in summary
+        assert "Run `/mcp login notion`" in summary
+
+    def test_omits_message_for_unknown_exception_types(self) -> None:
+        """Unrecognized exceptions degrade to a class-name chain — no `str()`.
+
+        Tokens can hide in `args`/`repr` of unfamiliar MCP-SDK error types;
+        the helper must never include those payloads.
+        """
+
+        class FakeMcpError(RuntimeError):
+            pass
+
+        sentinel = "TOKEN_PAYLOAD_DO_NOT_LEAK"
+        exc = FakeMcpError(sentinel)
+        summary = format_login_failure(exc)
+        assert sentinel not in summary
+        assert "FakeMcpError" in summary
+
+    def test_includes_message_for_known_loopback_errors(self) -> None:
+        """Loopback-internal exceptions are token-free and may include their message."""
+        from deepagents_code.mcp_auth import _LoopbackCallbackTimeoutError
+
+        exc = _LoopbackCallbackTimeoutError("Callback timed out")
+        summary = format_login_failure(exc)
+        assert "Callback timed out" in summary
+        assert "_LoopbackCallbackTimeoutError" in summary
+
+    def test_walks_cause_chain_into_class_names(self) -> None:
+        """A chained unknown exception still surfaces every link's class name."""
+
+        class OuterError(RuntimeError):
+            pass
+
+        class InnerError(RuntimeError):
+            pass
+
+        inner_msg = "inner-payload"
+        outer_msg = "outer-payload"
+        try:
+            try:
+                raise InnerError(inner_msg)  # noqa: TRY301
+            except InnerError as inner:
+                raise OuterError(outer_msg) from inner
+        except OuterError as exc:
+            summary = format_login_failure(exc)
+        assert "OuterError" in summary
+        assert "InnerError" in summary
+        assert inner_msg not in summary
+        assert outer_msg not in summary
+
+
 class TestAppendQueryParams:
     """Tests for `_append_query_params` URL manipulation."""
 
@@ -397,6 +460,7 @@ class TestLoopbackHandlers:
         from deepagents_code.mcp_auth import build_oauth_provider
 
         del socket_enabled
+        monkeypatch.setattr("webbrowser.get", lambda *_a, **_kw: object())
         monkeypatch.setattr("webbrowser.open", lambda _url: True)
         provider = build_oauth_provider(
             server_name="notion",
@@ -429,6 +493,7 @@ class TestLoopbackHandlers:
         from deepagents_code.mcp_auth import build_oauth_provider
 
         del socket_enabled
+        monkeypatch.setattr("webbrowser.get", lambda *_a, **_kw: object())
         monkeypatch.setattr("webbrowser.open", lambda _url: True)
         provider = build_oauth_provider(
             server_name="notion",
@@ -462,6 +527,7 @@ class TestLoopbackHandlers:
         from deepagents_code.mcp_auth import build_oauth_provider
 
         del socket_enabled
+        monkeypatch.setattr("webbrowser.get", lambda *_a, **_kw: object())
         monkeypatch.setattr("webbrowser.open", lambda _url: True)
         provider = build_oauth_provider(
             server_name="notion",
@@ -490,6 +556,7 @@ class TestLoopbackHandlers:
         """When the browser cannot open, callback() falls back to paste-back at once."""
         from deepagents_code.mcp_auth import build_oauth_provider
 
+        monkeypatch.setattr("webbrowser.get", lambda *_a, **_kw: object())
         monkeypatch.setattr("webbrowser.open", lambda _url: False)
         monkeypatch.setattr(
             "builtins.input",
@@ -519,6 +586,7 @@ class TestLoopbackHandlers:
             build_oauth_provider,
         )
 
+        monkeypatch.setattr("webbrowser.get", lambda *_a, **_kw: object())
         monkeypatch.setattr("webbrowser.open", lambda _url: True)
         monkeypatch.setattr(
             _LoopbackOAuthCallbackServer,
@@ -543,6 +611,124 @@ class TestLoopbackHandlers:
         code, state = await callback_handler()
         assert code == "fallback"
         assert state == "s"
+
+    async def test_loopback_falls_back_when_webbrowser_get_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No-browser environments (headless, SSH) skip the 300s loopback wait.
+
+        `webbrowser.open` can return `True` in some headless setups even
+        when nothing actually launches. `webbrowser.get` raising
+        `webbrowser.Error` is the reliable signal that no browser is
+        available — the redirect handler must trip the paste-back path
+        without binding a socket or burning the timeout.
+        """
+        import webbrowser
+
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        def _raise_no_browser(*_a: object, **_kw: object) -> object:
+            no_browser_msg = "no browser"
+            raise webbrowser.Error(no_browser_msg)
+
+        monkeypatch.setattr("webbrowser.get", _raise_no_browser)
+        # Sanity: webbrowser.open intentionally returns True to prove we
+        # never call it when get() fails first.
+        monkeypatch.setattr(
+            "webbrowser.open",
+            lambda _url: pytest.fail("webbrowser.open should not be called"),
+        )
+        monkeypatch.setattr(
+            "builtins.input",
+            lambda _: "https://localhost/?code=fallback&state=s",
+        )
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=FileTokenStorage("notion"),
+        )
+        redirect_handler = provider.context.redirect_handler
+        callback_handler = provider.context.callback_handler
+        assert redirect_handler is not None
+        assert callback_handler is not None
+
+        await redirect_handler("https://auth.example/authorize")
+        code, state = await callback_handler()
+        assert code == "fallback"
+        assert state == "s"
+
+    async def test_loopback_falls_back_on_callback_timeout(
+        self, monkeypatch: pytest.MonkeyPatch, socket_enabled: object
+    ) -> None:
+        """A loopback callback that never arrives falls through to paste-back.
+
+        Regression guard for `_LoopbackCallbackTimeoutError`. Without this
+        path, a user whose browser opens but never redirects would hang
+        for the full `_LOOPBACK_CALLBACK_TIMEOUT` (300s).
+        """
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        del socket_enabled
+        monkeypatch.setattr("deepagents_code.mcp_auth._LOOPBACK_CALLBACK_TIMEOUT", 0.05)
+        monkeypatch.setattr("webbrowser.get", lambda *_a, **_kw: object())
+        monkeypatch.setattr("webbrowser.open", lambda _url: True)
+        monkeypatch.setattr(
+            "builtins.input",
+            lambda _: "https://localhost/?code=after_timeout",
+        )
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=FileTokenStorage("notion"),
+        )
+        redirect_handler = provider.context.redirect_handler
+        callback_handler = provider.context.callback_handler
+        assert redirect_handler is not None
+        assert callback_handler is not None
+
+        await redirect_handler("https://auth.example/authorize")
+        code, _state = await callback_handler()
+        assert code == "after_timeout"
+
+    async def test_loopback_repeat_request_after_error_shows_error_page(
+        self, monkeypatch: pytest.MonkeyPatch, socket_enabled: object
+    ) -> None:
+        """A duplicate request after a failed callback must not show success HTML.
+
+        Regression guard: previously `_handle_get` early-returned success
+        whenever the future was done, even if the future resolved with an
+        exception. A second browser hit (prefetch, favicon) would render
+        "You're signed in" while the worker was actually surfacing the
+        underlying error.
+        """
+        import httpx
+
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        del socket_enabled
+        monkeypatch.setattr("webbrowser.get", lambda *_a, **_kw: object())
+        monkeypatch.setattr("webbrowser.open", lambda _url: True)
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=FileTokenStorage("notion"),
+        )
+        metadata = provider.context.client_metadata
+        assert metadata.redirect_uris is not None
+        redirect_uri = str(metadata.redirect_uris[0])
+        redirect_handler = provider.context.redirect_handler
+        assert redirect_handler is not None
+
+        await redirect_handler("https://auth.example/authorize")
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            first = await client.get(f"{redirect_uri}?error=access_denied")
+            second = await client.get(f"{redirect_uri}?code=late")
+
+        assert first.status_code == 400
+        # Second request must surface the prior error state, not success.
+        assert second.status_code == 400
+        assert "You're signed in" not in second.text
+        assert "did not complete" in second.text
 
 
 @pytest.mark.usefixtures("fake_home")

--- a/libs/code/tests/unit_tests/test_mcp_commands.py
+++ b/libs/code/tests/unit_tests/test_mcp_commands.py
@@ -282,7 +282,14 @@ class TestRunMCPLogin:
     async def test_login_runtime_error_returns_exit_1(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """Login raising `RuntimeError` prints the reason and exits 1."""
+        """Login raising `RuntimeError` exits 1 and prints a token-safe summary.
+
+        The CLI used to surface the raw `RuntimeError` message; that was
+        unsafe because upstream MCP-SDK errors can wrap an `OAuthToken` in
+        their `args`. `format_login_failure` now degrades unknown error
+        types to a class-name chain, so the user sees the failure class
+        but not its (potentially-token-bearing) message.
+        """
         from deepagents_code.mcp_commands import run_mcp_login
 
         config_path = tmp_path / "mcp.json"
@@ -301,8 +308,13 @@ class TestRunMCPLogin:
                 config_path=str(config_path),
             )
 
+        captured_err = capsys.readouterr().err
         assert exit_code == 1
-        assert "Login failed: provider offline" in capsys.readouterr().err
+        assert "Login failed:" in captured_err
+        assert "RuntimeError" in captured_err
+        # Token-safety: an arbitrary RuntimeError message must not bleed
+        # into the user-facing output, since its `args` could carry tokens.
+        assert "provider offline" not in captured_err
 
     async def test_login_http_error_returns_exit_1(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -25,6 +25,7 @@ from deepagents_code.textual_adapter import (
     _build_interrupted_ai_message,
     _handle_interrupt_cleanup,
     _is_summarization_chunk,
+    _persist_context_tokens,
     execute_task_textual,
     format_token_count,
     print_usage_table,
@@ -307,6 +308,45 @@ class TestInterruptCleanup:
         assert all(v is False for v in captured), (
             f"tracing was not disabled: {captured}"
         )
+
+
+class TestPersistContextTokens:
+    """Tests for `_persist_context_tokens`."""
+
+    async def test_skips_aupdate_state_for_remote_agent(self) -> None:
+        """Remote agents must not call aupdate_state for _context_tokens.
+
+        When the agent is a RemoteAgent, aupdate_state goes over HTTP to the
+        dev server, which creates its own LangSmith trace that the client
+        cannot suppress with tracing_context(enabled=False). Skipping the call
+        is safe because persistence is best-effort.
+        """
+        from deepagents_code.remote_client import RemoteAgent
+
+        agent = MagicMock(spec=RemoteAgent)
+        agent.aupdate_state = AsyncMock()
+
+        await _persist_context_tokens(
+            agent, {"configurable": {"thread_id": "t-1"}}, 1234
+        )
+
+        agent.aupdate_state.assert_not_called()
+
+    async def test_calls_aupdate_state_for_local_agent(self) -> None:
+        """Local agents should still call aupdate_state for _context_tokens."""
+        called_with: list[object] = []
+
+        def _capture(*args: object, **_kwargs: object) -> None:
+            called_with.append(args[1])  # the values dict
+
+        agent = SimpleNamespace(aupdate_state=AsyncMock(side_effect=_capture))
+
+        await _persist_context_tokens(
+            agent, {"configurable": {"thread_id": "t-2"}}, 9999
+        )
+
+        assert len(called_with) == 1
+        assert called_with[0] == {"_context_tokens": 9999}
 
 
 class TestBuildStreamConfig:


### PR DESCRIPTION
Tighten the MCP OAuth login flow surfaced by the recent in-TUI work: keep tokens out of error logs and chat history, stop showing a "you're signed in" page after the handshake actually failed, and skip the 300s loopback wait when no browser is actually available. Also sweeps stale `deepagents` CLI references to `dcode`, makes worker-side interrupt cleanup user-visible, and replaces three structural `getattr` probes with explicit `isinstance` checks.

## Changes
- **Token-safe error reporting**: new `format_login_failure` in `mcp_auth` unwraps `ExceptionGroup`/cause chains, surfaces known-safe message types (`MCPReauthRequiredError`, loopback-internal errors), and degrades everything else to a class-name chain. Replaces three unsafe `f"...{login_error}"` / `exc_info=login_error` sites in `_run_mcp_login_worker` and the broad catch in `run_mcp_login`. Tokens that could ride along in MCP-SDK exception `args`/`repr` no longer reach logs or the chat surface.
- **Loopback duplicate request after failure no longer renders success HTML**: `_LoopbackOAuthCallbackServer._handle_get` now branches on `future.exception() is None` before serving the success page; failed callbacks get a 400 + error page on retries (favicon, prefetch).
- **Reliable browser detection**: redirect handler probes `webbrowser.get()` before `webbrowser.open()` so headless/SSH sessions trip the paste-back fallback immediately instead of waiting out `_LOOPBACK_CALLBACK_TIMEOUT`.
- **Better failure surfaces**: `mcp_commands` distinguishes `PermissionError` on the tokens dir with an actionable remediation; `MCPReauthRequiredError` and corrupt-token-file errors now include `/mcp login <server>` (TUI) and `dcode mcp login <server>` (CLI) commands; the interrupt-cleanup `except Exception` in `textual_adapter` now mounts a chat-visible `AppMessage` instead of only file-logging.
- **Replace `getattr` probes with typed checks**: `find_reauth_required` and `format_login_failure` use `isinstance(current, BaseExceptionGroup)` instead of probing `.exceptions`; `_prompt_slack_team` checks `isinstance(ui, _SupportsSlackTeamPrompt)` against a new runtime-checkable capability protocol.
- **Encapsulation cleanups**: new `MCPLoginScreen.is_done`, `MCPServerHeaderItem.server`, and `_LoopbackOAuthCallbackServer.port` properties replace private-attribute reads from outside their owning modules.
- **Stale CLI name sweep**: `deepagents` → `dcode` in the remote-server-mode notify, the post-restart MCP-token notify, and the untrusted-project-config hint.
- **Docs**: `build_connecting_footer` docstring no longer contradicts itself on when `reconnecting` is honored; `OAuthInteraction.show_error` renamed from "terminal" to "fatal" wording for a TUI codebase; token-endpoint `ValueError` on malformed JSON now logs the cause before coercing to `{}`.

## Testing
- New `TestFormatLoginFailure` covers reauth unwrap, token-redaction for unknown exception types, known-loopback passthrough, and cause-chain walking with payload omission.
- New loopback tests for the `_LoopbackCallbackTimeoutError` paste-back fallback, the `webbrowser.get` failure path, and the duplicate-request-after-error 400 page.
- New `_run_mcp_login_worker` failure-branch tests for config-resolve error mounting and unknown-exception token redaction.
- `test_login_runtime_error_returns_exit_1` rewritten to assert the new token-safe summary — generic `RuntimeError` messages must not bleed into the CLI output.