### PR TITLE
fix(code): persist `_context_tokens` to local cache instead of graph state

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -5576,7 +5576,7 @@ class DeepAgentsApp(App):
             self._on_tokens_update(result.tokens_after)
             from deepagents_code.textual_adapter import _persist_context_tokens
 
-            await _persist_context_tokens(self._agent, config, result.tokens_after)
+            await _persist_context_tokens(config, result.tokens_after)
 
         except OffloadModelError as exc:
             logger.warning("Offload model creation failed: %s", exc, exc_info=True)
@@ -5946,10 +5946,22 @@ class DeepAgentsApp(App):
             context-token count.
         """
         state_values = await self._get_thread_state_values(thread_id)
-        raw_tokens = state_values.get("_context_tokens")
-        context_tokens = (
-            raw_tokens if isinstance(raw_tokens, int) and raw_tokens >= 0 else 0
-        )
+        # Prefer the local cache for `_context_tokens` (see
+        # `context_tokens_cache` for the rationale). Threads written before
+        # the move to local cache still carry the value in graph state, so
+        # fall back there on a true cache miss (sentinel `None`, distinct
+        # from a legitimate persisted `0`). This fallback can be removed
+        # once those threads have aged out.
+        from deepagents_code.context_tokens_cache import read_context_tokens
+
+        cached = await asyncio.to_thread(read_context_tokens, thread_id)
+        if cached is not None:
+            context_tokens = cached
+        else:
+            raw_tokens = state_values.get("_context_tokens")
+            context_tokens = (
+                raw_tokens if isinstance(raw_tokens, int) and raw_tokens >= 0 else 0
+            )
         messages = state_values.get("messages", [])
 
         if not messages:

--- a/libs/code/deepagents_code/context_tokens_cache.py
+++ b/libs/code/deepagents_code/context_tokens_cache.py
@@ -1,0 +1,148 @@
+"""Per-thread persistence for `_context_tokens` (client-side bookkeeping).
+
+`_context_tokens` is a dcode-client display value, not anything the agent or
+the deepagents SDK reads. Historically it was pushed into graph state via
+`aupdate_state` so it would survive across sessions — but for remote agents
+(`langgraph dev` / LangGraph Platform), every `aupdate_state` call traverses
+HTTP and the server emits its own `UpdateState` LangSmith trace as a
+root-level run. The client's `tracing_context(enabled=False)` cannot reach
+across the HTTP boundary, and as of langgraph-sdk 0.3 / langgraph-api 0.8
+there is no upstream mechanism to suppress server-side traces for
+`threads.update_state` (no `langsmith_tracing` parameter, no honored header,
+no server-side tracing context for state updates). Storing the value locally
+sidesteps the HTTP round-trip and the trace entirely.
+
+Long term, graph state is still the right home — it would carry the count
+across machines on thread resume. Once upstream exposes a way to suppress
+tracing on `threads.update_state` (or the field moves to a non-traced
+channel), this module should be deleted and `_context_tokens` should move
+back to graph state.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from deepagents_code.model_config import DEFAULT_STATE_DIR
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CONTEXT_TOKENS_DIR = DEFAULT_STATE_DIR / "context_tokens"
+"""Directory holding one JSON file per thread (`{thread_id}.json`)."""
+
+
+def _safe_path_for(thread_id: str) -> Path | None:
+    """Return the cache path for `thread_id`, or `None` if it would escape.
+
+    Thread IDs are UUID7 strings in normal flow; this guard is defensive
+    against a future caller passing untrusted input.
+    """
+    if (
+        not thread_id
+        or "/" in thread_id
+        or "\\" in thread_id
+        or thread_id in {".", ".."}
+    ):
+        logger.debug(
+            "Refusing context-tokens path for unsafe thread_id: %r", thread_id
+        )
+        return None
+    return CONTEXT_TOKENS_DIR / f"{thread_id}.json"
+
+
+def read_context_tokens(thread_id: str) -> int | None:
+    """Return the cached `_context_tokens` for a thread, or `None` if absent.
+
+    `None` signals cache miss — distinct from a legitimate persisted `0`, so
+    callers can fall back to a secondary source (e.g. graph state from older
+    builds) only when the cache truly has nothing.
+
+    Args:
+        thread_id: Thread identifier.
+
+    Returns:
+        The persisted token count, or `None` when no usable cache entry
+        exists (missing file, corrupt JSON, unexpected shape, negative value).
+    """
+    path = _safe_path_for(thread_id)
+    if path is None:
+        return None
+    try:
+        if not path.exists():
+            return None
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        logger.debug(
+            "Could not read context-tokens cache for %s",
+            thread_id,
+            exc_info=True,
+        )
+        return None
+    if not isinstance(raw, dict):
+        logger.debug(
+            "Unexpected shape in context-tokens cache for %s: %r", thread_id, raw
+        )
+        return None
+    value = raw.get("tokens")
+    if not isinstance(value, int) or value < 0:
+        logger.debug(
+            "Unexpected `tokens` field in context-tokens cache for %s: %r",
+            thread_id,
+            value,
+        )
+        return None
+    return value
+
+
+def write_context_tokens(thread_id: str, tokens: int) -> None:
+    """Best-effort write of `_context_tokens` for a thread.
+
+    Failures are logged at DEBUG and swallowed — a stale count on resume is
+    acceptable.
+
+    Args:
+        thread_id: Thread identifier.
+        tokens: Token count to persist (negative values are clamped to 0).
+    """
+    path = _safe_path_for(thread_id)
+    if path is None:
+        return
+    safe_tokens = max(int(tokens), 0)
+    try:
+        CONTEXT_TOKENS_DIR.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps({"tokens": safe_tokens}), encoding="utf-8")
+        tmp.replace(path)
+    except OSError:
+        logger.debug(
+            "Could not write context-tokens cache for %s=%d at %s",
+            thread_id,
+            safe_tokens,
+            path,
+            exc_info=True,
+        )
+
+
+def delete_context_tokens(thread_id: str) -> None:
+    """Remove the cached `_context_tokens` for a thread, if present.
+
+    Args:
+        thread_id: Thread identifier.
+    """
+    path = _safe_path_for(thread_id)
+    if path is None:
+        return
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        logger.debug(
+            "Could not delete context-tokens cache for %s at %s",
+            thread_id,
+            path,
+            exc_info=True,
+        )

--- a/libs/code/deepagents_code/sessions.py
+++ b/libs/code/deepagents_code/sessions.py
@@ -1007,8 +1007,16 @@ async def delete_thread(thread_id: str) -> bool:
     Returns:
         True if thread was deleted, False if not found.
     """
+    # Drop the client-side `_context_tokens` cache entry unconditionally so
+    # remote-only threads (no local checkpoint row, so `deleted` stays False)
+    # don't leak cache files. Run after `commit()` rather than inside the
+    # transaction — filesystem ops can't be rolled back, and an orphan cache
+    # file is harmless if the SQL delete fails. Best-effort, off the loop.
+    from deepagents_code.context_tokens_cache import delete_context_tokens
+
     async with _connect() as conn:
         if not await _table_exists(conn, "checkpoints"):
+            await asyncio.to_thread(delete_context_tokens, thread_id)
             return False
 
         cursor = await conn.execute(
@@ -1023,6 +1031,7 @@ async def delete_thread(thread_id: str) -> bool:
             for key, rows in list(_recent_threads_cache.items()):
                 filtered = [row for row in rows if row["thread_id"] != thread_id]
                 _recent_threads_cache[key] = filtered
+        await asyncio.to_thread(delete_context_tokens, thread_id)
         return deleted
 
 

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -1308,7 +1308,6 @@ async def execute_task_textual(
                     turn_stats.wall_time_seconds = time.monotonic() - start_time
                     await _report_and_persist_tokens(
                         adapter,
-                        agent,
                         config,
                         captured_input_tokens,
                         captured_output_tokens,
@@ -1338,7 +1337,6 @@ async def execute_task_textual(
     turn_stats.wall_time_seconds = time.monotonic() - start_time
     await _report_and_persist_tokens(
         adapter,
-        agent,
         config,
         captured_input_tokens,
         captured_output_tokens,
@@ -1437,7 +1435,6 @@ async def _handle_interrupt_cleanup(
     turn_stats.wall_time_seconds = time.monotonic() - start_time
     await _report_and_persist_tokens(
         adapter,
-        agent,
         config,
         captured_input_tokens,
         captured_output_tokens,
@@ -1447,57 +1444,32 @@ async def _handle_interrupt_cleanup(
 
 
 async def _persist_context_tokens(
-    agent: Any,  # noqa: ANN401  # Dynamic agent graph type
     config: RunnableConfig,
     tokens: int,
 ) -> None:
-    """Best-effort persist of the context token count into graph state.
+    """Best-effort persist of the context token count to the local cache.
 
-    For local agents, the `aupdate_state` call is wrapped in
-    `tracing_context(enabled=False)` so this purely-internal bookkeeping write
-    does not surface as a separate `UpdateState` run in LangSmith.
-    `_context_tokens` is already marked `PrivateStateAttr`, but `aupdate_state`
-    itself creates its own traced run that would otherwise clutter the project's
-    traces.
-
-    For remote agents (e.g. a `langgraph dev` server), `aupdate_state` goes
-    over HTTP and the server creates its own LangSmith trace that the client
-    cannot suppress with `tracing_context`. Skipping the call is safe because
-    persistence is best-effort — a stale count on resume is acceptable.
+    See `context_tokens_cache` for why this lives on local disk instead of
+    graph state.
 
     Args:
-        agent: The LangGraph agent (must support `aupdate_state`).
-        config: Runnable config with `thread_id`.
+        config: Runnable config with `thread_id` in `configurable`.
         tokens: Total context tokens to persist.
     """
-    from deepagents_code.remote_client import RemoteAgent
+    from deepagents_code.context_tokens_cache import write_context_tokens
 
-    if isinstance(agent, RemoteAgent):
+    thread_id = (config.get("configurable") or {}).get("thread_id")
+    if not isinstance(thread_id, str) or not thread_id:
+        logger.debug(
+            "Skipping context-tokens persist: missing thread_id in config"
+        )
         return
-
-    from langsmith import tracing_context
-
-    try:
-        with tracing_context(enabled=False):
-            await agent.aupdate_state(config, {"_context_tokens": tokens})
-    except (httpx.TransportError, httpx.TimeoutException) as e:
-        logger.warning(
-            "Could not persist _context_tokens=%d (network): %s; "
-            "token count may be stale on resume",
-            tokens,
-            e,
-        )
-    except Exception:  # non-critical; stale count on resume is acceptable
-        logger.warning(
-            "Failed to persist _context_tokens=%d; token count may be stale on resume",
-            tokens,
-            exc_info=True,
-        )
+    # Offload the file write so the event loop is not blocked.
+    await asyncio.to_thread(write_context_tokens, thread_id, tokens)
 
 
 async def _report_and_persist_tokens(
     adapter: TextualUIAdapter,
-    agent: Any,  # noqa: ANN401  # Dynamic agent graph type
     config: RunnableConfig,
     captured_input_tokens: int,
     captured_output_tokens: int,
@@ -1505,11 +1477,10 @@ async def _report_and_persist_tokens(
     shield: bool = False,
     approximate: bool = False,
 ) -> None:
-    """Update the token display and best-effort persist to graph state.
+    """Update the token display and best-effort persist to the local cache.
 
     Args:
         adapter: UI adapter with token callbacks.
-        agent: The LangGraph agent.
         config: Runnable config with `thread_id` in its configurable dict.
         captured_input_tokens: Total input tokens captured during the turn.
         captured_output_tokens: Total output tokens captured during the turn.
@@ -1522,15 +1493,19 @@ async def _report_and_persist_tokens(
         if adapter._on_tokens_update:
             adapter._on_tokens_update(captured_input_tokens, approximate=approximate)
         if shield:
+            # `_persist_context_tokens` is already best-effort (cache write
+            # errors are logged and swallowed), so the only thing we still
+            # need to shield against during interrupt cleanup is
+            # `CancelledError` propagating from `asyncio.to_thread`.
             try:
-                await _persist_context_tokens(agent, config, captured_input_tokens)
-            except (Exception, asyncio.CancelledError):
+                await _persist_context_tokens(config, captured_input_tokens)
+            except asyncio.CancelledError:
                 logger.debug(
-                    "Token persist suppressed during interrupt cleanup",
+                    "Token persist cancelled during interrupt cleanup",
                     exc_info=True,
                 )
         else:
-            await _persist_context_tokens(agent, config, captured_input_tokens)
+            await _persist_context_tokens(config, captured_input_tokens)
     elif adapter._on_tokens_show:
         adapter._on_tokens_show(approximate=approximate)
 

--- a/libs/code/tests/unit_tests/test_context_tokens_cache.py
+++ b/libs/code/tests/unit_tests/test_context_tokens_cache.py
@@ -1,0 +1,122 @@
+"""Unit tests for `deepagents_code.context_tokens_cache`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from deepagents_code import context_tokens_cache
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def cache_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Point the cache at a fresh temp directory for each test."""
+    cache_dir = tmp_path / "context_tokens"
+    monkeypatch.setattr(context_tokens_cache, "CONTEXT_TOKENS_DIR", cache_dir)
+    return cache_dir
+
+
+class TestReadContextTokens:
+    """`read_context_tokens` behavior."""
+
+    def test_returns_none_when_file_missing(self) -> None:
+        """A thread with no cache file should report `None` (cache miss)."""
+        assert context_tokens_cache.read_context_tokens("missing-thread") is None
+
+    def test_returns_persisted_value(self) -> None:
+        """A previously written value should round-trip."""
+        context_tokens_cache.write_context_tokens("t-1", 5000)
+        assert context_tokens_cache.read_context_tokens("t-1") == 5000
+
+    def test_returns_zero_for_legitimately_persisted_zero(self) -> None:
+        """A persisted `0` should round-trip as `0` (distinct from cache miss)."""
+        context_tokens_cache.write_context_tokens("t-zero", 0)
+        assert context_tokens_cache.read_context_tokens("t-zero") == 0
+
+    def test_returns_none_for_corrupt_file(self, cache_dir: Path) -> None:
+        """A non-JSON file should not crash; return `None`."""
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "t-bad.json").write_text("not json", encoding="utf-8")
+        assert context_tokens_cache.read_context_tokens("t-bad") is None
+
+    def test_returns_none_for_negative_value(
+        self, cache_dir: Path
+    ) -> None:
+        """A persisted negative value should be treated as cache miss."""
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "t-neg.json").write_text(
+            '{"tokens": -1}', encoding="utf-8"
+        )
+        assert context_tokens_cache.read_context_tokens("t-neg") is None
+
+    def test_returns_none_for_unexpected_shape(self, cache_dir: Path) -> None:
+        """A JSON value with the wrong shape should be treated as cache miss."""
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "t-shape.json").write_text('["unexpected"]', encoding="utf-8")
+        assert context_tokens_cache.read_context_tokens("t-shape") is None
+
+    def test_unsafe_thread_id_returns_none(self) -> None:
+        """Path-traversal-y thread IDs should refuse to read, not escape."""
+        assert context_tokens_cache.read_context_tokens("../escape") is None
+        assert context_tokens_cache.read_context_tokens("") is None
+
+
+class TestWriteContextTokens:
+    """`write_context_tokens` behavior."""
+
+    def test_creates_directory(self, cache_dir: Path) -> None:
+        """Writes should create the cache directory if absent."""
+        assert not cache_dir.exists()
+        context_tokens_cache.write_context_tokens("t-1", 42)
+        assert cache_dir.is_dir()
+
+    def test_overwrites_previous_value(self, cache_dir: Path) -> None:
+        """Successive writes should update the persisted value."""
+        context_tokens_cache.write_context_tokens("t-1", 100)
+        context_tokens_cache.write_context_tokens("t-1", 200)
+        assert context_tokens_cache.read_context_tokens("t-1") == 200
+        # The atomic-write pattern should never leave a `.tmp` behind.
+        assert not list(cache_dir.glob("*.tmp"))
+
+    def test_clamps_negative_to_zero(self) -> None:
+        """Negative inputs should be normalized to 0 on write."""
+        context_tokens_cache.write_context_tokens("t-1", -5)
+        assert context_tokens_cache.read_context_tokens("t-1") == 0
+
+    def test_unsafe_thread_id_does_not_write(self, cache_dir: Path) -> None:
+        """Path-traversal-y thread IDs should refuse to write, not escape."""
+        context_tokens_cache.write_context_tokens("../escape", 123)
+        assert not cache_dir.exists() or not any(cache_dir.iterdir())
+
+    def test_swallows_oserror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Filesystem errors during write must be best-effort, never raise."""
+        # Point the cache dir at a file path so mkdir(parents=True) fails
+        # with NotADirectoryError (an OSError subclass).
+        blocked = tmp_path / "blocked"
+        blocked.write_text("not a directory", encoding="utf-8")
+        monkeypatch.setattr(
+            context_tokens_cache, "CONTEXT_TOKENS_DIR", blocked / "ctx"
+        )
+
+        context_tokens_cache.write_context_tokens("t-1", 42)  # must not raise
+
+
+class TestDeleteContextTokens:
+    """`delete_context_tokens` behavior."""
+
+    def test_removes_existing_file(self) -> None:
+        context_tokens_cache.write_context_tokens("t-1", 42)
+        context_tokens_cache.delete_context_tokens("t-1")
+        assert context_tokens_cache.read_context_tokens("t-1") is None
+
+    def test_missing_file_is_noop(self) -> None:
+        """Deleting a nonexistent thread's cache should not raise."""
+        context_tokens_cache.delete_context_tokens("never-existed")

--- a/libs/code/tests/unit_tests/test_sessions.py
+++ b/libs/code/tests/unit_tests/test_sessions.py
@@ -241,6 +241,21 @@ class TestThreadFunctions:
             agent = asyncio.run(sessions.get_thread_agent("nonexistent"))
             assert agent is None
 
+    @pytest.fixture(autouse=True)
+    def _isolated_context_tokens_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Redirect the `_context_tokens` cache for every test in this class.
+
+        `delete_thread` now calls `delete_context_tokens` as part of cleanup.
+        Without this redirect the suite would `unlink` real files for any
+        test thread ID that happens to collide with a real one on disk.
+        """
+        from deepagents_code import context_tokens_cache
+
+        cache_dir = tmp_path / "context_tokens"
+        monkeypatch.setattr(context_tokens_cache, "CONTEXT_TOKENS_DIR", cache_dir)
+
     def test_delete_thread(self, temp_db):
         """Delete thread removes thread."""
         with patch.object(sessions, "get_db_path", return_value=temp_db):
@@ -253,6 +268,34 @@ class TestThreadFunctions:
         with patch.object(sessions, "get_db_path", return_value=temp_db):
             result = asyncio.run(sessions.delete_thread("nonexistent"))
             assert result is False
+
+    def test_delete_thread_removes_context_tokens_cache(self, temp_db):
+        """`delete_thread` should also remove the per-thread cache file."""
+        from deepagents_code import context_tokens_cache
+
+        context_tokens_cache.write_context_tokens("thread1", 4242)
+        assert context_tokens_cache.read_context_tokens("thread1") == 4242
+
+        with patch.object(sessions, "get_db_path", return_value=temp_db):
+            asyncio.run(sessions.delete_thread("thread1"))
+
+        assert context_tokens_cache.read_context_tokens("thread1") is None
+
+    def test_delete_thread_removes_cache_even_when_no_sql_row(self, temp_db):
+        """Remote-only threads (no local checkpoint) get their cache cleaned.
+
+        Without this, cache files would accumulate over time for any thread
+        whose checkpoint lives only on a remote LangGraph server.
+        """
+        from deepagents_code import context_tokens_cache
+
+        context_tokens_cache.write_context_tokens("remote-only", 999)
+
+        with patch.object(sessions, "get_db_path", return_value=temp_db):
+            result = asyncio.run(sessions.delete_thread("remote-only"))
+
+        assert result is False
+        assert context_tokens_cache.read_context_tokens("remote-only") is None
 
 
 class TestGetCheckpointer:

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -313,40 +313,38 @@ class TestInterruptCleanup:
 class TestPersistContextTokens:
     """Tests for `_persist_context_tokens`."""
 
-    async def test_skips_aupdate_state_for_remote_agent(self) -> None:
-        """Remote agents must not call aupdate_state for _context_tokens.
+    async def test_writes_to_local_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Persistence should go to the local cache, never aupdate_state.
 
-        When the agent is a RemoteAgent, aupdate_state goes over HTTP to the
-        dev server, which creates its own LangSmith trace that the client
-        cannot suppress with tracing_context(enabled=False). Skipping the call
-        is safe because persistence is best-effort.
+        Calling aupdate_state on remote agents creates server-side LangSmith
+        traces that we cannot suppress. The local cache sidesteps that.
         """
-        from deepagents_code.remote_client import RemoteAgent
+        from deepagents_code import context_tokens_cache
 
-        agent = MagicMock(spec=RemoteAgent)
-        agent.aupdate_state = AsyncMock()
-
-        await _persist_context_tokens(
-            agent, {"configurable": {"thread_id": "t-1"}}, 1234
+        monkeypatch.setattr(
+            context_tokens_cache, "CONTEXT_TOKENS_DIR", tmp_path / "context_tokens"
         )
 
-        agent.aupdate_state.assert_not_called()
-
-    async def test_calls_aupdate_state_for_local_agent(self) -> None:
-        """Local agents should still call aupdate_state for _context_tokens."""
-        called_with: list[object] = []
-
-        def _capture(*args: object, **_kwargs: object) -> None:
-            called_with.append(args[1])  # the values dict
-
-        agent = SimpleNamespace(aupdate_state=AsyncMock(side_effect=_capture))
-
         await _persist_context_tokens(
-            agent, {"configurable": {"thread_id": "t-2"}}, 9999
+            {"configurable": {"thread_id": "t-1"}}, 1234
         )
 
-        assert len(called_with) == 1
-        assert called_with[0] == {"_context_tokens": 9999}
+        assert context_tokens_cache.read_context_tokens("t-1") == 1234
+
+    async def test_no_thread_id_is_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing thread_id should be a silent no-op (no file written)."""
+        from deepagents_code import context_tokens_cache
+
+        cache_dir = tmp_path / "context_tokens"
+        monkeypatch.setattr(context_tokens_cache, "CONTEXT_TOKENS_DIR", cache_dir)
+
+        await _persist_context_tokens({"configurable": {}}, 9999)
+
+        assert not cache_dir.exists()
 
 
 class TestBuildStreamConfig:

--- a/libs/code/tests/unit_tests/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/test_thread_selector.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import Coroutine
+from pathlib import Path
 from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -2604,6 +2605,24 @@ class TestResumeThread:
 class TestFetchThreadHistoryData:
     """Tests for DeepAgentsApp._fetch_thread_history_data."""
 
+    @pytest.fixture(autouse=True)
+    def _isolated_context_tokens_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Redirect the `_context_tokens` cache to a temp dir.
+
+        `_fetch_thread_history_data` now reads the cache first and falls back
+        to graph state. Without this redirect, tests would hit the real
+        `~/.deepagents/.state/context_tokens/` and behave non-deterministically.
+        """
+        from deepagents_code import context_tokens_cache
+
+        monkeypatch.setattr(
+            context_tokens_cache,
+            "CONTEXT_TOKENS_DIR",
+            tmp_path / "context_tokens",
+        )
+
     async def test_returns_empty_when_agent_missing(self) -> None:
         """No active agent should return an empty history payload."""
         app = DeepAgentsApp()
@@ -2653,21 +2672,27 @@ class TestFetchThreadHistoryData:
         app._agent.aget_state = AsyncMock(return_value=state)
         converted = [MessageData(type=MessageType.USER, content="hello")]
 
+        # Two `to_thread` calls now: cache read (returns None — no cache
+        # entry exists, fixture-redirected dir is empty) then message
+        # conversion.
         with patch(
             "deepagents_code.app.asyncio.to_thread",
             new_callable=AsyncMock,
-            return_value=converted,
+            side_effect=[None, converted],
         ) as to_thread_mock:
             payload = await app._fetch_thread_history_data("tid-1")
 
         assert payload.messages == converted
-        to_thread_mock.assert_awaited_once()
-        await_args = to_thread_mock.await_args
-        assert await_args is not None
-        assert await_args.args[1] == raw_messages
+        assert to_thread_mock.await_count == 2
+        conversion_call = to_thread_mock.await_args_list[-1]
+        assert conversion_call.args[1] == raw_messages
 
-    async def test_extracts_nonzero_context_tokens(self) -> None:
-        """Persisted _context_tokens should propagate to the payload."""
+    async def test_extracts_nonzero_context_tokens_from_graph_state(self) -> None:
+        """A persisted graph-state value should be returned when cache is empty.
+
+        Covers the migration fallback path for threads written by older
+        builds that still carry `_context_tokens` in checkpoint state.
+        """
         from deepagents_code.widgets.message_store import MessageData, MessageType
 
         app = DeepAgentsApp()
@@ -2681,28 +2706,96 @@ class TestFetchThreadHistoryData:
         with patch(
             "deepagents_code.app.asyncio.to_thread",
             new_callable=AsyncMock,
-            return_value=converted,
+            side_effect=[None, converted],  # cache miss, then conversion
         ):
             payload = await app._fetch_thread_history_data("tid-1")
 
         assert payload.context_tokens == 12000
 
-    async def test_none_context_tokens_coerced_to_zero(self) -> None:
-        """`_context_tokens: None` in checkpoint should coerce to 0."""
+    async def test_cache_hit_overrides_graph_state(self) -> None:
+        """A live cache value should win over any stale graph-state value."""
+        from deepagents_code import context_tokens_cache
         from deepagents_code.widgets.message_store import MessageData, MessageType
+
+        context_tokens_cache.write_context_tokens("tid-1", 7777)
 
         app = DeepAgentsApp()
         app._agent = MagicMock()
         raw_messages = [object()]
         state = MagicMock()
-        state.values = {"messages": raw_messages, "_context_tokens": None}
+        # Graph state still carries a stale value from before the migration.
+        state.values = {"messages": raw_messages, "_context_tokens": 99999}
         app._agent.aget_state = AsyncMock(return_value=state)
-        converted = [MessageData(type=MessageType.USER, content="hello")]
+        converted = [MessageData(type=MessageType.USER, content="hi")]
+
+        # Only patch the message-conversion `to_thread`. The cache read uses
+        # the real `to_thread` against the fixture-redirected dir.
+        original_to_thread = asyncio.to_thread
+
+        # `fake_to_thread` mirrors `asyncio.to_thread`'s loose signature.
+        async def fake_to_thread(func, *args, **kwargs):  # type: ignore[no-untyped-def]  # noqa: ANN002, ANN003, ANN202
+            if func is app._convert_messages_to_data:
+                return converted
+            return await original_to_thread(func, *args, **kwargs)
+
+        with patch(
+            "deepagents_code.app.asyncio.to_thread",
+            new=fake_to_thread,
+        ):
+            payload = await app._fetch_thread_history_data("tid-1")
+
+        assert payload.context_tokens == 7777
+
+    async def test_legitimate_zero_in_cache_does_not_fall_back(self) -> None:
+        """A legitimately persisted `0` should not trigger graph-state fallback.
+
+        Distinguishing cache miss (`None`) from a real `0` prevents a stale
+        non-zero graph-state value from resurrecting after the user clears
+        context.
+        """
+        from deepagents_code import context_tokens_cache
+        from deepagents_code.widgets.message_store import MessageData, MessageType
+
+        context_tokens_cache.write_context_tokens("tid-1", 0)
+
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        raw_messages = [object()]
+        state = MagicMock()
+        state.values = {"messages": raw_messages, "_context_tokens": 50000}
+        app._agent.aget_state = AsyncMock(return_value=state)
+        converted = [MessageData(type=MessageType.USER, content="hi")]
+        original_to_thread = asyncio.to_thread
+
+        # `fake_to_thread` mirrors `asyncio.to_thread`'s loose signature.
+        async def fake_to_thread(func, *args, **kwargs):  # type: ignore[no-untyped-def]  # noqa: ANN002, ANN003, ANN202
+            if func is app._convert_messages_to_data:
+                return converted
+            return await original_to_thread(func, *args, **kwargs)
+
+        with patch(
+            "deepagents_code.app.asyncio.to_thread",
+            new=fake_to_thread,
+        ):
+            payload = await app._fetch_thread_history_data("tid-1")
+
+        assert payload.context_tokens == 0
+
+    async def test_no_cache_and_no_graph_state_yields_zero(self) -> None:
+        """Missing both sources should produce 0."""
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        state = MagicMock()
+        state.values = {"messages": [object()]}
+        app._agent.aget_state = AsyncMock(return_value=state)
+        from deepagents_code.widgets.message_store import MessageData, MessageType
+
+        converted = [MessageData(type=MessageType.USER, content="hi")]
 
         with patch(
             "deepagents_code.app.asyncio.to_thread",
             new_callable=AsyncMock,
-            return_value=converted,
+            side_effect=[None, converted],
         ):
             payload = await app._fetch_thread_history_data("tid-1")
 

--- a/libs/code/tests/unit_tests/test_token_tracker.py
+++ b/libs/code/tests/unit_tests/test_token_tracker.py
@@ -98,53 +98,22 @@ class TestTokenDisplayCallbacks:
 class TestPersistContextTokens:
     """Tests for the `_persist_context_tokens` helper."""
 
-    async def test_calls_aupdate_state_with_token_count(self):
-        """Happy path: persists the count via `aupdate_state`."""
-        from unittest.mock import AsyncMock
-
+    async def test_writes_to_local_cache(
+        self, tmp_path, monkeypatch
+    ):
+        """Happy path: persists the count to the local cache."""
+        from deepagents_code import context_tokens_cache
         from deepagents_code.textual_adapter import _persist_context_tokens
 
-        agent = AsyncMock()
+        monkeypatch.setattr(
+            context_tokens_cache, "CONTEXT_TOKENS_DIR", tmp_path / "context_tokens"
+        )
         config = {"configurable": {"thread_id": "t-1"}}
 
-        await _persist_context_tokens(agent, config, 4200)  # type: ignore[arg-type]
+        await _persist_context_tokens(config, 4200)  # type: ignore[arg-type]
 
-        agent.aupdate_state.assert_awaited_once_with(config, {"_context_tokens": 4200})
+        assert context_tokens_cache.read_context_tokens("t-1") == 4200
 
-    async def test_suppresses_exceptions(self):
-        """Failures should be swallowed (non-critical persistence)."""
-        from unittest.mock import AsyncMock
-
-        from deepagents_code.textual_adapter import _persist_context_tokens
-
-        agent = AsyncMock()
-        agent.aupdate_state.side_effect = RuntimeError("checkpointer down")
-        config = {"configurable": {"thread_id": "t-1"}}
-
-        # Should not raise
-        await _persist_context_tokens(agent, config, 1000)  # type: ignore[arg-type]
-
-    async def test_disables_tracing_during_update(self):
-        """`aupdate_state` should run with LangSmith tracing disabled.
-
-        The token-count write is a private bookkeeping update; surfacing it as a
-        standalone `UpdateState` run in LangSmith clutters traces.
-        """
-        from unittest.mock import AsyncMock
-
-        from langsmith import get_tracing_context
-
-        from deepagents_code.textual_adapter import _persist_context_tokens
-
-        captured: dict[str, object] = {}
-
-        async def _capture(*_args: object, **_kwargs: object) -> None:  # noqa: RUF029  # AsyncMock side_effect must be a coroutine function
-            captured["enabled"] = get_tracing_context().get("enabled")
-
-        agent = AsyncMock()
-        agent.aupdate_state.side_effect = _capture
-        config = {"configurable": {"thread_id": "t-1"}}
-
-        await _persist_context_tokens(agent, config, 4200)  # type: ignore[arg-type]
-
-        assert captured["enabled"] is False
+    # OSError swallowing is now owned by `write_context_tokens` itself
+    # (covered in `test_context_tokens_cache.py`); `_persist_context_tokens`
+    # is just an async wrapper around it.


### PR DESCRIPTION
`_context_tokens` is dcode-client display state — neither the agent nor the deepagents SDK reads it — but it was previously pushed into LangGraph state via `aupdate_state`. For remote agents (`langgraph dev` / LangGraph Platform), every `aupdate_state` call traverses HTTP and the server emits a root-level `UpdateState` LangSmith trace on every successful turn that the client cannot suppress (no `langsmith_tracing` kwarg on `threads.update_state`, no server-side header honored, no `TracingMiddleware` installed). Moving the value to a per-thread JSON file under `~/.deepagents/.state/context_tokens/` eliminates the trace noise. Graph state remains the right long-term home — once upstream gains a way to suppress tracing on `threads.update_state` the field should move back so cross-machine resume can carry the count again.