### PR TITLE
feat(cli): expand ${VAR} in mcp.json header values at deploy time

### DIFF
--- a/libs/cli/deepagents_cli/deploy/templates.py
+++ b/libs/cli/deepagents_cli/deploy/templates.py
@@ -409,9 +409,24 @@ AUTH_BLOCKS: dict[str, tuple[str, str | None]] = {
 
 MCP_TOOLS_TEMPLATE = '''\
 async def _load_mcp_tools():
-    """Load MCP tools from bundled config (http/sse only)."""
+    """Load MCP tools from bundled config (http/sse only).
+
+    ``url`` and ``headers`` values support ``${VAR}`` references which are
+    expanded against ``os.environ`` at activation time. This mirrors the
+    substitution behavior documented for ``deepagents-code``'s
+    ``.mcp.json`` (https://docs.langchain.com/oss/python/deepagents/code/mcp-tools).
+    Unset variables are left as-is so the resulting auth failure surfaces
+    a recognizable token at connect time.
+    """
     import json
+    import os
     from pathlib import Path
+
+    def _expand(value):
+        """Expand ``${VAR}`` references in strings; pass other types through."""
+        if isinstance(value, str):
+            return os.path.expandvars(value)
+        return value
 
     mcp_path = Path(__file__).parent / "_mcp.json"
     if not mcp_path.exists():
@@ -428,9 +443,9 @@ async def _load_mcp_tools():
     for name, cfg in servers.items():
         transport = cfg.get("type", cfg.get("transport", "stdio"))
         if transport in ("http", "sse"):
-            conn = {"transport": transport, "url": cfg["url"]}
+            conn = {"transport": transport, "url": _expand(cfg["url"])}
             if "headers" in cfg:
-                conn["headers"] = cfg["headers"]
+                conn["headers"] = {k: _expand(v) for k, v in cfg["headers"].items()}
             connections[name] = conn
 
     if not connections:

--- a/libs/cli/tests/unit_tests/deploy/test_bundler.py
+++ b/libs/cli/tests/unit_tests/deploy/test_bundler.py
@@ -207,6 +207,26 @@ class TestRenderDeployGraph:
         assert "_load_mcp_tools" not in result
         assert "pass  # no MCP servers configured" in result
 
+    def test_mcp_block_expands_env_vars(self) -> None:
+        """The emitted MCP loader must expand ``${VAR}`` in url + header values.
+
+        Mirrors the ``${VAR}`` substitution behavior of ``deepagents-code``'s
+        ``.mcp.json`` (per the docs). Without this, headers configured as
+        ``Authorization: Bearer ${TOKEN}`` reach MCP servers as the literal
+        string and auth fails silently.
+        """
+        config = _minimal_config()
+        result = _render_deploy_graph(config, mcp_present=True)
+
+        # The emitted helper must reference ``os.path.expandvars`` and apply it
+        # to both url and header values inside the loader.
+        assert "os.path.expandvars" in result
+        assert '"url": _expand(cfg["url"])' in result
+        assert (
+            'conn["headers"] = {k: _expand(v) for k, v in cfg["headers"].items()}'
+            in result
+        )
+
     def test_no_system_prompt_in_output(self) -> None:
         """AGENTS.md should not be baked into the deploy graph as a system prompt."""
         config = _minimal_config()


### PR DESCRIPTION
Fixes #3507

---

The emitted `_load_mcp_tools()` forwarded `mcp.json` header values to `MultiServerMCPClient` verbatim, so configs like `"Authorization": "Bearer ${SUBTEXT_API_KEY}"` reached MCP servers as the literal `${VAR}` string. `client.get_tools()` then errored and the loader's `except: return []` returned silently, leaving the agent with no MCP tools.

This adds an `os.path.expandvars` pass over `url` and each header value inside `MCP_TOOLS_TEMPLATE`, mirroring the `${VAR}` substitution already documented for `deepagents-code`'s `.mcp.json` headers — so an mcp config shape that works with `dcode` now also works with `deepagents deploy`. Unset variables are left as the literal `${VAR}` so a recognizable token surfaces in the failing request rather than a silent empty header.

Unit test asserts the rendered MCP block references `os.path.expandvars` and wires it through both the `url` and `headers` paths.