### PR TITLE
fix(code): refresh MCP OAuth tokens on restart

### DIFF
--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -22,6 +22,7 @@ import re
 import secrets
 import stat
 import threading
+import time
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Literal, TypedDict
 from urllib.parse import parse_qs, urlparse
@@ -110,6 +111,14 @@ risking a circular import. Keep both regexes in sync."""
 _STORAGE_VERSION = 1
 """Schema version stamped into persisted credential files; bump on incompatible
 shape changes so `_load_*` can reject or migrate older payloads."""
+
+_REFRESH_SAFETY_MARGIN_SECONDS = 30.0
+"""Refresh access tokens this many seconds before their advertised expiry.
+
+Absorbs clock skew and request latency so a token deemed valid locally isn't
+rejected as expired by the server — without the margin, a 401 sends the SDK
+into the full re-auth (browser) flow instead of the cheaper refresh grant.
+"""
 
 
 def resolve_headers(
@@ -234,10 +243,20 @@ class FileTokenStorage(TokenStorage):
         return OAuthToken.model_validate(raw)
 
     async def set_tokens(self, tokens: OAuthToken) -> None:
-        """Persist `tokens` to disk, preserving any stored client info."""
+        """Persist `tokens` to disk, preserving any stored client info.
+
+        Also records the absolute Unix-epoch expiry as a sidecar so a
+        cold-started provider can detect a stale access token and trigger
+        the SDK's `refresh_token` grant instead of a full browser re-auth.
+        Cleared when `expires_in` is absent so the sidecar can't go stale.
+        """
         data = self._read() or {}
         data["version"] = _STORAGE_VERSION
         data["tokens"] = json.loads(tokens.model_dump_json(exclude_none=True))
+        if tokens.expires_in is not None:
+            data["expires_at"] = time.time() + tokens.expires_in
+        else:
+            data.pop("expires_at", None)
         self._write(data)
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
@@ -271,7 +290,40 @@ class FileTokenStorage(TokenStorage):
         data["version"] = _STORAGE_VERSION
         data["tokens"] = json.loads(tokens.model_dump_json(exclude_none=True))
         data["client_info"] = json.loads(client_info.model_dump_json(exclude_none=True))
+        if tokens.expires_in is not None:
+            data["expires_at"] = time.time() + tokens.expires_in
+        else:
+            data.pop("expires_at", None)
         self._write(data)
+
+    async def get_expires_at(self) -> float | None:
+        """Return the stored absolute token expiry (Unix epoch), or `None`.
+
+        Returns `None` for token files written before this field existed,
+        for tokens whose provider omitted `expires_in`, or when the sidecar
+        value fails to coerce to `float`. Callers should treat `None` as
+        "expiry unknown" and decide policy (skip, assume-expired, etc.).
+        """
+        data = self._read()
+        if data is None:
+            return None
+        raw = data.get("expires_at")
+        if raw is None:
+            return None
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            # Log the value's type, never the value itself — the sidecar lives
+            # next to the bearer token in the same JSON envelope, so a
+            # misplaced token string would land here.
+            logger.warning(
+                "MCP token sidecar 'expires_at' for %s is not numeric (%s); "
+                "treating as unknown. The next request will trigger a refresh "
+                "or browser re-auth.",
+                self._server_name,
+                type(raw).__name__,
+            )
+            return None
 
     def _read(self) -> dict | None:
         path = self.path
@@ -816,6 +868,67 @@ def _append_query_params(url: str, params: dict[str, str]) -> str:
     return urlunparse(parsed._replace(query=urlencode(existing, doseq=True)))
 
 
+class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
+    """`OAuthClientProvider` that restores `token_expiry_time` from storage.
+
+    Upstream `_initialize` loads stored tokens but leaves
+    `context.token_expiry_time` at `None`, which makes `is_token_valid`
+    report any stored access token — even one that expired hours ago —
+    as valid. The SDK then sends a stale `Bearer`, gets a 401, and falls
+    into a full re-auth (browser) instead of the `refresh_token` grant.
+
+    Restoring the persisted absolute expiry to the context after load
+    lets the SDK's refresh-when-invalid-and-refreshable branch fire on
+    the first request after a cold start. When the sidecar is absent
+    (older token files written before this field existed), assume the
+    token is expired so the refresh path still gets a chance before
+    falling back to 401.
+    """
+
+    async def _initialize(self) -> None:
+        # Overrides a leading-underscore SDK method; behavior depends on
+        # `super()._initialize()` populating `context.current_tokens` from
+        # storage. If an upstream rename or refactor breaks that contract,
+        # the test suite's TestExpiryAwareOAuthClientProvider cases will
+        # fail loudly rather than silently regress to the 401-on-restart
+        # bug this class exists to prevent.
+        await super()._initialize()
+        get_expires_at = getattr(self.context.storage, "get_expires_at", None)
+        if get_expires_at is None:
+            return
+        expires_at = await get_expires_at()
+        tokens = self.context.current_tokens
+        if expires_at is None:
+            # Use 1.0 (one second after the Unix epoch) rather than 0.0 so the
+            # SDK's `not self.token_expiry_time` falsy-zero check doesn't treat
+            # the sentinel as "no expiry known" and mark the token valid again.
+            if tokens is not None and tokens.refresh_token:
+                self.context.token_expiry_time = 1.0
+            elif tokens is not None and tokens.access_token:
+                # Legacy file with no refresh_token: nothing we can do to
+                # pre-empt expiry. Surface a structural breadcrumb so the
+                # 401-then-browser-reauth flow isn't completely silent.
+                logger.info(
+                    "Legacy MCP token file for %s has no refresh_token; "
+                    "cannot pre-empt expiry. The next 401 will trigger "
+                    "browser re-auth.",
+                    self.context.server_url,
+                )
+            return
+        if expires_at - time.time() < _REFRESH_SAFETY_MARGIN_SECONDS:
+            # Token already inside its safety margin (or past it) — likely a
+            # cold start after a long pause, or a misconfigured server issuing
+            # sub-margin lifetimes. Log only the duration, never any token
+            # material.
+            logger.debug(
+                "MCP token for %s is within %.0fs of expiry on load; "
+                "scheduling refresh on next request.",
+                self.context.server_url,
+                _REFRESH_SAFETY_MARGIN_SECONDS,
+            )
+        self.context.token_expiry_time = expires_at - _REFRESH_SAFETY_MARGIN_SECONDS
+
+
 def build_oauth_provider(
     *,
     server_name: str,
@@ -870,7 +983,7 @@ def build_oauth_provider(
         else policy.client_metadata()
     )
 
-    return OAuthClientProvider(
+    return _ExpiryAwareOAuthClientProvider(
         server_url=server_url,
         client_metadata=metadata,
         storage=storage,

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import time
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
 import pytest
+from mcp.client.auth import TokenStorage
+from mcp.shared.auth import OAuthToken
 
 from deepagents_code.mcp_auth import (
     FileTokenStorage,
@@ -70,8 +73,6 @@ class TestResolveHeaders:
 
 
 def _make_tokens(access_token: str = "at"):
-    from mcp.shared.auth import OAuthToken
-
     return OAuthToken(
         access_token=access_token,
         token_type="Bearer",
@@ -186,6 +187,233 @@ class TestFileTokenStorage:
         """
         with pytest.raises(ValueError, match="Invalid MCP server name"):
             FileTokenStorage(name)
+
+    async def test_set_tokens_records_absolute_expiry(self) -> None:
+        """`set_tokens` writes an `expires_at` sidecar derived from `expires_in`."""
+        storage = FileTokenStorage("notion")
+        before = time.time()
+        await storage.set_tokens(_make_tokens())
+        after = time.time()
+
+        got = await storage.get_expires_at()
+        assert got is not None
+        # 3600 from `_make_tokens`; widen the wall-clock window to absorb
+        # GC pauses on busy CI runners.
+        assert before + 3600 <= got <= after + 3600 + 1.0
+
+    async def test_set_tokens_and_client_info_records_expiry(self) -> None:
+        """The combined writer also persists `expires_at`."""
+        storage = FileTokenStorage("notion")
+        before = time.time()
+        await storage.set_tokens_and_client_info(_make_tokens(), _make_client_info())
+        after = time.time()
+
+        got = await storage.get_expires_at()
+        assert got is not None
+        assert before + 3600 <= got <= after + 3600 + 1.0
+
+    async def test_get_expires_at_returns_none_for_legacy_file(
+        self, fake_home: Path
+    ) -> None:
+        """Token files written before this field existed return `None`."""
+        path = fake_home / ".deepagents" / ".state" / "mcp-tokens" / "notion.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps({"version": 1, "tokens": {"access_token": "x"}}))
+        storage = FileTokenStorage("notion")
+
+        assert await storage.get_expires_at() is None
+
+    async def test_get_expires_at_rejects_non_numeric(self, fake_home: Path) -> None:
+        """A garbage sidecar value falls back to `None` rather than raising."""
+        path = fake_home / ".deepagents" / ".state" / "mcp-tokens" / "notion.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "tokens": {"access_token": "x"},
+                    "expires_at": "soon",
+                }
+            )
+        )
+        storage = FileTokenStorage("notion")
+
+        assert await storage.get_expires_at() is None
+
+    async def test_set_tokens_clears_stale_expiry_when_expires_in_absent(self) -> None:
+        """Writing a token without `expires_in` removes any prior `expires_at`."""
+        storage = FileTokenStorage("notion")
+        await storage.set_tokens(_make_tokens())
+        assert await storage.get_expires_at() is not None
+
+        # Some providers omit `expires_in` on refresh; the sidecar must not
+        # linger from the prior write or the next cold start will use a
+        # bogus expiry.
+        await storage.set_tokens(
+            OAuthToken(access_token="x2", token_type="Bearer", refresh_token="rt2")
+        )
+        assert await storage.get_expires_at() is None
+
+
+@pytest.mark.usefixtures("fake_home")
+class TestExpiryAwareOAuthClientProvider:
+    """Tests for cold-start expiry restoration on the OAuth client provider."""
+
+    async def test_initialize_restores_expiry_minus_safety_margin(self) -> None:
+        """A live `expires_at` is loaded into `context.token_expiry_time`."""
+        from deepagents_code.mcp_auth import (
+            _REFRESH_SAFETY_MARGIN_SECONDS,
+            build_oauth_provider,
+        )
+
+        storage = FileTokenStorage("notion")
+        await storage.set_client_info(_make_client_info())
+        await storage.set_tokens(_make_tokens())
+        expected_expires_at = await storage.get_expires_at()
+        assert expected_expires_at is not None
+
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+        )
+        await provider._initialize()
+
+        assert provider.context.token_expiry_time == (
+            expected_expires_at - _REFRESH_SAFETY_MARGIN_SECONDS
+        )
+        assert provider.context.is_token_valid() is True
+        assert provider.context.can_refresh_token() is True
+
+    async def test_initialize_treats_expired_token_as_invalid(self) -> None:
+        """A past `expires_at` makes the loaded token report as invalid."""
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        storage = FileTokenStorage("notion")
+        await storage.set_client_info(_make_client_info())
+        await storage.set_tokens(_make_tokens())
+        path = storage.path
+        data = json.loads(path.read_text())
+        data["expires_at"] = time.time() - 60  # already expired
+        path.write_text(json.dumps(data))
+
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+        )
+        await provider._initialize()
+
+        assert provider.context.is_token_valid() is False
+        assert provider.context.can_refresh_token() is True
+
+    async def test_initialize_legacy_file_forces_refresh_when_refresh_token_present(
+        self,
+    ) -> None:
+        """No sidecar + refresh token => assume expired so refresh path fires."""
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        storage = FileTokenStorage("notion")
+        await storage.set_client_info(_make_client_info())
+        # Write a legacy-format file (no `expires_at`).
+        path = storage.path
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "client_info": json.loads(
+                        _make_client_info().model_dump_json(exclude_none=True)
+                    ),
+                    "tokens": json.loads(
+                        _make_tokens().model_dump_json(exclude_none=True)
+                    ),
+                }
+            )
+        )
+
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+        )
+        await provider._initialize()
+
+        # The exact sentinel float is documented in the source; assert the
+        # observable behavior (token invalid, refresh path reachable) rather
+        # than pinning the magic value.
+        assert provider.context.is_token_valid() is False
+        assert provider.context.can_refresh_token() is True
+
+    async def test_initialize_legacy_file_without_refresh_token_leaves_expiry_unset(
+        self,
+    ) -> None:
+        """Legacy file without `refresh_token` cannot pre-empt expiry."""
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        storage = FileTokenStorage("notion")
+        await storage.set_client_info(_make_client_info())
+        path = storage.path
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "client_info": json.loads(
+                        _make_client_info().model_dump_json(exclude_none=True)
+                    ),
+                    "tokens": {"access_token": "stale", "token_type": "Bearer"},
+                }
+            )
+        )
+
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+        )
+        await provider._initialize()
+
+        # No refresh_token means there's nothing to refresh with, so the
+        # provider must leave token_expiry_time at its default (None). The
+        # stale Bearer will go out, hit 401, and fall into the SDK's full
+        # re-auth path — there's no shortcut available.
+        assert provider.context.token_expiry_time is None
+        assert provider.context.can_refresh_token() is False
+
+    async def test_initialize_with_storage_lacking_get_expires_at(self) -> None:
+        """Custom `TokenStorage` impls without `get_expires_at` still initialize."""
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        class _MinimalStorage(TokenStorage):
+            """`TokenStorage` that omits the optional `get_expires_at` method."""
+
+            def __init__(self) -> None:
+                self._tokens: OAuthToken | None = _make_tokens()
+                self._client_info = _make_client_info()
+
+            async def get_tokens(self) -> OAuthToken | None:
+                return self._tokens
+
+            async def set_tokens(self, tokens: OAuthToken) -> None:
+                self._tokens = tokens
+
+            async def get_client_info(self):
+                return self._client_info
+
+            async def set_client_info(self, client_info) -> None:
+                self._client_info = client_info
+
+        provider = build_oauth_provider(
+            server_name="custom",
+            server_url="https://mcp.example.com/mcp",
+            storage=_MinimalStorage(),
+        )
+        await provider._initialize()
+
+        # Without the optional sidecar accessor, the provider falls back to
+        # the upstream SDK's behavior: no expiry known, token treated as
+        # valid until a 401 forces re-auth.
+        assert provider.context.token_expiry_time is None
+        assert provider.context.current_tokens is not None
 
 
 class TestFindReauthRequired:


### PR DESCRIPTION
MCP OAuth servers were prompting for a fresh browser login every time `dcode` restarted, even when a valid refresh token was already on disk. The persisted token file carries only the relative `expires_in`, so the upstream `OAuthClientProvider._initialize` left `context.token_expiry_time` at `None`, `is_token_valid` reported expired tokens as valid, the stale `Bearer` went out, and the 401 cascade dropped into a full re-auth (browser) instead of the cheaper `refresh_token` grant.