### PR TITLE
style(code): reopen `/mcp` switcher after deferring OAuth reconnect

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -8765,13 +8765,11 @@ class DeepAgentsApp(App):
                 # come back; without it, the "logged in" notify is the only
                 # signal and the missing viewer looks like a UI hang.
                 logger.exception(
-                    "Failed to reopen MCP viewer after deferring "
-                    "reconnect for %r",
+                    "Failed to reopen MCP viewer after deferring reconnect for %r",
                     server_name,
                 )
                 self.notify(
-                    "Couldn't reopen the MCP viewer — run `/mcp` to open "
-                    "it manually.",
+                    "Couldn't reopen the MCP viewer — run `/mcp` to open it manually.",
                     severity="warning",
                     timeout=8,
                     markup=False,

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -8749,6 +8749,33 @@ class DeepAgentsApp(App):
                 timeout=8,
                 markup=False,
             )
+            # Defer is the "log into another server first" path, so route the
+            # user back to the switcher where the next unauthenticated server
+            # is one click away. Timeout and push_screen-failure fallbacks
+            # also land here (both set `choice = "later"`), so they share
+            # both the notify above and this navigation — acceptable
+            # degradation since the viewer push is itself best-effort.
+            try:
+                await self._show_mcp_viewer()
+            except Exception:
+                # Broad catch: real failures here are Textual mount/stack
+                # errors plus the deferred SDK import — none worth crashing
+                # the worker for, since the token is already on disk.
+                # Surface a toast so the user knows why the switcher didn't
+                # come back; without it, the "logged in" notify is the only
+                # signal and the missing viewer looks like a UI hang.
+                logger.exception(
+                    "Failed to reopen MCP viewer after deferring "
+                    "reconnect for %r",
+                    server_name,
+                )
+                self.notify(
+                    "Couldn't reopen the MCP viewer — run `/mcp` to open "
+                    "it manually.",
+                    severity="warning",
+                    timeout=8,
+                    markup=False,
+                )
 
     async def _restart_server_for_mcp_refresh(self, server_name: str) -> None:
         """Restart the app-owned LangGraph server to pick up new MCP tokens.

--- a/libs/code/deepagents_code/widgets/mcp_reconnect.py
+++ b/libs/code/deepagents_code/widgets/mcp_reconnect.py
@@ -115,6 +115,19 @@ class MCPReconnectPromptScreen(ModalScreen[ReconnectChoice]):
         """Dismiss with `"later"`."""
         self.dismiss("later")
 
+    def action_cancel(self) -> None:
+        """Alias for `action_later` so the app-level Esc handler defers.
+
+        The app's `action_interrupt` (`escape` binding, `priority=True`)
+        fires before this screen's own `escape` binding. When the active
+        screen is a `ModalScreen`, it dispatches to `action_cancel` if
+        present, else falls through to `dismiss(None)`. Without this
+        alias, Esc would dismiss with `None`, which the caller treats as
+        a programmatic dismiss (no toast, no reopen) instead of an
+        explicit defer.
+        """
+        self.action_later()
+
 
 class MCPReconnectForceConfirmScreen(ModalScreen[bool]):
     """Confirmation overlay for `/mcp reconnect --force` with no pending login.

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -8868,7 +8868,11 @@ class TestMCPLoginCommand:
             assert app._pending_mcp_reconnect is False
 
     async def test_prompt_mcp_reconnect_later_choice_defers(self) -> None:
-        """Choosing `later` marks the reconnect pending and skips restart."""
+        """Choosing `later` marks the reconnect pending and reopens the switcher.
+
+        The viewer is the obvious launchpad for the next login, so deferring
+        routes the user back there instead of dropping them at the chat input.
+        """
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -8883,6 +8887,9 @@ class TestMCPLoginCommand:
                     app, "_restart_server_for_mcp_refresh", new=AsyncMock()
                 ) as restart,
                 patch.object(app, "notify") as notify,
+                patch.object(
+                    app, "_show_mcp_viewer", new=AsyncMock()
+                ) as show_viewer,
             ):
                 await app._prompt_mcp_reconnect("notion")
 
@@ -8892,6 +8899,7 @@ class TestMCPLoginCommand:
             message = notify.call_args.args[0]
             assert "notion" in message
             assert "/mcp reconnect" in message
+            show_viewer.assert_awaited_once()
 
     async def test_mcp_reconnect_subcommand_restarts_when_pending(self) -> None:
         """`/mcp reconnect` triggers a restart when a login is pending."""
@@ -9042,6 +9050,34 @@ class TestMCPLoginCommand:
                 await prompt_task
             restart.assert_awaited_once_with("notion")
 
+    async def test_prompt_mcp_reconnect_pilot_driven_escape_reopens_viewer(
+        self,
+    ) -> None:
+        """End-to-end: real Esc against `DeepAgentsApp` defers and reopens.
+
+        Guards the full chain that patch-based tests bypass:
+        `DeepAgentsApp.action_interrupt` (priority Esc binding) →
+        dispatch to `MCPReconnectPromptScreen.action_cancel` →
+        `dismiss("later")` → `_show_mcp_viewer`. A regression in any
+        link — removing `action_cancel`, the app routing the modal
+        differently, or the navigation never wiring up — fails here.
+        """
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with patch.object(
+                app, "_show_mcp_viewer", new=AsyncMock()
+            ) as show_viewer:
+                prompt_task = asyncio.create_task(
+                    app._prompt_mcp_reconnect("notion"),
+                )
+                await pilot.pause()
+                await pilot.press("escape")
+                await pilot.pause()
+                await prompt_task
+            assert app._pending_mcp_reconnect is True
+            show_viewer.assert_awaited_once()
+
     async def test_prompt_mcp_reconnect_none_dismiss_silent(self) -> None:
         """A `None` dismiss (programmatic) defers without a user notice.
 
@@ -9061,15 +9097,30 @@ class TestMCPLoginCommand:
                     app, "_restart_server_for_mcp_refresh", new=AsyncMock()
                 ) as restart,
                 patch.object(app, "notify") as notify,
+                patch.object(
+                    app, "_show_mcp_viewer", new=AsyncMock()
+                ) as show_viewer,
             ):
                 await app._prompt_mcp_reconnect("notion")
 
             restart.assert_not_called()
             assert app._pending_mcp_reconnect is True
             notify.assert_not_called()
+            # `None` is not an explicit user choice — don't navigate.
+            show_viewer.assert_not_called()
 
-    async def test_prompt_mcp_reconnect_push_screen_failure_defers(self) -> None:
-        """`push_screen` raising falls back to defer so the login isn't lost."""
+    async def test_prompt_mcp_reconnect_push_screen_failure_defers(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """`push_screen` raising falls back to defer so the login isn't lost.
+
+        The fallback also routes through the new "reopen viewer" path
+        (since the fallback sets `choice = "later"`), which tries to push
+        the viewer and hits the same patched failure. The outer try/except
+        around `_show_mcp_viewer` must swallow that secondary failure and
+        log it — anything else would crash the worker after the token
+        has already been persisted to disk.
+        """
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -9082,10 +9133,22 @@ class TestMCPLoginCommand:
                 patch.object(
                     app, "_restart_server_for_mcp_refresh", new=AsyncMock()
                 ) as restart,
+                patch.object(app, "notify") as notify,
+                caplog.at_level("ERROR", logger="deepagents_code.app"),
             ):
                 await app._prompt_mcp_reconnect("notion")
             restart.assert_not_called()
             assert app._pending_mcp_reconnect is True
+            assert any(
+                "Failed to reopen MCP viewer" in record.getMessage()
+                for record in caplog.records
+            )
+            # Both notifies fire: the "logged in / run /mcp reconnect"
+            # primary and the secondary "couldn't reopen the MCP viewer"
+            # warning that closes the silent-failure gap.
+            messages = [call.args[0] for call in notify.call_args_list]
+            assert any("Run `/mcp reconnect`" in m for m in messages)
+            assert any("Couldn't reopen the MCP viewer" in m for m in messages)
 
     async def test_pending_reconnect_coalesces_multiple_defers(self) -> None:
         """Two deferred logins resolve via a single `/mcp reconnect`.
@@ -9107,6 +9170,7 @@ class TestMCPLoginCommand:
                 patch.object(
                     app, "_restart_server_for_mcp_refresh", new=AsyncMock()
                 ) as restart,
+                patch.object(app, "_show_mcp_viewer", new=AsyncMock()),
             ):
                 await app._prompt_mcp_reconnect("notion")
                 await app._prompt_mcp_reconnect("github")

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -8887,9 +8887,7 @@ class TestMCPLoginCommand:
                     app, "_restart_server_for_mcp_refresh", new=AsyncMock()
                 ) as restart,
                 patch.object(app, "notify") as notify,
-                patch.object(
-                    app, "_show_mcp_viewer", new=AsyncMock()
-                ) as show_viewer,
+                patch.object(app, "_show_mcp_viewer", new=AsyncMock()) as show_viewer,
             ):
                 await app._prompt_mcp_reconnect("notion")
 
@@ -9065,9 +9063,7 @@ class TestMCPLoginCommand:
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
-            with patch.object(
-                app, "_show_mcp_viewer", new=AsyncMock()
-            ) as show_viewer:
+            with patch.object(app, "_show_mcp_viewer", new=AsyncMock()) as show_viewer:
                 prompt_task = asyncio.create_task(
                     app._prompt_mcp_reconnect("notion"),
                 )
@@ -9097,9 +9093,7 @@ class TestMCPLoginCommand:
                     app, "_restart_server_for_mcp_refresh", new=AsyncMock()
                 ) as restart,
                 patch.object(app, "notify") as notify,
-                patch.object(
-                    app, "_show_mcp_viewer", new=AsyncMock()
-                ) as show_viewer,
+                patch.object(app, "_show_mcp_viewer", new=AsyncMock()) as show_viewer,
             ):
                 await app._prompt_mcp_reconnect("notion")
 

--- a/libs/code/tests/unit_tests/test_mcp_reconnect.py
+++ b/libs/code/tests/unit_tests/test_mcp_reconnect.py
@@ -53,6 +53,33 @@ class TestMCPReconnectPromptScreen:
 
             assert outcomes == ["later"]
 
+    async def test_action_cancel_dismisses_with_later(self) -> None:
+        """`action_cancel` defers — the path taken by the app's Esc handler.
+
+        `DeepAgentsApp.action_interrupt` (a priority `escape` binding)
+        fires before the modal's own `escape` binding. When the active
+        screen is a `ModalScreen`, it dispatches to `action_cancel` if
+        present, else falls through to `dismiss(None)`. Without an
+        `action_cancel` that defers, real-app Esc would silently
+        None-dismiss instead of choosing `later`, breaking the
+        "log into another server first" workflow.
+        """
+        app = _ReconnectTestApp()
+        async with app.run_test() as pilot:
+            outcomes: list[str | None] = []
+
+            def on_dismiss(result: str | None) -> None:
+                outcomes.append(result)
+
+            screen = MCPReconnectPromptScreen("notion")
+            app.push_screen(screen, on_dismiss)
+            await pilot.pause()
+
+            screen.action_cancel()
+            await pilot.pause()
+
+            assert outcomes == ["later"]
+
     async def test_renders_server_name(self) -> None:
         """The server name is surfaced in the modal title."""
         app = _ReconnectTestApp()

--- a/libs/code/tests/unit_tests/test_mcp_viewer.py
+++ b/libs/code/tests/unit_tests/test_mcp_viewer.py
@@ -265,12 +265,9 @@ class TestMCPViewerScreen:
             headers = screen.query(".mcp-server-header")
             assert len(headers) == 2
             # Selection lands on the toggled server.
-            assert isinstance(
-                screen._row_widgets[screen._selected_index], MCPServerHeaderItem
-            )
-            assert (
-                screen._row_widgets[screen._selected_index].server.name == "filesystem"
-            )
+            selected_widget = screen._row_widgets[screen._selected_index]
+            assert isinstance(selected_widget, MCPServerHeaderItem)
+            assert selected_widget.server.name == "filesystem"
             # The other server's tools must still render.
             tools = screen.query(".mcp-tool-item")
             tool_text = " ".join(_widget_text(t) for t in tools)


### PR DESCRIPTION
After a successful in-TUI MCP OAuth, the post-login modal asked **Reconnect now** / **Esc to defer**, then dropped the user at the chat input on defer. Route them back to the `/mcp` switcher instead — defer almost always means "log into another server first," and the switcher is the launchpad. Required a prerequisite fix to the modal's Esc handling: `DeepAgentsApp.action_interrupt` (a `priority=True` Esc binding on the app) intercepts before any modal's own `escape` binding and dispatches to `action_cancel`, falling through to `dismiss(None)` when absent — so the modal never actually saw a `"later"` choice from Esc until now.