### PR TITLE
style(code): targeted recovery hint when a provider's LangChain package is missing

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -136,6 +136,7 @@ if TYPE_CHECKING:
     from deepagents_code._ask_user_types import AskUserWidgetResult, Question
     from deepagents_code.event_bus import EventSource, ExternalEvent
     from deepagents_code.mcp_tools import MCPServerInfo
+    from deepagents_code.model_config import MissingProviderPackageError
     from deepagents_code.remote_client import RemoteAgent
     from deepagents_code.server import ServerProcess
     from deepagents_code.skills.load import ExtendedSkillMetadata
@@ -1471,6 +1472,16 @@ class DeepAgentsApp(App):
         recovery hint without string-matching on the formatted error.
         """
 
+        self._server_startup_missing_provider_package: (
+            MissingProviderPackageError | None
+        ) = None
+        """The exception itself when startup failed with
+        `MissingProviderPackageError`; `None` otherwise. Stashing the exception
+        rather than a tuple gives the hint builder named access to `.provider`
+        and `.package`, and gates the `pip install` / `/model` recovery hint
+        without string-matching on the formatted error.
+        """
+
         self._retry_status_widget: AppMessage | None = None
         """Transient "Retrying startup with X…" breadcrumb. Mounted via
         `_mount_before_queued` (not `_mount_message`) because it is ephemeral
@@ -2584,7 +2595,10 @@ class DeepAgentsApp(App):
     def on_deep_agents_app_server_start_failed(self, event: ServerStartFailed) -> None:
         """Handle background server startup failure."""
         from deepagents_code.mcp_tools import MCPConfigError
-        from deepagents_code.model_config import MissingCredentialsError
+        from deepagents_code.model_config import (
+            MissingCredentialsError,
+            MissingProviderPackageError,
+        )
 
         self._connecting = False
         self._connection_ready_event.set()
@@ -2599,6 +2613,11 @@ class DeepAgentsApp(App):
         self._server_startup_missing_credentials_provider = (
             event.error.provider
             if isinstance(event.error, MissingCredentialsError)
+            else None
+        )
+        self._server_startup_missing_provider_package = (
+            event.error
+            if isinstance(event.error, MissingProviderPackageError)
             else None
         )
         logger.error("Server startup failed: %s", event.error, exc_info=event.error)
@@ -2628,6 +2647,17 @@ class DeepAgentsApp(App):
                 "\n\nHint: run `/auth` to add a key for this provider, then "
                 "`/model <provider>:<model>` to retry startup. Or pick a "
                 "different provider directly with `/model`."
+            )
+        elif (
+            self._server_startup_missing_provider_package is not None
+            and self._server_kwargs is not None
+        ):
+            missing = self._server_startup_missing_provider_package
+            text += (
+                f"\n\nHint: install the package with "
+                f"`pip install {missing.package}`, then run "
+                f"`/model {missing.provider}:<model>` to retry. "
+                f"Or pick a different provider with `/model`."
             )
 
         async def _mount_failure() -> None:
@@ -9294,6 +9324,7 @@ class DeepAgentsApp(App):
 
         self._server_startup_error = None
         self._server_startup_missing_credentials_provider = None
+        self._server_startup_missing_provider_package = None
         self._server_startup_deferred = False
         self._connecting = True
         try:

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -2104,11 +2104,18 @@ def _create_model_via_init(
             `init_chat_model` also fails to infer one. Carries the
             model spec and docs URL as attributes so the UI can render
             a clickable link.
+        MissingProviderPackageError: When the provider's LangChain package
+            is not installed. Carries the `provider` and `package` to install
+            so the UI can render a targeted recovery hint.
         ModelConfigError: On other import, value, or runtime errors.
     """
     from langchain.chat_models import init_chat_model
 
-    from deepagents_code.model_config import ModelConfigError, UnknownProviderError
+    from deepagents_code.model_config import (
+        MissingProviderPackageError,
+        ModelConfigError,
+        UnknownProviderError,
+    )
 
     try:
         if provider:
@@ -2129,7 +2136,15 @@ def _create_model_via_init(
         module_name = package.replace("-", "_")
         try:
             spec_found = importlib.util.find_spec(module_name) is not None
-        except (ImportError, ValueError):
+        except (ImportError, ValueError) as spec_exc:
+            # A broken finder is indistinguishable from "not installed" here;
+            # log so a real corruption doesn't masquerade as the missing-package
+            # hint without leaving a trail.
+            logger.debug(
+                "find_spec failed for %s; treating provider package as missing: %s",
+                module_name,
+                spec_exc,
+            )
             spec_found = False
         if spec_found:
             # Package is installed but an internal import failed — surface
@@ -2143,6 +2158,9 @@ def _create_model_via_init(
                 f"Missing package for provider '{provider}'. "
                 f"Install: pip install {package}"
             )
+            raise MissingProviderPackageError(
+                msg, provider=provider, package=package
+            ) from e
         raise ModelConfigError(msg) from e
     except (ValueError, TypeError) as e:
         if not provider:

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -186,6 +186,30 @@ class MissingCredentialsError(ModelConfigError):
         self.env_var = env_var
 
 
+class MissingProviderPackageError(ModelConfigError):
+    """Raised when a provider is selected but its LangChain package is not installed.
+
+    Subclasses `ModelConfigError` so existing `except ModelConfigError` blocks
+    keep working. Carries the `provider` name and the `package` to install so
+    callers can render targeted recovery hints (e.g., suggest
+    `pip install langchain-fireworks` or the `/model` slash command) without
+    string-matching on the formatted exception message.
+    """
+
+    def __init__(self, message: str, *, provider: str, package: str) -> None:
+        """Initialize the error.
+
+        Args:
+            message: Human-readable message describing the missing package.
+            provider: The provider whose package is missing (e.g., `'fireworks'`).
+            package: The pip-installable package name (e.g.,
+                `'langchain-fireworks'`).
+        """
+        super().__init__(message)
+        self.provider = provider
+        self.package = package
+
+
 class ProviderAuthState(StrEnum):
     """Credential readiness state for a model provider."""
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -5179,6 +5179,133 @@ class TestDeferredActions:
 
             assert app._server_startup_error == "RuntimeError: RuntimeError"
 
+    async def test_server_failure_missing_package_records_recovery_hint(
+        self,
+    ) -> None:
+        """`MissingProviderPackageError` stashes the exception and renders a hint.
+
+        Asserts both that the slot carries the exception itself (so the hint
+        builder gets named `.provider`/`.package` access) and that the hint
+        text actually lands in the mounted `ErrorMessage` widget — catching a
+        regression where the `elif` branch is dropped or `provider`/`package`
+        are swapped.
+        """
+        from deepagents_code.model_config import MissingProviderPackageError
+        from deepagents_code.widgets.messages import ErrorMessage
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # `_server_kwargs is not None` gates the hint — emulate a startup
+            # path where the user has a model selected.
+            app._server_kwargs = {"model_name": "fireworks:fake"}  # type: ignore[typeddict-item]
+            app._connecting = True
+
+            error = MissingProviderPackageError(
+                "Missing package for provider 'fireworks'. "
+                "Install: pip install langchain-fireworks",
+                provider="fireworks",
+                package="langchain-fireworks",
+            )
+            app.on_deep_agents_app_server_start_failed(
+                DeepAgentsApp.ServerStartFailed(error=error)
+            )
+            # Mount runs as a fire-and-forget task; let it land.
+            await pilot.pause()
+
+            stashed = app._server_startup_missing_provider_package
+            assert stashed is error
+            assert stashed.provider == "fireworks"
+            assert stashed.package == "langchain-fireworks"
+            # Credentials slot is a different recovery path; should stay clear.
+            assert app._server_startup_missing_credentials_provider is None
+
+            widget = app._startup_failure_widget
+            assert isinstance(widget, ErrorMessage)
+            rendered = str(widget._content)
+            assert "pip install langchain-fireworks" in rendered
+            assert "/model fireworks:<model>" in rendered
+
+    async def test_retry_startup_clears_missing_package_slot(self) -> None:
+        """`_retry_startup_with_model` must clear the package recovery slot.
+
+        Mirrors the credentials-slot reset directly above it. A regression
+        that drops the reset would leave a stale `pip install` hint visible
+        after a successful retry, or render the wrong hint on the next failure.
+        """
+        from deepagents_code.model_config import (
+            MissingProviderPackageError,
+            ProviderAuthState,
+            ProviderAuthStatus,
+        )
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._server_kwargs = {"model_name": "fireworks:fake"}  # type: ignore[typeddict-item]
+            app._server_startup_error = "stale"
+            app._server_startup_missing_provider_package = MissingProviderPackageError(
+                "stale",
+                provider="fireworks",
+                package="langchain-fireworks",
+            )
+            app._server_startup_missing_credentials_provider = "stale"
+            app.query_one = MagicMock(side_effect=NoMatches("any"))  # type: ignore[assignment]
+            app.run_worker = MagicMock()  # type: ignore[assignment]
+
+            with patch(
+                "deepagents_code.model_config.get_provider_auth_status",
+                return_value=ProviderAuthStatus(
+                    state=ProviderAuthState.UNKNOWN,
+                    provider="anthropic",
+                    detail="credentials unknown",
+                ),
+            ):
+                await app._retry_startup_with_model("anthropic:claude-opus-4-7")
+
+            assert app._server_startup_missing_provider_package is None
+            assert app._server_startup_missing_credentials_provider is None
+            assert app._server_startup_error is None
+
+    async def test_server_failure_missing_credentials_clears_package_slot(
+        self,
+    ) -> None:
+        """A `MissingCredentialsError` failure must clear the package slot.
+
+        Guards the mutual-exclusion invariant: the two recovery hints route
+        through separate `if`/`elif` branches, so stale state from a prior
+        retry-failure must never bleed into the next failure type.
+        """
+        from deepagents_code.model_config import (
+            MissingCredentialsError,
+            MissingProviderPackageError,
+        )
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._server_kwargs = {"model_name": "openai:gpt-4o"}  # type: ignore[typeddict-item]
+            # Seed a prior package failure so we can assert the next failure
+            # clears it.
+            app._server_startup_missing_provider_package = MissingProviderPackageError(
+                "stale",
+                provider="fireworks",
+                package="langchain-fireworks",
+            )
+            app._connecting = True
+
+            error = MissingCredentialsError(
+                "OPENAI_API_KEY is not set",
+                provider="openai",
+                env_var="OPENAI_API_KEY",
+            )
+            app.on_deep_agents_app_server_start_failed(
+                DeepAgentsApp.ServerStartFailed(error=error)
+            )
+
+            assert app._server_startup_missing_provider_package is None
+            assert app._server_startup_missing_credentials_provider == "openai"
+
     async def test_failing_deferred_action_does_not_block_others(self) -> None:
         """A failing deferred action should not prevent subsequent ones."""
         app = DeepAgentsApp()

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -2498,17 +2498,23 @@ class TestCreateModelViaInitImportError:
     @patch("langchain.chat_models.init_chat_model")
     def test_missing_package_error(self, mock_init: Mock) -> None:
         """Shows install hint when provider package is not installed."""
+        from deepagents_code.model_config import MissingProviderPackageError
+
         mock_init.side_effect = ImportError(
             "No module named 'langchain_nvidia_ai_endpoints'"
         )
         with (
             patch("importlib.util.find_spec", return_value=None),
             pytest.raises(
-                ModelConfigError,
+                MissingProviderPackageError,
                 match="Missing package for provider 'nvidia'",
-            ),
+            ) as exc_info,
         ):
             _create_model_via_init("nemotron", "nvidia", {})
+        assert exc_info.value.provider == "nvidia"
+        assert exc_info.value.package == "langchain-nvidia-ai-endpoints"
+        # Subclasses ModelConfigError so existing handlers keep working.
+        assert isinstance(exc_info.value, ModelConfigError)
 
     @patch("langchain.chat_models.init_chat_model")
     def test_installed_but_broken_import(self, mock_init: Mock) -> None:


### PR DESCRIPTION
When `dcode` starts with a provider whose LangChain package isn't installed (e.g. `fireworks` without `langchain-fireworks`), the failure now surfaces a typed exception and a recovery hint in the chat — pointing the user at `/model` to switch providers or `pip install` to add the missing package — instead of a bare `ModelConfigError: Missing package for provider 'fireworks'…` with no path forward.