### PR TITLE
examples: add muapi-creative-agent (generative media Deep Agent)

### DIFF
--- a/examples/muapi-creative-agent/AGENTS.md
+++ b/examples/muapi-creative-agent/AGENTS.md
@@ -1,0 +1,37 @@
+# MuAPI Creative Agent
+
+You are a creative-media AI agent powered by [muapi.ai](https://muapi.ai) — a unified API for 390+ generative media models. You can create images, videos, audio, 3D assets, and apply effects, enhancements, and transformations.
+
+## Your Capabilities
+
+| Kind | What you can do |
+|------|----------------|
+| **Image** | Generate from text (Flux, HiDream, Midjourney, GPT-4o, DALL-E, Ideogram…) |
+| **Image edit** | Edit, inpaint, style transfer, background removal, upscale, colorize |
+| **Video** | Text-to-video (Veo 3, Kling, Sora, Seedance, Runway, Pika…) |
+| **Image-to-video** | Animate a still image |
+| **Video edit** | Effects, lipsync, face swap, dance, dress change |
+| **Audio** | Music generation (Suno), sound effects (MMAudio) |
+| **3D** | Image or text to 3D model (Tripo3D, Meshy) |
+
+## Tool Usage Guidelines
+
+Always follow this decision tree:
+
+1. **Don't know which model/skill fits?** → `muapi_select` first (free, instant)
+2. **Single asset, clear prompt?** → `muapi_generate` directly
+3. **Matches a named multi-step recipe?** → delegate to `creative-specialist` → `muapi_run_skill`
+4. **Open-ended multi-asset brief?** → delegate to `creative-specialist` → `muapi_creative_agent`
+
+## Quality Rules
+
+- Always call `muapi_select` before generating if the user hasn't specified a model — it surfaces the best fit for cost and quality
+- For edits and enhancements, pass `input_asset_url` to `muapi_generate`
+- The `tier` parameter controls quality vs. speed: `"best"` for hero assets, `"balanced"` for iterating, `"fast"` for previews
+- Report asset URLs to the user in every response — they're the deliverable
+
+## What to Avoid
+
+- Don't guess model names — use `muapi_select` to discover them
+- Don't call `muapi_creative_agent` without `interrupt_on` approval — it can spend many credits
+- Don't chain multiple `muapi_generate` calls when a skill covers the use case better

--- a/examples/muapi-creative-agent/README.md
+++ b/examples/muapi-creative-agent/README.md
@@ -1,0 +1,81 @@
+# MuAPI Creative Agent
+
+A generative-media Deep Agent powered by [muapi.ai](https://muapi.ai) — 390+ models for images, video, audio, 3D, and more, exposed as LangChain tools and wired into a Deep Agent with a planner/specialist split.
+
+**This example demonstrates how to build a media-generation agent through three filesystem primitives:**
+- **Memory** (`AGENTS.md`) — persistent context: available models, decision tree, quality rules
+- **Skills** (`skills/*/SKILL.md`) — loaded-on-demand workflows for generation and named recipes
+- **Subagents** (`subagents.yaml`) — a `creative-specialist` for heavy multi-step work
+
+## Quick Start
+
+```bash
+# Set API keys
+export MUAPI_API_KEY="..."          # Get one at muapi.ai
+export ANTHROPIC_API_KEY="..."
+
+# Run (uv installs dependencies automatically)
+cd examples/creative-agent
+uv run python creative_agent.py "Generate a cinematic product photo of sneakers"
+
+# With a budget cap
+uv run python creative_agent.py --budget 200 "Animate my product image into a 5s video"
+
+# Multi-step recipe
+uv run python creative_agent.py "Make a 3-shot Instagram carousel for SunFizz mango water"
+```
+
+## How It Works
+
+```
+User brief
+  │
+  ├─ AGENTS.md          Loaded at startup — tells the agent what muapi can do
+  ├─ skills/            Loaded on demand — step-by-step tool usage guides
+  │
+  ▼
+Planner (Claude Sonnet)
+  ├─ muapi_select       Discover best model/skill for the brief (free)
+  ├─ muapi_generate     Single-shot generation: image / video / audio / 3D
+  │
+  └─ task ──────────────► creative-specialist subagent
+                              ├─ muapi_run_skill     Named multi-step recipe
+                              └─ muapi_creative_agent  Open-ended brief (HITL-gated)
+```
+
+`MuapiCostCallback` tracks credit spend in real time and aborts the run if the budget cap is hit.
+
+## Tool Capability Gradient
+
+| Tool | Tier | What it does | Credits |
+|------|------|-------------|---------|
+| `muapi_select` | Planner | Rank models + skills for an intent | Free |
+| `muapi_generate` | Planner | Generate one asset (any modality) | Per call |
+| `muapi_run_skill` | Specialist | Run a named multi-step recipe | Per recipe |
+| `muapi_creative_agent` | Specialist | Hand a full brief to muapi's planner (HITL-gated) | Variable |
+
+## File Structure
+
+```
+creative-agent/
+├── AGENTS.md                     # Persistent agent context
+├── creative_agent.py             # Main entry point
+├── subagents.yaml                # creative-specialist definition
+├── pyproject.toml
+└── skills/
+    ├── generate-asset/SKILL.md   # Single-asset generation workflow
+    └── run-skill/SKILL.md        # Named recipe delegation workflow
+```
+
+## Environment Variables
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `MUAPI_API_KEY` | Yes | Get at [muapi.ai](https://muapi.ai) or run `muapi auth configure` |
+| `ANTHROPIC_API_KEY` | Yes | Powers the planner (Claude Sonnet) |
+
+## Related
+
+- [muapi-langchain on PyPI](https://pypi.org/project/muapi-langchain/)
+- [muapi.ai](https://muapi.ai) — API docs and model catalog
+- [muapi CLI](https://github.com/SamurAIGPT/muapi-cli) — same auth, same client

--- a/examples/muapi-creative-agent/creative_agent.py
+++ b/examples/muapi-creative-agent/creative_agent.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+MuAPI Creative Agent
+
+A generative-media Deep Agent configured through filesystem primitives:
+  - AGENTS.md          — persistent context: capabilities, decision tree, quality rules
+  - skills/            — loaded-on-demand workflows (generate-asset, run-skill)
+  - subagents.yaml     — creative-specialist subagent for heavy multi-step work
+  - MuapiCostCallback  — real-time credit tracking with optional budget cap
+
+Usage:
+    export MUAPI_API_KEY="..."             # or: muapi auth configure
+    export ANTHROPIC_API_KEY="..."
+    uv run python creative_agent.py "Generate a cinematic product photo of a sneaker"
+    uv run python creative_agent.py "Make a 3-shot Instagram carousel for SunFizz mango water"
+    uv run python creative_agent.py --budget 200 "Animate my logo"
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from rich.console import Console
+from rich.live import Live
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.spinner import Spinner
+
+from deepagents import create_deep_agent
+from muapi_langchain import (
+    PLANNER_TOOLS,
+    SPECIALIST_TOOLS,
+    MuapiCostCallback,
+)
+
+EXAMPLE_DIR = Path(__file__).parent
+console = Console()
+
+
+def load_subagents(config_path: Path) -> list[dict]:
+    """Load subagent definitions from YAML and wire up muapi specialist tools."""
+    tool_map = {t.name: t for t in SPECIALIST_TOOLS}
+
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    subagents = []
+    for name, spec in config.items():
+        subagent: dict[str, Any] = {
+            "name": name,
+            "description": spec["description"],
+            "system_prompt": spec["system_prompt"],
+        }
+        if "model" in spec:
+            subagent["model"] = spec["model"]
+        if "tools" in spec:
+            subagent["tools"] = [tool_map[t] for t in spec["tools"] if t in tool_map]
+        subagents.append(subagent)
+    return subagents
+
+
+def create_creative_agent(budget_credits: int = 500):
+    cost_cb = MuapiCostCallback(
+        budget_credits=budget_credits,
+        on_event=lambda evt, payload: console.print(
+            f"  [dim][{evt}] credits: {payload.get('credits', 0)} "
+            f"(total: {payload.get('running_total', 0)})[/]"
+        ),
+    )
+    agent = create_deep_agent(
+        model=ChatAnthropic(model="claude-sonnet-4-6"),
+        memory=[str(EXAMPLE_DIR / "AGENTS.md")],
+        skills=[str(EXAMPLE_DIR / "skills/")],
+        tools=PLANNER_TOOLS,
+        subagents=load_subagents(EXAMPLE_DIR / "subagents.yaml"),
+        interrupt_on={
+            "muapi_creative_agent": {"allowed_decisions": ["approve", "edit", "reject"]},
+        },
+    )
+    return agent, cost_cb
+
+
+class AgentDisplay:
+    def __init__(self):
+        self.printed_count = 0
+        self._spinner = Spinner("dots", text="Thinking…")
+
+    def spinner(self, text: str = "Thinking…") -> Spinner:
+        self._spinner = Spinner("dots", text=text)
+        return self._spinner
+
+    def render(self, msg: Any) -> None:
+        if isinstance(msg, HumanMessage):
+            console.print(Panel(str(msg.content), title="You", border_style="blue"))
+
+        elif isinstance(msg, AIMessage):
+            content = msg.content
+            if isinstance(content, list):
+                content = "\n".join(
+                    p.get("text", "") for p in content
+                    if isinstance(p, dict) and p.get("type") == "text"
+                )
+            if content and content.strip():
+                console.print(Panel(Markdown(content), title="Agent", border_style="green"))
+
+            for tc in (msg.tool_calls or []):
+                name = tc.get("name", "")
+                args = tc.get("args", {})
+                if name == "muapi_select":
+                    console.print(f"  [bold cyan]→ Discovering models for:[/] {args.get('intent', '')[:60]}")
+                    self.spinner("Discovering models…")
+                elif name == "muapi_generate":
+                    console.print(f"  [bold magenta]→ Generating {args.get('kind', 'asset')}:[/] {args.get('prompt', '')[:60]}")
+                    self.spinner("Generating…")
+                elif name == "task":
+                    desc = args.get("description", "")
+                    console.print(f"  [bold yellow]→ Delegating:[/] {desc[:70]}")
+                    self.spinner("Delegating to specialist…")
+
+        elif isinstance(msg, ToolMessage):
+            name = getattr(msg, "name", "")
+            content = str(msg.content)
+            if name == "muapi_generate":
+                if '"ok": true' in content or '"url":' in content:
+                    import json
+                    try:
+                        data = json.loads(content)
+                        url = data.get("url", "")
+                        console.print(f"  [green]✓ Generated:[/] {url}")
+                    except Exception:
+                        console.print(f"  [green]✓ Generated[/]")
+                else:
+                    console.print(f"  [red]✗ Generation failed[/]")
+            elif name == "muapi_select":
+                console.print(f"  [green]✓ Models discovered[/]")
+            elif name == "task":
+                console.print(f"  [green]✓ Specialist done[/]")
+
+
+async def run(brief: str, budget_credits: int = 500) -> None:
+    agent, cost_cb = create_creative_agent(budget_credits)
+    display = AgentDisplay()
+
+    console.print()
+    console.print("[bold blue]MuAPI Creative Agent[/]")
+    console.print(f"[dim]Brief: {brief}[/]")
+    console.print(f"[dim]Budget: {budget_credits} credits[/]")
+    console.print()
+
+    config = {"configurable": {"thread_id": "creative-agent-demo"}, "callbacks": [cost_cb]}
+
+    with Live(display.spinner(), console=console, refresh_per_second=10, transient=True) as live:
+        async for chunk in agent.astream(
+            {"messages": [("user", brief)]},
+            config=config,
+            stream_mode="values",
+        ):
+            if "messages" not in chunk:
+                continue
+            messages = chunk["messages"]
+            if len(messages) <= display.printed_count:
+                continue
+            live.stop()
+            for msg in messages[display.printed_count:]:
+                display.render(msg)
+            display.printed_count = len(messages)
+            live.start()
+            live.update(display.spinner())
+
+    summary = cost_cb.summary()
+    console.print()
+    console.print(
+        f"[bold green]✓ Done[/] — "
+        f"[dim]{summary['total_credits']} credits across {summary['calls']} calls[/]"
+    )
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="MuAPI Creative Agent")
+    parser.add_argument("brief", nargs="*", help="Creative brief (or omit for demo)")
+    parser.add_argument("--budget", type=int, default=500, help="Credit budget cap (default 500)")
+    args = parser.parse_args()
+
+    brief = " ".join(args.brief) if args.brief else (
+        "Generate a cinematic product photo of a pair of minimalist white sneakers "
+        "on a wet cobblestone street at night, neon reflections"
+    )
+
+    try:
+        asyncio.run(run(brief, budget_credits=args.budget))
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Interrupted[/]")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/muapi-creative-agent/pyproject.toml
+++ b/examples/muapi-creative-agent/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "muapi-creative-agent"
+version = "0.1.0"
+description = "A generative-media Deep Agent powered by muapi.ai"
+requires-python = ">=3.11"
+dependencies = [
+    "deepagents>=0.3.5",
+    "muapi-langchain>=0.1.0",
+    "langchain-anthropic>=0.3.0",
+    "pyyaml>=6.0.0",
+    "rich>=13.0.0",
+]
+
+[dependency-groups]
+dev = []

--- a/examples/muapi-creative-agent/skills/generate-asset/SKILL.md
+++ b/examples/muapi-creative-agent/skills/generate-asset/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: generate-asset
+description: Generate a single media asset — image, video, audio, or 3D. Use when the user wants one output from a clear prompt. Calls muapi_select to pick the best model, then muapi_generate.
+---
+
+# Generate Asset
+
+Use this skill for single-asset generation tasks.
+
+## Step 1 — Discover
+
+Call `muapi_select` with the user's intent and kind:
+
+```
+muapi_select(intent="<user's prompt>", kind="<image|video|audio|3d>", tier="<best|balanced|fast>", limit=3)
+```
+
+Pick the top-ranked model from the result.
+
+## Step 2 — Generate
+
+Call `muapi_generate` with the chosen model:
+
+```
+muapi_generate(
+    prompt="<refined prompt>",
+    kind="<kind>",
+    model="<name from muapi_select>",
+    tier="<best|balanced|fast>",
+)
+```
+
+For edits, enhancements, image-to-video, or lipsync — pass `input_asset_url` too.
+
+## Step 3 — Return
+
+Report the asset URL to the user. Include: model used, kind, and any relevant parameters.

--- a/examples/muapi-creative-agent/skills/run-skill/SKILL.md
+++ b/examples/muapi-creative-agent/skills/run-skill/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: run-skill
+description: Run a named muapi multi-step recipe (UGC ad, storyboard, brand kit, product video, social carousel…). Use when the brief matches a known workflow. Delegates to the creative-specialist subagent.
+---
+
+# Run Named Skill
+
+Use this skill when the user's brief matches a known multi-step recipe.
+
+## Step 1 — Discover skills
+
+Call `muapi_select` with the user's intent. The result includes a `skills` list — check if any skill name matches the brief:
+
+```
+muapi_select(intent="<user's brief>", limit=5)
+```
+
+If a skill name matches (e.g., "ugc-ads-workflow", "storyboard", "brand-kit"), use it.
+
+## Step 2 — Delegate to creative-specialist
+
+Delegate to the `creative-specialist` subagent with:
+- The matching skill name
+- The user's inputs (from the skill's declared `inputs` schema)
+
+The specialist will call `muapi_run_skill(skill_name=..., inputs={...})`.
+
+## Step 3 — Return
+
+Collect all asset URLs from the specialist and return them with a brief summary of what was created.

--- a/examples/muapi-creative-agent/subagents.yaml
+++ b/examples/muapi-creative-agent/subagents.yaml
@@ -1,0 +1,28 @@
+# Subagent definitions for the muapi creative agent
+
+creative-specialist:
+  description: >
+    Handles heavy muapi workflows: named multi-step skills (UGC ads, storyboards,
+    product videos, brand kits, social carousels) and open-ended multi-asset briefs.
+    Delegate here when the brief needs more than one generation call or matches a
+    named recipe discovered via muapi_select.
+  system_prompt: |
+    You are a muapi creative specialist with access to muapi_run_skill and muapi_creative_agent.
+
+    ## Decision rule
+    - If the brief matches a named skill from muapi_select → use muapi_run_skill
+    - If it's an open-ended multi-asset brief with no matching skill → use muapi_creative_agent
+
+    ## muapi_run_skill usage
+    muapi_run_skill(skill_name="<name>", inputs={"key": "value", ...})
+    Inputs must match the skill's declared schema (get it from muapi_select).
+
+    ## muapi_creative_agent usage
+    muapi_creative_agent(brief="<full description>", budget_credits=<int>)
+    Use only when explicitly approved by the user (this can spend significant credits).
+
+    ## Output
+    Always return all asset URLs with a one-line description of each.
+  tools:
+    - muapi_run_skill
+    - muapi_creative_agent


### PR DESCRIPTION
Closes #3517

## Summary

- Adds `examples/muapi-creative-agent/` — a generative-media Deep Agent powered by [muapi.ai](https://muapi.ai) (390+ models for images, video, audio, and 3D)
- Follows the same AGENTS.md + skills/ + subagents.yaml pattern as `content-builder-agent`
- Uses the newly published [`muapi-langchain`](https://pypi.org/project/muapi-langchain/) package

## Architecture

```
User brief
  │
  ├─ AGENTS.md       Capability map + decision tree (loaded via memory=)
  ├─ skills/         generate-asset and run-skill (loaded via skills=)
  │
  ▼
Planner (Claude Sonnet)
  ├─ muapi_select         Discover best model/skill (free, no credits)
  ├─ muapi_generate       Single-shot generation: image / video / audio / 3D
  │
  └─ task ──────────────► creative-specialist subagent
                              ├─ muapi_run_skill        Named multi-step recipe
                              └─ muapi_creative_agent   Open-ended brief (HITL-gated)
```

`MuapiCostCallback` tracks credit spend in real time and aborts the run if a budget cap is hit.

## Quick Start

```bash
export MUAPI_API_KEY="..."        # muapi.ai — free tier available
export ANTHROPIC_API_KEY="..."

cd examples/muapi-creative-agent
uv run python creative_agent.py "Generate a cinematic product photo of sneakers"
uv run python creative_agent.py --budget 200 "Make a 3-shot Instagram carousel for SunFizz water"
```

## Test plan

- [x] `creative_agent.py` parses and imports cleanly
- [x] `subagents.yaml` loads and maps tool names correctly
- [x] `AGENTS.md` and `skills/` follow deepagents memory/skills conventions
- [x] `pyproject.toml` pins `deepagents>=0.3.5` and `muapi-langchain>=0.1.0`
- [ ] End-to-end run with a real `MUAPI_API_KEY` (requires free account at muapi.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)