### PR TITLE
style(code): show I-beam cursor when hovering message text

### DIFF
--- a/libs/code/deepagents_code/widgets/messages.py
+++ b/libs/code/deepagents_code/widgets/messages.py
@@ -177,6 +177,7 @@ class UserMessage(_TimestampClickMixin, Static):
         margin: 0 0 1 0;
         background: transparent;
         border-left: wide $primary;
+        pointer: text;
     }
     """
 
@@ -267,6 +268,7 @@ class QueuedUserMessage(Static):
         background: transparent;
         border-left: wide $panel;
         opacity: 0.6;
+        pointer: text;
     }
     """
     """Dimmed border + reduced opacity to distinguish queued messages from sent ones."""
@@ -605,6 +607,7 @@ class AssistantMessage(_TimestampClickMixin, Vertical):
     AssistantMessage Markdown {
         padding: 0;
         margin: 0;
+        pointer: text;
     }
     """
 
@@ -1871,6 +1874,7 @@ class DiffMessage(_TimestampClickMixin, Static):
         margin: 0 0 1 0;
         background: $surface;
         border: solid $primary;
+        pointer: text;
     }
 
     DiffMessage .diff-header {
@@ -1944,6 +1948,7 @@ class ErrorMessage(_TimestampClickMixin, Static):
         background: $error-muted;
         color: white;
         border-left: wide $error;
+        pointer: text;
     }
     """
     """Tinted background + left border to visually separate errors from output."""
@@ -2054,6 +2059,7 @@ class AppMessage(Static):
         margin: 0 0 1 0;
         color: $text-muted;
         text-style: italic;
+        pointer: text;
     }
     """
 
@@ -2110,6 +2116,7 @@ class SummarizationMessage(AppMessage):
         background: $surface;
         border-left: wide $primary;
         text-style: bold;
+        pointer: text;
     }
     """
 


### PR DESCRIPTION
Set `pointer: text` on prose-rendering message widgets so terminals that implement the Kitty pointer-shape protocol (Ghostty, Kitty) display an I-beam cursor when the mouse is over selectable text — matching the cursor already shown over the `Input` widget. Terminals without the protocol (iTerm2, Terminal.app) ignore the hint, so there's no regression for users on those.