### PR TITLE
fix(code): recover initial session prompts from writes table

### DIFF
--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -710,7 +710,7 @@ class _AgentCoreProvider(SandboxProvider):
 
         # Validate AWS credentials early for a clear error message.
         try:
-            import boto3  # ty: ignore[unresolved-import]
+            import boto3
 
             session = boto3.Session()
             credentials = session.get_credentials()

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -710,7 +710,7 @@ class _AgentCoreProvider(SandboxProvider):
 
         # Validate AWS credentials early for a clear error message.
         try:
-            import boto3
+            import boto3  # ty: ignore[unresolved-import]
 
             session = boto3.Session()
             credentials = session.get_credentials()

--- a/libs/code/deepagents_code/sessions.py
+++ b/libs/code/deepagents_code/sessions.py
@@ -718,22 +718,40 @@ async def _populate_checkpoint_fields(
 
     # Phase 2: batch-fetch all uncached threads.
     uncached_ids = [t["thread_id"] for t in uncached]
-    batch_results = await _load_latest_checkpoint_summaries_batch(
-        conn, uncached_ids, serde
-    )
+    batch_results: dict[str, _CheckpointSummary] = {}
+    if include_message_count or include_initial_prompt:
+        batch_results = await _load_latest_checkpoint_summaries_batch(
+            conn, uncached_ids, serde
+        )
+    # `initial_prompt` cannot be recovered from the latest checkpoint alone:
+    # `after_model` middleware (e.g., `TokenStateMiddleware`) writes partial
+    # checkpoints whose `channel_values` omit `messages`. Read the very first
+    # write to the `messages` channel from the `writes` table instead — that
+    # row holds the user's original input.
+    prompt_results: dict[str, str | None] = {}
+    if include_initial_prompt:
+        prompt_results = await _load_initial_prompts_from_writes_batch(
+            conn, uncached_ids, serde
+        )
 
     # Phase 3: apply results and update caches.
     for thread in uncached:
         thread_id = thread["thread_id"]
         freshness = _thread_freshness(thread)
-        summary = batch_results.get(thread_id, _CheckpointSummary(0, None))
 
         if include_message_count and "message_count" not in thread:
+            summary = batch_results.get(thread_id, _CheckpointSummary(0, None))
             thread["message_count"] = summary.message_count
             _cache_message_count(thread_id, freshness, summary.message_count)
         if include_initial_prompt and "initial_prompt" not in thread:
-            thread["initial_prompt"] = summary.initial_prompt
-            _cache_initial_prompt(thread_id, freshness, summary.initial_prompt)
+            if thread_id in prompt_results:
+                prompt = prompt_results[thread_id]
+            else:
+                prompt = batch_results.get(
+                    thread_id, _CheckpointSummary(0, None)
+                ).initial_prompt
+            thread["initial_prompt"] = prompt
+            _cache_initial_prompt(thread_id, freshness, prompt)
 
 
 _SQLITE_MAX_VARIABLE_NUMBER = 500
@@ -808,6 +826,74 @@ async def _load_latest_checkpoint_summaries_batch(
     return results
 
 
+async def _load_initial_prompts_from_writes_batch(
+    conn: aiosqlite.Connection,
+    thread_ids: list[str],
+    serde: JsonPlusSerializer,
+) -> dict[str, str | None]:
+    """Batch-load initial prompts from the LangGraph `writes` table.
+
+    For each thread, returns the first human/user message extracted from the
+    earliest write to the `messages` channel (ordered by `checkpoint_id` ASC,
+    then `idx` ASC).
+
+    Args:
+        conn: Database connection.
+        thread_ids: Thread IDs to look up.
+        serde: Serializer for decoding write blobs.
+
+    Returns:
+        Dict mapping thread IDs to their initial prompt text. Threads with no
+        write to the `messages` channel are absent from the result; threads
+        whose first such write decoded but contained no human/user entry map
+        to `None`.
+    """
+    if not thread_ids:
+        return {}
+
+    results: dict[str, str | None] = {}
+    loop = asyncio.get_running_loop()
+    for start in range(0, len(thread_ids), _SQLITE_MAX_VARIABLE_NUMBER):
+        chunk = thread_ids[start : start + _SQLITE_MAX_VARIABLE_NUMBER]
+        placeholders = ",".join("?" * len(chunk))
+        query = f"""
+            SELECT thread_id, type, value FROM (
+                SELECT thread_id, type, value,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY thread_id
+                           ORDER BY checkpoint_id ASC, idx ASC
+                       ) AS rn
+                FROM writes
+                WHERE thread_id IN ({placeholders}) AND channel = 'messages'
+            ) WHERE rn = 1
+        """  # noqa: S608  # placeholders built from len(chunk); user values use ? params
+        async with conn.execute(query, chunk) as cursor:
+            rows = await cursor.fetchall()
+
+        for row in rows:
+            tid, type_str, value_blob = row
+            if not type_str or not value_blob:
+                continue
+            try:
+                messages = await loop.run_in_executor(
+                    None, serde.loads_typed, (type_str, value_blob)
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to deserialize initial messages write for thread %s",
+                    tid,
+                    exc_info=True,
+                )
+                continue
+            if not isinstance(messages, list):
+                continue
+            results[tid] = _initial_prompt_from_messages(
+                cast("list[object]", messages)
+            )
+
+    return results
+
+
 async def _load_latest_checkpoint_summary(
     conn: aiosqlite.Connection,
     thread_id: str,
@@ -877,10 +963,23 @@ def _checkpoint_messages(data: object) -> list[object]:
 
 
 def _initial_prompt_from_messages(messages: list[object]) -> str | None:
-    """Return the first human message content from a checkpoint message list."""
+    """Return the first human message content from a message list.
+
+    Accepts both LangChain `HumanMessage` objects (with `type == "human"`) and
+    plain dicts in OpenAI chat shape (`{"role": "user", "content": ...}`). The
+    first write to the `messages` channel is the raw user input passed to the
+    agent, which is preserved verbatim as a dict; subsequent writes are
+    serialized `BaseMessage` instances produced after the model runs.
+    """
     for msg in messages:
         if getattr(msg, "type", None) == "human":
             return _coerce_prompt_text(getattr(msg, "content", None))
+        if isinstance(msg, dict):
+            msg_dict = cast("dict[str, object]", msg)
+            role = msg_dict.get("role")
+            type_ = msg_dict.get("type")
+            if role in {"user", "human"} or type_ == "human":
+                return _coerce_prompt_text(msg_dict.get("content"))
     return None
 
 

--- a/libs/code/deepagents_code/sessions.py
+++ b/libs/code/deepagents_code/sessions.py
@@ -887,9 +887,7 @@ async def _load_initial_prompts_from_writes_batch(
                 continue
             if not isinstance(messages, list):
                 continue
-            results[tid] = _initial_prompt_from_messages(
-                cast("list[object]", messages)
-            )
+            results[tid] = _initial_prompt_from_messages(cast("list[object]", messages))
 
     return results
 

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -187,6 +187,12 @@ extra-paths = [
 [tool.ty.rules]
 # https://docs.astral.sh/ty/rules/
 division-by-zero = "error"
+# Optional-dependency imports (e.g., `boto3` from the `bedrock` extra) need
+# `ty: ignore[unresolved-import]` suppressions to keep CI green when the extra
+# isn't installed. Devs who do install the extra would otherwise hit
+# "unused suppression" warnings; silence that rule so suppressions are stable
+# across environments.
+unused-ignore-comment = "ignore"
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/libs/code/tests/unit_tests/test_sessions.py
+++ b/libs/code/tests/unit_tests/test_sessions.py
@@ -664,8 +664,8 @@ class TestListThreadsWithMessageCount:
 class TestPopulateThreadCheckpointDetails:
     """Tests for combined checkpoint-detail enrichment."""
 
-    async def test_shared_summary_populates_count_and_prompt_once(self) -> None:
-        """One batch lookup should fill both fields for a thread row."""
+    async def test_populates_count_and_prompt_from_separate_sources(self) -> None:
+        """Counts come from the checkpoint summary, prompts from the writes table."""
         threads: list[sessions.ThreadInfo] = [
             {
                 "thread_id": "thread-a",
@@ -689,15 +689,21 @@ class TestPopulateThreadCheckpointDetails:
                 return_value={
                     "thread-a": sessions._CheckpointSummary(
                         message_count=4,
-                        initial_prompt="hello world",
+                        initial_prompt=None,
                     ),
                 },
-            ) as mock_batch,
+            ) as mock_summary,
+            patch.object(
+                sessions,
+                "_load_initial_prompts_from_writes_batch",
+                new_callable=AsyncMock,
+                return_value={"thread-a": "hello world"},
+            ) as mock_prompts,
         ):
             await sessions._populate_checkpoint_fields(  # pyright: ignore[reportPrivateUsage]
                 cast(
                     "aiosqlite.Connection",
-                    object(),  # connection is unused by the mocked loader
+                    object(),  # connection is unused by the mocked loaders
                 ),
                 threads,
                 include_message_count=True,
@@ -706,7 +712,102 @@ class TestPopulateThreadCheckpointDetails:
 
         assert threads[0]["message_count"] == 4
         assert threads[0]["initial_prompt"] == "hello world"
-        assert mock_batch.await_count == 1
+        assert mock_summary.await_count == 1
+        assert mock_prompts.await_count == 1
+
+    async def test_skips_prompt_query_when_not_requested(self) -> None:
+        """The writes-table prompt query should be skipped when prompts are off."""
+        threads: list[sessions.ThreadInfo] = [
+            {
+                "thread_id": "thread-a",
+                "agent_name": "agent",
+                "updated_at": "2026-03-08T02:00:00+00:00",
+                "latest_checkpoint_id": "cp_1",
+            }
+        ]
+
+        with (
+            patch.object(
+                sessions,
+                "_get_jsonplus_serializer",
+                new_callable=AsyncMock,
+                return_value=object(),
+            ),
+            patch.object(
+                sessions,
+                "_load_latest_checkpoint_summaries_batch",
+                new_callable=AsyncMock,
+                return_value={
+                    "thread-a": sessions._CheckpointSummary(2, None),
+                },
+            ),
+            patch.object(
+                sessions,
+                "_load_initial_prompts_from_writes_batch",
+                new_callable=AsyncMock,
+            ) as mock_prompts,
+        ):
+            await sessions._populate_checkpoint_fields(  # pyright: ignore[reportPrivateUsage]
+                cast("aiosqlite.Connection", object()),
+                threads,
+                include_message_count=True,
+                include_initial_prompt=False,
+            )
+
+        mock_prompts.assert_not_awaited()
+
+    async def test_falls_back_to_checkpoint_prompt_when_writes_omit_thread(
+        self,
+    ) -> None:
+        """Sessions without message writes still show checkpoint-backed prompts."""
+        sessions._initial_prompt_cache.clear()
+        try:
+            threads: list[sessions.ThreadInfo] = [
+                {
+                    "thread_id": "thread-a",
+                    "agent_name": "agent",
+                    "updated_at": "2026-03-08T02:00:00+00:00",
+                    "latest_checkpoint_id": "cp_1",
+                }
+            ]
+
+            with (
+                patch.object(
+                    sessions,
+                    "_get_jsonplus_serializer",
+                    new_callable=AsyncMock,
+                    return_value=object(),
+                ),
+                patch.object(
+                    sessions,
+                    "_load_latest_checkpoint_summaries_batch",
+                    new_callable=AsyncMock,
+                    return_value={
+                        "thread-a": sessions._CheckpointSummary(
+                            message_count=2,
+                            initial_prompt="hello from checkpoint",
+                        ),
+                    },
+                ) as mock_summary,
+                patch.object(
+                    sessions,
+                    "_load_initial_prompts_from_writes_batch",
+                    new_callable=AsyncMock,
+                    return_value={},
+                ) as mock_prompts,
+            ):
+                await sessions._populate_checkpoint_fields(  # pyright: ignore[reportPrivateUsage]
+                    cast("aiosqlite.Connection", object()),
+                    threads,
+                    include_message_count=False,
+                    include_initial_prompt=True,
+                )
+
+            assert threads[0]["initial_prompt"] == "hello from checkpoint"
+            mock_summary.assert_awaited_once()
+            mock_prompts.assert_awaited_once()
+        finally:
+            sessions._initial_prompt_cache.clear()
 
 
 class TestApplyCachedThreadMessageCounts:
@@ -1838,10 +1939,16 @@ class TestBatchCheckpointSummaries:
                     "_load_latest_checkpoint_summaries_batch",
                     new_callable=AsyncMock,
                     return_value={
-                        "t1": sessions._CheckpointSummary(3, "prompt1"),
-                        "t2": sessions._CheckpointSummary(7, "prompt2"),
+                        "t1": sessions._CheckpointSummary(3, None),
+                        "t2": sessions._CheckpointSummary(7, None),
                     },
                 ) as mock_batch,
+                patch.object(
+                    sessions,
+                    "_load_initial_prompts_from_writes_batch",
+                    new_callable=AsyncMock,
+                    return_value={"t1": "prompt1", "t2": "prompt2"},
+                ) as mock_prompts,
             ):
                 await sessions._populate_checkpoint_fields(
                     cast("aiosqlite.Connection", object()),
@@ -1855,6 +1962,145 @@ class TestBatchCheckpointSummaries:
             assert threads[1]["message_count"] == 7
             assert threads[1]["initial_prompt"] == "prompt2"
             mock_batch.assert_awaited_once()
+            mock_prompts.assert_awaited_once()
         finally:
             sessions._message_count_cache.clear()
             sessions._initial_prompt_cache.clear()
+
+
+class TestLoadInitialPromptsFromWritesBatch:
+    """Tests for the writes-table initial-prompt loader."""
+
+    async def test_returns_prompt_from_dict_message(self) -> None:
+        """Initial input is an OpenAI-shape dict; helper should extract its text."""
+        serde = JsonPlusSerializer()
+        blob = serde.dumps_typed([{"role": "user", "content": "hi there"}])
+
+        import aiosqlite
+
+        async with aiosqlite.connect(":memory:") as conn:
+            await conn.execute(
+                "CREATE TABLE writes "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "task_id TEXT, idx INTEGER, channel TEXT, type TEXT, value BLOB)"
+            )
+            await conn.execute(
+                "INSERT INTO writes VALUES (?, '', ?, '', 0, 'messages', ?, ?)",
+                ("t1", "cp_a", blob[0], blob[1]),
+            )
+            await conn.commit()
+
+            results = await sessions._load_initial_prompts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+                conn, ["t1"], serde
+            )
+
+        assert results == {"t1": "hi there"}
+
+    async def test_picks_earliest_messages_write(self) -> None:
+        """Earliest write by (checkpoint_id, idx) should win over later ones."""
+        serde = JsonPlusSerializer()
+        first_blob = serde.dumps_typed([{"role": "user", "content": "first"}])
+        later_blob = serde.dumps_typed([{"role": "user", "content": "second"}])
+
+        import aiosqlite
+
+        async with aiosqlite.connect(":memory:") as conn:
+            await conn.execute(
+                "CREATE TABLE writes "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "task_id TEXT, idx INTEGER, channel TEXT, type TEXT, value BLOB)"
+            )
+            await conn.executemany(
+                "INSERT INTO writes VALUES (?, '', ?, '', ?, 'messages', ?, ?)",
+                [
+                    ("t1", "cp_b", 0, later_blob[0], later_blob[1]),
+                    ("t1", "cp_a", 0, first_blob[0], first_blob[1]),
+                ],
+            )
+            await conn.commit()
+
+            results = await sessions._load_initial_prompts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+                conn, ["t1"], serde
+            )
+
+        assert results == {"t1": "first"}
+
+    async def test_omits_threads_with_no_messages_writes(self) -> None:
+        """Threads without any messages-channel write should be absent from result."""
+        serde = JsonPlusSerializer()
+
+        import aiosqlite
+
+        async with aiosqlite.connect(":memory:") as conn:
+            await conn.execute(
+                "CREATE TABLE writes "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "task_id TEXT, idx INTEGER, channel TEXT, type TEXT, value BLOB)"
+            )
+
+            results = await sessions._load_initial_prompts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+                conn, ["t1", "t2"], serde
+            )
+
+        assert results == {}
+
+    async def test_empty_input_returns_empty(self) -> None:
+        """Empty thread list should short-circuit without touching the connection."""
+        serde = JsonPlusSerializer()
+        result = await sessions._load_initial_prompts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+            None,  # type: ignore[arg-type]  # connection not used
+            [],
+            serde,
+        )
+        assert result == {}
+
+    async def test_corrupt_blob_is_skipped_without_raising(self) -> None:
+        """A row with valid type but undecodable bytes should be omitted, not raised."""
+        serde = JsonPlusSerializer()
+
+        import aiosqlite
+
+        async with aiosqlite.connect(":memory:") as conn:
+            await conn.execute(
+                "CREATE TABLE writes "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "task_id TEXT, idx INTEGER, channel TEXT, type TEXT, value BLOB)"
+            )
+            await conn.execute(
+                "INSERT INTO writes VALUES (?, '', ?, '', 0, 'messages', ?, ?)",
+                ("t1", "cp_a", "msgpack", b"\xff\xff garbage"),
+            )
+            await conn.commit()
+
+            results = await sessions._load_initial_prompts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+                conn, ["t1"], serde
+            )
+
+        assert results == {}
+
+
+class TestInitialPromptFromMessages:
+    """Tests for the message-list parser used by the writes-table reader."""
+
+    def test_handles_dict_with_user_role(self) -> None:
+        """OpenAI-shape dicts (the initial-input format) should match."""
+        result = sessions._initial_prompt_from_messages(  # pyright: ignore[reportPrivateUsage]
+            [{"role": "user", "content": "hello"}]
+        )
+        assert result == "hello"
+
+    def test_handles_human_message_object(self) -> None:
+        """LangChain `HumanMessage` objects continue to work."""
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        result = sessions._initial_prompt_from_messages(  # pyright: ignore[reportPrivateUsage]
+            [AIMessage(content="hi"), HumanMessage(content="hello")]
+        )
+        assert result == "hello"
+
+    def test_returns_none_for_no_human_message(self) -> None:
+        """Lists without any human/user message should return None."""
+        result = sessions._initial_prompt_from_messages(  # pyright: ignore[reportPrivateUsage]
+            [{"role": "assistant", "content": "ack"}]
+        )
+        assert result is None


### PR DESCRIPTION
Session list rows occasionally showed missing initial prompts because partial checkpoints written by `after_model` middleware (e.g., `TokenStateMiddleware`) omit `messages` from `channel_values`, leaving nothing to extract. Prompts are now read from the first write to the `messages` channel in the LangGraph `writes` table, which preserves the user's original input verbatim.