### PR TITLE
style(code): skip terminal background sync for ANSI themes to preserve native background

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3446,7 +3446,13 @@ class DeepAgentsApp(App):
         Custom themes use their stored registry colors; built-in Textual themes
         resolve colors from the active app theme. Terminal write failures are
         logged and swallowed because the OSC background sync is cosmetic.
+
+        ANSI themes intentionally skip this step so the terminal's native
+        background is preserved.
         """
+        if self.theme in {"ansi-dark", "ansi-light"}:
+            return
+
         from deepagents_code.terminal_escape import set_terminal_background
 
         entry = theme.get_registry().get(self.theme)

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -4561,6 +4561,10 @@ class TestTerminalBackgroundSync:
         )
 
         app = DeepAgentsApp()
+        # Force a known non-ANSI theme so the assertion is stable regardless
+        # of the test runner's saved preference (which may be ansi-dark).
+        app.theme = theme.DEFAULT_THEME
+        app.sync_terminal_background()
         entry = theme.get_registry()[app.theme]
 
         assert calls[-1] == entry.colors.background
@@ -4639,6 +4643,7 @@ class TestTerminalBackgroundSync:
         from deepagents_code import terminal_escape
 
         app = DeepAgentsApp()
+        app.theme = "langchain"  # force non-ANSI so the error path runs
 
         def _raise(_color: str) -> bool:
             msg = "terminal unavailable"
@@ -4650,6 +4655,42 @@ class TestTerminalBackgroundSync:
             app.sync_terminal_background()
 
         assert "set_terminal_background raised unexpectedly" in caplog.text
+
+    def test_sync_terminal_background_skips_ansi_dark(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_code import terminal_escape
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            terminal_escape,
+            "set_terminal_background",
+            lambda color: calls.append(color) or True,
+        )
+
+        app = DeepAgentsApp()
+        app.theme = "ansi-dark"
+        app.sync_terminal_background()
+
+        assert calls == []
+
+    def test_sync_terminal_background_skips_ansi_light(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from deepagents_code import terminal_escape
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            terminal_escape,
+            "set_terminal_background",
+            lambda color: calls.append(color) or True,
+        )
+
+        app = DeepAgentsApp()
+        app.theme = "ansi-light"
+        app.sync_terminal_background()
+
+        assert calls == []
 
     def test_exit_resets_terminal_background(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -4669,6 +4669,7 @@ class TestTerminalBackgroundSync:
         )
 
         app = DeepAgentsApp()
+        calls.clear()
         app.theme = "ansi-dark"
         app.sync_terminal_background()
 
@@ -4687,6 +4688,7 @@ class TestTerminalBackgroundSync:
         )
 
         app = DeepAgentsApp()
+        calls.clear()
         app.theme = "ansi-light"
         app.sync_terminal_background()
 


### PR DESCRIPTION
`sync_terminal_background()` was sending `OSC 11` with a hex fallback color for `ansi-dark` and `ansi-light`, overriding the terminal native background with a solid `#11121D`. ANSI themes should defer to the terminal palette instead.