### PR TITLE
feat(code): `dcode mcp config` and unify `--mcp-config` flag

### DIFF
--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -938,7 +938,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--mcp-config",
         help="Path to MCP servers JSON configuration file (Claude Desktop format). "
-        "Merged on top of auto-discovered configs (highest precedence).",
+        "Merged on top of auto-discovered configs (highest precedence). "
+        "Run `dcode mcp config` to see discovery paths.",
     )
     parser.add_argument(
         "--no-mcp",
@@ -2081,25 +2082,26 @@ def cli_main() -> None:
 
             execute_skills_command(args)
         elif args.command == "mcp":
-            from deepagents_code.mcp_commands import run_mcp_login
+            from deepagents_code.mcp_commands import run_mcp_config, run_mcp_login
             from deepagents_code.ui import show_mcp_help
 
             if args.mcp_command == "login":
-                if getattr(args, "mcp_config", None) and not args.config_path:
+                config_path = args.config_path or args.mcp_config
+                if config_path and not args.config_path:
                     print(  # noqa: T201
-                        "--mcp-config is not supported for 'mcp login'. "
-                        "Use: dcode mcp login <server> --config <path>",
+                        f"Using --mcp-config from top-level: {config_path}",
                         file=sys.stderr,
                     )
-                    sys.exit(2)
                 sys.exit(
                     asyncio.run(
                         run_mcp_login(
                             server=args.server,
-                            config_path=args.config_path,
+                            config_path=config_path,
                         )
                     )
                 )
+            if args.mcp_command == "config":
+                sys.exit(run_mcp_config())
             show_mcp_help()
         elif args.command == "threads":
             from deepagents_code.sessions import (

--- a/libs/code/deepagents_code/mcp_commands.py
+++ b/libs/code/deepagents_code/mcp_commands.py
@@ -57,15 +57,27 @@ def setup_mcp_parsers(
     )
     login_parser.add_argument("server", help="Server name from mcpServers config")
     login_parser.add_argument(
-        "--config",
+        "--mcp-config",
         dest="config_path",
         default=None,
-        help="Path to an MCP config JSON file (default: auto-discovered)",
+        help="Path to an MCP config JSON file. Falls back to the top-level "
+        "`--mcp-config`, then to auto-discovered configs.",
     )
     login_parser.add_argument(
         "-h",
         "--help",
         action=make_help_action(_lazy_ui_help("show_mcp_login_help")),
+    )
+
+    config_parser = mcp_sub.add_parser(
+        "config",
+        help="Show MCP config discovery paths",
+        add_help=False,
+    )
+    config_parser.add_argument(
+        "-h",
+        "--help",
+        action=make_help_action(_lazy_ui_help("show_mcp_config_help")),
     )
 
 
@@ -157,6 +169,66 @@ async def run_mcp_login(*, server: str, config_path: str | None) -> int:
             file=sys.stderr,
         )
         return 1
+    return 0
+
+
+def run_mcp_config() -> int:
+    """Handle `dcode mcp config`.
+
+    Prints the MCP config discovery paths in precedence order with a
+    marker showing which exist on disk. Stat-only; never opens config
+    files, so config-trust prompts are not triggered.
+
+    Returns:
+        Process exit code: always 0.
+    """
+    from pathlib import Path
+
+    from deepagents_code.mcp_tools import (
+        _resolve_project_config_base,
+        discover_mcp_configs,
+    )
+    from deepagents_code.ui import console
+
+    found = {str(p.resolve()) for p in discover_mcp_configs()}
+    user_dir = Path.home() / ".deepagents"
+    project_root = _resolve_project_config_base(None)
+
+    rows: list[tuple[str, str, bool]] = []
+    for display, label, resolved in (
+        ("~/.deepagents/.mcp.json", "user-level", user_dir / ".mcp.json"),
+        (
+            "<project-root>/.deepagents/.mcp.json",
+            "project subdir",
+            project_root / ".deepagents" / ".mcp.json",
+        ),
+        ("<project-root>/.mcp.json", "project root", project_root / ".mcp.json"),
+    ):
+        exists = str(resolved.resolve()) in found or resolved.is_file()
+        rows.append((display, label, exists))
+
+    width = max(len(p) for p, _, _ in rows)
+    console.print(
+        "MCP config discovery paths (lowest to highest precedence):",
+        highlight=False,
+    )
+    for display, label, exists in rows:
+        marker = "found" if exists else "missing"
+        console.print(
+            f"  [{marker:>7}]  {display:<{width}}  ({label})",
+            highlight=False,
+            markup=False,
+        )
+    console.print()
+    console.print(
+        "<project-root> = nearest ancestor with `.git`, else current directory.",
+        highlight=False,
+    )
+    console.print(
+        "Override via `--mcp-config <path>` at the top level or on "
+        "`dcode mcp login <server>`.",
+        highlight=False,
+    )
     return 0
 
 

--- a/libs/code/deepagents_code/mcp_login_service.py
+++ b/libs/code/deepagents_code/mcp_login_service.py
@@ -33,7 +33,7 @@ class ConfigErrorKind(StrEnum):
     """
 
     EXPLICIT_LOAD_FAILED = "explicit_load_failed"
-    """The `--config` path could not be parsed."""
+    """The `--mcp-config` path could not be parsed."""
 
     NO_CONFIG_FOUND = "no_config_found"
     """Auto-discovery returned zero candidate paths."""
@@ -127,7 +127,7 @@ def resolve_mcp_config(
     """Resolve an MCP config dict for login without printing anything.
 
     Args:
-        config_path: Explicit `--config` path, or `None` for auto-discovery.
+        config_path: Explicit `--mcp-config` path, or `None` for auto-discovery.
 
     Returns:
         A `ConfigResolution` on success, or a `ConfigResolutionError`
@@ -160,7 +160,7 @@ def resolve_mcp_config(
             kind=ConfigErrorKind.NO_CONFIG_FOUND,
             message=(
                 "No MCP config file found in any auto-discovered location. "
-                "Pass --config <path>, or run `dcode mcp login --help` "
+                "Pass --mcp-config <path>, or run `dcode mcp login --help` "
                 "to see the search paths and config format."
             ),
         )
@@ -266,7 +266,7 @@ def format_untrusted_project_notice(paths: tuple[Path, ...]) -> str:
         "Skipping untrusted project MCP config "
         f"(not yet approved or config changed): {skipped}. "
         "Approve it by running `dcode` in this project, or "
-        "pass --config <path> to use it explicitly."
+        "pass --mcp-config <path> to use it explicitly."
     )
 
 

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -125,7 +125,8 @@ def show_help() -> None:
     )
     console.print(
         "  --mcp-config PATH          Load MCP tools from config file"
-        " (merged on top of auto-discovered configs)"
+        " (merged on top of auto-discovered configs;"
+        " run `dcode mcp config` to list discovery paths)"
     )
     console.print("  --no-mcp                   Disable all MCP tool loading")
     console.print(
@@ -446,19 +447,21 @@ def show_mcp_help() -> None:
     console.print()
     console.print("[bold]Commands:[/bold]", style=theme.PRIMARY)
     console.print("  login <server>    Run the OAuth login flow for an MCP server")
+    console.print("  config            Show MCP config discovery paths")
     console.print()
     _print_option_section()
     console.print()
     _print_mcp_discovery_paths()
     console.print()
     console.print(
-        "  Pass --config <path> to any subcommand to bypass discovery.",
+        "  Pass --mcp-config <path> to any subcommand to bypass discovery.",
         style=theme.MUTED,
     )
     console.print()
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
+    console.print("  dcode mcp config")
     console.print("  dcode mcp login notion")
-    console.print("  dcode mcp login linear --config ./mcp-config.json")
+    console.print("  dcode mcp login linear --mcp-config ./mcp-config.json")
     console.print()
 
 
@@ -466,10 +469,10 @@ def show_mcp_login_help() -> None:
     """Show help information for the `mcp login` subcommand."""
     console.print()
     console.print("[bold]Usage:[/bold]", style=theme.PRIMARY)
-    console.print("  dcode mcp login <server> [--config PATH]")
+    console.print("  dcode mcp login <server> [--mcp-config PATH]")
     console.print()
     _print_option_section(
-        "  --config PATH           Path to an MCP config JSON file "
+        "  --mcp-config PATH       Path to an MCP config JSON file "
         "(default: auto-discovered)",
     )
     console.print()
@@ -480,7 +483,22 @@ def show_mcp_login_help() -> None:
     console.print()
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
     console.print("  dcode mcp login notion")
-    console.print("  dcode mcp login linear --config ./mcp-config.json")
+    console.print("  dcode mcp login linear --mcp-config ./mcp-config.json")
+    console.print()
+
+
+def show_mcp_config_help() -> None:
+    """Show help information for the `mcp config` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=theme.PRIMARY)
+    console.print("  dcode mcp config")
+    console.print()
+    console.print(
+        "Print the MCP config discovery paths in precedence order, marking"
+        " which files exist on disk.",
+    )
+    console.print()
+    _print_mcp_discovery_paths()
     console.print()
 
 

--- a/libs/code/tests/unit_tests/test_args.py
+++ b/libs/code/tests/unit_tests/test_args.py
@@ -414,10 +414,8 @@ class TestNoMcpArg:
 class TestMcpCommandDispatch:
     """Tests for `cli_main()` dispatch of `dcode mcp` subcommands."""
 
-    def test_mcp_login_rejects_global_mcp_config(
-        self, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """`dcode mcp login` errors if only top-level `--mcp-config` is set."""
+    def test_mcp_login_uses_top_level_mcp_config_as_fallback(self) -> None:
+        """`dcode --mcp-config PATH mcp login NAME` propagates PATH to login."""
         from deepagents_code.main import cli_main
 
         with (
@@ -443,13 +441,14 @@ class TestMcpCommandDispatch:
         ):
             cli_main()
 
-        assert exc_info.value.code == 2
-        mock_login.assert_not_awaited()
-        err = capsys.readouterr().err
-        assert "--mcp-config is not supported for 'mcp login'" in err
+        assert exc_info.value.code == 0
+        mock_login.assert_awaited_once_with(
+            server="notion",
+            config_path="/global/config.json",
+        )
 
-    def test_mcp_login_accepts_subcommand_config_with_global(self) -> None:
-        """Subcommand `--config` is used even if top-level `--mcp-config` is set."""
+    def test_mcp_login_subcommand_mcp_config_wins_over_top_level(self) -> None:
+        """Subcommand `--mcp-config` overrides the top-level value."""
         from deepagents_code.main import cli_main
 
         with (
@@ -463,7 +462,7 @@ class TestMcpCommandDispatch:
                     "mcp",
                     "login",
                     "notion",
-                    "--config",
+                    "--mcp-config",
                     "/subcommand/config.json",
                 ],
             ),
@@ -482,6 +481,149 @@ class TestMcpCommandDispatch:
             server="notion",
             config_path="/subcommand/config.json",
         )
+
+    def test_mcp_config_subcommand_prints_discovery_paths(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """`dcode mcp config` prints each discovery path."""
+        from deepagents_code.main import cli_main
+
+        with (
+            patch.object(sys, "argv", ["deepagents", "mcp", "config"]),
+            patch("deepagents_code.main.check_cli_dependencies"),
+            patch("deepagents_code.main.apply_stdin_pipe"),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "~/.deepagents/.mcp.json" in out
+        assert "<project-root>/.deepagents/.mcp.json" in out
+        assert "<project-root>/.mcp.json" in out
+
+    def test_mcp_login_subcommand_mcp_config_only(self) -> None:
+        """`dcode mcp login NAME --mcp-config PATH` passes PATH through.
+
+        Covers the subcommand-only path (no top-level value) so a future
+        reorder of the `or`-precedence in dispatch fails loudly.
+        """
+        from deepagents_code.main import cli_main
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "deepagents",
+                    "mcp",
+                    "login",
+                    "notion",
+                    "--mcp-config",
+                    "/sub/config.json",
+                ],
+            ),
+            patch("deepagents_code.main.check_cli_dependencies"),
+            patch("deepagents_code.main.apply_stdin_pipe"),
+            patch(
+                "deepagents_code.mcp_commands.run_mcp_login",
+                new=AsyncMock(return_value=0),
+            ) as mock_login,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+
+        assert exc_info.value.code == 0
+        mock_login.assert_awaited_once_with(
+            server="notion",
+            config_path="/sub/config.json",
+        )
+
+    def test_mcp_login_rejects_old_config_flag(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The renamed `--config` flag is rejected by argparse.
+
+        Documents the intentional backcompat break (renamed to
+        `--mcp-config`) and prevents a stealth re-introduction of the
+        alias.
+        """
+        from deepagents_code.main import cli_main
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "deepagents",
+                    "mcp",
+                    "login",
+                    "notion",
+                    "--config",
+                    "/some/path.json",
+                ],
+            ),
+            patch("deepagents_code.main.check_cli_dependencies"),
+            patch("deepagents_code.main.apply_stdin_pipe"),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+
+        assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "unrecognized arguments" in err
+        assert "--config" in err
+
+    def test_mcp_config_marker_reflects_filesystem(
+        self,
+        tmp_path: pytest.TempPathFactory,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`run_mcp_config()` marks files [found] / [missing] accurately.
+
+        Points `Path.home()` and `find_project_root()` at an isolated
+        tmp_path, creates the user-level file only, then asserts the
+        marker on each row.
+        """
+        import pathlib
+
+        from deepagents_code.mcp_commands import run_mcp_config
+
+        fake_home = pathlib.Path(str(tmp_path)) / "home"
+        fake_project = pathlib.Path(str(tmp_path)) / "project"
+        (fake_home / ".deepagents").mkdir(parents=True)
+        (fake_home / ".deepagents" / ".mcp.json").write_text("{}")
+        fake_project.mkdir()
+
+        monkeypatch.setattr(pathlib.Path, "home", lambda: fake_home)
+        monkeypatch.chdir(fake_project)
+        monkeypatch.setattr(
+            "deepagents_code.project_utils.find_project_root",
+            lambda: fake_project,
+        )
+
+        exit_code = run_mcp_config()
+
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        user_line = next(
+            line for line in out.splitlines() if "~/.deepagents/.mcp.json" in line
+        )
+        project_root_line = next(
+            line
+            for line in out.splitlines()
+            if "<project-root>/.mcp.json" in line
+            and "<project-root>/.deepagents" not in line
+        )
+        project_subdir_line = next(
+            line
+            for line in out.splitlines()
+            if "<project-root>/.deepagents/.mcp.json" in line
+        )
+        assert "found" in user_line
+        assert "missing" in project_root_line
+        assert "missing" in project_subdir_line
 
 
 class TestAutoUpdateArg:

--- a/libs/code/tests/unit_tests/test_mcp_commands.py
+++ b/libs/code/tests/unit_tests/test_mcp_commands.py
@@ -243,7 +243,7 @@ class TestRunMCPLogin:
         assert exit_code == 1
         mock_login.assert_not_awaited()
         assert "Skipping untrusted project MCP config" in err
-        assert "pass --config <path> to use it explicitly" in err
+        assert "pass --mcp-config <path> to use it explicitly" in err
 
     async def test_user_level_config_is_trusted_without_approval(
         self,

--- a/libs/code/tests/unit_tests/test_mcp_login_service.py
+++ b/libs/code/tests/unit_tests/test_mcp_login_service.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 class TestResolveMcpConfigExplicit:
-    """Explicit `--config <path>` resolution path."""
+    """Explicit `--mcp-config <path>` resolution path."""
 
     def test_loads_valid_config_file(self, tmp_path: Path) -> None:
         """A valid explicit config returns a `ConfigResolution`."""
@@ -288,4 +288,4 @@ class TestFormatUntrustedProjectNotice:
         notice = format_untrusted_project_notice((a, b))
         assert str(a) in notice
         assert str(b) in notice
-        assert "pass --config <path> to use it explicitly" in notice
+        assert "pass --mcp-config <path> to use it explicitly" in notice


### PR DESCRIPTION
Lowers the bar for configuring MCP from the CLI outside the TUI. New users can discover where to put their config without grepping the codebase, and the flag name no longer differs between the top-level and the `mcp login` subcommand.

## Changes
- New `dcode mcp config` subcommand prints the three MCP discovery paths in precedence order with `[found]` / `[missing]` markers, so users can see where to drop their `.mcp.json` without reading source. `--help` on the top-level `--mcp-config` flag points at it.
- Renamed the `mcp login` subcommand flag from `--config` to `--mcp-config` (no backcompat alias). `dcode --mcp-config X mcp login slack` now falls through to the subcommand with a one-line stderr notice naming the path; explicit subcommand `--mcp-config` still wins. Previously the top-level form was rejected outright.
- Fixed a correctness bug in `run_mcp_config`: it used `Path.cwd()` while runtime discovery (`discover_mcp_configs`) walks up to the nearest `.git`. Running `mcp config` from a subdirectory printed paths under the subdir while the actual loader read from the repo root. Now reuses `_resolve_project_config_base`, matching runtime behavior.
- Updated stale `--config` references in `mcp_login_service` error messages and docstrings (`ConfigErrorKind.EXPLICIT_LOAD_FAILED`, `resolve_mcp_config`, `NO_CONFIG_FOUND` message, `format_untrusted_project_notice`) so user-facing guidance reflects the new flag name.