### PR TITLE
fix(code): distinguish LangSmith failure modes in `/trace`

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -4924,7 +4924,14 @@ class DeepAgentsApp(App):
         Args:
             command: The raw command text (displayed as user message).
         """
-        from deepagents_code.config import build_langsmith_thread_url
+        from deepagents_code.config import (
+            LangSmithApiError,
+            LangSmithImportError,
+            LangSmithLookupTimeoutError,
+            _assemble_langsmith_thread_url,
+            fetch_langsmith_project_url_or_raise,
+            get_langsmith_project_name,
+        )
 
         if not self._session_state:
             await self._mount_message(UserMessage(command))
@@ -4932,15 +4939,18 @@ class DeepAgentsApp(App):
             return
         thread_id = self._session_state.thread_id
         try:
-            url = await asyncio.to_thread(build_langsmith_thread_url, thread_id)
+            project_name = await asyncio.to_thread(get_langsmith_project_name)
         except Exception:
-            logger.exception("Failed to build LangSmith thread URL for %s", thread_id)
+            logger.exception(
+                "Failed to resolve LangSmith project name for thread %s",
+                thread_id,
+            )
             await self._mount_message(UserMessage(command))
             await self._mount_message(
-                AppMessage("Failed to resolve LangSmith thread URL."),
+                AppMessage("Failed to resolve LangSmith project name."),
             )
             return
-        if not url:
+        if not project_name:
             await self._mount_message(UserMessage(command))
             await self._mount_message(
                 AppMessage(
@@ -4949,6 +4959,61 @@ class DeepAgentsApp(App):
                 ),
             )
             return
+        try:
+            project_url = await asyncio.to_thread(
+                fetch_langsmith_project_url_or_raise, project_name
+            )
+        except LangSmithImportError:
+            logger.warning(
+                "langsmith package not installed; cannot resolve thread URL for %s",
+                thread_id,
+            )
+            await self._mount_message(UserMessage(command))
+            await self._mount_message(
+                AppMessage(
+                    "The `langsmith` package is not installed. "
+                    "Install it with `pip install langsmith` to enable `/trace`.",
+                ),
+            )
+            return
+        except LangSmithLookupTimeoutError:
+            logger.warning(
+                "LangSmith project URL lookup timed out for thread %s",
+                thread_id,
+            )
+            await self._mount_message(UserMessage(command))
+            await self._mount_message(
+                AppMessage(
+                    "Could not reach LangSmith to resolve the thread URL. "
+                    "Check your network connection and try again.",
+                ),
+            )
+            return
+        except LangSmithApiError as exc:
+            logger.warning(
+                "LangSmith API call failed while resolving thread URL for %s: %s",
+                thread_id,
+                exc,
+            )
+            await self._mount_message(UserMessage(command))
+            await self._mount_message(
+                AppMessage(
+                    f"LangSmith rejected the project lookup: {exc}. "
+                    "Verify LANGSMITH_API_KEY and the project name are correct.",
+                ),
+            )
+            return
+        except Exception:
+            logger.exception(
+                "Failed to fetch LangSmith project URL for thread %s",
+                thread_id,
+            )
+            await self._mount_message(UserMessage(command))
+            await self._mount_message(
+                AppMessage("Failed to resolve LangSmith thread URL."),
+            )
+            return
+        url = _assemble_langsmith_thread_url(project_url, thread_id)
 
         def _open_browser() -> None:
             try:

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -1896,8 +1896,47 @@ def get_langsmith_project_name() -> str | None:
     )
 
 
-def fetch_langsmith_project_url(project_name: str) -> str | None:
-    """Fetch the LangSmith project URL via the LangSmith client.
+class LangSmithLookupError(Exception):
+    """Base class for typed LangSmith project URL lookup failures.
+
+    Concrete subclasses (`LangSmithImportError`, `LangSmithLookupTimeoutError`,
+    `LangSmithApiError`) let interactive callers like `/trace` show the user
+    the actual cause instead of collapsing every failure into a generic
+    "could not reach LangSmith" message.
+    """
+
+
+class LangSmithImportError(LangSmithLookupError):
+    """The `langsmith` package is not installed."""
+
+
+class LangSmithLookupTimeoutError(LangSmithLookupError):
+    """The LangSmith project URL lookup exceeded its hard timeout."""
+
+
+class LangSmithApiError(LangSmithLookupError):
+    """The LangSmith SDK call raised — auth, 404, network, etc.
+
+    Wraps the underlying SDK exception in `__cause__`.
+    """
+
+
+def _assemble_langsmith_thread_url(project_url: str, thread_id: str) -> str:
+    """Format a LangSmith thread URL from a project URL prefix.
+
+    Args:
+        project_url: Project URL prefix from `fetch_langsmith_project_url`
+            (e.g. `https://smith.langchain.com/o/<org>/projects/p/<proj>`).
+        thread_id: Thread identifier to append.
+
+    Returns:
+        Full thread URL with the `deepagents-code` utm tag.
+    """
+    return f"{project_url.rstrip('/')}/t/{thread_id}?utm_source=deepagents-code"
+
+
+def fetch_langsmith_project_url_or_raise(project_name: str) -> str:
+    """Fetch the LangSmith project URL, raising on any failure.
 
     Successful results are cached at module level so repeated calls do not
     make additional network requests.
@@ -1906,15 +1945,17 @@ def fetch_langsmith_project_url(project_name: str) -> str | None:
     `_LANGSMITH_URL_LOOKUP_TIMEOUT_SECONDS`, so this function blocks the
     calling thread for at most that duration even if LangSmith is unreachable.
 
-    Returns None (with a debug log) on any failure: missing `langsmith` package,
-    network errors, invalid project names, client initialization issues,
-    or timeouts.
-
     Args:
         project_name: LangSmith project name to look up.
 
     Returns:
-        Project URL string if found, None otherwise.
+        Project URL string.
+
+    Raises:
+        LangSmithImportError: `langsmith` is not installed.
+        LangSmithLookupTimeoutError: lookup exceeded the hard timeout.
+        LangSmithApiError: the SDK call raised (auth, 404, network, etc.);
+            wraps the original exception in `__cause__`.
     """
     global _langsmith_url_cache  # noqa: PLW0603  # Module-level cache requires global statement
 
@@ -1926,13 +1967,14 @@ def fetch_langsmith_project_url(project_name: str) -> str | None:
 
     try:
         from langsmith import Client
-    except ImportError:
+    except ImportError as exc:
         logger.debug(
-            "Could not fetch LangSmith project URL for '%s'",
+            "langsmith package not installed; cannot fetch project URL for '%s'",
             project_name,
             exc_info=True,
         )
-        return None
+        msg = "langsmith package is not installed"
+        raise LangSmithImportError(msg) from exc
 
     result: str | None = None
     lookup_error: Exception | None = None
@@ -1964,7 +2006,11 @@ def fetch_langsmith_project_url(project_name: str) -> str | None:
             project_name,
             _LANGSMITH_URL_LOOKUP_TIMEOUT_SECONDS,
         )
-        return None
+        msg = (
+            f"LangSmith project URL lookup timed out after "
+            f"{_LANGSMITH_URL_LOOKUP_TIMEOUT_SECONDS:.1f}s"
+        )
+        raise LangSmithLookupTimeoutError(msg)
 
     if lookup_error is not None:
         logger.debug(
@@ -1976,11 +2022,36 @@ def fetch_langsmith_project_url(project_name: str) -> str | None:
                 lookup_error.__traceback__,
             ),
         )
-        return None
+        msg = str(lookup_error) or repr(lookup_error)
+        raise LangSmithApiError(msg) from lookup_error
 
-    if result is not None:
-        _langsmith_url_cache = (project_name, result)
+    if not result:
+        # SDK returned a project with an empty URL — treat as an API anomaly.
+        msg = f"LangSmith returned no URL for project '{project_name}'"
+        raise LangSmithApiError(msg)
+
+    _langsmith_url_cache = (project_name, result)
     return result
+
+
+def fetch_langsmith_project_url(project_name: str) -> str | None:
+    """Fetch the LangSmith project URL, returning None on any failure.
+
+    Thin back-compat wrapper around `fetch_langsmith_project_url_or_raise`
+    for passive callers (status banners, non-interactive output) that just
+    want a URL-or-nothing answer. Interactive callers that need to tell the
+    user *why* the lookup failed should use the raising variant directly.
+
+    Args:
+        project_name: LangSmith project name to look up.
+
+    Returns:
+        Project URL string if found, None otherwise.
+    """
+    try:
+        return fetch_langsmith_project_url_or_raise(project_name)
+    except LangSmithLookupError:
+        return None
 
 
 def build_langsmith_thread_url(thread_id: str) -> str | None:
@@ -2004,7 +2075,7 @@ def build_langsmith_thread_url(thread_id: str) -> str | None:
     if not project_url:
         return None
 
-    return f"{project_url.rstrip('/')}/t/{thread_id}?utm_source=deepagents-code"
+    return _assemble_langsmith_thread_url(project_url, thread_id)
 
 
 def reset_langsmith_url_cache() -> None:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -2489,22 +2489,26 @@ class TestTraceCommand:
 
             with (
                 patch(
-                    "deepagents_code.config.build_langsmith_thread_url",
-                    return_value="https://smith.langchain.com/o/org/projects/p/proj/t/test-thread-123",
+                    "deepagents_code.config.get_langsmith_project_name",
+                    return_value="proj",
+                ),
+                patch(
+                    "deepagents_code.config.fetch_langsmith_project_url_or_raise",
+                    return_value="https://smith.langchain.com/o/org/projects/p/proj",
                 ),
                 patch("deepagents_code.app.webbrowser.open") as mock_open,
             ):
                 await app._handle_trace_command("/trace")
                 await pilot.pause()
 
-            mock_open.assert_called_once_with(
-                "https://smith.langchain.com/o/org/projects/p/proj/t/test-thread-123"
+            expected_url = (
+                "https://smith.langchain.com/o/org/projects/p/proj"
+                "/t/test-thread-123?utm_source=deepagents-code"
             )
+            mock_open.assert_called_once_with(expected_url)
             app_msgs = app.query(AppMessage)
             assert any(  # not a URL check—just verifying the link was rendered
-                "https://smith.langchain.com/o/org/projects/p/proj/t/test-thread-123"
-                in str(w._content)
-                for w in app_msgs
+                expected_url in str(w._content) for w in app_msgs
             )
 
     async def test_trace_shows_error_when_not_configured(self) -> None:
@@ -2515,7 +2519,7 @@ class TestTraceCommand:
             app._session_state = TextualSessionState()
 
             with patch(
-                "deepagents_code.config.build_langsmith_thread_url",
+                "deepagents_code.config.get_langsmith_project_name",
                 return_value=None,
             ):
                 await app._handle_trace_command("/trace")
@@ -2523,6 +2527,113 @@ class TestTraceCommand:
 
             app_msgs = app.query(AppMessage)
             assert any("LANGSMITH_API_KEY" in str(w._content) for w in app_msgs)
+
+    async def test_trace_shows_network_error_when_url_fetch_times_out(self) -> None:
+        """Should distinguish a network/timeout failure from a config gap.
+
+        When tracing is configured (project name resolves) but the URL fetch
+        raises `LangSmithLookupTimeoutError` (network unreachable, slow API),
+        the user should see a network-flavored error rather than the misleading
+        "not configured" message.
+        """
+        from deepagents_code.config import LangSmithLookupTimeoutError
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._session_state = TextualSessionState(thread_id="test-thread-123")
+
+            with (
+                patch(
+                    "deepagents_code.config.get_langsmith_project_name",
+                    return_value="proj",
+                ),
+                patch(
+                    "deepagents_code.config.fetch_langsmith_project_url_or_raise",
+                    side_effect=LangSmithLookupTimeoutError("timed out"),
+                ),
+            ):
+                await app._handle_trace_command("/trace")
+                await pilot.pause()
+
+            app_msgs = app.query(AppMessage)
+            rendered = " ".join(str(w._content) for w in app_msgs)
+            assert "Check your network" in rendered
+            assert "LANGSMITH_API_KEY" not in rendered
+
+    async def test_trace_shows_import_error_when_langsmith_missing(self) -> None:
+        """Should tell the user to install `langsmith` when import fails."""
+        from deepagents_code.config import LangSmithImportError
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._session_state = TextualSessionState(thread_id="test-thread-123")
+
+            with (
+                patch(
+                    "deepagents_code.config.get_langsmith_project_name",
+                    return_value="proj",
+                ),
+                patch(
+                    "deepagents_code.config.fetch_langsmith_project_url_or_raise",
+                    side_effect=LangSmithImportError("not installed"),
+                ),
+            ):
+                await app._handle_trace_command("/trace")
+                await pilot.pause()
+
+            app_msgs = app.query(AppMessage)
+            rendered = " ".join(str(w._content) for w in app_msgs)
+            assert "langsmith" in rendered.lower()
+            assert "install" in rendered.lower()
+            assert "network" not in rendered.lower()
+
+    async def test_trace_shows_api_error_when_lookup_rejected(self) -> None:
+        """Should surface the SDK error (auth, 404) rather than blame network."""
+        from deepagents_code.config import LangSmithApiError
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._session_state = TextualSessionState(thread_id="test-thread-123")
+
+            with (
+                patch(
+                    "deepagents_code.config.get_langsmith_project_name",
+                    return_value="proj",
+                ),
+                patch(
+                    "deepagents_code.config.fetch_langsmith_project_url_or_raise",
+                    side_effect=LangSmithApiError("401 Unauthorized"),
+                ),
+            ):
+                await app._handle_trace_command("/trace")
+                await pilot.pause()
+
+            app_msgs = app.query(AppMessage)
+            rendered = " ".join(str(w._content) for w in app_msgs)
+            assert "401 Unauthorized" in rendered
+            assert "LANGSMITH_API_KEY" in rendered
+            assert "Check your network" not in rendered
+
+    async def test_trace_shows_error_when_project_name_raises(self) -> None:
+        """Should surface a friendly error if `get_langsmith_project_name` raises."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._session_state = TextualSessionState(thread_id="test-thread-123")
+
+            with patch(
+                "deepagents_code.config.get_langsmith_project_name",
+                side_effect=RuntimeError("env resolution failed"),
+            ):
+                await app._handle_trace_command("/trace")
+                await pilot.pause()
+
+            app_msgs = app.query(AppMessage)
+            rendered = " ".join(str(w._content) for w in app_msgs)
+            assert "project name" in rendered.lower()
 
     async def test_trace_shows_error_when_no_session(self) -> None:
         """Should show error when there is no active session."""
@@ -2546,8 +2657,12 @@ class TestTraceCommand:
 
             with (
                 patch(
-                    "deepagents_code.config.build_langsmith_thread_url",
-                    return_value="https://smith.langchain.com/t/test-thread-123",
+                    "deepagents_code.config.get_langsmith_project_name",
+                    return_value="proj",
+                ),
+                patch(
+                    "deepagents_code.config.fetch_langsmith_project_url_or_raise",
+                    return_value="https://smith.langchain.com",
                 ),
                 patch(
                     "deepagents_code.app.webbrowser.open",
@@ -2583,8 +2698,12 @@ class TestTraceCommand:
 
             with (
                 patch(
-                    "deepagents_code.config.build_langsmith_thread_url",
-                    return_value="https://smith.langchain.com/t/test-thread-123",
+                    "deepagents_code.config.get_langsmith_project_name",
+                    return_value="proj",
+                ),
+                patch(
+                    "deepagents_code.config.fetch_langsmith_project_url_or_raise",
+                    return_value="https://smith.langchain.com",
                 ),
                 patch("deepagents_code.app.webbrowser.open"),
             ):
@@ -2613,15 +2732,21 @@ class TestTraceCommand:
             )
 
     async def test_trace_shows_error_when_url_build_raises(self) -> None:
-        """Should show error message when build_langsmith_thread_url raises."""
+        """Should show error message when the URL fetch raises."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
             app._session_state = TextualSessionState(thread_id="test-thread-123")
 
-            with patch(
-                "deepagents_code.config.build_langsmith_thread_url",
-                side_effect=RuntimeError("SDK error"),
+            with (
+                patch(
+                    "deepagents_code.config.get_langsmith_project_name",
+                    return_value="proj",
+                ),
+                patch(
+                    "deepagents_code.config.fetch_langsmith_project_url_or_raise",
+                    side_effect=RuntimeError("SDK error"),
+                ),
             ):
                 await app._handle_trace_command("/trace")
                 await pilot.pause()


### PR DESCRIPTION
`/trace` previously collapsed every LangSmith URL-lookup failure into a single "tracing is not configured" message, including the common case of a configured user with no network at thread startup. The lookup now raises typed exceptions so the slash command can report the actual cause and tell the user how to fix it.