### PR TITLE
fix(code): chat input history navigation and newline scrolling

### DIFF
--- a/libs/code/deepagents_code/widgets/chat_input.py
+++ b/libs/code/deepagents_code/widgets/chat_input.py
@@ -362,16 +362,6 @@ class ChatTextArea(TextArea):
     the counter.
     """
 
-    _in_history: bool
-    """Persistent flag that stays `True` while the user is browsing history.
-
-    Relaxes cursor-boundary checks so Up/Down work from either end of
-    the text.
-
-    Reset to `False` when navigating past the newest entry, submitting,
-    or clearing.
-    """
-
     class Submitted(Message):
         """Message sent when text is submitted."""
 
@@ -416,7 +406,6 @@ class ChatTextArea(TextArea):
         kwargs.pop("placeholder", None)
         super().__init__(**kwargs)
         self._skip_history_change_events = 0
-        self._in_history = False
         self._completion_active = False
         # Buffer quote-prefixed high-frequency key bursts from terminals that
         # emulate paste via rapid key events instead of dispatching a paste
@@ -594,6 +583,54 @@ class ChatTextArea(TextArea):
     def action_insert_newline(self) -> None:
         """Insert a newline character."""
         self.insert("\n")
+        # TextArea's built-in cursor-visible scroll runs before the widget
+        # reflows for the new row, so it sees stale dimensions and is a no-op
+        # when the cursor would land below `max-height`. Re-issue after
+        # refresh so it stays in view.
+        self.call_after_refresh(self.scroll_cursor_visible)
+
+    def _cursor_at_visual_top(self) -> bool:
+        """Return whether the cursor cannot move up further."""
+        try:
+            return self.get_cursor_up_location() == self.cursor_location
+        except ValueError:
+            # `WrappedDocument.location_to_offset` can raise during a brief
+            # text/cursor desync window (see `scroll_cursor_visible` guard).
+            # Treat as "not at top" so TextArea moves the cursor instead of
+            # firing history navigation on a transient state.
+            return False
+
+    def _cursor_at_visual_bottom(self) -> bool:
+        """Return whether the cursor cannot move down further."""
+        try:
+            return self.get_cursor_down_location() == self.cursor_location
+        except ValueError:
+            return False
+
+    def action_cursor_up(self, select: bool = False) -> None:
+        """Move cursor up, or navigate to the previous history entry at top.
+
+        When `select` is true or a selection is active, falls through to
+        TextArea's default so shift+up extends selection rather than
+        triggering navigation. History fires only when moving up cannot
+        advance the cursor — handled via the wrapped-document navigator so
+        soft-wrap is respected.
+        """
+        if not select and self.selection.is_empty and self._cursor_at_visual_top():
+            self.post_message(self.HistoryPrevious(self.text))
+            return
+        super().action_cursor_up(select)
+
+    def action_cursor_down(self, select: bool = False) -> None:
+        """Move cursor down, or navigate to the next history entry at bottom.
+
+        Mirrors `action_cursor_up`: defers to TextArea on selection or when
+        the cursor still has somewhere to move; otherwise fires history.
+        """
+        if not select and self.selection.is_empty and self._cursor_at_visual_bottom():
+            self.post_message(self.HistoryNext())
+            return
+        super().action_cursor_down(select)
 
     def _cancel_paste_burst_timer(self) -> None:
         """Cancel any scheduled paste-burst flush timer."""
@@ -757,7 +794,7 @@ class ChatTextArea(TextArea):
             if self._delete_preceding_backslash():
                 event.prevent_default()
                 event.stop()
-                self.insert("\n")
+                self.action_insert_newline()
                 return
         self._backslash_pending_time = None
 
@@ -768,7 +805,7 @@ class ChatTextArea(TextArea):
         if event.key in self._NEWLINE_KEYS:
             event.prevent_default()
             event.stop()
-            self.insert("\n")
+            self.action_insert_newline()
             return
 
         if event.key == "backspace" and self._delete_image_placeholder(backwards=True):
@@ -807,30 +844,6 @@ class ChatTextArea(TextArea):
             if value:
                 self.post_message(self.Submitted(value))
             return
-
-        # Up/Down arrow: only navigate history at input boundaries.
-        # Up requires cursor at position (0, 0); Down requires cursor at
-        # the very end.  When already browsing history, either boundary
-        # allows navigation in both directions.
-        if event.key in {"up", "down"}:
-            row, col = self.cursor_location
-            text = self.text
-            lines = text.split("\n")
-            last_row = len(lines) - 1
-            at_start = row == 0 and col == 0
-            at_end = row == last_row and col == len(lines[last_row])
-            navigate = (
-                event.key == "up" and (at_start or (self._in_history and at_end))
-            ) or (event.key == "down" and (at_end or (self._in_history and at_start)))
-
-            if navigate:
-                event.prevent_default()
-                event.stop()
-                if event.key == "up":
-                    self.post_message(self.HistoryPrevious(self.text))
-                else:
-                    self.post_message(self.HistoryNext())
-                return
 
         await super()._on_key(event)
 
@@ -913,23 +926,33 @@ class ChatTextArea(TextArea):
         event.stop()
         self.post_message(self.PastedPaths(event.text, parsed.paths))
 
-    def set_text_from_history(self, text: str) -> None:
-        """Set text from history navigation."""
+    def set_text_from_history(self, text: str, *, cursor_at_end: bool = True) -> None:
+        """Set text from history navigation.
+
+        Args:
+            text: The history entry text to load.
+            cursor_at_end: Place the cursor at the end of the loaded text
+                (use for down-navigation, so the next down press continues
+                forward through history). When `False`, place at the start
+                so the next up press continues backward. Defaults to `True`
+                to preserve historical cursor-at-end behavior for callers
+                that don't specify a direction.
+        """
         self._paste_burst_buffer = ""
         self._paste_burst_last_char_time = None
         self._cancel_paste_burst_timer()
         self._backslash_pending_time = None
         self._skip_history_change_events += 1
         self.text = text
-        # Move cursor to end
-        lines = text.split("\n")
-        last_row = len(lines) - 1
-        last_col = len(lines[last_row])
-        self.move_cursor((last_row, last_col))
+        if cursor_at_end:
+            lines = text.split("\n")
+            last_row = len(lines) - 1
+            self.move_cursor((last_row, len(lines[last_row])))
+        else:
+            self.move_cursor((0, 0))
 
     def clear_text(self) -> None:
         """Clear the text area."""
-        self._in_history = False
         # Increment (not reset) so any pending Changed event from a prior
         # set_text_from_history is still suppressed, plus one for the
         # self.text = "" assignment below.
@@ -1612,12 +1635,13 @@ class ChatInput(Vertical):
         if entry is not None and self._text_area:
             mode, display_text = self._history_entry_mode_and_text(entry)
             self.mode = mode
-            self._text_area.set_text_from_history(display_text)
-        # No-match path: don't reset the counter — a pending Changed event
-        # from a prior set_text_from_history call may still be in flight.
-        # Keep text area's _in_history in sync with the history manager.
-        if self._text_area:
-            self._text_area._in_history = self._history.in_history
+            # Cursor at top so pressing up again continues backward through
+            # history without the user having to navigate to the first row.
+            self._text_area.set_text_from_history(display_text, cursor_at_end=False)
+        else:
+            # No matching older entry — surface the boundary so the user
+            # doesn't think their keypress was lost.
+            self.app.bell()
 
     def on_chat_text_area_history_next(
         self,
@@ -1628,14 +1652,11 @@ class ChatInput(Vertical):
         if entry is not None and self._text_area:
             mode, display_text = self._history_entry_mode_and_text(entry)
             self.mode = mode
-            self._text_area.set_text_from_history(display_text)
-        # No-match path: don't reset the counter — a pending Changed event
-        # from a prior set_text_from_history call may still be in flight.
-        # Keep text area's _in_history in sync with the history manager.
-        # When the user presses Down past the newest entry, get_next()
-        # resets navigation internally, so in_history becomes False.
-        if self._text_area:
-            self._text_area._in_history = self._history.in_history
+            # Cursor at end so pressing down again continues forward through
+            # history.
+            self._text_area.set_text_from_history(display_text, cursor_at_end=True)
+        else:
+            self.app.bell()
 
     def on_chat_text_area_pasted_paths(self, event: ChatTextArea.PastedPaths) -> None:
         """Handle paste payloads that resolve to dropped file paths."""

--- a/libs/code/tests/unit_tests/test_chat_input.py
+++ b/libs/code/tests/unit_tests/test_chat_input.py
@@ -490,8 +490,8 @@ class TestHistoryNavigationFlag:
             assert text_area is not None
 
             # Call set_text_from_history twice without letting events process
-            text_area.set_text_from_history("first")
-            text_area.set_text_from_history("second")
+            text_area.set_text_from_history("first", cursor_at_end=False)
+            text_area.set_text_from_history("second", cursor_at_end=False)
             assert text_area._skip_history_change_events == 2
 
             # Let both Changed events fire and drain the counter
@@ -539,27 +539,33 @@ class TestHistoryNavigationFlag:
 class TestHistoryBoundaryNavigation:
     """Test that history navigation only triggers at input boundaries."""
 
-    async def test_up_arrow_only_triggers_at_cursor_start(self) -> None:
-        """Up arrow should only navigate history when cursor is at (0, 0)."""
+    async def test_up_at_end_of_single_line_snaps_cursor_first(self) -> None:
+        """Up at end of single-line typed input snaps cursor to start, no history."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
             assert chat._text_area is not None
 
-            chat._history._entries.append("previous entry")
+            # Entry must contain "hello" — substring-filtered history.
+            chat._history._entries.append("say hello world")
 
-            # Type some text — cursor ends up at the end
             chat._text_area.insert("hello")
             await pilot.pause()
             assert chat._text_area.cursor_location == (0, 5)
 
-            # Up arrow should NOT trigger history (cursor not at start)
+            # First up moves the cursor to (0, 0) — there is no row above.
             await pilot.press("up")
             await pilot.pause()
             assert chat._text_area.text == "hello"
+            assert chat._text_area.cursor_location == (0, 0)
 
-    async def test_up_arrow_triggers_at_cursor_zero(self) -> None:
-        """Up arrow should navigate history when cursor is at (0, 0)."""
+            # Second up has no further cursor movement available, so history.
+            await pilot.press("up")
+            await pilot.pause()
+            assert chat._text_area.text == "say hello world"
+
+    async def test_up_at_cursor_zero_navigates_history(self) -> None:
+        """Up at (0, 0) goes straight to history."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
@@ -567,42 +573,17 @@ class TestHistoryBoundaryNavigation:
 
             chat._history._entries.append("say hello world")
 
-            # Type text then move cursor to start
             chat._text_area.insert("hello")
             await pilot.pause()
             chat._text_area.move_cursor((0, 0))
             await pilot.pause()
 
-            # Up arrow should trigger history (cursor at start)
             await pilot.press("up")
             await pilot.pause()
             assert chat._text_area.text == "say hello world"
 
-    async def test_down_arrow_navigates_from_start_when_in_history(self) -> None:
-        """Down arrow at start navigates history when `_in_history` is True."""
-        app = _ChatInputTestApp()
-        async with app.run_test() as pilot:
-            chat = app.query_one(ChatInput)
-            assert chat._text_area is not None
-
-            chat._history._entries.extend(["first", "second"])
-
-            # Navigate into history first (cursor at start on empty)
-            await pilot.press("up")
-            await pilot.pause()
-            assert chat._text_area.text == "second"
-
-            # Move cursor to start — still a boundary
-            chat._text_area.move_cursor((0, 0))
-            await pilot.pause()
-
-            # _in_history is True so down at start (boundary) still navigates
-            await pilot.press("down")
-            await pilot.pause()
-            assert chat._text_area.text == ""
-
-    async def test_down_arrow_does_not_trigger_at_non_end(self) -> None:
-        """Down arrow should not navigate history when cursor is not at end."""
+    async def test_down_at_non_end_moves_cursor_not_history(self) -> None:
+        """Down with a row below moves the cursor, not history."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
@@ -610,43 +591,18 @@ class TestHistoryBoundaryNavigation:
 
             chat._history._entries.append("previous entry")
 
-            # Type text — cursor ends up at the end
-            chat._text_area.insert("hello world")
+            chat._text_area.text = "line one\nline two"
+            chat._text_area.move_cursor((0, 3))
             await pilot.pause()
 
-            # Move cursor to middle (not at end)
-            chat._text_area.move_cursor((0, 5))
-            await pilot.pause()
-
-            # Down arrow should NOT trigger history
             await pilot.press("down")
             await pilot.pause()
-            assert chat._text_area.text == "hello world"
+            assert chat._text_area.text == "line one\nline two"
+            cursor_row, _ = chat._text_area.cursor_location
+            assert cursor_row == 1
 
-    async def test_down_arrow_at_end_triggers_history(self) -> None:
-        """Down arrow at end of text should navigate history forward."""
-        app = _ChatInputTestApp()
-        async with app.run_test() as pilot:
-            chat = app.query_one(ChatInput)
-            assert chat._text_area is not None
-
-            chat._history._entries.extend(["first", "second"])
-
-            # Navigate up twice into history
-            await pilot.press("up")
-            await pilot.pause()
-            await pilot.press("up")
-            await pilot.pause()
-            assert chat._text_area.text == "first"
-
-            # Cursor should be at end after set_text_from_history
-            # Down arrow at end should navigate forward
-            await pilot.press("down")
-            await pilot.pause()
-            assert chat._text_area.text == "second"
-
-    async def test_up_at_middle_of_multiline_does_not_trigger(self) -> None:
-        """Up arrow on a middle line should not navigate history."""
+    async def test_up_in_middle_of_multiline_moves_cursor(self) -> None:
+        """Up from a middle row moves the cursor, not history."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
@@ -654,57 +610,95 @@ class TestHistoryBoundaryNavigation:
 
             chat._history._entries.append("previous entry")
 
-            # Insert multiline text and place cursor on line 1
             chat._text_area.text = "line one\nline two\nline three"
-            await pilot.pause()
             chat._text_area.move_cursor((1, 3))
             await pilot.pause()
 
-            # Up arrow should move cursor, not navigate history
             await pilot.press("up")
             await pilot.pause()
             assert chat._text_area.text == "line one\nline two\nline three"
+            cursor_row, _ = chat._text_area.cursor_location
+            assert cursor_row == 0
 
-    async def test_in_history_allows_up_from_end(self) -> None:
-        """When browsing history, up arrow at end should also navigate."""
+    async def test_up_load_places_cursor_at_top(self) -> None:
+        """A history entry loaded via up has cursor at (0, 0).
+
+        This is what enables continuous up-navigation: the next up press
+        immediately triggers another history previous without snapping the
+        cursor first.
+        """
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
             assert chat._text_area is not None
 
-            chat._history._entries.extend(["first", "second"])
+            chat._history._entries.append("line one\nline two")
 
-            # Navigate into history
             await pilot.press("up")
             await pilot.pause()
-            assert chat._text_area.text == "second"
-            assert chat._text_area._in_history is True
+            assert chat._text_area.text == "line one\nline two"
+            assert chat._text_area.cursor_location == (0, 0)
 
-            # Cursor is at end after set_text_from_history; up should
-            # still navigate because _in_history is True and at boundary
-            await pilot.press("up")
-            await pilot.pause()
-            assert chat._text_area.text == "first"
-
-    async def test_in_history_resets_after_submission(self) -> None:
-        """Submitting should clear the _in_history flag."""
-        app = _RecordingApp()
+    async def test_continuous_up_navigates_through_history(self) -> None:
+        """Repeated up presses walk back through history without manual cursor moves."""
+        app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
             assert chat._text_area is not None
 
-            chat._history._entries.append("recalled entry")
+            chat._history._entries.extend(
+                ["oldest", "middle entry\nwith two lines", "newest"]
+            )
 
             await pilot.press("up")
             await pilot.pause()
-            assert chat._text_area._in_history is True
+            assert chat._text_area.text == "newest"
 
-            await pilot.press("enter")
+            await pilot.press("up")
             await pilot.pause()
-            assert chat._text_area._in_history is False
+            assert chat._text_area.text == "middle entry\nwith two lines"
 
-    async def test_in_history_resets_after_navigating_past_end(self) -> None:
-        """Pressing down past history end should set `_in_history` to False."""
+            await pilot.press("up")
+            await pilot.pause()
+            assert chat._text_area.text == "oldest"
+
+    async def test_continuous_down_navigates_forward_through_history(self) -> None:
+        """Repeated down presses walk forward through history.
+
+        After down-navigation, cursor lands at the end of the loaded entry,
+        so the next down press triggers another history next.
+        """
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._history._entries.extend(["oldest", "middle", "newest"])
+
+            # Walk up to the oldest entry.
+            for _ in range(3):
+                await pilot.press("up")
+                await pilot.pause()
+            assert chat._text_area.text == "oldest"
+            assert chat._text_area.cursor_location == (0, 0)
+
+            # Switching direction requires one snap-to-end press first.
+            await pilot.press("down")
+            await pilot.pause()
+            assert chat._text_area.text == "oldest"
+            assert chat._text_area.cursor_location == (0, len("oldest"))
+
+            # Subsequent down presses navigate forward continuously.
+            await pilot.press("down")
+            await pilot.pause()
+            assert chat._text_area.text == "middle"
+
+            await pilot.press("down")
+            await pilot.pause()
+            assert chat._text_area.text == "newest"
+
+    async def test_down_past_newest_restores_typed_input(self) -> None:
+        """Down past the newest history entry restores the user's typed input."""
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
@@ -712,17 +706,121 @@ class TestHistoryBoundaryNavigation:
 
             chat._history._entries.append("only entry")
 
-            # Navigate up into history
             await pilot.press("up")
             await pilot.pause()
             assert chat._text_area.text == "only entry"
-            assert chat._text_area._in_history is True
 
-            # Navigate down past the end — returns to original (empty) input
+            # Cursor at (0, 0) after up-load; need to move to end first.
+            chat._text_area.move_cursor((0, len("only entry")))
+            await pilot.pause()
+
             await pilot.press("down")
             await pilot.pause()
             assert chat._text_area.text == ""
-            assert chat._text_area._in_history is False
+
+    async def test_typed_newlines_up_from_end_walks_rows(self) -> None:
+        """Up from the end of multi-row typed input walks the cursor up rows."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._text_area.text = "abc\ndef\nghi"
+            chat._text_area.move_cursor((2, len("ghi")))
+            await pilot.pause()
+
+            for expected_row in (1, 0):
+                await pilot.press("up")
+                await pilot.pause()
+                assert chat._text_area.text == "abc\ndef\nghi"
+                cursor_row, _ = chat._text_area.cursor_location
+                assert cursor_row == expected_row
+
+            # Cursor is now at (0, 3); next up snaps to (0, 0).
+            await pilot.press("up")
+            await pilot.pause()
+            assert chat._text_area.text == "abc\ndef\nghi"
+            assert chat._text_area.cursor_location == (0, 0)
+
+    async def test_soft_wrapped_single_row_navigates_visual_lines(self) -> None:
+        """Up/down on a soft-wrapped single doc row walks visual lines.
+
+        A row-based history trigger (`row == 0`) would incorrectly fire on the
+        last visual line of a wrapped doc row. The cursor-cannot-move check
+        avoids that: visual lines below the top of the wrapped row still have
+        a "row above" in the wrapped document, so cursor movement wins.
+        """
+        app = _ChatInputTestApp()
+        # Constrain width so a long single-line entry wraps to several
+        # visual lines but stays on doc row 0.
+        async with app.run_test(size=(20, 24)) as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._history._entries.append("history entry")
+
+            long_line = "word " * 30  # ~150 chars, well past wrap width
+            chat._text_area.text = long_line.strip()
+            chat._text_area.move_cursor((0, len(chat._text_area.text)))
+            await pilot.pause()
+
+            # Cursor on the last visual line of doc row 0 — up should walk
+            # back through visual lines, not fire history.
+            await pilot.press("up")
+            await pilot.pause()
+            assert chat._text_area.text == long_line.strip()
+            # Cursor should still be on doc row 0 but at a smaller column
+            # corresponding to the previous visual line.
+            row, col = chat._text_area.cursor_location
+            assert row == 0
+            assert col < len(chat._text_area.text)
+
+    async def test_shift_up_at_top_extends_selection_not_history(self) -> None:
+        """`shift+up` at (0, 0) should not fire history navigation.
+
+        The action_cursor_up guard requires `not select`, so shift+up must
+        fall through to TextArea's selection-extending behavior even when
+        the cursor literally cannot move further up.
+        """
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._history._entries.append("older entry")
+
+            chat._text_area.text = "hello"
+            chat._text_area.move_cursor((0, 3))
+            await pilot.pause()
+
+            # shift+up at row 0 should not replace text with history.
+            await pilot.press("shift+up")
+            await pilot.pause()
+            assert chat._text_area.text == "hello"
+
+    async def test_up_with_unmatched_query_is_noop(self) -> None:
+        """Up at (0,0) with typed text that matches no history entry is a no-op.
+
+        `HistoryManager.get_previous` filters by substring; when typed text
+        doesn't appear in any entry, the load is skipped. The text area
+        should stay unchanged (and the bell on the handler is allowed to
+        ring as a boundary signal).
+        """
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat._history._entries.append("totally different entry")
+
+            chat._text_area.insert("abc")
+            chat._text_area.move_cursor((0, 0))
+            await pilot.pause()
+
+            await pilot.press("up")
+            await pilot.pause()
+            assert chat._text_area.text == "abc"
+            assert chat._text_area.cursor_location == (0, 0)
 
 
 class TestCompletionPopupClickBubbling:
@@ -2290,6 +2388,52 @@ class TestBackslashEnterNewline:
             assert "\n" in ta.text
             assert "\\" not in ta.text
             assert len(app.submitted) == 0
+
+    @pytest.mark.parametrize(
+        "newline_keys",
+        [
+            pytest.param(["shift+enter"], id="modifier_enter"),
+            pytest.param(["ctrl+j"], id="ctrl_j"),
+            pytest.param(["backslash", "enter"], id="vscode_backslash_fallback"),
+        ],
+    )
+    async def test_newline_past_max_height_scrolls_cursor_into_view(
+        self, monkeypatch: pytest.MonkeyPatch, newline_keys: list[str]
+    ) -> None:
+        """Every newline-insertion path keeps the cursor in view past max-height.
+
+        All three paths (binding, `_NEWLINE_KEYS` branch, and the
+        backslash+enter fallback for terminals that emulate shift+enter)
+        must route through `action_insert_newline`, where the
+        `call_after_refresh(scroll_cursor_visible)` keeps the cursor visible.
+        """
+        # Widen the backslash+enter gap so the fallback test isn't racy on CI.
+        monkeypatch.setattr(chat_input_module, "_BACKSLASH_ENTER_GAP_SECONDS", 60.0)
+
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            ta = chat._text_area
+            assert ta is not None
+
+            # Build a doc tall enough to overflow the widget's max height,
+            # then move the cursor to the last row.
+            ta.text = "\n".join(f"row {i}" for i in range(15))
+            ta.move_cursor((14, len("row 14")))
+            await pilot.pause()
+            assert ta.scroll_offset.y > 0
+
+            for key in newline_keys:
+                await pilot.press(key)
+            await pilot.pause()
+
+            cursor_row = ta.cursor_location[0]
+            assert cursor_row == 15
+            rel_y = cursor_row - ta.scroll_offset.y
+            assert 0 <= rel_y < ta.size.height, (
+                f"cursor row {cursor_row} not in viewport "
+                f"[{ta.scroll_offset.y}, {ta.scroll_offset.y + ta.size.height})"
+            )
 
     async def test_backslash_alone_inserts_normally(self) -> None:
         """A lone backslash should be inserted immediately as normal text."""


### PR DESCRIPTION
Two user-reported bugs in the chat input: shift+enter past `max-height` left the cursor below the viewport, and arrow keys traversed history instead of moving between lines of multi-line input. Fixing the latter also surfaced an opportunity to simplify the navigation logic considerably.

## Changes
- Newline insertion now keeps the cursor in view when content overflows `max-height` — every insertion site (binding action, `_NEWLINE_KEYS` branch in `_on_key`, VSCode backslash+enter fallback) routes through `action_insert_newline`, which schedules `scroll_cursor_visible` via `call_after_refresh` so the scroll runs against post-reflow dimensions.
- Up/down arrows now move the cursor between rows of multi-line input and trigger history only when the cursor literally cannot move further in that direction. Implemented as `action_cursor_up` / `action_cursor_down` overrides comparing against `get_cursor_up_location()` / `get_cursor_down_location()`, which respect soft-wrap (a row-based check would misfire on the top/bottom visual line of a wrapped doc row).
- Continuous history browsing: `set_text_from_history` places the cursor at `(0, 0)` after up-loads and at end after down-loads, so repeated up presses walk back through history without snapping the cursor between entries (and symmetric for down).
- Removed the `_in_history` flag on `ChatTextArea` — the old up/down boundary logic depended on it, but with the new cursor-can't-move check the flag has no readers. `HistoryManager.in_history` is unchanged and still drives query filtering.
- Empty-history boundaries now ring `app.bell()` instead of silently consuming the keypress.
- Navigator calls are wrapped in `ValueError` guards (matching the existing `scroll_cursor_visible` guard) to tolerate the cursor/document desync window that can briefly open after a history load.