### PR TITLE
fix(sdk): handle None base state in _messages_delta_reducer

### DIFF
--- a/libs/deepagents/deepagents/_messages_reducer.py
+++ b/libs/deepagents/deepagents/_messages_reducer.py
@@ -46,7 +46,12 @@ def _messages_delta_reducer(  # noqa: C901, PLR0912
     # Steady state: the reducer's own output is already typed BaseMessages,
     # so skip convert_to_messages on the fast path. Only raw input (initial
     # dicts, deserialized blobs) hits the slow path.
-    state_msgs = state if state and isinstance(state[0], BaseMessage) else cast("list[AnyMessage]", convert_to_messages(state))
+    if state is None:
+        state_msgs = []
+    elif state and isinstance(state[0], BaseMessage):
+        state_msgs = state
+    else:
+        state_msgs = cast("list[AnyMessage]", convert_to_messages(state))
     msgs = cast("list[AnyMessage]", convert_to_messages(flat))
 
     # REMOVE_ALL_MESSAGES resets everything; find the last sentinel and

--- a/libs/deepagents/tests/unit_tests/test_messages_reducer.py
+++ b/libs/deepagents/tests/unit_tests/test_messages_reducer.py
@@ -17,3 +17,12 @@ def test_idless_message_gets_id_and_order_preserved() -> None:
     assert result[0].id == "existing-1"
     assert result[1] is new_msg
     assert result[1].id is not None
+
+
+def test_none_state_does_not_crash() -> None:
+    """Regression test for #3564: None base state must not TypeError."""
+    result = _messages_delta_reducer(None, [[HumanMessage(content="hi")]])
+
+    assert len(result) == 1
+    assert result[0].content == "hi"
+    assert result[0].id is not None


### PR DESCRIPTION
Fixes #3564

When `DeltaChannel` replays writes for a thread whose earliest checkpoint did not seed `messages=[]`, the base state is `None` rather than `[]`. The existing one-liner guard:

```python
state_msgs = state if state and isinstance(state[0], BaseMessage) else cast(...)
```

short-circuits to `None` (since `None and ...` evaluates to `None`), then the `else` branch passes `None` into `convert_to_messages()`, which iterates its argument and raises `TypeError: 'NoneType' object is not iterable`.

**Fix:** Add an explicit `None` check before the existing fast-path guard, treating `None` as an empty list.

**Test:** Added a regression test that calls `_messages_delta_reducer(None, [[HumanMessage(...)]])` and verifies it returns the expected result without crashing.

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.