### PR TITLE
fix(sdk): handle None base state in _messages_delta_reducer (issue #3564)

### DIFF
--- a/libs/deepagents/deepagents/_messages_reducer.py
+++ b/libs/deepagents/deepagents/_messages_reducer.py
@@ -46,6 +46,7 @@ def _messages_delta_reducer(  # noqa: C901, PLR0912
     # Steady state: the reducer's own output is already typed BaseMessages,
     # so skip convert_to_messages on the fast path. Only raw input (initial
     # dicts, deserialized blobs) hits the slow path.
+    state = state or []
     state_msgs = state if state and isinstance(state[0], BaseMessage) else cast("list[AnyMessage]", convert_to_messages(state))
     msgs = cast("list[AnyMessage]", convert_to_messages(flat))
 


### PR DESCRIPTION
Closes #3564

---

`_messages_delta_reducer` crashes with `TypeError: 'NoneType' object is not iterable` when the channel base state is `None`. This surfaces on LangGraph Platform when calling `GET /threads/{id}/history` or `GET /threads/{id}/state` for threads whose earliest checkpoint did not seed `messages: []`.

The reducer receives `state=None` (the default for an empty `DeltaChannel`) and passes it to `convert_to_messages()`, which tries to iterate over `None`.

**Fix**: Normalize `None` state to `[]` before the existing `state_msgs` logic runs. This matches the behavior of `add_messages`, which also treats `None` as an empty list.