### PR TITLE
fix: handle None state in _message_delta_reducer (#3564)

### DIFF
--- a/libs/deepagents/deepagents/_messages_reducer.py
+++ b/libs/deepagents/deepagents/_messages_reducer.py
@@ -23,7 +23,7 @@ from langgraph.graph.message import REMOVE_ALL_MESSAGES
 
 
 def _messages_delta_reducer(  # noqa: C901, PLR0912
-    state: list[AnyMessage], writes: list[list[AnyMessage]]
+    state: list[AnyMessage] | None, writes: list[list[AnyMessage]]
 ) -> list[AnyMessage]:
     """Batch reducer for use with `DeltaChannel` on the messages key.
 
@@ -46,7 +46,10 @@ def _messages_delta_reducer(  # noqa: C901, PLR0912
     # Steady state: the reducer's own output is already typed BaseMessages,
     # so skip convert_to_messages on the fast path. Only raw input (initial
     # dicts, deserialized blobs) hits the slow path.
-    state_msgs = state if state and isinstance(state[0], BaseMessage) else cast("list[AnyMessage]", convert_to_messages(state))
+    if state is None:
+        state_msgs = []
+    else:
+        state_msgs = state if state and isinstance(state[0], BaseMessage) else cast("list[AnyMessage]", convert_to_messages(state))
     msgs = cast("list[AnyMessage]", convert_to_messages(flat))
 
     # REMOVE_ALL_MESSAGES resets everything; find the last sentinel and

--- a/libs/deepagents/tests/unit_tests/test_messages_reducer.py
+++ b/libs/deepagents/tests/unit_tests/test_messages_reducer.py
@@ -17,3 +17,13 @@ def test_idless_message_gets_id_and_order_preserved() -> None:
     assert result[0].id == "existing-1"
     assert result[1] is new_msg
     assert result[1].id is not None
+
+
+def test_state_is_none() -> None:
+    new_msg = HumanMessage(content="hello")
+
+    result = _messages_delta_reducer(None, [[new_msg]])
+
+    assert len(result) == 1
+    assert result[0] is new_msg
+    assert result[0].id is not None


### PR DESCRIPTION
**Description**
This PR fixes an issue where `_messages_delta_reducer` crashes with a `TypeError` when the channel base state is `None`. 

**Changes:**
- Updated the signature of `_messages_delta_reducer` to accept `state: list[AnyMessage] | None`.
- Added a safety check to initialize `state_msgs = []` if `state` is `None`, bypassing the invalid conversion call.
- Added a unit test (`test_state_is_none`) to ensure future protection against this regression.

Fixes #3564 

**Testing:**
- Local MRE verified.
- `pytest` unit tests pass.
- `ruff` linters and type checking pass.