### PR TITLE
fix(sdk): handle None state in _messages_delta_reducer (issue #3564)

### DIFF
--- a/libs/deepagents/deepagents/_messages_reducer.py
+++ b/libs/deepagents/deepagents/_messages_reducer.py
@@ -46,7 +46,7 @@ def _messages_delta_reducer(  # noqa: C901, PLR0912
     # Steady state: the reducer's own output is already typed BaseMessages,
     # so skip convert_to_messages on the fast path. Only raw input (initial
     # dicts, deserialized blobs) hits the slow path.
-    state_msgs = state if state and isinstance(state[0], BaseMessage) else cast("list[AnyMessage]", convert_to_messages(state))
+    state_msgs = state if state and isinstance(state[0], BaseMessage) else cast("list[AnyMessage]", convert_to_messages(state or []))
     msgs = cast("list[AnyMessage]", convert_to_messages(flat))
 
     # REMOVE_ALL_MESSAGES resets everything; find the last sentinel and


### PR DESCRIPTION
Closes #3564

---

The reducer's fast-path guard short-circuits when `state is None`:

```python
state_msgs = state if state and isinstance(state[0], BaseMessage) \
    else cast("list[AnyMessage]", convert_to_messages(state))
```

`None and ...` evaluates to `None`, so the `else` branch runs and passes
`None` into `convert_to_messages`, which iterates its argument and raises
`TypeError: 'NoneType' object is not iterable`.

`[]` works fine (`convert_to_messages([])` returns `[]`); only `None` crashes.

**Impact:** affected threads become permanently unreadable via `/state` and
`/history` on LangGraph Platform (the LangGraph API surfaces the crash as
HTTP 500). Thread metadata via `/threads/{id}` still works because it reads
the denormalized `values`, not the checkpointer channels.

**Fix:** pass `state or []` to `convert_to_messages` so that `None` is coerced
to an empty list rather than iterated directly.