### PR TITLE
feat(sdk): add regex support to the `grep` tool (closes #3547)

### DIFF
--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -237,8 +237,17 @@ class ContextHubBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        regex: bool = False,
     ) -> GrepResult:
-        """Search contents for `pattern` (optional `path` / `glob` filters)."""
+        """Search contents for ``pattern`` (optional ``path`` / ``glob`` filters).
+
+        Historically this backend always compiled the input as a regular
+        expression. The protocol default is now literal substring matching,
+        so callers that pass meta-characters (``.``, ``*``, etc.) get the
+        substring semantics they expect from the other backends. Pass
+        ``regex=True`` to restore the regex behavior.
+        """
         try:
             cache = self._ensure_cache()
         except LangSmithError as exc:
@@ -247,7 +256,7 @@ class ContextHubBackend(BackendProtocol):
         matches: list[GrepMatch] = []
 
         try:
-            regex = re.compile(pattern)
+            compiled = re.compile(pattern if regex else re.escape(pattern))
         except re.error as e:
             return GrepResult(error=f"Invalid regex pattern: {e}")
 
@@ -259,7 +268,7 @@ class ContextHubBackend(BackendProtocol):
             if glob and not fnmatch.fnmatch(file_path, glob):
                 continue
             for i, line in enumerate(content.splitlines(), start=1):
-                if regex.search(line):
+                if compiled.search(line):
                     matches.append(GrepMatch(path=f"/{file_path}", line=i, text=line))
 
         return GrepResult(matches=matches)

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -514,18 +514,27 @@ class FilesystemBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        regex: bool = False,
     ) -> GrepResult:
-        """Search for a literal text pattern in files.
+        """Search for a text pattern in files.
 
         Uses ripgrep if available, falling back to Python search.
 
         Args:
-            pattern: Literal string to search for (NOT regex).
+            pattern: String to search for. Literal substring by default;
+                pass ``regex=True`` to interpret as a regular expression.
             path: Directory or file path to search in. Defaults to current directory.
             glob: Optional glob pattern to filter which files to search.
+            regex: When True, ``pattern`` is passed to ripgrep without
+                ``-F`` and to the Python fallback without :func:`re.escape`,
+                so it is interpreted as a regular expression.
 
         Returns:
-            GrepResult with matches or error.
+            GrepResult with matches or error. When ``regex=True`` and the
+            pattern fails to compile in the Python fallback, the error is
+            surfaced via ``GrepResult.error`` (not raised) so tool callers
+            can relay it to the model.
         """
         # Resolve base path
         try:
@@ -543,11 +552,16 @@ class FilesystemBackend(BackendProtocol):
             search_path = path or "."
             return GrepResult(error=f"Error searching path '{search_path}': {e}", matches=[])
 
-        # Try ripgrep first (with -F flag for literal search)
-        results = self._ripgrep_search(pattern, base_full, glob)
+        # ripgrep happily accepts user regex; the `-F` flag is dropped for
+        # regex mode in `_ripgrep_search`. If ripgrep is unavailable the
+        # Python fallback compiles the pattern itself.
+        results = self._ripgrep_search(pattern, base_full, glob, regex=regex)
         if results is None:
-            # Python fallback needs escaped pattern for literal search
-            results = self._python_search(re.escape(pattern), base_full, glob)
+            try:
+                effective = pattern if regex else re.escape(pattern)
+                results = self._python_search(effective, base_full, glob)
+            except re.error as e:
+                return GrepResult(error=f"Invalid regex pattern: {e}", matches=[])
 
         matches: list[GrepMatch] = []
         for fpath, items in results.items():
@@ -555,13 +569,16 @@ class FilesystemBackend(BackendProtocol):
                 matches.append({"path": fpath, "line": int(line_num), "text": line_text})
         return GrepResult(matches=matches)
 
-    def _ripgrep_search(self, pattern: str, base_full: Path, include_glob: str | None) -> dict[str, list[tuple[int, str]]] | None:  # noqa: C901, PLR0912  # C901: split except clauses for per-clause logging; PLR0912: dir/file cwd branch + containment check
-        """Search using ripgrep with fixed-string (literal) mode.
+    def _ripgrep_search(self, pattern: str, base_full: Path, include_glob: str | None, *, regex: bool = False) -> dict[str, list[tuple[int, str]]] | None:  # noqa: C901, PLR0912  # C901: split except clauses for per-clause logging; PLR0912: dir/file cwd branch + containment check
+        """Search using ripgrep.
 
         Args:
-            pattern: Literal string to search for (unescaped).
+            pattern: String to search for. Literal by default; passed to
+                ripgrep without ``-F`` when ``regex=True``.
             base_full: Resolved base path to search in.
             include_glob: Optional glob pattern to filter files.
+            regex: When True, drops the ``-F`` flag so ripgrep interprets
+                ``pattern`` as a regular expression.
 
         Returns:
             Dict mapping file paths to list of `(line_number, line_text)` tuples.
@@ -569,7 +586,10 @@ class FilesystemBackend(BackendProtocol):
                 Results whose resolved path lies outside `base_full` are silently
                 filtered regardless of `virtual_mode`.
         """
-        cmd = ["rg", "--json", "-F"]  # -F enables fixed-string (literal) mode
+        # Literal mode (`-F`) is the default to keep existing behavior; regex
+        # mode drops that flag so the caller's pattern is treated as a
+        # regular expression by ripgrep.
+        cmd = ["rg", "--json"] if regex else ["rg", "--json", "-F"]
         if include_glob:
             cmd.extend(["--glob", include_glob])
         # When rg is given an absolute search path, directory-component

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -402,15 +402,19 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        regex: bool = False,
     ) -> "GrepResult":
-        """Search for a literal text pattern in files.
+        """Search for a text pattern in files.
 
         Args:
-            pattern: Literal string to search for (NOT regex).
+            pattern: String to search for. By default this is a literal
+                substring; pass `regex=True` to interpret it as a Python /
+                ripgrep regular expression.
 
-                Performs exact substring matching within file content.
-
-                Example: "TODO" matches any line containing "TODO"
+                Example (literal): `"TODO"` matches any line containing `TODO`.
+                Example (regex): `r"def (get|set)_\\w+"` matches any
+                getter/setter definition.
 
             path: Optional directory path to search in.
 
@@ -428,6 +432,13 @@ class BackendProtocol(abc.ABC):  # noqa: B024
                 - `**` matches any directories recursively
                 - `?` matches single character
                 - `[abc]` matches one character from set
+
+            regex: When True, treat ``pattern`` as a regular expression
+                rather than a literal substring. Backends that compile the
+                pattern (the Python fallback in :class:`FilesystemBackend`,
+                :func:`grep_matches_from_files`, etc.) return a
+                :class:`GrepResult` with ``error`` set when the pattern is
+                not a valid regex, instead of raising.
 
         Examples:
             - `'*.py'` - only search Python files
@@ -449,6 +460,19 @@ class BackendProtocol(abc.ABC):  # noqa: B024
                 message=("`grep_raw` is deprecated and will be removed in deepagents==0.7.0; rename to `grep` instead."),
                 package="deepagents",
             )
+            # Legacy `grep_raw` predates the regex flag; callers requesting
+            # regex on a backend that only implements `grep_raw` would get
+            # silently literal matches, so surface that as an explicit error
+            # rather than mis-routing the search.
+            if regex:
+                return GrepResult(
+                    error=(
+                        "Backend implements the legacy `grep_raw` API and does not "
+                        "support regex search. Upgrade the backend to `grep` or pass "
+                        "`regex=False`."
+                    ),
+                    matches=[],
+                )
             result = self.grep_raw(pattern, path, glob)
             if isinstance(result, str):
                 return GrepResult(error=result)
@@ -461,9 +485,11 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        regex: bool = False,
     ) -> "GrepResult":
         """Async version of `grep`."""
-        return await asyncio.to_thread(self.grep, pattern, path, glob)
+        return await asyncio.to_thread(self.grep, pattern, path, glob, regex=regex)
 
     def glob(self, pattern: str, path: str = "/") -> "GlobResult":
         """Find files matching a glob pattern.

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -761,24 +761,33 @@ except PermissionError:
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        regex: bool = False,
     ) -> GrepResult:
-        """Search file contents for a literal string using `grep -F`.
+        """Search file contents using sandbox ``grep``.
 
         Args:
-            pattern: Literal string to search for (not a regex).
+            pattern: String to search for. Literal by default; pass
+                ``regex=True`` to interpret as an extended regex (``grep -E``).
             path: Directory or file to search in.
 
                 Defaults to `"."`.
             glob: Optional file-name glob to restrict the search
                 (e.g. `'*.py'`).
+            regex: When True, swap ``-F`` (fixed-strings) for ``-E``
+                (extended regex). The pattern itself is still shell-quoted
+                so the sandbox shell cannot interpret it.
 
         Returns:
             `GrepResult` with a list of `GrepMatch` dicts, or `error` on failure.
         """
         search_path = shlex.quote(path or ".")
 
-        # Build grep command to get structured output
-        grep_opts = "-rHnF"  # recursive, with filename, with line number, fixed-strings (literal)
+        # Recursive, with filename, with line number. Mode flag swaps in
+        # last per `regex`: ``-F`` keeps literal-string semantics (default);
+        # ``-E`` switches to extended regex so the agent can use
+        # ``def (get|set)_\w+``-style patterns.
+        grep_opts = "-rHnE" if regex else "-rHnF"
 
         # Add glob pattern if specified
         glob_pattern = ""

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -295,10 +295,17 @@ class StateBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        regex: bool = False,
     ) -> GrepResult:
-        """Search state files for a literal text pattern."""
+        """Search state files for a text pattern.
+
+        When ``regex=True``, ``pattern`` is compiled as a regular expression
+        via :func:`grep_matches_from_files`; otherwise it falls back to
+        literal substring matching for backwards compatibility.
+        """
         files = self._read_files()
-        return grep_matches_from_files(files, pattern, path if path is not None else "/", glob)
+        return grep_matches_from_files(files, pattern, path if path is not None else "/", glob, regex=regex)
 
     def glob(self, pattern: str, path: str = "/") -> GlobResult:
         """Get FileInfo for files matching glob pattern."""

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -688,8 +688,15 @@ class StoreBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        regex: bool = False,
     ) -> GrepResult:
-        """Search store files for a literal text pattern."""
+        """Search store files for a text pattern.
+
+        Passes ``regex`` through to :func:`grep_matches_from_files`, which
+        compiles the pattern with :mod:`re` when ``regex=True`` and falls
+        back to literal substring matching otherwise.
+        """
         store = self._get_store()
         namespace = self._get_namespace()
         items = self._search_store_paginated(store, namespace)
@@ -699,7 +706,7 @@ class StoreBackend(BackendProtocol):
                 files[item.key] = self._convert_store_item_to_file_data(item)
             except ValueError:
                 continue
-        return grep_matches_from_files(files, pattern, path, glob)
+        return grep_matches_from_files(files, pattern, path, glob, regex=regex)
 
     def glob(self, pattern: str, path: str = "/") -> GlobResult:
         """Find files matching a glob pattern in the store."""

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -697,10 +697,21 @@ def grep_matches_from_files(
     pattern: str,
     path: str | None = None,
     glob: str | None = None,
+    *,
+    regex: bool = False,
 ) -> GrepResult:
     """Return structured grep matches from an in-memory files mapping.
 
-    Performs literal text search (not regex).
+    Args:
+        files: Mapping of file path -> file data.
+        pattern: Search pattern. Literal substring by default; Python
+            regular expression when ``regex=True``.
+        path: Optional path filter.
+        glob: Optional glob filter on file basename.
+        regex: When True, ``pattern`` is compiled with :mod:`re` and matched
+            via :py:meth:`re.Pattern.search` against each line. An invalid
+            pattern is surfaced as a :class:`GrepResult` with ``error`` set
+            (no raise) so tool contexts can pass it back to the model.
 
     Returns a GrepResult with matches on success.
     We deliberately do not raise here to keep backends non-throwing in tool
@@ -716,11 +727,21 @@ def grep_matches_from_files(
     if glob:
         filtered = {fp: fd for fp, fd in filtered.items() if wcglob.globmatch(Path(fp).name, glob, flags=wcglob.BRACE)}
 
+    compiled: re.Pattern[str] | None = None
+    if regex:
+        try:
+            compiled = re.compile(pattern)
+        except re.error as exc:
+            return GrepResult(error=f"Invalid regex pattern: {exc}", matches=[])
+
     matches: list[GrepMatch] = []
     for file_path, file_data in filtered.items():
         content_str = _normalize_content(file_data)
         for line_num, line in enumerate(content_str.split("\n"), 1):
-            if pattern in line:  # Simple substring search for literal matching
+            if compiled is not None:
+                if compiled.search(line):
+                    matches.append({"path": file_path, "line": int(line_num), "text": line})
+            elif pattern in line:  # Simple substring search for literal matching
                 matches.append({"path": file_path, "line": int(line_num), "text": line})
     return GrepResult(matches=matches)
 

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -314,12 +314,25 @@ class GlobSchema(BaseModel):
 class GrepSchema(BaseModel):
     """Input schema for the `grep` tool."""
 
-    pattern: str = Field(description="Text pattern to search for (literal string, not regex).")
+    pattern: str = Field(
+        description=(
+            "Text pattern to search for. Literal substring by default; "
+            "pass `regex=true` to treat as a Python / ripgrep regular expression."
+        )
+    )
     path: str | None = Field(default=None, description="Directory to search in. Defaults to current working directory.")
     glob: str | None = Field(default=None, description="Glob pattern to filter which files to search (e.g., '*.py').")
     output_mode: Literal["files_with_matches", "content", "count"] = Field(
         default="files_with_matches",
         description="Output format: 'files_with_matches' (file paths only, default), 'content' (matching lines with context), 'count' (match counts per file).",
+    )
+    regex: bool = Field(
+        default=False,
+        description=(
+            "When true, `pattern` is interpreted as a regular expression. "
+            "Use for things like `def (get|set)_\\w+` or `except\\s+\\w*Error`. "
+            "Default is literal substring matching."
+        ),
     )
 
 
@@ -1302,7 +1315,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         tool_description = self._custom_tool_descriptions.get("grep") or GREP_TOOL_DESCRIPTION
 
         def sync_grep(
-            pattern: Annotated[str, "Text pattern to search for (literal string, not regex)."],
+            pattern: Annotated[
+                str,
+                "Text pattern to search for. Literal substring by default; pass `regex=true` to treat as a regex.",
+            ],
             runtime: ToolRuntime[None, FilesystemState],
             path: Annotated[str | None, "Directory to search in. Defaults to current working directory."] = None,
             glob: Annotated[str | None, "Glob pattern to filter which files to search (e.g., '*.py')."] = None,
@@ -1310,6 +1326,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 Literal["files_with_matches", "content", "count"],
                 "Output format: 'files_with_matches' (file paths only, default), 'content' (matching lines with context), 'count' (match counts per file).",
             ] = "files_with_matches",
+            regex: Annotated[
+                bool,
+                "When true, interpret `pattern` as a regular expression. Default is literal substring matching.",
+            ] = False,
         ) -> ToolMessage:
             """Synchronous wrapper for grep tool."""
             if path is not None:
@@ -1330,7 +1350,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                         status="error",
                     )
             resolved_backend = self._get_backend(runtime)
-            grep_result = resolved_backend.grep(pattern, path=path, glob=glob)
+            grep_result = resolved_backend.grep(pattern, path=path, glob=glob, regex=regex)
             if grep_result.error:
                 return ToolMessage(
                     content=grep_result.error,
@@ -1349,7 +1369,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             )
 
         async def async_grep(
-            pattern: Annotated[str, "Text pattern to search for (literal string, not regex)."],
+            pattern: Annotated[
+                str,
+                "Text pattern to search for. Literal substring by default; pass `regex=true` to treat as a regex.",
+            ],
             runtime: ToolRuntime[None, FilesystemState],
             path: Annotated[str | None, "Directory to search in. Defaults to current working directory."] = None,
             glob: Annotated[str | None, "Glob pattern to filter which files to search (e.g., '*.py')."] = None,
@@ -1357,6 +1380,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 Literal["files_with_matches", "content", "count"],
                 "Output format: 'files_with_matches' (file paths only, default), 'content' (matching lines with context), 'count' (match counts per file).",
             ] = "files_with_matches",
+            regex: Annotated[
+                bool,
+                "When true, interpret `pattern` as a regular expression. Default is literal substring matching.",
+            ] = False,
         ) -> ToolMessage:
             """Asynchronous wrapper for grep tool."""
             if path is not None:
@@ -1377,7 +1404,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                         status="error",
                     )
             resolved_backend = self._get_backend(runtime)
-            grep_result = await resolved_backend.agrep(pattern, path=path, glob=glob)
+            grep_result = await resolved_backend.agrep(pattern, path=path, glob=glob, regex=regex)
             if grep_result.error:
                 return ToolMessage(
                     content=grep_result.error,

--- a/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
@@ -304,10 +304,34 @@ def test_grep_with_path_prefix() -> None:
 
 
 def test_grep_invalid_regex() -> None:
+    # The protocol default is literal substring matching, so a meta-char
+    # like `[unclosed` is just searched verbatim and produces no matches —
+    # not a compile error. The error path is only taken when the caller
+    # explicitly opts into regex mode with `regex=True`.
     backend, _ = _make_backend()
-    result = backend.grep("[unclosed")
-    assert result.error is not None
-    assert "Invalid regex" in result.error
+    literal_result = backend.grep("[unclosed")
+    assert literal_result.error is None
+    assert literal_result.matches == []
+
+    regex_result = backend.grep("[unclosed", regex=True)
+    assert regex_result.error is not None
+    assert "Invalid regex" in regex_result.error
+
+
+def test_grep_regex_opt_in() -> None:
+    # With `regex=True` the context-hub backend keeps the historical
+    # behavior of compiling the pattern with `re.compile`, so callers can
+    # use real regular expressions across the hub contents.
+    backend, _ = _make_backend(
+        **{
+            "a.md": FileEntry(type="file", content="get_user\nset_value\nrandom\n"),
+        }
+    )
+    result = backend.grep(r"^(get|set)_\w+", regex=True)
+    assert result.error is None
+    assert result.matches is not None
+    matched_lines = {m["line"] for m in result.matches}
+    assert matched_lines == {1, 2}
 
 
 def test_glob_matches_pattern() -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_file_format.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_file_format.py
@@ -264,6 +264,34 @@ def test_grep_new_format():
 # ---------------------------------------------------------------------------
 
 
+def test_grep_regex_matches_meta_characters():
+    """`regex=True` switches `grep_matches_from_files` to `re.search`.
+
+    Pins the helper-side behavior for #3547 so the store / state / composite
+    backends that delegate here pick up regex semantics without each
+    needing its own regression test.
+    """
+    fd = create_file_data("get_user\nset_value\nrandom_helper\n")
+    files = {"/src/funcs.py": fd}
+
+    literal = grep_matches_from_files(files, r"(get|set)_\w+", path="/")
+    assert literal.matches == []  # literal mode treats `()` / `|` as text
+
+    regex = grep_matches_from_files(files, r"^(get|set)_\w+", path="/", regex=True)
+    assert regex.matches is not None
+    matched_lines = sorted(m["line"] for m in regex.matches)
+    assert matched_lines == [1, 2]
+
+
+def test_grep_regex_invalid_pattern_returns_error():
+    fd = create_file_data("anything")
+    files = {"/x.txt": fd}
+    result = grep_matches_from_files(files, "[unclosed", path="/", regex=True)
+    assert result.matches == []
+    assert result.error is not None
+    assert "Invalid regex" in result.error
+
+
 def test_grep_legacy_format():
     legacy_fd = {
         "content": ["def foo():", "    return 42", "def bar():", "    return 0"],

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -560,6 +560,54 @@ def test_grep_literal_search_with_special_chars(tmp_path: Path, pattern: str, ex
     assert any(expected_file in m["path"] for m in matches), f"Pattern '{pattern}' not found in {expected_file}"
 
 
+def test_grep_regex_mode_matches_meta_characters(tmp_path: Path) -> None:
+    """`regex=True` switches to ripgrep / Python-fallback regex semantics.
+
+    Pins the behavior added for #3547: with `regex=True`, meta characters
+    like alternation and word-boundary classes match instead of being
+    looked up as literal substrings.
+    """
+    root = tmp_path
+    (root / "code.py").write_text(
+        "def get_user():\n    pass\n\n"
+        "def set_value():\n    pass\n\n"
+        "def random_helper():\n    pass\n"
+    )
+
+    be = FilesystemBackend(root_dir=str(root), virtual_mode=True)
+
+    # Literal mode treats the parens / pipe as text and finds nothing.
+    literal = be.grep(r"def (get|set)_\w+", path="/").matches
+    assert literal == []
+
+    # Regex mode picks up both `get_user` and `set_value` but skips
+    # `random_helper`.
+    regex_matches = be.grep(r"def (get|set)_\w+", path="/", regex=True).matches
+    assert regex_matches is not None
+    matched_text = sorted(m["text"] for m in regex_matches)
+    assert matched_text == ["def get_user():", "def set_value():"]
+
+
+def test_grep_regex_mode_invalid_pattern_surfaces_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invalid regex on the Python fallback path must come back via
+    `GrepResult.error`, not raise.
+
+    Forces the Python fallback by pretending ripgrep is unavailable, so
+    this test pins the fallback-only branch even on machines where `rg`
+    is installed.
+    """
+    root = tmp_path
+    (root / "noop.txt").write_text("ignored")
+
+    be = FilesystemBackend(root_dir=str(root), virtual_mode=True)
+    monkeypatch.setattr(be, "_ripgrep_search", lambda *_args, **_kwargs: None)
+
+    result = be.grep("[unclosed", path="/", regex=True)
+    assert result.matches == []
+    assert result.error is not None
+    assert "Invalid regex" in result.error
+
+
 def test_grep_ripgrep_glob_with_directory_component(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Regression test for #2732.
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -209,8 +209,13 @@
             "description": "Directory to search in. Defaults to current working directory."
           },
           "pattern": {
-            "description": "Text pattern to search for (literal string, not regex).",
+            "description": "Text pattern to search for. Literal substring by default; pass `regex=true` to treat as a Python / ripgrep regular expression.",
             "type": "string"
+          },
+          "regex": {
+            "default": false,
+            "description": "When true, `pattern` is interpreted as a regular expression. Use for things like `def (get|set)_\\w+` or `except\\s+\\w*Error`. Default is literal substring matching.",
+            "type": "boolean"
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -209,8 +209,13 @@
             "description": "Directory to search in. Defaults to current working directory."
           },
           "pattern": {
-            "description": "Text pattern to search for (literal string, not regex).",
+            "description": "Text pattern to search for. Literal substring by default; pass `regex=true` to treat as a Python / ripgrep regular expression.",
             "type": "string"
+          },
+          "regex": {
+            "default": false,
+            "description": "When true, `pattern` is interpreted as a regular expression. Use for things like `def (get|set)_\\w+` or `except\\s+\\w*Error`. Default is literal substring matching.",
+            "type": "boolean"
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -209,8 +209,13 @@
             "description": "Directory to search in. Defaults to current working directory."
           },
           "pattern": {
-            "description": "Text pattern to search for (literal string, not regex).",
+            "description": "Text pattern to search for. Literal substring by default; pass `regex=true` to treat as a Python / ripgrep regular expression.",
             "type": "string"
+          },
+          "regex": {
+            "default": false,
+            "description": "When true, `pattern` is interpreted as a regular expression. Use for things like `def (get|set)_\\w+` or `except\\s+\\w*Error`. Default is literal substring matching.",
+            "type": "boolean"
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -209,8 +209,13 @@
             "description": "Directory to search in. Defaults to current working directory."
           },
           "pattern": {
-            "description": "Text pattern to search for (literal string, not regex).",
+            "description": "Text pattern to search for. Literal substring by default; pass `regex=true` to treat as a Python / ripgrep regular expression.",
             "type": "string"
+          },
+          "regex": {
+            "default": false,
+            "description": "When true, `pattern` is interpreted as a regular expression. Use for things like `def (get|set)_\\w+` or `except\\s+\\w*Error`. Default is literal substring matching.",
+            "type": "boolean"
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -209,8 +209,13 @@
             "description": "Directory to search in. Defaults to current working directory."
           },
           "pattern": {
-            "description": "Text pattern to search for (literal string, not regex).",
+            "description": "Text pattern to search for. Literal substring by default; pass `regex=true` to treat as a Python / ripgrep regular expression.",
             "type": "string"
+          },
+          "regex": {
+            "default": false,
+            "description": "When true, `pattern` is interpreted as a regular expression. Use for things like `def (get|set)_\\w+` or `except\\s+\\w*Error`. Default is literal substring matching.",
+            "type": "boolean"
           }
         },
         "required": [


### PR DESCRIPTION
## Why

The grep tool only supported literal substring matching: the ripgrep call hardcoded `-F` (`backends/filesystem.py:572`), the Python fallback wrapped patterns in `re.escape()` (`backends/filesystem.py:550`), and the in-memory helper used `pattern in line`. Agents that wanted to search for things like `def (get|set)_\w+`, `except\s+\w*Error`, or `\.(save|persist|commit)\(` had to fall back to multiple literal probes or read files they shouldn't have needed to open ([#3547](https://github.com/langchain-ai/deepagents/issues/3547)).

## What

Adds an opt-in `regex: bool = False` parameter to the `grep` tool, the `BackendProtocol.grep` / `agrep` contract, and every in-tree backend that implements grep:

| Backend | Change |
|---------|--------|
| `FilesystemBackend` | Drops `-F` from ripgrep when `regex=True`; skips `re.escape` on the Python fallback and surfaces `re.error` as `GrepResult(error=...)` instead of raising. |
| `grep_matches_from_files` (helper) | Compiles the pattern with `re.compile` when `regex=True`; literal substring match otherwise. Invalid pattern → `GrepResult(error=...)`. |
| `StoreBackend`, `StateBackend` | Forward the kwarg to the helper. |
| `SandboxBackend` | Swaps `-rHnF` for `-rHnE` (extended regex). Pattern still shell-quoted. |
| `ContextHubBackend` | Previously *always* compiled the pattern as regex (inconsistent with protocol default). Now matches the rest of the codebase — literal by default, regex when opted in — so meta characters don't silently change semantics on this one backend. |

Legacy `grep_raw` callers (deprecated since 0.5.0) get a clear `GrepResult.error` if they pass `regex=True` instead of being silently routed through the literal path.

Tool surface (`GrepSchema` + `sync_grep` / `async_grep` annotations in `middleware/filesystem.py`) is updated so the model sees the new parameter with example patterns from the issue.

## Example

```python
# Literal (existing behaviour, unchanged):
backend.grep("TODO", path="/")

# Regex (new):
backend.grep(r"def (get|set)_\w+", path="/", glob="*.py", regex=True)
backend.grep(r"except\s+\w*Error", path="/", glob="*.py", regex=True)
```

## Tests

- `test_filesystem_backend.py::test_grep_regex_mode_matches_meta_characters` — pins the new regex path against `def (get|set)_\w+`.
- `test_filesystem_backend.py::test_grep_regex_mode_invalid_pattern_surfaces_error` — forces the Python fallback and verifies invalid regex returns via `GrepResult.error` rather than raising.
- `test_file_format.py::test_grep_regex_matches_meta_characters` / `::test_grep_regex_invalid_pattern_returns_error` — exercise the shared `grep_matches_from_files` helper (covers store/state).
- `test_context_hub_backend.py::test_grep_invalid_regex` — updated to pin the new default-literal semantics; added `test_grep_regex_opt_in` for the explicit regex path.
- Smoke snapshots regenerated via `make update-snapshots`.

```
$ uv run --group test pytest tests/unit_tests --disable-socket --allow-unix-socket -q
1607 passed, 95 skipped
```

## Compatibility note

The only behavior change for existing callers is in `ContextHubBackend`: previously meta characters like `.` and `*` were silently treated as regex; they're now literal unless the caller passes `regex=True`. That matches the other backends and the protocol docstring. Happy to revert that specific backend to default-regex if you'd prefer to keep its historical behaviour and treat the cross-backend mismatch as a separate concern.

Closes #3547