### PR TITLE
fix(sdk): rewrite virtual route paths in `CompositeBackend.execute` (closes #3050)

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -17,8 +17,12 @@ Examples:
     ```
 """
 
+import logging
+import shlex
 from collections import defaultdict
 from typing import cast
+
+logger = logging.getLogger(__name__)
 
 from deepagents.backends.protocol import (
     BackendProtocol,
@@ -81,6 +85,105 @@ def _remap_file_info_path(fi: FileInfo, route_prefix: str) -> FileInfo:
             "path": f"{route_prefix[:-1]}{fi['path']}",
         },
     )
+
+
+def _rewrite_virtual_paths_in_command(
+    command: str,
+    sorted_routes: list[tuple[str, BackendProtocol]],
+) -> str:
+    """Rewrite known virtual-route prefixes in a shell command to host paths.
+
+    Background (#3050): ``CompositeBackend.execute`` delegates the raw
+    command to the default backend, but file-system tools translate
+    virtual paths via routes. A command like
+    ``python /common/skills/main.py`` resolves the file ops correctly
+    (``/common/`` → ``FilesystemBackend(root_dir=...)``) but the shell
+    receives ``/common/...`` verbatim and fails.
+
+    Strategy: tokenize with :mod:`shlex`, rewrite each token that exactly
+    matches a route prefix or starts with one, when the routed backend
+    exposes a host-side ``root_dir`` we can substitute. The tokenizer
+    keeps quoted arguments intact, so a literal occurrence of the
+    virtual path inside ``grep -F "/common/x"`` is preserved as a single
+    token and rewritten correctly (the agent really does want that
+    rewritten — the underlying file isn't accessible at the virtual
+    path either).
+
+    Conservative behaviour by design:
+
+    - Routes are walked longest-first so nested prefixes resolve correctly.
+    - Backends without a ``root_dir`` attribute (e.g. ``StoreBackend``)
+      are left untouched — there is no host path to substitute, and
+      letting the original token through preserves the existing
+      "command fails loudly" diagnostic.
+    - If the command can't be tokenized cleanly (unbalanced quotes,
+      heredoc-only input), the unmodified command is returned so we
+      never corrupt complex shell syntax.
+
+    Args:
+        command: The shell command as the caller would pass it to
+            ``execute``.
+        sorted_routes: ``CompositeBackend.sorted_routes`` (longest
+            prefix first).
+
+    Returns:
+        The rewritten command string, or the original ``command`` if no
+        token matched a known route or the input couldn't be tokenised.
+    """
+    if not sorted_routes:
+        return command
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        # Unbalanced quotes / heredoc-only input — don't risk mutating
+        # something we don't fully understand.
+        logger.debug("CompositeBackend.execute: command not shlex-parseable, leaving unmodified")
+        return command
+
+    if not tokens:
+        return command
+
+    rewritten = False
+    for index, token in enumerate(tokens):
+        if not token.startswith("/"):
+            continue
+        for route_prefix, backend in sorted_routes:
+            prefix_with_slash = route_prefix if route_prefix.endswith("/") else f"{route_prefix}/"
+            prefix_no_slash = route_prefix.rstrip("/")
+            if token == prefix_no_slash:
+                suffix = ""
+            elif token.startswith(prefix_with_slash):
+                suffix = token[len(prefix_with_slash) :]
+            else:
+                continue
+
+            # `FilesystemBackend`-derived backends (incl. `LocalShellBackend`)
+            # expose the host root as `self.cwd: Path`. Other backends
+            # may expose `root_dir` as a plain string. Try both before
+            # giving up.
+            host_root: str | None = None
+            cwd_attr = getattr(backend, "cwd", None)
+            if cwd_attr is not None:
+                host_root = str(cwd_attr)
+            else:
+                raw = getattr(backend, "root_dir", None)
+                if isinstance(raw, str) and raw:
+                    host_root = raw
+
+            if not host_root:
+                # Backend (e.g. StoreBackend, StateBackend) has no
+                # host-side filesystem path we can substitute. Stop
+                # walking shorter routes for this token; leave it alone.
+                break
+
+            host_root_clean = host_root.rstrip("/")
+            tokens[index] = f"{host_root_clean}/{suffix}" if suffix else host_root_clean
+            rewritten = True
+            break
+
+    if not rewritten:
+        return command
+    return shlex.join(tokens)
 
 
 def _route_for_path(
@@ -542,11 +645,18 @@ class CompositeBackend(BackendProtocol):
     ) -> ExecuteResponse:
         """Execute a shell command via the default backend.
 
-        Unlike file operations, execution is not path-routable — it always
-        delegates to the default backend.
+        Execution always delegates to the default backend, but virtual
+        route prefixes in the command string are first rewritten to the
+        corresponding host paths so that shell commands like
+        ``python /common/skills/main.py`` resolve consistently with the
+        file-operation tools (#3050). The rewrite is best-effort: only
+        tokens that exactly match (or start with) a known route prefix
+        whose backend exposes a ``root_dir`` are substituted; anything
+        else is passed through unchanged.
 
         Args:
-            command: Shell command to execute.
+            command: Shell command to execute. Virtual route prefixes
+                (e.g. ``/common/...``) are rewritten to host paths.
             timeout: Maximum time in seconds to wait for the command to complete.
 
                 If None, uses the backend's default timeout.
@@ -560,9 +670,10 @@ class CompositeBackend(BackendProtocol):
                 (i.e., it doesn't support execution).
         """
         if isinstance(self.default, SandboxBackendProtocol):
+            resolved_command = _rewrite_virtual_paths_in_command(command, self.sorted_routes)
             if timeout is not None and execute_accepts_timeout(type(self.default)):
-                return self.default.execute(command, timeout=timeout)
-            return self.default.execute(command)
+                return self.default.execute(resolved_command, timeout=timeout)
+            return self.default.execute(resolved_command)
 
         # This shouldn't be reached if the runtime check in the execute tool works correctly,
         # but we include it as a safety fallback.
@@ -585,9 +696,10 @@ class CompositeBackend(BackendProtocol):
         See `execute()` for detailed documentation on parameters and behavior.
         """
         if isinstance(self.default, SandboxBackendProtocol):
+            resolved_command = _rewrite_virtual_paths_in_command(command, self.sorted_routes)
             if timeout is not None and execute_accepts_timeout(type(self.default)):
-                return await self.default.aexecute(command, timeout=timeout)
-            return await self.default.aexecute(command)
+                return await self.default.aexecute(resolved_command, timeout=timeout)
+            return await self.default.aexecute(resolved_command)
 
         # This shouldn't be reached if the runtime check in the execute tool works correctly,
         # but we include it as a safety fallback.

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -553,6 +553,106 @@ def test_composite_backend_execute_with_routed_backends():
     assert "persistent content" in persistent_result.file_data["content"]
 
 
+def test_composite_execute_rewrites_virtual_route_path(tmp_path: Path):
+    """Pins the #3050 fix: virtual route prefixes in the command string are
+    rewritten to the routed backend's host ``root_dir`` before delegation,
+    so a command like ``python /common/skills/main.py`` actually finds the
+    file the SkillsMiddleware loader resolved through the route."""
+    mem_store = InMemoryStore()
+    sandbox = MockSandboxBackend(store=mem_store, namespace=lambda _rt: ("default",))
+
+    common = tmp_path / "common"
+    common.mkdir()
+    (common / "skills").mkdir()
+    (common / "skills" / "main.py").write_text("print('hi')")
+    fs_backend = FilesystemBackend(root_dir=str(common), virtual_mode=True)
+
+    comp = CompositeBackend(default=sandbox, routes={"/common/": fs_backend})
+
+    result = comp.execute("python /common/skills/main.py")
+    expected = f"Executed: python {str(common).rstrip('/')}/skills/main.py"
+    assert result.output == expected
+
+
+def test_composite_execute_leaves_non_matching_path_unchanged(tmp_path: Path):
+    """Tokens that don't sit under any route prefix are passed through as-is,
+    so existing host-shell commands (``ls /etc/hostname``) keep working."""
+    mem_store = InMemoryStore()
+    sandbox = MockSandboxBackend(store=mem_store, namespace=lambda _rt: ("default",))
+    fs_backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+    comp = CompositeBackend(default=sandbox, routes={"/common/": fs_backend})
+
+    result = comp.execute("ls /etc/hostname")
+    # The rewriter must not touch /etc/hostname; reconstructed command
+    # tokenises to the same shape.
+    assert result.output == "Executed: ls /etc/hostname"
+
+
+def test_composite_execute_skips_rewrite_for_backend_without_root_dir(tmp_path: Path):
+    """A routed backend without a host-side ``root_dir`` (e.g. StoreBackend)
+    has nothing to substitute, so the original virtual path is left alone
+    rather than being silently mis-rewritten."""
+    mem_store = InMemoryStore()
+    sandbox = MockSandboxBackend(store=mem_store, namespace=lambda _rt: ("default",))
+    store_be = StoreBackend(store=mem_store, namespace=lambda _rt: ("memories",))
+
+    comp = CompositeBackend(default=sandbox, routes={"/memories/": store_be})
+
+    result = comp.execute("cat /memories/note.txt")
+    assert result.output == "Executed: cat /memories/note.txt"
+
+
+def test_composite_execute_rewrites_quoted_argument(tmp_path: Path):
+    """A virtual path inside a quoted argument is one shlex token and must
+    still be rewritten — the quoted form was the original repro shape
+    (``python "/common/skills/main with spaces.py"``)."""
+    mem_store = InMemoryStore()
+    sandbox = MockSandboxBackend(store=mem_store, namespace=lambda _rt: ("default",))
+
+    common = tmp_path / "common"
+    common.mkdir()
+    fs_backend = FilesystemBackend(root_dir=str(common), virtual_mode=True)
+
+    comp = CompositeBackend(default=sandbox, routes={"/common/": fs_backend})
+
+    result = comp.execute('python "/common/skills/main with spaces.py"')
+    host_clean = str(common).rstrip("/")
+    # shlex.join re-quotes the path because it contains a space.
+    assert f"{host_clean}/skills/main with spaces.py" in result.output
+
+
+def test_composite_execute_unparseable_command_passes_through(tmp_path: Path):
+    """If the command can't be shlex-parsed (unbalanced quote), the rewriter
+    must leave it alone rather than corrupt the input."""
+    mem_store = InMemoryStore()
+    sandbox = MockSandboxBackend(store=mem_store, namespace=lambda _rt: ("default",))
+    fs_backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+    comp = CompositeBackend(default=sandbox, routes={"/common/": fs_backend})
+
+    malformed = "echo /common/x 'unterminated"
+    result = comp.execute(malformed)
+    assert result.output == f"Executed: {malformed}"
+
+
+def test_composite_execute_resolves_exact_route_prefix(tmp_path: Path):
+    """``cd /common`` (no trailing slash, exact route base) should also
+    rewrite to the route's host root."""
+    mem_store = InMemoryStore()
+    sandbox = MockSandboxBackend(store=mem_store, namespace=lambda _rt: ("default",))
+
+    common = tmp_path / "common"
+    common.mkdir()
+    fs_backend = FilesystemBackend(root_dir=str(common), virtual_mode=True)
+
+    comp = CompositeBackend(default=sandbox, routes={"/common/": fs_backend})
+
+    result = comp.execute("cd /common")
+    host_clean = str(common).rstrip("/")
+    assert result.output == f"Executed: cd {host_clean}"
+
+
 def test_composite_upload_routing(tmp_path: Path):
     """Test upload_files routing to different backends."""
     root = tmp_path


### PR DESCRIPTION
## Why

`CompositeBackend` routes filesystem ops (`read`/`ls`/`glob`/`grep`) by path prefix, but `execute` always delegates the raw command to the default backend. A skill that runs `python /common/skills/yyy/xxx.py` resolves the file ops correctly (because `/common/` is a route) but `subprocess.run` sees a literal OS path that doesn't exist, so `execute` fails. The agent then probes with `ls`/`grep` (which return more virtual paths) and gets stuck in a retry loop ([#3050](https://github.com/langchain-ai/deepagents/issues/3050)).

## What

Before delegating to `self.default.execute`, tokenize the command with `shlex.split` and rewrite each token that exactly matches a known route prefix or starts with one, when the routed backend exposes a host-side root path. The rewriter prefers `getattr(backend, "cwd")` (FilesystemBackend / LocalShellBackend expose the root as a resolved `Path` named `cwd`) and falls back to `root_dir` for backends that expose a plain string.

```python
default = LocalShellBackend(root_dir=specified_path, virtual_mode=True)
backend = CompositeBackend(
    default=default,
    routes={
        "/common/": FilesystemBackend(root_dir=common_path, virtual_mode=True),
        "/specified/": FilesystemBackend(root_dir=specified_path, virtual_mode=True),
    },
)

# was: subprocess.run("python /common/skills/yyy/xxx.py", cwd=specified_path)  # ENOENT
# now: subprocess.run(f"python {common_path}/skills/yyy/xxx.py", cwd=specified_path)
backend.execute("python /common/skills/yyy/xxx.py")
```

## Conservative behaviour

- Routes are walked **longest-first** so nested prefixes resolve correctly.
- Backends without a host-side root path (`StoreBackend`, `StateBackend`, etc.) are left untouched — there is no host path to substitute, and leaving the token through preserves the existing "command fails loudly" diagnostic.
- If the command can't be tokenised cleanly (unbalanced quotes, heredoc-only input), the unmodified command is returned so we never corrupt complex shell syntax.
- Quoted arguments containing virtual paths (e.g. `python "/common/skills/main with spaces.py"`) are one `shlex` token and are rewritten correctly; `shlex.join` re-quotes the substituted value if it needs it.

Both `execute` and `aexecute` go through the helper.

## Tests

| Test | What it pins |
|------|-------------|
| `test_composite_execute_rewrites_virtual_route_path` | Repro from the issue: `python /common/skills/main.py` reaches the sandbox as `python <host>/skills/main.py`. |
| `test_composite_execute_leaves_non_matching_path_unchanged` | `ls /etc/hostname` passed through verbatim. |
| `test_composite_execute_skips_rewrite_for_backend_without_root_dir` | `cat /memories/note.txt` against a `StoreBackend` route stays as `cat /memories/note.txt`. |
| `test_composite_execute_rewrites_quoted_argument` | Quoted token with spaces is rewritten. |
| `test_composite_execute_unparseable_command_passes_through` | Malformed shell input returns the original command unchanged. |
| `test_composite_execute_resolves_exact_route_prefix` | `cd /common` (no trailing slash) rewrites to the host root. |

```
$ uv run --group test pytest tests/unit_tests --disable-socket --allow-unix-socket -q
1608 passed, 95 skipped
```

## Notes / scope

The issue listed four directions; this PR implements direction (1) — "`CompositeBackend.execute` rewrites known virtual prefixes → backend `root_dir` in the command string before delegating" — because it's the most agent-transparent and lets skill authors keep using virtual paths in `SKILL.md`. The known footguns (substring matches inside heredocs / quoted args) are addressed by `shlex` tokenisation rather than naive `str.replace`, and a malformed-command pass-through guards against the cases shlex can't handle.

Happy to add an opt-out flag (e.g. `CompositeBackend(rewrite_execute_paths=False)`) if you'd prefer the behaviour to be opt-in for backwards-compatibility — flagging it explicitly here since the rewrite is the new default.

Closes #3050