### PR TITLE
feat(code): add macOS keyboard shortcuts for line navigation

### DIFF
--- a/libs/code/deepagents_code/widgets/chat_input.py
+++ b/libs/code/deepagents_code/widgets/chat_input.py
@@ -340,6 +340,24 @@ class ChatTextArea(TextArea):
             "Delete left to start of word",
             show=False,
         ),
+        Binding(
+            "cmd+delete",
+            "delete_to_line_start",
+            "Delete to line start",
+            show=False,
+        ),
+        Binding(
+            "cmd+right",
+            "cursor_line_end",
+            "Go to line end",
+            show=False,
+        ),
+        Binding(
+            "cmd+left",
+            "cursor_line_start",
+            "Go to line start",
+            show=False,
+        ),
     ]
     """Key bindings for the chat text area.
 
@@ -631,6 +649,38 @@ class ChatTextArea(TextArea):
             self.post_message(self.HistoryNext())
             return
         super().action_cursor_down(select)
+
+    def action_delete_to_line_start(self) -> None:
+        """Delete all characters from cursor to the start of the line."""
+        row, col = self.cursor_location
+        line_start = (row, 0)
+        if col > 0:
+            self.delete(line_start, self.cursor_location)
+
+    def action_cursor_line_end(self, select: bool = False) -> None:
+        """Move cursor to the end of the current line.
+
+        When `select` is true, extends selection to line end rather than
+        moving the cursor; otherwise falls through to TextArea's default.
+        """
+        if not select and self.selection.is_empty:
+            row = self.cursor_location[0]
+            line_length = len(self.document.get_line(row))
+            self.cursor_location = (row, line_length)
+            return
+        super().action_cursor_line_end(select)
+
+    def action_cursor_line_start(self, select: bool = False) -> None:
+        """Move cursor to the start of the current line.
+
+        When `select` is true, extends selection to line start rather than
+        moving the cursor; otherwise falls through to TextArea's default.
+        """
+        if not select and self.selection.is_empty:
+            row = self.cursor_location[0]
+            self.cursor_location = (row, 0)
+            return
+        super().action_cursor_line_start(select)
 
     def _cancel_paste_burst_timer(self) -> None:
         """Cancel any scheduled paste-burst flush timer."""

--- a/libs/code/tests/unit_tests/test_chat_input.py
+++ b/libs/code/tests/unit_tests/test_chat_input.py
@@ -3011,3 +3011,129 @@ class TestSetCursorBlink:
             await pilot.pause()
 
             assert chat._text_area.has_focus is True
+
+
+class TestKeyboardShortcuts:
+    """Test CMD+key keyboard shortcuts for macOS-style navigation."""
+
+    async def test_cmd_delete_deletes_to_line_start(self) -> None:
+        """CMD+DEL should delete all characters to the left of cursor."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            text_area = chat.query_one(ChatTextArea)
+
+            # Type some text
+            await pilot.press("h", "e", "l", "l", "o")
+            assert text_area.text == "hello"
+
+            # Move cursor to end
+            await pilot.press("end")
+            assert text_area.cursor_location == (0, 5)
+
+            # Press CMD+DEL to delete all characters to line start
+            text_area.action_delete_to_line_start()
+            assert text_area.text == ""
+            assert text_area.cursor_location == (0, 0)
+
+    async def test_cmd_delete_partial_deletion(self) -> None:
+        """CMD+DEL should only delete from cursor to line start."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            text_area = chat.query_one(ChatTextArea)
+
+            # Type some text
+            await pilot.press("h", "e", "l", "l", "o")
+            assert text_area.text == "hello"
+
+            # Move cursor to position 3
+            text_area.cursor_location = (0, 3)
+
+            # Press CMD+DEL to delete characters before cursor
+            text_area.action_delete_to_line_start()
+            assert text_area.text == "lo"
+            assert text_area.cursor_location == (0, 0)
+
+    async def test_cmd_right_goes_to_line_end(self) -> None:
+        """CMD+Right should move cursor to the end of the line."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            text_area = chat.query_one(ChatTextArea)
+
+            # Type some text
+            await pilot.press("h", "e", "l", "l", "o")
+            assert text_area.text == "hello"
+
+            # Move cursor to start
+            text_area.cursor_location = (0, 0)
+            assert text_area.cursor_location == (0, 0)
+
+            # Press CMD+Right to go to end
+            text_area.action_cursor_line_end()
+            assert text_area.cursor_location == (0, 5)
+
+    async def test_cmd_left_goes_to_line_start(self) -> None:
+        """CMD+Left should move cursor to the start of the line."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            text_area = chat.query_one(ChatTextArea)
+
+            # Type some text
+            await pilot.press("h", "e", "l", "l", "o")
+            assert text_area.text == "hello"
+
+            # Cursor should be at end
+            assert text_area.cursor_location == (0, 5)
+
+            # Press CMD+Left to go to start
+            text_area.action_cursor_line_start()
+            assert text_area.cursor_location == (0, 0)
+
+    async def test_cmd_shortcuts_on_empty_text(self) -> None:
+        """CMD+key shortcuts should handle empty text gracefully."""
+        app = _ChatInputTestApp()
+        async with app.run_test():
+            chat = app.query_one(ChatInput)
+            text_area = chat.query_one(ChatTextArea)
+
+            # All should work on empty text
+            text_area.action_delete_to_line_start()
+            assert text_area.text == ""
+            assert text_area.cursor_location == (0, 0)
+
+            text_area.action_cursor_line_end()
+            assert text_area.cursor_location == (0, 0)
+
+            text_area.action_cursor_line_start()
+            assert text_area.cursor_location == (0, 0)
+
+    async def test_cmd_shortcuts_multiline_text(self) -> None:
+        """CMD+key shortcuts should work correctly on specific lines."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            text_area = chat.query_one(ChatTextArea)
+
+            # Type multi-line text
+            await pilot.press("h", "e", "l", "l", "o")
+            await pilot.press("shift+enter")  # New line
+            await pilot.press("w", "o", "r", "l", "d")
+
+            # Cursor should be at end of second line
+            assert text_area.cursor_location == (1, 5)
+
+            # CMD+Left should go to start of current line (line 1)
+            text_area.action_cursor_line_start()
+            assert text_area.cursor_location == (1, 0)
+
+            # Move to end
+            text_area.action_cursor_line_end()
+            assert text_area.cursor_location == (1, 5)
+
+            # Delete current line content
+            text_area.action_delete_to_line_start()
+            assert text_area.text == "hello\n"
+            assert text_area.cursor_location == (1, 0)


### PR DESCRIPTION
Add three new keyboard shortcuts for improved text editing efficiency:

- CMD+DEL: Delete all characters from cursor to line start
- CMD+Right: Move cursor to end of current line
- CMD+Left: Move cursor to start of current line

These shortcuts follow standard macOS text editing conventions and provide a familiar experience for users coming from other macOS applications.

Includes comprehensive unit tests covering:
- Basic functionality of each shortcut
- Partial line deletion scenarios
- Empty text handling
- Multi-line text behavior
