### PR TITLE
FEAT: add `executable` parameter to `LocalShellBackend`

### DIFF
--- a/libs/deepagents/deepagents/backends/local_shell.py
+++ b/libs/deepagents/deepagents/backends/local_shell.py
@@ -98,6 +98,17 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
 
         # Inherit all environment variables
         backend = LocalShellBackend(root_dir="/home/user/project", inherit_env=True)
+
+        # Use zsh for all commands
+        backend = LocalShellBackend(root_dir="/home/user/project", executable="zsh")
+        result = backend.execute("echo $SHELL")
+
+        # Use absolute path to shell
+        backend = LocalShellBackend(executable="/opt/homebrew/bin/zsh")
+
+        # Override executable per-command
+        backend = LocalShellBackend()
+        result = backend.execute("ls", executable="/bin/zsh")
         ```
     """
 
@@ -110,6 +121,7 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
         max_output_bytes: int = 100_000,
         env: dict[str, str] | None = None,
         inherit_env: bool = False,
+        executable: str | None = None,
     ) -> None:
         """Initialize local shell backend with filesystem access.
 
@@ -158,6 +170,15 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
                 When False (default), only variables in `env` dict are available.
                 When True, inherits all `os.environ` variables and applies `env` overrides.
 
+            executable: Shell executable to use for command execution.
+
+                Accepts shell names ("zsh", "bash", "sh") or absolute paths
+                ("/bin/zsh", "/opt/homebrew/bin/zsh").
+
+                When None (default), uses the system default shell (`/bin/sh` on Unix).
+
+                Can be overridden per-command via the `executable` parameter on `execute()`.
+
         Raises:
             ValueError: If timeout is not positive.
         """
@@ -197,6 +218,7 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
         # Store execution parameters
         self._default_timeout = timeout
         self._max_output_bytes = max_output_bytes
+        self._executable = executable
 
         # Build environment based on inherit_env setting
         if inherit_env:
@@ -223,6 +245,7 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
         command: str,
         *,
         timeout: int | None = None,
+        executable: str | None = None,
     ) -> ExecuteResponse:
         r"""Execute a shell command directly on the host system.
 
@@ -241,9 +264,10 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
 
             **Always use Human-in-the-Loop (HITL) middleware when using this method.**
 
-        The command is executed using the system shell (`/bin/sh` or equivalent) with
-        the working directory set to the backend's `root_dir`. Stdout and stderr are
-        combined into a single output stream.
+        The command is executed using the configured shell (customizable via the
+        `executable` parameter, defaults to system shell `/bin/sh`) with the working
+        directory set to the backend's `root_dir`. Stdout and stderr are combined
+        into a single output stream.
 
         Args:
             command: Shell command string to execute.
@@ -257,6 +281,15 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
                 Overrides the default timeout set at init.
 
                 If None, uses the default.
+
+            executable: Shell executable to use for this command.
+
+                Accepts shell names ("zsh", "bash", "sh") or absolute paths
+                ("/bin/zsh", "/opt/homebrew/bin/zsh").
+
+                Overrides the default executable set at init.
+
+                If None, uses the executable set at init (or system default if not set).
 
         Returns:
             ExecuteResponse containing:
@@ -287,6 +320,12 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
             # Override timeout for long-running commands
             result = backend.execute("make build", timeout=300)
 
+            # Use zsh for a specific command
+            result = backend.execute("echo $SHELL", executable="zsh")
+
+            # Use absolute path to shell
+            result = backend.execute("ls", executable="/bin/zsh")
+
             # Commands run in root_dir, but can access any path
             result = backend.execute("cat /etc/passwd")  # Can read system files!
             ```
@@ -303,6 +342,9 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
             msg = f"timeout must be positive, got {effective_timeout}"
             raise ValueError(msg)
 
+        # Determine which executable to use (per-command override or instance default)
+        effective_executable = executable if executable is not None else self._executable
+
         try:
             result = subprocess.run(  # noqa: S602
                 command,
@@ -314,6 +356,7 @@ class LocalShellBackend(FilesystemBackend, SandboxBackendProtocol):
                 timeout=effective_timeout,
                 env=self._env,
                 cwd=str(self.cwd),  # Use the root_dir from FilesystemBackend
+                executable=effective_executable,
             )
 
             # Combine stdout and stderr

--- a/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_local_shell_backend.py
@@ -311,6 +311,83 @@ async def test_local_shell_backend_async_filesystem_operations() -> None:
         assert "modified content" in content.file_data["content"]
 
 
+def test_local_shell_backend_executable_at_init() -> None:
+    """Test specifying executable at initialization."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        backend = LocalShellBackend(root_dir=tmpdir, executable="bash", inherit_env=True)
+
+        # Execute a command that shows which shell is being used
+        result = backend.execute("echo $0")
+
+        assert result.exit_code == 0
+        # The output should contain 'bash' when using bash shell
+        assert "bash" in result.output.lower()
+
+
+def test_local_shell_backend_executable_per_command() -> None:
+    """Test overriding executable per-command."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create backend with default shell
+        backend = LocalShellBackend(root_dir=tmpdir, inherit_env=True)
+
+        # Override to use bash for this specific command
+        result = backend.execute("echo $0", executable="bash")
+
+        assert result.exit_code == 0
+        assert "bash" in result.output.lower()
+
+
+def test_local_shell_backend_executable_absolute_path() -> None:
+    """Test using absolute path for executable."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Use absolute path to bash
+        backend = LocalShellBackend(root_dir=tmpdir, executable="/bin/bash", inherit_env=True)
+
+        result = backend.execute("echo $0")
+
+        assert result.exit_code == 0
+        assert "bash" in result.output.lower()
+
+
+def test_local_shell_backend_executable_per_command_override() -> None:
+    """Test that per-command executable overrides initialization executable."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Initialize with bash
+        backend = LocalShellBackend(root_dir=tmpdir, executable="bash", inherit_env=True)
+
+        # Override with sh for this command
+        result = backend.execute("echo $0", executable="/bin/sh")
+
+        assert result.exit_code == 0
+        # When using /bin/sh, output should contain 'sh'
+        assert "sh" in result.output.lower()
+
+
+def test_local_shell_backend_no_executable_uses_default() -> None:
+    """Test that not specifying executable uses system default (/bin/sh)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        backend = LocalShellBackend(root_dir=tmpdir, inherit_env=True)
+
+        # Without executable parameter, should use system default
+        result = backend.execute("echo 'test'")
+
+        assert result.exit_code == 0
+        assert "test" in result.output
+
+
+def test_local_shell_backend_executable_with_shell_specific_features() -> None:
+    """Test using shell-specific features with the specified executable."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Use bash which supports arrays
+        backend = LocalShellBackend(root_dir=tmpdir, executable="bash", inherit_env=True)
+
+        # Use bash array syntax (not supported in /bin/sh)
+        result = backend.execute("arr=(1 2 3); echo ${arr[1]}")
+
+        assert result.exit_code == 0
+        assert "2" in result.output
+
+
 class TestLocalShellVirtualModeDefaultDeprecation:
     """`virtual_mode=None` (omitted) emits a deprecation; explicit values do not."""
 


### PR DESCRIPTION
Fixes #3447

  ---

  Adds an `executable` parameter to `LocalShellBackend` allowing developers to specify which shell (zsh, bash, or
  custom paths) to use for command execution instead of being limited to the system default `/bin/sh`. This enables
  shell-specific features (arrays, extended globbing, etc.) and matches local development environments where
  developers use zsh or bash with custom configurations.

  ## Implementation

  - Added optional `executable` parameter to `LocalShellBackend.__init__()` for instance-level configuration
  - Added optional `executable` parameter to `LocalShellBackend.execute()` for per-command override
  - Per-command executable takes precedence over instance-level setting, which takes precedence over system default
  - Fully backward compatible - existing code continues to work without changes
  - Accepts both shell names (`"bash"`, `"zsh"`) and absolute paths (`"/opt/homebrew/bin/zsh"`)

  ## Testing

  - Added 6 new unit tests covering:
    - Executable set at initialization
    - Per-command override
    - Absolute path usage
    - Override precedence
    - Backward compatibility
    - Shell-specific features (bash arrays)
  - All 27 tests passing (6 new + 21 existing)
  - Ran `make format`, `make lint`, and `make test` - all passing

  ## Example Usage

  ```python
  from deepagents.backends import LocalShellBackend

  # Use zsh for all commands
  backend = LocalShellBackend(executable="zsh")
  result = backend.execute("echo $SHELL")

  # Override per-command
  backend = LocalShellBackend()
  result = backend.execute("ls", executable="/bin/zsh")

  # Use bash-specific features
  backend = LocalShellBackend(executable="bash")
  result = backend.execute("arr=(1 2 3); echo ${arr[1]}")  # "2"

  Breaking Changes

  None - fully backward compatible.

  ---
  Verification:
  - All unit tests pass locally
  - Linting and formatting checks pass
  - Manual testing with zsh, bash, and default shell
  - Verified backward compatibility with existing tests
