### PR TITLE
feat(sdk): add `RepeatedToolCallMiddleware`

### DIFF
--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -50,6 +50,7 @@ Use a **plain tool** when:
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemPermission
 from deepagents.middleware.memory import MemoryMiddleware
+from deepagents.middleware.repeated_tool_call import RepeatedToolCallMiddleware
 from deepagents.middleware.skills import SkillsMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
 from deepagents.middleware.summarization import (
@@ -65,6 +66,7 @@ __all__ = [
     "FilesystemMiddleware",
     "FilesystemPermission",
     "MemoryMiddleware",
+    "RepeatedToolCallMiddleware",
     "SkillsMiddleware",
     "SubAgent",
     "SubAgentMiddleware",

--- a/libs/deepagents/deepagents/middleware/repeated_tool_call.py
+++ b/libs/deepagents/deepagents/middleware/repeated_tool_call.py
@@ -1,0 +1,191 @@
+"""Middleware that blocks repeated identical tool calls."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from typing import TYPE_CHECKING, Protocol, TypeAlias, TypeGuard, cast
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+if TYPE_CHECKING:
+    from langchain.tools.tool_node import ToolCallRequest
+    from langchain_core.tools import BaseTool
+    from langgraph.types import Command
+
+
+JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+
+
+class _ModelDump(Protocol):
+    def model_dump(self, *, mode: str, exclude_none: bool) -> object:
+        """Dump a Pydantic v2 model to JSON-compatible data."""
+
+
+class _DictDump(Protocol):
+    def dict(self) -> object:
+        """Dump a Pydantic v1 model to Python data."""
+
+
+class _ModelValidateSchema(Protocol):
+    def model_validate(self, obj: object) -> _ModelDump:
+        """Validate input with a Pydantic v2 schema."""
+
+
+class _ParseObjSchema(Protocol):
+    def parse_obj(self, obj: object) -> _DictDump:
+        """Validate input with a Pydantic v1 schema."""
+
+
+class RepeatedToolCallMiddleware(AgentMiddleware):
+    """Block execution of consecutively repeated tool calls.
+
+    This middleware compares tool calls by tool name plus schema-normalized
+    arguments. It blocks only the repeated call; the agent can continue with
+    different arguments, a different tool, or a final response.
+
+    Args:
+        max_repeats: Number of consecutive identical tool calls to allow before
+            blocking later repeats.
+
+    Raises:
+        ValueError: If `max_repeats` is less than 1.
+    """
+
+    def __init__(self, *, max_repeats: int = 5) -> None:
+        """Initialize the middleware with a repeat threshold."""
+        super().__init__()
+        if max_repeats < 1:
+            msg = "max_repeats must be >= 1"
+            raise ValueError(msg)
+        self.max_repeats = max_repeats
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[object]],
+    ) -> ToolMessage | Command[object]:
+        """Block the current tool call if it repeats too many times."""
+        if self._should_block(request):
+            return self._blocked_tool_message(request)
+        return handler(request)
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[object]]],
+    ) -> ToolMessage | Command[object]:
+        """Async version of `wrap_tool_call`."""
+        if self._should_block(request):
+            return self._blocked_tool_message(request)
+        return await handler(request)
+
+    def _should_block(self, request: ToolCallRequest) -> bool:
+        return _consecutive_repeat_count(request) > self.max_repeats
+
+    def _blocked_tool_message(self, request: ToolCallRequest) -> ToolMessage:
+        tool_name = request.tool_call["name"]
+        content = (
+            f"Repeated tool call blocked: `{tool_name}` was called more than "
+            f"{self.max_repeats} consecutive times with the same normalized "
+            "arguments. The repeated call was not executed. Continue the task "
+            "using the existing context or another approach."
+        )
+        return ToolMessage(
+            content=content,
+            name=tool_name,
+            tool_call_id=request.tool_call["id"],
+            status="error",
+        )
+
+
+def _consecutive_repeat_count(request: ToolCallRequest) -> int:
+    current = request.tool_call
+    current_id = current.get("id")
+    current_fingerprint = _tool_call_fingerprint(current, request.tool)
+    calls = _tool_calls_since_last_human_message(request.state.get("messages", []))
+
+    for index, call in enumerate(calls):
+        if current_id is not None and call.get("id") == current_id:
+            calls = calls[: index + 1]
+            break
+    else:
+        calls.append(current)
+
+    count = 0
+    for call in reversed(calls):
+        tool = request.tool if call.get("name") == current.get("name") else None
+        if _tool_call_fingerprint(call, tool) != current_fingerprint:
+            break
+        count += 1
+    return count
+
+
+def _tool_calls_since_last_human_message(messages: Sequence[object]) -> list[Mapping[str, object]]:
+    calls: list[Mapping[str, object]] = []
+    for message in messages:
+        if isinstance(message, HumanMessage):
+            calls = []
+            continue
+        if isinstance(message, AIMessage):
+            calls.extend(cast("Sequence[Mapping[str, object]]", message.tool_calls))
+    return calls
+
+
+def _tool_call_fingerprint(tool_call: Mapping[str, object], tool: BaseTool | None) -> str:
+    name = str(tool_call.get("name", ""))
+    raw_args = tool_call.get("args", {})
+    args = _coerce_args(raw_args)
+    normalized = _normalize_args(args, tool if _tool_name(tool) == name else None)
+    return _stable_json({"name": name, "args": normalized})
+
+
+def _coerce_args(raw_args: object) -> dict[str, object]:
+    if isinstance(raw_args, Mapping):
+        return {str(key): val for key, val in raw_args.items()}
+    return {"__arg__": raw_args}
+
+
+def _normalize_args(args: Mapping[str, object], tool: BaseTool | None) -> JsonValue:
+    schema = getattr(tool, "args_schema", None)
+    if schema is not None:
+        try:
+            if _has_model_validate(schema):
+                return _to_jsonable(schema.model_validate(args).model_dump(mode="json", exclude_none=False))
+            if _has_parse_obj(schema):
+                return _to_jsonable(schema.parse_obj(args).dict())
+        except (AttributeError, TypeError, ValueError):
+            return _to_jsonable(args)
+    return _to_jsonable(args)
+
+
+def _has_model_validate(schema: object) -> TypeGuard[_ModelValidateSchema]:
+    return hasattr(schema, "model_validate")
+
+
+def _has_parse_obj(schema: object) -> TypeGuard[_ParseObjSchema]:
+    return hasattr(schema, "parse_obj")
+
+
+def _tool_name(tool: BaseTool | None) -> str | None:
+    if tool is None:
+        return None
+    return getattr(tool, "name", None)
+
+
+def _stable_json(value: object) -> str:
+    return json.dumps(_to_jsonable(value), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _to_jsonable(value: object) -> JsonValue:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _to_jsonable(val) for key, val in sorted(value.items(), key=lambda item: str(item[0]))}
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_to_jsonable(item) for item in value]
+    return repr(value)
+
+
+__all__ = ["RepeatedToolCallMiddleware"]

--- a/libs/deepagents/tests/unit_tests/middleware/test_repeated_tool_call.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_repeated_tool_call.py
@@ -1,0 +1,235 @@
+"""Tests for repeated tool-call guard middleware."""
+
+from collections.abc import Callable
+
+import pytest
+from langchain.tools import ToolRuntime
+from langchain.tools.tool_node import ToolCallRequest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import BaseTool
+
+from deepagents.middleware.filesystem import FilesystemMiddleware
+from deepagents.middleware.repeated_tool_call import RepeatedToolCallMiddleware
+
+
+def _runtime(tool_call_id: str = "call-current") -> ToolRuntime:
+    return ToolRuntime(
+        state={},
+        context=None,
+        tool_call_id=tool_call_id,
+        store=None,
+        stream_writer=lambda _: None,
+        config={},
+    )
+
+
+def _read_file_tool() -> BaseTool:
+    middleware = FilesystemMiddleware()
+    return next(tool for tool in middleware.tools if tool.name == "read_file")
+
+
+def _ai_tool_call(call_id: str, name: str, args: dict[str, object]) -> AIMessage:
+    return AIMessage(content="", tool_calls=[{"id": call_id, "name": name, "args": args}])
+
+
+def _tool_result(call_id: str, name: str = "read_file", content: str = "ok") -> ToolMessage:
+    return ToolMessage(content=content, tool_call_id=call_id, name=name, status="success")
+
+
+def _request(
+    *,
+    call_id: str,
+    name: str,
+    args: dict[str, object],
+    messages: list[object],
+    tool: object | None = None,
+) -> ToolCallRequest:
+    return ToolCallRequest(
+        runtime=_runtime(call_id),
+        tool_call={"id": call_id, "name": name, "args": args},
+        state={"messages": messages},
+        tool=tool,
+    )
+
+
+def _handler(calls: list[ToolCallRequest]) -> Callable[[ToolCallRequest], ToolMessage]:
+    def handle(request: ToolCallRequest) -> ToolMessage:
+        calls.append(request)
+        return ToolMessage(
+            content="handler called",
+            tool_call_id=request.tool_call["id"],
+            name=request.tool_call["name"],
+            status="success",
+        )
+
+    return handle
+
+
+def test_blocks_repeated_read_file_after_schema_normalization() -> None:
+    read_file = _read_file_tool()
+    messages = [
+        HumanMessage(content="read directionality"),
+        _ai_tool_call("call-1", "read_file", {"file_path": "/directionality.md", "offset": 100}),
+        _tool_result("call-1"),
+        _ai_tool_call("call-2", "read_file", {"file_path": "/directionality.md", "offset": "100", "limit": "100"}),
+        _tool_result("call-2"),
+        _ai_tool_call("call-3", "read_file", {"file_path": "/directionality.md", "offset": 100}),
+    ]
+    request = _request(
+        call_id="call-3",
+        name="read_file",
+        args={"file_path": "/directionality.md", "offset": 100},
+        messages=messages,
+        tool=read_file,
+    )
+    calls: list[ToolCallRequest] = []
+
+    result = RepeatedToolCallMiddleware(max_repeats=2).wrap_tool_call(request, _handler(calls))
+
+    assert calls == []
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert result.tool_call_id == "call-3"
+    assert result.name == "read_file"
+    assert result.content == (
+        "Repeated tool call blocked: `read_file` was called more than "
+        "2 consecutive times with the same normalized arguments. "
+        "The repeated call was not executed. Continue the task using the "
+        "existing context or another approach."
+    )
+
+
+def test_allows_same_tool_with_different_normalized_args() -> None:
+    read_file = _read_file_tool()
+    messages = [
+        HumanMessage(content="read directionality"),
+        _ai_tool_call("call-1", "read_file", {"file_path": "/directionality.md", "offset": 100}),
+        _tool_result("call-1"),
+        _ai_tool_call("call-2", "read_file", {"file_path": "/directionality.md", "offset": 100}),
+        _tool_result("call-2"),
+        _ai_tool_call("call-3", "read_file", {"file_path": "/directionality.md", "offset": 200}),
+    ]
+    request = _request(
+        call_id="call-3",
+        name="read_file",
+        args={"file_path": "/directionality.md", "offset": 200},
+        messages=messages,
+        tool=read_file,
+    )
+    calls: list[ToolCallRequest] = []
+
+    result = RepeatedToolCallMiddleware(max_repeats=2).wrap_tool_call(request, _handler(calls))
+
+    assert len(calls) == 1
+    assert isinstance(result, ToolMessage)
+    assert result.status == "success"
+
+
+def test_human_message_resets_consecutive_repeat_count() -> None:
+    read_file = _read_file_tool()
+    messages = [
+        HumanMessage(content="first request"),
+        _ai_tool_call("call-1", "read_file", {"file_path": "/directionality.md", "offset": 100}),
+        _tool_result("call-1"),
+        _ai_tool_call("call-2", "read_file", {"file_path": "/directionality.md", "offset": 100}),
+        _tool_result("call-2"),
+        HumanMessage(content="read that section again"),
+        _ai_tool_call("call-3", "read_file", {"file_path": "/directionality.md", "offset": 100}),
+    ]
+    request = _request(
+        call_id="call-3",
+        name="read_file",
+        args={"file_path": "/directionality.md", "offset": 100},
+        messages=messages,
+        tool=read_file,
+    )
+    calls: list[ToolCallRequest] = []
+
+    result = RepeatedToolCallMiddleware(max_repeats=2).wrap_tool_call(request, _handler(calls))
+
+    assert len(calls) == 1
+    assert isinstance(result, ToolMessage)
+    assert result.status == "success"
+
+
+def test_falls_back_to_stable_json_for_tools_without_schema() -> None:
+    messages = [
+        HumanMessage(content="search"),
+        _ai_tool_call("call-1", "web_search", {"query": "LangGraph", "limit": 5}),
+        _tool_result("call-1", name="web_search"),
+        _ai_tool_call("call-2", "web_search", {"limit": 5, "query": "LangGraph"}),
+    ]
+    request = _request(
+        call_id="call-2",
+        name="web_search",
+        args={"limit": 5, "query": "LangGraph"},
+        messages=messages,
+    )
+    calls: list[ToolCallRequest] = []
+
+    result = RepeatedToolCallMiddleware(max_repeats=1).wrap_tool_call(request, _handler(calls))
+
+    assert calls == []
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+
+
+def test_blocks_repeated_tool_calls_in_same_ai_message() -> None:
+    read_file = _read_file_tool()
+    messages = [
+        HumanMessage(content="read directionality"),
+        AIMessage(
+            content="",
+            tool_calls=[
+                {"id": "call-1", "name": "read_file", "args": {"file_path": "/directionality.md", "offset": 100}},
+                {"id": "call-2", "name": "read_file", "args": {"file_path": "/directionality.md", "offset": 100}},
+            ],
+        ),
+    ]
+    request = _request(
+        call_id="call-2",
+        name="read_file",
+        args={"file_path": "/directionality.md", "offset": 100},
+        messages=messages,
+        tool=read_file,
+    )
+    calls: list[ToolCallRequest] = []
+
+    result = RepeatedToolCallMiddleware(max_repeats=1).wrap_tool_call(request, _handler(calls))
+
+    assert calls == []
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+
+
+def test_rejects_invalid_max_repeats() -> None:
+    with pytest.raises(ValueError, match="max_repeats must be >= 1"):
+        RepeatedToolCallMiddleware(max_repeats=0)
+
+
+async def test_async_wrap_tool_call_blocks_repeated_call() -> None:
+    read_file = _read_file_tool()
+    messages = [
+        HumanMessage(content="read directionality"),
+        _ai_tool_call("call-1", "read_file", {"file_path": "/directionality.md", "offset": 100}),
+        _tool_result("call-1"),
+        _ai_tool_call("call-2", "read_file", {"file_path": "/directionality.md", "offset": 100}),
+    ]
+    request = _request(
+        call_id="call-2",
+        name="read_file",
+        args={"file_path": "/directionality.md", "offset": 100},
+        messages=messages,
+        tool=read_file,
+    )
+    calls: list[ToolCallRequest] = []
+
+    async def handle(req: ToolCallRequest) -> ToolMessage:
+        calls.append(req)
+        return ToolMessage(content="handler called", tool_call_id=req.tool_call["id"], name=req.tool_call["name"])
+
+    result = await RepeatedToolCallMiddleware(max_repeats=1).awrap_tool_call(request, handle)
+
+    assert calls == []
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"


### PR DESCRIPTION
Adds an opt-in `RepeatedToolCallMiddleware` that short-circuits consecutive identical tool calls and returns a tool error observation instead of executing the repeated call again.

The guard compares tool name plus schema-normalized arguments, so repeated calls with equivalent defaults or coercible argument values are treated consistently while unrelated calls can continue. It is intentionally scoped to the repeated call and does not terminate the agent run.

Verified with `make lint` and `make test PYTEST_EXTRA=-q` from `libs/deepagents`.