### PR TITLE
feat(evals): add real-model evals for langchain `TodoListMiddleware` against `create_agent`

### DIFF
--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -7,7 +7,7 @@ Source of truth: [`tests/evals/`](tests/evals/).
 Categories (for `--eval-category` filtering):
 
 ```txt
-file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,langchain/middleware/todo
+file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,langchain/middleware
 ```
 
 **118 evals** across **8 categories**
@@ -144,7 +144,7 @@ file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,l
 - [`test_task_calls_general_purpose_subagent`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_subagents.py#L79) — `tests/evals/test_subagents.py:79`
 - [`test_custom_system_prompt`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_system_prompt.py#L29) — `tests/evals/test_system_prompt.py:29`
 
-## Upstream Middleware (`langchain/middleware/todo`) (7 evals)
+## Upstream Middleware (`langchain/middleware`) (7 evals)
 
 - [`test_density_rank_lands_in_final_message`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L105) — `tests/evals/test_langchain_middleware_todo.py:105`
 - [`test_population_compare_lands_in_final_message`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L144) — `tests/evals/test_langchain_middleware_todo.py:144`

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -144,7 +144,7 @@ file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,l
 - [`test_task_calls_general_purpose_subagent`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_subagents.py#L79) — `tests/evals/test_subagents.py:79`
 - [`test_custom_system_prompt`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_system_prompt.py#L29) — `tests/evals/test_system_prompt.py:29`
 
-## Todo Middleware (`langchain/middleware/todo`) (7 evals)
+## Upstream Middleware (`langchain/middleware/todo`) (7 evals)
 
 - [`test_density_rank_lands_in_final_message`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L105) — `tests/evals/test_langchain_middleware_todo.py:105`
 - [`test_population_compare_lands_in_final_message`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L144) — `tests/evals/test_langchain_middleware_todo.py:144`

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -7,10 +7,10 @@ Source of truth: [`tests/evals/`](tests/evals/).
 Categories (for `--eval-category` filtering):
 
 ```txt
-file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test
+file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,langchain/middleware/todo
 ```
 
-**111 evals** across **7 categories**
+**118 evals** across **8 categories**
 
 ## File Ops (`file_operations`) (13 evals)
 
@@ -143,3 +143,13 @@ file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test
 - [`test_task_calls_weather_subagent`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_subagents.py#L39) — `tests/evals/test_subagents.py:39`
 - [`test_task_calls_general_purpose_subagent`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_subagents.py#L79) — `tests/evals/test_subagents.py:79`
 - [`test_custom_system_prompt`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_system_prompt.py#L29) — `tests/evals/test_system_prompt.py:29`
+
+## Todo Middleware (`langchain/middleware/todo`) (7 evals)
+
+- [`test_density_rank_lands_in_final_message`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L105) — `tests/evals/test_langchain_middleware_todo.py:105`
+- [`test_population_compare_lands_in_final_message`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L144) — `tests/evals/test_langchain_middleware_todo.py:144`
+- [`test_trivial_arithmetic_skips_write_todos`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L187) — `tests/evals/test_langchain_middleware_todo.py:187`
+- [`test_rank_with_unknown_lookup_lands_in_final_message`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L222) — `tests/evals/test_langchain_middleware_todo.py:222`
+- [`test_design_api_lands_in_final_message`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L283) — `tests/evals/test_langchain_middleware_todo.py:283`
+- [`test_density_cairo_lands_in_final_message`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L321) — `tests/evals/test_langchain_middleware_todo.py:321`
+- [`test_trivial_plan_skips_write_todos`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L355) — `tests/evals/test_langchain_middleware_todo.py:355`

--- a/libs/evals/deepagents_evals/categories.json
+++ b/libs/evals/deepagents_evals/categories.json
@@ -7,7 +7,7 @@
     "conversation",
     "summarization",
     "unit_test",
-    "langchain/middleware/todo"
+    "langchain/middleware"
   ],
   "radar_categories": [
     "file_operations",
@@ -25,6 +25,6 @@
     "conversation": "Conversation",
     "summarization": "Summarization",
     "unit_test": "Unit Test",
-    "langchain/middleware/todo": "Upstream Middleware"
+    "langchain/middleware": "Upstream Middleware"
   }
 }

--- a/libs/evals/deepagents_evals/categories.json
+++ b/libs/evals/deepagents_evals/categories.json
@@ -6,7 +6,8 @@
     "memory",
     "conversation",
     "summarization",
-    "unit_test"
+    "unit_test",
+    "langchain/middleware/todo"
   ],
   "radar_categories": [
     "file_operations",
@@ -23,6 +24,7 @@
     "memory": "Memory",
     "conversation": "Conversation",
     "summarization": "Summarization",
-    "unit_test": "Unit Test"
+    "unit_test": "Unit Test",
+    "langchain/middleware/todo": "Todo Middleware"
   }
 }

--- a/libs/evals/deepagents_evals/categories.json
+++ b/libs/evals/deepagents_evals/categories.json
@@ -25,6 +25,6 @@
     "conversation": "Conversation",
     "summarization": "Summarization",
     "unit_test": "Unit Test",
-    "langchain/middleware/todo": "Todo Middleware"
+    "langchain/middleware/todo": "Upstream Middleware"
   }
 }

--- a/libs/evals/tests/evals/test_langchain_middleware_todo.py
+++ b/libs/evals/tests/evals/test_langchain_middleware_todo.py
@@ -1,0 +1,382 @@
+"""Eval tests for `langchain`'s `TodoListMiddleware` against bare `create_agent`.
+
+These tests probe the behavioral properties of `WRITE_TODOS_SYSTEM_PROMPT` and
+`WRITE_TODOS_TOOL_DESCRIPTION` directly — using `create_agent` +
+`TodoListMiddleware` (not `create_deep_agent`) — so they exercise the
+prompt content that ships in `langchain.agents.middleware.todo` without
+any deepagents-side `BASE_AGENT_PROMPT` running in front of it.
+
+The companion langchain PR landed a fix for the "wasted post-tool turn"
+pattern that fhuang originally reported on Sonnet 4.6: when the model
+finishes work with a `write_todos(all completed)` call, the agent loop
+forces one more model turn, and that turn was producing empty / recap
+messages instead of the substantive answer. The fix lives in
+`WRITE_TODOS_SYSTEM_PROMPT` (a "Finishing a task" section), in
+`WRITE_TODOS_TOOL_DESCRIPTION` (a "When You Finish" section), and in the
+`write_todos` tool message (neutralized from a verbose status dump to
+`"Todo list updated."`).
+
+These tests verify the fix holds on real models, with the same
+`TrajectoryScorer` framework deepagents already uses internally.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from langchain.agents import create_agent
+from langchain.agents.middleware import TodoListMiddleware
+from langchain_core.tools import tool
+
+from tests.evals.utils import (
+    AgentTrajectory,
+    MaxToolCallRequests,
+    SuccessAssertion,
+    TrajectoryScorer,
+    final_text_contains,
+    final_text_contains_any,
+    final_text_min_length,
+    run_agent,
+    tool_call,
+)
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+
+pytestmark = [pytest.mark.eval_category("langchain/middleware/todo")]
+
+
+# ---------------------------------------------------------------------------
+# Tools used by the tests
+# ---------------------------------------------------------------------------
+
+
+@tool
+def lookup_population(city: str) -> str:
+    """Return the population of a city as a string."""
+    data = {
+        "tokyo": "13,960,000",
+        "delhi": "32,900,000",
+        "shanghai": "29,200,000",
+        "cairo": "21,800,000",
+    }
+    return data.get(city.lower(), "unknown")
+
+
+@tool
+def lookup_area_km2(city: str) -> str:
+    """Return the area of a city in square kilometers as a string."""
+    data = {
+        "tokyo": "2,194",
+        "delhi": "1,484",
+        "shanghai": "6,341",
+        "cairo": "606",
+    }
+    return data.get(city.lower(), "unknown")
+
+
+def _max_tool_calls_success(n: int) -> SuccessAssertion:
+    """Wrap `MaxToolCallRequests` as a hard-fail success assertion.
+
+    `MaxToolCallRequests` is normally an `EfficiencyAssertion` (logged but
+    never fails). For the trivial-skip test where over-using `write_todos`
+    *is* the failure mode, promote it to hard-fail.
+    """
+    eff = MaxToolCallRequests(n=n)
+
+    class _AsSuccess(SuccessAssertion):
+        def check(self, trajectory: AgentTrajectory) -> bool:
+            return eff.check(trajectory)
+
+        def describe_failure(self, trajectory: AgentTrajectory) -> str:
+            return eff.describe_failure(trajectory)
+
+    return _AsSuccess()
+
+
+# ---------------------------------------------------------------------------
+# Baseline tier — regression gates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.langsmith
+def test_density_rank_lands_in_final_message(model: BaseChatModel) -> None:
+    """Substantive ranked answer must land in the last AIMessage.
+
+    Without the loop-contract fix the model puts the ranked output in the
+    same turn as the final `write_todos(completed)` call, and the
+    loop-terminating message becomes a 20-30 char wrap-up that omits the
+    cities by name. This test fails in that regime.
+    """
+    agent = create_agent(
+        model=model,
+        tools=[lookup_population, lookup_area_km2],
+        middleware=[TodoListMiddleware()],
+    )
+    run_agent(
+        agent,
+        model=model,
+        query=(
+            "Rank Tokyo, Delhi, and Shanghai by population density (people per "
+            "km²) from highest to lowest. Look up the population and area for "
+            "each city, compute density for each, and present the ranking. Use "
+            "a todo list to plan and track your work."
+        ),
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=6,
+            tool_call_requests=8,
+            tool_calls=[tool_call(name="write_todos")],
+        )
+        .success(
+            final_text_contains("tokyo", case_insensitive=True),
+            final_text_contains("delhi", case_insensitive=True),
+            final_text_contains("shanghai", case_insensitive=True),
+            final_text_min_length(80),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.langsmith
+def test_population_compare_lands_in_final_message(model: BaseChatModel) -> None:
+    """Binary comparison answer must land in the last AIMessage.
+
+    Delhi (32,900,000) - Tokyo (13,960,000) = 18,940,000 difference. The
+    model needs to communicate that gap — formatted any reasonable way.
+    """
+    agent = create_agent(
+        model=model,
+        tools=[lookup_population],
+        middleware=[TodoListMiddleware()],
+    )
+    run_agent(
+        agent,
+        model=model,
+        query=(
+            "Which has more people: Tokyo or Delhi? Use a todo list to plan, "
+            "look up the population for each city, and tell me which has more "
+            "and by how much."
+        ),
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=4,
+            tool_call_requests=4,
+            tool_calls=[tool_call(name="write_todos")],
+        )
+        .success(
+            final_text_contains("delhi", case_insensitive=True),
+            final_text_contains_any(
+                "18,940,000",
+                "18940000",
+                "18.94 million",
+                "18.9 million",
+                "19 million",
+                "18 million",
+                case_insensitive=True,
+            ),
+            final_text_min_length(50),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.langsmith
+def test_trivial_arithmetic_skips_write_todos(model: BaseChatModel) -> None:
+    """One-shot arithmetic must NOT invoke `write_todos`.
+
+    Cross-model baseline check for the "skip for simple" guidance in
+    `WRITE_TODOS_SYSTEM_PROMPT`. Pure single-step arithmetic with no list-
+    shape or planning bait, so every model with a working skip-for-simple
+    disposition should answer directly. If a future prompt change
+    accidentally removes the "skip for simple" line, every model would
+    start cargo-culting `write_todos` and this test catches it.
+    """
+    agent = create_agent(
+        model=model,
+        tools=[],
+        middleware=[TodoListMiddleware()],
+    )
+    run_agent(
+        agent,
+        model=model,
+        query="What is 47 + 18?",
+        scorer=TrajectoryScorer()
+        .expect(agent_steps=1, tool_call_requests=0)
+        .success(
+            final_text_contains("65"),
+            _max_tool_calls_success(0),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hillclimb tier — progress signals (not regression gates)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.eval_tier("hillclimb")
+@pytest.mark.langsmith
+def test_rank_with_unknown_lookup_lands_in_final_message(model: BaseChatModel) -> None:
+    """Substantive answer must land in the last AIMessage when a lookup fails.
+
+    Atlantis is intentionally absent from the lookup data — both lookups
+    return ``"unknown"`` for it. The agent has to revise its plan, present
+    a partial ranking for the cities it could look up, and surface the
+    missing data.
+
+    Hillclimb tier: this is the hardest baseline-style probe — multi-city
+    ranking + mid-flow data gap + revise-and-report. Some models flake on
+    it across consecutive runs even when other baseline tests pass
+    deterministically. Useful as a progress signal but not a hard gate.
+    """
+    agent = create_agent(
+        model=model,
+        tools=[lookup_population, lookup_area_km2],
+        middleware=[TodoListMiddleware()],
+    )
+    run_agent(
+        agent,
+        model=model,
+        query=(
+            "Rank Tokyo, Atlantis, and Cairo by population density (people "
+            "per km²) from highest to lowest. Look up the population and area "
+            "for each city, compute density for each, and present the "
+            "ranking. Use a todo list to plan and track your work."
+        ),
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=6,
+            tool_call_requests=8,
+            tool_calls=[tool_call(name="write_todos")],
+        )
+        .success(
+            final_text_contains("tokyo", case_insensitive=True),
+            final_text_contains("cairo", case_insensitive=True),
+            final_text_contains("atlantis", case_insensitive=True),
+            # Any reasonable acknowledgement of the missing data counts.
+            # A hallucinating model that invents stats for Atlantis would
+            # not include any of these phrases.
+            final_text_contains_any(
+                "unknown",
+                "no data",
+                "n/a",
+                "unable",
+                "cannot be ranked",
+                "not available",
+                "no information",
+                "missing",
+                "mythical",
+                "fictional",
+                "legendary",
+                case_insensitive=True,
+            ),
+            final_text_min_length(150),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("hillclimb")
+@pytest.mark.langsmith
+def test_design_api_lands_in_final_message(model: BaseChatModel) -> None:
+    """Design/synthesis answer must land in the last AIMessage.
+
+    No external tools; the agent has only `write_todos`. The substantive
+    output is a small API design that must mention endpoints,
+    authentication, and at least one HTTP method.
+    """
+    agent = create_agent(
+        model=model,
+        tools=[],
+        middleware=[TodoListMiddleware()],
+    )
+    run_agent(
+        agent,
+        model=model,
+        query=(
+            "Design a small REST API for a todo-list application. Use a todo "
+            "list to plan and track your work. Cover at minimum: endpoints "
+            "with their HTTP methods, request/response shape, and "
+            "authentication approach."
+        ),
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=5,
+            tool_call_requests=4,
+            tool_calls=[tool_call(name="write_todos")],
+        )
+        .success(
+            final_text_contains("endpoint", case_insensitive=True),
+            final_text_contains("authentication", case_insensitive=True),
+            final_text_contains("POST", case_insensitive=True),
+            final_text_min_length(200),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("hillclimb")
+@pytest.mark.langsmith
+def test_density_cairo_lands_in_final_message(model: BaseChatModel) -> None:
+    """Single-density answer must land in the last AIMessage.
+
+    Softer than density_rank because the recap-summary often happens to
+    include the looked-up values + density terms; partially passable under
+    a model that doesn't fully respect the loop contract. Useful directional
+    metric, not a regression gate.
+    """
+    agent = create_agent(
+        model=model,
+        tools=[lookup_population, lookup_area_km2],
+        middleware=[TodoListMiddleware()],
+    )
+    run_agent(
+        agent,
+        model=model,
+        query=(
+            "What is the approximate population density (people per km²) of "
+            "Cairo? Look up the population, look up the area, then compute "
+            "and report the density. Use a todo list to plan and track your "
+            "work."
+        ),
+        scorer=TrajectoryScorer()
+        .expect(agent_steps=5, tool_call_requests=5)
+        .success(
+            final_text_contains("21,800,000"),
+            final_text_contains("606"),
+            final_text_min_length(80),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("hillclimb")
+@pytest.mark.langsmith
+def test_trivial_plan_skips_write_todos(model: BaseChatModel) -> None:
+    """Trivial planning request should NOT invoke `write_todos`.
+
+    Hillclimb tier: the "Plan a 3-course dinner menu" shape (the word
+    "Plan" plus 3 explicit items) gets interpreted literally enough by
+    some models (Llama, Gemini in our observations) to invoke
+    `write_todos` despite the "skip for simple" guidance.
+    Claude/GPT-5/DeepSeek pass it. Useful progress signal but not a
+    hard regression gate.
+    """
+    agent = create_agent(
+        model=model,
+        tools=[],
+        middleware=[TodoListMiddleware()],
+    )
+    run_agent(
+        agent,
+        model=model,
+        query="Plan a simple 3-course dinner menu (appetizer, main, dessert).",
+        scorer=TrajectoryScorer()
+        .expect(agent_steps=1, tool_call_requests=0)
+        .success(
+            final_text_contains("appetizer", case_insensitive=True),
+            final_text_contains("main", case_insensitive=True),
+            final_text_contains("dessert", case_insensitive=True),
+            _max_tool_calls_success(0),
+        ),
+    )

--- a/libs/evals/tests/evals/test_langchain_middleware_todo.py
+++ b/libs/evals/tests/evals/test_langchain_middleware_todo.py
@@ -44,7 +44,7 @@ from tests.evals.utils import (
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
 
-pytestmark = [pytest.mark.eval_category("langchain/middleware/todo")]
+pytestmark = [pytest.mark.eval_category("langchain/middleware")]
 
 
 # ---------------------------------------------------------------------------

--- a/libs/evals/tests/evals/test_langchain_middleware_todo.py
+++ b/libs/evals/tests/evals/test_langchain_middleware_todo.py
@@ -126,7 +126,7 @@ def test_density_rank_lands_in_final_message(model: BaseChatModel) -> None:
         ),
         scorer=TrajectoryScorer()
         .expect(
-            agent_steps=6,
+            agent_steps=4,
             tool_call_requests=8,
             tool_calls=[tool_call(name="write_todos")],
         )
@@ -248,7 +248,7 @@ def test_rank_with_unknown_lookup_lands_in_final_message(model: BaseChatModel) -
         ),
         scorer=TrajectoryScorer()
         .expect(
-            agent_steps=6,
+            agent_steps=4,
             tool_call_requests=8,
             tool_calls=[tool_call(name="write_todos")],
         )
@@ -303,8 +303,8 @@ def test_design_api_lands_in_final_message(model: BaseChatModel) -> None:
         ),
         scorer=TrajectoryScorer()
         .expect(
-            agent_steps=5,
-            tool_call_requests=4,
+            agent_steps=3,
+            tool_call_requests=2,
             tool_calls=[tool_call(name="write_todos")],
         )
         .success(
@@ -341,7 +341,7 @@ def test_density_cairo_lands_in_final_message(model: BaseChatModel) -> None:
             "work."
         ),
         scorer=TrajectoryScorer()
-        .expect(agent_steps=5, tool_call_requests=5)
+        .expect(agent_steps=4, tool_call_requests=4)
         .success(
             final_text_contains("21,800,000"),
             final_text_contains("606"),

--- a/libs/evals/tests/evals/utils.py
+++ b/libs/evals/tests/evals/utils.py
@@ -299,6 +299,104 @@ class FinalTextExcludes(SuccessAssertion):
 
 
 @dataclass(frozen=True)
+class FinalTextContainsAny(SuccessAssertion):
+    """Assert that the final agent text contains at least ONE of the given substrings.
+
+    Useful when a behavior can be expressed in several equivalent phrasings
+    (e.g., a "value is missing" acknowledgement that could be worded as
+    "unknown", "no data", "n/a", "unable to look up", "cannot be ranked",
+    etc.). The any-of group still proves the behavior — a model that fakes
+    or hallucinates instead of acknowledging the gap would not include any
+    of these phrases.
+
+    Attributes:
+        texts: The set of substrings to look for; the check passes if any
+            one of them is present.
+        case_insensitive: Whether the comparison should ignore case.
+    """
+
+    texts: tuple[str, ...]
+    case_insensitive: bool = False
+
+    def check(self, trajectory: AgentTrajectory) -> bool:
+        """Check that the final step text contains at least one of ``self.texts``.
+
+        Args:
+            trajectory: The agent trajectory to check.
+
+        Returns:
+            Whether the final text contains any of the expected substrings.
+        """
+        haystack = _strip_common_zero_width(trajectory.steps[-1].action.text)
+        if self.case_insensitive:
+            haystack = haystack.lower()
+        for text in self.texts:
+            needle = _strip_common_zero_width(text)
+            if self.case_insensitive:
+                needle = needle.lower()
+            if needle in haystack:
+                return True
+        return False
+
+    def describe_failure(self, trajectory: AgentTrajectory) -> str:
+        """Describe why the final-text-contains-any check failed.
+
+        Args:
+            trajectory: The agent trajectory that failed the check.
+
+        Returns:
+            A human-readable failure description.
+        """
+        final_text = _strip_common_zero_width(trajectory.steps[-1].action.text)
+        return (
+            f"Expected final text to contain at least one of "
+            f"{list(self.texts)!r} (case_insensitive={self.case_insensitive}), "
+            f"got: {final_text!r}"
+        )
+
+
+@dataclass(frozen=True)
+class FinalTextMinLength(SuccessAssertion):
+    """Assert that the final agent text is at least ``n`` chars (after strip).
+
+    Useful for filtering out short recap-style wrap-up messages that may
+    happen to contain expected substrings but aren't the substantive
+    answer the user asked for.
+
+    Attributes:
+        n: Minimum length of ``trajectory.steps[-1].action.text.strip()``.
+    """
+
+    n: int
+
+    def check(self, trajectory: AgentTrajectory) -> bool:
+        """Check that the stripped final text is at least ``self.n`` chars.
+
+        Args:
+            trajectory: The agent trajectory to check.
+
+        Returns:
+            Whether the final text meets the minimum length.
+        """
+        return len(trajectory.steps[-1].action.text.strip()) >= self.n
+
+    def describe_failure(self, trajectory: AgentTrajectory) -> str:
+        """Describe why the final-text-min-length check failed.
+
+        Args:
+            trajectory: The agent trajectory that failed the check.
+
+        Returns:
+            A human-readable failure description.
+        """
+        final_text = _strip_common_zero_width(trajectory.steps[-1].action.text)
+        actual = len(final_text.strip())
+        return (
+            f"Expected final text length >= {self.n}, got {actual}: {final_text!r}"
+        )
+
+
+@dataclass(frozen=True)
 class FileEquals(SuccessAssertion):
     """Assert that a file in the trajectory has exactly the expected content.
 
@@ -489,6 +587,46 @@ class ToolCallRequests(EfficiencyAssertion):
 
 
 @dataclass(frozen=True)
+class MaxToolCallRequests(EfficiencyAssertion):
+    """Assert that the trajectory has AT MOST ``n`` total tool call requests.
+
+    Use this when a trivial task should not invoke tools at all (or invoke
+    them rarely): a model that lost its "skip for simple tasks" guidance
+    and cargo-cults a planning tool on every query produces 4+ tool calls
+    where 0-1 was expected.
+
+    Attributes:
+        n: Maximum allowed number of tool call requests in the trajectory.
+    """
+
+    n: int
+
+    def check(self, trajectory: AgentTrajectory) -> bool:
+        """Check that total tool call requests do not exceed ``self.n``.
+
+        Args:
+            trajectory: The agent trajectory to check.
+
+        Returns:
+            Whether the tool call count is at or below the maximum.
+        """
+        actual = sum(len(s.action.tool_calls) for s in trajectory.steps)
+        return actual <= self.n
+
+    def describe_failure(self, trajectory: AgentTrajectory) -> str:
+        """Describe why the max-tool-call-requests check failed.
+
+        Args:
+            trajectory: The agent trajectory that failed the check.
+
+        Returns:
+            A human-readable failure description.
+        """
+        actual = sum(len(s.action.tool_calls) for s in trajectory.steps)
+        return f"Expected at most {self.n} tool call requests, got {actual}"
+
+
+@dataclass(frozen=True)
 class ToolCall(EfficiencyAssertion):
     """Assert that a specific tool call occurred in the trajectory.
 
@@ -609,6 +747,35 @@ def final_text_excludes(
     return FinalTextExcludes(text=text, case_insensitive=case_insensitive)
 
 
+def final_text_contains_any(
+    *texts: str,
+    case_insensitive: bool = False,
+) -> FinalTextContainsAny:
+    """Create a ``FinalTextContainsAny`` success assertion.
+
+    Args:
+        *texts: The substrings to look for; the check passes if any one of
+            them is present.
+        case_insensitive: Whether the comparison should ignore case.
+
+    Returns:
+        A ``FinalTextContainsAny`` assertion instance.
+    """
+    return FinalTextContainsAny(texts=tuple(texts), case_insensitive=case_insensitive)
+
+
+def final_text_min_length(n: int) -> FinalTextMinLength:
+    """Create a ``FinalTextMinLength`` success assertion.
+
+    Args:
+        n: Minimum length of the final agent text (after stripping).
+
+    Returns:
+        A ``FinalTextMinLength`` assertion instance.
+    """
+    return FinalTextMinLength(n=n)
+
+
 def file_equals(path: str, content: str) -> FileEquals:
     """Create a ``FileEquals`` success assertion.
 
@@ -670,6 +837,18 @@ def tool_call_requests(n: int) -> ToolCallRequests:
         A ``ToolCallRequests`` assertion instance.
     """
     return ToolCallRequests(n=n)
+
+
+def max_tool_call_requests(n: int) -> MaxToolCallRequests:
+    """Create a ``MaxToolCallRequests`` efficiency assertion.
+
+    Args:
+        n: Maximum allowed number of tool call requests.
+
+    Returns:
+        A ``MaxToolCallRequests`` assertion instance.
+    """
+    return MaxToolCallRequests(n=n)
 
 
 def tool_call(

--- a/libs/evals/tests/evals/utils.py
+++ b/libs/evals/tests/evals/utils.py
@@ -391,9 +391,7 @@ class FinalTextMinLength(SuccessAssertion):
         """
         final_text = _strip_common_zero_width(trajectory.steps[-1].action.text)
         actual = len(final_text.strip())
-        return (
-            f"Expected final text length >= {self.n}, got {actual}: {final_text!r}"
-        )
+        return f"Expected final text length >= {self.n}, got {actual}: {final_text!r}"
 
 
 @dataclass(frozen=True)

--- a/libs/evals/tests/unit_tests/test_category_tagging.py
+++ b/libs/evals/tests/unit_tests/test_category_tagging.py
@@ -43,6 +43,7 @@ EXPECTED_CATEGORY_MODULES: dict[str, list[str]] = {
         "test_subagents",
         "test_skills",
     ],
+    "langchain/middleware/todo": ["test_langchain_middleware_todo"],
 }
 
 

--- a/libs/evals/tests/unit_tests/test_category_tagging.py
+++ b/libs/evals/tests/unit_tests/test_category_tagging.py
@@ -43,7 +43,7 @@ EXPECTED_CATEGORY_MODULES: dict[str, list[str]] = {
         "test_subagents",
         "test_skills",
     ],
-    "langchain/middleware/todo": ["test_langchain_middleware_todo"],
+    "langchain/middleware": ["test_langchain_middleware_todo"],
 }
 
 


### PR DESCRIPTION
Companion to **langchain PR [#37643](https://github.com/langchain-ai/langchain/pull/37643)**.

These tests probe `WRITE_TODOS_SYSTEM_PROMPT` and `WRITE_TODOS_TOOL_DESCRIPTION` directly via `create_agent` + `TodoListMiddleware` (not `create_deep_agent`), so they exercise the langchain prompt content without the deepagents-side `BASE_AGENT_PROMPT` running ahead of it.

## What's added

**3 new assertion primitives in `libs/evals/tests/evals/utils.py`:**
- `FinalTextContainsAny` — any-of substring matching (useful for missing-data acknowledgements like `unknown` / `no data` / `n/a` / etc.)
- `FinalTextMinLength` — filters out short recap-style wrap-ups
- `MaxToolCallRequests` — efficiency check for "skip for simple" guidance

**New test module `tests/evals/test_langchain_middleware_todo.py`:**

Baseline tier (regression gates):
- `test_density_rank_lands_in_final_message`
- `test_population_compare_lands_in_final_message`
- `test_trivial_arithmetic_skips_write_todos`

Hillclimb tier (progress signals, not gates):
- `test_rank_with_unknown_lookup_lands_in_final_message`
- `test_design_api_lands_in_final_message`
- `test_density_cairo_lands_in_final_message`
- `test_trivial_plan_skips_write_todos`

## Dependency on langchain #37643

These tests are expected to **fail** against the langchain version currently pinned in `libs/deepagents/pyproject.toml` (`sr/hitl-refactor`) because that version doesn't have the prompt fix. To validate this PR locally before #37643 merges, temporarily repoint the langchain source:

```toml
langchain = {
  git = "https://github.com/langchain-ai/langchain.git",
  branch = "nh/todo-middleware-loop-contract",
  subdirectory = "libs/langchain_v1",
}
```

After #37643 merges, bumping the langchain pin to the merged commit will make these tests start passing on the deterministic models.

## Cross-model evidence

The langchain branch with the fix was validated against 7 providers before consolidating evals into this repo:

- Sonnet 4.6, Haiku 4.5, GPT-5, Gemini 2.5 Pro, Kimi K2.6 — baseline passes deterministically
- DeepSeek, GLM 5.1 — pass intermittently (model-side variance documented in #37643)