### PR TITLE
chore(code): pin `FilesystemBackend`'s `virtual_mode=False`

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1268,7 +1268,7 @@ def create_cli_agent(
 
         agent_middleware.append(
             MemoryMiddleware(
-                backend=FilesystemBackend(),
+                backend=FilesystemBackend(virtual_mode=False),
                 sources=memory_sources,
             )
         )
@@ -1311,7 +1311,7 @@ def create_cli_agent(
 
         agent_middleware.append(
             SkillsMiddleware(
-                backend=FilesystemBackend(),
+                backend=FilesystemBackend(virtual_mode=False),
                 sources=middleware_sources,
             )
         )
@@ -1337,7 +1337,7 @@ def create_cli_agent(
             )
         else:
             # No shell access - use plain FilesystemBackend
-            backend = FilesystemBackend(root_dir=root_dir)
+            backend = FilesystemBackend(root_dir=root_dir, virtual_mode=False)
     else:
         # ========== REMOTE SANDBOX MODE ==========
         backend = sandbox  # Remote sandbox (ModalSandbox, etc.)

--- a/libs/code/deepagents_code/offload.py
+++ b/libs/code/deepagents_code/offload.py
@@ -307,7 +307,7 @@ async def perform_offload(
     if offload_backend is None:
         from deepagents.backends.filesystem import FilesystemBackend
 
-        offload_backend = FilesystemBackend()
+        offload_backend = FilesystemBackend(virtual_mode=False)
         logger.info("Using local FilesystemBackend for offload")
 
     middleware = SummarizationMiddleware(

--- a/libs/code/deepagents_code/skills/load.py
+++ b/libs/code/deepagents_code/skills/load.py
@@ -106,7 +106,7 @@ def list_skills(
         if not skill_dir or not skill_dir.exists():
             continue
         try:
-            backend = FilesystemBackend(root_dir=str(skill_dir))
+            backend = FilesystemBackend(root_dir=str(skill_dir), virtual_mode=False)
             skills = list_skills_from_backend(backend=backend, source_path=".")
             if experimental and skills:
                 logger.info(


### PR DESCRIPTION
Pin every `deepagents-code` instantiation of `FilesystemBackend` to `virtual_mode=False` so the CLI keeps its current real-filesystem semantics when the SDK flips the default. Also silences the pending `DeprecationWarning` the SDK now emits when `virtual_mode` is left unset.