### PR TITLE
fix(sdk): surface missing path errors in FilesystemBackend.ls (#3573)

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -246,8 +246,10 @@ class FilesystemBackend(BackendProtocol):
         """
         try:
             dir_path = self._resolve_path(path)
-            if not dir_path.exists() or not dir_path.is_dir():
-                return LsResult(entries=[])
+            if not dir_path.exists():
+                return LsResult(error=f"Path not found: '{path}'", entries=[])
+            if not dir_path.is_dir():
+                return LsResult(error=f"Not a directory: '{path}'", entries=[])
         except (OSError, RuntimeError) as e:
             msg = f"Cannot list '{path}': {e}"
             logger.warning("%s", msg)

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -151,8 +151,54 @@ def test_filesystem_backend_ls_nested_directories(tmp_path: Path):
     assert "/src/utils/common.py" in utils_paths
     assert len(utils_paths) == 2
 
-    empty_listing = be.ls("/nonexistent/")
-    assert empty_listing.entries == []
+    # Missing paths must be distinguishable from empty directories — see #3573.
+    missing_listing = be.ls("/nonexistent/")
+    assert missing_listing.entries == []
+    assert missing_listing.error is not None
+    assert "not found" in missing_listing.error.lower()
+    assert "/nonexistent/" in missing_listing.error
+
+
+def test_filesystem_backend_ls_missing_path_returns_error(tmp_path: Path):
+    """Regression for #3573 — missing path must populate `error`.
+
+    Previously `ls("/missing/")` returned `LsResult(error=None, entries=[])`
+    which is indistinguishable from an empty directory.
+    """
+    root = tmp_path
+    (root / "empty").mkdir()
+
+    be = FilesystemBackend(root_dir=str(root), virtual_mode=True)
+
+    missing = be.ls("/missing/")
+    empty = be.ls("/empty/")
+
+    assert missing.error is not None
+    assert "not found" in missing.error.lower()
+    assert missing.entries == []
+
+    # Empty directories stay error-free with empty entries (existing contract).
+    assert empty.error is None
+    assert empty.entries == []
+
+
+def test_filesystem_backend_ls_path_is_file_returns_error(tmp_path: Path):
+    """Regression for #3573 — file path must surface 'not a directory'.
+
+    Agents need to tell 'no such path', 'not a directory', and 'empty
+    directory' apart; previously all three collapsed to `LsResult(error=None,
+    entries=[])`.
+    """
+    root = tmp_path
+    (root / "file.txt").write_text("hello")
+
+    be = FilesystemBackend(root_dir=str(root), virtual_mode=True)
+
+    result = be.ls("/file.txt")
+    assert result.error is not None
+    assert "not a directory" in result.error.lower()
+    assert "/file.txt" in result.error
+    assert result.entries == []
 
 
 def test_filesystem_backend_ls_normal_mode_nested(tmp_path: Path):


### PR DESCRIPTION
## Summary

Closes #3573.

\`FilesystemBackend.ls()\` returned the same \`LsResult(error=None, entries=[])\` for empty directories, missing paths, and existing non-directory paths. Agents had no way to tell 'no such path', 'not a directory', and 'empty directory' apart. Distinguish the three cases at the guard in \`libs/deepagents/deepagents/backends/filesystem.py\`:

- Missing path → \`error='Path not found: <path>'\`
- Existing non-directory → \`error='Not a directory: <path>'\`
- Empty directory → \`error=None, entries=[]\` (unchanged contract)

\`BackendProtocol.als\` inherits the fix via the default \`asyncio.to_thread(self.ls)\` shim, so the async path needs no separate change.

## Test plan

- [x] Updated the existing \`test_filesystem_backend_ls_nested_directories\` case that relied on the collapsed behavior to assert the new error contract.
- [x] New \`test_filesystem_backend_ls_missing_path_returns_error\` pinning the missing-path branch.
- [x] New \`test_filesystem_backend_ls_path_is_file_returns_error\` pinning the file-path branch.
- [x] \`tests/unit_tests/backends/\` filesystem suite green locally (54 passed, 5 skipped).
- [x] Full \`tests/unit_tests\` suite green locally (1615 passed).
- [x] \`ruff check\` clean on touched files.