### PR TITLE
fix(code): render MCP tool errors and drop empty-string optional params

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6052,12 +6052,20 @@ class DeepAgentsApp(App):
             )
         except Exception as e:  # Resilient tool rendering
             logger.exception("Agent execution failed")
+            try:
+                from deepagents_code.remote_client import format_agent_exception
+
+                error_text = f"Agent error: {format_agent_exception(e)}"
+            except Exception:
+                # The formatter itself must never mask the original error.
+                logger.exception("format_agent_exception failed")
+                error_text = f"Agent error: {e!r}"
             # Ensure any in-flight tool calls don't remain stuck in "Running..."
             # when streaming aborts before tool results arrive.
             if self._ui_adapter:
-                self._ui_adapter.finalize_pending_tools_with_error(f"Agent error: {e}")
+                self._ui_adapter.finalize_pending_tools_with_error(error_text)
             try:
-                await self._mount_message(ErrorMessage(f"Agent error: {e}"))
+                await self._mount_message(ErrorMessage(error_text))
             except Exception:
                 logger.debug(
                     "Could not mount error message (app closing?)",

--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -960,6 +960,69 @@ async def _discover_tools(session: ClientSession) -> list[Any]:
     raise RuntimeError(msg)
 
 
+def _normalize_mcp_arguments(
+    arguments: dict[str, Any],
+    input_schema: Any,  # noqa: ANN401  # raw JSON Schema dict from the MCP tool
+) -> dict[str, Any]:
+    """Drop empty-string values for optional MCP tool params.
+
+    Some MCP servers (e.g. Slack's `slack_search_public_and_private`) validate
+    optional ID-typed params with `value is not a channel ID` when the model
+    fills them in with `""` instead of omitting them. JSON-Schema-derived
+    Pydantic models happily accept `""` for `Optional[str]`, so the request
+    reaches the server and gets rejected with a generic `ToolException`.
+
+    Treat `""` for non-required string fields as "omitted" so the MCP server
+    sees the same payload it would have for a field the model genuinely
+    skipped. Required fields are passed through unchanged so the server's
+    own missing-field error path still runs when applicable.
+
+    Only `""` is normalized; `None` is left to the caller / server. Schemas
+    that declare `["string", "null"]` will see `""` dropped but `None`
+    forwarded — callers that want symmetric "no value" handling should
+    omit the kwarg explicitly.
+
+    Dropped keys are logged at debug so unexpected MCP behavior is
+    diagnosable when a tool semantically distinguishes `""` from omitted.
+
+    Args:
+        arguments: Keyword arguments collected by LangChain's tool runner.
+        input_schema: The MCP tool's `inputSchema` (raw JSON Schema dict).
+
+    Returns:
+        A new dict suitable for `session.call_tool`.
+    """
+    if not isinstance(input_schema, dict):
+        return arguments
+    required = set(input_schema.get("required") or ())
+    properties = input_schema.get("properties") or {}
+    cleaned: dict[str, Any] = {}
+    for key, value in arguments.items():
+        if value != "" or key in required:  # noqa: PLC1901  # distinguishing "" from other falsy types (0, False, []) is the point
+            cleaned[key] = value
+            continue
+        prop = properties.get(key)
+        prop_type = prop.get("type") if isinstance(prop, dict) else None
+        is_string_typed = prop_type == "string" or (
+            isinstance(prop_type, list) and "string" in prop_type
+        )
+        # Three drop conditions converge here:
+        #   - explicit string type (the original Slack-style failure mode);
+        #   - missing `type` (oneOf/anyOf/$ref or untyped — treat as ambiguous
+        #     and conservatively drop, since the server will reject `""` for
+        #     any ID-shaped slot anyway);
+        #   - key absent from `properties` entirely (model invented a field).
+        # Anything with an explicit non-string `type` is kept — `""` can't be
+        # a valid integer/bool/array so it was the model's mistake to send,
+        # and the server's own validation gives a clearer error than ours.
+        if isinstance(prop, dict) and not is_string_typed and prop_type is not None:
+            cleaned[key] = value
+    if cleaned.keys() != arguments.keys():
+        dropped = sorted(set(arguments) - set(cleaned))
+        logger.debug("MCP arg normalize: dropped empty-string keys %s", dropped)
+    return cleaned
+
+
 def _build_cached_mcp_tool(
     *,
     mcp_tool: Any,  # noqa: ANN401
@@ -1005,6 +1068,8 @@ def _build_cached_mcp_tool(
         **arguments: Any,
     ) -> Any:  # noqa: ANN401
         from deepagents_code.mcp_auth import find_reauth_required
+
+        arguments = _normalize_mcp_arguments(arguments, mcp_tool.inputSchema)
 
         session = await session_manager.get_session(server_name)
         try:

--- a/libs/code/deepagents_code/remote_client.py
+++ b/libs/code/deepagents_code/remote_client.py
@@ -49,6 +49,35 @@ def _require_thread_id(config: dict[str, Any] | None) -> str:
     return thread_id
 
 
+def format_agent_exception(exc: BaseException) -> str:
+    """Render an exception from `RemoteAgent.astream` for the UI.
+
+    The LangGraph server serializes non-allowlisted exceptions as
+    `{"error": <ExceptionType>, "message": <text or "An internal error occurred">}`
+    (see `langgraph_api.serde`). `RemoteGraph` wraps that dict in
+    `RemoteException(payload)`, so the default `str(exc)` renders as an ugly
+    Python dict repr in the UI.
+
+    Args:
+        exc: The exception caught from the agent stream.
+
+    Returns:
+        `"<ErrorType>: <message>"` for `RemoteException` dict payloads,
+        otherwise `str(exc)`, falling back to the exception's class name when
+        the string form is empty.
+    """
+    payload = exc.args[0] if exc.args else None
+    if isinstance(payload, dict):
+        err_type = payload.get("error") or type(exc).__name__
+        message = payload.get("message")
+        if isinstance(err_type, str) and isinstance(message, str) and message:
+            return f"{err_type}: {message}"
+        if isinstance(err_type, str):
+            return err_type
+    text = str(exc)
+    return text or type(exc).__name__
+
+
 class RemoteAgent:
     """Client that talks to a LangGraph server over HTTP+SSE.
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -3070,6 +3070,47 @@ class TestRunAgentTaskMediaTracker:
             errors = app.query(ErrorMessage)
             assert any("Agent error: boom" in str(w._content) for w in errors)
 
+    async def test_run_agent_task_formats_remote_exception_dict_payload(
+        self,
+    ) -> None:
+        """`RemoteException({...})` renders as `Type: message`, not dict repr.
+
+        Regression guard: the production fix replaces `f"Agent error: {e}"`
+        with `format_agent_exception(e)`. Without this test, reverting the
+        helper call would silently regress (the existing `RuntimeError("boom")`
+        test passes either way).
+        """
+        from langgraph.pregel.remote import RemoteException
+
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._ui_adapter is not None
+
+            pending_tool = MagicMock()
+            app._ui_adapter._current_tool_messages = {"tool-1": pending_tool}
+
+            exc = RemoteException(
+                {"error": "ToolException", "message": "An internal error occurred"}
+            )
+            with patch(
+                "deepagents_code.textual_adapter.execute_task_textual",
+                new_callable=AsyncMock,
+                side_effect=exc,
+            ):
+                await app._run_agent_task("hello")
+                await pilot.pause()
+
+            expected = "Agent error: ToolException: An internal error occurred"
+            pending_tool.set_error.assert_called_once_with(expected)
+
+            errors = app.query(ErrorMessage)
+            assert any(expected in str(w._content) for w in errors)
+            # Confirm the ugly dict repr would have differed.
+            assert not any(
+                "{'error': 'ToolException'" in str(w._content) for w in errors
+            )
+
 
 class TestAppFocusRestoresChatInput:
     """Test `on_app_focus` restores chat input focus after terminal regains focus."""

--- a/libs/code/tests/unit_tests/test_mcp_tools.py
+++ b/libs/code/tests/unit_tests/test_mcp_tools.py
@@ -25,6 +25,7 @@ from deepagents_code.mcp_tools import (
     _check_remote_server,
     _check_stdio_server,
     _load_tools_from_config,
+    _normalize_mcp_arguments,
     classify_discovered_configs,
     discover_mcp_configs,
     extract_project_server_summaries,
@@ -2535,3 +2536,135 @@ class TestToolFilterEndToEnd:
         assert names == ["api_search", "fs_read_file"]
         assert manager is not None
         await manager.cleanup()
+
+
+class TestNormalizeMCPArguments:
+    """Cover the empty-string-stripping at the MCP tool boundary."""
+
+    def _schema(
+        self,
+        properties: dict[str, dict],
+        required: list[str] | None = None,
+    ) -> dict:
+        return {
+            "type": "object",
+            "properties": properties,
+            "required": required or [],
+        }
+
+    def test_drops_empty_optional_string(self) -> None:
+        schema = self._schema(
+            {
+                "query": {"type": "string"},
+                "context_channel_id": {"type": "string"},
+            },
+            required=["query"],
+        )
+        out = _normalize_mcp_arguments(
+            {"query": "hello", "context_channel_id": ""}, schema
+        )
+        assert out == {"query": "hello"}
+
+    def test_keeps_empty_required_string(self) -> None:
+        schema = self._schema({"query": {"type": "string"}}, required=["query"])
+        out = _normalize_mcp_arguments({"query": ""}, schema)
+        assert out == {"query": ""}
+
+    def test_keeps_nonempty_strings(self) -> None:
+        schema = self._schema({"q": {"type": "string"}})
+        out = _normalize_mcp_arguments({"q": "x"}, schema)
+        assert out == {"q": "x"}
+
+    def test_keeps_non_string_values(self) -> None:
+        schema = self._schema(
+            {
+                "limit": {"type": "integer"},
+                "include_bots": {"type": "boolean"},
+            }
+        )
+        out = _normalize_mcp_arguments({"limit": 0, "include_bots": False}, schema)
+        assert out == {"limit": 0, "include_bots": False}
+
+    def test_drops_empty_when_property_missing_type(self) -> None:
+        schema = self._schema({"hint": {"description": "free-form"}})
+        out = _normalize_mcp_arguments({"hint": ""}, schema)
+        assert out == {}
+
+    def test_drops_empty_for_unknown_property(self) -> None:
+        # Tool calls sometimes carry extra fields not listed in `properties`.
+        # Without a schema entry we can't prove the field is string-typed,
+        # but treating empty as "omitted" is the safer default.
+        schema = self._schema({"known": {"type": "string"}})
+        out = _normalize_mcp_arguments({"known": "a", "extra": ""}, schema)
+        assert out == {"known": "a"}
+
+    def test_passes_through_when_schema_is_not_dict(self) -> None:
+        out = _normalize_mcp_arguments({"a": "", "b": 1}, None)
+        assert out == {"a": "", "b": 1}
+
+    def test_handles_union_string_type(self) -> None:
+        schema = self._schema({"v": {"type": ["string", "null"]}})
+        out = _normalize_mcp_arguments({"v": ""}, schema)
+        assert out == {}
+
+    def test_drops_empty_for_oneof_schema(self) -> None:
+        """`oneOf` props have no top-level `type` → conservative drop."""
+        schema = self._schema({"v": {"oneOf": [{"type": "string"}, {"type": "null"}]}})
+        out = _normalize_mcp_arguments({"v": ""}, schema)
+        assert out == {}
+
+    def test_drops_empty_for_anyof_schema(self) -> None:
+        """`anyOf` props share the same no-top-level-`type` shape."""
+        schema = self._schema({"v": {"anyOf": [{"type": "string"}]}})
+        out = _normalize_mcp_arguments({"v": ""}, schema)
+        assert out == {}
+
+    def test_drops_empty_for_ref_schema(self) -> None:
+        """`$ref` props look like `{"$ref": "#/..."}` — no `type` either."""
+        schema = self._schema({"v": {"$ref": "#/definitions/ChannelId"}})
+        out = _normalize_mcp_arguments({"v": ""}, schema)
+        assert out == {}
+
+    def test_drops_empty_when_property_is_boolean_schema(self) -> None:
+        """JSON Schema allows `{"properties": {"k": true}}` — `prop` non-dict.
+
+        `isinstance(prop, dict)` guards the `.get("type")` call so we don't
+        crash, and the field is treated as ambiguous (drop).
+        """
+        schema = {"type": "object", "properties": {"k": True}, "required": []}
+        out = _normalize_mcp_arguments({"k": ""}, schema)
+        assert out == {}
+
+    def test_passes_through_falsy_non_string_values(self) -> None:
+        """Guards against a `if not value` refactor — `0`/`False`/`[]`/`{}` survive."""
+        schema = self._schema(
+            {
+                "i": {"type": "integer"},
+                "b": {"type": "boolean"},
+                "a": {"type": "array"},
+                "o": {"type": "object"},
+            }
+        )
+        out = _normalize_mcp_arguments({"i": 0, "b": False, "a": [], "o": {}}, schema)
+        assert out == {"i": 0, "b": False, "a": [], "o": {}}
+
+    def test_required_takes_precedence_over_string_schema(self) -> None:
+        """`required` wins even when properties confirm the field is string-typed."""
+        schema = self._schema({"query": {"type": "string"}}, required=["query"])
+        out = _normalize_mcp_arguments({"query": ""}, schema)
+        assert out == {"query": ""}
+
+    def test_logs_dropped_keys(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Diagnostic log fires when at least one key is stripped."""
+        import logging
+
+        schema = self._schema(
+            {"q": {"type": "string"}, "ctx": {"type": "string"}},
+            required=["q"],
+        )
+        with caplog.at_level(logging.DEBUG, logger="deepagents_code.mcp_tools"):
+            _normalize_mcp_arguments({"q": "x", "ctx": ""}, schema)
+        assert any(
+            "dropped empty-string keys" in r.message and "ctx" in r.message
+            for r in caplog.records
+        )

--- a/libs/code/tests/unit_tests/test_remote_client.py
+++ b/libs/code/tests/unit_tests/test_remote_client.py
@@ -15,6 +15,7 @@ from deepagents_code.remote_client import (
     _convert_message_data,
     _convert_tool_message,
     _prepare_config,
+    format_agent_exception,
 )
 
 _TEST_THREAD_ID = "01966f3a-0000-7000-8000-000000000001"
@@ -821,3 +822,63 @@ class TestRemoteAgentWithConfig:
     def test_returns_self(self) -> None:
         agent = RemoteAgent(url="http://localhost:8123", graph_name="agent")
         assert agent.with_config({"configurable": {}}) is agent
+
+
+class TestFormatAgentException:
+    """Cover the rendering helper for agent-stream exceptions."""
+
+    def test_remote_exception_dict_payload(self) -> None:
+        from langgraph.pregel.remote import RemoteException
+
+        exc = RemoteException(
+            {"error": "ToolException", "message": "An internal error occurred"}
+        )
+        assert (
+            format_agent_exception(exc) == "ToolException: An internal error occurred"
+        )
+
+    def test_remote_exception_dict_payload_no_message(self) -> None:
+        from langgraph.pregel.remote import RemoteException
+
+        exc = RemoteException({"error": "ToolException"})
+        assert format_agent_exception(exc) == "ToolException"
+
+    def test_remote_exception_dict_payload_empty_message(self) -> None:
+        """Falsy `message` still falls through to the error-type-only branch."""
+        from langgraph.pregel.remote import RemoteException
+
+        exc = RemoteException({"error": "ToolException", "message": ""})
+        assert format_agent_exception(exc) == "ToolException"
+
+    def test_remote_exception_dict_payload_non_string_error(self) -> None:
+        """Non-string `error` keys must not crash; fall back to `str(exc)`."""
+        from langgraph.pregel.remote import RemoteException
+
+        exc = RemoteException({"error": 500, "message": "boom"})
+        # Both keys non-string-typed → no clean rendering possible; fall through.
+        assert "boom" in format_agent_exception(exc)
+
+    def test_remote_exception_dict_payload_empty_dict(self) -> None:
+        """Empty payload dict resolves `error` to the exception class name."""
+        from langgraph.pregel.remote import RemoteException
+
+        exc = RemoteException({})
+        # `payload.get("error") or type(exc).__name__` → "RemoteException",
+        # and `message` is None so the err-only branch returns the class.
+        assert format_agent_exception(exc) == "RemoteException"
+
+    def test_remote_exception_non_dict_payload(self) -> None:
+        """`RemoteException("string")` is not the dict shape; uses `str(exc)`."""
+        from langgraph.pregel.remote import RemoteException
+
+        exc = RemoteException("just a string")
+        assert format_agent_exception(exc) == "just a string"
+
+    def test_plain_exception_uses_str(self) -> None:
+        assert format_agent_exception(ValueError("bad thing")) == "bad thing"
+
+    def test_exception_without_message_falls_back_to_type(self) -> None:
+        class _BoomError(Exception):
+            pass
+
+        assert format_agent_exception(_BoomError()) == "_BoomError"


### PR DESCRIPTION
Two small fixes for `dcode` tool failures. When an MCP tool raised a `ToolException` server-side, the UI surfaced `Agent error: {'error': 'ToolException', 'message': 'An internal error occurred'}` as a raw Python dict repr — the redacted-payload shape that `langgraph_api` emits for non-allowlisted exceptions. Separately, Slack's `slack_search_public_and_private` (and similar ID-shaped MCP params) rejected `context_channel_id=""` with `"value is not a channel ID"` whenever the model filled an optional string param with `""` instead of omitting it.