### PR TITLE
fix(code): char-truncate execute tool preview output

### DIFF
--- a/libs/code/deepagents_code/widgets/messages.py
+++ b/libs/code/deepagents_code/widgets/messages.py
@@ -1551,7 +1551,7 @@ class ToolCallMessage(Vertical):
 
         return FormattedOutput(content=content, truncation=truncation)
 
-    def _format_shell_output(  # noqa: PLR6301  # Grouped as method for widget cohesion
+    def _format_shell_output(
         self, output: str, *, is_preview: bool = False
     ) -> FormattedOutput:
         """Format shell command output.
@@ -1562,18 +1562,40 @@ class ToolCallMessage(Vertical):
         lines = output.split("\n")
         max_lines = 4 if is_preview else len(lines)
 
+        char_budget = self._PREVIEW_CHARS if is_preview else None
         parts: list[Content] = []
+        chars_used = 0
+        char_truncated = False
         for i, line in enumerate(lines[:max_lines]):
-            if i == 0 and line.startswith("$ "):
-                parts.append(Content.styled(line, "dim"))
+            display_line = line
+            if char_budget is not None:
+                separator_cost = 1 if parts else 0
+                remaining = char_budget - chars_used - separator_cost
+                if remaining <= 0:
+                    char_truncated = True
+                    break
+                if len(line) > remaining:
+                    display_line = line[:remaining]
+                    char_truncated = True
+                chars_used += separator_cost + len(display_line)
+
+            if i == 0 and display_line.startswith("$ "):
+                parts.append(Content.styled(display_line, "dim"))
             else:
-                parts.append(Content(line))
+                parts.append(Content(display_line))
+            if char_truncated:
+                break
 
         content = Content("\n").join(parts) if parts else Content("")
 
         truncation = None
-        if is_preview and len(lines) > max_lines:
-            truncation = f"{len(lines) - max_lines} more lines"
+        if is_preview:
+            hidden_lines = len(lines) - len(parts)
+            hidden_chars = len(output) - chars_used
+            if char_truncated:
+                truncation = f"{hidden_chars} more chars"
+            elif hidden_lines > 0:
+                truncation = f"{hidden_lines} more lines"
 
         return FormattedOutput(content=content, truncation=truncation)
 

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -712,6 +712,60 @@ class TestToolCallMessageShellCommand:
         assert lines[2].plain == "$ not a command"
         assert "dim" not in lines[2].markup
 
+    def test_format_shell_output_preview_truncates_long_single_line(self) -> None:
+        """Preview should char-truncate single-line output past the budget."""
+        msg = ToolCallMessage("execute", {"command": "gh api graphql"})
+        # One huge JSON-like line, well past _PREVIEW_CHARS (400).
+        output = "x" * 5000
+        result = msg._format_shell_output(output, is_preview=True)
+
+        assert result.truncation is not None
+        assert "more chars" in result.truncation
+        assert len(result.content.plain) <= msg._PREVIEW_CHARS
+
+    def test_format_shell_output_preview_short_no_truncation(self) -> None:
+        """Short shell output should not report any truncation in preview."""
+        msg = ToolCallMessage("execute", {"command": "echo hi"})
+        output = "$ echo hi\nhi"
+        result = msg._format_shell_output(output, is_preview=True)
+
+        assert result.truncation is None
+        assert result.content.plain == output
+
+    def test_format_shell_output_preview_cumulative_chars_exceed_budget(self) -> None:
+        """Many small lines whose total exceeds the budget should char-truncate."""
+        msg = ToolCallMessage("execute", {"command": "noisy"})
+        # 4 lines of 200 chars => 800 + 3 separators, well past 400.
+        # The preview formatter caps at max_lines=4 regardless.
+        output = "\n".join("x" * 200 for _ in range(4))
+        result = msg._format_shell_output(output, is_preview=True)
+
+        assert result.truncation is not None
+        assert "more chars" in result.truncation
+        # Rendered content stays under budget.
+        assert len(result.content.plain) <= msg._PREVIEW_CHARS
+
+    def test_format_shell_output_preview_preserves_dim_when_first_line_clipped(
+        self,
+    ) -> None:
+        """Char-clipping line 0 must keep the `$ ` prefix dim styling."""
+        msg = ToolCallMessage("execute", {"command": "echo"})
+        output = "$ " + ("x" * 5000)
+        result = msg._format_shell_output(output, is_preview=True)
+
+        first_line = result.content.split("\n")[0]
+        assert first_line.plain.startswith("$ ")
+        assert "dim" in first_line.markup
+
+    def test_format_shell_output_full_never_truncates(self) -> None:
+        """`is_preview=False` must render full output regardless of size."""
+        msg = ToolCallMessage("execute", {"command": "big"})
+        output = "x" * 5000
+        result = msg._format_shell_output(output, is_preview=False)
+
+        assert result.truncation is None
+        assert result.content.plain == output
+
 
 class TestToolCallMessageAwaitingApproval:
     """Tests for `set_awaiting_approval` / `clear_awaiting_approval`."""


### PR DESCRIPTION
The `execute` tool widget previewed shell output by line count only, so a single huge line (e.g., a JSON blob from `gh api graphql`) blew past the preview budget and rendered in full with no "click or Ctrl+O to expand" hint. `_format_shell_output` now also enforces the `_PREVIEW_CHARS` budget and clips a long line in place when needed.