### PR TITLE
fix(sdk): filter `PrivateStateAttr` fields from subagent inputs without tool rebuild

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -38,6 +38,7 @@ from deepagents._tools import _apply_tool_description_overrides
 from deepagents._version import __version__
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
+from deepagents.middleware._state import private_state_field_names
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
 from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemPermission
@@ -734,6 +735,15 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         matched_classes=_main_matched_classes,
         matched_names=_main_matched_names,
     )
+    # Now that the middleware stack is fully assembled and exclusions applied,
+    # derive which state keys are private and tell SubAgentMiddleware about
+    # them. This must happen after _apply_excluded_middleware so that keys
+    # from user-supplied middleware (added after SubAgentMiddleware was
+    # constructed) are included.
+    if sub_agent_middleware is not None:
+        sub_agent_middleware.set_private_state_keys(
+            private_state_field_names(*(mw.state_schema for mw in deepagent_middleware if getattr(mw, "state_schema", None) is not None))
+        )
     # Verify every main-profile exclusion matched at least one middleware in
     # either the main agent stack or the GP subagent stack. An entry that
     # matched nothing across both is almost certainly a typo or a stale

--- a/libs/deepagents/deepagents/middleware/_state.py
+++ b/libs/deepagents/deepagents/middleware/_state.py
@@ -1,0 +1,30 @@
+"""Helpers for working with Deep Agents state schemas."""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Annotated, get_args, get_origin, get_type_hints
+
+from langchain.agents.middleware.types import PrivateStateAttr
+
+
+def private_state_field_names(*state_schemas: type[object]) -> frozenset[str]:
+    """Return fields annotated with `PrivateStateAttr` across state schemas."""
+    names: set[str] = set()
+    for state_schema in state_schemas:
+        with contextlib.suppress(Exception):
+            hints = get_type_hints(state_schema, include_extras=True)
+            for name, annotation in hints.items():
+                if _has_marker(annotation, PrivateStateAttr):
+                    names.add(name)
+    return frozenset(names)
+
+
+def _has_marker(annotation: object, marker: object) -> bool:
+    origin = get_origin(annotation)
+    if origin is Annotated:
+        args = get_args(annotation)
+        return any(meta is marker for meta in args[1:])
+    if origin is not None:
+        return any(_has_marker(arg, marker) for arg in get_args(annotation))
+    return False

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -244,16 +244,18 @@ returning updates from subagents.
 When returning updates:
 
 1. The messages key is handled explicitly to ensure only the final message
-    is included
+    is included.
 2. The todos and `structured_response` keys are excluded as they do not have
     a defined reducer and no clear meaning for returning them from a subagent
     to the main agent.
 3. The `skills_metadata`, `skills_load_errors`, and `memory_contents` keys are
     automatically excluded from subagent output via `PrivateStateAttr`
-    annotations on their respective state schemas. However, they must ALSO
-    be explicitly filtered from runtime.state when invoking a subagent to
-    prevent parent state from leaking to child agents (e.g., the general-purpose
-    subagent loads its own skills via `SkillsMiddleware`).
+    annotations on their respective state schemas.  They are also listed here
+    as a belt-and-suspenders guard against them leaking through the input path;
+    the primary mechanism for input-side filtering is the dynamic
+    `_private_state_keys` set on `SubAgentMiddleware`, which covers all
+    middleware that declares `PrivateStateAttr` fields (including user-supplied
+    middleware not listed here).
 """
 
 
@@ -460,6 +462,8 @@ def _subagent_tracing_context() -> Generator[None, None, None]:
 def _build_task_tool(  # noqa: C901, PLR0915
     subagents: list[_SubagentSpec],
     task_description: str | None = None,
+    *,
+    get_private_keys: Callable[[], frozenset[str]] = frozenset,
 ) -> BaseTool:
     """Create a task tool from pre-built subagent graphs.
 
@@ -467,6 +471,10 @@ def _build_task_tool(  # noqa: C901, PLR0915
         subagents: List of subagent specs containing name, description, and runnable.
         task_description: Custom description for the task tool. If `None`,
             uses default template. Supports `{available_agents}` placeholder.
+        get_private_keys: Zero-arg callable that returns the current set of
+            state keys to strip before passing parent state to a subagent.
+            Read at invocation time so callers can update the set after the
+            tool is built without rebuilding it.
 
     Returns:
         A StructuredTool that can invoke subagents by type.
@@ -527,8 +535,9 @@ def _build_task_tool(  # noqa: C901, PLR0915
     def _validate_and_prepare_state(subagent_type: str, description: str, runtime: ToolRuntime) -> tuple[Runnable, dict]:
         """Prepare state for invocation."""
         subagent = subagent_graphs[subagent_type]
+        private_keys = get_private_keys()
         # Create a new state dict to avoid mutating the original
-        subagent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS}
+        subagent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS and k not in private_keys}
         subagent_state["messages"] = [HumanMessage(content=description)]
         return subagent, subagent_state
 
@@ -680,12 +689,17 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             raise ValueError(msg)
         self._backend = backend
         self._subagents = subagents
+        self._private_state_keys: frozenset[str] = frozenset()
         subagent_specs = self._get_subagents()
         self.subagent_names: frozenset[str] = frozenset(spec["name"] for spec in subagent_specs)
         """Declared subagent names. Public so streamers can discover them
         without introspecting the `task` tool's closure."""
 
-        task_tool = _build_task_tool(subagent_specs, task_description)
+        task_tool = _build_task_tool(
+            subagent_specs,
+            task_description,
+            get_private_keys=lambda: self._private_state_keys,
+        )
 
         # Build system prompt with available agents
         if system_prompt and subagent_specs:
@@ -695,6 +709,10 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             self.system_prompt = system_prompt
 
         self.tools = [task_tool]
+
+    def set_private_state_keys(self, keys: frozenset[str]) -> None:
+        """Update the private-state filter applied when invoking subagents."""
+        self._private_state_keys = keys
 
     def _get_subagents(self) -> list[_SubagentSpec]:
         """Create runnable agents from specs.

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -10,12 +10,13 @@ import json
 import uuid
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Annotated, Any, TypedDict
 from unittest.mock import MagicMock
 
 import pytest
 from langchain.agents import create_agent
 from langchain.agents.middleware import TodoListMiddleware
+from langchain.agents.middleware.types import AgentMiddleware, AgentState, PrivateStateAttr
 from langchain.agents.structured_output import ToolStrategy
 from langchain.tools import ToolRuntime
 from langchain_core.callbacks import BaseCallbackHandler, CallbackManagerForLLMRun
@@ -325,6 +326,164 @@ class TestSubAgents:
         multiplication_tool_message = tool_messages_by_id["call_multiplication"]
         assert multiplication_tool_message.content == "The product of 4 and 6 is 24.", (
             f"Multiplication subagent should return exact message, got: {multiplication_tool_message.content}"
+        )
+
+    def test_private_state_does_not_propagate_from_parent_to_subagent(self) -> None:
+        """A private state field on the parent should not be visible to a child subagent."""
+
+        class _ParentPrivateState(AgentState):
+            secret: Annotated[str | None, PrivateStateAttr]
+
+        captured_child_states: list[dict[str, Any]] = []
+
+        class _ParentSeedMiddleware(AgentMiddleware[_ParentPrivateState, Any, Any]):
+            state_schema = _ParentPrivateState
+
+            def before_agent(self, state: _ParentPrivateState, runtime: object) -> dict[str, Any] | None:
+                if "secret" in state:
+                    return None
+                return {"secret": "parent-secret"}
+
+        class _ChildCaptureState(AgentState):
+            secret: Annotated[str | None, PrivateStateAttr]
+
+        class _ChildCaptureMiddleware(AgentMiddleware[_ChildCaptureState, Any, Any]):
+            state_schema = _ChildCaptureState
+
+            def before_agent(self, state: _ChildCaptureState, runtime: object) -> dict[str, Any] | None:
+                captured_child_states.append(dict(state))
+                return None
+
+        parent_chat_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "task",
+                                "args": {"description": "Run the child subagent", "subagent_type": "child"},
+                                "id": "call_child",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="done"),
+                ]
+            )
+        )
+        child_model = GenericFakeChatModel(messages=iter([AIMessage(content="child done")]))
+
+        parent_agent = create_deep_agent(
+            model=parent_chat_model,
+            checkpointer=InMemorySaver(),
+            middleware=[_ParentSeedMiddleware()],
+            subagents=[
+                SubAgent(
+                    name="child",
+                    description="Captures its incoming state.",
+                    system_prompt="Capture the incoming state and complete the task.",
+                    model=child_model,
+                    middleware=[_ChildCaptureMiddleware()],
+                ),
+            ],
+        )
+
+        parent_agent.invoke(
+            {"messages": [HumanMessage(content="run the child subagent")]},
+            config={"configurable": {"thread_id": "test_private_state_parent_to_child"}},
+        )
+
+        assert captured_child_states, "Child subagent should have received state"
+        assert "secret" not in captured_child_states[0], f"Private parent field 'secret' leaked into child state: {captured_child_states[0]}"
+
+    def test_private_state_does_not_propagate_between_sibling_subagents(self) -> None:
+        """A private state field written by one sibling subagent must not reach another."""
+        # The writer subagent seeds a private field; the reader subagent must not see it.
+        # Sibling isolation works because the framework strips PrivateStateAttr fields
+        # from a compiled subgraph's returned state before they reach the parent, so
+        # the field never enters the parent's runtime.state at all.
+
+        class _WriterState(AgentState):
+            writer_secret: Annotated[str | None, PrivateStateAttr]
+
+        written_values: list[str | None] = []
+
+        class _WriterMiddleware(AgentMiddleware[_WriterState, Any, Any]):
+            state_schema = _WriterState
+
+            def before_agent(self, state: _WriterState, runtime: object) -> dict[str, Any] | None:
+                written_values.append(state.get("writer_secret"))
+                return {"writer_secret": "sibling-secret"}
+
+        captured_reader_states: list[dict[str, Any]] = []
+
+        class _ReaderCaptureMiddleware(AgentMiddleware[AgentState, Any, Any]):
+            def before_agent(self, state: AgentState, runtime: object) -> dict[str, Any] | None:
+                captured_reader_states.append(dict(state))
+                return None
+
+        parent_chat_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "task",
+                                "args": {"description": "Seed the writer state", "subagent_type": "writer"},
+                                "id": "call_writer",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "task",
+                                "args": {"description": "Read the state", "subagent_type": "reader"},
+                                "id": "call_reader",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="done"),
+                ]
+            )
+        )
+        writer_model = GenericFakeChatModel(messages=iter([AIMessage(content="writer done")]))
+        reader_model = GenericFakeChatModel(messages=iter([AIMessage(content="reader done")]))
+
+        parent_agent = create_deep_agent(
+            model=parent_chat_model,
+            checkpointer=InMemorySaver(),
+            subagents=[
+                SubAgent(
+                    name="writer",
+                    description="Seeds private state.",
+                    system_prompt="Seed private state and complete.",
+                    model=writer_model,
+                    middleware=[_WriterMiddleware()],
+                ),
+                SubAgent(
+                    name="reader",
+                    description="Reads state.",
+                    system_prompt="Report what state you received.",
+                    model=reader_model,
+                    middleware=[_ReaderCaptureMiddleware()],
+                ),
+            ],
+        )
+
+        parent_agent.invoke(
+            {"messages": [HumanMessage(content="run writer then reader")]},
+            config={"configurable": {"thread_id": "test_private_state_sibling"}},
+        )
+
+        assert captured_reader_states, "Reader subagent should have received state"
+        assert "writer_secret" not in captured_reader_states[0], (
+            f"Private writer field 'writer_secret' leaked into reader state: {captured_reader_states[0]}"
         )
 
     def test_agent_with_structured_output_tool_strategy(self) -> None:


### PR DESCRIPTION
## Summary

Alternative implementation of #3542. Same correctness goal (strip `PrivateStateAttr`-marked fields before passing parent state to a subagent), cleaner mechanism.

**Problem with #3542:** `SubAgentMiddleware` is constructed early in `create_deep_agent`, but the full middleware stack isn't finalized until after `_apply_excluded_middleware`. That PR's fix works by calling `set_private_state_keys()` post-construction, which *rebuilds the entire task tool closure* — a two-phase init with unnecessary churn.

**This PR's approach:** `_build_task_tool` accepts a `get_private_keys: Callable[[], frozenset[str]]` parameter that the inner `_validate_and_prepare_state` closure calls at *invocation time*, not construction time. `SubAgentMiddleware` stores `_private_state_keys` as a plain attribute and passes `lambda: self._private_state_keys` to the builder. `set_private_state_keys` becomes a one-liner (`self._private_state_keys = keys`) — no tool rebuild.

## Changes

- `middleware/_state.py` (new): `private_state_field_names(*schemas)` helper that walks `get_type_hints(include_extras=True)` looking for `PrivateStateAttr` markers
- `middleware/subagents.py`: `_build_task_tool` gains `get_private_keys` kwarg; `SubAgentMiddleware` stores `_private_state_keys` and passes a lambda; `set_private_state_keys` is now a one-liner
- `graph.py`: after `_apply_excluded_middleware` finalizes the stack, computes private keys and calls the setter (same call site as #3542, simpler effect)
- Two new unit tests: parent→child isolation and sibling→sibling isolation

## Test plan

- [x] `test_private_state_does_not_propagate_from_parent_to_subagent` — verifies `PrivateStateAttr` fields on parent middleware are stripped before child receives state
- [x] `test_private_state_does_not_propagate_between_sibling_subagents` — verifies a private field written by one sibling's middleware doesn't reach another sibling
- [x] Full unit test suite passes (33 tests, 0 failures)