### PR TITLE
chore: improve deepagents maintenance path

### DIFF
--- a/libs/acp/tests/chat_model.py
+++ b/libs/acp/tests/chat_model.py
@@ -73,6 +73,7 @@ class GenericFakeChatModel(BaseChatModel):
         generation = ChatGeneration(message=message_)
         return ChatResult(generations=[generation])
 
+    @override
     def _stream(
         self,
         messages: list[BaseMessage],

--- a/libs/acp/tests/test_agent.py
+++ b/libs/acp/tests/test_agent.py
@@ -1061,3 +1061,17 @@ def test_build_config_options_empty_models_list_omits_entry() -> None:
     options = agent._build_config_options("session-1")
 
     assert options == []
+
+
+def test_generic_fake_chat_model_stream_rejects_non_string_content() -> None:
+    """Edge case: streaming an AIMessage whose content is a list must raise ValueError.
+
+    The fake model's `_stream` assumes string content for chunking. Multimodal
+    list content should fail fast with a clear error instead of silently breaking.
+    """
+    model = GenericFakeChatModel(
+        messages=iter([AIMessage(content=[{"type": "text", "text": "hello"}])]),
+        stream_delimiter=None,
+    )
+    with pytest.raises(ValueError, match="Expected content to be a string"):
+        list(model.stream("hi"))


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in libs/acp/tests/chat_model.py, libs/acp/tests/test_agent.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.