### PR TITLE
fix(code): prevent duplicate-id crash on MCP reconnect and clipboard `NoScreen`

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1531,6 +1531,17 @@ class DeepAgentsApp(App):
         until the session reaches its first stable busy/idle state.
         """
 
+        self._initial_session_started = False
+        """Set on first entry into `_run_session_start_sequence` past gating.
+
+        Server respawns (`/mcp reconnect`, `/restart`) post a fresh
+        `ServerReady`; without this flag the sequence re-runs and
+        `_load_thread_history` bulk-mounts widgets whose IDs already exist in
+        the DOM, raising `DuplicateIds`. Set on entry (not on success) because
+        if `_load_thread_history` partially mounted before failing, retrying
+        would still hit the duplicate-ID path.
+        """
+
         # Message queue & store
         self._pending_messages: deque[QueuedMessage] = deque()
         """User message queue for sequential processing."""
@@ -4141,6 +4152,17 @@ class DeepAgentsApp(App):
         if self._server_startup_deferred:
             return
 
+        if self._initial_session_started:
+            # Server respawns (e.g. `/mcp reconnect`, `/restart`) fire another
+            # `ServerReady`; rerunning the sequence would attempt to bulk-load
+            # the active thread on top of widgets already mounted in the DOM.
+            logger.debug(
+                "Skipping session start sequence; already initialized for thread %s",
+                self._lc_thread_id,
+            )
+            await self._drain_startup_backlog()
+            return
+
         if self._launch_init_requested:
             self._ensure_launch_init_task()
         launch_init_task = self._launch_init_task
@@ -4148,6 +4170,7 @@ class DeepAgentsApp(App):
             self._schedule_session_start_after_launch_init(launch_init_task)
             return
 
+        self._initial_session_started = True
         self._startup_sequence_running = True
         try:
             should_load_history = bool(self._lc_thread_id and self._agent) and (
@@ -4169,6 +4192,10 @@ class DeepAgentsApp(App):
         finally:
             self._startup_sequence_running = False
 
+        await self._drain_startup_backlog()
+
+    async def _drain_startup_backlog(self) -> None:
+        """Drain deferred actions and queued input after server readiness."""
         if self._agent_running or self._shell_running:
             return
 

--- a/libs/code/deepagents_code/clipboard.py
+++ b/libs/code/deepagents_code/clipboard.py
@@ -8,6 +8,8 @@ import os
 import pathlib
 from typing import TYPE_CHECKING
 
+from textual.dom import NoScreen
+
 from deepagents_code.config import get_glyphs
 
 logger = logging.getLogger(__name__)
@@ -102,10 +104,27 @@ def copy_selection_to_clipboard(app: App) -> None:
     selected_texts = []
 
     for widget in app.query("*"):
-        if not hasattr(widget, "text_selection") or not widget.text_selection:
+        # Skip detached widgets before touching `text_selection` — the
+        # property reads `widget.screen.selections`, which raises `NoScreen`
+        # for transient toasts mid-mount. `hasattr` is not a safe precheck
+        # because it would itself invoke the property and propagate
+        # `NoScreen`. The try/except handles lifecycle races between the
+        # `is_attached` check and the property read.
+        if not getattr(widget, "is_attached", False):
             continue
 
-        selection = widget.text_selection
+        try:
+            selection = widget.text_selection
+        except (NoScreen, AttributeError) as e:
+            logger.debug(
+                "Skipping widget %s during selection copy: %s",
+                type(widget).__name__,
+                e,
+            )
+            continue
+
+        if not selection:
+            continue
 
         if selection.end is None:
             continue

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -340,6 +340,63 @@ class TestInitialPromptOnMount:
 class TestStartupSequence:
     """Tests for post-connect startup sequencing."""
 
+    async def test_session_start_sequence_is_idempotent_across_server_ready(
+        self,
+    ) -> None:
+        """Subsequent `ServerReady` events must not re-run history hydration.
+
+        Regression for the `/mcp reconnect` and `/restart` flows: respawns
+        post a fresh `ServerReady`, which would otherwise re-run
+        `_load_thread_history` against an already-populated `MessageStore`
+        and raise `DuplicateIds` during widget mount.
+        """
+        app = DeepAgentsApp(
+            agent=MagicMock(),
+            thread_id="thread-123",
+            resume_thread="thread-123",
+        )
+        call_count = 0
+
+        async def capture_history(  # noqa: RUF029
+            *,
+            thread_id: str | None = None,
+            preloaded_payload: object | None = None,
+        ) -> None:
+            del thread_id, preloaded_payload
+            nonlocal call_count
+            call_count += 1
+
+        app._load_thread_history = capture_history  # type: ignore[assignment]
+
+        await app._run_session_start_sequence()
+        await app._run_session_start_sequence()
+        await app._run_session_start_sequence()
+
+        assert call_count == 1
+        assert app._initial_session_started is True
+
+    async def test_reconnect_drains_queue_without_reloading_history(self) -> None:
+        """Later `ServerReady` events should drain queued input once connected."""
+        app = DeepAgentsApp(
+            agent=MagicMock(),
+            thread_id="thread-123",
+            resume_thread="thread-123",
+        )
+        app._initial_session_started = True
+        app._pending_messages.append(QueuedMessage(text="queued", mode="normal"))
+        load_history = AsyncMock()
+        drain_deferred = AsyncMock()
+        process_next = AsyncMock()
+        app._load_thread_history = load_history  # type: ignore[assignment]
+        app._maybe_drain_deferred = drain_deferred  # type: ignore[assignment]
+        app._process_next_from_queue = process_next  # type: ignore[assignment]
+
+        await app._run_session_start_sequence()
+
+        load_history.assert_not_awaited()
+        drain_deferred.assert_awaited_once()
+        process_next.assert_awaited_once()
+
     async def test_resumed_history_loads_before_startup_command(self) -> None:
         """Resumed threads should mount prior history before startup output."""
         app = DeepAgentsApp(

--- a/libs/code/tests/unit_tests/test_clipboard.py
+++ b/libs/code/tests/unit_tests/test_clipboard.py
@@ -265,6 +265,65 @@ class TestCopySelectionToClipboard:
         assert "Failed to get selection from widget" in caplog.text
         assert "No selection" in caplog.text
 
+    def test_skips_detached_widget_without_reading_text_selection(self) -> None:
+        """Un-attached widgets are skipped before `text_selection` is read.
+
+        Guards the contract that `is_attached` short-circuits the property
+        access — `widget.text_selection` raises `NoScreen` for detached
+        widgets, so reading it would re-introduce the crash this fix
+        addresses.
+        """
+        from unittest.mock import PropertyMock
+
+        mock_app = MagicMock()
+        detached = MagicMock()
+        detached.is_attached = False
+        type(detached).text_selection = PropertyMock(
+            side_effect=AssertionError("text_selection must not be read"),
+        )
+        mock_app.query.return_value = [detached]
+
+        with patch(
+            "deepagents_code.clipboard.copy_text_to_clipboard",
+            return_value=(True, None),
+        ) as copy:
+            copy_selection_to_clipboard(mock_app)
+
+        copy.assert_not_called()
+
+    def test_skips_widget_when_text_selection_raises_noscreen(self, caplog) -> None:
+        """`NoScreen` from a lifecycle race is logged; sibling copy proceeds."""
+        from unittest.mock import PropertyMock
+
+        from textual.dom import NoScreen
+
+        mock_app = MagicMock()
+
+        racy = MagicMock()
+        racy.is_attached = True
+        type(racy).text_selection = PropertyMock(
+            side_effect=NoScreen("node has no screen"),
+        )
+
+        sibling = MagicMock()
+        sibling.is_attached = True
+        sibling.text_selection = MagicMock(end=1)
+        sibling.get_selection.return_value = ("sibling text", None)
+
+        mock_app.query.return_value = [racy, sibling]
+
+        with (
+            caplog.at_level(logging.DEBUG),
+            patch(
+                "deepagents_code.clipboard.copy_text_to_clipboard",
+                return_value=(True, None),
+            ) as copy,
+        ):
+            copy_selection_to_clipboard(mock_app)
+
+        copy.assert_called_once_with(mock_app, "sibling text")
+        assert "Skipping widget" in caplog.text
+
 
 class TestClipboardLogger:
     """Sanity check: module exposes a properly named logger."""


### PR DESCRIPTION
Two unrelated Textual lifecycle bugs hit together when reconnecting an MCP server mid-thread. The first surfaced as `Could not load history: ... a widget already exists with that ID`; the second crashed the app when the user tried to select-copy the error toast itself.