### PR TITLE
fix(sdk): forward parent metadata into subagent invoke config

### DIFF
--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -433,6 +433,48 @@ class _SubagentSpec(TypedDict):
     runnable: Runnable
 
 
+# Metadata keys (and prefixes) set by LangChain / LangGraph / deepagents
+# framework code on `runtime.config["metadata"]` that must NOT be forwarded
+# from parent to subagent — they are framework-owned, not user-set:
+# - `lc_agent_name`, `ls_integration`, `versions`: bound by `create_agent` /
+#   `create_deep_agent`; forwarding would overwrite the subagent's own bound
+#   identity under LangChain's `merge_configs` semantics.
+# - `langgraph_*`, `thread_id`, `checkpoint_ns`: added per-step by LangGraph;
+#   forwarding seeds the subagent's invoke with the parent's step context and
+#   interferes with the subagent's own Pregel machinery (observed to drop the
+#   subagent's bound `lc_agent_name` from tool-runtime metadata).
+_RESERVED_SUBAGENT_METADATA_KEYS = frozenset({"thread_id", "checkpoint_ns", "versions"})
+_RESERVED_SUBAGENT_METADATA_PREFIXES = ("lc_", "ls_", "langgraph_")
+
+
+def _is_reserved_subagent_metadata_key(key: str) -> bool:
+    return key in _RESERVED_SUBAGENT_METADATA_KEYS or key.startswith(_RESERVED_SUBAGENT_METADATA_PREFIXES)
+
+
+def _build_subagent_config(runtime: ToolRuntime) -> RunnableConfig:
+    """Derive the subagent's `RunnableConfig` from the parent's runtime config.
+
+    Forwards `callbacks`, `tags`, `configurable`, and `metadata` — with
+    framework-reserved metadata keys stripped (see
+    `_is_reserved_subagent_metadata_key`) so the subagent's bound identity
+    and its own Pregel step context aren't clobbered when LangChain merges
+    configs at invoke time.
+
+    `recursion_limit` is intentionally not forwarded — the subagent's own
+    bound limit must take precedence.
+    """
+    parent_config = runtime.config or {}
+    config: RunnableConfig = {}
+    for key in ("callbacks", "tags", "configurable"):
+        if key in parent_config:
+            config[key] = parent_config[key]  # type: ignore[literal-required]
+    parent_metadata = parent_config.get("metadata") or {}
+    forwarded_metadata = {k: v for k, v in parent_metadata.items() if not _is_reserved_subagent_metadata_key(k)}
+    if forwarded_metadata:
+        config["metadata"] = forwarded_metadata
+    return config
+
+
 @contextlib.contextmanager
 def _subagent_tracing_context() -> Generator[None, None, None]:
     """Context manager that tags subagent runs with `ls_agent_type="subagent"`.
@@ -531,29 +573,6 @@ def _build_task_tool(  # noqa: C901, PLR0915
         subagent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS}
         subagent_state["messages"] = [HumanMessage(content=description)]
         return subagent, subagent_state
-
-    def _build_subagent_config(runtime: ToolRuntime) -> RunnableConfig:
-        """Derive the subagent's `RunnableConfig` from the parent's runtime config.
-
-        Only `callbacks`, `tags`, and `configurable` are forwarded.
-
-        Callbacks let Pregel's streaming handlers propagate into the subagent
-        so its events land on the parent's stream.  Tags are forwarded
-        for tracing continuity. `configurable` is needed for Pregel to recognize
-        the subagent as a nested subgraph.
-
-        `recursion_limit` and `metadata` are intentionally
-        *not* forwarded — the subagent's own bound config must take precedence.
-
-        Passing `metadata` in the invoke config replaces the
-        subagent's bound metadata (e.g. `lc_agent_name`).
-        """
-        parent_config = runtime.config or {}
-        config: RunnableConfig = {}
-        for key in ("callbacks", "tags", "configurable"):
-            if key in parent_config:
-                config[key] = parent_config[key]  # type: ignore[literal-required]
-        return config
 
     def task(
         description: str,

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -692,6 +692,100 @@ class TestSubAgents:
         # so that lc_agent_name in streamed chunks reflects the declared subagent name.
         assert captured_config["metadata"]["lc_agent_name"] == "general-purpose"
 
+    def test_subagent_forwards_parent_metadata_without_clobbering_bound_identity(self) -> None:
+        """Verify metadata forwarding stripping behavior.
+
+        Parent `metadata` reaches the subagent's tools, but LangChain-reserved keys
+        (`lc_agent_name`, `ls_integration`) are stripped so the subagent's bound identity
+        survives the merge. Regression test for #3634.
+        """
+        captured_config: Any = None
+
+        @tool
+        def capture_metadata(runtime: ToolRuntime) -> str:
+            """Capture runtime config so the test can inspect propagated metadata."""
+            nonlocal captured_config
+            captured_config = runtime.config
+            return "OK"
+
+        parent_chat_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "task",
+                                "args": {
+                                    "description": "Capture the metadata.",
+                                    "subagent_type": "general-purpose",
+                                },
+                                "id": "call_subagent_metadata",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+        subagent_chat_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "capture_metadata",
+                                "args": {},
+                                "id": "call_capture_metadata",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="done"),
+                ]
+            )
+        )
+
+        compiled_subagent = create_agent(
+            model=subagent_chat_model,
+            tools=[capture_metadata],
+            name="metadata-check-subagent",
+        )
+        parent_agent = create_deep_agent(
+            model=parent_chat_model,
+            checkpointer=InMemorySaver(),
+            subagents=[
+                CompiledSubAgent(
+                    name="general-purpose",
+                    description="A general-purpose agent.",
+                    runnable=compiled_subagent,
+                )
+            ],
+        )
+
+        parent_agent.invoke(
+            {"messages": [HumanMessage(content="Run the metadata check.")]},
+            config={
+                "configurable": {"thread_id": str(uuid.uuid4())},
+                "metadata": {
+                    "customer_id": "abc-123",
+                    "lc_agent_name": "PARENT-OVERRIDE",
+                    "ls_integration": "PARENT-INTEGRATION",
+                },
+            },
+            durability="exit",
+        )
+
+        assert captured_config is not None
+        metadata = captured_config.get("metadata", {})
+        assert metadata.get("customer_id") == "abc-123", f"User-set parent metadata should reach subagent tools, got {metadata!r}"
+        assert metadata.get("lc_agent_name") != "PARENT-OVERRIDE", f"Parent's `lc_agent_name` must be stripped before forwarding, got {metadata!r}"
+        assert metadata.get("ls_integration") != "PARENT-INTEGRATION", (
+            f"Parent's `ls_integration` must be stripped before forwarding, got {metadata!r}"
+        )
+
     def test_subagent_inherits_interrupt_on_from_parent_agent(self) -> None:
         interrupt_payloads: list[Any] = []
 


### PR DESCRIPTION
Closes #3634

---

Follow-up to #2362 (closed by #2845 + #3193). The task tool's `_build_subagent_config` previously forwarded `callbacks`, `tags`, and `configurable` from the parent's runtime config into the subagent's invoke, but dropped `metadata` entirely. The original justification was that forwarding metadata would let LangChain's \`merge_configs\` (passed values win on key collisions) overwrite the subagent's bound \`lc_agent_name\`.

This change forwards \`metadata\` with framework-owned keys stripped, so user-set parent metadata (e.g. \`customer_id\`) reaches subagent runs in LangSmith / Langfuse while the subagent's bound identity and Pregel step context survive intact.

The stripped set covers:

- LangChain / deepagents bound identity: \`lc_agent_name\`, \`ls_integration\`, \`versions\`. Forwarding these would overwrite the subagent's own bound values under LangChain's merge semantics.
- LangGraph per-step internals: any key prefixed \`langgraph_\`, plus \`thread_id\` and \`checkpoint_ns\`. Forwarding these seeds the subagent's invoke with the parent's step context and was observed to drop the subagent's bound \`lc_agent_name\` from tool-runtime metadata.

\`_build_subagent_config\` is hoisted from a closure inside \`_build_task_tool\` to module level so the strip predicate and its companion constants live alongside it.

The existing xfail test on callbacks (#2315) is unrelated and left as-is.