### PR TITLE
chore(infra): tighten commit lint and silence changelog markdownlint

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -63,6 +63,21 @@ jobs:
     name: "validate format"
     runs-on: ubuntu-latest
     steps:
+      - name: "🚫 Reject leading/trailing whitespace"
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # The semantic-pull-request action reports a confusing "No release
+          # type found" error when the title is otherwise valid but has
+          # surrounding whitespace (e.g., " feat(sdk): ..."). Catch that here
+          # with a clearer message before delegating to the action.
+          trimmed="${PR_TITLE#"${PR_TITLE%%[![:space:]]*}"}"
+          trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+          if [[ "$PR_TITLE" != "$trimmed" ]]; then
+            echo "::error::PR title has leading or trailing whitespace: '$PR_TITLE'"
+            echo "Edit the PR title to remove surrounding whitespace. Suggested title: '$trimmed'"
+            exit 1
+          fi
       - name: "🚫 Reject empty scope"
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,29 @@
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.6.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        # Types mirror `.github/workflows/pr_lint.yml`. Scopes are validated in
+        # CI on the PR title, not here — keeps the local hook lean and avoids
+        # drift on the partner-scope list.
+        args:
+          - feat
+          - fix
+          - docs
+          - style
+          - refactor
+          - perf
+          - test
+          - build
+          - ci
+          - chore
+          - revert
+          - release
+          - hotfix
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:

--- a/libs/acp/CHANGELOG.md
+++ b/libs/acp/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD024 -->
+
 # Changelog
 
 ## [0.0.6](https://github.com/langchain-ai/deepagents/compare/deepagents-acp==0.0.5...deepagents-acp==0.0.6) (2026-04-18)

--- a/libs/cli/CHANGELOG.md
+++ b/libs/cli/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD024 -->
+
 # Deep Agents CLI Changelog
 
 From 0.1.0 onward, `deepagents-cli` only contains `deploy`, `dev`, and `init`.

--- a/libs/code/CHANGELOG.md
+++ b/libs/code/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD024 -->
+
 # Deep Agents Code Changelog
 
 ## [0.1.6](https://github.com/langchain-ai/deepagents/compare/deepagents-code==0.1.5...deepagents-code==0.1.6) (2026-05-27)

--- a/libs/deepagents/CHANGELOG.md
+++ b/libs/deepagents/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD024 -->
+
 # Changelog
 
 ## [0.6.5](https://github.com/langchain-ai/deepagents/compare/deepagents==0.6.4...deepagents==0.6.5) (2026-05-28)

--- a/libs/partners/daytona/CHANGELOG.md
+++ b/libs/partners/daytona/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD024 -->
+
 # Changelog
 
 ## [0.0.6](https://github.com/langchain-ai/deepagents/compare/langchain-daytona==0.0.5...langchain-daytona==0.0.6) (2026-05-12)

--- a/libs/partners/modal/CHANGELOG.md
+++ b/libs/partners/modal/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD024 -->
+
 # Changelog
 
 ## [0.0.4](https://github.com/langchain-ai/deepagents/compare/langchain-modal==0.0.3...langchain-modal==0.0.4) (2026-05-12)

--- a/libs/partners/quickjs/CHANGELOG.md
+++ b/libs/partners/quickjs/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD024 -->
+
 # Changelog
 
 ## [0.1.2](https://github.com/langchain-ai/deepagents/compare/langchain-quickjs==0.1.1...langchain-quickjs==0.1.2) (2026-05-11)

--- a/libs/partners/runloop/CHANGELOG.md
+++ b/libs/partners/runloop/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD024 -->
+
 # Changelog
 
 ## [0.0.5](https://github.com/langchain-ai/deepagents/compare/langchain-runloop==0.0.4...langchain-runloop==0.0.5) (2026-05-12)


### PR DESCRIPTION
Adds a local commit-message hook so Conventional Commits violations are caught before push, and clarifies the CI error when a PR title has surrounding whitespace. Also silences `MD024` across release-please-managed CHANGELOGs where duplicate `### Features`/`### Bug Fixes` headings are unavoidable.