### PR TITLE
fix(code): handle stale slash-command `Enter` before completion popup renders

### DIFF
--- a/libs/code/deepagents_code/widgets/autocomplete.py
+++ b/libs/code/deepagents_code/widgets/autocomplete.py
@@ -156,6 +156,23 @@ class SlashCommandController:
             self._selected_index = 0
             self._view.clear_completion_suggestions()
 
+    def name_prefix_matches(self, text: str, cursor_index: int) -> list[CommandEntry]:
+        """Return commands whose names start with the current slash query."""
+        if cursor_index < 0 or cursor_index > len(text):
+            return []
+        if not self.can_handle(text, cursor_index):
+            return []
+
+        search = text[1:cursor_index].lower()
+        if not search or " " in search:
+            return []
+
+        return [
+            entry
+            for entry in self._commands
+            if entry.name.lstrip("/").lower().startswith(search)
+        ]
+
     @staticmethod
     def _score_command(search: str, cmd: str, desc: str, keywords: str = "") -> float:
         """Score a command against a search string. Higher = better match.
@@ -300,6 +317,18 @@ class SlashCommandController:
         self._view.replace_completion_range(0, cursor_index, command)
         self.reset()
         return True
+
+    def apply_name_prefix_completion(
+        self, match: CommandEntry, cursor_index: int
+    ) -> None:
+        """Apply a command-name prefix match.
+
+        Args:
+            match: Command entry to apply.
+            cursor_index: Cursor index in completion-space coordinates.
+        """
+        self._view.replace_completion_range(0, cursor_index, match.name)
+        self.reset()
 
 
 # ============================================================================

--- a/libs/code/deepagents_code/widgets/chat_input.py
+++ b/libs/code/deepagents_code/widgets/chat_input.py
@@ -405,6 +405,7 @@ class ChatTextArea(TextArea):
         # Remove placeholder if passed, TextArea doesn't support it the same way
         kwargs.pop("placeholder", None)
         super().__init__(**kwargs)
+        self._chat_input_owner: ChatInput | None = None
         self._skip_history_change_events = 0
         self._completion_active = False
         # Buffer quote-prefixed high-frequency key bursts from terminals that
@@ -840,6 +841,11 @@ class ChatTextArea(TextArea):
         if event.key == "enter":
             event.prevent_default()
             event.stop()
+            if (
+                self._chat_input_owner is not None
+                and self._chat_input_owner._handle_stale_slash_enter()
+            ):
+                return
             value = self.text.strip()
             if value:
                 self.post_message(self.Submitted(value))
@@ -1184,6 +1190,7 @@ class ChatInput(Vertical):
 
         self._text_area = self.query_one("#chat-input", ChatTextArea)
         self._popup = self.query_one("#completion-popup", CompletionPopup)
+        self._text_area._chat_input_owner = self
 
         # Both controllers implement the CompletionController protocol but have
         # different concrete types; the list-item warning is a false positive.
@@ -1557,6 +1564,46 @@ class ChatInput(Vertical):
                 self.mode,
             )
         return max(0, min(mapped, text_len))
+
+    def _handle_stale_slash_enter(self) -> bool:
+        """Refresh stale slash completions during an Enter-key race.
+
+        Returns:
+            `True` when Enter was handled by applying a single visible
+            suggestion or by showing multiple visible suggestions.
+        """
+        if self.mode != "command" or self._text_area is None:
+            return False
+
+        slash_controller = self._slash_controller
+        if slash_controller is None:
+            return False
+
+        if self._text_area._completion_active:
+            return False
+
+        text, cursor = self._completion_text_and_cursor()
+        if not text.startswith("/"):
+            return False
+
+        matches = slash_controller.name_prefix_matches(text, cursor)
+        if not matches:
+            return False
+
+        completion_manager = self._completion_manager
+        if completion_manager is None:
+            logger.warning(
+                "Slash controller is initialized without completion manager; "
+                "stale slash Enter cannot refresh completions."
+            )
+            return False
+
+        completion_manager.on_text_changed(text, cursor)
+        if len(matches) == 1:
+            slash_controller.apply_name_prefix_completion(matches[0], cursor)
+            self._submit_value(self._text_area.text.strip())
+            return True
+        return True
 
     def _submit_value(self, value: str) -> None:
         """Prepend mode prefix, save to history, post message, and reset input.

--- a/libs/code/deepagents_code/widgets/chat_input.py
+++ b/libs/code/deepagents_code/widgets/chat_input.py
@@ -22,6 +22,7 @@ from textual.strip import Strip
 from textual.widgets import Static, TextArea
 
 from deepagents_code import theme
+from deepagents_code._debug import configure_debug_logging
 from deepagents_code.command_registry import SLASH_COMMANDS, CommandEntry
 from deepagents_code.config import (
     MODE_DISPLAY_GLYPHS,
@@ -39,6 +40,7 @@ from deepagents_code.widgets.autocomplete import (
 from deepagents_code.widgets.history import HistoryManager
 
 logger = logging.getLogger(__name__)
+configure_debug_logging(logger)
 
 
 def _default_history_path() -> Path:

--- a/libs/code/tests/unit_tests/test_chat_input.py
+++ b/libs/code/tests/unit_tests/test_chat_input.py
@@ -1483,6 +1483,89 @@ class TestHistoryRecallModeReset:
 class TestSlashCompletionCursorMapping:
     """Regression: virtual-to-real index translation for slash replacement."""
 
+    async def test_stale_enter_single_slash_match_submits_completion(self) -> None:
+        """Fast Enter on an unambiguous slash prefix should submit the match."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat.mode = "command"
+            chat._text_area.text = "mod"
+            chat._text_area.move_cursor((0, 3))
+            chat._text_area.set_completion_active(active=False)
+
+            await chat._text_area._on_key(events.Key("enter", None))
+            await pilot.pause()
+
+            assert [event.value for event in app.submitted] == ["/model"]
+            assert app.submitted[0].mode == "command"
+
+    async def test_stale_enter_multiple_slash_matches_shows_popup(self) -> None:
+        """Fast Enter on an ambiguous slash prefix should show choices."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat.mode = "command"
+            chat._text_area.text = "re"
+            chat._text_area.move_cursor((0, 2))
+            chat._text_area.set_completion_active(active=False)
+
+            await chat._text_area._on_key(events.Key("enter", None))
+            await pilot.pause()
+
+            labels = [label for label, _ in chat._current_suggestions]
+            assert not app.submitted
+            assert "/reload" in labels
+            assert "/remember" in labels
+            assert chat._text_area._completion_active is True
+
+    async def test_stale_enter_multiple_slash_matches_next_enter_selects(
+        self,
+    ) -> None:
+        """Popup shown by stale Enter should remain keyboard-operable."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat.mode = "command"
+            chat._text_area.text = "re"
+            chat._text_area.move_cursor((0, 2))
+            chat._text_area.set_completion_active(active=False)
+
+            await chat._text_area._on_key(events.Key("enter", None))
+            await pilot.pause()
+            assert not app.submitted
+            assert chat._current_suggestions
+            selected_label = chat._current_suggestions[chat._current_selected_index][0]
+
+            await chat.on_key(events.Key("enter", None))
+            await pilot.pause()
+
+            assert [event.value for event in app.submitted] == [selected_label]
+            assert app.submitted[0].mode == "command"
+
+    async def test_stale_enter_does_not_hide_exact_hidden_command(self) -> None:
+        """Exact hidden commands should still submit without autocomplete."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat.mode = "command"
+            chat._text_area.text = "restart"
+            chat._text_area.move_cursor((0, 7))
+            chat._text_area.set_completion_active(active=False)
+
+            await chat._text_area._on_key(events.Key("enter", None))
+            await pilot.pause()
+
+            assert [event.value for event in app.submitted] == ["/restart"]
+            assert app.submitted[0].mode == "command"
+
     async def test_tab_completion_mid_token_preserves_suffix(self) -> None:
         """Applying slash completion mid-token should keep text after cursor."""
         app = _ChatInputTestApp()


### PR DESCRIPTION
When a user types a slash command prefix and hits Enter faster than the completion popup renders, the raw prefix (e.g. `/mod`) is submitted instead of the intended command. Add a recovery path that detects this race and either completes an unambiguous prefix or shows the popup when multiple commands match.