### PR TITLE
fix(code): centralize debug logging setup to package root

### DIFF
--- a/libs/code/AGENTS.md
+++ b/libs/code/AGENTS.md
@@ -65,6 +65,14 @@ Textual's `App.notify(message)` parses the message string as Rich markup by defa
 - Features that run shell commands silently must be opt-in, never default-enabled. Gate behind an explicit env var or config key.
 - Background workers that spawn subprocesses must set a timeout to avoid blocking indefinitely.
 
+## Logging
+
+Debug logging is configured **once**, on the `deepagents_code` package logger, by the `configure_debug_logging` call in `deepagents_code/__init__.py`. Child module loggers (`logging.getLogger(__name__)`) reach the shared debug file via propagation.
+
+- Do **not** add per-module `configure_debug_logging(logger)` calls. They are redundant now that the package logger is configured at import, and they reintroduce the duplicate-handler problem the single-config approach solves.
+- Every module should create its logger with `logging.getLogger(__name__)` so it stays inside the `deepagents_code.*` hierarchy and inherits the package handler. Don't set `logger.propagate = False` or attach your own handlers.
+- The handler only attaches when `DEEPAGENTS_CODE_DEBUG` is truthy; the no-op path is a single env-var read, so it's safe on the startup hot path. See `DEV.md` for the `DEEPAGENTS_CODE_DEBUG` / `DEEPAGENTS_CODE_DEBUG_FILE` env vars.
+
 ## CLI help screen
 
 The `deepagents-code --help` screen is hand-maintained in `ui.show_help()`, separate from the argparse definitions in `main.parse_args()`. When adding a new CLI flag, update **both** files. A drift-detection test (`test_args.TestHelpScreenDrift`) fails if a flag is registered in argparse but missing from the help screen.

--- a/libs/code/DEV.md
+++ b/libs/code/DEV.md
@@ -60,9 +60,22 @@ The app runs a `langgraph dev` subprocess for every interactive session. When th
 | Variable | Effect |
 | --- | --- |
 | `DEEPAGENTS_CODE_DEBUG=1` | Preserves the server subprocess log on shutdown and prints its path to stderr. Without this, the log is deleted when the process stops. Also enables the app-process file handler below. Accepts `1`/`true`/`yes`/`on` (case-insensitive) as enabled; `0`/`false`/`no`/`off`/empty/unset as disabled. |
-| `DEEPAGENTS_CODE_DEBUG_FILE=<path>` | Overrides the default path (`/tmp/deepagents_debug.log`) for the app-process file handler, which attaches at `DEBUG` level to `textual_adapter` and `remote_client`. **Only takes effect when `DEEPAGENTS_CODE_DEBUG` is truthy.** Useful for diagnosing streaming/client-side issues; does **not** capture the server subprocess. |
+| `DEEPAGENTS_CODE_DEBUG_FILE=<path>` | Overrides the default path (`/tmp/deepagents_debug.log`) for the app-process file handler, which attaches at `DEBUG` level to the `deepagents_code` package logger. **Only takes effect when `DEEPAGENTS_CODE_DEBUG` is truthy.** Useful for diagnosing client-side app issues; does **not** capture the server subprocess. |
 
 `DEEPAGENTS_CODE_DEBUG` is what you want for startup crashes (graph init, MCP config, sandbox): the preserved subprocess log contains the real traceback. The optional `DEEPAGENTS_CODE_DEBUG_FILE` override is for post-startup client-side debugging.
+
+To capture client-side logs while reproducing an issue:
+
+```bash
+cd libs/code
+DEEPAGENTS_CODE_DEBUG=1 uv run deepagents-code
+```
+
+Then in another terminal:
+
+```bash
+tail -f /tmp/deepagents_debug.log
+```
 
 ### Finding the server subprocess log
 

--- a/libs/code/deepagents_code/__init__.py
+++ b/libs/code/deepagents_code/__init__.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
+from deepagents_code._debug import configure_debug_logging
 from deepagents_code._version import __version__
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+configure_debug_logging(logging.getLogger(__name__))  # noqa: RUF067  # package logger must be configured before child modules emit logs
 
 __all__ = [
     "__version__",

--- a/libs/code/deepagents_code/_debug.py
+++ b/libs/code/deepagents_code/_debug.py
@@ -10,17 +10,27 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from pathlib import Path
 
 from deepagents_code._env_vars import DEBUG, DEBUG_FILE, is_env_truthy
+
+_DEBUG_HANDLER_ATTR = "_deepagents_code_debug_handler"
 
 
 def configure_debug_logging(target: logging.Logger) -> None:
     """Attach a file handler to *target* when `DEEPAGENTS_CODE_DEBUG` is set.
 
+    Intended to be called once on the `deepagents_code` package logger; child
+    module loggers reach the same file via propagation, so individual modules do
+    not configure logging themselves.
+
     The log file defaults to `'/tmp/deepagents_debug.log'` but can be overridden
-    with `DEEPAGENTS_CODE_DEBUG_FILE`. The handler appends so that multiple
-    modules share the same log file across a session.
+    with `DEEPAGENTS_CODE_DEBUG_FILE`. The handler appends (`mode='a'`) so logs
+    are preserved across separate process runs. Calling this again with the same
+    resolved path is a no-op: the existing tagged handler is reused rather than
+    stacking duplicates. If the resolved path changes, the stale handler is
+    closed and replaced.
 
     Does nothing when `DEEPAGENTS_CODE_DEBUG` is not truthy (see `is_env_truthy`).
 
@@ -36,16 +46,30 @@ def configure_debug_logging(target: logging.Logger) -> None:
             "/tmp/deepagents_debug.log",  # noqa: S108
         )
     )
+    for existing in list(target.handlers):
+        if not (
+            isinstance(existing, logging.FileHandler)
+            and getattr(existing, _DEBUG_HANDLER_ATTR, False)
+        ):
+            continue
+        if Path(existing.baseFilename) == debug_path:
+            # Already configured for this path; reuse rather than duplicate.
+            target.setLevel(logging.DEBUG)
+            return
+        # The debug path changed; drop the stale handler before re-attaching so
+        # we don't leak its file descriptor or fan logs out to two files.
+        target.removeHandler(existing)
+        existing.close()
+
     try:
         handler = logging.FileHandler(str(debug_path), mode="a")
     except OSError as exc:
-        import sys
-
         print(  # noqa: T201
             f"Warning: could not open debug log file {debug_path}: {exc}",
             file=sys.stderr,
         )
         return
+    setattr(handler, _DEBUG_HANDLER_ATTR, True)
     handler.setLevel(logging.DEBUG)
     handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(message)s"))
     target.addHandler(handler)

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -43,7 +43,6 @@ from deepagents_code import (
 )
 from deepagents_code._cli_context import CLIContext
 from deepagents_code._constants import DEFAULT_AGENT_NAME as DEFAULT_ASSISTANT_ID
-from deepagents_code._debug import configure_debug_logging
 from deepagents_code._git import (
     read_git_branch_from_filesystem,
     read_git_branch_via_subprocess,
@@ -91,7 +90,6 @@ from deepagents_code.widgets.status import StatusBar
 from deepagents_code.widgets.welcome import WelcomeBanner
 
 logger = logging.getLogger(__name__)
-configure_debug_logging(logger)
 _monotonic = time.monotonic
 
 _DEFERRED_START_NOTICE = (

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -24,13 +24,11 @@ from urllib.parse import urlparse
 import tomli_w
 
 from deepagents_code import _env_vars, auth_store
-from deepagents_code._debug import configure_debug_logging
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
 logger = logging.getLogger(__name__)
-configure_debug_logging(logger)
 
 _ENV_PREFIX = "DEEPAGENTS_CODE_"
 

--- a/libs/code/deepagents_code/remote_client.py
+++ b/libs/code/deepagents_code/remote_client.py
@@ -15,10 +15,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable
 
-from deepagents_code._debug import configure_debug_logging
-
 logger = logging.getLogger(__name__)
-configure_debug_logging(logger)
 
 _RUN_CANCEL_WAIT_SECONDS = 10.0
 """Per-run cancel wait. Picked so a stuck server-side run can't hang the UI on

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -48,7 +48,6 @@ if TYPE_CHECKING:
 
 from deepagents_code._ask_user_types import AskUserRequest
 from deepagents_code._cli_context import CLIContext  # noqa: TC001
-from deepagents_code._debug import configure_debug_logging
 from deepagents_code._session_stats import (
     ModelStats as ModelStats,
     SessionStats as SessionStats,
@@ -71,7 +70,6 @@ from deepagents_code.widgets.messages import (
 )
 
 logger = logging.getLogger(__name__)
-configure_debug_logging(logger)
 
 _hitl_adapter_cache: TypeAdapter | None = None
 """Lazy singleton for the HITL request validator."""

--- a/libs/code/deepagents_code/widgets/chat_input.py
+++ b/libs/code/deepagents_code/widgets/chat_input.py
@@ -22,7 +22,6 @@ from textual.strip import Strip
 from textual.widgets import Static, TextArea
 
 from deepagents_code import theme
-from deepagents_code._debug import configure_debug_logging
 from deepagents_code.command_registry import SLASH_COMMANDS, CommandEntry
 from deepagents_code.config import (
     MODE_DISPLAY_GLYPHS,
@@ -40,7 +39,6 @@ from deepagents_code.widgets.autocomplete import (
 from deepagents_code.widgets.history import HistoryManager
 
 logger = logging.getLogger(__name__)
-configure_debug_logging(logger)
 
 
 def _default_history_path() -> Path:

--- a/libs/code/tests/unit_tests/test_debug.py
+++ b/libs/code/tests/unit_tests/test_debug.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 import os
 from unittest.mock import patch
 
+import deepagents_code
 from deepagents_code._debug import configure_debug_logging
 
 
@@ -52,6 +54,103 @@ class TestConfigureDebugLogging:
             h.close()
             logger.removeHandler(h)
 
+    def test_repeated_configuration_is_idempotent(self, tmp_path) -> None:
+        logger = logging.getLogger("test.debug.idempotent")
+        log_file = tmp_path / "debug.log"
+        with patch.dict(
+            os.environ,
+            {"DEEPAGENTS_CODE_DEBUG": "1", "DEEPAGENTS_CODE_DEBUG_FILE": str(log_file)},
+        ):
+            configure_debug_logging(logger)
+            configure_debug_logging(logger)
+
+        file_handlers = [
+            h for h in logger.handlers if isinstance(h, logging.FileHandler)
+        ]
+        try:
+            assert len(file_handlers) == 1
+        finally:
+            for h in file_handlers:
+                h.close()
+                logger.removeHandler(h)
+
+    def test_changed_path_swaps_handler(self, tmp_path) -> None:
+        """Re-configuring with a new path replaces the stale handler, not stacks."""
+        logger = logging.getLogger("test.debug.swap")
+        first = tmp_path / "first.log"
+        second = tmp_path / "second.log"
+        with patch.dict(
+            os.environ,
+            {"DEEPAGENTS_CODE_DEBUG": "1", "DEEPAGENTS_CODE_DEBUG_FILE": str(first)},
+        ):
+            configure_debug_logging(logger)
+        with patch.dict(
+            os.environ,
+            {"DEEPAGENTS_CODE_DEBUG": "1", "DEEPAGENTS_CODE_DEBUG_FILE": str(second)},
+        ):
+            configure_debug_logging(logger)
+
+        file_handlers = [
+            h for h in logger.handlers if isinstance(h, logging.FileHandler)
+        ]
+        try:
+            assert len(file_handlers) == 1
+            assert str(second) in file_handlers[0].baseFilename
+        finally:
+            for h in file_handlers:
+                h.close()
+                logger.removeHandler(h)
+
+    def test_untagged_handler_does_not_block_configuration(self, tmp_path) -> None:
+        """A foreign FileHandler on the same path must not suppress our handler."""
+        logger = logging.getLogger("test.debug.untagged")
+        log_file = tmp_path / "debug.log"
+        foreign = logging.FileHandler(str(log_file), mode="a")
+        logger.addHandler(foreign)
+        with patch.dict(
+            os.environ,
+            {"DEEPAGENTS_CODE_DEBUG": "1", "DEEPAGENTS_CODE_DEBUG_FILE": str(log_file)},
+        ):
+            configure_debug_logging(logger)
+
+        file_handlers = [
+            h for h in logger.handlers if isinstance(h, logging.FileHandler)
+        ]
+        try:
+            # Both the pre-existing foreign handler and our tagged handler remain.
+            assert foreign in file_handlers
+            assert any(
+                getattr(h, "_deepagents_code_debug_handler", False)
+                for h in file_handlers
+            )
+        finally:
+            for h in file_handlers:
+                h.close()
+                logger.removeHandler(h)
+
+    def test_child_logger_propagates_to_configured_parent(self, tmp_path) -> None:
+        logger = logging.getLogger("test.debug.parent")
+        child = logging.getLogger("test.debug.parent.child")
+        log_file = tmp_path / "debug.log"
+        with patch.dict(
+            os.environ,
+            {"DEEPAGENTS_CODE_DEBUG": "1", "DEEPAGENTS_CODE_DEBUG_FILE": str(log_file)},
+        ):
+            configure_debug_logging(logger)
+
+        file_handlers = [
+            h for h in logger.handlers if isinstance(h, logging.FileHandler)
+        ]
+        try:
+            child.warning("child warning")
+            for h in file_handlers:
+                h.flush()
+            assert "test.debug.parent.child child warning" in log_file.read_text()
+        finally:
+            for h in file_handlers:
+                h.close()
+                logger.removeHandler(h)
+
     def test_bad_path_prints_warning_no_crash(self, capsys) -> None:
         """Invalid log path should print warning to stderr, not crash."""
         logger = logging.getLogger("test.debug.bad_path")
@@ -67,3 +166,34 @@ class TestConfigureDebugLogging:
         assert len(logger.handlers) == original_count
         captured = capsys.readouterr()
         assert "Warning" in captured.err
+
+    def test_package_import_configures_package_logger(self, tmp_path) -> None:
+        logger = logging.getLogger("deepagents_code")
+        original_handlers = list(logger.handlers)
+        original_level = logger.level
+        log_file = tmp_path / "package.log"
+        with patch.dict(
+            os.environ,
+            {"DEEPAGENTS_CODE_DEBUG": "1", "DEEPAGENTS_CODE_DEBUG_FILE": str(log_file)},
+        ):
+            importlib.reload(deepagents_code)
+
+        new_handlers = [h for h in logger.handlers if h not in original_handlers]
+        try:
+            child = logging.getLogger("deepagents_code.test_child")
+            child.warning("package child warning")
+            for h in new_handlers:
+                h.flush()
+            assert "deepagents_code.test_child package child warning" in (
+                log_file.read_text()
+            )
+        finally:
+            for h in new_handlers:
+                h.close()
+                logger.removeHandler(h)
+            logger.setLevel(original_level)
+            # Reload with the debug env cleared so cleanup never re-attaches a
+            # handler to the real package logger (e.g. when a developer runs the
+            # suite with DEEPAGENTS_CODE_DEBUG exported in their shell).
+            with patch.dict(os.environ, {}, clear=True):
+                importlib.reload(deepagents_code)


### PR DESCRIPTION
Move `configure_debug_logging` from individual modules to the package root in `__init__.py` so all child loggers inherit the same file handler via propagation. This eliminates duplicate handler attachments when multiple modules import the debug helper, and makes the logging configuration idempotent across reloads.