### PR TITLE
fix(code): tool spinner, result formatting, and expand-hint fixes

### DIFF
--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -952,8 +952,20 @@ async def execute_task_textual(
                                 tool_msg = ToolCallMessage(buffer_name, parsed_args)
                                 await adapter._mount_message(tool_msg)
                                 adapter._current_tool_messages[buffer_id] = tool_msg
-                                if adapter._set_spinner and keep_thinking_spinner:
-                                    await adapter._set_spinner("Thinking")
+                                if keep_thinking_spinner:
+                                    # The argument/approval phase uses the global
+                                    # "Thinking" spinner instead of a per-tool one.
+                                    if adapter._set_spinner:
+                                        await adapter._set_spinner("Thinking")
+                                else:
+                                    # Show a per-tool running spinner immediately so
+                                    # auto-executed tools such as grep, glob,
+                                    # read_file, and ls display activity instead of
+                                    # sitting idle until their result arrives. Every
+                                    # tool outside the frozenset hits this branch;
+                                    # those that go on to interrupt for approval are
+                                    # paused again below.
+                                    tool_msg.set_running()
 
                             tool_call_buffers.pop(buffer_key, None)
 
@@ -997,6 +1009,22 @@ async def execute_task_textual(
                 any_rejected = False
                 ask_user_cancelled = False
                 resume_payload: dict[str, Any] = {}
+
+                # Tools mounted above start their spinner immediately, but a
+                # tool blocked on HITL approval or `ask_user` input is not
+                # actually running. Pause every in-flight row so none shows a
+                # misleading "Running..."; the approve branches below call
+                # `set_running` again to resume those that proceed. Guard each
+                # row individually so a single bad widget can't abort the whole
+                # interrupt handler (mirrors `clear_awaiting_approval` below).
+                for tool_msg in adapter._current_tool_messages.values():
+                    try:
+                        tool_msg.pause_running()
+                    except Exception:
+                        logger.exception(
+                            "Failed to pause running state on tool widget %s",
+                            tool_msg.tool_name,
+                        )
 
                 for interrupt_id, ask_req in list(pending_ask_user.items()):
                     questions = ask_req["questions"]

--- a/libs/code/deepagents_code/tool_display.py
+++ b/libs/code/deepagents_code/tool_display.py
@@ -7,6 +7,7 @@ path). Heavy SDK dependencies (e.g., `backends`) are deferred to function bodies
 """
 
 import json
+from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
@@ -95,6 +96,38 @@ def _sanitize_display_value(value: object, *, max_length: int = MAX_ARG_LENGTH) 
     return display
 
 
+def _format_scope_path(
+    path_value: object,
+    abbreviate: Callable[[str], str],
+) -> str:
+    """Format a glob/grep `path` argument as a display suffix.
+
+    The glob tool defaults `path` to the backend root (`"/"`); the grep tool
+    defaults it to `None` (the backend's working directory). In either case the
+    default scope adds no information and is omitted. Only an explicit, non-root
+    path is rendered, so that two otherwise-identical calls scoped to different
+    directories are distinguishable in the UI. The rendered path is shortened
+    via the supplied `abbreviate` helper.
+
+    Args:
+        path_value: The raw `path` argument, or `None` when not supplied.
+        abbreviate: Path-shortening helper from the calling scope.
+
+    Returns:
+        A suffix like ` in langchain`, or an empty string for the default scope.
+    """
+    if path_value is None:
+        return ""
+    raw = str(path_value)
+    if raw in {"", "/"}:
+        return ""
+    sanitized = strip_dangerous_unicode(raw)
+    display = abbreviate(sanitized)
+    if sanitized != raw:
+        display += _HIDDEN_CHAR_MARKER
+    return f" in {display}"
+
+
 def format_tool_display(tool_name: str, tool_args: dict) -> str:
     """Format tool calls for display with tool-specific smart formatting.
 
@@ -167,10 +200,11 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
             return f'{prefix} {tool_name}("{query}")'
 
     elif tool_name == "grep":
-        # Grep: show the search pattern
+        # Grep: show the search pattern, and the scoped path when non-default
         if "pattern" in tool_args:
             pattern = _sanitize_display_value(tool_args["pattern"], max_length=70)
-            return f'{prefix} {tool_name}("{pattern}")'
+            scope = _format_scope_path(tool_args.get("path"), abbreviate_path)
+            return f'{prefix} {tool_name}("{pattern}"{scope})'
 
     elif tool_name == "execute":
         # Execute: show the command, and timeout only if non-default
@@ -203,10 +237,11 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
         return f"{prefix} {tool_name}()"
 
     elif tool_name == "glob":
-        # Glob: show the pattern
+        # Glob: show the pattern, and the scoped path when non-default
         if "pattern" in tool_args:
             pattern = _sanitize_display_value(tool_args["pattern"], max_length=80)
-            return f'{prefix} {tool_name}("{pattern}")'
+            scope = _format_scope_path(tool_args.get("path"), abbreviate_path)
+            return f'{prefix} {tool_name}("{pattern}"{scope})'
 
     elif tool_name == "fetch_url":
         # Fetch URL: show the URL being fetched

--- a/libs/code/deepagents_code/widgets/messages.py
+++ b/libs/code/deepagents_code/widgets/messages.py
@@ -1003,6 +1003,23 @@ class ToolCallMessage(Vertical):
             Content.styled(text, theme.get_theme_colors(self).warning)
         )
 
+    def pause_running(self) -> None:
+        """Pause the running spinner while the tool awaits a user decision.
+
+        Reverts the row to its pending appearance (status hidden) and stops the
+        animation so a tool blocked on HITL approval or `ask_user` input does
+        not misleadingly display "Running...". Resume with `set_running`, which
+        restarts the elapsed timer from the moment execution actually begins.
+        """
+        if self._status != "running":
+            return
+        self._stop_animation()
+        self._status = "pending"
+        self._start_time = None
+        if self._status_widget:
+            self._status_widget.remove_class("pending")
+            self._status_widget.display = False
+
     def _stop_animation(self) -> None:
         """Stop the running animation."""
         if self._animation_timer is not None:

--- a/libs/code/deepagents_code/widgets/messages.py
+++ b/libs/code/deepagents_code/widgets/messages.py
@@ -1123,7 +1123,10 @@ class ToolCallMessage(Vertical):
         """Toggle expansion of the tool's preview/full output."""
         if not self._output:
             return
-        if not self._expanded and not self._has_expandable_output():
+        # No-op in both directions when nothing is hidden: the collapsed and
+        # expanded forms are identical, so toggling only flickers the hint.
+        # This also covers force-expanded errors (see `set_error`).
+        if not self._has_expandable_output():
             return
         self._expanded = not self._expanded
         self._update_output_display()
@@ -1199,11 +1202,16 @@ class ToolCallMessage(Vertical):
         if not output:
             return False
 
+        if self._tool_name == "write_todos":
+            return self._format_output(output, is_preview=True).truncation is not None
+
         lines = output.split("\n")
         if len(lines) > self._PREVIEW_LINES or len(output) > self._PREVIEW_CHARS:
-            return True
-
-        if self._tool_name == "write_todos":
+            # The outer size threshold is necessary but not sufficient: only
+            # treat output as expandable if the formatter actually hides
+            # content. Formatters that truncate by line count (e.g. grep/glob)
+            # leave long single-line output fully visible, so expanding it
+            # would reveal nothing.
             return self._format_output(output, is_preview=True).truncation is not None
 
         return False
@@ -1579,7 +1587,7 @@ class ToolCallMessage(Vertical):
                         display = str(rel)
                     except ValueError:
                         display = path.name
-                    parts.append(Content(f"    {display}"))
+                    parts.append(Content(display))
 
                 truncation = None
                 if is_preview and len(items) > max_items:
@@ -1596,7 +1604,7 @@ class ToolCallMessage(Vertical):
         max_lines = 5 if is_preview else len(lines)
 
         parts = [
-            Content(f"    {raw_line.strip()}")
+            Content(raw_line.strip())
             for raw_line in lines[:max_lines]
             if raw_line.strip()
         ]
@@ -1812,53 +1820,49 @@ class ToolCallMessage(Vertical):
             prefixed = self._prefix_output(result.content)
             self._full_widget.update(prefixed)
             self._full_widget.display = True
-            # Show collapse hint underneath
-            self._hint_widget.update(
-                Content.styled("click or Ctrl+O to collapse", "dim italic")
-            )
-            self._hint_widget.display = True
-        else:
-            # Show preview
-            self._full_widget.display = False
-            if needs_truncation:
-                result = self._format_output(self._output, is_preview=True)
-                prefixed = self._prefix_output(result.content)
-                self._preview_widget.update(prefixed)
-                self._preview_widget.display = True
-
-                # Build hint with truncation info if available
-                if result.truncation:
-                    ellipsis = get_glyphs().ellipsis
-                    hint = Content.styled(
-                        f"{ellipsis} {result.truncation} — click or Ctrl+O to expand",
-                        "dim",
-                    )
-                else:
-                    hint = Content.styled("click or Ctrl+O to expand", "dim italic")
-                self._hint_widget.update(hint)
-                self._hint_widget.display = True
-            elif output_stripped:
-                # Output fits in preview, show formatted
-                is_tool_preview = self._tool_name == "write_todos"
-                result = self._format_output(
-                    output_stripped,
-                    is_preview=is_tool_preview,
+            # Only offer a collapse affordance when collapsing would actually
+            # hide something. Errors are force-expanded (see `set_error`), so a
+            # short single-line error has no smaller collapsed form — showing
+            # "click to collapse" there is misleading.
+            if self._has_expandable_output():
+                self._hint_widget.update(
+                    Content.styled("click or Ctrl+O to collapse", "dim italic")
                 )
-                prefixed = self._prefix_output(result.content)
-                self._preview_widget.update(prefixed)
-                self._preview_widget.display = True
-                if result.truncation:
-                    ellipsis = get_glyphs().ellipsis
-                    hint = Content.styled(
+                self._hint_widget.display = True
+            else:
+                self._hint_widget.display = False
+        else:
+            # Show collapsed preview
+            self._full_widget.display = False
+            if not output_stripped:
+                self._preview_widget.display = False
+                self._hint_widget.display = False
+                return
+
+            # Truncate the preview only when the output is large enough to
+            # warrant it; `write_todos` always uses its compact per-item preview
+            # regardless of size.
+            is_preview = needs_truncation or self._tool_name == "write_todos"
+            result = self._format_output(output_stripped, is_preview=is_preview)
+            prefixed = self._prefix_output(result.content)
+            self._preview_widget.update(prefixed)
+            self._preview_widget.display = True
+
+            # Offer expansion only when the formatter actually hid content.
+            # The raw size threshold can trip without anything being hidden
+            # (e.g. a long single-line grep/glob result, which only truncates
+            # by line count), and promising an expansion that reveals nothing
+            # is misleading.
+            if result.truncation:
+                ellipsis = get_glyphs().ellipsis
+                self._hint_widget.update(
+                    Content.styled(
                         f"{ellipsis} {result.truncation} — click or Ctrl+O to expand",
                         "dim",
                     )
-                    self._hint_widget.update(hint)
-                    self._hint_widget.display = True
-                else:
-                    self._hint_widget.display = False
+                )
+                self._hint_widget.display = True
             else:
-                self._preview_widget.display = False
                 self._hint_widget.display = False
 
     @property

--- a/libs/code/deepagents_code/widgets/messages.py
+++ b/libs/code/deepagents_code/widgets/messages.py
@@ -1480,6 +1480,51 @@ class ToolCallMessage(Vertical):
         # Fallback: plain text
         return FormattedOutput(content=Content(output))
 
+    @staticmethod
+    def _compact_line_gutter(output: str) -> str:
+        r"""Tighten `read_file`'s cat -n line-number gutter for display.
+
+        The tool emits `f"{line_num:6d}\t{line}"` — a 6-wide right-justified
+        number plus a tab — so even single-digit line numbers carry five
+        leading spaces and the tab pushes content to a distant tab stop. The
+        model needs that raw format for edits, but the TUI renders a compact
+        gutter instead: numbers right-justified to the widest number actually
+        present, then two spaces, mirroring how grep/glob results sit flush
+        left. Source indentation after the gutter is preserved untouched.
+
+        Lines that don't match the cat -n shape (e.g. test fixtures or
+        non-numbered output) are passed through unchanged.
+
+        Returns:
+            The output with compacted gutters, or the original string if no
+                line-numbered content was found.
+        """
+        lines = output.split("\n")
+        # Split each line on its gutter tab into (number, source). The gutter
+        # tab is always the first one; any tabs in `text` are real source
+        # indentation and stay put. The head must be a bare `N` or `N.M` (the
+        # latter is a wrapped-line continuation marker) — both sides of the dot
+        # are required, so a stray `.5` head marks a non-gutter line.
+        parsed: list[tuple[str, str] | None] = []
+        width = 0
+        for line in lines:
+            head, tab, text = line.partition("\t")
+            num = head.strip()
+            whole, dot, frac = num.partition(".")
+            if tab and whole.isdigit() and (not dot or frac.isdigit()):
+                parsed.append((num, text))
+                width = max(width, len(num))
+            else:
+                parsed.append(None)
+
+        if width == 0:
+            return output
+
+        return "\n".join(
+            f"{row[0]:>{width}}  {row[1]}" if row else line
+            for line, row in zip(lines, parsed, strict=True)
+        )
+
     def _format_file_output(
         self, output: str, *, is_preview: bool = False
     ) -> FormattedOutput:
@@ -1492,6 +1537,7 @@ class ToolCallMessage(Vertical):
         Returns:
             FormattedOutput with file content and optional truncation info.
         """
+        output = self._compact_line_gutter(output)
         lines = output.split("\n")
         # Files conventionally end in "\n"; the trailing empty element isn't a
         # real line and would inflate truncation counts.

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -1117,6 +1117,91 @@ class TestToolCallMessageFileOutput:
 
         assert result.truncation == "2 more lines"
 
+    def test_format_output_compacts_line_number_gutter(self) -> None:
+        r"""Line-number gutters are tightened, all rows aligned to one column.
+
+        `read_file` emits `f"{line_num:6d}\t{line}"` — a 6-wide right-justified
+        number plus a tab — which renders far from the line numbers and (when
+        the first row's padding was stripped) misaligned. The TUI recomputes a
+        compact gutter: numbers right-justified to the widest number present,
+        two spaces, then the original source indentation.
+        """
+        msg = ToolCallMessage("read_file", {"path": "/tmp/a.py"})
+        # cat -n style: 6-wide right-justified number + tab + source line.
+        output = '     1\t"""doc"""\n     2\t\n     3\t    indented'
+        result = msg._format_output(output, is_preview=False)
+
+        # No tab, no 6-wide pad: `{num}  ` gutter, then the original source
+        # indentation (the 4 spaces on line 3) preserved verbatim.
+        assert result.content.plain == '1  """doc"""\n2  \n3      indented'
+
+    def test_compact_line_gutter_right_justifies_to_widest_number(self) -> None:
+        r"""Multi-digit line numbers set a uniform, right-justified gutter."""
+        # Lines 9 and 10: single- vs double-digit numbers must align right.
+        output = "     9\tnine\n    10\tten"
+        compacted = ToolCallMessage._compact_line_gutter(output)
+
+        assert compacted == " 9  nine\n10  ten"
+
+    def test_compact_line_gutter_handles_continuation_markers(self) -> None:
+        r"""`N.M` wrapped-line markers are gutters and drive the column width.
+
+        Long lines are chunked by the SDK with decimal continuation markers
+        (`f"{line_num}.{chunk_idx}"`). The marker's width (e.g. `1.1` = 3)
+        must set the right-justified column like any other line number.
+        """
+        output = "     1\tfirst\n   1.1\twrapped"
+        compacted = ToolCallMessage._compact_line_gutter(output)
+
+        assert compacted == "  1  first\n1.1  wrapped"
+
+    def test_compact_line_gutter_preserves_source_tabs(self) -> None:
+        r"""Only the first (gutter) tab is consumed; source tabs stay put.
+
+        Tab-indented source means a tab immediately after the gutter tab.
+        `partition` splits on the first tab only, so the source tab survives.
+        """
+        output = "     1\t\tdef foo():"
+        compacted = ToolCallMessage._compact_line_gutter(output)
+
+        assert compacted == "1  \tdef foo():"
+
+    def test_compact_line_gutter_passes_through_non_numbered(self) -> None:
+        """Output without a cat -n gutter is returned unchanged."""
+        output = "plain text\nno line numbers here"
+        assert ToolCallMessage._compact_line_gutter(output) == output
+
+    def test_compact_line_gutter_rejects_malformed_number_heads(self) -> None:
+        r"""Heads that aren't a bare `N`/`N.M` are treated as source, not gutter.
+
+        Guards against corrupting tab-separated data whose first column merely
+        resembles a number (leading/trailing dot, multiple dots).
+        """
+        # Leading dot, trailing dot, and multi-dot heads must all pass through.
+        output = "   .5\tweird\n   5.\talso\n 1.2.3\tnope"
+        assert ToolCallMessage._compact_line_gutter(output) == output
+
+    def test_compact_line_gutter_preview_truncates_with_compacted_gutters(
+        self,
+    ) -> None:
+        """Compaction runs before truncation: previews show compact gutters.
+
+        The char budget and `more lines` hint operate on the already-compacted
+        string, so a long cat -n file previews with tight gutters and a
+        line-count hint.
+        """
+        msg = ToolCallMessage("read_file", {"path": "/tmp/a.py"})
+        output = "\n".join(f"{i:6d}\tline {i}" for i in range(1, 21))
+        result = msg._format_file_output(output, is_preview=True)
+
+        rendered = result.content.plain.split("\n")
+        assert rendered[0] == " 1  line 1"  # width 2 (max line number is 20)
+        assert result.truncation == "16 more lines"
+
+    def test_compact_line_gutter_empty_output(self) -> None:
+        """Empty output has no gutter lines and is returned unchanged."""
+        assert ToolCallMessage._compact_line_gutter("") == ""
+
 
 class TestToolCallMessageAwaitingApproval:
     """Tests for `set_awaiting_approval` / `clear_awaiting_approval`."""

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from rich.style import Style
+from textual.app import App
 from textual.content import Content
 
 from deepagents_code import theme
@@ -499,6 +500,236 @@ class TestToolCallMessageTodos:
 
         assert len(lines) > todo_start + 1
         assert lines[todo_start + 1].startswith("             ")
+
+
+def _tool_msg_app(tool_name: str, args: dict | None = None) -> App[None]:
+    """Build a single-`ToolCallMessage` Textual app for pilot-driven tests.
+
+    Args:
+        tool_name: Tool name the message represents.
+        args: Optional tool-call arguments.
+
+    Returns:
+        An unmounted `App` exposing the message as `app.msg`.
+    """
+    from textual.app import ComposeResult
+
+    class _Harness(App[None]):
+        def __init__(self) -> None:
+            super().__init__()
+            self.msg = ToolCallMessage(tool_name, args)
+
+        def compose(self) -> ComposeResult:
+            yield self.msg
+
+    return _Harness()
+
+
+class TestToolCallMessageSearchOutput:
+    """Tests for grep/glob result formatting in `_format_search_output`."""
+
+    def test_glob_list_output_has_no_hardcoded_indent(self) -> None:
+        """Glob (list) results must not carry a hardcoded leading indent.
+
+        Alignment is owned by `_prefix_output`; the formatter emits bare paths
+        so results aren't double-indented under the output marker.
+        """
+        msg = ToolCallMessage("glob", {"pattern": "**/*.py"})
+        result = msg._format_search_output(
+            "['/tmp/zzz_a.py', '/tmp/zzz_b.py']", is_preview=False
+        )
+        lines = result.content.plain.split("\n")
+        assert lines
+        assert all(not line.startswith(" ") for line in lines)
+
+    def test_grep_line_output_has_no_hardcoded_indent(self) -> None:
+        """Grep (line-based) results must not carry a hardcoded leading indent.
+
+        This is a distinct branch from the glob list path: `ast.literal_eval`
+        fails for grep output, so it falls through to line-based formatting.
+        """
+        msg = ToolCallMessage("grep", {"pattern": "x"})
+        result = msg._format_search_output(
+            "file.py:1:match one\nfile.py:2:match two", is_preview=False
+        )
+        assert result.content.plain.split("\n") == [
+            "file.py:1:match one",
+            "file.py:2:match two",
+        ]
+
+
+class TestToolCallMessageExpandHint:
+    """Tests for the preview/expand hint on collapsed tool output."""
+
+    async def test_long_single_line_search_output_has_no_expand_hint(self) -> None:
+        """Long-but-single-line grep/glob output should not offer expansion.
+
+        The outer collapse threshold counts characters, but `_format_search_output`
+        only truncates by line count. A long single-line result (e.g. a glob
+        error string returned as normal output) trips the char threshold while
+        leaving nothing hidden, so the preview must not promise an expansion
+        that would reveal identical content.
+        """
+        from textual.app import App, ComposeResult
+
+        # Single line, no newlines, comfortably over the character threshold.
+        output = "Invalid glob pattern: " + "a" * ToolCallMessage._PREVIEW_CHARS
+        assert "\n" not in output
+        assert len(output) > ToolCallMessage._PREVIEW_CHARS
+
+        class _Harness(App[None]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.msg = ToolCallMessage("glob", {"pattern": "**/*.py"})
+
+            def compose(self) -> ComposeResult:
+                yield self.msg
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.msg.set_success(output)
+            await pilot.pause()
+
+            assert app.msg._hint_widget is not None
+            # Nothing is hidden, so no expand affordance and no toggle.
+            assert app.msg._hint_widget.display is False
+            assert app.msg._has_expandable_output() is False
+
+            app.msg.toggle_output()
+            await pilot.pause()
+
+            assert app.msg._expanded is False
+            assert app.msg._hint_widget.display is False
+
+    async def test_short_error_force_expanded_has_no_collapse_hint(self) -> None:
+        """A short force-expanded error must not show a collapse affordance.
+
+        `set_error` force-expands so the full error is always visible. When the
+        error is short enough that the collapsed form would be identical, there
+        is nothing to collapse — so no hint, and toggling is a no-op.
+        """
+        from textual.app import App, ComposeResult
+
+        error = "Error: glob timed out after 20.0s. Try a narrower path."
+        assert "\n" not in error
+        assert len(error) < ToolCallMessage._PREVIEW_CHARS
+
+        class _Harness(App[None]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.msg = ToolCallMessage("glob", {"pattern": "**/*.py"})
+
+            def compose(self) -> ComposeResult:
+                yield self.msg
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.msg.set_error(error)
+            await pilot.pause()
+
+            assert app.msg._expanded is True
+            assert app.msg._hint_widget is not None
+            assert app.msg._hint_widget.display is False
+            assert app.msg._has_expandable_output() is False
+
+            app.msg.toggle_output()
+            await pilot.pause()
+
+            # Nothing to collapse — stays expanded with the hint hidden.
+            assert app.msg._expanded is True
+            assert app.msg._hint_widget.display is False
+
+    async def test_multiline_error_force_expanded_offers_collapse(self) -> None:
+        """A long force-expanded error should still offer a collapse affordance.
+
+        The positive counterpart to the short-error case: a multi-line error
+        exceeds the line threshold and the formatter truncates it, so a smaller
+        collapsed form exists and the collapse hint must appear.
+        """
+        error = "\n".join(f"line {index} of the traceback" for index in range(10))
+        assert error.count("\n") + 1 > ToolCallMessage._PREVIEW_LINES
+
+        app = _tool_msg_app("glob", {"pattern": "**/*.py"})
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.msg.set_error(error)
+            await pilot.pause()
+
+            assert app.msg._expanded is True
+            assert app.msg._has_expandable_output() is True
+            assert app.msg._hint_widget is not None
+            assert app.msg._hint_widget.display is True
+            hint = app.msg._hint_widget._Static__content  # type: ignore[attr-defined]
+            assert "collapse" in hint.plain
+
+            app.msg.toggle_output()
+            await pilot.pause()
+
+            assert app.msg._expanded is False
+            assert app.msg._hint_widget.display is True
+            collapsed = app.msg._hint_widget._Static__content  # type: ignore[attr-defined]
+            assert "expand" in collapsed.plain
+
+    async def test_long_grep_output_truncates_and_expands(self) -> None:
+        """A multi-line grep result should preview-truncate then expand on toggle."""
+        output = "\n".join(f"file.py:{index}:hit {index}" for index in range(8))
+        assert output.count("\n") + 1 > ToolCallMessage._PREVIEW_LINES
+
+        app = _tool_msg_app("grep", {"pattern": "hit"})
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.msg.set_success(output)
+            await pilot.pause()
+
+            assert app.msg._expanded is False
+            assert app.msg._has_expandable_output() is True
+            assert app.msg._preview_widget is not None
+            assert app.msg._full_widget is not None
+            assert app.msg._hint_widget is not None
+            assert app.msg._hint_widget.display is True
+            hint = app.msg._hint_widget._Static__content  # type: ignore[attr-defined]
+            assert "expand" in hint.plain
+            # The preview hides the trailing lines.
+            preview = app.msg._preview_widget._Static__content  # type: ignore[attr-defined]
+            assert "hit 7" not in preview.plain
+
+            app.msg.toggle_output()
+            await pilot.pause()
+
+            assert app.msg._expanded is True
+            full = app.msg._full_widget._Static__content  # type: ignore[attr-defined]
+            assert "hit 7" in full.plain
+            collapsed = app.msg._hint_widget._Static__content  # type: ignore[attr-defined]
+            assert "collapse" in collapsed.plain
+
+    async def test_short_non_todo_output_renders_full_without_hint(self) -> None:
+        """Short non-todo output uses non-preview formatting and shows no hint.
+
+        Guards the merged collapsed branch: `is_preview` must stay `False` for
+        a non-`write_todos` tool below the size threshold, so the full content
+        is shown rather than a truncated preview.
+        """
+        # Five lines: under `_PREVIEW_LINES` (6) but over the file formatter's
+        # own four-line preview cap, so a stray `is_preview=True` would truncate.
+        output = "\n".join(f"line {index}" for index in range(5))
+        assert output.count("\n") + 1 < ToolCallMessage._PREVIEW_LINES
+
+        app = _tool_msg_app("read_file", {"path": "/tmp/x"})
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.msg.set_success(output)
+            await pilot.pause()
+
+            assert app.msg._expanded is False
+            assert app.msg._has_expandable_output() is False
+            assert app.msg._preview_widget is not None
+            assert app.msg._hint_widget is not None
+            assert app.msg._hint_widget.display is False
+            preview = app.msg._preview_widget._Static__content  # type: ignore[attr-defined]
+            assert "line 0" in preview.plain
+            assert "line 4" in preview.plain
 
 
 class TestToolCallMessageExpandableArgs:

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from rich.style import Style
-from textual.app import App
+from textual.app import App, ComposeResult
 from textual.content import Content
 
 from deepagents_code import theme
@@ -502,7 +502,18 @@ class TestToolCallMessageTodos:
         assert lines[todo_start + 1].startswith("             ")
 
 
-def _tool_msg_app(tool_name: str, args: dict | None = None) -> App[None]:
+class _ToolMsgApp(App[None]):
+    """Single-`ToolCallMessage` Textual app for pilot-driven tests."""
+
+    def __init__(self, tool_name: str, args: dict | None = None) -> None:
+        super().__init__()
+        self.msg = ToolCallMessage(tool_name, args)
+
+    def compose(self) -> ComposeResult:
+        yield self.msg
+
+
+def _tool_msg_app(tool_name: str, args: dict | None = None) -> _ToolMsgApp:
     """Build a single-`ToolCallMessage` Textual app for pilot-driven tests.
 
     Args:
@@ -512,17 +523,7 @@ def _tool_msg_app(tool_name: str, args: dict | None = None) -> App[None]:
     Returns:
         An unmounted `App` exposing the message as `app.msg`.
     """
-    from textual.app import ComposeResult
-
-    class _Harness(App[None]):
-        def __init__(self) -> None:
-            super().__init__()
-            self.msg = ToolCallMessage(tool_name, args)
-
-        def compose(self) -> ComposeResult:
-            yield self.msg
-
-    return _Harness()
+    return _ToolMsgApp(tool_name, args)
 
 
 class TestToolCallMessageSearchOutput:
@@ -669,7 +670,7 @@ class TestToolCallMessageExpandHint:
 
             assert app.msg._expanded is False
             assert app.msg._hint_widget.display is True
-            collapsed = app.msg._hint_widget._Static__content  # type: ignore[attr-defined]
+            collapsed = app.msg._hint_widget._Static__content
             assert "expand" in collapsed.plain
 
     async def test_long_grep_output_truncates_and_expands(self) -> None:
@@ -699,9 +700,9 @@ class TestToolCallMessageExpandHint:
             await pilot.pause()
 
             assert app.msg._expanded is True
-            full = app.msg._full_widget._Static__content  # type: ignore[attr-defined]
+            full = app.msg._full_widget._Static__content
             assert "hit 7" in full.plain
-            collapsed = app.msg._hint_widget._Static__content  # type: ignore[attr-defined]
+            collapsed = app.msg._hint_widget._Static__content
             assert "collapse" in collapsed.plain
 
     async def test_short_non_todo_output_renders_full_without_hint(self) -> None:

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -1253,6 +1253,116 @@ class TestToolCallMessageAwaitingApproval:
             assert msg.display is True
 
 
+class TestToolCallMessageRunningSpinner:
+    """Tests for `set_running` / `pause_running` spinner state."""
+
+    async def test_set_running_shows_status_widget(self) -> None:
+        """`set_running` should reveal the status row and start the timer."""
+        from textual.app import App, ComposeResult
+
+        class _Harness(App[None]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.msg = ToolCallMessage("grep", {"pattern": "foo"})
+
+            def compose(self) -> ComposeResult:
+                yield self.msg
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            msg = app.msg
+            assert msg._status_widget is not None
+            # Pending tools hide the status row until they run.
+            assert msg._status_widget.display is False
+
+            msg.set_running()
+            await pilot.pause()
+            assert msg._status == "running"
+            assert msg._status_widget.display is True
+            assert msg._animation_timer is not None
+
+    async def test_pause_running_hides_status_and_stops_timer(self) -> None:
+        """`pause_running` should revert a running tool to its pending look."""
+        from textual.app import App, ComposeResult
+
+        class _Harness(App[None]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.msg = ToolCallMessage("grep", {"pattern": "foo"})
+
+            def compose(self) -> ComposeResult:
+                yield self.msg
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            msg = app.msg
+            msg.set_running()
+            await pilot.pause()
+
+            msg.pause_running()
+            await pilot.pause()
+            assert msg._status == "pending"
+            assert msg._start_time is None
+            assert msg._animation_timer is None
+            assert msg._status_widget is not None
+            assert msg._status_widget.display is False
+
+    async def test_pause_running_no_op_when_not_running(self) -> None:
+        """Pausing a pending tool should leave its status untouched."""
+        from textual.app import App, ComposeResult
+
+        class _Harness(App[None]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.msg = ToolCallMessage("grep", {"pattern": "foo"})
+
+            def compose(self) -> ComposeResult:
+                yield self.msg
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            msg = app.msg
+            assert msg._status == "pending"
+            msg.pause_running()
+            await pilot.pause()
+            assert msg._status == "pending"
+            assert msg._status_widget is not None
+            assert msg._status_widget.display is False
+
+    async def test_set_running_resumes_after_pause(self) -> None:
+        """A paused tool should be resumable via `set_running` (HITL approve)."""
+        from textual.app import App, ComposeResult
+
+        class _Harness(App[None]):
+            def __init__(self) -> None:
+                super().__init__()
+                self.msg = ToolCallMessage("write_file", {"file_path": "a.txt"})
+
+            def compose(self) -> ComposeResult:
+                yield self.msg
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            msg = app.msg
+            msg.set_running()
+            await pilot.pause()
+            msg.pause_running()
+            await pilot.pause()
+            assert msg._status == "pending"
+
+            msg.set_running()
+            await pilot.pause()
+            assert msg._status == "running"
+            assert msg._start_time is not None
+            assert msg._animation_timer is not None
+            assert msg._status_widget is not None
+            assert msg._status_widget.display is True
+
+
 class TestToolCallMessageRejectReason:
     """Tests for surfacing a user-supplied HITL reject reason."""
 

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -1101,6 +1101,82 @@ class TestExecuteTaskTextualParallelToolSpinner:
         assert statuses[:2] == ["Thinking", "Thinking"]
         assert None not in statuses
 
+    async def test_auto_executed_tool_shows_running_at_mount(self) -> None:
+        """Auto-executed tools (no approval) spin immediately when mounted.
+
+        Regression guard: read-only tools such as `grep`/`glob` previously sat
+        visually idle from mount until their result arrived. The stream here
+        ends right after the tool call (no result), so the row is observed in
+        its mount-time state.
+        """
+        chunks = [
+            (
+                (),
+                "messages",
+                (_tool_call_message("grep", {"pattern": "foo"}, "tool-1"), {}),
+            ),
+        ]
+
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+
+        await execute_task_textual(
+            user_input="search",
+            agent=_FakeAgent(chunks),
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=True),
+            adapter=adapter,
+        )
+
+        tool_msg = adapter._current_tool_messages["tool-1"]
+        assert tool_msg._status == "running"
+
+    async def test_edit_file_does_not_get_per_tool_spinner_at_mount(self) -> None:
+        """`edit_file` relies on the global Thinking spinner, not a per-tool one.
+
+        Negative counterpart to the auto-executed case: tools in
+        `_TOOL_CALLS_KEEP_THINKING_SPINNER` must NOT be flipped to "running" at
+        mount, or they would show a duplicate spinner alongside "Thinking".
+        """
+        chunks = [
+            (
+                (),
+                "messages",
+                (
+                    _tool_call_message(
+                        "edit_file",
+                        {
+                            "file_path": "example.py",
+                            "old_string": "old",
+                            "new_string": "new",
+                        },
+                        "tool-1",
+                    ),
+                    {},
+                ),
+            ),
+        ]
+
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+
+        await execute_task_textual(
+            user_input="edit",
+            agent=_FakeAgent(chunks),
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=True),
+            adapter=adapter,
+        )
+
+        tool_msg = adapter._current_tool_messages["tool-1"]
+        assert tool_msg._status != "running"
+
     async def test_spinner_with_three_parallel_tools_out_of_order(self) -> None:
         """Three parallel tools completed out of order; Thinking after all."""
         statuses: list[str | None] = []
@@ -1411,16 +1487,18 @@ class TestExecuteTaskTextualHITLShellSuppression:
     ) -> tuple[
         TextualUIAdapter,
         list[object],
-        dict[str, tuple[bool, bool]],
+        dict[str, tuple[bool, bool, str]],
     ]:
         """Drive a HITL flow and snapshot widget visibility during the await.
 
         Returns the adapter, the mounted widgets, and a mapping of
-        `tool_call_id -> (display, _awaiting_approval)` captured while the
-        approval future is pending.
+        `tool_call_id -> (display, _awaiting_approval, _status)` captured while
+        the approval future is pending. The status entry locks in the pause
+        behavior: tools start their spinner at mount but are reverted to
+        `pending` while blocked on the approval decision.
         """
         mounted: list[object] = []
-        snapshots: dict[str, tuple[bool, bool]] = {}
+        snapshots: dict[str, tuple[bool, bool, str]] = {}
 
         async def mount_message(widget: object) -> None:
             await asyncio.sleep(0)
@@ -1437,6 +1515,7 @@ class TestExecuteTaskTextualHITLShellSuppression:
                 snapshots[tid] = (
                     bool(tool_msg.display),
                     tool_msg._awaiting_approval,
+                    tool_msg._status,
                 )
             future.set_result(approval_decision)
             return future
@@ -1506,11 +1585,14 @@ class TestExecuteTaskTextualHITLShellSuppression:
         )
         tool_rows = [w for w in mounted if isinstance(w, ToolCallMessage)]
         assert len(tool_rows) == 1
-        # While the future was pending, the widget was hidden.
-        assert snapshots["tool-shell"] == (False, True)
-        # After the finally block, it was restored.
+        # While the future was pending, the widget was hidden and its spinner
+        # paused (reverted from the mount-time "running" to "pending").
+        assert snapshots["tool-shell"] == (False, True, "pending")
+        # After the finally block, it was restored and the spinner resumed
+        # (the resumed stream is empty, so the row never reaches a result).
         assert tool_rows[0].display is True
         assert tool_rows[0]._awaiting_approval is False
+        assert tool_rows[0]._status == "running"
 
     async def test_non_shell_tool_widget_not_suppressed(self) -> None:
         """`read_file` widget should stay visible — only shell tools are hidden."""
@@ -1521,10 +1603,13 @@ class TestExecuteTaskTextualHITLShellSuppression:
         )
         tool_rows = [w for w in mounted if isinstance(w, ToolCallMessage)]
         assert len(tool_rows) == 1
-        # Visible the whole time, never marked as awaiting approval.
-        assert snapshots["tool-read"] == (True, False)
+        # Visible the whole time, never marked as awaiting approval, but the
+        # spinner is paused to "pending" while the decision is outstanding.
+        assert snapshots["tool-read"] == (True, False, "pending")
         assert tool_rows[0].display is True
         assert tool_rows[0]._awaiting_approval is False
+        # Resumed to "running" after approval (resumed stream yields no result).
+        assert tool_rows[0]._status == "running"
 
     async def test_batch_approval_keeps_all_widgets_visible(self) -> None:
         """Batched approvals (>1 request) must not hide any tool widget.
@@ -1540,8 +1625,8 @@ class TestExecuteTaskTextualHITLShellSuppression:
             approval_decision={"type": "approve"},
             extra_tool_calls=[("read_file", {"path": "notes.txt"}, "tool-read")],
         )
-        assert snapshots["tool-shell"] == (True, False)
-        assert snapshots["tool-read"] == (True, False)
+        assert snapshots["tool-shell"] == (True, False, "pending")
+        assert snapshots["tool-read"] == (True, False, "pending")
 
     async def test_batch_of_shell_tools_keeps_all_widgets_visible(self) -> None:
         """Multiple parallel `execute` calls: all rows stay visible.
@@ -1558,8 +1643,8 @@ class TestExecuteTaskTextualHITLShellSuppression:
                 ("execute", {"command": "echo bye"}, "tool-shell-2"),
             ],
         )
-        assert snapshots["tool-shell-1"] == (True, False)
-        assert snapshots["tool-shell-2"] == (True, False)
+        assert snapshots["tool-shell-1"] == (True, False, "pending")
+        assert snapshots["tool-shell-2"] == (True, False, "pending")
 
     async def test_shell_widget_restored_when_approval_raises(self) -> None:
         """`finally` must restore the widget even if approval raises."""

--- a/libs/code/tests/unit_tests/test_tool_display.py
+++ b/libs/code/tests/unit_tests/test_tool_display.py
@@ -230,6 +230,40 @@ class TestFormatToolDisplay:
         result = format_tool_display("grep", {"pattern": "def foo"})
         assert 'grep("def foo")' in result
 
+    def test_grep_shows_scoped_path(self) -> None:
+        abs_path = str(Path.cwd() / "subdir")
+        result = format_tool_display("grep", {"pattern": "def foo", "path": abs_path})
+        assert 'grep("def foo" in subdir)' in result
+
+    def test_grep_omits_default_root_path(self) -> None:
+        result = format_tool_display("grep", {"pattern": "def foo", "path": "/"})
+        assert 'grep("def foo")' in result
+        assert " in " not in result
+
+    def test_grep_omits_empty_path(self) -> None:
+        result = format_tool_display("grep", {"pattern": "def foo", "path": ""})
+        assert 'grep("def foo")' in result
+        assert " in " not in result
+
+    def test_grep_omits_none_path(self) -> None:
+        result = format_tool_display("grep", {"pattern": "def foo", "path": None})
+        assert 'grep("def foo")' in result
+        assert " in " not in result
+
+    def test_grep_shows_out_of_cwd_path(self) -> None:
+        # A path outside cwd cannot be made relative; it must still render.
+        result = format_tool_display(
+            "grep", {"pattern": "def foo", "path": "/etc/nginx"}
+        )
+        assert " in /etc/nginx" in result
+
+    def test_grep_scoped_path_strips_dangerous_unicode(self) -> None:
+        # A zero-width space in the path is stripped and flagged for the user.
+        abs_path = str(Path.cwd() / "subdir") + "\u200b"
+        result = format_tool_display("grep", {"pattern": "def foo", "path": abs_path})
+        assert " in subdir" in result
+        assert _HIDDEN_CHAR_MARKER in result
+
     # --- execute ---
 
     def test_execute_shows_command(self) -> None:
@@ -273,6 +307,48 @@ class TestFormatToolDisplay:
     def test_glob_shows_pattern(self) -> None:
         result = format_tool_display("glob", {"pattern": "**/*.py"})
         assert 'glob("**/*.py")' in result
+
+    def test_glob_shows_scoped_path(self) -> None:
+        abs_path = str(Path.cwd() / "subdir")
+        result = format_tool_display("glob", {"pattern": "**/*.py", "path": abs_path})
+        assert 'glob("**/*.py" in subdir)' in result
+
+    def test_glob_omits_default_root_path(self) -> None:
+        result = format_tool_display("glob", {"pattern": "**/*.py", "path": "/"})
+        assert 'glob("**/*.py")' in result
+        assert " in " not in result
+
+    def test_glob_distinguishes_scoped_from_unscoped(self) -> None:
+        # The two calls from the LangSmith trace must render differently.
+        unscoped = format_tool_display("glob", {"pattern": "**/*.py"})
+        scoped = format_tool_display(
+            "glob", {"pattern": "**/*.py", "path": str(Path.cwd() / "langchain")}
+        )
+        assert unscoped != scoped
+
+    def test_glob_omits_empty_path(self) -> None:
+        result = format_tool_display("glob", {"pattern": "**/*.py", "path": ""})
+        assert 'glob("**/*.py")' in result
+        assert " in " not in result
+
+    def test_glob_omits_none_path(self) -> None:
+        result = format_tool_display("glob", {"pattern": "**/*.py", "path": None})
+        assert 'glob("**/*.py")' in result
+        assert " in " not in result
+
+    def test_glob_shows_out_of_cwd_path(self) -> None:
+        # A path outside cwd cannot be made relative; it must still render.
+        result = format_tool_display(
+            "glob", {"pattern": "**/*.py", "path": "/etc/nginx"}
+        )
+        assert " in /etc/nginx" in result
+
+    def test_glob_scoped_path_strips_dangerous_unicode(self) -> None:
+        # A zero-width space in the path is stripped and flagged for the user.
+        abs_path = str(Path.cwd() / "subdir") + "\u200b"
+        result = format_tool_display("glob", {"pattern": "**/*.py", "path": abs_path})
+        assert " in subdir" in result
+        assert _HIDDEN_CHAR_MARKER in result
 
     # --- fetch_url ---
 


### PR DESCRIPTION
Several display fixes for the TUI, centered on auto-executed read tools (`grep`, `glob`, `read_file`, `ls`). Previously these sat idle with no spinner until results arrived, scoped searches were indistinguishable in the transcript, and the expand/collapse hint frequently promised an expansion that revealed nothing.

## Changes
- Show a per-tool running spinner the moment an auto-executed tool mounts, instead of falling back to the global "Thinking" spinner. Tools that then block on HITL approval or `ask_user` are paused via a new `ToolCallMessage.pause_running`, which reverts the row to its pending look and resets the elapsed timer so it doesn't misleadingly read "Running…"; the approve branches call `set_running` to resume.
- Append the scoped `path` to `grep`/`glob` displays when it's non-default via `_format_scope_path` in `tool_display.py` — the glob default (`"/"`) and grep default (`None`) are omitted, so two otherwise-identical calls on different directories are now distinguishable.
- Compact `read_file`'s `cat -n` gutter for display via `ToolCallMessage._compact_line_gutter`: line numbers are right-justified to the widest number present plus two spaces, replacing the raw 6-wide-plus-tab format, while preserving source indentation and passing non-numbered lines through untouched.
- Fix the expand/collapse affordance so it only appears when the formatter actually hides content. The raw size threshold alone could trip on long single-line `grep`/`glob` output that truncates by line count, and force-expanded errors have no smaller collapsed form — both cases previously showed a misleading hint. `_has_expandable_output` now gates this in both directions.
- Drop the leading four-space indent from `glob`/`grep` result lines so they sit flush left.