### PR TITLE
docs(code,sdk): explain tool-error propagation in the tool-call path

### DIFF
--- a/libs/code/deepagents_code/ask_user.py
+++ b/libs/code/deepagents_code/ask_user.py
@@ -248,6 +248,11 @@ class AskUserMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
                 questions=questions,
                 tool_call_id=tool_call_id,
             )
+            # interrupt() raises GraphInterrupt from INSIDE tool execution,
+            # within ToolNode's wrap_tool_call chain. Any
+            # wrap_tool_call middleware that catches exceptions MUST re-raise
+            # GraphBubbleUp — a broad `except Exception` (e.g. ToolRetryMiddleware)
+            # would swallow this interrupt and silently break ask_user.
             response = interrupt(ask_request)
             return _parse_answers(response, questions, tool_call_id)
 

--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -1074,6 +1074,12 @@ def _build_cached_mcp_tool(
         session = await session_manager.get_session(server_name)
         try:
             result = await session.call_tool(original_tool_name, arguments)
+        # Re-raise control-flow/shutdown signals (CancelledError,
+        # KeyboardInterrupt, SystemExit) and ToolException unchanged. Wrapping a
+        # ToolException here would bury its actionable message (e.g. an MCP
+        # `isError` instruction like "use the X tool instead") under a
+        # generic retry wrapper; re-raising preserves it for the tool-error
+        # handling layer and the model.
         except (asyncio.CancelledError, KeyboardInterrupt, SystemExit, ToolException):
             raise
         except Exception as exc:
@@ -1139,6 +1145,11 @@ def _build_cached_mcp_tool(
                             exc_info=True,
                         )
 
+        # `_convert_call_tool_result` raises ToolException when the MCP server
+        # returns a result flagged isError=True. That ToolException propagates
+        # up through ToolNode, whose default handler re-raises everything except
+        # ToolInvocationError — so it aborts the turn unless a wrap_tool_call
+        # middleware converts it to a recoverable ToolMessage.
         return _convert_call_tool_result(result)
 
     return StructuredTool(

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -2064,6 +2064,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         Returns:
             The raw ToolMessage, or a pseudo tool message with the ToolResult in state.
+
+        Note:
+            Tool-execution exceptions (including `ToolException`) propagate
+            through this wrapper unhandled by design.
         """
         tool_result = handler(request)
 
@@ -2085,6 +2089,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         Returns:
             The raw ToolMessage, or a pseudo tool message with the ToolResult in state.
+
+        Note:
+            Tool-execution exceptions (including `ToolException`) propagate
+            through this wrapper unhandled by design.
         """
         tool_result = await handler(request)
 


### PR DESCRIPTION
Code comments documenting *why* a `ToolException` raised by a tool aborts the whole agent turn rather than coming back as a recoverable result. The behavior is non-obvious: langgraph's `ToolNode` default handler re-raises everything except argument-validation errors, and `create_agent` doesn't expose a knob to change it — so the path from "MCP server returns an error" to "turn dies" spans three layers with no breadcrumbs. These notes mark each layer so the next reader (or agent) doesn't have to re-derive it.