### PR TITLE
fix(code): reconstruct message counts for `DeltaChannel` threads from writes table

### DIFF
--- a/libs/code/deepagents_code/sessions.py
+++ b/libs/code/deepagents_code/sessions.py
@@ -9,7 +9,7 @@ import sqlite3
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple, NotRequired, TypedDict, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, NotRequired, TypedDict, cast
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -149,8 +149,16 @@ class ThreadInfo(TypedDict):
 class _CheckpointSummary(NamedTuple):
     """Structured data extracted from a thread's latest checkpoint."""
 
-    message_count: int
-    """Number of messages in the latest checkpoint."""
+    message_count: int | None
+    """Number of messages inlined in the latest checkpoint, or `None`.
+
+    `None` means the latest checkpoint did not inline the `messages` channel
+    value, so the count is unknown and must be reconstructed from the `writes`
+    table. This happens when `messages` uses a `DeltaChannel` (a LangGraph
+    channel the deepagents SDK applies to `messages` as of v0.6) and the latest
+    checkpoint falls between periodic snapshots. An `int` (including `0`) is a
+    trustworthy count.
+    """
 
     initial_prompt: str | None
     """First human prompt recovered from the latest checkpoint."""
@@ -632,7 +640,23 @@ def _cache_initial_prompt(
 
 
 def _thread_freshness(thread: ThreadInfo) -> str | None:
-    """Return a cache freshness token for a thread row."""
+    """Return a cache freshness token for a thread row.
+
+    The token is checkpoint-granular (`latest_checkpoint_id`). The
+    writes-reconstructed `message_count` includes pending writes on the latest
+    checkpoint, which in principle can change without a new checkpoint ID — so
+    this token does not capture intra-checkpoint write churn. In practice that
+    is benign: dcode only mutates `messages` through the agent graph, and every
+    batch of message writes culminates in a new checkpoint (each superstep,
+    `aupdate_state`, interrupt, and cancellation all advance
+    `latest_checkpoint_id`). The only window where a cached count can lag is
+    opening the `/threads` selector mid-superstep against an actively streaming
+    thread; the selector does not live-refresh, so that count stays put until
+    the modal is reopened (by then a new checkpoint exists and the cache
+    refreshes). Making the key write-sensitive would require probing the
+    `writes` table for every row on every `list_threads`, which is not worth it
+    for a cosmetic count.
+    """
     return thread.get("latest_checkpoint_id") or thread.get("updated_at")
 
 
@@ -653,28 +677,6 @@ def _cache_recent_threads(
 def _copy_threads(threads: list[ThreadInfo]) -> list[ThreadInfo]:
     """Return shallow-copied thread rows."""
     return [ThreadInfo(**thread) for thread in threads]
-
-
-async def _count_messages_from_checkpoint(
-    conn: aiosqlite.Connection,
-    thread_id: str,
-    serde: JsonPlusSerializer,
-) -> int:
-    """Count messages from the most recent checkpoint blob.
-
-    With `durability='exit'`, messages are stored in the checkpoint blob, not in
-    the writes table. This function deserializes the checkpoint and counts the
-    messages in channel_values.
-
-    Args:
-        conn: Database connection.
-        thread_id: The thread ID to count messages for.
-        serde: Serializer for decoding checkpoint data.
-
-    Returns:
-        Number of messages in the checkpoint, or 0 if not found.
-    """
-    return (await _load_latest_checkpoint_summary(conn, thread_id, serde)).message_count
 
 
 async def _extract_initial_prompt(
@@ -770,24 +772,46 @@ async def _populate_checkpoint_fields(
             conn, uncached_ids, serde
         )
 
-    # Phase 3: apply results and update caches.
+    # Phase 3: apply inline results, deferring threads whose latest checkpoint
+    # does not inline the `messages` channel value. When `messages` uses a
+    # `DeltaChannel` (LangGraph channel applied by the deepagents SDK as of
+    # v0.6) the full list is only snapshotted into `channel_values` periodically,
+    # so the latest checkpoint usually omits it; the count must then be
+    # reconstructed from the `writes` table.
+    needs_writes_count: list[str] = []
     for thread in uncached:
         thread_id = thread["thread_id"]
         freshness = _thread_freshness(thread)
 
         if include_message_count and "message_count" not in thread:
-            summary = batch_results.get(thread_id, _CheckpointSummary(0, None))
-            thread["message_count"] = summary.message_count
-            _cache_message_count(thread_id, freshness, summary.message_count)
+            summary = batch_results.get(thread_id)
+            if summary is not None and summary.message_count is not None:
+                thread["message_count"] = summary.message_count
+                _cache_message_count(thread_id, freshness, summary.message_count)
+            else:
+                needs_writes_count.append(thread_id)
         if include_initial_prompt and "initial_prompt" not in thread:
             if thread_id in prompt_results:
                 prompt = prompt_results[thread_id]
             else:
                 prompt = batch_results.get(
-                    thread_id, _CheckpointSummary(0, None)
+                    thread_id, _CheckpointSummary(None, None)
                 ).initial_prompt
             thread["initial_prompt"] = prompt
             _cache_initial_prompt(thread_id, freshness, prompt)
+
+    # Phase 4: reconstruct counts for delta-channel threads from the `writes`
+    # table by replaying the `messages` writes through the canonical reducer.
+    if needs_writes_count:
+        writes_counts = await _load_message_counts_from_writes_batch(
+            conn, needs_writes_count, serde
+        )
+        uncached_by_id = {t["thread_id"]: t for t in uncached}
+        for thread_id in needs_writes_count:
+            count = writes_counts.get(thread_id, 0)
+            thread = uncached_by_id[thread_id]
+            thread["message_count"] = count
+            _cache_message_count(thread_id, _thread_freshness(thread), count)
 
 
 _SQLITE_MAX_VARIABLE_NUMBER = 500
@@ -843,7 +867,9 @@ async def _load_latest_checkpoint_summaries_batch(
         for row in rows:
             tid, type_str, checkpoint_blob = row
             if not type_str or not checkpoint_blob:
-                results[tid] = _CheckpointSummary(message_count=0, initial_prompt=None)
+                results[tid] = _CheckpointSummary(
+                    message_count=None, initial_prompt=None
+                )
                 continue
             try:
                 data = await loop.run_in_executor(
@@ -857,7 +883,9 @@ async def _load_latest_checkpoint_summaries_batch(
                     tid,
                     exc_info=True,
                 )
-                results[tid] = _CheckpointSummary(message_count=0, initial_prompt=None)
+                results[tid] = _CheckpointSummary(
+                    message_count=None, initial_prompt=None
+                )
 
     return results
 
@@ -928,6 +956,104 @@ async def _load_initial_prompts_from_writes_batch(
     return results
 
 
+async def _load_message_counts_from_writes_batch(
+    conn: aiosqlite.Connection,
+    thread_ids: list[str],
+    serde: JsonPlusSerializer,
+) -> dict[str, int]:
+    """Reconstruct message counts from the LangGraph `writes` table.
+
+    For threads whose latest checkpoint does not inline the `messages` channel
+    value — a `DeltaChannel` between snapshots, where the deepagents SDK (>= 0.6)
+    applies LangGraph's `DeltaChannel` to `messages` — the full list is rebuilt
+    by replaying every `messages` write, then counted. We replay through
+    `add_messages` as a count-equivalent stand-in for the channel's actual
+    reducer (`_messages_delta_reducer`): both dedup by ID and honor
+    `RemoveMessage` / `REMOVE_ALL_MESSAGES`, so they produce the same final
+    message set. The reducer is batching-invariant, so folding the write history
+    from empty yields the same value LangGraph reconstructs from the latest
+    snapshot plus subsequent deltas. An `Overwrite` write resets the accumulator
+    to its value, matching the net effect of `DeltaChannel.replay_writes` (where
+    the last `Overwrite` is the reset point).
+
+    Only the root namespace (`checkpoint_ns = ''`) is counted, matching both the
+    inline path and the conversation the `/threads` selector cares about;
+    subgraph (subagent) writes under the same `thread_id` are excluded.
+
+    Folding the *entire* write history (rather than walking the head
+    checkpoint's parent chain) is intentional and matches what dcode shows when
+    a thread is opened: it reads state via `aget_state` without a
+    `checkpoint_id`, which applies pending writes (`apply_pending_writes=True`),
+    so the latest checkpoint's not-yet-committed `messages` writes are part of
+    the user-visible list and must be counted. dcode only ever appends to the
+    latest checkpoint (no time travel, no `checkpoint_id`-targeted
+    `aupdate_state`), so histories are linear and the full fold equals the
+    head-of-chain reconstruction. A forked/abandoned branch (which dcode does
+    not create) is the only case where this could over-count.
+
+    Args:
+        conn: Database connection.
+        thread_ids: Thread IDs to look up.
+        serde: Serializer for decoding write blobs.
+
+    Returns:
+        Dict mapping each thread ID with at least one decodable `messages`
+            write to its reconstructed message count. Threads with no such
+            writes are absent from the result.
+    """
+    if not thread_ids:
+        return {}
+
+    from langgraph.graph.message import add_messages
+    from langgraph.types import Overwrite
+
+    loop = asyncio.get_running_loop()
+    # Accumulate one reduced message list per thread across chunks. Ordering by
+    # (checkpoint_id, task_id, idx) replays deltas oldest-to-newest, matching
+    # how LangGraph applies them on load.
+    reduced: dict[str, list[Any]] = {}
+    for start in range(0, len(thread_ids), _SQLITE_MAX_VARIABLE_NUMBER):
+        chunk = thread_ids[start : start + _SQLITE_MAX_VARIABLE_NUMBER]
+        placeholders = ",".join("?" * len(chunk))
+        query = f"""
+            SELECT thread_id, type, value
+            FROM writes
+            WHERE thread_id IN ({placeholders})
+              AND checkpoint_ns = ''
+              AND channel = 'messages'
+            ORDER BY thread_id, checkpoint_id ASC, task_id ASC, idx ASC
+        """  # noqa: S608  # placeholders built from len(chunk); user values use ? params
+        async with conn.execute(query, chunk) as cursor:
+            rows = await cursor.fetchall()
+
+        for tid, type_str, value_blob in rows:
+            if not type_str or not value_blob:
+                continue
+            try:
+                delta = await loop.run_in_executor(
+                    None, serde.loads_typed, (type_str, value_blob)
+                )
+                if isinstance(delta, Overwrite):
+                    # Overwrite resets the channel; its value becomes the base.
+                    value = delta.value
+                    reduced[tid] = list(value) if isinstance(value, list) else []
+                else:
+                    # `add_messages` with a list left arg returns a list.
+                    reduced[tid] = cast(
+                        "list[Any]", add_messages(reduced.get(tid, []), delta)
+                    )
+            except Exception:
+                logger.warning(
+                    "Failed to replay messages write for thread %s; "
+                    "message count may be inaccurate",
+                    tid,
+                    exc_info=True,
+                )
+                continue
+
+    return {tid: len(messages) for tid, messages in reduced.items()}
+
+
 async def _load_latest_checkpoint_summary(
     conn: aiosqlite.Connection,
     thread_id: str,
@@ -948,7 +1074,7 @@ async def _load_latest_checkpoint_summary(
     async with conn.execute(query, (thread_id,)) as cursor:
         row = await cursor.fetchone()
         if not row or not row[0] or not row[1]:
-            return _CheckpointSummary(message_count=0, initial_prompt=None)
+            return _CheckpointSummary(message_count=None, initial_prompt=None)
 
         type_str, checkpoint_blob = row
         try:
@@ -960,7 +1086,7 @@ async def _load_latest_checkpoint_summary(
                 thread_id,
                 exc_info=True,
             )
-            return _CheckpointSummary(message_count=0, initial_prompt=None)
+            return _CheckpointSummary(message_count=None, initial_prompt=None)
 
     return _summarize_checkpoint(data)
 
@@ -973,25 +1099,32 @@ def _summarize_checkpoint(data: object) -> _CheckpointSummary:
     """
     messages = _checkpoint_messages(data)
     return _CheckpointSummary(
-        message_count=len(messages),
-        initial_prompt=_initial_prompt_from_messages(messages),
+        message_count=len(messages) if messages is not None else None,
+        initial_prompt=_initial_prompt_from_messages(messages or []),
     )
 
 
-def _checkpoint_messages(data: object) -> list[object]:
-    """Return checkpoint messages when the decoded payload has the expected shape."""
+def _checkpoint_messages(data: object) -> list[object] | None:
+    """Return inlined checkpoint messages, or `None` when not inlined.
+
+    A `None` return distinguishes a checkpoint that omits the `messages`
+    channel entirely (a `DeltaChannel` between snapshots, where the deepagents
+    SDK applies LangGraph's `DeltaChannel` to `messages` as of v0.6) from one
+    that inlines an empty list. The former requires reconstructing the count
+    from the `writes` table; the latter is a genuine zero.
+    """
     if not isinstance(data, dict):
-        return []
+        return None
 
     payload = cast("dict[str, object]", data)
     channel_values = payload.get("channel_values")
     if not isinstance(channel_values, dict):
-        return []
+        return None
 
     channel_values_dict = cast("dict[str, object]", channel_values)
     messages = channel_values_dict.get("messages")
     if not isinstance(messages, list):
-        return []
+        return None
 
     return cast("list[object]", messages)
 

--- a/libs/code/tests/unit_tests/test_sessions.py
+++ b/libs/code/tests/unit_tests/test_sessions.py
@@ -1286,6 +1286,153 @@ class TestMessageCountFromCheckpointBlob:
             # EXPECTED: 4 messages from checkpoint blob
             assert threads[0]["message_count"] == 4
 
+    @pytest.fixture
+    def temp_db_delta_channel(self, tmp_path: Path) -> Path:
+        """DB whose latest checkpoint omits `messages` (DeltaChannel, SDK >= 0.6).
+
+        The full message list is not inlined in `channel_values`; it lives only
+        as per-message deltas in the `writes` table, exactly as the deepagents
+        SDK's `DeltaChannel` messages channel stores it between snapshots.
+        """
+        db_path = tmp_path / "delta.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE checkpoints (thread_id TEXT, checkpoint_ns TEXT "
+            "DEFAULT '', checkpoint_id TEXT, parent_checkpoint_id TEXT, type "
+            "TEXT, checkpoint BLOB, metadata BLOB, "
+            "PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id))"
+        )
+        conn.execute(
+            "CREATE TABLE writes (thread_id TEXT, checkpoint_ns TEXT DEFAULT '', "
+            "checkpoint_id TEXT, task_id TEXT, idx INTEGER, channel TEXT, type "
+            "TEXT, value BLOB, PRIMARY KEY "
+            "(thread_id, checkpoint_ns, checkpoint_id, task_id, idx))"
+        )
+
+        serde = JsonPlusSerializer()
+        # Latest checkpoint: messages absent from channel_values (DeltaChannel
+        # only snapshots periodically); other channels still present.
+        checkpoint_data = {
+            "v": 1,
+            "ts": "2024-01-01T00:00:00+00:00",
+            "id": "cp_latest",
+            "channel_values": {"_context_tokens": 5},
+            "channel_versions": {"messages": "00000000000000000000000000000002"},
+            "versions_seen": {},
+            "updated_channels": [],
+        }
+        type_str, checkpoint_blob = serde.dumps_typed(checkpoint_data)
+        metadata = json.dumps({"agent_name": "agent1", "updated_at": "2024-01-02"})
+        conn.execute(
+            "INSERT INTO checkpoints (thread_id, checkpoint_ns, checkpoint_id, "
+            "type, checkpoint, metadata) VALUES (?, '', ?, ?, ?, ?)",
+            ("delta_thread", "cp_latest", type_str, checkpoint_blob, metadata),
+        )
+
+        # Three message deltas across two checkpoints (one human, one ai, one
+        # tool) — the true current count is 3.
+        deltas = [
+            ("cp_a", "task1", 0, [{"type": "human", "content": "hi", "id": "h1"}]),
+            ("cp_a", "task2", 0, [{"type": "ai", "content": "hello", "id": "a1"}]),
+            (
+                "cp_b",
+                "task3",
+                0,
+                [{"type": "tool", "content": "ok", "id": "t1", "tool_call_id": "c1"}],
+            ),
+        ]
+        for cid, task, idx, value in deltas:
+            vtype, vblob = serde.dumps_typed(value)
+            conn.execute(
+                "INSERT INTO writes (thread_id, checkpoint_ns, checkpoint_id, "
+                "task_id, idx, channel, type, value) VALUES (?, '', ?, ?, ?, "
+                "'messages', ?, ?)",
+                ("delta_thread", cid, task, idx, vtype, vblob),
+            )
+
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def test_counts_messages_from_writes_when_not_inlined(
+        self, temp_db_delta_channel: Path
+    ) -> None:
+        """Regression: DeltaChannel threads reconstruct the count from writes.
+
+        The latest checkpoint omits `messages` from `channel_values`, so the
+        count must be rebuilt by replaying the `messages` writes. Before the
+        fix this returned 0 for every such thread.
+        """
+        sessions._message_count_cache.clear()  # pyright: ignore[reportPrivateUsage]
+        try:
+            with patch.object(
+                sessions, "get_db_path", return_value=temp_db_delta_channel
+            ):
+                threads = asyncio.run(sessions.list_threads(include_message_count=True))
+            assert len(threads) == 1
+            assert threads[0]["message_count"] == 3
+        finally:
+            sessions._message_count_cache.clear()  # pyright: ignore[reportPrivateUsage]
+
+    def test_inlined_messages_take_precedence_over_writes(
+        self, temp_db_with_checkpoint_messages: Path
+    ) -> None:
+        """When the latest checkpoint inlines messages, writes are not replayed.
+
+        The fixture inlines 4 messages and has no writes; the count must come
+        from the checkpoint without falling back to (here, empty) writes.
+        """
+        sessions._message_count_cache.clear()  # pyright: ignore[reportPrivateUsage]
+        try:
+            with (
+                patch.object(
+                    sessions,
+                    "get_db_path",
+                    return_value=temp_db_with_checkpoint_messages,
+                ),
+                patch.object(
+                    sessions,
+                    "_load_message_counts_from_writes_batch",
+                    new_callable=AsyncMock,
+                ) as mock_writes,
+            ):
+                threads = asyncio.run(sessions.list_threads(include_message_count=True))
+            assert threads[0]["message_count"] == 4
+            mock_writes.assert_not_awaited()
+        finally:
+            sessions._message_count_cache.clear()  # pyright: ignore[reportPrivateUsage]
+
+    def test_writes_reconstructed_count_is_cached(
+        self, temp_db_delta_channel: Path
+    ) -> None:
+        """A delta-channel count is cached so the writes replay runs only once.
+
+        The freshness-keyed cache is what keeps the `/threads` modal cheap; a
+        second open must not re-query the `writes` table.
+        """
+        sessions._message_count_cache.clear()  # pyright: ignore[reportPrivateUsage]
+        try:
+            with patch.object(
+                sessions, "get_db_path", return_value=temp_db_delta_channel
+            ):
+                first = asyncio.run(sessions.list_threads(include_message_count=True))
+                assert first[0]["message_count"] == 3
+
+                # Second open: the reconstructed count is served from cache, so
+                # the writes-replay loader must not run again.
+                with patch.object(
+                    sessions,
+                    "_load_message_counts_from_writes_batch",
+                    new_callable=AsyncMock,
+                ) as mock_writes:
+                    second = asyncio.run(
+                        sessions.list_threads(include_message_count=True)
+                    )
+                assert second[0]["message_count"] == 3
+                mock_writes.assert_not_awaited()
+        finally:
+            sessions._message_count_cache.clear()  # pyright: ignore[reportPrivateUsage]
+
 
 class TestGetThreadLimit:
     """Tests for get_thread_limit() env var parsing."""
@@ -2122,6 +2269,318 @@ class TestLoadInitialPromptsFromWritesBatch:
             )
 
         assert results == {}
+
+
+class TestLoadMessageCountsFromWritesBatch:
+    """Tests for the writes-table message-count reconstruction loader."""
+
+    async def test_reconstructs_count_across_checkpoints(self) -> None:
+        """Deltas spread across checkpoints fold into the full message count."""
+        serde = JsonPlusSerializer()
+        first = serde.dumps_typed([{"type": "human", "content": "hi", "id": "h1"}])
+        second = serde.dumps_typed([{"type": "ai", "content": "yo", "id": "a1"}])
+
+        import aiosqlite
+
+        async with aiosqlite.connect(":memory:") as conn:
+            await conn.execute(
+                "CREATE TABLE writes "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "task_id TEXT, idx INTEGER, channel TEXT, type TEXT, value BLOB)"
+            )
+            await conn.executemany(
+                "INSERT INTO writes VALUES (?, '', ?, ?, 0, 'messages', ?, ?)",
+                [
+                    ("t1", "cp_b", "task2", second[0], second[1]),
+                    ("t1", "cp_a", "task1", first[0], first[1]),
+                ],
+            )
+            await conn.commit()
+
+            results = await sessions._load_message_counts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+                conn, ["t1"], serde
+            )
+
+        assert results == {"t1": 2}
+
+    async def test_dedups_updates_by_id(self) -> None:
+        """A later write that reuses a message ID updates, not appends."""
+        serde = JsonPlusSerializer()
+        original = serde.dumps_typed([{"type": "ai", "content": "draft", "id": "a1"}])
+        updated = serde.dumps_typed([{"type": "ai", "content": "final", "id": "a1"}])
+
+        import aiosqlite
+
+        async with aiosqlite.connect(":memory:") as conn:
+            await conn.execute(
+                "CREATE TABLE writes "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "task_id TEXT, idx INTEGER, channel TEXT, type TEXT, value BLOB)"
+            )
+            await conn.executemany(
+                "INSERT INTO writes VALUES (?, '', ?, ?, 0, 'messages', ?, ?)",
+                [
+                    ("t1", "cp_a", "task1", original[0], original[1]),
+                    ("t1", "cp_b", "task2", updated[0], updated[1]),
+                ],
+            )
+            await conn.commit()
+
+            results = await sessions._load_message_counts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+                conn, ["t1"], serde
+            )
+
+        assert results == {"t1": 1}
+
+    async def test_remove_message_tombstone_decrements(self) -> None:
+        """A `RemoveMessage` write drops the matching message from the count."""
+        from langchain_core.messages import RemoveMessage
+
+        serde = JsonPlusSerializer()
+        add_two = serde.dumps_typed(
+            [
+                {"type": "human", "content": "hi", "id": "h1"},
+                {"type": "ai", "content": "yo", "id": "a1"},
+            ]
+        )
+        remove_one = serde.dumps_typed([RemoveMessage(id="a1")])
+
+        import aiosqlite
+
+        async with aiosqlite.connect(":memory:") as conn:
+            await conn.execute(
+                "CREATE TABLE writes "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "task_id TEXT, idx INTEGER, channel TEXT, type TEXT, value BLOB)"
+            )
+            await conn.executemany(
+                "INSERT INTO writes VALUES (?, '', ?, ?, 0, 'messages', ?, ?)",
+                [
+                    ("t1", "cp_a", "task1", add_two[0], add_two[1]),
+                    ("t1", "cp_b", "task2", remove_one[0], remove_one[1]),
+                ],
+            )
+            await conn.commit()
+
+            results = await sessions._load_message_counts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+                conn, ["t1"], serde
+            )
+
+        assert results == {"t1": 1}
+
+    async def test_overwrite_resets_accumulator(self) -> None:
+        """An `Overwrite` write replaces the accumulated list as a reset point."""
+        from langgraph.types import Overwrite
+
+        serde = JsonPlusSerializer()
+        seed = serde.dumps_typed(
+            [
+                {"type": "human", "content": "a", "id": "h1"},
+                {"type": "ai", "content": "b", "id": "a1"},
+                {"type": "human", "content": "c", "id": "h2"},
+            ]
+        )
+        overwrite = serde.dumps_typed(
+            Overwrite(value=[{"type": "human", "content": "fresh", "id": "h9"}])
+        )
+
+        import aiosqlite
+
+        async with aiosqlite.connect(":memory:") as conn:
+            await conn.execute(
+                "CREATE TABLE writes "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "task_id TEXT, idx INTEGER, channel TEXT, type TEXT, value BLOB)"
+            )
+            await conn.executemany(
+                "INSERT INTO writes VALUES (?, '', ?, ?, 0, 'messages', ?, ?)",
+                [
+                    ("t1", "cp_a", "task1", seed[0], seed[1]),
+                    ("t1", "cp_b", "task2", overwrite[0], overwrite[1]),
+                ],
+            )
+            await conn.commit()
+
+            results = await sessions._load_message_counts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+                conn, ["t1"], serde
+            )
+
+        assert results == {"t1": 1}
+
+    async def test_remove_all_messages_resets_then_appends(self) -> None:
+        """`REMOVE_ALL_MESSAGES` clears the list; later deltas rebuild from there.
+
+        The deepagents SDK uses this for compaction/reset, so it is a live path
+        for the threads this loader targets.
+        """
+        from langchain_core.messages import RemoveMessage
+        from langgraph.graph.message import REMOVE_ALL_MESSAGES
+
+        serde = JsonPlusSerializer()
+        seed = serde.dumps_typed(
+            [
+                {"type": "human", "content": "a", "id": "h1"},
+                {"type": "ai", "content": "b", "id": "a1"},
+            ]
+        )
+        # Clear everything, then add a single fresh message in the same delta.
+        reset = serde.dumps_typed(
+            [
+                RemoveMessage(id=REMOVE_ALL_MESSAGES),
+                {"type": "human", "content": "fresh", "id": "h9"},
+            ]
+        )
+
+        import aiosqlite
+
+        async with aiosqlite.connect(":memory:") as conn:
+            await conn.execute(
+                "CREATE TABLE writes "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "task_id TEXT, idx INTEGER, channel TEXT, type TEXT, value BLOB)"
+            )
+            await conn.executemany(
+                "INSERT INTO writes VALUES (?, '', ?, ?, 0, 'messages', ?, ?)",
+                [
+                    ("t1", "cp_a", "task1", seed[0], seed[1]),
+                    ("t1", "cp_b", "task2", reset[0], reset[1]),
+                ],
+            )
+            await conn.commit()
+
+            results = await sessions._load_message_counts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+                conn, ["t1"], serde
+            )
+
+        assert results == {"t1": 1}
+
+    async def test_excludes_subgraph_namespace_writes(self) -> None:
+        """Only root-namespace writes count; subagent (`checkpoint_ns`) excluded.
+
+        Subagents persist their own `messages` writes under the same
+        `thread_id` with a non-empty `checkpoint_ns`; those must not inflate the
+        root conversation's count.
+        """
+        serde = JsonPlusSerializer()
+        root = serde.dumps_typed([{"type": "human", "content": "hi", "id": "h1"}])
+        sub_a = serde.dumps_typed([{"type": "ai", "content": "x", "id": "s1"}])
+        sub_b = serde.dumps_typed([{"type": "tool", "content": "y", "id": "s2"}])
+
+        import aiosqlite
+
+        async with aiosqlite.connect(":memory:") as conn:
+            await conn.execute(
+                "CREATE TABLE writes "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "task_id TEXT, idx INTEGER, channel TEXT, type TEXT, value BLOB)"
+            )
+            await conn.executemany(
+                "INSERT INTO writes VALUES (?, ?, ?, ?, 0, 'messages', ?, ?)",
+                [
+                    ("t1", "", "cp_a", "task1", root[0], root[1]),
+                    ("t1", "subagent:abc", "cp_a", "task2", sub_a[0], sub_a[1]),
+                    ("t1", "subagent:abc", "cp_b", "task3", sub_b[0], sub_b[1]),
+                ],
+            )
+            await conn.commit()
+
+            results = await sessions._load_message_counts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+                conn, ["t1"], serde
+            )
+
+        assert results == {"t1": 1}
+
+    async def test_counts_each_thread_independently(self) -> None:
+        """Multiple threads in one batch fold separately."""
+        serde = JsonPlusSerializer()
+        one = serde.dumps_typed([{"type": "human", "content": "hi", "id": "h1"}])
+        two = serde.dumps_typed(
+            [
+                {"type": "human", "content": "x", "id": "h2"},
+                {"type": "ai", "content": "y", "id": "a2"},
+            ]
+        )
+
+        import aiosqlite
+
+        async with aiosqlite.connect(":memory:") as conn:
+            await conn.execute(
+                "CREATE TABLE writes "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "task_id TEXT, idx INTEGER, channel TEXT, type TEXT, value BLOB)"
+            )
+            await conn.executemany(
+                "INSERT INTO writes VALUES (?, '', ?, ?, 0, 'messages', ?, ?)",
+                [
+                    ("t1", "cp_a", "task1", one[0], one[1]),
+                    ("t2", "cp_a", "task1", two[0], two[1]),
+                ],
+            )
+            await conn.commit()
+
+            results = await sessions._load_message_counts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+                conn, ["t1", "t2"], serde
+            )
+
+        assert results == {"t1": 1, "t2": 2}
+
+    async def test_omits_threads_with_no_messages_writes(self) -> None:
+        """Threads without any messages-channel write are absent from result."""
+        serde = JsonPlusSerializer()
+
+        import aiosqlite
+
+        async with aiosqlite.connect(":memory:") as conn:
+            await conn.execute(
+                "CREATE TABLE writes "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "task_id TEXT, idx INTEGER, channel TEXT, type TEXT, value BLOB)"
+            )
+
+            results = await sessions._load_message_counts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+                conn, ["t1", "t2"], serde
+            )
+
+        assert results == {}
+
+    async def test_empty_input_returns_empty(self) -> None:
+        """Empty thread list short-circuits without touching the connection."""
+        serde = JsonPlusSerializer()
+        result = await sessions._load_message_counts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+            None,  # type: ignore[arg-type]  # connection not used
+            [],
+            serde,
+        )
+        assert result == {}
+
+    async def test_corrupt_blob_is_skipped_without_raising(self) -> None:
+        """A row with undecodable bytes is skipped, not raised."""
+        serde = JsonPlusSerializer()
+        good = serde.dumps_typed([{"type": "human", "content": "hi", "id": "h1"}])
+
+        import aiosqlite
+
+        async with aiosqlite.connect(":memory:") as conn:
+            await conn.execute(
+                "CREATE TABLE writes "
+                "(thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, "
+                "task_id TEXT, idx INTEGER, channel TEXT, type TEXT, value BLOB)"
+            )
+            await conn.executemany(
+                "INSERT INTO writes VALUES (?, '', ?, ?, 0, 'messages', ?, ?)",
+                [
+                    ("t1", "cp_a", "task1", good[0], good[1]),
+                    ("t1", "cp_b", "task2", "msgpack", b"\xff\xff garbage"),
+                ],
+            )
+            await conn.commit()
+
+            results = await sessions._load_message_counts_from_writes_batch(  # pyright: ignore[reportPrivateUsage]
+                conn, ["t1"], serde
+            )
+
+        # The good write still counts; the corrupt one is skipped.
+        assert results == {"t1": 1}
 
 
 class TestInitialPromptFromMessages:


### PR DESCRIPTION
Message counts in the thread list were returning 0 for threads using LangGraph's `DeltaChannel` for `messages`, because the latest checkpoint omits the full message list between periodic snapshots. The count is now reconstructed by replaying `messages` writes through `add_messages`, matching how LangGraph rebuilds state on load.