### PR TITLE
ci(infra): rename release workflow to `Package Release`

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -202,7 +202,7 @@ This label transition signals to release-please that the merged PR has been full
 
 For hotfixes or exceptional cases, you can trigger a release manually. Use the `hotfix` commit type so as to not trigger a further PR update/version bump.
 
-1. Go to **Actions** > `⚠️ Manual Package Release`
+1. Go to **Actions** > `Package Release`
 2. Click **Run workflow**
 3. Select the package to release
 4. **Provide `version`**: the version you want to publish (e.g. `0.0.35`). The workflow checks that the code you selected has the same version.
@@ -305,7 +305,7 @@ Alpha releases use a **throwaway branch** + [manual release](#manual-release). T
 
 4. **Trigger the release workflow:**
 
-   - Go to **Actions** > `⚠️ Manual Package Release` > **Run workflow**
+   - Go to **Actions** > `Package Release` > **Run workflow**
    - Branch: `alpha/<PACKAGE>-<VERSION>`
    - Package: `<PACKAGE>`
    - Version: `<VERSION>` (e.g. `0.0.35a1`) — required input; surfaces in the run name
@@ -554,7 +554,7 @@ This means `deepagents-code`'s pinned `deepagents` dependency in `libs/code/pypr
    ```
 
 2. **Manually trigger the release** (the push to `main` won't re-trigger the release because the commit doesn't modify `libs/code/CHANGELOG.md`):
-   - Go to **Actions** > `⚠️ Manual Package Release`
+   - Go to **Actions** > `Package Release`
    - Click **Run workflow**
    - Select `main` branch and `deepagents-code` package
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@
 #
 # Flow: build -> pre-release-checks -> test-pypi -> publish -> release
 
-name: "⚠️ Manual Package Release"
+name: "Package Release"
 run-name: "release(${{ inputs.package-override || inputs.package }}):${{
   inputs.version && format(' {0}', inputs.version) || '' }}"
 on:


### PR DESCRIPTION
The release workflow's display name dropped the `⚠️ Manual` prefix because it no longer reflects reality — the workflow is dispatched automatically by `release-please.yml` on release-PR merge, not just manually. `Package Release` describes both trigger paths without the misleading warning glyph.