### PR TITLE
feat(sdk): add `use_regex` parameter to the `grep` tool

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -308,17 +308,19 @@ class CompositeBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        use_regex: bool = False,  # noqa: FBT001, FBT002
     ) -> GrepResult:
-        """Search files for literal text pattern.
+        """Search files for a text pattern.
 
         Routes to backends based on path: specific route searches one backend,
         "/" or None searches all backends, otherwise searches default backend.
 
         Args:
-            pattern: Literal text to search for (NOT regex).
+            pattern: Text pattern to search for (literal or regex, see `use_regex`).
             path: Directory to search. None searches all backends.
             glob: Glob pattern to filter files (e.g., "*.py", "**/*.txt").
                 Filters by filename, not content.
+            use_regex: If True, treat pattern as a regular expression.
 
         Returns:
             GrepResult with matches or error.
@@ -337,7 +339,7 @@ class CompositeBackend(BackendProtocol):
                 path=path,
             )
             if route_prefix is not None:
-                grep_result = self._coerce_grep_result(backend.grep(pattern, backend_path, glob))
+                grep_result = self._coerce_grep_result(backend.grep(pattern, backend_path, glob, use_regex))
                 if grep_result.error:
                     return grep_result
                 return GrepResult(matches=[_remap_grep_path(m, route_prefix) for m in (grep_result.matches or [])])
@@ -346,26 +348,27 @@ class CompositeBackend(BackendProtocol):
         # Otherwise, search only the default backend
         if path is None or path == "/":
             all_matches: list[GrepMatch] = []
-            default_result = self._coerce_grep_result(self.default.grep(pattern, path, glob))
+            default_result = self._coerce_grep_result(self.default.grep(pattern, path, glob, use_regex))
             if default_result.error:
                 return default_result
             all_matches.extend(default_result.matches or [])
 
             for route_prefix, backend in self.routes.items():
-                grep_result = self._coerce_grep_result(backend.grep(pattern, "/", glob))
+                grep_result = self._coerce_grep_result(backend.grep(pattern, "/", glob, use_regex))
                 if grep_result.error:
                     return grep_result
                 all_matches.extend(_remap_grep_path(m, route_prefix) for m in (grep_result.matches or []))
 
             return GrepResult(matches=all_matches)
         # Path specified but doesn't match a route - search only default
-        return self._coerce_grep_result(self.default.grep(pattern, path, glob))
+        return self._coerce_grep_result(self.default.grep(pattern, path, glob, use_regex))
 
     async def agrep(
         self,
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        use_regex: bool = False,  # noqa: FBT001, FBT002
     ) -> GrepResult:
         """Async version of grep.
 
@@ -378,7 +381,7 @@ class CompositeBackend(BackendProtocol):
                 path=path,
             )
             if route_prefix is not None:
-                grep_result = self._coerce_grep_result(await backend.agrep(pattern, backend_path, glob))
+                grep_result = self._coerce_grep_result(await backend.agrep(pattern, backend_path, glob, use_regex))
                 if grep_result.error:
                     return grep_result
                 return GrepResult(matches=[_remap_grep_path(m, route_prefix) for m in (grep_result.matches or [])])
@@ -387,20 +390,20 @@ class CompositeBackend(BackendProtocol):
         # Otherwise, search only the default backend
         if path is None or path == "/":
             all_matches: list[GrepMatch] = []
-            default_result = self._coerce_grep_result(await self.default.agrep(pattern, path, glob))
+            default_result = self._coerce_grep_result(await self.default.agrep(pattern, path, glob, use_regex))
             if default_result.error:
                 return default_result
             all_matches.extend(default_result.matches or [])
 
             for route_prefix, backend in self.routes.items():
-                grep_result = self._coerce_grep_result(await backend.agrep(pattern, "/", glob))
+                grep_result = self._coerce_grep_result(await backend.agrep(pattern, "/", glob, use_regex))
                 if grep_result.error:
                     return grep_result
                 all_matches.extend(_remap_grep_path(m, route_prefix) for m in (grep_result.matches or []))
 
             return GrepResult(matches=all_matches)
         # Path specified but doesn't match a route - search only default
-        return self._coerce_grep_result(await self.default.agrep(pattern, path, glob))
+        return self._coerce_grep_result(await self.default.agrep(pattern, path, glob, use_regex))
 
     def glob(self, pattern: str, path: str = "/") -> GlobResult:
         """Find files matching a glob pattern, routing by path prefix."""

--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -237,6 +237,7 @@ class ContextHubBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        use_regex: bool = False,  # noqa: FBT001, FBT002
     ) -> GrepResult:
         """Search contents for `pattern` (optional `path` / `glob` filters)."""
         try:
@@ -247,7 +248,7 @@ class ContextHubBackend(BackendProtocol):
         matches: list[GrepMatch] = []
 
         try:
-            regex = re.compile(pattern)
+            regex = re.compile(pattern if use_regex else re.escape(pattern))
         except re.error as e:
             return GrepResult(error=f"Invalid regex pattern: {e}")
 

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -536,19 +536,29 @@ class FilesystemBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        use_regex: bool = False,  # noqa: FBT001, FBT002
     ) -> GrepResult:
-        """Search for a literal text pattern in files.
+        """Search for a text pattern in files.
 
         Uses ripgrep if available, falling back to Python search.
 
         Args:
-            pattern: Literal string to search for (NOT regex).
+            pattern: Text pattern to search for. Treated as a literal string
+                when `use_regex=False` (default), or as a regular expression
+                when `use_regex=True`.
             path: Directory or file path to search in. Defaults to current directory.
             glob: Optional glob pattern to filter which files to search.
+            use_regex: If True, treat pattern as a regular expression.
 
         Returns:
             GrepResult with matches or error.
         """
+        if use_regex:
+            try:
+                re.compile(pattern)
+            except re.error as e:
+                return GrepResult(error=f"Invalid regex pattern: {e}", matches=[])
+
         # Resolve base path
         try:
             base_full = self._resolve_path(path or ".")
@@ -565,12 +575,11 @@ class FilesystemBackend(BackendProtocol):
             search_path = path or "."
             return GrepResult(error=f"Error searching path '{search_path}': {e}", matches=[])
 
-        # Try ripgrep first (with -F flag for literal search)
-        results = self._ripgrep_search(pattern, base_full, glob)
+        results = self._ripgrep_search(pattern, base_full, glob, use_regex=use_regex)
         partial_error: str | None = None
         if results is None:
-            # Python fallback needs escaped pattern for literal search
-            results, partial_error = self._python_search(re.escape(pattern), base_full, glob)
+            search_pattern = pattern if use_regex else re.escape(pattern)
+            results, partial_error = self._python_search(search_pattern, base_full, glob)
 
         matches: list[GrepMatch] = []
         for fpath, items in results.items():
@@ -578,13 +587,20 @@ class FilesystemBackend(BackendProtocol):
                 matches.append({"path": fpath, "line": int(line_num), "text": line_text})
         return GrepResult(error=partial_error, matches=matches)
 
-    def _ripgrep_search(self, pattern: str, base_full: Path, include_glob: str | None) -> dict[str, list[tuple[int, str]]] | None:  # noqa: C901, PLR0912, PLR0915  # except clauses split per-exception for targeted logging (timeout vs exec-race vs ripgrep hard-error)
-        """Search using ripgrep with fixed-string (literal) mode.
+    def _ripgrep_search(  # noqa: C901, PLR0912, PLR0915  # except clauses split per-exception for targeted logging (timeout vs exec-race vs ripgrep hard-error)
+        self,
+        pattern: str,
+        base_full: Path,
+        include_glob: str | None,
+        use_regex: bool = False,  # noqa: FBT001, FBT002
+    ) -> dict[str, list[tuple[int, str]]] | None:
+        """Search using ripgrep.
 
         Args:
-            pattern: Literal string to search for (unescaped).
+            pattern: Pattern to search for.
             base_full: Resolved base path to search in.
             include_glob: Optional glob pattern to filter files.
+            use_regex: If False (default), pass -F for literal fixed-string mode.
 
         Returns:
             Dict mapping file paths to list of `(line_number, line_text)` tuples.
@@ -596,7 +612,9 @@ class FilesystemBackend(BackendProtocol):
         if rg_path is None:
             return None
 
-        cmd = [rg_path, "--json", "-F"]  # -F enables fixed-string (literal) mode
+        cmd = [rg_path, "--json"]
+        if not use_regex:
+            cmd.append("-F")  # -F enables fixed-string (literal) mode
         if include_glob:
             cmd.extend(["--glob", include_glob])
         # When rg is given an absolute search path, directory-component
@@ -708,7 +726,8 @@ class FilesystemBackend(BackendProtocol):
         Recursively searches files, respecting `max_file_size_bytes` limit.
 
         Args:
-            pattern: Escaped regex pattern (from re.escape) for literal search.
+            pattern: Regex pattern. Pass `re.escape(raw)` for literal search,
+                or the raw pattern for regex search.
             base_full: Resolved base path to search in.
             include_glob: Optional glob pattern to filter files by name.
 

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -402,13 +402,20 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        use_regex: bool = False,  # noqa: FBT001, FBT002, ARG002  # legacy shim path passes to grep_raw which lacks this param
     ) -> "GrepResult":
-        """Search for a literal text pattern in files.
+        """Search for a text pattern in files.
 
         Args:
-            pattern: Literal string to search for (NOT regex).
+            pattern: Text pattern to search for.
 
-                Performs exact substring matching within file content.
+                When `use_regex=False` (default), treated as a literal string —
+                special characters like `(`, `[`, `|` are matched verbatim.
+
+                When `use_regex=True`, treated as a regular expression.
+                Returns an error if the pattern is invalid. Note: regex
+                syntax may differ between backends (Python ``re`` vs. POSIX
+                ERE in sandbox environments).
 
                 Example: "TODO" matches any line containing "TODO"
 
@@ -428,6 +435,9 @@ class BackendProtocol(abc.ABC):  # noqa: B024
                 - `**` matches any directories recursively
                 - `?` matches single character
                 - `[abc]` matches one character from set
+
+            use_regex: If `True`, treat `pattern` as a regular expression.
+                If `False` (default), treat `pattern` as a literal string.
 
         Examples:
             - `'*.py'` - only search Python files
@@ -461,9 +471,10 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        use_regex: bool = False,  # noqa: FBT001, FBT002
     ) -> "GrepResult":
         """Async version of `grep`."""
-        return await asyncio.to_thread(self.grep, pattern, path, glob)
+        return await asyncio.to_thread(self.grep, pattern, path, glob, use_regex)
 
     def glob(self, pattern: str, path: str = "/") -> "GlobResult":
         """Find files matching a glob pattern.

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -18,6 +18,7 @@ import base64
 import json
 import logging
 import os
+import re
 import shlex
 from abc import ABC, abstractmethod
 from typing import Final
@@ -761,26 +762,37 @@ except PermissionError:
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        use_regex: bool = False,  # noqa: FBT001, FBT002
     ) -> GrepResult:
-        """Search file contents for a literal string using `grep -F`.
+        """Search file contents for a text pattern.
 
         Args:
-            pattern: Literal string to search for (not a regex).
+            pattern: Text pattern to search for. Treated as a literal string
+                when `use_regex=False` (default), or as an extended regular
+                expression when `use_regex=True`.
             path: Directory or file to search in.
 
                 Defaults to `"."`.
             glob: Optional file-name glob to restrict the search
                 (e.g. `'*.py'`).
+            use_regex: If True, treat pattern as an extended regular expression.
 
         Returns:
             `GrepResult` with a list of `GrepMatch` dicts, or `error` on failure.
         """
+        if use_regex:
+            try:
+                re.compile(pattern)
+            except re.error as e:
+                return GrepResult(error=f"Invalid regex pattern: {e}", matches=[])
+
         search_path = shlex.quote(path or ".")
 
         # Build grep command to get structured output
         # `-Z` separates the filename from line data with NUL, so filenames may
         # contain `:` without making the output ambiguous.
-        grep_opts = "-rHnFZ"
+        # -F: fixed-string (literal); -E: extended regex
+        grep_opts = "-rHnEZ" if use_regex else "-rHnFZ"
 
         # Add glob pattern if specified
         glob_pattern = ""

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -295,10 +295,11 @@ class StateBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        use_regex: bool = False,  # noqa: FBT001, FBT002
     ) -> GrepResult:
-        """Search state files for a literal text pattern."""
+        """Search state files for a text pattern."""
         files = self._read_files()
-        return grep_matches_from_files(files, pattern, path if path is not None else "/", glob)
+        return grep_matches_from_files(files, pattern, path if path is not None else "/", glob, use_regex=use_regex)
 
     def glob(self, pattern: str, path: str = "/") -> GlobResult:
         """Get FileInfo for files matching glob pattern."""

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -688,8 +688,9 @@ class StoreBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        use_regex: bool = False,  # noqa: FBT001, FBT002
     ) -> GrepResult:
-        """Search store files for a literal text pattern."""
+        """Search store files for a text pattern."""
         store = self._get_store()
         namespace = self._get_namespace()
         items = self._search_store_paginated(store, namespace)
@@ -699,7 +700,7 @@ class StoreBackend(BackendProtocol):
                 files[item.key] = self._convert_store_item_to_file_data(item)
             except ValueError:
                 continue
-        return grep_matches_from_files(files, pattern, path, glob)
+        return grep_matches_from_files(files, pattern, path, glob, use_regex=use_regex)
 
     def glob(self, pattern: str, path: str = "/") -> GlobResult:
         """Find files matching a glob pattern in the store."""

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -634,61 +634,6 @@ def _format_grep_results(
     return "\n".join(lines)
 
 
-def _grep_search_files(
-    files: dict[str, Any],
-    pattern: str,
-    path: str | None = None,
-    glob: str | None = None,
-    output_mode: Literal["files_with_matches", "content", "count"] = "files_with_matches",
-) -> str:
-    r"""Search file contents for regex pattern.
-
-    Args:
-        files: Dictionary of file paths to FileData.
-        pattern: Regex pattern to search for.
-        path: Base path to search from.
-        glob: Optional glob pattern to filter files (e.g., "*.py").
-        output_mode: Output format - "files_with_matches", "content", or "count".
-
-    Returns:
-        Formatted search results. Returns "No matches found" if no results.
-
-    Example:
-        ```python
-        files = {"/file.py": FileData(content="import os\nprint('hi')", ...)}
-        _grep_search_files(files, "import", "/")
-        # Returns: "/file.py" (with output_mode="files_with_matches")
-        ```
-    """
-    try:
-        regex = re.compile(pattern)
-    except re.error as e:
-        return f"Invalid regex pattern: {e}"
-
-    try:
-        normalized_path = _normalize_path(path)
-    except ValueError:
-        return "No matches found"
-
-    filtered = _filter_files_by_path(files, normalized_path)
-
-    if glob:
-        filtered = {fp: fd for fp, fd in filtered.items() if wcglob.globmatch(Path(fp).name, glob, flags=wcglob.BRACE)}
-
-    results: dict[str, list[tuple[int, str]]] = {}
-    for file_path, file_data in filtered.items():
-        content_str = _normalize_content(file_data)
-        for line_num, line in enumerate(content_str.split("\n"), 1):
-            if regex.search(line):
-                if file_path not in results:
-                    results[file_path] = []
-                results[file_path].append((line_num, line))
-
-    if not results:
-        return "No matches found"
-    return _format_grep_results(results, output_mode)
-
-
 # -------- Structured helpers for composition --------
 
 
@@ -697,10 +642,9 @@ def grep_matches_from_files(
     pattern: str,
     path: str | None = None,
     glob: str | None = None,
+    use_regex: bool = False,  # noqa: FBT001, FBT002
 ) -> GrepResult:
     """Return structured grep matches from an in-memory files mapping.
-
-    Performs literal text search (not regex).
 
     Returns a GrepResult with matches on success.
     We deliberately do not raise here to keep backends non-throwing in tool
@@ -716,11 +660,19 @@ def grep_matches_from_files(
     if glob:
         filtered = {fp: fd for fp, fd in filtered.items() if wcglob.globmatch(Path(fp).name, glob, flags=wcglob.BRACE)}
 
+    compiled: re.Pattern[str] | None = None
+    if use_regex:
+        try:
+            compiled = re.compile(pattern)
+        except re.error as e:
+            return GrepResult(error=f"Invalid regex pattern: {e}", matches=[])
+
     matches: list[GrepMatch] = []
     for file_path, file_data in filtered.items():
         content_str = _normalize_content(file_data)
         for line_num, line in enumerate(content_str.split("\n"), 1):
-            if pattern in line:  # Simple substring search for literal matching
+            hit = bool(compiled.search(line)) if compiled is not None else (pattern in line)
+            if hit:
                 matches.append({"path": file_path, "line": int(line_num), "text": line})
     return GrepResult(matches=matches)
 

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -314,12 +314,16 @@ class GlobSchema(BaseModel):
 class GrepSchema(BaseModel):
     """Input schema for the `grep` tool."""
 
-    pattern: str = Field(description="Text pattern to search for (literal string, not regex).")
+    pattern: str = Field(description="Text pattern to search for. Literal string by default; set use_regex=True for regular expressions.")
     path: str | None = Field(default=None, description="Directory to search in. Defaults to current working directory.")
     glob: str | None = Field(default=None, description="Glob pattern to filter which files to search (e.g., '*.py').")
     output_mode: Literal["files_with_matches", "content", "count"] = Field(
         default="files_with_matches",
         description="Output format: 'files_with_matches' (file paths only, default), 'content' (matching lines with context), 'count' (match counts per file).",
+    )
+    use_regex: bool = Field(
+        default=False,
+        description="If True, treat pattern as a regular expression. If False (default), pattern is matched as a literal string and special characters like (, [, | are treated verbatim.",
     )
 
 
@@ -390,14 +394,16 @@ Examples:
 
 GREP_TOOL_DESCRIPTION = """Search for a text pattern across files.
 
-Searches for literal text (not regex) and returns matching files or content based on output_mode.
-Special characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.
+Searches for text patterns and returns matching files or content based on output_mode.
+By default, pattern is treated as a literal string — special characters like (, [, | are matched verbatim.
+Set use_regex=True to search with regular expressions.
 
 Examples:
 - Search all files: `grep(pattern="TODO")`
 - Search Python files only: `grep(pattern="import", glob="*.py")`
 - Show matching lines: `grep(pattern="error", output_mode="content")`
-- Search for code with special chars: `grep(pattern="def __init__(self):")`"""
+- Search for code with special chars: `grep(pattern="def __init__(self):")`
+- Regex search: `grep(pattern="def (get|set)_\\w+", glob="*.py", use_regex=True)`"""
 
 EXECUTE_TOOL_DESCRIPTION = """Executes a shell command in an isolated sandbox environment.
 
@@ -1310,7 +1316,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         tool_description = self._custom_tool_descriptions.get("grep") or GREP_TOOL_DESCRIPTION
 
         def sync_grep(
-            pattern: Annotated[str, "Text pattern to search for (literal string, not regex)."],
+            pattern: Annotated[str, "Text pattern to search for. Literal string by default; set use_regex=True for regular expressions."],
             runtime: ToolRuntime[None, FilesystemState],
             path: Annotated[str | None, "Directory to search in. Defaults to current working directory."] = None,
             glob: Annotated[str | None, "Glob pattern to filter which files to search (e.g., '*.py')."] = None,
@@ -1318,6 +1324,9 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 Literal["files_with_matches", "content", "count"],
                 "Output format: 'files_with_matches' (file paths only, default), 'content' (matching lines with context), 'count' (match counts per file).",
             ] = "files_with_matches",
+            use_regex: Annotated[  # noqa: FBT002
+                bool, "If True, treat pattern as a regular expression. If False (default), pattern is matched as a literal string."
+            ] = False,
         ) -> ToolMessage:
             """Synchronous wrapper for grep tool."""
             if path is not None:
@@ -1338,7 +1347,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                         status="error",
                     )
             resolved_backend = self._get_backend(runtime)
-            grep_result = resolved_backend.grep(pattern, path=path, glob=glob)
+            grep_result = resolved_backend.grep(pattern, path=path, glob=glob, use_regex=use_regex)
             if grep_result.error:
                 return ToolMessage(
                     content=grep_result.error,
@@ -1357,7 +1366,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             )
 
         async def async_grep(
-            pattern: Annotated[str, "Text pattern to search for (literal string, not regex)."],
+            pattern: Annotated[str, "Text pattern to search for. Literal string by default; set use_regex=True for regular expressions."],
             runtime: ToolRuntime[None, FilesystemState],
             path: Annotated[str | None, "Directory to search in. Defaults to current working directory."] = None,
             glob: Annotated[str | None, "Glob pattern to filter which files to search (e.g., '*.py')."] = None,
@@ -1365,6 +1374,9 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 Literal["files_with_matches", "content", "count"],
                 "Output format: 'files_with_matches' (file paths only, default), 'content' (matching lines with context), 'count' (match counts per file).",
             ] = "files_with_matches",
+            use_regex: Annotated[  # noqa: FBT002
+                bool, "If True, treat pattern as a regular expression. If False (default), pattern is matched as a literal string."
+            ] = False,
         ) -> ToolMessage:
             """Asynchronous wrapper for grep tool."""
             if path is not None:
@@ -1385,7 +1397,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                         status="error",
                     )
             resolved_backend = self._get_backend(runtime)
-            grep_result = await resolved_backend.agrep(pattern, path=path, glob=glob)
+            grep_result = await resolved_backend.agrep(pattern, path=path, glob=glob, use_regex=use_regex)
             if grep_result.error:
                 return ToolMessage(
                     content=grep_result.error,

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -1042,7 +1042,7 @@ def test_composite_grep_error_in_routed_backend() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorBackend(StoreBackend):
-        def grep(self, pattern: str, path: str | None = None, glob: str | None = None):
+        def grep(self, pattern: str, path: str | None = None, glob: str | None = None, use_regex: bool = False):  # noqa: FBT001, FBT002
             return "Invalid regex pattern error"
 
     error_backend = ErrorBackend()
@@ -1061,7 +1061,7 @@ def test_composite_grep_error_in_routed_backend_at_root() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorBackend(StoreBackend):
-        def grep(self, pattern: str, path: str | None = None, glob: str | None = None):
+        def grep(self, pattern: str, path: str | None = None, glob: str | None = None, use_regex: bool = False):  # noqa: FBT001, FBT002
             return "Backend error occurred"
 
     error_backend = ErrorBackend()
@@ -1080,7 +1080,7 @@ def test_composite_grep_error_in_default_backend_at_root() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorDefaultBackend(StoreBackend):
-        def grep(self, pattern: str, path: str | None = None, glob: str | None = None):
+        def grep(self, pattern: str, path: str | None = None, glob: str | None = None, use_regex: bool = False):  # noqa: FBT001, FBT002
             return "Default backend error"
 
     error_default = ErrorDefaultBackend()

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
@@ -928,7 +928,7 @@ async def test_composite_agrep_error_in_routed_backend_async() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorBackend(StoreBackend):
-        async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None):
+        async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None, use_regex: bool = False):  # noqa: FBT001, FBT002
             return "Invalid regex pattern error"
 
     error_backend = ErrorBackend()
@@ -947,7 +947,7 @@ async def test_composite_agrep_error_in_routed_backend_at_root_async() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorBackend(StoreBackend):
-        async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None):
+        async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None, use_regex: bool = False):  # noqa: FBT001, FBT002
             return "Backend error occurred"
 
     error_backend = ErrorBackend()
@@ -966,7 +966,7 @@ async def test_composite_agrep_error_in_default_backend_at_root_async() -> None:
 
     # Create a mock backend that returns error strings for grep
     class ErrorDefaultBackend(StoreBackend):
-        async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None):
+        async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None, use_regex: bool = False):  # noqa: FBT001, FBT002
             return "Default backend error"
 
     error_default = ErrorDefaultBackend()

--- a/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
@@ -305,9 +305,40 @@ def test_grep_with_path_prefix() -> None:
 
 def test_grep_invalid_regex() -> None:
     backend, _ = _make_backend()
-    result = backend.grep("[unclosed")
+    result = backend.grep("[unclosed", use_regex=True)
     assert result.error is not None
     assert "Invalid regex" in result.error
+
+
+def test_grep_literal_special_chars_not_treated_as_regex() -> None:
+    backend, _ = _make_backend(
+        **{
+            "a.md": FileEntry(type="file", content="api_key = 'secret'\n"),
+            "b.md": FileEntry(type="file", content="api.key lookup\n"),
+        }
+    )
+    # use_regex=False (default): "api.key" matches only literal "api.key", not "api_key"
+    result = backend.grep("api.key")
+    assert result.error is None
+    assert result.matches is not None
+    paths = {m["path"] for m in result.matches}
+    assert "/b.md" in paths
+    assert "/a.md" not in paths
+
+
+def test_grep_regex_matches_pattern() -> None:
+    backend, _ = _make_backend(
+        **{
+            "a.md": FileEntry(type="file", content="def get_user():\n    pass\n"),
+            "b.md": FileEntry(type="file", content="unrelated content\n"),
+        }
+    )
+    result = backend.grep("def \\w+_user", use_regex=True)
+    assert result.error is None
+    assert result.matches is not None
+    paths = {m["path"] for m in result.matches}
+    assert "/a.md" in paths
+    assert "/b.md" not in paths
 
 
 def test_glob_matches_pattern() -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -1180,3 +1180,107 @@ class TestReadTrailingNewlineRoundtrip:
         assert result.error is not None
         assert "old_string ends with a newline" in result.error
         assert target.read_text() == "# Agent Role:\nyou are an assistant"
+
+
+# ---------------------------------------------------------------------------
+# grep use_regex tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("pattern", "expected_files", "unexpected_files"),
+    [
+        # Alternation
+        ("def (get|set)_value", ["funcs.py"], ["other.py"]),
+        # Quantifier
+        ("error\\d+", ["log.py"], ["other.py"]),
+        # Wildcard
+        ("TODO.*refactor", ["todo.py"], ["other.py"]),
+    ],
+)
+def test_grep_regex_matches_patterns(tmp_path: Path, pattern: str, expected_files: list, unexpected_files: list) -> None:
+    """use_regex=True returns results that only regex (not literal) matching finds."""
+    (tmp_path / "funcs.py").write_text("def get_value():\n    pass\ndef set_value(v):\n    pass\n")
+    (tmp_path / "log.py").write_text("error1 occurred\nerror42 recorded\n")
+    (tmp_path / "todo.py").write_text("# TODO: refactor this module\n")
+    (tmp_path / "other.py").write_text("nothing relevant here\n")
+
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+    result = be.grep(pattern, path="/", use_regex=True)
+
+    assert result.error is None
+    matched = [m["path"] for m in (result.matches or [])]
+    for f in expected_files:
+        assert any(f in p for p in matched), f"Expected {f} in results for pattern {pattern!r}, got {matched}"
+    for f in unexpected_files:
+        assert not any(f in p for p in matched), f"Unexpected {f} in results for pattern {pattern!r}"
+
+
+def test_grep_regex_special_chars_not_escaped(tmp_path: Path) -> None:
+    """With use_regex=True, special chars are NOT escaped — (.*) matches as regex."""
+    (tmp_path / "a.py").write_text("anything on this line\n")
+    (tmp_path / "b.py").write_text("no match\n")
+
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+    result = be.grep("(.*)", path="/", use_regex=True)
+
+    assert result.error is None
+    assert result.matches  # (.*) matches every non-empty line as regex
+
+
+def test_grep_literal_special_chars_unchanged(tmp_path: Path) -> None:
+    """With use_regex=False (default), (.*) is treated literally and matches only that exact string."""
+    (tmp_path / "a.py").write_text("pattern = '(.*)'\n")
+    (tmp_path / "b.py").write_text("anything on this line\n")
+
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+    result = be.grep("(.*)", path="/")  # default use_regex=False
+
+    assert result.error is None
+    matched = [m["path"] for m in (result.matches or [])]
+    assert any("a.py" in p for p in matched), "Literal (.*) should match file containing that exact string"
+    assert not any("b.py" in p for p in matched), "Literal (.*) should not match arbitrary lines"
+
+
+def test_grep_invalid_regex_returns_error(tmp_path: Path) -> None:
+    """An invalid regex pattern returns a GrepResult with an error, not an exception."""
+    (tmp_path / "a.py").write_text("hello\n")
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+    result = be.grep("[invalid", path="/", use_regex=True)
+
+    assert result.error is not None
+    assert "Invalid regex pattern" in result.error
+
+
+def test_grep_regex_python_fallback(tmp_path: Path) -> None:
+    """use_regex=True works through the Python fallback when ripgrep is unavailable."""
+    (tmp_path / "src.py").write_text("def calculate_total():\n    return 42\n")
+    (tmp_path / "other.py").write_text("unrelated content\n")
+
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+    # Force Python fallback by making ripgrep appear unavailable
+    original_ripgrep_search = be._ripgrep_search
+    be._ripgrep_search = lambda *_, **__: None  # type: ignore[method-assign]
+
+    result = be.grep("def \\w+_total", path="/", use_regex=True)
+    be._ripgrep_search = original_ripgrep_search
+
+    assert result.error is None
+    matched = [m["path"] for m in (result.matches or [])]
+    assert any("src.py" in p for p in matched)
+    assert not any("other.py" in p for p in matched)
+
+
+def test_grep_regex_glob_combined(tmp_path: Path) -> None:
+    """use_regex=True can be combined with glob to restrict file types."""
+    (tmp_path / "main.py").write_text("def get_user():\n    pass\n")
+    (tmp_path / "readme.md").write_text("def get_user() is documented here\n")
+
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+    result = be.grep("def \\w+_user", path="/", glob="*.py", use_regex=True)
+
+    assert result.error is None
+    matched = [m["path"] for m in (result.matches or [])]
+    assert any("main.py" in p for p in matched)
+    assert not any("readme.md" in p for p in matched)

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -515,3 +515,57 @@ def test_store_backend_legacy_path_rejects_malicious_assistant_id() -> None:
             warnings.simplefilter("always")
             with pytest.raises(ValueError, match="disallowed characters"):
                 be.write("/test.txt", "content")
+
+
+# ---------------------------------------------------------------------------
+# grep use_regex tests (StoreBackend via grep_matches_from_files)
+# ---------------------------------------------------------------------------
+
+
+def _make_store_backend() -> StoreBackend:
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    files = {
+        "/funcs.py": "def get_value():\n    pass\ndef set_value(v):\n    pass\n",
+        "/log.py": "error1 occurred\nerror42 recorded\n",
+        "/other.py": "nothing relevant here\n",
+    }
+    for path, content in files.items():
+        be.write(path, content)
+    return be
+
+
+def test_store_grep_regex_alternation() -> None:
+    """use_regex=True matches alternation patterns."""
+    be = _make_store_backend()
+    result = be.grep("def (get|set)_value", use_regex=True)
+    assert result.error is None
+    matched = [m["path"] for m in (result.matches or [])]
+    assert any("funcs.py" in p for p in matched)
+    assert not any("other.py" in p for p in matched)
+
+
+def test_store_grep_regex_quantifier() -> None:
+    """use_regex=True matches quantifier patterns."""
+    be = _make_store_backend()
+    result = be.grep("error\\d+", use_regex=True)
+    assert result.error is None
+    matched = [m["path"] for m in (result.matches or [])]
+    assert any("log.py" in p for p in matched)
+    assert not any("funcs.py" in p for p in matched)
+
+
+def test_store_grep_regex_invalid_pattern_returns_error() -> None:
+    """An invalid regex returns a GrepResult with an error field."""
+    be = _make_store_backend()
+    result = be.grep("[invalid", use_regex=True)
+    assert result.error is not None
+    assert "Invalid regex pattern" in result.error
+
+
+def test_store_grep_literal_unchanged_with_special_chars() -> None:
+    """Default literal mode is not affected by the new use_regex param."""
+    be = _make_store_backend()
+    result = be.grep("def (get|set)_value")  # literal — pipe and parens are not regex
+    assert result.error is None
+    assert not result.matches  # literal string not present in any file

--- a/libs/deepagents/tests/unit_tests/middleware/test_tool_schemas.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_tool_schemas.py
@@ -26,7 +26,7 @@ class TestFilesystemToolSchemas:
             "write_file": ["file_path", "content"],
             "edit_file": ["file_path", "old_string", "new_string", "replace_all"],
             "glob": ["pattern", "path"],
-            "grep": ["pattern", "path", "glob", "output_mode"],
+            "grep": ["pattern", "path", "glob", "output_mode", "use_regex"],
             "execute": ["command"],
         }
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -170,7 +170,7 @@
   },
   {
     "function": {
-      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
+      "description": "Search for a text pattern across files.\n\nSearches for text patterns and returns matching files or content based on output_mode.\nBy default, pattern is treated as a literal string \u2014 special characters like (, [, | are matched verbatim.\nSet use_regex=True to search with regular expressions.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`\n- Regex search: `grep(pattern=\"def (get|set)_\\w+\", glob=\"*.py\", use_regex=True)`",
       "name": "grep",
       "parameters": {
         "properties": {
@@ -209,8 +209,13 @@
             "description": "Directory to search in. Defaults to current working directory."
           },
           "pattern": {
-            "description": "Text pattern to search for (literal string, not regex).",
+            "description": "Text pattern to search for. Literal string by default; set use_regex=True for regular expressions.",
             "type": "string"
+          },
+          "use_regex": {
+            "default": false,
+            "description": "If True, treat pattern as a regular expression. If False (default), pattern is matched as a literal string and special characters like (, [, | are treated verbatim.",
+            "type": "boolean"
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -170,7 +170,7 @@
   },
   {
     "function": {
-      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
+      "description": "Search for a text pattern across files.\n\nSearches for text patterns and returns matching files or content based on output_mode.\nBy default, pattern is treated as a literal string \u2014 special characters like (, [, | are matched verbatim.\nSet use_regex=True to search with regular expressions.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`\n- Regex search: `grep(pattern=\"def (get|set)_\\w+\", glob=\"*.py\", use_regex=True)`",
       "name": "grep",
       "parameters": {
         "properties": {
@@ -209,8 +209,13 @@
             "description": "Directory to search in. Defaults to current working directory."
           },
           "pattern": {
-            "description": "Text pattern to search for (literal string, not regex).",
+            "description": "Text pattern to search for. Literal string by default; set use_regex=True for regular expressions.",
             "type": "string"
+          },
+          "use_regex": {
+            "default": false,
+            "description": "If True, treat pattern as a regular expression. If False (default), pattern is matched as a literal string and special characters like (, [, | are treated verbatim.",
+            "type": "boolean"
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -170,7 +170,7 @@
   },
   {
     "function": {
-      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
+      "description": "Search for a text pattern across files.\n\nSearches for text patterns and returns matching files or content based on output_mode.\nBy default, pattern is treated as a literal string \u2014 special characters like (, [, | are matched verbatim.\nSet use_regex=True to search with regular expressions.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`\n- Regex search: `grep(pattern=\"def (get|set)_\\w+\", glob=\"*.py\", use_regex=True)`",
       "name": "grep",
       "parameters": {
         "properties": {
@@ -209,8 +209,13 @@
             "description": "Directory to search in. Defaults to current working directory."
           },
           "pattern": {
-            "description": "Text pattern to search for (literal string, not regex).",
+            "description": "Text pattern to search for. Literal string by default; set use_regex=True for regular expressions.",
             "type": "string"
+          },
+          "use_regex": {
+            "default": false,
+            "description": "If True, treat pattern as a regular expression. If False (default), pattern is matched as a literal string and special characters like (, [, | are treated verbatim.",
+            "type": "boolean"
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -170,7 +170,7 @@
   },
   {
     "function": {
-      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
+      "description": "Search for a text pattern across files.\n\nSearches for text patterns and returns matching files or content based on output_mode.\nBy default, pattern is treated as a literal string \u2014 special characters like (, [, | are matched verbatim.\nSet use_regex=True to search with regular expressions.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`\n- Regex search: `grep(pattern=\"def (get|set)_\\w+\", glob=\"*.py\", use_regex=True)`",
       "name": "grep",
       "parameters": {
         "properties": {
@@ -209,8 +209,13 @@
             "description": "Directory to search in. Defaults to current working directory."
           },
           "pattern": {
-            "description": "Text pattern to search for (literal string, not regex).",
+            "description": "Text pattern to search for. Literal string by default; set use_regex=True for regular expressions.",
             "type": "string"
+          },
+          "use_regex": {
+            "default": false,
+            "description": "If True, treat pattern as a regular expression. If False (default), pattern is matched as a literal string and special characters like (, [, | are treated verbatim.",
+            "type": "boolean"
           }
         },
         "required": [

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -170,7 +170,7 @@
   },
   {
     "function": {
-      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
+      "description": "Search for a text pattern across files.\n\nSearches for text patterns and returns matching files or content based on output_mode.\nBy default, pattern is treated as a literal string \u2014 special characters like (, [, | are matched verbatim.\nSet use_regex=True to search with regular expressions.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`\n- Regex search: `grep(pattern=\"def (get|set)_\\w+\", glob=\"*.py\", use_regex=True)`",
       "name": "grep",
       "parameters": {
         "properties": {
@@ -209,8 +209,13 @@
             "description": "Directory to search in. Defaults to current working directory."
           },
           "pattern": {
-            "description": "Text pattern to search for (literal string, not regex).",
+            "description": "Text pattern to search for. Literal string by default; set use_regex=True for regular expressions.",
             "type": "string"
+          },
+          "use_regex": {
+            "default": false,
+            "description": "If True, treat pattern as a regular expression. If False (default), pattern is matched as a literal string and special characters like (, [, | are treated verbatim.",
+            "type": "boolean"
           }
         },
         "required": [


### PR DESCRIPTION
Fixes #3547 



Makes the hardcoded `-F` flag and `re.escape()` conditional behind a `use_regex: bool = False` parameter. When `use_regex=False` (the default), behavior is identical to today. When `use_regex=True`, ripgrep runs without `-F` and treats the pattern as a regex.

`use_regex=True` is only supported on backends that use a linear-time regex engine: `FilesystemBackend` (ripgrep) and `SandboxBackend` (system `grep -E`). In-memory backends (`StoreBackend`, `StateBackend`, `ContextHubBackend`) and the Python ripgrep fallback return an explicit error — Python's `re` engine has no ReDoS protection and the `use_regex` parameter is reachable from LLM tool calls and ACP clients.

When `use_regex=True`, agents can express queries that are impossible today:

```python
# Find all functions matching a naming convention
grep(pattern="def (get|set|update)_\w+", glob="*.py", use_regex=True)

# Find all callers of a group of methods
grep(pattern="\.(save|persist|commit)\(", glob="*.py", use_regex=True)

# Audit exception handling
grep(pattern="except\s+\w*Error", glob="*.py", use_regex=True)
```

Without this, the agent must fall back to multiple literal searches or open files it shouldn't need to read. `execute` is not a workaround — it's unavailable on the default `FilesystemBackend`, and the system prompt explicitly tells the agent to use `grep` instead of shell commands.

## Files changed

**`backends/protocol.py`** — added `use_regex` to the abstract `grep` / `agrep` signatures. The default `agrep` implementation in this file forwards the flag through `asyncio.to_thread`.

**`backends/filesystem.py`** — `-F` is now conditional in `_ripgrep_search`: present when `use_regex=False`, omitted when `use_regex=True`. If ripgrep is unavailable and `use_regex=True`, returns an explicit error instead of falling back to Python `re` (ReDoS protection). The Python fallback path is now always literal-only. Invalid patterns are validated with `re.compile` before either path and returned as `GrepResult(error=...)`.

**`backends/sandbox.py`** — switches subprocess `grep` between `-F` (literal) and `-E` (extended regex) while preserving the `-Z` NUL-separator flag. Invalid patterns caught early.

**`backends/context_hub.py`** — returns an explicit error when `use_regex=True` (ReDoS protection). In literal mode, now correctly wraps the pattern in `re.escape()` so special characters like `(`, `[`, `|` are matched verbatim.

**`backends/utils.py`** — `grep_matches_from_files` (shared by `StoreBackend` and `StateBackend`) returns an explicit error when `use_regex=True` (ReDoS protection). Literal path simplified back to a plain `pattern in line` check. Also removed the dead `_grep_search_files` function that had been superseded by this helper.

**`backends/store.py`**, **`backends/state.py`**, **`backends/composite.py`** — mechanical forwarding of `use_regex` to their respective `grep_matches_from_files` or backend-delegation calls.

**`middleware/filesystem.py`** — exposes `use_regex` in `GrepSchema`, `sync_grep`, and `async_grep`; updates `GREP_TOOL_DESCRIPTION` with a regex example.

## How did you verify your code works?

- **`test_filesystem_backend.py`** — new tests: parametrized regex patterns (alternation, quantifier, wildcard), literal special chars unchanged with `use_regex=False`, invalid regex returns `GrepResult(error=...)`, Python-fallback with ripgrep patched out now asserts an error is returned, `glob` + `use_regex` combined.
- **`test_store_backend.py`** — `use_regex=True` now asserts an explicit error (in-memory backend); literal-unchanged test retained.
- **`test_context_hub_backend.py`** — `use_regex=True` now asserts an explicit error (in-memory backend); literal special chars test retained.
- **`test_composite_backend.py`** / **`test_composite_backend_async.py`** — 3 mock signatures updated in each to match the new protocol.
- **`test_tool_schemas.py`** — expected `grep` parameter list updated to include `use_regex`.
- **5 smoke-test snapshots** regenerated to reflect the updated description and new schema field.

## Social handles (optional)

LinkedIn: https://linkedin.com/in/ninaadrao