### PR TITLE
fix(code): preserve MCP token refresh when metadata discovery fails

### DIFF
--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -23,13 +23,23 @@ import secrets
 import stat
 import threading
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import TYPE_CHECKING, Literal, TypedDict
 from urllib.parse import parse_qs, urlparse
 
+import httpx
 from mcp.client.auth import OAuthClientProvider, TokenStorage
+from mcp.client.auth.utils import (
+    build_oauth_authorization_server_metadata_discovery_urls,
+    build_protected_resource_metadata_discovery_urls,
+    create_oauth_metadata_request,
+    handle_auth_metadata_response,
+    handle_protected_resource_response,
+)
+from mcp.client.streamable_http import MCP_PROTOCOL_VERSION
 from mcp.shared.auth import (
     OAuthClientInformationFull,
+    OAuthMetadata,
     OAuthToken,
 )
 from pydantic import BaseModel, ConfigDict, ValidationError
@@ -274,6 +284,23 @@ class FileTokenStorage(TokenStorage):
         data = self._read() or {}
         data["version"] = _STORAGE_VERSION
         data["client_info"] = json.loads(client_info.model_dump_json(exclude_none=True))
+        self._write(data)
+
+    async def get_oauth_metadata(self) -> OAuthMetadata | None:
+        """Return stored public OAuth authorization metadata, if available."""
+        data = self._read()
+        if data is None:
+            return None
+        raw = data.get("oauth_metadata")
+        if raw is None:
+            return None
+        return OAuthMetadata.model_validate(raw)
+
+    async def set_oauth_metadata(self, metadata: OAuthMetadata) -> None:
+        """Persist public OAuth authorization metadata beside the token state."""
+        data = self._read() or {}
+        data["version"] = _STORAGE_VERSION
+        data["oauth_metadata"] = json.loads(metadata.model_dump_json(exclude_none=True))
         self._write(data)
 
     async def set_tokens_and_client_info(
@@ -960,6 +987,14 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
         # fail loudly rather than silently regress to the 401-on-restart
         # bug this class exists to prevent.
         await super()._initialize()
+        if self.context.oauth_metadata is None:
+            get_oauth_metadata = getattr(
+                self.context.storage,
+                "get_oauth_metadata",
+                None,
+            )
+            if get_oauth_metadata is not None:
+                self.context.oauth_metadata = await get_oauth_metadata()
         get_expires_at = getattr(self.context.storage, "get_expires_at", None)
         if get_expires_at is None:
             return
@@ -994,6 +1029,87 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
                 _REFRESH_SAFETY_MARGIN_SECONDS,
             )
         self.context.token_expiry_time = expires_at - _REFRESH_SAFETY_MARGIN_SECONDS
+
+    async def _persist_oauth_metadata(self) -> None:
+        """Persist discovered public OAuth metadata when storage supports it."""
+        if self.context.oauth_metadata is None:
+            return
+        set_oauth_metadata = getattr(self.context.storage, "set_oauth_metadata", None)
+        if set_oauth_metadata is not None:
+            await set_oauth_metadata(self.context.oauth_metadata)
+
+    async def _handle_token_response(self, response: httpx.Response) -> None:
+        """Persist tokens and any metadata discovered during full OAuth login."""
+        await super()._handle_token_response(response)
+        await self._persist_oauth_metadata()
+
+    async def async_auth_flow(
+        self,
+        request: httpx.Request,
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        """Discover and cache OAuth metadata before the SDK refresh branch.
+
+        Yields:
+            HTTP requests for OAuth metadata discovery and the delegated SDK auth flow.
+        """
+        async with self.context.lock:
+            if not self._initialized:
+                await self._initialize()
+            self.context.protocol_version = request.headers.get(MCP_PROTOCOL_VERSION)
+            if (
+                not self.context.is_token_valid()
+                and self.context.can_refresh_token()
+                and self.context.oauth_metadata is None
+            ):
+                # Pre-empt the SDK's 401-path discovery so its refresh branch
+                # finds populated `oauth_metadata` and uses the advertised token
+                # endpoint instead of guessing `/token`. The resource-metadata
+                # URL is `None`: no 401 yet, so no `WWW-Authenticate` to read.
+                try:
+                    prm_urls = build_protected_resource_metadata_discovery_urls(
+                        None,
+                        self.context.server_url,
+                    )
+                    for url in prm_urls:
+                        response = yield create_oauth_metadata_request(url)
+                        prm = await handle_protected_resource_response(response)
+                        if prm is None:
+                            logger.debug(
+                                "Protected resource metadata discovery failed: %s",
+                                url,
+                            )
+                            continue
+                        self.context.protected_resource_metadata = prm
+                        self.context.auth_server_url = str(prm.authorization_servers[0])
+                        break
+
+                    asm_urls = build_oauth_authorization_server_metadata_discovery_urls(
+                        self.context.auth_server_url,
+                        self.context.server_url,
+                    )
+                    for url in asm_urls:
+                        response = yield create_oauth_metadata_request(url)
+                        ok, metadata = await handle_auth_metadata_response(response)
+                        if not ok:
+                            break
+                        if metadata is None:
+                            logger.debug("OAuth metadata discovery failed: %s", url)
+                            continue
+                        self.context.oauth_metadata = metadata
+                        await self._persist_oauth_metadata()
+                        break
+                except httpx.HTTPError as exc:
+                    # Log only the exception type, never its payload — discovery
+                    # responses travel the same channel as bearer tokens.
+                    logger.debug(
+                        "Pre-emptive OAuth metadata discovery for %s raised %s; "
+                        "deferring to the SDK auth flow.",
+                        self.context.server_url,
+                        type(exc).__name__,
+                    )
+
+        async for flow_request in super().async_auth_flow(request):
+            yield flow_request
 
 
 def build_oauth_provider(

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -93,6 +93,18 @@ def _make_client_info():
     )
 
 
+def _make_oauth_metadata(token_endpoint: str = "https://auth.example/token"):
+    from mcp.shared.auth import AnyHttpUrl, OAuthMetadata
+
+    return OAuthMetadata(
+        issuer=AnyHttpUrl("https://auth.example"),
+        authorization_endpoint=AnyHttpUrl("https://auth.example/authorize"),
+        token_endpoint=AnyHttpUrl(token_endpoint),
+        response_types_supported=["code"],
+        grant_types_supported=["authorization_code", "refresh_token"],
+    )
+
+
 def _make_client_info_with_loopback(port: int):
     from mcp.shared.auth import AnyUrl, OAuthClientInformationFull
 
@@ -265,6 +277,18 @@ class TestFileTokenStorage:
             OAuthToken(access_token="x2", token_type="Bearer", refresh_token="rt2")
         )
         assert await storage.get_expires_at() is None
+
+    async def test_round_trip_oauth_metadata(self) -> None:
+        """Public OAuth metadata round-trips beside token state."""
+        storage = FileTokenStorage("notion")
+        metadata = _make_oauth_metadata()
+
+        assert await storage.get_oauth_metadata() is None
+        await storage.set_oauth_metadata(metadata)
+
+        stored = await storage.get_oauth_metadata()
+        assert stored is not None
+        assert str(stored.token_endpoint) == "https://auth.example/token"
 
 
 @pytest.mark.usefixtures("fake_home")
@@ -658,6 +682,176 @@ class TestBuildOAuthProvider:
         assert metadata.token_endpoint_auth_method == "none"
         assert metadata.redirect_uris is not None
         assert [str(uri) for uri in metadata.redirect_uris] == [_SLACK_REDIRECT_URI]
+
+    async def test_refresh_uses_cached_oauth_metadata_endpoint(
+        self,
+        fake_home: Path,
+    ) -> None:
+        """Expired tokens refresh against cached metadata, not guessed `/token`."""
+        del fake_home
+        from deepagents_code.mcp_auth import build_oauth_provider
+        from deepagents_code.mcp_providers.slack import _preseed_slack_client_info
+
+        token_endpoint = "https://slack.com/api/oauth.v2.user.access"
+        storage = FileTokenStorage("slack", server_url="https://mcp.slack.com/mcp")
+        await _preseed_slack_client_info(storage)
+        await storage.set_oauth_metadata(_make_oauth_metadata(token_endpoint))
+        await storage.set_tokens(_make_tokens())
+        data = json.loads(storage.path.read_text())
+        data["expires_at"] = time.time() - 60
+        storage.path.write_text(json.dumps(data))
+
+        provider = build_oauth_provider(
+            server_name="slack",
+            server_url="https://mcp.slack.com/mcp",
+            storage=storage,
+            interactive=False,
+        )
+        await provider._initialize()
+        refresh_request = await provider._refresh_token()
+
+        assert provider.context.oauth_metadata is not None
+        assert str(refresh_request.url) == token_endpoint
+
+    async def test_refresh_discovers_and_caches_oauth_metadata_endpoint(
+        self,
+        fake_home: Path,
+    ) -> None:
+        """Legacy token files discover metadata before refreshing."""
+        del fake_home
+        import httpx
+
+        from deepagents_code.mcp_auth import build_oauth_provider
+        from deepagents_code.mcp_providers.slack import _preseed_slack_client_info
+
+        token_endpoint = "https://slack.com/api/oauth.v2.user.access"
+        storage = FileTokenStorage("slack", server_url="https://mcp.slack.com/mcp")
+        await _preseed_slack_client_info(storage)
+        await storage.set_tokens(_make_tokens())
+        data = json.loads(storage.path.read_text())
+        data["expires_at"] = time.time() - 60
+        storage.path.write_text(json.dumps(data))
+
+        provider = build_oauth_provider(
+            server_name="slack",
+            server_url="https://mcp.slack.com/mcp",
+            storage=storage,
+            interactive=False,
+        )
+        flow = provider.async_auth_flow(
+            httpx.Request("POST", "https://mcp.slack.com/mcp")
+        )
+
+        prm_path_request = await anext(flow)
+        assert str(prm_path_request.url).endswith(
+            "/.well-known/oauth-protected-resource/mcp"
+        )
+        prm_root_request = await flow.asend(
+            httpx.Response(404, request=prm_path_request)
+        )
+        assert str(prm_root_request.url).endswith(
+            "/.well-known/oauth-protected-resource"
+        )
+        auth_metadata_request = await flow.asend(
+            httpx.Response(
+                200,
+                request=prm_root_request,
+                json={
+                    "resource": "https://mcp.slack.com",
+                    "authorization_servers": ["https://mcp.slack.com"],
+                },
+            )
+        )
+        assert str(auth_metadata_request.url).endswith(
+            "/.well-known/oauth-authorization-server"
+        )
+        refresh_request = await flow.asend(
+            httpx.Response(
+                200,
+                request=auth_metadata_request,
+                json={
+                    "issuer": "https://slack.com",
+                    "authorization_endpoint": "https://slack.com/oauth/v2_user/authorize",
+                    "token_endpoint": token_endpoint,
+                    "response_types_supported": ["code"],
+                    "grant_types_supported": ["authorization_code", "refresh_token"],
+                },
+            )
+        )
+
+        assert str(refresh_request.url) == token_endpoint
+        stored = await storage.get_oauth_metadata()
+        assert stored is not None
+        assert str(stored.token_endpoint) == token_endpoint
+        await flow.aclose()
+
+    async def test_refresh_falls_back_when_preemptive_metadata_discovery_raises(
+        self,
+        fake_home: Path,
+    ) -> None:
+        """Transient metadata discovery errors still defer to SDK refresh."""
+        del fake_home
+        import httpx
+
+        from deepagents_code.mcp_auth import build_oauth_provider
+        from deepagents_code.mcp_providers.slack import _preseed_slack_client_info
+
+        storage = FileTokenStorage("slack", server_url="https://mcp.slack.com/mcp")
+        await _preseed_slack_client_info(storage)
+        await storage.set_tokens(_make_tokens())
+        data = json.loads(storage.path.read_text())
+        data["expires_at"] = time.time() - 60
+        storage.path.write_text(json.dumps(data))
+
+        provider = build_oauth_provider(
+            server_name="slack",
+            server_url="https://mcp.slack.com/mcp",
+            storage=storage,
+            interactive=False,
+        )
+        flow = provider.async_auth_flow(
+            httpx.Request("POST", "https://mcp.slack.com/mcp")
+        )
+
+        metadata_request = await anext(flow)
+        refresh_request = await flow.athrow(
+            httpx.TransportError("metadata unavailable", request=metadata_request)
+        )
+
+        assert str(refresh_request.url).endswith("/token")
+        await flow.aclose()
+
+    async def test_full_login_persists_discovered_oauth_metadata(
+        self,
+        fake_home: Path,
+    ) -> None:
+        """Metadata discovered during full login is cached for later refreshes."""
+        del fake_home
+        import httpx
+
+        from deepagents_code.mcp_auth import build_oauth_provider
+        from deepagents_code.mcp_providers.slack import _preseed_slack_client_info
+
+        storage = FileTokenStorage("slack", server_url="https://mcp.slack.com/mcp")
+        await _preseed_slack_client_info(storage)
+        provider = build_oauth_provider(
+            server_name="slack",
+            server_url="https://mcp.slack.com/mcp",
+            storage=storage,
+            interactive=False,
+        )
+        await provider._initialize()
+        # Simulate the SDK's 401-path discovery populating the context during a
+        # full browser login, just before the token exchange completes.
+        provider.context.oauth_metadata = _make_oauth_metadata()
+
+        assert await storage.get_oauth_metadata() is None
+        token_json = json.loads(_make_tokens().model_dump_json(exclude_none=True))
+        await provider._handle_token_response(httpx.Response(200, json=token_json))
+
+        stored = await storage.get_oauth_metadata()
+        assert stored is not None
+        assert str(stored.token_endpoint) == "https://auth.example/token"
 
     def test_generic_branch_uses_loopback_callback(self) -> None:
         """Non-Slack URLs (including Notion) use a local callback server redirect."""


### PR DESCRIPTION
This caches discovered OAuth metadata for MCP refreshes so providers with non-standard token endpoints can keep using refresh tokens across restarts. The SDK can refresh expired tokens when metadata is already present, but it does not have a clean, generalizable place to rediscover and persist provider-specific authorization metadata before refresh. Deep Agents already owns the file-backed token store and provider policy layer, so this keeps the provider-specific compatibility logic here.

The pre-refresh metadata lookup is best-effort. If discovery fails because a `.well-known` endpoint is temporarily unavailable, authentication now falls back to the normal SDK refresh path instead of aborting before refresh can run.

This is especially relevant for providers whose token endpoint cannot be safely guessed from the MCP server URL.