### PR TITLE
feat(code): add MCP error detail modal

### DIFF
--- a/libs/code/deepagents_code/local_context.py
+++ b/libs/code/deepagents_code/local_context.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import unicodedata
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -29,7 +28,7 @@ from langchain.agents.middleware.types import (
     PrivateStateAttr,
 )
 
-from deepagents_code.unicode_security import strip_dangerous_unicode
+from deepagents_code.unicode_security import sanitize_control_chars
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -70,16 +69,8 @@ def _sanitize_error_detail(error: str | None) -> str:
     """
     if not error:
         return "unknown error"
-    stripped = strip_dangerous_unicode(error)
-    flattened = "".join(
-        " " if unicodedata.category(ch).startswith("C") else ch for ch in stripped
-    )
-    collapsed = " ".join(flattened.split())
-    if not collapsed:
-        return "unknown error"
-    if len(collapsed) > _MCP_ERROR_DETAIL_LIMIT:
-        return collapsed[: _MCP_ERROR_DETAIL_LIMIT - 1].rstrip() + "…"
-    return collapsed
+    sanitized = sanitize_control_chars(error, max_length=_MCP_ERROR_DETAIL_LIMIT)
+    return sanitized or "unknown error"
 
 
 def _build_mcp_context(servers: list[MCPServerInfo]) -> str:

--- a/libs/code/deepagents_code/unicode_security.py
+++ b/libs/code/deepagents_code/unicode_security.py
@@ -173,6 +173,53 @@ def strip_dangerous_unicode(text: str) -> str:
     return "".join(ch for ch in text if ch not in _DANGEROUS_CHARACTERS)
 
 
+def sanitize_control_chars(
+    text: str,
+    *,
+    keep_newlines: bool = False,
+    collapse_whitespace: bool = True,
+    max_length: int | None = None,
+) -> str:
+    """Neutralize control characters and deceptive Unicode in untrusted text.
+
+    Untrusted strings (MCP server errors, config-file contents, tool output)
+    can carry ANSI escape sequences, other control characters, or invisible
+    Unicode that corrupts the terminal, breaks out of a layout, or injects fake
+    lines into logs and prompts. This first removes the invisible/bidi code
+    points flagged by `strip_dangerous_unicode`, then replaces every remaining
+    Unicode "Other" (control/format) character with a space.
+
+    Args:
+        text: Untrusted text to sanitize.
+        keep_newlines: When `True`, newlines survive so multiline, scrollable
+            surfaces keep their line structure; otherwise newlines are
+            flattened to spaces along with the other control characters.
+        collapse_whitespace: When `True`, runs of whitespace are collapsed to a
+            single space and surrounding whitespace is stripped. With
+            `keep_newlines`, collapsing is applied per line so line breaks are
+            preserved.
+        max_length: When set, truncate to at most this many characters,
+            replacing the final character with an ellipsis.
+
+    Returns:
+        Sanitized text safe to embed in terminal output, markup substitutions,
+        logs, or prompts.
+    """
+    allowed = {" ", "\n"} if keep_newlines else {" "}
+    cleaned = "".join(
+        ch if ch in allowed or not unicodedata.category(ch).startswith("C") else " "
+        for ch in strip_dangerous_unicode(text)
+    )
+    if collapse_whitespace:
+        if keep_newlines:
+            cleaned = "\n".join(" ".join(line.split()) for line in cleaned.split("\n"))
+        else:
+            cleaned = " ".join(cleaned.split())
+    if max_length is not None and len(cleaned) > max_length:
+        cleaned = cleaned[: max_length - 1].rstrip() + "…"
+    return cleaned
+
+
 def render_with_unicode_markers(text: str) -> str:
     """Render hidden Unicode characters as explicit markers.
 

--- a/libs/code/deepagents_code/widgets/mcp_viewer.py
+++ b/libs/code/deepagents_code/widgets/mcp_viewer.py
@@ -14,6 +14,8 @@ from textual.events import (
 from textual.screen import ModalScreen
 from textual.widgets import Input, Static
 
+from deepagents_code.clipboard import copy_text_to_clipboard
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
@@ -23,6 +25,7 @@ if TYPE_CHECKING:
 
 from deepagents_code import theme
 from deepagents_code.config import Glyphs, get_glyphs, is_ascii_mode
+from deepagents_code.unicode_security import sanitize_control_chars
 
 logger = logging.getLogger(__name__)
 
@@ -145,28 +148,12 @@ def _format_prop_type(prop_type: Any) -> str:  # noqa: ANN401 - JSON Schema fiel
     return str(prop_type) or "any"
 
 
-def _sanitize_inline(text: str, *, max_length: int = 200) -> str:
-    """Strip control characters and truncate text rendered inline in a header.
+_INLINE_TEXT_LIMIT = 200
+"""Max characters for untrusted text rendered inline in a server header.
 
-    External-origin strings (e.g. `MCPServerInfo.error` returned by an MCP
-    server) might contain newlines, ANSI escape sequences, or other control
-    characters that would corrupt the modal layout. Replace control chars
-    with spaces and truncate to `max_length` so a hostile or buggy server
-    cannot break the screen.
-
-    Args:
-        text: Untrusted inline text.
-        max_length: Maximum characters to retain (truncated with `…`).
-
-    Returns:
-        Sanitized single-line text safe to embed inside a `Content.assemble`
-        tuple or `from_markup` substitution.
-    """
-    cleaned = "".join(ch if ch == " " or ch.isprintable() else " " for ch in text)
-    cleaned = " ".join(cleaned.split())
-    if len(cleaned) > max_length:
-        cleaned = cleaned[: max_length - 1] + "…"
-    return cleaned
+Bounds a hostile or buggy server's error/name so it cannot overflow the
+single-line header; full text is available in the error-detail modal.
+"""
 
 
 def _sort_servers_for_display(
@@ -447,7 +434,7 @@ def _render_server_header(
     injection-safe: each span's `text` is rendered verbatim, never
     markup-parsed, so a server name like `[bold]foo[/]` shows literally
     rather than getting styled. `server.error` additionally goes through
-    `_sanitize_inline` because MCP servers can return arbitrary error
+    `sanitize_control_chars` because MCP servers can return arbitrary error
     text including newlines or terminal escapes.
 
     Args:
@@ -466,15 +453,14 @@ def _render_server_header(
     dim_style = "" if selected else "dim"
     tool_count = len(visible_tools)
     t_label = "tool" if tool_count == 1 else "tools"
-    if server.is_loaded():
+    if server.status == "ok":
         summary = f" {server.transport} {glyphs.bullet} {tool_count} {t_label}"
         return Content.assemble(
             (f"{indicator_glyph} ", indicator_color),
             (server.name, "bold"),
             (summary, dim_style),
         )
-    error_text = _sanitize_inline(server.error or "")
-    if server.needs_attention():
+    if server.status == "unauthenticated":
         login_hint = " — Enter to log in"
         return Content.assemble(
             (f"{indicator_glyph} ", indicator_color),
@@ -491,7 +477,18 @@ def _render_server_header(
             (f" {glyphs.bullet} ready to load", indicator_color),
             (f" — {MCP_RECONNECT_KEY_LABEL} to load tools", dim_style),
         )
-    if server.status in {"error", "disabled"}:
+    if server.status == "error":
+        return Content.assemble(
+            (f"{indicator_glyph} ", indicator_color),
+            (server.name, "bold"),
+            (f" {server.transport}", dim_style),
+            (f" {glyphs.bullet} {server.status}", indicator_color),
+            (" — Enter for details", dim_style),
+        )
+    if server.status == "disabled":
+        error_text = sanitize_control_chars(
+            server.error or "", max_length=_INLINE_TEXT_LIMIT
+        )
         return Content.assemble(
             (f"{indicator_glyph} ", indicator_color),
             (server.name, "bold"),
@@ -500,6 +497,123 @@ def _render_server_header(
             (f" — {error_text}", dim_style) if error_text else "",
         )
     assert_never(server.status)
+
+
+class MCPServerErrorScreen(ModalScreen[None]):
+    """Read-only modal for a failed MCP server's error details."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("c", "copy_error", "Copy", show=False, priority=True),
+        Binding("escape", "cancel", "Close", show=False, priority=True),
+    ]
+
+    CSS = """
+    MCPServerErrorScreen {
+        align: center middle;
+    }
+
+    MCPServerErrorScreen > Vertical {
+        width: 100;
+        max-width: 90%;
+        height: 80%;
+        background: $surface;
+        border: solid $error;
+        padding: 1 2;
+    }
+
+    MCPServerErrorScreen .mcp-error-title {
+        text-style: bold;
+        color: $error;
+        text-align: center;
+        margin-bottom: 1;
+    }
+
+    MCPServerErrorScreen .mcp-error-body {
+        height: 1fr;
+        background: $background;
+        scrollbar-gutter: stable;
+        padding: 0 1;
+    }
+
+    MCPServerErrorScreen .mcp-error-text {
+        color: $text;
+    }
+
+    MCPServerErrorScreen .mcp-error-help {
+        height: 1;
+        color: $text-muted;
+        text-style: italic;
+        margin-top: 1;
+        text-align: center;
+    }
+    """
+
+    def __init__(self, server: MCPServerInfo) -> None:
+        """Initialize the error-detail modal.
+
+        Args:
+            server: Failed MCP server whose error text should be displayed.
+        """
+        super().__init__()
+        self._server = server
+        self._error = sanitize_control_chars(
+            server.error or "No error details were reported.",
+            keep_newlines=True,
+            collapse_whitespace=False,
+        )
+
+    def compose(self) -> ComposeResult:
+        """Compose the modal layout.
+
+        Yields:
+            Modal shell with title, scrollable error text, and help footer.
+        """
+        glyphs = get_glyphs()
+        yield Vertical(
+            Static(
+                Content.from_markup(
+                    "MCP Server Error: $server",
+                    server=sanitize_control_chars(
+                        self._server.name, max_length=_INLINE_TEXT_LIMIT
+                    ),
+                ),
+                classes="mcp-error-title",
+            ),
+            VerticalScroll(
+                Static(
+                    Content.from_markup("$error", error=self._error),
+                    classes="mcp-error-text",
+                ),
+                classes="mcp-error-body",
+            ),
+            Static(
+                f"c copy error {glyphs.bullet} Esc close",
+                classes="mcp-error-help",
+            ),
+        )
+
+    def action_copy_error(self) -> None:
+        """Copy the server error details to the clipboard."""
+        success, error = copy_text_to_clipboard(self.app, self._error)
+        if success:
+            self.app.notify(
+                "MCP error copied",
+                severity="information",
+                timeout=2,
+                markup=False,
+            )
+            return
+        suffix = f": {error}" if error else ""
+        self.app.notify(
+            f"Failed to copy MCP error{suffix}",
+            severity="warning",
+            timeout=3,
+            markup=False,
+        )
+
+    def action_cancel(self) -> None:
+        """Close the error details modal."""
+        self.dismiss(None)
 
 
 class MCPServerHeaderItem(Static):
@@ -623,9 +737,9 @@ class MCPServerHeaderItem(Static):
         """Handle click — select the header, or start login on unauth re-click.
 
         Headers are not expandable. Clicking once moves the cursor;
-        clicking the already-selected header for a server in
-        `unauthenticated` state dismisses the viewer with the server name
-        so the parent app can start in-TUI OAuth login.
+        clicking the already-selected header either starts login for
+        an `unauthenticated` server or opens details for an `error`
+        server.
 
         Args:
             event: The click event.
@@ -637,6 +751,9 @@ class MCPServerHeaderItem(Static):
         if self._selected and self._server.needs_attention():
             screen.dismiss(self._server.name)
             return
+        if self._selected and self._server.status == "error":
+            screen.show_server_error(self._server)
+            return
         screen._move_to(self.index)
 
 
@@ -644,10 +761,10 @@ class MCPViewerScreen(ModalScreen[str | None]):
     """Modal viewer for active MCP servers and their tools.
 
     Displays servers grouped by name with transport type and tool count.
-    Navigate with arrow keys, Enter to expand/collapse tool descriptions
-    or start in-app OAuth login for an unauthenticated server, Ctrl+R to
-    request a reconnect, F2 on a server header to toggle its disabled
-    state, and Escape to close.
+    Navigate with arrow keys, Enter to expand/collapse tool descriptions,
+    start in-app OAuth login for an unauthenticated server, or inspect a
+    failed server. Ctrl+R requests a reconnect, F2 on a server header
+    toggles its disabled state, and Escape closes the modal.
 
     Dismisses with `None` when closed without action, the server name to
     drive an in-TUI OAuth login when the user activates an
@@ -1101,7 +1218,7 @@ class MCPViewerScreen(ModalScreen[str | None]):
         """
         help_parts = [
             f"{glyphs.arrow_up}/{glyphs.arrow_down} navigate",
-            "Enter expand/login",
+            "Enter expand/login/details",
             "F2 disable/enable",
             "Ctrl+E expand all",
         ]
@@ -1341,13 +1458,22 @@ class MCPViewerScreen(ModalScreen[str | None]):
         self._move_to(target)
         self._reveal_selection(self._row_widgets[target], direction=1)
 
+    def show_server_error(self, server: MCPServerInfo) -> None:
+        """Open the read-only error detail modal for `server`.
+
+        Args:
+            server: Failed MCP server to inspect.
+        """
+        self.app.push_screen(MCPServerErrorScreen(server))
+
     def action_toggle_expand(self) -> None:
-        """Toggle expand on a tool row, or start login on an unauth header.
+        """Toggle expand on a tool row, log in, or show error details.
 
         Tool rows expand/collapse as before; activating a header row for
         a server in `unauthenticated` state dismisses the viewer with the
-        server name so the app can drive in-TUI OAuth login. Headers for
-        other states (ok, awaiting reconnect, error, disabled) remain no-ops.
+        server name so the app can drive in-TUI OAuth login. Activating an
+        `error` header opens a read-only detail modal. Headers for other
+        states (ok, awaiting reconnect, disabled) remain no-ops.
         """
         if not self._row_widgets:
             return
@@ -1362,6 +1488,9 @@ class MCPViewerScreen(ModalScreen[str | None]):
         server = row.server
         if server.needs_attention():
             self.dismiss(server.name)
+            return
+        if server.status == "error":
+            self.show_server_error(server)
 
     def action_toggle_all(self) -> None:
         """Expand or collapse every visible tool at once.

--- a/libs/code/tests/unit_tests/test_mcp_viewer.py
+++ b/libs/code/tests/unit_tests/test_mcp_viewer.py
@@ -2,13 +2,16 @@
 
 import asyncio
 
+import pytest
 from textual.app import App, ComposeResult
+from textual.notifications import Notification
 from textual.widget import Widget
 from textual.widgets import Static
 
 from deepagents_code.mcp_tools import MCPServerInfo, MCPToolInfo
 from deepagents_code.widgets.mcp_viewer import (
     MCP_VIEWER_RECONNECT_REQUEST,
+    MCPServerErrorScreen,
     MCPServerHeaderItem,
     MCPToolItem,
     MCPViewerScreen,
@@ -19,6 +22,12 @@ def _widget_text(widget: Widget) -> str:
     """Extract plain text content from a Static widget."""
     content = widget._Static__content  # type: ignore[attr-defined]
     return str(content)
+
+
+def _latest_notification(app: App[None]) -> Notification | None:
+    """Return the most recently raised toast, or `None` if there are none."""
+    notifications = list(app._notifications)
+    return notifications[-1] if notifications else None
 
 
 class MCPViewerTestApp(App[None]):
@@ -1359,8 +1368,29 @@ class TestMCPViewerScreen:
 
             assert dismissed_with == ["github"]
 
-    async def test_enter_on_error_header_is_noop(self) -> None:
-        """Activating an error-status header does not dismiss the viewer."""
+    async def test_error_header_hides_error_until_enter(self) -> None:
+        """Error headers show an affordance, not the raw exception text."""
+        app = MCPViewerTestApp()
+        async with app.run_test() as pilot:
+            screen = MCPViewerScreen(server_info=_mixed_status_info())
+            app.push_screen(screen)
+            await pilot.pause()
+
+            # Attention-needed states are floated to the top: github(0),
+            # notion(1), filesystem(2), read_file tool(3), broken(4).
+            for _ in range(4):
+                await pilot.press("down")
+                await pilot.pause()
+            header = screen._row_widgets[4]
+            assert isinstance(header, MCPServerHeaderItem)
+            assert header.server.name == "broken"
+
+            text = _widget_text(header)
+            assert "Enter for details" in text
+            assert "Connection refused" not in text
+
+    async def test_enter_on_error_header_opens_detail_modal(self) -> None:
+        """Activating an error-status header opens a detail modal."""
         app = MCPViewerTestApp()
         async with app.run_test() as pilot:
             dismissed_with: list[str | None] = []
@@ -1383,6 +1413,14 @@ class TestMCPViewerScreen:
             await pilot.pause()
 
             assert dismissed_with == []
+            assert isinstance(app.screen, MCPServerErrorScreen)
+            assert "Connection refused" in _widget_text(
+                app.screen.query_one(".mcp-error-text", Static)
+            )
+
+            await pilot.press("escape")
+            await pilot.pause()
+            assert app.screen is screen
 
     async def test_enter_on_awaiting_reconnect_header_is_noop(self) -> None:
         """Activating a pending-reconnect header does not restart login."""
@@ -1639,7 +1677,8 @@ class TestMCPViewerScreen:
 
             assert "broken" in err_text
             assert "error" in err_text
-            assert "Connection refused" in err_text
+            assert "Enter for details" in err_text
+            assert "Connection refused" not in err_text
 
             assert "paused" in disabled_text
             assert "disabled" in disabled_text
@@ -1696,9 +1735,147 @@ class TestMCPViewerScreen:
             assert len(headers) == 1
             text = _widget_text(headers[0])
             assert "<config:bad.json>" in text
-            assert "JSON decode failed" in text
+            assert "Enter for details" in text
+            assert "JSON decode failed" not in text
+
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert isinstance(app.screen, MCPServerErrorScreen)
+            assert "JSON decode failed" in _widget_text(
+                app.screen.query_one(".mcp-error-text", Static)
+            )
             # No tools to render — only the header line and the help footer.
             assert len(screen.query(".mcp-tool-item")) == 0
+
+    async def test_click_on_selected_error_header_opens_modal(self) -> None:
+        """Clicking an already-selected error header opens the detail modal."""
+        app = MCPViewerTestApp()
+        async with app.run_test() as pilot:
+            screen = MCPViewerScreen(server_info=_mixed_status_info())
+            app.push_screen(screen)
+            await pilot.pause()
+
+            # broken (error status) floats to index 4; see ordering note above.
+            # Move the cursor onto it so the click hits an already-selected row,
+            # the precondition the `on_click` error branch guards on.
+            for _ in range(4):
+                await pilot.press("down")
+                await pilot.pause()
+            header = screen._row_widgets[4]
+            assert isinstance(header, MCPServerHeaderItem)
+            assert header.server.name == "broken"
+            assert header._selected
+
+            await pilot.click(header)
+            await pilot.pause()
+            assert isinstance(app.screen, MCPServerErrorScreen)
+            assert "Connection refused" in _widget_text(
+                app.screen.query_one(".mcp-error-text", Static)
+            )
+
+    async def test_error_modal_copy_success_notifies(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The copy action writes the error and raises an info toast."""
+        copied: list[str] = []
+
+        def _fake_copy(_app: App[None], text: str) -> tuple[bool, str | None]:
+            copied.append(text)
+            return True, None
+
+        monkeypatch.setattr(
+            "deepagents_code.widgets.mcp_viewer.copy_text_to_clipboard",
+            _fake_copy,
+        )
+
+        server = MCPServerInfo(
+            name="broken",
+            transport="sse",
+            status="error",
+            error="Connection refused",
+        )
+        app = MCPViewerTestApp()
+        async with app.run_test() as pilot:
+            app.push_screen(MCPServerErrorScreen(server))
+            await pilot.pause()
+
+            await pilot.press("c")
+            await pilot.pause()
+
+            assert copied == ["Connection refused"]
+            toast = _latest_notification(app)
+            assert toast is not None
+            assert toast.message == "MCP error copied"
+            assert toast.severity == "information"
+
+    async def test_error_modal_copy_failure_notifies(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed copy surfaces a warning toast with the backend reason."""
+
+        def _fake_copy(_app: App[None], _text: str) -> tuple[bool, str | None]:
+            return False, "no clipboard backend"
+
+        monkeypatch.setattr(
+            "deepagents_code.widgets.mcp_viewer.copy_text_to_clipboard",
+            _fake_copy,
+        )
+
+        server = MCPServerInfo(
+            name="broken",
+            transport="sse",
+            status="error",
+            error="Connection refused",
+        )
+        app = MCPViewerTestApp()
+        async with app.run_test() as pilot:
+            app.push_screen(MCPServerErrorScreen(server))
+            await pilot.pause()
+
+            await pilot.press("c")
+            await pilot.pause()
+
+            toast = _latest_notification(app)
+            assert toast is not None
+            assert toast.message == "Failed to copy MCP error: no clipboard backend"
+            assert toast.severity == "warning"
+
+    async def test_error_modal_escape_dismisses(self) -> None:
+        """Escape closes the error modal without disturbing the parent."""
+        screen = MCPViewerScreen(server_info=_mixed_status_info())
+        server = MCPServerInfo(
+            name="broken",
+            transport="sse",
+            status="error",
+            error="Connection refused",
+        )
+        app = MCPViewerTestApp()
+        async with app.run_test() as pilot:
+            app.push_screen(screen)
+            await pilot.pause()
+            screen.show_server_error(server)
+            await pilot.pause()
+            assert isinstance(app.screen, MCPServerErrorScreen)
+
+            await pilot.press("escape")
+            await pilot.pause()
+            assert app.screen is screen
+
+    async def test_error_modal_falls_back_when_error_missing(self) -> None:
+        """A server without error text renders the placeholder message."""
+        # An `ok` server is the only way to obtain `error=None` — the
+        # `MCPServerInfo` invariant forbids a non-`ok` status without an
+        # error — so this exercises the modal's defensive fallback.
+        server = MCPServerInfo(name="filesystem", transport="stdio")
+        assert server.error is None
+        app = MCPViewerTestApp()
+        async with app.run_test() as pilot:
+            app.push_screen(MCPServerErrorScreen(server))
+            await pilot.pause()
+
+            body = app.screen.query_one(".mcp-error-text", Static)
+            assert "No error details were reported." in _widget_text(body)
 
     async def test_click_expands_tool(self) -> None:
         """Clicking a tool selects it and toggles expand."""
@@ -1842,45 +2019,6 @@ class TestModuleLevelHelpers:
         ]
         ordered = _sort_servers_for_display(info)
         assert [s.name for s in ordered] == ["alpha", "bravo"]
-
-    # --- _sanitize_inline ---
-
-    def test_sanitize_inline_plain_text_unchanged(self) -> None:
-        """Plain printable text is returned unchanged."""
-        from deepagents_code.widgets.mcp_viewer import _sanitize_inline
-
-        assert _sanitize_inline("Connection refused") == "Connection refused"
-
-    def test_sanitize_inline_strips_ansi_escapes(self) -> None:
-        """ANSI escape sequences are replaced with spaces."""
-        from deepagents_code.widgets.mcp_viewer import _sanitize_inline
-
-        result = _sanitize_inline("\x1b[31mred error\x1b[0m")
-        assert "\x1b" not in result
-        assert "red error" in result
-
-    def test_sanitize_inline_strips_newlines(self) -> None:
-        """Newlines are replaced with spaces."""
-        from deepagents_code.widgets.mcp_viewer import _sanitize_inline
-
-        result = _sanitize_inline("line one\nline two")
-        assert "\n" not in result
-
-    def test_sanitize_inline_truncates_long_text(self) -> None:
-        """Text longer than max_length is truncated with ellipsis."""
-        from deepagents_code.widgets.mcp_viewer import _sanitize_inline
-
-        long_text = "x" * 300
-        result = _sanitize_inline(long_text)
-        assert len(result) <= 200
-        assert result.endswith("…")
-
-    def test_sanitize_inline_custom_max_length(self) -> None:
-        """Custom max_length is respected."""
-        from deepagents_code.widgets.mcp_viewer import _sanitize_inline
-
-        result = _sanitize_inline("hello world", max_length=5)
-        assert len(result) <= 5
 
     # --- _visible_tools_for ---
 

--- a/libs/code/tests/unit_tests/test_unicode_security.py
+++ b/libs/code/tests/unit_tests/test_unicode_security.py
@@ -12,6 +12,7 @@ from deepagents_code.unicode_security import (
     iter_string_values,
     looks_like_url_key,
     render_with_unicode_markers,
+    sanitize_control_chars,
     strip_dangerous_unicode,
     summarize_issues,
 )
@@ -34,6 +35,74 @@ def test_detect_dangerous_unicode_finds_bidi_and_zero_width() -> None:
 def test_strip_dangerous_unicode_removes_hidden_chars() -> None:
     """Sanitizer should remove hidden controls and preserve visible text."""
     assert strip_dangerous_unicode("ap\u200bple") == "apple"
+
+
+def test_sanitize_control_chars_plain_text_unchanged() -> None:
+    """Plain printable text passes through untouched."""
+    assert sanitize_control_chars("Connection refused") == "Connection refused"
+
+
+def test_sanitize_control_chars_strips_ansi_escapes() -> None:
+    """ANSI escape sequences are replaced so they cannot reach the terminal."""
+    result = sanitize_control_chars("\x1b[31mred error\x1b[0m")
+    assert "\x1b" not in result
+    assert "red error" in result
+
+
+def test_sanitize_control_chars_removes_dangerous_unicode() -> None:
+    """Invisible/bidi code points are dropped, not merely spaced."""
+    result = sanitize_control_chars("safe\u200btext")
+    assert "\u200b" not in result
+    assert "safetext" in result
+
+
+def test_sanitize_control_chars_flattens_newlines_by_default() -> None:
+    """Newlines collapse to a single space when not explicitly kept."""
+    assert sanitize_control_chars("line one\nline two") == "line one line two"
+
+
+def test_sanitize_control_chars_keeps_newlines_when_requested() -> None:
+    """`keep_newlines` preserves line breaks for multiline surfaces."""
+    result = sanitize_control_chars(
+        "line one\nline two", keep_newlines=True, collapse_whitespace=False
+    )
+    assert result == "line one\nline two"
+
+
+def test_sanitize_control_chars_keeps_newlines_but_strips_other_controls() -> None:
+    """With `keep_newlines`, only newlines survive — escapes still go."""
+    result = sanitize_control_chars(
+        "a\x1b[2J\nb\x07c", keep_newlines=True, collapse_whitespace=False
+    )
+    assert "\x1b" not in result
+    assert "\x07" not in result
+    assert "\n" in result
+
+
+def test_sanitize_control_chars_collapse_preserves_lines_with_newlines() -> None:
+    """Per-line collapse trims intra-line runs while keeping line breaks."""
+    result = sanitize_control_chars(
+        "a   b\n  c  ", keep_newlines=True, collapse_whitespace=True
+    )
+    assert result == "a b\nc"
+
+
+def test_sanitize_control_chars_no_collapse_keeps_internal_spacing() -> None:
+    """Without collapsing, original spacing is retained."""
+    assert sanitize_control_chars("a   b", collapse_whitespace=False) == "a   b"
+
+
+def test_sanitize_control_chars_truncates_with_ellipsis() -> None:
+    """`max_length` bounds the output and marks truncation."""
+    result = sanitize_control_chars("x" * 300, max_length=200)
+    assert len(result) <= 200
+    assert result.endswith("…")
+
+
+def test_sanitize_control_chars_no_truncation_by_default() -> None:
+    """Without `max_length`, the full text survives."""
+    long_text = "x" * 300
+    assert sanitize_control_chars(long_text, collapse_whitespace=False) == long_text
 
 
 def test_render_with_unicode_markers_makes_hidden_chars_visible() -> None:


### PR DESCRIPTION
Failed MCP servers now keep noisy or raw errors out of the inline server list while still making full details accessible on demand. Shared Unicode and control-character sanitization is reused across MCP local context and UI rendering so terminal escapes and deceptive characters are handled consistently.