### PR TITLE
fix(code): pluralize singular MCP login splash text

### DIFF
--- a/libs/code/deepagents_code/widgets/welcome.py
+++ b/libs/code/deepagents_code/widgets/welcome.py
@@ -438,8 +438,9 @@ class WelcomeBanner(Static):
         warn_color: str = "bold yellow" if ansi else colors.warning
         if self._mcp_unauthenticated > 0:
             server_label = "server" if self._mcp_unauthenticated == 1 else "servers"
+            verb = "needs" if self._mcp_unauthenticated == 1 else "need"
             unauth_text = (
-                f"{self._mcp_unauthenticated} MCP {server_label} need login "
+                f"{self._mcp_unauthenticated} MCP {server_label} {verb} login "
                 "— open /mcp\n"
             )
             parts.extend(

--- a/libs/code/tests/unit_tests/test_welcome.py
+++ b/libs/code/tests/unit_tests/test_welcome.py
@@ -695,7 +695,7 @@ class TestMcpServerCounters:
         ):
             widget = WelcomeBanner(mcp_unauthenticated=1)
         plain = widget._build_banner().plain
-        assert "1 MCP server need login — open /mcp" in plain
+        assert "1 MCP server needs login — open /mcp" in plain
         assert "/mcp login" not in plain
 
     def test_errored_line_plural(self) -> None:
@@ -739,7 +739,7 @@ class TestMcpServerCounters:
                 mcp_awaiting_reconnect=1,
             )
         plain = widget._build_banner().plain
-        assert "need login" in plain
+        assert "needs login" in plain
         assert "failed to load" in plain
         assert "ready to load" in plain
 


### PR DESCRIPTION
The welcome banner now renders grammatically correct copy for a single unauthenticated MCP server. Plural server counts still use `need`, so both singular and plural counter lines read naturally.