### PR TITLE
fix(code): search all models from `/model` filter

### DIFF
--- a/libs/code/deepagents_code/widgets/model_selector.py
+++ b/libs/code/deepagents_code/widgets/model_selector.py
@@ -375,6 +375,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         Returns:
             Styled `Content` for the info line.
         """
+        if self._filter_text.strip():
+            return Content.styled("Searching all models from installed providers")
         if self._recommended_only:
             return Content.styled(
                 "Showing recommended models — Ctrl+R for all",
@@ -382,6 +384,13 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         return Content.styled(
             "Showing all models from installed providers — Ctrl+R for recommended",
         )
+
+    def _update_info_line(self) -> None:
+        """Refresh the standard selector info line."""
+        if self._curated:
+            return
+        info = self.query_one("#model-selector-info", Static)
+        info.update(self._info_line_content())
 
     def _help_text(self) -> str:
         """Build the footer help text.
@@ -621,6 +630,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             event: The input changed event.
         """
         self._filter_text = event.value
+        self._update_info_line()
         if not self._loaded:
             return  # on_mount will re-apply filter after data loads
         self._update_filtered_list()
@@ -647,7 +657,9 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
     def _update_filtered_list(self) -> None:
         """Update the filtered models based on search text using fuzzy matching.
 
-        Results are sorted by match score (best first).
+        Results are sorted by match score (best first). In standard `/model`
+        mode, non-empty searches span the full installed model list even when
+        the default view is currently constrained to recommended models.
         """
         query = self._filter_text.strip()
         if not query:
@@ -656,11 +668,12 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             return
 
         tokens = query.split()
+        search_models = self._all_models if self._curated else self._unfiltered_models
 
         try:
             matchers = [Matcher(token, case_sensitive=False) for token in tokens]
             scored: list[tuple[float, str, str]] = []
-            for spec, provider in self._all_models:
+            for spec, provider in search_models:
                 scores = [m.match(spec) for m in matchers]
                 if all(s > 0 for s in scores):
                     scored.append((min(scores), spec, provider))
@@ -671,7 +684,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 query,
                 exc_info=True,
             )
-            self._filtered_models = list(self._all_models)
+            self._filtered_models = list(search_models)
             self._selected_index = self._find_current_model_index()
             return
 

--- a/libs/code/tests/unit_tests/test_model_selector.py
+++ b/libs/code/tests/unit_tests/test_model_selector.py
@@ -253,6 +253,41 @@ class TestRecommendedToggle:
             info = screen.query_one("#model-selector-info", Static)
             assert "Showing recommended models" in str(info.content)
 
+    def test_search_uses_full_list_from_recommended_view(self) -> None:
+        """Typing a filter should search beyond the recommended subset."""
+        screen = ModelSelectorScreen()
+        screen._unfiltered_models = [
+            ("openai:gpt-5.5", "openai"),
+            ("openai:gpt-4o", "openai"),
+        ]
+        screen._all_models = screen._apply_subset(screen._unfiltered_models)
+
+        assert screen._recommended_only is True
+        assert screen._all_models == [("openai:gpt-5.5", "openai")]
+
+        screen._filter_text = "gpt-4o"
+        screen._update_filtered_list()
+
+        assert screen._filtered_models == [("openai:gpt-4o", "openai")]
+
+    async def test_info_line_reflects_active_search(self) -> None:
+        """Typing a filter should avoid stale recommended-only copy."""
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            screen = ModelSelectorScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+
+            info = screen.query_one("#model-selector-info", Static)
+            assert "Showing recommended models" in str(info.content)
+
+            for char in "gpt":
+                await pilot.press(char)
+            await pilot.pause()
+
+            assert "Searching all models" in str(info.content)
+            assert "Showing recommended models" not in str(info.content)
+
     async def test_toggle_expands_to_full_list(self) -> None:
         """Ctrl+R from the default recommended view should expand to all."""
         app = ModelSelectorTestApp()


### PR DESCRIPTION
The `/model` picker still opens on the recommended subset, but a non-empty filter now searches across every installed provider model. The modal info line also switches to search-specific copy so it does not claim only recommended models are shown while full-list filtering is active.