### PR TITLE
fix(code): repair MCP OAuth login redirect and stale client registration

### DIFF
--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -385,17 +385,8 @@ class FileTokenStorage(TokenStorage):
         if not redirect_uris:
             return None
         uri = str(redirect_uris[0])
-        parsed = urlparse(uri)
-        try:
-            port = parsed.port
-        except ValueError:
-            port = None
-        if (
-            parsed.scheme != "http"
-            or parsed.hostname != _LOOPBACK_URI_HOST
-            or parsed.path != _LOOPBACK_CALLBACK_PATH
-            or port is None
-        ):
+        port = self._loopback_callback_port(uri)
+        if port is None:
             logger.warning(
                 "Stored MCP OAuth redirect URI for %s is not a reusable "
                 "loopback callback URI; falling back to a fresh random port. "
@@ -406,6 +397,94 @@ class FileTokenStorage(TokenStorage):
             )
             return None
         return port
+
+    @staticmethod
+    def _loopback_callback_port(uri: str) -> int | None:
+        """Return `uri`'s port if it is a reusable loopback callback URI.
+
+        A reusable URI is `http://localhost:<port>/callback` with an explicit
+        port. Anything else (a different scheme/host/path, or a portless
+        `http://localhost/callback`) returns `None` because it cannot be paired
+        with the loopback callback server a CLI login binds.
+        """
+        parsed = urlparse(uri)
+        try:
+            port = parsed.port
+        except ValueError:
+            return None
+        if (
+            parsed.scheme != "http"
+            or parsed.hostname != _LOOPBACK_URI_HOST
+            or parsed.path != _LOOPBACK_CALLBACK_PATH
+            or port is None
+        ):
+            return None
+        return port
+
+    def discard_client_info_if_loopback_unusable(self) -> bool:
+        """Drop a persisted client registration that can't serve loopback login.
+
+        `stored_loopback_port` explains why the authorize request's
+        `redirect_uri` must match the one registered against the persisted
+        `client_id`. When that registered URI is not a reusable loopback
+        callback (e.g. a portless `http://localhost/callback` left by an earlier
+        non-loopback login), no port can be reused, so a CLI login binds a fresh
+        random port and the server rejects the mismatched `redirect_uri`
+        ("invalid or missing redirect_uri"). Removing the stale `client_info`
+        makes the SDK perform a fresh DCR with the loopback redirect URI it will
+        actually use.
+
+        Only discards when no token is persisted at all, so a session with a
+        usable (or refreshable) token is never downgraded to a full re-auth.
+        The presence check is deliberately conservative: it errs toward keeping
+        the registration, never toward deleting one that might still be needed.
+
+        Returns:
+            `True` if a stale client registration was removed. `False` covers
+                both "nothing to discard" and "could not discard" (an
+                unreadable or unwritable token file, logged where it happens).
+        """
+        try:
+            data = self._read()
+        except RuntimeError as exc:
+            # Mirror `stored_loopback_port`: a corrupt or unsupported-version
+            # token file carries actionable "delete the file" guidance in the
+            # `RuntimeError` message, so surface it rather than dropping it.
+            logger.warning(
+                "MCP token file for %s is unreadable while checking for a "
+                "stale client registration; skipping self-heal. Delete the "
+                "file and log in again if OAuth authorization fails: %s",
+                self.path,
+                exc,
+            )
+            return False
+        if data is None or "client_info" not in data:
+            return False
+        # A persisted access/refresh token can still authenticate (or refresh)
+        # without re-running the authorization-code grant, so leave the
+        # registration intact rather than forcing an avoidable re-auth.
+        if data.get("tokens") is not None:
+            return False
+        redirect_uris = (data.get("client_info") or {}).get("redirect_uris") or []
+        if (
+            redirect_uris
+            and self._loopback_callback_port(str(redirect_uris[0])) is not None
+        ):
+            return False
+        del data["client_info"]
+        try:
+            self._write(data)
+        except OSError as exc:
+            # Surface the failure but don't crash login: the stale registration
+            # simply remains, and the login attempt fails the same way it would
+            # have without this self-heal.
+            logger.warning(
+                "Could not remove stale MCP client registration in %s: %s",
+                self.path,
+                exc,
+            )
+            return False
+        return True
 
     def _read(self) -> dict | None:
         path = self.path
@@ -1178,6 +1257,22 @@ def build_oauth_provider(
                     if isinstance(storage, FileTokenStorage)
                     else None
                 )
+                # No reusable port means any persisted registration can't be
+                # paired with the random loopback port we're about to bind. Drop
+                # a stale registration so the handshake re-runs DCR with a
+                # matching redirect URI instead of failing with "invalid or
+                # missing redirect_uri".
+                if (
+                    stored is None
+                    and isinstance(storage, FileTokenStorage)
+                    and storage.discard_client_info_if_loopback_unusable()
+                ):
+                    logger.info(
+                        "Discarded a stale MCP client registration for %s "
+                        "whose redirect URI can't serve loopback login; the "
+                        "handshake will register a fresh client.",
+                        server_name,
+                    )
                 port = stored if stored is not None else _choose_loopback_port()
             callback_server = _LoopbackOAuthCallbackServer(port=port)
             redirect_uri = callback_server.redirect_uri

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -1108,8 +1108,30 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
                         type(exc).__name__,
                     )
 
-        async for flow_request in super().async_auth_flow(request):
-            yield flow_request
+        # Delegate to the SDK flow by manually pumping the inner generator so
+        # the HTTP responses httpx feeds back via `auth_flow.asend(response)`
+        # are forwarded into it. A plain `async for` would advance the inner
+        # generator with `__anext__()` (i.e. `asend(None)`), discarding every
+        # response — the SDK's `response = yield request` and refresh-path
+        # `yield refresh_request` would then see `None` and raise
+        # `AttributeError: 'NoneType' object has no attribute 'status_code'`,
+        # surfacing as the `ExceptionGroup` users hit on MCP OAuth login.
+        # httpx primes the flow with `__anext__()`, then drives it with
+        # `asend`/`aclose` (never `athrow`), so forwarding sent values and
+        # closing the inner generator on `GeneratorExit` is sufficient — no
+        # `athrow` forwarding needed.
+        inner = super().async_auth_flow(request)
+        try:
+            # Prime with `anext()` (no response to send yet); thereafter every
+            # resume carries httpx's response back in via `asend`.
+            flow_request = await anext(inner)
+            while True:
+                response = yield flow_request
+                flow_request = await inner.asend(response)
+        except StopAsyncIteration:
+            return
+        finally:
+            await inner.aclose()
 
 
 def build_oauth_provider(

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -1012,7 +1012,13 @@ class TestBuildOAuthProvider:
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """A non-loopback stored URI falls back to a fresh random port."""
+        """A non-loopback stored URI falls back to a fresh random port.
+
+        A token is seeded so the stale-registration self-heal is skipped
+        (`discard_client_info_if_loopback_unusable` only fires when no token is
+        persisted); that keeps this test focused on the random-port fallback,
+        distinct from `test_build_oauth_provider_clears_stale_portless_registration`.
+        """
         del fake_home
         from deepagents_code.mcp_auth import build_oauth_provider
 
@@ -1022,6 +1028,7 @@ class TestBuildOAuthProvider:
         )
         storage = FileTokenStorage("notion")
         asyncio.run(storage.set_client_info(_make_client_info()))  # localhost, no port
+        asyncio.run(storage.set_tokens(_make_tokens()))  # blocks self-heal discard
         provider = build_oauth_provider(
             server_name="notion",
             server_url="https://mcp.notion.com/mcp",
@@ -1414,6 +1421,117 @@ class TestFileTokenStorageExtras:
         assert "client_info" in data
         assert data["tokens"]["access_token"] == "at"
         assert data["client_info"]["client_id"] == "client-id"
+
+    async def test_discard_removes_portless_registration_without_tokens(
+        self, fake_home: Path
+    ) -> None:
+        """A portless loopback registration with no tokens is removed."""
+        del fake_home
+        storage = FileTokenStorage("notion")
+        await storage.set_client_info(_make_client_info())  # localhost, no port
+
+        assert storage.discard_client_info_if_loopback_unusable() is True
+        assert await storage.get_client_info() is None
+
+    async def test_discard_keeps_ported_loopback_registration(
+        self, fake_home: Path
+    ) -> None:
+        """A reusable ported loopback registration is left intact."""
+        del fake_home
+        storage = FileTokenStorage("notion")
+        await storage.set_client_info(_make_client_info_with_loopback(51208))
+
+        assert storage.discard_client_info_if_loopback_unusable() is False
+        assert await storage.get_client_info() is not None
+
+    async def test_discard_keeps_registration_when_tokens_present(
+        self, fake_home: Path
+    ) -> None:
+        """A still-usable token blocks discard so refresh isn't downgraded."""
+        del fake_home
+        storage = FileTokenStorage("notion")
+        # Portless registration, but a persisted token can still authenticate.
+        await storage.set_client_info(_make_client_info())
+        await storage.set_tokens(_make_tokens())
+
+        assert storage.discard_client_info_if_loopback_unusable() is False
+        assert await storage.get_client_info() is not None
+
+    async def test_discard_noop_without_client_info(self, fake_home: Path) -> None:
+        """No persisted registration means nothing to discard."""
+        del fake_home
+        storage = FileTokenStorage("notion")
+
+        assert storage.discard_client_info_if_loopback_unusable() is False
+
+    def test_discard_returns_false_and_warns_on_unreadable_file(
+        self, fake_home: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A corrupt token file is surfaced (not silently swallowed)."""
+        del fake_home
+        caplog.set_level(logging.WARNING, logger="deepagents_code.mcp_auth")
+        storage = FileTokenStorage("notion")
+        storage.path.parent.mkdir(parents=True)
+        storage.path.write_bytes(b"{not json")
+
+        assert storage.discard_client_info_if_loopback_unusable() is False
+        assert "unreadable while checking for a stale client registration" in (
+            caplog.text
+        )
+
+    async def test_discard_returns_false_and_keeps_file_when_write_fails(
+        self, fake_home: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A failed atomic write leaves the registration intact and warns."""
+        del fake_home
+        caplog.set_level(logging.WARNING, logger="deepagents_code.mcp_auth")
+        storage = FileTokenStorage("notion")
+        await storage.set_client_info(_make_client_info())  # portless, no tokens
+        # Occupy the temp path with a directory so the real atomic write fails
+        # with an OSError instead of replacing the token file — no mocks needed.
+        tmp = storage.path.with_suffix(storage.path.suffix + ".tmp")
+        tmp.mkdir()
+
+        assert storage.discard_client_info_if_loopback_unusable() is False
+        # The original registration must still be on disk.
+        assert await storage.get_client_info() is not None
+        assert "Could not remove stale MCP client registration" in caplog.text
+
+    def test_build_oauth_provider_clears_stale_portless_registration(
+        self,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Interactive loopback login drops a stale portless registration.
+
+        Regression: a portless `http://localhost/callback` registration (left
+        by an earlier non-loopback login) was reused with a fresh random port,
+        so the authorize request sent the stale `client_id` with a
+        redirect_uri it was never registered for and the server rejected it
+        with "invalid or missing redirect_uri". The build must instead discard
+        the registration so the handshake re-runs DCR with a matching URI.
+        """
+        del fake_home
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        monkeypatch.setattr(
+            "deepagents_code.mcp_auth._choose_loopback_port", lambda: 60001
+        )
+        storage = FileTokenStorage("notion")
+        asyncio.run(storage.set_client_info(_make_client_info()))  # localhost, no port
+
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+        )
+
+        # Stale registration gone, so the SDK will re-register via DCR.
+        assert asyncio.run(storage.get_client_info()) is None
+        # The authorize request will carry the freshly bound loopback URI.
+        metadata = provider.context.client_metadata
+        assert metadata.redirect_uris is not None
+        assert str(metadata.redirect_uris[0]) == "http://localhost:60001/callback"
 
 
 @pytest.fixture

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -451,6 +451,98 @@ class TestExpiryAwareOAuthClientProvider:
         assert provider.context.token_expiry_time is None
         assert provider.context.current_tokens is not None
 
+    async def test_delegated_flow_forwards_responses_into_sdk(
+        self,
+        fake_home: Path,
+    ) -> None:
+        """Responses sent into the outer flow reach the delegated SDK flow.
+
+        Regression test: the override used to delegate with `async for`, which
+        advances the inner SDK generator via `__anext__()` (`asend(None)`) and
+        discards the HTTP responses httpx feeds back through `asend(response)`.
+        The SDK's `response = yield request` then saw `None` and raised
+        `AttributeError: 'NoneType' object has no attribute 'status_code'`,
+        surfacing as the `ExceptionGroup` users hit on MCP OAuth login. With a
+        valid stored token the pre-emptive discovery branch is skipped, so the
+        first response forwarded is the one whose `status_code` the SDK reads.
+        """
+        del fake_home
+        import httpx
+
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        storage = FileTokenStorage("notion")
+        await storage.set_client_info(_make_client_info())
+        await storage.set_tokens(_make_tokens())
+
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+            interactive=False,
+        )
+        flow = provider.async_auth_flow(
+            httpx.Request("POST", "https://mcp.notion.com/mcp")
+        )
+
+        # The valid token is attached and the request is yielded unchanged.
+        first_request = await anext(flow)
+        assert first_request.headers["Authorization"] == "Bearer at"
+
+        # Feeding a 401 back must reach the SDK's `response.status_code` check
+        # and trigger metadata discovery — not raise AttributeError.
+        discovery_request = await flow.asend(httpx.Response(401, request=first_request))
+        assert "/.well-known/oauth-protected-resource" in str(discovery_request.url)
+        await flow.aclose()
+
+    async def test_delegated_flow_forwards_responses_on_every_iteration(
+        self,
+        fake_home: Path,
+    ) -> None:
+        """The pump loop forwards responses on every round-trip, not just one.
+
+        Guards against a regression that primes the inner generator correctly
+        but then reverts to discarding subsequent sends (e.g. back toward
+        `async for`): the SDK's protected-resource-metadata discovery walks
+        several URLs, sending a response into the delegated generator each
+        time. Each forwarded response must advance discovery to the next URL.
+        """
+        del fake_home
+        import httpx
+
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        storage = FileTokenStorage("notion")
+        await storage.set_client_info(_make_client_info())
+        await storage.set_tokens(_make_tokens())
+
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+            interactive=False,
+        )
+        flow = provider.async_auth_flow(
+            httpx.Request("POST", "https://mcp.notion.com/mcp")
+        )
+
+        first_request = await anext(flow)
+        # First forwarded response (401) advances to the path-scoped PRM URL.
+        prm_path_request = await flow.asend(httpx.Response(401, request=first_request))
+        assert str(prm_path_request.url).endswith(
+            "/.well-known/oauth-protected-resource/mcp"
+        )
+        # Second forwarded response (404) must also reach the SDK and advance
+        # discovery to the root PRM URL — proving the loop didn't stop after
+        # the first send.
+        prm_root_request = await flow.asend(
+            httpx.Response(404, request=prm_path_request)
+        )
+        assert str(prm_root_request.url).endswith(
+            "/.well-known/oauth-protected-resource"
+        )
+        await flow.aclose()
+
 
 class TestFindReauthRequired:
     """Tests for unwrapping nested re-auth errors."""


### PR DESCRIPTION
Two distinct bugs broke MCP OAuth login (e.g. Slack, LangSmith), both surfacing as a cryptic `ExceptionGroup` / `unhandled errors in a TaskGroup`. The first made every login crash before reaching the browser; the second rejected DCR logins with `invalid or missing redirect_uri` when a stale client registration was reused.