### PR TITLE
fix(code): reduce OAuth login modal noise

### DIFF
--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -960,6 +960,7 @@ def _make_loopback_handlers(
     """
     extras = dict(extra_auth_params or {})
     interaction = ui if ui is not None else _default_ui()
+    last_authorize_url: str | None = None
     _paste_redirect, paste_callback = _make_paste_back_handlers(
         extra_auth_params=extra_auth_params,
         ui=interaction,
@@ -969,7 +970,9 @@ def _make_loopback_handlers(
         import asyncio
         import webbrowser
 
+        nonlocal last_authorize_url
         final_url = _append_query_params(auth_url, extras) if extras else auth_url
+        last_authorize_url = final_url
 
         # Resolve a browser explicitly before opening so headless / SSH
         # environments fall through to paste-back without burning the
@@ -1008,9 +1011,6 @@ def _make_loopback_handlers(
             )
             await interaction.show_authorize_url(final_url, opened_in_browser=False)
             return
-        # Communicate the URL regardless of `webbrowser.open` returning
-        # success — headless setups can report success without actually
-        # rendering a browser, and users still need the paste-back URL.
         await interaction.show_authorize_url(final_url, opened_in_browser=True)
 
     async def callback() -> tuple[str, str | None]:
@@ -1020,6 +1020,11 @@ def _make_loopback_handlers(
             _LoopbackCallbackTimeoutError,
             _LoopbackCallbackUnavailableError,
         ) as exc:
+            if last_authorize_url is not None:
+                await interaction.show_authorize_url(
+                    last_authorize_url,
+                    opened_in_browser=False,
+                )
             await interaction.show_notice(
                 f"{exc}\nPaste the full callback URL instead.",
             )

--- a/libs/code/deepagents_code/widgets/mcp_login.py
+++ b/libs/code/deepagents_code/widgets/mcp_login.py
@@ -59,6 +59,7 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
     """
 
     BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("enter", "toggle_authorize_url", "Toggle URL", show=False),
         Binding("escape", "cancel", "Cancel", show=False, priority=True),
     ]
     """Esc unblocks the worker; the worker performs the actual shutdown.
@@ -111,7 +112,7 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
     }
 
     MCPLoginScreen .ml-history-line {
-        height: 1;
+        height: auto;
         color: $text-muted;
         padding: 0 1;
     }
@@ -156,6 +157,10 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
         self._help_widget: Static | None = None
         self._spinner = Spinner()
         self._spinner_timer: Timer | None = None
+        self._authorize_url: str | None = None
+        self._authorize_url_opened_in_browser = False
+        self._authorize_url_expanded = False
+        self._waiting_for_authorization = False
 
         # Each prompt method blocks on a fresh Future; cancellation completes
         # it with MCPLoginCancelledError so the worker unblocks rather than
@@ -164,6 +169,7 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
         self._cancelled = False
         self._done = False
         self._outcome: LoginOutcome | None = None
+        self._last_history_line: str | None = None
 
     @property
     def is_done(self) -> bool:
@@ -216,8 +222,17 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
             container.styles.border = ("ascii", colors.primary)
         self._spinner_timer = self.set_interval(0.1, self._tick_spinner)
 
-    def on_click(self, event: Click) -> None:  # noqa: PLR6301 - Textual handler
-        """Open style-embedded hyperlinks (the authorize and verification URLs)."""
+    def on_click(self, event: Click) -> None:
+        """Open style links, or expand/collapse the manual authorize URL."""
+        if (
+            event.widget is self._link_widget
+            and self._authorize_url is not None
+            and self._authorize_url_opened_in_browser
+            and not event.style.link
+        ):
+            self._toggle_authorize_url()
+            event.stop()
+            return
         open_style_link(event)
 
     # ------------------------------------------------------------------
@@ -225,21 +240,18 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
     # ------------------------------------------------------------------
 
     async def show_authorize_url(self, url: str, *, opened_in_browser: bool) -> None:
-        """Render the authorize URL as a clickable link with surrounding text."""
+        """Render browser-open status and only reveal the URL when needed."""
+        self._authorize_url = url
+        self._authorize_url_opened_in_browser = opened_in_browser
+        self._authorize_url_expanded = not opened_in_browser
+        self._waiting_for_authorization = opened_in_browser
         if opened_in_browser:
-            self._set_status(
-                f"Opened your browser to approve access for {self._server_name}.",
-            )
+            self._render_authorization_wait_status(self._spinner.next_frame())
         else:
-            self._set_status("Open the authorize URL below in a browser to continue.")
-        if self._link_widget is not None:
-            self._link_widget.display = True
-            self._link_widget.update(
-                Content.assemble(
-                    ("Authorize URL: ", "bold"),
-                    (url, TStyle(link=url, underline=True)),
-                ),
+            self._set_status(
+                f"Open the authorization URL manually to connect {self._server_name}.",
             )
+        self._render_authorize_url()
 
     async def request_callback_url(self) -> str:
         """Wait for the user to paste back the OAuth callback URL.
@@ -257,6 +269,7 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
         expires_in: int,
     ) -> None:
         """Render RFC 8628 device-code instructions inline."""
+        self._waiting_for_authorization = False
         self._set_status(
             f"Visit the URL below and enter the code (expires in {expires_in}s):",
         )
@@ -275,9 +288,10 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
         )
 
     async def show_success(self, message: str) -> None:
-        """Render a success status line and append it to the history pane."""
+        """Render a success status line without leaving OAuth fallback UI behind."""
+        self._waiting_for_authorization = False
+        self._hide_authorize_url()
         self._set_status(message)
-        self._append_history(message)
 
     async def show_notice(self, message: str) -> None:
         """Append a progress notice without disrupting the active prompt."""
@@ -285,6 +299,7 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
 
     async def show_error(self, message: str) -> None:
         """Render a fatal (flow-ending) error status line and history entry."""
+        self._waiting_for_authorization = False
         self._set_status(message)
         self._append_history(message)
 
@@ -292,16 +307,92 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
     # Internal helpers.
     # ------------------------------------------------------------------
 
+    def _hide_authorize_url(self) -> None:
+        """Hide any OAuth authorization URL or fallback affordance."""
+        self._authorize_url = None
+        self._authorize_url_opened_in_browser = False
+        self._authorize_url_expanded = False
+        self._waiting_for_authorization = False
+        self._render_authorize_url()
+        self._set_help("Esc to cancel")
+
+    def _toggle_authorize_url(self) -> None:
+        """Toggle the manual authorize URL when the fallback affordance is active."""
+        if (
+            self._pending_input is not None
+            or self._authorize_url is None
+            or not self._authorize_url_opened_in_browser
+        ):
+            return
+        self._authorize_url_expanded = not self._authorize_url_expanded
+        self._render_authorize_url()
+
+    def _render_authorize_url(self) -> None:
+        """Render the manual authorize URL affordance."""
+        if self._link_widget is None:
+            return
+        url = self._authorize_url
+        if url is None:
+            self._link_widget.display = False
+            self._link_widget.update("")
+            return
+        self._link_widget.display = True
+        glyphs = get_glyphs()
+        if self._authorize_url_opened_in_browser and not self._authorize_url_expanded:
+            self._link_widget.update(
+                Content.assemble(
+                    ("Having trouble? Show manual authorization URL ", "dim"),
+                    (glyphs.cursor, "dim"),
+                ),
+            )
+            self._set_help("Enter to show URL · Esc to cancel")
+            return
+        prefix = (
+            f"Having trouble? Hide manual authorization URL {glyphs.arrow_down}\n"
+            if self._authorize_url_opened_in_browser
+            else "Authorization URL:\n"
+        )
+        self._link_widget.update(
+            Content.assemble(
+                (prefix, "bold"),
+                (url, TStyle(link=url, underline=True)),
+            ),
+        )
+        if self._authorize_url_opened_in_browser:
+            self._set_help("Enter to hide URL · Esc to cancel")
+        else:
+            self._set_help("Esc to cancel")
+
+    def _render_authorization_wait_status(self, frame: str) -> None:
+        """Render the browser-opened waiting state with an animated status line."""
+        self._set_status(
+            f"We opened your browser to connect {self._server_name}.\n"
+            "Complete authorization there to continue.\n\n"
+            f"Status: {frame} Waiting…",
+        )
+
     def _set_status(self, message: str) -> None:
         """Update the top status line."""
         self._status = message
         if self._status_widget is not None:
             self._status_widget.update(Content.from_markup("$msg", msg=message))
 
+    def _set_help(self, message: str) -> None:
+        """Update the footer help text."""
+        if self._help_widget is not None:
+            self._help_widget.update(message)
+
+    def _hide_history(self) -> None:
+        """Hide the history pane for clean terminal states."""
+        if self._history_widget is not None:
+            self._history_widget.display = False
+        self._last_history_line = None
+
     def _append_history(self, line: str) -> None:
         """Append a line to the scrolling history pane."""
-        if self._history_widget is None:
+        if self._history_widget is None or line == self._last_history_line:
             return
+        self._last_history_line = line
         self._history_widget.display = True
         self._history_widget.mount(
             Static(line, classes="ml-history-line", markup=False)
@@ -356,6 +447,10 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
         if future is not None and not future.done():
             future.set_result(event.value)
 
+    def action_toggle_authorize_url(self) -> None:
+        """Toggle the manual authorize URL fallback via Enter."""
+        self._toggle_authorize_url()
+
     def action_cancel(self) -> None:
         """Cancel the login flow.
 
@@ -390,10 +485,15 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
             return
         self._done = True
         self._outcome = "success" if success else "failed"
+        self._stop_spinner_timer()
+        self._waiting_for_authorization = False
+        if success:
+            self._hide_authorize_url()
+            self._hide_history()
         if message is not None:
             self._set_status(message)
-            self._append_history(message)
-        self._stop_spinner_timer()
+            if not success:
+                self._append_history(message)
         glyphs = get_glyphs()
         marker = glyphs.checkmark if success else glyphs.error
         if self._title_widget is not None:
@@ -415,17 +515,10 @@ class MCPLoginScreen(ModalScreen[LoginOutcome]):
         self.set_timer(0.6, _deferred_dismiss)
 
     def _tick_spinner(self) -> None:
-        """Advance the title spinner while login is in progress."""
-        if self._done or self._title_widget is None:
+        """Advance the status-line spinner while waiting for browser auth."""
+        if self._done or not self._waiting_for_authorization:
             return
-        frame = self._spinner.next_frame()
-        self._title_widget.update(
-            Content.from_markup(
-                "MCP login: $name $frame",
-                name=self._server_name,
-                frame=frame,
-            )
-        )
+        self._render_authorization_wait_status(self._spinner.next_frame())
 
     def _stop_spinner_timer(self) -> None:
         if self._spinner_timer is not None:

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -1229,6 +1229,17 @@ class TestInstallExtraSubcommand:
             patch.object(sys, "argv", argv),
             patch.object(sys, "stdin", mock_stdin),
             patch("deepagents_code.main.check_cli_dependencies"),
+            # `cli_main` resolves `console` via a lazy `__getattr__` on
+            # `deepagents_code.config` that caches a single real `Console` in
+            # the module globals for the whole worker process. Left unpatched,
+            # the `--install` handler's `console.print(...)` calls run against
+            # that shared instance, so console/stdout state leaked by an earlier
+            # test in the same xdist worker can make `print` raise. The handler
+            # wraps the flow in a broad `except Exception` that turns any such
+            # error into `sys.exit(1)`, which would mask the intended refusal
+            # exit code. Patch with `create=True` so the mock is installed
+            # before the lazy import line runs.
+            patch("deepagents_code.config.console", MagicMock(), create=True),
             patch("deepagents_code.config._is_editable_install", return_value=editable),
             patch(
                 "deepagents_code.update_check.create_update_log_path",

--- a/libs/code/tests/unit_tests/test_mcp_login_modal.py
+++ b/libs/code/tests/unit_tests/test_mcp_login_modal.py
@@ -126,6 +126,74 @@ class TestMCPLoginScreen:
             link_text = str(screen._link_widget._Static__content)  # type: ignore[attr-defined]
             assert "https://example.test/auth" in link_text
 
+    async def test_browser_opened_authorize_url_is_collapsed(self) -> None:
+        """The happy path hides the raw authorize URL behind manual fallback."""
+        app = _LoginTestApp()
+        async with app.run_test() as pilot:
+            screen = MCPLoginScreen("slack")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            await screen.show_authorize_url(
+                "https://example.test/auth", opened_in_browser=True
+            )
+            await pilot.pause()
+
+            assert screen._link_widget is not None
+            assert screen._link_widget.display
+            link_text = str(screen._link_widget._Static__content)  # type: ignore[attr-defined]
+            assert "Show manual authorization URL" in link_text
+            assert "https://example.test/auth" not in link_text
+
+    async def test_enter_toggles_browser_opened_authorize_url(self) -> None:
+        """Enter expands and collapses the manual authorization URL fallback."""
+        app = _LoginTestApp()
+        async with app.run_test() as pilot:
+            screen = MCPLoginScreen("slack")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            await screen.show_authorize_url(
+                "https://example.test/auth", opened_in_browser=True
+            )
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert screen._link_widget is not None
+            link_text = str(screen._link_widget._Static__content)  # type: ignore[attr-defined]
+            assert "Hide manual authorization URL" in link_text
+            assert "https://example.test/auth" in link_text
+
+            await pilot.press("enter")
+            await pilot.pause()
+            link_text = str(screen._link_widget._Static__content)  # type: ignore[attr-defined]
+            assert "Show manual authorization URL" in link_text
+            assert "https://example.test/auth" not in link_text
+
+    async def test_browser_wait_spinner_animates_status_not_title(self) -> None:
+        """The browser-wait spinner advances in the status line, not the title."""
+        app = _LoginTestApp()
+        async with app.run_test() as pilot:
+            screen = MCPLoginScreen("slack")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            await screen.show_authorize_url(
+                "https://example.test/auth", opened_in_browser=True
+            )
+            assert screen._status_widget is not None
+            assert screen._title_widget is not None
+            status_before = str(screen._status_widget._Static__content)  # type: ignore[attr-defined]
+            title_before = str(screen._title_widget._Static__content)  # type: ignore[attr-defined]
+
+            screen._tick_spinner()
+            status_after = str(screen._status_widget._Static__content)  # type: ignore[attr-defined]
+            title_after = str(screen._title_widget._Static__content)  # type: ignore[attr-defined]
+
+            assert status_before != status_after
+            assert "Status:" in status_after
+            assert title_after == title_before
+
     async def test_device_code_renders_user_code(self) -> None:
         """`show_device_code` displays the user code and verification URL."""
         app = _LoginTestApp()
@@ -146,7 +214,7 @@ class TestMCPLoginScreen:
             assert "ABCD-1234" in link_text
 
     async def test_show_success_does_not_leak_tokens(self) -> None:
-        """Tokens passed by mistake stay only in the status line history."""
+        """Tokens passed by mistake stay only in the status line."""
         app = _LoginTestApp()
         async with app.run_test() as pilot:
             screen = MCPLoginScreen("notion")
@@ -155,11 +223,46 @@ class TestMCPLoginScreen:
 
             # Caller is responsible for not leaking; we assert the modal
             # does not also paste the message into the authorize-URL slot.
+            await screen.show_authorize_url(
+                "https://example.test/auth", opened_in_browser=True
+            )
             await screen.show_success("Logged in to 'notion'.")
             await pilot.pause()
             assert screen._link_widget is not None
+            assert not screen._link_widget.display
             link_text = str(screen._link_widget._Static__content)  # type: ignore[attr-defined]
             assert "Logged in" not in link_text
+            assert screen._history_widget is not None
+            assert not screen._history_widget.display
+
+    async def test_finish_success_hides_history_and_auth_fallback(self) -> None:
+        """Clean success leaves only the final status message visible."""
+        app = _LoginTestApp()
+        async with app.run_test() as pilot:
+            screen = MCPLoginScreen("langsmith")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            await screen.show_authorize_url(
+                "https://example.test/auth", opened_in_browser=True
+            )
+            await screen.show_success("Logged in to MCP server 'langsmith'.")
+            screen.finish(
+                success=True,
+                message=(
+                    "Logged in to 'langsmith'. "
+                    "Reconnect required to load new tools."
+                ),
+            )
+            await pilot.pause()
+
+            assert screen._link_widget is not None
+            assert not screen._link_widget.display
+            assert screen._history_widget is not None
+            assert not screen._history_widget.display
+            assert screen._status_widget is not None
+            status_text = str(screen._status_widget._Static__content)  # type: ignore[attr-defined]
+            assert "Reconnect required" in status_text
 
 
 class TestMCPLoginScreenWithLoginCoroutine:

--- a/libs/code/tests/unit_tests/test_mcp_login_modal.py
+++ b/libs/code/tests/unit_tests/test_mcp_login_modal.py
@@ -250,8 +250,7 @@ class TestMCPLoginScreen:
             screen.finish(
                 success=True,
                 message=(
-                    "Logged in to 'langsmith'. "
-                    "Reconnect required to load new tools."
+                    "Logged in to 'langsmith'. Reconnect required to load new tools."
                 ),
             )
             await pilot.pause()


### PR DESCRIPTION
OAuth login in the TUI now keeps the happy path focused on the browser handoff instead of dumping the full authorization URL into the modal. Manual authorization is still available for fallback cases, and terminal success states are cleaned up so users do not see duplicate or truncated log output.

## Changes
- Hide the raw OAuth authorize URL when `MCPLoginScreen.show_authorize_url` successfully opens a browser, replacing it with a collapsed "Having trouble? Show manual authorization URL" affordance.
- Add keyboard support for the manual URL fallback via `Enter`, alongside click-to-toggle behavior, with footer help text that reflects whether the URL is currently shown.
- Move the OAuth waiting spinner out of the modal title and into the `Status:` line, so the title remains stable while browser authorization is pending.
- Reveal the authorize URL again when loopback OAuth falls back after timeout or callback-server unavailability by retaining the last generated URL in `_make_loopback_handlers`.
- Clean up success rendering by hiding stale authorize fallback UI, suppressing the history pane for clean success states, skipping duplicate consecutive history lines, and allowing history entries to wrap when they are shown.