### PR TITLE
feat(code): list valid extras when `/install` has no argument

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3349,9 +3349,13 @@ class DeepAgentsApp(App):
         force = "--force" in parts[1:]
         extras = [p for p in parts[1:] if not p.startswith("-")]
         if not extras:
+            from deepagents_code.extras_info import format_known_extras
+
             await self._mount_message(
                 AppMessage(
-                    "Usage: /install <extra> [--force]\nExample: /install quickjs",
+                    "Usage: /install <extra> [--force]\n"
+                    "Example: /install quickjs\n\n"
+                    f"{format_known_extras()}",
                 ),
             )
             return

--- a/libs/code/deepagents_code/extras_info.py
+++ b/libs/code/deepagents_code/extras_info.py
@@ -84,6 +84,31 @@ model-provider-drift checks; new extras must be added to the corresponding
 category frozenset above.
 """
 
+
+def format_known_extras() -> str:
+    """Render the installable extras grouped by category as plain text.
+
+    Drives the no-argument `/install` slash-command help so users can
+    discover valid extras without consulting `pyproject.toml`. Sourced from
+    the category frozensets above, so it stays in sync with `KNOWN_EXTRAS`
+    automatically.
+
+    Returns:
+        Multi-line string with one labeled line per category, each listing
+            its extras alphabetically.
+    """
+    groups: tuple[tuple[str, frozenset[str]], ...] = (
+        ("Model providers", MODEL_PROVIDER_EXTRAS),
+        ("Sandboxes", SANDBOX_EXTRAS),
+        ("Other", STANDALONE_EXTRAS),
+    )
+    lines = ["Available extras:"]
+    lines.extend(
+        f"  {label}: {', '.join(sorted(extras))}" for label, extras in groups if extras
+    )
+    return "\n".join(lines)
+
+
 ExtrasStatus = dict[str, list[tuple[str, str]]]
 """Mapping from extra name to `(package, installed_version)` tuples.
 

--- a/libs/code/tests/unit_tests/test_extras_info.py
+++ b/libs/code/tests/unit_tests/test_extras_info.py
@@ -16,6 +16,7 @@ from deepagents_code.extras_info import (
     extra_for_package,
     format_extras_status,
     format_extras_status_plain,
+    format_known_extras,
     get_extras_status,
     get_optional_dependency_status,
     verify_interpreter_deps,
@@ -267,6 +268,39 @@ def test_extras_categories_are_disjoint() -> None:
     )
     for label, overlap in pairs:
         assert not overlap, f"Extras classified twice in {label}: {sorted(overlap)}"
+
+
+def _parse_known_extras(rendered: str) -> dict[str, list[str]]:
+    """Parse `format_known_extras` output into `{label: [extras]}`.
+
+    Lets tests assert per-line grouping and ordering rather than matching
+    substrings against the whole blob, which would pass even if extras were
+    rendered under the wrong category or all collapsed onto one line.
+    """
+    groups: dict[str, list[str]] = {}
+    for line in rendered.splitlines()[1:]:  # skip the "Available extras:" header
+        label, _, extras = line.strip().partition(": ")
+        groups[label] = extras.split(", ")
+    return groups
+
+
+def test_format_known_extras_lists_exactly_known_extras() -> None:
+    """The listing must contain every `KNOWN_EXTRAS` member and nothing else."""
+    rendered = format_known_extras()
+    assert rendered.startswith("Available extras:")
+    groups = _parse_known_extras(rendered)
+    rendered_extras = {extra for extras in groups.values() for extra in extras}
+    # Bidirectional: catches both a new category left out of the listing and a
+    # listing that drifts ahead of `KNOWN_EXTRAS`.
+    assert rendered_extras == set(KNOWN_EXTRAS)
+
+
+def test_format_known_extras_groups_extras_under_correct_label() -> None:
+    """Each category renders under its own label with alphabetical ordering."""
+    groups = _parse_known_extras(format_known_extras())
+    assert groups["Model providers"] == sorted(MODEL_PROVIDER_EXTRAS)
+    assert groups["Sandboxes"] == sorted(SANDBOX_EXTRAS)
+    assert groups["Other"] == sorted(STANDALONE_EXTRAS)
 
 
 # `verify_interpreter_deps` does a lazy `from deepagents_code.config import

--- a/libs/code/tests/unit_tests/test_install_command.py
+++ b/libs/code/tests/unit_tests/test_install_command.py
@@ -13,7 +13,7 @@ from deepagents_code.widgets.messages import AppMessage, ErrorMessage
 
 
 async def test_install_slash_usage_when_no_extra() -> None:
-    """`/install` with no argument prints a usage hint, no install attempt."""
+    """`/install` with no argument prints a usage hint plus the valid extras."""
     app = DeepAgentsApp()
     async with app.run_test() as pilot:
         await pilot.pause()
@@ -25,7 +25,13 @@ async def test_install_slash_usage_when_no_extra() -> None:
             await pilot.pause()
         perform_mock.assert_not_awaited()
         app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
-        assert any("Usage: /install" in str(m._content) for m in app_msgs)
+        usage = next(m for m in app_msgs if "Usage: /install" in str(m._content))
+        rendered = str(usage._content)
+        # The no-arg path must list valid extras so they're discoverable.
+        assert "Available extras:" in rendered
+        assert "quickjs" in rendered
+        assert "daytona" in rendered
+        assert "openai" in rendered
 
 
 async def test_install_slash_known_extra_runs() -> None:


### PR DESCRIPTION
Running `/install` in dcode with no argument previously printed only `Usage: /install <extra> [--force]`, leaving users to guess which extras exist or dig through `pyproject.toml`. The no-arg path now renders the full set of installable extras grouped by category, so discovery happens inline.