### PR TITLE
feat: add volatile_system_suffix to control prompt-cache breakpoint placement

### DIFF
--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -12,6 +12,7 @@ from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemPer
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.rubric import RubricMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
+from deepagents.middleware.volatile_system_suffix import VolatileSystemSuffixMiddleware
 from deepagents.profiles.harness.harness_profiles import (
     GeneralPurposeSubagentProfile,
     HarnessProfile,
@@ -41,6 +42,7 @@ __all__ = [
     "SubAgentMiddleware",
     "SubagentRunStream",
     "SubagentTransformer",
+    "VolatileSystemSuffixMiddleware",
     "__version__",
     "create_deep_agent",
     "register_harness_profile",

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -16,7 +16,7 @@ from langchain.agents.structured_output import ResponseFormat
 from langchain_anthropic import ChatAnthropic
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AnyMessage, SystemMessage
+from langchain_core.messages import AnyMessage, ContentBlock, SystemMessage
 from langchain_core.tools import BaseTool
 from langgraph.cache.base import BaseCache
 from langgraph.channels.delta import DeltaChannel
@@ -51,6 +51,7 @@ from deepagents.middleware.subagents import (
     SubAgentMiddleware,
 )
 from deepagents.middleware.summarization import create_summarization_middleware
+from deepagents.middleware.volatile_system_suffix import VolatileSystemSuffixMiddleware
 from deepagents.profiles.harness.harness_profiles import (
     GeneralPurposeSubagentProfile,
     _apply_profile_prompt,
@@ -223,6 +224,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     subagents: Sequence[SubAgent | CompiledSubAgent | AsyncSubAgent] | None = None,
     skills: list[str] | None = None,
     memory: list[str] | None = None,
+    volatile_system_suffix: str | list[ContentBlock] | None = None,
     permissions: list[FilesystemPermission] | None = None,
     backend: BackendProtocol | BackendFactory | None = None,
     interrupt_on: dict[str, bool | InterruptOnConfig] | None = None,
@@ -332,6 +334,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             - [`AnthropicPromptCachingMiddleware`][langchain_anthropic.middleware.AnthropicPromptCachingMiddleware] (unconditional; no-ops for
                 non-Anthropic models)
             - [`MemoryMiddleware`][deepagents.middleware.memory.MemoryMiddleware] (if `memory` is provided)
+            - [`VolatileSystemSuffixMiddleware`][deepagents.middleware.volatile_system_suffix.VolatileSystemSuffixMiddleware]
+                (if `volatile_system_suffix` is provided)
             - [`HumanInTheLoopMiddleware`][langchain.agents.middleware.HumanInTheLoopMiddleware] (if `interrupt_on` is provided)
 
             After assembly, any entries in the profile's
@@ -396,6 +400,25 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             Display names are automatically derived from paths.
 
             Memory is loaded at agent startup and added into the system prompt.
+        volatile_system_suffix: Volatile content to append as the final system
+            content block, *after* the Anthropic prompt-cache breakpoint.
+
+            Use this for per-turn context that belongs in the system prompt but
+            must stay out of the cached prefix — the current date, the
+            signed-in user's identity, and similar values that change every
+            turn. Placing such content last *without* a breakpoint keeps the
+            stable prefix (base prompt, and `AGENTS.md` when `memory` is set)
+            cacheable while the volatile block trails it uncached.
+
+            Pass a `str` to append a single trailing text block, or a list of
+            content blocks to append verbatim. The block is never tagged with
+            `cache_control`; on non-Anthropic models it is simply serialized as
+            the last part of the system instruction. Applies to the main agent
+            and its subagents.
+
+            The content is inserted as system-role text verbatim. Callers
+            folding in user-controlled data should wrap it in explicit boundary
+            markers (e.g. `<user_context>...</user_context>`).
         permissions: List of `FilesystemPermission` rules for the main agent
             and its subagents.
 
@@ -607,6 +630,9 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
             # Prompt caching
             subagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
+            if volatile_system_suffix is not None:
+                # Innermost: trails the caching breakpoint with an uncached block.
+                subagent_middleware.append(VolatileSystemSuffixMiddleware(volatile_system_suffix))
 
             _subagent_matched_classes: set[type[AgentMiddleware[Any, Any, Any]]] = set()
             _subagent_matched_names: set[str] = set()
@@ -678,6 +704,9 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             gp_middleware.append(_ToolExclusionMiddleware(excluded=_profile.excluded_tools))
         # Prompt caching is unconditional: "ignore" silently skips non-Anthropic models
         gp_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
+        if volatile_system_suffix is not None:
+            # Innermost: trails the caching breakpoint with an uncached block.
+            gp_middleware.append(VolatileSystemSuffixMiddleware(volatile_system_suffix))
 
         gp_middleware = _apply_excluded_middleware(
             gp_middleware,
@@ -767,6 +796,10 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 add_cache_control=True,
             )
         )
+    if volatile_system_suffix is not None:
+        # Innermost system-prompt middleware: runs after the caching and memory
+        # breakpoints so the volatile block trails the cached prefix uncached.
+        deepagent_middleware.append(VolatileSystemSuffixMiddleware(volatile_system_suffix))
     if interrupt_on is not None:
         deepagent_middleware.append(HumanInTheLoopMiddleware(interrupt_on=interrupt_on))
     deepagent_middleware = _apply_excluded_middleware(

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -70,6 +70,7 @@ from deepagents.middleware.summarization import (
     SummarizationToolMiddleware,
     create_summarization_tool_middleware,
 )
+from deepagents.middleware.volatile_system_suffix import VolatileSystemSuffixMiddleware
 
 __all__ = [
     "GRADER_SYSTEM_PROMPT",
@@ -94,5 +95,6 @@ __all__ = [
     "SubAgentMiddleware",
     "SummarizationMiddleware",
     "SummarizationToolMiddleware",
+    "VolatileSystemSuffixMiddleware",
     "create_summarization_tool_middleware",
 ]

--- a/libs/deepagents/deepagents/middleware/volatile_system_suffix.py
+++ b/libs/deepagents/deepagents/middleware/volatile_system_suffix.py
@@ -1,0 +1,138 @@
+"""Middleware that appends a volatile (un-cached) trailing system block.
+
+## Overview
+
+Anthropic prompt caching works by tagging a content block with
+`cache_control`; everything up to and including that block forms the cached
+prefix. `AnthropicPromptCachingMiddleware` (and, when memory is configured,
+`MemoryMiddleware`) place that breakpoint on the *last* system content block.
+
+That is the wrong place for content that changes every turn -- the current
+date, the signed-in user's identity, and similar per-request context. If such
+content is the last block, it carries the breakpoint and shifts on every turn,
+invalidating the prefix cache.
+
+`VolatileSystemSuffixMiddleware` solves this by appending the volatile content
+as a trailing system block *without* `cache_control`. Wired innermost by
+`create_deep_agent` (after `AnthropicPromptCachingMiddleware` and
+`MemoryMiddleware`), it runs last, so the breakpoint those middlewares set
+stays on the stable block (the base prompt, or `AGENTS.md` when memory is
+configured) and the volatile block simply trails it, outside the cached prefix.
+
+## Usage
+
+```python
+from deepagents import create_deep_agent
+
+agent = create_deep_agent(
+    model="anthropic:claude-sonnet-4-6",
+    volatile_system_suffix="Current date: 2026-06-01. You are speaking with Ada.",
+)
+```
+
+## Trust boundary
+
+The suffix is appended verbatim as system-role content. Callers that fold in
+user-controlled data (names, emails, free text) are responsible for wrapping it
+in explicit boundary markers (e.g. `<user_context>...</user_context>`) so the
+model treats it as reference material rather than instructions.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    ModelRequest,
+    ModelResponse,
+)
+from langchain_core.messages import ContentBlock, SystemMessage
+
+from deepagents.middleware._utils import append_to_system_message
+
+
+class VolatileSystemSuffixMiddleware(AgentMiddleware):
+    """Append a trailing system content block that is never cached.
+
+    Designed to run innermost -- after `AnthropicPromptCachingMiddleware` and
+    `MemoryMiddleware` -- so the prompt-cache breakpoint they set stays on the
+    stable block and the volatile block trails it without `cache_control`.
+
+    The middleware never adds `cache_control` itself, so the appended content is
+    always outside the cached prefix regardless of the model provider. On
+    non-Anthropic models no caching metadata exists at all and the block is
+    simply serialized as the final part of the single system instruction.
+    """
+
+    def __init__(self, suffix: str | list[ContentBlock]) -> None:
+        """Initialize the middleware.
+
+        Args:
+            suffix: Volatile content to append after the cache breakpoint.
+
+                A `str` is appended as a single trailing text block (separated
+                from existing content by a blank line). A `list` of content
+                blocks is appended verbatim, in order, as the trailing blocks.
+
+                An empty string or empty list is a no-op.
+        """
+        self._suffix = suffix
+
+    def modify_request(self, request: ModelRequest) -> ModelRequest:
+        """Append the volatile suffix as the final system content block(s).
+
+        Args:
+            request: Model request to modify.
+
+        Returns:
+            Request whose system message ends with the volatile suffix, or the
+            original request unchanged when the suffix is empty.
+        """
+        suffix = self._suffix
+        if not suffix:
+            return request
+
+        if isinstance(suffix, str):
+            new_system_message = append_to_system_message(request.system_message, suffix)
+        else:
+            blocks: list[ContentBlock] = list(request.system_message.content_blocks) if request.system_message else []
+            blocks.extend(suffix)
+            new_system_message = SystemMessage(content_blocks=blocks)
+
+        return request.override(system_message=new_system_message)
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse:
+        """Append the volatile suffix before delegating to the handler.
+
+        Args:
+            request: Model request being processed.
+            handler: Handler function to call with the modified request.
+
+        Returns:
+            Model response from the handler.
+        """
+        return handler(self.modify_request(request))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        """Append the volatile suffix before delegating to the async handler.
+
+        Args:
+            request: Model request being processed.
+            handler: Async handler function to call with the modified request.
+
+        Returns:
+            Model response from the handler.
+        """
+        return await handler(self.modify_request(request))

--- a/libs/deepagents/tests/unit_tests/middleware/test_volatile_system_suffix_graph.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_volatile_system_suffix_graph.py
@@ -1,0 +1,218 @@
+"""End-to-end tests for `create_deep_agent(volatile_system_suffix=...)`.
+
+These verify the assembled middleware stack so the prompt-cache breakpoint
+lands where intended:
+
+1. With a suffix set, the breakpoint is on the stable block, NOT the suffix.
+2. The suffix is the last system content block.
+3. Backward compat: with the param unset, breakpoint placement is unchanged.
+4. The `AGENTS.md`/memory breakpoint is preserved when memory is configured.
+5. Non-Anthropic models add no `cache_control`; the suffix still trails.
+
+Plus that the middleware is wired into all three agent stacks (main agent and
+both subagent builders).
+"""
+
+from pathlib import Path
+
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.graph import create_deep_agent
+from deepagents.middleware import volatile_system_suffix as vss_module
+from tests.unit_tests.chat_model import GenericFakeChatModel
+
+_VOLATILE = "Current date: 2026-06-01. You are speaking with Ada."
+
+
+def _make_capturing_anthropic(captured: list[SystemMessage], responses: list[AIMessage] | None = None) -> ChatAnthropic:
+    """A `ChatAnthropic` whose `_generate` records system messages and returns scripted replies."""
+    reply_iter = iter(responses or [AIMessage(content="ok")])
+
+    class _CapturingAnthropic(ChatAnthropic):
+        def _generate(self, messages: list, *args: object, **kwargs: object) -> ChatResult:
+            captured.extend(m for m in messages if isinstance(m, SystemMessage))
+            try:
+                message = next(reply_iter)
+            except StopIteration:
+                message = AIMessage(content="ok")
+            return ChatResult(generations=[ChatGeneration(message=message)])
+
+    return _CapturingAnthropic(model_name="claude-sonnet-4-6", anthropic_api_key="fake")  # type: ignore[call-arg]
+
+
+# --- 1 & 2: breakpoint on stable block, suffix is last ----------------------
+
+
+def test_breakpoint_on_stable_block_not_volatile_suffix() -> None:
+    """With a suffix, the cache breakpoint stays on the base prompt; the suffix trails uncached."""
+    captured: list[SystemMessage] = []
+    agent = create_deep_agent(model=_make_capturing_anthropic(captured), volatile_system_suffix=_VOLATILE)
+    agent.invoke({"messages": [HumanMessage(content="hi")]})
+
+    assert captured, "Model never received a SystemMessage"
+    blocks = captured[0].content_blocks
+
+    # Suffix is the final block...
+    assert _VOLATILE in blocks[-1].get("text", "")
+    assert "cache_control" not in blocks[-1]
+    # ...and the breakpoint is on the stable block before it.
+    assert blocks[-2].get("cache_control", {}).get("type") == "ephemeral"
+
+
+# --- 3: backward compatibility ----------------------------------------------
+
+
+def test_without_volatile_suffix_breakpoint_unchanged() -> None:
+    """Unset param leaves the breakpoint on the last (stable) block, as before."""
+    captured: list[SystemMessage] = []
+    agent = create_deep_agent(model=_make_capturing_anthropic(captured))
+    agent.invoke({"messages": [HumanMessage(content="hi")]})
+
+    assert captured, "Model never received a SystemMessage"
+    blocks = captured[0].content_blocks
+    assert blocks[-1].get("cache_control", {}).get("type") == "ephemeral"
+
+
+# --- 4: memory breakpoint preserved -----------------------------------------
+
+
+def test_memory_breakpoint_preserved_with_volatile_suffix(tmp_path: Path) -> None:
+    """With memory configured, both the base and AGENTS.md breakpoints survive; suffix trails."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+    memory_path = str(tmp_path / "AGENTS.md")
+    backend.upload_files([(memory_path, b"# Memory\nBe concise.")])
+
+    captured: list[SystemMessage] = []
+    agent = create_deep_agent(
+        backend=backend,
+        memory=[memory_path],
+        model=_make_capturing_anthropic(captured),
+        volatile_system_suffix=_VOLATILE,
+    )
+    agent.invoke({"messages": [HumanMessage(content="hi")]})
+
+    assert captured, "Model never received a SystemMessage"
+    blocks = captured[0].content_blocks
+
+    # Volatile suffix is last and uncached.
+    assert _VOLATILE in blocks[-1].get("text", "")
+    assert "cache_control" not in blocks[-1]
+    # The AGENTS.md memory block keeps its breakpoint (Memory middleware)...
+    assert "<agent_memory>" in blocks[-2].get("text", "")
+    assert blocks[-2].get("cache_control", {}).get("type") == "ephemeral"
+    # ...and the stable prefix keeps its breakpoint (AnthropicPromptCachingMiddleware
+    # tags the last stable block, which sits just before the memory block).
+    assert blocks[-3].get("cache_control", {}).get("type") == "ephemeral"
+
+
+# --- 5: non-Anthropic provider ----------------------------------------------
+
+
+def test_non_anthropic_no_cache_control_suffix_trails() -> None:
+    """Non-Anthropic models get the suffix as the trailing block and no cache_control anywhere."""
+    model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+    agent = create_deep_agent(model=model, volatile_system_suffix=_VOLATILE)
+    agent.invoke({"messages": [HumanMessage(content="hi")]})
+
+    assert model.call_history, "Model was never called"
+    system_messages = [m for m in model.call_history[0]["messages"] if isinstance(m, SystemMessage)]
+    assert system_messages, "Model never received a SystemMessage"
+    blocks = system_messages[0].content_blocks
+
+    assert _VOLATILE in blocks[-1].get("text", "")
+    assert all("cache_control" not in block for block in blocks)
+
+
+# --- wiring into all three stacks -------------------------------------------
+
+
+def test_wired_into_main_and_both_subagent_stacks(monkeypatch) -> None:
+    """The middleware is constructed once for the main agent and once per subagent builder."""
+    suffixes: list[object] = []
+    original_init = vss_module.VolatileSystemSuffixMiddleware.__init__
+
+    def spy_init(self: object, suffix: object) -> None:
+        suffixes.append(suffix)
+        original_init(self, suffix)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(vss_module.VolatileSystemSuffixMiddleware, "__init__", spy_init)
+
+    create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([AIMessage(content="ok")])),
+        volatile_system_suffix=_VOLATILE,
+        subagents=[
+            {
+                "name": "researcher",
+                "description": "Researches things.",
+                "system_prompt": "You are a researcher.",
+            }
+        ],
+    )
+
+    # Main agent + auto-added general-purpose subagent + the declared inline subagent.
+    assert len(suffixes) == 3
+    assert all(s == _VOLATILE for s in suffixes)
+
+
+def test_not_wired_when_suffix_unset(monkeypatch) -> None:
+    """No middleware is constructed when the param is unset."""
+    suffixes: list[object] = []
+    original_init = vss_module.VolatileSystemSuffixMiddleware.__init__
+
+    def spy_init(self: object, suffix: object) -> None:
+        suffixes.append(suffix)
+        original_init(self, suffix)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(vss_module.VolatileSystemSuffixMiddleware, "__init__", spy_init)
+
+    create_deep_agent(model=GenericFakeChatModel(messages=iter([AIMessage(content="ok")])))
+
+    assert suffixes == []
+
+
+def test_suffix_reaches_inline_subagent_at_runtime() -> None:
+    """A declarative subagent's system message ends with the volatile suffix, uncached."""
+    subagent_captured: list[SystemMessage] = []
+    subagent_model = _make_capturing_anthropic(subagent_captured)
+
+    parent_model = GenericFakeChatModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "task",
+                            "args": {"description": "Look it up", "subagent_type": "researcher"},
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(content="done"),
+            ]
+        )
+    )
+
+    agent = create_deep_agent(
+        model=parent_model,
+        volatile_system_suffix=_VOLATILE,
+        subagents=[
+            {
+                "name": "researcher",
+                "description": "Researches things.",
+                "system_prompt": "You are a researcher.",
+                "model": subagent_model,
+            }
+        ],
+    )
+    agent.invoke({"messages": [HumanMessage(content="research X")]})
+
+    assert subagent_captured, "Subagent model never received a SystemMessage"
+    blocks = subagent_captured[0].content_blocks
+    assert _VOLATILE in blocks[-1].get("text", "")
+    assert "cache_control" not in blocks[-1]
+    assert "You are a researcher." in blocks[0].get("text", "")

--- a/libs/deepagents/tests/unit_tests/middleware/test_volatile_system_suffix_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_volatile_system_suffix_middleware.py
@@ -1,0 +1,209 @@
+"""Unit tests for `VolatileSystemSuffixMiddleware`.
+
+The middleware appends a trailing system content block that is intentionally
+*not* tagged with `cache_control`, so volatile per-turn content (user identity,
+current date, ...) can live in the system prompt without invalidating the
+Anthropic prompt-cache prefix. It is wired innermost by `create_deep_agent`
+(after `AnthropicPromptCachingMiddleware` and `MemoryMiddleware`); the
+end-to-end placement tests live in `test_volatile_system_suffix_graph.py`.
+"""
+
+from langchain.agents.middleware.types import ModelRequest
+from langchain_anthropic import ChatAnthropic
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+import deepagents
+from deepagents import middleware as deepagents_middleware
+from deepagents.middleware.volatile_system_suffix import VolatileSystemSuffixMiddleware
+from tests.unit_tests.chat_model import GenericFakeChatModel
+
+
+def _build_model_request(model: BaseChatModel, system_message: SystemMessage | None) -> ModelRequest:
+    """Construct a minimal `ModelRequest` for direct `modify_request` tests."""
+    return ModelRequest(
+        model=model,
+        messages=[HumanMessage(content="hi")],
+        system_message=system_message,
+        state={"messages": []},  # type: ignore[typeddict-unknown-key]
+    )
+
+
+def _fake_anthropic() -> ChatAnthropic:
+    """Build a `ChatAnthropic` instance with a dummy key."""
+    return ChatAnthropic(model_name="claude-sonnet-4-6", anthropic_api_key="fake")  # type: ignore[call-arg]
+
+
+def _fake_other() -> GenericFakeChatModel:
+    """Build a non-Anthropic fake chat model."""
+    return GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+
+
+def _system_blocks(message: SystemMessage | None) -> list:
+    """Extract content blocks from a required system message; fails test if absent."""
+    assert message is not None, "modify_request must return a SystemMessage"
+    return list(message.content_blocks)
+
+
+def test_str_suffix_appended_as_trailing_text_block() -> None:
+    """A string suffix becomes the final text block of the system message."""
+    middleware = VolatileSystemSuffixMiddleware("Current date: 2026-06-01")
+    request = _build_model_request(_fake_anthropic(), SystemMessage(content="base prompt"))
+
+    result = middleware.modify_request(request)
+    blocks = _system_blocks(result.system_message)
+
+    assert blocks[-1].get("type") == "text"
+    assert "Current date: 2026-06-01" in blocks[-1].get("text", "")
+    # The stable base prompt is preserved as an earlier block.
+    assert "base prompt" in blocks[0].get("text", "")
+
+
+def test_str_suffix_never_carries_cache_control() -> None:
+    """The volatile block must not be tagged with `cache_control`, even for Anthropic."""
+    middleware = VolatileSystemSuffixMiddleware("volatile content")
+    request = _build_model_request(_fake_anthropic(), SystemMessage(content="base prompt"))
+
+    result = middleware.modify_request(request)
+    blocks = _system_blocks(result.system_message)
+
+    assert "cache_control" not in blocks[-1]
+
+
+def test_str_suffix_separated_by_blank_line() -> None:
+    """A string suffix is appended as a distinct block, not merged into the prior one."""
+    middleware = VolatileSystemSuffixMiddleware("SUFFIX")
+    request = _build_model_request(_fake_anthropic(), SystemMessage(content="BASE"))
+
+    result = middleware.modify_request(request)
+    blocks = _system_blocks(result.system_message)
+
+    assert len(blocks) == 2
+    assert blocks[0].get("text") == "BASE"
+    assert blocks[1].get("text", "").endswith("SUFFIX")
+
+
+def test_list_suffix_appended_verbatim_in_order() -> None:
+    """A list suffix is appended block-for-block, preserving order, as the trailing blocks."""
+    suffix = [
+        {"type": "text", "text": "first volatile"},
+        {"type": "text", "text": "second volatile"},
+    ]
+    middleware = VolatileSystemSuffixMiddleware(suffix)
+    request = _build_model_request(_fake_anthropic(), SystemMessage(content="base prompt"))
+
+    result = middleware.modify_request(request)
+    blocks = _system_blocks(result.system_message)
+
+    assert blocks[-2].get("text") == "first volatile"
+    assert blocks[-1].get("text") == "second volatile"
+    assert "cache_control" not in blocks[-1]
+    assert "cache_control" not in blocks[-2]
+
+
+def test_empty_str_suffix_is_noop() -> None:
+    """An empty string leaves the request untouched."""
+    middleware = VolatileSystemSuffixMiddleware("")
+    base = SystemMessage(content="base prompt")
+    request = _build_model_request(_fake_anthropic(), base)
+
+    result = middleware.modify_request(request)
+
+    assert result is request
+    assert result.system_message is base
+
+
+def test_empty_list_suffix_is_noop() -> None:
+    """An empty list leaves the request untouched."""
+    middleware = VolatileSystemSuffixMiddleware([])
+    base = SystemMessage(content="base prompt")
+    request = _build_model_request(_fake_anthropic(), base)
+
+    result = middleware.modify_request(request)
+
+    assert result is request
+    assert result.system_message is base
+
+
+def test_none_system_message_creates_message_with_suffix() -> None:
+    """With no existing system message, the suffix becomes the sole system block."""
+    middleware = VolatileSystemSuffixMiddleware("only volatile")
+    request = _build_model_request(_fake_anthropic(), None)
+
+    result = middleware.modify_request(request)
+    blocks = _system_blocks(result.system_message)
+
+    assert len(blocks) == 1
+    assert "only volatile" in blocks[0].get("text", "")
+    assert "cache_control" not in blocks[0]
+
+
+def test_preserves_cache_control_on_existing_last_block() -> None:
+    """Appending the suffix must not strip `cache_control` from the (now earlier) stable block."""
+    cached_system = SystemMessage(content_blocks=[{"type": "text", "text": "stable prompt", "cache_control": {"type": "ephemeral"}}])
+    middleware = VolatileSystemSuffixMiddleware("volatile content")
+    request = _build_model_request(_fake_anthropic(), cached_system)
+
+    result = middleware.modify_request(request)
+    blocks = _system_blocks(result.system_message)
+
+    # Breakpoint stays on the stable block...
+    assert blocks[-2].get("cache_control") == {"type": "ephemeral"}
+    # ...and the volatile suffix trails it uncached.
+    assert "cache_control" not in blocks[-1]
+    assert "volatile content" in blocks[-1].get("text", "")
+
+
+def test_non_anthropic_model_appends_suffix_without_cache_control() -> None:
+    """Non-Anthropic models get the trailing block too, and no `cache_control` anywhere."""
+    middleware = VolatileSystemSuffixMiddleware("volatile content")
+    request = _build_model_request(_fake_other(), SystemMessage(content="base prompt"))
+
+    result = middleware.modify_request(request)
+    blocks = _system_blocks(result.system_message)
+
+    assert "volatile content" in blocks[-1].get("text", "")
+    assert all("cache_control" not in block for block in blocks)
+
+
+async def test_awrap_model_call_appends_suffix() -> None:
+    """The async hook applies the same modification as the sync path."""
+    middleware = VolatileSystemSuffixMiddleware("async volatile")
+    request = _build_model_request(_fake_other(), SystemMessage(content="base prompt"))
+
+    captured: dict[str, ModelRequest] = {}
+
+    async def handler(req: ModelRequest) -> AIMessage:
+        captured["request"] = req
+        return AIMessage(content="ok")
+
+    await middleware.awrap_model_call(request, handler)  # type: ignore[arg-type]
+
+    blocks = _system_blocks(captured["request"].system_message)
+    assert "async volatile" in blocks[-1].get("text", "")
+    assert "cache_control" not in blocks[-1]
+
+
+def test_wrap_model_call_appends_suffix() -> None:
+    """The sync hook passes the modified request to the handler."""
+    middleware = VolatileSystemSuffixMiddleware("sync volatile")
+    request = _build_model_request(_fake_other(), SystemMessage(content="base prompt"))
+
+    captured: dict[str, ModelRequest] = {}
+
+    def handler(req: ModelRequest) -> AIMessage:
+        captured["request"] = req
+        return AIMessage(content="ok")
+
+    middleware.wrap_model_call(request, handler)  # type: ignore[arg-type]
+
+    blocks = _system_blocks(captured["request"].system_message)
+    assert "sync volatile" in blocks[-1].get("text", "")
+
+
+def test_public_exports() -> None:
+    """The middleware is exported from both `deepagents` and `deepagents.middleware`."""
+    assert deepagents.VolatileSystemSuffixMiddleware is VolatileSystemSuffixMiddleware
+    assert deepagents_middleware.VolatileSystemSuffixMiddleware is VolatileSystemSuffixMiddleware
+    assert "VolatileSystemSuffixMiddleware" in deepagents.__all__
+    assert "VolatileSystemSuffixMiddleware" in deepagents_middleware.__all__


### PR DESCRIPTION
## Summary

Adds a `volatile_system_suffix` parameter to `create_deep_agent` (and a public `VolatileSystemSuffixMiddleware`) that appends a trailing **system** content block **after** the Anthropic `cache_control` breakpoint, without tagging it for caching.

This lets a caller keep volatile per-turn content — the current date, the signed-in user's identity, etc. — *in* the system prompt but *out* of the cached prefix. Previously this was impossible from the outside: user-supplied `middleware=` is always extended **before** deepagents' caching/memory tail, so a downstream caller could not append a post-breakpoint system block. Hence this upstream hook.

## Design

- **New `VolatileSystemSuffixMiddleware`** (`deepagents/middleware/volatile_system_suffix.py`): its `wrap_model_call`/`awrap_model_call` append the suffix as the final system content block, never adding `cache_control`. Accepts `str` (single trailing text block) or `list[ContentBlock]` (appended verbatim); empty input is a no-op.
- **Innermost ordering is the crux.** LangChain composes `wrap_model_call` so first-in-list = outermost and the innermost middleware mutates the request *last*. The new middleware is appended **after** `AnthropicPromptCachingMiddleware` **and** `MemoryMiddleware`, so:
  - `AnthropicPromptCachingMiddleware` tags the last *stable* block,
  - `MemoryMiddleware` (when `memory=` is set) appends `AGENTS.md` and tags it (a second breakpoint),
  - then this middleware appends the volatile block **without** `cache_control`.
  
  Result: the breakpoint(s) stay on the stable block (base prompt, and `AGENTS.md`), and the volatile block trails them uncached.
- **Wired into all three agent stacks**: main agent, the auto-added general-purpose subagent, and inline (declarative) subagents.
- **Provider-agnostic.** On non-Anthropic models no `cache_control` is added at all. Verified that `langchain_openai`'s `_convert_message_to_dict` (system branch) and `langchain_google_genai`'s `_parse_chat_history` both preserve ordered parts, so the volatile block simply serializes as the last part of the single system instruction.

## Tests

`tests/unit_tests/middleware/test_volatile_system_suffix_middleware.py` (middleware in isolation) and `test_volatile_system_suffix_graph.py` (end-to-end through `create_deep_agent`). Covers the required cases:

1. With a suffix set, the `cache_control` breakpoint is on the stable block, **not** the volatile suffix.
2. The suffix is the last system content block.
3. **Backward compat:** with the param unset, breakpoint placement is unchanged (also guarded by existing smoke-test snapshots, which are unaffected).
4. The `AGENTS.md`/memory breakpoint is preserved when memory is configured.
5. Non-Anthropic model: no `cache_control` added; suffix still trails the stable system content.

Plus: str/list inputs, empty-input no-op, `None` system message, async hook, public exports, and that the middleware is wired into all three stacks (main + both subagent builders).

Full unit suite green (`make test`): 1706 passed, 95 skipped, 4 xfailed. `ruff check`, `ruff format`, and `ty check deepagents` all pass.

## Trust boundary

The suffix is appended verbatim as system-role content. Callers folding in user-controlled data are responsible for wrapping it in explicit boundary markers (e.g. `<user_context>...</user_context>`); this is documented on both the param and the middleware.

## How `langchainplus` consumes this

The downstream Fleet agent (`langchain-ai/langchainplus`, `agent-builder-graphs`) currently ships an **interim in-repo monkeypatch** to achieve this breakpoint placement, plus a `UserContextMiddleware` that folds identity into the first *user* message. Once this lands and is released:

- `agent-builder-graphs/agent_builder_graphs/deep_agent/agent.py` passes `volatile_system_suffix=build_user_context_block(...)` (from `deep_agent/prompts.py`) into `create_deep_agent`, moving user identity/date into a **system-role** trailing block.
- The interim monkeypatch override is removed and the `deepagents` pin is bumped.

## Notes

- No new dependencies. No public-API breakage — purely additive (new keyword-only param defaulting to `None`).
