### PR TITLE
hotfix(cli): smoother deploy onboarding and mcp servers ergonomics

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -105,8 +105,8 @@ jobs:
         working-directory: ${{ matrix.working-directory }}
         run: uv sync --group test
 
-      - name: "📦 Install Sandbox Extras (CLI only)"
-        if: matrix.working-directory == 'libs/cli'
+      - name: "📦 Install Sandbox Extras (Code only)"
+        if: matrix.working-directory == 'libs/code'
         working-directory: ${{ matrix.working-directory }}
         run: uv sync --group test --extra all-sandboxes
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -763,9 +763,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIR }}
 
       - name: Install sandbox provider extras
-        if: |
-          needs.setup.outputs.package == 'deepagents-cli'
-          || needs.setup.outputs.package == 'deepagents-code'
+        if: needs.setup.outputs.package == 'deepagents-code'
         run: uv sync --group test --extra all-sandboxes
         working-directory: ${{ env.WORKING_DIR }}
 

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -39,27 +39,27 @@ deepagents mcp-servers add --url https://tools.langchain.com \
                             --header X-Api-Key=$LANGSMITH_API_KEY \
                             --name Fleet
 
-# Reference the server's tools in tools.json (otherwise the agent has no tools)
-cat > my-agent/tools.json <<'JSON'
-{
-  "tools": [
-    {
-      "name": "tavily_web_search",
-      "mcp_server_url": "https://tools.langchain.com",
-      "mcp_server_name": "Fleet"
-    }
-  ]
-}
-JSON
+# init scaffolds an empty tools.json. Add tools that reference a registered
+# MCP server's URL (otherwise the agent has no tools), e.g. the Fleet server
+# registered above:
+#   { "name": "read_url_content", "mcp_server_url": "https://tools.langchain.com",
+#     "mcp_server_name": "Fleet", "display_name": "read_url_content" }
 
 # Upsert the project as a managed agent on /v1/deepagents/*
 cd my-agent && deepagents deploy
 ```
 
-`deepagents init` configures new agents with the managed
-`thread_scoped_sandbox` backend by default. The CLI does not create or run
-sandboxes locally; sandbox lifecycle is handled by the Managed Deep Agents
-platform.
+`deepagents init` scaffolds an empty `tools.json`, an example skill under
+`skills/`, and an example subagent under `subagents/`; edit or remove them to
+suit your agent. `tools.json` starts empty because every tool must reference an
+MCP server that is already registered in the workspace
+(`deepagents mcp-servers add`) — so a freshly scaffolded project deploys
+without first registering a server.
+
+New agents default to the `default` backend — switch `agent.json`'s
+`backend.type` to `thread_scoped_sandbox` (or `agent_scoped_sandbox`) to opt
+into a managed sandbox. The CLI does not create or run sandboxes locally;
+sandbox lifecycle is handled by the Managed Deep Agents platform.
 
 ### Project layout
 
@@ -79,11 +79,17 @@ deepagents agents list                  # list workspace agents
 deepagents agents get <agent_id>        # show one agent
 deepagents agents delete <agent_id>     # delete an agent
 
-deepagents mcp-servers list             # list workspace MCP servers
-deepagents mcp-servers add --url URL    # register a server
-deepagents mcp-servers update <id>      # update server URL or headers
-deepagents mcp-servers delete <id>      # remove a server
+deepagents mcp-servers list                  # list workspace MCP servers
+deepagents mcp-servers add --url URL          # register a server
+deepagents mcp-servers get <id|name|url>      # show one server
+deepagents mcp-servers update <id|name|url>   # update server URL or headers
+deepagents mcp-servers delete <id|name|url>   # remove a server
+deepagents mcp-servers connect <id|name|url>  # start OAuth for a server
 ```
+
+`get`, `update`, `delete`, and `connect` accept an MCP server's id, exact name,
+or URL — a non-id value is resolved against `mcp-servers list` (URLs are matched
+ignoring case and trailing slash).
 
 ## 📖 Resources
 

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -82,6 +82,7 @@ deepagents agents delete <agent_id>     # delete an agent
 deepagents mcp-servers list                  # list workspace MCP servers
 deepagents mcp-servers add --url URL          # register a server
 deepagents mcp-servers get <id|name|url>      # show one server
+deepagents mcp-servers tools <id|name|url>    # list a server's tools
 deepagents mcp-servers update <id|name|url>   # update server URL or headers
 deepagents mcp-servers delete <id|name|url>   # remove a server
 deepagents mcp-servers connect <id|name|url>  # start OAuth for a server

--- a/libs/cli/deepagents_cli/deploy/api_client.py
+++ b/libs/cli/deepagents_cli/deploy/api_client.py
@@ -267,6 +267,34 @@ class ApiClient:
         """Delete an MCP server by ID."""
         self._request("DELETE", f"{_DEPLOY_PATH}/mcp-servers/{mcp_server_id}")
 
+    def list_mcp_server_tools(
+        self,
+        url: str,
+        *,
+        oauth_provider_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return the tools exposed by a registered MCP server.
+
+        Backed by `GET /v1/deepagents/mcp/tools`, which resolves the server by
+        URL (cache-first, with a remote MCP `tools/list` fallback).
+
+        Args:
+            url: The registered MCP server URL.
+            oauth_provider_id: OAuth provider id; required for OAuth servers.
+
+        Returns:
+            MCP tool definitions, each with `name`, `description`, and
+            `inputSchema`.
+        """
+        params: dict[str, Any] = {"url": url}
+        if oauth_provider_id:
+            params["oauth_provider_id"] = oauth_provider_id
+        body = self._request("GET", f"{_DEPLOY_PATH}/mcp/tools", params=params)
+        if isinstance(body, dict) and isinstance(body.get("tools"), list):
+            return list(body["tools"])
+        msg = "Unexpected MCP tools response."
+        raise ApiError(status=0, detail=msg)
+
     def register_mcp_oauth_provider(self, mcp_server_id: str) -> dict[str, Any]:
         """Register the caller's per-user OAuth provider for an MCP server."""
         return self._request(

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -74,6 +74,7 @@ def execute_init_command(args: argparse.Namespace) -> None:
             print("Error: project name is required.")
             raise SystemExit(1)
     _scaffold(name=name, force=args.force)
+    _print_post_init_welcome(name)
 
 
 def _scaffold(*, name: str, force: bool) -> None:
@@ -101,14 +102,32 @@ def _scaffold(*, name: str, force: bool) -> None:
         f"Created {name}/ with: agent.json, AGENTS.md, .gitignore, tools.json, "
         f"skills/{_STARTER_SKILL_NAME}/, subagents/{_STARTER_SUBAGENT_NAME}/"
     )
-    print("\nNext steps:")
-    print(f"  cd {name}")
-    print("  # set LANGSMITH_API_KEY in your shell, repo .env, or ~/.deepagents/.env")
-    print("  # edit AGENTS.md; tweak or remove subagents/ and skills/")
-    print("  # to give your agent tools, first register an MCP server:")
-    print("  #   deepagents mcp-servers add --url <url> --header KEY=VALUE")
-    print("  #   then reference it in tools.json by its mcp_server_url")
-    print("  deepagents deploy")
+
+
+def _print_post_init_welcome(name: str) -> None:
+    """Print a formatted, scannable walkthrough after scaffolding."""
+    print("\nNext steps")
+    print("──────────")
+    print("  1. Edit your agent's files")
+    print("       AGENTS.md    system prompt / instructions")
+    print("       agent.json   name, model, backend")
+    print("       tools.json   tools the agent can call (starts empty)")
+    print("       skills/      reusable instructions (optional; example included)")
+    print("       subagents/   delegated agents (optional; example included)")
+    print()
+    print("  2. Connect tools (optional)")
+    print("       Set LANGSMITH_API_KEY, then register or reuse an MCP server:")
+    print("         deepagents mcp-servers list      # servers already connected")
+    print("         deepagents mcp-servers add ...   # register a new server")
+    print("       Auth options for `add`:")
+    print("         --header X-Api-Key=$LANGSMITH_API_KEY   # API key")
+    print("         --auth-type oauth --connect             # OAuth (browser)")
+    print("       List a server's tools (prints a tools.json snippet):")
+    print("         deepagents mcp-servers tools <id|name|url>")
+    print()
+    print("  3. Deploy")
+    print(f"       cd {name}")
+    print("       deepagents deploy")
 
 
 _STARTER_AGENT_JSON = """\
@@ -572,6 +591,11 @@ def _add_mcp_servers_parser(
     a.add_argument("--header", action="append", default=[], metavar="KEY=VALUE")
     a.add_argument("--auth-type", default="headers", choices=["headers", "oauth"])
     a.add_argument(
+        "--no-tools",
+        action="store_true",
+        help="Skip listing the server's tools after registering",
+    )
+    a.add_argument(
         "--connect",
         action="store_true",
         help="Start OAuth connection after creating an OAuth MCP server",
@@ -592,6 +616,8 @@ def _add_mcp_servers_parser(
     c = sub.add_parser("connect")
     c.add_argument("mcp_server_id", metavar="ID|NAME|URL", help=id_help)
     _add_oauth_connect_options(c)
+    tl = sub.add_parser("tools")
+    tl.add_argument("mcp_server_id", metavar="ID|NAME|URL", help=id_help)
 
 
 def _add_oauth_connect_options(parser: argparse.ArgumentParser) -> None:
@@ -712,6 +738,7 @@ def execute_mcp_servers_command(args: argparse.Namespace) -> None:
             srv_name = srv.get("name")
             srv_url = srv.get("url")
             print(f"Created mcp_server {srv_id}: {srv_name} → {srv_url}")
+            connect_attempted = False
             if getattr(args, "connect", False):
                 if not isinstance(srv_id, str) or not srv_id:
                     print("Error: created OAuth MCP server did not include an id.")
@@ -724,6 +751,14 @@ def execute_mcp_servers_command(args: argparse.Namespace) -> None:
                     timeout_seconds=args.timeout,
                     no_browser=args.no_browser,
                 )
+                connect_attempted = True
+            _show_tools_after_add(
+                client,
+                srv,
+                auth_type=args.auth_type,
+                connect_attempted=connect_attempted,
+                suppressed=getattr(args, "no_tools", False),
+            )
         elif args.mcp_cmd == "get":
             server_id = _resolve_mcp_server_id(client, args.mcp_server_id)
             server = client.get_mcp_server(server_id)
@@ -775,6 +810,18 @@ def execute_mcp_servers_command(args: argparse.Namespace) -> None:
                 timeout_seconds=args.timeout,
                 no_browser=args.no_browser,
             )
+        elif args.mcp_cmd == "tools":
+            server = client.get_mcp_server(
+                _resolve_mcp_server_id(client, args.mcp_server_id)
+            )
+            url = server.get("url")
+            if not isinstance(url, str) or not url:
+                print("Error: that MCP server record has no URL.")
+                raise SystemExit(1)
+            tools = client.list_mcp_server_tools(
+                url, oauth_provider_id=server.get("oauth_provider_id")
+            )
+            _print_mcp_tools(server, tools)
     except ApiError as exc:
         print(f"Error: {exc}")
         raise SystemExit(1) from None
@@ -912,6 +959,85 @@ def _parse_update_headers(
     if raw is None:
         return None
     return _parse_header_args(raw)
+
+
+def _show_tools_after_add(
+    client: ApiClient,
+    srv: dict[str, Any],
+    *,
+    auth_type: str,
+    connect_attempted: bool,
+    suppressed: bool,
+) -> None:
+    """Best-effort: list a freshly registered server's tools after `add`.
+
+    Closes the discovery loop so the user sees what the server exposes (and a
+    paste-ready tools.json snippet) without a separate `tools` call. It never
+    raises: a missing tools endpoint, OAuth server that isn't connected yet, or
+    any API error degrades to a hint pointing at `mcp-servers tools`.
+
+    Args:
+        client: Authenticated deploy API client.
+        srv: The MCP server record returned by `create_mcp_server`.
+        auth_type: The server's auth type (`headers` or `oauth`).
+        connect_attempted: Whether an OAuth connect flow was just run.
+        suppressed: When `True` (the `--no-tools` flag), skip listing entirely.
+    """
+    if suppressed:
+        return
+    srv_id = srv.get("id")
+    if not isinstance(srv_id, str) or not srv_id:
+        return
+    if auth_type == "oauth" and not connect_attempted:
+        print(f"  After connecting, run: deepagents mcp-servers tools {srv_id}")
+        return
+
+    try:
+        # OAuth servers need `oauth_provider_id`, which is only populated after
+        # connect, so refresh the record before listing.
+        record = client.get_mcp_server(srv_id) if auth_type == "oauth" else srv
+        url = record.get("url")
+        if not isinstance(url, str) or not url:
+            return
+        tools = client.list_mcp_server_tools(
+            url, oauth_provider_id=record.get("oauth_provider_id")
+        )
+    except Exception:  # tool listing is best-effort; it must never fail `add`
+        print(f"  Run `deepagents mcp-servers tools {srv_id}` to list its tools.")
+        return
+    print()
+    _print_mcp_tools(record, tools)
+
+
+def _print_mcp_tools(server: dict[str, Any], tools: list[dict[str, Any]]) -> None:
+    """Print an MCP server's tools and a paste-ready tools.json snippet."""
+    url = str(server.get("url") or "")
+    name = str(server.get("name") or "")
+    label = name or url
+    if not tools:
+        print(f"No tools found for {label}.")
+        return
+
+    print(f"Tools for {label} ({url}):")
+    width = max(len(str(t.get("name") or "")) for t in tools)
+    for tool in tools:
+        tname = str(tool.get("name") or "")
+        description = str(tool.get("description") or "").strip()
+        summary = description.splitlines()[0] if description else ""
+        print(f"  {tname.ljust(width)}  {summary}")
+
+    entries: list[dict[str, str]] = []
+    for tool in tools:
+        tname = str(tool.get("name") or "")
+        if not tname:
+            continue
+        entry = {"name": tname, "mcp_server_url": url, "display_name": tname}
+        if name:
+            entry["mcp_server_name"] = name
+        entries.append(entry)
+    snippet = {"tools": entries, "interrupt_config": {}}
+    print("\nAdd to tools.json:")
+    print(json.dumps(snippet, indent=2))
 
 
 def _redact_mcp_server(server: dict[str, Any]) -> dict[str, Any]:

--- a/libs/cli/deepagents_cli/deploy/commands.py
+++ b/libs/cli/deepagents_cli/deploy/commands.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -85,13 +86,28 @@ def _scaffold(*, name: str, force: bool) -> None:
     (project_dir / "agent.json").write_text(_STARTER_AGENT_JSON.format(name=name))
     (project_dir / "AGENTS.md").write_text(_STARTER_AGENTS_MD)
     (project_dir / ".gitignore").write_text(_STARTER_GITIGNORE)
-    (project_dir / "skills").mkdir(exist_ok=True)
+    (project_dir / "tools.json").write_text(_STARTER_TOOLS_JSON)
 
-    print(f"Created {name}/ with: agent.json, AGENTS.md, .gitignore, skills/")
+    skill_dir = project_dir / "skills" / _STARTER_SKILL_NAME
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(_STARTER_SKILL_MD)
+
+    subagent_dir = project_dir / "subagents" / _STARTER_SUBAGENT_NAME
+    subagent_dir.mkdir(parents=True, exist_ok=True)
+    (subagent_dir / "agent.json").write_text(_STARTER_SUBAGENT_AGENT_JSON)
+    (subagent_dir / "AGENTS.md").write_text(_STARTER_SUBAGENT_AGENTS_MD)
+
+    print(
+        f"Created {name}/ with: agent.json, AGENTS.md, .gitignore, tools.json, "
+        f"skills/{_STARTER_SKILL_NAME}/, subagents/{_STARTER_SUBAGENT_NAME}/"
+    )
     print("\nNext steps:")
     print(f"  cd {name}")
     print("  # set LANGSMITH_API_KEY in your shell, repo .env, or ~/.deepagents/.env")
-    print("  # edit AGENTS.md, optionally add tools.json / skills/ / subagents/")
+    print("  # edit AGENTS.md; tweak or remove subagents/ and skills/")
+    print("  # to give your agent tools, first register an MCP server:")
+    print("  #   deepagents mcp-servers add --url <url> --header KEY=VALUE")
+    print("  #   then reference it in tools.json by its mcp_server_url")
     print("  deepagents deploy")
 
 
@@ -99,9 +115,9 @@ _STARTER_AGENT_JSON = """\
 {{
   "name": "{name}",
   "description": "A managed deep agent.",
-  "model": "anthropic:claude-sonnet-4-6",
+  "model": "openai:gpt-5.5",
   "backend": {{
-    "type": "thread_scoped_sandbox"
+    "type": "default"
   }}
 }}
 """
@@ -119,6 +135,62 @@ You are a helpful AI agent.
 
 _STARTER_GITIGNORE = """\
 .env
+"""
+
+# Empty by default so the first `deepagents deploy` succeeds out of the box.
+# Tools reference an MCP server that must already be registered in the
+# workspace (see `deepagents mcp-servers add`); add entries to `tools` once a
+# server exists, e.g.:
+#   {"name": "read_url_content", "mcp_server_url": "https://tools.langchain.com",
+#    "mcp_server_name": "Fleet", "display_name": "read_url_content"}
+_STARTER_TOOLS_JSON = """\
+{
+  "tools": [],
+  "interrupt_config": {}
+}
+"""
+
+# Example subagent. The main agent can delegate to it via the Task tool.
+_STARTER_SUBAGENT_NAME = "researcher"
+
+_STARTER_SUBAGENT_AGENT_JSON = """\
+{
+  "description": "Researches a topic and returns a concise summary.",
+  "model": "openai:gpt-5.5"
+}
+"""
+
+_STARTER_SUBAGENT_AGENTS_MD = """\
+# Researcher
+
+You are a focused research subagent.
+
+## Guidelines
+
+- Gather the requested information and return a concise, well-sourced summary.
+- State assumptions and call out anything you could not verify.
+"""
+
+# Example skill. Skills are progressive-disclosure instructions the agent loads
+# on demand; the SKILL.md frontmatter `name` and `description` are required.
+_STARTER_SKILL_NAME = "example-skill"
+
+_STARTER_SKILL_MD = """\
+---
+name: example-skill
+description: Worked example of the skill format; replace with your own trigger.
+---
+
+# Example skill
+
+Skills hold detailed, reusable instructions the agent pulls in only when the
+description above matches the task.
+
+## Steps
+
+1. Describe the first step the agent should take.
+2. Add any constraints, formats, or examples it should follow.
+3. Delete or replace this skill once you have your own.
 """
 
 # --- deploy / agents / mcp-servers (stubs filled by later tasks) ------------
@@ -505,19 +577,20 @@ def _add_mcp_servers_parser(
         help="Start OAuth connection after creating an OAuth MCP server",
     )
     _add_oauth_connect_options(a)
+    id_help = "MCP server id, exact name, or URL"
     g = sub.add_parser("get")
-    g.add_argument("mcp_server_id")
+    g.add_argument("mcp_server_id", metavar="ID|NAME|URL", help=id_help)
     u = sub.add_parser("update")
-    u.add_argument("mcp_server_id")
+    u.add_argument("mcp_server_id", metavar="ID|NAME|URL", help=id_help)
     u.add_argument("--url", default=None)
     u.add_argument("--header", action="append", default=None, metavar="KEY=VALUE")
     u.add_argument("--clear-headers", action="store_true")
     u.add_argument("--auth-type", default=None, choices=["headers"])
     d = sub.add_parser("delete")
-    d.add_argument("mcp_server_id")
+    d.add_argument("mcp_server_id", metavar="ID|NAME|URL", help=id_help)
     d.add_argument("--yes", action="store_true")
     c = sub.add_parser("connect")
-    c.add_argument("mcp_server_id")
+    c.add_argument("mcp_server_id", metavar="ID|NAME|URL", help=id_help)
     _add_oauth_connect_options(c)
 
 
@@ -545,6 +618,63 @@ def _add_oauth_connect_options(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Print the verification URL without opening a browser",
     )
+
+
+_MCP_UUID_RE = re.compile(
+    r"\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\Z"
+)
+
+
+def _resolve_mcp_server_id(client: ApiClient, identifier: str) -> str:
+    """Resolve an MCP server *identifier* to its id.
+
+    The platform addresses MCP servers by id, so a non-UUID *identifier* is
+    matched against the workspace server list by exact name first, then by
+    normalized URL (lowercased, trailing slash stripped — same rules deploy
+    uses). A UUID is returned as-is without a lookup.
+
+    Args:
+        client: Authenticated deploy API client.
+        identifier: An MCP server id (UUID), exact name, or URL.
+
+    Returns:
+        The resolved MCP server id.
+
+    Raises:
+        SystemExit: If nothing matches or the identifier is ambiguous.
+    """
+    from deepagents_cli.deploy.mcp_resolver import _normalize_url
+
+    candidate = identifier.strip()
+    if _MCP_UUID_RE.match(candidate):
+        return candidate
+
+    servers = client.list_mcp_servers()
+    matches = [s for s in servers if s.get("name") == identifier]
+    if not matches:
+        target = _normalize_url(identifier)
+        matches = [
+            s
+            for s in servers
+            if isinstance(s.get("url"), str) and _normalize_url(s["url"]) == target
+        ]
+
+    ids = sorted({s["id"] for s in matches if isinstance(s.get("id"), str)})
+    if not ids:
+        print(
+            f"Error: no MCP server matches {identifier!r}. "
+            "Run `deepagents mcp-servers list` to see ids, names, and URLs."
+        )
+        raise SystemExit(1)
+    if len(ids) > 1:
+        listed = ", ".join(ids)
+        print(
+            f"Error: {identifier!r} matches multiple MCP servers ({listed}). "
+            "Re-run with the id."
+        )
+        raise SystemExit(1)
+    return ids[0]
 
 
 def execute_mcp_servers_command(args: argparse.Namespace) -> None:
@@ -595,7 +725,8 @@ def execute_mcp_servers_command(args: argparse.Namespace) -> None:
                     no_browser=args.no_browser,
                 )
         elif args.mcp_cmd == "get":
-            server = client.get_mcp_server(args.mcp_server_id)
+            server_id = _resolve_mcp_server_id(client, args.mcp_server_id)
+            server = client.get_mcp_server(server_id)
             print(json.dumps(_redact_mcp_server(server), indent=2))
         elif args.mcp_cmd == "update":
             headers = _parse_update_headers(args.header, args.clear_headers)
@@ -606,7 +737,7 @@ def execute_mcp_servers_command(args: argparse.Namespace) -> None:
                 )
                 raise SystemExit(1)
             srv = client.update_mcp_server(
-                args.mcp_server_id,
+                _resolve_mcp_server_id(client, args.mcp_server_id),
                 url=args.url,
                 headers=headers,
                 auth_type=args.auth_type,
@@ -616,9 +747,15 @@ def execute_mcp_servers_command(args: argparse.Namespace) -> None:
             srv_url = srv.get("url")
             print(f"Updated mcp_server {srv_id}: {srv_name} → {srv_url}")
         elif args.mcp_cmd == "delete":
+            server_id = _resolve_mcp_server_id(client, args.mcp_server_id)
+            label = (
+                server_id
+                if args.mcp_server_id == server_id
+                else f"{args.mcp_server_id} ({server_id})"
+            )
             if not args.yes:
                 try:
-                    prompt = f"Delete MCP server {args.mcp_server_id}? [y/N]: "
+                    prompt = f"Delete MCP server {label}? [y/N]: "
                     answer = input(prompt).strip().lower()
                 except (EOFError, KeyboardInterrupt):
                     print()
@@ -627,12 +764,12 @@ def execute_mcp_servers_command(args: argparse.Namespace) -> None:
                 if answer not in {"y", "yes"}:
                     print("Aborted.")
                     return
-            client.delete_mcp_server(args.mcp_server_id)
-            print(f"Deleted {args.mcp_server_id}")
+            client.delete_mcp_server(server_id)
+            print(f"Deleted {server_id}")
         elif args.mcp_cmd == "connect":
             _connect_mcp_server_oauth(
                 client,
-                args.mcp_server_id,
+                _resolve_mcp_server_id(client, args.mcp_server_id),
                 scopes=args.scope,
                 force_new=args.force_new,
                 timeout_seconds=args.timeout,

--- a/libs/cli/deepagents_cli/deploy/mcp_resolver.py
+++ b/libs/cli/deepagents_cli/deploy/mcp_resolver.py
@@ -116,7 +116,7 @@ def resolve_referenced_servers(
             f"are not registered in this workspace:\n{listed}\n\n"
             f"Register each with:\n"
             f"  deepagents mcp-servers add --url <url> "
-            f"--header KEY=VALUE [--name <name>]"
+            f"--name <name> --header <api-key-name>=<value>"
         )
         raise UnresolvedServersError(msg, urls=urls)
     return out

--- a/libs/cli/deepagents_cli/deploy/project.py
+++ b/libs/cli/deepagents_cli/deploy/project.py
@@ -430,6 +430,38 @@ def _read_skills(root: Path) -> list[Skill]:
     return result
 
 
+def _read_subagent_model(data: dict[str, Any], *, source: Path) -> str | None:
+    """Read a subagent's model from `model`, falling back to legacy `model_id`.
+
+    The top-level `agent.json` and the SDK's `SubAgent` spec both spell this key
+    `model`, so subagents accept the same. `model_id` is still honored for
+    backward compatibility but should be migrated to `model`.
+
+    Args:
+        data: The parsed subagent `agent.json` object.
+        source: Path to the subagent `agent.json`, used in error messages.
+
+    Returns:
+        The stripped model identifier, or `None` when unspecified.
+
+    Raises:
+        ProjectError: If both keys are set, or the value is not a non-empty
+            string.
+    """
+    model = data.get("model")
+    legacy = data.get("model_id")
+    if model is not None and legacy is not None:
+        msg = f"{source}: use either `model` or `model_id`, not both."
+        raise ProjectError(msg)
+    value = model if model is not None else legacy
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        msg = f"{source}: `model` must be a non-empty string when provided."
+        raise ProjectError(msg)
+    return value.strip()
+
+
 def _read_subagents(root: Path) -> list[Subagent]:
     sa_dir = root / _SUBAGENTS_DIR
     if not _is_project_dir(root, sa_dir):
@@ -490,7 +522,7 @@ def _read_subagents(root: Path) -> list[Subagent]:
             Subagent(
                 name=name,
                 description=data.get("description"),
-                model_id=data.get("model_id"),
+                model_id=_read_subagent_model(data, source=agent_json),
                 instructions=_read_project_text(
                     root,
                     agents_md,
@@ -521,7 +553,7 @@ Then run `deepagents init --force` to refresh scaffolding or migrate by hand.
 _LEGACY_MCP_HINT = """\
 Found legacy `mcp.json` in {root}. MCP servers are now workspace-level resources:
 
-  deepagents mcp-servers add --url <url> --header KEY=VALUE [--name <name>]
+  deepagents mcp-servers add --url <url> --header <api-key-name>=<value> --name <name>
 
 Then reference the server in tools.json by mcp_server_url.
 """

--- a/libs/cli/tests/unit_tests/deploy/fixtures/projects/with_subagents/subagents/researcher/agent.json
+++ b/libs/cli/tests/unit_tests/deploy/fixtures/projects/with_subagents/subagents/researcher/agent.json
@@ -1,1 +1,1 @@
-{"description": "Researches a topic.", "model_id": "anthropic:claude-sonnet-4-6"}
+{"description": "Researches a topic.", "model": "anthropic:claude-sonnet-4-6"}

--- a/libs/cli/tests/unit_tests/deploy/test_init_command.py
+++ b/libs/cli/tests/unit_tests/deploy/test_init_command.py
@@ -27,8 +27,8 @@ def test_init_scaffolds_new_layout(
     assert (project / "agent.json").is_file()
     agent = json.loads((project / "agent.json").read_text())
     assert agent["name"] == "my-agent"
-    assert agent["model"] == "anthropic:claude-sonnet-4-6"
-    assert agent["backend"] == {"type": "thread_scoped_sandbox"}
+    assert agent["model"] == "openai:gpt-5.5"
+    assert agent["backend"] == {"type": "default"}
     assert "runtime" not in agent
     assert (project / "AGENTS.md").is_file()
     assert (project / ".gitignore").is_file()
@@ -37,6 +37,31 @@ def test_init_scaffolds_new_layout(
     assert ".env" in gitignore
     assert ".deepagents/" not in gitignore
     assert (project / "skills").is_dir()
+    assert (project / "skills" / "example-skill" / "SKILL.md").is_file()
+    tools = json.loads((project / "tools.json").read_text())
+    assert tools["tools"] == []
+    subagent = project / "subagents" / "researcher"
+    assert (subagent / "agent.json").is_file()
+    assert (subagent / "AGENTS.md").is_file()
+    subagent_cfg = json.loads((subagent / "agent.json").read_text())
+    assert subagent_cfg["model"] == "openai:gpt-5.5"
+
+
+def test_init_scaffold_loads_as_valid_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from deepagents_cli.deploy.project import Project
+
+    monkeypatch.chdir(tmp_path)
+    execute_init_command(_ns("my-agent"))
+    project = Project.load(tmp_path / "my-agent")
+    assert project.backend == {"type": "default"}
+    assert project.tools is not None
+    assert len(project.skills) == 1
+    assert project.skills[0].name == "example-skill"
+    assert len(project.subagents) == 1
+    assert project.subagents[0].name == "researcher"
+    assert project.subagents[0].model_id == "openai:gpt-5.5"
 
 
 def test_init_refuses_existing_dir(

--- a/libs/cli/tests/unit_tests/deploy/test_init_command.py
+++ b/libs/cli/tests/unit_tests/deploy/test_init_command.py
@@ -64,6 +64,24 @@ def test_init_scaffold_loads_as_valid_project(
     assert project.subagents[0].model_id == "openai:gpt-5.5"
 
 
+def test_init_prints_welcome_walkthrough(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    execute_init_command(_ns("my-agent"))
+    out = capsys.readouterr().out
+    # Walkthrough covers editing, the API key prereq + MCP servers
+    # (API key and OAuth auth), and deploy.
+    assert "Next steps" in out
+    assert "AGENTS.md" in out
+    assert "LANGSMITH_API_KEY" in out
+    assert "mcp-servers" in out
+    assert "OAuth" in out
+    assert "deepagents deploy" in out
+
+
 def test_init_refuses_existing_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/libs/cli/tests/unit_tests/deploy/test_mcp_servers_command.py
+++ b/libs/cli/tests/unit_tests/deploy/test_mcp_servers_command.py
@@ -626,9 +626,7 @@ def test_mcp_servers_tools_lists_and_prints_snippet(
         raise AssertionError(msg)
 
     _patch_client(monkeypatch, handler)
-    execute_mcp_servers_command(
-        argparse.Namespace(mcp_cmd="tools", mcp_server_id=_SID)
-    )
+    execute_mcp_servers_command(argparse.Namespace(mcp_cmd="tools", mcp_server_id=_SID))
     out = capsys.readouterr().out
     assert "read_wiki" in out
     assert "Read a page." in out  # only the first description line
@@ -677,7 +675,9 @@ def test_mcp_servers_delete_resolves_url(
         if request.method == "GET":
             return httpx.Response(
                 200,
-                json=[{"id": _SID, "name": "notion", "url": "https://mcp.notion.com/mcp"}],
+                json=[
+                    {"id": _SID, "name": "notion", "url": "https://mcp.notion.com/mcp"}
+                ],
             )
         return httpx.Response(204)
 

--- a/libs/cli/tests/unit_tests/deploy/test_mcp_servers_command.py
+++ b/libs/cli/tests/unit_tests/deploy/test_mcp_servers_command.py
@@ -17,6 +17,10 @@ from deepagents_cli.deploy.commands import execute_mcp_servers_command
 
 Handler = Callable[[httpx.Request], httpx.Response]
 
+# A UUID-shaped id keeps get/update/delete/connect on the resolver fast path
+# (no list lookup), matching how real server ids look.
+_SID = "11111111-1111-4111-8111-111111111111"
+
 
 def _patch_client(
     monkeypatch: pytest.MonkeyPatch,
@@ -258,7 +262,7 @@ def test_mcp_servers_connect_opens_url_and_polls(
     execute_mcp_servers_command(
         argparse.Namespace(
             mcp_cmd="connect",
-            mcp_server_id="s1",
+            mcp_server_id=_SID,
             scope=["repo", "read:user"],
             force_new=True,
             timeout=30,
@@ -267,7 +271,7 @@ def test_mcp_servers_connect_opens_url_and_polls(
     )
     assert opened == ["https://auth.example/authorize"]
     assert requests == [
-        ("POST", "/v1/deepagents/mcp-servers/s1/oauth-provider", {}, ""),
+        ("POST", f"/v1/deepagents/mcp-servers/{_SID}/oauth-provider", {}, ""),
         (
             "POST",
             "/v1/deepagents/auth-sessions",
@@ -322,17 +326,17 @@ def test_mcp_servers_get_redacts_header_values(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.path == "/v1/deepagents/mcp-servers/s1"
+        assert request.url.path == f"/v1/deepagents/mcp-servers/{_SID}"
         return httpx.Response(
             200,
             json={
-                "id": "s1",
+                "id": _SID,
                 "headers": [{"key": "X-Api-Key", "value": "secret-value"}],
             },
         )
 
     _patch_client(monkeypatch, handler)
-    execute_mcp_servers_command(argparse.Namespace(mcp_cmd="get", mcp_server_id="s1"))
+    execute_mcp_servers_command(argparse.Namespace(mcp_cmd="get", mcp_server_id=_SID))
     out = capsys.readouterr().out
     parsed = json.loads(out)
     assert parsed["headers"] == [{"key": "X-Api-Key", "value": "***"}]
@@ -358,7 +362,7 @@ def test_mcp_servers_update_sends_patch_body(
     execute_mcp_servers_command(
         argparse.Namespace(
             mcp_cmd="update",
-            mcp_server_id="s1",
+            mcp_server_id=_SID,
             url="https://new.example/mcp",
             header=["X-Api-Key=new-value"],
             clear_headers=False,
@@ -367,14 +371,14 @@ def test_mcp_servers_update_sends_patch_body(
     )
     assert captured == {
         "method": "PATCH",
-        "path": "/v1/deepagents/mcp-servers/s1",
+        "path": f"/v1/deepagents/mcp-servers/{_SID}",
         "body": {
             "url": "https://new.example/mcp",
             "headers": [{"key": "X-Api-Key", "value": "new-value"}],
             "auth_type": "headers",
         },
     }
-    assert "Updated mcp_server s1" in capsys.readouterr().out
+    assert "Updated mcp_server" in capsys.readouterr().out
 
 
 def test_mcp_servers_update_clear_headers(
@@ -390,7 +394,7 @@ def test_mcp_servers_update_clear_headers(
     execute_mcp_servers_command(
         argparse.Namespace(
             mcp_cmd="update",
-            mcp_server_id="s1",
+            mcp_server_id=_SID,
             url=None,
             header=None,
             clear_headers=True,
@@ -454,7 +458,100 @@ def test_mcp_servers_delete(
 
     _patch_client(monkeypatch, handler)
     execute_mcp_servers_command(
-        argparse.Namespace(mcp_cmd="delete", mcp_server_id="s1", yes=True)
+        argparse.Namespace(mcp_cmd="delete", mcp_server_id=_SID, yes=True)
     )
     assert methods == ["DELETE"]
     assert "Deleted" in capsys.readouterr().out
+
+
+def test_mcp_servers_delete_resolves_name(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    requests: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append((request.method, request.url.path))
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json=[
+                    {"id": _SID, "name": "vic-notion", "url": "https://notion/mcp"},
+                    {"id": "other", "name": "deep-wiki", "url": "https://wiki/mcp"},
+                ],
+            )
+        return httpx.Response(204)
+
+    _patch_client(monkeypatch, handler)
+    execute_mcp_servers_command(
+        argparse.Namespace(mcp_cmd="delete", mcp_server_id="vic-notion", yes=True)
+    )
+    assert requests == [
+        ("GET", "/v1/deepagents/mcp-servers"),
+        ("DELETE", f"/v1/deepagents/mcp-servers/{_SID}"),
+    ]
+    assert _SID in capsys.readouterr().out
+
+
+def test_mcp_servers_delete_resolves_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append((request.method, request.url.path))
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json=[{"id": _SID, "name": "notion", "url": "https://mcp.notion.com/mcp"}],
+            )
+        return httpx.Response(204)
+
+    _patch_client(monkeypatch, handler)
+    # Trailing slash differs from the registered URL; normalization should match.
+    execute_mcp_servers_command(
+        argparse.Namespace(
+            mcp_cmd="delete",
+            mcp_server_id="https://mcp.notion.com/mcp/",
+            yes=True,
+        )
+    )
+    assert ("DELETE", f"/v1/deepagents/mcp-servers/{_SID}") in requests
+
+
+def test_mcp_servers_resolve_not_found_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        return httpx.Response(200, json=[{"id": _SID, "name": "other"}])
+
+    _patch_client(monkeypatch, handler)
+    with pytest.raises(SystemExit):
+        execute_mcp_servers_command(
+            argparse.Namespace(mcp_cmd="delete", mcp_server_id="missing", yes=True)
+        )
+    assert "no MCP server matches" in capsys.readouterr().out
+
+
+def test_mcp_servers_resolve_ambiguous_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        return httpx.Response(
+            200,
+            json=[
+                {"id": "id-a", "name": "dupe", "url": "https://a"},
+                {"id": "id-b", "name": "dupe", "url": "https://b"},
+            ],
+        )
+
+    _patch_client(monkeypatch, handler)
+    with pytest.raises(SystemExit):
+        execute_mcp_servers_command(
+            argparse.Namespace(mcp_cmd="delete", mcp_server_id="dupe", yes=True)
+        )
+    assert "matches multiple MCP servers" in capsys.readouterr().out

--- a/libs/cli/tests/unit_tests/deploy/test_mcp_servers_command.py
+++ b/libs/cli/tests/unit_tests/deploy/test_mcp_servers_command.py
@@ -77,6 +77,7 @@ def test_mcp_servers_add_parses_header_pairs(
             name="Fleet",
             header=["X-Api-Key=secret-value"],
             auth_type="headers",
+            no_tools=True,
         )
     )
     assert dotenv_calls
@@ -105,6 +106,7 @@ def test_mcp_servers_add_defaults_name_to_hostname(
             name=None,
             header=[],
             auth_type="headers",
+            no_tools=True,
         )
     )
     assert captured["body"]["name"] == "tools.langchain.com"
@@ -132,6 +134,7 @@ def test_mcp_servers_add_oauth_sends_per_user_mode(
             force_new=False,
             timeout=300,
             no_browser=False,
+            no_tools=True,
         )
     )
     assert captured["body"] == {
@@ -205,6 +208,7 @@ def test_mcp_servers_add_connect_runs_oauth_flow(
             force_new=False,
             timeout=300,
             no_browser=True,
+            no_tools=True,
         )
     )
     assert requests == [
@@ -307,6 +311,134 @@ def test_mcp_servers_add_bad_header_raises(
                 auth_type="headers",
             )
         )
+
+
+def test_mcp_servers_add_headers_lists_tools(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path.endswith("/mcp-servers"):
+            return httpx.Response(
+                201,
+                json={"id": _SID, "name": "Fleet", "url": "https://tools.example"},
+            )
+        if request.url.path == "/v1/deepagents/mcp/tools":
+            assert request.url.params.get("url") == "https://tools.example"
+            return httpx.Response(
+                200,
+                json={"tools": [{"name": "read_url", "description": "Read a URL."}]},
+            )
+        msg = f"unexpected path {request.url.path}"
+        raise AssertionError(msg)
+
+    _patch_client(monkeypatch, handler)
+    execute_mcp_servers_command(
+        argparse.Namespace(
+            mcp_cmd="add",
+            url="https://tools.example",
+            name="Fleet",
+            header=["X-Api-Key=secret"],
+            auth_type="headers",
+            no_tools=False,
+        )
+    )
+    out = capsys.readouterr().out
+    assert "Created mcp_server" in out
+    assert "read_url" in out
+    assert '"mcp_server_url": "https://tools.example"' in out
+
+
+def test_mcp_servers_add_oauth_without_connect_hints(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        return httpx.Response(
+            201,
+            json={"id": _SID, "name": "GitHub", "url": "https://tools.example"},
+        )
+
+    _patch_client(monkeypatch, handler)
+    execute_mcp_servers_command(
+        argparse.Namespace(
+            mcp_cmd="add",
+            url="https://tools.example",
+            name="GitHub",
+            header=[],
+            auth_type="oauth",
+            connect=False,
+            scope=[],
+            force_new=False,
+            timeout=300,
+            no_browser=False,
+            no_tools=False,
+        )
+    )
+    out = capsys.readouterr().out
+    assert "After connecting, run" in out
+    assert "/v1/deepagents/mcp/tools" not in paths
+
+
+def test_mcp_servers_add_tool_listing_error_degrades(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path.endswith("/mcp-servers"):
+            return httpx.Response(
+                201,
+                json={"id": _SID, "name": "Fleet", "url": "https://tools.example"},
+            )
+        if request.url.path == "/v1/deepagents/mcp/tools":
+            return httpx.Response(404, json={"detail": "not found"})
+        msg = f"unexpected path {request.url.path}"
+        raise AssertionError(msg)
+
+    _patch_client(monkeypatch, handler)
+    # `add` must still succeed (exit 0) even though tool discovery 404s.
+    execute_mcp_servers_command(
+        argparse.Namespace(
+            mcp_cmd="add",
+            url="https://tools.example",
+            name="Fleet",
+            header=[],
+            auth_type="headers",
+            no_tools=False,
+        )
+    )
+    out = capsys.readouterr().out
+    assert "Created mcp_server" in out
+    assert "mcp-servers tools" in out
+
+
+def test_mcp_servers_add_no_tools_skips_listing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        return httpx.Response(
+            201,
+            json={"id": _SID, "name": "Fleet", "url": "https://tools.example"},
+        )
+
+    _patch_client(monkeypatch, handler)
+    execute_mcp_servers_command(
+        argparse.Namespace(
+            mcp_cmd="add",
+            url="https://tools.example",
+            name="Fleet",
+            header=[],
+            auth_type="headers",
+            no_tools=True,
+        )
+    )
+    assert "/v1/deepagents/mcp/tools" not in paths
 
 
 def test_mcp_servers_list(
@@ -462,6 +594,48 @@ def test_mcp_servers_delete(
     )
     assert methods == ["DELETE"]
     assert "Deleted" in capsys.readouterr().out
+
+
+def test_mcp_servers_tools_lists_and_prints_snippet(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == f"/v1/deepagents/mcp-servers/{_SID}":
+            return httpx.Response(
+                200,
+                json={
+                    "id": _SID,
+                    "name": "deep-wiki",
+                    "url": "https://mcp.deepwiki.com/mcp",
+                },
+            )
+        if request.url.path == "/v1/deepagents/mcp/tools":
+            assert request.url.params.get("url") == "https://mcp.deepwiki.com/mcp"
+            return httpx.Response(
+                200,
+                json={
+                    "tools": [
+                        {"name": "read_wiki", "description": "Read a page.\nMore."},
+                        {"name": "search", "description": "Search."},
+                    ],
+                    "cached": True,
+                },
+            )
+        msg = f"unexpected path {request.url.path}"
+        raise AssertionError(msg)
+
+    _patch_client(monkeypatch, handler)
+    execute_mcp_servers_command(
+        argparse.Namespace(mcp_cmd="tools", mcp_server_id=_SID)
+    )
+    out = capsys.readouterr().out
+    assert "read_wiki" in out
+    assert "Read a page." in out  # only the first description line
+    assert '"mcp_server_url": "https://mcp.deepwiki.com/mcp"' in out
+    assert '"mcp_server_name": "deep-wiki"' in out
+    snippet = json.loads(out[out.index("{") :])
+    assert [t["name"] for t in snippet["tools"]] == ["read_wiki", "search"]
 
 
 def test_mcp_servers_delete_resolves_name(

--- a/libs/cli/tests/unit_tests/deploy/test_project.py
+++ b/libs/cli/tests/unit_tests/deploy/test_project.py
@@ -402,9 +402,7 @@ def test_subagent_model_and_model_id_conflict_raises(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize("model", ["", 123])
-def test_subagent_model_must_be_non_empty_string(
-    tmp_path: Path, model: object
-) -> None:
+def test_subagent_model_must_be_non_empty_string(tmp_path: Path, model: object) -> None:
     _write_subagent(tmp_path, '{"model": ' + json.dumps(model) + "}")
     with pytest.raises(ProjectError, match="model"):
         Project.load(tmp_path)

--- a/libs/cli/tests/unit_tests/deploy/test_project.py
+++ b/libs/cli/tests/unit_tests/deploy/test_project.py
@@ -375,6 +375,41 @@ def test_load_with_subagents() -> None:
     assert sa.extra_files == {}
 
 
+def _write_subagent(root: Path, agent_json: str) -> None:
+    _write_minimal_project(root)
+    sa = root / "subagents" / "researcher"
+    sa.mkdir(parents=True)
+    (sa / "agent.json").write_text(agent_json)
+    (sa / "AGENTS.md").write_text("Research.")
+
+
+def test_subagent_model_round_trip(tmp_path: Path) -> None:
+    _write_subagent(tmp_path, '{"model": "  anthropic:claude-sonnet-4-6  "}')
+    proj = Project.load(tmp_path)
+    assert proj.subagents[0].model_id == "anthropic:claude-sonnet-4-6"
+
+
+def test_subagent_legacy_model_id_still_supported(tmp_path: Path) -> None:
+    _write_subagent(tmp_path, '{"model_id": "anthropic:claude-sonnet-4-6"}')
+    proj = Project.load(tmp_path)
+    assert proj.subagents[0].model_id == "anthropic:claude-sonnet-4-6"
+
+
+def test_subagent_model_and_model_id_conflict_raises(tmp_path: Path) -> None:
+    _write_subagent(tmp_path, '{"model": "a:b", "model_id": "a:b"}')
+    with pytest.raises(ProjectError, match="either `model` or `model_id`"):
+        Project.load(tmp_path)
+
+
+@pytest.mark.parametrize("model", ["", 123])
+def test_subagent_model_must_be_non_empty_string(
+    tmp_path: Path, model: object
+) -> None:
+    _write_subagent(tmp_path, '{"model": ' + json.dumps(model) + "}")
+    with pytest.raises(ProjectError, match="model"):
+        Project.load(tmp_path)
+
+
 def test_subagent_local_skills_go_into_extra_files() -> None:
     proj = Project.load(_FIXTURES / "subagent_with_local_skills")
     sa = proj.subagents[0]


### PR DESCRIPTION
Minor clean up for the `deepagents` deploy CLI so going from `init` to a deployed agent
is less fiddly, plus a few `mcp-servers` fixes.

- Subagent `agent.json` now takes `model` (same key as the top-level config and
  the SDK `SubAgent` spec). `model_id` still works as a deprecated fallback.
- `init` now defaults `backend.type` to `default`, ships an empty `tools.json`
  (so the first deploy works before any MCP server is registered), scaffolds an
  example skill and subagent, and prints a short walkthrough of the workflow.
- `mcp-servers get`/`update`/`delete`/`connect` accept an id, name, or URL
  instead of only the UUID (resolved client-side against the server list).
- New `mcp-servers tools <id|name|url>` lists a server's tools and prints a
  ready-to-paste `tools.json` snippet. `mcp-servers add` runs the same discovery
  automatically after registering (best-effort; `--no-tools` to skip).

The tools features rely on the platform change that mounts
`/v1/deepagents/mcp/tools` (langchainplus #26365) — merge that first. Until it's
live, `mcp-servers tools` errors and the post-`add` listing falls back to a hint,
so nothing breaks.