### PR TITLE
docs(ci): clarify release-sha commit

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -239,7 +239,7 @@ Because nothing was published, you still get to decide what eventually goes out 
 1. **Figure out why the release failed.** Look at the workflow run logs.
 2. **Open a PR with the fix.** Use a `hotfix(<scope>): <description>` title so it doesn't trigger another release PR update. Merge it to `main`.
    - Important: leave `pyproject.toml`'s version exactly as the release-please PR set it. The hotfix should only fix the problem that broke the release.
-3. **Manually re-dispatch the release workflow** ([Manual Release](#manual-release)). Pass `release-sha` = `main`'s HEAD (the hotfix commit). The workflow will build, publish, and tag that commit.
+3. **Manually re-dispatch the release workflow** ([Manual Release](#manual-release)). Pass `release-sha` = the SHA of your hotfix commit — the one that fixed the release *and* still declares the target version. Right after you merge it, that's the tip of `main`, but pin the explicit SHA rather than relying on "HEAD" (e.g. `gh pr view <hotfix-pr-number> --json mergeCommit --jq .mergeCommit.oid`), since `main` can advance if another PR lands first. The workflow checks out, builds, publishes, and tags that exact commit.
 4. **Confirm the label swap.** The `mark-release` job swaps the original release-please PR's `autorelease: pending` label to `autorelease: tagged` — it finds the right PR via a fallback label search, even though `release-sha` points at the hotfix commit, not the release-please commit. Double-check the original release-please PR in GitHub after the workflow succeeds. If the label didn't swap, fix it by hand — see [Release PR Stuck with "autorelease: pending" Label](#release-pr-stuck-with-autorelease-pending-label).
 
 > [!NOTE]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,14 @@ on:
         type: string
         default: ""
         description:
-          "SHA on main whose pyproject.toml declares the input version.
-          Typically the release-please PR's squash-merge commit. May also be a
-          pre-publish hotfix commit on top of it. Look up the release-please
-          merge with: gh pr view <release-pr-number> --json mergeCommit --jq
-          .mergeCommit.oid. Required unless dangerous-nonmain-release=true. See
-          .github/RELEASING.md > Manual Release."
+          "Exact commit (40-char SHA, not a branch ref) to build, publish, and
+          tag, so PyPI bytes and the git tag agree. Its pyproject.toml must
+          declare the `version` input. Usually the release-please squash-merge
+          commit, or the most recent pre-publish hotfix commit on top of it
+          (hotfixes keep the version string). Find it: gh pr view <pr-number>
+          --json mergeCommit
+          --jq .mergeCommit.oid. Required unless dangerous-nonmain-release=true.
+          See .github/RELEASING.md > Manual Release, > Hotfix Protocol."
       dangerous-nonmain-release:
         required: false
         type: boolean


### PR DESCRIPTION
The `release-sha` input help text and the Case A hotfix steps both described the value as "`main`'s HEAD," which conflates a moving branch ref with the specific commit you actually want. Both now spell out that it's an exact 40-char SHA — the one whose `pyproject.toml` declares the target version — and explain why pinning it (rather than trusting HEAD) matters when `main` can advance.