### PR TITLE
chore(ci): tidy changelogs and quiet an expected release annotation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -988,7 +988,11 @@ jobs:
               #      PR (no autorelease label). Try 2 will find the real one.
               #   2. dangerous-nonmain-release: alpha/hotfix branches have no
               #      release-please PR at all.
-              echo "::notice::PR #$PR_NUMBER lacks 'autorelease: pending'. Falling through to label search."
+              # Plain echo (not ::notice::): this is an expected, healthy path,
+              # so it stays in the step log for debugging without raising a
+              # run-level annotation. The annotation-worthy outcomes below
+              # (no release PR found, edit failure) use ::warning::/::error::.
+              echo "PR #$PR_NUMBER lacks 'autorelease: pending'. Falling through to label search."
             fi
           else
             echo "No PR found via commit ${RELEASE_SHA}."

--- a/libs/acp/CHANGELOG.md
+++ b/libs/acp/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 * Restore passing tests after acp v0.9 schema bump ([#2813](https://github.com/langchain-ai/deepagents/issues/2813)) ([29a351a](https://github.com/langchain-ai/deepagents/commit/29a351a8f5de8c460a3eeaadd76a3c2ace0072e0))
 
-## Changelog
-
 ---
 
 ## Prior Releases

--- a/libs/cli/CHANGELOG.md
+++ b/libs/cli/CHANGELOG.md
@@ -2,25 +2,21 @@
 
 # Deep Agents CLI Changelog
 
-From 0.2.0 onward, `deepagents-cli` exposes `init`, `deploy`, `agents`, and
-`mcp-servers` against the Managed Deep Agents `/v1/deepagents/*` API.
-The coding agent (interactive TUI & headless CLI) moved to [`deepagents-code`](https://github.com/langchain-ai/deepagents/blob/main/libs/code/CHANGELOG.md).
+From 0.2.0 onward, `deepagents-cli` exposes `init`, `deploy`, `agents`, and `mcp-servers` against the Managed Deep Agents `/v1/deepagents/*` API. The coding agent (interactive TUI & headless CLI) moved to [`deepagents-code`](https://github.com/langchain-ai/deepagents/blob/main/libs/code/CHANGELOG.md).
 
 ## [0.2.0](https://github.com/langchain-ai/deepagents/compare/deepagents-cli==0.1.2...deepagents-cli==0.2.0) (2026-06-01)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **cli:** `deepagents deploy` now targets the Managed Deep Agents API; `deepagents dev`, `deepagents.toml`, and the `--config`/`--dry-run` flags are removed. Run `deepagents init` to re-scaffold (`agent.json` + `tools.json`). See [PR](https://github.com/langchain-ai/deepagents/pull/3609) for the full migration guide.
+* `deepagents deploy` now targets the Managed Deep Agents API; `deepagents dev`, `deepagents.toml`, and the `--config`/`--dry-run` flags are removed. Run `deepagents init` to re-scaffold (`agent.json` + `tools.json`). See [PR](https://github.com/langchain-ai/deepagents/pull/3609) for the full migration guide.
 
 ### Features
 
-* **cli:** migrate deepagents deploy to use managed deep agents api [AB-2470] ([#3609](https://github.com/langchain-ai/deepagents/issues/3609)) ([72aef52](https://github.com/langchain-ai/deepagents/commit/72aef52542a3fd4a7eebcb3dba40e28adf1aa044))
-
+* Migrate `deepagents deploy` to use Managed Deep Agents API ([#3609](https://github.com/langchain-ai/deepagents/issues/3609)) ([72aef52](https://github.com/langchain-ai/deepagents/commit/72aef52542a3fd4a7eebcb3dba40e28adf1aa044))
 
 ### Bug Fixes
 
-* **sdk:** stable `HumanMessage` IDs across resumed threads ([#3591](https://github.com/langchain-ai/deepagents/issues/3591)) ([82c3194](https://github.com/langchain-ai/deepagents/commit/82c31947f9dc938ffc71e1cea96d162a39aec3a1))
+* Stable `HumanMessage` IDs across resumed threads ([#3591](https://github.com/langchain-ai/deepagents/issues/3591)) ([82c3194](https://github.com/langchain-ai/deepagents/commit/82c31947f9dc938ffc71e1cea96d162a39aec3a1))
 
 ## [0.1.2](https://github.com/langchain-ai/deepagents/compare/deepagents-cli==0.1.1...deepagents-cli==0.1.2) (2026-05-21)
 

--- a/libs/code/CHANGELOG.md
+++ b/libs/code/CHANGELOG.md
@@ -102,5 +102,7 @@ Hello world! Ported from `libs/cli`.
 
 ---
 
+## Prior Releases
+
 `deepagents-code` was forked from `deepagents-cli` at v0.1.0 (2026-05-12).
 For history prior to the fork, see [the `deepagents-cli` changelog](https://github.com/langchain-ai/deepagents/blob/main/libs/cli/CHANGELOG.md).

--- a/libs/deepagents/CHANGELOG.md
+++ b/libs/deepagents/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD024 -->
 
-# Changelog
+# Deep Agents Changelog
 
 ## [0.6.7](https://github.com/langchain-ai/deepagents/compare/deepagents==0.6.6...deepagents==0.6.7) (2026-05-30)
 
@@ -171,6 +171,6 @@ See the [profiles documentation](https://docs.langchain.com/oss/python/deepagent
 
 ---
 
-# Prior Releases
+## Prior Releases
 
 Versions prior to 0.5.1 were released without release-please and do not have changelog entries. Refer to the [releases page](https://github.com/langchain-ai/deepagents/releases?q=deepagents) for details on previous versions.

--- a/libs/partners/daytona/CHANGELOG.md
+++ b/libs/partners/daytona/CHANGELOG.md
@@ -4,12 +4,9 @@
 
 ## [0.0.6](https://github.com/langchain-ai/deepagents/compare/langchain-daytona==0.0.5...langchain-daytona==0.0.6) (2026-05-12)
 
-
 ### Features
 
-* **sdk:** v0.6 ([4db09ac](https://github.com/langchain-ai/deepagents/commit/4db09acba34b38521192b8f278723524be560779))
-
-## Changelog
+* v0.6 ([4db09ac](https://github.com/langchain-ai/deepagents/commit/4db09acba34b38521192b8f278723524be560779))
 
 ---
 

--- a/libs/partners/modal/CHANGELOG.md
+++ b/libs/partners/modal/CHANGELOG.md
@@ -4,12 +4,9 @@
 
 ## [0.0.4](https://github.com/langchain-ai/deepagents/compare/langchain-modal==0.0.3...langchain-modal==0.0.4) (2026-05-12)
 
-
 ### Features
 
-* **sdk:** v0.6 ([4db09ac](https://github.com/langchain-ai/deepagents/commit/4db09acba34b38521192b8f278723524be560779))
-
-## Changelog
+* v0.6 ([4db09ac](https://github.com/langchain-ai/deepagents/commit/4db09acba34b38521192b8f278723524be560779))
 
 ---
 

--- a/libs/partners/quickjs/CHANGELOG.md
+++ b/libs/partners/quickjs/CHANGELOG.md
@@ -4,12 +4,10 @@
 
 ## [0.1.3](https://github.com/langchain-ai/deepagents/compare/langchain-quickjs==0.1.2...langchain-quickjs==0.1.3) (2026-06-01)
 
-
 ### Features
 
 * Add REPL persistence modes ([#3557](https://github.com/langchain-ai/deepagents/issues/3557)) ([0cda6f3](https://github.com/langchain-ai/deepagents/commit/0cda6f3ab28bc83cd16ec9fcc48229bdf6f2dc1a))
 * Add swarm task tool ([#3472](https://github.com/langchain-ai/deepagents/issues/3472)) ([2c28b7b](https://github.com/langchain-ai/deepagents/commit/2c28b7b8c2ac7571fc3a1f0d8d00f5697fe3e90e))
-
 
 ### Bug Fixes
 
@@ -20,47 +18,19 @@
 
 ## [0.1.2](https://github.com/langchain-ai/deepagents/compare/langchain-quickjs==0.1.1...langchain-quickjs==0.1.2) (2026-05-11)
 
-
 ### Features
 
-* **quickjs:** rename middleware ([#3334](https://github.com/langchain-ai/deepagents/issues/3334)) ([fc80075](https://github.com/langchain-ai/deepagents/commit/fc80075c65c3b4beb8f672b6bb27464fee6d79c2))
+* Rename middleware ([#3334](https://github.com/langchain-ai/deepagents/issues/3334)) ([fc80075](https://github.com/langchain-ai/deepagents/commit/fc80075c65c3b4beb8f672b6bb27464fee6d79c2))
 
 ## [0.1.1](https://github.com/langchain-ai/deepagents/compare/langchain-quickjs==0.1.0...langchain-quickjs==0.1.1) (2026-05-08)
 
-
 ### Features
 
-* **quickjs:** propagate return types ([#3210](https://github.com/langchain-ai/deepagents/issues/3210)) ([e26bccb](https://github.com/langchain-ai/deepagents/commit/e26bccbe81b4e3ff2f0332f56f683106e0bafd88))
-
-
-### Reverted Changes
-
-* **quickjs:** release: 0.1.1 ([#3255](https://github.com/langchain-ai/deepagents/issues/3255)) ([8125f71](https://github.com/langchain-ai/deepagents/commit/8125f71a6ffd40b75a25c017e2b255eeb3be48a6))
+* Propagate return types ([#3210](https://github.com/langchain-ai/deepagents/issues/3210)) ([e26bccb](https://github.com/langchain-ai/deepagents/commit/e26bccbe81b4e3ff2f0332f56f683106e0bafd88))
 
 ## [0.1.0](https://github.com/langchain-ai/deepagents/compare/langchain-quickjs==0.0.1...langchain-quickjs==0.1.0) (2026-05-05)
 
-This release introduces a new QuickJS runtime implementation backed by
-`quickjs-rs`, replacing the previous interpreter path.
-
-### Features
-
-* **quickjs:** add `max_ptc_calls` budget for ptc calls ([#2994](https://github.com/langchain-ai/deepagents/issues/2994)) ([13f6c2d](https://github.com/langchain-ai/deepagents/commit/13f6c2dec448e270d7e685447292d394d31fe528))
-* **quickjs:** add snapshot-based repl persistence between turns ([#3064](https://github.com/langchain-ai/deepagents/issues/3064)) ([c46feed](https://github.com/langchain-ai/deepagents/commit/c46feed66e83876054489a8454904de4c87ddf6b))
-* **quickjs:** surface tool exceptions as the original error ([#3049](https://github.com/langchain-ai/deepagents/issues/3049)) ([d96dc8c](https://github.com/langchain-ai/deepagents/commit/d96dc8ce4a1d2d25abc606266cfe14629789c457))
-* **quickjs:** use quickjs-rs ([#2979](https://github.com/langchain-ai/deepagents/issues/2979)) ([7491899](https://github.com/langchain-ai/deepagents/commit/7491899074fa1ed7946f2f5a0e84c2b3793d39bd))
-
-
-### Bug Fixes
-
-* **quickjs:** add `ls_code_input_language` metadata to `eval` tool ([#3062](https://github.com/langchain-ai/deepagents/issues/3062)) ([b9bc674](https://github.com/langchain-ai/deepagents/commit/b9bc674fe67ac40e000b30bbb4a753a9b6e167ed))
-* **quickjs:** bound console buffering at capture time ([#2999](https://github.com/langchain-ai/deepagents/issues/2999)) ([251e405](https://github.com/langchain-ai/deepagents/commit/251e405d8b1897ae09ee47b0a8be48edfaaad8a1))
-* **quickjs:** handle top-level await in snapshot step ([#3161](https://github.com/langchain-ai/deepagents/issues/3161)) ([b330c22](https://github.com/langchain-ai/deepagents/commit/b330c222ee661f7944a59d7b0ef2e0c7a42b1e29))
-* **quickjs:** keep PTC loop and runtime context in `_PTCState` ([#3134](https://github.com/langchain-ai/deepagents/issues/3134)) ([c70cc5a](https://github.com/langchain-ai/deepagents/commit/c70cc5a602bd26191f347dd31cc4e5d17c75f65f))
-* **quickjs:** per-thread_id Runtimes ([#2931](https://github.com/langchain-ai/deepagents/issues/2931)) ([4021b03](https://github.com/langchain-ai/deepagents/commit/4021b032f79913ddbfbb233fce5aff3f245fd1db))
-* **quickjs:** prompt improvements ([#2564](https://github.com/langchain-ai/deepagents/issues/2564)) ([4999c6b](https://github.com/langchain-ai/deepagents/commit/4999c6b064266a0f0189964241323fd0f0ba345e))
-* **quickjs:** remove ptc command buffering ([#3023](https://github.com/langchain-ai/deepagents/issues/3023)) ([ac1218a](https://github.com/langchain-ai/deepagents/commit/ac1218a1b14cde2f066c59804ab86567821f8c9d))
-
-## Changelog
+This release introduces a new QuickJS runtime implementation backed by `quickjs-rs`.
 
 ---
 

--- a/libs/partners/runloop/CHANGELOG.md
+++ b/libs/partners/runloop/CHANGELOG.md
@@ -4,12 +4,9 @@
 
 ## [0.0.5](https://github.com/langchain-ai/deepagents/compare/langchain-runloop==0.0.4...langchain-runloop==0.0.5) (2026-05-12)
 
-
 ### Features
 
-* **sdk:** v0.6 ([4db09ac](https://github.com/langchain-ai/deepagents/commit/4db09acba34b38521192b8f278723524be560779))
-
-## Changelog
+* v0.6 ([4db09ac](https://github.com/langchain-ai/deepagents/commit/4db09acba34b38521192b8f278723524be560779))
 
 ---
 


### PR DESCRIPTION
Housekeeping pass over the per-package `CHANGELOG.md` files plus one follow-on to the release workflow. The changelog edits remove artifacts left by release-please's generation (stray `## Changelog` headings, redundant per-entry scope prefixes, duplicated history, double blank lines) so each file reads cleanly as a standalone package log.