### PR TITLE
fix(code): allow recovery commands when startup fails

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -4847,9 +4847,21 @@ class DeepAgentsApp(App):
             BYPASS_WHEN_CONNECTING,
             IMMEDIATE_UI,
             SIDE_EFFECT_FREE,
+            STARTUP_RECOVERY_COMMANDS,
         )
 
         cmd = value.split(maxsplit=1)[0] if value else ""
+        # Recovery escape hatch: when startup failed (`_server_startup_error`
+        # set) and nothing is running, the commands that repair the session
+        # must run instead of being parked behind the failure they fix — e.g.
+        # `/install <pkg>` for a missing provider package. Gated on no active
+        # work so a reinstall never swaps the running binary mid-turn.
+        if (
+            cmd in STARTUP_RECOVERY_COMMANDS
+            and self._server_startup_error is not None
+            and not (self._agent_running or self._shell_running)
+        ):
+            return True
         if cmd in BYPASS_WHEN_CONNECTING:
             return self._connecting and not (self._agent_running or self._shell_running)
         if cmd in IMMEDIATE_UI:

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -282,6 +282,23 @@ Includes both debug helpers (`/debug-error`) and recovery escape hatches
 (`/restart` — hot-respawn the app-owned LangGraph server).
 """
 
+STARTUP_RECOVERY_COMMANDS: frozenset[str] = frozenset(
+    {"/install", "/reload", "/update"}
+)
+"""`QUEUED`-tier commands that must still run when startup has failed.
+
+When the configured model can't be built (e.g. its provider package is
+missing) the server never starts and the app holds a `_server_startup_error`
+state that parks queued messages. These are the recovery escape hatches for
+that state — install the missing package, reload config/env, or upgrade the
+tool — so they must bypass the queue rather than sit behind the very failure
+they repair. `/model` and `/auth` already escape via `IMMEDIATE_UI` (which
+opens a modal and defers the real work); the commands here instead perform
+their repair work directly, so they stay `QUEUED` and rely on this exemption.
+The bypass itself is gated in `_can_bypass_queue`. Every entry is also
+`QUEUE_BOUND` — the recovery exemption is orthogonal to the normal queue.
+"""
+
 ALL_CLASSIFIED: frozenset[str] = (
     ALWAYS_IMMEDIATE
     | BYPASS_WHEN_CONNECTING

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -4,6 +4,17 @@
 # Usage:
 #   curl -LsSf https://langch.in/dcode | bash
 #
+# Uninstall:
+#   This script installs deepagents-code as a uv tool. To remove it:
+#     uv tool uninstall deepagents-code
+#   That removes the dcode/deepagents-code binary and its isolated venv.
+#   User config and data live separately in ~/.deepagents (config.toml,
+#   hooks.json, a global .env, and a .state/ dir holding sessions and saved
+#   credentials) and are NOT removed by the uninstall above. To also wipe them:
+#     rm -rf ~/.deepagents
+#   Optionally clear uv's shared tool cache (~/.cache/uv on Linux,
+#   ~/Library/Caches/uv on macOS) — only if no other uv tools rely on it.
+#
 # Environment variables:
 #   DEEPAGENTS_CODE_EXTRAS  — comma-separated pip extras, e.g. "ollama",
 #                             "ollama,groq", or "daytona"
@@ -371,7 +382,11 @@ if [ "$VERBOSE" != "1" ] && command -v awk >/dev/null 2>&1; then
         if ((p in removed) && (p in added)) {
           printf "  %s%s  %s → %s\n", p, pad, removed[p], added[p]
         } else if (p in added) {
-          printf "  %s%s  %s (new)\n", p, pad, added[p]
+          # "(new)" only disambiguates within an Updated list (mixed with
+          # upgraded/removed rows). Under "Installed packages:" every row is
+          # new, so the header already says it — drop the suffix.
+          if (any_removed) printf "  %s%s  %s (new)\n", p, pad, added[p]
+          else             printf "  %s%s  %s\n", p, pad, added[p]
         } else {
           printf "  %s%s  %s (removed)\n", p, pad, removed[p]
         }
@@ -446,15 +461,15 @@ if [ "$VERBOSE" = "1" ] && [ -n "$DCODE_BIN_DISPLAY" ]; then
 fi
 
 if [ "$VERIFY_OK" = true ]; then
-  # Skip the redundant "Verified" line on the already-up-to-date path —
-  # the prior log_success above already named the version. Only emit it on
-  # fresh install, upgrade, or editable→PyPI swap.
+  # The prior log_success already named the installed/updated version, so the
+  # "Verified" line is redundant for the common case — gate it behind VERBOSE.
+  # The empty-output warning stays unconditional: it signals a broken install.
   if [ -z "$NEW_VERSION" ] || [ "$PRE_VERSION" != "$NEW_VERSION" ] || [ "$IS_EDITABLE" = true ]; then
     VERIFY_FIRST=$(printf '%s\n' "$VERIFY_OUTPUT" | head -1)
-    if [ -n "$VERIFY_FIRST" ]; then
-      log_success "Verified: ${DCODE_NAME} ${VERIFY_FIRST}"
-    else
+    if [ -z "$VERIFY_FIRST" ]; then
       log_warn "${DCODE_NAME} -v exited 0 but produced no output; installation may be incomplete."
+    elif [ "$VERBOSE" = "1" ]; then
+      log_success "Verified: ${DCODE_NAME} ${VERIFY_FIRST}"
     fi
   fi
 elif [ -n "$DCODE_BIN" ]; then

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -10765,3 +10765,107 @@ class TestRespawnServer:
             ready = [m for m in posted if isinstance(m, app.ServerReady)]
             assert len(ready) == 1
             assert ready[0].mcp_server_info is None
+
+
+class TestCanBypassQueue:
+    """Tests for `_can_bypass_queue`, focused on failed-startup recovery.
+
+    A failed model build (e.g. a missing provider package) leaves the app in a
+    `_server_startup_error` state that parks queued messages until a successful
+    start drains them. Recovery commands like `/install` must escape that wedge
+    so the user can repair the session, but only while nothing is running.
+    """
+
+    def _app(self) -> DeepAgentsApp:
+        return DeepAgentsApp(thread_id="thread-bypass")
+
+    def test_install_bypasses_when_startup_failed(self) -> None:
+        app = self._app()
+        app._server_startup_error = "Missing package for provider 'baseten'."
+        app._agent_running = False
+        app._shell_running = False
+        assert app._can_bypass_queue("/install baseten") is True
+
+    def test_reload_and_update_bypass_when_startup_failed(self) -> None:
+        app = self._app()
+        app._server_startup_error = "boom"
+        assert app._can_bypass_queue("/reload") is True
+        assert app._can_bypass_queue("/update") is True
+
+    def test_install_does_not_bypass_without_startup_error(self) -> None:
+        # Normal idle: `/install` is QUEUED-tier and only earns the recovery
+        # exemption when startup has actually failed.
+        app = self._app()
+        app._server_startup_error = None
+        assert app._can_bypass_queue("/install baseten") is False
+
+    def test_install_does_not_bypass_while_agent_running(self) -> None:
+        # Reinstalling the tool mid-turn could swap the running binary, so the
+        # recovery bypass is gated on no active work even when an error is set.
+        app = self._app()
+        app._server_startup_error = "boom"
+        app._agent_running = True
+        assert app._can_bypass_queue("/install baseten") is False
+
+    def test_install_does_not_bypass_while_shell_running(self) -> None:
+        app = self._app()
+        app._server_startup_error = "boom"
+        app._shell_running = True
+        assert app._can_bypass_queue("/install baseten") is False
+
+    def test_non_recovery_queued_command_stays_queued_on_failure(self) -> None:
+        # The exemption is allowlisted; an unrelated QUEUED command (`/clear`)
+        # must not ride along into the failed-startup bypass.
+        app = self._app()
+        app._server_startup_error = "boom"
+        assert app._can_bypass_queue("/clear") is False
+
+    def test_install_bypasses_even_during_startup_sequence(self) -> None:
+        # `_startup_sequence_running` and `_connecting` intentionally do NOT
+        # block recovery — only active agent/shell work does. This pins that
+        # decision so a future "tightening" of the guard can't silently
+        # re-wedge the recovery path.
+        app = self._app()
+        app._server_startup_error = "boom"
+        app._startup_sequence_running = True
+        app._connecting = True
+        assert app._can_bypass_queue("/install baseten") is True
+
+    async def test_submit_input_processes_install_after_failed_startup(self) -> None:
+        # End-to-end: the fix is only real if `_submit_input` actually routes
+        # `/install` to processing instead of the pending queue. The predicate
+        # tests above don't catch a regression that unwires `_can_bypass_queue`
+        # from the queue decision — this does.
+        app = self._app()
+        app._server_startup_error = "Missing package for provider 'baseten'."
+        processed: list[tuple[str, str]] = []
+
+        async def _process(value: str, mode: str) -> None:  # noqa: RUF029  # replaces an awaited coroutine method; must stay async
+            processed.append((value, mode))
+
+        app._process_message = _process  # type: ignore[assignment]
+        app._mount_message = AsyncMock()  # type: ignore[assignment]
+
+        await app._submit_input("/install baseten", "command")
+
+        assert processed == [("/install baseten", "command")]
+        assert not app._pending_messages
+
+    async def test_submit_input_queues_non_recovery_after_failed_startup(self) -> None:
+        # The mirror of the above: a non-recovery command still parks in the
+        # queue during the failed-startup state instead of being processed.
+        app = self._app()
+        app._server_startup_error = "boom"
+        processed: list[tuple[str, str]] = []
+
+        async def _process(value: str, mode: str) -> None:  # noqa: RUF029  # replaces an awaited coroutine method; must stay async
+            processed.append((value, mode))
+
+        app._process_message = _process  # type: ignore[assignment]
+        app._mount_message = AsyncMock()  # type: ignore[assignment]
+
+        await app._submit_input("/clear", "command")
+
+        assert processed == []
+        assert len(app._pending_messages) == 1
+        assert app._pending_messages[0].text == "/clear"

--- a/libs/code/tests/unit_tests/test_command_registry.py
+++ b/libs/code/tests/unit_tests/test_command_registry.py
@@ -15,6 +15,7 @@ from deepagents_code.command_registry import (
     QUEUE_BOUND,
     SIDE_EFFECT_FREE,
     SLASH_COMMANDS,
+    STARTUP_RECOVERY_COMMANDS,
     CommandEntry,
 )
 
@@ -85,6 +86,17 @@ class TestBypassTiers:
                 assert alias in ALL_CLASSIFIED, (
                     f"Alias {alias!r} of {cmd.name} not in any tier"
                 )
+
+    def test_startup_recovery_commands_are_queue_bound(self) -> None:
+        # The recovery exemption is orthogonal to the normal tier: every
+        # recovery command keeps its QUEUED tier and only gains an extra
+        # failed-startup bypass. If one drifts to another tier, the comment
+        # in STARTUP_RECOVERY_COMMANDS (and the bypass rationale) goes stale.
+        assert STARTUP_RECOVERY_COMMANDS <= QUEUE_BOUND
+
+    def test_startup_recovery_commands_are_known(self) -> None:
+        names = {cmd.name for cmd in COMMANDS}
+        assert names >= STARTUP_RECOVERY_COMMANDS
 
 
 class TestSlashCommands:


### PR DESCRIPTION
When a configured model's provider package can't be imported, the model is built *before* the LangGraph server starts, so construction fails and the app holds a `_server_startup_error` state that parks queued slash commands until a successful start drains them. `/install` — the command that installs the missing package — is `QUEUED`, so it was trapped behind the very failure it repairs: typing `/install <pkg>` appeared to hang because it never ran. `/model` and `/auth` already escaped this wedge via `IMMEDIATE_UI`, but the package-recovery path did not.