### PR TITLE
fix(code): add terminal progress preference

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -560,6 +560,56 @@ def save_theme_preference(name: str) -> bool:
     return _save_theme_preference_result(name).ok
 
 
+def _load_bool_ui_preference(key: str, *, log_label: str) -> bool:
+    """Load a boolean `[ui]` preference from `~/.deepagents/config.toml`.
+
+    These preferences have no in-app command; the file is edited manually. The
+    loader is intentionally forgiving: any problem reading or parsing the config
+    falls back to `True` (the feature stays on) after logging a warning, so a
+    typo in a cosmetic setting never breaks startup.
+
+    Args:
+        key: The key to read from the `[ui]` table.
+        log_label: Human-readable name of the preference, used in warning logs.
+
+    Returns:
+        The saved `[ui].<key>` value, or `True` when unset, unreadable,
+            or malformed.
+    """
+    import tomllib
+
+    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
+
+    if not DEFAULT_CONFIG_PATH.exists():
+        return True
+    try:
+        with DEFAULT_CONFIG_PATH.open("rb") as f:
+            data = tomllib.load(f)
+    except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
+        logger.warning("Could not read config for %s preference: %s", log_label, exc)
+        return True
+
+    ui = data.get("ui", {})
+    if not isinstance(ui, dict):
+        logger.warning(
+            "[ui] should be a table; got %s while loading %s preference",
+            type(ui).__name__,
+            log_label,
+        )
+        return True
+
+    value = ui.get(key)
+    if isinstance(value, bool):
+        return value
+    if value is not None:
+        logger.warning(
+            "[ui].%s should be a boolean; got %s",
+            key,
+            type(value).__name__,
+        )
+    return True
+
+
 def _load_cursor_blink_preference() -> bool:
     """Load the saved cursor-blink preference from `~/.deepagents/config.toml`.
 
@@ -569,85 +619,25 @@ def _load_cursor_blink_preference() -> bool:
 
     Returns:
         The saved `[ui].cursor_blink` value, or `True` (blink on) when unset,
-            unreadable, or malformed.
+        unreadable, or malformed.
     """
-    import tomllib
-
-    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
-
-    if not DEFAULT_CONFIG_PATH.exists():
-        return True
-    try:
-        with DEFAULT_CONFIG_PATH.open("rb") as f:
-            data = tomllib.load(f)
-    except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
-        logger.warning("Could not read config for cursor blink preference: %s", exc)
-        return True
-
-    ui = data.get("ui", {})
-    if not isinstance(ui, dict):
-        logger.warning(
-            "[ui] should be a table; got %s while loading cursor blink preference",
-            type(ui).__name__,
-        )
-        return True
-
-    value = ui.get("cursor_blink")
-    if isinstance(value, bool):
-        return value
-    if value is not None:
-        logger.warning(
-            "[ui].cursor_blink should be a boolean; got %s",
-            type(value).__name__,
-        )
-    return True
+    return _load_bool_ui_preference("cursor_blink", log_label="cursor blink")
 
 
 def _load_terminal_progress_preference() -> bool:
     """Load the `OSC 9;4` progress preference from `~/.deepagents/config.toml`.
 
-    The terminal taskbar/dock/tab progress indicator can be turned off by
-    setting `[ui].terminal_progress = false` in the config file. There is no
-    in-app command for this; the file is edited manually. The
+    The terminal taskbar/dock/tab progress indicator (where supported) can be
+    turned off by setting `[ui].terminal_progress = false` in the config file.
+    There is no in-app command for this; the file is edited manually. The
     `DEEPAGENTS_CODE_NO_TERMINAL_ESCAPE` environment variable still disables all
     terminal escapes regardless of this value.
 
     Returns:
         The saved `[ui].terminal_progress` value, or `True` (progress on) when
-            unset, unreadable, or malformed.
+        unset, unreadable, or malformed.
     """
-    import tomllib
-
-    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
-
-    if not DEFAULT_CONFIG_PATH.exists():
-        return True
-    try:
-        with DEFAULT_CONFIG_PATH.open("rb") as f:
-            data = tomllib.load(f)
-    except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
-        logger.warning(
-            "Could not read config for terminal progress preference: %s", exc
-        )
-        return True
-
-    ui = data.get("ui", {})
-    if not isinstance(ui, dict):
-        logger.warning(
-            "[ui] should be a table; got %s while loading terminal progress preference",
-            type(ui).__name__,
-        )
-        return True
-
-    value = ui.get("terminal_progress")
-    if isinstance(value, bool):
-        return value
-    if value is not None:
-        logger.warning(
-            "[ui].terminal_progress should be a boolean; got %s",
-            type(value).__name__,
-        )
-    return True
+    return _load_bool_ui_preference("terminal_progress", log_label="terminal progress")
 
 
 def _save_terminal_theme_mapping_result(

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -603,6 +603,53 @@ def _load_cursor_blink_preference() -> bool:
     return True
 
 
+def _load_terminal_progress_preference() -> bool:
+    """Load the `OSC 9;4` progress preference from `~/.deepagents/config.toml`.
+
+    The terminal taskbar/dock/tab progress indicator can be turned off by
+    setting `[ui].terminal_progress = false` in the config file. There is no
+    in-app command for this; the file is edited manually. The
+    `DEEPAGENTS_CODE_NO_TERMINAL_ESCAPE` environment variable still disables all
+    terminal escapes regardless of this value.
+
+    Returns:
+        The saved `[ui].terminal_progress` value, or `True` (progress on) when
+            unset, unreadable, or malformed.
+    """
+    import tomllib
+
+    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
+
+    if not DEFAULT_CONFIG_PATH.exists():
+        return True
+    try:
+        with DEFAULT_CONFIG_PATH.open("rb") as f:
+            data = tomllib.load(f)
+    except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
+        logger.warning(
+            "Could not read config for terminal progress preference: %s", exc
+        )
+        return True
+
+    ui = data.get("ui", {})
+    if not isinstance(ui, dict):
+        logger.warning(
+            "[ui] should be a table; got %s while loading terminal progress preference",
+            type(ui).__name__,
+        )
+        return True
+
+    value = ui.get("terminal_progress")
+    if isinstance(value, bool):
+        return value
+    if value is not None:
+        logger.warning(
+            "[ui].terminal_progress should be a boolean; got %s",
+            type(value).__name__,
+        )
+    return True
+
+
 def _save_terminal_theme_mapping_result(
     term_program: str,
     name: str,
@@ -1409,6 +1456,9 @@ class DeepAgentsApp(App):
 
         self._cursor_blink_enabled = _load_cursor_blink_preference()
         """Whether the chat input cursor should blink (user preference)."""
+
+        self._terminal_progress_enabled = _load_terminal_progress_preference()
+        """Whether to emit `OSC 9;4` taskbar progress (user preference)."""
 
         self.sync_terminal_background()
 
@@ -3948,18 +3998,20 @@ class DeepAgentsApp(App):
             if self._loading_widget:
                 await self._loading_widget.remove()
                 self._loading_widget = None
-            try:
-                clear_terminal_progress()
-            except Exception:
-                # Cosmetic only — must never break spinner lifecycle.
-                logger.exception("clear_terminal_progress raised unexpectedly")
+            if self._terminal_progress_enabled:
+                try:
+                    clear_terminal_progress()
+                except Exception:
+                    # Cosmetic only — must never break spinner lifecycle.
+                    logger.exception("clear_terminal_progress raised unexpectedly")
             return
 
-        try:
-            set_terminal_progress(state=TerminalProgressState.INDETERMINATE)
-        except Exception:
-            # Cosmetic only — must never break spinner lifecycle.
-            logger.exception("set_terminal_progress raised unexpectedly")
+        if self._terminal_progress_enabled:
+            try:
+                set_terminal_progress(state=TerminalProgressState.INDETERMINATE)
+            except Exception:
+                # Cosmetic only — must never break spinner lifecycle.
+                logger.exception("set_terminal_progress raised unexpectedly")
 
         try:
             messages = self.query_one("#messages", Container)

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -9263,6 +9263,39 @@ class TestSetSpinnerTerminalProgress:
 
         assert "clear" in calls
 
+    async def test_config_opt_out_suppresses_progress(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`[ui].terminal_progress = false` should suppress progress escapes."""
+        from deepagents_code import terminal_escape
+
+        config = tmp_path / "config.toml"
+        config.write_text("[ui]\nterminal_progress = false\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+
+        calls: list[str] = []
+
+        def _record_set(*_args: object, **_kwargs: object) -> bool:
+            calls.append("set")
+            return True
+
+        def _record_clear() -> bool:
+            calls.append("clear")
+            return True
+
+        monkeypatch.setattr(terminal_escape, "set_terminal_progress", _record_set)
+        monkeypatch.setattr(terminal_escape, "clear_terminal_progress", _record_clear)
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-osc-disabled")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app._set_spinner("Thinking")
+            await pilot.pause()
+            await app._set_spinner(None)
+            await pilot.pause()
+
+        assert calls == []
+
     async def test_consecutive_set_spinner_calls_keep_emitting(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -9200,6 +9200,21 @@ from deepagents_code.command_registry import BypassTier  # noqa: E402
 class TestSetSpinnerTerminalProgress:
     """`_set_spinner` should drive the `OSC 9;4` terminal progress indicator."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Point the config path at an empty temp dir.
+
+        Without this, `_load_terminal_progress_preference` reads the developer's
+        real `~/.deepagents/config.toml` during `DeepAgentsApp.__init__`, so a
+        local `[ui].terminal_progress = false` would silently flip the
+        positive-path tests below to failing. Tests that need a specific config
+        write to and re-point at this same path.
+        """
+        monkeypatch.setattr(
+            "deepagents_code.model_config.DEFAULT_CONFIG_PATH",
+            tmp_path / "config.toml",
+        )
+
     async def test_status_triggers_indeterminate_progress(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -9295,6 +9310,41 @@ class TestSetSpinnerTerminalProgress:
             await pilot.pause()
 
         assert calls == []
+
+    async def test_config_opt_in_emits_progress(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`[ui].terminal_progress = true` should emit set and clear escapes."""
+        from deepagents_code import terminal_escape
+
+        config = tmp_path / "config.toml"
+        config.write_text("[ui]\nterminal_progress = true\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+
+        calls: list[str] = []
+
+        def _record_set(*_args: object, **_kwargs: object) -> bool:
+            calls.append("set")
+            return True
+
+        def _record_clear() -> bool:
+            calls.append("clear")
+            return True
+
+        monkeypatch.setattr(terminal_escape, "set_terminal_progress", _record_set)
+        monkeypatch.setattr(terminal_escape, "clear_terminal_progress", _record_clear)
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-osc-enabled")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            calls.clear()
+            await app._set_spinner("Thinking")
+            await pilot.pause()
+            await app._set_spinner(None)
+            await pilot.pause()
+
+        assert "set" in calls
+        assert "clear" in calls
 
     async def test_consecutive_set_spinner_calls_keep_emitting(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_terminal_progress_preference.py
+++ b/libs/code/tests/unit_tests/test_terminal_progress_preference.py
@@ -34,6 +34,15 @@ class TestLoadTerminalProgressPreference:
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
         assert _load_terminal_progress_preference() is False
 
+    def test_default_true_when_key_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A `[ui]` table without `terminal_progress` defaults to `True`."""
+        config = tmp_path / "config.toml"
+        config.write_text("[ui]\ncursor_blink = false\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        assert _load_terminal_progress_preference() is True
+
     def test_default_true_on_corrupt_toml(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/test_terminal_progress_preference.py
+++ b/libs/code/tests/unit_tests/test_terminal_progress_preference.py
@@ -1,0 +1,59 @@
+"""Tests for terminal `OSC 9;4` progress preference loading."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from deepagents_code.app import (
+    _load_terminal_progress_preference,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+class TestLoadTerminalProgressPreference:
+    """_load_terminal_progress_preference reads config.toml correctly."""
+
+    def test_default_true_when_no_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "deepagents_code.model_config.DEFAULT_CONFIG_PATH",
+            tmp_path / "config.toml",
+        )
+        assert _load_terminal_progress_preference() is True
+
+    def test_returns_saved_value(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = tmp_path / "config.toml"
+        config.write_text("[ui]\nterminal_progress = false\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        assert _load_terminal_progress_preference() is False
+
+    def test_default_true_on_corrupt_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = tmp_path / "config.toml"
+        config.write_text("this is not = valid = toml\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        assert _load_terminal_progress_preference() is True
+
+    def test_defaults_true_on_non_bool_value(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = tmp_path / "config.toml"
+        config.write_text('[ui]\nterminal_progress = "nope"\n', encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        assert _load_terminal_progress_preference() is True
+
+    def test_defaults_true_when_ui_not_a_table(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = tmp_path / "config.toml"
+        config.write_text('ui = "not a table"\n', encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        assert _load_terminal_progress_preference() is True


### PR DESCRIPTION
Fixes #3683

---

Adds a `terminal_progress` UI config preference so users can disable `OSC 9;4` taskbar progress without turning off every terminal escape. The preference defaults to enabled and falls back to the existing behavior when config is missing or malformed.