### PR TITLE
fix(acp): require `agent-client-protocol>=0.9.0`

### DIFF
--- a/libs/acp/pyproject.toml
+++ b/libs/acp/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "agent-client-protocol>=0.8.0",
+    "agent-client-protocol>=0.9.0",
     "deepagents",
     "python-dotenv>=1.2.2",
 ]

--- a/libs/acp/uv.lock
+++ b/libs/acp/uv.lock
@@ -501,7 +501,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-client-protocol", specifier = ">=0.8.0" },
+    { name = "agent-client-protocol", specifier = ">=0.9.0" },
     { name = "deepagents", editable = "../deepagents" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]


### PR DESCRIPTION
`deepagents_acp.server` imports `SetSessionConfigOptionResponse`, a symbol introduced in `agent-client-protocol` 0.9.0 as part of the v0.9 schema migration, but the dependency floor was left at `>=0.8.0`. Any install that resolved to 0.8.x raised `ImportError` on `import deepagents_acp.server` — which surfaced downstream as `module 'deepagents_acp' has no attribute 'server'` in `deepagents-code`'s ACP-mode tests, since the locked transitive landed on 0.8.0.