### PR TITLE
ci(acp): run ACP lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 # - Linting for changed packages
 # - Unit Tests for changed packages
 #
-# Only packages with changes are tested. SDK changes also trigger CLI tests.
+# Only packages with changes are tested. SDK changes also trigger CLI and ACP tests.
 # Pushes to main and workflow changes run full CI.
 
 name: "🔧 CI"
@@ -38,6 +38,7 @@ jobs:
       cli: ${{ steps.filter.outputs.cli }}
       code: ${{ steps.filter.outputs.code }}
       evals: ${{ steps.filter.outputs.evals }}
+      acp: ${{ steps.filter.outputs.acp }}
       daytona: ${{ steps.filter.outputs.daytona }}
       modal: ${{ steps.filter.outputs.modal }}
       runloop: ${{ steps.filter.outputs.runloop }}
@@ -85,6 +86,13 @@ jobs:
               - '.github/actions/**'
             evals:
               - 'libs/evals/**'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/_lint.yml'
+              - '.github/workflows/_test.yml'
+              - '.github/actions/**'
+            acp:
+              - 'libs/acp/**'
+              - 'libs/deepagents/**'
               - '.github/workflows/ci.yml'
               - '.github/workflows/_lint.yml'
               - '.github/workflows/_test.yml'
@@ -150,6 +158,15 @@ jobs:
     with:
       working-directory: "libs/evals"
       python-version: "3.13"
+
+  lint-acp:
+    name: "🧹 Lint acp"
+    needs: changes
+    if: needs.changes.outputs.acp == 'true' || github.event_name == 'push'
+    uses: ./.github/workflows/_lint.yml
+    with:
+      working-directory: "libs/acp"
+      python-version: "3.11"
 
   lint-daytona:
     name: "🧹 Lint daytona"
@@ -227,6 +244,16 @@ jobs:
     with:
       working-directory: "libs/evals"
       python-versions: '["3.12", "3.13"]'
+      coverage-python-version: "3.12"
+
+  test-acp:
+    name: "🧪 Test acp"
+    needs: changes
+    if: needs.changes.outputs.acp == 'true' || github.event_name == 'push'
+    uses: ./.github/workflows/_test.yml
+    with:
+      working-directory: "libs/acp"
+      python-versions: '["3.11", "3.12", "3.13", "3.14"]'
       coverage-python-version: "3.12"
 
   test-daytona:
@@ -327,6 +354,7 @@ jobs:
       - lint-cli
       - lint-code
       - lint-evals
+      - lint-acp
       - lint-daytona
       - lint-modal
       - lint-runloop
@@ -335,6 +363,7 @@ jobs:
       - test-cli
       - test-code
       - test-evals
+      - test-acp
       - test-daytona
       - test-modal
       - test-runloop


### PR DESCRIPTION
ACP now participates in the monorepo CI package gating instead of being skipped when only `libs/acp` changes. SDK changes also trigger ACP checks because `deepagents-acp` depends on the core `deepagents` package.