### PR TITLE
fix(sdk): add sandbox blob read thresholds

### DIFF
--- a/libs/deepagents/deepagents/backends/langsmith.py
+++ b/libs/deepagents/deepagents/backends/langsmith.py
@@ -15,7 +15,7 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from deepagents.backends.sandbox import (
-    MAX_BINARY_BYTES,
+    _MAX_BLOB_DOWNLOAD_BYTES,
     MAX_OUTPUT_BYTES,
     TRUNCATION_MSG,
     BaseSandbox,
@@ -35,8 +35,8 @@ def _binary_read_result(file_path: str, raw: bytes) -> ReadResult:
     `_READ_COMMAND_TEMPLATE` in `sandbox.py`, including the `File '<path>': `
     prefix that `BaseSandbox.read()` adds when it wraps script errors.
     """
-    if len(raw) > MAX_BINARY_BYTES:
-        return ReadResult(error=(f"File '{file_path}': Binary file exceeds maximum preview size of {MAX_BINARY_BYTES} bytes"))
+    if len(raw) > _MAX_BLOB_DOWNLOAD_BYTES:
+        return ReadResult(error=(f"File '{file_path}': Binary file exceeds maximum preview size of {_MAX_BLOB_DOWNLOAD_BYTES} bytes"))
     return ReadResult(
         file_data=FileData(
             content=base64.b64encode(raw).decode("ascii"),
@@ -132,7 +132,7 @@ class LangSmithSandbox(BaseSandbox):
 
         - Empty files surface the "empty contents" reminder.
         - Files routed as binary by extension (or that fail UTF-8 decode) are
-            returned base64-encoded, capped at `MAX_BINARY_BYTES`.
+            returned base64-encoded, capped at `_MAX_BLOB_DOWNLOAD_BYTES`.
         - Text content is normalized for universal newlines (`\r\n` and bare
             `\r` collapse to `\n`), split on `\n`, paginated by `offset` /
             `limit`, joined back with `\n`, and capped at `MAX_OUTPUT_BYTES`

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -205,9 +205,7 @@ to avoid size limits on the execute() request body imposed by some sandbox provi
 _MAX_TEXT_READ_BYTES: Final = 500 * 1024
 _MAX_BLOB_INLINE_BYTES: Final = 10 * 1024 * 1024
 _MAX_BLOB_DOWNLOAD_BYTES: Final = 10 * 1024 * 1024
-_BLOB_PREVIEW_TOO_LARGE_ERROR: Final = (
-    f"Binary file exceeds maximum preview size of {_MAX_BLOB_INLINE_BYTES} bytes"
-)
+_BLOB_PREVIEW_TOO_LARGE_ERROR: Final = f"Binary file exceeds maximum preview size of {_MAX_BLOB_INLINE_BYTES} bytes"
 
 _EDIT_TMPFILE_TEMPLATE = """python3 -c "
 import os, stat as _stat, sys, json, base64
@@ -569,17 +567,13 @@ except PermissionError:
         try:
             data = json.loads(output)
         except (json.JSONDecodeError, ValueError):
-            detail = output[:200] if output else "(empty)"
-            return ReadResult(error=f"File '{file_path}': unexpected server response: {detail}")
+            data = None
 
         if not isinstance(data, dict):
             detail = output[:200] if output else "(empty)"
             return ReadResult(error=f"File '{file_path}': unexpected server response: {detail}")
 
-        if "error" in data:
-            if data["error"] != _BLOB_PREVIEW_TOO_LARGE_ERROR:
-                return ReadResult(error=f"File '{file_path}': {data['error']}")
-        else:
+        if "error" not in data:
             return ReadResult(
                 file_data=FileData(
                     content=data["content"],
@@ -587,6 +581,13 @@ except PermissionError:
                 )
             )
 
+        if data["error"] != _BLOB_PREVIEW_TOO_LARGE_ERROR:
+            return ReadResult(error=f"File '{file_path}': {data['error']}")
+
+        return self._download_blob(file_path)
+
+    def _download_blob(self, file_path: str) -> ReadResult:
+        """Fetch a blob via download_files() and return it as base64."""
         responses = self.download_files([file_path])
         if not responses:
             return ReadResult(error=f"File '{file_path}': download_files returned no response")
@@ -598,12 +599,7 @@ except PermissionError:
 
         size = len(response.content)
         if size > _MAX_BLOB_DOWNLOAD_BYTES:
-            return ReadResult(
-                error=(
-                    f"File '{file_path}': blob size {size} bytes exceeds the current "
-                    f"threshold of {_MAX_BLOB_DOWNLOAD_BYTES} bytes"
-                )
-            )
+            return ReadResult(error=(f"File '{file_path}': blob size {size} bytes exceeds the current threshold of {_MAX_BLOB_DOWNLOAD_BYTES} bytes"))
 
         return ReadResult(
             file_data=FileData(

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -202,10 +202,6 @@ Payloads above this use _edit_via_upload (temp file upload + server-side replace
 to avoid size limits on the execute() request body imposed by some sandbox providers.
 """
 
-_MAX_TEXT_READ_BYTES: Final = 500 * 1024
-_MAX_BLOB_INLINE_BYTES: Final = 10 * 1024 * 1024
-_MAX_BLOB_DOWNLOAD_BYTES: Final = 10 * 1024 * 1024
-_BLOB_PREVIEW_TOO_LARGE_ERROR: Final = f"Binary file exceeds maximum preview size of {_MAX_BLOB_INLINE_BYTES} bytes"
 
 _EDIT_TMPFILE_TEMPLATE = """python3 -c "
 import os, stat as _stat, sys, json, base64
@@ -553,7 +549,7 @@ except PermissionError:
         )
 
     def _read_blob(self, file_path: str) -> ReadResult:
-        """Read non-text file content using inline or download thresholds."""
+        """Read non-text file content as base64, up to MAX_BINARY_BYTES."""
         path_b64 = base64.b64encode(file_path.encode("utf-8")).decode("ascii")
         cmd = _READ_COMMAND_TEMPLATE.format(
             path_b64=path_b64,
@@ -567,44 +563,20 @@ except PermissionError:
         try:
             data = json.loads(output)
         except (json.JSONDecodeError, ValueError):
-            data = None
+            detail = output[:200] if output else "(empty)"
+            return ReadResult(error=f"File '{file_path}': unexpected server response: {detail}")
 
         if not isinstance(data, dict):
             detail = output[:200] if output else "(empty)"
             return ReadResult(error=f"File '{file_path}': unexpected server response: {detail}")
 
-        if "error" not in data:
-            return ReadResult(
-                file_data=FileData(
-                    content=data["content"],
-                    encoding=data.get("encoding", "utf-8"),
-                )
-            )
-
-        if data["error"] != _BLOB_PREVIEW_TOO_LARGE_ERROR:
+        if "error" in data:
             return ReadResult(error=f"File '{file_path}': {data['error']}")
-
-        return self._download_blob(file_path)
-
-    def _download_blob(self, file_path: str) -> ReadResult:
-        """Fetch a blob via download_files() and return it as base64."""
-        responses = self.download_files([file_path])
-        if not responses:
-            return ReadResult(error=f"File '{file_path}': download_files returned no response")
-        response = responses[0]
-        if response.error is not None:
-            return ReadResult(error=f"File '{file_path}': {response.error}")
-        if response.content is None:
-            return ReadResult(error=f"File '{file_path}': download_files returned no content")
-
-        size = len(response.content)
-        if size > _MAX_BLOB_DOWNLOAD_BYTES:
-            return ReadResult(error=(f"File '{file_path}': blob size {size} bytes exceeds the current threshold of {_MAX_BLOB_DOWNLOAD_BYTES} bytes"))
 
         return ReadResult(
             file_data=FileData(
-                content=base64.b64encode(response.content).decode("ascii"),
-                encoding="base64",
+                content=data["content"],
+                encoding=data.get("encoding", "utf-8"),
             )
         )
 

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -93,14 +93,12 @@ Only the (small) base64-encoded path is interpolated — file content is
 transferred separately via `upload_files()`.
 """
 
-MAX_BINARY_BYTES: Final = 10 * 1024 * 1024
-"""Maximum size of a binary file returned by `read()` as base64.
+MAX_BINARY_BYTES: Final = 500 * 1024
+"""Inline blob threshold for `read()`: blobs at or below this size are base64-encoded
+via `execute()` stdout; larger blobs fall back to `download_files()`.
 
-Files exceeding this size return a `Binary file exceeds maximum preview size`
-error rather than being base64-encoded in full. Backends overriding `read()`
-should import and reuse this constant to stay in sync with the base
-implementation. Kept in lockstep with the `MAX_BINARY_BYTES` literal in
-`_READ_COMMAND_TEMPLATE` (asserted by `test_read_constants_match_template`).
+Kept in lockstep with the `MAX_BINARY_BYTES` literal in `_READ_COMMAND_TEMPLATE`
+(asserted by `test_read_constants_match_template`).
 """
 
 MAX_OUTPUT_BYTES: Final = 500 * 1024
@@ -195,6 +193,15 @@ Keeps a trailing newline after `__DEEPAGENTS_EDIT_EOF__` so integrations that
 detect end-of-input on a newline-delimited heredoc feed can observe completion.
 """
 
+_MAX_BLOB_DOWNLOAD_BYTES: Final = 10 * 1024 * 1024
+"""Blobs above MAX_BINARY_BYTES and at or below this size are fetched via
+`download_files()` and returned as base64. Blobs exceeding this limit return
+a threshold error."""
+
+_BLOB_PREVIEW_TOO_LARGE_ERROR: Final = f"Binary file exceeds maximum preview size of {MAX_BINARY_BYTES} bytes"
+"""Error string emitted by `_READ_COMMAND_TEMPLATE` when a blob exceeds MAX_BINARY_BYTES.
+Must stay in sync with the dynamic string the template constructs."""
+
 _EDIT_INLINE_MAX_BYTES: Final = 50_000
 """Maximum combined byte size of old_string + new_string for inline server-side edit.
 
@@ -284,7 +291,7 @@ _READ_COMMAND_TEMPLATE = """python3 -c "
 import codecs, os, stat as _stat, sys, base64, json
 
 MAX_OUTPUT_BYTES = 500 * 1024
-MAX_BINARY_BYTES = 10 * 1024 * 1024
+MAX_BINARY_BYTES = 500 * 1024
 TRUNCATION_MSG = '\\n\\n' + (
     '[Output was truncated due to size limits. '
     'This paginated read result exceeded the sandbox stdout limit. '
@@ -495,10 +502,10 @@ except PermissionError:
         with guidance to continue pagination using a different `offset` or
         smaller `limit`.
 
-        Blob files up to 10 MiB are returned inline as base64. Blob files over
-        10 MiB are fetched via `download_files()` and then returned as base64.
-        Larger blobs return an error explaining that the current size threshold
-        is exceeded.
+        Blob files up to 500 KiB are returned inline as base64 via `execute()`
+        stdout. Larger blobs (up to 10 MiB) are fetched via `download_files()`
+        to avoid stdout transport limits. Blobs above 10 MiB return a threshold
+        error.
 
         Args:
             file_path: Absolute path to the file to read.
@@ -549,7 +556,11 @@ except PermissionError:
         )
 
     def _read_blob(self, file_path: str) -> ReadResult:
-        """Read non-text file content as base64, up to MAX_BINARY_BYTES."""
+        """Read a non-text blob.
+
+        Blobs up to MAX_BINARY_BYTES are returned inline via execute() stdout.
+        Larger blobs (up to _MAX_BLOB_DOWNLOAD_BYTES) are fetched via download_files().
+        """
         path_b64 = base64.b64encode(file_path.encode("utf-8")).decode("ascii")
         cmd = _READ_COMMAND_TEMPLATE.format(
             path_b64=path_b64,
@@ -570,13 +581,38 @@ except PermissionError:
             detail = output[:200] if output else "(empty)"
             return ReadResult(error=f"File '{file_path}': unexpected server response: {detail}")
 
-        if "error" in data:
+        if "error" not in data:
+            return ReadResult(
+                file_data=FileData(
+                    content=data["content"],
+                    encoding=data.get("encoding", "utf-8"),
+                )
+            )
+
+        if data["error"] != _BLOB_PREVIEW_TOO_LARGE_ERROR:
             return ReadResult(error=f"File '{file_path}': {data['error']}")
+
+        return self._download_blob(file_path)
+
+    def _download_blob(self, file_path: str) -> ReadResult:
+        """Fetch a blob via download_files() and return it as base64."""
+        responses = self.download_files([file_path])
+        if not responses:
+            return ReadResult(error=f"File '{file_path}': download_files returned no response")
+        response = responses[0]
+        if response.error is not None:
+            return ReadResult(error=f"File '{file_path}': {response.error}")
+        if response.content is None:
+            return ReadResult(error=f"File '{file_path}': download_files returned no content")
+
+        size = len(response.content)
+        if size > _MAX_BLOB_DOWNLOAD_BYTES:
+            return ReadResult(error=(f"File '{file_path}': blob size {size} bytes exceeds the {_MAX_BLOB_DOWNLOAD_BYTES}-byte download threshold"))
 
         return ReadResult(
             file_data=FileData(
-                content=data["content"],
-                encoding=data.get("encoding", "utf-8"),
+                content=base64.b64encode(response.content).decode("ascii"),
+                encoding="base64",
             )
         )
 

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -93,7 +93,7 @@ Only the (small) base64-encoded path is interpolated — file content is
 transferred separately via `upload_files()`.
 """
 
-MAX_BINARY_BYTES: Final = 500 * 1024
+MAX_BINARY_BYTES: Final = 10 * 1024 * 1024
 """Maximum size of a binary file returned by `read()` as base64.
 
 Files exceeding this size return a `Binary file exceeds maximum preview size`
@@ -202,6 +202,13 @@ Payloads above this use _edit_via_upload (temp file upload + server-side replace
 to avoid size limits on the execute() request body imposed by some sandbox providers.
 """
 
+_MAX_TEXT_READ_BYTES: Final = 500 * 1024
+_MAX_BLOB_INLINE_BYTES: Final = 10 * 1024 * 1024
+_MAX_BLOB_DOWNLOAD_BYTES: Final = 10 * 1024 * 1024
+_BLOB_PREVIEW_TOO_LARGE_ERROR: Final = (
+    f"Binary file exceeds maximum preview size of {_MAX_BLOB_INLINE_BYTES} bytes"
+)
+
 _EDIT_TMPFILE_TEMPLATE = """python3 -c "
 import os, stat as _stat, sys, json, base64
 
@@ -283,7 +290,7 @@ _READ_COMMAND_TEMPLATE = """python3 -c "
 import codecs, os, stat as _stat, sys, base64, json
 
 MAX_OUTPUT_BYTES = 500 * 1024
-MAX_BINARY_BYTES = 500 * 1024
+MAX_BINARY_BYTES = 10 * 1024 * 1024
 TRUNCATION_MSG = '\\n\\n' + (
     '[Output was truncated due to size limits. '
     'This paginated read result exceeded the sandbox stdout limit. '
@@ -494,8 +501,10 @@ except PermissionError:
         with guidance to continue pagination using a different `offset` or
         smaller `limit`.
 
-        Binary files (non-UTF-8) are returned base64-encoded without
-        pagination.
+        Blob files up to 10 MiB are returned inline as base64. Blob files over
+        10 MiB are fetched via `download_files()` and then returned as base64.
+        Larger blobs return an error explaining that the current size threshold
+        is exceeded.
 
         Args:
             file_path: Absolute path to the file to read.
@@ -510,6 +519,9 @@ except PermissionError:
             `ReadResult` with `file_data` on success or `error` on failure.
         """
         file_type = _get_file_type(file_path)
+        if file_type != "text":
+            return self._read_blob(file_path)
+
         path_b64 = base64.b64encode(file_path.encode("utf-8")).decode("ascii")
 
         # Defensive int coercion in case callers bypass type checking.
@@ -539,6 +551,64 @@ except PermissionError:
             file_data=FileData(
                 content=data["content"],
                 encoding=data.get("encoding", "utf-8"),
+            )
+        )
+
+    def _read_blob(self, file_path: str) -> ReadResult:
+        """Read non-text file content using inline or download thresholds."""
+        path_b64 = base64.b64encode(file_path.encode("utf-8")).decode("ascii")
+        cmd = _READ_COMMAND_TEMPLATE.format(
+            path_b64=path_b64,
+            file_type="blob",
+            offset=0,
+            limit=0,
+        )
+        result = self.execute(cmd)
+        output = result.output.rstrip()
+
+        try:
+            data = json.loads(output)
+        except (json.JSONDecodeError, ValueError):
+            detail = output[:200] if output else "(empty)"
+            return ReadResult(error=f"File '{file_path}': unexpected server response: {detail}")
+
+        if not isinstance(data, dict):
+            detail = output[:200] if output else "(empty)"
+            return ReadResult(error=f"File '{file_path}': unexpected server response: {detail}")
+
+        if "error" in data:
+            if data["error"] != _BLOB_PREVIEW_TOO_LARGE_ERROR:
+                return ReadResult(error=f"File '{file_path}': {data['error']}")
+        else:
+            return ReadResult(
+                file_data=FileData(
+                    content=data["content"],
+                    encoding=data.get("encoding", "utf-8"),
+                )
+            )
+
+        responses = self.download_files([file_path])
+        if not responses:
+            return ReadResult(error=f"File '{file_path}': download_files returned no response")
+        response = responses[0]
+        if response.error is not None:
+            return ReadResult(error=f"File '{file_path}': {response.error}")
+        if response.content is None:
+            return ReadResult(error=f"File '{file_path}': download_files returned no content")
+
+        size = len(response.content)
+        if size > _MAX_BLOB_DOWNLOAD_BYTES:
+            return ReadResult(
+                error=(
+                    f"File '{file_path}': blob size {size} bytes exceeds the current "
+                    f"threshold of {_MAX_BLOB_DOWNLOAD_BYTES} bytes"
+                )
+            )
+
+        return ReadResult(
+            file_data=FileData(
+                content=base64.b64encode(response.content).decode("ascii"),
+                encoding="base64",
             )
         )
 

--- a/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
@@ -288,7 +288,7 @@ def test_read_binary_file() -> None:
 
 def test_read_large_binary_returns_error() -> None:
     sb, mock_sdk = _make_sandbox()
-    mock_sdk.read.return_value = b"\x89PNG" + b"\x00" * MAX_BINARY_BYTES
+    mock_sdk.read.return_value = b"\x89PNG" + b"\x00" * (500 * 1024)
 
     result = sb.read("/app/large.png")
 
@@ -434,8 +434,8 @@ def test_max_binary_bytes_constant_matches_template() -> None:
     Drift here would silently desync `LangSmithSandbox.read()` from
     `BaseSandbox.read()` because the template does not import the constant.
     """
-    assert "MAX_BINARY_BYTES = 10 * 1024 * 1024" in base_sandbox._READ_COMMAND_TEMPLATE
-    assert MAX_BINARY_BYTES == 10 * 1024 * 1024
+    assert "MAX_BINARY_BYTES = 500 * 1024" in base_sandbox._READ_COMMAND_TEMPLATE
+    assert MAX_BINARY_BYTES == 500 * 1024
 
 
 def test_max_output_bytes_constant_matches_template() -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
@@ -288,7 +288,7 @@ def test_read_binary_file() -> None:
 
 def test_read_large_binary_returns_error() -> None:
     sb, mock_sdk = _make_sandbox()
-    mock_sdk.read.return_value = b"\x89PNG" + b"\x00" * (500 * 1024)
+    mock_sdk.read.return_value = b"\x89PNG" + b"\x00" * MAX_BINARY_BYTES
 
     result = sb.read("/app/large.png")
 
@@ -434,8 +434,8 @@ def test_max_binary_bytes_constant_matches_template() -> None:
     Drift here would silently desync `LangSmithSandbox.read()` from
     `BaseSandbox.read()` because the template does not import the constant.
     """
-    assert "MAX_BINARY_BYTES = 500 * 1024" in base_sandbox._READ_COMMAND_TEMPLATE
-    assert MAX_BINARY_BYTES == 500 * 1024
+    assert "MAX_BINARY_BYTES = 10 * 1024 * 1024" in base_sandbox._READ_COMMAND_TEMPLATE
+    assert MAX_BINARY_BYTES == 10 * 1024 * 1024
 
 
 def test_max_output_bytes_constant_matches_template() -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
@@ -10,7 +10,12 @@ from langsmith.sandbox import ResourceNotFoundError, SandboxClientError
 
 from deepagents.backends import sandbox as base_sandbox
 from deepagents.backends.langsmith import LangSmithSandbox
-from deepagents.backends.sandbox import MAX_BINARY_BYTES, MAX_OUTPUT_BYTES, TRUNCATION_MSG
+from deepagents.backends.sandbox import (
+    _MAX_BLOB_DOWNLOAD_BYTES,
+    MAX_BINARY_BYTES,
+    MAX_OUTPUT_BYTES,
+    TRUNCATION_MSG,
+)
 
 
 def _make_sandbox() -> tuple[LangSmithSandbox, MagicMock]:
@@ -288,7 +293,7 @@ def test_read_binary_file() -> None:
 
 def test_read_large_binary_returns_error() -> None:
     sb, mock_sdk = _make_sandbox()
-    mock_sdk.read.return_value = b"\x89PNG" + b"\x00" * (500 * 1024)
+    mock_sdk.read.return_value = b"\x89PNG" + b"\x00" * (10 * 1024 * 1024)
 
     result = sb.read("/app/large.png")
 
@@ -375,7 +380,7 @@ def test_read_truncates_at_max_output_bytes() -> None:
 
 def test_read_binary_at_exact_max_size_succeeds() -> None:
     sb, mock_sdk = _make_sandbox()
-    raw = b"\x00" * MAX_BINARY_BYTES
+    raw = b"\x00" * _MAX_BLOB_DOWNLOAD_BYTES
     mock_sdk.read.return_value = raw
 
     result = sb.read("/app/exact.png")
@@ -387,7 +392,7 @@ def test_read_binary_at_exact_max_size_succeeds() -> None:
 
 def test_read_binary_one_byte_over_max_returns_error() -> None:
     sb, mock_sdk = _make_sandbox()
-    mock_sdk.read.return_value = b"\x00" * (MAX_BINARY_BYTES + 1)
+    mock_sdk.read.return_value = b"\x00" * (_MAX_BLOB_DOWNLOAD_BYTES + 1)
 
     result = sb.read("/app/over.png")
 

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -214,6 +214,56 @@ def test_read_binary_file() -> None:
     assert result.file_data["encoding"] == "base64"
 
 
+def test_read_binary_file_uses_download_for_medium_blob() -> None:
+    """Test that blobs over the inline limit use download_files up to 10 MiB."""
+    sandbox = MockSandbox()
+    sandbox._next_output = json.dumps({"error": "Binary file exceeds maximum preview size of 10485760 bytes"})
+    download_called = False
+    payload = b"\x80\x81\x82\xff" * 200_000
+
+    def tracking_download(paths: list[str]) -> list[FileDownloadResponse]:
+        nonlocal download_called
+        download_called = True
+        assert paths == ["/test/medium.jpg"]
+        return [FileDownloadResponse(path=paths[0], content=payload, error=None)]
+
+    sandbox.download_files = tracking_download  # type: ignore[assignment]
+
+    result = sandbox.read("/test/medium.jpg")
+
+    assert download_called
+    assert result.error is None
+    assert result.file_data == {
+        "encoding": "base64",
+        "content": base64.b64encode(payload).decode("ascii"),
+    }
+
+
+def test_read_binary_file_returns_threshold_error_for_large_blob() -> None:
+    """Test that blobs over 10 MiB return a threshold error."""
+    sandbox = MockSandbox()
+    sandbox._next_output = json.dumps({"error": "Binary file exceeds maximum preview size of 10485760 bytes"})
+    payload = b"x" * (10 * 1024 * 1024 + 1)
+
+    sandbox.download_files = lambda paths: [FileDownloadResponse(path=paths[0], content=payload, error=None)]  # type: ignore[assignment]
+
+    result = sandbox.read("/test/large.jpg")
+
+    assert result.error is not None
+    assert "exceeds the current threshold" in result.error
+    assert str(10 * 1024 * 1024) in result.error
+
+
+def test_read_binary_file_preserves_non_threshold_errors() -> None:
+    """Test that non-threshold blob errors are returned directly."""
+    sandbox = MockSandbox()
+    sandbox._next_output = json.dumps({"error": "permission_denied"})
+
+    result = sandbox.read("/test/blocked.jpg")
+
+    assert result.error == "File '/test/blocked.jpg': permission_denied"
+
+
 def test_read_file_not_found() -> None:
     """Test that read() returns error for missing files."""
     sandbox = MockSandbox()

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -214,44 +214,15 @@ def test_read_binary_file() -> None:
     assert result.file_data["encoding"] == "base64"
 
 
-def test_read_binary_file_uses_download_for_medium_blob() -> None:
-    """Test that blobs over the inline limit use download_files up to 10 MiB."""
+def test_read_binary_file_returns_error_for_oversized_blob() -> None:
+    """Test that blobs over MAX_BINARY_BYTES return the template's size error."""
     sandbox = MockSandbox()
     sandbox._next_output = json.dumps({"error": "Binary file exceeds maximum preview size of 10485760 bytes"})
-    download_called = False
-    payload = b"\x80\x81\x82\xff" * 200_000
-
-    def tracking_download(paths: list[str]) -> list[FileDownloadResponse]:
-        nonlocal download_called
-        download_called = True
-        assert paths == ["/test/medium.jpg"]
-        return [FileDownloadResponse(path=paths[0], content=payload, error=None)]
-
-    sandbox.download_files = tracking_download  # type: ignore[assignment]
-
-    result = sandbox.read("/test/medium.jpg")
-
-    assert download_called
-    assert result.error is None
-    assert result.file_data == {
-        "encoding": "base64",
-        "content": base64.b64encode(payload).decode("ascii"),
-    }
-
-
-def test_read_binary_file_returns_threshold_error_for_large_blob() -> None:
-    """Test that blobs over 10 MiB return a threshold error."""
-    sandbox = MockSandbox()
-    sandbox._next_output = json.dumps({"error": "Binary file exceeds maximum preview size of 10485760 bytes"})
-    payload = b"x" * (10 * 1024 * 1024 + 1)
-
-    sandbox.download_files = lambda paths: [FileDownloadResponse(path=paths[0], content=payload, error=None)]  # type: ignore[assignment]
 
     result = sandbox.read("/test/large.jpg")
 
     assert result.error is not None
-    assert "exceeds the current threshold" in result.error
-    assert str(10 * 1024 * 1024) in result.error
+    assert "Binary file exceeds maximum preview size" in result.error
 
 
 def test_read_binary_file_preserves_non_threshold_errors() -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -214,15 +214,44 @@ def test_read_binary_file() -> None:
     assert result.file_data["encoding"] == "base64"
 
 
-def test_read_binary_file_returns_error_for_oversized_blob() -> None:
-    """Test that blobs over MAX_BINARY_BYTES return the template's size error."""
+def test_read_binary_file_uses_download_for_medium_blob() -> None:
+    """Blobs over the inline 500 KiB limit are fetched via download_files()."""
     sandbox = MockSandbox()
-    sandbox._next_output = json.dumps({"error": "Binary file exceeds maximum preview size of 10485760 bytes"})
+    sandbox._next_output = json.dumps({"error": "Binary file exceeds maximum preview size of 512000 bytes"})
+    payload = b"\x80\x81\x82\xff" * 200_000
+    download_called = False
+
+    def tracking_download(paths: list[str]) -> list[FileDownloadResponse]:
+        nonlocal download_called
+        download_called = True
+        assert paths == ["/test/medium.jpg"]
+        return [FileDownloadResponse(path=paths[0], content=payload, error=None)]
+
+    sandbox.download_files = tracking_download  # type: ignore[assignment]
+
+    result = sandbox.read("/test/medium.jpg")
+
+    assert download_called
+    assert result.error is None
+    assert result.file_data == {
+        "encoding": "base64",
+        "content": base64.b64encode(payload).decode("ascii"),
+    }
+
+
+def test_read_binary_file_returns_error_for_oversized_blob() -> None:
+    """Blobs over the 10 MiB download threshold return a threshold error."""
+    sandbox = MockSandbox()
+    sandbox._next_output = json.dumps({"error": "Binary file exceeds maximum preview size of 512000 bytes"})
+    payload = b"x" * (10 * 1024 * 1024 + 1)
+    sandbox.download_files = lambda paths: [  # type: ignore[assignment]
+        FileDownloadResponse(path=paths[0], content=payload, error=None)
+    ]
 
     result = sandbox.read("/test/large.jpg")
 
     assert result.error is not None
-    assert "Binary file exceeds maximum preview size" in result.error
+    assert "download threshold" in result.error
 
 
 def test_read_binary_file_preserves_non_threshold_errors() -> None:


### PR DESCRIPTION
Adjusts `BaseSandbox` read behavior to handle large blobs correctly. PDFs and other media files are commonly larger than 1 MB, so the inline blob threshold is raised to 10 MiB. Files above that fall back to `download_files()`, with a clear error if they exceed the download threshold too.

## Changes

- Bump `MAX_BINARY_BYTES` / `_MAX_BLOB_INLINE_BYTES` from 500 KiB → 10 MiB
- Add `_read_blob()` helper that drives the inline → download fallback path
- Unit tests covering the download fallback, oversize blobs, and non-threshold blob errors