### PR TITLE
feat(code): word-level double-click selection

### DIFF
--- a/libs/code/deepagents_code/_textual_patches.py
+++ b/libs/code/deepagents_code/_textual_patches.py
@@ -1,10 +1,22 @@
-r"""Preserve the `alt` modifier on legacy `ESC + <byte>` sequences.
+r"""Runtime patches over Textual internals, imported for side effect.
 
-Upstream `XTermParser._sequence_to_key_events` drops the `alt` flag on
-the tuple-branch fast path, so VSCode's `sendSequence` shift+enter
-binding (which writes `\x1b\r` to the PTY) arrives as bare `enter`
-instead of `alt+enter`. Tracked in Textualize/textual#6378. Remove this
-file and the Textual pin comment in `pyproject.toml` when that lands.
+This module hosts two independent best-effort patches over private Textual
+APIs. Each guards its own import/assignment and degrades to stock Textual
+behavior (logging a warning) if the targeted internals move, so they have
+separate lifecycles — do not delete the whole file when only one lands
+upstream.
+
+1. Alt-modifier preservation on legacy `ESC + <byte>` sequences. Upstream
+    `XTermParser._sequence_to_key_events` drops the `alt` flag on the
+    tuple-branch fast path, so VSCode's `sendSequence` shift+enter binding
+    (which writes `\x1b\r` to the PTY) arrives as bare `enter` instead of
+    `alt+enter`. Tracked in Textualize/textual#6378. Remove this patch and
+    the Textual pin comment in `pyproject.toml` when that lands.
+
+2. Double-click word selection. Stock Textual selects the entire widget on
+    a click chain; these patches narrow a double-click (and double-click
+    drag) to word boundaries. No upstream issue tracks this yet, so it has
+    no removal criterion — it stays until Textual grows native word select.
 
 Imported for side effect from `app.py` before any `App()` is created.
 """
@@ -12,14 +24,29 @@ Imported for side effect from `app.py` before any `App()` is created.
 from __future__ import annotations
 
 import logging
+from inspect import isawaitable
 from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual import __version__ as _textual_version
+from textual.content import Content
+from textual.geometry import Offset
+from textual.selection import Selection
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from textual.events import Click, Event
+    from textual.screen import Screen
+    from textual.selection import SelectState
+    from textual.widget import Widget
+
 logger = logging.getLogger(__name__)
 
 _ESC_PREFIX_LEN = 2
+_DOUBLE_CLICK_CHAIN = 2
+_TRIPLE_CLICK_CHAIN = 3
+_DEEPAGENTS_WORD_SELECT_ACTIVE = "_deepagents_word_select_active"
 
 try:
     from textual import events
@@ -64,3 +91,197 @@ else:
         XTermParser._sequence_to_key_events = _sequence_to_key_events_with_alt  # ty: ignore[invalid-assignment]
     except (AttributeError, TypeError) as exc:  # pragma: no cover - defensive
         logger.warning("Textual keyboard parser patch assignment rejected: %s", exc)
+
+
+def _rendered_text(widget: Widget) -> str | None:
+    visual = widget._render()  # match Textual's get_selection path
+    if isinstance(visual, (Content, Text)):
+        return str(visual)
+    return None
+
+
+def _word_bounds(text: str, offset: Offset) -> tuple[Offset, Offset] | None:
+    lines = text.splitlines()
+    if not lines:
+        return None
+
+    y = min(max(offset.y, 0), len(lines) - 1)
+    line = lines[y]
+    if not line:
+        return None
+
+    x = min(max(offset.x, 0), len(line))
+    index = min(x, len(line) - 1)
+    if line[index].isspace():
+        # A click just past the final character (x == len(line)) lands on the
+        # virtual end-of-line position; snap back onto the trailing word so
+        # double-clicking after a word still selects it. Genuine whitespace
+        # clicks fall through and select nothing.
+        if x == len(line) and x > 0 and not line[x - 1].isspace():
+            index = x - 1
+        else:
+            return None
+
+    start = index
+    while start > 0 and not line[start - 1].isspace():
+        start -= 1
+
+    end = index + 1
+    while end < len(line) and not line[end].isspace():
+        end += 1
+
+    return Offset(start, y), Offset(end, y)
+
+
+def _word_selection(widget: Widget, selection: Selection) -> Selection | None:
+    if selection.start is None or selection.end is None:
+        return None
+
+    text = _rendered_text(widget)
+    if text is None:
+        return None
+
+    start, end = selection.start, selection.end
+    # `Offset.transpose` is (y, x) — Textual's reading-order key. A backward
+    # drag leaves end before start in reading order; normalize so the word
+    # bounds below extend outward from the correct endpoints.
+    if end.transpose < start.transpose:
+        start, end = end, start
+
+    start_bounds = _word_bounds(text, start)
+    end_bounds = _word_bounds(text, end)
+    if start_bounds is None and end_bounds is None:
+        return None
+
+    return Selection(
+        start_bounds[0] if start_bounds is not None else start,
+        end_bounds[1] if end_bounds is not None else end,
+    )
+
+
+def _select_word_at_click(widget: Widget, event: Click) -> bool:
+    offset = event.get_content_offset(widget)
+    if offset is None:
+        return False
+
+    text = _rendered_text(widget)
+    if text is None:
+        return False
+
+    bounds = _word_bounds(text, offset)
+    if bounds is None:
+        widget.screen.clear_selection()
+        return True
+
+    widget.screen.selections = {widget: Selection(*bounds)}
+    return True
+
+
+try:
+    from textual import events as _events
+    from textual.screen import Screen as _Screen
+    from textual.widget import Widget as _Widget
+
+    _original_forward_event = _Screen._forward_event
+    _original_watch_select_state = _Screen._watch__select_state
+    _original_widget_on_click = _Widget._on_click
+except (ImportError, AttributeError) as exc:  # pragma: no cover - defensive
+    logger.warning(
+        "Textual word-selection patch skipped (textual %s): %s",
+        _textual_version,
+        exc,
+    )
+else:
+
+    def _is_word_select_start(screen: Screen, event: Event) -> bool:
+        # Mirrors Textual's own click-chain detection (App._on_mouse_down),
+        # reading its private `_click_chain_last_*` bookkeeping to recognize
+        # the second press of a double-click before Textual increments the
+        # chain count. Re-verify these attribute names on every Textual bump.
+        if not isinstance(event, _events.MouseDown) or screen.app.mouse_captured:
+            return False
+
+        last_offset = getattr(screen.app, "_click_chain_last_offset", None)
+        last_time = getattr(screen.app, "_click_chain_last_time", None)
+        if last_offset != event.screen_offset or last_time is None:
+            return False
+
+        if event.time - last_time > screen.app.CLICK_CHAIN_TIME_THRESHOLD:
+            return False
+
+        select_widget, select_offset = screen.get_widget_and_offset_at(event.x, event.y)
+        return (
+            select_widget is not None
+            and select_widget.allow_select
+            and screen.allow_select
+            and screen.app.ALLOW_SELECT
+            and select_offset is not None
+        )
+
+    def _forward_event_with_word_select(self: Screen, event: Event) -> None:
+        if isinstance(event, _events.MouseDown):
+            setattr(
+                self,
+                _DEEPAGENTS_WORD_SELECT_ACTIVE,
+                _is_word_select_start(self, event),
+            )
+        try:
+            _original_forward_event(self, event)
+        finally:
+            if isinstance(event, _events.MouseUp):
+                setattr(self, _DEEPAGENTS_WORD_SELECT_ACTIVE, False)
+
+    async def _watch_select_state_with_word_select(
+        self: Screen,
+        select_state: SelectState | None,
+    ) -> None:
+        result = _original_watch_select_state(self, select_state)
+        # `_watch__select_state` is synchronous in the pinned Textual; the
+        # isawaitable guard tolerates a future release making it a coroutine
+        # without forcing a same-day patch update.
+        if isawaitable(result):
+            await result
+        if not getattr(self, _DEEPAGENTS_WORD_SELECT_ACTIVE, False):
+            return
+
+        selections = dict(self.selections)
+        changed = False
+        for widget, selection in selections.items():
+            word_selection = _word_selection(widget, selection)
+            if word_selection is None or word_selection == selection:
+                continue
+            selections[widget] = word_selection
+            changed = True
+
+        if changed:
+            self.selections = selections
+
+    async def _on_click_with_word_select(self: Widget, event: Click) -> None:
+        if (
+            event.widget is self
+            and self.allow_select
+            and self.screen.allow_select
+            and self.app.ALLOW_SELECT
+        ):
+            if event.chain == _DOUBLE_CLICK_CHAIN and _select_word_at_click(
+                self, event
+            ):
+                await self.broker_event("click", event)
+                return
+            if event.chain == _TRIPLE_CLICK_CHAIN:
+                self.text_select_all()
+                await self.broker_event("click", event)
+                return
+
+        await _original_widget_on_click(self, event)
+
+    try:
+        _Screen._forward_event = _forward_event_with_word_select  # ty: ignore[invalid-assignment]
+        _Screen._watch__select_state = _watch_select_state_with_word_select  # ty: ignore[invalid-assignment]
+        _Widget._on_click = _on_click_with_word_select  # ty: ignore[invalid-assignment]
+    except (AttributeError, TypeError) as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "Textual word-selection patch assignment rejected (textual %s): %s",
+            _textual_version,
+            exc,
+        )

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7839,10 +7839,10 @@ class DeepAgentsApp(App):
         self.call_after_refresh(self._chat_input.focus_input)
 
     def on_mouse_up(self, event: MouseUp) -> None:  # noqa: ARG002  # Textual event handler signature
-        """Copy selection to clipboard on mouse release."""
+        """Copy selection to clipboard after click-chain selection updates."""
         from deepagents_code.clipboard import copy_selection_to_clipboard
 
-        copy_selection_to_clipboard(self)
+        self.call_after_refresh(copy_selection_to_clipboard, self)
 
     # =========================================================================
     # Model Switching

--- a/libs/code/deepagents_code/clipboard.py
+++ b/libs/code/deepagents_code/clipboard.py
@@ -126,9 +126,6 @@ def copy_selection_to_clipboard(app: App) -> None:
         if not selection:
             continue
 
-        if selection.end is None:
-            continue
-
         try:
             result = widget.get_selection(selection)
         except (AttributeError, TypeError, ValueError, IndexError) as e:

--- a/libs/code/tests/unit_tests/test_clipboard.py
+++ b/libs/code/tests/unit_tests/test_clipboard.py
@@ -251,6 +251,25 @@ class TestCopySelectionToClipboard:
             markup=False,
         )
 
+    def test_copies_select_all_selection(self) -> None:
+        """Textual represents triple-click/select-all as `Selection(None, None)`."""
+        from textual.selection import SELECT_ALL
+
+        mock_app = MagicMock()
+        widget = MagicMock()
+        widget.is_attached = True
+        widget.text_selection = SELECT_ALL
+        widget.get_selection.return_value = ("full widget text", None)
+        mock_app.query.return_value = [widget]
+
+        with patch(
+            "deepagents_code.clipboard.copy_text_to_clipboard",
+            return_value=(True, None),
+        ) as copy:
+            copy_selection_to_clipboard(mock_app)
+
+        copy.assert_called_once_with(mock_app, "full widget text")
+
     def test_handles_widget_selection_failures(self, caplog) -> None:
         """A failing widget logs and is skipped, not re-raised."""
         mock_app = MagicMock()
@@ -323,6 +342,21 @@ class TestCopySelectionToClipboard:
 
         copy.assert_called_once_with(mock_app, "sibling text")
         assert "Skipping widget" in caplog.text
+
+
+class TestAppSelectionCopy:
+    """Regression coverage for click-chain selection copy timing."""
+
+    def test_mouse_up_defers_copy_until_after_click_selection_updates(self) -> None:
+        from deepagents_code.app import DeepAgentsApp
+
+        mock_app = MagicMock()
+        event = MagicMock()
+        with patch("deepagents_code.clipboard.copy_selection_to_clipboard") as copy:
+            DeepAgentsApp.on_mouse_up(mock_app, event)
+
+        copy.assert_not_called()
+        mock_app.call_after_refresh.assert_called_once_with(copy, mock_app)
 
 
 class TestClipboardLogger:

--- a/libs/code/tests/unit_tests/test_textual_patches.py
+++ b/libs/code/tests/unit_tests/test_textual_patches.py
@@ -9,7 +9,12 @@ import ast
 import importlib.util
 from pathlib import Path
 
+from textual._time import get_time
 from textual._xterm_parser import XTermParser
+from textual.app import App, ComposeResult
+from textual.containers import Vertical
+from textual.geometry import Offset
+from textual.widgets import Markdown, Static
 
 from deepagents_code import _textual_patches  # triggers patch
 
@@ -20,6 +25,55 @@ def _keys_for(sequence: str, *, alt: bool) -> list[tuple[str, str | None]]:
         (event.key, event.character)
         for event in parser._sequence_to_key_events(sequence, alt=alt)
     ]
+
+
+class SelectableTextApp(App[None]):
+    def compose(self) -> ComposeResult:
+        yield Static("alpha beta gamma", id="msg")
+
+
+class SelectableMarkdownApp(App[None]):
+    def compose(self) -> ComposeResult:
+        yield Markdown("alpha **beta** gamma", id="msg")
+
+
+class SelectableHistoryApp(App[None]):
+    def compose(self) -> ComposeResult:
+        with Vertical(id="history"):
+            yield Static("first message", id="first")
+            yield Static("second message", id="second")
+
+
+class TestPatchedWordSelection:
+    async def test_double_click_selects_word_not_entire_widget(self) -> None:
+        async with SelectableTextApp().run_test() as pilot:
+            await pilot.double_click("#msg", offset=(7, 0))
+
+            assert pilot.app.screen.get_selected_text() == "beta"
+
+    async def test_double_click_drag_expands_to_word_boundaries(self) -> None:
+        async with SelectableTextApp().run_test() as pilot:
+            widget = pilot.app.query_one("#msg", Static)
+            start = widget.content_region.offset + Offset(1, 0)
+            pilot.app._click_chain_last_offset = start
+            pilot.app._click_chain_last_time = get_time()
+
+            await pilot.mouse_down("#msg", offset=(1, 0))
+            await pilot.mouse_up("#msg", offset=(13, 0))
+
+            assert pilot.app.screen.get_selected_text() == "alpha beta gamma"
+
+    async def test_double_click_falls_back_for_non_text_renderable(self) -> None:
+        async with SelectableMarkdownApp().run_test() as pilot:
+            await pilot.double_click("#msg", offset=(7, 0))
+
+            assert pilot.app.screen.get_selected_text() is not None
+
+    async def test_triple_click_selects_clicked_widget_not_history(self) -> None:
+        async with SelectableHistoryApp().run_test() as pilot:
+            await pilot.triple_click("#second", offset=(1, 0))
+
+            assert pilot.app.screen.get_selected_text() == "second message"
 
 
 class TestPatchedSequenceToKeyEvents:


### PR DESCRIPTION
Double-click selection in the Textual app now targets word boundaries instead of selecting an entire widget. Clipboard copying is deferred until Textual finishes click-chain selection updates, so copied text reflects the final double- or triple-click selection.