### PR TITLE
fix(code): move MCP trust state out of user config

### DIFF
--- a/libs/code/THREAT_MODEL.md
+++ b/libs/code/THREAT_MODEL.md
@@ -156,7 +156,7 @@
 | DC1 | API Keys / Credentials | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `TAVILY_API_KEY`, `LANGSMITH_API_KEY`, `LANGGRAPH_API_KEY` | Critical | Process environment only; never written to disk by CLI code | N/A (in-memory) | Process lifetime | All — breach trigger |
 | DC2 | Conversation Messages  | User prompts, LLM responses, tool args/results   | High        | SQLite (`~/.deepagents/*.db`) via LangGraph checkpointer | No (local file, unencrypted) | Unbounded (session files persist) | GDPR if personal data is discussed |
 | DC3 | System Prompt Content  | `DA_SERVER_SYSTEM_PROMPT` env var; custom AGENTS.md contents | Medium | Process environment (transient); `~/.deepagents/{agent}/AGENTS.md` on disk | No | Config lifetime | None direct |
-| DC4 | MCP Trust Fingerprints | `mcp_trust.projects.*` in `config.toml`          | Low         | `~/.deepagents/config.toml`      | No                | Until revoked      | None       |
+| DC4 | MCP Trust Fingerprints | `projects.*` in `mcp_trust.json`                 | Low         | `~/.deepagents/.state/mcp_trust.json` | No           | Until revoked      | None       |
 | DC5 | Offloaded Conversation History | Summarized + raw conversation messages written to sandbox backend | High | Sandbox filesystem at `/conversation_history/{thread_id}.md` | Depends on sandbox provider | Sandbox session lifetime | GDPR if personal data is discussed |
 
 ### Data Classification Details

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1649,8 +1649,12 @@ def _check_mcp_project_trust(*, trust_flag: bool = False) -> bool | None:
         answer = ""
 
     if answer == "y":
-        if not debug_prompt:
-            trust_project_mcp(project_root, fingerprint)
+        if not debug_prompt and not trust_project_mcp(project_root, fingerprint):
+            prompt_console.print(
+                "[yellow]Approved for this session, but the decision could not be "
+                "saved — you'll be asked again next time.[/yellow]",
+                highlight=False,
+            )
         return True
     return False
 

--- a/libs/code/deepagents_code/mcp_disabled.py
+++ b/libs/code/deepagents_code/mcp_disabled.py
@@ -2,8 +2,8 @@
 
 Disabled servers are skipped at config merge time so their tools never
 reach the agent and no connection is attempted. State lives under
-`[mcp_disabled]` in `~/.deepagents/config.toml`, mirroring the layout
-used by `mcp_trust.py`.
+`[mcp_disabled]` in `~/.deepagents/config.toml`, alongside the user's
+other configuration sections.
 
 The store keys on server *name* alone. Two configs that both declare a
 `github` server will both be disabled by a single entry — intentional,
@@ -34,7 +34,7 @@ class _ConfigLoadError(Exception):
     Distinct from "file does not exist" so callers can refuse to
     overwrite a config they could not parse — otherwise a transient
     read error or a hand-edit typo would silently truncate sibling
-    sections (e.g. `[mcp_trust]`) on the next write.
+    sections (e.g. model profiles) on the next write.
     """
 
 
@@ -141,7 +141,7 @@ def set_server_disabled(
 
     Refuses to write when the existing config cannot be parsed so a
     corrupt or permission-denied file is not silently overwritten —
-    that would discard sibling sections such as `[mcp_trust]`.
+    that would discard sibling sections such as model profiles.
 
     Args:
         server_name: MCP server name from `mcpServers` config.

--- a/libs/code/deepagents_code/mcp_trust.py
+++ b/libs/code/deepagents_code/mcp_trust.py
@@ -4,23 +4,39 @@ Manages persistent approval of project-level MCP configs that contain stdio
 servers (which execute local commands). Trust is fingerprint-based: if the
 config content changes, the user must re-approve.
 
-Trust entries are stored in `~/.deepagents/config.toml` under
-`[mcp_trust.projects]`.
+Trust entries are app-managed bookkeeping (a map of project root to config
+fingerprint), not user-facing configuration, so they live alongside the
+other state files under `~/.deepagents/.state/mcp_trust.json` rather than in
+the hand-editable `config.toml`.
 """
 
 from __future__ import annotations
 
 import contextlib
 import hashlib
+import json
 import logging
 import os
 import tempfile
 from pathlib import Path
 from typing import Any
 
-from deepagents_code.model_config import DEFAULT_CONFIG_PATH as _DEFAULT_CONFIG_PATH
-
 logger = logging.getLogger(__name__)
+
+_STORAGE_VERSION = 1
+"""Schema version stamped into `mcp_trust.json`; bump on incompatible changes."""
+
+
+def _default_store_path() -> Path:
+    """Return `~/.deepagents/.state/mcp_trust.json`.
+
+    Resolved at call time (not import time) so tests can redirect storage by
+    monkeypatching `deepagents_code.model_config.DEFAULT_STATE_DIR` — the same
+    pattern `auth_store._auth_path` and `mcp_auth._tokens_dir` use.
+    """
+    from deepagents_code.model_config import DEFAULT_STATE_DIR
+
+    return DEFAULT_STATE_DIR / "mcp_trust.json"
 
 
 def compute_config_fingerprint(config_paths: list[Path]) -> str:
@@ -41,127 +57,151 @@ def compute_config_fingerprint(config_paths: list[Path]) -> str:
     return f"sha256:{hasher.hexdigest()}"
 
 
-def _load_config(config_path: Path) -> dict[str, Any]:
-    """Read the TOML config file.
+def _load_store(store_path: Path) -> dict[str, Any]:
+    """Read the JSON trust store file.
 
     Returns:
-        Parsed TOML data, or an empty dict on failure.
+        Parsed JSON data, or an empty dict when the file is missing,
+        unreadable, or corrupt. A corrupt store degrades to "nothing
+        trusted" so a bad file can't crash startup — the next write
+        rewrites it cleanly.
     """
-    import tomllib
-
     try:
-        if not config_path.exists():
+        if not store_path.exists():
             return {}
-        with config_path.open("rb") as f:
-            return tomllib.load(f)
-    except (OSError, tomllib.TOMLDecodeError):
-        logger.debug("Could not read config %s", config_path, exc_info=True)
+        data = json.loads(store_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        # A corrupt store silently drops every prior approval and forces a
+        # re-prompt, so log at WARNING (not DEBUG) to leave a breadcrumb for
+        # the otherwise-unexplained re-prompt — consistent with the WARNING in
+        # compute_config_fingerprint and the exception log in _save_store.
+        logger.warning(
+            "MCP trust store %s is corrupt; treating as empty: %s", store_path, exc
+        )
         return {}
+    except OSError as exc:
+        logger.warning(
+            "Could not read MCP trust store %s; treating as empty: %s",
+            store_path,
+            exc,
+        )
+        return {}
+    if not isinstance(data, dict):
+        logger.warning("MCP trust store %s is not a JSON object; ignoring", store_path)
+        return {}
+    return data
 
 
-def _save_config(data: dict[str, Any], config_path: Path) -> bool:
-    """Atomic write of TOML data to config_path.
+def _save_store(data: dict[str, Any], store_path: Path) -> bool:
+    """Atomic write of JSON trust data to `store_path`.
 
     Uses `tempfile.mkstemp` + `Path.replace` for crash safety.
 
     Args:
-        data: Full TOML data dict to write.
-        config_path: Destination path.
+        data: Full store dict to write.
+        store_path: Destination path.
 
     Returns:
         `True` on success, `False` on I/O failure.
     """
-    import tomli_w
-
     try:
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_path = tempfile.mkstemp(dir=config_path.parent, suffix=".tmp")
+        store_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=store_path.parent, suffix=".tmp")
         try:
-            with os.fdopen(fd, "wb") as f:
-                tomli_w.dump(data, f)
-            Path(tmp_path).replace(config_path)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+            Path(tmp_path).replace(store_path)
         except BaseException:
             with contextlib.suppress(OSError):
                 Path(tmp_path).unlink()
             raise
     except (OSError, ValueError):
-        logger.exception("Failed to save config to %s", config_path)
+        logger.exception("Failed to save MCP trust store to %s", store_path)
         return False
     return True
+
+
+def _read_projects(store_path: Path) -> dict[str, Any]:
+    """Return the `projects` mapping from the store, or an empty dict."""
+    projects = _load_store(store_path).get("projects", {})
+    return projects if isinstance(projects, dict) else {}
 
 
 def is_project_mcp_trusted(
     project_root: str,
     fingerprint: str,
     *,
-    config_path: Path | None = None,
+    store_path: Path | None = None,
 ) -> bool:
     """Check whether a project's MCP config is trusted with the given fingerprint.
 
     Args:
         project_root: Absolute path to the project root.
         fingerprint: Expected fingerprint string (`sha256:<hex>`).
-        config_path: Path to the trust config file.
+        store_path: Path to the trust store file. Defaults to
+            `~/.deepagents/.state/mcp_trust.json`.
 
     Returns:
         `True` if the stored fingerprint matches.
     """
-    if config_path is None:
-        config_path = _DEFAULT_CONFIG_PATH
-
-    data = _load_config(config_path)
-    projects = data.get("mcp_trust", {}).get("projects", {})
-    return projects.get(project_root) == fingerprint
+    if store_path is None:
+        store_path = _default_store_path()
+    return _read_projects(store_path).get(project_root) == fingerprint
 
 
 def trust_project_mcp(
     project_root: str,
     fingerprint: str,
     *,
-    config_path: Path | None = None,
+    store_path: Path | None = None,
 ) -> bool:
     """Persist trust for a project's MCP config.
 
     Args:
         project_root: Absolute path to the project root.
         fingerprint: Fingerprint to store (`sha256:<hex>`).
-        config_path: Path to the trust config file.
+        store_path: Path to the trust store file. Defaults to
+            `~/.deepagents/.state/mcp_trust.json`.
 
     Returns:
         `True` if the entry was saved successfully.
     """
-    if config_path is None:
-        config_path = _DEFAULT_CONFIG_PATH
+    if store_path is None:
+        store_path = _default_store_path()
 
-    data = _load_config(config_path)
-    if "mcp_trust" not in data:
-        data["mcp_trust"] = {}
-    if "projects" not in data["mcp_trust"]:
-        data["mcp_trust"]["projects"] = {}
-    data["mcp_trust"]["projects"][project_root] = fingerprint
-    return _save_config(data, config_path)
+    data = _load_store(store_path)
+    projects = data.get("projects")
+    if not isinstance(projects, dict):
+        projects = {}
+    projects[project_root] = fingerprint
+    data["version"] = _STORAGE_VERSION
+    data["projects"] = projects
+    return _save_store(data, store_path)
 
 
 def revoke_project_mcp_trust(
     project_root: str,
     *,
-    config_path: Path | None = None,
+    store_path: Path | None = None,
 ) -> bool:
     """Remove trust for a project's MCP config.
 
     Args:
         project_root: Absolute path to the project root.
-        config_path: Path to the trust config file.
+        store_path: Path to the trust store file. Defaults to
+            `~/.deepagents/.state/mcp_trust.json`.
 
     Returns:
         `True` if the entry was removed (or didn't exist).
     """
-    if config_path is None:
-        config_path = _DEFAULT_CONFIG_PATH
+    if store_path is None:
+        store_path = _default_store_path()
 
-    data = _load_config(config_path)
-    projects = data.get("mcp_trust", {}).get("projects", {})
-    if project_root not in projects:
+    data = _load_store(store_path)
+    projects = data.get("projects")
+    if not isinstance(projects, dict) or project_root not in projects:
         return True
-    del data["mcp_trust"]["projects"][project_root]
-    return _save_config(data, config_path)
+    del projects[project_root]
+    data["version"] = _STORAGE_VERSION
+    data["projects"] = projects
+    return _save_store(data, store_path)

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -1039,6 +1039,59 @@ class TestCheckMcpProjectTrustPrompt:
         )
         assert "Learn more:" in captured.err
 
+    def test_warns_when_trust_cannot_be_saved(
+        self, capsys: pytest.CaptureFixture[str], tmp_path: Path
+    ) -> None:
+        """A failed persist still allows this session but warns it wasn't saved."""
+        from deepagents_code.main import _check_mcp_project_trust
+
+        project_root = tmp_path / "proj"
+        project_root.mkdir()
+        project_cfg = project_root / ".mcp.json"
+        project_cfg.write_text("{}")
+
+        project_context = SimpleNamespace(
+            project_root=project_root, user_cwd=project_root
+        )
+
+        with (
+            patch(
+                "deepagents_code.project_utils.ProjectContext.from_user_cwd",
+                return_value=project_context,
+            ),
+            patch(
+                "deepagents_code.mcp_tools.discover_mcp_configs",
+                return_value=[project_cfg],
+            ),
+            patch(
+                "deepagents_code.mcp_tools.classify_discovered_configs",
+                return_value=([], [project_cfg]),
+            ),
+            patch(
+                "deepagents_code.mcp_tools.load_mcp_config_lenient",
+                return_value={
+                    "mcpServers": {"fs": {"command": "node", "args": ["server.js"]}}
+                },
+            ),
+            patch(
+                "deepagents_code.mcp_tools.extract_project_server_summaries",
+                return_value=[("fs", "stdio", "node server.js")],
+            ),
+            patch(
+                "deepagents_code.mcp_trust.is_project_mcp_trusted",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_code.mcp_trust.trust_project_mcp",
+                return_value=False,
+            ),
+            patch("builtins.input", return_value="y"),
+        ):
+            decision = _check_mcp_project_trust(trust_flag=False)
+
+        assert decision is True
+        assert "could not be saved" in capsys.readouterr().err
+
 
 class TestCheckMcpProjectTrustDedupe:
     """Regression tests for the project MCP approval prompt deduplication.

--- a/libs/code/tests/unit_tests/test_mcp_disabled.py
+++ b/libs/code/tests/unit_tests/test_mcp_disabled.py
@@ -94,7 +94,7 @@ class TestSetServerDisabled:
         """Corrupt config must not be silently overwritten.
 
         A transient parse failure could otherwise truncate sibling
-        sections (e.g. `[mcp_trust]`) the next time the user toggles a
+        sections (e.g. model profiles) the next time the user toggles a
         disable state.
         """
         cfg = tmp_path / "config.toml"

--- a/libs/code/tests/unit_tests/test_mcp_trust.py
+++ b/libs/code/tests/unit_tests/test_mcp_trust.py
@@ -54,59 +54,105 @@ class TestTrustStore:
     """Tests for is_project_mcp_trusted / trust_project_mcp / revoke."""
 
     def test_untrusted_by_default(self, tmp_path: Path) -> None:
-        """A project is not trusted when the config file doesn't exist."""
-        cfg = tmp_path / "config.toml"
+        """A project is not trusted when the store file doesn't exist."""
+        store = tmp_path / "mcp_trust.json"
         assert not is_project_mcp_trusted(
-            "/some/project", "sha256:abc", config_path=cfg
+            "/some/project", "sha256:abc", store_path=store
         )
 
     def test_trust_and_verify(self, tmp_path: Path) -> None:
         """Trusting a project then checking returns True."""
-        cfg = tmp_path / "config.toml"
+        store = tmp_path / "mcp_trust.json"
         fp = "sha256:deadbeef"
-        assert trust_project_mcp("/my/project", fp, config_path=cfg)
-        assert is_project_mcp_trusted("/my/project", fp, config_path=cfg)
+        assert trust_project_mcp("/my/project", fp, store_path=store)
+        assert is_project_mcp_trusted("/my/project", fp, store_path=store)
 
     def test_fingerprint_mismatch(self, tmp_path: Path) -> None:
         """Different fingerprint returns False."""
-        cfg = tmp_path / "config.toml"
-        trust_project_mcp("/my/project", "sha256:aaa", config_path=cfg)
-        assert not is_project_mcp_trusted("/my/project", "sha256:bbb", config_path=cfg)
+        store = tmp_path / "mcp_trust.json"
+        trust_project_mcp("/my/project", "sha256:aaa", store_path=store)
+        assert not is_project_mcp_trusted("/my/project", "sha256:bbb", store_path=store)
 
     def test_revoke(self, tmp_path: Path) -> None:
         """Revoking trust makes the project untrusted."""
-        cfg = tmp_path / "config.toml"
+        store = tmp_path / "mcp_trust.json"
         fp = "sha256:123"
-        trust_project_mcp("/proj", fp, config_path=cfg)
-        assert is_project_mcp_trusted("/proj", fp, config_path=cfg)
-        assert revoke_project_mcp_trust("/proj", config_path=cfg)
-        assert not is_project_mcp_trusted("/proj", fp, config_path=cfg)
+        trust_project_mcp("/proj", fp, store_path=store)
+        assert is_project_mcp_trusted("/proj", fp, store_path=store)
+        assert revoke_project_mcp_trust("/proj", store_path=store)
+        assert not is_project_mcp_trusted("/proj", fp, store_path=store)
 
     def test_revoke_nonexistent(self, tmp_path: Path) -> None:
         """Revoking a nonexistent entry returns True."""
-        cfg = tmp_path / "config.toml"
-        assert revoke_project_mcp_trust("/nope", config_path=cfg)
+        store = tmp_path / "mcp_trust.json"
+        assert revoke_project_mcp_trust("/nope", store_path=store)
 
     def test_multiple_projects(self, tmp_path: Path) -> None:
         """Multiple projects can be independently trusted."""
-        cfg = tmp_path / "config.toml"
-        trust_project_mcp("/a", "sha256:a1", config_path=cfg)
-        trust_project_mcp("/b", "sha256:b1", config_path=cfg)
-        assert is_project_mcp_trusted("/a", "sha256:a1", config_path=cfg)
-        assert is_project_mcp_trusted("/b", "sha256:b1", config_path=cfg)
+        store = tmp_path / "mcp_trust.json"
+        trust_project_mcp("/a", "sha256:a1", store_path=store)
+        trust_project_mcp("/b", "sha256:b1", store_path=store)
+        assert is_project_mcp_trusted("/a", "sha256:a1", store_path=store)
+        assert is_project_mcp_trusted("/b", "sha256:b1", store_path=store)
 
-    def test_preserves_existing_config(self, tmp_path: Path) -> None:
-        """Trust operations preserve other config sections."""
-        import tomllib
+    def test_save_failure_returns_false(self, tmp_path: Path) -> None:
+        """An unwritable store path returns False instead of raising."""
+        # Parent is a regular file, so mkdir(parents=True) fails with an OSError
+        # subclass that _save_store must catch and report as a failed write.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("x")
+        store = blocker / "mcp_trust.json"
+        assert trust_project_mcp("/proj", "sha256:x", store_path=store) is False
 
-        import tomli_w
+    def test_trust_heals_malformed_projects_value(self, tmp_path: Path) -> None:
+        """A non-dict `projects` value is replaced, not crashed on or appended to."""
+        import json
 
-        cfg = tmp_path / "config.toml"
-        cfg.write_text('[warnings]\nsuppress = ["ripgrep"]\n')
+        store = tmp_path / "mcp_trust.json"
+        store.write_text(json.dumps({"version": 1, "projects": []}))
+        assert trust_project_mcp("/proj", "sha256:x", store_path=store)
+        assert is_project_mcp_trusted("/proj", "sha256:x", store_path=store)
 
-        trust_project_mcp("/proj", "sha256:x", config_path=cfg)
+    def test_revoke_preserves_other_entries(self, tmp_path: Path) -> None:
+        """Revoking one project leaves siblings intact and re-stamps the version."""
+        import json
 
-        with cfg.open("rb") as f:
-            data = tomllib.load(f)
-        assert data["warnings"]["suppress"] == ["ripgrep"]
-        assert data["mcp_trust"]["projects"]["/proj"] == "sha256:x"
+        store = tmp_path / "mcp_trust.json"
+        trust_project_mcp("/a", "sha256:a1", store_path=store)
+        trust_project_mcp("/b", "sha256:b1", store_path=store)
+        assert revoke_project_mcp_trust("/a", store_path=store)
+        assert not is_project_mcp_trusted("/a", "sha256:a1", store_path=store)
+        assert is_project_mcp_trusted("/b", "sha256:b1", store_path=store)
+        data = json.loads(store.read_text(encoding="utf-8"))
+        assert data["version"] == 1
+
+    def test_on_disk_shape(self, tmp_path: Path) -> None:
+        """The store is a versioned JSON object mapping roots to fingerprints."""
+        import json
+
+        store = tmp_path / "mcp_trust.json"
+        trust_project_mcp("/proj", "sha256:x", store_path=store)
+
+        data = json.loads(store.read_text(encoding="utf-8"))
+        assert data["version"] == 1
+        assert data["projects"]["/proj"] == "sha256:x"
+
+    def test_corrupt_store_degrades_to_untrusted(self, tmp_path: Path) -> None:
+        """A corrupt store reads as nothing-trusted instead of raising."""
+        store = tmp_path / "mcp_trust.json"
+        store.write_text("not valid json {{{")
+        assert not is_project_mcp_trusted("/proj", "sha256:x", store_path=store)
+        # A subsequent write rewrites the file cleanly.
+        assert trust_project_mcp("/proj", "sha256:x", store_path=store)
+        assert is_project_mcp_trusted("/proj", "sha256:x", store_path=store)
+
+    def test_default_path_uses_state_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without an explicit path, the store lives under DEFAULT_STATE_DIR."""
+        from deepagents_code import model_config
+
+        monkeypatch.setattr(model_config, "DEFAULT_STATE_DIR", tmp_path)
+        trust_project_mcp("/proj", "sha256:x")
+        assert (tmp_path / "mcp_trust.json").exists()
+        assert is_project_mcp_trusted("/proj", "sha256:x")


### PR DESCRIPTION
[Docs](https://github.com/langchain-ai/docs/pull/4291)

Move project MCP trust fingerprints out of the hand-editable user config and into the app-managed state directory.

MCP trust entries are bookkeeping data keyed by project root and config fingerprint, not user configuration. Storing them in `config.toml` made unrelated config writes more fragile and mixed internal state with settings users may edit directly. This change stores trust data in a versioned JSON file under the Deep Agents state directory instead.

This is an intentional breaking storage/API change:
- existing `[mcp_trust.projects]` entries in `config.toml` are not migrated
- trust helpers now use `store_path` for the JSON trust store rather than `config_path`
- users with previously trusted project MCP configs may be prompted to approve them again

Also warn when an approval succeeds for the current session but cannot be persisted, so users understand why they will be prompted again later.