### PR TITLE
fix(code): guard pasted-path probes against `OSError`

### DIFF
--- a/libs/code/deepagents_code/input.py
+++ b/libs/code/deepagents_code/input.py
@@ -685,6 +685,67 @@ def _normalize_posix_pasted_path(text: str) -> Path | None:
     return None
 
 
+def _safe_exists(path: Path) -> bool:
+    """Return whether `path` exists, treating OS rejections as non-existent.
+
+    Filesystem probes (`exists`/`is_file`/`is_dir`) issue an `os.stat` that can
+    raise `OSError` for inputs the OS refuses outright — notably `ENAMETOOLONG`
+    when a path component exceeds the filesystem limit. Whether `pathlib`
+    swallows such an error is version-dependent (Python <=3.13 ignores only a
+    small set of errnos and lets `ENAMETOOLONG` propagate; 3.14 routes these
+    through `os.path.*`, which swallows more), so we guard unconditionally for
+    uniform behavior. Callers here only care whether the path is usable, so a
+    failed probe is equivalent to "not there".
+
+    Args:
+        path: Path candidate to probe.
+
+    Returns:
+        `True` if the path exists, `False` if it does not or cannot be probed.
+    """
+    try:
+        return path.exists()
+    except OSError as e:
+        logger.debug("exists() check failed for %r: %s", path, e)
+        return False
+
+
+def _safe_is_file(path: Path) -> bool:
+    """Return whether `path` is an existing file, ignoring stat failures.
+
+    See `_safe_exists` for why probes are guarded.
+
+    Args:
+        path: Path candidate to probe.
+
+    Returns:
+        `True` if the path is a regular file, `False` otherwise or on failure.
+    """
+    try:
+        return path.is_file()
+    except OSError as e:
+        logger.debug("is_file() check failed for %r: %s", path, e)
+        return False
+
+
+def _safe_is_dir(path: Path) -> bool:
+    """Return whether `path` is an existing directory, ignoring stat failures.
+
+    See `_safe_exists` for why probes are guarded.
+
+    Args:
+        path: Path candidate to probe.
+
+    Returns:
+        `True` if the path is a directory, `False` otherwise or on failure.
+    """
+    try:
+        return path.is_dir()
+    except OSError as e:
+        logger.debug("is_dir() check failed for %r: %s", path, e)
+        return False
+
+
 def _resolve_existing_pasted_path(path: Path) -> Path | None:
     """Resolve a pasted path candidate to an existing file.
 
@@ -701,7 +762,7 @@ def _resolve_existing_pasted_path(path: Path) -> Path | None:
     except (OSError, RuntimeError) as e:
         logger.debug("Path resolution failed for %r: %s", path, e)
         return None
-    if resolved.exists() and resolved.is_file():
+    if _safe_is_file(resolved):
         return resolved
 
     fuzzy = _resolve_with_unicode_space_variants(path)
@@ -712,7 +773,7 @@ def _resolve_existing_pasted_path(path: Path) -> Path | None:
     except (OSError, RuntimeError) as e:
         logger.debug("Unicode-space resolution failed for %r: %s", fuzzy, e)
         return None
-    if resolved_fuzzy.exists() and resolved_fuzzy.is_file():
+    if _safe_is_file(resolved_fuzzy):
         return resolved_fuzzy
     return None
 
@@ -748,11 +809,11 @@ def _resolve_with_unicode_space_variants(path: Path) -> Path | None:
 
     for index, part in enumerate(parts):
         candidate = current / part
-        if candidate.exists():
+        if _safe_exists(candidate):
             current = candidate
             continue
 
-        if not current.exists() or not current.is_dir():
+        if not _safe_is_dir(current):
             return None
         if " " not in part and "\u00a0" not in part and "\u202f" not in part:
             return None
@@ -773,11 +834,11 @@ def _resolve_with_unicode_space_variants(path: Path) -> Path | None:
 
         is_last = index == len(parts) - 1
         if is_last:
-            file_matches = [entry for entry in matches if entry.is_file()]
+            file_matches = [entry for entry in matches if _safe_is_file(entry)]
             if file_matches:
                 matches = file_matches
         else:
-            dir_matches = [entry for entry in matches if entry.is_dir()]
+            dir_matches = [entry for entry in matches if _safe_is_dir(entry)]
             if dir_matches:
                 matches = dir_matches
 

--- a/libs/code/tests/unit_tests/test_input_parsing.py
+++ b/libs/code/tests/unit_tests/test_input_parsing.py
@@ -412,3 +412,71 @@ def test_extract_leading_pasted_file_path_unquoted_path_with_spaces(
     resolved, end = result
     assert resolved == img.resolve()
     assert payload[end:] == " what's in this"
+
+
+def test_parse_pasted_file_paths_handles_overlong_component(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An over-long path component must not crash path probing.
+
+    Regression test: holding a key floods the input with a single long token.
+    Resolving it against the cwd produces a path whose component exceeds the
+    filesystem name limit, so `os.stat` raises `OSError` (`ENAMETOOLONG`). On
+    Python <=3.13 `pathlib` lets that propagate (the original crash); on 3.14
+    it is swallowed, so this asserts the no-match contract on every version.
+    The version-independent guard is `*_handles_oserror_on_probe` below.
+    """
+    monkeypatch.chdir(tmp_path)
+    overlong = "a" * 5000
+
+    assert parse_pasted_file_paths(overlong) == []
+
+
+def test_parse_pasted_path_payload_handles_overlong_component(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The dropped-path entrypoint must not crash on an over-long token.
+
+    This mirrors the exact path that crashed the TUI: `on_text_area_changed`
+    routes freshly typed text through `parse_pasted_path_payload`.
+    """
+    monkeypatch.chdir(tmp_path)
+    overlong = "a" * 5000
+
+    assert parse_pasted_path_payload(overlong) is None
+
+
+def test_parse_pasted_file_paths_handles_oserror_on_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker
+) -> None:
+    """`OSError` raised by an `is_file` probe must be swallowed, not propagated.
+
+    Guards against platforms/filesystems that surface the limit at a different
+    probe than `resolve`, ensuring the fix does not rely on a specific errno.
+    """
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "real.txt"
+    target.write_text("hi")
+    mocker.patch("pathlib.Path.is_file", side_effect=OSError(63, "File name too long"))
+
+    assert parse_pasted_file_paths(str(target)) == []
+
+
+def test_parse_pasted_file_paths_handles_oserror_in_unicode_variant(
+    tmp_path: Path, mocker
+) -> None:
+    """An `OSError` probe inside the Unicode-space fallback must not propagate.
+
+    Exercises the `_resolve_with_unicode_space_variants` traversal: the on-disk
+    name carries a narrow no-break space while the paste uses an ASCII space,
+    forcing the `iterdir`-match branch where component `is_file`/`is_dir` probes
+    run. The path is quoted so it stays a single token instead of being split.
+    """
+    unicode_name = "Screenshot 2026-02-26 at 2.02.42 AM.png"
+    img = tmp_path / unicode_name
+    img.write_bytes(b"img")
+    ascii_name = unicode_name.replace(chr(0x202F), " ")
+    pasted = f"'{str(img).replace(unicode_name, ascii_name)}'"
+    mocker.patch("pathlib.Path.is_file", side_effect=OSError(63, "File name too long"))
+
+    assert parse_pasted_file_paths(pasted) == []


### PR DESCRIPTION
Holding a key in the chat input floods the text area with a long run of characters, which the dropped-path detector speculatively resolves against the cwd. The resulting path component exceeds the filesystem name limit, so `os.stat` raises `OSError [Errno 63] ENAMETOOLONG` — and on Python ≤3.13 `pathlib` lets it propagate out of `.exists()`/`.is_file()`, crashing the Textual app. The resolution helpers wrapped `.resolve()` in a `try/except` but left the subsequent filesystem probes unguarded.