### PR TITLE
fix(quickjs): swarm subagent doesn't allow configuring middleware

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/_swarm_task.py
+++ b/libs/partners/quickjs/langchain_quickjs/_swarm_task.py
@@ -4,17 +4,19 @@ import json
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Literal
 
 from deepagents._models import resolve_model
 from langchain.agents import create_agent
-from langchain.agents.middleware import AgentMiddleware
 from langchain_core.language_models import BaseChatModel  # noqa: TC002
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.tools import BaseTool, StructuredTool
 from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from langchain.agents.middleware import AgentMiddleware
     from langchain_core.runnables import Runnable
 
 logger = logging.getLogger(__name__)

--- a/libs/partners/quickjs/langchain_quickjs/_swarm_task.py
+++ b/libs/partners/quickjs/langchain_quickjs/_swarm_task.py
@@ -4,10 +4,11 @@ import json
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Sequence
 
 from deepagents._models import resolve_model
 from langchain.agents import create_agent
+from langchain.agents.middleware import AgentMiddleware
 from langchain_core.language_models import BaseChatModel  # noqa: TC002
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.tools import BaseTool, StructuredTool
@@ -46,6 +47,9 @@ class SwarmSubAgent:
 
     model: str | BaseChatModel | None = None
     """Model override for this subagent. Falls back to the tool's `default_model`."""
+
+    middleware: Sequence[AgentMiddleware] = field(default_factory=list)
+    """Middleware applied to this subagent's agent loop."""
 
 
 def _validate_response_schema(schema: dict[str, Any]) -> None:
@@ -175,11 +179,13 @@ class _AgentSpec:
         system_prompt: str,
         tools: list[BaseTool],
         name: str,
+        middleware: Sequence[AgentMiddleware] = (),
     ) -> None:
         self.model = model
         self.system_prompt = system_prompt
         self.tools = tools
         self.name = name
+        self.middleware = middleware
 
 
 class _CompiledAgent:
@@ -208,6 +214,7 @@ async def _invoke_agent(
                 system_prompt=entry.spec.system_prompt,
                 tools=entry.spec.tools,
                 name=entry.spec.name,
+                middleware=list(entry.spec.middleware),
                 response_format=response_schema,
             ),
         )
@@ -282,17 +289,20 @@ def create_swarm_task_tool(
 
     for sub in subs:
         model = sub.model if sub.model is not None else default_model
+        middleware = list(sub.middleware)
         spec = _AgentSpec(
             model=model,
             system_prompt=sub.system_prompt,
             tools=sub.tools,
             name=sub.name,
+            middleware=middleware,
         )
         agent = create_agent(
             model=model,
             system_prompt=sub.system_prompt,
             tools=sub.tools,
             name=sub.name,
+            middleware=middleware,
         )
         compiled[sub.name] = _CompiledAgent(agent=agent, spec=spec)
 

--- a/libs/partners/quickjs/tests/unit_tests/test_swarm_task.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_swarm_task.py
@@ -645,7 +645,7 @@ class TestMiddleware:
             middleware_b,
         ]
 
-    def test_passes_middleware_to_variant_recompilation(self) -> None:
+    async def test_passes_middleware_to_variant_recompilation(self) -> None:
         middleware_a = MagicMock()
 
         with patch(
@@ -668,19 +668,15 @@ class TestMiddleware:
             "langchain_quickjs._swarm_task.create_agent",
             return_value=_make_fake_agent(),
         ) as mock_create_variant:
-            import asyncio
-
-            asyncio.get_event_loop().run_until_complete(
-                tool.ainvoke(
-                    {
-                        "description": "work",
-                        "subagent_type": "worker",
-                        "response_schema": {
-                            "type": "object",
-                            "properties": {"label": {"type": "string"}},
-                        },
-                    }
-                )
+            await tool.ainvoke(
+                {
+                    "description": "work",
+                    "subagent_type": "worker",
+                    "response_schema": {
+                        "type": "object",
+                        "properties": {"label": {"type": "string"}},
+                    },
+                }
             )
 
         mock_create_variant.assert_called_once()

--- a/libs/partners/quickjs/tests/unit_tests/test_swarm_task.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_swarm_task.py
@@ -651,7 +651,7 @@ class TestMiddleware:
         with patch(
             "langchain_quickjs._swarm_task.create_agent",
             return_value=_make_fake_agent(),
-        ) as mock_create:
+        ):
             tool = create_swarm_task_tool(
                 subagents=[
                     SwarmSubAgent(

--- a/libs/partners/quickjs/tests/unit_tests/test_swarm_task.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_swarm_task.py
@@ -612,6 +612,97 @@ class TestMultipleSubagents:
 
 
 # ---------------------------------------------------------------------------
+# Middleware pass-through
+# ---------------------------------------------------------------------------
+
+
+class TestMiddleware:
+    """Tests for middleware pass-through to create_agent."""
+
+    def test_passes_middleware_to_create_agent_at_construction(self) -> None:
+        middleware_a = MagicMock()
+        middleware_b = MagicMock()
+
+        with patch(
+            "langchain_quickjs._swarm_task.create_agent",
+            return_value=_make_fake_agent(),
+        ) as mock_create:
+            create_swarm_task_tool(
+                subagents=[
+                    SwarmSubAgent(
+                        name="worker",
+                        description="W",
+                        system_prompt="W.",
+                        middleware=[middleware_a, middleware_b],
+                    )
+                ],
+                default_model=_make_mock_model(),
+            )
+
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs["middleware"] == [
+            middleware_a,
+            middleware_b,
+        ]
+
+    def test_passes_middleware_to_variant_recompilation(self) -> None:
+        middleware_a = MagicMock()
+
+        with patch(
+            "langchain_quickjs._swarm_task.create_agent",
+            return_value=_make_fake_agent(),
+        ) as mock_create:
+            tool = create_swarm_task_tool(
+                subagents=[
+                    SwarmSubAgent(
+                        name="worker",
+                        description="W",
+                        system_prompt="W.",
+                        middleware=[middleware_a],
+                    )
+                ],
+                default_model=_make_mock_model(),
+            )
+
+        with patch(
+            "langchain_quickjs._swarm_task.create_agent",
+            return_value=_make_fake_agent(),
+        ) as mock_create_variant:
+            import asyncio
+
+            asyncio.get_event_loop().run_until_complete(
+                tool.ainvoke(
+                    {
+                        "description": "work",
+                        "subagent_type": "worker",
+                        "response_schema": {
+                            "type": "object",
+                            "properties": {"label": {"type": "string"}},
+                        },
+                    }
+                )
+            )
+
+        mock_create_variant.assert_called_once()
+        assert mock_create_variant.call_args.kwargs["middleware"] == [middleware_a]
+
+    def test_defaults_to_empty_middleware_when_not_specified(self) -> None:
+        with patch(
+            "langchain_quickjs._swarm_task.create_agent",
+            return_value=_make_fake_agent(),
+        ) as mock_create:
+            create_swarm_task_tool(
+                subagents=[
+                    SwarmSubAgent(name="worker", description="W", system_prompt="W.")
+                ],
+                default_model=_make_mock_model(),
+            )
+
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs["middleware"] == []
+
+
+# ---------------------------------------------------------------------------
 # TTL variant cache integration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
### Summary

This PR exposes a middleware option for swarm subagents to allow configuring middleware with swarm subagents.

 ### Tests

Added 3 unit tests:
- test_passes_middleware_to_create_agent_at_construction — verifies middleware is forwarded to create_agent when the swarm tool is built
- test_passes_middleware_to_variant_recompilation — verifies middleware is forwarded when a response_schema triggers a new agent variant
- test_defaults_to_empty_middleware_when_not_specified — verifies backwards compatibility (no middleware = empty list)
