### PR TITLE
fix(sdk): Remove implementation detail leak to the LLM

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -39,7 +39,7 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.state import StateBackend
 
-_DELETE_UNSUPPORTED_ERROR = "Error: deletion is not supported for '{file_path}' (its backend does not implement delete)."
+_DELETE_UNSUPPORTED_ERROR = "Error: deletion is not supported for '{file_path}'."
 
 
 def _remap_grep_path(m: GrepMatch, route_prefix: str) -> GrepMatch:


### PR DESCRIPTION
The term "backend" leaked an implementation detail to the LLM in _DELETE_UNSUPPORTED_ERROR, even though the LLM has no notion of different backend implementations.

**What changed:** 
Reworded the error message to remove backend-specific details and describe the failure in user/LLM-facing terms.