### PR TITLE
feat(code): pair model API keys with their endpoints

### DIFF
--- a/libs/code/AGENTS.md
+++ b/libs/code/AGENTS.md
@@ -10,10 +10,10 @@ For monorepo-wide conventions (commit titles, lint, testing, docs, CI, benchmark
 
 **Key Textual resources:**
 
-- **Guide:** https://textual.textualize.io/guide/
-- **Widget gallery:** https://textual.textualize.io/widget_gallery/
-- **CSS reference:** https://textual.textualize.io/styles/
-- **API reference:** https://textual.textualize.io/api/
+- **Guide:** <https://textual.textualize.io/guide/>
+- **Widget gallery:** <https://textual.textualize.io/widget_gallery/>
+- **CSS reference:** <https://textual.textualize.io/styles/>
+- **API reference:** <https://textual.textualize.io/api/>
 
 ### Styled text in widgets
 
@@ -92,8 +92,18 @@ To add a new slash command: (1) add a `SlashCommand` entry to `COMMANDS`, (2) se
 `deepagents-code` supports LangChain-based chat model providers as optional dependencies. To add a new provider, update these files (all entries alphabetically sorted):
 
 1. `deepagents_code/model_config.py` — add `"provider_name": "ENV_VAR_NAME"` to `PROVIDER_API_KEY_ENV`
-2. `pyproject.toml` — add `provider = ["langchain-provider>=X.Y.Z,<N.0.0"]` to `[project.optional-dependencies]` and include it in the `all-providers` composite extra
-3. `tests/unit_tests/test_model_config.py` — add `assert PROVIDER_API_KEY_ENV["provider_name"] == "ENV_VAR_NAME"` to `TestProviderApiKeyEnv.test_contains_major_providers`
+2. `deepagents_code/model_config.py` — if the provider reads a *dedicated* endpoint env var, add `"provider_name": ("CANONICAL_BASE_URL", "ALTERNATE", ...)` to `PROVIDER_BASE_URL_ENV` (see guidelines below); omit the provider entirely when it has no provider-specific endpoint variable
+3. `pyproject.toml` — add `provider = ["langchain-provider>=X.Y.Z,<N.0.0"]` to `[project.optional-dependencies]` and include it in the `all-providers` composite extra
+4. `tests/unit_tests/test_model_config.py` — add `assert PROVIDER_API_KEY_ENV["provider_name"] == "ENV_VAR_NAME"` to `TestProviderApiKeyEnv.test_contains_major_providers`, and pin any `PROVIDER_BASE_URL_ENV` entry with a matching assertion
+
+### `PROVIDER_BASE_URL_ENV` guidelines
+
+`PROVIDER_BASE_URL_ENV` pairs a provider with the endpoint env var(s) its LangChain integration and SDK read, so a stored `/auth` endpoint resolves and an inherited gateway URL cannot leak. Before adding an entry:
+
+- **Verify against source — never infer from naming.** Read both the `langchain-<provider>` chat model (look for `from_env` / `get_from_dict_or_env` / `secret_from_env`, or a `Field` default on the `base_url`/`endpoint` alias) and the underlying vendor SDK, and record the exact env var name each reads. The integration and the SDK often read different names (e.g. `GROQ_API_BASE` vs `GROQ_BASE_URL`).
+- **Canonical name first.** Element `[0]` is written by `apply_stored_credentials` and read by `get_base_url`; every other name the integration or SDK may read goes in the tuple so it is cleared too. By convention the SDK's `*_BASE_URL`-style name is canonical and the integration's `*_API_BASE`/`*_API_URL` name is the alternate.
+- **Never list another provider's shared var.** OpenAI-compatible providers (e.g. `deepseek`, `openrouter`, `together`, `xai`, `baseten`) sit on the `openai` SDK, whose only endpoint var is the shared `OPENAI_BASE_URL`. Listing it under those providers would clobber the user's real OpenAI endpoint when their credential is written or cleared — list only the provider's own var (e.g. `DEEPSEEK_API_BASE`), or nothing.
+- **Omit providers with no dedicated var.** When the endpoint is a hardcoded default plus a constructor arg (`baseten`), an `api_base` arg resolved per-provider inside the library (`litellm`), or derived from the region (`google_vertexai`), leave the provider out. A `/auth` endpoint still resolves through `get_base_url`'s stored-credential step and reaches the model as the `base_url` kwarg.
 
 **Not required** unless the provider's models have a distinctive name prefix (like `gpt-*`, `claude*`, `gemini*`):
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3505,28 +3505,36 @@ class DeepAgentsApp(App):
         """
         parts = command.split()
         force = "--force" in parts[1:]
-        extras = [p for p in parts[1:] if not p.startswith("-")]
-        if not extras:
+        package_mode = "--package" in parts[1:]
+        names = [p for p in parts[1:] if not p.startswith("-")]
+        if not names:
             from deepagents_code.extras_info import format_known_extras
 
             await self._mount_message(
                 AppMessage(
                     "Usage: /install <extra> [--force]\n"
+                    "       /install <package> --package [--force]\n"
                     "Example: /install quickjs\n\n"
                     f"{format_known_extras()}",
                 ),
             )
             return
-        if len(extras) > 1:
+        if len(names) > 1:
+            label = "package" if package_mode else "extra"
             await self._mount_message(
                 AppMessage(
-                    "Only one extra may be installed per /install command. "
-                    f"Got: {', '.join(extras)}",
+                    f"Only one {label} may be installed per /install command. "
+                    f"Got: {', '.join(names)}",
                 ),
             )
             return
-        extra = extras[0].lower()
         await self._mount_message(UserMessage(command))
+
+        if package_mode:
+            await self._handle_install_package(names[0], force=force)
+            return
+
+        extra = names[0].lower()
 
         try:
             from deepagents_code.config import _is_editable_install
@@ -3645,6 +3653,95 @@ class DeepAgentsApp(App):
 
         await self._mount_message(
             AppMessage(f"Installed extra '{extra}'. {next_step}"),
+        )
+
+    async def _handle_install_package(self, package: str, *, force: bool) -> None:
+        """Install an arbitrary package into the dcode tool env via `uv --with`.
+
+        Backs `/install <package> --package`, the escape hatch for a provider
+        whose package is not a `deepagents-code` extra (e.g. a custom
+        `class_path` model). Arbitrary packages have no curated allowlist, so a
+        `--force` token is required to confirm pulling in third-party code.
+
+        Args:
+            package: The package name to install.
+            force: Whether the user passed `--force` to confirm the install.
+        """
+        try:
+            from deepagents_code.config import _is_editable_install
+            from deepagents_code.update_check import (
+                create_update_log_path,
+                editable_package_hint,
+                is_valid_package_name,
+                perform_install_package,
+            )
+        except ImportError as exc:
+            logger.warning("/install --package import failed", exc_info=True)
+            await self._mount_message(
+                ErrorMessage(f"Install failed: {type(exc).__name__}: {exc}"),
+            )
+            return
+
+        if not is_valid_package_name(package):
+            await self._mount_message(
+                AppMessage(
+                    "Invalid package name. Package names must be "
+                    "alphanumeric with `-`, `_`, or `.` (PEP 508).",
+                ),
+            )
+            return
+
+        if await asyncio.to_thread(_is_editable_install):
+            await self._mount_message(
+                AppMessage(
+                    "Editable install detected — cannot install packages.\n"
+                    + editable_package_hint(package),
+                ),
+            )
+            return
+
+        if not force:
+            await self._mount_message(
+                AppMessage(
+                    f"Installing the package '{package}' runs third-party code. "
+                    "Re-run with `--force` to proceed: "
+                    f"`/install {package} --package --force`",
+                ),
+            )
+            return
+
+        log_path = create_update_log_path()
+        await self._mount_message(
+            AppMessage(f"Installing package '{package}'..."),
+        )
+        try:
+            success, output = await perform_install_package(package, log_path=log_path)
+        except OSError as exc:
+            # Let `asyncio.CancelledError` propagate — this runs in the message
+            # pump, so swallowing it would suppress shutdown/cancellation.
+            logger.warning("/install --package command failed", exc_info=True)
+            await self._mount_message(
+                ErrorMessage(
+                    f"Install failed: {type(exc).__name__}: {exc}\n"
+                    f"Log: {log_path}",
+                ),
+            )
+            return
+
+        if not success:
+            detail = f": {output[-200:]}" if output else ""
+            await self._mount_message(
+                ErrorMessage(
+                    f"Install failed{detail}\nLog: {log_path}",
+                ),
+            )
+            return
+
+        await self._mount_message(
+            AppMessage(
+                f"Installed package '{package}'. Run `/restart` to load it "
+                "now, or relaunch dcode.",
+            ),
         )
 
     async def _handle_version_command(self) -> None:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2986,11 +2986,17 @@ class DeepAgentsApp(App):
                     "Or pick a different provider with `/model`."
                 )
             else:
+                from deepagents_code.extras_info import ExtrasIntrospectionError
                 from deepagents_code.update_check import install_package_command
 
                 try:
                     install_cmd = install_package_command(missing.package)
-                except ValueError:
+                except (ValueError, ExtrasIntrospectionError) as exc:
+                    logger.debug(
+                        "install_package_command failed; falling back to "
+                        "manual hint: %s",
+                        exc,
+                    )
                     install_hint = f"install the `{missing.package}` package manually"
                 else:
                     install_hint = f"run `{install_cmd}`"

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3722,8 +3722,7 @@ class DeepAgentsApp(App):
             logger.warning("/install --package command failed", exc_info=True)
             await self._mount_message(
                 ErrorMessage(
-                    f"Install failed: {type(exc).__name__}: {exc}\n"
-                    f"Log: {log_path}",
+                    f"Install failed: {type(exc).__name__}: {exc}\nLog: {log_path}",
                 ),
             )
             return

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7629,7 +7629,7 @@ class DeepAgentsApp(App):
         bar indicator and session state.
         """
         from deepagents_code.widgets.agent_selector import AgentSelectorScreen
-        from deepagents_code.widgets.auth import AuthManagerScreen
+        from deepagents_code.widgets.auth import AuthManagerScreen, AuthPromptScreen
         from deepagents_code.widgets.mcp_viewer import MCPViewerScreen
         from deepagents_code.widgets.notification_center import (
             NotificationCenterScreen,
@@ -7651,7 +7651,10 @@ class DeepAgentsApp(App):
         ):
             self.screen.action_cursor_up()
             return
-        if isinstance(self.screen, NotificationSettingsScreen):
+        if isinstance(self.screen, (AuthPromptScreen, NotificationSettingsScreen)):
+            # These modals hold multiple focusable inputs; reuse shift+tab to
+            # step focus backward (the Screen's own app.focus_previous binding
+            # never fires because this priority binding consumes the key first).
             self.screen.focus_previous()
             return
         if isinstance(

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3568,6 +3568,9 @@ class DeepAgentsApp(App):
             )
             return
 
+        # KNOWN_EXTRAS is a curated "did you mean" list, not the authoritative
+        # set (that's pyproject, resolved by uv): defer to --force rather than
+        # refuse, since valid-but-unlisted names exist (e.g. all-providers).
         if extra not in KNOWN_EXTRAS and not force:
             try:
                 manual_cmd = await asyncio.to_thread(install_extra_command, extra)

--- a/libs/code/deepagents_code/auth_store.py
+++ b/libs/code/deepagents_code/auth_store.py
@@ -62,7 +62,9 @@ class ApiKeyCredential(TypedDict):
     Stored only when the user supplied one in `/auth`. A key and its endpoint
     form a coherent pair — applying the key also applies (or, when this is
     absent, resets to the provider default) the base URL, so a personal key is
-    never sent to a gateway it doesn't belong to. Non-secret; may be logged.
+    never sent to a gateway it doesn't belong to. Not treated as a secret (it is
+    logged when malformed and surfaced in hints); avoid embedding credentials in
+    the URL.
     """
 
 
@@ -275,6 +277,14 @@ def _coerce_credential(raw: Any) -> StoredCredential | None:  # noqa: ANN401
         base_url = raw.get("base_url")
         if isinstance(base_url, str) and base_url:
             credential["base_url"] = base_url
+        elif base_url is not None:
+            # Present but not a usable string (e.g. a hand-edit left an int or
+            # an empty value). Dropping it silently would pair the key with the
+            # provider default — possibly the wrong endpoint — with no trace, so
+            # log it. `base_url` is non-secret, so logging the value is safe.
+            logger.warning(
+                "Ignoring malformed base_url for a stored credential: %r", base_url
+            )
         return credential
     # OAuth is reserved for a future PR — silently skip until the producer
     # path lands. `cred_type in {"oauth"}` falls through to None here.

--- a/libs/code/deepagents_code/auth_store.py
+++ b/libs/code/deepagents_code/auth_store.py
@@ -29,7 +29,7 @@ import os
 import stat
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -55,6 +55,15 @@ class ApiKeyCredential(TypedDict):
 
     added_at: str
     """ISO-8601 UTC timestamp recording when the credential was stored."""
+
+    base_url: NotRequired[str]
+    """Optional provider endpoint paired with this key.
+
+    Stored only when the user supplied one in `/auth`. A key and its endpoint
+    form a coherent pair — applying the key also applies (or, when this is
+    absent, resets to the provider default) the base URL, so a personal key is
+    never sent to a gateway it doesn't belong to. Non-secret; may be logged.
+    """
 
 
 class OAuthCredential(TypedDict):
@@ -262,7 +271,11 @@ def _coerce_credential(raw: Any) -> StoredCredential | None:  # noqa: ANN401
         added_at = raw.get("added_at")
         if not isinstance(added_at, str):
             added_at = ""
-        return ApiKeyCredential(type="api_key", key=key, added_at=added_at)
+        credential = ApiKeyCredential(type="api_key", key=key, added_at=added_at)
+        base_url = raw.get("base_url")
+        if isinstance(base_url, str) and base_url:
+            credential["base_url"] = base_url
+        return credential
     # OAuth is reserved for a future PR — silently skip until the producer
     # path lands. `cred_type in {"oauth"}` falls through to None here.
     return None
@@ -285,7 +298,26 @@ def get_stored_key(provider: str) -> str | None:
     return entry["key"] or None
 
 
-def set_stored_key(provider: str, key: str) -> WriteOutcome:
+def get_stored_base_url(provider: str) -> str | None:
+    """Return the base URL paired with `provider`'s stored key, or `None`.
+
+    Returns `None` both when no key is stored and when a key is stored without
+    an accompanying base URL (the user left the field blank, meaning "use the
+    provider default"). Callers distinguish the two via `get_stored_key`.
+
+    Raises:
+        RuntimeError: If the credential file is corrupt.
+    """  # noqa: DOC502 - re-raised from `_read_raw` via `load_credentials`
+    creds = load_credentials()
+    entry = creds.get(provider)
+    if entry is None or entry["type"] != "api_key":
+        return None
+    return entry.get("base_url") or None
+
+
+def set_stored_key(
+    provider: str, key: str, *, base_url: str | None = None
+) -> WriteOutcome:
     """Persist an API key for `provider`.
 
     Empty / whitespace-only keys are rejected so callers don't accidentally
@@ -296,6 +328,9 @@ def set_stored_key(provider: str, key: str) -> WriteOutcome:
     Args:
         provider: Provider identifier (e.g., `"anthropic"`).
         key: The API key value. Whitespace is stripped before storage.
+        base_url: Optional provider endpoint to pair with the key. Whitespace
+            is stripped; blank/`None` stores no endpoint, meaning the key uses
+            the provider default rather than any inherited (e.g. gateway) URL.
 
     Returns:
         A `WriteOutcome` whose `warnings` tuple lists chmod failures the
@@ -316,11 +351,15 @@ def set_stored_key(provider: str, key: str) -> WriteOutcome:
     creds = data.get("credentials")
     if not isinstance(creds, dict):
         creds = {}
-    creds[provider] = {
+    entry: dict[str, str] = {
         "type": "api_key",
         "key": cleaned,
         "added_at": datetime.now(tz=UTC).isoformat(timespec="seconds"),
     }
+    cleaned_base_url = base_url.strip() if base_url else ""
+    if cleaned_base_url:
+        entry["base_url"] = cleaned_base_url
+    creds[provider] = entry
     data["version"] = _STORAGE_VERSION
     data["credentials"] = creds
     warnings = _write_raw(data)

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -2473,11 +2473,17 @@ def _create_model_via_init(
                     f"Install: /install {extra}"
                 )
             else:
+                from deepagents_code.extras_info import ExtrasIntrospectionError
                 from deepagents_code.update_check import install_package_command
 
                 try:
                     install_cmd = install_package_command(package)
-                except ValueError:
+                except (ValueError, ExtrasIntrospectionError) as exc:
+                    logger.debug(
+                        "install_package_command failed; falling back to "
+                        "manual hint: %s",
+                        exc,
+                    )
                     install_hint = f"Install the '{package}' package manually"
                 else:
                     install_hint = f"Install with: {install_cmd}"

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -2640,6 +2640,7 @@ def create_model(
         apply_stored_credentials,
         get_credential_env_var,
         has_provider_credentials,
+        warn_on_split_credential_source,
     )
 
     if not model_spec:
@@ -2674,6 +2675,11 @@ def create_model(
     # the env var name LangChain reads. Apply before the credential check so
     # `has_provider_credentials` and the downstream SDK see the same value.
     if provider:
+        # Flag a key/endpoint resolved from different env tiers *before*
+        # `apply_stored_credentials` bridges stored values onto plain env vars,
+        # so the check sees the user's raw env intent rather than post-bridge
+        # state. Diagnostic only -- never alters resolution.
+        warn_on_split_credential_source(provider)
         apply_stored_credentials(provider)
 
     # Early credential check — fail fast with an actionable message instead of

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1997,8 +1997,7 @@ def cli_main() -> None:
 
         if args.package and not args.install:
             console.print(
-                "[bold red]Error:[/bold red] --package requires --install "
-                "<package>.",
+                "[bold red]Error:[/bold red] --package requires --install <package>.",
             )
             sys.exit(2)
 

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -991,8 +991,16 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--install",
-        metavar="EXTRA",
+        metavar="NAME",
         help="Install an optional extra (e.g. quickjs, daytona, fireworks), then exit",
+    )
+    parser.add_argument(
+        "--package",
+        action="store_true",
+        help=(
+            "With --install, treat NAME as a package added via `uv --with` "
+            "(for a custom provider package), not a deepagents-code extra"
+        ),
     )
     parser.add_argument(
         "--yes",
@@ -1984,6 +1992,116 @@ def cli_main() -> None:
                     "[bold red]Error:[/bold red] Update failed.\n"
                     "Run manually: [cyan]uv tool upgrade "
                     "deepagents-code[/cyan]"
+                )
+                sys.exit(1)
+
+        if args.package and not args.install:
+            console.print(
+                "[bold red]Error:[/bold red] --package requires --install "
+                "<package>.",
+            )
+            sys.exit(2)
+
+        # Handle --install <package> --package flag (headless, no session).
+        # Installs an arbitrary package via `uv --with` for a custom provider,
+        # rather than a deepagents-code extra. Always exits.
+        if args.install and args.package:
+            from rich.markup import escape
+
+            from deepagents_code.config import _is_editable_install
+            from deepagents_code.update_check import (
+                create_update_log_path,
+                editable_package_hint,
+                is_valid_package_name,
+                perform_install_package,
+            )
+
+            package: str = args.install
+            pkg_log_path: Path | None = None
+            try:
+                if not is_valid_package_name(package):
+                    # Defense in depth — the package is interpolated into a
+                    # shell command. Reject malformed names before any prompt
+                    # or uv call, even with --yes.
+                    console.print(
+                        f"[bold red]Error:[/bold red] "
+                        f"Invalid package name '{escape(package)}'. "
+                        "Package names must be alphanumeric with `-`, `_`, "
+                        "or `.` (PEP 508).",
+                        highlight=False,
+                    )
+                    sys.exit(2)
+                if _is_editable_install():
+                    console.print(
+                        "[bold yellow]Warning:[/bold yellow] "
+                        "--install --package is not supported on editable "
+                        "installs.\n" + escape(editable_package_hint(package)),
+                        highlight=False,
+                    )
+                    sys.exit(1)
+
+                # Arbitrary packages have no curated allowlist to vet against,
+                # so confirm before pulling third-party code into the tool env.
+                console.print(
+                    f"This will install the package '{escape(package)}' into "
+                    "the Deep Agents Code environment (this runs third-party "
+                    "code).",
+                    highlight=False,
+                )
+                if not args.yes:
+                    if not sys.stdin.isatty():
+                        console.print(
+                            "[bold red]Error:[/bold red] "
+                            "Refusing package install in non-interactive mode. "
+                            "Pass --yes to proceed."
+                        )
+                        sys.exit(2)
+                    try:
+                        reply = input(f"Install package '{package}'? [y/N] ")
+                    except EOFError:
+                        console.print("\nAborted.", style="dim")
+                        sys.exit(130)
+                    if reply.strip().lower() not in {"y", "yes"}:
+                        console.print("Aborted.", style="dim")
+                        sys.exit(1)
+
+                console.print(f"Installing package '{package}'...")
+                pkg_log_path = create_update_log_path()
+                console.print(
+                    f"Install log: {pkg_log_path}\n"
+                    f"Tail progress: tail -f {pkg_log_path}",
+                    style="dim",
+                    highlight=False,
+                    markup=False,
+                )
+                success, output = asyncio.run(
+                    perform_install_package(package, log_path=pkg_log_path)
+                )
+                if success:
+                    console.print(f"[green]Installed package '{package}'.[/green]")
+                    sys.exit(0)
+                # Tail the last 200 chars — uv prints the resolved error at the
+                # end. The full output is in the log.
+                detail = f": {output[-200:]}" if output else ""
+                console.print(
+                    f"[bold red]Install failed[/bold red]{escape(detail)}\n"
+                    f"Log: {pkg_log_path}",
+                    markup=True,
+                    highlight=False,
+                )
+                sys.exit(1)
+            except KeyboardInterrupt:
+                console.print("\nAborted.", style="dim")
+                sys.exit(130)
+            except Exception as exc:
+                logger.warning("--install --package failed", exc_info=True)
+                log_line = f"\nLog: {pkg_log_path}" if pkg_log_path else ""
+                console.print(
+                    f"[bold red]Error:[/bold red] "
+                    f"{type(exc).__name__}: {escape(str(exc))}"
+                    f"{escape(log_line)}",
+                    markup=True,
+                    highlight=False,
                 )
                 sys.exit(1)
 

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2027,6 +2027,10 @@ def cli_main() -> None:
                     sys.exit(1)
 
                 manual_cmd = install_extra_command(extra)
+                # KNOWN_EXTRAS is a curated "did you mean" list, not the
+                # authoritative set (that's pyproject, resolved by uv): warn and
+                # confirm rather than refuse, since valid-but-unlisted names
+                # exist (e.g. all-providers). Malformed names blocked above.
                 if extra not in KNOWN_EXTRAS:
                     known = ", ".join(sorted(KNOWN_EXTRAS))
                     console.print(

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -1934,9 +1934,7 @@ def warn_on_split_credential_source(provider: str) -> None:
     # present (an empty prefixed var would shadow the plain one in
     # `resolve_env_var`, so its mere presence means the endpoint is not "plain").
     key_from_prefixed = bool(os.environ.get(prefixed_key))
-    base_from_plain = prefixed_base not in os.environ and bool(
-        os.environ.get(base_env)
-    )
+    base_from_plain = prefixed_base not in os.environ and bool(os.environ.get(base_env))
     if key_from_prefixed and base_from_plain:
         logger.debug(
             "Provider %s: API key resolved from %s but base URL resolved from "

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -1808,9 +1808,13 @@ def apply_stored_credentials(provider: str) -> bool:
         return False
     if not stored:
         return False
+    # Reconcile the endpoint first: it resolves env-var names (which can touch
+    # the config) and so is the only step that might raise. Doing it before the
+    # key write means the key is never left applied while an inherited gateway
+    # URL stays uncleared — the key and endpoint move together.
+    _apply_stored_base_url(provider, stored_base_url)
     if os.environ.get(env_var) != stored:
         os.environ[env_var] = stored
-    _apply_stored_base_url(provider, stored_base_url)
     return True
 
 
@@ -2069,6 +2073,18 @@ class ModelConfig:
             keys resolve. This also surfaces the value `apply_stored_credentials`
             bridged in from a `/auth` credential, and the gateway-provisioned
             URL in the default (no-override) case.
+        3. The endpoint stored with a `/auth` credential. This is the source
+            for providers that have no base-URL env var (e.g. an OpenAI-
+            compatible router like LiteLLM or OpenRouter): step 2 has no name to
+            read, so the stored endpoint is taken directly. It then reaches the
+            SDK as the `base_url` constructor kwarg via `_get_provider_kwargs`,
+            the same path a `config.toml` literal uses. For providers that *do*
+            have an env var, the stored endpoint already arrives via step 2
+            (it was bridged onto the env var), so this step is a redundant — and
+            consistent — fallback.
+
+        A corrupt credential store is treated as "no stored endpoint" rather than
+        propagating, so endpoint resolution never newly raises.
 
         Args:
             provider_name: The provider to get base URL for.
@@ -2083,7 +2099,13 @@ class ModelConfig:
         env_var = (provider.get("base_url_env") if provider else None) or (
             _canonical_base_url_env(provider_name)
         )
-        return resolve_env_var(env_var) if env_var else None
+        resolved = resolve_env_var(env_var) if env_var else None
+        if resolved:
+            return resolved
+        try:
+            return auth_store.get_stored_base_url(provider_name)
+        except RuntimeError:
+            return None
 
     def get_api_key_env(self, provider_name: str) -> str | None:
         """Get the environment variable name for a provider's API key.

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -428,6 +428,16 @@ class ProviderConfig(TypedDict, total=False):
     base_url: str
     """Custom base URL."""
 
+    base_url_env: str
+    """Name of the environment variable that holds this provider's base URL.
+
+    Parallel to `api_key_env`: lets a provider that is not one of the built-in
+    `PROVIDER_BASE_URL_ENV` entries participate in endpoint resolution and in
+    the key/endpoint pairing applied by `apply_stored_credentials` (so a stored
+    `/auth` override clears an inherited gateway URL). The static `base_url`
+    field still wins over this when both are set.
+    """
+
     # Level 2: arbitrary BaseChatModel classes
 
     class_path: str
@@ -515,6 +525,47 @@ time.
 Providers not listed here fall through to the config-file check or the langchain
 registry fallback.
 """
+
+PROVIDER_BASE_URL_ENV: dict[str, tuple[str, ...]] = {
+    # langchain_openai reads OPENAI_API_BASE, then the openai SDK reads
+    # OPENAI_BASE_URL; langchain_anthropic reads ANTHROPIC_API_URL, then
+    # ANTHROPIC_BASE_URL. The google-genai SDK reads GOOGLE_GEMINI_BASE_URL
+    # (the lone name langchain_google_genai threads through HttpOptions).
+    "anthropic": ("ANTHROPIC_BASE_URL", "ANTHROPIC_API_URL"),
+    "google_genai": ("GOOGLE_GEMINI_BASE_URL",),
+    "openai": ("OPENAI_BASE_URL", "OPENAI_API_BASE"),
+}
+"""Every base-URL env var a provider's SDK may read.
+
+Element `[0]` is the *canonical* name — the one we write a stored endpoint to,
+and the one `get_base_url` reads through `resolve_env_var` so `base_url` gets the
+same `DEEPAGENTS_CODE_*` > plain-var precedence as API keys. The remaining names
+are alternates the SDK might also honor; `apply_stored_credentials` clears them
+when applying or resetting an endpoint, so a stale value (e.g. an inherited
+gateway URL) can't leak through. Clearing every name is what lets the write path
+treat the canonical as authoritative regardless of which name the SDK prefers.
+
+The key and its endpoint are a coherent pair: a gateway key only works against
+the gateway URL, a provider-native key only against the provider's own endpoint,
+so both must resolve from the same source.
+"""
+
+
+def _canonical_base_url_env(provider: str) -> str | None:
+    """Return the canonical (written) base-URL env var name for a provider.
+
+    The canonical name is element `[0]` of the provider's `PROVIDER_BASE_URL_ENV`
+    tuple. Returns `None` for providers outside the built-in set.
+
+    Args:
+        provider: Provider name.
+
+    Returns:
+        Canonical env var name, or `None` if the provider has no built-in entry.
+    """
+    names = PROVIDER_BASE_URL_ENV.get(provider)
+    return names[0] if names else None
+
 
 IMPLICIT_AUTH_PROVIDERS: frozenset[str] = frozenset({"google_vertexai"})
 """Providers that support ambient auth outside app env-var checks.
@@ -1663,18 +1714,82 @@ def get_credential_env_var(provider: str) -> str | None:
     return PROVIDER_API_KEY_ENV.get(provider)
 
 
+def get_base_url_env_var(provider: str) -> str | None:
+    """Return the canonical base-URL env var name for a provider.
+
+    Checks the config file's `base_url_env` first (user override), then falls
+    back to the canonical name in the hardcoded `PROVIDER_BASE_URL_ENV` map.
+    Parallel to `get_credential_env_var`.
+
+    Args:
+        provider: Provider name.
+
+    Returns:
+        Environment variable name, or None if the provider has no base-URL env
+        var (config-declared or built-in).
+    """
+    config = ModelConfig.load()
+    config_env = config.get_base_url_env(provider)
+    if config_env:
+        return config_env
+    return _canonical_base_url_env(provider)
+
+
+def get_default_base_url_env(provider: str) -> str | None:
+    """Return the env var that supplies a provider's endpoint when none is stored.
+
+    Answers "what does leaving the `/auth` base-URL field blank fall back to?"
+    A blank save clears the *plain* endpoint env vars (so an inherited gateway
+    URL can't leak through — see `apply_stored_credentials`), so the only env
+    var that still supplies a value afterward is the `DEEPAGENTS_CODE_`-prefixed
+    one. The name is returned (not its value) for display next to the field, so
+    the user sees the knob rather than a long or sensitive URL.
+
+    Returns `None` when that variable holds no value — the endpoint then comes
+    from a `config.toml` literal or the provider SDK's own default, neither of
+    which is a single env var to name here.
+
+    Args:
+        provider: Provider name.
+
+    Returns:
+        The `DEEPAGENTS_CODE_`-prefixed env var name still in effect after a
+        blank save, or `None`.
+    """
+    env_var = get_base_url_env_var(provider)
+    if not env_var:
+        return None
+    prefixed = f"{_ENV_PREFIX}{env_var}"
+    return prefixed if os.environ.get(prefixed) else None
+
+
 def apply_stored_credentials(provider: str) -> bool:
-    """Export this provider's stored API key into `os.environ` for SDK use.
+    """Export this provider's stored key *and endpoint* into `os.environ`.
 
     LangChain's chat-model factories read credentials from process env vars,
     so a stored key only takes effect once it's copied onto the env var name
     registered for that provider. This is a no-op when the provider has no
     env-var mapping (custom auth) or no stored credential.
 
-    The env var is overwritten whether or not it was already set, matching
+    The key env var is overwritten whether or not it was already set, matching
     the precedence rule documented on `resolve_provider_credential`: a
     credential the user typed in `/auth` is the most recent deliberate
     action and should take effect.
+
+    Because a key and its endpoint are a coherent pair (a gateway key only
+    works against the gateway URL; a provider-native key only against the
+    provider's own endpoint), the base URL is applied atomically with the key:
+
+    - A stored `base_url` is written to the provider's canonical base-URL env
+        var, and every *other* base-URL name the SDK reads is cleared so an
+        inherited gateway URL can't leak through an alternate variable.
+    - No stored `base_url` (the user left the field blank) clears *all* of the
+        provider's base-URL env vars, so the SDK falls back to the provider
+        default rather than an inherited gateway URL. This is what prevents a
+        personal key from being shipped to the gateway.
+
+    Only the unprefixed canonical names are written, so an explicit
+    `DEEPAGENTS_CODE_{VAR}` override still wins via `resolve_env_var`.
 
     Args:
         provider: Provider name.
@@ -1687,15 +1802,43 @@ def apply_stored_credentials(provider: str) -> bool:
         return False
     try:
         stored = auth_store.get_stored_key(provider)
+        stored_base_url = auth_store.get_stored_base_url(provider)
     except RuntimeError:
         logger.warning("Could not read stored credentials for provider %s", provider)
         return False
     if not stored:
         return False
-    if os.environ.get(env_var) == stored:
-        return True
-    os.environ[env_var] = stored
+    if os.environ.get(env_var) != stored:
+        os.environ[env_var] = stored
+    _apply_stored_base_url(provider, stored_base_url)
     return True
+
+
+def _apply_stored_base_url(provider: str, base_url: str | None) -> None:
+    """Reconcile a provider's base-URL env vars with a `/auth` credential.
+
+    Writes `base_url` to the canonical name and clears the alternates, or
+    clears every name when `base_url` is `None` (reset to the provider
+    default). See `apply_stored_credentials` for the pairing rationale.
+
+    Args:
+        provider: Provider name.
+        base_url: The stored endpoint, or `None` to reset to the default.
+    """
+    canonical = get_base_url_env_var(provider)
+    # Clear every name the SDK might read: the built-in alternates plus any
+    # config-declared `base_url_env` (which extends pairing to providers
+    # outside the hardcoded set).
+    names = set(PROVIDER_BASE_URL_ENV.get(provider, ()))
+    if canonical:
+        names.add(canonical)
+    if not names:
+        return
+    for name in names:
+        if base_url and name == canonical:
+            os.environ[name] = base_url
+        else:
+            os.environ.pop(name, None)
 
 
 @dataclass(frozen=True)
@@ -1916,7 +2059,16 @@ class ModelConfig:
         return bool(resolve_env_var(env_var))
 
     def get_base_url(self, provider_name: str) -> str | None:
-        """Get custom base URL.
+        """Get the configured base URL for a provider.
+
+        Resolution order (first match wins):
+
+        1. `base_url` in the provider's `config.toml` section.
+        2. The provider's base-URL env var via `resolve_env_var`, so
+            `DEEPAGENTS_CODE_{VAR}` beats the plain `{VAR}` — mirroring how API
+            keys resolve. This also surfaces the value `apply_stored_credentials`
+            bridged in from a `/auth` credential, and the gateway-provisioned
+            URL in the default (no-override) case.
 
         Args:
             provider_name: The provider to get base URL for.
@@ -1925,7 +2077,13 @@ class ModelConfig:
             Base URL if configured, None otherwise.
         """
         provider = self.providers.get(provider_name)
-        return provider.get("base_url") if provider else None
+        config_url = provider.get("base_url") if provider else None
+        if config_url:
+            return config_url
+        env_var = (provider.get("base_url_env") if provider else None) or (
+            _canonical_base_url_env(provider_name)
+        )
+        return resolve_env_var(env_var) if env_var else None
 
     def get_api_key_env(self, provider_name: str) -> str | None:
         """Get the environment variable name for a provider's API key.
@@ -1938,6 +2096,18 @@ class ModelConfig:
         """
         provider = self.providers.get(provider_name)
         return provider.get("api_key_env") if provider else None
+
+    def get_base_url_env(self, provider_name: str) -> str | None:
+        """Get the environment variable name for a provider's base URL.
+
+        Args:
+            provider_name: The provider to get the base-URL env var for.
+
+        Returns:
+            Environment variable name if configured, None otherwise.
+        """
+        provider = self.providers.get(provider_name)
+        return provider.get("base_url_env") if provider else None
 
     def get_class_path(self, provider_name: str) -> str | None:
         """Get the custom class path for a provider.

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -527,13 +527,63 @@ registry fallback.
 """
 
 PROVIDER_BASE_URL_ENV: dict[str, tuple[str, ...]] = {
-    # langchain_openai reads OPENAI_API_BASE, then the openai SDK reads
-    # OPENAI_BASE_URL; langchain_anthropic reads ANTHROPIC_API_URL, then
-    # ANTHROPIC_BASE_URL. The google-genai SDK reads GOOGLE_GEMINI_BASE_URL
-    # (the lone name langchain_google_genai threads through HttpOptions).
+    # Each tuple lists every base-URL env var the provider's LangChain
+    # integration and underlying SDK may read, canonical name first. Names were
+    # verified against the integration and SDK source, not inferred:
+    #   anthropic     langchain_anthropic reads ANTHROPIC_API_URL; the anthropic
+    #                 SDK reads ANTHROPIC_BASE_URL.
+    #   azure_openai  AzureChatOpenAI and the openai SDK both read
+    #                 AZURE_OPENAI_ENDPOINT.
+    #   cohere        langchain_cohere passes base_url=None, so the cohere SDK's
+    #                 CO_API_URL is what takes effect.
+    #   deepseek      ChatDeepSeek reads DEEPSEEK_API_BASE (alias base_url).
+    #   fireworks     ChatFireworks reads FIREWORKS_API_BASE; when unset the
+    #                 fireworks SDK reads FIREWORKS_BASE_URL.
+    #   google_genai  the google-genai SDK reads GOOGLE_GEMINI_BASE_URL (the lone
+    #                 name langchain_google_genai threads through HttpOptions).
+    #   groq          ChatGroq reads GROQ_API_BASE; when unset the groq SDK reads
+    #                 GROQ_BASE_URL.
+    #   huggingface   the integration and huggingface_hub both read
+    #                 HF_INFERENCE_ENDPOINT.
+    #   ibm           ChatWatsonx reads WATSONX_URL.
+    #   mistralai     ChatMistralAI reads MISTRAL_BASE_URL.
+    #   nvidia        ChatNVIDIA reads NVIDIA_BASE_URL.
+    #   openai        langchain_openai reads OPENAI_API_BASE; the openai SDK
+    #                 reads OPENAI_BASE_URL.
+    #   openrouter    ChatOpenRouter reads OPENROUTER_API_BASE (alias base_url).
+    #   perplexity    the integration passes no base_url, so the perplexity SDK's
+    #                 PERPLEXITY_BASE_URL is what takes effect.
+    #   together      ChatTogether reads TOGETHER_API_BASE (alias base_url).
+    #   xai           ChatXAI reads XAI_API_BASE (alias base_url).
+    #
+    # OpenAI-compatible providers (deepseek, openrouter, together, xai, baseten)
+    # sit on the openai SDK, whose only base-URL env var is the shared
+    # OPENAI_BASE_URL. That name is intentionally NOT listed under those
+    # providers: writing or clearing it under another provider's name would
+    # clobber the user's real OpenAI endpoint. In practice the integration always
+    # passes base_url explicitly, so the shared fallback never fires.
+    #
+    # Omitted (no dedicated, provider-specific endpoint env var): baseten
+    # (hardcoded default + base_url arg), litellm (api_base arg, per-provider
+    # env), google_vertexai (endpoint derived from the region). A `/auth`
+    # endpoint for these still resolves through the stored-credential step of
+    # `get_base_url` and reaches the model as the `base_url` kwarg.
     "anthropic": ("ANTHROPIC_BASE_URL", "ANTHROPIC_API_URL"),
+    "azure_openai": ("AZURE_OPENAI_ENDPOINT",),
+    "cohere": ("CO_API_URL",),
+    "deepseek": ("DEEPSEEK_API_BASE",),
+    "fireworks": ("FIREWORKS_BASE_URL", "FIREWORKS_API_BASE"),
     "google_genai": ("GOOGLE_GEMINI_BASE_URL",),
+    "groq": ("GROQ_BASE_URL", "GROQ_API_BASE"),
+    "huggingface": ("HF_INFERENCE_ENDPOINT",),
+    "ibm": ("WATSONX_URL",),
+    "mistralai": ("MISTRAL_BASE_URL",),
+    "nvidia": ("NVIDIA_BASE_URL",),
     "openai": ("OPENAI_BASE_URL", "OPENAI_API_BASE"),
+    "openrouter": ("OPENROUTER_API_BASE",),
+    "perplexity": ("PERPLEXITY_BASE_URL",),
+    "together": ("TOGETHER_API_BASE",),
+    "xai": ("XAI_API_BASE",),
 }
 """Every base-URL env var a provider's SDK may read.
 
@@ -2075,13 +2125,21 @@ class ModelConfig:
             URL in the default (no-override) case.
         3. The endpoint stored with a `/auth` credential. This is the source
             for providers that have no base-URL env var (e.g. an OpenAI-
-            compatible router like LiteLLM or OpenRouter): step 2 has no name to
-            read, so the stored endpoint is taken directly. It then reaches the
-            SDK as the `base_url` constructor kwarg via `_get_provider_kwargs`,
-            the same path a `config.toml` literal uses. For providers that *do*
-            have an env var, the stored endpoint already arrives via step 2
-            (it was bridged onto the env var), so this step is a redundant — and
-            consistent — fallback.
+            compatible provider like OpenRouter, Groq, or Baseten): step 2 has
+            no name to read, so the stored endpoint is taken directly. It then
+            reaches the model as the `base_url` constructor kwarg via
+            `_get_provider_kwargs`, the same path a `config.toml` literal uses.
+            For providers that *do* have an env var, the stored endpoint already
+            arrives via step 2 (it was bridged onto the env var), so this step
+            is a redundant — and consistent — fallback.
+
+        This function only *resolves* the endpoint; whether it takes effect is a
+        separate contract owned by the provider's LangChain class. The value is
+        delivered as the `base_url` kwarg (see `_get_provider_kwargs`), which the
+        OpenAI/Anthropic-compatible classes accept via a Pydantic `base_url`
+        alias. A class that names the field differently may silently
+        ignore `base_url` — Pydantic models default to `extra="ignore"` — so for
+        those the endpoint must be set via `params`.
 
         A corrupt credential store is treated as "no stored endpoint" rather than
         propagating, so endpoint resolution never newly raises.

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -1895,6 +1895,61 @@ def _apply_stored_base_url(provider: str, base_url: str | None) -> None:
             os.environ.pop(name, None)
 
 
+def warn_on_split_credential_source(provider: str) -> None:
+    """Log when a provider's key and endpoint resolve from different env tiers.
+
+    The `DEEPAGENTS_CODE_` prefix is a *per-variable* override, not a credential
+    bundle: setting `DEEPAGENTS_CODE_OPENAI_API_KEY` while leaving the endpoint to
+    a plain `OPENAI_BASE_URL` makes the key resolve from the prefixed tier and the
+    endpoint from the unprefixed one. A key and its endpoint are a coherent pair
+    (see `PROVIDER_BASE_URL_ENV`), so a split source is a likely misconfiguration
+    -- e.g. a provider-native key shipped to a gateway URL, or vice versa.
+
+    This is purely diagnostic: it never mutates `os.environ` or changes
+    resolution. Only the env var *names* are logged, never the secret value or
+    the URL. It is emitted at DEBUG because the `deepagents_code` package logger
+    only attaches a handler when `DEEPAGENTS_CODE_DEBUG` is set, and DEBUG stays
+    below `logging.lastResort`'s WARNING stderr threshold so it cannot bleed onto
+    stderr and corrupt the Textual TUI. The `DEEPAGENTS_CODE_DEBUG` file log is
+    where someone chasing a wrong-endpoint bug will look.
+
+    A `config.toml` `base_url` literal wins over env vars in `get_base_url`, so
+    when one is set there is no env-tier split to flag and this returns early.
+
+    Args:
+        provider: Provider name (e.g. `"openai"`).
+    """
+    key_env = get_credential_env_var(provider)
+    base_env = get_base_url_env_var(provider)
+    if not key_env or not base_env:
+        return
+    config = ModelConfig.load()
+    provider_cfg = config.providers.get(provider)
+    if provider_cfg and provider_cfg.get("base_url"):
+        return
+    prefixed_key = f"{_ENV_PREFIX}{key_env}"
+    prefixed_base = f"{_ENV_PREFIX}{base_env}"
+    # Key must actually resolve from the prefixed tier (present and non-empty),
+    # while the endpoint falls back to the plain tier: no prefixed override
+    # present (an empty prefixed var would shadow the plain one in
+    # `resolve_env_var`, so its mere presence means the endpoint is not "plain").
+    key_from_prefixed = bool(os.environ.get(prefixed_key))
+    base_from_plain = prefixed_base not in os.environ and bool(
+        os.environ.get(base_env)
+    )
+    if key_from_prefixed and base_from_plain:
+        logger.debug(
+            "Provider %s: API key resolved from %s but base URL resolved from "
+            "the unprefixed %s. Key and endpoint came from different sources and "
+            "may not be a matching pair. Set %s to pin the endpoint, or unset %s.",
+            provider,
+            prefixed_key,
+            base_env,
+            prefixed_base,
+            base_env,
+        )
+
+
 @dataclass(frozen=True)
 class ModelConfig:
     """Parsed model configuration from `config.toml`.

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -168,7 +168,11 @@ def show_help() -> None:
         "  --auto-update              Toggle automatic updates on or off, then exit"
     )
     console.print(
-        "  --install EXTRA            Install an optional extra (e.g. quickjs)"
+        "  --install NAME             Install an optional extra (e.g. quickjs)"
+    )
+    console.print(
+        "  --package                  With --install, treat NAME as a package "
+        "(uv --with), not an extra"
     )
     console.print("  --yes                      Skip --install confirmation prompts")
     console.print("  --acp                      Run as an ACP server over stdio")

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -17,6 +17,7 @@ import logging
 import operator
 import os
 import re
+import shlex
 import shutil
 import sys
 import time
@@ -920,14 +921,32 @@ def is_valid_extra_name(extra: str) -> bool:
     return bool(_EXTRA_NAME_RE.fullmatch(extra))
 
 
+def is_valid_package_name(package: str) -> bool:
+    """Return whether `package` is safe to embed in a `--with` install command.
+
+    Args:
+        package: Candidate package name from CLI or slash-command input.
+
+    Returns:
+        `True` when the value is a conservative PEP 508-style package name.
+    """
+    return bool(_PACKAGE_NAME_RE.fullmatch(package))
+
+
 def install_package_command(package: str) -> str:
     """Return the shell command that adds a package to the dcode tool env.
+
+    The result is built for *execution* (via `perform_install_package`), not for
+    display — surfacing raw `uv tool` invocations to the user is intentionally
+    avoided. `package` is validated and then `shlex.quote`-d: the validation
+    already blocks shell metacharacters, so the quoting is defense in depth that
+    keeps the command safe even if the pattern is later loosened.
 
     Args:
         package: Package name to install into the existing tool environment.
 
     Returns:
-        Shell command string suitable for display in error messages.
+        Shell command string suitable for execution via the shell.
 
     Raises:
         ValueError: If `package` is not a conservative PEP 508-style package
@@ -939,7 +958,7 @@ def install_package_command(package: str) -> str:
             f"({_PACKAGE_NAME_RE.pattern})"
         )
         raise ValueError(msg)
-    return f"uv tool install -U deepagents-code --with {package}"
+    return f"uv tool install -U deepagents-code --with {shlex.quote(package)}"
 
 
 def install_extras_command(extras: Iterable[str]) -> str:
@@ -1030,6 +1049,20 @@ def editable_extra_hint(extra: str) -> str:
     )
 
 
+def editable_package_hint(package: str) -> str:
+    """Return the canonical action hint for editable installs needing a package.
+
+    Editable installs can't have packages added automatically, so this points
+    the user at adding it to their own development environment. Phrased without
+    a raw install command, since surfacing `uv tool` invocations to the user is
+    intentionally avoided.
+    """
+    return (
+        f"Add '{package}' to your editable checkout's environment (the one your "
+        "editable install of Deep Agents Code runs from), then relaunch."
+    )
+
+
 async def perform_install_extra(
     extra: str,
     *,
@@ -1093,6 +1126,74 @@ async def perform_install_extra(
     try:
         cmd = install_extra_command(extra)
     except (ExtrasIntrospectionError, ValueError) as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+    return await _run_install_subprocess(cmd, progress=progress, log_path=log_path)
+
+
+async def perform_install_package(
+    package: str,
+    *,
+    progress: UpgradeProgressCallback | None = None,
+    log_path: Path | None = None,
+) -> tuple[bool, str]:
+    """Add an arbitrary `package` to the installed dcode tool environment.
+
+    Runs `uv tool install -U deepagents-code --with <package>`, the escape
+    hatch for a provider whose package is not a `deepagents-code` extra (e.g. a
+    custom or in-house `class_path` model). Editable installs are refused — the
+    caller should rerun their `uv tool install --editable` command with `--with
+    <package>` added so it resolves against the editable source.
+
+    Args:
+        package: The package name to install. Must satisfy
+            `is_valid_package_name`; invalid names are rejected without invoking
+            uv (defense in depth against shell injection via the
+            `--force`/`--yes` bypass paths).
+        progress: Optional callback invoked for each output line.
+        log_path: Optional path to persist command output.
+
+    Returns:
+        `(success, output)` — on success, *output* is the combined
+            stdout/stderr from the install. On failure it is an explanatory
+            message: when the install method is unsupported, `package` is
+            malformed, `uv` is unavailable, or the install subprocess fails or
+            times out.
+    """
+    if not is_valid_package_name(package):
+        return False, (
+            f"Invalid package name {package!r}: must match "
+            f"{_PACKAGE_NAME_RE.pattern}"
+        )
+    method = detect_install_method()
+    if method == "unknown":
+        return False, (
+            "Editable install detected — cannot add packages automatically.\n"
+            + editable_package_hint(package)
+        )
+    if method == "brew":
+        return False, (
+            "Homebrew install detected — packages can't be added to a brew "
+            "install. Reinstall Deep Agents Code as a uv-managed tool (see the "
+            "installation docs) to enable adding packages."
+        )
+    if method == "other":
+        return False, (
+            "Unsupported install method detected — cannot add packages without "
+            "knowing which environment provides `dcode`. Reinstall Deep Agents "
+            "Code as a uv-managed tool (see the installation docs) to enable "
+            "adding packages."
+        )
+
+    if not shutil.which("uv"):
+        return False, (
+            "Package installs require uv, which was not found. Reinstall Deep "
+            "Agents Code following the installation docs so packages can be "
+            "added."
+        )
+
+    try:
+        cmd = install_package_command(package)
+    except ValueError as exc:
         return False, f"{type(exc).__name__}: {exc}"
     return await _run_install_subprocess(cmd, progress=progress, log_path=log_path)
 

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -933,43 +933,25 @@ def is_valid_package_name(package: str) -> bool:
     return bool(_PACKAGE_NAME_RE.fullmatch(package))
 
 
-def install_package_command(package: str) -> str:
-    """Return the shell command that adds a package to the dcode tool env.
+def _dcode_extras_requirement(extras: Iterable[str]) -> str:
+    """Return the validated `deepagents-code[...]` requirement for a uv install.
 
-    The result is built for *execution* (via `perform_install_package`), not for
-    display — surfacing raw `uv tool` invocations to the user is intentionally
-    avoided. `package` is validated and then `shlex.quote`-d: the validation
-    already blocks shell metacharacters, so the quoting is defense in depth that
-    keeps the command safe even if the pattern is later loosened.
-
-    Args:
-        package: Package name to install into the existing tool environment.
-
-    Returns:
-        Shell command string suitable for execution via the shell.
-
-    Raises:
-        ValueError: If `package` is not a conservative PEP 508-style package
-            name.
-    """
-    if not _PACKAGE_NAME_RE.fullmatch(package):
-        msg = (
-            f"Invalid package name {package!r}: must match PEP 508 "
-            f"({_PACKAGE_NAME_RE.pattern})"
-        )
-        raise ValueError(msg)
-    return f"uv tool install -U deepagents-code --with {shlex.quote(package)}"
-
-
-def install_extras_command(extras: Iterable[str]) -> str:
-    """Return the uv command that installs the exact set of dcode extras.
+    Shared by the extra- and package-install commands so already-installed
+    extras survive a `uv tool install` reinstall — a bare `deepagents-code`
+    request would replace the tool and drop them. Returns plain
+    `deepagents-code` when no extras are selected; otherwise the single-quoted
+    bracket form, which keeps zsh from globbing the brackets.
 
     Args:
-        extras: Extra names to include in the tool reinstall.
+        extras: Extra names to encode. Each is validated against PEP 508
+            grammar before interpolation. This is the authoritative gate for
+            caller-supplied extras (`install_extras_command`) and a
+            redundant re-check for extras read from distribution metadata
+            (`install_package_command`).
 
     Returns:
-        Shell command string suitable for display in error messages and
-            execution via `perform_install_extra`.
+        Shell-safe requirement token, e.g. `deepagents-code` or
+            `'deepagents-code[baseten,nvidia]'`.
 
     Raises:
         ValueError: If any extra fails PEP 508 validation.
@@ -982,8 +964,79 @@ def install_extras_command(extras: Iterable[str]) -> str:
                 f"({_EXTRA_NAME_RE.pattern})"
             )
             raise ValueError(msg)
+    if not names:
+        return "deepagents-code"
     extras_part = ",".join(names)
-    return f"uv tool install -U 'deepagents-code[{extras_part}]'"
+    return f"'deepagents-code[{extras_part}]'"
+
+
+def install_package_command(
+    package: str,
+    *,
+    distribution_name: str = "deepagents-code",
+) -> str:
+    """Return the shell command that adds a package to the dcode tool env.
+
+    The result is built for *execution* (via `perform_install_package`), not for
+    display — surfacing raw `uv tool` invocations to the user is intentionally
+    avoided. `package` is validated and then `shlex.quote`-d: the validation
+    already blocks shell metacharacters, so the quoting is defense in depth that
+    keeps the command safe even if the pattern is later loosened.
+
+    Already-installed extras are folded into the `deepagents-code[...]`
+    requirement via the shared `_dcode_extras_requirement` helper, the same way
+    `install_extras_command` builds its requirement. Without this the reinstall
+    would replace the tool with a plain `deepagents-code`, silently dropping any
+    extras the user added through `/install <extra>`.
+
+    Args:
+        package: Package name to install into the existing tool environment.
+        distribution_name: Name of the installed distribution to inspect for
+            already-installed extras.
+
+    Returns:
+        Shell command string suitable for execution via the shell.
+
+    Raises:
+        ExtrasIntrospectionError: If installed extras cannot be determined
+            safely from distribution metadata (refused rather than risk
+            dropping them).
+        ValueError: If `package` or any already-installed extra fails PEP 508
+            validation.
+    """
+    if not _PACKAGE_NAME_RE.fullmatch(package):
+        msg = (
+            f"Invalid package name {package!r}: must match PEP 508 "
+            f"({_PACKAGE_NAME_RE.pattern})"
+        )
+        raise ValueError(msg)
+    from deepagents_code.extras_info import (
+        ExtrasIntrospectionError,
+        installed_extra_names,
+    )
+
+    try:
+        extras = installed_extra_names(distribution_name, strict=True)
+    except ExtrasIntrospectionError as exc:
+        msg = str(exc)
+        raise ExtrasIntrospectionError(msg) from exc
+    requirement = _dcode_extras_requirement(extras)
+    return f"uv tool install -U {requirement} --with {shlex.quote(package)}"
+
+
+def install_extras_command(extras: Iterable[str]) -> str:
+    """Return the uv command that installs the exact set of dcode extras.
+
+    Args:
+        extras: Extra names to include in the tool reinstall. Validated by
+            `_dcode_extras_requirement`, which raises `ValueError` on any name
+            that fails PEP 508 validation.
+
+    Returns:
+        Shell command string suitable for display in error messages and
+            execution via `perform_install_extra`.
+    """
+    return f"uv tool install -U {_dcode_extras_requirement(extras)}"
 
 
 def install_extra_command(
@@ -1138,11 +1191,12 @@ async def perform_install_package(
 ) -> tuple[bool, str]:
     """Add an arbitrary `package` to the installed dcode tool environment.
 
-    Runs `uv tool install -U deepagents-code --with <package>`, the escape
-    hatch for a provider whose package is not a `deepagents-code` extra (e.g. a
-    custom or in-house `class_path` model). Editable installs are refused — the
-    caller should rerun their `uv tool install --editable` command with `--with
-    <package>` added so it resolves against the editable source.
+    Runs `uv tool install -U 'deepagents-code[<extras>]' --with <package>`, the
+    escape hatch for a provider whose package is not a `deepagents-code` extra
+    (e.g. a custom or in-house `class_path` model). Already-installed extras are
+    preserved so the reinstall does not drop them. Editable installs are refused
+    — the caller should rerun their `uv tool install --editable` command with
+    `--with <package>` added so it resolves against the editable source.
 
     Args:
         package: The package name to install. Must satisfy
@@ -1190,9 +1244,21 @@ async def perform_install_package(
             "added."
         )
 
+    from deepagents_code.extras_info import ExtrasIntrospectionError
+
     try:
         cmd = install_package_command(package)
     except ValueError as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+    except ExtrasIntrospectionError as exc:
+        # Distinct from a malformed package name: the running distribution's own
+        # metadata could not be read or parsed. Leave a breadcrumb so the cause
+        # is recoverable from logs, even though the user message is unchanged.
+        logger.warning(
+            "Could not introspect installed extras for package install of %r",
+            package,
+            exc_info=True,
+        )
         return False, f"{type(exc).__name__}: {exc}"
     return await _run_install_subprocess(cmd, progress=progress, log_path=log_path)
 

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -1161,8 +1161,7 @@ async def perform_install_package(
     """
     if not is_valid_package_name(package):
         return False, (
-            f"Invalid package name {package!r}: must match "
-            f"{_PACKAGE_NAME_RE.pattern}"
+            f"Invalid package name {package!r}: must match {_PACKAGE_NAME_RE.pattern}"
         )
     method = detect_install_method()
     if method == "unknown":

--- a/libs/code/deepagents_code/widgets/auth.py
+++ b/libs/code/deepagents_code/widgets/auth.py
@@ -43,7 +43,9 @@ from deepagents_code.model_config import (
     ProviderAuthSource,
     clear_caches,
     get_available_models,
+    get_base_url_env_var,
     get_credential_env_var,
+    get_default_base_url_env,
     get_provider_auth_status,
     resolved_env_var_name,
 )
@@ -195,12 +197,14 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
         margin-bottom: 1;
     }
 
-    AuthPromptScreen #auth-prompt-input {
+    AuthPromptScreen #auth-prompt-input,
+    AuthPromptScreen #auth-prompt-base-url {
         margin-bottom: 1;
         border: solid $primary-lighten-2;
     }
 
-    AuthPromptScreen #auth-prompt-input:focus {
+    AuthPromptScreen #auth-prompt-input:focus,
+    AuthPromptScreen #auth-prompt-base-url:focus {
         border: solid $primary;
     }
 
@@ -245,9 +249,11 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
         # "no existing key" and surface a one-line warning at compose time.
         try:
             self._has_existing = auth_store.get_stored_key(provider) is not None
+            self._existing_base_url = auth_store.get_stored_base_url(provider) or ""
             self._store_warning: str | None = None
         except RuntimeError as exc:
             self._has_existing = False
+            self._existing_base_url = ""
             self._store_warning = (
                 f"Credential file is unreadable ({exc}). Saving here will overwrite it."
             )
@@ -281,9 +287,15 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
                 )
             if self._env_var:
                 yield Static(
-                    f"Equivalent to setting {self._env_var} (or "
-                    f"DEEPAGENTS_CODE_{self._env_var}).",
+                    Content.from_markup(
+                        "Saved here and used automatically — no need to set "
+                        "[bold]$plain[/bold] in your shell. If "
+                        "[bold]$prefixed[/bold] is set, it takes priority.",
+                        plain=self._env_var,
+                        prefixed=f"DEEPAGENTS_CODE_{self._env_var}",
+                    ),
                     classes="auth-prompt-meta",
+                    id="auth-prompt-key-meta",
                 )
             if self._store_warning:
                 yield Static(
@@ -298,6 +310,39 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
                 ),
                 password=True,
                 id="auth-prompt-input",
+            )
+            yield Input(
+                value=self._existing_base_url,
+                placeholder="Optional base URL",
+                id="auth-prompt-base-url",
+            )
+            # The hint lives on its own wrapping line, not in the Input
+            # placeholder (which clips to one line and can't show the full var
+            # name). Three tiers: the prefixed var that actually survives a
+            # blank save (what blank uses), else the provider's known endpoint
+            # var as a discoverability hint, else a generic line for providers
+            # with no base-URL env var at all.
+            surviving_base_url_env = get_default_base_url_env(self._provider)
+            endpoint_env = get_base_url_env_var(self._provider)
+            if surviving_base_url_env:
+                base_url_hint = Content.from_markup(
+                    "Leave blank to use [bold]$var[/bold].",
+                    var=surviving_base_url_env,
+                )
+            elif endpoint_env:
+                base_url_hint = Content.from_markup(
+                    "Leave blank for the provider default "
+                    "(endpoint var: [bold]$var[/bold]).",
+                    var=endpoint_env,
+                )
+            else:
+                base_url_hint = Content.from_markup(
+                    "Leave blank to use the provider's default endpoint."
+                )
+            yield Static(
+                base_url_hint,
+                classes="auth-prompt-meta",
+                id="auth-prompt-base-url-hint",
             )
             yield Static("", classes="auth-prompt-error", id="auth-prompt-error")
             save_label = "Enter replace" if self._has_existing else "Enter save"
@@ -317,14 +362,21 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
             container.styles.border = ("ascii", colors.success)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
-        """Validate, persist, and dismiss."""
+        """Validate, persist, and dismiss.
+
+        Reads both fields regardless of which one was submitted, so pressing
+        Enter in either the key or the base-URL input saves the pair.
+        """
         event.stop()
-        cleaned = event.value.strip()
+        cleaned = self.query_one("#auth-prompt-input", Input).value.strip()
+        base_url = self.query_one("#auth-prompt-base-url", Input).value.strip()
         if not cleaned:
             self._show_error("API key cannot be empty.")
             return
         try:
-            outcome = auth_store.set_stored_key(self._provider, cleaned)
+            outcome = auth_store.set_stored_key(
+                self._provider, cleaned, base_url=base_url or None
+            )
         except (ValueError, RuntimeError, OSError) as exc:
             # `auth_store` exception messages never include the secret value,
             # but the path can include user-controlled `DEFAULT_STATE_DIR`
@@ -347,8 +399,16 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
         self.dismiss(AuthResult.CANCELLED)
 
     def action_delete_stored(self) -> None:
-        """Open the delete-confirmation overlay for the stored credential."""
+        """Open the delete-confirmation overlay, or quit when nothing is stored.
+
+        Ctrl+D deletes a stored credential, but its `priority` binding also
+        intercepts the app-level Ctrl+D=quit. When there's no credential to
+        delete, fall through to quit rather than swallowing the key (mirroring
+        the thread selector). `app.exit()` is used instead of `dismiss()`, which
+        would just close the modal silently and re-swallow the key.
+        """
         if not self._has_existing:
+            self.app.exit()
             return
         self.app.push_screen(
             DeleteCredentialConfirmScreen(self._provider),

--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -63,6 +63,28 @@ def _clear_langsmith_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _clear_provider_base_url_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent provider base-URL env vars from leaking into tests.
+
+    A developer machine provisioned with the LangSmith gateway exports
+    `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL`, which `get_base_url` now reads as
+    a fallback. Clear them (and the `DEEPAGENTS_CODE_` overrides) so base-URL
+    tests are deterministic. Tests that need a value set it explicitly.
+    """
+    for key in (
+        "OPENAI_BASE_URL",
+        "OPENAI_API_BASE",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_URL",
+        "GOOGLE_GEMINI_BASE_URL",
+        "DEEPAGENTS_CODE_OPENAI_BASE_URL",
+        "DEEPAGENTS_CODE_ANTHROPIC_BASE_URL",
+        "DEEPAGENTS_CODE_GOOGLE_GEMINI_BASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _clear_onboarding_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent local debug onboarding env vars from affecting tests."""
     monkeypatch.delenv("DEEPAGENTS_CODE_DEBUG_ONBOARDING", raising=False)

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -5936,9 +5936,15 @@ class TestDeferredActions:
                 provider="custom_provider",
                 package="langchain-custom_provider",
             )
-            with patch(
-                "deepagents_code.extras_info.extra_for_package",
-                return_value=None,
+            with (
+                patch(
+                    "deepagents_code.extras_info.extra_for_package",
+                    return_value=None,
+                ),
+                patch(
+                    "deepagents_code.extras_info.installed_extra_names",
+                    return_value=set(),
+                ),
             ):
                 app.on_deep_agents_app_server_start_failed(
                     DeepAgentsApp.ServerStartFailed(error=error)
@@ -5954,7 +5960,53 @@ class TestDeferredActions:
             )
             assert "/model custom_provider:<model>" in rendered
 
-    async def test_retry_startup_clears_missing_package_slot(self) -> None:
+    async def test_server_failure_unknown_package_introspection_failure_manual(
+        self,
+    ) -> None:
+        """Unreadable extras metadata degrades the hint to a manual instruction.
+
+        Exercises the `ExtrasIntrospectionError` arm so a corrupted-metadata
+        environment still surfaces an actionable hint rather than crashing the
+        failure-rendering path.
+        """
+        from deepagents_code.extras_info import ExtrasIntrospectionError
+        from deepagents_code.model_config import MissingProviderPackageError
+        from deepagents_code.widgets.messages import ErrorMessage
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._server_kwargs = {"model_name": "custom_provider:fake"}
+            app._connecting = True
+
+            error = MissingProviderPackageError(
+                "Missing package for provider 'custom_provider'.",
+                provider="custom_provider",
+                package="langchain-custom_provider",
+            )
+            with (
+                patch(
+                    "deepagents_code.extras_info.extra_for_package",
+                    return_value=None,
+                ),
+                patch(
+                    "deepagents_code.extras_info.installed_extra_names",
+                    side_effect=ExtrasIntrospectionError("metadata unreadable"),
+                ),
+            ):
+                app.on_deep_agents_app_server_start_failed(
+                    DeepAgentsApp.ServerStartFailed(error=error)
+                )
+                await pilot.pause()
+
+            widget = app._startup_failure_widget
+            assert isinstance(widget, ErrorMessage)
+            rendered = str(widget._content)
+            assert (
+                "install the `langchain-custom_provider` package manually" in rendered
+            )
+            assert "uv tool install" not in rendered
+            assert "/model custom_provider:<model>" in rendered
         """`_retry_startup_with_model` must clear the package recovery slot.
 
         Mirrors the credentials-slot reset directly above it. A regression

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -1686,6 +1686,42 @@ class TestModalScreenCtrlDHandling:
             assert isinstance(app.screen, DeleteCredentialConfirmScreen)
             exit_mock.assert_not_called()
 
+    async def test_shift_tab_moves_focus_back_in_auth_prompt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Shift+Tab steps focus from the base-URL field back to the key field.
+
+        The app binds Shift+Tab (priority) to auto-approve toggling, so the
+        Screen's own ``app.focus_previous`` binding never fires. The prompt has
+        two inputs now, so the toggle handler must delegate backward navigation
+        instead of swallowing the key.
+        """
+        from deepagents_code.widgets.auth import AuthPromptScreen
+
+        monkeypatch.setattr(
+            "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / ".state"
+        )
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app.push_screen(AuthPromptScreen("openai", "OPENAI_API_KEY"))
+            await pilot.pause()
+
+            assert app.focused is not None
+            assert app.focused.id == "auth-prompt-input"
+
+            await pilot.press("tab")
+            await pilot.pause()
+            assert app.focused is not None
+            assert app.focused.id == "auth-prompt-base-url"
+
+            await pilot.press("shift+tab")
+            await pilot.pause()
+            assert app.focused is not None
+            assert app.focused.id == "auth-prompt-input"
+
     async def test_ctrl_d_in_auth_confirm_arms_quit(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/test_auth_store.py
+++ b/libs/code/tests/unit_tests/test_auth_store.py
@@ -89,6 +89,37 @@ class TestRoundTrip:
         assert auth_store.get_stored_base_url("openai") is None
         assert auth_store.get_stored_key("openai") == "k"
 
+    def test_malformed_base_url_is_dropped_and_logged(
+        self, fake_home: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A non-string base_url is dropped, the key survives, and it's logged.
+
+        A hand-edit (or truncated write) leaving a non-string base_url must not
+        silently degrade the key to the provider default with no trace — the
+        drop is greppable so a wrong endpoint is diagnosable.
+        """
+        path = _auth_file(fake_home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "credentials": {
+                        "openai": {
+                            "type": "api_key",
+                            "key": "k",
+                            "added_at": "",
+                            "base_url": 1234,
+                        }
+                    },
+                }
+            )
+        )
+        with caplog.at_level("WARNING", logger="deepagents_code.auth_store"):
+            assert auth_store.get_stored_base_url("openai") is None
+            assert auth_store.get_stored_key("openai") == "k"
+        assert any("malformed base_url" in r.getMessage() for r in caplog.records)
+
     def test_delete_returns_true_when_removed(self) -> None:
         """Deleting an existing entry returns `True` and clears the value."""
         auth_store.set_stored_key("openai", "k")

--- a/libs/code/tests/unit_tests/test_auth_store.py
+++ b/libs/code/tests/unit_tests/test_auth_store.py
@@ -63,6 +63,32 @@ class TestRoundTrip:
         auth_store.set_stored_key("anthropic", "new")
         assert auth_store.get_stored_key("anthropic") == "new"
 
+    def test_base_url_round_trips(self) -> None:
+        """A stored base_url is persisted alongside the key."""
+        auth_store.set_stored_key("openai", "k", base_url="  https://mine.example/v1  ")
+        assert auth_store.get_stored_key("openai") == "k"
+        assert auth_store.get_stored_base_url("openai") == "https://mine.example/v1"
+
+    def test_blank_base_url_not_stored(self) -> None:
+        """A blank/omitted base_url stores nothing (use provider default)."""
+        auth_store.set_stored_key("openai", "k", base_url="   ")
+        assert auth_store.get_stored_base_url("openai") is None
+        auth_store.set_stored_key("anthropic", "k")
+        assert auth_store.get_stored_base_url("anthropic") is None
+
+    def test_resave_without_base_url_drops_it(self) -> None:
+        """Replacing a credential without a base_url clears the prior one."""
+        auth_store.set_stored_key("openai", "k", base_url="https://mine.example/v1")
+        auth_store.set_stored_key("openai", "k2")
+        assert auth_store.get_stored_base_url("openai") is None
+
+    def test_reads_legacy_entry_without_base_url(self) -> None:
+        """Entries written before base_url existed read back cleanly."""
+        auth_store.set_stored_key("openai", "k")
+        # get_stored_base_url returns None and the key still resolves.
+        assert auth_store.get_stored_base_url("openai") is None
+        assert auth_store.get_stored_key("openai") == "k"
+
     def test_delete_returns_true_when_removed(self) -> None:
         """Deleting an existing entry returns `True` and clears the value."""
         auth_store.set_stored_key("openai", "k")

--- a/libs/code/tests/unit_tests/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/test_auth_widgets.py
@@ -9,11 +9,24 @@ from textual.app import App, ComposeResult
 from textual.containers import Container
 from textual.widgets import Input, OptionList, Static
 
-from deepagents_code import auth_store
+from deepagents_code import auth_store, model_config
 from deepagents_code.widgets.auth import AuthManagerScreen, AuthPromptScreen, AuthResult
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _restore_model_caches() -> Iterator[None]:
+    """Reset model-config caches after tests that repoint `DEFAULT_CONFIG_PATH`.
+
+    A few tests patch the config path to isolate base-URL resolution; clearing
+    on teardown stops their throwaway config from leaking into later tests via
+    the cached singleton.
+    """
+    yield
+    model_config.clear_caches()
 
 
 @pytest.fixture
@@ -140,22 +153,24 @@ class TestAuthPromptScreen:
         assert app.prompt_dismissed is False
         assert auth_store.get_stored_key("openai") == "still-here"
 
-    async def test_ctrl_d_noop_without_existing_credential(self) -> None:
-        """Ctrl+D does nothing when there's no stored key to delete."""
-        from deepagents_code.widgets.auth import (
-            AuthPromptScreen,
-            DeleteCredentialConfirmScreen,
-        )
+    async def test_ctrl_d_quits_without_existing_credential(self) -> None:
+        """Ctrl+D falls through to quit when there's no stored key to delete.
+
+        The `priority` binding would otherwise swallow the app-level
+        Ctrl+D=quit, leaving the key dead in the modal.
+        """
+        from deepagents_code.widgets.auth import DeleteCredentialConfirmScreen
 
         app = _AuthHostApp()
         async with app.run_test() as pilot:
             app.show_prompt("openai", "OPENAI_API_KEY")
             await pilot.pause()
+            # No confirm modal — there's nothing to delete.
             await pilot.press("ctrl+d")
             await pilot.pause()
-            # Stay on the prompt — no confirm modal pushed.
             assert not isinstance(app.screen, DeleteCredentialConfirmScreen)
-            assert isinstance(app.screen, AuthPromptScreen)
+            # The key fell through to quit instead of being swallowed.
+            assert app._exit is True
 
     async def test_title_shows_stored_when_existing(self) -> None:
         """Title surfaces a `(stored)` marker when a key already exists."""
@@ -194,14 +209,74 @@ class TestAuthPromptScreen:
             warning_text = " ".join(str(w.render()) for w in error_widgets)
             assert "unreadable" in warning_text
 
-    async def test_helper_text_mentions_env_var(self) -> None:
-        """Helper text shows the canonical env-var name as a hint."""
+    async def test_helper_text_describes_precedence(self) -> None:
+        """Helper text names both env vars and their order vs the stored key.
+
+        A stored key sits between the plain var (which it beats) and the
+        `DEEPAGENTS_CODE_`-prefixed var (which beats it). The meta line must
+        convey that ordering, not imply the three are interchangeable.
+        """
         app = _AuthHostApp()
         async with app.run_test() as pilot:
             app.show_prompt("openai", "OPENAI_API_KEY")
             await pilot.pause()
-            meta = app.screen.query_one(".auth-prompt-meta", Static)
-            assert "OPENAI_API_KEY" in str(meta.content)
+            meta = app.screen.query_one("#auth-prompt-key-meta", Static)
+            text = str(meta.content)
+            assert "OPENAI_API_KEY" in text
+            assert "DEEPAGENTS_CODE_OPENAI_API_KEY" in text
+            # The prefixed var is described as overriding the stored key.
+            assert "takes priority" in text
+
+    async def test_base_url_hint_names_endpoint_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With a known endpoint var but no survivor set, name it as a hint."""
+        monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", tmp_path / "none.toml")
+        model_config.clear_caches()
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_prompt("openai", "OPENAI_API_KEY")
+            await pilot.pause()
+            hint = app.screen.query_one("#auth-prompt-base-url-hint", Static)
+            text = str(hint.content)
+            assert "endpoint var: OPENAI_BASE_URL" in text
+            # It must not claim blank *uses* the plain var (it gets cleared).
+            assert "use OPENAI_BASE_URL" not in text
+
+    async def test_base_url_hint_generic_without_endpoint_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A provider with no base-URL env var falls back to the generic line."""
+        monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", tmp_path / "none.toml")
+        model_config.clear_caches()
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            # `google_vertexai` has an API-key env var but no base-URL mapping.
+            app.show_prompt("google_vertexai", "GOOGLE_CLOUD_PROJECT")
+            await pilot.pause()
+            hint = app.screen.query_one("#auth-prompt-base-url-hint", Static)
+            text = str(hint.content)
+            assert "provider's default endpoint" in text
+            assert "endpoint var" not in text
+
+    async def test_base_url_hint_names_surviving_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The surviving env var is named (not its value) so blank is unambiguous."""
+        monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", tmp_path / "none.toml")
+        monkeypatch.setenv(
+            "DEEPAGENTS_CODE_OPENAI_BASE_URL", "https://scoped.example/v1"
+        )
+        model_config.clear_caches()
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_prompt("openai", "OPENAI_API_KEY")
+            await pilot.pause()
+            hint = app.screen.query_one("#auth-prompt-base-url-hint", Static)
+            text = str(hint.content)
+            assert "DEEPAGENTS_CODE_OPENAI_BASE_URL" in text
+            # The URL value itself is not leaked into the hint.
+            assert "scoped.example" not in text
 
     async def test_no_logging_of_secret(self, caplog: pytest.LogCaptureFixture) -> None:
         """Submitting a key never lands its value in widget logs."""

--- a/libs/code/tests/unit_tests/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/test_auth_widgets.py
@@ -91,6 +91,67 @@ class TestAuthPromptScreen:
         assert app.prompt_result is AuthResult.SAVED
         assert auth_store.get_stored_key("anthropic") == "sk-ant-test-12345"
 
+    async def test_base_url_round_trips_on_submit(self) -> None:
+        """A base URL typed alongside the key is persisted as the pair."""
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_prompt("openai", "OPENAI_API_KEY")
+            await pilot.pause()
+            app.screen.query_one("#auth-prompt-input", Input).value = "sk-key"
+            app.screen.query_one("#auth-prompt-base-url", Input).value = (
+                "  https://proxy.example/v1  "
+            )
+            await pilot.press("enter")
+            await pilot.pause()
+        assert app.prompt_result is AuthResult.SAVED
+        assert auth_store.get_stored_key("openai") == "sk-key"
+        # Whitespace is stripped before storage.
+        assert auth_store.get_stored_base_url("openai") == "https://proxy.example/v1"
+
+    async def test_submit_from_base_url_field_saves_pair(self) -> None:
+        """Enter in the base-URL field saves the pair, not just the key field.
+
+        `on_input_submitted` reads both inputs regardless of which one fired, so
+        submitting from either field must persist the same key + endpoint.
+        """
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_prompt("openai", "OPENAI_API_KEY")
+            await pilot.pause()
+            app.screen.query_one("#auth-prompt-input", Input).value = "sk-key"
+            base_url_field = app.screen.query_one("#auth-prompt-base-url", Input)
+            base_url_field.value = "https://proxy.example/v1"
+            base_url_field.focus()
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+        assert app.prompt_result is AuthResult.SAVED
+        assert auth_store.get_stored_key("openai") == "sk-key"
+        assert auth_store.get_stored_base_url("openai") == "https://proxy.example/v1"
+
+    async def test_blank_base_url_field_stores_no_endpoint(self) -> None:
+        """A whitespace-only base URL stores nothing (uses the provider default)."""
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_prompt("openai", "OPENAI_API_KEY")
+            await pilot.pause()
+            app.screen.query_one("#auth-prompt-input", Input).value = "sk-key"
+            app.screen.query_one("#auth-prompt-base-url", Input).value = "   "
+            await pilot.press("enter")
+            await pilot.pause()
+        assert app.prompt_result is AuthResult.SAVED
+        assert auth_store.get_stored_base_url("openai") is None
+
+    async def test_existing_base_url_prefills_field(self) -> None:
+        """Reopening the prompt pre-fills the stored endpoint for editing."""
+        auth_store.set_stored_key("openai", "k", base_url="https://stored.example/v1")
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_prompt("openai", "OPENAI_API_KEY")
+            await pilot.pause()
+            base_url_field = app.screen.query_one("#auth-prompt-base-url", Input)
+            assert base_url_field.value == "https://stored.example/v1"
+
     async def test_empty_submit_shows_error_and_does_not_dismiss(self) -> None:
         """Empty input renders an inline error instead of dismissing."""
         app = _AuthHostApp()

--- a/libs/code/tests/unit_tests/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/test_auth_widgets.py
@@ -98,9 +98,9 @@ class TestAuthPromptScreen:
             app.show_prompt("openai", "OPENAI_API_KEY")
             await pilot.pause()
             app.screen.query_one("#auth-prompt-input", Input).value = "sk-key"
-            app.screen.query_one("#auth-prompt-base-url", Input).value = (
-                "  https://proxy.example/v1  "
-            )
+            app.screen.query_one(
+                "#auth-prompt-base-url", Input
+            ).value = "  https://proxy.example/v1  "
             await pilot.press("enter")
             await pilot.pause()
         assert app.prompt_result is AuthResult.SAVED

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -1538,10 +1538,11 @@ api_key_env = "TOGETHER_API_KEY"
     ) -> None:
         """A `/auth` endpoint reaches the `base_url` kwarg for a non-mapped provider.
 
-        `together` has an API-key env var but no base-URL env var, so the stored
+        `baseten` has an API-key env var but no base-URL env var, so the stored
         endpoint resolves only through `get_base_url`'s store fallback. This is
-        the end-to-end path that makes a saved base URL actually take effect
-        rather than being silently dropped.
+        the end-to-end path that makes a saved base URL reach the model as the
+        `base_url` constructor kwarg (which `ChatBaseten` accepts via its
+        `base_url` alias) rather than being silently dropped.
         """
         from deepagents_code import auth_store
 
@@ -1551,13 +1552,13 @@ api_key_env = "TOGETHER_API_KEY"
         with (
             patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
             patch.object(model_config, "DEFAULT_STATE_DIR", state_dir),
-            patch.dict("os.environ", {"TOGETHER_API_KEY": "tk"}, clear=True),
+            patch.dict("os.environ", {"BASETEN_API_KEY": "tk"}, clear=True),
         ):
             clear_caches()
             auth_store.set_stored_key(
-                "together", "tk", base_url="https://proxy.example/v1"
+                "baseten", "tk", base_url="https://proxy.example/v1"
             )
-            kwargs = _get_provider_kwargs("together")
+            kwargs = _get_provider_kwargs("baseten")
 
         assert kwargs["base_url"] == "https://proxy.example/v1"
 

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -797,6 +797,87 @@ class TestCreateModelProfileExtraction:
         assert result.unsupported_modalities == frozenset()
 
 
+class TestCreateModelSplitCredentialWiring:
+    """`create_model` wires the split-credential diagnostic in correctly."""
+
+    @pytest.fixture(autouse=True)
+    def _bypass_credential_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "deepagents_code.model_config.has_provider_credentials", lambda _: True
+        )
+
+    @pytest.fixture(autouse=True)
+    def _isolate_openai_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in (
+            "OPENAI_API_KEY",
+            "DEEPAGENTS_CODE_OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+            "OPENAI_API_BASE",
+            "DEEPAGENTS_CODE_OPENAI_BASE_URL",
+            "DEEPAGENTS_CODE_OPENAI_API_BASE",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_create_model_emits_split_credential_warning(
+        self,
+        mock_init_chat_model: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A prefixed key + plain base URL surfaces the DEBUG diagnostic.
+
+        Guards the call site itself: `TestSplitCredentialSource` only exercises
+        the helper in isolation, so without this a dropped call would go unnoticed.
+        """
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 128000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+
+        monkeypatch.setenv("DEEPAGENTS_CODE_OPENAI_API_KEY", "sk-secret-value")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1")
+
+        with caplog.at_level(logging.DEBUG, logger="deepagents_code.model_config"):
+            create_model("openai:gpt-5.5")
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any(
+            "DEEPAGENTS_CODE_OPENAI_API_KEY" in m and "OPENAI_BASE_URL" in m
+            for m in messages
+        )
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_diagnostic_runs_before_apply_stored_credentials(
+        self,
+        mock_init_chat_model: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The diagnostic must observe raw env intent, i.e. run before the bridge.
+
+        `apply_stored_credentials` rewrites the unprefixed base-URL env vars, so
+        the ordering claimed by the call-site comment is load-bearing. Pin it by
+        asserting the relative call order, which a reorder/removal would break.
+        """
+        mock_model = Mock()
+        mock_model.profile = {"max_input_tokens": 128000, "tool_calling": True}
+        mock_init_chat_model.return_value = mock_model
+
+        manager = Mock()
+        monkeypatch.setattr(
+            "deepagents_code.model_config.warn_on_split_credential_source",
+            manager.warn,
+        )
+        monkeypatch.setattr(
+            "deepagents_code.model_config.apply_stored_credentials",
+            manager.apply,
+        )
+
+        create_model("openai:gpt-5.5")
+
+        ordered = [name for name, _args, _kwargs in manager.mock_calls]
+        assert ordered == ["warn", "apply"]
+
+
 class TestModelResultApplyToSettings:
     """Tests for ModelResult.apply_to_settings propagation."""
 

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -1533,6 +1533,34 @@ api_key_env = "TOGETHER_API_KEY"
         assert kwargs["api_key"] == "together-key"
         assert "base_url" not in kwargs
 
+    def test_stored_auth_base_url_reaches_kwargs_without_env_var(
+        self, tmp_path: Path
+    ) -> None:
+        """A `/auth` endpoint reaches the `base_url` kwarg for a non-mapped provider.
+
+        `together` has an API-key env var but no base-URL env var, so the stored
+        endpoint resolves only through `get_base_url`'s store fallback. This is
+        the end-to-end path that makes a saved base URL actually take effect
+        rather than being silently dropped.
+        """
+        from deepagents_code import auth_store
+
+        state_dir = tmp_path / ".state"
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("")
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            patch.object(model_config, "DEFAULT_STATE_DIR", state_dir),
+            patch.dict("os.environ", {"TOGETHER_API_KEY": "tk"}, clear=True),
+        ):
+            clear_caches()
+            auth_store.set_stored_key(
+                "together", "tk", base_url="https://proxy.example/v1"
+            )
+            kwargs = _get_provider_kwargs("together")
+
+        assert kwargs["base_url"] == "https://proxy.example/v1"
+
     def test_prefixed_env_var_beats_canonical(self, tmp_path: Path) -> None:
         """DEEPAGENTS_CODE_ prefixed var overrides canonical in provider kwargs."""
         config_path = tmp_path / "config.toml"

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -2605,12 +2605,42 @@ class TestCreateModelViaInitImportError:
         mock_init.side_effect = ImportError("no module")
         with (
             patch("importlib.util.find_spec", return_value=None),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=set(),
+            ),
             pytest.raises(
                 ModelConfigError,
                 match=(
                     "Install with: uv tool install -U deepagents-code "
                     "--with langchain-custom_provider"
                 ),
+            ),
+        ):
+            _create_model_via_init("some-model", "custom_provider", {})
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_unknown_provider_introspection_failure_falls_back_to_manual(
+        self, mock_init: Mock
+    ) -> None:
+        """Unreadable extras metadata degrades to the manual-install hint.
+
+        Exercises the `ExtrasIntrospectionError` arm of the fallback so the
+        user still gets an actionable message instead of an unhandled error
+        leaking out of hint construction.
+        """
+        from deepagents_code.extras_info import ExtrasIntrospectionError
+
+        mock_init.side_effect = ImportError("no module")
+        with (
+            patch("importlib.util.find_spec", return_value=None),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                side_effect=ExtrasIntrospectionError("metadata unreadable"),
+            ),
+            pytest.raises(
+                ModelConfigError,
+                match="Install the 'langchain-custom_provider' package manually",
             ),
         ):
             _create_model_via_init("some-model", "custom_provider", {})

--- a/libs/code/tests/unit_tests/test_install_command.py
+++ b/libs/code/tests/unit_tests/test_install_command.py
@@ -245,3 +245,113 @@ async def test_install_slash_editable_install_refuses() -> None:
         perform_mock.assert_not_awaited()
         app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
         assert any("Editable install detected" in str(m._content) for m in app_msgs)
+
+
+async def test_install_slash_package_requires_force() -> None:
+    """`--package` without `--force` must not call `perform_install_package`."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_package",
+                new_callable=AsyncMock,
+            ) as perform_mock,
+        ):
+            await app._handle_command("/install langchain-custom --package")
+            await pilot.pause()
+        perform_mock.assert_not_awaited()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        joined = "\n".join(str(m._content) for m in app_msgs)
+        assert "--force" in joined
+        assert "third-party code" in joined
+        # The raw `uv tool` command is never surfaced to the user.
+        assert "uv tool" not in joined
+
+
+async def test_install_slash_package_with_force_runs() -> None:
+    """`--package --force` invokes `perform_install_package` and recommends restart."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_package",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as perform_mock,
+        ):
+            await app._handle_command("/install langchain-custom --package --force")
+            await pilot.pause()
+        perform_mock.assert_awaited_once()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        success = next(
+            m
+            for m in app_msgs
+            if "Installed package 'langchain-custom'" in str(m._content)
+        )
+        assert "/restart" in str(success._content)
+
+
+async def test_install_slash_package_failure_renders_log() -> None:
+    """A failed package install surfaces the detail + log, but no `uv` command."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_package",
+                new_callable=AsyncMock,
+                return_value=(False, "resolver: conflict"),
+            ) as perform_mock,
+        ):
+            await app._handle_command("/install langchain-custom --package --force")
+            await pilot.pause()
+        perform_mock.assert_awaited_once()
+        err_msgs = list(app.query(ErrorMessage))
+        joined = "\n".join(str(m._content) for m in err_msgs)
+        assert "Install failed" in joined
+        assert "resolver: conflict" in joined
+        assert "Log:" in joined
+        assert "uv tool" not in joined
+
+
+async def test_install_slash_package_invalid_refuses_even_with_force() -> None:
+    """Malformed package names must not reach command construction."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_package",
+                new_callable=AsyncMock,
+            ) as perform_mock,
+        ):
+            await app._handle_command("/install custom;touch --package --force")
+            await pilot.pause()
+        perform_mock.assert_not_awaited()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        assert any("Invalid package name" in str(m._content) for m in app_msgs)
+
+
+async def test_install_slash_package_editable_install_refuses() -> None:
+    """Editable installs must not invoke `perform_install_package` from the TUI."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=True),
+            patch(
+                "deepagents_code.update_check.perform_install_package",
+                new_callable=AsyncMock,
+            ) as perform_mock,
+        ):
+            await app._handle_command("/install langchain-custom --package --force")
+            await pilot.pause()
+        perform_mock.assert_not_awaited()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        assert any("Editable install detected" in str(m._content) for m in app_msgs)

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -1599,8 +1599,6 @@ class TestInstallPackageSubcommand:
 
     def test_option_injection_name_refused(self) -> None:
         """A leading-dash name is rejected before any install path (exit 2)."""
-        code, perform_mock, _console = self._run_install_package(
-            "-rreqs.txt", yes=True
-        )
+        code, perform_mock, _console = self._run_install_package("-rreqs.txt", yes=True)
         assert code == 2
         perform_mock.assert_not_awaited()

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -1451,3 +1451,156 @@ class TestInstallExtraSubcommand:
         assert code == 1
         perform_mock.assert_not_awaited()
         assert "Aborted" in self._printed_text(console_mock)
+
+
+class TestInstallPackageSubcommand:
+    """Control-flow tests for `dcode --install <pkg> --package`."""
+
+    @staticmethod
+    def _run_install_package(
+        package: str,
+        *,
+        with_install: bool = True,
+        editable: bool = False,
+        yes: bool = False,
+        interactive: bool = False,
+        perform_return: tuple[bool, str] = (True, ""),
+        perform_side_effect: BaseException | None = None,
+        input_reply: str = "n",
+    ) -> tuple[int, MagicMock, MagicMock]:
+        """Invoke `cli_main()` with `--package`; return exit code + mocks."""
+        from deepagents_code.main import cli_main
+
+        argv = ["deepagents"]
+        if with_install:
+            argv += ["--install", package]
+        argv.append("--package")
+        if yes:
+            argv.append("--yes")
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = interactive
+        # Empty piped input so `apply_stdin_pipe` returns before its TTY
+        # restoration path clobbers this mocked stdin. See `_run_install`.
+        mock_stdin.read.return_value = ""
+        console_mock = MagicMock()
+        if perform_side_effect is not None:
+            perform_mock = AsyncMock(side_effect=perform_side_effect)
+        else:
+            perform_mock = AsyncMock(return_value=perform_return)
+        with (
+            patch.object(sys, "argv", argv),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_code.main.check_cli_dependencies"),
+            patch("deepagents_code.config.console", console_mock, create=True),
+            patch("deepagents_code.config._is_editable_install", return_value=editable),
+            patch(
+                "deepagents_code.update_check.create_update_log_path",
+                return_value=Path("/tmp/deepagents-install.log"),
+            ),
+            patch(
+                "deepagents_code.update_check.perform_install_package",
+                perform_mock,
+            ),
+            patch("builtins.input", return_value=input_reply),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+        return int(exc_info.value.code or 0), perform_mock, console_mock
+
+    @staticmethod
+    def _printed_text(console_mock: MagicMock) -> str:
+        chunks: list[str] = []
+        for call in console_mock.print.call_args_list:
+            chunks.extend(str(arg) for arg in call.args)
+        return "\n".join(chunks)
+
+    def test_package_with_yes_runs(self) -> None:
+        """`--package --yes` invokes `perform_install_package` and exits 0."""
+        code, perform_mock, console_mock = self._run_install_package(
+            "langchain-custom", yes=True, interactive=False
+        )
+        assert code == 0
+        perform_mock.assert_awaited_once()
+        text = self._printed_text(console_mock)
+        assert "Installed package 'langchain-custom'" in text
+
+    def test_package_non_interactive_without_yes_refuses(self) -> None:
+        """Non-TTY stdin + no --yes must exit 2 without installing."""
+        code, perform_mock, _console = self._run_install_package(
+            "langchain-custom", interactive=False
+        )
+        assert code == 2
+        perform_mock.assert_not_awaited()
+
+    def test_package_editable_install_refuses(self) -> None:
+        """Editable install short-circuits with a `--with` hint, exit 1."""
+        code, perform_mock, _console = self._run_install_package(
+            "langchain-custom", editable=True, yes=True
+        )
+        assert code == 1
+        perform_mock.assert_not_awaited()
+
+    def test_invalid_package_refuses_even_with_yes(self) -> None:
+        """Malformed package names must never reach the installer command path."""
+        code, perform_mock, _console = self._run_install_package(
+            "custom;touch", yes=True, interactive=False
+        )
+        assert code == 2
+        perform_mock.assert_not_awaited()
+
+    def test_package_flag_without_install_errors(self) -> None:
+        """`--package` with no `--install` value must exit 2."""
+        code, perform_mock, _console = self._run_install_package(
+            "langchain-custom", with_install=False
+        )
+        assert code == 2
+        perform_mock.assert_not_awaited()
+
+    def test_package_interactive_decline_aborts(self) -> None:
+        """Interactive TTY + reply 'n' aborts with exit 1."""
+        code, perform_mock, console_mock = self._run_install_package(
+            "langchain-custom", interactive=True, input_reply="n"
+        )
+        assert code == 1
+        perform_mock.assert_not_awaited()
+        assert "Aborted" in self._printed_text(console_mock)
+
+    def test_package_failure_renders_log(self) -> None:
+        """A failed package install surfaces the detail + log path, no uv command."""
+        code, _perform, console_mock = self._run_install_package(
+            "langchain-custom", yes=True, perform_return=(False, "resolver: conflict")
+        )
+        assert code == 1
+        text = self._printed_text(console_mock)
+        assert "Install failed" in text
+        assert "resolver: conflict" in text
+        assert "/tmp/deepagents-install.log" in text
+        # The raw `uv tool` command is never surfaced to the user.
+        assert "uv tool" not in text
+
+    def test_package_keyboard_interrupt_exits_130(self) -> None:
+        """Ctrl+C during the install exits 130 via the catch-all."""
+        code, _perform, console_mock = self._run_install_package(
+            "langchain-custom", yes=True, perform_side_effect=KeyboardInterrupt()
+        )
+        assert code == 130
+        assert "Aborted" in self._printed_text(console_mock)
+
+    def test_package_unexpected_error_exits_nonzero_with_log(self) -> None:
+        """An unexpected exception is caught, logged, and exits 1 (not a traceback)."""
+        code, _perform, console_mock = self._run_install_package(
+            "langchain-custom", yes=True, perform_side_effect=RuntimeError("boom")
+        )
+        assert code == 1
+        text = self._printed_text(console_mock)
+        assert "RuntimeError" in text
+        assert "uv tool" not in text
+
+    def test_option_injection_name_refused(self) -> None:
+        """A leading-dash name is rejected before any install path (exit 2)."""
+        code, perform_mock, _console = self._run_install_package(
+            "-rreqs.txt", yes=True
+        )
+        assert code == 2
+        perform_mock.assert_not_awaited()

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -1074,19 +1074,19 @@ models = ["m1"]
     ) -> None:
         """A `/auth` endpoint resolves for a provider with no base-URL env var.
 
-        OpenAI-compatible routers (LiteLLM, OpenRouter, …) have an API-key env
-        var but no base-URL env var, so steps 1-2 find nothing. The stored
-        endpoint must still resolve here so it reaches the model as a kwarg —
-        otherwise a value the user saved in `/auth` is silently ignored.
+        Some OpenAI-compatible providers (e.g. Baseten) have an API-key env var
+        but no dedicated base-URL env var, so steps 1-2 find nothing. The
+        stored endpoint must still resolve here so it reaches the model as the
+        `base_url` kwarg — otherwise a value saved in `/auth` is silently lost.
         """
         from deepagents_code import auth_store
 
         auth_store.set_stored_key(
-            "litellm", "k", base_url="https://proxy.example/v1"
+            "baseten", "k", base_url="https://proxy.example/v1"
         )
         config = ModelConfig()
 
-        assert config.get_base_url("litellm") == "https://proxy.example/v1"
+        assert config.get_base_url("baseten") == "https://proxy.example/v1"
 
     def test_config_literal_wins_over_stored_base_url(
         self,
@@ -1097,17 +1097,17 @@ models = ["m1"]
         from deepagents_code import auth_store
 
         auth_store.set_stored_key(
-            "litellm", "k", base_url="https://stored.example/v1"
+            "baseten", "k", base_url="https://stored.example/v1"
         )
         config_path = tmp_path / "config.toml"
         config_path.write_text("""
-[models.providers.litellm]
+[models.providers.baseten]
 base_url = "https://config.example/v1"
 models = ["m1"]
 """)
         config = ModelConfig.load(config_path)
 
-        assert config.get_base_url("litellm") == "https://config.example/v1"
+        assert config.get_base_url("baseten") == "https://config.example/v1"
 
     def test_blank_stored_base_url_yields_none(
         self,
@@ -1116,10 +1116,10 @@ models = ["m1"]
         """A stored key with no endpoint leaves `get_base_url` at the default."""
         from deepagents_code import auth_store
 
-        auth_store.set_stored_key("litellm", "k")
+        auth_store.set_stored_key("baseten", "k")
         config = ModelConfig()
 
-        assert config.get_base_url("litellm") is None
+        assert config.get_base_url("baseten") is None
 
     def test_corrupt_store_does_not_raise(
         self,
@@ -1130,7 +1130,7 @@ models = ["m1"]
         (fake_state_dir / "auth.json").write_text("{ not valid json")
         config = ModelConfig()
 
-        assert config.get_base_url("litellm") is None
+        assert config.get_base_url("baseten") is None
 
 
 class TestGetDefaultBaseUrlEnv:

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -1081,9 +1081,7 @@ models = ["m1"]
         """
         from deepagents_code import auth_store
 
-        auth_store.set_stored_key(
-            "baseten", "k", base_url="https://proxy.example/v1"
-        )
+        auth_store.set_stored_key("baseten", "k", base_url="https://proxy.example/v1")
         config = ModelConfig()
 
         assert config.get_base_url("baseten") == "https://proxy.example/v1"
@@ -1096,9 +1094,7 @@ models = ["m1"]
         """A `config.toml` literal still wins over the stored endpoint."""
         from deepagents_code import auth_store
 
-        auth_store.set_stored_key(
-            "baseten", "k", base_url="https://stored.example/v1"
-        )
+        auth_store.set_stored_key("baseten", "k", base_url="https://stored.example/v1")
         config_path = tmp_path / "config.toml"
         config_path.write_text("""
 [models.providers.baseten]
@@ -1145,7 +1141,9 @@ class TestGetDefaultBaseUrlEnv:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """The prefixed var survives the clear, so its name is returned."""
-        monkeypatch.setenv("DEEPAGENTS_CODE_OPENAI_BASE_URL", "https://scoped.example/v1")
+        monkeypatch.setenv(
+            "DEEPAGENTS_CODE_OPENAI_BASE_URL", "https://scoped.example/v1"
+        )
         assert (
             model_config.get_default_base_url_env("openai")
             == "DEEPAGENTS_CODE_OPENAI_BASE_URL"

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -402,8 +402,9 @@ class TestSplitCredentialSource:
     def _isolate_openai_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Clear every OpenAI key/endpoint env var so each test sets its own.
 
-        `dotenv.load_dotenv()` runs at import time and may inject prefixed
-        variants that would otherwise leak into these assertions.
+        `dotenv.load_dotenv()` runs during config bootstrap (first `Settings`
+        access) and may inject prefixed variants from a developer's
+        `~/.deepagents/.env` that would otherwise leak into these assertions.
         """
         for var in (
             "OPENAI_API_KEY",
@@ -508,6 +509,93 @@ class TestSplitCredentialSource:
             warn_on_split_credential_source("openai")
 
         assert not caplog.records
+
+    def test_no_warning_when_prefixed_key_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An empty prefixed key does not resolve from the prefixed tier: no warning.
+
+        Symmetric to `test_empty_prefixed_base_url_is_not_treated_as_plain`: the
+        key half of the pair must be *present and non-empty* for a split to exist.
+        """
+        from deepagents_code.model_config import warn_on_split_credential_source
+
+        monkeypatch.setenv("DEEPAGENTS_CODE_OPENAI_API_KEY", "")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1")
+
+        with caplog.at_level(logging.DEBUG, logger="deepagents_code.model_config"):
+            warn_on_split_credential_source("openai")
+
+        assert not caplog.records
+
+    def test_no_warning_when_provider_has_no_base_url_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A provider with a key env var but no base-URL env var returns early.
+
+        `google_vertexai` maps to `GOOGLE_CLOUD_PROJECT` for credentials but has
+        no entry in `PROVIDER_BASE_URL_ENV`, so there is no endpoint variable to
+        compare against.
+        """
+        from deepagents_code.model_config import warn_on_split_credential_source
+
+        monkeypatch.setenv("DEEPAGENTS_CODE_GOOGLE_CLOUD_PROJECT", "my-project")
+
+        with caplog.at_level(logging.DEBUG, logger="deepagents_code.model_config"):
+            warn_on_split_credential_source("google_vertexai")
+
+        assert not caplog.records
+
+    def test_warns_for_config_declared_env_vars(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path: Path,
+    ) -> None:
+        """The prefix is applied to config-declared env names, not just built-ins.
+
+        A `config.toml` provider that declares its own `api_key_env` /
+        `base_url_env` participates in the same split-source detection.
+        """
+        from deepagents_code import model_config
+        from deepagents_code.model_config import (
+            clear_caches,
+            warn_on_split_credential_source,
+        )
+
+        for var in (
+            "MYCO_KEY",
+            "DEEPAGENTS_CODE_MYCO_KEY",
+            "MYCO_BASE_URL",
+            "DEEPAGENTS_CODE_MYCO_BASE_URL",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.myco]
+api_key_env = "MYCO_KEY"
+base_url_env = "MYCO_BASE_URL"
+models = ["m1"]
+""")
+        monkeypatch.setenv("DEEPAGENTS_CODE_MYCO_KEY", "sk-secret-value")
+        monkeypatch.setenv("MYCO_BASE_URL", "https://gateway.example/myco")
+
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            caplog.at_level(logging.DEBUG, logger="deepagents_code.model_config"),
+        ):
+            clear_caches()
+            warn_on_split_credential_source("myco")
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any(
+            "DEEPAGENTS_CODE_MYCO_KEY" in m and "MYCO_BASE_URL" in m for m in messages
+        )
 
     def test_no_warning_when_config_base_url_literal_set(
         self,

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -274,6 +274,111 @@ class TestStoredCredentials:
 
         assert os.environ["ANTHROPIC_API_KEY"] == "from-env"
 
+    def test_apply_stored_credentials_sets_base_url(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A stored base_url is exported alongside the key, alt name cleared."""
+        import os
+
+        from deepagents_code import auth_store
+        from deepagents_code.model_config import apply_stored_credentials
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_BASE", "https://stale.example/v1")
+        auth_store.set_stored_key(
+            "openai", "from-store", base_url="https://mine.example/v1"
+        )
+
+        assert apply_stored_credentials("openai") is True
+        assert os.environ["OPENAI_BASE_URL"] == "https://mine.example/v1"
+        # The alternate name the SDK also reads must not retain a stale value.
+        assert "OPENAI_API_BASE" not in os.environ
+
+    def test_apply_stored_credentials_blank_base_url_clears_gateway(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A stored key with no base_url clears the inherited (gateway) URL.
+
+        This is what stops a personal key from being shipped to the gateway.
+        """
+        import os
+
+        from deepagents_code import auth_store
+        from deepagents_code.model_config import apply_stored_credentials
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv(
+            "OPENAI_BASE_URL", "https://gateway.smith.langchain.com/openai/v1"
+        )
+        auth_store.set_stored_key("openai", "sk-personal")
+
+        assert apply_stored_credentials("openai") is True
+        assert os.environ["OPENAI_API_KEY"] == "sk-personal"
+        assert "OPENAI_BASE_URL" not in os.environ
+        assert "OPENAI_API_BASE" not in os.environ
+
+    def test_apply_stored_credentials_blank_base_url_clears_gemini_gateway(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Gemini routes via GOOGLE_GEMINI_BASE_URL, so the pairing applies too.
+
+        The google-genai SDK reads GOOGLE_GEMINI_BASE_URL natively, so a stored
+        key with no base_url must clear it or a personal key reaches the gateway.
+        """
+        import os
+
+        from deepagents_code import auth_store
+        from deepagents_code.model_config import apply_stored_credentials
+
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.setenv(
+            "GOOGLE_GEMINI_BASE_URL", "https://gateway.smith.langchain.com/gemini"
+        )
+        auth_store.set_stored_key("google_genai", "personal-gemini-key")
+
+        assert apply_stored_credentials("google_genai") is True
+        assert "GOOGLE_GEMINI_BASE_URL" not in os.environ
+
+    def test_apply_stored_credentials_clears_config_base_url_env(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A config-declared `base_url_env` participates in the pairing.
+
+        Lets a provider outside the hardcoded set clear an inherited gateway
+        URL when a `/auth` key with no base URL is applied.
+        """
+        import os
+
+        from deepagents_code import auth_store, model_config
+        from deepagents_code.model_config import apply_stored_credentials, clear_caches
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.myco]
+api_key_env = "MYCO_KEY"
+base_url_env = "MYCO_BASE_URL"
+models = ["m1"]
+""")
+        monkeypatch.delenv("MYCO_KEY", raising=False)
+        monkeypatch.setenv("MYCO_BASE_URL", "https://gateway.example/myco")
+        auth_store.set_stored_key("myco", "myco-personal")
+
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            clear_caches()
+            assert apply_stored_credentials("myco") is True
+
+        assert os.environ["MYCO_KEY"] == "myco-personal"
+        assert "MYCO_BASE_URL" not in os.environ
+
     def test_corrupt_store_does_not_block_status(
         self,
         fake_state_dir: Path,
@@ -919,6 +1024,99 @@ models = ["llama3"]
         config = ModelConfig.load(config_path)
 
         assert config.get_base_url("local") == "http://localhost:11434/v1"
+
+    def test_falls_back_to_env_var(self, monkeypatch):
+        """With no config base_url, reads the provider's base-URL env var."""
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://gw.example/openai/v1")
+        config = ModelConfig()
+
+        assert config.get_base_url("openai") == "https://gw.example/openai/v1"
+
+    def test_env_prefix_overrides_plain(self, monkeypatch):
+        """`DEEPAGENTS_CODE_*` beats the plain env var, like API keys."""
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://plain.example/v1")
+        monkeypatch.setenv(
+            "DEEPAGENTS_CODE_OPENAI_BASE_URL", "https://scoped.example/v1"
+        )
+        config = ModelConfig()
+
+        assert config.get_base_url("openai") == "https://scoped.example/v1"
+
+    def test_config_wins_over_env(self, tmp_path, monkeypatch):
+        """A config.toml base_url takes precedence over the env fallback."""
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://env.example/v1")
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.openai]
+base_url = "https://config.example/v1"
+models = ["gpt-5.5"]
+""")
+        config = ModelConfig.load(config_path)
+
+        assert config.get_base_url("openai") == "https://config.example/v1"
+
+    def test_falls_back_to_config_base_url_env(self, tmp_path, monkeypatch):
+        """A config `base_url_env` extends env resolution beyond built-ins."""
+        monkeypatch.setenv("MYCO_BASE_URL", "https://myco.example/v1")
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.myco]
+base_url_env = "MYCO_BASE_URL"
+models = ["m1"]
+""")
+        config = ModelConfig.load(config_path)
+
+        assert config.get_base_url("myco") == "https://myco.example/v1"
+
+
+class TestGetDefaultBaseUrlEnv:
+    """Tests for `get_default_base_url_env` — the var a blank save falls back to.
+
+    A blank save clears the *plain* endpoint vars, so only the
+    `DEEPAGENTS_CODE_`-prefixed name still supplies a value afterward. The
+    helper returns that name (for display), never the plain name or a value.
+    """
+
+    def test_returns_prefixed_name_when_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The prefixed var survives the clear, so its name is returned."""
+        monkeypatch.setenv("DEEPAGENTS_CODE_OPENAI_BASE_URL", "https://scoped.example/v1")
+        assert (
+            model_config.get_default_base_url_env("openai")
+            == "DEEPAGENTS_CODE_OPENAI_BASE_URL"
+        )
+
+    def test_ignores_plain_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A plain endpoint var is cleared on a blank save, so it is not named."""
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1")
+        assert model_config.get_default_base_url_env("openai") is None
+
+    def test_uses_config_base_url_env_for_custom_provider(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A config `base_url_env` extends the survivor name to custom providers."""
+        monkeypatch.setenv("DEEPAGENTS_CODE_MYCO_BASE_URL", "https://scoped.example/v1")
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.myco]
+base_url_env = "MYCO_BASE_URL"
+models = ["m1"]
+""")
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            model_config.clear_caches()
+            assert (
+                model_config.get_default_base_url_env("myco")
+                == "DEEPAGENTS_CODE_MYCO_BASE_URL"
+            )
+
+    def test_returns_none_when_unset(self) -> None:
+        """No prefixed var means the default comes from config or the SDK."""
+        assert model_config.get_default_base_url_env("openai") is None
+
+    def test_returns_none_for_unknown_provider(self) -> None:
+        """A provider with no base-URL mapping has no env var to name."""
+        assert model_config.get_default_base_url_env("nonexistent") is None
 
 
 class TestModelConfigGetApiKeyEnv:

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -1068,6 +1068,70 @@ models = ["m1"]
 
         assert config.get_base_url("myco") == "https://myco.example/v1"
 
+    def test_falls_back_to_stored_base_url_for_provider_without_env_var(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+    ) -> None:
+        """A `/auth` endpoint resolves for a provider with no base-URL env var.
+
+        OpenAI-compatible routers (LiteLLM, OpenRouter, …) have an API-key env
+        var but no base-URL env var, so steps 1-2 find nothing. The stored
+        endpoint must still resolve here so it reaches the model as a kwarg —
+        otherwise a value the user saved in `/auth` is silently ignored.
+        """
+        from deepagents_code import auth_store
+
+        auth_store.set_stored_key(
+            "litellm", "k", base_url="https://proxy.example/v1"
+        )
+        config = ModelConfig()
+
+        assert config.get_base_url("litellm") == "https://proxy.example/v1"
+
+    def test_config_literal_wins_over_stored_base_url(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        """A `config.toml` literal still wins over the stored endpoint."""
+        from deepagents_code import auth_store
+
+        auth_store.set_stored_key(
+            "litellm", "k", base_url="https://stored.example/v1"
+        )
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.litellm]
+base_url = "https://config.example/v1"
+models = ["m1"]
+""")
+        config = ModelConfig.load(config_path)
+
+        assert config.get_base_url("litellm") == "https://config.example/v1"
+
+    def test_blank_stored_base_url_yields_none(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+    ) -> None:
+        """A stored key with no endpoint leaves `get_base_url` at the default."""
+        from deepagents_code import auth_store
+
+        auth_store.set_stored_key("litellm", "k")
+        config = ModelConfig()
+
+        assert config.get_base_url("litellm") is None
+
+    def test_corrupt_store_does_not_raise(
+        self,
+        fake_state_dir: Path,
+    ) -> None:
+        """A corrupt credential store resolves to None, never propagating."""
+        fake_state_dir.mkdir(parents=True, exist_ok=True)
+        (fake_state_dir / "auth.json").write_text("{ not valid json")
+        config = ModelConfig()
+
+        assert config.get_base_url("litellm") is None
+
 
 class TestGetDefaultBaseUrlEnv:
     """Tests for `get_default_base_url_env` — the var a blank save falls back to.

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -395,6 +395,151 @@ models = ["m1"]
         assert status.source is ProviderAuthSource.ENV
 
 
+class TestSplitCredentialSource:
+    """`warn_on_split_credential_source` flags key/endpoint env-tier mismatches."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_openai_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Clear every OpenAI key/endpoint env var so each test sets its own.
+
+        `dotenv.load_dotenv()` runs at import time and may inject prefixed
+        variants that would otherwise leak into these assertions.
+        """
+        for var in (
+            "OPENAI_API_KEY",
+            "DEEPAGENTS_CODE_OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+            "OPENAI_API_BASE",
+            "DEEPAGENTS_CODE_OPENAI_BASE_URL",
+            "DEEPAGENTS_CODE_OPENAI_API_BASE",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_warns_when_key_prefixed_but_base_url_plain(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Prefixed key + plain base URL (no prefixed base URL) emits a DEBUG line."""
+        from deepagents_code.model_config import warn_on_split_credential_source
+
+        monkeypatch.setenv("DEEPAGENTS_CODE_OPENAI_API_KEY", "sk-secret-value")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1")
+
+        with caplog.at_level(logging.DEBUG, logger="deepagents_code.model_config"):
+            warn_on_split_credential_source("openai")
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any(
+            "DEEPAGENTS_CODE_OPENAI_API_KEY" in m and "OPENAI_BASE_URL" in m
+            for m in messages
+        )
+        # The secret value and the URL value must never appear in the log.
+        assert all("sk-secret-value" not in m for m in messages)
+        assert all("https://gateway.example/v1" not in m for m in messages)
+
+    def test_no_warning_when_both_prefixed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A matching prefixed base URL means the pair shares a source: no warning."""
+        from deepagents_code.model_config import warn_on_split_credential_source
+
+        monkeypatch.setenv("DEEPAGENTS_CODE_OPENAI_API_KEY", "sk-secret-value")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1")
+        monkeypatch.setenv(
+            "DEEPAGENTS_CODE_OPENAI_BASE_URL", "https://gateway.example/v1"
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="deepagents_code.model_config"):
+            warn_on_split_credential_source("openai")
+
+        assert not caplog.records
+
+    def test_no_warning_when_key_is_plain(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A plain key with a plain base URL is a same-tier pair: no warning."""
+        from deepagents_code.model_config import warn_on_split_credential_source
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-secret-value")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1")
+
+        with caplog.at_level(logging.DEBUG, logger="deepagents_code.model_config"):
+            warn_on_split_credential_source("openai")
+
+        assert not caplog.records
+
+    def test_no_warning_when_no_base_url_set(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A prefixed key with no endpoint at all has nothing to mismatch."""
+        from deepagents_code.model_config import warn_on_split_credential_source
+
+        monkeypatch.setenv("DEEPAGENTS_CODE_OPENAI_API_KEY", "sk-secret-value")
+
+        with caplog.at_level(logging.DEBUG, logger="deepagents_code.model_config"):
+            warn_on_split_credential_source("openai")
+
+        assert not caplog.records
+
+    def test_empty_prefixed_base_url_is_not_treated_as_plain(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An empty prefixed base URL shadows the plain one, so there is no split.
+
+        Mirrors `resolve_env_var`: a present-but-empty prefixed variant
+        suppresses the plain value rather than falling through to it.
+        """
+        from deepagents_code.model_config import warn_on_split_credential_source
+
+        monkeypatch.setenv("DEEPAGENTS_CODE_OPENAI_API_KEY", "sk-secret-value")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1")
+        monkeypatch.setenv("DEEPAGENTS_CODE_OPENAI_BASE_URL", "")
+
+        with caplog.at_level(logging.DEBUG, logger="deepagents_code.model_config"):
+            warn_on_split_credential_source("openai")
+
+        assert not caplog.records
+
+    def test_no_warning_when_config_base_url_literal_set(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        tmp_path: Path,
+    ) -> None:
+        """A `config.toml` `base_url` literal wins over env vars: no env split."""
+        from deepagents_code import model_config
+        from deepagents_code.model_config import (
+            clear_caches,
+            warn_on_split_credential_source,
+        )
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.openai]
+base_url = "https://configured.example/v1"
+""")
+        monkeypatch.setenv("DEEPAGENTS_CODE_OPENAI_API_KEY", "sk-secret-value")
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://gateway.example/v1")
+
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            caplog.at_level(logging.DEBUG, logger="deepagents_code.model_config"),
+        ):
+            clear_caches()
+            warn_on_split_credential_source("openai")
+
+        assert not caplog.records
+
+
 class TestThreadColumnPersistence:
     """Tests for thread selector column visibility persistence."""
 

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import time
 import tomllib
@@ -1054,19 +1055,85 @@ class TestEditableExtraHint:
 class TestInstallPackageCommand:
     """`install_package_command` builds a uv tool package install string."""
 
-    def test_basic(self) -> None:
+    def test_basic_no_extras(self, tmp_path, monkeypatch) -> None:
+        """Clean metadata with no installed extras yields a plain requirement."""
+        _write_dist_info(
+            tmp_path,
+            "deepagents-code",
+            requires=('definitely-absent-dcode-test-quickjs-xyz; extra == "quickjs"',),
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
         assert (
-            install_package_command("langchain-custom")
+            install_package_command(
+                "langchain-custom", distribution_name="deepagents-code"
+            )
             == "uv tool install -U deepagents-code --with langchain-custom"
         )
 
-    def test_allows_pep508_name_separators(self) -> None:
+    def test_allows_pep508_name_separators(self, tmp_path, monkeypatch) -> None:
+        _write_dist_info(
+            tmp_path,
+            "deepagents-code",
+            requires=('definitely-absent-dcode-test-quickjs-xyz; extra == "quickjs"',),
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
         assert (
-            install_package_command("langchain.custom_provider")
+            install_package_command(
+                "langchain.custom_provider", distribution_name="deepagents-code"
+            )
             == "uv tool install -U deepagents-code --with langchain.custom_provider"
         )
 
+    def test_preserves_installed_extras(self, tmp_path, monkeypatch) -> None:
+        """Adding a package keeps already-installed extras selected."""
+        _write_dist_info(tmp_path, "definitely-present-dcode-test-nvidia")
+        _write_dist_info(
+            tmp_path,
+            "deepagents-code",
+            requires=(
+                'definitely-present-dcode-test-nvidia; extra == "nvidia"',
+                'definitely-absent-dcode-test-baseten-xyz; extra == "baseten"',
+            ),
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        assert installed_extra_names("deepagents-code") == {"nvidia"}
+        assert (
+            install_package_command(
+                "langchain-custom", distribution_name="deepagents-code"
+            )
+            == "uv tool install -U 'deepagents-code[nvidia]' --with langchain-custom"
+        )
+
+    def test_refuses_missing_distribution(self) -> None:
+        """Reinstalls must not drop extras when metadata is unavailable."""
+        with pytest.raises(ExtrasIntrospectionError, match="cannot preserve"):
+            install_package_command(
+                "langchain-custom", distribution_name="missing-dcode-test"
+            )
+
+    def test_refuses_invalid_metadata(self, tmp_path, monkeypatch) -> None:
+        """Malformed optional-dependency metadata must not drop existing extras."""
+        _write_dist_info(
+            tmp_path,
+            "deepagents-code",
+            requires=("not a valid requirement ; ;",),
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        with pytest.raises(ExtrasIntrospectionError, match="Could not parse"):
+            install_package_command(
+                "langchain-custom", distribution_name="deepagents-code"
+            )
+
     def test_rejects_shell_metacharacters(self) -> None:
+        """A bad package name raises before extras introspection runs.
+
+        Validation precedes the distribution lookup, so the rejection holds
+        regardless of metadata availability.
+        """
         with pytest.raises(ValueError, match="Invalid package name"):
             install_package_command("langchain-custom; touch /tmp/pwned")
 
@@ -1288,6 +1355,37 @@ class TestPerformInstallPackage:
         assert success is False
         assert "uv" in output
         assert "not found" in output
+
+    async def test_extras_introspection_failure_is_reported_and_logged(
+        self, caplog
+    ) -> None:
+        """Unreadable distribution metadata surfaces as a reported, logged error.
+
+        Guards the `ExtrasIntrospectionError` arm distinctly from the
+        `ValueError` arm: a narrowing back to `except ValueError` would let the
+        error escape unhandled, and dropping the log would erase the only
+        breadcrumb for what is an environment-corruption signal.
+        """
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.update_check.shutil.which",
+                return_value="/usr/bin/uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                side_effect=ExtrasIntrospectionError("metadata unreadable"),
+            ),
+            caplog.at_level(logging.WARNING, logger="deepagents_code.update_check"),
+        ):
+            success, output = await perform_install_package("langchain-custom")
+        assert success is False
+        assert "ExtrasIntrospectionError" in output
+        assert "metadata unreadable" in output
+        assert "introspect installed extras" in caplog.text
 
 
 class TestRunInstallSubprocessFailureModes:

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -27,6 +27,7 @@ from deepagents_code.update_check import (
     create_update_log_path,
     detect_install_method,
     editable_extra_hint,
+    editable_package_hint,
     format_age_suffix,
     format_installed_age_suffix,
     format_release_age,
@@ -43,9 +44,11 @@ from deepagents_code.update_check import (
     is_auto_update_enabled,
     is_update_available,
     is_valid_extra_name,
+    is_valid_package_name,
     mark_update_notified,
     mark_version_seen,
     perform_install_extra,
+    perform_install_package,
     perform_upgrade,
     set_auto_update,
     should_notify_update,
@@ -1149,6 +1152,139 @@ class TestPerformInstallExtra:
             ),
         ):
             success, output = await perform_install_extra("quickjs")
+        assert success is False
+        assert "uv" in output
+        assert "not found" in output
+
+
+class TestIsValidPackageName:
+    """`is_valid_package_name` accepts PEP 508 names, rejects the rest."""
+
+    def test_accepts_plain_and_separated_names(self) -> None:
+        assert is_valid_package_name("langchain-custom")
+        assert is_valid_package_name("langchain.custom_provider")
+
+    def test_rejects_shell_metacharacters(self) -> None:
+        assert not is_valid_package_name("langchain-custom; touch /tmp/pwned")
+
+    def test_rejects_option_injection_leading_dash(self) -> None:
+        """A leading dash would smuggle uv options into `--with <name>`.
+
+        The command is `uv tool install -U deepagents-code --with <name>`; a name
+        like `-rreqs.txt` or `--editable` would be parsed by uv as a flag, not a
+        package. The validator must reject these regardless of `--force`/`--yes`.
+        """
+        assert not is_valid_package_name("-rreqs.txt")
+        assert not is_valid_package_name("--force")
+        assert not is_valid_package_name("-e.")
+
+    def test_rejects_boundary_separators_and_whitespace(self) -> None:
+        """Leading/trailing separators and internal whitespace are rejected."""
+        for bad in (".foo", "foo.", "-foo", "foo-", "_foo", "foo_", "foo bar"):
+            assert not is_valid_package_name(bad), bad
+
+    def test_rejects_non_ascii(self) -> None:
+        r"""The pattern is ASCII-only; a `\w`-based regex would wrongly accept."""
+        assert not is_valid_package_name("foöbar")
+
+    def test_rejects_empty(self) -> None:
+        assert not is_valid_package_name("")
+
+
+class TestEditablePackageHint:
+    """`editable_package_hint` names the package without a raw `uv` command."""
+
+    def test_names_package_without_uv_command(self) -> None:
+        hint = editable_package_hint("langchain-custom")
+        assert "langchain-custom" in hint
+        # We intentionally don't surface raw `uv tool` commands to the user.
+        assert "uv tool" not in hint
+
+
+class TestPerformInstallPackage:
+    """`perform_install_package` execution paths."""
+
+    async def test_editable_install_refuses(self) -> None:
+        """Editable installs cannot accept packages via uv tool install."""
+        with patch(
+            "deepagents_code.update_check.detect_install_method",
+            return_value="unknown",
+        ):
+            success, output = await perform_install_package("langchain-custom")
+        assert success is False
+        assert "Editable install" in output
+        assert "langchain-custom" in output
+        # No raw `uv tool` command is surfaced to the user.
+        assert "uv tool" not in output
+
+    async def test_brew_install_refuses(self) -> None:
+        """Homebrew formula can't add packages to the tool env."""
+        with patch(
+            "deepagents_code.update_check.detect_install_method",
+            return_value="brew",
+        ):
+            success, output = await perform_install_package("langchain-custom")
+        assert success is False
+        assert "Homebrew" in output
+
+    async def test_other_install_refuses(self) -> None:
+        """Unknown non-editable installs cannot be updated through uv tool."""
+        with patch(
+            "deepagents_code.update_check.detect_install_method",
+            return_value="other",
+        ):
+            success, output = await perform_install_package("langchain-custom")
+        assert success is False
+        assert "Unsupported install method" in output
+
+    async def test_invalid_package_refuses_before_detecting_install(self) -> None:
+        """Malformed package names must never reach command construction."""
+        with patch(
+            "deepagents_code.update_check.detect_install_method",
+        ) as detect:
+            success, output = await perform_install_package("custom; echo nope")
+        assert success is False
+        assert "Invalid package name" in output
+        detect.assert_not_called()
+
+    async def test_uv_install_runs(self, tmp_path) -> None:
+        """`uv` method runs the subprocess and returns success."""
+        log_path = tmp_path / "install.log"
+        # Inject a no-op command in place of the real uv tool install so the
+        # subprocess actually exits 0 without touching the environment.
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.update_check.shutil.which",
+                return_value="/usr/bin/uv",
+            ),
+            patch(
+                "deepagents_code.update_check.install_package_command",
+                return_value="printf 'ok\\n'",
+            ),
+        ):
+            success, output = await perform_install_package(
+                "langchain-custom", log_path=log_path
+            )
+        assert success is True
+        assert output == "ok"
+
+    async def test_uv_missing_returns_actionable_error(self) -> None:
+        """When `uv` is not on PATH, surface a clear error before exec."""
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.update_check.shutil.which",
+                return_value=None,
+            ),
+        ):
+            success, output = await perform_install_package("langchain-custom")
         assert success is False
         assert "uv" in output
         assert "not found" in output


### PR DESCRIPTION
A provider's API key and its endpoint (`base_url`) are a coupled pair: a gateway's API key typically only authenticates against that specific gateway. A provider-native key only against the provider's own API.

Previously the two resolved through independent paths — keys honored `/auth`, the `DEEPAGENTS_CODE_` prefix, and env vars, while `base_url` came only from `config.toml` or whatever the provider SDK happened to read from the environment. Overriding just the key (e.g. entering a personal key in `/auth` on a machine provisioned with a model gateway) left the gateway `base_url` in place, so the key shipped to the wrong endpoint and could fail with an opaque error message.

This makes the key and endpoint resolve and apply together. It also adds `/install <pkg> --package`, an escape hatch for providers whose package isn't a bundled extra.

## Changes
- `/auth` now stores an optional `base_url` alongside the key. `set_stored_key` takes a `base_url` param and `get_stored_base_url` reads it back; `ApiKeyCredential.base_url` is a new (non-secret, backward-compatible) field, and legacy entries written before it read cleanly as `base_url=None`.
- `apply_stored_credentials` applies the key and endpoint atomically via `_apply_stored_base_url`, which writes the canonical base-URL env var and **clears every alternate name** a provider's SDK might read (e.g. both `OPENAI_API_BASE` and `OPENAI_BASE_URL`). A stored key with a blank URL clears any inherited gateway endpoint so it falls back to the provider default rather than a leftover value.
- `PROVIDER_BASE_URL_ENV` registers base-URL env vars (canonical name first) for ~16 providers — `anthropic`, `openai`, `google_genai`, `azure_openai`, `cohere`, `groq`, `mistralai`, `xai`, etc. OpenAI-compatible providers deliberately omit the shared `OPENAI_BASE_URL`. A `base_url_env` `ProviderConfig` field (parallel to `api_key_env`) lets an out-of-registry provider declare its own endpoint variable.
- `ModelConfig.get_base_url` resolution order is now: (1) `config.toml` literal `base_url`; (2) the provider's base-URL env var via `resolve_env_var`, so a `DEEPAGENTS_CODE_*` override beats the plain name and the gateway-provisioned URL is honored in the default case; (3) the stored `/auth` endpoint, for providers with no base-URL env var. A corrupt credential store resolves to "no endpoint" rather than raising.
- The `/auth` modal gains an optional base-URL `Input` with a three-tier hint (surviving `DEEPAGENTS_CODE_*` var → provider's endpoint var → generic default), and `on_input_submitted` saves the key/URL pair from Enter in either field. `action_cursor_up` lets Shift+Tab cycle back from the new field.
- Add `/install <pkg> --package` (TUI, via `_handle_install_package`) and `dcode --install <pkg> --package` (headless), running `uv tool install -U deepagents-code --with <pkg>` for providers outside the curated extras. Package names are validated against a PEP 508 pattern and `shlex.quote`-d as defense in depth; editable, Homebrew, and uv-less installs are refused with actionable hints; `--force`/`--yes` is required since arbitrary packages have no allowlist.