### PR TITLE
fix(code): unify auth status labels

### DIFF
--- a/libs/code/deepagents_code/auth_display.py
+++ b/libs/code/deepagents_code/auth_display.py
@@ -1,0 +1,156 @@
+"""Shared provider auth status formatting."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, assert_never, overload
+
+from textual.content import Content
+
+from deepagents_code.model_config import (
+    ProviderAuthSource,
+    ProviderAuthState,
+    ProviderAuthStatus,
+    resolved_env_var_name,
+)
+
+if TYPE_CHECKING:
+    from deepagents_code.config import Glyphs
+
+AuthStatusStyle = Literal["auth", "model"]
+
+
+@overload
+def format_auth_status(
+    status: ProviderAuthStatus,
+    *,
+    style: Literal["auth"],
+    glyphs: Glyphs | None = None,
+) -> Content: ...
+
+
+@overload
+def format_auth_status(
+    status: ProviderAuthStatus,
+    *,
+    style: Literal["model"],
+    glyphs: Glyphs,
+) -> str: ...
+
+
+def format_auth_status(
+    status: ProviderAuthStatus,
+    *,
+    style: AuthStatusStyle,
+    glyphs: Glyphs | None = None,
+) -> Content | str:
+    """Format provider auth status for a UI surface.
+
+    Args:
+        status: Provider auth/readiness status.
+        style: UI surface vocabulary to render.
+        glyphs: Glyph table required for the model selector style.
+
+    Returns:
+        A status label in the selected surface style.
+
+    Raises:
+        ValueError: If model selector style is requested without glyphs.
+    """
+    if style == "auth":
+        return _format_auth_manager_status(status)
+    if glyphs is None:
+        msg = "glyphs are required for model auth status formatting"
+        raise ValueError(msg)
+    return _format_model_selector_status(status, glyphs)
+
+
+def _auth_badge(detail: str, *, prefix: str = "") -> Content:
+    """Format a muted auth manager badge.
+
+    Args:
+        detail: Badge text inside the brackets.
+        prefix: Text to prepend inside the brackets.
+
+    Returns:
+        Formatted auth manager badge content.
+    """
+    return Content.assemble(
+        ("[", "$text-muted"),
+        (prefix, "$text-muted"),
+        Content.styled(detail, "$text-muted"),
+        ("]", "$text-muted"),
+    )
+
+
+def _format_auth_manager_status(status: ProviderAuthStatus) -> Content:
+    """Format an auth manager badge.
+
+    Args:
+        status: Provider auth/readiness status.
+
+    Returns:
+        Formatted auth manager badge content.
+
+    Raises:
+        ValueError: If a configured status has an unsupported source.
+    """
+    state = status.state
+    match state:
+        case ProviderAuthState.CONFIGURED:
+            if status.source is ProviderAuthSource.STORED:
+                return Content.styled("[stored]", "bold $success")
+            if status.source is ProviderAuthSource.ENV:
+                if status.env_var:
+                    return Content.assemble(
+                        ("[env: ", "$text-muted"),
+                        Content.styled(
+                            resolved_env_var_name(status.env_var), "$text-muted"
+                        ),
+                        ("]", "$text-muted"),
+                    )
+                return Content.styled("[env]", "$text-muted")
+            msg = f"Unsupported configured auth source: {status.source!r}"
+            raise ValueError(msg)
+        case ProviderAuthState.MISSING:
+            return Content.styled("[missing]", "bold $warning")
+        case ProviderAuthState.NOT_REQUIRED:
+            return _auth_badge(status.detail or "no API key required")
+        case ProviderAuthState.IMPLICIT:
+            return _auth_badge(status.detail or "implicit auth")
+        case ProviderAuthState.MANAGED:
+            return _auth_badge(status.detail or "custom auth")
+        case ProviderAuthState.UNKNOWN:
+            return _auth_badge(status.detail or "credentials unknown", prefix="? ")
+        case _:
+            assert_never(state)
+
+
+def _format_model_selector_status(status: ProviderAuthStatus, glyphs: Glyphs) -> str:
+    """Format a model selector provider-header indicator.
+
+    Args:
+        status: Provider auth/readiness status.
+        glyphs: Glyph table for the active terminal mode.
+
+    Returns:
+        Text shown next to the provider name.
+    """
+    state = status.state
+    match state:
+        case ProviderAuthState.CONFIGURED:
+            return ""
+        case ProviderAuthState.MISSING:
+            if status.env_var:
+                return f"{glyphs.warning} missing {status.env_var}"
+            return f"{glyphs.warning} missing credentials"
+        case ProviderAuthState.NOT_REQUIRED:
+            return status.detail or "no API key required"
+        case ProviderAuthState.IMPLICIT:
+            return status.detail or "implicit auth"
+        case ProviderAuthState.MANAGED:
+            return status.detail or "custom auth"
+        case ProviderAuthState.UNKNOWN:
+            detail = status.detail or "credentials unknown"
+            return f"{glyphs.question} {detail}"
+        case _:
+            assert_never(state)

--- a/libs/code/deepagents_code/auth_display.py
+++ b/libs/code/deepagents_code/auth_display.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, assert_never, overload
+from typing import TYPE_CHECKING, assert_never
 
 from textual.content import Content
 
@@ -16,101 +16,23 @@ from deepagents_code.model_config import (
 if TYPE_CHECKING:
     from deepagents_code.config import Glyphs
 
-AuthStatusStyle = Literal["auth", "model"]
 
+def format_auth_badge(status: ProviderAuthStatus) -> Content:
+    """Format an auth manager badge for a provider.
 
-@overload
-def format_auth_status(
-    status: ProviderAuthStatus,
-    *,
-    style: Literal["auth"],
-    glyphs: Glyphs | None = None,
-) -> Content: ...
-
-
-@overload
-def format_auth_status(
-    status: ProviderAuthStatus,
-    *,
-    style: Literal["model"],
-    glyphs: Glyphs,
-) -> str: ...
-
-
-def format_auth_status(
-    status: ProviderAuthStatus,
-    *,
-    style: AuthStatusStyle,
-    glyphs: Glyphs | None = None,
-) -> Content | str:
-    """Format provider auth status for a UI surface.
-
-    Args:
-        status: Provider auth/readiness status.
-        style: UI surface vocabulary to render.
-        glyphs: Glyph table required for the model selector style.
-
-    Returns:
-        A status label in the selected surface style.
-
-    Raises:
-        ValueError: If model selector style is requested without glyphs.
-    """
-    if style == "auth":
-        return _format_auth_manager_status(status)
-    if glyphs is None:
-        msg = "glyphs are required for model auth status formatting"
-        raise ValueError(msg)
-    return _format_model_selector_status(status, glyphs)
-
-
-def _auth_badge(detail: str, *, prefix: str = "") -> Content:
-    """Format a muted auth manager badge.
-
-    Args:
-        detail: Badge text inside the brackets.
-        prefix: Text to prepend inside the brackets.
-
-    Returns:
-        Formatted auth manager badge content.
-    """
-    return Content.assemble(
-        ("[", "$text-muted"),
-        (prefix, "$text-muted"),
-        Content.styled(detail, "$text-muted"),
-        ("]", "$text-muted"),
-    )
-
-
-def _format_auth_manager_status(status: ProviderAuthStatus) -> Content:
-    """Format an auth manager badge.
+    Used by the `/auth` manager, where each provider renders a bracketed,
+    styled badge (e.g. `[stored]`, `[env: ANTHROPIC_API_KEY]`, `[missing]`).
 
     Args:
         status: Provider auth/readiness status.
 
     Returns:
-        Formatted auth manager badge content.
-
-    Raises:
-        ValueError: If a configured status has an unsupported source.
+        A styled badge `Content` for the auth manager surface.
     """
     state = status.state
     match state:
         case ProviderAuthState.CONFIGURED:
-            if status.source is ProviderAuthSource.STORED:
-                return Content.styled("[stored]", "bold $success")
-            if status.source is ProviderAuthSource.ENV:
-                if status.env_var:
-                    return Content.assemble(
-                        ("[env: ", "$text-muted"),
-                        Content.styled(
-                            resolved_env_var_name(status.env_var), "$text-muted"
-                        ),
-                        ("]", "$text-muted"),
-                    )
-                return Content.styled("[env]", "$text-muted")
-            msg = f"Unsupported configured auth source: {status.source!r}"
-            raise ValueError(msg)
+            return _format_configured_badge(status)
         case ProviderAuthState.MISSING:
             return Content.styled("[missing]", "bold $warning")
         case ProviderAuthState.NOT_REQUIRED:
@@ -125,15 +47,20 @@ def _format_auth_manager_status(status: ProviderAuthStatus) -> Content:
             assert_never(state)
 
 
-def _format_model_selector_status(status: ProviderAuthStatus, glyphs: Glyphs) -> str:
+def format_auth_indicator(status: ProviderAuthStatus, glyphs: Glyphs) -> str:
     """Format a model selector provider-header indicator.
+
+    Used by `/model`, where the indicator is plain text shown next to the
+    provider name. Returns an empty string for `CONFIGURED` providers, which
+    need no indicator.
 
     Args:
         status: Provider auth/readiness status.
         glyphs: Glyph table for the active terminal mode.
 
     Returns:
-        Text shown next to the provider name.
+        Text shown next to the provider name, or an empty string when no
+            indicator should be rendered (e.g., `CONFIGURED`).
     """
     state = status.state
     match state:
@@ -154,3 +81,57 @@ def _format_model_selector_status(status: ProviderAuthStatus, glyphs: Glyphs) ->
             return f"{glyphs.question} {detail}"
         case _:
             assert_never(state)
+
+
+def _auth_badge(detail: str, *, prefix: str = "") -> Content:
+    """Format a muted auth manager badge.
+
+    Args:
+        detail: Badge text inside the brackets.
+        prefix: Text prepended verbatim before `detail` inside the brackets.
+            Callers include any separator themselves (e.g. `"? "`); this
+            helper does not insert one.
+
+    Returns:
+        Formatted auth manager badge content.
+    """
+    return Content.assemble(
+        ("[", "$text-muted"),
+        (prefix, "$text-muted"),
+        Content.styled(detail, "$text-muted"),
+        ("]", "$text-muted"),
+    )
+
+
+def _format_configured_badge(status: ProviderAuthStatus) -> Content:
+    """Format the auth manager badge for a `CONFIGURED` provider.
+
+    Args:
+        status: A `CONFIGURED` provider auth status.
+
+    Returns:
+        A styled badge naming the credential source (`[stored]` or `[env: …]`).
+
+    Raises:
+        ValueError: If the status carries no source. `ProviderAuthStatus`
+            guarantees `CONFIGURED` implies a source, so this guards against
+            that invariant being violated rather than a normal input.
+    """
+    match status.source:
+        case ProviderAuthSource.STORED:
+            return Content.styled("[stored]", "bold $success")
+        case ProviderAuthSource.ENV:
+            if status.env_var:
+                return Content.assemble(
+                    ("[env: ", "$text-muted"),
+                    Content.styled(
+                        resolved_env_var_name(status.env_var), "$text-muted"
+                    ),
+                    ("]", "$text-muted"),
+                )
+            return Content.styled("[env]", "$text-muted")
+        case None:
+            msg = f"CONFIGURED auth status has no source: {status!r}"
+            raise ValueError(msg)
+        case _:
+            assert_never(status.source)

--- a/libs/code/deepagents_code/widgets/auth.py
+++ b/libs/code/deepagents_code/widgets/auth.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from textual.events import Click
 
 from deepagents_code import auth_store, theme
-from deepagents_code.auth_display import format_auth_status
+from deepagents_code.auth_display import format_auth_badge
 from deepagents_code.config import get_glyphs, is_ascii_mode
 from deepagents_code.model_config import (
     PROVIDER_API_KEY_ENV,
@@ -670,7 +670,7 @@ class AuthManagerScreen(ModalScreen[None]):
             A composed `Content` with the provider name and a status badge.
         """
         status = get_provider_auth_status(provider)
-        badge = format_auth_status(status, style="auth")
+        badge = format_auth_badge(status)
         return Content.assemble(
             Content.from_markup("$provider", provider=provider),
             "  ",

--- a/libs/code/deepagents_code/widgets/auth.py
+++ b/libs/code/deepagents_code/widgets/auth.py
@@ -35,19 +35,18 @@ if TYPE_CHECKING:
     from textual.events import Click
 
 from deepagents_code import auth_store, theme
+from deepagents_code.auth_display import format_auth_status
 from deepagents_code.config import get_glyphs, is_ascii_mode
 from deepagents_code.model_config import (
     PROVIDER_API_KEY_ENV,
     PROVIDERS_DOCS_URL as _PROVIDERS_DOCS_URL,
     ModelConfig,
-    ProviderAuthSource,
     clear_caches,
     get_available_models,
     get_base_url_env_var,
     get_credential_env_var,
     get_default_base_url_env,
     get_provider_auth_status,
-    resolved_env_var_name,
 )
 from deepagents_code.widgets._links import open_style_link
 
@@ -671,20 +670,7 @@ class AuthManagerScreen(ModalScreen[None]):
             A composed `Content` with the provider name and a status badge.
         """
         status = get_provider_auth_status(provider)
-        env_var = status.env_var or get_credential_env_var(provider) or ""
-        if status.source is ProviderAuthSource.STORED:
-            badge = Content.styled("[stored]", "bold $success")
-        elif status.source is ProviderAuthSource.ENV:
-            if env_var:
-                badge = Content.assemble(
-                    ("[env: ", "$text-muted"),
-                    Content.styled(resolved_env_var_name(env_var), "$text-muted"),
-                    ("]", "$text-muted"),
-                )
-            else:
-                badge = Content.styled("[env]", "$text-muted")
-        else:
-            badge = Content.styled("[missing]", "bold $warning")
+        badge = format_auth_status(status, style="auth")
         return Content.assemble(
             Content.from_markup("$provider", provider=provider),
             "  ",

--- a/libs/code/deepagents_code/widgets/model_selector.py
+++ b/libs/code/deepagents_code/widgets/model_selector.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, ClassVar, assert_never
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from textual.binding import Binding, BindingType
 from textual.containers import Container, Vertical, VerticalScroll
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from textual.app import ComposeResult
 
 from deepagents_code import theme
+from deepagents_code.auth_display import format_auth_status
 from deepagents_code.config import Glyphs, get_glyphs, is_ascii_mode
 from deepagents_code.model_config import (
     ModelConfig,
@@ -915,25 +916,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             Text shown next to the provider name, or an empty string when no
                 indicator should be rendered (e.g., `CONFIGURED`).
         """
-        state = auth_status.state
-        match state:
-            case ProviderAuthState.CONFIGURED:
-                return ""
-            case ProviderAuthState.MISSING:
-                if auth_status.env_var:
-                    return f"{glyphs.warning} missing {auth_status.env_var}"
-                return f"{glyphs.warning} missing credentials"
-            case ProviderAuthState.NOT_REQUIRED:
-                return auth_status.detail or "no API key required"
-            case ProviderAuthState.IMPLICIT:
-                return auth_status.detail or "implicit auth"
-            case ProviderAuthState.MANAGED:
-                return auth_status.detail or "custom auth"
-            case ProviderAuthState.UNKNOWN:
-                detail = auth_status.detail or "credentials unknown"
-                return f"{glyphs.question} {detail}"
-            case _:
-                assert_never(state)
+        return format_auth_status(auth_status, style="model", glyphs=glyphs)
 
     @staticmethod
     def _format_option_label(

--- a/libs/code/deepagents_code/widgets/model_selector.py
+++ b/libs/code/deepagents_code/widgets/model_selector.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from textual.app import ComposeResult
 
 from deepagents_code import theme
-from deepagents_code.auth_display import format_auth_status
+from deepagents_code.auth_display import format_auth_indicator
 from deepagents_code.config import Glyphs, get_glyphs, is_ascii_mode
 from deepagents_code.model_config import (
     ModelConfig,
@@ -916,7 +916,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
             Text shown next to the provider name, or an empty string when no
                 indicator should be rendered (e.g., `CONFIGURED`).
         """
-        return format_auth_status(auth_status, style="model", glyphs=glyphs)
+        return format_auth_indicator(auth_status, glyphs)
 
     @staticmethod
     def _format_option_label(

--- a/libs/code/tests/unit_tests/test_auth_display.py
+++ b/libs/code/tests/unit_tests/test_auth_display.py
@@ -1,0 +1,152 @@
+"""Tests for shared auth status rendering."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+from deepagents_code import model_config
+from deepagents_code.auth_display import format_auth_status
+from deepagents_code.config import get_glyphs
+from deepagents_code.model_config import (
+    ProviderAuthSource,
+    ProviderAuthState,
+    ProviderAuthStatus,
+    get_provider_auth_status,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_model_caches() -> Iterator[None]:
+    """Clear module-level model config caches around each test."""
+    model_config.clear_caches()
+    yield
+    model_config.clear_caches()
+
+
+@pytest.fixture
+def isolated_model_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point config and credential state at temporary paths."""
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config_path)
+    monkeypatch.setattr(model_config, "DEFAULT_STATE_DIR", tmp_path / ".state")
+
+
+_AUTH_STATUS_CASES = [
+    (
+        ProviderAuthStatus(
+            state=ProviderAuthState.CONFIGURED,
+            provider="anthropic",
+            env_var="ANTHROPIC_API_KEY",
+            source=ProviderAuthSource.ENV,
+        ),
+        "[env: ANTHROPIC_API_KEY]",
+        "",
+    ),
+    (
+        ProviderAuthStatus(
+            state=ProviderAuthState.MISSING,
+            provider="anthropic",
+            env_var="ANTHROPIC_API_KEY",
+        ),
+        "[missing]",
+        f"{get_glyphs().warning} missing ANTHROPIC_API_KEY",
+    ),
+    (
+        ProviderAuthStatus(
+            state=ProviderAuthState.NOT_REQUIRED,
+            provider="ollama",
+            detail="local provider",
+        ),
+        "[local provider]",
+        "local provider",
+    ),
+    (
+        ProviderAuthStatus(
+            state=ProviderAuthState.IMPLICIT,
+            provider="google_vertexai",
+            env_var="GOOGLE_CLOUD_PROJECT",
+            detail="implicit auth",
+        ),
+        "[implicit auth]",
+        "implicit auth",
+    ),
+    (
+        ProviderAuthStatus(
+            state=ProviderAuthState.MANAGED,
+            provider="custom",
+            detail="custom auth",
+        ),
+        "[custom auth]",
+        "custom auth",
+    ),
+    (
+        ProviderAuthStatus(
+            state=ProviderAuthState.UNKNOWN,
+            provider="unknown",
+            detail="credentials unknown",
+        ),
+        "[? credentials unknown]",
+        f"{get_glyphs().question} credentials unknown",
+    ),
+]
+
+
+@pytest.mark.parametrize(("status", "auth_label", "model_label"), _AUTH_STATUS_CASES)
+def test_format_auth_status_covers_all_states(
+    status: ProviderAuthStatus, auth_label: str, model_label: str
+) -> None:
+    """Both UI styles render every provider auth state from the shared helper."""
+    assert str(format_auth_status(status, style="auth")) == auth_label
+    assert format_auth_status(status, style="model", glyphs=get_glyphs()) == model_label
+
+
+def test_auth_style_formats_stored_credentials() -> None:
+    """The auth manager keeps its stored-credential badge."""
+    status = ProviderAuthStatus(
+        state=ProviderAuthState.CONFIGURED,
+        provider="openai",
+        env_var="OPENAI_API_KEY",
+        source=ProviderAuthSource.STORED,
+    )
+
+    assert str(format_auth_status(status, style="auth")) == "[stored]"
+
+
+def test_auth_style_uses_resolved_env_var_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The auth manager names the env var that wins resolution."""
+    monkeypatch.setenv("OPENAI_API_KEY", "canonical")
+    monkeypatch.setenv("DEEPAGENTS_CODE_OPENAI_API_KEY", "prefixed")
+    status = ProviderAuthStatus(
+        state=ProviderAuthState.CONFIGURED,
+        provider="openai",
+        env_var="OPENAI_API_KEY",
+        source=ProviderAuthSource.ENV,
+    )
+
+    label = str(format_auth_status(status, style="auth"))
+
+    assert label == "[env: DEEPAGENTS_CODE_OPENAI_API_KEY]"
+
+
+@pytest.mark.usefixtures("isolated_model_config")
+def test_vertex_adc_path_renders_implicit_not_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Vertex AI without env credentials uses implicit ADC auth labels."""
+    monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+    monkeypatch.delenv("DEEPAGENTS_CODE_GOOGLE_CLOUD_PROJECT", raising=False)
+    status = get_provider_auth_status("google_vertexai")
+
+    assert status.state is ProviderAuthState.IMPLICIT
+    assert status.env_var == "GOOGLE_CLOUD_PROJECT"
+    assert str(format_auth_status(status, style="auth")) == "[implicit auth]"
+    assert (
+        format_auth_status(status, style="model", glyphs=get_glyphs())
+        == "implicit auth"
+    )

--- a/libs/code/tests/unit_tests/test_auth_display.py
+++ b/libs/code/tests/unit_tests/test_auth_display.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from deepagents_code import model_config
-from deepagents_code.auth_display import format_auth_status
+from deepagents_code.auth_display import format_auth_badge, format_auth_indicator
 from deepagents_code.config import get_glyphs
 from deepagents_code.model_config import (
     ProviderAuthSource,
@@ -98,15 +98,15 @@ _AUTH_STATUS_CASES = [
 
 
 @pytest.mark.parametrize(("status", "auth_label", "model_label"), _AUTH_STATUS_CASES)
-def test_format_auth_status_covers_all_states(
+def test_format_auth_covers_all_states(
     status: ProviderAuthStatus, auth_label: str, model_label: str
 ) -> None:
-    """Both UI styles render every provider auth state from the shared helper."""
-    assert str(format_auth_status(status, style="auth")) == auth_label
-    assert format_auth_status(status, style="model", glyphs=get_glyphs()) == model_label
+    """Both UI surfaces render every provider auth state."""
+    assert format_auth_badge(status).plain == auth_label
+    assert format_auth_indicator(status, get_glyphs()) == model_label
 
 
-def test_auth_style_formats_stored_credentials() -> None:
+def test_auth_badge_formats_stored_credentials() -> None:
     """The auth manager keeps its stored-credential badge."""
     status = ProviderAuthStatus(
         state=ProviderAuthState.CONFIGURED,
@@ -115,10 +115,22 @@ def test_auth_style_formats_stored_credentials() -> None:
         source=ProviderAuthSource.STORED,
     )
 
-    assert str(format_auth_status(status, style="auth")) == "[stored]"
+    assert format_auth_badge(status).plain == "[stored]"
 
 
-def test_auth_style_uses_resolved_env_var_name(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_auth_badge_env_source_without_var() -> None:
+    """An ENV-source status with no env var falls back to a bare `[env]` badge."""
+    status = ProviderAuthStatus(
+        state=ProviderAuthState.CONFIGURED,
+        provider="openai",
+        env_var=None,
+        source=ProviderAuthSource.ENV,
+    )
+
+    assert format_auth_badge(status).plain == "[env]"
+
+
+def test_auth_badge_uses_resolved_env_var_name(monkeypatch: pytest.MonkeyPatch) -> None:
     """The auth manager names the env var that wins resolution."""
     monkeypatch.setenv("OPENAI_API_KEY", "canonical")
     monkeypatch.setenv("DEEPAGENTS_CODE_OPENAI_API_KEY", "prefixed")
@@ -129,9 +141,35 @@ def test_auth_style_uses_resolved_env_var_name(monkeypatch: pytest.MonkeyPatch) 
         source=ProviderAuthSource.ENV,
     )
 
-    label = str(format_auth_status(status, style="auth"))
+    assert format_auth_badge(status).plain == "[env: DEEPAGENTS_CODE_OPENAI_API_KEY]"
 
-    assert label == "[env: DEEPAGENTS_CODE_OPENAI_API_KEY]"
+
+def _badge_styles(status: ProviderAuthStatus) -> str:
+    """Return the concatenated span styles of a provider's auth badge."""
+    return " ".join(span.style or "" for span in format_auth_badge(status).spans)
+
+
+def test_missing_badge_carries_warning_style() -> None:
+    """A missing-credential badge is styled as a warning, not muted text."""
+    status = ProviderAuthStatus(
+        state=ProviderAuthState.MISSING,
+        provider="anthropic",
+        env_var="ANTHROPIC_API_KEY",
+    )
+
+    assert "$warning" in _badge_styles(status)
+
+
+def test_stored_badge_carries_success_style() -> None:
+    """A stored-credential badge is styled as a success, not muted text."""
+    status = ProviderAuthStatus(
+        state=ProviderAuthState.CONFIGURED,
+        provider="openai",
+        env_var="OPENAI_API_KEY",
+        source=ProviderAuthSource.STORED,
+    )
+
+    assert "$success" in _badge_styles(status)
 
 
 @pytest.mark.usefixtures("isolated_model_config")
@@ -145,8 +183,5 @@ def test_vertex_adc_path_renders_implicit_not_missing(
 
     assert status.state is ProviderAuthState.IMPLICIT
     assert status.env_var == "GOOGLE_CLOUD_PROJECT"
-    assert str(format_auth_status(status, style="auth")) == "[implicit auth]"
-    assert (
-        format_auth_status(status, style="model", glyphs=get_glyphs())
-        == "implicit auth"
-    )
+    assert format_auth_badge(status).plain == "[implicit auth]"
+    assert format_auth_indicator(status, get_glyphs()) == "implicit auth"

--- a/libs/code/tests/unit_tests/test_auth_display.py
+++ b/libs/code/tests/unit_tests/test_auth_display.py
@@ -146,7 +146,7 @@ def test_auth_badge_uses_resolved_env_var_name(monkeypatch: pytest.MonkeyPatch) 
 
 def _badge_styles(status: ProviderAuthStatus) -> str:
     """Return the concatenated span styles of a provider's auth badge."""
-    return " ".join(span.style or "" for span in format_auth_badge(status).spans)
+    return " ".join(str(span.style or "") for span in format_auth_badge(status).spans)
 
 
 def test_missing_badge_carries_warning_style() -> None:


### PR DESCRIPTION
## Description
Unifies provider auth status labels through one helper so `/auth` and `/model` interpret `CONFIGURED`, `MISSING`, `NOT_REQUIRED`, `IMPLICIT`, `MANAGED`, and `UNKNOWN` consistently. This fixes implicit auth providers such as Vertex AI rendering as missing in `/auth`.

## Release Note
Fix `/auth` provider labels for implicit, local/no-auth, managed, and unknown credential states.

## Test Plan
- [x] Added unit coverage for both auth-label styles and the Vertex implicit ADC regression.

Made by [Open SWE](https://openswe.vercel.app)