### PR TITLE
feat(quickjs): introduce interpreter extensions

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/__init__.py
+++ b/libs/partners/quickjs/langchain_quickjs/__init__.py
@@ -1,5 +1,13 @@
 """langchain-quickjs: persistent JS REPL middleware for agents."""
 
+from quickjs_rs import ModuleScope
+
+from langchain_quickjs._extensions import (
+    ExtensionContext,
+    ExtensionError,
+    HostFunction,
+    InterpreterExtension,
+)
 from langchain_quickjs._ptc import PTCOption
 from langchain_quickjs._swarm_task import (
     SwarmSubAgent,
@@ -11,6 +19,11 @@ from langchain_quickjs.middleware import CodeInterpreterMiddleware
 
 __all__ = [
     "CodeInterpreterMiddleware",
+    "ExtensionContext",
+    "ExtensionError",
+    "HostFunction",
+    "InterpreterExtension",
+    "ModuleScope",
     "PTCOption",
     "SwarmSubAgent",
     "SwarmTaskMode",

--- a/libs/partners/quickjs/langchain_quickjs/_extensions.py
+++ b/libs/partners/quickjs/langchain_quickjs/_extensions.py
@@ -1,0 +1,297 @@
+"""Interpreter extensions for ``CodeInterpreterMiddleware``.
+
+An *extension* is a reusable unit that wires capability into the QuickJS
+interpreter: JS modules the guest imports, host (FFI) functions backed by
+Python callables, install-time setup eval, and a system-prompt fragment.
+Both are optional, but an extension must implement at least one of two
+lifecycle hooks:
+
+- ``on_setup(ctx)`` — runs once per context creation (every turn under
+  ``snapshot_between_turns``, since the middleware rebuilds the context).
+  Register modules, stateless host functions, and run setup eval here.
+- ``on_eval(ctx, runtime)`` — runs at the start of every eval, with that
+  eval's ``ToolRuntime``. Re-register host functions that close over
+  fresh per-eval scratch here; re-registering a symbol overwrites it.
+
+This module defines the public ``InterpreterExtension`` Protocol and the
+``ExtensionContext`` an extension registers against. The wiring that calls
+the hooks lives on ``_ThreadREPL`` / the middleware.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Protocol, overload, runtime_checkable
+
+from langchain_quickjs._ptc import is_valid_js_identifier
+
+if TYPE_CHECKING:
+    from deepagents.backends.protocol import BackendProtocol
+    from langgraph.prebuilt import ToolRuntime
+    from quickjs_rs import Context, ModuleScope, Runtime
+
+# A host function is a sync or async Python callable invoked from inside
+# QuickJS. It receives the guest's arguments (already coerced to Python
+# values) and returns a JSON-serializable result. Installed via
+# ``Context.register(symbol, fn, is_async=...)``.
+HostFunction = Callable[..., Any | Awaitable[Any]]
+
+
+class ExtensionError(RuntimeError):
+    """Raised when an extension does something invalid.
+
+    Covers an invalid JS identifier and the at-least-one-hook check.
+    Surfaced at the point of failure so the traceback names the offending
+    extension.
+    """
+
+
+class ExtensionContext:
+    """The interpreter-wiring handle passed to an extension's hooks.
+
+    Constructed per ``_ThreadREPL`` (i.e. per context creation) and bound
+    to that REPL's ``quickjs_rs.Context`` and ``Runtime``.
+
+    Registration maps straight to the binding — ``module`` →
+    ``Runtime.install``, ``function`` → ``Context.register``, ``eval`` →
+    ``Context.eval``. The context object is ``!Send``, so **every method
+    here must be called on the owning worker thread**: the REPL invokes the
+    hooks from inside its worker-loop coroutines (``_ainit`` for
+    ``on_setup``, the eval driver for ``on_eval``), exactly where
+    ``_install_console`` registers the console functions. Callers off the
+    worker thread must wrap the hook invocation in ``worker.run_sync``;
+    these methods do not re-dispatch (doing so from the worker thread
+    deadlocks).
+    """
+
+    def __init__(
+        self,
+        *,
+        ctx: Context,
+        runtime: Runtime,
+        backend: BackendProtocol | None,
+    ) -> None:
+        self._ctx = ctx
+        self._runtime = runtime
+        self._backend = backend
+
+    @property
+    def backend(self) -> BackendProtocol | None:
+        """The deepagents backend.
+
+        Host functions the extension registers can close over this to reach
+        the filesystem/store. This hands the *extension* the full backend;
+        the guest never sees it — it only reaches whatever narrow surface
+        the extension re-exposes through registered host functions. May be
+        ``None`` when no backend is configured (a backend-free extension —
+        pure host functions / modules — is valid).
+        """
+        return self._backend
+
+    def module(self, scope: ModuleScope) -> None:
+        """Register JS modules the guest can import.
+
+        ``scope`` is a ``ModuleScope``: a bare import name maps to a nested
+        ``ModuleScope`` whose files include an ``index.<ext>`` entrypoint
+        (the same shape the skills loader builds). Installs onto the
+        ``Runtime`` so the name resolves as a bare import.
+        """
+        self._runtime.install(scope)
+
+    @overload
+    def function(self, fn: HostFunction, /) -> HostFunction: ...
+    @overload
+    def function(
+        self, *, name: str | None = ..., is_async: bool | None = ...
+    ) -> Callable[[HostFunction], HostFunction]: ...
+    def function(
+        self,
+        fn: HostFunction | None = None,
+        *,
+        name: str | None = None,
+        is_async: bool | None = None,
+    ) -> Any:
+        """Decorator that registers a Python callable as an FFI host function.
+
+        Bare (``@ctx.function``) infers the symbol from ``fn.__name__``.
+        Parameterized (``@ctx.function(name="__x")``) sets it explicitly.
+        ``is_async=None`` (default) lets the binding infer from whether the
+        callable is a coroutine function. Returns the original callable
+        unchanged, so the extension can still call it from Python.
+
+        The symbol lands in one global scope shared by every extension and
+        the guest, so a repeat symbol overwrites the prior registration
+        (last write wins, matching ``Context.register``). Use a distinctive
+        prefix — ``__<ext>_<name>`` — to avoid clobbering another
+        extension. Raises ``ExtensionError`` only if the symbol fails
+        ``is_valid_js_identifier``.
+        """
+
+        def _register(func: HostFunction) -> HostFunction:
+            symbol = name if name is not None else getattr(func, "__name__", None)
+            if not symbol or not is_valid_js_identifier(symbol):
+                msg = (
+                    f"host-function symbol {symbol!r} is not a valid JS "
+                    "identifier (/^[A-Za-z_$][A-Za-z0-9_$]*$/)"
+                )
+                raise ExtensionError(msg)
+            self._ctx.register(symbol, func, is_async=is_async)
+            return func
+
+        # Bare ``@ctx.function`` — called with the function directly.
+        if fn is not None:
+            return _register(fn)
+        return _register
+
+    def eval(self, script: str) -> Any:
+        """Evaluate ``script`` against the context, now, and return its value.
+
+        Wire registered host symbols into idiomatic globals — the move the
+        REPL makes for ``globalThis.console`` / ``globalThis.tools``. A
+        setup eval *assigns* host symbols into a global object; it does not
+        *await* a host function, so the synchronous ``Context.eval`` is the
+        right call here (and is what ``_install_console`` uses).
+
+        The completion value is marshaled back to Python; a non-marshalable
+        return (e.g. a JS object) raises ``MarshalError``, which is why
+        setup evals end in ``; undefined``. ``script`` is extension-
+        authored, never guest-derived.
+        """
+        return self._ctx.eval(script)
+
+
+@runtime_checkable
+class InterpreterExtension(Protocol):
+    """A reusable unit installed into the QuickJS interpreter.
+
+    An extension declares an optional ``system_prompt`` and implements one
+    or both lifecycle hooks the middleware drives against an
+    ``ExtensionContext``. Both are optional, but an extension must
+    implement at least one — one with neither does nothing, and the
+    middleware rejects it at registration (see ``extension_hooks``).
+
+    The Protocol is ``runtime_checkable`` for ``isinstance`` convenience,
+    but the check is structural and weak — the middleware uses explicit
+    method-presence detection, not ``isinstance``, to decide which hooks
+    to call.
+    """
+
+    system_prompt: str | None
+
+    def on_setup(self, ctx: ExtensionContext) -> None:
+        """Register durable contributions, once per context creation.
+
+        Optional. Omit it if all wiring is per-eval (then implement
+        ``on_eval``).
+        """
+
+    def on_eval(self, ctx: ExtensionContext, runtime: ToolRuntime | None) -> None:
+        """Run at the start of every eval with that eval's ``ToolRuntime``.
+
+        Optional. Re-register host functions that close over fresh
+        per-eval scratch (``ctx.function`` overwrites here). Omit it if all
+        wiring is one-time (then implement ``on_setup``).
+
+        ``runtime`` is ``None`` for runtime-less evals (e.g. a bare
+        ``eval_sync`` in tests); guard for it if you read agent state.
+        """
+
+
+def has_on_setup(ext: InterpreterExtension) -> bool:
+    """Return whether ``ext`` provides its own ``on_setup`` implementation.
+
+    The Protocol carries default method bodies, so ``hasattr`` is always
+    true. We compare the bound method's underlying function against the
+    Protocol default to detect a genuine override.
+    """
+    return _overrides(ext, "on_setup")
+
+
+def has_on_eval(ext: InterpreterExtension) -> bool:
+    """Return whether ``ext`` provides its own ``on_eval`` implementation."""
+    return _overrides(ext, "on_eval")
+
+
+def _overrides(ext: object, method: str) -> bool:
+    impl = getattr(type(ext), method, None)
+    if impl is None:
+        return False
+    return impl is not getattr(InterpreterExtension, method, None)
+
+
+def validate_extension_hooks(ext: InterpreterExtension) -> None:
+    """Raise if ``ext`` implements neither lifecycle hook.
+
+    An extension with neither ``on_setup`` nor ``on_eval`` does nothing;
+    reject it at registration (fail-fast) rather than accept it silently.
+    """
+    if not has_on_setup(ext) and not has_on_eval(ext):
+        msg = (
+            f"{type(ext).__name__} implements neither on_setup nor on_eval; "
+            "an extension must implement at least one lifecycle hook"
+        )
+        raise ExtensionError(msg)
+
+
+def run_setup_hooks(
+    extensions: list[InterpreterExtension],
+    *,
+    ctx: Context,
+    runtime: Runtime,
+    backend: BackendProtocol | None,
+) -> None:
+    """Run every extension's ``on_setup`` against a fresh context.
+
+    Called by the REPL from inside ``_ainit`` — i.e. **on the worker
+    thread**, where the ``!Send`` context lives — after the console is
+    installed. One ``ExtensionContext`` is shared across all extensions.
+
+    Each extension's ``on_setup`` is plain synchronous Python; the binding
+    calls it makes (``module`` / ``function`` / ``eval``) run directly on
+    this worker thread.
+    """
+    ext_ctx = ExtensionContext(ctx=ctx, runtime=runtime, backend=backend)
+    for ext in extensions:
+        if has_on_setup(ext):
+            ext.on_setup(ext_ctx)
+
+
+def run_eval_hooks(
+    extensions: list[InterpreterExtension],
+    *,
+    ctx: Context,
+    runtime: Runtime,
+    backend: BackendProtocol | None,
+    tool_runtime: ToolRuntime | None,
+) -> None:
+    """Run every extension's ``on_eval`` at the start of an eval.
+
+    Called by the REPL from inside ``_aeval_async`` — **on the worker
+    thread**, where the ``!Send`` context lives — after per-eval state is
+    set up and before the guest code runs. Each ``on_eval`` gets
+    ``tool_runtime`` (this eval's ``ToolRuntime``); re-registering a host
+    symbol here overwrites the prior one, which is how an extension swaps
+    in a closure over fresh per-eval scratch.
+
+    ``tool_runtime`` is ``None`` for runtime-less evals (e.g. a bare
+    ``eval_sync`` in tests); extensions that read it must tolerate ``None``.
+    Exceptions propagate to ``_aeval_async``'s error handling — do not
+    swallow them here.
+    """
+    ext_ctx = ExtensionContext(ctx=ctx, runtime=runtime, backend=backend)
+    for ext in extensions:
+        if has_on_eval(ext):
+            ext.on_eval(ext_ctx, tool_runtime)
+
+
+__all__ = [
+    "ExtensionContext",
+    "ExtensionError",
+    "HostFunction",
+    "InterpreterExtension",
+    "has_on_eval",
+    "has_on_setup",
+    "run_eval_hooks",
+    "run_setup_hooks",
+    "validate_extension_hooks",
+]

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -34,6 +34,11 @@ from quickjs_rs import (
     TimeoutError as QJSTimeoutError,
 )
 
+from langchain_quickjs._extensions import (
+    InterpreterExtension,
+    run_eval_hooks,
+    run_setup_hooks,
+)
 from langchain_quickjs._format import (
     coerce_tool_output_for_ptc,
     format_handle,
@@ -347,9 +352,20 @@ class _ThreadREPL:
         capture_console: bool,
         max_stdout_chars: int,
         max_ptc_calls: int | None = 256,
+        extensions: list[InterpreterExtension] | None = None,
+        backend: BackendProtocol | None = None,
     ) -> None:
         self._worker = worker
         self._runtime = runtime
+        # Interpreter extensions and the backend their host functions read.
+        # ``on_setup`` runs in ``_ainit`` every time this REPL (and thus the
+        # context) is built — which, because the middleware evicts+rebuilds
+        # the slot each turn under ``snapshot_between_turns``, is every turn.
+        # That matches host-function lifetime: a snapshot restores the JS
+        # heap but not the Python host functions, so they must be re-
+        # registered on each fresh context — exactly as the console is.
+        self._extensions = extensions or []
+        self._backend = backend
         # The Context-level ``timeout`` is used as the cumulative budget
         # for sync evals. Async evals pass ``timeout=`` per call so each
         # call gets a fresh budget — matches what a REPL user expects,
@@ -394,6 +410,15 @@ class _ThreadREPL:
         self._ctx = self._runtime.new_context(timeout=self._per_call_timeout)
         if self._capture_console:
             self._install_console()
+        # Runs on the worker thread (we're inside it), where the !Send
+        # context lives — the same place the console functions register.
+        if self._extensions:
+            run_setup_hooks(
+                self._extensions,
+                ctx=self._require_ctx(),
+                runtime=self._runtime,
+                backend=self._backend,
+            )
 
     def _require_ctx(self) -> Context:
         """Return the live QuickJS context or raise if this REPL is closed."""
@@ -733,6 +758,20 @@ class _ThreadREPL:
             outer_loop=outer_loop,
         )
         try:
+            # Per-eval extension hooks run before the guest code, on this
+            # worker loop, with this eval's runtime. Re-registering a host
+            # symbol overwrites the prior one, so an extension can swap in a
+            # closure over fresh per-eval scratch. Inside the try so a hook
+            # error surfaces as an eval error (and the finally restores
+            # _ptc_state); the worker context means binding calls go direct.
+            if self._extensions:
+                run_eval_hooks(
+                    self._extensions,
+                    ctx=ctx,
+                    runtime=self._runtime,
+                    backend=self._backend,
+                    tool_runtime=outer_runtime,
+                )
             # Drive any final-expression Promise (e.g. a bare async
             # IIFE) to its resolved value before marshaling. Without
             # this the Promise object itself fails to marshal and
@@ -862,6 +901,8 @@ class _Registry:
     capture_console: bool
     max_stdout_chars: int
     max_ptc_calls: int | None = 256
+    extensions: list[InterpreterExtension] = field(default_factory=list)
+    backend: BackendProtocol | None = None
     _slots: dict[str, _Slot] = field(default_factory=dict)
     _lock: threading.Lock = field(default_factory=threading.Lock)
 
@@ -904,6 +945,8 @@ class _Registry:
             capture_console=self.capture_console,
             max_stdout_chars=self.max_stdout_chars,
             max_ptc_calls=self.max_ptc_calls,
+            extensions=self.extensions,
+            backend=self.backend,
         )
         return _Slot(worker=worker, runtime=runtime, repl=repl)
 

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -33,6 +33,9 @@ if TYPE_CHECKING:
     from deepagents.middleware.skills import SkillMetadata
     from langgraph.runtime import Runtime
 
+    from langchain_quickjs._extensions import InterpreterExtension
+
+from langchain_quickjs._extensions import validate_extension_hooks
 from langchain_quickjs._format import format_outcome
 from langchain_quickjs._prompt import render_repl_system_prompt
 from langchain_quickjs._ptc import (
@@ -131,6 +134,19 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
             When `None`, skill modules are not installed
             (`import(...)` fails at the resolver). This must be the
             same backend `SkillsMiddleware` uses.
+        extensions: Interpreter extensions (`InterpreterExtension`)
+            installed into the REPL. Each registers JS modules, host
+            (FFI) functions, setup eval, and/or a system-prompt fragment
+            via its `on_setup` / `on_eval` hooks. An extension must
+            implement at least one hook (validated here, fail-fast).
+            Extension `system_prompt` fragments are appended to the REPL
+            system prompt; their `on_setup` runs on every context build
+            and `on_eval` at the start of each eval.
+        backend: Optional `BackendProtocol` exposed to extensions as
+            `ctx.backend` (host functions close over it to reach the
+            filesystem/store). Defaults to `skills_backend` when unset, so
+            callers configuring only that still feed extensions. May be
+            `None` — a backend-free extension is valid.
         ptc: Programmatic tool calling — expose agent tools inside the
             REPL as `tools.<camelCase>(input) => Promise<string>`. One
             `eval` call can then orchestrate many tool calls (loops,
@@ -188,6 +204,8 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         capture_console: bool = True,
         ptc: PTCOption | None = None,
         skills_backend: "BackendProtocol | None" = None,
+        extensions: "list[InterpreterExtension] | None" = None,
+        backend: "BackendProtocol | None" = None,
         snapshot_between_turns: bool = True,
         max_snapshot_bytes: int | None = None,
     ) -> None:
@@ -207,6 +225,13 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         self._capture_console = capture_console
         self._ptc = ptc
         self._skills_backend = skills_backend
+        # Extensions: fail-fast reject any implementing neither hook. The
+        # backend their host functions read defaults to skills_backend so
+        # existing callers configuring only that still feed extensions.
+        self._extensions: list[InterpreterExtension] = list(extensions or [])
+        for ext in self._extensions:
+            validate_extension_hooks(ext)
+        self._backend = backend if backend is not None else skills_backend
         self._snapshot_between_turns = snapshot_between_turns
         self._max_snapshot_bytes = (
             memory_limit if max_snapshot_bytes is None else max_snapshot_bytes
@@ -217,12 +242,22 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
             capture_console=capture_console,
             max_stdout_chars=max_result_chars,
             max_ptc_calls=max_ptc_calls,
+            extensions=self._extensions,
+            backend=self._backend,
         )
         self._base_system_prompt = render_repl_system_prompt(
             tool_name=tool_name,
             timeout=timeout,
             memory_limit_mb=memory_limit // (1024 * 1024),
             snapshot_between_turns=snapshot_between_turns,
+        )
+        # Extension prompt fragments are static class attributes; precompute
+        # the concatenation once. Each is delimited so the model can tell an
+        # extension's guidance from the core REPL instructions.
+        self._extension_prompt = "".join(
+            f"\n\n<extension_prompt>\n{ext.system_prompt}\n</extension_prompt>"
+            for ext in self._extensions
+            if ext.system_prompt
         )
         self._ptc_prompt_cache: tuple[frozenset[str], str] | None = None
         # Stable fallback thread id — used when `thread_id` isn't in
@@ -442,7 +477,8 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         rebuilds `globalThis.tools` if the exposed name set changed.
         """
         if self._ptc is None:
-            return self._base_system_prompt
+            # No PTC, but extensions may still contribute prompt fragments.
+            return self._base_system_prompt + self._extension_prompt
         request_tools: list[BaseTool] = list(getattr(request, "tools", []) or [])
         exposed = filter_tools_for_ptc(
             request_tools,
@@ -468,7 +504,11 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
                 exposed_names,
                 render_ptc_prompt(exposed, tool_name=self._tool_name),
             )
-        return self._base_system_prompt + self._ptc_prompt_cache[1]
+        return (
+            self._base_system_prompt
+            + self._ptc_prompt_cache[1]
+            + self._extension_prompt
+        )
 
     def _extend(
         self, system_message: SystemMessage | None, prompt: str

--- a/libs/partners/quickjs/tests/unit_tests/test_extensions.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_extensions.py
@@ -1,0 +1,481 @@
+"""Unit tests for interpreter extensions.
+
+Phase 1 — ``ExtensionContext`` + the Protocol: the context method →
+``quickjs_rs`` binding mapping (host-function registration, module
+install, setup eval), re-registration overwrite, identifier validation,
+and the hook-detection helpers.
+
+Phase 2 — ``on_setup`` wired into the REPL slot lifecycle: an extension's
+module + host function are usable through a real ``_ThreadREPL``, and they
+survive a snapshot round-trip onto a freshly built REPL (the production
+per-turn behavior).
+
+Phase 3 — ``on_eval`` wired into the eval path: an extension re-registers a
+host function closing over fresh per-eval scratch, which accumulates within
+one eval and resets across evals (the PTC call-budget pattern).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from quickjs_rs import Context, ModuleScope, Runtime, ThreadWorker
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from langchain_quickjs import (
+    ExtensionContext,
+    ExtensionError,
+    InterpreterExtension,
+)
+from langchain_quickjs._extensions import (
+    has_on_eval,
+    has_on_setup,
+    validate_extension_hooks,
+)
+from langchain_quickjs._repl import _ThreadREPL
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror tests/unit_tests/test_ptc.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def worker() -> Iterator[ThreadWorker]:
+    w = ThreadWorker()
+    try:
+        yield w
+    finally:
+        w.close()
+
+
+@pytest.fixture
+def runtime(worker: ThreadWorker) -> Iterator[Runtime]:
+    async def _make() -> Runtime:
+        return Runtime()
+
+    rt = worker.run_sync(_make())
+    try:
+        yield rt
+    finally:
+
+        async def _close() -> None:
+            rt.close()
+
+        worker.run_sync(_close())
+
+
+@pytest.fixture
+def ctx(worker: ThreadWorker, runtime: Runtime) -> ExtensionContext:
+    async def _make() -> Context:
+        return runtime.new_context(timeout=5.0)
+
+    qjs_ctx = worker.run_sync(_make())
+    return ExtensionContext(ctx=qjs_ctx, runtime=runtime, backend=None)
+
+
+def _on_worker(worker: ThreadWorker, ctx: ExtensionContext, fn):
+    """Run ``fn(ctx)`` on the worker thread.
+
+    ``ExtensionContext`` methods touch the ``!Send`` context, so they must
+    run on the owning worker thread — exactly how the REPL drives the hooks
+    from inside ``_ainit`` / the eval loop. Tests use this to register
+    against the context the way the real wiring does.
+    """
+
+    async def _run():
+        return fn(ctx)
+
+    return worker.run_sync(_run())
+
+
+def _eval(worker: ThreadWorker, ctx: ExtensionContext, code: str):
+    """Run guest-style code against the underlying context for assertions."""
+
+    async def _run():
+        return await ctx._ctx.eval_async(code)
+
+    return worker.run_sync(_run())
+
+
+def test_function_registers_callable_callable_from_js(
+    worker: ThreadWorker, ctx: ExtensionContext
+) -> None:
+    def register(c: ExtensionContext) -> None:
+        @c.function(name="__ext_add")
+        def add(a: int, b: int) -> int:
+            return a + b
+
+    _on_worker(worker, ctx, register)
+    assert _eval(worker, ctx, "__ext_add(2, 3)") == 5
+
+
+def test_function_bare_decorator_infers_name(
+    worker: ThreadWorker, ctx: ExtensionContext
+) -> None:
+    def register(c: ExtensionContext) -> None:
+        @c.function
+        def __ext_double(x: int) -> int:
+            return x * 2
+
+    _on_worker(worker, ctx, register)
+    assert _eval(worker, ctx, "__ext_double(21)") == 42
+
+
+def test_function_returns_original_callable(
+    worker: ThreadWorker, ctx: ExtensionContext
+) -> None:
+    def register(c: ExtensionContext):
+        @c.function(name="__ext_id")
+        def ident(x: int) -> int:
+            return x
+
+        return ident
+
+    ident = _on_worker(worker, ctx, register)
+    # Decorator returns the callable unchanged — still usable from Python.
+    assert ident(7) == 7
+
+
+def test_function_async_host(worker: ThreadWorker, ctx: ExtensionContext) -> None:
+    def register(c: ExtensionContext) -> None:
+        @c.function(name="__ext_aval", is_async=True)
+        async def aval() -> str:
+            return "from python"
+
+    _on_worker(worker, ctx, register)
+    # eval_async supports top-level await and unwraps the result.
+    assert _eval(worker, ctx, "await __ext_aval()") == "from python"
+
+
+def test_function_rejects_invalid_identifier(
+    worker: ThreadWorker, ctx: ExtensionContext
+) -> None:
+    def register(c: ExtensionContext) -> None:
+        @c.function(name="bad-name")
+        def f() -> None: ...
+
+    with pytest.raises(ExtensionError, match="valid JS identifier"):
+        _on_worker(worker, ctx, register)
+
+
+def test_function_rejects_leading_digit(
+    worker: ThreadWorker, ctx: ExtensionContext
+) -> None:
+    def register(c: ExtensionContext) -> None:
+        @c.function(name="9fn")
+        def f() -> None: ...
+
+    with pytest.raises(ExtensionError, match="valid JS identifier"):
+        _on_worker(worker, ctx, register)
+
+
+def test_function_reregister_overwrites(
+    worker: ThreadWorker, ctx: ExtensionContext
+) -> None:
+    # Re-registering the same symbol overwrites (last write wins) — no
+    # collision guard.
+    def register_first(c: ExtensionContext) -> None:
+        @c.function(name="__ext_dup")
+        def first() -> int:
+            return 1
+
+    _on_worker(worker, ctx, register_first)
+    assert _eval(worker, ctx, "__ext_dup()") == 1
+
+    def register_second(c: ExtensionContext) -> None:
+        @c.function(name="__ext_dup")
+        def second() -> int:
+            return 2
+
+    _on_worker(worker, ctx, register_second)
+    assert _eval(worker, ctx, "__ext_dup()") == 2
+
+
+def test_module_single_file_importable(
+    worker: ThreadWorker, ctx: ExtensionContext
+) -> None:
+    # A bare import name is a nested ModuleScope keyed by that name; the
+    # scope's files live inside, with an `index.<ext>` entrypoint. This
+    # mirrors how the skills loader builds scopes (see _skills.py).
+    _on_worker(
+        worker,
+        ctx,
+        lambda c: c.module(
+            ModuleScope(
+                {
+                    "greet": ModuleScope(
+                        {
+                            "index.js": (
+                                "export function hello(n) { return `hi ${n}`; }\n"
+                            )
+                        }
+                    )
+                }
+            )
+        ),
+    )
+    result = _eval(
+        worker,
+        ctx,
+        'const m = await import("greet"); m.hello("ada")',
+    )
+    assert result == "hi ada"
+
+
+def test_module_multi_file_relative_import(
+    worker: ThreadWorker, ctx: ExtensionContext
+) -> None:
+    # Entrypoint plus an internal sibling. Sibling keys are plain file
+    # names (no leading ./); the import specifier in source keeps the ./.
+    _on_worker(
+        worker,
+        ctx,
+        lambda c: c.module(
+            ModuleScope(
+                {
+                    "calc": ModuleScope(
+                        {
+                            "index.js": (
+                                'import { two } from "./nums.js";\n'
+                                "export function addTwo(x) { return x + two(); }\n"
+                            ),
+                            "nums.js": "export function two() { return 2; }\n",
+                        }
+                    )
+                }
+            )
+        ),
+    )
+    result = _eval(
+        worker,
+        ctx,
+        'const m = await import("calc"); m.addTwo(40)',
+    )
+    assert result == 42
+
+
+def test_eval_wires_host_symbols_into_global(
+    worker: ThreadWorker, ctx: ExtensionContext
+) -> None:
+    def register(c: ExtensionContext) -> None:
+        @c.function(name="__ext_now")
+        def now() -> int:
+            return 1234
+
+        # Setup eval assembles an idiomatic global from the bare symbol.
+        c.eval("globalThis.clock = { now: __ext_now }; undefined")
+
+    _on_worker(worker, ctx, register)
+    assert _eval(worker, ctx, "clock.now()") == 1234
+
+
+def test_eval_returns_completion_value(
+    worker: ThreadWorker, ctx: ExtensionContext
+) -> None:
+    assert _on_worker(worker, ctx, lambda c: c.eval("1 + 2")) == 3
+
+
+class _SetupOnly(InterpreterExtension):
+    system_prompt = None
+
+    def on_setup(self, ctx: ExtensionContext) -> None: ...
+
+
+class _EvalOnly(InterpreterExtension):
+    system_prompt = None
+
+    def on_eval(self, ctx, runtime) -> None: ...
+
+
+class _Both(InterpreterExtension):
+    system_prompt = "use the thing"
+
+    def on_setup(self, ctx: ExtensionContext) -> None: ...
+
+    def on_eval(self, ctx, runtime) -> None: ...
+
+
+class _Neither(InterpreterExtension):
+    system_prompt = None
+
+
+def test_hook_detection() -> None:
+    assert has_on_setup(_SetupOnly()) is True
+    assert has_on_eval(_SetupOnly()) is False
+
+    assert has_on_setup(_EvalOnly()) is False
+    assert has_on_eval(_EvalOnly()) is True
+
+    assert has_on_setup(_Both()) is True
+    assert has_on_eval(_Both()) is True
+
+    assert has_on_setup(_Neither()) is False
+    assert has_on_eval(_Neither()) is False
+
+
+def test_validate_accepts_at_least_one_hook() -> None:
+    validate_extension_hooks(_SetupOnly())
+    validate_extension_hooks(_EvalOnly())
+    validate_extension_hooks(_Both())
+
+
+def test_validate_rejects_empty_extension() -> None:
+    with pytest.raises(ExtensionError, match="at least one"):
+        validate_extension_hooks(_Neither())
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: on_setup wired into the REPL slot lifecycle
+# ---------------------------------------------------------------------------
+
+
+class _GreetExtension(InterpreterExtension):
+    """Registers a host function plus a module that forwards to it."""
+
+    system_prompt = None
+
+    def on_setup(self, ctx: ExtensionContext) -> None:
+        @ctx.function(name="__greet_host")
+        def greet(name: str) -> str:
+            return f"hello {name}"
+
+        ctx.module(
+            ModuleScope(
+                {
+                    "greet": ModuleScope(
+                        {
+                            "index.js": (
+                                "export function greet(name) {\n"
+                                "  return __greet_host(name);\n"
+                                "}\n"
+                            )
+                        }
+                    )
+                }
+            )
+        )
+
+
+def _make_repl(
+    worker: ThreadWorker,
+    runtime: Runtime,
+    extensions: list[InterpreterExtension],
+) -> _ThreadREPL:
+    return _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+        extensions=extensions,
+    )
+
+
+def test_on_setup_runs_at_repl_build(worker: ThreadWorker, runtime: Runtime) -> None:
+    repl = _make_repl(worker, runtime, [_GreetExtension()])
+    # The host function and the module that forwards to it are both live
+    # immediately after the REPL is built — on_setup ran in _ainit.
+    outcome = repl.eval_sync('const m = await import("greet"); m.greet("ada")')
+    assert outcome.error_type is None
+    assert outcome.result == "hello ada"
+
+
+def test_on_setup_host_function_directly_callable(
+    worker: ThreadWorker, runtime: Runtime
+) -> None:
+    repl = _make_repl(worker, runtime, [_GreetExtension()])
+    outcome = repl.eval_sync('__greet_host("bob")')
+    assert outcome.result == "hello bob"
+
+
+def test_on_setup_reruns_on_fresh_repl(worker: ThreadWorker, runtime: Runtime) -> None:
+    # Production rebuilds a fresh _ThreadREPL each turn (the middleware
+    # evicts + recreates the slot). Host functions don't live in a
+    # snapshot, so they must be re-registered by on_setup on every fresh
+    # context. Build a second REPL with the same extensions and confirm
+    # on_setup ran again — the host function is live on the new context.
+    _make_repl(worker, runtime, [_GreetExtension()])
+    repl2 = _make_repl(worker, runtime, [_GreetExtension()])
+    assert repl2.eval_sync('__greet_host("eve")').result == "hello eve"
+
+
+def test_module_reinstall_on_same_runtime_is_tolerated(
+    worker: ThreadWorker, runtime: Runtime
+) -> None:
+    # Two REPLs on one Runtime both install the "greet" module specifier in
+    # their on_setup. Re-installing the same specifier must not raise (it
+    # would break the per-turn rebuild) — this is implementation-plan risk
+    # #3, resolved: runtime.install tolerates a repeat specifier.
+    _make_repl(worker, runtime, [_GreetExtension()])
+    repl2 = _make_repl(worker, runtime, [_GreetExtension()])
+    outcome = repl2.eval_sync('const m = await import("greet"); m.greet("zoe")')
+    assert outcome.error_type is None
+    assert outcome.result == "hello zoe"
+
+
+def test_no_extensions_is_noop(worker: ThreadWorker, runtime: Runtime) -> None:
+    repl = _make_repl(worker, runtime, [])
+    assert repl.eval_sync("1 + 1").result == "2"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: on_eval wired into the eval path
+# ---------------------------------------------------------------------------
+
+
+class _CounterExtension(InterpreterExtension):
+    """on_eval-only: re-registers a host fn closing over fresh per-eval state.
+
+    Each eval gets a brand-new counter, so calls within one eval accumulate
+    but never carry across evals — the PTC call-budget pattern in miniature.
+    """
+
+    system_prompt = None
+
+    def on_eval(self, ctx: ExtensionContext, runtime) -> None:
+        count = [0]
+
+        @ctx.function(name="__counter_tick")
+        def tick() -> int:
+            count[0] += 1
+            return count[0]
+
+
+def test_on_eval_runs_and_host_fn_works(
+    worker: ThreadWorker, runtime: Runtime
+) -> None:
+    repl = _make_repl(worker, runtime, [_CounterExtension()])
+    # on_eval registered __counter_tick before the guest code ran.
+    assert repl.eval_sync("__counter_tick()").result == "1"
+
+
+def test_on_eval_state_accumulates_within_one_eval(
+    worker: ThreadWorker, runtime: Runtime
+) -> None:
+    repl = _make_repl(worker, runtime, [_CounterExtension()])
+    outcome = repl.eval_sync("__counter_tick(); __counter_tick(); __counter_tick()")
+    assert outcome.result == "3"
+
+
+def test_on_eval_state_resets_each_eval(
+    worker: ThreadWorker, runtime: Runtime
+) -> None:
+    repl = _make_repl(worker, runtime, [_CounterExtension()])
+    # Two ticks in the first eval...
+    assert repl.eval_sync("__counter_tick(); __counter_tick()").result == "2"
+    # ...the second eval starts from a fresh counter (on_eval re-ran).
+    assert repl.eval_sync("__counter_tick()").result == "1"
+
+
+def test_on_eval_only_extension_needs_no_on_setup(
+    worker: ThreadWorker, runtime: Runtime
+) -> None:
+    # _CounterExtension implements only on_eval. Before its first eval the
+    # symbol doesn't exist; on_eval establishes it. This confirms the
+    # on_eval-only shape works end to end through the REPL.
+    repl = _make_repl(worker, runtime, [_CounterExtension()])
+    assert has_on_setup(_CounterExtension()) is False
+    assert repl.eval_sync("typeof __counter_tick").result == "function"

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -14,7 +14,12 @@ from langchain_core.tools import StructuredTool
 from pydantic import BaseModel
 from quickjs_rs import Runtime, ThreadWorker
 
-from langchain_quickjs import CodeInterpreterMiddleware
+from langchain_quickjs import (
+    CodeInterpreterMiddleware,
+    ExtensionContext,
+    ExtensionError,
+    InterpreterExtension,
+)
 from langchain_quickjs._format import format_outcome
 from langchain_quickjs._repl import _clear_exception_references, _Registry, _ThreadREPL
 
@@ -169,6 +174,111 @@ def test_system_prompt_injected_once() -> None:
 def test_system_prompt_mentions_single_turn_when_snapshots_disabled() -> None:
     mw = CodeInterpreterMiddleware(snapshot_between_turns=False)
     assert "DO NOT persist across multiple turns" in mw._base_system_prompt
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: extension system-prompt fragments
+# ---------------------------------------------------------------------------
+
+
+def _injected_system_text(mw: CodeInterpreterMiddleware) -> str:
+    """Drive wrap_model_call once and return the injected system text."""
+    seen: list[ModelRequest] = []
+
+    def handler(req: ModelRequest):
+        from langchain.agents.middleware.types import ModelResponse
+        from langchain_core.messages import AIMessage
+
+        seen.append(req)
+        return ModelResponse(result=[AIMessage(content="ok")])
+
+    req = MagicMock(spec=ModelRequest)
+    req.system_message = SystemMessage(content="base")
+    req.tools = []
+
+    def _override(**kwargs):
+        new = MagicMock(spec=ModelRequest)
+        new.system_message = kwargs.get("system_message", req.system_message)
+        return new
+
+    req.override = _override
+    mw.wrap_model_call(req, handler)
+    return "\n".join(
+        block["text"]
+        for block in seen[0].system_message.content_blocks
+        if block["type"] == "text"
+    )
+
+
+class _PromptExtension(InterpreterExtension):
+    system_prompt = "EXTENSION GUIDANCE: use the widget"
+
+    def on_setup(self, ctx: ExtensionContext) -> None: ...
+
+
+class _SilentExtension(InterpreterExtension):
+    system_prompt = None
+
+    def on_setup(self, ctx: ExtensionContext) -> None: ...
+
+
+class _NoHookExtension(InterpreterExtension):
+    system_prompt = "ignored"
+
+
+def test_extension_prompt_injected_without_ptc() -> None:
+    # The ptc=None early-return path must still append extension prompts.
+    mw = CodeInterpreterMiddleware(extensions=[_PromptExtension()])
+    assert "EXTENSION GUIDANCE: use the widget" in _injected_system_text(mw)
+
+
+def test_extension_prompt_injected_with_ptc() -> None:
+    mw = CodeInterpreterMiddleware(ptc=[], extensions=[_PromptExtension()])
+    text = _injected_system_text(mw)
+    assert "EXTENSION GUIDANCE: use the widget" in text
+
+
+def test_extension_prompt_delimited() -> None:
+    mw = CodeInterpreterMiddleware(extensions=[_PromptExtension()])
+    text = _injected_system_text(mw)
+    assert "<extension_prompt>" in text
+    assert "</extension_prompt>" in text
+
+
+def test_silent_extension_contributes_nothing() -> None:
+    mw = CodeInterpreterMiddleware(extensions=[_SilentExtension()])
+    assert mw._extension_prompt == ""
+    assert "<extension_prompt>" not in _injected_system_text(mw)
+
+
+def test_multiple_extension_prompts_concatenate() -> None:
+    class _Other(InterpreterExtension):
+        system_prompt = "SECOND FRAGMENT"
+
+        def on_setup(self, ctx: ExtensionContext) -> None: ...
+
+    mw = CodeInterpreterMiddleware(extensions=[_PromptExtension(), _Other()])
+    text = _injected_system_text(mw)
+    assert "EXTENSION GUIDANCE: use the widget" in text
+    assert "SECOND FRAGMENT" in text
+
+
+def test_no_hook_extension_rejected_at_init() -> None:
+    with pytest.raises(ExtensionError, match="at least one"):
+        CodeInterpreterMiddleware(extensions=[_NoHookExtension()])
+
+
+def test_backend_defaults_to_skills_backend() -> None:
+    sentinel = MagicMock()
+    mw = CodeInterpreterMiddleware(skills_backend=sentinel)
+    assert mw._backend is sentinel
+
+
+def test_backend_explicit_overrides_skills_backend() -> None:
+    skills = MagicMock()
+    explicit = MagicMock()
+    mw = CodeInterpreterMiddleware(skills_backend=skills, backend=explicit)
+    assert mw._backend is explicit
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Introduces a first-class **interpreter extensions** mechanism for `CodeInterpreterMiddleware`. An extension is a Python object that wires capability into the QuickJS interpreter — JS modules, host (FFI) functions, install-time setup eval, and a system-prompt fragment — without the consumer having to thread any of that together.

```python
class GrepExtension(InterpreterExtension):
    system_prompt = "Use `grep-host` to search the workspace from JS."

    def on_setup(self, ctx: ExtensionContext) -> None:
        @ctx.function(name="__grep_host_search")
        async def search(pattern: str) -> list[dict]:
            result = await ctx.backend.agrep(pattern, "/")
            return [dict(m) for m in (result.matches or [])]

        ctx.module(ModuleScope({"grep-host": ModuleScope({"index.js": _SOURCE})}))

CodeInterpreterMiddleware(extensions=[GrepExtension()])
```

## Design

An `InterpreterExtension` implements one or both lifecycle hooks (at least one required):

- **`on_setup(ctx)`** — once per context creation. Register modules, host functions, run setup eval. It re-runs every turn because a QuickJS snapshot restores the JS heap but **not** Python host functions — so they must be re-registered on each fresh context, exactly as the console is.
- **`on_eval(ctx, runtime)`** — start of every eval, with that eval's `ToolRuntime`. Re-register host functions closing over fresh per-eval scratch (a call-budget counter, etc.). Re-registration overwrites.

`ExtensionContext` maps registration straight to the `quickjs_rs` binding (`module` → `Runtime.install`, `function` → `Context.register`, `eval` → `Context.eval`), bound per `_ThreadREPL` and driven on the worker thread. Extensions read the deepagents backend off `ctx.backend` and contribute a `system_prompt` fragment that's injected (delimited) into the REPL system prompt.

Middleware gains `extensions=` and `backend=` kwargs (the latter defaults to `skills_backend`).

## Scope

- **PTC is left untouched.** Extensions are additive; the existing PTC path is unchanged.
- A swarm extension built on this mechanism is in a stacked follow-up PR.

## Tests

- `test_extensions.py` — `ExtensionContext` ↔ binding mapping, host-fn register/call (sync/async/bare/named), identifier validation, re-register overwrite, module install + multi-file imports, setup eval; `on_setup` through a real `_ThreadREPL` + survives a fresh rebuild; `on_eval` per-eval scratch accumulates within an eval and resets across evals.
- `test_repl_middleware.py` — `extensions=` kwarg, prompt-fragment injection (with and without PTC), delimiting, fail-fast rejection of a no-hook extension, `backend` fallback.

All unit tests green (`ruff`, `ty`, `pytest`).