### PR TITLE
fix(code): skip update prompts for editable installs

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3212,11 +3212,15 @@ class DeepAgentsApp(App):
         """
         # Phase 1: version check (benign failure)
         try:
+            from deepagents_code.config import _is_editable_install
             from deepagents_code.update_check import (
                 is_auto_update_enabled,
                 is_update_available,
                 upgrade_command,
             )
+
+            if await asyncio.to_thread(_is_editable_install):
+                return
 
             available, latest = await asyncio.to_thread(
                 is_update_available,

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -7960,6 +7960,24 @@ class TestNotificationCenterIntegration:
         assert entry is not None
         assert app._notice_registry.toast_identity_for("dep:ripgrep") is not None
 
+    async def test_update_check_skips_editable_install(self) -> None:
+        """Editable installs skip update detection and never queue the modal."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=True),
+            patch("deepagents_code.update_check.is_update_available") as available,
+        ):
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                await app._check_for_updates()
+                await pilot.pause()
+
+        available.assert_not_called()
+        assert app._notice_registry.get("update:available") is None
+        assert app._update_available == (False, None)
+        assert not app._update_modal_pending.is_set()
+
     async def test_update_check_auto_opens_dedicated_modal(self) -> None:
         """A detected update auto-opens the dedicated update modal after first paint."""
         from deepagents_code.widgets.update_available import UpdateAvailableScreen
@@ -7967,6 +7985,10 @@ class TestNotificationCenterIntegration:
         app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
 
         with (
+            patch(
+                "deepagents_code.config._is_editable_install",
+                return_value=False,
+            ),
             patch(
                 "deepagents_code.update_check.is_update_available",
                 return_value=(True, "9.9.9"),
@@ -8016,6 +8038,10 @@ class TestNotificationCenterIntegration:
         app._notify_actionable = capture_notify_actionable  # type: ignore[method-assign]
 
         with (
+            patch(
+                "deepagents_code.config._is_editable_install",
+                return_value=False,
+            ),
             patch(
                 "deepagents_code.update_check.is_update_available",
                 return_value=(True, "9.9.9"),


### PR DESCRIPTION
Editable installs can be intentionally behind the latest PyPI release, so startup update prompts should not appear for local checkout sessions. The update check now exits before contacting PyPI or registering the update modal when `deepagents-code` is installed editable.