### PR TITLE
fix(code): pause loading timer during approvals

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -4105,6 +4105,24 @@ class DeepAgentsApp(App):
             # Cosmetic only: must never break app startup or theme changes.
             logger.warning("set_terminal_background raised unexpectedly", exc_info=True)
 
+    def _pause_loading_spinner_for_approval(self) -> None:
+        """Pause the global spinner timer while an approval widget is visible."""
+        if self._loading_widget is not None:
+            self._loading_widget.pause()
+
+    def _resume_loading_spinner_after_approval(
+        self,
+        _future: asyncio.Future[Any] | None = None,
+    ) -> None:
+        """Resume the global spinner timer after an approval decision.
+
+        Accepts an unused `_future` argument so it can be registered directly as
+        a `Future.add_done_callback`, which always passes the completed future
+        positionally.
+        """
+        if self._loading_widget is not None:
+            self._loading_widget.resume()
+
     async def _set_spinner(self, status: SpinnerStatus) -> None:
         """Show, update, or hide the loading spinner.
 
@@ -4153,6 +4171,11 @@ class DeepAgentsApp(App):
             self._loading_widget = LoadingWidget(status)
             await self._mount_before_queued(messages, self._loading_widget)
         else:
+            # A fresh status update means the agent is active again, so
+            # un-pause as a backstop in case an approval future was ever
+            # abandoned without completing the resume callback. `resume()` is a
+            # no-op when the spinner is not paused.
+            self._loading_widget.resume()
             # Update existing
             self._loading_widget.set_status(status)
             # Reposition via move_child so elapsed-time and animation state
@@ -4264,6 +4287,13 @@ class DeepAgentsApp(App):
         if self._pending_approval_widget is not None:
             while self._pending_approval_widget is not None:  # noqa: ASYNC110  # Simple polling is sufficient here
                 await asyncio.sleep(0.1)
+
+        # Pause the elapsed-time counter while the user decides, then resume it
+        # when the decision future completes. Resolve, reject, and cancel all
+        # fire the done-callback; the `_set_spinner` backstop covers the
+        # remaining case where a future is abandoned without completing.
+        self._pause_loading_spinner_for_approval()
+        result_future.add_done_callback(self._resume_loading_spinner_after_approval)
 
         # Create menu with unique ID to avoid conflicts
         from deepagents_code.widgets.approval import ApprovalMenu

--- a/libs/code/deepagents_code/widgets/loading.py
+++ b/libs/code/deepagents_code/widgets/loading.py
@@ -100,7 +100,7 @@ class LoadingWidget(Static):
         self._hint_widget: Static | None = None
         self._animation_timer: Timer | None = None
         self._paused = False
-        self._paused_elapsed: int = 0
+        self._paused_elapsed: float = 0.0
 
     def compose(self) -> ComposeResult:
         """Compose the loading widget layout.
@@ -185,19 +185,38 @@ class LoadingWidget(Static):
         """
         self._paused = True
         if self._start_time is not None:
-            self._paused_elapsed = int(time() - self._start_time)
+            self._paused_elapsed = time() - self._start_time
         self._status = status
         if self._status_widget:
             self._status_widget.update(f" {status}... ")
         if self._hint_widget:
+            # Display whole seconds to match the live counter in
+            # `_update_animation`; `_paused_elapsed` stays a float only so
+            # `resume()` can rebase `_start_time` with sub-second precision.
             self._hint_widget.update(
-                f"(paused at {format_duration(self._paused_elapsed)})"
+                f"(paused at {format_duration(int(self._paused_elapsed))})"
             )
         if self._spinner_widget:
             self._spinner_widget.update(Content.styled(get_glyphs().pause, "dim"))
 
     def resume(self) -> None:
-        """Resume the animation."""
+        """Resume the animation, excluding the paused interval from elapsed time.
+
+        Rebases `_start_time` forward by the paused duration so the elapsed-time
+        counter continues from where it paused rather than counting the wait.
+
+        No-op when not currently paused. This method is wired both as a
+        `Future.add_done_callback` and as a self-healing net in the app's
+        `_set_spinner`, so it can fire on a widget that was never paused (e.g.
+        one created to replace the paused spinner mid-approval). Returning early
+        there avoids rebasing the start time or clobbering that widget's status.
+        """
+        if not self._paused:
+            # Load-bearing guard: resuming a never-paused (or replacement)
+            # widget must not rebase `_start_time` with a stale
+            # `_paused_elapsed`, which would silently jump its timer.
+            return
+        self._start_time = time() - self._paused_elapsed
         self._paused = False
         self._status = "Thinking"
         if self._status_widget:

--- a/libs/code/tests/unit_tests/test_loading.py
+++ b/libs/code/tests/unit_tests/test_loading.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+from typing import TYPE_CHECKING
 
 from textual.app import App, ComposeResult
 
 from deepagents_code.widgets.loading import LoadingWidget
+
+if TYPE_CHECKING:
+    import pytest
 
 
 class LoadingWidgetApp(App[None]):
@@ -63,6 +67,80 @@ class TestLoadingWidget:
 
             assert widget._animation_timer is None
             assert not pilot.app.query("LoadingWidget")
+
+    def test_pause_resume_excludes_paused_duration(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Elapsed time should not include time spent paused for HITL approval."""
+        now = 100.0
+
+        def fake_time() -> float:
+            return now
+
+        monkeypatch.setattr("deepagents_code.widgets.loading.time", fake_time)
+        widget = LoadingWidget()
+        widget._start_time = now
+
+        now = 112.5
+        widget.pause()
+
+        now = 145.0
+        widget.resume()
+
+        assert widget._start_time == 132.5
+        assert not widget._paused
+
+    def test_resume_when_not_paused_leaves_start_time_unchanged(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`resume()` must be a no-op when the widget was never paused.
+
+        The resume callback fires on every approval-future completion and as a
+        `_set_spinner` backstop, so it can land on a never-paused (or
+        replacement) widget. It must not rebase `_start_time` there.
+        """
+        monkeypatch.setattr(
+            "deepagents_code.widgets.loading.time",
+            lambda: 999.0,
+        )
+        widget = LoadingWidget()
+        widget._start_time = 100.0
+        widget._paused_elapsed = 12.5  # stale value from a prior pause cycle
+
+        widget.resume()
+
+        assert widget._start_time == 100.0
+        assert not widget._paused
+
+    def test_pause_without_start_time_does_not_raise(self) -> None:
+        """`pause()` before the timer starts must not raise or fabricate time."""
+        widget = LoadingWidget()
+        assert widget._start_time is None
+
+        widget.pause()
+
+        assert widget._paused
+        assert widget._paused_elapsed == 0.0
+
+    async def test_pause_hint_renders_whole_seconds(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The paused hint shows whole seconds, matching the live counter."""
+        async with LoadingWidgetApp().run_test() as pilot:
+            widget = pilot.app.query_one("#loading", LoadingWidget)
+            widget._start_time = 100.0
+            monkeypatch.setattr(
+                "deepagents_code.widgets.loading.time",
+                lambda: 112.7,
+            )
+
+            widget.pause()
+
+            assert widget._hint_widget is not None
+            assert str(widget._hint_widget.render()) == "(paused at 12s)"
 
     async def test_on_mount_preserves_start_time_across_remount(self) -> None:
         """`on_mount` must not reset `_start_time` when it is already set.


### PR DESCRIPTION
Approval waits no longer inflate the loading spinner's elapsed-time counter while the user is deciding on an HITL approval. The spinner now pauses when an approval menu is shown and resumes from the pre-approval elapsed time once the decision future completes.