### PR TITLE
fix(code): run auto-update before startup

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -134,6 +134,16 @@ and `/api/show`. See `_ollama_discovery_enabled` for accepted truthy/falsy
 values.
 """
 
+RESTARTED_AFTER_UPDATE = "DEEPAGENTS_CODE_RESTARTED_AFTER_UPDATE"
+"""Internal sentinel recording the target version immediately before the
+startup auto-update re-execs the process.
+
+Not user-facing. The re-exec'd process consumes it and, if that same version
+still reports as available (a no-op upgrade that did not change the running
+version), skips auto-updating to break out of an otherwise endless
+upgrade/restart loop. Set and read internally across `os.execv`.
+"""
+
 SERVER_ENV_PREFIX = "DEEPAGENTS_CODE_SERVER_"
 """Environment variable prefix used to pass CLI config to the server subprocess."""
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3201,11 +3201,15 @@ class DeepAgentsApp(App):
             self._update_check_done.set()
 
     async def _check_for_updates_impl(self, *, periodic: bool = False) -> None:
-        """Check PyPI for a newer version and either auto-update or queue a modal.
+        """Check PyPI for a newer version and surface it in-session.
 
         Phase 1 contacts PyPI and records the latest version on the app.
-        Phase 2 either performs the auto-upgrade (when enabled), or
-        registers the actionable notice and schedules the update modal.
+        Phase 2 surfaces a detected update without installing it in-session
+        (the actual install runs at startup via `_run_startup_auto_update`):
+        when auto-update is enabled it toasts a prompt to restart so the
+        startup path can upgrade; otherwise it raises an actionable notice
+        (periodic recheck) or registers the notice and schedules the update
+        modal (initial check).
         Phase 2 sets `_update_modal_pending` *only* when the modal is
         actually being scheduled; a detected-but-throttled update
         leaves the event clear so missing-dep toasts still fire.
@@ -3237,68 +3241,16 @@ class DeepAgentsApp(App):
         # Phase 2: auto-update or register actionable notice
         try:
             from deepagents_code._version import __version__ as cli_version
+            from deepagents_code.update_check import (
+                format_installed_age_suffix,
+                format_release_age_parenthetical,
+                mark_update_notified,
+                should_notify_update,
+            )
 
             if is_auto_update_enabled():
-                from deepagents_code._env_vars import DEBUG_UPDATE
-                from deepagents_code.update_check import (
-                    create_update_log_path,
-                    perform_upgrade,
-                )
-
-                if os.environ.get(DEBUG_UPDATE):
-                    self.notify(
-                        "Skipped update install (debug mode).",
-                        severity="information",
-                        timeout=4,
-                        markup=False,
-                    )
-                    return
-
-                log_path = create_update_log_path()
-                self.notify(
-                    f"Updating to v{latest}... Logs: {log_path}",
-                    severity="information",
-                    timeout=5,
-                    markup=False,
-                )
-                success, output = await perform_upgrade(log_path=log_path)
-                if success:
-                    self.notify(
-                        f"Updated to v{latest}. Restart to use the new version.",
-                        severity="information",
-                        timeout=10,
-                    )
-                else:
-                    logger.warning(
-                        "Background auto-upgrade to v%s failed. Output:\n%s",
-                        latest,
-                        output,
-                    )
-                    cmd = upgrade_command()
-                    snippet = _truncate(output, limit=160) if output else ""
-                    message = (
-                        f"Auto-update failed. Run manually: {cmd}\nLog: {log_path}"
-                    )
-                    if snippet:
-                        message = f"{message}\n{snippet}"
-                    self.notify(
-                        message,
-                        severity="warning",
-                        timeout=15,
-                        markup=False,
-                    )
-            else:
-                from deepagents_code.update_check import (
-                    format_installed_age_suffix,
-                    format_release_age_parenthetical,
-                    mark_update_notified,
-                    should_notify_update,
-                )
-
                 if not await asyncio.to_thread(should_notify_update, latest):
                     return
-
-                cmd = upgrade_command()
                 release_age = await asyncio.to_thread(
                     format_release_age_parenthetical,
                     latest,
@@ -3307,33 +3259,56 @@ class DeepAgentsApp(App):
                     format_installed_age_suffix,
                     cli_version,
                 )
-                notification = self._build_update_notification(
-                    latest=latest,
-                    cli_version=cli_version,
-                    release_age=release_age,
-                    installed_age=installed_age,
-                    upgrade_cmd=cmd,
+                self.notify(
+                    f"Update available: v{latest}{release_age}. "
+                    f"Currently installed: {cli_version}{installed_age}. "
+                    "Restart dcode to auto-update before startup.",
+                    severity="information",
+                    timeout=12,
+                    markup=False,
                 )
-                if periodic:
-                    self._notify_actionable(
-                        notification,
-                        severity="information",
-                        timeout=12,
-                        action_hint="Press ctrl+n to install.",
-                    )
-                    await asyncio.to_thread(mark_update_notified, latest)
-                    return
-                # Register without a toast: the dedicated modal is
-                # the update's UI, so a parallel toast would be
-                # redundant. Registration still makes the entry
-                # reachable via ctrl+n if the modal is dismissed.
-                self._notice_registry.add(notification)
                 await asyncio.to_thread(mark_update_notified, latest)
-                # Set *before* scheduling the modal: the optional-tools
-                # worker may race with this path, and it gates toast
-                # suppression on this event.
-                self._update_modal_pending.set()
-                self.call_after_refresh(self._open_update_available_modal, notification)
+                return
+
+            if not await asyncio.to_thread(should_notify_update, latest):
+                return
+
+            cmd = upgrade_command()
+            release_age = await asyncio.to_thread(
+                format_release_age_parenthetical,
+                latest,
+            )
+            installed_age = await asyncio.to_thread(
+                format_installed_age_suffix,
+                cli_version,
+            )
+            notification = self._build_update_notification(
+                latest=latest,
+                cli_version=cli_version,
+                release_age=release_age,
+                installed_age=installed_age,
+                upgrade_cmd=cmd,
+            )
+            if periodic:
+                self._notify_actionable(
+                    notification,
+                    severity="information",
+                    timeout=12,
+                    action_hint="Press ctrl+n to install.",
+                )
+                await asyncio.to_thread(mark_update_notified, latest)
+                return
+            # Register without a toast: the dedicated modal is
+            # the update's UI, so a parallel toast would be
+            # redundant. Registration still makes the entry
+            # reachable via ctrl+n if the modal is dismissed.
+            self._notice_registry.add(notification)
+            await asyncio.to_thread(mark_update_notified, latest)
+            # Set *before* scheduling the modal: the optional-tools
+            # worker may race with this path, and it gates toast
+            # suppression on this event.
+            self._update_modal_pending.set()
+            self.call_after_refresh(self._open_update_available_modal, notification)
         except Exception:
             logger.warning("Update check/notify failed unexpectedly", exc_info=True)
             if is_auto_update_enabled():

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -20,9 +20,11 @@ import sys
 import traceback
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 if TYPE_CHECKING:
+    from rich.console import Console
+
     from deepagents_code.app import AppResult
     from deepagents_code.mcp_tools import MCPServerInfo
     from deepagents_code.notifications import PendingNotification
@@ -33,6 +35,127 @@ warnings.filterwarnings("ignore", message=".*Pydantic V1.*", category=UserWarnin
 from deepagents_code._version import __version__
 
 logger = logging.getLogger(__name__)
+
+
+def _restart_current_process() -> NoReturn:
+    """Replace the current process with a fresh `deepagents_code` invocation.
+
+    Raises:
+        RuntimeError: If process replacement unexpectedly returns.
+    """
+    argv = [sys.executable, "-m", "deepagents_code", *sys.argv[1:]]
+    # Re-exec the trusted interpreter with the user's own argv verbatim; the
+    # only "input" is the command the user already ran, so S606's concern
+    # (untrusted/unsanitized args to a spawned executable) does not apply.
+    os.execv(sys.executable, argv)  # noqa: S606
+    msg = "os.execv returned unexpectedly"
+    raise RuntimeError(msg)
+
+
+def _run_startup_auto_update(console: "Console") -> None:
+    """Apply enabled auto-updates before the TUI and server start.
+
+    On a successful upgrade the process is re-exec'd so the new version is
+    loaded. Any failure is fail-soft: the installed version is launched and
+    the error is surfaced, never blocking startup.
+
+    Raises:
+        SystemExit: Re-raised rather than suppressed by the fail-soft handler,
+            so a process-exit request is never swallowed (the `os.execv`
+            re-exec is simulated this way under test).
+    """
+    from rich.markup import escape
+
+    from deepagents_code._env_vars import DEBUG_UPDATE, RESTARTED_AFTER_UPDATE
+    from deepagents_code._version import __version__ as cli_version
+    from deepagents_code.config import _is_editable_install
+    from deepagents_code.update_check import (
+        create_update_log_path,
+        format_release_age_parenthetical,
+        get_cached_update_available,
+        is_auto_update_enabled,
+        perform_upgrade,
+        upgrade_command,
+    )
+
+    try:
+        if _is_editable_install() or not is_auto_update_enabled():
+            return
+        # Consume the re-exec sentinel recorded before the previous restart.
+        restarted_for = os.environ.pop(RESTARTED_AFTER_UPDATE, None)
+        available, latest = get_cached_update_available()
+        if not available or latest is None:
+            return
+        if restarted_for == latest:
+            # Already restarted after upgrading to this version, yet it still
+            # reports as available: the install did not change the running
+            # version. Bail out instead of upgrading and restarting forever
+            # (this runs before the TUI, so there is no in-app way to stop it).
+            cmd = upgrade_command()
+            console.print(
+                f"[bold yellow]Warning:[/bold yellow] v{latest} still reports as "
+                "available after an automatic update; skipping auto-update to "
+                f"avoid a restart loop. Update manually: [cyan]{cmd}[/cyan]\n"
+                f"Continuing with v{cli_version}.",
+                highlight=False,
+            )
+            return
+        release_age = format_release_age_parenthetical(latest)
+        console.print(
+            f"Auto-updating deepagents-code from v{cli_version} to "
+            f"v{latest}{release_age} before startup..."
+        )
+        if os.environ.get(DEBUG_UPDATE):
+            console.print("Skipped update install (debug mode).", style="dim")
+            return
+        log_path = create_update_log_path()
+        console.print(
+            f"Update log: {log_path}\nTail progress: tail -f {log_path}",
+            style="dim",
+            highlight=False,
+            markup=False,
+        )
+        success, output = asyncio.run(perform_upgrade(log_path=log_path))
+        if success:
+            console.print(f"[green]Updated to v{latest}. Restarting...[/green]")
+            # Record the target version so the re-exec'd process can detect a
+            # no-op upgrade and break the loop (see the `restarted_for` guard).
+            os.environ[RESTARTED_AFTER_UPDATE] = latest
+            try:
+                _restart_current_process()
+            except (OSError, RuntimeError):
+                # Upgrade succeeded but the re-exec did not happen (`os.execv`
+                # raised, or returned unexpectedly). Drop the sentinel and
+                # continue on the old in-memory code; the user must restart
+                # manually to load the new version.
+                os.environ.pop(RESTARTED_AFTER_UPDATE, None)
+                logger.warning("Restart after update failed", exc_info=True)
+                console.print(
+                    f"[bold yellow]Warning:[/bold yellow] Updated to v{latest} but "
+                    "the automatic restart failed. Restart dcode manually to use "
+                    "the new version.",
+                    highlight=False,
+                )
+            return
+        cmd = upgrade_command()
+        detail = f": {escape(output[:200])}" if output else ""
+        console.print(
+            f"[bold red]Auto-update failed{detail}[/bold red]\n"
+            f"Run manually: [cyan]{cmd}[/cyan]\n"
+            f"Continuing with v{cli_version}.",
+            markup=True,
+            highlight=False,
+        )
+    except SystemExit:
+        # Process replacement (and test doubles that simulate it) must not be
+        # swallowed by the fail-soft handler below.
+        raise
+    except Exception:
+        logger.warning("Startup auto-update failed", exc_info=True)
+        console.print(
+            "[bold yellow]Warning:[/bold yellow] Auto-update failed before startup; "
+            "continuing with the installed version."
+        )
 
 
 def _resolve_agent_arg(args: argparse.Namespace) -> str:
@@ -2491,6 +2614,7 @@ def cli_main() -> None:
                 sys.exit(130)
             sys.exit(exit_code)
         else:
+            _run_startup_auto_update(console)
             # Resolve recent-agent fallback only for actual session launches.
             assistant_id = _resolve_agent_arg(args)
             # Interactive mode - handle thread resume

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -158,6 +158,49 @@ def _latest_from_releases(
     return best_str
 
 
+def get_cached_update_available() -> tuple[bool, str | None]:
+    """Check for updates using only a fresh local cache entry.
+
+    This is the startup fast path: it never contacts PyPI. Stale, missing,
+    corrupt, or unparsable cache data is treated as "no cached update answer" so
+    callers can launch immediately and let a background update check refresh the
+    cache later.
+
+    Returns:
+        A `(available, latest)` tuple. `latest` is `None` when the cache cannot
+            provide a fresh answer.
+    """
+    try:
+        installed = _parse_version(__version__)
+    except InvalidVersion:
+        logger.warning(
+            "Installed version %r is not PEP 440 compliant; "
+            "cache-only update checks disabled for this install",
+            __version__,
+        )
+        return False, None
+
+    cache_key = "version_prerelease" if installed.is_prerelease else "version"
+    try:
+        if not CACHE_FILE.exists():
+            return False, None
+        data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return False, None
+        checked_at = data.get("checked_at")
+        if not isinstance(checked_at, (int, float)):
+            return False, None
+        if time.time() - checked_at >= CACHE_TTL:
+            return False, None
+        value = data.get(cache_key)
+        if not isinstance(value, str):
+            return False, None
+        return _parse_version(value) > installed, value
+    except (OSError, json.JSONDecodeError, TypeError, InvalidVersion):
+        logger.debug("Failed to read cache-only update answer", exc_info=True)
+        return False, None
+
+
 def get_latest_version(
     *,
     bypass_cache: bool = False,

--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -91,6 +91,20 @@ def _clear_onboarding_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _clear_update_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent update debug/loop-guard env vars from affecting tests.
+
+    `DEEPAGENTS_CODE_DEBUG_UPDATE` short-circuits the install path, and the
+    internal `DEEPAGENTS_CODE_RESTARTED_AFTER_UPDATE` sentinel suppresses
+    auto-update to break a restart loop. Either leaking in (from a developer
+    shell, or a prior test exercising the production code that sets the
+    sentinel) would make the startup auto-update tests non-deterministic.
+    """
+    monkeypatch.delenv("DEEPAGENTS_CODE_DEBUG_UPDATE", raising=False)
+    monkeypatch.delenv("DEEPAGENTS_CODE_RESTARTED_AFTER_UPDATE", raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _clear_external_event_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent local alpha event-listener env vars from affecting tests."""
     monkeypatch.delenv("DEEPAGENTS_CODE_EXTERNAL_EVENT_SOCKET", raising=False)

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import inspect
+import os
+import sys
 from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,12 +15,302 @@ import pytest
 from deepagents_code.app import AppResult, DeepAgentsApp, run_textual_app
 from deepagents_code.config import build_langsmith_thread_url, reset_langsmith_url_cache
 from deepagents_code.main import (
+    _restart_current_process,
     _ripgrep_install_hint,
+    _run_startup_auto_update,
     build_missing_tool_notification,
     check_optional_tools,
+    cli_main,
     format_tool_warning_cli,
     run_textual_cli_async,
 )
+
+
+class TestStartupAutoUpdate:
+    """Tests for startup auto-update behavior."""
+
+    def test_successful_update_restarts_before_launch(self) -> None:
+        """A successful startup auto-update should exec a fresh process."""
+        console = MagicMock()
+        upgrade = AsyncMock(return_value=(True, "updated"))
+
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.update_check.get_cached_update_available",
+                return_value=(True, "9.9.9"),
+            ),
+            patch(
+                "deepagents_code.update_check.format_release_age_parenthetical",
+                return_value="",
+            ),
+            patch(
+                "deepagents_code.update_check.create_update_log_path",
+                return_value=Path("/tmp/dcode-update.log"),
+            ),
+            patch("deepagents_code.update_check.perform_upgrade", upgrade),
+            patch(
+                "deepagents_code.main._restart_current_process",
+                side_effect=SystemExit(0),
+            ) as restart,
+            pytest.raises(SystemExit),
+        ):
+            _run_startup_auto_update(console)
+
+        upgrade.assert_awaited_once()
+        restart.assert_called_once_with()
+
+    def test_disabled_update_does_not_check_pypi(self) -> None:
+        """Disabled auto-update should not perform network or install work."""
+        console = MagicMock()
+
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=False,
+            ),
+            patch("deepagents_code.update_check.get_cached_update_available") as check,
+            patch("deepagents_code.update_check.perform_upgrade") as upgrade,
+        ):
+            _run_startup_auto_update(console)
+
+        check.assert_not_called()
+        upgrade.assert_not_called()
+
+    def test_restart_uses_module_entrypoint(self) -> None:
+        """Restart should reload package code from the updated environment."""
+        with (
+            patch.object(sys, "executable", "/tool/bin/python"),
+            patch.object(sys, "argv", ["dcode", "--model", "openai:gpt-5.5"]),
+            patch("os.execv", side_effect=SystemExit(0)) as execv,
+            pytest.raises(SystemExit),
+        ):
+            _restart_current_process()
+
+        execv.assert_called_once_with(
+            "/tool/bin/python",
+            ["/tool/bin/python", "-m", "deepagents_code", "--model", "openai:gpt-5.5"],
+        )
+
+    def test_failed_update_does_not_restart_and_continues(self) -> None:
+        """A failed upgrade must not restart; it surfaces the error and returns."""
+        console = MagicMock()
+        upgrade = AsyncMock(return_value=(False, "pip exploded"))
+
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.update_check.get_cached_update_available",
+                return_value=(True, "9.9.9"),
+            ),
+            patch(
+                "deepagents_code.update_check.format_release_age_parenthetical",
+                return_value="",
+            ),
+            patch(
+                "deepagents_code.update_check.create_update_log_path",
+                return_value=Path("/tmp/dcode-update.log"),
+            ),
+            patch(
+                "deepagents_code.update_check.upgrade_command",
+                return_value="uv tool upgrade deepagents-code",
+            ),
+            patch("deepagents_code.update_check.perform_upgrade", upgrade),
+            patch("deepagents_code.main._restart_current_process") as restart,
+        ):
+            # Must not raise: a failed upgrade falls through to launch.
+            _run_startup_auto_update(console)
+
+        upgrade.assert_awaited_once()
+        restart.assert_not_called()
+        printed = " ".join(str(c.args[0]) for c in console.print.call_args_list)
+        assert "Auto-update failed" in printed
+
+    def test_editable_install_skips_update(self) -> None:
+        """Editable installs must short-circuit before any PyPI/install work."""
+        console = MagicMock()
+
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=True),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=True,
+            ),
+            patch("deepagents_code.update_check.get_cached_update_available") as check,
+            patch("deepagents_code.update_check.perform_upgrade") as upgrade,
+        ):
+            _run_startup_auto_update(console)
+
+        check.assert_not_called()
+        upgrade.assert_not_called()
+
+    def test_no_update_available_returns_early(self) -> None:
+        """When already current, nothing is announced, installed, or restarted."""
+        console = MagicMock()
+
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.update_check.get_cached_update_available",
+                return_value=(False, None),
+            ),
+            patch("deepagents_code.update_check.perform_upgrade") as upgrade,
+            patch("deepagents_code.main._restart_current_process") as restart,
+        ):
+            _run_startup_auto_update(console)
+
+        upgrade.assert_not_called()
+        restart.assert_not_called()
+        console.print.assert_not_called()
+
+    def test_debug_update_skips_install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """DEBUG_UPDATE announces the update but skips the actual install."""
+        console = MagicMock()
+        monkeypatch.setenv("DEEPAGENTS_CODE_DEBUG_UPDATE", "1")
+
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.update_check.get_cached_update_available",
+                return_value=(True, "9.9.9"),
+            ),
+            patch(
+                "deepagents_code.update_check.format_release_age_parenthetical",
+                return_value="",
+            ),
+            patch("deepagents_code.update_check.perform_upgrade") as upgrade,
+            patch("deepagents_code.main._restart_current_process") as restart,
+        ):
+            _run_startup_auto_update(console)
+
+        upgrade.assert_not_called()
+        restart.assert_not_called()
+        printed = " ".join(str(c.args[0]) for c in console.print.call_args_list)
+        assert "debug mode" in printed
+
+    def test_unexpected_error_does_not_block_startup(self) -> None:
+        """An error in the update machinery must never block launch."""
+        console = MagicMock()
+
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.update_check.get_cached_update_available",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("deepagents_code.main._restart_current_process") as restart,
+        ):
+            # Must swallow the error rather than propagate it.
+            _run_startup_auto_update(console)
+
+        restart.assert_not_called()
+        printed = " ".join(str(c.args[0]) for c in console.print.call_args_list)
+        assert "Auto-update failed before startup" in printed
+
+    def test_restart_loop_guard_skips_repeat_upgrade(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A re-exec that did not change the version must not re-upgrade."""
+        console = MagicMock()
+        # Simulate the sentinel set by the prior generation before its restart.
+        monkeypatch.setenv("DEEPAGENTS_CODE_RESTARTED_AFTER_UPDATE", "9.9.9")
+
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.update_check.get_cached_update_available",
+                return_value=(True, "9.9.9"),
+            ),
+            patch(
+                "deepagents_code.update_check.upgrade_command",
+                return_value="uv tool upgrade deepagents-code",
+            ),
+            patch("deepagents_code.update_check.perform_upgrade") as upgrade,
+            patch("deepagents_code.main._restart_current_process") as restart,
+        ):
+            _run_startup_auto_update(console)
+
+        upgrade.assert_not_called()
+        restart.assert_not_called()
+        # Sentinel is consumed so a genuine future update is not suppressed.
+        assert os.environ.get("DEEPAGENTS_CODE_RESTARTED_AFTER_UPDATE") is None
+        printed = " ".join(str(c.args[0]) for c in console.print.call_args_list)
+        assert "restart loop" in printed
+
+    def test_restart_failure_after_successful_install_continues(self) -> None:
+        """A successful install with a failed re-exec reports an accurate message."""
+        console = MagicMock()
+        upgrade = AsyncMock(return_value=(True, "updated"))
+
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.update_check.get_cached_update_available",
+                return_value=(True, "9.9.9"),
+            ),
+            patch(
+                "deepagents_code.update_check.format_release_age_parenthetical",
+                return_value="",
+            ),
+            patch(
+                "deepagents_code.update_check.create_update_log_path",
+                return_value=Path("/tmp/dcode-update.log"),
+            ),
+            patch("deepagents_code.update_check.perform_upgrade", upgrade),
+            patch(
+                "deepagents_code.main._restart_current_process",
+                side_effect=OSError("exec failed"),
+            ) as restart,
+        ):
+            # Install succeeded; a failed re-exec must not raise or claim the
+            # update failed.
+            _run_startup_auto_update(console)
+
+        restart.assert_called_once_with()
+        # Sentinel is dropped since the restart did not happen.
+        assert os.environ.get("DEEPAGENTS_CODE_RESTARTED_AFTER_UPDATE") is None
+        printed = " ".join(str(c.args[0]) for c in console.print.call_args_list)
+        assert "automatic restart failed" in printed
+        assert "Auto-update failed" not in printed
+
+    def test_startup_auto_update_wired_into_interactive_launch(self) -> None:
+        """`cli_main` must invoke the startup auto-update on interactive launch.
+
+        Without this guard the feature could be dropped from `cli_main` and
+        every other unit test would still pass, silently regressing it to a
+        no-op.
+        """
+        source = inspect.getsource(cli_main)
+        assert "_run_startup_auto_update(console)" in source
 
 
 class TestResumeHintLogic:

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -35,6 +35,7 @@ from deepagents_code.update_check import (
     format_release_age_parenthetical,
     format_sdk_age_suffix,
     format_sdk_release_age,
+    get_cached_update_available,
     get_latest_version,
     get_release_time,
     get_sdk_release_time,
@@ -181,6 +182,51 @@ class TestLatestFromReleases:
         }
         assert _latest_from_releases(releases, include_prereleases=False) is None
         assert _latest_from_releases(releases, include_prereleases=True) == "1.0.0b1"
+
+
+class TestCachedUpdateAvailable:
+    def test_fresh_cache_reports_update_without_http(self, cache_file) -> None:
+        """Fresh cache can drive startup auto-update without network access."""
+        cache_file.write_text(
+            json.dumps({"version": "99.0.0", "checked_at": time.time()}),
+            encoding="utf-8",
+        )
+
+        with patch("requests.get") as mock_get:
+            assert get_cached_update_available() == (True, "99.0.0")
+
+        mock_get.assert_not_called()
+
+    def test_stale_cache_returns_no_answer_without_http(self, cache_file) -> None:
+        """Stale cache must not trigger a startup network request."""
+        cache_file.write_text(
+            json.dumps(
+                {"version": "99.0.0", "checked_at": time.time() - CACHE_TTL - 1}
+            ),
+            encoding="utf-8",
+        )
+
+        with patch("requests.get") as mock_get:
+            assert get_cached_update_available() == (False, None)
+
+        mock_get.assert_not_called()
+
+    def test_missing_cache_returns_no_answer_without_http(self, cache_file) -> None:
+        """Missing cache should not block startup on a network request."""
+        assert not cache_file.exists()
+        with patch("requests.get") as mock_get:
+            assert get_cached_update_available() == (False, None)
+
+        mock_get.assert_not_called()
+
+    def test_fresh_current_cache_reports_no_update(self, cache_file) -> None:
+        """A fresh cache at the installed version should not update."""
+        cache_file.write_text(
+            json.dumps({"version": __version__, "checked_at": time.time()}),
+            encoding="utf-8",
+        )
+
+        assert get_cached_update_available() == (False, __version__)
 
 
 class TestGetLatestVersion:


### PR DESCRIPTION
Auto-update now runs before the interactive app and server are launched, so a successful upgrade can immediately restart into the newly installed `deepagents-code` version. In-session update checks now surface restart guidance instead of attempting a background install while the TUI is already running.