### PR TITLE
feat(sdk): consume `requested_skills` before model invocation

### DIFF
--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -292,6 +292,14 @@ class SkillMetadata(TypedDict):
 class SkillsState(AgentState):
     """State for the skills middleware."""
 
+    requested_skills: NotRequired[list[str]]
+    """Optional skill names to inject into model context.
+
+    When provided, `before_model` consumes this list by filtering
+    `skills_metadata` to matching skill names, then clears this field
+    by setting it to an empty list in the returned state update.
+    """
+
     skills_metadata: NotRequired[Annotated[list[SkillMetadata], PrivateStateAttr]]
     """List of loaded skill metadata from configured sources. Not propagated to parent agents."""
 
@@ -299,11 +307,14 @@ class SkillsState(AgentState):
     """Skill source loading errors. Not propagated to parent agents."""
 
 
-class SkillsStateUpdate(TypedDict):
+class SkillsStateUpdate(TypedDict, total=False):
     """State update for the skills middleware."""
 
     skills_metadata: list[SkillMetadata]
     """List of loaded skill metadata to merge into state."""
+
+    requested_skills: list[str]
+    """Requested skills after middleware consumption."""
 
     skills_load_errors: NotRequired[list[str]]
     """Skill source loading errors to merge into state."""
@@ -910,6 +921,58 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
         lines.append("</skill_load_warnings>")
         return "\n".join(lines)
 
+    def _select_skills_for_context(
+        self,
+        requested_skills: list[object],
+        skills_metadata: list[SkillMetadata],
+    ) -> tuple[list[SkillMetadata], list[str]]:
+        """Filter loaded skills by an explicit request list."""
+        requested_names: set[str] = set()
+        for candidate in requested_skills:
+            if not isinstance(candidate, str):
+                logger.warning(
+                    "Ignoring non-string entry in `requested_skills` state value (got %s)",
+                    type(candidate).__name__,
+                )
+                continue
+            name = candidate.strip()
+            if name:
+                requested_names.add(name)
+
+        if not requested_names:
+            return skills_metadata, []
+
+        available_names = {skill["name"] for skill in skills_metadata}
+        selected = [skill for skill in skills_metadata if skill["name"] in requested_names]
+        missing_names = sorted(requested_names - available_names)
+        missing_errors = [f"Requested skill not found: {name}" for name in missing_names]
+        return selected, missing_errors
+
+    def _consume_requested_skills(self, state: SkillsState) -> SkillsStateUpdate | None:
+        """Consume `requested_skills` into `skills_metadata` once skills are loaded."""
+        if "skills_metadata" not in state:
+            return None
+
+        raw_requested = state.get("requested_skills")
+        if raw_requested is None or raw_requested == []:
+            return None
+
+        if not isinstance(raw_requested, list):
+            logger.warning(
+                "Ignoring non-list `requested_skills` state value (got %s)",
+                type(raw_requested).__name__,
+            )
+            return SkillsStateUpdate(requested_skills=[])
+
+        selected_skills, missing_errors = self._select_skills_for_context(raw_requested, state.get("skills_metadata", []))
+        update = SkillsStateUpdate(
+            skills_metadata=selected_skills,
+            requested_skills=[],
+        )
+        if missing_errors:
+            update["skills_load_errors"] = [*state.get("skills_load_errors", []), *missing_errors]
+        return update
+
     def modify_request(self, request: ModelRequest[ContextT]) -> ModelRequest[ContextT]:
         """Inject skills documentation into a model request's system message.
 
@@ -937,6 +1000,14 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
         new_system_message = append_to_system_message(request.system_message, skills_section)
 
         return request.override(system_message=new_system_message)
+
+    def before_model(self, state: SkillsState, runtime: Runtime[ContextT]) -> SkillsStateUpdate | None:  # noqa: ARG002
+        """Consume `requested_skills` into loaded skills before model invocation."""
+        return self._consume_requested_skills(state)
+
+    async def abefore_model(self, state: SkillsState, runtime: Runtime[ContextT]) -> SkillsStateUpdate | None:  # noqa: ARG002
+        """Async variant of `before_model`."""
+        return self._consume_requested_skills(state)
 
     def before_agent(self, state: SkillsState, runtime: Runtime, config: RunnableConfig) -> SkillsStateUpdate | None:  # ty: ignore[invalid-method-override]
         """Load skills metadata before agent execution (synchronous).

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
@@ -1707,6 +1707,45 @@ def test_agent_with_skills_middleware_multiple_registries_override(tmp_path: Pat
     assert "Base registry description" not in content, "Should not contain base source description"
 
 
+def test_agent_with_skills_middleware_requested_skills_filters_prompt(tmp_path: Path) -> None:
+    """`requested_skills` state key should deterministically filter prompt skills."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+    skills_dir = tmp_path / "skills" / "user"
+
+    first_skill_path = str(skills_dir / "skill-one" / "SKILL.md")
+    second_skill_path = str(skills_dir / "skill-two" / "SKILL.md")
+
+    responses = backend.upload_files(
+        [
+            (first_skill_path, make_skill_content("skill-one", "First skill description").encode("utf-8")),
+            (second_skill_path, make_skill_content("skill-two", "Second skill description").encode("utf-8")),
+        ]
+    )
+    assert all(r.error is None for r in responses)
+
+    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="I can see selected skills only.")]))
+    middleware = SkillsMiddleware(backend=backend, sources=[str(skills_dir)])
+    agent = create_agent(model=fake_model, middleware=[middleware])
+
+    result = agent.invoke(
+        {
+            "messages": [HumanMessage(content="Use only one skill.")],
+            "requested_skills": ["skill-two"],
+        }
+    )
+
+    assert "messages" in result
+    assert len(result["messages"]) > 0
+
+    first_call = fake_model.call_history[0]
+    system_message = first_call["messages"][0]
+    content = system_message.text
+    assert "skill-two" in content
+    assert "Second skill description" in content
+    assert "skill-one" not in content
+    assert "First skill description" not in content
+
+
 def test_before_agent_skips_loading_if_metadata_present(tmp_path: Path) -> None:
     """Test that before_agent skips loading if skills_metadata is already in state."""
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
@@ -2102,6 +2141,73 @@ def test_modify_request_uses_custom_template() -> None:
     assert "WARN:" in appended
     assert "LIST:" in appended
     assert "## Skills System" not in appended  # default template marker absent
+
+
+def test_before_model_consumes_requested_skills() -> None:
+    """`before_model` should consume `requested_skills` and clear the key."""
+    middleware = SkillsMiddleware(
+        backend=StateBackend(),
+        sources=[],
+        system_prompt="LOC:{skills_locations}|WARN:{skills_load_warnings}|LIST:{skills_list}",
+    )
+    state = {
+        "requested_skills": ["skill-b"],
+        "skills_metadata": [
+            {
+                "name": "skill-a",
+                "description": "Skill A",
+                "path": "/skills/skill-a/SKILL.md",
+                "license": None,
+                "compatibility": None,
+                "metadata": {},
+                "allowed_tools": [],
+            },
+            {
+                "name": "skill-b",
+                "description": "Skill B",
+                "path": "/skills/skill-b/SKILL.md",
+                "license": None,
+                "compatibility": None,
+                "metadata": {},
+                "allowed_tools": [],
+            },
+        ],
+    }
+
+    result = middleware.before_model(state, None)  # type: ignore[arg-type]
+    assert result is not None
+    assert result["requested_skills"] == []
+    assert [skill["name"] for skill in result["skills_metadata"]] == ["skill-b"]
+
+
+def test_before_model_warns_for_missing_requested_skills() -> None:
+    """Missing requested skills should be recorded in `skills_load_errors`."""
+    middleware = SkillsMiddleware(
+        backend=StateBackend(),
+        sources=[],
+        system_prompt="LOC:{skills_locations}|WARN:{skills_load_warnings}|LIST:{skills_list}",
+    )
+    state = {
+        "requested_skills": ["missing-skill"],
+        "skills_metadata": [
+            {
+                "name": "skill-a",
+                "description": "Skill A",
+                "path": "/skills/skill-a/SKILL.md",
+                "license": None,
+                "compatibility": None,
+                "metadata": {},
+                "allowed_tools": [],
+            }
+        ],
+        "skills_load_errors": ["baseline warning"],
+    }
+
+    result = middleware.before_model(state, None)  # type: ignore[arg-type]
+    assert result is not None
+    assert result["requested_skills"] == []
+    assert result["skills_metadata"] == []
+    assert result["skills_load_errors"] == ["baseline warning", "Requested skill not found: missing-skill"]
 
 
 # --- required-ptc-tools stays in metadata ----------------------------------

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware_async.py
@@ -14,6 +14,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import FileDownloadResponse, FileInfo, LsResult
+from deepagents.backends.state import StateBackend
 from deepagents.middleware.skills import SkillsMiddleware, _alist_skills
 from tests.unit_tests.chat_model import GenericFakeChatModel
 
@@ -450,6 +451,78 @@ async def test_agent_with_skills_middleware_multiple_sources_async(tmp_path: Pat
 
     assert "base-skill" in content
     assert "user-skill" in content
+
+
+async def test_agent_with_skills_middleware_requested_skills_async(tmp_path: Path) -> None:
+    """`requested_skills` state key should filter prompt skills in async flows."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+    skills_dir = tmp_path / "skills" / "user"
+
+    first_skill_path = str(skills_dir / "skill-one" / "SKILL.md")
+    second_skill_path = str(skills_dir / "skill-two" / "SKILL.md")
+
+    responses = backend.upload_files(
+        [
+            (first_skill_path, make_skill_content("skill-one", "First skill description").encode("utf-8")),
+            (second_skill_path, make_skill_content("skill-two", "Second skill description").encode("utf-8")),
+        ]
+    )
+    assert all(r.error is None for r in responses)
+
+    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="I can see selected skills only.")]))
+    middleware = SkillsMiddleware(backend=backend, sources=[str(skills_dir)])
+    agent = create_agent(model=fake_model, middleware=[middleware])
+
+    result = await agent.ainvoke(
+        {
+            "messages": [HumanMessage(content="Use only one skill.")],
+            "requested_skills": ["skill-two"],
+        }
+    )
+
+    assert "messages" in result
+    assert len(result["messages"]) > 0
+
+    first_call = fake_model.call_history[0]
+    system_message = first_call["messages"][0]
+    content = system_message.text
+    assert "skill-two" in content
+    assert "Second skill description" in content
+    assert "skill-one" not in content
+    assert "First skill description" not in content
+
+
+async def test_abefore_model_consumes_requested_skills() -> None:
+    """`abefore_model` should consume `requested_skills` and clear the key."""
+    middleware = SkillsMiddleware(backend=StateBackend(), sources=[])
+    state = {
+        "requested_skills": ["skill-b"],
+        "skills_metadata": [
+            {
+                "name": "skill-a",
+                "description": "Skill A",
+                "path": "/skills/skill-a/SKILL.md",
+                "license": None,
+                "compatibility": None,
+                "metadata": {},
+                "allowed_tools": [],
+            },
+            {
+                "name": "skill-b",
+                "description": "Skill B",
+                "path": "/skills/skill-b/SKILL.md",
+                "license": None,
+                "compatibility": None,
+                "metadata": {},
+                "allowed_tools": [],
+            },
+        ],
+    }
+
+    result = await middleware.abefore_model(state, None)  # type: ignore[arg-type]
+    assert result is not None
+    assert result["requested_skills"] == []
+    assert [skill["name"] for skill in result["skills_metadata"]] == ["skill-b"]
 
 
 async def test_agent_with_skills_middleware_empty_sources_async(tmp_path: Path) -> None:


### PR DESCRIPTION
This change makes skill context injection deterministic per invocation by adding a `requested_skills` state key that is consumed before model calls. `SkillsMiddleware` now applies requested-skill filtering in `before_model`/`abefore_model`, updates `skills_metadata` to the requested subset, and clears `requested_skills` after consumption to avoid stale reuse across later turns.

## Changes

- `SkillsMiddleware` state schema now includes `requested_skills` and its state update shape now supports clearing consumed requests.
- Added a dedicated consume path that:
  - validates and filters requested skill names against loaded `skills_metadata`
  - appends missing-skill warnings to `skills_load_errors`
  - clears `requested_skills` once processed
- Kept prompt rendering (`modify_request`) focused on current `skills_metadata`, so model context reflects the preprocessed state from `before_model`.
- Updated sync and async middleware tests to assert:
  - invocation-time filtering via `requested_skills`
  - `before_model`/`abefore_model` consumption and clearing behavior
  - missing requested-skill warning behavior
