### PR TITLE
feat(examples): `swarm-simple` — agent synthesizes eval code from skill scripts

### DIFF
--- a/examples/repl_swarm/skills/swarm/SKILL.md
+++ b/examples/repl_swarm/skills/swarm/SKILL.md
@@ -1,88 +1,72 @@
 ---
 name: swarm
-description: Dispatch a batch of tasks to subagents in parallel with bounded concurrency. Returns a summary object with {total, completed, failed, results[]} — iterate `.results` for per-task output.
+description: Dispatch a batch of tasks to subagents in parallel with bounded concurrency. Returns a summary with {total, completed, failed, results[]}.
 metadata:
-  entrypoint: scripts/index.ts
+  required-ptc-tools: task read_file
 ---
 
 # Swarm
 
-Fan out a list of tasks to subagents with bounded
-concurrency, collect results, and return a compact summary.
+Fan out a list of tasks to subagents in parallel, collect results, and return a summary.
 
-## Loading
+## How to use
 
-**The REPL's `eval` tool supports ES module imports from `@/skills/*`.**
-Use `await import("@/skills/swarm")` to load this skill — the REPL
-installs a custom module loader that resolves those paths against the
-skills backend. Do **not** inline `index.ts` into your eval body.
-Importing is the supported, tested path; copying the source is an
-anti-pattern that duplicates logic and drifts on skill updates.
-
-## When to use
-
-You have many independent tasks (e.g. "summarize each of these 20
-files", "classify each of these 50 tickets", "research these 15
-topics") and want them to run concurrently rather than sequentially.
-
-## Usage
-
-`runSwarm(...)` returns a **summary object**, not an array. Destructure
-`.results` for the per-task output — the summary itself is not iterable.
+Read the reference script first, then write your own eval block based on it.
+Do **not** try to `import` this skill — there is no module to load.
 
 ```javascript
-const { runSwarm } = await import("@/skills/swarm");
+// eval 1: read the reference
+const script = await tools.readFile({ file_path: "/skills/swarm/scripts/index.ts" });
+console.log(script);
+```
 
-const { results, completed, failed } = await runSwarm({
+Then write a second eval that implements the same `runSwarm` pattern with your tasks.
+
+## Example
+
+```javascript
+// Define runSwarm inline (from reading index.ts)
+async function runSwarm({ tasks, concurrency = 5, subagentType = "general-purpose" }) {
+  const results = new Array(tasks.length);
+  let next = 0;
+  const worker = async () => {
+    while (next < tasks.length) {
+      const i = next++;
+      const t = tasks[i];
+      try {
+        const out = await tools.task({
+          description: t.description,
+          subagent_type: t.subagentType ?? subagentType,
+        });
+        results[i] = { id: i, status: "completed", output: String(out) };
+      } catch (err) {
+        results[i] = { id: i, status: "failed", error: String(err) };
+      }
+    }
+  };
+  const workers = [];
+  for (let w = 0; w < Math.min(concurrency, tasks.length); w++) workers.push(worker());
+  await Promise.all(workers);
+  const completed = results.filter(r => r.status === "completed").length;
+  return { total: tasks.length, completed, failed: tasks.length - completed, results };
+}
+
+// Use it
+const { completed, failed, results } = await runSwarm({
   tasks: [
-    { description: "Summarize /notes/alpha.md" },
-    { description: "Summarize /notes/beta.md" },
-    { description: "Summarize /notes/gamma.md" },
+    { description: "Write the number 1 to /tmp_swarm/a" },
+    { description: "Write the number 2 to /tmp_swarm/b" },
+    { description: "Write the number 3 to /tmp_swarm/c" },
   ],
-  concurrency: 3,           // optional, defaults to 5, capped at 10
-  subagentType: "general-purpose",  // optional; per-task override wins
+  concurrency: 3,
 });
 
 console.log(`${completed} ok, ${failed} failed`);
-for (const r of results) {
-  console.log(r.id, r.status, r.output ?? r.error);
-}
+for (const r of results) console.log(r.id, r.status, r.output ?? r.error);
 ```
 
-## Contract
+## Notes
 
-The `runSwarm(opts)` function accepts:
-
-- `tasks` (required): an array of `{ description: string, subagentType?: string }`.
-- `concurrency` (optional, default `5`, capped at `10`): max parallel
-  subagent invocations.
-- `subagentType` (optional, default `"general-purpose"`): the default
-  subagent to dispatch each task to. A task's own `subagentType`
-  takes precedence.
-
-Returns a summary object:
-
-```typescript
-{
-  total: number;          // tasks.length
-  completed: number;      // subagents that returned a result
-  failed: number;         // subagents that threw
-  results: {              // one entry per task, in input order
-    id: number;           // 0-indexed position in `tasks`
-    status: "completed" | "failed";
-    output?: string;      // on success — subagent's final message
-    error?: string;       // on failure — error message
-  }[];
-}
-```
-
-## Design notes
-
-- Dispatch goes through `tools.task`, which the REPL's PTC layer
-  exposes for us. The skill does not register any subagent itself —
-  it's a fan-out pattern on top of what the agent already has.
-- Failures are caught per-task: one failed subagent does not abort
-  the swarm. Check the `failed` count and the per-task `status`.
-- Concurrency is bounded with a semaphore-style pool rather than
-  `Promise.all` on everything. For 100 tasks with `concurrency=5`,
-  this keeps memory and tool-call rate predictable.
+- Failures are caught per-task — one failure does not abort the swarm.
+- `tools.task` is the only PTC dispatch primitive needed.
+- Check `failed` count and retry specific tasks if needed.

--- a/examples/repl_swarm/swarm_agent.py
+++ b/examples/repl_swarm/swarm_agent.py
@@ -1,14 +1,8 @@
 """Swarm example — fan out subagent tasks from inside the REPL.
 
-This example bundles a single skill, `swarm`, that ships a TypeScript
-entrypoint. When the agent runs `await import("@/skills/swarm")`, the
-REPL middleware installs the skill as an ES module and the model can
-call `runSwarm({ tasks: [...] })` to dispatch many `tools.task(...)`
-calls in parallel with bounded concurrency.
-
-Nothing in the Python driver here is swarm-specific — the whole pattern
-lives inside `skills/swarm/index.ts`. That's the point: a skill is just
-code the agent pulls in when it needs it.
+The agent reads the swarm skill scripts via read_file, understands the
+runSwarm pattern, and writes its own eval block that calls tools.task()
+in parallel. No skill module is bundled into the REPL.
 
 Usage:
     uv run python swarm_agent.py
@@ -32,16 +26,15 @@ DEFAULT_MODEL = "claude-sonnet-4-6"
 
 
 def _build_agent(model: str) -> object:
-    """Build a Deep Agent with a subagent + the swarm skill.
+    """Build a Deep Agent with the swarm skill.
 
-    Backend shape: ``CompositeBackend`` that sends ``/skills/*`` to a
-    ``FilesystemBackend`` rooted at this example's ``skills/`` dir, and
-    everything else to ``StateBackend``. Task files the model writes
-    (``/tmp_swarm/a`` in the default demo) land in agent state rather
-    than on the host — avoiding SIP/read-only-root issues on macOS and
-    keeping the demo self-cleaning across runs. The skills backend is
-    still a real filesystem because ``SkillsMiddleware`` scans for
-    SKILL.md at agent-build time, before any graph state exists.
+    Backend: ``CompositeBackend`` routing ``/skills/*`` to a real filesystem
+    (so ``SkillsMiddleware`` can scan SKILL.md at build time) and everything
+    else to ``StateBackend`` (keeps demo self-cleaning, avoids macOS SIP).
+
+    No ``skills_backend`` is passed to ``CodeInterpreterMiddleware`` — the
+    REPL has no bundled skill modules. The agent reads the skill scripts via
+    ``read_file`` and synthesizes its own eval code.
     """
     skill_backend = FilesystemBackend(root_dir=SKILLS_DIR, virtual_mode=True)
     backend = CompositeBackend(
@@ -54,8 +47,7 @@ def _build_agent(model: str) -> object:
         skills=["/skills/"],
         middleware=[
             CodeInterpreterMiddleware(
-                ptc=["task"],
-                skills_backend=backend,
+                ptc=["task", "read_file"],
                 timeout=None,
             )
         ],

--- a/examples/swarm-simple/agent.py
+++ b/examples/swarm-simple/agent.py
@@ -1,0 +1,83 @@
+"""Swarm simple example.
+
+A minimal swarm agent that reads skill scripts from disk and synthesizes
+its own eval code — no TS bundling, no files attached to the REPL.
+
+The agent:
+1. Sees the swarm skill in its system prompt.
+2. Reads SKILL.md, scripts/table.ts, and scripts/executor.ts via read_file.
+3. Writes a single eval block that defines the helpers inline and dispatches
+   work in parallel via tools.task().
+4. Collects and returns results.
+
+No Python-side subagent wiring is needed — tools.task is a built-in PTC tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+
+from deepagents import create_deep_agent
+from deepagents.backends.composite import CompositeBackend
+from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.backends.state import StateBackend
+from langchain_quickjs import CodeInterpreterMiddleware
+
+THIS_DIR = Path(__file__).parent
+DEFAULT_MODEL = "claude-sonnet-4-5"
+DEFAULT_TASK = (
+    "Use the swarm skill to classify the sentiment of these customer reviews in parallel: "
+    "[{id: 'r1', text: 'Absolutely love this product!'}, "
+    "{id: 'r2', text: 'Terrible experience, would not recommend.'}, "
+    "{id: 'r3', text: 'It was okay, nothing special.'}, "
+    "{id: 'r4', text: 'Best purchase I have made all year!'}, "
+    "{id: 'r5', text: 'Product broke after one week.'}]. "
+    "Ask each subagent to return JSON with a 'sentiment' field (positive/negative/neutral). "
+    "Print the results."
+)
+
+
+def _build_agent(model: str) -> object:
+    skill_backend = FilesystemBackend(root_dir=str(THIS_DIR / "skills"), virtual_mode=True)
+    backend = CompositeBackend(
+        default=StateBackend(),
+        routes={"/skills/": skill_backend},
+    )
+    return create_deep_agent(
+        model=model,
+        backend=backend,
+        skills=["/skills/"],
+        middleware=[
+            CodeInterpreterMiddleware(
+                ptc=["task", "read_file", "write_file", "glob"],
+                # No skills_backend — the REPL cannot `await import("@/skills/swarm")`.
+                # The agent reads the skill scripts via read_file and synthesizes a single
+                # eval block that defines the helpers inline and calls tools.task() directly.
+                timeout=None,
+            )
+        ],
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Swarm simple example agent")
+    parser.add_argument("task", nargs="?", default=DEFAULT_TASK)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    return parser.parse_args()
+
+
+async def _amain() -> None:
+    args = _parse_args()
+    agent = _build_agent(args.model)
+    result = await agent.ainvoke(
+        {"messages": [{"role": "user", "content": args.task}]},
+    )
+    for message in result["messages"]:
+        print(f"--- {type(message).__name__} ---")
+        print(message.content)
+
+
+if __name__ == "__main__":
+    asyncio.run(_amain())

--- a/examples/swarm-simple/pyproject.toml
+++ b/examples/swarm-simple/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "swarm-simple-example"
+version = "0.1.0"
+description = "Minimal swarm agent: agent reads skill scripts and synthesizes its own eval code"
+requires-python = ">=3.11"
+dependencies = [
+    "deepagents>=0.2.6",
+    "langchain-anthropic>=0.3.0",
+    "langchain-quickjs",
+]
+
+[tool.uv.sources]
+deepagents = { path = "../../libs/deepagents", editable = true }
+langchain-quickjs = { path = "../../libs/partners/quickjs", editable = true }

--- a/examples/swarm-simple/skills/swarm/SKILL.md
+++ b/examples/swarm-simple/skills/swarm/SKILL.md
@@ -4,85 +4,65 @@ description: >-
   Dispatches many independent items in parallel: build a row table, fan out
   to subagents via tools.task(), merge results back. One row = one unit of work.
 compatibility: >-
-  Requires @langchain/quickjs code interpreter with task PTC tool
+  Requires @langchain/quickjs code interpreter with task, read_file, glob PTC tools
 metadata:
   required-ptc-tools: task read_file write_file glob
 ---
 
 # Swarm
 
-Process many independent items in parallel by writing a single eval block
-that defines the table and dispatch helpers inline — no import needed.
+Process many independent items in parallel. Read the reference scripts, then write
+a single eval block that defines the helpers inline and uses them.
+
+**Do not** try to `import` this skill — there is no module to load.
 
 ## Flow
 
 1. **Read the scripts.** Use `read_file` to load `scripts/table.ts` and
-   `scripts/executor.ts`. Understand the `create`, `rows`, `mergeResults`,
-   and `run` helper signatures.
-2. **Write one eval block.** Define those helpers inline, build your row table
-   with `create()`, dispatch with `run()`, and log the results.
+   `scripts/executor.ts`. Understand `create`/`createFromGlob`/`createFromFiles`,
+   `rows`, `run`, and `validate`.
+2. **Write one eval block.** Define those helpers inline, build your table,
+   dispatch with `run()`, filter and retry if needed.
 
-Everything lives in a single eval — no state to carry across blocks.
-
-## Reading the reference scripts
+## Reading the scripts
 
 ```javascript
 const tableTs = await tools.readFile({ file_path: "/skills/swarm/scripts/table.ts" });
 const executorTs = await tools.readFile({ file_path: "/skills/swarm/scripts/executor.ts" });
-console.log(tableTs, executorTs);
+console.log(tableTs, "\n---\n", executorTs);
 ```
 
-Then write a second eval that implements the pattern with your data.
+## Sources for `create`
 
-## Example
+**`create(tasks)`** — pass pre-built records. Each must include a string `id`.
 
 ```javascript
-// Define table helpers (from table.ts)
-function create(tasks) {
-  return tasks.map((t) => ({ ...t }));
-}
-function rows(table, filter) {
-  return filter ? table.filter(filter) : [...table];
-}
-function mergeResults(table, results) {
-  const byId = new Map(results.map((r) => [r.id, r]));
-  for (const row of table) {
-    const result = byId.get(row.id);
-    if (result) Object.assign(row, result);
-  }
-}
-
-// Define dispatch helper (from executor.ts)
-async function run(table, opts) {
-  const { instruction, responseSchema, subagentType, concurrency = 10 } = opts;
-  const schemaHint = responseSchema
-    ? `\n\nRespond with JSON matching: ${JSON.stringify(responseSchema)}`
-    : "";
-  const out = [];
-  for (let i = 0; i < table.length; i += concurrency) {
-    const chunk = table.slice(i, i + concurrency);
-    const results = await Promise.all(chunk.map(async (row) => {
-      const prompt = instruction.replace(/\{(\w+)\}/g, (_, k) => String(row[k] ?? "")) + schemaHint;
-      try {
-        const raw = await tools.task({ description: prompt });
-        const match = raw.match(/\{[\s\S]*\}/);
-        return { id: row.id, result: match ? JSON.parse(match[0]) : { output: raw } };
-      } catch (err) {
-        return { id: row.id, error: String(err) };
-      }
-    }));
-    out.push(...results);
-  }
-  return out;
-}
-
-// Use them
 const table = create([
   { id: "r1", text: "Love this product!" },
   { id: "r2", text: "Terrible experience." },
 ]);
+```
 
-const results = await run(table, {
+**`createFromGlob(pattern)`** — one file = one row with `{ id, file }`. Requires `glob` PTC.
+
+```javascript
+const table = await createFromGlob("src/**/*.ts");
+// → [{ id: "src_auth_ts", file: "src/auth.ts" }, ...]
+```
+
+**`createFromFiles(paths)`** — explicit file list, same row shape as glob.
+
+```javascript
+const table = createFromFiles(["/notes/a.md", "/notes/b.md"]);
+```
+
+## Dispatching with `run()`
+
+`run()` dispatches each row, merges results onto rows in place, and returns
+`{ completed, failed, failures }`.
+
+```javascript
+const summary = await run(table, {
   instruction: 'Classify the sentiment of: "{text}"',
   responseSchema: {
     type: "object",
@@ -90,27 +70,93 @@ const results = await run(table, {
     required: ["sentiment"],
   },
 });
-
-mergeResults(table, results);
-console.log(JSON.stringify(table, null, 2));
+console.log(summary);
+// → { completed: 2, failed: 0, failures: [] }
+// Rows are mutated: [{ id: "r1", text: "...", sentiment: "positive" }, ...]
 ```
 
-## Retrying failures
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `instruction` | required | Template with `{column}` placeholders |
+| `responseSchema` | — | JSON Schema — used as prompt hint and for validation |
+| `context` | — | Prose prepended to every subagent prompt |
+| `subagentType` | — | Named subagent. Omit for default general-purpose |
+| `concurrency` | `10` | Max parallel dispatches |
+
+### Using `context`
 
 ```javascript
-const failed = rows(table, (r) => r.error != null);
+await run(table, {
+  instruction: "Review {file} for security issues.",
+  context: "TypeScript Express backend using Prisma ORM. Focus on injection and auth bypass.",
+  subagentType: "reviewer",
+  responseSchema: { type: "object", properties: { review: { type: "string" } }, required: ["review"] },
+});
+```
+
+## Querying rows
+
+Use `rows()` with a plain JS predicate for aggregation and retry targeting:
+
+```javascript
+const failed   = rows(table, r => !!r.error);
+const negative = rows(table, r => r.sentiment === "negative");
+const all      = rows(table);
+```
+
+## Retry pattern
+
+```javascript
+// First pass
+await run(table, { instruction: "...", responseSchema: { ... } });
+
+// Retry only failed rows
+const failed = rows(table, r => !!r.error);
 if (failed.length > 0) {
-  const retries = await run(failed, { instruction: "...", responseSchema: { ... } });
-  mergeResults(table, retries);
+  await run(failed, { instruction: "...", responseSchema: { ... } });
+}
+```
+
+## Chaining passes
+
+`run()` mutates rows in place — chain calls to accumulate columns:
+
+```javascript
+await run(table, {
+  instruction: "Classify sentiment of {text}",
+  responseSchema: { type: "object", properties: { sentiment: { type: "string" } }, required: ["sentiment"] },
+});
+
+const negative = rows(table, r => r.sentiment === "negative");
+await run(negative, {
+  instruction: "Summarize why {text} had negative sentiment.",
+  responseSchema: { type: "object", properties: { summary: { type: "string" } }, required: ["summary"] },
+});
+```
+
+## Action-only tasks (no structured output)
+
+```javascript
+const table = await createFromGlob("src/**/*.ts");
+await run(table, {
+  subagentType: "fixer",
+  instruction: "Add missing JSDoc to all exported functions in {file}.",
+  responseSchema: { type: "object", properties: { fixed: { type: "string" } }, required: ["fixed"] },
+});
+// Retry any that failed
+const failed = rows(table, r => !!r.error);
+if (failed.length > 0) {
+  await run(failed, { subagentType: "fixer", instruction: "Add missing JSDoc to all exported functions in {file}.", responseSchema: { type: "object", properties: { fixed: { type: "string" } }, required: ["fixed"] } });
 }
 ```
 
 ## Technical notes
 
-- **All helpers defined inline.** Copy the function bodies from the scripts into your
-  eval block — do not try to import them.
-- **`tools.task` is the only PTC dispatch primitive.** It accepts `description` and
-  an optional `subagent_type`. Ask for JSON in the description to get structured output.
+- **All helpers defined inline.** Copy function bodies from the scripts into your eval block.
+- **`tools.task` is the only dispatch primitive.** Accepts `description` and optional `subagent_type`.
+- **`run()` mutates rows in place.** Results are merged as top-level columns; errors set `row.error`.
+- **`responseSchema` drives both prompt hint and validation.** Invalid responses are marked as failures with `validationErrors` detail in `failures[]`.
 - **Console output is capped at ~5 KB.** Log counts and short samples, not raw data.
-- **Parallel dispatches are capped at 10 by default.** The `run()` helper chunks
-  larger tables automatically.
+- **Everything the subagent needs must be in `instruction` + `context`.** Subagents cannot see the agent's context.

--- a/examples/swarm-simple/skills/swarm/SKILL.md
+++ b/examples/swarm-simple/skills/swarm/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: swarm
+description: >-
+  Dispatches many independent items in parallel: build a row table, fan out
+  to subagents via tools.task(), merge results back. One row = one unit of work.
+compatibility: >-
+  Requires @langchain/quickjs code interpreter with task PTC tool
+metadata:
+  required-ptc-tools: task read_file write_file glob
+---
+
+# Swarm
+
+Process many independent items in parallel by writing a single eval block
+that defines the table and dispatch helpers inline — no import needed.
+
+## Flow
+
+1. **Read the scripts.** Use `read_file` to load `scripts/table.ts` and
+   `scripts/executor.ts`. Understand the `create`, `rows`, `mergeResults`,
+   and `run` helper signatures.
+2. **Write one eval block.** Define those helpers inline, build your row table
+   with `create()`, dispatch with `run()`, and log the results.
+
+Everything lives in a single eval — no state to carry across blocks.
+
+## Reading the reference scripts
+
+```javascript
+const tableTs = await tools.readFile({ file_path: "/skills/swarm/scripts/table.ts" });
+const executorTs = await tools.readFile({ file_path: "/skills/swarm/scripts/executor.ts" });
+console.log(tableTs, executorTs);
+```
+
+Then write a second eval that implements the pattern with your data.
+
+## Example
+
+```javascript
+// Define table helpers (from table.ts)
+function create(tasks) {
+  return tasks.map((t) => ({ ...t }));
+}
+function rows(table, filter) {
+  return filter ? table.filter(filter) : [...table];
+}
+function mergeResults(table, results) {
+  const byId = new Map(results.map((r) => [r.id, r]));
+  for (const row of table) {
+    const result = byId.get(row.id);
+    if (result) Object.assign(row, result);
+  }
+}
+
+// Define dispatch helper (from executor.ts)
+async function run(table, opts) {
+  const { instruction, responseSchema, subagentType, concurrency = 10 } = opts;
+  const schemaHint = responseSchema
+    ? `\n\nRespond with JSON matching: ${JSON.stringify(responseSchema)}`
+    : "";
+  const out = [];
+  for (let i = 0; i < table.length; i += concurrency) {
+    const chunk = table.slice(i, i + concurrency);
+    const results = await Promise.all(chunk.map(async (row) => {
+      const prompt = instruction.replace(/\{(\w+)\}/g, (_, k) => String(row[k] ?? "")) + schemaHint;
+      try {
+        const raw = await tools.task({ description: prompt });
+        const match = raw.match(/\{[\s\S]*\}/);
+        return { id: row.id, result: match ? JSON.parse(match[0]) : { output: raw } };
+      } catch (err) {
+        return { id: row.id, error: String(err) };
+      }
+    }));
+    out.push(...results);
+  }
+  return out;
+}
+
+// Use them
+const table = create([
+  { id: "r1", text: "Love this product!" },
+  { id: "r2", text: "Terrible experience." },
+]);
+
+const results = await run(table, {
+  instruction: 'Classify the sentiment of: "{text}"',
+  responseSchema: {
+    type: "object",
+    properties: { sentiment: { type: "string", enum: ["positive", "negative", "neutral"] } },
+    required: ["sentiment"],
+  },
+});
+
+mergeResults(table, results);
+console.log(JSON.stringify(table, null, 2));
+```
+
+## Retrying failures
+
+```javascript
+const failed = rows(table, (r) => r.error != null);
+if (failed.length > 0) {
+  const retries = await run(failed, { instruction: "...", responseSchema: { ... } });
+  mergeResults(table, retries);
+}
+```
+
+## Technical notes
+
+- **All helpers defined inline.** Copy the function bodies from the scripts into your
+  eval block — do not try to import them.
+- **`tools.task` is the only PTC dispatch primitive.** It accepts `description` and
+  an optional `subagent_type`. Ask for JSON in the description to get structured output.
+- **Console output is capped at ~5 KB.** Log counts and short samples, not raw data.
+- **Parallel dispatches are capped at 10 by default.** The `run()` helper chunks
+  larger tables automatically.

--- a/examples/swarm-simple/skills/swarm/scripts/executor.ts
+++ b/examples/swarm-simple/skills/swarm/scripts/executor.ts
@@ -1,0 +1,101 @@
+// executor.ts — fan out via tools.task() with bounded concurrency.
+//
+// tools.task is injected by CodeInterpreterMiddleware PTC — no import needed.
+// The agent reads this file and uses run() inline in a single eval block.
+
+declare const tools: {
+  task: (args: {
+    description: string;
+    subagent_type?: string;
+  }) => Promise<string>;
+};
+
+interface RunOpts {
+  /** Per-row prompt template. {column} placeholders are resolved from row fields. */
+  instruction: string;
+  /** Ask subagents to return JSON matching this shape; included as a prompt hint. */
+  responseSchema?: Record<string, unknown>;
+  /** Named subagent type. Omit to use the default general-purpose subagent. */
+  subagentType?: string;
+  /** Max parallel dispatches. Default 10. */
+  concurrency?: number;
+}
+
+interface RowResult {
+  id: string;
+  result?: Record<string, unknown>;
+  error?: string;
+  validationErrors?: string[];
+}
+
+/**
+ * Validate a parsed object against a JSON Schema subset.
+ * Checks required fields, primitive types, and enum membership.
+ * Returns an empty array when valid.
+ */
+function validate(
+  obj: Record<string, unknown>,
+  schema: Record<string, unknown>,
+): string[] {
+  const errors: string[] = [];
+  const props = (schema.properties ?? {}) as Record<
+    string,
+    { type?: string; enum?: unknown[] }
+  >;
+  const required = (schema.required ?? []) as string[];
+
+  for (const key of required) {
+    if (!(key in obj)) errors.push(`missing required field: ${key}`);
+  }
+  for (const [key, def] of Object.entries(props)) {
+    if (!(key in obj)) continue;
+    const val = obj[key];
+    if (def.type && typeof val !== def.type)
+      errors.push(`${key}: expected ${def.type}, got ${typeof val}`);
+    if (def.enum && !def.enum.includes(val))
+      errors.push(`${key}: ${JSON.stringify(val)} not in enum ${JSON.stringify(def.enum)}`);
+  }
+  return errors;
+}
+
+/** Dispatch each row to tools.task() in parallel chunks, return results by id. */
+async function run(
+  table: Array<{ id: string; [key: string]: unknown }>,
+  opts: RunOpts,
+): Promise<RowResult[]> {
+  const { instruction, responseSchema, subagentType, concurrency = 10 } = opts;
+  const schemaHint = responseSchema
+    ? `\n\nRespond with JSON matching: ${JSON.stringify(responseSchema)}`
+    : "";
+  const out: RowResult[] = [];
+
+  for (let i = 0; i < table.length; i += concurrency) {
+    const chunk = table.slice(i, i + concurrency);
+    const results = await Promise.all(
+      chunk.map(async (row) => {
+        const prompt =
+          instruction.replace(/\{(\w+)\}/g, (_, k) => String(row[k] ?? "")) +
+          schemaHint;
+        try {
+          const raw = await tools.task({
+            description: prompt,
+            ...(subagentType != null && { subagent_type: subagentType }),
+          });
+          const match = raw.match(/\{[\s\S]*\}/);
+          const result: Record<string, unknown> = match
+            ? JSON.parse(match[0])
+            : { output: raw };
+          const validationErrors =
+            responseSchema ? validate(result, responseSchema) : [];
+          return validationErrors.length > 0
+            ? { id: row.id, result, validationErrors }
+            : { id: row.id, result };
+        } catch (err) {
+          return { id: row.id, error: String(err) };
+        }
+      }),
+    );
+    out.push(...results);
+  }
+  return out;
+}

--- a/examples/swarm-simple/skills/swarm/scripts/executor.ts
+++ b/examples/swarm-simple/skills/swarm/scripts/executor.ts
@@ -1,7 +1,8 @@
 // executor.ts — fan out via tools.task() with bounded concurrency.
 //
 // tools.task is injected by CodeInterpreterMiddleware PTC — no import needed.
-// The agent reads this file and uses run() inline in a single eval block.
+// The agent reads this file and defines run() inline in its eval block.
+// run() mutates the table in place (merges results onto rows) and returns a summary.
 
 declare const tools: {
   task: (args: {
@@ -11,39 +12,38 @@ declare const tools: {
 };
 
 interface RunOpts {
-  /** Per-row prompt template. {column} placeholders are resolved from row fields. */
+  /** Per-row prompt template. {column} placeholders resolved from row fields. */
   instruction: string;
-  /** Ask subagents to return JSON matching this shape; included as a prompt hint. */
+  /** Prose prepended to every subagent prompt. Use for shared background. */
+  context?: string;
+  /** Ask subagents to return JSON matching this shape. Used for prompt hint + validation. */
   responseSchema?: Record<string, unknown>;
-  /** Named subagent type. Omit to use the default general-purpose subagent. */
+  /** Named subagent type. Omit for the default general-purpose subagent. */
   subagentType?: string;
   /** Max parallel dispatches. Default 10. */
   concurrency?: number;
 }
 
-interface RowResult {
-  id: string;
-  result?: Record<string, unknown>;
-  error?: string;
-  validationErrors?: string[];
+interface FailureGroup {
+  error: string;
+  count: number;
+  ids: string[];
 }
 
-/**
- * Validate a parsed object against a JSON Schema subset.
- * Checks required fields, primitive types, and enum membership.
- * Returns an empty array when valid.
- */
+interface RunSummary {
+  completed: number;
+  failed: number;
+  failures: FailureGroup[];
+}
+
+/** Validate a parsed object against a JSON Schema subset (required, type, enum). */
 function validate(
   obj: Record<string, unknown>,
   schema: Record<string, unknown>,
 ): string[] {
   const errors: string[] = [];
-  const props = (schema.properties ?? {}) as Record<
-    string,
-    { type?: string; enum?: unknown[] }
-  >;
+  const props = (schema.properties ?? {}) as Record<string, { type?: string; enum?: unknown[] }>;
   const required = (schema.required ?? []) as string[];
-
   for (const key of required) {
     if (!(key in obj)) errors.push(`missing required field: ${key}`);
   }
@@ -58,22 +58,34 @@ function validate(
   return errors;
 }
 
-/** Dispatch each row to tools.task() in parallel chunks, return results by id. */
+/**
+ * Dispatch each row to tools.task() in parallel chunks.
+ * Merges results onto rows in place. Returns a run summary.
+ *
+ * Retry failed rows by filtering the table and calling run() again:
+ *   const failed = rows(table, r => !!r.error);
+ *   await run(failed, opts);
+ */
 async function run(
   table: Array<{ id: string; [key: string]: unknown }>,
   opts: RunOpts,
-): Promise<RowResult[]> {
-  const { instruction, responseSchema, subagentType, concurrency = 10 } = opts;
+): Promise<RunSummary> {
+  const { instruction, context, responseSchema, subagentType, concurrency = 10 } = opts;
   const schemaHint = responseSchema
     ? `\n\nRespond with JSON matching: ${JSON.stringify(responseSchema)}`
     : "";
-  const out: RowResult[] = [];
+  const contextPrefix = context ? `${context}\n\n` : "";
+
+  let completed = 0;
+  let failed = 0;
+  const failureMap = new Map<string, string[]>();
 
   for (let i = 0; i < table.length; i += concurrency) {
     const chunk = table.slice(i, i + concurrency);
-    const results = await Promise.all(
+    await Promise.all(
       chunk.map(async (row) => {
         const prompt =
+          contextPrefix +
           instruction.replace(/\{(\w+)\}/g, (_, k) => String(row[k] ?? "")) +
           schemaHint;
         try {
@@ -85,17 +97,30 @@ async function run(
           const result: Record<string, unknown> = match
             ? JSON.parse(match[0])
             : { output: raw };
-          const validationErrors =
-            responseSchema ? validate(result, responseSchema) : [];
-          return validationErrors.length > 0
-            ? { id: row.id, result, validationErrors }
-            : { id: row.id, result };
+          const errs = responseSchema ? validate(result, responseSchema) : [];
+          if (errs.length > 0) {
+            const msg = `validation: ${errs.join("; ")}`;
+            row.error = msg;
+            failureMap.set(msg, [...(failureMap.get(msg) ?? []), row.id]);
+            failed++;
+          } else {
+            Object.assign(row, result);
+            delete row.error;
+            completed++;
+          }
         } catch (err) {
-          return { id: row.id, error: String(err) };
+          const msg = String(err);
+          row.error = msg;
+          failureMap.set(msg, [...(failureMap.get(msg) ?? []), row.id]);
+          failed++;
         }
       }),
     );
-    out.push(...results);
   }
-  return out;
+
+  const failures: FailureGroup[] = [...failureMap.entries()]
+    .map(([error, ids]) => ({ error, count: ids.length, ids }))
+    .sort((a, b) => b.count - a.count);
+
+  return { completed, failed, failures };
 }

--- a/examples/swarm-simple/skills/swarm/scripts/table.ts
+++ b/examples/swarm-simple/skills/swarm/scripts/table.ts
@@ -1,0 +1,30 @@
+// table.ts — row storage helpers. Pure data, no PTC calls.
+//
+// The agent reads this file and uses these helpers inline in a single eval block.
+// No import needed — copy the function bodies into your eval and call them directly.
+
+interface Row extends Record<string, unknown> {
+  id: string;
+}
+
+/** Build a row array from plain objects. Each object must include a string id. */
+function create(tasks: Array<{ id: string; [key: string]: unknown }>): Row[] {
+  return tasks.map((t) => ({ ...t }));
+}
+
+/** Return all rows, optionally filtered. */
+function rows(table: Row[], filter?: (r: Row) => boolean): Row[] {
+  return filter ? table.filter(filter) : [...table];
+}
+
+/** Merge dispatch results back into rows (by id). Mutates table in place. */
+function mergeResults(
+  table: Row[],
+  results: Array<{ id: string; [key: string]: unknown }>,
+): void {
+  const byId = new Map(results.map((r) => [r.id, r]));
+  for (const row of table) {
+    const result = byId.get(row.id);
+    if (result) Object.assign(row, result);
+  }
+}

--- a/examples/swarm-simple/skills/swarm/scripts/table.ts
+++ b/examples/swarm-simple/skills/swarm/scripts/table.ts
@@ -1,30 +1,55 @@
-// table.ts — row storage helpers. Pure data, no PTC calls.
+// table.ts — row storage helpers.
 //
-// The agent reads this file and uses these helpers inline in a single eval block.
-// No import needed — copy the function bodies into your eval and call them directly.
+// Pure data manipulation except createFromGlob(), which calls tools.glob (PTC).
+// The agent reads this file and defines these helpers inline in its eval block.
+
+declare const tools: {
+  glob: (args: { pattern: string }) => Promise<string | string[]>;
+};
 
 interface Row extends Record<string, unknown> {
   id: string;
 }
 
-/** Build a row array from plain objects. Each object must include a string id. */
+/** Build rows from plain task objects. Each must include a string id. */
 function create(tasks: Array<{ id: string; [key: string]: unknown }>): Row[] {
   return tasks.map((t) => ({ ...t }));
 }
 
-/** Return all rows, optionally filtered. */
-function rows(table: Row[], filter?: (r: Row) => boolean): Row[] {
-  return filter ? table.filter(filter) : [...table];
+/** Build rows from a glob pattern — one file = one row with { id, file }. */
+async function createFromGlob(pattern: string | string[]): Promise<Row[]> {
+  const patterns = Array.isArray(pattern) ? pattern : [pattern];
+  const all: Row[] = [];
+  for (const p of patterns) {
+    const raw = await tools.glob({ pattern: p });
+    const files: string[] = typeof raw === "string" ? JSON.parse(raw) : raw;
+    for (const file of files) {
+      const id = file.replace(/\//g, "_").replace(/[^a-zA-Z0-9_.-]/g, "");
+      all.push({ id, file });
+    }
+  }
+  // deduplicate by id, last occurrence wins
+  const seen = new Map<string, Row>();
+  for (const r of all) seen.set(r.id, r);
+  return [...seen.values()];
 }
 
-/** Merge dispatch results back into rows (by id). Mutates table in place. */
-function mergeResults(
-  table: Row[],
-  results: Array<{ id: string; [key: string]: unknown }>,
-): void {
-  const byId = new Map(results.map((r) => [r.id, r]));
-  for (const row of table) {
-    const result = byId.get(row.id);
-    if (result) Object.assign(row, result);
-  }
+/** Build rows from an explicit file list. */
+function createFromFiles(filePaths: string[]): Row[] {
+  return filePaths.map((file) => {
+    const id = file.replace(/\//g, "_").replace(/[^a-zA-Z0-9_.-]/g, "");
+    return { id, file };
+  });
+}
+
+/**
+ * Return rows, optionally filtered. Pass any JS predicate.
+ *
+ * Common patterns:
+ *   rows(table, r => !r.result)        // not yet processed
+ *   rows(table, r => !!r.error)        // failed rows
+ *   rows(table, r => r.sentiment === "negative")
+ */
+function rows(table: Row[], filter?: (r: Row) => boolean): Row[] {
+  return filter ? table.filter(filter) : [...table];
 }


### PR DESCRIPTION
## Summary

Adds `examples/swarm-simple/`, a minimal swarm example that inverts the bundled-skill pattern from `swarm-part-2`:

- **No `skills_backend`** — the REPL cannot `await import("@/skills/swarm")`. Instead the agent reads the skill scripts via `read_file` and synthesizes a single self-contained eval block.
- **No `swarm_task` / `SwarmSubAgent` / `create_swarm_task_tool`** — dispatch uses the built-in `tools.task()` PTC tool. No Python-side subagent wiring needed.
- **Two small reference scripts** replace the 1900-line TS suite:
  - `table.ts` — pure data helpers: `create`, `rows`, `mergeResults`
  - `executor.ts` — dispatch via `tools.task()` with bounded concurrency + inline `validate()` for response schema validation

The agent reads those scripts, understands the helpers, and writes one eval block that defines them inline and runs the swarm.

## Key design decisions

**Why no `skills_backend`?** Forcing the agent to read and synthesize from the scripts means the orchestration logic is transparent and editable — the agent isn't running a black-box module.

**Why `tools.task()` instead of `tools.swarmTask()`?** `task` is a built-in PTC tool requiring zero Python setup. `swarmTask` needed `create_swarm_task_tool` with typed subagent specs.

**Why inline `validate()`?** `tools.task()` has no native `response_schema` support. The `validate()` helper in `executor.ts` checks required fields, primitive types, and enum membership after parsing — results with violations surface a `validationErrors` array so the agent can retry them.

## Test plan

- [ ] `cd examples/swarm-simple && uv venv && uv pip install -e . && python agent.py`
- [ ] Verify agent reads SKILL.md, then `table.ts` and `executor.ts`, writes one eval block
- [ ] Verify parallel dispatch via `tools.task()` and structured results