### PR TITLE
feat(sdk): add Landlock-confined SandboxedShellBackend

### DIFF
--- a/libs/deepagents/deepagents/backends/__init__.py
+++ b/libs/deepagents/deepagents/backends/__init__.py
@@ -6,6 +6,7 @@ from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.langsmith import LangSmithSandbox
 from deepagents.backends.local_shell import DEFAULT_EXECUTE_TIMEOUT, LocalShellBackend
 from deepagents.backends.protocol import BackendProtocol
+from deepagents.backends.sandboxed_shell import SandboxedShellBackend
 from deepagents.backends.state import StateBackend
 from deepagents.backends.store import (
     BackendContext,
@@ -23,6 +24,7 @@ __all__ = [
     "LangSmithSandbox",
     "LocalShellBackend",
     "NamespaceFactory",
+    "SandboxedShellBackend",
     "StateBackend",
     "StoreBackend",
 ]

--- a/libs/deepagents/deepagents/backends/_landlock_exec.py
+++ b/libs/deepagents/deepagents/backends/_landlock_exec.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Self-contained Landlock exec wrapper for `SandboxedShellBackend`.
+
+Run as a standalone subprocess (``python3 _landlock_exec.py ...``). It applies a
+Linux Landlock filesystem ruleset to *itself* -- confining reads/writes to the
+supplied roots -- and then ``execve``s the agent's command under ``/bin/sh -c``.
+Because Landlock restrictions are inherited across ``exec`` and by all child
+processes, and can only ever *add* restrictions, every process the shell spawns
+stays confined.
+
+Deliberately stdlib-only and designed to be invoked *by path* (not ``-m``) so it
+never imports the ``deepagents`` package (which would pull in LangChain and slow
+down every shell command). It is launched by
+``deepagents.backends.sandboxed_shell.SandboxedShellBackend``.
+
+Threat model: stop the shell from reading or writing files outside the granted
+roots (e.g. ``.env`` files, sibling sessions, ``/etc`` secrets). It is a
+filesystem boundary only -- it does not restrict network, and on Landlock ABI
+< 3 it cannot gate ``truncate()`` on already-accessible files (acceptable:
+confinement is about which paths are reachable, not in-place truncation).
+
+Fails closed: if Landlock is unavailable (kernel too old / disabled) or any
+mandatory rule cannot be installed, it exits non-zero WITHOUT running the
+command, so a misconfiguration can never silently downgrade to an unconfined
+shell.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import ctypes
+import ctypes.util
+import os
+import sys
+from typing import NoReturn
+
+# x86_64 / arm64 share these syscall numbers for the Landlock syscalls.
+_NR_CREATE_RULESET = 444
+_NR_ADD_RULE = 445
+_NR_RESTRICT_SELF = 446
+_PR_SET_NO_NEW_PRIVS = 38
+_LANDLOCK_CREATE_RULESET_VERSION = 1 << 0
+_LANDLOCK_RULE_PATH_BENEATH = 1
+
+# Landlock ABI versions that unlock additional filesystem access-right bits.
+_ABI_REFER = 2  # adds LANDLOCK_ACCESS_FS_REFER (reparent)
+_ABI_TRUNCATE = 3  # adds LANDLOCK_ACCESS_FS_TRUNCATE
+_ABI_IOCTL_DEV = 5  # adds LANDLOCK_ACCESS_FS_IOCTL_DEV
+
+# Filesystem access-right bits (uapi/linux/landlock.h).
+_FS_EXECUTE = 1 << 0
+_FS_WRITE_FILE = 1 << 1
+_FS_READ_FILE = 1 << 2
+_FS_READ_DIR = 1 << 3
+# Read-only roots grant traversal + read + execute (enough to run interpreters
+# and shared libraries), but no write/create/remove bits.
+_RO_ACCESS = _FS_READ_FILE | _FS_READ_DIR | _FS_EXECUTE
+# Device roots (/dev) grant read+write to existing nodes plus dir traversal, so
+# shells can redirect to /dev/null, read /dev/urandom, use ttys, etc. -- but not
+# execute or create/remove nodes.
+_DEV_ACCESS = _FS_READ_FILE | _FS_WRITE_FILE | _FS_READ_DIR
+
+_EXIT_SANDBOX_SETUP_FAILED = 127
+
+_libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6", use_errno=True)
+
+
+class _RulesetAttr(ctypes.Structure):
+    """``struct landlock_ruleset_attr`` -- only ``handled_access_fs`` is passed.
+
+    The size matches the v1 layout, so the call is valid on every ABI that
+    supports filesystem rules (v1+) regardless of network-rule support.
+    """
+
+    _fields_ = (("handled_access_fs", ctypes.c_uint64),)
+
+
+class _PathBeneathAttr(ctypes.Structure):
+    """``struct landlock_path_beneath_attr`` for ``LANDLOCK_RULE_PATH_BENEATH``."""
+
+    _pack_ = 1
+    _fields_ = (
+        ("allowed_access", ctypes.c_uint64),
+        ("parent_fd", ctypes.c_int32),
+    )
+
+
+def _syscall(*args: int) -> int:
+    """Invoke ``syscall(2)`` with ``c_long`` arguments and return its result."""
+    _libc.syscall.restype = ctypes.c_long
+    return _libc.syscall(*[ctypes.c_long(a) for a in args])
+
+
+def _abi_version() -> int:
+    """Return the kernel's Landlock ABI version, or <= 0 if unavailable."""
+    return _syscall(_NR_CREATE_RULESET, 0, 0, _LANDLOCK_CREATE_RULESET_VERSION)
+
+
+def _fs_mask_for_abi(version: int) -> int:
+    """Return the full set of filesystem rights the running kernel understands.
+
+    Passing a bit the kernel does not support makes ``create_ruleset`` fail with
+    ``EINVAL``, so the handled set must be clamped to the ABI version.
+    """
+    mask = (1 << 13) - 1  # v1: bits 0..12 (execute/read/write/remove/make-*)
+    if version >= _ABI_REFER:
+        mask |= 1 << 13  # REFER (reparent)
+    if version >= _ABI_TRUNCATE:
+        mask |= 1 << 14  # TRUNCATE
+    if version >= _ABI_IOCTL_DEV:
+        mask |= 1 << 15  # IOCTL_DEV
+    return mask
+
+
+def _add_path_rule(ruleset_fd: int, path: str, access: int) -> None:
+    """Grant ``access`` to everything beneath ``path``. Raise ``OSError`` on failure."""
+    fd = os.open(path, os.O_PATH | os.O_CLOEXEC)
+    try:
+        attr = _PathBeneathAttr(allowed_access=access, parent_fd=fd)
+        rc = _syscall(
+            _NR_ADD_RULE,
+            ruleset_fd,
+            _LANDLOCK_RULE_PATH_BENEATH,
+            ctypes.addressof(attr),
+            0,
+        )
+        if rc != 0:
+            msg = f"landlock_add_rule failed for {path}"
+            raise OSError(ctypes.get_errno(), msg)
+    finally:
+        os.close(fd)
+
+
+def _die(message: str) -> NoReturn:
+    """Write ``message`` to stderr and exit with the sandbox-setup failure code."""
+    sys.stderr.write(f"[landlock-exec] {message}\n")
+    sys.exit(_EXIT_SANDBOX_SETUP_FAILED)
+
+
+def _add_optional_roots(ruleset_fd: int, roots: list[str], access: int, label: str) -> None:
+    """Grant ``access`` to each existing root; skip absent ones, log other errors.
+
+    Used for read-only and device roots, where a missing path (e.g. ``/lib64``
+    on some layouts) should be silently skipped so the allowlist can stay
+    generous across images.
+    """
+    for root in roots:
+        try:
+            _add_path_rule(ruleset_fd, root, access)
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            sys.stderr.write(f"[landlock-exec] skipping {label} root {root!r}: {exc}\n")
+
+
+def _apply_landlock(
+    writable_roots: list[str],
+    readonly_roots: list[str],
+    device_roots: list[str],
+) -> None:
+    """Create a Landlock ruleset for the given roots and restrict this process."""
+    version = _abi_version()
+    if version < 1:
+        _die(f"Landlock unavailable on this kernel (ABI {version}); refusing to run the command unconfined.")
+
+    fs_mask = _fs_mask_for_abi(version)
+    attr = _RulesetAttr(handled_access_fs=fs_mask)
+    ruleset_fd = _syscall(_NR_CREATE_RULESET, ctypes.addressof(attr), ctypes.sizeof(attr), 0)
+    if ruleset_fd < 0:
+        _die(f"landlock_create_ruleset failed (errno={ctypes.get_errno()})")
+
+    # Writable roots must exist -- a missing session dir is a hard error (the
+    # workspace should have been prepared first).
+    granted_writable = 0
+    for root in writable_roots:
+        try:
+            _add_path_rule(ruleset_fd, root, fs_mask)
+            granted_writable += 1
+        except OSError as exc:
+            _die(f"cannot grant writable root {root!r}: {exc}")
+    if granted_writable == 0:
+        _die("no writable roots were granted; refusing to run")
+
+    _add_optional_roots(ruleset_fd, readonly_roots, _RO_ACCESS, "ro")
+    _add_optional_roots(ruleset_fd, device_roots, _DEV_ACCESS, "dev")
+
+    if _libc.prctl(_PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0:
+        _die(f"prctl(PR_SET_NO_NEW_PRIVS) failed (errno={ctypes.get_errno()})")
+    if _syscall(_NR_RESTRICT_SELF, ruleset_fd, 0) != 0:
+        _die(f"landlock_restrict_self failed (errno={ctypes.get_errno()})")
+    os.close(ruleset_fd)
+
+
+def main(argv: list[str]) -> int:
+    """Parse args, apply the sandbox, then ``execve`` the command under ``/bin/sh``."""
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--rw", action="append", default=[], dest="writable")
+    parser.add_argument("--ro", action="append", default=[], dest="readonly")
+    parser.add_argument("--dev", action="append", default=[], dest="device")
+    parser.add_argument("--cmd-b64", required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        command = base64.b64decode(args.cmd_b64).decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as exc:
+        _die(f"invalid --cmd-b64 payload: {exc}")
+
+    _apply_landlock(args.writable, args.readonly, args.device)
+
+    # Hand off to the shell so pipes/redirects/etc. behave exactly as the
+    # unsandboxed backend. execve never returns on success.
+    try:
+        os.execv("/bin/sh", ["/bin/sh", "-c", command])  # noqa: S606  # confined shell, command from a trusted base64 arg
+    except OSError as exc:  # pragma: no cover - only on a broken image
+        _die(f"failed to exec /bin/sh: {exc}")
+    return _EXIT_SANDBOX_SETUP_FAILED  # unreachable
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/libs/deepagents/deepagents/backends/sandboxed_shell.py
+++ b/libs/deepagents/deepagents/backends/sandboxed_shell.py
@@ -1,0 +1,193 @@
+"""`SandboxedShellBackend`: a Landlock-confined `LocalShellBackend`.
+
+`LocalShellBackend` runs ``execute()`` as a raw host subprocess with no
+filesystem confinement -- ``virtual_mode`` only scopes the *file* tools, not the
+shell (see that backend's own security note). This subclass keeps every
+file-tool behavior identical and overrides only ``execute()`` so each shell
+command runs under a Linux Landlock exec wrapper (``_landlock_exec.py``),
+confined to the backend's ``root_dir`` plus a read-only system allowlist.
+
+The wrapper is a separate process that restricts *itself* and then ``execve``s
+the command, so the backend process is never restricted and we avoid the
+fork-safety hazards of ``preexec_fn`` in a threaded async server.
+
+Filesystem boundary only -- network is not restricted (the Landlock network ABI
+is not present on most deployed kernels, and many CLIs need outbound access) and
+this is Linux-only (Landlock requires kernel >= 5.13). On kernels without
+Landlock the wrapper fails closed: the command is reported as failed rather than
+run unconfined.
+"""
+
+from __future__ import annotations
+
+import base64
+import shlex
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from deepagents.backends.local_shell import LocalShellBackend
+from deepagents.backends.protocol import ExecuteResponse
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+_HELPER_PATH = str(Path(__file__).with_name("_landlock_exec.py"))
+
+_EXIT_SANDBOX_SETUP_FAILED = 127
+
+
+def _python_prefix_roots() -> tuple[str, ...]:
+    """Return the active interpreter's install prefixes, de-duplicated.
+
+    Granting read+execute on these keeps ``python3``, the standard library, and
+    site-packages (including the current virtualenv) reachable inside the
+    sandbox without hard-coding a venv path. Venvs add a prefix outside the
+    system roots; system installs resolve under ``/usr`` and are covered anyway.
+    """
+    prefixes = (sys.prefix, sys.base_prefix, sys.exec_prefix, sys.base_exec_prefix)
+    return tuple(dict.fromkeys(p for p in prefixes if p))
+
+
+# Read-only roots the confined shell may read/execute from. Generous on purpose:
+# interpreters, system tools, CA certs, and the active Python prefixes. Missing
+# entries are skipped by the helper, so this is safe across images. Override via
+# the ``readonly_roots`` constructor argument when you need to tighten or extend.
+DEFAULT_READONLY_ROOTS: tuple[str, ...] = (
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/lib",
+    "/lib64",
+    "/etc",
+    "/opt",
+    *_python_prefix_roots(),
+)
+
+# Extra writable roots beyond ``root_dir`` (which is always writable). ``/tmp``
+# is included for tool compatibility (many tools write scratch files there), but
+# it is shared across processes; pass ``extra_writable_roots=[]`` for stricter
+# isolation.
+DEFAULT_EXTRA_WRITABLE_ROOTS: tuple[str, ...] = ("/tmp",)  # noqa: S108  # opt-in scratch root, documented and overridable
+
+# Device roots granted read+write to existing nodes (no exec/create). Required
+# for a usable shell: ``>/dev/null``, ``/dev/urandom``, ttys, ``/dev/std*``.
+# Not user-configurable -- these are a floor for a working shell.
+DEFAULT_DEVICE_ROOTS: tuple[str, ...] = ("/dev",)
+
+
+class SandboxedShellBackend(LocalShellBackend):
+    """`LocalShellBackend` whose ``execute()`` is confined with Linux Landlock.
+
+    File-tool behavior (``read``/``write``/``ls``/``grep``/``glob``/``edit``) is
+    inherited unchanged from `LocalShellBackend`. Only ``execute()`` is
+    overridden: each shell command (and every process it spawns) is confined to
+    ``root_dir`` plus ``extra_writable_roots`` (writable), ``readonly_roots``
+    (read + execute), and ``/dev`` (read + write existing nodes).
+
+    Requires Linux with Landlock (kernel >= 5.13). On any other platform or an
+    older kernel the sandbox setup fails and ``execute()`` returns a non-zero
+    `ExecuteResponse` *without running the command* -- it never silently falls
+    back to an unconfined shell.
+
+    !!! warning
+
+        This is a **filesystem** boundary only. It does **not** restrict
+        network access, CPU/memory, or in-place truncation of already-readable
+        files on Landlock ABI < 3. For untrusted code, combine it with network
+        controls and Human-in-the-Loop review, or use a container/VM sandbox.
+
+    Examples:
+        ```python
+        from deepagents import create_deep_agent
+        from deepagents.backends import SandboxedShellBackend
+
+        backend = SandboxedShellBackend(root_dir="/workspace/session-123", virtual_mode=True)
+        agent = create_deep_agent(model=model, tools=tools, backend=backend)
+
+        # Reads inside root_dir succeed; reads outside are denied by the kernel.
+        backend.execute("cat notes.txt")  # ok
+        backend.execute("cat /etc/shadow")  # permission denied
+
+        # Tighten isolation by dropping the shared /tmp grant, or extend the
+        # read-only allowlist for tools that live elsewhere.
+        backend = SandboxedShellBackend(
+            root_dir="/workspace/session-123",
+            virtual_mode=True,
+            extra_writable_roots=[],
+            readonly_roots=[*SandboxedShellBackend.DEFAULT_READONLY_ROOTS, "/srv/models"],
+        )
+        ```
+    """
+
+    DEFAULT_READONLY_ROOTS = DEFAULT_READONLY_ROOTS
+    DEFAULT_EXTRA_WRITABLE_ROOTS = DEFAULT_EXTRA_WRITABLE_ROOTS
+
+    def __init__(
+        self,
+        *args: object,
+        readonly_roots: Sequence[str] | None = None,
+        extra_writable_roots: Sequence[str] | None = None,
+        **kwargs: object,
+    ) -> None:
+        """Initialize the backend, forwarding all other arguments to the parent.
+
+        Args:
+            *args: Positional arguments forwarded to `LocalShellBackend`
+                (e.g. ``root_dir``).
+            readonly_roots: Directories the shell may read and execute from. If
+                ``None``, uses `DEFAULT_READONLY_ROOTS`. Absent paths are skipped.
+            extra_writable_roots: Writable directories *in addition to*
+                ``root_dir``. If ``None``, uses `DEFAULT_EXTRA_WRITABLE_ROOTS`
+                (``/tmp``). Pass ``[]`` to make ``root_dir`` the only writable
+                location.
+            **kwargs: Keyword arguments forwarded to `LocalShellBackend`
+                (e.g. ``virtual_mode``, ``timeout``, ``env``, ``inherit_env``).
+        """
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+        self._readonly_roots = list(DEFAULT_READONLY_ROOTS if readonly_roots is None else readonly_roots)
+        self._extra_writable_roots = list(DEFAULT_EXTRA_WRITABLE_ROOTS if extra_writable_roots is None else extra_writable_roots)
+
+    def _writable_roots(self) -> list[str]:
+        # ``self.cwd`` is the resolved root_dir (set by FilesystemBackend and
+        # used as the subprocess cwd by LocalShellBackend.execute).
+        return [str(self.cwd), *self._extra_writable_roots]
+
+    def _wrap_command(self, command: str) -> str:
+        """Build the ``python3 _landlock_exec.py ... --cmd-b64 <cmd>`` wrapper.
+
+        The original command is base64-encoded so arbitrary shell content
+        (quotes, pipes, heredocs) survives untouched; the helper decodes it and
+        re-runs it under ``/bin/sh -c``.
+        """
+        cmd_b64 = base64.b64encode(command.encode("utf-8")).decode("ascii")
+        parts = [shlex.quote(sys.executable), shlex.quote(_HELPER_PATH)]
+        for root in self._writable_roots():
+            parts += ["--rw", shlex.quote(root)]
+        for root in self._readonly_roots:
+            parts += ["--ro", shlex.quote(root)]
+        for root in DEFAULT_DEVICE_ROOTS:
+            parts += ["--dev", shlex.quote(root)]
+        parts += ["--cmd-b64", cmd_b64]
+        return " ".join(parts)
+
+    def execute(
+        self,
+        command: str,
+        *,
+        timeout: int | None = None,
+    ) -> ExecuteResponse:
+        """Run ``command`` under the Landlock wrapper; see `LocalShellBackend.execute`."""
+        # Defer non-string / empty validation to the parent's error contract.
+        if not command or not isinstance(command, str):
+            return super().execute(command, timeout=timeout)
+        if not Path(_HELPER_PATH).exists():  # pragma: no cover - packaging guard
+            return ExecuteResponse(
+                output=f"Error: Landlock helper missing at {_HELPER_PATH}; refusing to run unconfined.",
+                exit_code=_EXIT_SANDBOX_SETUP_FAILED,
+                truncated=False,
+            )
+        return super().execute(self._wrap_command(command), timeout=timeout)
+
+
+__all__ = ["SandboxedShellBackend"]

--- a/libs/deepagents/tests/unit_tests/backends/test_sandboxed_shell_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandboxed_shell_backend.py
@@ -1,0 +1,126 @@
+"""Unit tests for SandboxedShellBackend (Landlock-confined shell).
+
+Skipped automatically on Windows and on kernels without Landlock support
+(ABI < 1), so the suite stays green everywhere while still being exercised
+wherever Landlock is present.
+"""
+
+import ctypes
+import ctypes.util
+import sys
+from pathlib import Path
+
+import pytest
+
+import deepagents.backends.sandboxed_shell as sandboxed_shell_module
+from deepagents import backends as backends_pkg
+from deepagents.backends.sandboxed_shell import SandboxedShellBackend
+
+
+def _landlock_abi() -> int:
+    try:
+        libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6", use_errno=True)
+        libc.syscall.restype = ctypes.c_long
+        return libc.syscall(ctypes.c_long(444), 0, 0, 1)  # create_ruleset(VERSION)
+    except Exception:  # noqa: BLE001
+        return -1
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" or _landlock_abi() < 1,
+    reason="requires Linux with Landlock support",
+)
+
+_SYS_ENV = {"PATH": "/usr/bin:/bin"}
+
+
+@pytest.fixture
+def session(tmp_path):
+    (tmp_path / "inside.txt").write_text("SESSION DATA")
+    return tmp_path
+
+
+def _backend(session, **kwargs: object) -> SandboxedShellBackend:
+    return SandboxedShellBackend(root_dir=str(session), virtual_mode=True, env=_SYS_ENV, **kwargs)
+
+
+def test_reads_inside_session_allowed(session) -> None:
+    r = _backend(session).execute("cat inside.txt")
+    assert r.exit_code == 0
+    assert "SESSION DATA" in r.output
+
+
+def test_writes_inside_session_allowed(session) -> None:
+    r = _backend(session).execute("echo hi > out.txt && cat out.txt")
+    assert r.exit_code == 0
+    assert "hi" in r.output
+    assert (session / "out.txt").exists()
+
+
+def test_read_outside_session_denied(session, tmp_path_factory) -> None:
+    secret_dir = tmp_path_factory.mktemp("outside")
+    secret = secret_dir / "secret.txt"
+    secret.write_text("TOPSECRET")
+    # extra_writable_roots=[] so /tmp (where pytest tmp lives) is NOT granted.
+    r = _backend(session, extra_writable_roots=[]).execute(f"cat {secret}")
+    assert r.exit_code != 0
+    assert "Permission denied" in r.output
+    assert "TOPSECRET" not in r.output
+
+
+def test_sibling_session_denied(session, tmp_path_factory) -> None:
+    """A second session dir must be unreadable from the first."""
+    sibling = tmp_path_factory.mktemp("sibling")
+    (sibling / "other.txt").write_text("OTHER SESSION")
+    r = _backend(session, extra_writable_roots=[]).execute(f"cat {sibling}/other.txt")
+    assert r.exit_code != 0
+    assert "OTHER SESSION" not in r.output
+
+
+def test_write_outside_session_denied(session) -> None:
+    target = Path("/tmp/landlock_escape_probe")  # noqa: S108  # deliberately probing that writes outside root_dir are denied
+    target.unlink(missing_ok=True)
+    r = _backend(session, extra_writable_roots=[]).execute(f"echo pwn > {target}")
+    assert r.exit_code != 0
+    assert not target.exists()
+
+
+def test_dev_null_and_urandom_work(session) -> None:
+    r = _backend(session).execute("echo noise > /dev/null && head -c 4 /dev/urandom | wc -c")
+    assert r.exit_code == 0
+    assert "4" in r.output
+
+
+def test_shell_features_and_child_processes(session) -> None:
+    """Pipes work and spawned children inherit confinement (still run)."""
+    r = _backend(session).execute("echo a b c | tr ' ' '\\n' | wc -l")
+    assert r.exit_code == 0
+    assert "3" in r.output
+    child = _backend(session).execute('python3 -c "print(6*7)"')
+    assert child.exit_code == 0
+    assert "42" in child.output
+
+
+def test_extra_writable_root_allows_write(session, tmp_path_factory) -> None:
+    scratch = tmp_path_factory.mktemp("scratch")
+    r = _backend(session, extra_writable_roots=[str(scratch)]).execute(f"echo ok > {scratch}/w.txt && cat {scratch}/w.txt")
+    assert r.exit_code == 0
+    assert (scratch / "w.txt").read_text().strip() == "ok"
+
+
+def test_missing_helper_fails_closed(session, monkeypatch) -> None:
+    monkeypatch.setattr(sandboxed_shell_module, "_HELPER_PATH", "/nonexistent/_landlock_exec.py")
+    r = _backend(session).execute("echo should-not-run")
+    assert r.exit_code == 127
+    assert "should-not-run" not in r.output
+
+
+def test_empty_command_defers_to_parent_contract(session) -> None:
+    r = _backend(session).execute("")
+    assert r.exit_code == 1
+    assert "non-empty string" in r.output
+
+
+def test_exported_from_backends_package() -> None:
+    assert "SandboxedShellBackend" in backends_pkg.__all__
+    assert backends_pkg.SandboxedShellBackend is SandboxedShellBackend


### PR DESCRIPTION

---

Adds `SandboxedShellBackend`, a `LocalShellBackend` subclass that confines each shell command (and every process it spawns) to the backend's `root_dir` plus a read-only system allowlist using Linux Landlock. This closes the gap where `virtual_mode` scopes the file tools but `execute()` still runs unconfined on the host

The backend overrides only `execute()`; all file-changed. Commands are wrapped by a stdlib-only
helper (`_landlock_exec.py`) that applies a Landlhen `execve`s `/bin/sh -c`, so the boundary isinherited by all children. It is opt-in (you construct it explicitly and pass it as `backend=`), Linux-only (kernel ≥ 5.13), and **fails closed** — if Landlock is unavailable or any rule fails, the command is reported as failed rather than run unconfined.

Scope: this is a **filesystem** boundary only. It does not restrict network, CPU/memory, or in-place truncation on Landlock ABI < 3.

### How I verified it

- `make format`, `make lint` (ruff `select = ["ALL"]`), and `make test` pass for `libs/deepagents`.
- New test suite (`tests/unit_tests/backends/test, auto-skipped on Windows and on kernels without
Landlock (ABI < 1). Covers: reads/writes inside t outside are denied; sibling directories areunreadable; `/dev/null` + `/dev/urandom` work; pipes and spawned child processes work and inherit confinement; extra writable roots can be granted; missing helper fails closed (exit 127); the export is reachable from `deepagents.backends`.
- Manually confirmed kernel-level enforcement on -root reads/writes return `Permission denied`, noescape file is created, and a spawned `python3` child also hits `PermissionError` reading outside the root.

### Notes

- No new dependencies and no `pyproject.toml` / ` is stdlib-only (`ctypes` + `os`).
- Touches a single package (`libs/deepagents`).
- No breaking changes; existing backends are untouched. `SandboxedShellBackend` is additive and exported alongside
`LocalShellBackend`.

### Disclaimer

Generative AI (Claude) was used to help draft thehis description. All code was reviewed, adapted
from a production deployment, and verified by the
[Before]
<img width="677" height="450" alt="Screenshot from 2026-06-08 16-09-25" src="https://github.com/user-attachments/assets/4a44162d-3a9a-4968-8b0a-f1dda7659744" />
[After]
<img width="673" height="196" alt="Screenshot from 2026-06-08 16-09-33" src="https://github.com/user-attachments/assets/571dde6f-1dae-40ea-b62b-38f217fa63a6" />
