### PR TITLE
build(evals): bump dependency minimums

### DIFF
--- a/libs/evals/deepagents_evals/radar.py
+++ b/libs/evals/deepagents_evals/radar.py
@@ -8,7 +8,6 @@ encodes the score (0-1 correctness).
 from __future__ import annotations
 
 import importlib
-import importlib.util
 import json
 import math
 from dataclasses import dataclass, field
@@ -16,9 +15,10 @@ from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-plt: Any = None
-if importlib.util.find_spec("matplotlib.pyplot") is not None:
-    plt = importlib.import_module("matplotlib.pyplot")
+try:
+    plt: Any = importlib.import_module("matplotlib.pyplot")
+except ImportError:
+    plt = None
 
 if TYPE_CHECKING:
     from matplotlib.figure import Figure

--- a/libs/evals/deepagents_evals/radar.py
+++ b/libs/evals/deepagents_evals/radar.py
@@ -7,18 +7,18 @@ encodes the score (0-1 correctness).
 
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import json
 import math
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
-try:
-    import matplotlib.pyplot as plt
-except ImportError:
-    plt = None  # type: ignore[assignment]
+plt: Any = None
+if importlib.util.find_spec("matplotlib.pyplot") is not None:
+    plt = importlib.import_module("matplotlib.pyplot")
 
 if TYPE_CHECKING:
     from matplotlib.figure import Figure

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any
 
 from dockerfile_parse import DockerfileParser
 from harbor.environments.base import BaseEnvironment, ExecResult
+from harbor.environments.capabilities import EnvironmentCapabilities
+from harbor.models.task.config import NetworkMode
 from harbor.models.trial.paths import EnvironmentPaths, TrialPaths
 from harbor.utils.logger import logger
 from langsmith.sandbox import AsyncSandboxClient
@@ -102,6 +104,11 @@ class LangSmithEnvironment(BaseEnvironment):
         raise NotImplementedError(msg)
 
     @property
+    def capabilities(self) -> EnvironmentCapabilities:
+        """Capabilities supported by LangSmith sandboxes."""
+        return EnvironmentCapabilities(disable_internet=True, network_allowlist=True)
+
+    @property
     def is_mounted(self) -> bool:
         """Whether the environment mounts host logging directories."""
         return False
@@ -114,7 +121,7 @@ class LangSmithEnvironment(BaseEnvironment):
     @property
     def can_disable_internet(self) -> bool:
         """Whether LangSmith sandboxes support network isolation."""
-        return False
+        return True
 
     # -- Validation overrides --------------------------------------------------
     # Override base-class validators so they never call self.type(), which
@@ -146,11 +153,28 @@ class LangSmithEnvironment(BaseEnvironment):
             msg = "LangSmith sandbox does not support GPU allocation."
             raise RuntimeError(msg)
 
+    def _validate_network_policy_support(self) -> None:
+        """LangSmith supports no-network and allowlist policies via proxy config."""
+        return
+
     def _validate_internet_config(self) -> None:
-        """Override base to avoid calling `self.type()`."""
-        if not self.task_env_config.allow_internet:
-            msg = "LangSmith sandbox does not support disabling internet access."
-            raise ValueError(msg)
+        """Deprecated validation hook kept for compatibility with older Harbor."""
+        return
+
+    def _network_proxy_config(self) -> dict[str, Any] | None:
+        """Build LangSmith proxy_config for Harbor's network policy."""
+        network_mode = self.network_policy.network_mode
+        allowed_hosts = list(self.network_policy.allowed_hosts)
+
+        if self.task_env_config.allow_internet is False:
+            network_mode = NetworkMode.NO_NETWORK
+            allowed_hosts = []
+
+        if network_mode == NetworkMode.NO_NETWORK:
+            return {"access_control": {"deny_list": ["*"]}}
+        if network_mode == NetworkMode.ALLOWLIST:
+            return {"access_control": {"allow_list": allowed_hosts}}
+        return None
 
     # -- Image resolution ------------------------------------------------------
 
@@ -258,13 +282,18 @@ class LangSmithEnvironment(BaseEnvironment):
         await self._ensure_snapshot(client, snapshot_name, image, fs_capacity_bytes)
         self._snapshot_name = snapshot_name
 
-        sandbox = await client.create_sandbox(
-            snapshot_name=snapshot_name,
-            vcpus=vcpus,
-            mem_bytes=mem_bytes,
-            fs_capacity_bytes=fs_capacity_bytes,
-            timeout=120,
-        )
+        proxy_config = self._network_proxy_config()
+        create_sandbox_kwargs: dict[str, Any] = {
+            "snapshot_name": snapshot_name,
+            "vcpus": vcpus,
+            "mem_bytes": mem_bytes,
+            "fs_capacity_bytes": fs_capacity_bytes,
+            "timeout": 120,
+        }
+        if proxy_config is not None:
+            create_sandbox_kwargs["proxy_config"] = proxy_config
+
+        sandbox = await client.create_sandbox(**create_sandbox_kwargs)
         self._sandbox = sandbox
         logger.info(
             "Created LangSmith sandbox '%s' from snapshot '%s' "

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -142,7 +142,7 @@ class LangSmithEnvironment(BaseEnvironment):
 
     def _validate_gpu_support(self) -> None:
         """Override base to avoid calling `self.type()`."""
-        if self.task_env_config.gpus > 0:
+        if (self.task_env_config.gpus or 0) > 0:
             msg = "LangSmith sandbox does not support GPU allocation."
             raise RuntimeError(msg)
 
@@ -247,8 +247,13 @@ class LangSmithEnvironment(BaseEnvironment):
         snapshot_name = self._build_snapshot_name(image)
 
         vcpus = self.task_env_config.cpus
-        mem_bytes = self.task_env_config.memory_mb * _BYTES_PER_MB
-        fs_capacity_bytes = self.task_env_config.storage_mb * _BYTES_PER_MB
+        memory_mb = self.task_env_config.memory_mb
+        storage_mb = self.task_env_config.storage_mb
+        if memory_mb is None or storage_mb is None:
+            msg = "LangSmith sandbox requires memory_mb and storage_mb to be configured."
+            raise ValueError(msg)
+        mem_bytes = memory_mb * _BYTES_PER_MB
+        fs_capacity_bytes = storage_mb * _BYTES_PER_MB
 
         await self._ensure_snapshot(client, snapshot_name, image, fs_capacity_bytes)
         self._snapshot_name = snapshot_name

--- a/libs/evals/pyproject.toml
+++ b/libs/evals/pyproject.toml
@@ -18,35 +18,35 @@ classifiers = [
 ]
 dependencies = [
     # SDK — local editable in dev (see [tool.uv.sources]), versioned for published package
-    "deepagents>=0.5.7",
+    "deepagents>=0.6.8",
     "langchain>=1.3.4,<2.0.0",
-    "deepagents-code",
+    "deepagents-code>=0.1.11",
     # Harbor runtime
-    "harbor>=0.6.4,<0.7.0",
+    "harbor>=0.13.1,<0.14.0",
     # LangSmith for observability
-    "langsmith>=0.8.1,<0.9.0",
+    "langsmith>=0.8.9,<0.9.0",
     # Sandbox runtimes
     "dockerfile-parse>=2.0.1",
-    "modal>=0.64.0",
+    "modal>=1.4.3",
     # LangChain model providers (evals run against many providers)
-    "langchain-anthropic>=1.4.3,<1.5.0",
+    "langchain-anthropic>=1.4.4,<1.5.0",
     "langchain-baseten>=0.2.0,<0.3.0",
     "langchain-deepseek>=1.0.1,<1.1.0",
     "langchain-fireworks>=1.3.1,<1.4.0",
-    "langchain-google-genai>=4.2.2,<4.3.0",
+    "langchain-google-genai>=4.2.4,<4.3.0",
     "langchain-groq>=1.1.2,<1.2.0",
     "langchain-mistralai>=1.1.4,<1.2.0",
-    "langchain-nvidia-ai-endpoints>=1.2.1,<1.3.0",
+    "langchain-nvidia-ai-endpoints>=1.4.1,<1.5.0",
     "langchain-ollama>=1.1.0,<1.2.0",
-    "langchain-openai>=1.2.1,<1.3.0",
+    "langchain-openai>=1.2.2,<1.3.0",
     "langchain-openrouter>=0.2.3,<0.3.0",
     "langchain-xai>=1.2.2,<1.3.0",
     # Eval-specific dependencies
-    "datasets>=3.0.0",
-    "nltk>=3.9.0",
+    "datasets>=5.0.0",
+    "nltk>=3.9.4",
     "openevals>=0.2.0",
-    "tiktoken>=0.8.0",
-    "langchain-quickjs",
+    "tiktoken>=0.13.0",
+    "langchain-quickjs>=0.1.4",
 ]
 
 [project.scripts]
@@ -54,20 +54,20 @@ deepagents-evals = "deepagents_evals.cli:main"
 
 [project.optional-dependencies]
 charts = [
-    "matplotlib>=3.9.0",
+    "matplotlib>=3.10.9",
 ]
 
 [dependency-groups]
 test = [
     "pytest>=9.0.3",
-    "pytest-asyncio>=1.2.0",
-    "pytest-watcher>=0.3.4,<1.0.0",
-    "ruff>=0.8.0",
-    "ty>=0.0.1,<1.0.0",
+    "pytest-asyncio>=1.4.0",
+    "pytest-watcher>=0.6.3,<1.0.0",
+    "ruff>=0.15.16",
+    "ty>=0.0.44,<1.0.0",
     "python-dotenv>=1.2.2",
-    "pytest-socket>=0.7.0",
-    "pytest-cov>=7.0.0",
-    "matplotlib>=3.9.0",
+    "pytest-socket>=0.8.0",
+    "pytest-cov>=7.1.0",
+    "matplotlib>=3.10.9",
 ]
 
 [project.urls]
@@ -80,7 +80,7 @@ Slack = "https://www.langchain.com/join-community"
 Reddit = "https://www.reddit.com/r/LangChain/"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=80.9.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
@@ -100,12 +100,12 @@ required-environments = [
     "sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
 override-dependencies = [
-    "openai>=1.109.1,<2.0.0",
-    "e2b==2.4.3",
+    "openai>=2.41.0,<3.0.0",
+    "e2b==2.26.0",
     # CVE-2026-42561: DoS via unbounded multipart part headers in < 0.0.27
-    "python-multipart>=0.0.27",
+    "python-multipart>=0.0.32",
     # CVE-2026-0994: JSON recursion depth bypass DoS in <= 6.33.4
-    "protobuf>=6.33.5",
+    "protobuf>=7.35.0",
 ]
 
 [tool.uv.sources]

--- a/libs/evals/tests/unit_tests/test_harbor_backend.py
+++ b/libs/evals/tests/unit_tests/test_harbor_backend.py
@@ -66,7 +66,7 @@ class _FakeHarborEnvironment:
 async def test_aedit_preserves_existing_line_endings(line_ending: str) -> None:
     original = f"alpha{line_ending}old{line_ending}omega{line_ending}".encode()
     env = _FakeHarborEnvironment(files={"/app/test.txt": original})
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     result = await sandbox.aedit("/app/test.txt", "old", "new")
 
@@ -79,7 +79,7 @@ async def test_aedit_preserves_existing_line_endings(line_ending: str) -> None:
 
 async def test_aedit_file_not_found() -> None:
     env = _FakeHarborEnvironment()
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     result = await sandbox.aedit("/app/missing.txt", "old", "new")
 
@@ -89,7 +89,7 @@ async def test_aedit_file_not_found() -> None:
 
 async def test_aedit_binary_file_returns_error() -> None:
     env = _FakeHarborEnvironment(files={"/app/binary.bin": b"\x80\x81\x82\xff"})
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     result = await sandbox.aedit("/app/binary.bin", "old", "new")
 
@@ -99,7 +99,7 @@ async def test_aedit_binary_file_returns_error() -> None:
 
 async def test_aedit_string_not_found() -> None:
     env = _FakeHarborEnvironment(files={"/app/test.txt": b"hello world"})
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     result = await sandbox.aedit("/app/test.txt", "missing", "new")
 
@@ -109,7 +109,7 @@ async def test_aedit_string_not_found() -> None:
 
 async def test_aedit_multiple_occurrences_without_replace_all() -> None:
     env = _FakeHarborEnvironment(files={"/app/test.txt": b"foo bar foo"})
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     result = await sandbox.aedit("/app/test.txt", "foo", "baz")
 
@@ -119,7 +119,7 @@ async def test_aedit_multiple_occurrences_without_replace_all() -> None:
 
 async def test_aedit_replace_all() -> None:
     env = _FakeHarborEnvironment(files={"/app/test.txt": b"foo bar foo"})
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     result = await sandbox.aedit("/app/test.txt", "foo", "baz", replace_all=True)
 
@@ -132,7 +132,7 @@ async def test_aedit_propagates_unknown_download_errors() -> None:
     env = _FakeHarborEnvironment(
         download_errors={"/app/test.txt": RuntimeError("transient failure")}
     )
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(RuntimeError, match="transient failure"):
         await sandbox.aedit("/app/test.txt", "old", "new")
@@ -143,7 +143,7 @@ async def test_aedit_propagates_unknown_upload_errors() -> None:
         files={"/app/test.txt": b"hello old world"},
         upload_errors={"/app/test.txt": RuntimeError("transient upload failure")},
     )
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(RuntimeError, match="transient upload failure"):
         await sandbox.aedit("/app/test.txt", "old", "new")
@@ -154,7 +154,7 @@ async def test_aedit_maps_known_upload_errors() -> None:
         files={"/app/test.txt": b"hello old world"},
         upload_errors={"/app/test.txt": PermissionError("denied")},
     )
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     result = await sandbox.aedit("/app/test.txt", "old", "new")
 
@@ -167,7 +167,7 @@ async def test_aedit_maps_known_upload_errors() -> None:
 
 async def test_awrite_uploads_content() -> None:
     env = _FakeHarborEnvironment(exec_result=_FakeExecResult())
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     result = await sandbox.awrite("/app/new.txt", "hello world")
 
@@ -181,7 +181,7 @@ async def test_awrite_propagates_unknown_upload_errors() -> None:
         exec_result=_FakeExecResult(),
         upload_errors={"/app/new.txt": RuntimeError("transient failure")},
     )
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(RuntimeError, match="transient failure"):
         await sandbox.awrite("/app/new.txt", "content")
@@ -192,7 +192,7 @@ async def test_awrite_maps_known_upload_errors() -> None:
         exec_result=_FakeExecResult(),
         upload_errors={"/app/new.txt": PermissionError("denied")},
     )
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     result = await sandbox.awrite("/app/new.txt", "content")
 
@@ -207,7 +207,7 @@ async def test_awrite_returns_error_when_file_exists() -> None:
             return_code=1,
         ),
     )
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     result = await sandbox.awrite("/app/existing.txt", "content")
 
@@ -229,7 +229,7 @@ async def test_awrite_returns_error_when_file_exists() -> None:
 )
 async def test_adownload_files_maps_known_errors(exc: Exception, expected_error: str) -> None:
     env = _FakeHarborEnvironment(download_errors={"/app/test.txt": exc})
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     responses = await sandbox.adownload_files(["/app/test.txt"])
 
@@ -244,7 +244,7 @@ async def test_adownload_files_propagates_unknown_errors() -> None:
     env = _FakeHarborEnvironment(
         download_errors={"/app/test.txt": RuntimeError("transient download failure")}
     )
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(RuntimeError, match="transient download failure"):
         await sandbox.adownload_files(["/app/test.txt"])
@@ -255,7 +255,7 @@ async def test_adownload_files_partial_success() -> None:
         files={"/app/good.txt": b"content"},
         download_errors={"/app/bad.txt": PermissionError("denied")},
     )
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     responses = await sandbox.adownload_files(["/app/good.txt", "/app/bad.txt"])
 
@@ -272,7 +272,7 @@ async def test_adownload_files_unknown_error_aborts_batch() -> None:
         files={"/app/good.txt": b"content"},
         download_errors={"/app/bad.txt": RuntimeError("transient download failure")},
     )
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(RuntimeError, match="transient download failure"):
         await sandbox.adownload_files(["/app/bad.txt", "/app/good.txt"])
@@ -283,7 +283,7 @@ async def test_adownload_files_unknown_error_aborts_batch() -> None:
 
 async def test_aupload_files_happy_path() -> None:
     env = _FakeHarborEnvironment()
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     responses = await sandbox.aupload_files([("/app/file.txt", b"content")])
 
@@ -294,7 +294,7 @@ async def test_aupload_files_happy_path() -> None:
 
 async def test_aupload_files_maps_known_errors() -> None:
     env = _FakeHarborEnvironment(upload_errors={"/app/denied.txt": PermissionError("denied")})
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     responses = await sandbox.aupload_files([("/app/denied.txt", b"content")])
 
@@ -305,7 +305,7 @@ async def test_aupload_files_maps_known_errors() -> None:
 async def test_aupload_files_propagates_unknown_errors() -> None:
     """Unclassified exceptions propagate instead of being captured."""
     env = _FakeHarborEnvironment(upload_errors={"/app/file.txt": RuntimeError("transient failure")})
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(RuntimeError, match="transient failure"):
         await sandbox.aupload_files([("/app/file.txt", b"content")])
@@ -314,7 +314,7 @@ async def test_aupload_files_propagates_unknown_errors() -> None:
 async def test_aupload_files_unknown_error_aborts_batch() -> None:
     """Unclassified error on one file aborts the entire batch."""
     env = _FakeHarborEnvironment(upload_errors={"/app/bad.txt": RuntimeError("transient failure")})
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(RuntimeError, match="transient failure"):
         await sandbox.aupload_files([("/app/bad.txt", b"first"), ("/app/good.txt", b"second")])
@@ -340,7 +340,7 @@ async def test_aupload_files_unknown_error_aborts_batch() -> None:
 def test_sync_stubs_raise_not_implemented(method_name: str, args: tuple[object, ...]) -> None:
     """Every sync method on HarborSandbox must raise NotImplementedError."""
     env = _FakeHarborEnvironment()
-    sandbox = HarborSandbox(env)  # type: ignore[invalid-argument-type]
+    sandbox = HarborSandbox(env)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(NotImplementedError, match="only supports async"):
         getattr(sandbox, method_name)(*args)

--- a/libs/evals/tests/unit_tests/test_langsmith.py
+++ b/libs/evals/tests/unit_tests/test_langsmith.py
@@ -65,7 +65,7 @@ class TestResolveLangsmithApiKey:
         monkeypatch.setenv("LANGSMITH_SANDBOX_API_KEY", "sandbox-key")
         monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
         monkeypatch.setenv("LANGCHAIN_API_KEY", "lc-key")
-        value, name = resolve_langsmith_api_key()  # type: ignore[misc]
+        value, name = resolve_langsmith_api_key()  # ty: ignore[not-iterable]
         assert value == "sandbox-key"
         assert name == "LANGSMITH_SANDBOX_API_KEY"
 
@@ -73,7 +73,7 @@ class TestResolveLangsmithApiKey:
         monkeypatch.delenv("LANGSMITH_SANDBOX_API_KEY", raising=False)
         monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
         monkeypatch.setenv("LANGCHAIN_API_KEY", "lc-key")
-        value, name = resolve_langsmith_api_key()  # type: ignore[misc]
+        value, name = resolve_langsmith_api_key()  # ty: ignore[not-iterable]
         assert value == "ls-key"
         assert name == "LANGSMITH_API_KEY"
 
@@ -81,7 +81,7 @@ class TestResolveLangsmithApiKey:
         monkeypatch.delenv("LANGSMITH_SANDBOX_API_KEY", raising=False)
         monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
         monkeypatch.setenv("LANGCHAIN_API_KEY", "lc-key")
-        value, name = resolve_langsmith_api_key()  # type: ignore[misc]
+        value, name = resolve_langsmith_api_key()  # ty: ignore[not-iterable]
         assert value == "lc-key"
         assert name == "LANGCHAIN_API_KEY"
 
@@ -89,7 +89,7 @@ class TestResolveLangsmithApiKey:
         monkeypatch.setenv("LANGSMITH_SANDBOX_API_KEY", "")
         monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
         monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
-        value, name = resolve_langsmith_api_key()  # type: ignore[misc]
+        value, name = resolve_langsmith_api_key()  # ty: ignore[not-iterable]
         assert value == "ls-key"
         assert name == "LANGSMITH_API_KEY"
 

--- a/libs/evals/tests/unit_tests/test_langsmith_environment.py
+++ b/libs/evals/tests/unit_tests/test_langsmith_environment.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from harbor.models.task.config import EnvironmentConfig
+from harbor.models.task.config import EnvironmentConfig, NetworkMode, NetworkPolicy
 from harbor.models.trial.paths import TrialPaths
 
 from deepagents_harbor.langsmith_environment import (
@@ -72,6 +72,7 @@ def _make_env(
     cpus: int = 1,
     memory_mb: int = 2048,
     storage_mb: int = 10240,
+    network_policy: NetworkPolicy | None = None,
 ) -> LangSmithEnvironment:
     """Create a LangSmithEnvironment with a temp directory.
 
@@ -108,6 +109,7 @@ def _make_env(
         session_id="test-session-001",
         trial_paths=trial_paths,
         task_env_config=config,
+        network_policy=network_policy,
     )
 
 
@@ -191,7 +193,7 @@ class TestValidation:
                 task_env_config=config,
             )
 
-    def test_internet_disabled_raises(self, tmp_path: Path) -> None:
+    def test_internet_disabled_is_accepted(self, tmp_path: Path) -> None:
         env_dir = tmp_path / "environment"
         env_dir.mkdir()
         (env_dir / "Dockerfile").write_text("FROM ubuntu:24.04\n")
@@ -202,14 +204,15 @@ class TestValidation:
         trial_paths = TrialPaths(trial_dir=trial_dir)
         trial_paths.mkdir()
 
-        with pytest.raises(ValueError, match="internet"):
-            LangSmithEnvironment(
-                environment_dir=env_dir,
-                environment_name="test",
-                session_id="s1",
-                trial_paths=trial_paths,
-                task_env_config=config,
-            )
+        env = LangSmithEnvironment(
+            environment_dir=env_dir,
+            environment_name="test",
+            session_id="s1",
+            trial_paths=trial_paths,
+            task_env_config=config,
+        )
+
+        assert env._network_proxy_config() == {"access_control": {"deny_list": ["*"]}}
 
     def test_accepts_factory_kwargs(self, tmp_path: Path) -> None:
         """Harbor's EnvironmentFactory passes logger, override_* kwargs."""
@@ -279,7 +282,35 @@ class TestProperties:
 
     def test_can_disable_internet(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
-        assert env.can_disable_internet is False
+        assert env.can_disable_internet is True
+        assert env.capabilities.disable_internet is True
+        assert env.capabilities.network_allowlist is True
+
+    def test_no_network_policy_builds_deny_all_proxy_config(self, tmp_path: Path) -> None:
+        env = _make_env(
+            tmp_path,
+            network_policy=NetworkPolicy(network_mode=NetworkMode.NO_NETWORK),
+        )
+
+        assert env._network_proxy_config() == {"access_control": {"deny_list": ["*"]}}
+
+    def test_allowlist_policy_builds_allowlist_proxy_config(self, tmp_path: Path) -> None:
+        env = _make_env(
+            tmp_path,
+            network_policy=NetworkPolicy(
+                network_mode=NetworkMode.ALLOWLIST,
+                allowed_hosts=["api.openai.com", "github.com"],
+            ),
+        )
+
+        assert env._network_proxy_config() == {
+            "access_control": {"allow_list": ["api.openai.com", "github.com"]}
+        }
+
+    def test_public_network_policy_omits_proxy_config(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+
+        assert env._network_proxy_config() is None
 
     def test_type_raises(self, tmp_path: Path) -> None:
         with pytest.raises(NotImplementedError):
@@ -488,8 +519,44 @@ class TestStartSnapshotProvisioning:
             assert kwargs["mem_bytes"] == 2048 * 1024 * 1024
             assert kwargs["fs_capacity_bytes"] == 10240 * 1024 * 1024
             assert kwargs["timeout"] == 120
+            assert "proxy_config" not in kwargs
             assert "template_name" not in kwargs
             assert "snapshot_id" not in kwargs
+
+    async def test_create_sandbox_passes_no_network_proxy_config(self, tmp_path: Path) -> None:
+        env = _make_env(
+            tmp_path,
+            network_policy=NetworkPolicy(network_mode=NetworkMode.NO_NETWORK),
+        )
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client()
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+            assert mock_client.create_sandbox.call_args.kwargs["proxy_config"] == {
+                "access_control": {"deny_list": ["*"]}
+            }
+
+    async def test_create_sandbox_passes_allowlist_proxy_config(self, tmp_path: Path) -> None:
+        env = _make_env(
+            tmp_path,
+            network_policy=NetworkPolicy(
+                network_mode=NetworkMode.ALLOWLIST,
+                allowed_hosts=["api.openai.com", "github.com"],
+            ),
+        )
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client()
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+            assert mock_client.create_sandbox.call_args.kwargs["proxy_config"] == {
+                "access_control": {"allow_list": ["api.openai.com", "github.com"]}
+            }
 
     async def test_force_build_is_noop(self, tmp_path: Path) -> None:
         """force_build accepted for interface compat but does not change calls."""

--- a/libs/evals/tests/unit_tests/test_langsmith_environment.py
+++ b/libs/evals/tests/unit_tests/test_langsmith_environment.py
@@ -548,7 +548,7 @@ class TestExec:
     async def test_exec_delegates_to_sandbox(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
         sandbox = _FakeSandbox()
-        env._sandbox = sandbox  # type: ignore[assignment]
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
 
         result = await env.exec("echo hello")
 
@@ -558,7 +558,7 @@ class TestExec:
     async def test_exec_passes_cwd_and_env(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
         sandbox = _FakeSandbox()
-        env._sandbox = sandbox  # type: ignore[assignment]
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
 
         await env.exec("ls", cwd="/app", env={"FOO": "bar"})
 
@@ -573,7 +573,7 @@ class TestExec:
         """
         env = _make_env(tmp_path)
         sandbox = _FakeSandbox()
-        env._sandbox = sandbox  # type: ignore[assignment]
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
         env._default_cwd = "/app"
 
         await env.exec("ls")
@@ -584,7 +584,7 @@ class TestExec:
     async def test_exec_explicit_cwd_overrides_default(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
         sandbox = _FakeSandbox()
-        env._sandbox = sandbox  # type: ignore[assignment]
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
         env._default_cwd = "/app"
 
         await env.exec("ls", cwd="/tmp")
@@ -595,7 +595,7 @@ class TestExec:
     async def test_exec_uses_default_timeout(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
         sandbox = _FakeSandbox()
-        env._sandbox = sandbox  # type: ignore[assignment]
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
 
         await env.exec("echo hello")
 
@@ -604,7 +604,7 @@ class TestExec:
     async def test_exec_forwards_custom_timeout(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
         sandbox = _FakeSandbox()
-        env._sandbox = sandbox  # type: ignore[assignment]
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
 
         await env.exec("echo hello", timeout_sec=10)
 
@@ -648,7 +648,7 @@ class TestWorkdirDetection:
                 return _FakeExecResult(stdout=dir_probe_stdout)
             return _FakeExecResult()
 
-        sandbox.run = _run  # type: ignore[assignment]
+        sandbox.run = _run  # ty: ignore[invalid-assignment]
         mock_client.create_sandbox.return_value = sandbox
         return sandbox
 
@@ -715,7 +715,7 @@ class TestWorkdirDetection:
                     raise RuntimeError(msg)
                 return _FakeExecResult()
 
-            sandbox.run = _run  # type: ignore[assignment]
+            sandbox.run = _run  # ty: ignore[invalid-assignment]
             mock_client.create_sandbox.return_value = sandbox
             mock_cls.return_value = mock_client
 
@@ -743,7 +743,7 @@ class TestWorkdirDetection:
 
     async def test_stop_clears_default_cwd(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
-        env._sandbox = _FakeSandbox()  # type: ignore[assignment]
+        env._sandbox = _FakeSandbox()  # ty: ignore[invalid-assignment]
         env._client = AsyncMock()
         env._snapshot_name = "snap-tmpl"
         env._default_cwd = "/app"
@@ -759,7 +759,7 @@ class TestFileOps:
     async def test_upload_file(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
         sandbox = _FakeSandbox()
-        env._sandbox = sandbox  # type: ignore[assignment]
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
 
         src = tmp_path / "local.txt"
         src.write_text("hello world")
@@ -772,7 +772,7 @@ class TestFileOps:
         env = _make_env(tmp_path)
         sandbox = _FakeSandbox()
         sandbox._read_files["/app/data.txt"] = b"file content"
-        env._sandbox = sandbox  # type: ignore[assignment]
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
 
         dest = tmp_path / "downloaded.txt"
         await env.download_file("/app/data.txt", dest)
@@ -782,7 +782,7 @@ class TestFileOps:
     async def test_upload_dir(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
         sandbox = _FakeSandbox()
-        env._sandbox = sandbox  # type: ignore[assignment]
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
 
         src_dir = tmp_path / "mydir"
         src_dir.mkdir()
@@ -801,12 +801,12 @@ class TestFileOps:
         sandbox = _FakeSandbox()
         sandbox._read_files["/remote/a.txt"] = b"aaa"
         sandbox._read_files["/remote/sub/b.txt"] = b"bbb"
-        env._sandbox = sandbox  # type: ignore[assignment]
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
 
         async def _fake_run(_cmd: str, **_kw: Any) -> _FakeExecResult:
             return _FakeExecResult(stdout="/remote/a.txt\n/remote/sub/b.txt\n")
 
-        sandbox.run = _fake_run  # type: ignore[assignment]
+        sandbox.run = _fake_run  # ty: ignore[invalid-assignment]
 
         dest = tmp_path / "downloaded"
         await env.download_dir("/remote", dest)
@@ -819,12 +819,12 @@ class TestFileOps:
         env = _make_env(tmp_path)
         sandbox = _FakeSandbox()
         sandbox._read_files["/remote/good.txt"] = b"ok"
-        env._sandbox = sandbox  # type: ignore[assignment]
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
 
         async def _fake_run(_cmd: str, **_kw: Any) -> _FakeExecResult:
             return _FakeExecResult(stdout="/remote/good.txt\n/remote/bad.txt\n")
 
-        sandbox.run = _fake_run  # type: ignore[assignment]
+        sandbox.run = _fake_run  # ty: ignore[invalid-assignment]
 
         # bad.txt is not in _read_files, so download_file → sandbox.read
         # returns b"" by default, but we override read to raise for bad.txt.
@@ -836,7 +836,7 @@ class TestFileOps:
                 raise FileNotFoundError(msg)
             return await original_read(path)
 
-        sandbox.read = _failing_read  # type: ignore[assignment]
+        sandbox.read = _failing_read  # ty: ignore[invalid-assignment]
 
         dest = tmp_path / "downloaded"
         await env.download_dir("/remote", dest)
@@ -854,12 +854,12 @@ class TestFileOps:
     async def test_download_dir_empty(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
         sandbox = _FakeSandbox()
-        env._sandbox = sandbox  # type: ignore[assignment]
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
 
         async def _fake_run(_cmd: str, **_kw: Any) -> _FakeExecResult:
             return _FakeExecResult(exit_code=1, stderr="No such file or directory")
 
-        sandbox.run = _fake_run  # type: ignore[assignment]
+        sandbox.run = _fake_run  # ty: ignore[invalid-assignment]
 
         dest = tmp_path / "downloaded"
         await env.download_dir("/nonexistent", dest)
@@ -879,7 +879,7 @@ class TestStop:
         env = _make_env(tmp_path)
         mock_client = AsyncMock()
         mock_sandbox = _FakeSandbox(name="my-sandbox")
-        env._sandbox = mock_sandbox  # type: ignore[assignment]
+        env._sandbox = mock_sandbox  # ty: ignore[invalid-assignment]
         env._client = mock_client
         env._snapshot_name = "harbor-ubuntu-24-04"
 
@@ -895,7 +895,7 @@ class TestStop:
     async def test_stop_no_delete_skips_cleanup(self, tmp_path: Path) -> None:
         env = _make_env(tmp_path)
         mock_client = AsyncMock()
-        env._sandbox = _FakeSandbox()  # type: ignore[assignment]
+        env._sandbox = _FakeSandbox()  # ty: ignore[invalid-assignment]
         env._client = mock_client
         env._snapshot_name = "snap-tmpl"
 
@@ -910,7 +910,7 @@ class TestStop:
         env = _make_env(tmp_path)
         mock_client = AsyncMock()
         mock_client.delete_sandbox.side_effect = RuntimeError("API timeout")
-        env._sandbox = _FakeSandbox(name="my-sandbox")  # type: ignore[assignment]
+        env._sandbox = _FakeSandbox(name="my-sandbox")  # ty: ignore[invalid-assignment]
         env._client = mock_client
         env._snapshot_name = "harbor-my-image"
 

--- a/libs/evals/tests/unit_tests/test_pytest_reporter.py
+++ b/libs/evals/tests/unit_tests/test_pytest_reporter.py
@@ -60,7 +60,7 @@ class TestFailuresCapture:
             duration=1.5,
             longreprtext="Expected 'TurboWidget' in final text, got 'unknown'",
         )
-        reporter.pytest_runtest_logreport(report)  # type: ignore[arg-type]
+        reporter.pytest_runtest_logreport(report)  # ty: ignore[invalid-argument-type]
 
         assert len(reporter._FAILURES) == 1
         failure = reporter._FAILURES[0]
@@ -75,7 +75,7 @@ class TestFailuresCapture:
             outcome="passed",
             duration=0.5,
         )
-        reporter.pytest_runtest_logreport(report)  # type: ignore[arg-type]
+        reporter.pytest_runtest_logreport(report)  # ty: ignore[invalid-argument-type]
         assert reporter._FAILURES == []
 
     def test_skipped_test_does_not_append(self):
@@ -85,7 +85,7 @@ class TestFailuresCapture:
             outcome="skipped",
             duration=0.0,
         )
-        reporter.pytest_runtest_logreport(report)  # type: ignore[arg-type]
+        reporter.pytest_runtest_logreport(report)  # ty: ignore[invalid-argument-type]
         assert reporter._FAILURES == []
 
     def test_setup_phase_ignored(self):
@@ -96,7 +96,7 @@ class TestFailuresCapture:
             duration=0.0,
             longreprtext="fixture error",
         )
-        reporter.pytest_runtest_logreport(report)  # type: ignore[arg-type]
+        reporter.pytest_runtest_logreport(report)  # ty: ignore[invalid-argument-type]
         assert reporter._FAILURES == []
 
     def test_missing_category_defaults_to_empty(self):
@@ -107,7 +107,7 @@ class TestFailuresCapture:
             duration=1.0,
             longreprtext="some failure",
         )
-        reporter.pytest_runtest_logreport(report)  # type: ignore[arg-type]
+        reporter.pytest_runtest_logreport(report)  # ty: ignore[invalid-argument-type]
 
         assert len(reporter._FAILURES) == 1
         assert reporter._FAILURES[0]["category"] == ""
@@ -121,7 +121,7 @@ class TestFailuresCapture:
                 duration=1.0,
                 longreprtext=f"failure {i}",
             )
-            reporter.pytest_runtest_logreport(report)  # type: ignore[arg-type]
+            reporter.pytest_runtest_logreport(report)  # ty: ignore[invalid-argument-type]
 
         assert len(reporter._FAILURES) == 3
         assert [f["failure_message"] for f in reporter._FAILURES] == [
@@ -139,7 +139,7 @@ class TestFailuresCapture:
             duration=1.0,
             longreprtext=long_msg,
         )
-        reporter.pytest_runtest_logreport(report)  # type: ignore[arg-type]
+        reporter.pytest_runtest_logreport(report)  # ty: ignore[invalid-argument-type]
 
         assert len(reporter._FAILURES) == 1
         msg = reporter._FAILURES[0]["failure_message"]
@@ -162,18 +162,18 @@ class TestSessionExitStatus:
     def test_exit_1_swallowed_when_tests_ran(self):
         reporter._RESULTS.update(passed=2, failed=1, total=3)
         session = _FakeSession(exitstatus=1)
-        reporter.pytest_sessionfinish(session, 1)  # type: ignore[arg-type]
+        reporter.pytest_sessionfinish(session, 1)  # ty: ignore[invalid-argument-type]
         assert session.exitstatus == 0
 
     def test_exit_1_preserved_when_no_tests_ran(self):
         session = _FakeSession(exitstatus=1)
-        reporter.pytest_sessionfinish(session, 1)  # type: ignore[arg-type]
+        reporter.pytest_sessionfinish(session, 1)  # ty: ignore[invalid-argument-type]
         assert session.exitstatus == 1
 
     def test_exit_0_unchanged(self):
         reporter._RESULTS.update(passed=3, total=3)
         session = _FakeSession(exitstatus=0)
-        reporter.pytest_sessionfinish(session, 0)  # type: ignore[arg-type]
+        reporter.pytest_sessionfinish(session, 0)  # ty: ignore[invalid-argument-type]
         assert session.exitstatus == 0
 
     def test_exit_1_preserved_when_only_marked_skips(self):
@@ -188,11 +188,11 @@ class TestSessionExitStatus:
             outcome="skipped",
             duration=0.0,
         )
-        reporter.pytest_runtest_logreport(report)  # type: ignore[arg-type]
+        reporter.pytest_runtest_logreport(report)  # ty: ignore[invalid-argument-type]
         assert reporter._RESULTS["total"] == 0
 
         session = _FakeSession(exitstatus=1)
-        reporter.pytest_sessionfinish(session, 1)  # type: ignore[arg-type]
+        reporter.pytest_sessionfinish(session, 1)  # ty: ignore[invalid-argument-type]
         assert session.exitstatus == 1
 
     @pytest.mark.parametrize("exitstatus", [2, 3, 4, 5])
@@ -202,7 +202,7 @@ class TestSessionExitStatus:
         """
         reporter._RESULTS.update(passed=3, total=3)
         session = _FakeSession(exitstatus=exitstatus)
-        reporter.pytest_sessionfinish(session, exitstatus)  # type: ignore[arg-type]
+        reporter.pytest_sessionfinish(session, exitstatus)  # ty: ignore[invalid-argument-type]
         assert session.exitstatus == exitstatus
 
 
@@ -318,7 +318,7 @@ class TestFilterByMarker:
         # The excluded item must be reported via `pytest_deselected`, otherwise
         # pytest's CLI summary loses the "deselected" line.
         assert len(deselected) == 1
-        deselected_mark = deselected[0].get_closest_marker("eval_category")  # type: ignore[attr-defined]
+        deselected_mark = deselected[0].get_closest_marker("eval_category")  # ty: ignore[unresolved-attribute]
         assert deselected_mark is not None
         assert deselected_mark.args == ("valid_cat",)
 

--- a/libs/evals/tests/unit_tests/test_radar.py
+++ b/libs/evals/tests/unit_tests/test_radar.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import importlib
 import json
 
 import pytest
 
+import deepagents_evals.radar as radar_module
 from deepagents_evals.radar import (
     ALL_CATEGORIES,
     CATEGORY_LABELS,
@@ -19,6 +21,27 @@ from deepagents_evals.radar import (
 
 mpl = pytest.importorskip("matplotlib")
 mpl.use("Agg")
+
+
+def test_radar_import_handles_missing_matplotlib(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str, package: str | None = None) -> object:
+        if name == "matplotlib.pyplot":
+            msg = "No module named 'matplotlib'"
+            raise ModuleNotFoundError(msg)
+        return real_import_module(name, package)
+
+    try:
+        with monkeypatch.context() as mp:
+            mp.setattr(importlib, "import_module", fake_import_module)
+            reloaded = importlib.reload(radar_module)
+
+        assert reloaded.plt is None
+        with pytest.raises(ImportError, match="deepagents-evals\\[charts\\]"):
+            reloaded.generate_radar([reloaded.ModelResult(model="test", scores={})])
+    finally:
+        importlib.reload(radar_module)
 
 
 def test_toy_data_covers_all_categories():

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -16,10 +16,10 @@ required-markers = [
 
 [manifest]
 overrides = [
-    { name = "e2b", specifier = "==2.4.3" },
-    { name = "openai", specifier = ">=1.109.1,<2.0.0" },
-    { name = "protobuf", specifier = ">=6.33.5" },
-    { name = "python-multipart", specifier = ">=0.0.27" },
+    { name = "e2b", specifier = "==2.26.0" },
+    { name = "openai", specifier = ">=2.41.0,<3.0.0" },
+    { name = "protobuf", specifier = ">=7.35.0" },
+    { name = "python-multipart", specifier = ">=0.0.32" },
 ]
 
 [[package]]
@@ -452,7 +452,7 @@ wheels = [
 
 [[package]]
 name = "datasets"
-version = "4.8.2"
+version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dill", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -470,9 +470,9 @@ dependencies = [
     { name = "tqdm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "xxhash", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/02/741da3bed890bdf9720eb1b24780a58456bfdde49c4c78237953bb08abae/datasets-4.8.2.tar.gz", hash = "sha256:c6ad7e6c28c7436a9c6c23f817d1a450d395c771df881252dfe63697297cbcdf", size = 603879, upload-time = "2026-03-17T01:09:55.623Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/85/ce4f780c32f7e36d71257f1c27e8ba898ebe379cb54f211f5f2013f2c219/datasets-5.0.0.tar.gz", hash = "sha256:83dbbbdb07a33b82192b8c419deb18739b138ee2ce1a322d55ce6b100954ec1a", size = 631708, upload-time = "2026-06-05T13:18:26.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/7e/1649f47eb4f20ba2edb80e239a021e8ad9e199774d9925efc28179621066/datasets-4.8.2-py3-none-any.whl", hash = "sha256:433a07acb2e5c7e413e54a579cf2fb161397eecb36bc1a99439f0df103f15ae5", size = 526646, upload-time = "2026-03-17T01:09:53.858Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/73034ad30b59f13439b75e620989dacba4c047256e358ba7c2e9ec98ea22/datasets-5.0.0-py3-none-any.whl", hash = "sha256:7dd34927a0fd7046e98aad5cb9430e699c373238a15befa7b9bf22b991a7fee6", size = 555084, upload-time = "2026-06-05T13:18:24.435Z" },
 ]
 
 [[package]]
@@ -702,45 +702,45 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "datasets", specifier = ">=3.0.0" },
+    { name = "datasets", specifier = ">=5.0.0" },
     { name = "deepagents", editable = "../deepagents" },
     { name = "deepagents-code", directory = "../code" },
     { name = "dockerfile-parse", specifier = ">=2.0.1" },
-    { name = "harbor", specifier = ">=0.6.4,<0.7.0" },
+    { name = "harbor", specifier = ">=0.13.1,<0.14.0" },
     { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
-    { name = "langchain-anthropic", specifier = ">=1.4.3,<1.5.0" },
+    { name = "langchain-anthropic", specifier = ">=1.4.4,<1.5.0" },
     { name = "langchain-baseten", specifier = ">=0.2.0,<0.3.0" },
     { name = "langchain-deepseek", specifier = ">=1.0.1,<1.1.0" },
     { name = "langchain-fireworks", specifier = ">=1.3.1,<1.4.0" },
-    { name = "langchain-google-genai", specifier = ">=4.2.2,<4.3.0" },
+    { name = "langchain-google-genai", specifier = ">=4.2.4,<4.3.0" },
     { name = "langchain-groq", specifier = ">=1.1.2,<1.2.0" },
     { name = "langchain-mistralai", specifier = ">=1.1.4,<1.2.0" },
-    { name = "langchain-nvidia-ai-endpoints", specifier = ">=1.2.1,<1.3.0" },
+    { name = "langchain-nvidia-ai-endpoints", specifier = ">=1.4.1,<1.5.0" },
     { name = "langchain-ollama", specifier = ">=1.1.0,<1.2.0" },
-    { name = "langchain-openai", specifier = ">=1.2.1,<1.3.0" },
+    { name = "langchain-openai", specifier = ">=1.2.2,<1.3.0" },
     { name = "langchain-openrouter", specifier = ">=0.2.3,<0.3.0" },
     { name = "langchain-quickjs", editable = "../partners/quickjs" },
     { name = "langchain-xai", specifier = ">=1.2.2,<1.3.0" },
-    { name = "langsmith", specifier = ">=0.8.1,<0.9.0" },
-    { name = "matplotlib", marker = "extra == 'charts'", specifier = ">=3.9.0" },
-    { name = "modal", specifier = ">=0.64.0" },
-    { name = "nltk", specifier = ">=3.9.0" },
+    { name = "langsmith", specifier = ">=0.8.9,<0.9.0" },
+    { name = "matplotlib", marker = "extra == 'charts'", specifier = ">=3.10.9" },
+    { name = "modal", specifier = ">=1.4.3" },
+    { name = "nltk", specifier = ">=3.9.4" },
     { name = "openevals", specifier = ">=0.2.0" },
-    { name = "tiktoken", specifier = ">=0.8.0" },
+    { name = "tiktoken", specifier = ">=0.13.0" },
 ]
 provides-extras = ["charts"]
 
 [package.metadata.requires-dev]
 test = [
-    { name = "matplotlib", specifier = ">=3.9.0" },
+    { name = "matplotlib", specifier = ">=3.10.9" },
     { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.2.0" },
-    { name = "pytest-cov", specifier = ">=7.0.0" },
-    { name = "pytest-socket", specifier = ">=0.7.0" },
-    { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-socket", specifier = ">=0.8.0" },
+    { name = "pytest-watcher", specifier = ">=0.6.3,<1.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "ruff", specifier = ">=0.8.0" },
-    { name = "ty", specifier = ">=0.0.1,<1.0.0" },
+    { name = "ruff", specifier = ">=0.15.16" },
+    { name = "ty", specifier = ">=0.0.44,<1.0.0" },
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ wheels = [
 
 [[package]]
 name = "harbor"
-version = "0.6.4"
+version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "claude-agent-sdk", version = "0.1.48", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -1110,9 +1110,9 @@ dependencies = [
     { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "uvicorn", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/b8/d2f0522180a38a52ab1a0f31f62037b3aeb521bd19cdc096d24b68622349/harbor-0.6.4.tar.gz", hash = "sha256:eab7ba3b010b78d880658aeb7af124340a67a1781f63db7d631bad0596119ade", size = 981327, upload-time = "2026-05-01T18:33:21.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/5a/89fe6831dba01c53cffed5afb0dd9cfa7dd1e62c0d6b531294742270e30c/harbor-0.13.1.tar.gz", hash = "sha256:4c9f8a345a3bda772dbba2053ee68bc735ca641d083b083f7e81a3c3fb6fb2cc", size = 1094654, upload-time = "2026-06-03T20:45:47.738Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/69/e944a417f7e3a612b2758083a74c52a8999ef6b067166791ca15caa07992/harbor-0.6.4-py3-none-any.whl", hash = "sha256:d6c268175ef499fffbe7f70f855b4423198b2125550e5a151386bb283469e6e9", size = 1113713, upload-time = "2026-05-01T18:33:22.623Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d9/640ae0d85f0c63bdda20341f3eee1dbdcd22448258d0ca4970a8523f7eb5/harbor-0.13.1-py3-none-any.whl", hash = "sha256:6116305f7d756ae919b50ce1c5363e14ea377ae924dfd68b10ed00dc20f6f432", size = 1247918, upload-time = "2026-06-03T20:45:49.273Z" },
 ]
 
 [[package]]
@@ -1553,7 +1553,7 @@ wheels = [
 
 [[package]]
 name = "langchain-nvidia-ai-endpoints"
-version = "1.2.1"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1561,9 +1561,9 @@ dependencies = [
     { name = "langchain-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/d5/5d70c7b7a66dfabc4c355e408a066e8bef7d2715f3b7854ce44704886119/langchain_nvidia_ai_endpoints-1.2.1.tar.gz", hash = "sha256:055d2511fa7374da65e5d3dd1705fb09125620a124c6247212d661286f64fa8d", size = 57520, upload-time = "2026-03-16T16:42:34.682Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/26/cae8babfecb9b7b503dbf5d6c0d98df74149c3151247d20e7bbfd17ca461/langchain_nvidia_ai_endpoints-1.4.1.tar.gz", hash = "sha256:8835f7e56d559b370b87164f937c1eb048ab837f25de91598f00555a705c2d16", size = 58092, upload-time = "2026-06-03T19:34:15.117Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/b7/99f72331842b0f62da891411c5590ff7fab70a1a753a9a1be9348921995e/langchain_nvidia_ai_endpoints-1.2.1-py3-none-any.whl", hash = "sha256:eafb2186dea25d163089552c062274664540f2cbe251861c515700645fbf256d", size = 61820, upload-time = "2026-03-16T16:42:33.657Z" },
+    { url = "https://files.pythonhosted.org/packages/30/50/9dcb23c73270e775c38e8d264ccbf8b1b352dbac089bce3746756d895e46/langchain_nvidia_ai_endpoints-1.4.1-py3-none-any.whl", hash = "sha256:3edd1678a3e2c55789128e53ba32aab3dffe94cb201c70e6cea521fab7c261ff", size = 63203, upload-time = "2026-06-03T19:34:11.08Z" },
 ]
 
 [[package]]
@@ -1832,7 +1832,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.8.8"
+version = "0.8.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1846,9 +1846,9 @@ dependencies = [
     { name = "xxhash", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "zstandard", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/93/28df12b3b3c776077983b92f1299c623592b5999695af2a755fb90ff048b/langsmith-0.8.8.tar.gz", hash = "sha256:9d00e54f54d833c1914003527ff03ad0364741034330da72f0adbeaba852b6cf", size = 4468035, upload-time = "2026-05-31T22:14:57.698Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/dd/f4c8a12987318e505b10760d30c3c2d45e8dc87ba8f47a004c753a9e7b35/langsmith-0.8.9.tar.gz", hash = "sha256:f16e37fcd5a8a2d4db30eae0e399a866a65ce5cc86218825c59409ed57a3bf53", size = 4428684, upload-time = "2026-06-03T17:56:09.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/71/94a8f2b573278a0b0b7dfd37663c0ddd36867f9e2bba69addd183de0cd56/langsmith-0.8.8-py3-none-any.whl", hash = "sha256:9d60d724c0d187c036e184b3ffdf9fa5c6822aa0bb88144a5fb898e79be645af", size = 402712, upload-time = "2026-05-31T22:14:55.908Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2f/a701663c9fb4d9630448622a684bc372b4905b9a6dbe2297d55a70fde04e/langsmith-0.8.9-py3-none-any.whl", hash = "sha256:c9519cabc75568d088df045710d1b86eae9780c91054528b2aa7e6cb1fc80c52", size = 403165, upload-time = "2026-06-03T17:56:07.226Z" },
 ]
 
 [package.optional-dependencies]
@@ -1942,7 +1942,7 @@ wheels = [
 
 [[package]]
 name = "matplotlib"
-version = "3.10.8"
+version = "3.10.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "contourpy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1955,17 +1955,17 @@ dependencies = [
     { name = "pyparsing", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "python-dateutil", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/76/d3c6e3a13fe484ebe7718d14e269c9569c4eb0020a968a327acb3b9a8fe6/matplotlib-3.10.8.tar.gz", hash = "sha256:2299372c19d56bcd35cf05a2738308758d32b9eaed2371898d8f5bd33f084aa3", size = 34806269, upload-time = "2025-12-10T22:56:51.155Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/65/07d5f5c7f7c994f12c768708bd2e17a4f01a2b0f44a1c9eccad872433e2e/matplotlib-3.10.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b9a5ca4ac220a0cdd1ba6bcba3608547117d30468fefce49bb26f55c1a3d5c58", size = 8148321, upload-time = "2025-12-10T22:55:33.265Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/f3/c5195b1ae57ef85339fd7285dfb603b22c8b4e79114bae5f4f0fcf688677/matplotlib-3.10.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3ab4aabc72de4ff77b3ec33a6d78a68227bf1123465887f9905ba79184a1cc04", size = 8716944, upload-time = "2025-12-10T22:55:34.922Z" },
-    { url = "https://files.pythonhosted.org/packages/57/61/78cd5920d35b29fd2a0fe894de8adf672ff52939d2e9b43cb83cd5ce1bc7/matplotlib-3.10.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:99eefd13c0dc3b3c1b4d561c1169e65fe47aab7b8158754d7c084088e2329466", size = 9613040, upload-time = "2025-12-10T22:55:38.715Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/a0/2ba3473c1b66b9c74dc7107c67e9008cb1782edbe896d4c899d39ae9cf78/matplotlib-3.10.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56271f3dac49a88d7fca5060f004d9d22b865f743a12a23b1e937a0be4818ee1", size = 8148794, upload-time = "2025-12-10T22:55:46.252Z" },
-    { url = "https://files.pythonhosted.org/packages/75/97/a471f1c3eb1fd6f6c24a31a5858f443891d5127e63a7788678d14e249aea/matplotlib-3.10.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a0a7f52498f72f13d4a25ea70f35f4cb60642b466cbb0a9be951b5bc3f45a486", size = 8718474, upload-time = "2025-12-10T22:55:47.864Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7c/8dc289776eae5109e268c4fb92baf870678dc048a25d4ac903683b86d5bf/matplotlib-3.10.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f89c151aab2e2e23cb3fe0acad1e8b82841fd265379c4cecd0f3fcb34c15e0f6", size = 9613678, upload-time = "2025-12-10T22:55:52.21Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/1e/4de865bc591ac8e3062e835f42dd7fe7a93168d519557837f0e37513f629/matplotlib-3.10.8-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:eb3823f11823deade26ce3b9f40dcb4a213da7a670013929f31d5f5ed1055b22", size = 8198336, upload-time = "2025-12-10T22:55:59.371Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/cb/2f7b6e75fb4dce87ef91f60cac4f6e34f4c145ab036a22318ec837971300/matplotlib-3.10.8-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d9050fee89a89ed57b4fb2c1bfac9a3d0c57a0d55aed95949eedbc42070fea39", size = 8731653, upload-time = "2025-12-10T22:56:01.032Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/3d/8b94a481456dfc9dfe6e39e93b5ab376e50998cddfd23f4ae3b431708f16/matplotlib-3.10.8-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0a33deb84c15ede243aead39f77e990469fff93ad1521163305095b77b72ce4a", size = 9614000, upload-time = "2025-12-10T22:56:05.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/18/4880dd762e40cd360c1bf06e890c5a97b997e91cb324602b1a19950ad5ce/matplotlib-3.10.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cb28c2bd769aa3e98322c6ab09854cbcc52ab69d2759d681bba3e327b2b320", size = 8216016, upload-time = "2026-04-24T00:12:23.4Z" },
+    { url = "https://files.pythonhosted.org/packages/32/91/d024616abdba99e83120e07a20658976f6a343646710760c4a51df126029/matplotlib-3.10.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ae20801130378b82d647ff5047c07316295b68dc054ca6b3c13519d0ea624285", size = 8789336, upload-time = "2026-04-24T00:12:26.096Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c2/541e4d09d87bb6b5830fc28b4c887a9a8cf4e1c6cee698a8c05552ae2003/matplotlib-3.10.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d75d11c949914165976c621b2324f9ef162af7ebf4b057ddf95dd1dba7e5edcf", size = 9670966, upload-time = "2026-04-24T00:12:32.131Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d9/9e14bc7564bf92d5ffa801ae5fac819ce74b925dfb55e3ebde61a3bbad3e/matplotlib-3.10.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b1b745c489cd1a77a0dc1120a05dc87af9798faebc913601feb8c73d89bf2d1e", size = 8216461, upload-time = "2026-04-24T00:12:42.494Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/4402d0d14ccf1dfc70932600b68097fbbf9c898a4871d2cbbe79c7801a32/matplotlib-3.10.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8f3bcac1ca5ed000a6f4337d47ba67dfddf37ed6a46c15fd7f014997f7bf865f", size = 8790091, upload-time = "2026-04-24T00:12:44.789Z" },
+    { url = "https://files.pythonhosted.org/packages/74/88/5f13482f55e7b00bcfc09838b093c2456e1379978d2a146844aae05350ad/matplotlib-3.10.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d843374407c4017a6403b59c6c81606773d136f3259d5b6da3131bc814542cc2", size = 9671269, upload-time = "2026-04-24T00:12:50.878Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0a/c8e3d3bba245f0f7fc424937f8ff7ef77291a36af3edb97ccd78aa93d84f/matplotlib-3.10.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:82368699727bfb7b0182e1aa13082e3c08e092fa1a25d3e1fd92405bff96f6d4", size = 8264645, upload-time = "2026-04-24T00:13:01.406Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/aa/5bf5a14fe4fed73a4209a155606f8096ff797aad89c6c35179026571133e/matplotlib-3.10.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3225f4e1edcb8c86c884ddf79ebe20ecd0a67d30188f279897554ccd8fded4dc", size = 8802194, upload-time = "2026-04-24T00:13:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/ed428c971139112ef730f62770654d609467346d09d4b62617e1afd68a5a/matplotlib-3.10.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b2b9516251cb89ff618d757daec0e2ed1bf21248013844a853d87ef85ab3081d", size = 9680790, upload-time = "2026-04-24T00:13:10.009Z" },
 ]
 
 [[package]]
@@ -2034,7 +2034,7 @@ wheels = [
 
 [[package]]
 name = "modal"
-version = "1.3.5"
+version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2046,15 +2046,14 @@ dependencies = [
     { name = "rich", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "synchronicity", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "toml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "types-certifi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "types-toml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "watchfiles", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/fd/f4a684209dab54d7dc9d92f48d779b30d04aa8b4c6dd1395d6c61967ee34/modal-1.3.5.tar.gz", hash = "sha256:2e320e7dbc8995ce0769796a9027248a8b976b519469cc4599d6855a1a53a123", size = 655193, upload-time = "2026-03-03T18:13:06.22Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/7d/4126d0fe879ef3e86002ca821a34cb68a2588ea2e8ccb2bfe421d0f42ffe/modal-1.4.3.tar.gz", hash = "sha256:35b2fc840f759b512e12527afb538e1ea4cc232b84cfbfcef3f5d96d5a66abaa", size = 720488, upload-time = "2026-05-18T22:34:45.842Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/39/aa5c773a4dddef833f1c846bb4204b442588b99a1d15ab7818157e66b32c/modal-1.3.5-py3-none-any.whl", hash = "sha256:67e5d3635c2c355d63b3e30f9012dd2bc9c38d5747349335c7ba9da65edca1cb", size = 755272, upload-time = "2026-03-03T18:13:03.323Z" },
+    { url = "https://files.pythonhosted.org/packages/56/54/400262056c144ceee5edab40efa2541ae8928ae5f244fd9025f3ad26c909/modal-1.4.3-py3-none-any.whl", hash = "sha256:802917181f576458a0cb833322157dab09c4f367326426c5a732661a0c519577", size = 826232, upload-time = "2026-05-18T22:34:43.335Z" },
 ]
 
 [[package]]
@@ -2105,7 +2104,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.3"
+version = "3.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2113,9 +2112,9 @@ dependencies = [
     { name = "regex", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tqdm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/8f/915e1c12df07c70ed779d18ab83d065718a926e70d3ea33eb0cd66ffb7c0/nltk-3.9.3.tar.gz", hash = "sha256:cb5945d6424a98d694c2b9a0264519fab4363711065a46aa0ae7a2195b92e71f", size = 2923673, upload-time = "2026-02-24T12:05:53.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/7e/9af5a710a1236e4772de8dfcc6af942a561327bb9f42b5b4a24d0cf100fd/nltk-3.9.3-py3-none-any.whl", hash = "sha256:60b3db6e9995b3dd976b1f0fa7dec22069b2677e759c28eb69b62ddd44870522", size = 1525385, upload-time = "2026-02-24T12:05:46.54Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
 ]
 
 [[package]]
@@ -2153,7 +2152,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.109.1"
+version = "2.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2165,9 +2164,9 @@ dependencies = [
     { name = "tqdm", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/a1/a303104dc55fc546a3f6914c842d3da471c64eec92043aef8f652eb6c524/openai-1.109.1.tar.gz", hash = "sha256:d173ed8dbca665892a6db099b4a2dfac624f94d20a93f46eb0b56aae940ed869", size = 564133, upload-time = "2025-09-24T13:00:53.075Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/a6/5815fe2e2aca74b36c650d1bd43b69827cee568073d0d2d9b6fc5aaac80c/openai-2.41.0.tar.gz", hash = "sha256:db5c362acd6604b84f076abbefa66826ea4b46ecba2954ed866e6a149a1352c0", size = 783525, upload-time = "2026-06-03T22:39:40.719Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/2a/7dd3d207ec669cacc1f186fd856a0f61dbc255d24f6fdc1a6715d6051b0f/openai-1.109.1-py3-none-any.whl", hash = "sha256:6bcaf57086cf59159b8e27447e4e7dd019db5d29a438072fbd49c290c7e65315", size = 948627, upload-time = "2025-09-24T13:00:50.754Z" },
+    { url = "https://files.pythonhosted.org/packages/be/51/d82bb424e8aa372190c5233253a2ceb399a778747d18b42cff487411e663/openai-2.41.0-py3-none-any.whl", hash = "sha256:20cc7952e8501c7e5773dd2ef7be437bae9cb549044902e1041a83a54516e375", size = 1353378, upload-time = "2026-06-03T22:39:38.964Z" },
 ]
 
 [[package]]
@@ -2441,13 +2440,13 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "7.34.0"
+version = "7.35.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/00/04a2ab36b70a52d0356852979e08b44edde0435f2115dc66e25f2100f3ab/protobuf-7.34.0.tar.gz", hash = "sha256:3871a3df67c710aaf7bb8d214cc997342e63ceebd940c8c7fc65c9b3d697591a", size = 454726, upload-time = "2026-02-27T00:30:25.421Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/fd/5b1491d9e4b586d621c54f4c36b888714164b6875f8d6afa3f9072906a51/protobuf-7.35.0.tar.gz", hash = "sha256:a2efd84605f41e559f1881b0912b44099d0a2ac9bf46b3474823f10fb393b0e6", size = 458677, upload-time = "2026-05-19T23:02:29.197Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/c4/6322ab5c8f279c4c358bc14eb8aefc0550b97222a39f04eb3c1af7a830fa/protobuf-7.34.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:8e329966799f2c271d5e05e236459fe1cbfdb8755aaa3b0914fa60947ddea408", size = 429248, upload-time = "2026-02-27T00:30:14.924Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/57/89727baef7578897af5ed166735ceb315819f1c184da8c3441271dbcfde7/protobuf-7.34.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:964cf977e07f479c0697964e83deda72bcbc75c3badab506fb061b352d991b01", size = 324268, upload-time = "2026-02-27T00:30:20.088Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/e7/14dc9366696dcb53a413449881743426ed289d687bcf3d5aee4726c32ebb/protobuf-7.34.0-py3-none-any.whl", hash = "sha256:e3b914dd77fa33fa06ab2baa97937746ab25695f389869afdf03e81f34e45dc7", size = 170716, upload-time = "2026-02-27T00:30:23.994Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ee/93d06e358a4aa32280b00e722d3ea0a1f25fc3cc5778d80581c9cca2c10e/protobuf-7.35.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:66be6c513931c794fa92c080ffee41671390da3d79da219cf9c0c0907f035dda", size = 433225, upload-time = "2026-05-19T23:02:19.884Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5b/6baf9008817964454055ff3fe65f1de0b5f1e26c80c82f7fb108b7cd4ea3/protobuf-7.35.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:6c0f98f10c8a05ea30f8993dfef2de093d27b490fdae78bb60c8343795d55011", size = 327130, upload-time = "2026-05-19T23:02:24.637Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ef/50433d346c56657a70d27f156c7b349ac59a068b01de4eb796e747eecc43/protobuf-7.35.0-py3-none-any.whl", hash = "sha256:c13f325cf242bad135c350629eeb5d54b24228eb472fb3e2e9ebbd4c5dc20ca0", size = 171659, upload-time = "2026-05-19T23:02:27.842Z" },
 ]
 
 [[package]]
@@ -2647,41 +2646,41 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(python_full_version < '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pluggy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
 name = "pytest-socket"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/ff/90c7e1e746baf3d62ce864c479fd53410b534818b9437413903596f81580/pytest_socket-0.7.0.tar.gz", hash = "sha256:71ab048cbbcb085c15a4423b73b619a8b35d6a307f46f78ea46be51b1b7e11b3", size = 12389, upload-time = "2024-01-28T20:17:23.177Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/3c/f9b58e57830e58980dbe8867d0e348f45701d3f3ea065672d448f4366da5/pytest_socket-0.8.0.tar.gz", hash = "sha256:af9bb5f487da72be63573a6194cfac033b6c7a1c1561e150521105970f9e99f2", size = 13912, upload-time = "2026-05-21T16:50:22.552Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/58/5d14cb5cb59409e491ebe816c47bf81423cd03098ea92281336320ae5681/pytest_socket-0.7.0-py3-none-any.whl", hash = "sha256:7e0f4642177d55d317bbd58fc68c6bd9048d6eadb2d46a89307fa9221336ce45", size = 6754, upload-time = "2024-01-28T20:17:22.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e8/4a8568580bae3dcd678599ed8e86a82d505a44df71c1ced4246c1aa14b4b/pytest_socket-0.8.0-py3-none-any.whl", hash = "sha256:81821ba59f07d7600fe2b551d8714f40b068bd46e8b6704c48664e9d60cdacb8", size = 8414, upload-time = "2026-05-21T16:50:21.022Z" },
 ]
 
 [[package]]
@@ -2719,11 +2718,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.28"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -2874,13 +2873,13 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.12"
+version = "0.15.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
-    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
+    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
 ]
 
 [[package]]
@@ -3079,14 +3078,14 @@ wheels = [
 
 [[package]]
 name = "synchronicity"
-version = "0.11.1"
+version = "0.12.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/26/8874d34755691994266d4a844ba8d53d10c2690ec67f246ca4d6b6f34cbb/synchronicity-0.11.1.tar.gz", hash = "sha256:3628df9ab34bd7be89b729104114841c62612c5d5ec43b76f4b7b243185ec1a8", size = 58131, upload-time = "2025-12-19T18:28:42.291Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/d5/e96e6082790c92480380f28aa53e111844cdac7b0f75846f4772cb535a43/synchronicity-0.12.3.tar.gz", hash = "sha256:0d4228b85eaf2805f23b4615b2039a9d24ea811646e2d9f8d0c033094eb85841", size = 60261, upload-time = "2026-05-28T12:33:50.206Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/b9/71153db12f4ad029cfe9b7fbf9792ef3fc9ade4485d31a13470b52954e62/synchronicity-0.11.1-py3-none-any.whl", hash = "sha256:53959c7f8b9b852fb5ea4d3d290a47a04310ede483a4cf0f8452cb4b5fa09db2", size = 40399, upload-time = "2025-12-19T18:28:40.972Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ea/531a6ea751cbd989da386144810b1b8f529b0aae8c1a9beda8b40966c9c2/synchronicity-0.12.3-py3-none-any.whl", hash = "sha256:e476818cd14102136f41622c619de548f0000c024485fc18521c8fe908ea7574", size = 40982, upload-time = "2026-05-28T12:33:49.125Z" },
 ]
 
 [[package]]
@@ -3159,23 +3158,23 @@ wheels = [
 
 [[package]]
 name = "tiktoken"
-version = "0.12.0"
+version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "regex", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/42/6573e9129bc55c9bf7300b3a35bef2c6b9117018acca0dc760ac2d93dffe/tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b", size = 994049, upload-time = "2025-10-06T20:21:53.782Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/90/3dae6cc5436137ebd38944d396b5849e167896fc2073da643a49f372dc4f/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:edde1ec917dfd21c1f2f8046b86348b0f54a2c0547f68149d8600859598769ad", size = 1152665, upload-time = "2025-10-06T20:21:56.129Z" },
-    { url = "https://files.pythonhosted.org/packages/20/cc/b064cae1a0e9fac84b0d2c46b89f4e57051a5f41324e385d10225a984c24/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3", size = 1254688, upload-time = "2025-10-06T20:21:58.619Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/05/dcf94486d5c5c8d34496abe271ac76c5b785507c8eae71b3708f1ad9b45a/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160", size = 993995, upload-time = "2025-10-06T20:22:02.788Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/da/c028aa0babf77315e1cef357d4d768800c5f8a6de04d0eac0f377cb619fa/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be", size = 1151986, upload-time = "2025-10-06T20:22:05.173Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f8/4db272048397636ac7a078d22773dd2795b1becee7bc4922fe6207288d57/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3", size = 1255097, upload-time = "2025-10-06T20:22:07.403Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b8/57ef1456504c43a849821920d582a738a461b76a047f352f18c0b26c6516/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a", size = 993712, upload-time = "2025-10-06T20:22:12.115Z" },
-    { url = "https://files.pythonhosted.org/packages/05/df/4f80030d44682235bdaecd7346c90f67ae87ec8f3df4a3442cb53834f7e4/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb", size = 1151875, upload-time = "2025-10-06T20:22:14.559Z" },
-    { url = "https://files.pythonhosted.org/packages/78/a7/f8ead382fce0243cb625c4f266e66c27f65ae65ee9e77f59ea1653b6d730/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25", size = 1253794, upload-time = "2025-10-06T20:22:16.624Z" },
+    { url = "https://files.pythonhosted.org/packages/36/18/d4ac9d20956cdebca04841316660ed584c2fecdc2b81722a28bc7ad3b1e4/tiktoken-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d9980f11429ed2d737c463bb1fb78cf330caa026adf002f714aced7849a687b", size = 982970, upload-time = "2026-05-15T04:50:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/34/de/2ca96b07a82d972b74fe4b46de055b79c904e45c7eab699354a0bfa697dc/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a116178fa7e1b4065bff05214360373a65cac22f965be7b3f73d00a0dbfe7649", size = 1136523, upload-time = "2026-05-15T04:50:35.782Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d0/1f8578c45b2f24759b46f0b50d31878c63c73e6bf0f2227e10ec5c5408dc/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:95097e4f89b06403976e498abf61a0ee73a7497e73fb599cb211d8197a054d91", size = 1240069, upload-time = "2026-05-15T04:50:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
 ]
 
 [[package]]
@@ -3230,13 +3229,13 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.23"
+version = "0.0.44"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/75/ba/d3c998ff4cf6b5d75b39356db55fe1b7caceecc522b9586174e6a5dee6f7/ty-0.0.23.tar.gz", hash = "sha256:5fb05db58f202af366f80ef70f806e48f5237807fe424ec787c9f289e3f3a4ef", size = 5341461, upload-time = "2026-03-13T12:34:23.125Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/f4/fbb120226e4f239652525a664bad976a23fea58c646d1323f2296fee8a61/ty-0.0.44.tar.gz", hash = "sha256:5886229830ab77022842a1c55d2ef57405621a91fc465969fa6d538661898173", size = 5803665, upload-time = "2026-06-05T03:33:48.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/01/3f25909b02fac29bb0a62b2251f8d62e65d697781ffa4cf6b47a4c075c85/ty-0.0.23-py3-none-macosx_11_0_arm64.whl", hash = "sha256:bd6a340969577b4645f231572c4e46012acba2d10d4c0c6570fe1ab74e76ae00", size = 9653211, upload-time = "2026-03-13T12:34:15.049Z" },
-    { url = "https://files.pythonhosted.org/packages/18/14/69a25a0cad493fb6a947302471b579a03516a3b00e7bece77fdc6b4afb9b/ty-0.0.23-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:559d9a299df793cb7a7902caed5eda8a720ff69164c31c979673e928f02251ee", size = 10752487, upload-time = "2026-03-13T12:34:31.785Z" },
-    { url = "https://files.pythonhosted.org/packages/98/c7/dfc83203d37998620bba9c4873a080c8850a784a8a46f56f8163c5b4e320/ty-0.0.23-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:252539c3fcd7aeb9b8d5c14e2040682c3e1d7ff640906d63fd2c4ce35865a4ba", size = 10848162, upload-time = "2026-03-13T12:34:45.421Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/aa/fb9835aa492b148d7754cb4c3db07f31a7e2e09f0d8e0e8e297f01125dd2/ty-0.0.44-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4d42cfd84a690f6654b2a4f0515027c21b692cf2512d32e6433f754893a95609", size = 10809741, upload-time = "2026-06-05T03:33:33.22Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c7/e1c9260ea5188195962ff1214ace418b5d69187e8fa7c0a1ec4994b8071b/ty-0.0.44-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:503a585f4007387c3afc58bae23a7ca1b9f236cbdb1a881dc36110655ceb1937", size = 11986201, upload-time = "2026-06-05T03:34:00.624Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f7/256e1538ce21cab67b381201444c42454de69d310059c4929d92a0ee9c48/ty-0.0.44-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2b237a143bac4f30cec9257d45f01e72da97030a80a09a2b69cfef065f09c37f", size = 12085723, upload-time = "2026-06-05T03:33:45.953Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The evals package now pins its minimum supported runtime, provider, sandbox, charting, and test dependency versions to the latest releases available on PyPI. Several compatibility caps were advanced where packages have moved to newer minor or major lines.

Update some code to match.