### PR TITLE
fix(code): suppress stale update notices

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3219,6 +3219,7 @@ class DeepAgentsApp(App):
             from deepagents_code.config import _is_editable_install
             from deepagents_code.update_check import (
                 is_auto_update_enabled,
+                is_installed_version_at_least,
                 is_update_available,
                 upgrade_command,
             )
@@ -3231,6 +3232,9 @@ class DeepAgentsApp(App):
                 bypass_cache=periodic,
             )
             if not available or latest is None:
+                return
+            if await asyncio.to_thread(is_installed_version_at_least, latest):
+                self._update_available = (False, None)
                 return
 
             self._update_available = (True, latest)

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2736,13 +2736,18 @@ def cli_main() -> None:
                         format_installed_age_suffix,
                         format_release_age_parenthetical,
                         is_auto_update_enabled,
+                        is_installed_version_at_least,
                         mark_update_notified,
                         should_notify_update,
                         upgrade_command,
                     )
 
                     latest = result.update_available[1]
-                    if latest and should_notify_update(latest):
+                    if (
+                        latest
+                        and not is_installed_version_at_least(latest)
+                        and should_notify_update(latest)
+                    ):
                         console.print()
                         release_age = format_release_age_parenthetical(latest)
                         installed_age = format_installed_age_suffix(cli_version)

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -123,6 +123,18 @@ def _parse_version(v: str) -> Version:
     return Version(v.strip())  # raises InvalidVersion for non-PEP 440 strings
 
 
+def is_installed_version_at_least(version: str) -> bool:
+    """Return whether installed package metadata is at least `version`."""
+    try:
+        from importlib.metadata import PackageNotFoundError, version as pkg_version
+
+        installed = _parse_version(pkg_version("deepagents-code"))
+        target = _parse_version(version)
+    except (InvalidVersion, PackageNotFoundError):
+        return False
+    return installed >= target
+
+
 def _latest_from_releases(
     releases: dict[str, list[object]],
     *,

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -7978,6 +7978,39 @@ class TestNotificationCenterIntegration:
         assert app._update_available == (False, None)
         assert not app._update_modal_pending.is_set()
 
+    async def test_update_check_ignores_stale_notice_after_in_place_upgrade(
+        self,
+    ) -> None:
+        """Skip stale notices after an in-place upgrade."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+
+        with (
+            patch(
+                "deepagents_code.config._is_editable_install",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_code.update_check.is_update_available",
+                return_value=(True, "9.9.9"),
+            ),
+            patch(
+                "deepagents_code.update_check.is_installed_version_at_least",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+            ) as auto_update_enabled,
+        ):
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                await app._check_for_updates()
+                await pilot.pause()
+
+        auto_update_enabled.assert_not_called()
+        assert app._notice_registry.get("update:available") is None
+        assert app._update_available == (False, None)
+        assert not app._update_modal_pending.is_set()
+
     async def test_update_check_auto_opens_dedicated_modal(self) -> None:
         """A detected update auto-opens the dedicated update modal after first paint."""
         from deepagents_code.widgets.update_available import UpdateAvailableScreen

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -44,6 +44,7 @@ from deepagents_code.update_check import (
     install_extras_command,
     install_package_command,
     is_auto_update_enabled,
+    is_installed_version_at_least,
     is_update_available,
     is_valid_extra_name,
     is_valid_package_name,
@@ -140,6 +141,20 @@ class TestParseVersion:
         assert _parse_version("1.0.0a2") < _parse_version("1.0.0b1")
         assert _parse_version("1.0.0b1") < _parse_version("1.0.0rc1")
         assert _parse_version("1.0.0rc1") < _parse_version("1.0.0")
+
+
+class TestInstalledVersionAtLeast:
+    def test_true_when_distribution_metadata_matches_target(self) -> None:
+        with patch("importlib.metadata.version", return_value="2.0.0"):
+            assert is_installed_version_at_least("2.0.0") is True
+
+    def test_true_when_distribution_metadata_is_newer(self) -> None:
+        with patch("importlib.metadata.version", return_value="2.0.1"):
+            assert is_installed_version_at_least("2.0.0") is True
+
+    def test_false_when_distribution_metadata_is_older(self) -> None:
+        with patch("importlib.metadata.version", return_value="1.9.9"):
+            assert is_installed_version_at_least("2.0.0") is False
 
 
 class TestLatestFromReleases:


### PR DESCRIPTION
Suppresses stale update-available notices when the package metadata already shows the advertised version is installed, which can happen after an in-place auto-update while old code is still in memory.

Made by [Open SWE](https://openswe.vercel.app)