### PR TITLE
fix(code): recover from tool errors instead of aborting run

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -199,6 +199,101 @@ class ShellAllowListMiddleware(AgentMiddleware):
         return await handler(request)
 
 
+class _ToolExceptionRecoveryMiddleware(AgentMiddleware):
+    """Convert expected tool failures into recoverable tool messages.
+
+    A `ToolException` signals a tool-side failure that the model should see and
+    work around (e.g. an MCP server returning `isError`, which
+    `langchain-mcp-adapters` surfaces as a raised `ToolException`) rather than a
+    bug that should abort the run. LangGraph's default tool-error handling
+    re-raises plain `ToolException`, so without this shim such a failure would
+    propagate and crash the entire agent run. Catching it here turns it into an
+    error `ToolMessage` the model can recover from. Only `ToolException` is
+    caught; every other exception propagates so genuine bugs surface.
+
+    Temporary workaround shim while we determine whether an upstream change to
+    `langchain-mcp-adapters` is sensible.
+    """
+
+    @staticmethod
+    def _error_message(request: ToolCallRequest, exc: Exception) -> ToolMessage:
+        """Build an error-status `ToolMessage` from a caught exception.
+
+        Args:
+            request: The tool call request whose handler raised.
+            exc: The recoverable exception to surface to the model.
+
+        Returns:
+            A `ToolMessage` with `status="error"` carrying the exception text,
+                or a tool-named fallback when the exception has no message.
+        """
+        from langchain_core.messages import ToolMessage as LCToolMessage
+
+        tool_call = request.tool_call
+        return LCToolMessage(
+            content=str(exc) or f"{tool_call['name']} failed with no error detail",
+            name=tool_call["name"],
+            tool_call_id=tool_call["id"],
+            status="error",
+        )
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Convert a recoverable `ToolException` into an error `ToolMessage`.
+
+        Args:
+            request: The tool call request being processed.
+            handler: The next handler in the middleware chain.
+
+        Returns:
+            The tool execution result, or an error `ToolMessage` when the tool
+                raised a `ToolException`. Other exceptions propagate unchanged.
+        """
+        from langchain_core.tools import ToolException
+
+        try:
+            return handler(request)
+        except ToolException as exc:
+            logger.warning(
+                "Tool %r failed with recoverable ToolException: %s",
+                request.tool_call.get("name"),
+                exc,
+                exc_info=True,
+            )
+            return self._error_message(request, exc)
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
+    ) -> ToolMessage | Command[Any]:
+        """Convert a recoverable `ToolException` into an error `ToolMessage`.
+
+        Args:
+            request: The tool call request being processed.
+            handler: The next handler in the middleware chain.
+
+        Returns:
+            The tool execution result, or an error `ToolMessage` when the tool
+                raised a `ToolException`. Other exceptions propagate unchanged.
+        """
+        from langchain_core.tools import ToolException
+
+        try:
+            return await handler(request)
+        except ToolException as exc:
+            logger.warning(
+                "Tool %r failed with recoverable ToolException: %s",
+                request.tool_call.get("name"),
+                exc,
+                exc_info=True,
+            )
+            return self._error_message(request, exc)
+
+
 _INTERPRETER_WRITE_TOOLS: frozenset[str] = frozenset(
     {"execute", "write_file", "edit_file"}
 )
@@ -1211,6 +1306,11 @@ def create_cli_agent(
             middleware.append(ConfigurableModelMiddleware())
         if restrictive_shell_allow_list is not None:
             middleware.append(ShellAllowListMiddleware(restrictive_shell_allow_list))
+        # Recovery sits last so it is the innermost tool-call wrapper, matching
+        # the main agent stack: it then wraps tool execution as tightly as
+        # possible and only intercepts `ToolException`s from the tool itself,
+        # not from sibling middleware (which return error messages, not raise).
+        middleware.append(_ToolExceptionRecoveryMiddleware())
         return middleware
 
     for subagent_meta in list_subagents(
@@ -1257,6 +1357,7 @@ def create_cli_agent(
     agent_middleware = [
         ConfigurableModelMiddleware(),
         _FilesystemEmptyResultMiddleware(),
+        _ToolExceptionRecoveryMiddleware(),
     ]
 
     # Resume state: declares the `_context_tokens` and `_model_spec` channels

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -22,6 +22,7 @@ from deepagents_code.agent import (
     _format_task_description,
     _format_web_search_description,
     _format_write_file_description,
+    _ToolExceptionRecoveryMiddleware,
     build_model_identity_section,
     create_cli_agent,
     get_available_agent_names,
@@ -1871,6 +1872,138 @@ class TestLoadAsyncSubagents:
         assert result == []
 
 
+class TestToolExceptionRecoveryMiddleware:
+    """Tests for converting tool exceptions into recoverable tool messages."""
+
+    @staticmethod
+    def _request(tool_call_id: str) -> Mock:
+        """Build a minimal tool-call request the middleware can read."""
+        request = Mock()
+        request.tool_call = {
+            "name": "langsmith_fetch_runs",
+            "args": {},
+            "id": tool_call_id,
+        }
+        return request
+
+    def test_converts_tool_exception_sync(self) -> None:
+        from langchain_core.messages import ToolMessage
+        from langchain_core.tools import ToolException
+
+        middleware = _ToolExceptionRecoveryMiddleware()
+        request = self._request("tc1")
+        handler = Mock(side_effect=ToolException('no project found with name "abc"'))
+
+        result = middleware.wrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert result.name == "langsmith_fetch_runs"
+        assert result.tool_call_id == "tc1"
+        assert 'no project found with name "abc"' in result.content
+
+    async def test_converts_tool_exception_async(self) -> None:
+        from unittest.mock import AsyncMock
+
+        from langchain_core.messages import ToolMessage
+        from langchain_core.tools import ToolException
+
+        middleware = _ToolExceptionRecoveryMiddleware()
+        request = self._request("tc2")
+        handler = AsyncMock(
+            side_effect=ToolException('no project found with name "abc"')
+        )
+
+        result = await middleware.awrap_tool_call(request, handler)
+
+        handler.assert_awaited_once_with(request)
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert result.name == "langsmith_fetch_runs"
+        assert result.tool_call_id == "tc2"
+        assert 'no project found with name "abc"' in result.content
+
+    def test_passes_through_success_sync(self) -> None:
+        """A successful handler result is returned unchanged (sync)."""
+        from langchain_core.messages import ToolMessage
+
+        middleware = _ToolExceptionRecoveryMiddleware()
+        request = self._request("tc3")
+        sentinel = ToolMessage(content="ok", name="x", tool_call_id="tc3")
+
+        result = middleware.wrap_tool_call(request, lambda _req: sentinel)
+
+        assert result is sentinel
+
+    async def test_passes_through_success_async(self) -> None:
+        """A successful handler result is returned unchanged (async)."""
+        from unittest.mock import AsyncMock
+
+        from langgraph.types import Command
+
+        middleware = _ToolExceptionRecoveryMiddleware()
+        request = self._request("tc4")
+        sentinel = Command(update={"messages": []})
+        handler = AsyncMock(return_value=sentinel)
+
+        result = await middleware.awrap_tool_call(request, handler)
+
+        handler.assert_awaited_once_with(request)
+        assert result is sentinel
+
+    def test_propagates_non_tool_exception_sync(self) -> None:
+        """Non-`ToolException` errors propagate rather than being swallowed."""
+        middleware = _ToolExceptionRecoveryMiddleware()
+        request = self._request("tc5")
+        handler = Mock(side_effect=ValueError("boom"))
+
+        with pytest.raises(ValueError, match="boom"):
+            middleware.wrap_tool_call(request, handler)
+
+    async def test_propagates_non_tool_exception_async(self) -> None:
+        """Non-`ToolException` errors propagate rather than being swallowed."""
+        from unittest.mock import AsyncMock
+
+        middleware = _ToolExceptionRecoveryMiddleware()
+        request = self._request("tc6")
+        handler = AsyncMock(side_effect=ValueError("boom"))
+
+        with pytest.raises(ValueError, match="boom"):
+            await middleware.awrap_tool_call(request, handler)
+
+    def test_empty_exception_message_falls_back_to_tool_name(self) -> None:
+        """An exception with no message yields an informative fallback."""
+        from langchain_core.tools import ToolException
+
+        middleware = _ToolExceptionRecoveryMiddleware()
+        request = self._request("tc7")
+        handler = Mock(side_effect=ToolException())
+
+        result = middleware.wrap_tool_call(request, handler)
+
+        assert result.content == "langsmith_fetch_runs failed with no error detail"
+
+    def test_logs_warning_with_traceback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The recovered failure is logged at WARNING with a traceback."""
+        import logging
+
+        from langchain_core.tools import ToolException
+
+        middleware = _ToolExceptionRecoveryMiddleware()
+        request = self._request("tc8")
+        handler = Mock(side_effect=ToolException("kaboom"))
+
+        with caplog.at_level(logging.WARNING, logger="deepagents_code.agent"):
+            middleware.wrap_tool_call(request, handler)
+
+        records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("langsmith_fetch_runs" in r.getMessage() for r in records)
+        assert any(r.exc_info is not None for r in records)
+
+
 class TestShellAllowListMiddleware:
     """Tests for inline shell command validation middleware."""
 
@@ -2122,6 +2255,8 @@ class TestCreateCliAgentShellMiddlewareWiring:
         assert kwargs["interrupt_on"] == {}
         middleware_types = [type(m) for m in kwargs["middleware"]]
         assert ShellAllowListMiddleware in middleware_types
+        # Recovery middleware is wired onto the main agent, not just subagents.
+        assert _ToolExceptionRecoveryMiddleware in middleware_types
 
     def test_interrupt_shell_only_skipped_when_auto_approve(
         self, tmp_path: Path
@@ -2450,9 +2585,11 @@ class TestCreateCliAgentShellMiddlewareWiring:
             subagent["name"]: subagent for subagent in kwargs["subagents"]
         }
 
-        # Implicit-model subagents (and the general-purpose fallback) get both
-        # middlewares, with the configurable-model swap ordered before the shell
-        # gate so a runtime `/model` switch applies before tools are filtered.
+        # Implicit-model subagents (and the general-purpose fallback) get
+        # configurable-model, shell, and recovery middlewares, with the
+        # configurable-model swap ordered before the shell gate so a runtime
+        # `/model` switch applies before tools are filtered, and recovery last
+        # so it wraps tool execution innermost (matching the main agent stack).
         for name in ("researcher", "general-purpose"):
             middleware_types = [
                 type(mw) for mw in subagents_by_name[name]["middleware"]
@@ -2460,6 +2597,7 @@ class TestCreateCliAgentShellMiddlewareWiring:
             assert middleware_types == [
                 ConfigurableModelMiddleware,
                 ShellAllowListMiddleware,
+                _ToolExceptionRecoveryMiddleware,
             ], f"Unexpected middleware on subagent {name!r}: {middleware_types}"
 
         # The pinned subagent keeps shell restriction but is NOT given the


### PR DESCRIPTION
When an MCP tool returns an error, `langchain-mcp-adapters` raises a `ToolException`, and LangGraph's default tool-error handling re-raises plain `ToolException` rather than converting it — so a recoverable tool-level failure (e.g. `langsmith_fetch_runs` reporting `no project found`) would crash the entire agent run. A new middleware catches these and hands the model an error message it can work around.

## Changes
- Add `_ToolExceptionRecoveryMiddleware`, which catches `ToolException` from tool execution and returns an error `ToolMessage` (`status="error"`) so the run continues. Only `ToolException` is caught — every other exception propagates so genuine bugs still surface.
- Wire the middleware onto both the main agent and CLI subagents, placed innermost in each stack so it wraps tool execution as tightly as possible and only intercepts the tool's own failures, not sibling middleware (which return error messages rather than raise).
- Log recovered failures at `WARNING` with `exc_info=True` so the traceback is preserved for debugging.
- Fall back to a tool-named message (`"<tool> failed with no error detail"`) when the exception carries no text, instead of an opaque exception class name.