### PR TITLE
fix(code): expose `/restart` slash command

### DIFF
--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -6,7 +6,7 @@ Canonical list of slash commands for `deepagents-code`, derived from
 regenerate after editing the registry.
 
 
-## Public (27)
+## Public (28)
 
 | Command | Aliases | Description |
 | --- | --- | --- |
@@ -29,6 +29,7 @@ regenerate after editing the registry.
 | `/quit` | `/q` | Exit app |
 | `/reload` |  | Reload config from environment variables and .env |
 | `/remember` |  | Update memory and skills from conversation |
+| `/restart` |  | Restart the app-owned LangGraph server |
 | `/skill-creator` |  | Guide for creating effective agent skills |
 | `/theme` |  | Switch color theme |
 | `/threads` |  | Browse and resume previous threads |
@@ -38,9 +39,8 @@ regenerate after editing the registry.
 | `/update` |  | Check for and install updates |
 | `/version` | `/about` | Show version |
 
-## Hidden (2)
+## Hidden (1)
 
 Hidden commands not exposed in autocomplete or help. See the `HIDDEN_COMMANDS` docstring in the registry for context.
 
 - `/debug-error`
-- `/restart`

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -5192,9 +5192,8 @@ class DeepAgentsApp(App):
             HIDDEN_COMMANDS,
         )
 
-        # Hidden commands are recovery / power-user escape hatches and
-        # must work even when the app is busy or wedged — treat them as
-        # always-immediate.
+        # Hidden commands are power-user escape hatches and must work even
+        # when the app is busy or wedged — treat them as always-immediate.
         always_bypass = ALWAYS_IMMEDIATE | HIDDEN_COMMANDS
 
         if force_bypass or (
@@ -5765,7 +5764,7 @@ class DeepAgentsApp(App):
                 "Commands: /quit, /agents, /auth, /clear, /force-clear, "
                 "/copy, /offload, /editor, "
                 "/mcp, /model [--model-params JSON] [--default], "
-                "/notifications, /reload, /skill:<name>, /remember, "
+                "/notifications, /reload, /restart, /skill:<name>, /remember, "
                 "/skill-creator, /theme, /timestamps, /tokens, /threads, /trace, "
                 "/update, /auto-update, /install, /changelog, /docs, "
                 "/feedback, /help\n\n"
@@ -6087,7 +6086,7 @@ class DeepAgentsApp(App):
             await self._maybe_start_deferred_server_from_default()
         elif cmd.startswith("/skill:"):
             await self._handle_skill_command(command)
-        # -- Hidden commands (not in COMMANDS / autocomplete) -----------------
+        # -- Debug commands (not in COMMANDS / autocomplete) ------------------
         elif cmd == "/debug-error":
             await self._mount_message(
                 ErrorMessage(
@@ -9927,7 +9926,7 @@ class DeepAgentsApp(App):
         )
 
     async def _handle_restart_command(self, command: str) -> None:
-        """Drive the hidden `/restart` slash command.
+        """Drive the `/restart` slash command.
 
         Superset of `/reload`: re-reads `.env` / environment, clears
         configuration caches, then respawns the app-owned LangGraph

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -5192,8 +5192,11 @@ class DeepAgentsApp(App):
             HIDDEN_COMMANDS,
         )
 
-        # Hidden commands are power-user escape hatches and must work even
-        # when the app is busy or wedged — treat them as always-immediate.
+        # Union of two always-immediate sets. ALWAYS_IMMEDIATE holds public
+        # urgent commands (/quit, /force-clear, /restart); HIDDEN_COMMANDS
+        # holds debug helpers (/debug-error) that aren't registered in
+        # COMMANDS and so carry no bypass tier. Both must run even when the
+        # app is busy or wedged, so neither sits behind the queue.
         always_bypass = ALWAYS_IMMEDIATE | HIDDEN_COMMANDS
 
         if force_bypass or (
@@ -6094,6 +6097,7 @@ class DeepAgentsApp(App):
                     " exited with code 3",
                 ),
             )
+        # -- /restart: public, but ALWAYS_IMMEDIATE so it runs even when wedged
         elif cmd == "/restart":
             await self._handle_restart_command(command)
         else:
@@ -9931,7 +9935,7 @@ class DeepAgentsApp(App):
         Superset of `/reload`: re-reads `.env` / environment, clears
         configuration caches, then respawns the app-owned LangGraph
         server subprocess. Used as a recovery escape hatch when the
-        server wedges; intentionally hidden from autocomplete and help.
+        server wedges.
 
         Cancels any in-flight agent work and drops the queued message
         backlog before respawning. The streaming HTTP connection to the

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -172,6 +172,12 @@ COMMANDS: tuple[SlashCommand, ...] = (
         hidden_keywords="refresh",
     ),
     SlashCommand(
+        name="/restart",
+        description="Restart the app-owned LangGraph server",
+        bypass_tier=BypassTier.ALWAYS,
+        hidden_keywords="respawn server",
+    ),
+    SlashCommand(
         name="/theme",
         description="Switch color theme",
         bypass_tier=BypassTier.IMMEDIATE_UI,
@@ -275,12 +281,8 @@ SIDE_EFFECT_FREE: frozenset[str] = _build_bypass_set(BypassTier.SIDE_EFFECT_FREE
 QUEUE_BOUND: frozenset[str] = _build_bypass_set(BypassTier.QUEUED)
 """Commands that must wait in the queue when the app is busy."""
 
-HIDDEN_COMMANDS: frozenset[str] = frozenset({"/debug-error", "/restart"})
-"""Power-user commands kept out of autocomplete and help.
-
-Includes both debug helpers (`/debug-error`) and recovery escape hatches
-(`/restart` — hot-respawn the app-owned LangGraph server).
-"""
+HIDDEN_COMMANDS: frozenset[str] = frozenset({"/debug-error"})
+"""Power-user commands kept out of autocomplete and help."""
 
 STARTUP_RECOVERY_COMMANDS: frozenset[str] = frozenset(
     {"/install", "/reload", "/update"}

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -5399,6 +5399,25 @@ class TestSlashCommandBypass:
             pm.assert_called_once_with("/force-clear", "command")
             assert len(app._pending_messages) == 0
 
+    async def test_restart_bypasses_queue_when_agent_running(self) -> None:
+        """/restart should process immediately when the agent is running.
+
+        Guards the motivating behavior: as an `ALWAYS_IMMEDIATE` command,
+        `/restart` must reach `_process_message` rather than being parked in
+        the queue behind the in-flight work it is meant to recover from.
+        """
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+
+            with patch.object(app, "_process_message", new_callable=AsyncMock) as pm:
+                app.post_message(ChatInput.Submitted("/restart", "command"))
+                await pilot.pause()
+
+            pm.assert_called_once_with("/restart", "command")
+            assert len(app._pending_messages) == 0
+
     async def test_external_command_uses_same_bypass_policy(self) -> None:
         """External command events should route through normal command policy."""
         app = DeepAgentsApp()

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -10785,7 +10785,7 @@ class TestParseReconnectArgs:
 
 
 class TestRestartCommand:
-    """Hidden `/restart` slash command — config reload + server respawn."""
+    """`/restart` slash command — config reload + server respawn."""
 
     async def test_remote_server_mode_short_circuits(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_chat_input.py
+++ b/libs/code/tests/unit_tests/test_chat_input.py
@@ -1548,8 +1548,8 @@ class TestSlashCompletionCursorMapping:
             assert [event.value for event in app.submitted] == [selected_label]
             assert app.submitted[0].mode == "command"
 
-    async def test_stale_enter_does_not_hide_exact_hidden_command(self) -> None:
-        """Exact hidden commands should still submit without autocomplete."""
+    async def test_stale_enter_submits_exact_restart_command(self) -> None:
+        """Exact restart command should submit without requiring autocomplete."""
         app = _RecordingApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)

--- a/libs/code/tests/unit_tests/test_command_registry.py
+++ b/libs/code/tests/unit_tests/test_command_registry.py
@@ -131,9 +131,6 @@ class TestSlashCommands:
 class TestHiddenCommands:
     """`HIDDEN_COMMANDS` membership and autocomplete absence."""
 
-    def test_restart_is_hidden(self) -> None:
-        assert "/restart" in HIDDEN_COMMANDS
-
     def test_debug_error_is_hidden(self) -> None:
         assert "/debug-error" in HIDDEN_COMMANDS
 
@@ -143,6 +140,21 @@ class TestHiddenCommands:
             assert hidden not in names, (
                 f"Hidden command {hidden!r} leaked into SLASH_COMMANDS"
             )
+
+
+class TestRestartCommand:
+    """Validate the `/restart` entry specifically."""
+
+    def test_restart_registered_for_autocomplete(self) -> None:
+        restart_entry = next(
+            entry for entry in SLASH_COMMANDS if entry.name == "/restart"
+        )
+
+        assert restart_entry.description == "Restart the app-owned LangGraph server"
+
+    def test_restart_classified_as_always_immediate(self) -> None:
+        assert "/restart" in ALWAYS_IMMEDIATE
+        assert "/restart" not in HIDDEN_COMMANDS
 
 
 class TestAgentsCommand:

--- a/libs/code/tests/unit_tests/test_welcome.py
+++ b/libs/code/tests/unit_tests/test_welcome.py
@@ -437,6 +437,10 @@ class TestBuildWelcomeFooter:
         """The `/copy` command must have a discoverability tip."""
         assert "Use /copy to copy the latest assistant message" in _TIPS
 
+    def test_restart_command_tip_registered(self) -> None:
+        """The newly public `/restart` command must have a discoverability tip."""
+        assert any("/restart" in tip for tip in _TIPS)
+
     def test_tip_varies_across_calls(self) -> None:
         """Tips should rotate (not always the same)."""
         seen = {build_welcome_footer().plain for _ in range(50)}

--- a/libs/code/tests/unit_tests/test_welcome.py
+++ b/libs/code/tests/unit_tests/test_welcome.py
@@ -437,10 +437,6 @@ class TestBuildWelcomeFooter:
         """The `/copy` command must have a discoverability tip."""
         assert "Use /copy to copy the latest assistant message" in _TIPS
 
-    def test_restart_command_tip_registered(self) -> None:
-        """The newly public `/restart` command must have a discoverability tip."""
-        assert any("/restart" in tip for tip in _TIPS)
-
     def test_tip_varies_across_calls(self) -> None:
         """Tips should rotate (not always the same)."""
         seen = {build_welcome_footer().plain for _ in range(50)}


### PR DESCRIPTION
Makes `/restart` a public `deepagents-code` slash command so users can discover it in autocomplete and `/help` while preserving its always-immediate recovery behavior.

Made by [Open SWE](https://openswe.vercel.app)