### PR TITLE
fix(sdk): validate CompositeBackend route prefixes at construction time

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -159,6 +159,11 @@ class CompositeBackend(BackendProtocol):
         # Virtual routes
         self.routes = routes
 
+        for prefix in routes:
+            if not prefix.startswith("/"):
+                msg = f"Route prefix must start with '/': {prefix!r}"
+                raise ValueError(msg)
+
         # Sort routes by length (longest first) for correct prefix matching
         self.sorted_routes = sorted(routes.items(), key=lambda x: len(x[0]), reverse=True)
 

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -1403,3 +1403,24 @@ def test_edit_result_path_restored_to_full_routed_path():
 
     assert res.error is None
     assert res.path == "/memories/notes.md"  # not "/notes.md"
+
+
+def test_composite_backend_rejects_prefix_without_leading_slash() -> None:
+    mem_store = InMemoryStore()
+    with pytest.raises(ValueError, match="Route prefix must start with '/'"):
+        CompositeBackend(
+            default=StoreBackend(store=mem_store, namespace=lambda _: ("default",)),
+            routes={"memories/": StoreBackend(store=mem_store, namespace=lambda _: ("mem",))},
+        )
+
+
+def test_composite_backend_rejects_prefix_without_leading_slash_mixed() -> None:
+    mem_store = InMemoryStore()
+    with pytest.raises(ValueError, match="Route prefix must start with '/'"):
+        CompositeBackend(
+            default=StoreBackend(store=mem_store, namespace=lambda _: ("default",)),
+            routes={
+                "/valid/": StoreBackend(store=mem_store, namespace=lambda _: ("valid",)),
+                "invalid": StoreBackend(store=mem_store, namespace=lambda _: ("bad",)),
+            },
+        )


### PR DESCRIPTION
Fixes #2928

`CompositeBackend.__init__` accepted route prefixes without a leading `/` (e.g. `"memories/"`) without raising an error. The invalid prefix was silently stored but never matched any path, so requests fell through to the default backend with no indication of the problem.

This PR adds a validation loop in `__init__` that raises `ValueError` for any prefix not starting with `/`, following the same pattern as `FilesystemPermission.__post_init__`.

> I used AI tools (Claude Code) to help navigate the codebase and understand existing patterns. All code was reviewed and tested by me.