### PR TITLE
fix(code): unblock `/remember` in server mode

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6277,8 +6277,9 @@ class DeepAgentsApp(App):
             from langchain_core.messages import HumanMessage
 
             # Use the shared helper so the thread is registered first
-            # (`aensure_thread`) in server mode — otherwise the dev server
-            # returns empty state for a thread it has not seen this session.
+            # (`aensure_thread`, remote agents only) in server mode — otherwise
+            # the dev server returns empty state for a thread it has not seen
+            # this session.
             state_values = await self._get_thread_state_values(self._lc_thread_id)
             messages = state_values.get("messages", [])
             # `RemoteGraph.aget_state` returns messages as raw JSON dicts, so an

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6271,19 +6271,24 @@ class DeepAgentsApp(App):
             `True` so that `/remember` is not blocked with a misleading
             "nothing to remember" message.
         """
-        if not self._agent:
+        if not self._agent or not self._lc_thread_id:
             return False
         try:
             from langchain_core.messages import HumanMessage
 
-            config: RunnableConfig = {
-                "configurable": {"thread_id": self._lc_thread_id},
-            }
-            state = await self._agent.aget_state(config)
-            if not state or not state.values:
-                return False
-            messages = state.values.get("messages", [])
-            return any(isinstance(m, HumanMessage) for m in messages)
+            # Use the shared helper so the thread is registered first
+            # (`aensure_thread`) in server mode — otherwise the dev server
+            # returns empty state for a thread it has not seen this session.
+            state_values = await self._get_thread_state_values(self._lc_thread_id)
+            messages = state_values.get("messages", [])
+            # `RemoteGraph.aget_state` returns messages as raw JSON dicts, so an
+            # `isinstance(m, HumanMessage)` check alone misses them and wrongly
+            # reports "nothing to remember". Detect both object and dict forms.
+            return any(
+                isinstance(m, HumanMessage)
+                or (isinstance(m, dict) and m.get("type") == "human")
+                for m in messages
+            )
         except Exception:
             logger.warning(
                 "Failed to check conversation messages; allowing /remember to proceed",

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -6343,6 +6343,17 @@ class TestHasConversationMessages:
             agent = AsyncMock()
             agent.aget_state = AsyncMock(return_value=state)
             app._agent = agent
+            app._lc_thread_id = "t1"
+
+            assert await app._has_conversation_messages() is False
+
+    async def test_returns_false_when_no_thread_id(self) -> None:
+        """Should return False when no thread id is resolved yet."""
+        app = DeepAgentsApp()
+        async with app.run_test():
+            agent = AsyncMock()
+            app._agent = agent
+            app._lc_thread_id = None
 
             assert await app._has_conversation_messages() is False
 
@@ -6357,6 +6368,7 @@ class TestHasConversationMessages:
             agent = AsyncMock()
             agent.aget_state = AsyncMock(return_value=state)
             app._agent = agent
+            app._lc_thread_id = "t1"
 
             assert await app._has_conversation_messages() is False
 
@@ -6371,6 +6383,20 @@ class TestHasConversationMessages:
             agent = AsyncMock()
             agent.aget_state = AsyncMock(return_value=state)
             app._agent = agent
+            app._lc_thread_id = "t1"
+
+            assert await app._has_conversation_messages() is True
+
+    async def test_returns_true_when_human_message_is_dict(self) -> None:
+        """Should detect human messages returned as raw dicts (RemoteGraph)."""
+        app = DeepAgentsApp()
+        async with app.run_test():
+            state = MagicMock()
+            state.values = {"messages": [{"type": "human", "content": "hi"}]}
+            agent = AsyncMock()
+            agent.aget_state = AsyncMock(return_value=state)
+            app._agent = agent
+            app._lc_thread_id = "t1"
 
             assert await app._has_conversation_messages() is True
 
@@ -6381,6 +6407,7 @@ class TestHasConversationMessages:
             agent = AsyncMock()
             agent.aget_state = AsyncMock(side_effect=RuntimeError("connection lost"))
             app._agent = agent
+            app._lc_thread_id = "t1"
 
             assert await app._has_conversation_messages() is True
 
@@ -6393,6 +6420,7 @@ class TestHasConversationMessages:
             agent = AsyncMock()
             agent.aget_state = AsyncMock(return_value=state)
             app._agent = agent
+            app._lc_thread_id = "t1"
 
             assert await app._has_conversation_messages() is False
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -6400,6 +6400,19 @@ class TestHasConversationMessages:
 
             assert await app._has_conversation_messages() is True
 
+    async def test_returns_false_when_only_non_human_dicts(self) -> None:
+        """Should not treat every raw dict as human; non-human dicts are False."""
+        app = DeepAgentsApp()
+        async with app.run_test():
+            state = MagicMock()
+            state.values = {"messages": [{"type": "ai", "content": "hello"}]}
+            agent = AsyncMock()
+            agent.aget_state = AsyncMock(return_value=state)
+            app._agent = agent
+            app._lc_thread_id = "t1"
+
+            assert await app._has_conversation_messages() is False
+
     async def test_returns_true_on_aget_state_exception(self) -> None:
         """Should return True on transient errors so /remember is not blocked."""
         app = DeepAgentsApp()


### PR DESCRIPTION
`/remember` was wrongly blocked with "Nothing to remember yet" even after a real conversation when running in server mode.

`RemoteGraph.aget_state` returns messages as raw JSON dicts, so `_has_conversation_messages`' `isinstance(m, HumanMessage)` check never matched. This now detects both object and dict (`{"type": "human"}`) forms, and routes through `_get_thread_state_values` so the thread is registered (`aensure_thread`) before reading state.

Made by [Open SWE](https://openswe.vercel.app)