### PR TITLE
fix(code): don't show `"No threads found"` while threads load

### DIFF
--- a/libs/code/deepagents_code/widgets/thread_selector.py
+++ b/libs/code/deepagents_code/widgets/thread_selector.py
@@ -864,6 +864,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         self._threads: list[ThreadInfo] = initial
         self._filtered_threads: list[ThreadInfo] = list(self._threads)
         self._has_initial_threads = initial_threads is not None
+        self._disk_load_complete = False
         self._selected_index = 0
         self._option_widgets: list[ThreadOption] = []
         self._filter_text = ""
@@ -1064,21 +1065,11 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
                             yield cell
 
                     with VerticalScroll(classes="thread-list"):
-                        if self._has_initial_threads:
-                            if self._filtered_threads:
-                                self._option_widgets, _ = self._create_option_widgets()
-                                yield from self._option_widgets
-                            else:
-                                yield Static(
-                                    Content.styled("No threads found", "dim"),
-                                    classes="thread-empty",
-                                )
+                        if self._has_initial_threads and self._filtered_threads:
+                            self._option_widgets, _ = self._create_option_widgets()
+                            yield from self._option_widgets
                         else:
-                            yield Static(
-                                Content.styled("Loading threads...", "dim"),
-                                classes="thread-empty",
-                                id="thread-loading",
-                            )
+                            yield self._build_empty_state()
 
                 with Vertical(classes="thread-controls"):
                     yield Static("Options", classes="thread-controls-title")
@@ -1613,9 +1604,11 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
             )
         except (OSError, sqlite3.Error) as exc:
             logger.exception("Failed to load threads for thread selector")
+            self._disk_load_complete = True
             await self._show_mount_error(str(exc))
             return
 
+        self._disk_load_complete = True
         apply_cached_thread_message_counts(self._threads)
         apply_cached_thread_initial_prompts(self._threads)
         if not self._has_initial_threads:
@@ -1785,6 +1778,26 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
             )
         self.focus()
 
+    def _build_empty_state(self) -> Static:
+        """Build the empty-list placeholder.
+
+        Shows "Loading threads..." while the disk load is still pending so the
+        picker never claims "No threads found" before the query completes.
+
+        Returns:
+            The placeholder `Static` widget to mount in the thread list.
+        """
+        if not self._disk_load_complete:
+            return Static(
+                Content.styled("Loading threads...", "dim"),
+                classes="thread-empty",
+                id="thread-loading",
+            )
+        return Static(
+            Content.styled("No threads found", "dim"),
+            classes="thread-empty",
+        )
+
     async def _build_list(self, *, recompute_widths: bool = True) -> None:
         """Build the thread option widgets.
 
@@ -1805,12 +1818,7 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
 
                 if not self._filtered_threads:
                     self._option_widgets = []
-                    await scroll.mount(
-                        Static(
-                            Content.styled("No threads found", "dim"),
-                            classes="thread-empty",
-                        )
-                    )
+                    await scroll.mount(self._build_empty_state())
                     return
 
                 self._option_widgets, selected_widget = self._create_option_widgets()

--- a/libs/code/deepagents_code/widgets/thread_selector.py
+++ b/libs/code/deepagents_code/widgets/thread_selector.py
@@ -1607,6 +1607,16 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
             self._disk_load_complete = True
             await self._show_mount_error(str(exc))
             return
+        except Exception as exc:
+            # An unexpected error (e.g. a malformed row raising ValueError) must
+            # still mark the load complete and surface the failure; otherwise the
+            # picker stays stuck on the "Loading threads..." placeholder forever.
+            # CancelledError is a BaseException and is intentionally not caught
+            # here, so a superseding exclusive worker keeps ownership of the flag.
+            logger.exception("Unexpected error loading threads for thread selector")
+            self._disk_load_complete = True
+            await self._show_mount_error(str(exc))
+            return
 
         self._disk_load_complete = True
         apply_cached_thread_message_counts(self._threads)

--- a/libs/code/tests/unit_tests/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/test_thread_selector.py
@@ -1804,6 +1804,60 @@ class TestThreadSelectorPrefetchedRows:
                 assert len(screen._threads) == 1
                 assert screen._threads[0]["thread_id"] == "new12345"
 
+    async def test_empty_snapshot_shows_loading_until_disk_load_completes(
+        self,
+    ) -> None:
+        """An empty snapshot must not claim "No threads found" while loading."""
+        refreshed: list[ThreadInfo] = [
+            {
+                "thread_id": "new12345",
+                "agent_name": "my-agent",
+                "updated_at": "2025-01-16T12:00:00",
+                "message_count": 6,
+            }
+        ]
+        app = ThreadSelectorTestApp(current_thread="abc12345")
+
+        gate = asyncio.Event()
+
+        async def _list_threads(*_args: object, **_kwargs: object) -> list[ThreadInfo]:
+            await gate.wait()
+            return refreshed
+
+        with patch(
+            "deepagents_code.sessions.list_threads",
+            new_callable=AsyncMock,
+            side_effect=_list_threads,
+        ):
+            async with app.run_test() as pilot:
+                app.push_screen(
+                    ThreadSelectorScreen(
+                        current_thread="abc12345",
+                        thread_limit=20,
+                        initial_threads=[],
+                        filter_cwd=None,
+                    )
+                )
+                await pilot.pause()
+
+                screen = app.screen
+                assert isinstance(screen, ThreadSelectorScreen)
+                # While the disk load is in flight, show the loading placeholder
+                # rather than "No threads found".
+                assert not screen._disk_load_complete
+                screen.query_one("#thread-loading", Static)
+                assert not screen._option_widgets
+
+                gate.set()
+
+                for _ in range(10):
+                    if len(screen._threads) == 1:
+                        break
+                    await pilot.pause(0.05)
+
+                assert screen._disk_load_complete
+                assert len(screen._option_widgets) == 1
+
 
 class TestThreadSelectorInitialSortOrder:
     """Tests for initial sort order applied to prefetched rows."""

--- a/libs/code/tests/unit_tests/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/test_thread_selector.py
@@ -1468,6 +1468,36 @@ class TestThreadSelectorErrorHandling:
                 assert len(screen._threads) == 0
 
                 assert len(screen._option_widgets) == 0
+                # A failed load is still a completed load: the flag must flip so
+                # the picker never strands on the "Loading threads..." placeholder.
+                assert screen._disk_load_complete is True
+
+                await pilot.press("escape")
+                await pilot.pause()
+
+                assert app.dismissed is True
+                assert app.result is None
+
+    async def test_unexpected_load_error_surfaces_and_completes(self) -> None:
+        """A non-OSError/sqlite3 error must surface and not strand the UI."""
+        with patch(
+            "deepagents_code.sessions.list_threads",
+            new_callable=AsyncMock,
+            side_effect=ValueError("malformed row"),
+        ):
+            app = ThreadSelectorTestApp()
+            async with app.run_test() as pilot:
+                app.show_selector()
+                await pilot.pause()
+
+                screen = app.screen
+                assert isinstance(screen, ThreadSelectorScreen)
+                # The catch-all handler marks the load complete and replaces the
+                # loading placeholder with the error message instead of leaving a
+                # perpetual "Loading threads..." spinner.
+                assert screen._disk_load_complete is True
+                with pytest.raises(NoMatches):
+                    screen.query_one("#thread-loading", Static)
 
                 await pilot.press("escape")
                 await pilot.pause()
@@ -1857,6 +1887,71 @@ class TestThreadSelectorPrefetchedRows:
 
                 assert screen._disk_load_complete
                 assert len(screen._option_widgets) == 1
+
+    async def test_empty_snapshot_resolves_to_no_threads_found(self) -> None:
+        """An empty disk load must flip the placeholder to "No threads found"."""
+        app = ThreadSelectorTestApp(current_thread="abc12345")
+
+        gate = asyncio.Event()
+
+        async def _list_threads(*_args: object, **_kwargs: object) -> list[ThreadInfo]:
+            await gate.wait()
+            return []
+
+        with patch(
+            "deepagents_code.sessions.list_threads",
+            new_callable=AsyncMock,
+            side_effect=_list_threads,
+        ):
+            async with app.run_test() as pilot:
+                app.push_screen(
+                    ThreadSelectorScreen(
+                        current_thread="abc12345",
+                        thread_limit=20,
+                        initial_threads=[],
+                        filter_cwd=None,
+                    )
+                )
+                await pilot.pause()
+
+                screen = app.screen
+                assert isinstance(screen, ThreadSelectorScreen)
+                assert not screen._disk_load_complete
+                screen.query_one("#thread-loading", Static)
+
+                gate.set()
+
+                for _ in range(10):
+                    if screen._disk_load_complete:
+                        break
+                    await pilot.pause(0.05)
+
+                # Once the load completes with zero rows, the loading placeholder
+                # must resolve to the real empty state, not a perpetual spinner.
+                assert screen._disk_load_complete
+                assert not screen._option_widgets
+                with pytest.raises(NoMatches):
+                    screen.query_one("#thread-loading", Static)
+                empty = screen.query_one(".thread-empty", Static)
+                assert "No threads found" in str(empty.content)
+
+    def test_build_empty_state_reflects_disk_load_flag(self) -> None:
+        """`_build_empty_state` chooses its message from `_disk_load_complete`."""
+        screen = ThreadSelectorScreen(
+            current_thread="abc12345",
+            thread_limit=20,
+            initial_threads=[],
+            filter_cwd=None,
+        )
+
+        loading = screen._build_empty_state()
+        assert loading.id == "thread-loading"
+        assert "Loading threads..." in str(loading.content)
+
+        screen._disk_load_complete = True
+        resolved = screen._build_empty_state()
+        assert resolved.id is None
+        assert "No threads found" in str(resolved.content)
 
 
 class TestThreadSelectorInitialSortOrder:


### PR DESCRIPTION
Fixed the `/threads` switcher incorrectly showing "No threads found" while threads were still loading from disk.

Made by [Open SWE](https://openswe.vercel.app)