### PR TITLE
test(code): stop unit tests from recoloring the real terminal

### DIFF
--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -112,6 +112,21 @@ def _clear_external_event_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _disable_terminal_escape(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop tests from leaking terminal control sequences to the real terminal.
+
+    Production code constructs `DeepAgentsApp` and exercises the spinner / theme
+    paths, which emit `OSC 11` (background color) and `OSC 9;4` (taskbar
+    progress) via `terminal_escape.write_terminal_escape`. That writer targets
+    `/dev/tty`, which pytest does not capture, so running the suite from inside
+    a real terminal (e.g. an editable install) visibly recolors the developer's
+    session. Opting out keeps the run inert. `test_terminal_escape.py` clears
+    this var in its own fixture so its assertions still exercise the real path.
+    """
+    monkeypatch.setenv("DEEPAGENTS_CODE_NO_TERMINAL_ESCAPE", "1")
+
+
+@pytest.fixture(autouse=True)
 def _register_theme_variables(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make app-specific CSS variables available to all test `App` instances.
 


### PR DESCRIPTION
Running `libs/code` unit tests from inside a real terminal (e.g. an editable install via the bash tool, or VSCode's zsh) visibly changed the terminal's theme. `DeepAgentsApp.__init__` calls `sync_terminal_background()` and the spinner path calls `set_terminal_progress()`, which emit `OSC 11` (background color) and `OSC 9;4` (taskbar progress) sequences through `terminal_escape.write_terminal_escape`. That writer targets `/dev/tty`, which pytest does not capture, so the escapes leaked to the developer's live session. An autouse fixture sets `DEEPAGENTS_CODE_NO_TERMINAL_ESCAPE=1` for the whole unit run; `test_terminal_escape.py` still clears it in its own fixture so the real write path stays covered.

Made by [Open SWE](https://openswe.vercel.app)