### PR TITLE
fix(code): coalesce streamed markdown writes to keep input responsive

### DIFF
--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -793,11 +793,12 @@ async def execute_task_textual(
 
                     # Process content blocks
                     blocks = message.content_blocks
-                    logger.debug(
-                        "content_blocks count=%d blocks=%s",
-                        len(blocks),
-                        repr(blocks)[:500],
-                    )
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.debug(
+                            "content_blocks count=%d blocks=%s",
+                            len(blocks),
+                            repr(blocks)[:500],
+                        )
                     for block in blocks:
                         block_type = block.get("type")
 

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -1361,6 +1361,7 @@ async def execute_task_textual(
             agent=agent,
             config=config,
             pending_text_by_namespace=pending_text_by_namespace,
+            assistant_message_by_namespace=assistant_message_by_namespace,
             captured_input_tokens=captured_input_tokens,
             captured_output_tokens=captured_output_tokens,
             turn_stats=turn_stats,
@@ -1379,12 +1380,34 @@ async def execute_task_textual(
     return turn_stats
 
 
+async def _stop_assistant_streams(
+    adapter: TextualUIAdapter,
+    assistant_message_by_namespace: dict[tuple, Any] | None,
+) -> None:
+    """Finalize active assistant streams during interrupt cleanup."""
+    if not assistant_message_by_namespace:
+        return
+
+    for current_msg in list(assistant_message_by_namespace.values()):
+        try:
+            await current_msg.stop_stream()
+        except Exception:
+            logger.warning("Failed to stop interrupted assistant stream", exc_info=True)
+            continue
+
+        if adapter._sync_message_content and current_msg.id:
+            adapter._sync_message_content(current_msg.id, current_msg._content)
+
+    assistant_message_by_namespace.clear()
+
+
 async def _handle_interrupt_cleanup(
     *,
     adapter: TextualUIAdapter,
     agent: Any,  # noqa: ANN401  # Dynamic agent graph type
     config: RunnableConfig,
     pending_text_by_namespace: dict[tuple, str],
+    assistant_message_by_namespace: dict[tuple, Any] | None = None,
     captured_input_tokens: int,
     captured_output_tokens: int,
     turn_stats: SessionStats,
@@ -1397,6 +1420,7 @@ async def _handle_interrupt_cleanup(
         agent: The LangGraph agent.
         config: Runnable config with `thread_id`.
         pending_text_by_namespace: Accumulated text per namespace.
+        assistant_message_by_namespace: Active assistant message widgets per namespace.
         captured_input_tokens: Input tokens captured before interrupt.
         captured_output_tokens: Output tokens captured before interrupt.
         turn_stats: Stats for the current turn.
@@ -1414,6 +1438,8 @@ async def _handle_interrupt_cleanup(
     # Hide spinner (may still show "Offloading" if interrupted mid-offload)
     if adapter._set_spinner:
         await adapter._set_spinner(None)
+
+    await _stop_assistant_streams(adapter, assistant_message_by_namespace)
 
     await adapter._mount_message(AppMessage("Interrupted by user"))
 

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -1368,6 +1368,18 @@ async def execute_task_textual(
             start_time=start_time,
         )
         return turn_stats
+    finally:
+        # Streamed text is coalesced in each AssistantMessage's `_pending_append`
+        # buffer and flushed on a throttled timer, so up to one flush interval of
+        # tokens can be in flight at any moment. Normal completion (the flush loop
+        # above) and interrupt cleanup both clear the namespace dict, leaving this
+        # a no-op there. The path that matters is a non-cancel mid-stream error
+        # propagating to the caller: without this drain those buffered tokens are
+        # never written and the user sees a silently truncated reply.
+        try:
+            await _stop_assistant_streams(adapter, assistant_message_by_namespace)
+        except Exception:  # drain must not mask the original error
+            logger.exception("Failed to drain assistant streams on exit")
 
     # Update token count and return stats. Persistence is handled inside the
     # graph by `ResumeStateMiddleware.after_model`, so this only refreshes UI.

--- a/libs/code/deepagents_code/widgets/messages.py
+++ b/libs/code/deepagents_code/widgets/messages.py
@@ -656,13 +656,24 @@ class AssistantMessage(Vertical):
             )
 
     async def _flush_pending_append(self) -> None:
-        """Write any buffered streamed text to the markdown stream."""
+        """Write any buffered streamed text to the markdown stream.
+
+        Runs from a Textual timer callback, where an unhandled exception
+        escalates to `App._handle_exception` and tears down the whole REPL.
+        On a transient write failure the buffer is restored (re-prepended
+        ahead of any text that arrived in the meantime) so the next tick
+        retries instead of silently dropping the fragment.
+        """
         if not self._pending_append:
             return
         pending = self._pending_append
         self._pending_append = ""
-        stream = self._ensure_stream()
-        await stream.write(pending)
+        try:
+            stream = self._ensure_stream()
+            await stream.write(pending)
+        except Exception:  # a render hiccup must not crash the app
+            self._pending_append = pending + self._pending_append
+            logger.exception("Failed to flush streamed markdown fragment")
 
     def _stop_flush_timer(self) -> None:
         """Cancel the coalescing flush timer if it is running."""

--- a/libs/code/deepagents_code/widgets/messages.py
+++ b/libs/code/deepagents_code/widgets/messages.py
@@ -551,7 +551,16 @@ class AssistantMessage(Vertical):
     the first chunk, so any later recompose (click, focus change, theme
     update) re-yields the stale value and wrapped fenced-code bodies vanish.
     A full re-parse rebuilds every fence with correct internal state.
+
+    Streamed tokens are coalesced in `_pending_append` and flushed to the
+    `MarkdownStream` on a throttled timer (`_STREAM_FLUSH_INTERVAL`). Writing
+    every token immediately forced a markdown re-parse per chunk on the UI
+    event loop, which starved keyboard input while the model streamed.
+    Batching the writes keeps the event loop free so typing stays responsive.
     """
+
+    _STREAM_FLUSH_INTERVAL: ClassVar[float] = 0.1
+    """Seconds between coalesced flushes of streamed text to the markdown widget."""
 
     DEFAULT_CSS = """
     AssistantMessage {
@@ -584,6 +593,8 @@ class AssistantMessage(Vertical):
         self._content = content
         self._markdown: Markdown | None = None
         self._stream: MarkdownStream | None = None
+        self._pending_append = ""
+        self._flush_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:  # noqa: PLR6301  # Textual widget method convention
         """Compose the assistant message layout.
@@ -626,10 +637,11 @@ class AssistantMessage(Vertical):
         return self._stream
 
     async def append_content(self, text: str) -> None:
-        """Append content to the message (for streaming).
+        """Append streamed content, coalescing writes onto a throttled timer.
 
-        Uses MarkdownStream for smoother rendering instead of re-rendering
-        the full content on each chunk.
+        Tokens are buffered in `_pending_append` and written to the
+        `MarkdownStream` at most once per `_STREAM_FLUSH_INTERVAL` so the UI
+        event loop stays free to process keypresses while the model streams.
 
         Args:
             text: Text to append
@@ -637,8 +649,26 @@ class AssistantMessage(Vertical):
         if not text:
             return
         self._content += text
+        self._pending_append += text
+        if self._flush_timer is None:
+            self._flush_timer = self.set_interval(
+                self._STREAM_FLUSH_INTERVAL, self._flush_pending_append
+            )
+
+    async def _flush_pending_append(self) -> None:
+        """Write any buffered streamed text to the markdown stream."""
+        if not self._pending_append:
+            return
+        pending = self._pending_append
+        self._pending_append = ""
         stream = self._ensure_stream()
-        await stream.write(text)
+        await stream.write(pending)
+
+    def _stop_flush_timer(self) -> None:
+        """Cancel the coalescing flush timer if it is running."""
+        if self._flush_timer is not None:
+            self._flush_timer.stop()
+            self._flush_timer = None
 
     async def write_initial_content(self) -> None:
         """Write initial content if provided at construction time."""
@@ -647,6 +677,8 @@ class AssistantMessage(Vertical):
 
     async def stop_stream(self) -> None:
         """Stop the streaming and finalize the content."""
+        self._stop_flush_timer()
+        await self._flush_pending_append()
         if self._stream is not None:
             await self._stream.stop()
             self._stream = None
@@ -662,6 +694,8 @@ class AssistantMessage(Vertical):
         Args:
             content: The markdown content to display
         """
+        self._stop_flush_timer()
+        self._pending_append = ""
         if self._stream is not None:
             await self._stream.stop()
             self._stream = None

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -1,5 +1,6 @@
 """Unit tests for message widgets markup safety."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -285,6 +286,72 @@ class TestAssistantMessageMarkdownRendering:
         markdown.update.assert_awaited_once_with("```python\nnew content\n```")
         assert msg._stream is None
         assert msg._content == "```python\nnew content\n```"
+
+
+class _AssistantMessageApp(App[None]):
+    """Minimal app that mounts an AssistantMessage for timer-based tests."""
+
+    def compose(self) -> ComposeResult:
+        widget = AssistantMessage()
+        widget.id = "assistant"
+        yield widget
+
+
+class TestAssistantMessageStreamCoalescing:
+    """Tests for the throttled streaming flush that keeps input responsive."""
+
+    async def test_append_buffers_until_flush(self) -> None:
+        """Tokens accumulate in `_content` but defer the markdown write."""
+        async with _AssistantMessageApp().run_test() as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+            stream = MagicMock()
+            stream.write = AsyncMock()
+            msg._stream = stream
+
+            await msg.append_content("hello ")
+            await msg.append_content("world")
+
+            # No immediate write — tokens are buffered for the timer.
+            stream.write.assert_not_awaited()
+            assert msg._content == "hello world"
+            assert msg._pending_append == "hello world"
+            assert msg._flush_timer is not None
+
+    async def test_timer_flushes_coalesced_text_once(self) -> None:
+        """The throttled timer writes buffered tokens as a single fragment."""
+        async with _AssistantMessageApp().run_test() as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+            stream = MagicMock()
+            stream.write = AsyncMock()
+            msg._stream = stream
+
+            await msg.append_content("foo")
+            await msg.append_content("bar")
+            await asyncio.sleep(msg._STREAM_FLUSH_INTERVAL * 2)
+            await pilot.pause()
+
+            stream.write.assert_awaited_once_with("foobar")
+            assert msg._pending_append == ""
+
+    async def test_stop_stream_flushes_and_cancels_timer(self) -> None:
+        """Stopping the stream drains buffered text and clears the timer."""
+        async with _AssistantMessageApp().run_test() as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+            markdown = MagicMock()
+            markdown.update = AsyncMock()
+            stream = MagicMock()
+            stream.write = AsyncMock()
+            stream.stop = AsyncMock()
+            msg._markdown = markdown
+            msg._stream = stream
+
+            await msg.append_content("partial")
+            await msg.stop_stream()
+
+            stream.write.assert_awaited_once_with("partial")
+            stream.stop.assert_awaited_once_with()
+            assert msg._flush_timer is None
+            assert msg._pending_append == ""
 
 
 class TestSummarizationMessage:

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -353,6 +353,101 @@ class TestAssistantMessageStreamCoalescing:
             assert msg._flush_timer is None
             assert msg._pending_append == ""
 
+    async def test_set_content_drains_and_cancels_active_timer(self) -> None:
+        """`set_content` cancels a live flush timer and drops the buffer."""
+        async with _AssistantMessageApp().run_test() as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+            markdown = MagicMock()
+            markdown.update = AsyncMock()
+            stream = MagicMock()
+            stream.write = AsyncMock()
+            stream.stop = AsyncMock()
+            msg._markdown = markdown
+            msg._stream = stream
+
+            await msg.append_content("buffered")
+            assert msg._flush_timer is not None
+
+            await msg.set_content("replacement")
+            # Give a stale timer the chance to fire if it was not cancelled.
+            await asyncio.sleep(msg._STREAM_FLUSH_INTERVAL * 2)
+            await pilot.pause()
+
+            assert msg._flush_timer is None
+            assert msg._pending_append == ""
+            # Buffered token must not bleed into the replacement render.
+            stream.write.assert_not_awaited()
+            markdown.update.assert_awaited_once_with("replacement")
+
+    async def test_timer_created_once_across_appends(self) -> None:
+        """Repeated appends reuse a single flush timer rather than spawning many."""
+        async with _AssistantMessageApp().run_test() as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+            stream = MagicMock()
+            stream.write = AsyncMock()
+            msg._stream = stream
+
+            await msg.append_content("a")
+            timer = msg._flush_timer
+            assert timer is not None
+
+            await msg.append_content("b")
+            await msg.append_content("c")
+
+            assert msg._flush_timer is timer
+
+    async def test_flush_drains_successive_batches(self) -> None:
+        """Each flush writes the latest batch; an empty buffer is a no-op."""
+        async with _AssistantMessageApp().run_test() as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+            stream = MagicMock()
+            stream.write = AsyncMock()
+            msg._stream = stream
+
+            await msg.append_content("first")
+            await msg._flush_pending_append()
+            stream.write.assert_awaited_once_with("first")
+
+            # Idle tick with nothing buffered must not write again.
+            await msg._flush_pending_append()
+            assert stream.write.await_count == 1
+
+            await msg.append_content("second")
+            await msg._flush_pending_append()
+            assert stream.write.await_count == 2
+            stream.write.assert_awaited_with("second")
+
+    async def test_append_empty_text_is_noop(self) -> None:
+        """Empty tokens neither buffer text nor arm the flush timer."""
+        async with _AssistantMessageApp().run_test() as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+
+            await msg.append_content("")
+
+            assert msg._flush_timer is None
+            assert msg._pending_append == ""
+            assert msg._content == ""
+
+    async def test_flush_restores_buffer_when_write_fails(self) -> None:
+        """A failed write keeps the buffer for retry and never escapes the timer."""
+        async with _AssistantMessageApp().run_test() as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+            stream = MagicMock()
+            stream.write = AsyncMock(side_effect=RuntimeError("render boom"))
+            msg._stream = stream
+
+            await msg.append_content("kept")
+            # Must not raise: an escaping exception here would crash the app
+            # via the Textual timer's exception handler.
+            await msg._flush_pending_append()
+
+            stream.write.assert_awaited_once_with("kept")
+            assert msg._pending_append == "kept"
+
+            # Text arriving after the failure queues behind the retried fragment.
+            await msg.append_content(" more")
+            assert msg._pending_append == "kept more"
+
 
 class TestSummarizationMessage:
     """Tests for summarization notification widget."""

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -224,6 +224,42 @@ class TestInterruptCleanup:
         assert interrupted_msg.tool_calls[0]["id"] == "call-1"
         assert interrupted_msg.tool_calls[0]["name"] == "read_file"
 
+    async def test_interrupt_stops_active_assistant_streams(self) -> None:
+        """Interrupted streaming messages should not leave flush timers running."""
+        sync_message_content = MagicMock()
+        assistant_msg = SimpleNamespace(
+            id="asst-1",
+            _content="partial response",
+            stop_stream=AsyncMock(),
+        )
+        assistant_messages = {(): assistant_msg}
+
+        adapter = TextualUIAdapter(
+            mount_message=AsyncMock(),
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            set_spinner=AsyncMock(),
+            set_active_message=MagicMock(),
+            sync_message_content=sync_message_content,
+        )
+        agent = SimpleNamespace(aupdate_state=AsyncMock())
+
+        await _handle_interrupt_cleanup(
+            adapter=adapter,
+            agent=agent,
+            config={"configurable": {"thread_id": "t-1"}},
+            pending_text_by_namespace={(): "partial response"},
+            assistant_message_by_namespace=assistant_messages,
+            captured_input_tokens=0,
+            captured_output_tokens=0,
+            turn_stats=SessionStats(),
+            start_time=0.0,
+        )
+
+        assistant_msg.stop_stream.assert_awaited_once_with()
+        sync_message_content.assert_called_once_with("asst-1", "partial response")
+        assert assistant_messages == {}
+
     async def test_disables_tracing_during_state_save(self) -> None:
         """Interrupt-cleanup `aupdate_state` calls must run with tracing disabled.
 


### PR DESCRIPTION
Typing in the chat input lagged while the model was actively streaming tokens. The streaming loop wrote every token straight to Textual's `MarkdownStream`, which woke its background task and re-parsed/re-rendered the markdown tail on essentially every chunk. That CPU-bound work runs on the same event loop that dispatches keypresses, so input stalled until streaming paused.

This buffers streamed tokens in `AssistantMessage` and flushes them to the `MarkdownStream` on a throttled timer (`_STREAM_FLUSH_INTERVAL`), so the event loop stays free to handle keyboard input. `stop_stream` and `set_content` drain the buffer and cancel the timer so finalized content is never dropped. Also gates the per-chunk `content_blocks` `repr()` in the streaming adapter behind a debug-level check so it isn't built on every token.

## Release Note
Fix laggy keyboard input in the interactive REPL while the model is streaming a response.

## Test Plan
- [ ] Stream a long response and confirm typing in the input stays smooth.

Made by [Open SWE](https://openswe.vercel.app)