### PR TITLE
feat(code): add `get_current_thread_id` tool

### DIFF
--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1402,7 +1402,7 @@ async def _run_acp_cli_async(
         save_recent_model,
         touch_recent_model,
     )
-    from deepagents_code.tools import fetch_url, web_search
+    from deepagents_code.tools import fetch_url, get_current_thread_id, web_search
 
     try:
         model_result = create_model(
@@ -1421,7 +1421,7 @@ async def _run_acp_cli_async(
     save_recent_model(resolved_spec)
     touch_recent_model(resolved_spec)
 
-    tools: list[Any] = [fetch_url]
+    tools: list[Any] = [fetch_url, get_current_thread_id]
     if settings.has_tavily:
         tools.append(web_search)
 

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -90,9 +90,9 @@ def _build_tools(
         RuntimeError: If MCP tool loading fails.
     """
     from deepagents_code.config import settings
-    from deepagents_code.tools import fetch_url, web_search
+    from deepagents_code.tools import fetch_url, get_current_thread_id, web_search
 
-    tools: list[Any] = [fetch_url]
+    tools: list[Any] = [fetch_url, get_current_thread_id]
     if settings.has_tavily:
         tools.append(web_search)
 

--- a/libs/code/deepagents_code/tools.py
+++ b/libs/code/deepagents_code/tools.py
@@ -10,6 +10,9 @@ import threading
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urljoin, urlparse
 
+from langchain_core.runnables import RunnableConfig  # noqa: TC002  # runtime hint
+from langchain_core.tools import tool
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -216,6 +219,22 @@ def _get_tavily_client() -> TavilyClient | None:
     else:
         _tavily_client = None
     return _tavily_client
+
+
+@tool
+def get_current_thread_id(config: RunnableConfig) -> str:
+    """Get the current Deep Agents thread ID for LangSmith or MCP tooling.
+
+    Args:
+        config: Runtime config injected by LangChain.
+
+    Returns:
+        The current `configurable.thread_id`, or an explanatory message if missing.
+    """
+    thread_id = config.get("configurable", {}).get("thread_id")
+    if isinstance(thread_id, str) and thread_id:
+        return thread_id
+    return "No current thread ID is available."
 
 
 def web_search(  # noqa: ANN201  # Return type depends on dynamic tool configuration

--- a/libs/code/tests/unit_tests/test_main_acp_mode.py
+++ b/libs/code/tests/unit_tests/test_main_acp_mode.py
@@ -54,6 +54,7 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server() -> None:
     mcp_tool = object()
     mcp_server_info = [SimpleNamespace(name="docs")]
     fetch_tool = object()
+    thread_tool = object()
     search_tool = object()
 
     def _resolve_mcp_tools_with_bound_loop(
@@ -87,6 +88,7 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server() -> None:
             "deepagents_code.mcp_tools.resolve_and_load_mcp_tools", resolve_mcp_tools
         ),
         patch("deepagents_code.tools.fetch_url", new=fetch_tool),
+        patch("deepagents_code.tools.get_current_thread_id", new=thread_tool),
         patch("deepagents_code.tools.web_search", new=search_tool),
         patch(
             "deepagents_code.agent.create_cli_agent", return_value=("graph", object())
@@ -115,7 +117,7 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server() -> None:
     call_kwargs = mock_create_agent.call_args.kwargs
     assert call_kwargs["model"] is model_obj
     assert call_kwargs["assistant_id"] == "agent"
-    assert call_kwargs["tools"] == [fetch_tool, search_tool, mcp_tool]
+    assert call_kwargs["tools"] == [fetch_tool, thread_tool, search_tool, mcp_tool]
     assert call_kwargs["mcp_server_info"] is mcp_server_info
     assert call_kwargs["checkpointer"] is not None
     mock_server_cls.assert_called_once_with("graph")
@@ -136,6 +138,7 @@ def test_acp_mode_omits_web_search_without_tavily() -> None:
     server = object()
     run_agent = AsyncMock(return_value=None)
     fetch_tool = object()
+    thread_tool = object()
     search_tool = object()
     resolve_mcp_tools = AsyncMock(return_value=([], None, []))
 
@@ -153,6 +156,7 @@ def test_acp_mode_omits_web_search_without_tavily() -> None:
             "deepagents_code.mcp_tools.resolve_and_load_mcp_tools", resolve_mcp_tools
         ),
         patch("deepagents_code.tools.fetch_url", new=fetch_tool),
+        patch("deepagents_code.tools.get_current_thread_id", new=thread_tool),
         patch("deepagents_code.tools.web_search", new=search_tool),
         patch(
             "deepagents_code.agent.create_cli_agent", return_value=("graph", object())
@@ -168,7 +172,7 @@ def test_acp_mode_omits_web_search_without_tavily() -> None:
     call_kwargs = mock_create_agent.call_args.kwargs
     assert call_kwargs["model"] is model_obj
     assert call_kwargs["assistant_id"] == "agent"
-    assert call_kwargs["tools"] == [fetch_tool]
+    assert call_kwargs["tools"] == [fetch_tool, thread_tool]
     assert call_kwargs["mcp_server_info"] == []
     assert call_kwargs["checkpointer"] is not None
 

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -38,6 +38,7 @@ class TestServerGraph:
         graph_obj = object()
         model_obj = object()
         fetch_tool = object()
+        thread_tool = object()
         mcp_tool = object()
         mcp_server_info = [SimpleNamespace(name="docs")]
         create_cli_agent = MagicMock(return_value=(graph_obj, object()))
@@ -64,6 +65,7 @@ class TestServerGraph:
         tools_module = _module_with_attrs(
             "deepagents_code.tools",
             fetch_url=fetch_tool,
+            get_current_thread_id=thread_tool,
             web_search=object(),
         )
 
@@ -123,7 +125,7 @@ class TestServerGraph:
         create_cli_agent.assert_called_once_with(
             model=model_obj,
             assistant_id="agent",
-            tools=[fetch_tool, mcp_tool],
+            tools=[fetch_tool, thread_tool, mcp_tool],
             sandbox=None,
             sandbox_type=None,
             system_prompt=None,

--- a/libs/code/tests/unit_tests/tools/test_current_thread.py
+++ b/libs/code/tests/unit_tests/tools/test_current_thread.py
@@ -1,0 +1,27 @@
+"""Tests for the `get_current_thread_id` tool."""
+
+from __future__ import annotations
+
+from deepagents_code.tools import get_current_thread_id
+
+
+def test_get_current_thread_id_returns_config_thread() -> None:
+    """Tool should read the injected LangGraph thread ID."""
+    result = get_current_thread_id.invoke(
+        {},
+        config={"configurable": {"thread_id": "thread-123"}},
+    )
+
+    assert result == "thread-123"
+
+
+def test_get_current_thread_id_has_no_model_visible_args() -> None:
+    """Runtime config injection should keep the schema argument-free."""
+    assert get_current_thread_id.args == {}
+
+
+def test_get_current_thread_id_handles_missing_thread() -> None:
+    """Tool should return a clear message when no thread ID is present."""
+    result = get_current_thread_id.invoke({}, config={"configurable": {}})
+
+    assert result == "No current thread ID is available."


### PR DESCRIPTION
Adds a `get_current_thread_id` agent tool to `deepagents-code` so models can retrieve the active LangGraph thread ID and pass it to thread-scoped tooling like the LangSmith CLI or an MCP server. The tool reads `configurable.thread_id` from the injected `RunnableConfig` (so it takes no model-visible arguments) and returns an explanatory message when no thread ID is available. It is wired into the tool lists for both ACP mode (`main.py`) and the server graph (`server_graph.py`).

Made by [Open SWE](https://openswe.vercel.app)