### PR TITLE
feat(code): offer restart after restart-capable install

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -10140,9 +10140,36 @@ class DeepAgentsApp(App):
             return
 
         if choice == "restart":
+            if not await self._reload_configuration_for_restart():
+                return
             await self._mount_message(AppMessage("Restarting server..."))
             if await self._restart_server_manual():
                 await self._mount_message(AppMessage("Restart complete."))
+
+    async def _reload_configuration_for_restart(self) -> bool:
+        """Reload config state before respawning the owned server.
+
+        Returns:
+            Whether reload completed and restart should continue.
+        """
+        from deepagents_code.config import settings
+        from deepagents_code.model_config import clear_caches
+
+        try:
+            settings.reload_from_environment()
+            clear_caches()
+        except (OSError, ValueError, KeyError, TypeError, ImportError) as exc:
+            logger.exception("Failed to reload configuration during restart")
+            await self._mount_message(
+                AppMessage(
+                    "Failed to reload configuration "
+                    f"({type(exc).__name__}: {exc}). Check your .env "
+                    "file and environment variables for syntax errors, "
+                    "then try again.",
+                ),
+            )
+            return False
+        return True
 
     async def _handle_restart_command(self, command: str) -> None:
         """Drive the `/restart` slash command.
@@ -10160,9 +10187,6 @@ class DeepAgentsApp(App):
         Args:
             command: Raw command string for echoing back to chat.
         """
-        from deepagents_code.config import settings
-        from deepagents_code.model_config import clear_caches
-
         await self._mount_message(UserMessage(command))
 
         # Sever in-flight work bound to the dying subprocess. `_cancel_worker`
@@ -10174,19 +10198,7 @@ class DeepAgentsApp(App):
         else:
             self._discard_queue()
 
-        try:
-            settings.reload_from_environment()
-            clear_caches()
-        except (OSError, ValueError, KeyError, TypeError, ImportError) as exc:
-            logger.exception("Failed to reload configuration during /restart")
-            await self._mount_message(
-                AppMessage(
-                    "Failed to reload configuration "
-                    f"({type(exc).__name__}: {exc}). Check your .env "
-                    "file and environment variables for syntax errors, "
-                    "then try again.",
-                ),
-            )
+        if not await self._reload_configuration_for_restart():
             return
 
         if self._server_proc is None or self._server_kwargs is None:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3752,7 +3752,8 @@ class DeepAgentsApp(App):
         # STANDALONE_EXTRAS) are wired into the parent process at startup
         # (`verify_interpreter_deps` gates `--interpreter`), so a full
         # relaunch is required.
-        if extra in MODEL_PROVIDER_EXTRAS or extra in SANDBOX_EXTRAS:
+        restart_capable = extra in MODEL_PROVIDER_EXTRAS or extra in SANDBOX_EXTRAS
+        if restart_capable:
             next_step = "Run `/restart` to load it now, or relaunch dcode."
         else:
             next_step = "Exit and relaunch dcode to use the new dependencies."
@@ -3760,6 +3761,8 @@ class DeepAgentsApp(App):
         await self._mount_message(
             AppMessage(f"Installed extra '{extra}'. {next_step}"),
         )
+        if restart_capable:
+            await self._offer_restart_after_install(extra)
 
     async def _handle_install_package(self, package: str, *, force: bool) -> None:
         """Install an arbitrary package into the dcode tool env via `uv --with`.
@@ -3848,6 +3851,7 @@ class DeepAgentsApp(App):
                 "now, or relaunch dcode.",
             ),
         )
+        await self._offer_restart_after_install(package)
 
     async def _handle_version_command(self) -> None:
         """Handle the `/version` slash command — show versions and update status.
@@ -10077,6 +10081,46 @@ class DeepAgentsApp(App):
                 "Your tool list may be stale — use /mcp to check."
             ),
         )
+
+    async def _offer_restart_after_install(self, label: str) -> None:
+        """Offer a one-keypress restart after a restart-capable install.
+
+        Provider/sandbox extras and `--package` installs are imported by the
+        app-owned LangGraph server subprocess, so a `/restart` loads them
+        without exiting the TUI. When dcode owns that subprocess and is idle,
+        prompt to run the restart immediately instead of making the user type
+        `/restart`. Skipped while a run is in flight (a restart cancels it) and
+        in remote-server mode (no subprocess to respawn) — both already carry
+        the manual-restart hint in the install message.
+
+        Args:
+            label: Installed extra/package name, surfaced in the prompt title.
+        """
+        if self._server_proc is None or self._server_kwargs is None:
+            return
+        if self._agent_running or self._connecting:
+            return
+
+        from deepagents_code.widgets.restart_prompt import (
+            RestartChoice,
+            RestartPromptScreen,
+        )
+
+        choice: RestartChoice | None
+        try:
+            choice = await self._push_screen_wait(RestartPromptScreen(label))
+        except Exception:
+            # Modal could not be mounted (e.g. another modal hijacked the
+            # stack). Leave the manual `/restart` hint in place.
+            logger.exception(
+                "Failed to mount restart prompt after installing %r", label
+            )
+            return
+
+        if choice == "restart":
+            await self._mount_message(AppMessage("Restarting server..."))
+            if await self._restart_server_manual():
+                await self._mount_message(AppMessage("Restart complete."))
 
     async def _handle_restart_command(self, command: str) -> None:
         """Drive the `/restart` slash command.

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -10111,9 +10111,11 @@ class DeepAgentsApp(App):
         app-owned LangGraph server subprocess, so a `/restart` loads them
         without exiting the TUI. When dcode owns that subprocess and is idle,
         prompt to run the restart immediately instead of making the user type
-        `/restart`. Skipped while a run is in flight (a restart cancels it) and
-        in remote-server mode (no subprocess to respawn) — both already carry
-        the manual-restart hint in the install message.
+        `/restart`. Skipped while a run is in flight or the server is still
+        connecting/restarting (a restart cancels in-flight work and a
+        connecting server has nothing to respawn into yet) and in
+        remote-server mode (no subprocess to respawn) — every skipped path
+        already carries the manual-restart hint in the install message.
 
         Args:
             label: Installed extra/package name, surfaced in the prompt title.
@@ -10130,7 +10132,22 @@ class DeepAgentsApp(App):
 
         choice: RestartChoice | None
         try:
-            choice = await self._push_screen_wait(RestartPromptScreen(label))
+            # Watchdog: bound the handler against a screen that never resolves
+            # (compose crash, programmatic teardown that skips the dismiss
+            # callback). 10 minutes is well past any human latency but stops a
+            # genuinely broken modal from wedging command handling. Mirrors the
+            # MCP reconnect prompt's watchdog.
+            choice = await asyncio.wait_for(
+                self._push_screen_wait(RestartPromptScreen(label)),
+                timeout=600.0,
+            )
+        except TimeoutError:
+            logger.warning(
+                "Restart prompt after installing %r timed out; leaving the "
+                "manual /restart hint in place",
+                label,
+            )
+            return
         except Exception:
             # Modal could not be mounted (e.g. another modal hijacked the
             # stack). Leave the manual `/restart` hint in place.

--- a/libs/code/deepagents_code/widgets/restart_prompt.py
+++ b/libs/code/deepagents_code/widgets/restart_prompt.py
@@ -99,6 +99,7 @@ class RestartPromptScreen(ModalScreen[RestartChoice]):
                     name=self._label,
                 ),
                 classes="restart-prompt-title",
+                markup=False,
             )
             yield Static(
                 "Restart the server to load it now, or defer with `/restart`.",
@@ -120,13 +121,15 @@ class RestartPromptScreen(ModalScreen[RestartChoice]):
         self.dismiss("later")
 
     def action_cancel(self) -> None:
-        """Alias for `action_later` so the app-level Esc handler defers.
+        """Alias for `action_later` so Esc resolves to a deliberate defer.
 
         The app's `action_interrupt` (`escape` binding, `priority=True`)
         fires before this screen's own `escape` binding. When the active
         screen is a `ModalScreen`, it dispatches to `action_cancel` if
-        present, else falls through to `dismiss(None)`. Without this alias,
-        Esc would dismiss with `None`, which the caller treats as a
-        programmatic dismiss instead of an explicit defer.
+        present, else falls through to `dismiss(None)`. The current caller
+        no-ops on both `None` and `"later"`, but defining this alias pins Esc
+        to an explicit `"later"` — matching the sibling reconnect/cwd-switch
+        modals and keeping the outcome unambiguous for any future caller that
+        branches on a deliberate defer versus a programmatic dismiss.
         """
         self.action_later()

--- a/libs/code/deepagents_code/widgets/restart_prompt.py
+++ b/libs/code/deepagents_code/widgets/restart_prompt.py
@@ -1,0 +1,132 @@
+"""Confirmation modal offered after a restart-capable `/install`.
+
+Provider and sandbox extras (and `--package` installs) are imported by the
+app-owned LangGraph server subprocess, so a `/restart` loads them without
+exiting the TUI. Rather than make the user type `/restart` by hand, this
+modal offers to run that restart immediately while leaving deferral one
+keypress away.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, Literal
+
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.content import Content
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+from deepagents_code.config import get_glyphs
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+
+RestartChoice = Literal["restart", "later"]
+"""Outcome of the prompt: restart the server now or defer."""
+
+
+class RestartPromptScreen(ModalScreen[RestartChoice]):
+    """Modal asking whether to restart the server after a successful install.
+
+    Dismisses with `"restart"` when the user accepts and `"later"` when the
+    user defers. Esc is treated as "later" so the user is never forced into a
+    restart they did not explicitly choose.
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("enter", "restart", "Restart", show=False, priority=True),
+        Binding("escape", "later", "Later", show=False, priority=True),
+    ]
+
+    CSS = """
+    RestartPromptScreen {
+        align: center middle;
+    }
+
+    RestartPromptScreen > Vertical {
+        width: 64;
+        max-width: 90%;
+        height: auto;
+        background: $surface;
+        border: solid $primary;
+        padding: 1 2;
+    }
+
+    RestartPromptScreen .restart-prompt-title {
+        text-style: bold;
+        color: $primary;
+        text-align: center;
+        margin-bottom: 1;
+    }
+
+    RestartPromptScreen .restart-prompt-body {
+        height: auto;
+        color: $text;
+        margin-bottom: 1;
+    }
+
+    RestartPromptScreen .restart-prompt-help {
+        height: 1;
+        color: $text-muted;
+        text-style: italic;
+        text-align: center;
+    }
+    """
+
+    def __init__(self, label: str) -> None:
+        """Initialize the prompt.
+
+        Args:
+            label: Installed extra/package name, surfaced in the title.
+        """
+        super().__init__()
+        self._label = label
+
+    def compose(self) -> ComposeResult:
+        """Compose the confirmation dialog.
+
+        Yields:
+            Title, body, and help-row widgets parented inside a `Vertical`.
+        """
+        glyphs = get_glyphs()
+        with Vertical():
+            yield Static(
+                Content.from_markup(
+                    "$check Installed [bold]$name[/bold]",
+                    check=glyphs.checkmark,
+                    name=self._label,
+                ),
+                classes="restart-prompt-title",
+            )
+            yield Static(
+                "Restart the server to load it now, or defer with `/restart`.",
+                classes="restart-prompt-body",
+                markup=False,
+            )
+            yield Static(
+                "Enter to restart, Esc to defer",
+                classes="restart-prompt-help",
+                markup=False,
+            )
+
+    def action_restart(self) -> None:
+        """Dismiss with `"restart"`."""
+        self.dismiss("restart")
+
+    def action_later(self) -> None:
+        """Dismiss with `"later"`."""
+        self.dismiss("later")
+
+    def action_cancel(self) -> None:
+        """Alias for `action_later` so the app-level Esc handler defers.
+
+        The app's `action_interrupt` (`escape` binding, `priority=True`)
+        fires before this screen's own `escape` binding. When the active
+        screen is a `ModalScreen`, it dispatches to `action_cancel` if
+        present, else falls through to `dismiss(None)`. Without this alias,
+        Esc would dismiss with `None`, which the caller treats as a
+        programmatic dismiss instead of an explicit defer.
+        """
+        self.action_later()

--- a/libs/code/tests/unit_tests/test_install_command.py
+++ b/libs/code/tests/unit_tests/test_install_command.py
@@ -364,6 +364,19 @@ async def test_install_restart_capable_extra_offers_restart_when_idle() -> None:
         await pilot.pause()
         app._server_proc = MagicMock()
         app._server_kwargs = {"model_name": "fireworks:fake"}
+        calls: list[str] = []
+
+        def _reload() -> list[str]:
+            calls.append("reload")
+            return []
+
+        def _clear() -> None:
+            calls.append("clear")
+
+        async def _restart() -> bool:  # noqa: RUF029  # patched async app hook
+            calls.append("restart")
+            return True
+
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
             patch(
@@ -374,14 +387,19 @@ async def test_install_restart_capable_extra_offers_restart_when_idle() -> None:
             patch.object(
                 app, "_push_screen_wait", new=AsyncMock(return_value="restart")
             ) as prompt,
+            patch("deepagents_code.config.settings.reload_from_environment", _reload),
+            patch("deepagents_code.model_config.clear_caches", _clear),
             patch.object(
-                app, "_restart_server_manual", new=AsyncMock(return_value=True)
+                app,
+                "_restart_server_manual",
+                new=AsyncMock(side_effect=_restart),
             ) as restart,
         ):
             await app._handle_command("/install fireworks")
             await pilot.pause()
         prompt.assert_awaited_once()
         restart.assert_awaited_once()
+        assert calls == ["reload", "clear", "restart"]
         app_msgs = [
             str(m._content) for m in app.query(AppMessage) if not m._is_markdown
         ]
@@ -486,6 +504,19 @@ async def test_install_package_offers_restart_when_idle() -> None:
         await pilot.pause()
         app._server_proc = MagicMock()
         app._server_kwargs = {"model_name": "custom_provider:fake"}
+        calls: list[str] = []
+
+        def _reload() -> list[str]:
+            calls.append("reload")
+            return []
+
+        def _clear() -> None:
+            calls.append("clear")
+
+        async def _restart() -> bool:  # noqa: RUF029  # patched async app hook
+            calls.append("restart")
+            return True
+
         with (
             patch("deepagents_code.config._is_editable_install", return_value=False),
             patch(
@@ -496,11 +527,16 @@ async def test_install_package_offers_restart_when_idle() -> None:
             patch.object(
                 app, "_push_screen_wait", new=AsyncMock(return_value="restart")
             ) as prompt,
+            patch("deepagents_code.config.settings.reload_from_environment", _reload),
+            patch("deepagents_code.model_config.clear_caches", _clear),
             patch.object(
-                app, "_restart_server_manual", new=AsyncMock(return_value=True)
+                app,
+                "_restart_server_manual",
+                new=AsyncMock(side_effect=_restart),
             ) as restart,
         ):
             await app._handle_command("/install langchain-custom --package --force")
             await pilot.pause()
         prompt.assert_awaited_once()
         restart.assert_awaited_once()
+        assert calls == ["reload", "clear", "restart"]

--- a/libs/code/tests/unit_tests/test_install_command.py
+++ b/libs/code/tests/unit_tests/test_install_command.py
@@ -540,3 +540,122 @@ async def test_install_package_offers_restart_when_idle() -> None:
         prompt.assert_awaited_once()
         restart.assert_awaited_once()
         assert calls == ["reload", "clear", "restart"]
+
+
+async def test_install_package_defer_skips_restart() -> None:
+    """Declining the prompt after a `--package` install leaves it untouched."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._server_proc = MagicMock()
+        app._server_kwargs = {"model_name": "custom_provider:fake"}
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_package",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                app, "_push_screen_wait", new=AsyncMock(return_value="later")
+            ) as prompt,
+            patch.object(
+                app, "_restart_server_manual", new=AsyncMock(return_value=True)
+            ) as restart,
+        ):
+            await app._handle_command("/install langchain-custom --package --force")
+            await pilot.pause()
+        prompt.assert_awaited_once()
+        restart.assert_not_called()
+
+
+async def test_install_restart_prompt_skipped_while_connecting() -> None:
+    """A connecting/restarting server has nothing to respawn into, so skip."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._server_proc = MagicMock()
+        app._server_kwargs = {"model_name": "fireworks:fake"}
+        app._connecting = True
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_extra",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(app, "_push_screen_wait", new=AsyncMock()) as prompt,
+        ):
+            await app._handle_command("/install fireworks")
+            await pilot.pause()
+        prompt.assert_not_called()
+
+
+async def test_install_restart_prompt_mount_failure_leaves_manual_hint() -> None:
+    """If the modal cannot be mounted, fall back to the manual `/restart` hint."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._server_proc = MagicMock()
+        app._server_kwargs = {"model_name": "fireworks:fake"}
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_extra",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                app,
+                "_push_screen_wait",
+                new=AsyncMock(side_effect=RuntimeError("modal hijacked")),
+            ) as prompt,
+            patch.object(
+                app, "_restart_server_manual", new=AsyncMock(return_value=True)
+            ) as restart,
+        ):
+            await app._handle_command("/install fireworks")
+            await pilot.pause()
+        prompt.assert_awaited_once()
+        restart.assert_not_called()
+        app_msgs = [
+            str(m._content) for m in app.query(AppMessage) if not m._is_markdown
+        ]
+        # The install message keeps the manual recovery path, and no restart
+        # was attempted.
+        assert any("/restart" in m for m in app_msgs)
+        assert not any("Restarting server..." in m for m in app_msgs)
+
+
+async def test_install_restart_failure_omits_complete_message() -> None:
+    """A failed restart shows the attempt but never claims completion."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._server_proc = MagicMock()
+        app._server_kwargs = {"model_name": "fireworks:fake"}
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_extra",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                app, "_push_screen_wait", new=AsyncMock(return_value="restart")
+            ) as prompt,
+            patch("deepagents_code.config.settings.reload_from_environment", list),
+            patch("deepagents_code.model_config.clear_caches", lambda: None),
+            patch.object(
+                app, "_restart_server_manual", new=AsyncMock(return_value=False)
+            ) as restart,
+        ):
+            await app._handle_command("/install fireworks")
+            await pilot.pause()
+        prompt.assert_awaited_once()
+        restart.assert_awaited_once()
+        app_msgs = [
+            str(m._content) for m in app.query(AppMessage) if not m._is_markdown
+        ]
+        assert any("Restarting server..." in m for m in app_msgs)
+        assert not any("Restart complete." in m for m in app_msgs)

--- a/libs/code/tests/unit_tests/test_install_command.py
+++ b/libs/code/tests/unit_tests/test_install_command.py
@@ -6,7 +6,7 @@ this module focuses on the in-app slash dispatch in `DeepAgentsApp`.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from deepagents_code.app import DeepAgentsApp
 from deepagents_code.widgets.messages import AppMessage, ErrorMessage
@@ -355,3 +355,152 @@ async def test_install_slash_package_editable_install_refuses() -> None:
         perform_mock.assert_not_awaited()
         app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
         assert any("Editable install detected" in str(m._content) for m in app_msgs)
+
+
+async def test_install_restart_capable_extra_offers_restart_when_idle() -> None:
+    """A provider extra prompts to restart and runs it on accept when idle."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._server_proc = MagicMock()
+        app._server_kwargs = {"model_name": "fireworks:fake"}
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_extra",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                app, "_push_screen_wait", new=AsyncMock(return_value="restart")
+            ) as prompt,
+            patch.object(
+                app, "_restart_server_manual", new=AsyncMock(return_value=True)
+            ) as restart,
+        ):
+            await app._handle_command("/install fireworks")
+            await pilot.pause()
+        prompt.assert_awaited_once()
+        restart.assert_awaited_once()
+        app_msgs = [
+            str(m._content) for m in app.query(AppMessage) if not m._is_markdown
+        ]
+        assert any("Restart complete." in m for m in app_msgs)
+
+
+async def test_install_restart_capable_extra_defer_skips_restart() -> None:
+    """Declining the restart prompt leaves the server untouched."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._server_proc = MagicMock()
+        app._server_kwargs = {"model_name": "fireworks:fake"}
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_extra",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                app, "_push_screen_wait", new=AsyncMock(return_value="later")
+            ) as prompt,
+            patch.object(
+                app, "_restart_server_manual", new=AsyncMock(return_value=True)
+            ) as restart,
+        ):
+            await app._handle_command("/install fireworks")
+            await pilot.pause()
+        prompt.assert_awaited_once()
+        restart.assert_not_called()
+
+
+async def test_install_standalone_extra_does_not_offer_restart() -> None:
+    """Standalone extras (e.g. `quickjs`) never prompt to restart."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._server_proc = MagicMock()
+        app._server_kwargs = {"model_name": "fireworks:fake"}
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_extra",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(app, "_push_screen_wait", new=AsyncMock()) as prompt,
+        ):
+            await app._handle_command("/install quickjs")
+            await pilot.pause()
+        prompt.assert_not_called()
+
+
+async def test_install_restart_prompt_skipped_in_remote_server_mode() -> None:
+    """Remote-server mode (no owned subprocess) must not offer a restart."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._server_proc = None
+        app._server_kwargs = None
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_extra",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(app, "_push_screen_wait", new=AsyncMock()) as prompt,
+        ):
+            await app._handle_command("/install fireworks")
+            await pilot.pause()
+        prompt.assert_not_called()
+
+
+async def test_install_restart_prompt_skipped_while_agent_running() -> None:
+    """A restart cancels in-flight work, so don't prompt mid-run."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._server_proc = MagicMock()
+        app._server_kwargs = {"model_name": "fireworks:fake"}
+        app._agent_running = True
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_extra",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(app, "_push_screen_wait", new=AsyncMock()) as prompt,
+        ):
+            await app._handle_command("/install fireworks")
+            await pilot.pause()
+        prompt.assert_not_called()
+
+
+async def test_install_package_offers_restart_when_idle() -> None:
+    """A `--package` install prompts to restart and runs it on accept."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._server_proc = MagicMock()
+        app._server_kwargs = {"model_name": "custom_provider:fake"}
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_package",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            patch.object(
+                app, "_push_screen_wait", new=AsyncMock(return_value="restart")
+            ) as prompt,
+            patch.object(
+                app, "_restart_server_manual", new=AsyncMock(return_value=True)
+            ) as restart,
+        ):
+            await app._handle_command("/install langchain-custom --package --force")
+            await pilot.pause()
+        prompt.assert_awaited_once()
+        restart.assert_awaited_once()

--- a/libs/code/tests/unit_tests/test_restart_prompt.py
+++ b/libs/code/tests/unit_tests/test_restart_prompt.py
@@ -1,0 +1,88 @@
+"""Tests for the post-install restart confirmation modal."""
+
+from __future__ import annotations
+
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from deepagents_code.widgets.restart_prompt import RestartPromptScreen
+
+
+class _RestartTestApp(App[None]):
+    def compose(self) -> ComposeResult:
+        yield Static("base")
+
+
+class TestRestartPromptScreen:
+    """Behavior tests for `RestartPromptScreen`."""
+
+    async def test_enter_dismisses_with_restart(self) -> None:
+        """Pressing Enter chooses `restart`."""
+        app = _RestartTestApp()
+        async with app.run_test() as pilot:
+            outcomes: list[str | None] = []
+
+            def on_dismiss(result: str | None) -> None:
+                outcomes.append(result)
+
+            app.push_screen(RestartPromptScreen("fireworks"), on_dismiss)
+            await pilot.pause()
+
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert outcomes == ["restart"]
+
+    async def test_escape_dismisses_with_later(self) -> None:
+        """Pressing Esc chooses `later` (no implicit restart)."""
+        app = _RestartTestApp()
+        async with app.run_test() as pilot:
+            outcomes: list[str | None] = []
+
+            def on_dismiss(result: str | None) -> None:
+                outcomes.append(result)
+
+            app.push_screen(RestartPromptScreen("fireworks"), on_dismiss)
+            await pilot.pause()
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert outcomes == ["later"]
+
+    async def test_action_cancel_dismisses_with_later(self) -> None:
+        """`action_cancel` defers — the path taken by the app's Esc handler.
+
+        `DeepAgentsApp.action_interrupt` (a priority `escape` binding) fires
+        before the modal's own `escape` binding. When the active screen is a
+        `ModalScreen`, it dispatches to `action_cancel` if present, else falls
+        through to `dismiss(None)`. Without an `action_cancel` that defers,
+        real-app Esc would silently None-dismiss instead of choosing `later`,
+        which the caller cannot distinguish from a programmatic dismiss.
+        """
+        app = _RestartTestApp()
+        async with app.run_test() as pilot:
+            outcomes: list[str | None] = []
+
+            def on_dismiss(result: str | None) -> None:
+                outcomes.append(result)
+
+            screen = RestartPromptScreen("fireworks")
+            app.push_screen(screen, on_dismiss)
+            await pilot.pause()
+
+            screen.action_cancel()
+            await pilot.pause()
+
+            assert outcomes == ["later"]
+
+    async def test_renders_label(self) -> None:
+        """The installed extra/package label is surfaced in the modal title."""
+        app = _RestartTestApp()
+        async with app.run_test() as pilot:
+            app.push_screen(RestartPromptScreen("langchain-custom"))
+            await pilot.pause()
+
+            titles = app.screen.query(".restart-prompt-title")
+            assert len(titles) == 1
+            assert "langchain-custom" in str(titles.first().render())


### PR DESCRIPTION
`/install` now offers to restart the server immediately after installing a provider/sandbox extra or package, instead of requiring a manual `/restart`.

---

After a successful provider/sandbox extra or `--package` install, the user still has to type `/restart` to load it. Since dcode already owns the server subprocess and knows whether it's idle, this offers a one-keypress "Restart now?" prompt that runs the existing restart path. It falls back to the current manual hint during an active run (a restart cancels it) and in remote-server mode (no subprocess to respawn).

Made by [Open SWE](https://openswe.vercel.app)