### PR TITLE
feat(code): guard managed onboarding-name memory block from edits

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1391,6 +1391,18 @@ def create_cli_agent(
             )
         )
 
+        # Protect the machine-managed onboarding-name block in the user
+        # AGENTS.md from being rewritten by agent file edits. The block's
+        # markers are HTML comments stripped before injection, so the model
+        # can't see the boundary and would otherwise clobber it.
+        from deepagents_code.memory_guard import ManagedMemoryGuardMiddleware
+
+        agent_middleware.append(
+            ManagedMemoryGuardMiddleware(
+                [str(settings.get_user_agent_md_path(assistant_id))]
+            )
+        )
+
     # Add skills middleware
     if enable_skills:
         # Lowest to highest precedence:

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1306,6 +1306,18 @@ def create_cli_agent(
             middleware.append(ConfigurableModelMiddleware())
         if restrictive_shell_allow_list is not None:
             middleware.append(ShellAllowListMiddleware(restrictive_shell_allow_list))
+        # Subagents share the on-disk filesystem backend and can edit the user
+        # AGENTS.md, so they get the same managed onboarding-name block guard as
+        # the main agent. Gated on memory because the block only exists when
+        # memory is enabled.
+        if enable_memory:
+            from deepagents_code.memory_guard import ManagedMemoryGuardMiddleware
+
+            middleware.append(
+                ManagedMemoryGuardMiddleware(
+                    [settings.get_user_agent_md_path(assistant_id)]
+                )
+            )
         # Recovery sits last so it is the innermost tool-call wrapper, matching
         # the main agent stack: it then wraps tool execution as tightly as
         # possible and only intercepts `ToolException`s from the tool itself,
@@ -1399,7 +1411,7 @@ def create_cli_agent(
 
         agent_middleware.append(
             ManagedMemoryGuardMiddleware(
-                [str(settings.get_user_agent_md_path(assistant_id))]
+                [settings.get_user_agent_md_path(assistant_id)]
             )
         )
 

--- a/libs/code/deepagents_code/memory_guard.py
+++ b/libs/code/deepagents_code/memory_guard.py
@@ -1,0 +1,189 @@
+"""Protect machine-managed memory blocks from agent edits.
+
+The onboarding flow writes the user's preferred name into the user `AGENTS.md`
+inside a marker-delimited block (see `onboarding.ONBOARDING_NAME_MEMORY_START` /
+`ONBOARDING_NAME_MEMORY_END`). `MemoryMiddleware` strips HTML comments before
+injecting memory, so the model never sees those markers and has no way to know
+the region is off-limits. Since the same prompt tells the model to `edit_file`
+that file to persist learnings, nothing stops it from rewriting the managed
+block.
+
+This middleware intercepts `write_file`/`edit_file` calls targeting the guarded
+file(s). When a call would change or remove the managed block, the model's other
+edits are kept but the managed block is restored to its prior content, and an
+error is returned so the model learns the region is machine-managed.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from langchain.agents.middleware.types import AgentMiddleware
+
+from deepagents_code.onboarding import (
+    _upsert_onboarding_name_memory,
+    extract_onboarding_name_block,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain_core.messages import ToolMessage
+    from langgraph.prebuilt.tool_node import ToolCallRequest
+    from langgraph.types import Command
+
+logger = logging.getLogger(__name__)
+
+_GUARDED_TOOLS: frozenset[str] = frozenset({"write_file", "edit_file"})
+
+_REJECTION_MESSAGE = (
+    "The region between the `deepagents:onboarding-name` markers in "
+    "{path} is machine-managed and must not be edited. Your other changes "
+    "to the file were kept, but the managed block was restored to its "
+    "previous content. Do not modify content between those markers."
+)
+
+
+class ManagedMemoryGuardMiddleware(AgentMiddleware):
+    """Revert agent edits to the managed onboarding-name memory block.
+
+    Guards a fixed set of memory files. A `write_file`/`edit_file` that leaves
+    the managed block untouched passes through; one that alters or drops it has
+    the block restored (other edits preserved) and returns an error.
+    """
+
+    def __init__(self, guarded_paths: list[str]) -> None:
+        """Initialize the guard with the memory files to protect.
+
+        Args:
+            guarded_paths: Absolute paths whose managed onboarding-name block
+                must be protected from agent edits.
+        """
+        super().__init__()
+        self._guarded: set[Path] = set()
+        for raw in guarded_paths:
+            try:
+                self._guarded.add(Path(raw).expanduser().resolve())
+            except (OSError, RuntimeError, ValueError):
+                logger.debug("Could not resolve guarded memory path %r", raw)
+
+    def _guarded_path(self, request: ToolCallRequest) -> Path | None:
+        """Return the resolved guarded path targeted by the call, if any.
+
+        Returns:
+            The matching guarded `Path`, or `None` when the call is unrelated.
+        """
+        if request.tool_call["name"] not in _GUARDED_TOOLS:
+            return None
+        args = request.tool_call.get("args") or {}
+        file_path = args.get("file_path")
+        if not isinstance(file_path, str) or not file_path:
+            return None
+        try:
+            resolved = Path(file_path).expanduser().resolve()
+        except (OSError, RuntimeError, ValueError):
+            return None
+        return resolved if resolved in self._guarded else None
+
+    @staticmethod
+    def _read(path: Path) -> str | None:
+        """Read `path` as UTF-8, returning `None` on failure.
+
+        Returns:
+            File content, or `None` when the file is missing or unreadable.
+        """
+        try:
+            return path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+
+    def _restore(self, path: Path, before_block: str) -> bool:
+        """Re-apply `before_block` into `path`, preserving other edits.
+
+        Returns:
+            `True` when the managed block was restored, otherwise `False`.
+        """
+        after = self._read(path)
+        if after is None:
+            return False
+        if extract_onboarding_name_block(after) == before_block:
+            return False
+        try:
+            path.write_text(
+                _upsert_onboarding_name_memory(after, before_block),
+                encoding="utf-8",
+            )
+        except OSError:
+            logger.warning(
+                "Could not restore managed memory block at %s", path, exc_info=True
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _error(request: ToolCallRequest, path: Path) -> ToolMessage:
+        """Build the error result returned after a reverted managed-block edit.
+
+        Returns:
+            An error-status `ToolMessage` explaining the managed region.
+        """
+        from langchain_core.messages import ToolMessage as LCToolMessage
+
+        return LCToolMessage(
+            content=_REJECTION_MESSAGE.format(path=path),
+            name=request.tool_call["name"],
+            tool_call_id=request.tool_call["id"],
+            status="error",
+        )
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Restore the managed block when a sync edit would change it.
+
+        Returns:
+            The tool result, or an error `ToolMessage` when the managed block
+                was altered and restored.
+        """
+        path = self._guarded_path(request)
+        if path is None:
+            return handler(request)
+        before = self._read(path)
+        before_block = (
+            extract_onboarding_name_block(before) if before is not None else None
+        )
+        result = handler(request)
+        if before_block is None:
+            return result
+        if self._restore(path, before_block):
+            return self._error(request, path)
+        return result
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
+    ) -> ToolMessage | Command[Any]:
+        """Restore the managed block when an async edit would change it.
+
+        Returns:
+            The tool result, or an error `ToolMessage` when the managed block
+                was altered and restored.
+        """
+        path = self._guarded_path(request)
+        if path is None:
+            return await handler(request)
+        before = self._read(path)
+        before_block = (
+            extract_onboarding_name_block(before) if before is not None else None
+        )
+        result = await handler(request)
+        if before_block is None:
+            return result
+        if self._restore(path, before_block):
+            return self._error(request, path)
+        return result

--- a/libs/code/deepagents_code/memory_guard.py
+++ b/libs/code/deepagents_code/memory_guard.py
@@ -19,6 +19,7 @@ completed, an error is still returned so the failure is never silent.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from enum import Enum
 from pathlib import Path
@@ -283,14 +284,16 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
             The tool result, or an error `ToolMessage` when the managed block
                 was altered.
         """
-        path = self._guarded_path(request)
+        path = await asyncio.to_thread(self._guarded_path, request)
         if path is None:
             return await handler(request)
-        before = self._read(path)
+        before = await asyncio.to_thread(self._read, path)
         before_block = (
             extract_onboarding_name_block(before) if before is not None else None
         )
         result = await handler(request)
         if before_block is None:
             return result
-        return self._result_after_restore(request, path, before_block, result)
+        return await asyncio.to_thread(
+            self._result_after_restore, request, path, before_block, result
+        )

--- a/libs/code/deepagents_code/memory_guard.py
+++ b/libs/code/deepagents_code/memory_guard.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from difflib import SequenceMatcher
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -161,7 +162,96 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
             logger.warning("Could not read guarded memory file %s", path, exc_info=True)
             return None
 
-    def _restore(self, path: Path, before_block: str) -> _RestoreOutcome:
+    @staticmethod
+    def _line_range_for_block(before: str, before_block: str) -> tuple[int, int] | None:
+        """Return the line range occupied by `before_block` in `before`.
+
+        Returns:
+            A `(start, end)` line range, or `None` when the block is absent.
+        """
+        block_start = before.find(before_block)
+        if block_start == -1:
+            return None
+        block_end = block_start + len(before_block)
+        start_line: int | None = None
+        end_line: int | None = None
+        offset = 0
+        for line_number, line in enumerate(before.splitlines(keepends=True)):
+            line_end = offset + len(line)
+            if start_line is None and offset <= block_start < line_end:
+                start_line = line_number
+            if offset < block_end <= line_end:
+                end_line = line_number + 1
+                break
+            offset = line_end
+        if start_line is None or end_line is None:
+            return None
+        return start_line, end_line
+
+    @staticmethod
+    def _without_managed_block_edits(
+        before: str, after: str, before_block: str
+    ) -> str | None:
+        """Remove post-edit lines that originated from the managed block.
+
+        Returns:
+            `after` with lines mapped from `before_block` removed, or `None` when
+                the old block cannot be located in `before`.
+        """
+        block_range = ManagedMemoryGuardMiddleware._line_range_for_block(
+            before, before_block
+        )
+        if block_range is None:
+            return None
+        block_start, block_end = block_range
+        # Use line-level matching so a damaged marker cannot leave the old
+        # managed memory body behind as regular user-editable memory.
+        before_lines = before.splitlines(keepends=True)
+        after_lines = after.splitlines(keepends=True)
+        ranges: list[tuple[int, int]] = []
+        matcher = SequenceMatcher(None, before_lines, after_lines, autojunk=False)
+        for (
+            tag,
+            before_start,
+            before_end,
+            after_start,
+            after_end,
+        ) in matcher.get_opcodes():
+            overlaps = before_start < block_end and block_start < before_end
+            if tag == "insert":
+                if block_start < before_start < block_end:
+                    ranges.append((after_start, after_end))
+                continue
+            if not overlaps or tag == "delete":
+                continue
+            if tag == "equal":
+                start = max(before_start, block_start)
+                end = min(before_end, block_end)
+                ranges.append(
+                    (
+                        after_start + start - before_start,
+                        after_start + end - before_start,
+                    )
+                )
+            else:
+                ranges.append((after_start, after_end))
+
+        if not ranges:
+            return after
+        parts: list[str] = []
+        cursor = 0
+        for start, end in sorted(ranges):
+            range_start = start
+            range_end = end
+            if range_start < cursor:
+                range_end = max(range_end, cursor)
+                range_start = cursor
+            parts.extend(after_lines[cursor:range_start])
+            cursor = range_end
+        parts.extend(after_lines[cursor:])
+        return "".join(parts)
+
+    def _restore(self, path: Path, before: str, before_block: str) -> _RestoreOutcome:
         """Re-apply `before_block` into `path`, preserving other edits.
 
         The restored content is verified before it is written, so a malformed
@@ -188,14 +278,17 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
         if block_after == before_block:
             return _RestoreOutcome.UNCHANGED
         if block_after is not None:
-            # Markers are intact but the content between them changed; let the
-            # upsert replace the block in place so the edit is fully reverted.
             source = after
         else:
-            # The markers were altered or dropped. Strip any fragments the edit
-            # left behind so the re-inserted block can't collide with an
-            # orphaned marker, then re-append a clean block.
-            source = strip_onboarding_name_markers(after)
+            source = self._without_managed_block_edits(before, after, before_block)
+            if source is None:
+                logger.error(
+                    "Could not locate previous managed block in %s; leaving the "
+                    "edited file untouched",
+                    path,
+                )
+                return _RestoreOutcome.FAILED
+            source = strip_onboarding_name_markers(source)
         restored = _upsert_onboarding_name_memory(source, before_block)
         if extract_onboarding_name_block(restored) != before_block:
             logger.error(
@@ -234,6 +327,7 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
         self,
         request: ToolCallRequest,
         path: Path,
+        before: str,
         before_block: str,
         result: ToolMessage | Command[Any],
     ) -> ToolMessage | Command[Any]:
@@ -243,7 +337,7 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
             The original `result` when the block was untouched, otherwise an
                 error `ToolMessage` describing the restore.
         """
-        outcome = self._restore(path, before_block)
+        outcome = self._restore(path, before, before_block)
         if outcome is _RestoreOutcome.UNCHANGED:
             return result
         return self._error(
@@ -269,9 +363,9 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
             extract_onboarding_name_block(before) if before is not None else None
         )
         result = handler(request)
-        if before_block is None:
+        if before is None or before_block is None:
             return result
-        return self._result_after_restore(request, path, before_block, result)
+        return self._result_after_restore(request, path, before, before_block, result)
 
     async def awrap_tool_call(
         self,
@@ -292,8 +386,8 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
             extract_onboarding_name_block(before) if before is not None else None
         )
         result = await handler(request)
-        if before_block is None:
+        if before is None or before_block is None:
             return result
         return await asyncio.to_thread(
-            self._result_after_restore, request, path, before_block, result
+            self._result_after_restore, request, path, before, before_block, result
         )

--- a/libs/code/deepagents_code/memory_guard.py
+++ b/libs/code/deepagents_code/memory_guard.py
@@ -10,64 +10,111 @@ block.
 
 This middleware intercepts `write_file`/`edit_file` calls targeting the guarded
 file(s). When a call would change or remove the managed block, the model's other
-edits are kept but the managed block is restored to its prior content, and an
-error is returned so the model learns the region is machine-managed.
+edits are kept (though surrounding whitespace may be normalized, and a fully
+removed block is re-appended rather than restored in place) while the managed
+block is restored, and an error is returned so the model learns the region is
+machine-managed. When the block was altered but the restore could not be
+completed, an error is still returned so the failure is never silent.
 """
 
 from __future__ import annotations
 
 import logging
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import ToolMessage
 
 from deepagents_code.onboarding import (
     _upsert_onboarding_name_memory,
     extract_onboarding_name_block,
+    strip_onboarding_name_markers,
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Iterable
 
-    from langchain_core.messages import ToolMessage
     from langgraph.prebuilt.tool_node import ToolCallRequest
     from langgraph.types import Command
 
 logger = logging.getLogger(__name__)
 
 _GUARDED_TOOLS: frozenset[str] = frozenset({"write_file", "edit_file"})
+"""Tool names whose calls can mutate a guarded file and must be inspected."""
 
 _REJECTION_MESSAGE = (
-    "The region between the `deepagents:onboarding-name` markers in "
-    "{path} is machine-managed and must not be edited. Your other changes "
-    "to the file were kept, but the managed block was restored to its "
-    "previous content. Do not modify content between those markers."
+    "The region between the `deepagents:onboarding-name:start` and "
+    "`deepagents:onboarding-name:end` markers in {path} is machine-managed and "
+    "must not be edited. Your other changes to the file were kept, but the "
+    "managed block was restored to its previous content. Do not modify content "
+    "between those markers."
 )
+"""Error returned when a managed-block edit was reverted (`{path}` formatted in)."""
+
+_RESTORE_FAILED_MESSAGE = (
+    "The region between the `deepagents:onboarding-name:start` and "
+    "`deepagents:onboarding-name:end` markers in {path} is machine-managed and "
+    "must not be edited. Your edit changed it and the previous content could "
+    "not be restored, so the managed block may now be corrupted. Do not modify "
+    "content between those markers, and do not rely on this edit having "
+    "succeeded."
+)
+"""Error returned when a managed-block edit could not be reverted."""
+
+
+class _RestoreOutcome(Enum):
+    """Result of attempting to restore a managed block after a tool call."""
+
+    UNCHANGED = "unchanged"
+    """The managed block was not altered; nothing to restore."""
+
+    RESTORED = "restored"
+    """The managed block was altered and successfully restored."""
+
+    FAILED = "failed"
+    """The managed block was altered but could not be restored."""
 
 
 class ManagedMemoryGuardMiddleware(AgentMiddleware):
     """Revert agent edits to the managed onboarding-name memory block.
 
-    Guards a fixed set of memory files. A `write_file`/`edit_file` that leaves
-    the managed block untouched passes through; one that alters or drops it has
-    the block restored (other edits preserved) and returns an error.
+    Guards the managed onboarding-name block in a fixed set of memory files. A
+    `write_file`/`edit_file` that leaves the managed block untouched passes
+    through; one that alters or drops it has the block restored (other edits
+    kept) and returns an error. If the restore itself fails, an error is still
+    returned so the failure is never silent.
     """
 
-    def __init__(self, guarded_paths: list[str]) -> None:
+    def __init__(self, guarded_paths: Iterable[str | Path]) -> None:
         """Initialize the guard with the memory files to protect.
 
         Args:
-            guarded_paths: Absolute paths whose managed onboarding-name block
-                must be protected from agent edits.
+            guarded_paths: Paths whose managed onboarding-name block must be
+                protected from agent edits. Resolved to absolute form for
+                matching; unresolvable entries are skipped.
         """
         super().__init__()
-        self._guarded: set[Path] = set()
-        for raw in guarded_paths:
+        requested = list(guarded_paths)
+        resolved: set[Path] = set()
+        for raw in requested:
             try:
-                self._guarded.add(Path(raw).expanduser().resolve())
+                resolved.add(Path(raw).expanduser().resolve())
             except (OSError, RuntimeError, ValueError):
-                logger.debug("Could not resolve guarded memory path %r", raw)
+                logger.warning(
+                    "Could not resolve guarded memory path %r", raw, exc_info=True
+                )
+        self._guarded: frozenset[Path] = frozenset(resolved)
+        if requested and not self._guarded:
+            # Every configured path failed to resolve, so this guard now
+            # protects nothing. That nullifies an integrity control, so surface
+            # it loudly rather than letting protection silently disappear.
+            logger.error(
+                "ManagedMemoryGuardMiddleware resolved no guarded paths from %r; "
+                "managed memory-block protection is disabled",
+                requested,
+            )
 
     def _guarded_path(self, request: ToolCallRequest) -> Path | None:
         """Return the resolved guarded path targeted by the call, if any.
@@ -84,6 +131,14 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
         try:
             resolved = Path(file_path).expanduser().resolve()
         except (OSError, RuntimeError, ValueError):
+            # A guarded-tool call whose path won't resolve could be an attempt
+            # to slip past the set-membership match, so leave a trail.
+            logger.warning(
+                "Could not resolve target path %r for %s",
+                file_path,
+                request.tool_call["name"],
+                exc_info=True,
+            )
             return None
         return resolved if resolved in self._guarded else None
 
@@ -96,46 +151,102 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
         """
         try:
             return path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            # Expected when the guarded file has not been created yet.
+            return None
         except (OSError, UnicodeDecodeError):
+            # An existing-but-unreadable guarded file would otherwise silently
+            # disable protection for this call, so make it visible.
+            logger.warning("Could not read guarded memory file %s", path, exc_info=True)
             return None
 
-    def _restore(self, path: Path, before_block: str) -> bool:
+    def _restore(self, path: Path, before_block: str) -> _RestoreOutcome:
         """Re-apply `before_block` into `path`, preserving other edits.
 
+        The restored content is verified before it is written, so a malformed
+        re-insertion (for example from a partially deleted block) is reported as
+        a failure instead of being persisted.
+
         Returns:
-            `True` when the managed block was restored, otherwise `False`.
+            `UNCHANGED` when the block was untouched, `RESTORED` when it was
+                altered and successfully restored, or `FAILED` when it was
+                altered but could not be restored.
         """
         after = self._read(path)
         if after is None:
-            return False
-        if extract_onboarding_name_block(after) == before_block:
-            return False
-        try:
-            path.write_text(
-                _upsert_onboarding_name_memory(after, before_block),
-                encoding="utf-8",
+            # The file vanished or became unreadable after the edit, so the
+            # block cannot be restored. Treat as a failure rather than passing
+            # the clobbering edit through as a success.
+            logger.warning(
+                "Guarded memory file %s is unreadable after edit; "
+                "cannot restore managed block",
+                path,
             )
+            return _RestoreOutcome.FAILED
+        block_after = extract_onboarding_name_block(after)
+        if block_after == before_block:
+            return _RestoreOutcome.UNCHANGED
+        if block_after is not None:
+            # Markers are intact but the content between them changed; let the
+            # upsert replace the block in place so the edit is fully reverted.
+            source = after
+        else:
+            # The markers were altered or dropped. Strip any fragments the edit
+            # left behind so the re-inserted block can't collide with an
+            # orphaned marker, then re-append a clean block.
+            source = strip_onboarding_name_markers(after)
+        restored = _upsert_onboarding_name_memory(source, before_block)
+        if extract_onboarding_name_block(restored) != before_block:
+            logger.error(
+                "Restored content for %s did not reproduce the managed block; "
+                "leaving the edited file untouched",
+                path,
+            )
+            return _RestoreOutcome.FAILED
+        try:
+            path.write_text(restored, encoding="utf-8")
         except OSError:
             logger.warning(
                 "Could not restore managed memory block at %s", path, exc_info=True
             )
-            return False
-        return True
+            return _RestoreOutcome.FAILED
+        return _RestoreOutcome.RESTORED
 
     @staticmethod
-    def _error(request: ToolCallRequest, path: Path) -> ToolMessage:
-        """Build the error result returned after a reverted managed-block edit.
+    def _error(
+        request: ToolCallRequest, path: Path, *, restore_failed: bool
+    ) -> ToolMessage:
+        """Build the error result returned after a managed-block edit.
 
         Returns:
             An error-status `ToolMessage` explaining the managed region.
         """
-        from langchain_core.messages import ToolMessage as LCToolMessage
-
-        return LCToolMessage(
-            content=_REJECTION_MESSAGE.format(path=path),
+        template = _RESTORE_FAILED_MESSAGE if restore_failed else _REJECTION_MESSAGE
+        return ToolMessage(
+            content=template.format(path=path),
             name=request.tool_call["name"],
             tool_call_id=request.tool_call["id"],
             status="error",
+        )
+
+    def _result_after_restore(
+        self,
+        request: ToolCallRequest,
+        path: Path,
+        before_block: str,
+        result: ToolMessage | Command[Any],
+    ) -> ToolMessage | Command[Any]:
+        """Restore the managed block and pick the result to return.
+
+        Returns:
+            The original `result` when the block was untouched, otherwise an
+                error `ToolMessage` describing the restore.
+        """
+        outcome = self._restore(path, before_block)
+        if outcome is _RestoreOutcome.UNCHANGED:
+            return result
+        return self._error(
+            request, path, restore_failed=outcome is _RestoreOutcome.FAILED
         )
 
     def wrap_tool_call(
@@ -147,7 +258,7 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
 
         Returns:
             The tool result, or an error `ToolMessage` when the managed block
-                was altered and restored.
+                was altered.
         """
         path = self._guarded_path(request)
         if path is None:
@@ -159,9 +270,7 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
         result = handler(request)
         if before_block is None:
             return result
-        if self._restore(path, before_block):
-            return self._error(request, path)
-        return result
+        return self._result_after_restore(request, path, before_block, result)
 
     async def awrap_tool_call(
         self,
@@ -172,7 +281,7 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
 
         Returns:
             The tool result, or an error `ToolMessage` when the managed block
-                was altered and restored.
+                was altered.
         """
         path = self._guarded_path(request)
         if path is None:
@@ -184,6 +293,4 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
         result = await handler(request)
         if before_block is None:
             return result
-        if self._restore(path, before_block):
-            return self._error(request, path)
-        return result
+        return self._result_after_restore(request, path, before_block, result)

--- a/libs/code/deepagents_code/memory_guard.py
+++ b/libs/code/deepagents_code/memory_guard.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from difflib import SequenceMatcher
 from enum import Enum
 from pathlib import Path
@@ -152,7 +153,9 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
             File content, or `None` when the file is missing or unreadable.
         """
         try:
-            return path.read_text(encoding="utf-8")
+            fd = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+            with os.fdopen(fd, "r", encoding="utf-8") as f:
+                return f.read()
         except FileNotFoundError:
             # Expected when the guarded file has not been created yet.
             return None
@@ -161,6 +164,16 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
             # disable protection for this call, so make it visible.
             logger.warning("Could not read guarded memory file %s", path, exc_info=True)
             return None
+
+    @staticmethod
+    def _write(path: Path, content: str) -> None:
+        """Write `content` to `path` without following symlinks."""
+        flags = os.O_WRONLY | os.O_TRUNC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags)
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as f:
+            f.write(content)
 
     @staticmethod
     def _line_range_for_block(before: str, before_block: str) -> tuple[int, int] | None:
@@ -298,8 +311,8 @@ class ManagedMemoryGuardMiddleware(AgentMiddleware):
             )
             return _RestoreOutcome.FAILED
         try:
-            path.write_text(restored, encoding="utf-8")
-        except OSError:
+            self._write(path, restored)
+        except (OSError, UnicodeEncodeError):
             logger.warning(
                 "Could not restore managed memory block at %s", path, exc_info=True
             )

--- a/libs/code/deepagents_code/onboarding.py
+++ b/libs/code/deepagents_code/onboarding.py
@@ -174,6 +174,23 @@ def _upsert_onboarding_name_memory(existing: str, block: str) -> str:
     return f"{base}\n\n## User Preferences\n\n{block}\n"
 
 
+def extract_onboarding_name_block(text: str) -> str | None:
+    """Return the managed onboarding name block (markers included) if present.
+
+    Args:
+        text: Memory file content to inspect.
+
+    Returns:
+        The substring from the start marker through the end marker, or `None`
+            when a well-formed block is absent.
+    """
+    start = text.find(ONBOARDING_NAME_MEMORY_START)
+    end = text.find(ONBOARDING_NAME_MEMORY_END)
+    if start == -1 or end == -1 or start >= end:
+        return None
+    return text[start : end + len(ONBOARDING_NAME_MEMORY_END)]
+
+
 def should_run_onboarding(state_dir: Path | None = None) -> bool:
     """Return whether onboarding should open at interactive startup.
 

--- a/libs/code/deepagents_code/onboarding.py
+++ b/libs/code/deepagents_code/onboarding.py
@@ -191,6 +191,24 @@ def extract_onboarding_name_block(text: str) -> str | None:
     return text[start : end + len(ONBOARDING_NAME_MEMORY_END)]
 
 
+def strip_onboarding_name_markers(text: str) -> str:
+    """Remove every onboarding-name marker occurrence from `text`.
+
+    A partial edit can leave a lone start or end marker behind. Stripping all
+    marker strings before re-inserting the managed block keeps re-insertion from
+    producing orphaned markers that would confuse `extract_onboarding_name_block`.
+
+    Args:
+        text: Memory file content to sanitize.
+
+    Returns:
+        `text` with all start and end marker strings removed.
+    """
+    return text.replace(ONBOARDING_NAME_MEMORY_START, "").replace(
+        ONBOARDING_NAME_MEMORY_END, ""
+    )
+
+
 def should_run_onboarding(state_dir: Path | None = None) -> bool:
     """Return whether onboarding should open at interactive startup.
 

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -2612,6 +2612,109 @@ class TestCreateCliAgentShellMiddlewareWiring:
             isinstance(mw, ConfigurableModelMiddleware) for mw in pinned_middleware
         ), "Pinned subagent must not gain configurable model middleware"
 
+    def test_subagents_get_managed_memory_guard_when_memory_enabled(
+        self, tmp_path: Path
+    ) -> None:
+        """Subagents share the disk backend, so they get the managed-block guard."""
+        from deepagents_code.memory_guard import ManagedMemoryGuardMiddleware
+
+        mock_settings = self._build_mock_settings(tmp_path)
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
+        fake_model = _make_fake_chat_model()
+
+        subagent_meta = {
+            "name": "researcher",
+            "description": "Researches things",
+            "system_prompt": "Investigate the task thoroughly.",
+            "model": None,
+        }
+
+        with (
+            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.SkillsMiddleware"),
+            patch("deepagents_code.agent.MemoryMiddleware"),
+            patch(
+                "deepagents_code.agent.list_subagents",
+                return_value=[subagent_meta],
+            ),
+            patch(
+                "deepagents_code.agent.create_deep_agent",
+                return_value=mock_agent,
+            ) as mock_create,
+            patch(
+                "deepagents._models.init_chat_model",
+                return_value=fake_model,
+            ),
+        ):
+            create_cli_agent(
+                model="fake-model",
+                assistant_id="test",
+                enable_memory=True,
+                enable_skills=False,
+                enable_shell=False,
+            )
+
+        _, kwargs = mock_create.call_args
+        subagents_by_name = {
+            subagent["name"]: subagent for subagent in kwargs["subagents"]
+        }
+        for name in ("researcher", "general-purpose"):
+            middleware = subagents_by_name[name]["middleware"]
+            assert any(
+                isinstance(mw, ManagedMemoryGuardMiddleware) for mw in middleware
+            ), f"Expected managed memory guard on subagent {name!r}"
+
+    def test_subagents_skip_managed_memory_guard_when_memory_disabled(
+        self, tmp_path: Path
+    ) -> None:
+        """With memory off there is no managed block, so no guard is added."""
+        from deepagents_code.memory_guard import ManagedMemoryGuardMiddleware
+
+        mock_settings = self._build_mock_settings(tmp_path)
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
+        fake_model = _make_fake_chat_model()
+
+        subagent_meta = {
+            "name": "researcher",
+            "description": "Researches things",
+            "system_prompt": "Investigate the task thoroughly.",
+            "model": None,
+        }
+
+        with (
+            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.SkillsMiddleware"),
+            patch("deepagents_code.agent.MemoryMiddleware"),
+            patch(
+                "deepagents_code.agent.list_subagents",
+                return_value=[subagent_meta],
+            ),
+            patch(
+                "deepagents_code.agent.create_deep_agent",
+                return_value=mock_agent,
+            ) as mock_create,
+            patch(
+                "deepagents._models.init_chat_model",
+                return_value=fake_model,
+            ),
+        ):
+            create_cli_agent(
+                model="fake-model",
+                assistant_id="test",
+                enable_memory=False,
+                enable_skills=False,
+                enable_shell=False,
+            )
+
+        _, kwargs = mock_create.call_args
+        for subagent in kwargs["subagents"]:
+            assert not any(
+                isinstance(mw, ManagedMemoryGuardMiddleware)
+                for mw in subagent["middleware"]
+            ), f"Subagent {subagent['name']!r} should not have the memory guard"
+
     def test_empty_string_subagent_model_treated_as_implicit(
         self, tmp_path: Path
     ) -> None:

--- a/libs/code/tests/unit_tests/test_memory_guard.py
+++ b/libs/code/tests/unit_tests/test_memory_guard.py
@@ -222,17 +222,15 @@ def test_edit_removing_block_is_restored(tmp_path) -> None:
 def test_partial_marker_edit_is_restored(tmp_path) -> None:
     """Deleting one marker still restores a clean block without orphan markers."""
     path = tmp_path / "agent" / "AGENTS.md"
-    _managed_file(path, "Ada")
+    _managed_file(path, "Ada", extra="\nOld note.\n")
     middleware = ManagedMemoryGuardMiddleware([str(path)])
 
     def handler(_request: ToolCallRequest) -> ToolMessage:
-        # Drop only the end marker, leaving a dangling start marker behind.
-        path.write_text(
-            path.read_text(encoding="utf-8").replace(
-                f"{ONBOARDING_NAME_MEMORY_END}\n", ""
-            ),
-            encoding="utf-8",
-        )
+        text = path.read_text(encoding="utf-8")
+        text = text.replace(f"{ONBOARDING_NAME_MEMORY_END}\n", "")
+        text = text.replace("Ada", "Mallory")
+        text = text.replace("Old note.", "New note.")
+        path.write_text(text, encoding="utf-8")
         return _success()
 
     result = middleware.wrap_tool_call(_request("edit_file", str(path)), handler)
@@ -243,6 +241,9 @@ def test_partial_marker_edit_is_restored(tmp_path) -> None:
     assert extract_onboarding_name_block(content) is not None
     assert content.count(ONBOARDING_NAME_MEMORY_START) == 1
     assert content.count(ONBOARDING_NAME_MEMORY_END) == 1
+    assert content.count('- The user\'s preferred name is "Ada".') == 1
+    assert "Mallory" not in content
+    assert "New note." in content
 
 
 def test_write_file_altering_block_is_reverted(tmp_path) -> None:
@@ -355,11 +356,14 @@ async def test_async_guard_filesystem_helpers_run_off_event_loop(
     def result_after_restore(
         request: ToolCallRequest,
         path: Path,
+        before: str,
         before_block: str,
         result: ToolMessage | Command[Any],
     ) -> ToolMessage | Command[Any]:
         helper_threads.append(threading.get_ident())
-        return original_result_after_restore(request, path, before_block, result)
+        return original_result_after_restore(
+            request, path, before, before_block, result
+        )
 
     monkeypatch.setattr(middleware, "_guarded_path", guarded_path)
     monkeypatch.setattr(middleware, "_read", read)

--- a/libs/code/tests/unit_tests/test_memory_guard.py
+++ b/libs/code/tests/unit_tests/test_memory_guard.py
@@ -1,0 +1,193 @@
+"""Tests for the managed onboarding-name memory guard middleware."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+from langchain_core.messages import ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
+
+from deepagents_code.memory_guard import ManagedMemoryGuardMiddleware
+from deepagents_code.onboarding import (
+    ONBOARDING_NAME_MEMORY_END,
+    ONBOARDING_NAME_MEMORY_START,
+    extract_onboarding_name_block,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _managed_file(path: Path, name: str = "Ada", *, extra: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "## User Preferences\n\n"
+        f"{ONBOARDING_NAME_MEMORY_START}\n"
+        f'- The user\'s preferred name is "{name}".\n'
+        f"{ONBOARDING_NAME_MEMORY_END}\n"
+        f"{extra}",
+        encoding="utf-8",
+    )
+
+
+def _request(tool_name: str, file_path: str, **args: Any) -> ToolCallRequest:
+    return ToolCallRequest(
+        runtime=cast("Any", None),
+        tool_call={
+            "id": "call-1",
+            "name": tool_name,
+            "args": {"file_path": file_path, **args},
+        },
+        state={},
+        tool=None,
+    )
+
+
+def _success(name: str = "edit_file") -> ToolMessage:
+    return ToolMessage(content="ok", name=name, tool_call_id="call-1", status="success")
+
+
+def test_edit_inside_managed_block_is_reverted(tmp_path) -> None:
+    """An edit that rewrites the managed block is restored and reported as error."""
+    path = tmp_path / "agent" / "AGENTS.md"
+    _managed_file(path, "Ada", extra="\nKeep this note.\n")
+    middleware = ManagedMemoryGuardMiddleware([str(path)])
+
+    def handler(_request: ToolCallRequest) -> ToolMessage:
+        path.write_text(
+            path.read_text(encoding="utf-8").replace("Ada", "Mallory"),
+            encoding="utf-8",
+        )
+        return _success()
+
+    result = middleware.wrap_tool_call(_request("edit_file", str(path)), handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    content = path.read_text(encoding="utf-8")
+    assert '- The user\'s preferred name is "Ada".' in content
+    assert "Mallory" not in content
+    assert "Keep this note." in content
+
+
+def test_edit_outside_managed_block_passes_through(tmp_path) -> None:
+    """Edits that leave the managed block intact are not disturbed."""
+    path = tmp_path / "agent" / "AGENTS.md"
+    _managed_file(path, "Ada", extra="\nOld note.\n")
+    middleware = ManagedMemoryGuardMiddleware([str(path)])
+
+    def handler(_request: ToolCallRequest) -> ToolMessage:
+        path.write_text(
+            path.read_text(encoding="utf-8").replace("Old note.", "New note."),
+            encoding="utf-8",
+        )
+        return _success()
+
+    result = middleware.wrap_tool_call(_request("edit_file", str(path)), handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "success"
+    content = path.read_text(encoding="utf-8")
+    assert "New note." in content
+    assert extract_onboarding_name_block(content) is not None
+    assert '- The user\'s preferred name is "Ada".' in content
+
+
+def test_other_edits_preserved_when_block_reverted(tmp_path) -> None:
+    """The model's unrelated edits survive even when the managed block is restored."""
+    path = tmp_path / "agent" / "AGENTS.md"
+    _managed_file(path, "Ada", extra="\nKeep this note.\n")
+    middleware = ManagedMemoryGuardMiddleware([str(path)])
+
+    def handler(_request: ToolCallRequest) -> ToolMessage:
+        text = path.read_text(encoding="utf-8")
+        text = text.replace("Ada", "Mallory").replace(
+            "Keep this note.", "Added a real learning."
+        )
+        path.write_text(text, encoding="utf-8")
+        return _success()
+
+    result = middleware.wrap_tool_call(_request("edit_file", str(path)), handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    content = path.read_text(encoding="utf-8")
+    assert '- The user\'s preferred name is "Ada".' in content
+    assert "Mallory" not in content
+    assert "Added a real learning." in content
+
+
+def test_unguarded_file_passes_through(tmp_path) -> None:
+    """A guarded middleware ignores writes to other files."""
+    guarded = tmp_path / "agent" / "AGENTS.md"
+    _managed_file(guarded, "Ada")
+    other = tmp_path / "project" / "AGENTS.md"
+    other.parent.mkdir(parents=True)
+    other.write_text("project notes\n", encoding="utf-8")
+    middleware = ManagedMemoryGuardMiddleware([str(guarded)])
+
+    def handler(_request: ToolCallRequest) -> ToolMessage:
+        other.write_text("rewritten\n", encoding="utf-8")
+        return _success("write_file")
+
+    result = middleware.wrap_tool_call(
+        _request("write_file", str(other), content="rewritten\n"), handler
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "success"
+    assert other.read_text(encoding="utf-8") == "rewritten\n"
+
+
+def test_non_write_tool_passes_through(tmp_path) -> None:
+    """Read-only tools targeting the guarded file are never intercepted."""
+    path = tmp_path / "agent" / "AGENTS.md"
+    _managed_file(path, "Ada")
+    middleware = ManagedMemoryGuardMiddleware([str(path)])
+
+    sentinel = ToolMessage(
+        content="contents", name="read_file", tool_call_id="call-1", status="success"
+    )
+    result = middleware.wrap_tool_call(
+        _request("read_file", str(path)), lambda _r: sentinel
+    )
+
+    assert result is sentinel
+
+
+def test_file_without_managed_block_passes_through(tmp_path) -> None:
+    """When no managed block exists, edits are left untouched."""
+    path = tmp_path / "agent" / "AGENTS.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("## Notes\n\nfreeform\n", encoding="utf-8")
+    middleware = ManagedMemoryGuardMiddleware([str(path)])
+
+    def handler(_request: ToolCallRequest) -> ToolMessage:
+        path.write_text("## Notes\n\nedited\n", encoding="utf-8")
+        return _success()
+
+    result = middleware.wrap_tool_call(_request("edit_file", str(path)), handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "success"
+    assert "edited" in path.read_text(encoding="utf-8")
+
+
+async def test_async_edit_inside_managed_block_is_reverted(tmp_path) -> None:
+    """The async wrapper reverts managed-block edits like the sync path."""
+    path = tmp_path / "agent" / "AGENTS.md"
+    _managed_file(path, "Ada")
+    middleware = ManagedMemoryGuardMiddleware([str(path)])
+
+    async def handler(_request: ToolCallRequest) -> ToolMessage:  # noqa: RUF029
+        path.write_text(
+            path.read_text(encoding="utf-8").replace("Ada", "Mallory"),
+            encoding="utf-8",
+        )
+        return _success()
+
+    result = await middleware.awrap_tool_call(_request("edit_file", str(path)), handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert "Mallory" not in path.read_text(encoding="utf-8")

--- a/libs/code/tests/unit_tests/test_memory_guard.py
+++ b/libs/code/tests/unit_tests/test_memory_guard.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import os
 import threading
 from typing import TYPE_CHECKING, Any, cast
 
+import pytest
 from langchain_core.messages import ToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
 
@@ -118,6 +120,31 @@ def test_other_edits_preserved_when_block_reverted(tmp_path) -> None:
     assert '- The user\'s preferred name is "Ada".' in content
     assert "Mallory" not in content
     assert "Added a real learning." in content
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "O_NOFOLLOW"),
+    reason="symlink hardening requires O_NOFOLLOW",
+)
+def test_restore_does_not_follow_replaced_guarded_file_symlink(tmp_path) -> None:
+    """A symlink swap during restore must not overwrite the symlink target."""
+    path = tmp_path / "agent" / "AGENTS.md"
+    target = tmp_path / "target.txt"
+    _managed_file(path, "Ada")
+    target.write_text("do not overwrite\n", encoding="utf-8")
+    middleware = ManagedMemoryGuardMiddleware([str(path)])
+
+    def handler(_request: ToolCallRequest) -> ToolMessage:
+        path.unlink()
+        path.symlink_to(target)
+        return _success()
+
+    result = middleware.wrap_tool_call(_request("edit_file", str(path)), handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert target.read_text(encoding="utf-8") == "do not overwrite\n"
+    assert path.is_symlink()
 
 
 def test_unguarded_file_passes_through(tmp_path) -> None:

--- a/libs/code/tests/unit_tests/test_memory_guard.py
+++ b/libs/code/tests/unit_tests/test_memory_guard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Any, cast
 
 from langchain_core.messages import ToolMessage
@@ -16,6 +17,8 @@ from deepagents_code.onboarding import (
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from langgraph.types import Command
 
 
 def _managed_file(path: Path, name: str = "Ada", *, extra: str = "") -> None:
@@ -325,3 +328,53 @@ async def test_async_edit_outside_block_passes_through(tmp_path) -> None:
     content = path.read_text(encoding="utf-8")
     assert "New note." in content
     assert extract_onboarding_name_block(content) is not None
+
+
+async def test_async_guard_filesystem_helpers_run_off_event_loop(
+    tmp_path, monkeypatch
+) -> None:
+    """The async wrapper offloads guard filesystem work to worker threads."""
+    path = tmp_path / "agent" / "AGENTS.md"
+    _managed_file(path, "Ada")
+    middleware = ManagedMemoryGuardMiddleware([str(path)])
+    event_loop_thread = threading.get_ident()
+    helper_threads: list[int] = []
+
+    original_guarded_path = middleware._guarded_path
+    original_read = middleware._read
+    original_result_after_restore = middleware._result_after_restore
+
+    def guarded_path(request: ToolCallRequest) -> Path | None:
+        helper_threads.append(threading.get_ident())
+        return original_guarded_path(request)
+
+    def read(path: Path) -> str | None:
+        helper_threads.append(threading.get_ident())
+        return original_read(path)
+
+    def result_after_restore(
+        request: ToolCallRequest,
+        path: Path,
+        before_block: str,
+        result: ToolMessage | Command[Any],
+    ) -> ToolMessage | Command[Any]:
+        helper_threads.append(threading.get_ident())
+        return original_result_after_restore(request, path, before_block, result)
+
+    monkeypatch.setattr(middleware, "_guarded_path", guarded_path)
+    monkeypatch.setattr(middleware, "_read", read)
+    monkeypatch.setattr(middleware, "_result_after_restore", result_after_restore)
+
+    async def handler(_request: ToolCallRequest) -> ToolMessage:  # noqa: RUF029
+        path.write_text(
+            path.read_text(encoding="utf-8").replace("Ada", "Mallory"),
+            encoding="utf-8",
+        )
+        return _success()
+
+    result = await middleware.awrap_tool_call(_request("edit_file", str(path)), handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert helper_threads
+    assert all(thread != event_loop_thread for thread in helper_threads)

--- a/libs/code/tests/unit_tests/test_memory_guard.py
+++ b/libs/code/tests/unit_tests/test_memory_guard.py
@@ -191,3 +191,137 @@ async def test_async_edit_inside_managed_block_is_reverted(tmp_path) -> None:
     assert isinstance(result, ToolMessage)
     assert result.status == "error"
     assert "Mallory" not in path.read_text(encoding="utf-8")
+
+
+def test_edit_removing_block_is_restored(tmp_path) -> None:
+    """Dropping the managed block entirely restores it and reports an error."""
+    path = tmp_path / "agent" / "AGENTS.md"
+    _managed_file(path, "Ada", extra="\nKeep this note.\n")
+    middleware = ManagedMemoryGuardMiddleware([str(path)])
+
+    def handler(_request: ToolCallRequest) -> ToolMessage:
+        text = path.read_text(encoding="utf-8")
+        block = extract_onboarding_name_block(text)
+        assert block is not None
+        path.write_text(text.replace(block, "").rstrip() + "\n", encoding="utf-8")
+        return _success()
+
+    result = middleware.wrap_tool_call(_request("edit_file", str(path)), handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    content = path.read_text(encoding="utf-8")
+    assert extract_onboarding_name_block(content) is not None
+    assert '- The user\'s preferred name is "Ada".' in content
+    assert "Keep this note." in content
+
+
+def test_partial_marker_edit_is_restored(tmp_path) -> None:
+    """Deleting one marker still restores a clean block without orphan markers."""
+    path = tmp_path / "agent" / "AGENTS.md"
+    _managed_file(path, "Ada")
+    middleware = ManagedMemoryGuardMiddleware([str(path)])
+
+    def handler(_request: ToolCallRequest) -> ToolMessage:
+        # Drop only the end marker, leaving a dangling start marker behind.
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                f"{ONBOARDING_NAME_MEMORY_END}\n", ""
+            ),
+            encoding="utf-8",
+        )
+        return _success()
+
+    result = middleware.wrap_tool_call(_request("edit_file", str(path)), handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    content = path.read_text(encoding="utf-8")
+    assert extract_onboarding_name_block(content) is not None
+    assert content.count(ONBOARDING_NAME_MEMORY_START) == 1
+    assert content.count(ONBOARDING_NAME_MEMORY_END) == 1
+
+
+def test_write_file_altering_block_is_reverted(tmp_path) -> None:
+    """`write_file` clobbering the block is reverted like `edit_file`."""
+    path = tmp_path / "agent" / "AGENTS.md"
+    _managed_file(path, "Ada")
+    middleware = ManagedMemoryGuardMiddleware([str(path)])
+
+    def handler(_request: ToolCallRequest) -> ToolMessage:
+        path.write_text(
+            path.read_text(encoding="utf-8").replace("Ada", "Mallory"),
+            encoding="utf-8",
+        )
+        return _success("write_file")
+
+    result = middleware.wrap_tool_call(
+        _request("write_file", str(path), content="ignored"), handler
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    content = path.read_text(encoding="utf-8")
+    assert "Mallory" not in content
+    assert '- The user\'s preferred name is "Ada".' in content
+
+
+def test_file_created_with_block_passes_through(tmp_path) -> None:
+    """Creating the guarded file with a fresh block is not treated as an edit."""
+    path = tmp_path / "agent" / "AGENTS.md"  # does not exist yet
+    middleware = ManagedMemoryGuardMiddleware([str(path)])
+
+    def handler(_request: ToolCallRequest) -> ToolMessage:
+        _managed_file(path, "Ada")
+        return _success("write_file")
+
+    result = middleware.wrap_tool_call(
+        _request("write_file", str(path), content="ignored"), handler
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "success"
+    assert '- The user\'s preferred name is "Ada".' in path.read_text(encoding="utf-8")
+
+
+def test_error_message_propagates_call_metadata(tmp_path) -> None:
+    """The error result carries the originating tool name and call id."""
+    path = tmp_path / "agent" / "AGENTS.md"
+    _managed_file(path, "Ada")
+    middleware = ManagedMemoryGuardMiddleware([str(path)])
+
+    def handler(_request: ToolCallRequest) -> ToolMessage:
+        path.write_text(
+            path.read_text(encoding="utf-8").replace("Ada", "Mallory"),
+            encoding="utf-8",
+        )
+        return _success()
+
+    result = middleware.wrap_tool_call(_request("edit_file", str(path)), handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert result.name == "edit_file"
+    assert result.tool_call_id == "call-1"
+
+
+async def test_async_edit_outside_block_passes_through(tmp_path) -> None:
+    """The async wrapper passes through edits that leave the block intact."""
+    path = tmp_path / "agent" / "AGENTS.md"
+    _managed_file(path, "Ada", extra="\nOld note.\n")
+    middleware = ManagedMemoryGuardMiddleware([str(path)])
+
+    async def handler(_request: ToolCallRequest) -> ToolMessage:  # noqa: RUF029
+        path.write_text(
+            path.read_text(encoding="utf-8").replace("Old note.", "New note."),
+            encoding="utf-8",
+        )
+        return _success()
+
+    result = await middleware.awrap_tool_call(_request("edit_file", str(path)), handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "success"
+    content = path.read_text(encoding="utf-8")
+    assert "New note." in content
+    assert extract_onboarding_name_block(content) is not None

--- a/libs/code/tests/unit_tests/test_onboarding.py
+++ b/libs/code/tests/unit_tests/test_onboarding.py
@@ -9,6 +9,7 @@ from deepagents_code.onboarding import (
     ONBOARDING_MARKER_FILENAME,
     ONBOARDING_NAME_MEMORY_END,
     ONBOARDING_NAME_MEMORY_START,
+    extract_onboarding_name_block,
     has_completed_onboarding,
     mark_onboarding_complete,
     onboarding_marker_path,
@@ -239,3 +240,53 @@ class TestOnboardingState:
         assert content.count("## User Preferences") == 1
         assert ONBOARDING_NAME_MEMORY_START in content
         assert '- The user\'s preferred name is "Grace Hopper".' in content
+
+
+class TestExtractOnboardingNameBlock:
+    """Tests for `extract_onboarding_name_block`."""
+
+    def test_well_formed_block_returned_with_markers(self) -> None:
+        """A well-formed block is returned inclusive of both markers."""
+        block = (
+            f"{ONBOARDING_NAME_MEMORY_START}\n"
+            '- The user\'s preferred name is "Ada".\n'
+            f"{ONBOARDING_NAME_MEMORY_END}"
+        )
+        text = f"## User Preferences\n\n{block}\n"
+
+        assert extract_onboarding_name_block(text) == block
+
+    def test_trailing_content_after_end_marker_excluded(self) -> None:
+        """Extraction stops at the end marker and drops trailing content."""
+        block = (
+            f"{ONBOARDING_NAME_MEMORY_START}\n"
+            '- The user\'s preferred name is "Ada".\n'
+            f"{ONBOARDING_NAME_MEMORY_END}"
+        )
+        text = f"{block}\n\nUnrelated note after the block.\n"
+
+        assert extract_onboarding_name_block(text) == block
+
+    def test_only_start_marker_returns_none(self) -> None:
+        """A lone start marker is not a well-formed block."""
+        text = f"{ONBOARDING_NAME_MEMORY_START}\n- dangling content\n"
+
+        assert extract_onboarding_name_block(text) is None
+
+    def test_only_end_marker_returns_none(self) -> None:
+        """A lone end marker is not a well-formed block."""
+        text = f"- dangling content\n{ONBOARDING_NAME_MEMORY_END}\n"
+
+        assert extract_onboarding_name_block(text) is None
+
+    def test_end_before_start_returns_none(self) -> None:
+        """Markers in the wrong order are not a well-formed block."""
+        text = (
+            f"{ONBOARDING_NAME_MEMORY_END}\nbetween\n{ONBOARDING_NAME_MEMORY_START}\n"
+        )
+
+        assert extract_onboarding_name_block(text) is None
+
+    def test_no_markers_returns_none(self) -> None:
+        """Text without markers has no managed block."""
+        assert extract_onboarding_name_block("## Notes\n\nfreeform\n") is None


### PR DESCRIPTION
Protect the machine-managed onboarding-name block in the user `AGENTS.md` from being overwritten by agent file edits.

---

The onboarding flow writes the user's preferred name into the user `AGENTS.md` inside a block delimited by `deepagents:onboarding-name` HTML-comment markers. `MemoryMiddleware` strips HTML comments before injecting memory, so the model never sees those markers — yet the same prompt tells it to `edit_file` that file to persist learnings, leaving nothing to stop it from rewriting the managed block.

This adds `ManagedMemoryGuardMiddleware`, a deterministic `wrap_tool_call` guard wired into the agent's memory stack. When `write_file`/`edit_file` targets the guarded user `AGENTS.md` and changes (or drops) the managed block, the model's other edits are kept but the block is restored to its prior content via the existing `_upsert_onboarding_name_memory`, and an error is returned so the model learns the region is machine-managed. Edits that leave the block untouched, reads, and writes to other files pass through unchanged.

<details>
<summary>Scenario where this applies</summary>

A user has completed onboarding, so their preferred name is stored in the machine-managed block inside their user `AGENTS.md`.

Later, the agent tries to persist a new memory by calling `edit_file` on that file. `ManagedMemoryGuardMiddleware` intercepts the tool call to ensure the onboarding-name block is not changed. If the agent's edit touches or removes that block, the middleware preserves the agent's other edits, restores the onboarding-name block to its previous content, and returns an error telling the agent not to modify the machine-managed region.

</details>

Made by [Open SWE](https://openswe.vercel.app)
