### PR TITLE
fix(code): clarify `/restart` message during server startup

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -10123,7 +10123,7 @@ class DeepAgentsApp(App):
             )
             return
 
-        if self._server_proc is None or self._server_kwargs is None:
+        if self._server_kwargs is None:
             await self._mount_message(
                 AppMessage(
                     "Cannot restart: this app is connected to a remote "
@@ -10131,6 +10131,30 @@ class DeepAgentsApp(App):
                     "was reloaded; relaunch dcode to fully restart.",
                 ),
             )
+            return
+
+        # We own a server (`_server_kwargs is not None`) but `_server_proc`
+        # is only assigned once `ServerReady` fires. A `None` proc here means
+        # the server is still coming up — not remote-server mode. There's no
+        # subprocess to respawn yet, and config was already reloaded above, so
+        # the pending startup will use it.
+        if self._server_proc is None:
+            if self._server_startup_deferred:
+                await self._mount_message(
+                    AppMessage(
+                        "Server startup is waiting for a model. Configuration "
+                        "was reloaded; set credentials with `/auth` or pick a "
+                        "model with `/model` to start the server.",
+                    ),
+                )
+            else:
+                await self._mount_message(
+                    AppMessage(
+                        "The server is still starting. Configuration was "
+                        "reloaded and will apply once it finishes connecting; "
+                        "run `/restart` again afterward if needed.",
+                    ),
+                )
             return
 
         await self._mount_message(AppMessage("Restarting server..."))

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -10229,10 +10229,9 @@ class DeepAgentsApp(App):
             return
 
         # We own a server (`_server_kwargs is not None`) but `_server_proc`
-        # is only assigned once `ServerReady` fires. A `None` proc here means
-        # the server is still coming up — not remote-server mode. There's no
-        # subprocess to respawn yet, and config was already reloaded above, so
-        # the pending startup will use it.
+        # is only assigned once `ServerReady` fires. A `None` proc here can
+        # mean startup is still pending, deferred for model selection, or that
+        # startup already failed before a subprocess was available.
         if self._server_proc is None:
             if self._server_startup_deferred:
                 await self._mount_message(
@@ -10242,12 +10241,31 @@ class DeepAgentsApp(App):
                         "model with `/model` to start the server.",
                     ),
                 )
-            else:
+            elif self._connecting:
                 await self._mount_message(
                     AppMessage(
                         "The server is still starting. Configuration was "
                         "reloaded and will apply once it finishes connecting; "
                         "run `/restart` again afterward if needed.",
+                    ),
+                )
+            elif self._server_startup_error is not None:
+                await self._mount_message(
+                    AppMessage(
+                        "Cannot restart yet because the server did not finish "
+                        "starting. Configuration was reloaded; update "
+                        "credentials with `/auth` if needed, then pick a model "
+                        "with `/model` to try again. You can also relaunch "
+                        "dcode.\n\n"
+                        f"Last error: {self._server_startup_error}",
+                    ),
+                )
+            else:
+                await self._mount_message(
+                    AppMessage(
+                        "Cannot restart yet because the server is not running. "
+                        "Configuration was reloaded; relaunch dcode to start "
+                        "again.",
                     ),
                 )
             return

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -10228,17 +10228,25 @@ class DeepAgentsApp(App):
             )
             return
 
-        # We own a server (`_server_kwargs is not None`) but `_server_proc`
-        # is only assigned once `ServerReady` fires. A `None` proc here can
-        # mean startup is still pending, deferred for model selection, or that
-        # startup already failed before a subprocess was available.
-        if self._server_proc is None:
+        # We own a server (`_server_kwargs is not None`) but it may not be
+        # ready to respawn. `_server_proc` stays `None` until the startup
+        # worker obtains the subprocess (assigned before `ServerReady` is
+        # posted; see `_run_startup_worker`), and `_connecting` stays set until
+        # the `ServerReady` handler runs. Guarding on both also covers the
+        # brief window where the proc is assigned but the handler hasn't fired,
+        # where restarting would let the still-queued startup `ServerReady`
+        # clobber state with the just-killed proc. A match here means the
+        # server is still coming up, deferred for model selection, or failed
+        # before a subprocess existed — not remote-server mode. Mirrors the
+        # sibling guards elsewhere in this file.
+        if self._connecting or self._server_proc is None:
             if self._server_startup_deferred:
                 await self._mount_message(
                     AppMessage(
                         "Server startup is waiting for a model. Configuration "
-                        "was reloaded; set credentials with `/auth` or pick a "
-                        "model with `/model` to start the server.",
+                        "was reloaded; set credentials with `/auth`, reload the "
+                        "environment with `/reload`, or pick a model with "
+                        "`/model` to start the server.",
                     ),
                 )
             elif self._connecting:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -11158,8 +11158,9 @@ class TestRestartCommand:
         """`/restart` during startup must not show the remote-server message.
 
         We own a server (`_server_kwargs` set) but `_server_proc` is `None`
-        until `ServerReady` fires. The handler should report "still starting"
-        rather than the misleading "connected to a remote LangGraph server".
+        while the startup worker is still obtaining it. The handler should
+        report "still starting" rather than the misleading "connected to a
+        remote LangGraph server".
         """
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
@@ -11172,10 +11173,9 @@ class TestRestartCommand:
 
             called = False
 
-            async def _fail() -> bool:  # noqa: RUF029  # awaited by handler
+            async def _fail() -> None:  # noqa: RUF029  # awaited by handler
                 nonlocal called
                 called = True
-                return True
 
             from deepagents_code.config import settings
 
@@ -11191,6 +11191,7 @@ class TestRestartCommand:
             assert called is False
             app_msgs = [str(w._content) for w in app.query(AppMessage)]
             assert any("still starting" in m for m in app_msgs)
+            assert not any("waiting for a model" in m for m in app_msgs)
             assert not any("remote LangGraph server" in m for m in app_msgs)
 
     async def test_failed_startup_does_not_claim_still_starting(
@@ -11209,10 +11210,9 @@ class TestRestartCommand:
 
             called = False
 
-            async def _fail() -> bool:  # noqa: RUF029  # awaited by handler
+            async def _fail() -> None:  # noqa: RUF029  # awaited by handler
                 nonlocal called
                 called = True
-                return True
 
             from deepagents_code.config import settings
 
@@ -11232,6 +11232,7 @@ class TestRestartCommand:
                 "Last error: ModelConfigError: missing API key" in m for m in app_msgs
             )
             assert not any("still starting" in m for m in app_msgs)
+            assert not any("waiting for a model" in m for m in app_msgs)
             assert not any("remote LangGraph server" in m for m in app_msgs)
 
     async def test_deferred_startup_reports_waiting_for_model(
@@ -11248,10 +11249,9 @@ class TestRestartCommand:
 
             called = False
 
-            async def _fail() -> bool:  # noqa: RUF029  # awaited by handler
+            async def _fail() -> None:  # noqa: RUF029  # awaited by handler
                 nonlocal called
                 called = True
-                return True
 
             from deepagents_code.config import settings
 
@@ -11267,6 +11267,7 @@ class TestRestartCommand:
             assert called is False
             app_msgs = [str(w._content) for w in app.query(AppMessage)]
             assert any("waiting for a model" in m for m in app_msgs)
+            assert not any("still starting" in m for m in app_msgs)
             assert not any("remote LangGraph server" in m for m in app_msgs)
 
     async def test_calls_server_restart_and_clears_caches(

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -11168,6 +11168,7 @@ class TestRestartCommand:
             app._server_proc = None
             app._server_kwargs = {}
             app._server_startup_deferred = False
+            app._connecting = True
 
             called = False
 
@@ -11190,6 +11191,47 @@ class TestRestartCommand:
             assert called is False
             app_msgs = [str(w._content) for w in app.query(AppMessage)]
             assert any("still starting" in m for m in app_msgs)
+            assert not any("remote LangGraph server" in m for m in app_msgs)
+
+    async def test_failed_startup_does_not_claim_still_starting(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`/restart` after failed startup must not imply work is still pending."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._server_proc = None
+            app._server_kwargs = {}
+            app._server_startup_deferred = False
+            app._connecting = False
+            app._server_startup_error = "ModelConfigError: missing API key"
+
+            called = False
+
+            async def _fail() -> bool:  # noqa: RUF029  # awaited by handler
+                nonlocal called
+                called = True
+                return True
+
+            from deepagents_code.config import settings
+
+            monkeypatch.setattr(settings, "reload_from_environment", list)
+            monkeypatch.setattr(
+                "deepagents_code.model_config.clear_caches", lambda: None
+            )
+            monkeypatch.setattr(app, "_restart_server_manual", _fail)
+
+            await app._handle_command("/restart")
+            await pilot.pause()
+
+            assert called is False
+            app_msgs = [str(w._content) for w in app.query(AppMessage)]
+            assert any("server did not finish starting" in m for m in app_msgs)
+            assert any(
+                "Last error: ModelConfigError: missing API key" in m for m in app_msgs
+            )
+            assert not any("still starting" in m for m in app_msgs)
             assert not any("remote LangGraph server" in m for m in app_msgs)
 
     async def test_deferred_startup_reports_waiting_for_model(

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -11100,6 +11100,81 @@ class TestRestartCommand:
             app_msgs = [str(w._content) for w in app.query(AppMessage)]
             assert any("Cannot restart" in m for m in app_msgs)
 
+    async def test_server_still_starting_does_not_claim_remote(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`/restart` during startup must not show the remote-server message.
+
+        We own a server (`_server_kwargs` set) but `_server_proc` is `None`
+        until `ServerReady` fires. The handler should report "still starting"
+        rather than the misleading "connected to a remote LangGraph server".
+        """
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._server_proc = None
+            app._server_kwargs = {}
+            app._server_startup_deferred = False
+
+            called = False
+
+            async def _fail() -> bool:  # noqa: RUF029  # awaited by handler
+                nonlocal called
+                called = True
+                return True
+
+            from deepagents_code.config import settings
+
+            monkeypatch.setattr(settings, "reload_from_environment", list)
+            monkeypatch.setattr(
+                "deepagents_code.model_config.clear_caches", lambda: None
+            )
+            monkeypatch.setattr(app, "_restart_server_manual", _fail)
+
+            await app._handle_command("/restart")
+            await pilot.pause()
+
+            assert called is False
+            app_msgs = [str(w._content) for w in app.query(AppMessage)]
+            assert any("still starting" in m for m in app_msgs)
+            assert not any("remote LangGraph server" in m for m in app_msgs)
+
+    async def test_deferred_startup_reports_waiting_for_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`/restart` while startup is deferred guides the user to `/auth`/`/model`."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._server_proc = None
+            app._server_kwargs = {}
+            app._server_startup_deferred = True
+
+            called = False
+
+            async def _fail() -> bool:  # noqa: RUF029  # awaited by handler
+                nonlocal called
+                called = True
+                return True
+
+            from deepagents_code.config import settings
+
+            monkeypatch.setattr(settings, "reload_from_environment", list)
+            monkeypatch.setattr(
+                "deepagents_code.model_config.clear_caches", lambda: None
+            )
+            monkeypatch.setattr(app, "_restart_server_manual", _fail)
+
+            await app._handle_command("/restart")
+            await pilot.pause()
+
+            assert called is False
+            app_msgs = [str(w._content) for w in app.query(AppMessage)]
+            assert any("waiting for a model" in m for m in app_msgs)
+            assert not any("remote LangGraph server" in m for m in app_msgs)
+
     async def test_calls_server_restart_and_clears_caches(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
`/restart` during server startup now reports that the server is still starting instead of falsely claiming a remote-server connection.

Made by [Open SWE](https://openswe.vercel.app)