### PR TITLE
feat(code): persist `/threads` directory-scope preference

### DIFF
--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -2927,30 +2927,6 @@ def save_thread_sort_order(sort_order: str, config_path: Path | None = None) -> 
     return True
 
 
-def load_thread_scope(config_path: Path | None = None) -> str:
-    """Load the directory-scope preference for the thread selector.
-
-    Args:
-        config_path: Path to config file.
-
-    Returns:
-        `"cwd"` (current working directory) or `"all"` (all directories).
-    """
-    if config_path is None:
-        config_path = DEFAULT_CONFIG_PATH
-    try:
-        if not config_path.exists():
-            return "cwd"
-        with config_path.open("rb") as f:
-            data = tomllib.load(f)
-        value = data.get("threads", {}).get("scope")
-        if value in {"cwd", "all"}:
-            return value
-    except (OSError, tomllib.TOMLDecodeError):
-        logger.debug("Could not read thread scope config", exc_info=True)
-    return "cwd"
-
-
 def save_thread_scope(scope: str, config_path: Path | None = None) -> bool:
     """Save the directory-scope preference for the thread selector.
 
@@ -2984,11 +2960,15 @@ def save_thread_scope(scope: str, config_path: Path | None = None) -> bool:
             with os.fdopen(fd, "wb") as f:
                 tomli_w.dump(data, f)
             Path(tmp_path).replace(config_path)
-        except Exception:
+        except BaseException:
+            # Clean up temp file on any failure, including interrupts.
             with contextlib.suppress(OSError):
                 Path(tmp_path).unlink()
             raise
-    except (OSError, tomllib.TOMLDecodeError):
+    except (OSError, tomllib.TOMLDecodeError, TypeError, ValueError):
+        # `TypeError`/`ValueError` cover `tomli_w.dump` rejecting a payload
+        # from a pre-existing config that does not round-trip; folding them in
+        # keeps the `bool` contract intact for `_persist_scope`'s failure toast.
         logger.exception("Could not save thread scope preference")
         return False
     invalidate_thread_config_cache()

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -1174,8 +1174,6 @@ def _is_local_endpoint(url: str | None) -> bool:
     """Return whether a provider endpoint points at the local machine."""
     if not url:
         return True
-    if not isinstance(url, str):
-        return False
 
     # Bare hostname literal (no scheme, no port) — short-circuit so IPv6
     # forms like `::1` don't get misparsed by urlparse.
@@ -2060,7 +2058,10 @@ class ModelConfig:
 
         # Validate enabled field type and class_path format / params references
         for name, provider in self.providers.items():
-            enabled = provider.get("enabled")
+            # `enabled` originates from untyped TOML; cast to `object` so the
+            # runtime non-bool validation below stays reachable (the TypedDict
+            # types it as `bool`, which would otherwise mark this branch dead).
+            enabled = cast("object", provider.get("enabled"))
             if enabled is not None and not isinstance(enabled, bool):
                 logger.warning(
                     "Provider '%s' has non-boolean 'enabled' value %r "

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -2641,6 +2641,9 @@ class ThreadConfig(NamedTuple):
     sort_order: str
     """`'updated_at'` or `'created_at'`."""
 
+    scope: str
+    """`'cwd'` (current working directory) or `'all'` (all directories)."""
+
 
 _thread_config_cache: ThreadConfig | None = None
 
@@ -2669,10 +2672,11 @@ def load_thread_config(config_path: Path | None = None) -> ThreadConfig:
     columns = dict(THREAD_COLUMN_DEFAULTS)
     relative_time = True
     sort_order = "updated_at"
+    scope = "cwd"
 
     try:
         if not config_path.exists():
-            result = ThreadConfig(columns, relative_time, sort_order)
+            result = ThreadConfig(columns, relative_time, sort_order, scope)
             if use_default:
                 _thread_config_cache = result
             return result
@@ -2696,13 +2700,18 @@ def load_thread_config(config_path: Path | None = None) -> ThreadConfig:
         so_value = threads_section.get("sort_order")
         if so_value in {"updated_at", "created_at"}:
             sort_order = so_value
+
+        # scope
+        scope_value = threads_section.get("scope")
+        if scope_value in {"cwd", "all"}:
+            scope = scope_value
     except (OSError, tomllib.TOMLDecodeError):
         logger.warning("Could not read thread config; using defaults", exc_info=True)
         # Do not cache on error — allow retry on next call in case the
         # file is fixed or permissions are restored.
-        return ThreadConfig(columns, relative_time, sort_order)
+        return ThreadConfig(columns, relative_time, sort_order, scope)
 
-    result = ThreadConfig(columns, relative_time, sort_order)
+    result = ThreadConfig(columns, relative_time, sort_order, scope)
     if use_default:
         _thread_config_cache = result
     return result
@@ -2913,6 +2922,74 @@ def save_thread_sort_order(sort_order: str, config_path: Path | None = None) -> 
             raise
     except (OSError, tomllib.TOMLDecodeError):
         logger.exception("Could not save thread sort_order preference")
+        return False
+    invalidate_thread_config_cache()
+    return True
+
+
+def load_thread_scope(config_path: Path | None = None) -> str:
+    """Load the directory-scope preference for the thread selector.
+
+    Args:
+        config_path: Path to config file.
+
+    Returns:
+        `"cwd"` (current working directory) or `"all"` (all directories).
+    """
+    if config_path is None:
+        config_path = DEFAULT_CONFIG_PATH
+    try:
+        if not config_path.exists():
+            return "cwd"
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+        value = data.get("threads", {}).get("scope")
+        if value in {"cwd", "all"}:
+            return value
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.debug("Could not read thread scope config", exc_info=True)
+    return "cwd"
+
+
+def save_thread_scope(scope: str, config_path: Path | None = None) -> bool:
+    """Save the directory-scope preference for the thread selector.
+
+    Args:
+        scope: `"cwd"` (current working directory) or `"all"` (all directories).
+        config_path: Path to config file.
+
+    Returns:
+        True if save succeeded, False on I/O error.
+
+    Raises:
+        ValueError: If `scope` is not a recognised value.
+    """
+    if scope not in {"cwd", "all"}:
+        msg = f"Invalid scope {scope!r}; expected 'cwd' or 'all'"
+        raise ValueError(msg)
+    if config_path is None:
+        config_path = DEFAULT_CONFIG_PATH
+    try:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        if config_path.exists():
+            with config_path.open("rb") as f:
+                data = tomllib.load(f)
+        else:
+            data = {}
+        if "threads" not in data:
+            data["threads"] = {}
+        data["threads"]["scope"] = scope
+        fd, tmp_path = tempfile.mkstemp(dir=config_path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                tomli_w.dump(data, f)
+            Path(tmp_path).replace(config_path)
+        except Exception:
+            with contextlib.suppress(OSError):
+                Path(tmp_path).unlink()
+            raise
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.exception("Could not save thread scope preference")
         return False
     invalidate_thread_config_cache()
     return True

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -1170,10 +1170,16 @@ _LOCAL_HOSTNAMES: frozenset[str] = frozenset(
 )
 
 
-def _is_local_endpoint(url: str | None) -> bool:
-    """Return whether a provider endpoint points at the local machine."""
+def _is_local_endpoint(url: object) -> bool:
+    """Return whether a provider endpoint points at the local machine.
+
+    Accepts `object` rather than `str | None` because the endpoint originates
+    from untyped TOML; the `isinstance` guard below defends against drift.
+    """
     if not url:
         return True
+    if not isinstance(url, str):
+        return False
 
     # Bare hostname literal (no scheme, no port) — short-circuit so IPv6
     # forms like `::1` don't get misparsed by urlparse.

--- a/libs/code/deepagents_code/widgets/thread_selector.py
+++ b/libs/code/deepagents_code/widgets/thread_selector.py
@@ -851,8 +851,17 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         super().__init__()
         self._current_thread = current_thread
         self._thread_limit = thread_limit
+
+        from deepagents_code.model_config import load_thread_config
+
+        cfg = load_thread_config()
+
         if isinstance(filter_cwd, _Sentinel):
-            self._filter_cwd: str | None = _safe_cwd_string()
+            # Honor the persisted scope: "all" starts with no cwd filter,
+            # "cwd" scopes to the current working directory.
+            self._filter_cwd: str | None = (
+                None if cfg.scope == "all" else _safe_cwd_string()
+            )
         else:
             self._filter_cwd = filter_cwd
         initial = list(initial_threads) if initial_threads is not None else []
@@ -874,9 +883,6 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         self._filter_controls: list[Input | Checkbox | Select[str]] | None = None
         self._cell_text: dict[tuple[str, str], str] = {}
 
-        from deepagents_code.model_config import load_thread_config
-
-        cfg = load_thread_config()
         self._columns = dict(cfg.columns)
         self._relative_time = cfg.relative_time
         self._sort_by_updated = cfg.sort_order == "updated_at"
@@ -2114,6 +2120,9 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
                 )
         else:
             new_cwd = None
+        self._persist_scope(
+            _SCOPE_VALUE_CWD if event.value == _SCOPE_VALUE_CWD else _SCOPE_VALUE_ALL
+        )
         if new_cwd == self._filter_cwd:
             return
         self._filter_cwd = new_cwd
@@ -2121,6 +2130,18 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         self.run_worker(
             self._load_threads, exclusive=True, group="thread-selector-load"
         )
+
+    def _persist_scope(self, scope: str) -> None:
+        """Save directory-scope preference to config, notifying on failure."""
+
+        async def _save() -> None:
+            from deepagents_code.model_config import save_thread_scope
+
+            ok = await asyncio.to_thread(save_thread_scope, scope)
+            if not ok:
+                self.app.notify("Could not save scope preference", severity="warning")
+
+        self.run_worker(_save(), group="thread-selector-save")
 
     def _persist_sort_order(self, order: str) -> None:
         """Save sort-order preference to config, notifying on failure."""

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -762,31 +762,31 @@ class TestThreadScopePersistence:
     def test_save_and_load_round_trip(self, tmp_path: Path) -> None:
         """Saved scope should load back on the next session."""
         from deepagents_code.model_config import (
-            load_thread_scope,
+            load_thread_config,
             save_thread_scope,
         )
 
         config_path = tmp_path / "config.toml"
         assert save_thread_scope("all", config_path) is True
-        assert load_thread_scope(config_path) == "all"
+        assert load_thread_config(config_path).scope == "all"
 
         assert save_thread_scope("cwd", config_path) is True
-        assert load_thread_scope(config_path) == "cwd"
+        assert load_thread_config(config_path).scope == "cwd"
 
     def test_default_is_cwd(self, tmp_path: Path) -> None:
         """When no config file exists, scope defaults to cwd."""
-        from deepagents_code.model_config import load_thread_scope
+        from deepagents_code.model_config import load_thread_config
 
         config_path = tmp_path / "config.toml"
-        assert load_thread_scope(config_path) == "cwd"
+        assert load_thread_config(config_path).scope == "cwd"
 
     def test_invalid_value_falls_back_to_default(self, tmp_path: Path) -> None:
         """An unrecognized scope value should fall back to cwd."""
-        from deepagents_code.model_config import load_thread_scope
+        from deepagents_code.model_config import load_thread_config
 
         config_path = tmp_path / "config.toml"
         config_path.write_text('[threads]\nscope = "bogus"\n')
-        assert load_thread_scope(config_path) == "cwd"
+        assert load_thread_config(config_path).scope == "cwd"
 
     def test_save_invalid_value_raises(self, tmp_path: Path) -> None:
         """Saving an unrecognized scope value should raise ValueError."""
@@ -861,7 +861,6 @@ messages = false
             load_thread_columns,
             load_thread_config,
             load_thread_relative_time,
-            load_thread_scope,
             load_thread_sort_order,
         )
 
@@ -882,7 +881,9 @@ cwd = true
         assert cfg.columns == load_thread_columns(config_path)
         assert cfg.relative_time == load_thread_relative_time(config_path)
         assert cfg.sort_order == load_thread_sort_order(config_path)
-        assert cfg.scope == load_thread_scope(config_path)
+        # `scope` has no standalone loader; it is read only via the coalesced
+        # `load_thread_config`. Assert it parsed from the same combined file.
+        assert cfg.scope == "all"
 
     def test_corrupt_toml_returns_defaults(self, tmp_path: Path) -> None:
         """A corrupt config file should return defaults without crashing."""

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -3295,7 +3295,7 @@ class TestIsLocalEndpoint:
 
     def test_non_string_input_returns_false(self) -> None:
         """Non-string input must not raise (defensive against TOML drift)."""
-        assert _is_local_endpoint(123) is False  # ty: ignore
+        assert _is_local_endpoint(123) is False
 
 
 class TestProviderAuthStatusBranches:

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -756,6 +756,65 @@ class TestThreadSortOrderPersistence:
         assert data["threads"]["sort_order"] == "created_at"
 
 
+class TestThreadScopePersistence:
+    """Tests for thread-selector directory-scope persistence."""
+
+    def test_save_and_load_round_trip(self, tmp_path: Path) -> None:
+        """Saved scope should load back on the next session."""
+        from deepagents_code.model_config import (
+            load_thread_scope,
+            save_thread_scope,
+        )
+
+        config_path = tmp_path / "config.toml"
+        assert save_thread_scope("all", config_path) is True
+        assert load_thread_scope(config_path) == "all"
+
+        assert save_thread_scope("cwd", config_path) is True
+        assert load_thread_scope(config_path) == "cwd"
+
+    def test_default_is_cwd(self, tmp_path: Path) -> None:
+        """When no config file exists, scope defaults to cwd."""
+        from deepagents_code.model_config import load_thread_scope
+
+        config_path = tmp_path / "config.toml"
+        assert load_thread_scope(config_path) == "cwd"
+
+    def test_invalid_value_falls_back_to_default(self, tmp_path: Path) -> None:
+        """An unrecognized scope value should fall back to cwd."""
+        from deepagents_code.model_config import load_thread_scope
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[threads]\nscope = "bogus"\n')
+        assert load_thread_scope(config_path) == "cwd"
+
+    def test_save_invalid_value_raises(self, tmp_path: Path) -> None:
+        """Saving an unrecognized scope value should raise ValueError."""
+        import pytest
+
+        from deepagents_code.model_config import save_thread_scope
+
+        config_path = tmp_path / "config.toml"
+        with pytest.raises(ValueError, match="Invalid scope"):
+            save_thread_scope("bogus", config_path)
+
+    def test_preserves_other_config_sections(self, tmp_path: Path) -> None:
+        """Saving scope should not clobber other config sections."""
+        from deepagents_code.model_config import save_thread_scope
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[models]\ndefault = "anthropic:claude-sonnet-4-5"\n')
+
+        save_thread_scope("all", config_path)
+
+        import tomllib
+
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+        assert data["models"]["default"] == "anthropic:claude-sonnet-4-5"
+        assert data["threads"]["scope"] == "all"
+
+
 class TestThreadConfigCoalesced:
     """Tests for the coalesced `load_thread_config()` helper."""
 
@@ -768,9 +827,10 @@ class TestThreadConfigCoalesced:
         assert cfg.columns == THREAD_COLUMN_DEFAULTS
         assert cfg.relative_time is True
         assert cfg.sort_order == "updated_at"
+        assert cfg.scope == "cwd"
 
     def test_reads_all_sections_from_one_parse(self, tmp_path: Path) -> None:
-        """A single TOML read should populate columns, relative_time, and sort_order."""
+        """A single TOML read should populate columns, relative_time, sort, scope."""
         from deepagents_code.model_config import load_thread_config
 
         config_path = tmp_path / "config.toml"
@@ -779,6 +839,7 @@ class TestThreadConfigCoalesced:
 [threads]
 relative_time = false
 sort_order = "created_at"
+scope = "all"
 
 [threads.columns]
 thread_id = true
@@ -792,13 +853,15 @@ messages = false
         assert cfg.columns["updated_at"] is True
         assert cfg.relative_time is False
         assert cfg.sort_order == "created_at"
+        assert cfg.scope == "all"
 
     def test_matches_individual_loaders(self, tmp_path: Path) -> None:
-        """Coalesced result should match the three individual loaders."""
+        """Coalesced result should match the individual loaders."""
         from deepagents_code.model_config import (
             load_thread_columns,
             load_thread_config,
             load_thread_relative_time,
+            load_thread_scope,
             load_thread_sort_order,
         )
 
@@ -808,6 +871,7 @@ messages = false
 [threads]
 relative_time = false
 sort_order = "created_at"
+scope = "all"
 
 [threads.columns]
 git_branch = true
@@ -818,6 +882,7 @@ cwd = true
         assert cfg.columns == load_thread_columns(config_path)
         assert cfg.relative_time == load_thread_relative_time(config_path)
         assert cfg.sort_order == load_thread_sort_order(config_path)
+        assert cfg.scope == load_thread_scope(config_path)
 
     def test_corrupt_toml_returns_defaults(self, tmp_path: Path) -> None:
         """A corrupt config file should return defaults without crashing."""
@@ -829,6 +894,7 @@ cwd = true
         assert cfg.columns == THREAD_COLUMN_DEFAULTS
         assert cfg.relative_time is True
         assert cfg.sort_order == "updated_at"
+        assert cfg.scope == "cwd"
 
     def test_default_path_uses_cache(self) -> None:
         """Second call with default path should return cached result."""
@@ -899,6 +965,25 @@ cwd = true
         try:
             load_thread_config()
             save_thread_sort_order("created_at", tmp_path / "c.toml")
+            from deepagents_code.model_config import _thread_config_cache
+
+            assert _thread_config_cache is None
+        finally:
+            invalidate_thread_config_cache()
+
+    def test_save_scope_invalidates_cache(self, tmp_path: Path) -> None:
+        """Saving scope should invalidate the cached value."""
+        from deepagents_code.model_config import (
+            _thread_config_cache,
+            invalidate_thread_config_cache,
+            load_thread_config,
+            save_thread_scope,
+        )
+
+        invalidate_thread_config_cache()
+        try:
+            load_thread_config()
+            save_thread_scope("all", tmp_path / "c.toml")
             from deepagents_code.model_config import _thread_config_cache
 
             assert _thread_config_cache is None

--- a/libs/code/tests/unit_tests/test_sessions.py
+++ b/libs/code/tests/unit_tests/test_sessions.py
@@ -1093,6 +1093,7 @@ class TestPrewarmThreadMessageCounts:
                     },
                     relative_time=True,
                     sort_order="updated_at",
+                    scope="cwd",
                 ),
             ),
             patch.object(

--- a/libs/code/tests/unit_tests/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/test_thread_selector.py
@@ -1064,6 +1064,87 @@ class TestThreadSelectorScopeSelect:
                 await pilot.pause()
                 mock_save.assert_any_call("cwd")
 
+    async def test_scope_persists_even_when_cwd_unresolvable(self) -> None:
+        """Selecting "Current directory" persists "cwd" even if the cwd is gone.
+
+        When `_safe_cwd_string()` returns `None`, the resolved filter stays
+        `None` and the reload short-circuits, but the user's explicit "cwd"
+        choice must still be persisted. This pins the intentional ordering of
+        the persist call ahead of the `new_cwd == self._filter_cwd` early return.
+        """
+        mock_list = AsyncMock(return_value=MOCK_THREADS)
+        mock_save = MagicMock(return_value=True)
+
+        with (
+            patch("deepagents_code.sessions.list_threads", mock_list),
+            _patch_columns(),
+            patch(
+                "deepagents_code.widgets.thread_selector._safe_cwd_string",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_code.model_config.save_thread_scope",
+                mock_save,
+            ),
+        ):
+            # Start unfiltered ("all"); the cwd is unresolvable below.
+            app = _ThreadSelectorScopedTestApp(filter_cwd=None)
+            async with app.run_test() as pilot:
+                app.show_selector()
+                await pilot.pause()
+                await pilot.pause()
+
+                screen = app.screen
+                assert isinstance(screen, ThreadSelectorScreen)
+                assert screen._filter_cwd is None
+                scope_select = screen.query_one("#thread-scope-select", Select)
+
+                scope_select.value = "cwd"
+                await pilot.pause()
+                await pilot.pause()
+
+                mock_save.assert_any_call("cwd")
+                # Filter stays unfiltered (cwd unresolvable), yet the preference
+                # was still persisted before the early return fired.
+                assert screen._filter_cwd is None
+
+    async def test_scope_save_failure_notifies(self) -> None:
+        """A failed scope save should surface a warning notification."""
+        starting_cwd = "/home/user/project-a"
+        mock_list = AsyncMock(return_value=MOCK_THREADS)
+        mock_save = MagicMock(return_value=False)
+
+        with (
+            patch("deepagents_code.sessions.list_threads", mock_list),
+            _patch_columns(),
+            patch(
+                "deepagents_code.widgets.thread_selector._safe_cwd_string",
+                return_value=starting_cwd,
+            ),
+            patch(
+                "deepagents_code.model_config.save_thread_scope",
+                mock_save,
+            ),
+        ):
+            app = _ThreadSelectorScopedTestApp(filter_cwd=starting_cwd)
+            async with app.run_test() as pilot:
+                app.show_selector()
+                await pilot.pause()
+                await pilot.pause()
+
+                screen = app.screen
+                assert isinstance(screen, ThreadSelectorScreen)
+                scope_select = screen.query_one("#thread-scope-select", Select)
+
+                with patch.object(app, "notify") as mock_notify:
+                    scope_select.value = "all"
+                    await app.workers.wait_for_complete()
+                    await pilot.pause()
+
+                mock_notify.assert_any_call(
+                    "Could not save scope preference", severity="warning"
+                )
+
 
 class TestThreadSelectorClickHandling:
     """Tests for mouse click handling."""

--- a/libs/code/tests/unit_tests/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/test_thread_selector.py
@@ -96,6 +96,7 @@ def _patch_columns(columns: dict[str, bool] | None = None) -> Any:  # noqa: ANN4
                     columns=dict(cols),
                     relative_time=True,
                     sort_order="updated_at",
+                    scope="cwd",
                 ),
             ),
         ):
@@ -762,6 +763,48 @@ class _ThreadSelectorScopedTestApp(App):
         self.push_screen(screen, handle_result)
 
 
+class TestThreadSelectorScopePersistedDefault:
+    """Tests that the picker honors the persisted scope preference on open."""
+
+    def test_persisted_all_scope_starts_unfiltered(self) -> None:
+        """A persisted scope of "all" should start the picker with no cwd filter."""
+        from deepagents_code.model_config import THREAD_COLUMN_DEFAULTS, ThreadConfig
+
+        with patch(
+            "deepagents_code.model_config.load_thread_config",
+            return_value=ThreadConfig(
+                columns=dict(THREAD_COLUMN_DEFAULTS),
+                relative_time=True,
+                sort_order="updated_at",
+                scope="all",
+            ),
+        ):
+            screen = ThreadSelectorScreen(current_thread=None)
+        assert screen._filter_cwd is None
+
+    def test_persisted_cwd_scope_starts_filtered(self) -> None:
+        """A persisted scope of "cwd" should scope the picker to the cwd."""
+        from deepagents_code.model_config import THREAD_COLUMN_DEFAULTS, ThreadConfig
+
+        with (
+            patch(
+                "deepagents_code.model_config.load_thread_config",
+                return_value=ThreadConfig(
+                    columns=dict(THREAD_COLUMN_DEFAULTS),
+                    relative_time=True,
+                    sort_order="updated_at",
+                    scope="cwd",
+                ),
+            ),
+            patch(
+                "deepagents_code.widgets.thread_selector._safe_cwd_string",
+                return_value="/home/user/project-a",
+            ),
+        ):
+            screen = ThreadSelectorScreen(current_thread=None)
+        assert screen._filter_cwd == "/home/user/project-a"
+
+
 class TestThreadSelectorScopeSelect:
     """Tests for the cwd scope `Select` in the Options panel."""
 
@@ -981,6 +1024,44 @@ class TestThreadSelectorScopeSelect:
                 scope_select.value = "all"
                 await pilot.pause()
                 mock_list.assert_not_awaited()
+
+    async def test_scope_change_persists_preference(self) -> None:
+        """Switching the scope dropdown should persist the new preference."""
+        starting_cwd = "/home/user/project-a"
+        mock_list = AsyncMock(return_value=MOCK_THREADS)
+        mock_save = MagicMock(return_value=True)
+
+        with (
+            patch("deepagents_code.sessions.list_threads", mock_list),
+            _patch_columns(),
+            patch(
+                "deepagents_code.widgets.thread_selector._safe_cwd_string",
+                return_value=starting_cwd,
+            ),
+            patch(
+                "deepagents_code.model_config.save_thread_scope",
+                mock_save,
+            ),
+        ):
+            app = _ThreadSelectorScopedTestApp(filter_cwd=starting_cwd)
+            async with app.run_test() as pilot:
+                app.show_selector()
+                await pilot.pause()
+                await pilot.pause()
+
+                screen = app.screen
+                assert isinstance(screen, ThreadSelectorScreen)
+                scope_select = screen.query_one("#thread-scope-select", Select)
+
+                scope_select.value = "all"
+                await pilot.pause()
+                await pilot.pause()
+                mock_save.assert_any_call("all")
+
+                scope_select.value = "cwd"
+                await pilot.pause()
+                await pilot.pause()
+                mock_save.assert_any_call("cwd")
 
 
 class TestThreadSelectorClickHandling:
@@ -1996,6 +2077,7 @@ class TestThreadSelectorInitialSortOrder:
                         columns=dict(THREAD_COLUMN_DEFAULTS),
                         relative_time=True,
                         sort_order="created_at",
+                        scope="cwd",
                     ),
                 ),
             ):


### PR DESCRIPTION
## Description
The `/threads` switcher reset its "current directory / all directories" scope on every open. This persists the scope to config (under `[threads].scope`), mirroring the existing `sort_order` and `relative_time` preferences, so the picker reopens with the user's last choice.

## Release Note
The `/threads` switcher now remembers your "current directory / all directories" filter across sessions.

## Test Plan
- [ ] Open `/threads`, switch to "All directories", close and reopen — it stays on "All directories".

Made by [Open SWE](https://openswe.vercel.app)