### PR TITLE
fix(code): make non-incognito `!` shell output visible to the model

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -5668,19 +5668,25 @@ class DeepAgentsApp(App):
         """
         if not self._pending_shell_messages:
             return
+        if not self._lc_thread_id and self._session_state:
+            self._lc_thread_id = self._session_state.thread_id
         if not self._agent or not self._lc_thread_id:
-            self._pending_shell_messages.clear()
             return
 
         messages = self._pending_shell_messages
         self._pending_shell_messages = []
         config: RunnableConfig = {"configurable": {"thread_id": self._lc_thread_id}}
+        remote_config: dict[str, Any] = {
+            "configurable": {"thread_id": self._lc_thread_id}
+        }
         try:
             # Suppress the standalone `UpdateState` LangSmith run this write would
             # otherwise emit — it's bookkeeping, not a user-driven agent turn.
             from langsmith import tracing_context
 
             with tracing_context(enabled=False):
+                if remote := self._remote_agent():
+                    await remote.aensure_thread(remote_config)
                 await self._agent.aupdate_state(config, {"messages": messages})
         except Exception:  # best-effort; UI already showed the output
             logger.warning(

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -5548,6 +5548,15 @@ class DeepAgentsApp(App):
             if proc.returncode and proc.returncode != 0:
                 await self._mount_message(ErrorMessage(f"Exit code: {proc.returncode}"))
 
+            # Non-incognito `!` commands are part of the conversation the model
+            # can see; `!!` (incognito) stays local-only. Mounting widgets only
+            # updates the UI store, so without this write the command/output
+            # would never reach the graph checkpoint the model reads.
+            if not incognito:
+                await self._record_shell_in_model_context(
+                    command, output, proc.returncode
+                )
+
             # Anchor to bottom so shell output stays visible
             with suppress(NoMatches, ScreenStackError):
                 self.query_one("#chat", VerticalScroll).anchor()
@@ -5574,6 +5583,46 @@ class DeepAgentsApp(App):
             raise
         finally:
             await self._cleanup_shell_task(refresh_git_branch=not refresh_started)
+
+    async def _record_shell_in_model_context(
+        self, command: str, output: str, returncode: int | None
+    ) -> None:
+        """Persist a non-incognito `!` command and its output to graph state.
+
+        `!` commands run as local subprocesses that bypass the agent graph, so
+        their command/output never reach the checkpoint the model reads on the
+        next turn. This writes a `HumanMessage`/`AIMessage` pair into thread
+        state so the model sees them, matching the documented `!` vs `!!`
+        contract. `!!` (incognito) callers skip this and stay local-only.
+
+        Args:
+            command: The shell command that was run (without the `!` prefix).
+            output: Combined stdout/stderr captured from the command.
+            returncode: Process exit code, or `None` if unavailable.
+        """
+        if not self._agent or not self._lc_thread_id:
+            return
+
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        status = f"\n[Command exited with code {returncode}]" if returncode else ""
+        body = output or "(no output)"
+        messages = [
+            HumanMessage(content=f"!{command}"),
+            AIMessage(content=f"```\n{body}\n```{status}"),
+        ]
+        config: RunnableConfig = {"configurable": {"thread_id": self._lc_thread_id}}
+        try:
+            # Suppress the standalone `UpdateState` LangSmith run this write would
+            # otherwise emit — it's bookkeeping, not a user-driven agent turn.
+            from langsmith import tracing_context
+
+            with tracing_context(enabled=False):
+                await self._agent.aupdate_state(config, {"messages": messages})
+        except Exception:  # best-effort; UI already showed the output
+            logger.warning(
+                "Failed to record shell command in model context", exc_info=True
+            )
 
     async def _cleanup_shell_task(self, *, refresh_git_branch: bool = True) -> None:
         """Clean up after shell command task completes or is cancelled.

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -5551,10 +5551,19 @@ class DeepAgentsApp(App):
                 )
             except TimeoutError:
                 await self._kill_shell_process()
-                await self._mount_message(ErrorMessage("Command timed out (60s limit)"))
+                err_msg = "Command timed out (60s limit)"
+                await self._mount_message(ErrorMessage(err_msg))
+                if not incognito:
+                    self._buffer_shell_for_model_context(command, err_msg, None)
                 return
             except asyncio.CancelledError:
                 await self._kill_shell_process()
+                if not incognito:
+                    self._buffer_shell_for_model_context(
+                        command,
+                        "Command interrupted",
+                        None,
+                    )
                 raise
 
             # Start branch refresh as soon as the shell exits so it can overlap
@@ -5598,6 +5607,8 @@ class DeepAgentsApp(App):
             logger.exception("Failed to execute shell command: %s", command)
             err_msg = f"Failed to run command: {e}"
             await self._mount_message(ErrorMessage(err_msg))
+            if not incognito:
+                self._buffer_shell_for_model_context(command, err_msg, None)
         except Exception:
             # Defense in depth: a crash between subprocess read and
             # `_mount_message` could leave the user with no signal that the

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1844,6 +1844,14 @@ class DeepAgentsApp(App):
         self._shell_running = False
         """True while a `!` shell command is executing."""
 
+        self._pending_shell_messages: list[Any] = []
+        """Non-incognito `!` command/output messages awaiting flush.
+
+        `!` runs outside the agent graph, so its command/output are buffered
+        here and written into thread state on the next user send (see
+        `_flush_pending_shell_messages`) — never proactively. `!!` (incognito)
+        never appends here."""
+
         self._prewarm_worker: Worker[None] | None = None
         """Background worker that prewarms `deepagents`/LangChain imports.
 
@@ -5549,13 +5557,12 @@ class DeepAgentsApp(App):
                 await self._mount_message(ErrorMessage(f"Exit code: {proc.returncode}"))
 
             # Non-incognito `!` commands are part of the conversation the model
-            # can see; `!!` (incognito) stays local-only. Mounting widgets only
-            # updates the UI store, so without this write the command/output
-            # would never reach the graph checkpoint the model reads.
+            # can see; `!!` (incognito) stays local-only. `!` runs outside the
+            # graph, so buffer its command/output and flush into thread state on
+            # the next user send — never proactively, to avoid spending a model
+            # turn on output the user may never reference.
             if not incognito:
-                await self._record_shell_in_model_context(
-                    command, output, proc.returncode
-                )
+                self._buffer_shell_for_model_context(command, output, proc.returncode)
 
             # Anchor to bottom so shell output stays visible
             with suppress(NoMatches, ScreenStackError):
@@ -5584,33 +5591,52 @@ class DeepAgentsApp(App):
         finally:
             await self._cleanup_shell_task(refresh_git_branch=not refresh_started)
 
-    async def _record_shell_in_model_context(
+    def _buffer_shell_for_model_context(
         self, command: str, output: str, returncode: int | None
     ) -> None:
-        """Persist a non-incognito `!` command and its output to graph state.
+        """Buffer a non-incognito `!` command/output for the next user send.
 
         `!` commands run as local subprocesses that bypass the agent graph, so
-        their command/output never reach the checkpoint the model reads on the
-        next turn. This writes a `HumanMessage`/`AIMessage` pair into thread
-        state so the model sees them, matching the documented `!` vs `!!`
-        contract. `!!` (incognito) callers skip this and stay local-only.
+        their command/output never reach the checkpoint the model reads. Rather
+        than write to thread state immediately (which would spend a model turn
+        on output the user may never reference), the command/output are queued
+        here as a `HumanMessage`/`AIMessage` pair and flushed when the user
+        sends their next message (see `_flush_pending_shell_messages`). `!!`
+        (incognito) callers skip this and stay local-only.
 
         Args:
             command: The shell command that was run (without the `!` prefix).
             output: Combined stdout/stderr captured from the command.
             returncode: Process exit code, or `None` if unavailable.
         """
-        if not self._agent or not self._lc_thread_id:
-            return
-
         from langchain_core.messages import AIMessage, HumanMessage
 
         status = f"\n[Command exited with code {returncode}]" if returncode else ""
         body = output or "(no output)"
-        messages = [
-            HumanMessage(content=f"!{command}"),
-            AIMessage(content=f"```\n{body}\n```{status}"),
-        ]
+        self._pending_shell_messages.extend(
+            [
+                HumanMessage(content=f"!{command}"),
+                AIMessage(content=f"```\n{body}\n```{status}"),
+            ]
+        )
+
+    async def _flush_pending_shell_messages(self) -> None:
+        """Write buffered `!` command/output into thread state, then clear it.
+
+        Called right before a user-driven agent turn so the model sees any
+        `!` commands run since the last turn. Best-effort: a checkpoint write
+        failure is logged and the buffer is still cleared so stale output is
+        not replayed onto a later turn. No-ops when nothing is buffered or no
+        agent/thread is active.
+        """
+        if not self._pending_shell_messages:
+            return
+        if not self._agent or not self._lc_thread_id:
+            self._pending_shell_messages.clear()
+            return
+
+        messages = self._pending_shell_messages
+        self._pending_shell_messages = []
         config: RunnableConfig = {"configurable": {"thread_id": self._lc_thread_id}}
         try:
             # Suppress the standalone `UpdateState` LangSmith run this write would
@@ -5621,7 +5647,7 @@ class DeepAgentsApp(App):
                 await self._agent.aupdate_state(config, {"messages": messages})
         except Exception:  # best-effort; UI already showed the output
             logger.warning(
-                "Failed to record shell command in model context", exc_info=True
+                "Failed to flush shell command into model context", exc_info=True
             )
 
     async def _cleanup_shell_task(self, *, refresh_git_branch: bool = True) -> None:
@@ -6695,6 +6721,10 @@ class DeepAgentsApp(App):
         if self._agent and self._ui_adapter and self._session_state:
             self._agent_running = True
 
+            # Flush any buffered non-incognito `!` shell output into thread
+            # state so this turn's model sees commands run since the last turn.
+            await self._flush_pending_shell_messages()
+
             if self._chat_input:
                 self._chat_input.set_cursor_active(active=False)
 
@@ -7533,6 +7563,9 @@ class DeepAgentsApp(App):
 
     async def _clear_messages(self) -> None:
         """Clear the messages area and message store."""
+        # Drop buffered `!` shell output so it never leaks across a thread
+        # reset, switch, or resume.
+        self._pending_shell_messages.clear()
         # Clear the message store first
         self._message_store.clear()
         try:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -181,6 +181,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Mapping
 
     from deepagents.backends import CompositeBackend
+    from langchain_core.messages import BaseMessage
     from langchain_core.runnables import RunnableConfig
     from langgraph.pregel import Pregel
     from textual.app import ComposeResult
@@ -1842,7 +1843,7 @@ class DeepAgentsApp(App):
         self._shell_running = False
         """True while a `!` shell command is executing."""
 
-        self._pending_shell_messages: list[Any] = []
+        self._pending_shell_messages: list[BaseMessage] = []
         """Non-incognito `!` command/output messages awaiting flush.
 
         `!` runs outside the agent graph, so its command/output are buffered
@@ -5591,11 +5592,8 @@ class DeepAgentsApp(App):
             if proc.returncode and proc.returncode != 0:
                 await self._mount_message(ErrorMessage(f"Exit code: {proc.returncode}"))
 
-            # Non-incognito `!` commands are part of the conversation the model
-            # can see; `!!` (incognito) stays local-only. `!` runs outside the
-            # graph, so buffer its command/output and flush into thread state on
-            # the next user send — never proactively, to avoid spending a model
-            # turn on output the user may never reference.
+            # Non-incognito `!` only; `!!` stays local. Buffered, not written
+            # now — see `_buffer_shell_for_model_context` for the rationale.
             if not incognito:
                 self._buffer_shell_for_model_context(command, output, proc.returncode)
 
@@ -5661,10 +5659,13 @@ class DeepAgentsApp(App):
         """Write buffered `!` command/output into thread state, then clear it.
 
         Called right before a user-driven agent turn so the model sees any
-        `!` commands run since the last turn. Best-effort: a checkpoint write
-        failure is logged and the buffer is still cleared so stale output is
-        not replayed onto a later turn. No-ops when nothing is buffered or no
-        agent/thread is active.
+        `!` commands run since the last turn. Adopts the session thread id when
+        one has not been resolved yet (e.g. a `!` run before the first send).
+        Best-effort: a checkpoint write failure is logged and surfaced as a
+        toast, and the buffer is still cleared so stale output is not replayed
+        onto a later turn. Returns early when nothing is buffered; when output
+        is buffered but no agent/thread is active yet, the buffer is left intact
+        for a later send rather than dropped.
         """
         if not self._pending_shell_messages:
             return
@@ -5689,9 +5690,16 @@ class DeepAgentsApp(App):
                     await remote.aensure_thread(remote_config)
                 await self._agent.aupdate_state(config, {"messages": messages})
         except Exception:  # best-effort; UI already showed the output
-            logger.warning(
-                "Failed to flush shell command into model context", exc_info=True
-            )
+            # Parity with the offload path's `aupdate_state` failure handling:
+            # log the traceback and surface a non-blocking toast, since the
+            # model silently lacking output the user expects is confusing.
+            logger.exception("Failed to flush shell command into model context")
+            with suppress(Exception):
+                self.notify(
+                    "Couldn't add ! output to the model's context.",
+                    severity="warning",
+                    markup=False,
+                )
 
     async def _cleanup_shell_task(self, *, refresh_git_branch: bool = True) -> None:
         """Clean up after shell command task completes or is cancelled.

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -4593,8 +4593,8 @@ class TestShellCommandInterrupt:
             for msg in messages
         )
 
-    async def test_non_incognito_shell_output_written_to_model_context(self) -> None:
-        """A `!` command/output must be written into the graph checkpoint."""
+    async def test_non_incognito_shell_buffers_for_model_context(self) -> None:
+        """A `!` command/output is buffered, not written immediately."""
         from langchain_core.messages import AIMessage, HumanMessage
 
         app = DeepAgentsApp()
@@ -4621,19 +4621,49 @@ class TestShellCommandInterrupt:
                 await app._run_shell_task("echo hello world", incognito=False)
                 await pilot.pause()
 
+        # Deferred: nothing written to graph state until the next user send.
+        app._agent.aupdate_state.assert_not_awaited()
+        buffered = app._pending_shell_messages
+        assert isinstance(buffered[0], HumanMessage)
+        assert buffered[0].content == "!echo hello world"
+        assert isinstance(buffered[1], AIMessage)
+        assert "hello world" in buffered[1].content
+
+    async def test_pending_shell_flushed_on_next_user_send(self) -> None:
+        """Buffered `!` output is written to graph state on the next send."""
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        app._agent.aupdate_state = AsyncMock()
+        app._lc_thread_id = "thread-123"
+        app._ui_adapter = MagicMock()
+        app._session_state = MagicMock()
+        app._pending_shell_messages = [
+            HumanMessage(content="!echo hi"),
+            AIMessage(content="```\nhi\n```"),
+        ]
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            with patch.object(app, "run_worker") as mock_rw:
+                mock_rw.return_value = MagicMock()
+                await app._send_to_agent("what did that print?")
+                coro = mock_rw.call_args[0][0]
+                coro.close()
+
         app._agent.aupdate_state.assert_awaited_once()
         call = app._agent.aupdate_state.await_args
         assert call is not None
-        config = call.args[0]
-        assert config["configurable"]["thread_id"] == "thread-123"
+        assert call.args[0]["configurable"]["thread_id"] == "thread-123"
         sent = call.args[1]["messages"]
-        assert isinstance(sent[0], HumanMessage)
-        assert sent[0].content == "!echo hello world"
-        assert isinstance(sent[1], AIMessage)
-        assert "hello world" in sent[1].content
+        assert sent[0].content == "!echo hi"
+        # Buffer is drained so it is not replayed onto a later turn.
+        assert app._pending_shell_messages == []
 
-    async def test_incognito_shell_output_not_written_to_model_context(self) -> None:
-        """A `!!` command/output must never reach the graph checkpoint."""
+    async def test_incognito_shell_output_not_buffered(self) -> None:
+        """A `!!` command/output must never be buffered for the model."""
         app = DeepAgentsApp()
         app._agent = MagicMock()
         app._agent.aupdate_state = AsyncMock()
@@ -4664,10 +4694,11 @@ class TestShellCommandInterrupt:
                 await app._run_shell_task("echo secret", incognito=True)
                 await pilot.pause()
 
+        assert app._pending_shell_messages == []
         app._agent.aupdate_state.assert_not_awaited()
 
-    async def test_non_incognito_shell_nonzero_exit_recorded(self) -> None:
-        """A failing `!` command should record its exit code for the model."""
+    async def test_non_incognito_shell_nonzero_exit_buffered(self) -> None:
+        """A failing `!` command should buffer its exit code for the model."""
         app = DeepAgentsApp()
         app._agent = MagicMock()
         app._agent.aupdate_state = AsyncMock()
@@ -4692,12 +4723,25 @@ class TestShellCommandInterrupt:
                 await app._run_shell_task("falsey", incognito=False)
                 await pilot.pause()
 
-        app._agent.aupdate_state.assert_awaited_once()
-        call = app._agent.aupdate_state.await_args
-        assert call is not None
-        sent = call.args[1]["messages"]
-        assert "boom" in sent[1].content
-        assert "exited with code 2" in sent[1].content
+        buffered = app._pending_shell_messages
+        assert "boom" in buffered[1].content
+        assert "exited with code 2" in buffered[1].content
+
+    async def test_clear_messages_drops_pending_shell_buffer(self) -> None:
+        """`_clear_messages` must drop buffered `!` output (no cross-thread leak)."""
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        app = DeepAgentsApp()
+        app._pending_shell_messages = [
+            HumanMessage(content="!echo secret"),
+            AIMessage(content="```\nsecret\n```"),
+        ]
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await app._clear_messages()
+
+        assert app._pending_shell_messages == []
 
     async def test_unknown_input_mode_does_not_dispatch_to_agent(self) -> None:
         """An unrecognized mode must surface an error rather than reach the LLM.

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -4130,6 +4130,9 @@ class TestShellCommandInterrupt:
                 await app._run_shell_task("sleep 999")
 
             mock_killpg.assert_called()
+            buffered = app._pending_shell_messages
+            assert buffered[0].content == "!sleep 999"
+            assert "Command interrupted" in buffered[1].content
 
     async def test_cleanup_clears_state(self) -> None:
         """_cleanup_shell_task should reset all shell state."""
@@ -4414,6 +4417,9 @@ class TestShellCommandInterrupt:
             assert app._shell_process is None
             error_msgs = app.query(ErrorMessage)
             assert any("timed out" in w._content for w in error_msgs)
+            buffered = app._pending_shell_messages
+            assert buffered[0].content == "!sleep 999"
+            assert "timed out" in buffered[1].content
 
     async def test_incognito_timeout_feedback_is_not_model_visible(self) -> None:
         """Incognito timeout feedback should stay out of user/assistant records."""
@@ -4525,6 +4531,9 @@ class TestShellCommandInterrupt:
             assert app._shell_process is None
             error_msgs = app.query(ErrorMessage)
             assert any("Permission denied" in w._content for w in error_msgs)
+            buffered = app._pending_shell_messages
+            assert buffered[0].content == "!forbidden"
+            assert "Permission denied" in buffered[1].content
 
     async def test_handle_shell_command_sets_running_state(self) -> None:
         """_handle_shell_command should set _shell_running and spawn worker."""

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -4868,6 +4868,104 @@ class TestShellCommandInterrupt:
 
         assert app._pending_shell_messages == []
 
+    async def test_pending_shell_flush_failure_drops_buffer(self) -> None:
+        """A checkpoint-write failure must not raise and must clear the buffer."""
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        app._agent.aupdate_state = AsyncMock(
+            side_effect=RuntimeError("checkpoint down")
+        )
+        app._lc_thread_id = "thread-123"
+        app._pending_shell_messages = [
+            HumanMessage(content="!echo hi"),
+            AIMessage(content="```\nhi\n```"),
+        ]
+
+        # Must not propagate; buffer is dropped so stale output is not replayed.
+        await app._flush_pending_shell_messages()
+
+        app._agent.aupdate_state.assert_awaited_once()
+        assert app._pending_shell_messages == []
+
+    async def test_pending_shell_flush_without_agent_retains_buffer(self) -> None:
+        """With no agent/thread, the buffer is kept for a later send, not dropped."""
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        app = DeepAgentsApp()
+        app._agent = None
+        app._lc_thread_id = None
+        app._session_state = None
+        buffered = [
+            HumanMessage(content="!echo hi"),
+            AIMessage(content="```\nhi\n```"),
+        ]
+        app._pending_shell_messages = list(buffered)
+
+        await app._flush_pending_shell_messages()
+
+        # Retained verbatim for a later flush once an agent/thread exists.
+        assert app._pending_shell_messages == buffered
+
+    async def test_pending_shell_flush_precedes_agent_worker(self) -> None:
+        """The `!` flush must land before the user-message turn is spawned."""
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        app._agent.aupdate_state = AsyncMock()
+        app._lc_thread_id = "thread-123"
+        app._ui_adapter = MagicMock()
+        app._session_state = MagicMock()
+        app._pending_shell_messages = [
+            HumanMessage(content="!echo hi"),
+            AIMessage(content="```\nhi\n```"),
+        ]
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            manager = MagicMock()
+            with patch.object(app, "run_worker") as mock_rw:
+                mock_rw.return_value = MagicMock()
+                manager.attach_mock(app._agent.aupdate_state, "flush")
+                manager.attach_mock(mock_rw, "spawn")
+                await app._send_to_agent("what did that print?")
+                coro = mock_rw.call_args[0][0]
+                coro.close()
+
+        # Flush the `!` pair into state before spawning the turn, so the model
+        # sees the shell output ahead of this turn's user message.
+        names = [c[0] for c in manager.mock_calls if c[0] in {"flush", "spawn"}]
+        assert names == ["flush", "spawn"]
+
+    async def test_buffer_shell_appends_in_command_order(self) -> None:
+        """Multiple `!` commands buffer as ordered Human/AI pairs."""
+        app = DeepAgentsApp()
+        app._buffer_shell_for_model_context("cmd-a", "out-a", 0)
+        app._buffer_shell_for_model_context("cmd-b", "out-b", 0)
+
+        contents = [m.content for m in app._pending_shell_messages]
+        assert contents[0] == "!cmd-a"
+        assert "out-a" in contents[1]
+        assert contents[2] == "!cmd-b"
+        assert "out-b" in contents[3]
+
+    async def test_buffer_shell_empty_output_uses_placeholder(self) -> None:
+        """Empty output is buffered as `(no output)` so the pair is never blank."""
+        app = DeepAgentsApp()
+        app._buffer_shell_for_model_context("true", "", 0)
+
+        assert "(no output)" in app._pending_shell_messages[1].content
+
+    async def test_buffer_shell_zero_exit_omits_status_suffix(self) -> None:
+        """A successful `!` command must not annotate an exit code."""
+        app = DeepAgentsApp()
+        app._buffer_shell_for_model_context("echo ok", "ok", 0)
+
+        assert "exited with code" not in app._pending_shell_messages[1].content
+
     async def test_unknown_input_mode_does_not_dispatch_to_agent(self) -> None:
         """An unrecognized mode must surface an error rather than reach the LLM.
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -4723,6 +4723,70 @@ class TestShellCommandInterrupt:
         # Buffer is drained so it is not replayed onto a later turn.
         assert app._pending_shell_messages == []
 
+    async def test_pending_shell_first_message_uses_session_thread(self) -> None:
+        """A first-message `!` command should flush to the new session thread."""
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        app._agent.aupdate_state = AsyncMock()
+        app._ui_adapter = MagicMock()
+        app._pending_shell_messages = [
+            HumanMessage(content="!echo before-chat"),
+            AIMessage(content="```\nbefore-chat\n```"),
+        ]
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._session_state is not None
+            app._lc_thread_id = None
+            app._session_state.thread_id = "thread-first"
+
+            with patch.object(app, "run_worker") as mock_rw:
+                mock_rw.return_value = MagicMock()
+                await app._send_to_agent("what did that print?")
+                coro = mock_rw.call_args[0][0]
+                coro.close()
+
+        app._agent.aupdate_state.assert_awaited_once()
+        call = app._agent.aupdate_state.await_args
+        assert call is not None
+        assert call.args[0]["configurable"]["thread_id"] == "thread-first"
+        assert app._lc_thread_id == "thread-first"
+        assert app._pending_shell_messages == []
+
+    async def test_pending_shell_flush_ensures_remote_thread_first(self) -> None:
+        """Server mode must register a fresh thread before flushing shell output."""
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        from deepagents_code.remote_client import RemoteAgent
+
+        calls: list[str] = []
+        remote = MagicMock(spec=RemoteAgent)
+        remote.aensure_thread = AsyncMock(
+            side_effect=lambda _config: calls.append("ensure")
+        )
+        agent = MagicMock()
+        agent.aupdate_state = AsyncMock(
+            side_effect=lambda _config, _values: calls.append("update")
+        )
+
+        app = DeepAgentsApp(agent=agent, thread_id="thread-remote")
+        app._pending_shell_messages = [
+            HumanMessage(content="!pwd"),
+            AIMessage(content="```\n/tmp/project\n```"),
+        ]
+
+        with patch.object(app, "_remote_agent", return_value=remote):
+            await app._flush_pending_shell_messages()
+
+        remote.aensure_thread.assert_awaited_once_with(
+            {"configurable": {"thread_id": "thread-remote"}}
+        )
+        agent.aupdate_state.assert_awaited_once()
+        assert calls == ["ensure", "update"]
+        assert app._pending_shell_messages == []
+
     async def test_incognito_shell_output_not_buffered(self) -> None:
         """A `!!` command/output must never be buffered for the model."""
         app = DeepAgentsApp()

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -4593,6 +4593,112 @@ class TestShellCommandInterrupt:
             for msg in messages
         )
 
+    async def test_non_incognito_shell_output_written_to_model_context(self) -> None:
+        """A `!` command/output must be written into the graph checkpoint."""
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        app._agent.aupdate_state = AsyncMock()
+        app._lc_thread_id = "thread-123"
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"hello world\n", b""))
+        mock_proc.returncode = 0
+        mock_proc.pid = 12345
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._schedule_git_branch_refresh = MagicMock()  # ty: ignore
+            app._maybe_drain_deferred = AsyncMock()  # ty: ignore
+            app._process_next_from_queue = AsyncMock()  # ty: ignore
+
+            with patch(
+                "asyncio.create_subprocess_shell",
+                return_value=mock_proc,
+            ):
+                await app._run_shell_task("echo hello world", incognito=False)
+                await pilot.pause()
+
+        app._agent.aupdate_state.assert_awaited_once()
+        call = app._agent.aupdate_state.await_args
+        assert call is not None
+        config = call.args[0]
+        assert config["configurable"]["thread_id"] == "thread-123"
+        sent = call.args[1]["messages"]
+        assert isinstance(sent[0], HumanMessage)
+        assert sent[0].content == "!echo hello world"
+        assert isinstance(sent[1], AIMessage)
+        assert "hello world" in sent[1].content
+
+    async def test_incognito_shell_output_not_written_to_model_context(self) -> None:
+        """A `!!` command/output must never reach the graph checkpoint."""
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        app._agent.aupdate_state = AsyncMock()
+        app._lc_thread_id = "thread-123"
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"secret\n", b""))
+        mock_proc.returncode = 0
+        mock_proc.pid = 12345
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._schedule_git_branch_refresh = MagicMock()  # ty: ignore
+            app._maybe_drain_deferred = AsyncMock()  # ty: ignore
+            app._process_next_from_queue = AsyncMock()  # ty: ignore
+
+            with (
+                patch(
+                    "asyncio.create_subprocess_shell",
+                    return_value=mock_proc,
+                ),
+                patch(
+                    "deepagents_code.app.AssistantMessage.write_initial_content",
+                    new=AsyncMock(),
+                ),
+            ):
+                await app._run_shell_task("echo secret", incognito=True)
+                await pilot.pause()
+
+        app._agent.aupdate_state.assert_not_awaited()
+
+    async def test_non_incognito_shell_nonzero_exit_recorded(self) -> None:
+        """A failing `!` command should record its exit code for the model."""
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        app._agent.aupdate_state = AsyncMock()
+        app._lc_thread_id = "thread-123"
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"", b"boom"))
+        mock_proc.returncode = 2
+        mock_proc.pid = 12345
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._schedule_git_branch_refresh = MagicMock()  # ty: ignore
+            app._maybe_drain_deferred = AsyncMock()  # ty: ignore
+            app._process_next_from_queue = AsyncMock()  # ty: ignore
+
+            with patch(
+                "asyncio.create_subprocess_shell",
+                return_value=mock_proc,
+            ):
+                await app._run_shell_task("falsey", incognito=False)
+                await pilot.pause()
+
+        app._agent.aupdate_state.assert_awaited_once()
+        call = app._agent.aupdate_state.await_args
+        assert call is not None
+        sent = call.args[1]["messages"]
+        assert "boom" in sent[1].content
+        assert "exited with code 2" in sent[1].content
+
     async def test_unknown_input_mode_does_not_dispatch_to_agent(self) -> None:
         """An unrecognized mode must surface an error rather than reach the LLM.
 


### PR DESCRIPTION
`!` shell commands in the TUI now add their command and output to the model's context as intended; `!!` remains local-only.

---

In the `deepagents-code` TUI, `!command` (bang-shell) runs as a local subprocess that bypasses the agent graph. Its command/output were only mounted into the UI message store, never written to the LangGraph checkpoint the model reads on the next turn. As a result the documented `!` vs `!!` contract was unmet: `/help` says `!!` runs "without adding command/output to model context" (implying `!` *does*), but in practice both were hidden from the model.

This adds `_record_shell_in_model_context`, which writes a `HumanMessage`/`AIMessage` pair into thread state via `aupdate_state` (wrapped in `tracing_context(enabled=False)`, matching the existing interrupt-recovery pattern) for non-incognito `!` only. `!!` (incognito) stays local-only. The write is best-effort and no-ops when no agent/thread is active.

Made by [Open SWE](https://openswe.vercel.app)