### PR TITLE
fix(code): unblock TUI input during `/restart`

### DIFF
--- a/libs/code/deepagents_code/server.py
+++ b/libs/code/deepagents_code/server.py
@@ -556,7 +556,11 @@ class ServerProcess:
             timeout: Max seconds to wait for the server to become healthy.
         """
         logger.info("Restarting langgraph dev server")
-        self._stop_process()
+        # Offload the synchronous subprocess shutdown (it blocks up to
+        # `_SHUTDOWN_TIMEOUT` + SIGKILL grace waiting on `process.wait`) so the
+        # caller's event loop — the Textual reactor for `/restart` — keeps
+        # processing input instead of freezing the TUI.
+        await asyncio.to_thread(self._stop_process)
 
         with _scoped_env_overrides(self._env_overrides):
             await self.start(timeout=timeout)

--- a/libs/code/tests/unit_tests/test_server.py
+++ b/libs/code/tests/unit_tests/test_server.py
@@ -290,6 +290,33 @@ class TestServerProcess:
         # Overrides cleared after successful restart
         assert server._env_overrides == {}
 
+    async def test_restart_offloads_blocking_stop_to_thread(
+        self, tmp_path: Path
+    ) -> None:
+        """restart() must not run the blocking subprocess stop on the event loop.
+
+        `_stop_process` blocks up to `_SHUTDOWN_TIMEOUT` on `process.wait`; if
+        called directly on the loop it freezes the Textual reactor so `/restart`
+        wedges the TUI input. It must be offloaded via `asyncio.to_thread`.
+        """
+        config_dir = tmp_path / "runtime"
+        config_dir.mkdir()
+        (config_dir / "langgraph.json").write_text("{}")
+
+        server = ServerProcess(config_dir=config_dir, owns_config_dir=False)
+        server._process = MagicMock()
+
+        with (
+            patch.object(server, "start", new=AsyncMock()),
+            patch(
+                "deepagents_code.server.asyncio.to_thread",
+                new=AsyncMock(),
+            ) as to_thread,
+        ):
+            await server.restart()
+
+        to_thread.assert_awaited_once_with(server._stop_process)
+
     async def test_restart_rollback_on_failure(self, tmp_path: Path) -> None:
         """Env overrides are rolled back when restart fails."""
         config_dir = tmp_path / "runtime"

--- a/libs/code/tests/unit_tests/test_server.py
+++ b/libs/code/tests/unit_tests/test_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import socket
+import threading
 from typing import TYPE_CHECKING, Self
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -290,14 +291,16 @@ class TestServerProcess:
         # Overrides cleared after successful restart
         assert server._env_overrides == {}
 
-    async def test_restart_offloads_blocking_stop_to_thread(
+    async def test_restart_runs_blocking_stop_off_event_loop(
         self, tmp_path: Path
     ) -> None:
-        """restart() must not run the blocking subprocess stop on the event loop.
+        """restart() must run the blocking subprocess stop off the event loop.
 
-        `_stop_process` blocks up to `_SHUTDOWN_TIMEOUT` on `process.wait`; if
-        called directly on the loop it freezes the Textual reactor so `/restart`
-        wedges the TUI input. It must be offloaded via `asyncio.to_thread`.
+        `_stop_process` blocks up to `_SHUTDOWN_TIMEOUT` (plus a SIGKILL grace
+        wait) on `process.wait`; running it directly on the loop freezes the
+        Textual reactor so `/restart` wedges the TUI input. `restart()` must
+        offload it to a worker thread, so the stop executes on a thread other
+        than the one running the event loop.
         """
         config_dir = tmp_path / "runtime"
         config_dir.mkdir()
@@ -306,16 +309,26 @@ class TestServerProcess:
         server = ServerProcess(config_dir=config_dir, owns_config_dir=False)
         server._process = MagicMock()
 
+        loop_thread_id = threading.get_ident()
+        stop_thread_id: int | None = None
+
+        def recording_stop() -> None:
+            nonlocal stop_thread_id
+            stop_thread_id = threading.get_ident()
+            server._process = None
+
+        # Patch only `start` (avoid spawning a real server) and `_stop_process`
+        # (record its executing thread). The real `restart()` and real
+        # `asyncio.to_thread` run, so a regression to a direct call would run
+        # `_stop_process` on the loop thread and fail the off-loop assertion.
         with (
             patch.object(server, "start", new=AsyncMock()),
-            patch(
-                "deepagents_code.server.asyncio.to_thread",
-                new=AsyncMock(),
-            ) as to_thread,
+            patch.object(server, "_stop_process", new=recording_stop),
         ):
             await server.restart()
 
-        to_thread.assert_awaited_once_with(server._stop_process)
+        assert stop_thread_id is not None
+        assert stop_thread_id != loop_thread_id
 
     async def test_restart_rollback_on_failure(self, tmp_path: Path) -> None:
         """Env overrides are rolled back when restart fails."""


### PR DESCRIPTION
## Description
`/restart` froze the TUI input field because `ServerProcess.restart()` ran the synchronous `_stop_process` (which blocks up to `_SHUTDOWN_TIMEOUT` waiting on `process.wait`) directly on the Textual event loop. Offloading the stop to a worker thread via `asyncio.to_thread` keeps the reactor responsive.

## Release Note
Fixed `/restart` in dcode freezing the input field while the server subprocess shut down.

## Test Plan
- [ ] Run `/restart` in dcode and confirm the input field stays responsive while the server restarts.

Made by [Open SWE](https://openswe.vercel.app)