### PR TITLE
hotfix(sdk): support upcoming `SummarizationMiddleware` trigger clauses

### DIFF
--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -53,6 +53,7 @@ import asyncio
 import logging
 import uuid
 import warnings
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, NotRequired, cast
 
@@ -120,6 +121,19 @@ class SummarizationEvent(TypedDict):
     cutoff_index: int
     summary_message: HumanMessage
     file_path: str | None
+
+
+class TriggerClause(TypedDict, total=False):
+    """Dictionary-based summarization trigger with AND semantics."""
+
+    tokens: int
+    """Trigger when token count reaches or exceeds this value."""
+
+    messages: int
+    """Trigger when message count reaches or exceeds this value."""
+
+    fraction: float
+    """Trigger when token count reaches this fraction of the model context window."""
 
 
 class TruncateArgsSettings(TypedDict, total=False):
@@ -236,7 +250,7 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
         model: str | BaseChatModel,
         *,
         backend: BACKEND_TYPES,
-        trigger: ContextSize | list[ContextSize] | None = None,
+        trigger: ContextSize | TriggerClause | list[ContextSize | TriggerClause] | None = None,
         keep: ContextSize = ("messages", _DEFAULT_MESSAGES_TO_KEEP),
         token_counter: TokenCounter = count_tokens_approximately,
         summary_prompt: str = DEFAULT_SUMMARY_PROMPT,
@@ -249,7 +263,9 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
         Args:
             model: The language model to use for generating summaries.
             backend: Backend instance or factory for persisting conversation history.
-            trigger: Threshold(s) that trigger summarization.
+            trigger: Threshold(s) that trigger summarization. A tuple is a single threshold,
+                a dict combines thresholds with AND semantics, and a list combines items
+                with OR semantics.
             keep: Context retention policy after summarization.
 
                 Defaults to keeping last 20 messages.
@@ -300,16 +316,23 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
                 package="deepagents",
             )
 
+        lc_trigger = self._trigger_for_lc_constructor(trigger)
+
         # Initialize langchain helper for core summarization logic
         self._lc_helper = LCSummarizationMiddleware(
             model=model,
-            trigger=trigger,
+            trigger=lc_trigger,
             keep=keep,
             token_counter=token_counter,
             summary_prompt=summary_prompt,
             trim_tokens_to_summarize=trim_tokens_to_summarize,
             **deprecated_kwargs,
         )
+        self.trigger = self._copy_trigger(trigger)
+        self._trigger_conditions = self._normalize_trigger(trigger)
+        lc_helper = cast("Any", self._lc_helper)
+        lc_helper.trigger = self.trigger
+        lc_helper._trigger_conditions = self._trigger_conditions
 
         # Deep Agents specific attributes
         self._backend = backend
@@ -334,6 +357,106 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
             self._max_arg_length = truncate_args_settings.get("max_length", 2000)
             self._truncation_text = truncate_args_settings.get("truncation_text", "...(argument truncated)")
 
+    @staticmethod
+    def _copy_trigger(
+        trigger: ContextSize | TriggerClause | list[ContextSize | TriggerClause] | None,
+    ) -> ContextSize | TriggerClause | list[ContextSize | TriggerClause] | None:
+        """Copy mutable trigger containers so caller mutations do not affect this instance."""
+        if isinstance(trigger, Mapping):
+            return cast("TriggerClause", dict(trigger))
+        if isinstance(trigger, list):
+            return [cast("TriggerClause", dict(item)) if isinstance(item, Mapping) else item for item in trigger]
+        return trigger
+
+    @staticmethod
+    def _validate_trigger_clause(clause: Mapping[str, Any]) -> TriggerClause:
+        """Validate a dict trigger clause and return a typed shallow copy."""
+        if not clause:
+            msg = "trigger clause must specify at least one of 'tokens', 'messages', 'fraction'"
+            raise ValueError(msg)
+
+        validated: dict[str, int | float] = {}
+        for kind, value in clause.items():
+            if kind not in {"tokens", "messages", "fraction"}:
+                msg = f"Unsupported trigger metric: {kind!r}"
+                raise ValueError(msg)
+            if isinstance(value, bool):
+                msg = f"{kind} trigger value must be numeric, got {value!r}"
+                raise ValueError(msg)  # noqa: TRY004
+            if kind == "fraction":
+                if not isinstance(value, (int, float)):
+                    msg = f"Fraction trigger values must be numeric, got {value!r}"
+                    raise ValueError(msg)
+            elif not isinstance(value, int):
+                msg = f"{kind} trigger values must be integers, got {value!r}"
+                raise ValueError(msg)
+            LCSummarizationMiddleware._validate_context_size(cast("ContextSize", (kind, value)), "trigger")
+            validated[kind] = value
+        return cast("TriggerClause", validated)
+
+    @classmethod
+    def _normalize_trigger(
+        cls,
+        trigger: ContextSize | TriggerClause | list[ContextSize | TriggerClause] | None,
+    ) -> list[TriggerClause]:
+        """Normalize supported trigger inputs into dict clauses."""
+        if trigger is None:
+            return []
+
+        def _tuple_to_clause(context: ContextSize) -> TriggerClause:
+            kind, value = LCSummarizationMiddleware._validate_context_size(context, "trigger")
+            return cast("TriggerClause", {kind: value})
+
+        subject: Any = trigger
+        if isinstance(subject, Mapping):
+            return [cls._validate_trigger_clause(subject)]
+        if isinstance(subject, tuple):
+            return [_tuple_to_clause(cast("ContextSize", subject))]
+        if isinstance(subject, list):
+            clauses: list[TriggerClause] = []
+            for item in subject:
+                if isinstance(item, Mapping):
+                    clauses.append(cls._validate_trigger_clause(item))
+                elif isinstance(item, tuple):
+                    clauses.append(_tuple_to_clause(cast("ContextSize", item)))
+                else:
+                    msg = f"Unsupported trigger item type: {type(item)}"
+                    raise TypeError(msg)
+            return clauses
+
+        msg = f"Unsupported trigger type: {type(subject)}"
+        raise TypeError(msg)
+
+    @classmethod
+    def _trigger_for_lc_constructor(
+        cls,
+        trigger: ContextSize | TriggerClause | list[ContextSize | TriggerClause] | None,
+    ) -> ContextSize | list[ContextSize] | None:
+        """Convert dict trigger clauses into tuple triggers accepted by old LangChain."""
+        if trigger is None or isinstance(trigger, tuple):
+            return trigger
+
+        contexts: list[ContextSize] = []
+        subject: Any = trigger
+        if isinstance(subject, Mapping):
+            clause = cls._validate_trigger_clause(subject)
+            contexts.extend(cast("ContextSize", (kind, value)) for kind, value in clause.items())
+            return contexts
+        if isinstance(subject, list):
+            for item in subject:
+                if isinstance(item, Mapping):
+                    clause = cls._validate_trigger_clause(item)
+                    contexts.extend(cast("ContextSize", (kind, value)) for kind, value in clause.items())
+                elif isinstance(item, tuple):
+                    contexts.append(LCSummarizationMiddleware._validate_context_size(cast("ContextSize", item), "trigger"))
+                else:
+                    msg = f"Unsupported trigger item type: {type(item)}"
+                    raise TypeError(msg)
+            return contexts
+
+        msg = f"Unsupported trigger type: {type(subject)}"
+        raise TypeError(msg)
+
     # Delegated properties and methods from langchain helper
     @property
     def model(self) -> BaseChatModel:
@@ -351,7 +474,39 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
 
     def _should_summarize(self, messages: list[AnyMessage], total_tokens: int) -> bool:
         """Determine whether summarization should run for the current token usage."""
-        return self._lc_helper._should_summarize(messages, total_tokens)
+        if not self._trigger_conditions:
+            return False
+        return any(self._is_summarization_clause_met(clause, messages, total_tokens) for clause in self._trigger_conditions)
+
+    def _is_summarization_clause_met(
+        self,
+        clause: TriggerClause,
+        messages: list[AnyMessage],
+        total_tokens: int,
+    ) -> bool:
+        """Check whether all thresholds in a summarization trigger clause are met."""
+        return all(self._is_summarization_condition_met(kind, cast("float", value), messages, total_tokens) for kind, value in clause.items())
+
+    def _is_summarization_condition_met(
+        self,
+        kind: str,
+        value: float,
+        messages: list[AnyMessage],
+        total_tokens: int,
+    ) -> bool:
+        """Check whether one summarization trigger threshold is met."""
+        if kind == "messages":
+            return len(messages) >= cast("int", value)
+        if kind == "tokens":
+            threshold = cast("int", value)
+            return total_tokens >= threshold or self._lc_helper._should_summarize_based_on_reported_tokens(messages, threshold)
+        if kind == "fraction":
+            max_input_tokens = self._get_profile_limits()
+            if max_input_tokens is None:
+                return False
+            threshold = max(1, int(max_input_tokens * value))
+            return total_tokens >= threshold or self._lc_helper._should_summarize_based_on_reported_tokens(messages, threshold)
+        return False
 
     def _determine_cutoff_index(self, messages: list[AnyMessage]) -> int:
         """Choose cutoff index respecting retention configuration."""
@@ -1528,6 +1683,38 @@ class SummarizationToolMiddleware(AgentMiddleware):
             }
         )
 
+    @staticmethod
+    def _compact_threshold(value: float) -> int:
+        """Return the half-trigger threshold used by the compact tool."""
+        return max(1, int(value * 0.5))
+
+    @staticmethod
+    def _compact_trigger_clause(condition: object) -> Mapping[str, float]:
+        """Normalize old tuple and new dict trigger conditions for compact gating."""
+        if isinstance(condition, Mapping):
+            return cast("Mapping[str, float]", condition)
+        kind, value = cast("tuple[str, float]", condition)
+        return {kind: value}
+
+    def _is_compaction_clause_met(self, clause: Mapping[str, float], messages: list[AnyMessage]) -> bool:
+        """Check whether a normalized compact eligibility clause is met."""
+        lc = self._summarization._lc_helper
+        for kind, value in clause.items():
+            if kind == "messages" and len(messages) < self._compact_threshold(value):
+                return False
+            if kind == "tokens" and not lc._should_summarize_based_on_reported_tokens(messages, self._compact_threshold(value)):
+                return False
+            if kind == "fraction":
+                max_input_tokens = lc._get_profile_limits()
+                if max_input_tokens is None:
+                    return False
+                threshold = self._compact_threshold(max_input_tokens * value)
+                if not lc._should_summarize_based_on_reported_tokens(messages, threshold):
+                    return False
+            if kind not in {"messages", "tokens", "fraction"}:
+                return False
+        return True
+
     def _is_eligible_for_compaction(self, messages: list[AnyMessage]) -> bool:
         """Check if manual compaction is currently allowed.
 
@@ -1536,33 +1723,17 @@ class SummarizationToolMiddleware(AgentMiddleware):
         the configured auto-summarization trigger:
 
         - For `("tokens", N)`, eligibility starts at `0.5 * N`.
+        - For `("messages", N)`, eligibility starts at `0.5 * N` messages.
         - For `("fraction", F)`, eligibility starts at `0.5 * F` of model max
             input tokens.
+        - For dict clauses, all specified thresholds must be met.
 
         Uses reported usage metadata when available.
         """
-        lc = self._summarization._lc_helper
-        trigger_conditions = lc._trigger_conditions
+        trigger_conditions = self._summarization._lc_helper._trigger_conditions
         if not trigger_conditions:
             return False
-
-        for kind, value in trigger_conditions:
-            if kind == "tokens":
-                threshold = int(value * 0.5)
-                if threshold <= 0:
-                    threshold = 1
-                if lc._should_summarize_based_on_reported_tokens(messages, threshold):
-                    return True
-            elif kind == "fraction":
-                max_input_tokens = lc._get_profile_limits()
-                if max_input_tokens is None:
-                    continue
-                threshold = int(max_input_tokens * value * 0.5)
-                if threshold <= 0:
-                    threshold = 1
-                if lc._should_summarize_based_on_reported_tokens(messages, threshold):
-                    return True
-        return False
+        return any(self._is_compaction_clause_met(self._compact_trigger_clause(condition), messages) for condition in trigger_conditions)
 
     def _run_compact(self, runtime: ToolRuntime) -> Command:
         """Synchronous compact implementation called by the compact tool.

--- a/libs/deepagents/tests/unit_tests/middleware/test_compact_tool.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_compact_tool.py
@@ -636,6 +636,68 @@ class TestIsEligibleForCompaction:
             result = mw._run_compact(runtime)
         assert "_summarization_event" in result.update
 
+    def test_dict_clause_requires_all_thresholds(self) -> None:
+        """Dict trigger clauses use AND semantics for compact eligibility."""
+        mw = _make_middleware_with_trigger(("tokens", 100_000))
+        mw._summarization._lc_helper._trigger_conditions = [{"tokens": 100_000, "messages": 6}]
+        messages = [HumanMessage(content="hi"), _ai_message_with_usage(60_000)]
+        runtime = _make_runtime(messages)
+        result = mw._run_compact(runtime)
+        assert "Nothing to compact" in result.update["messages"][0].content
+
+        messages.append(HumanMessage(content="more context"))
+        runtime = _make_runtime(messages)
+        with (
+            patch.object(mw._summarization, "_determine_cutoff_index", return_value=1),
+            patch.object(mw._summarization, "_partition_messages", side_effect=lambda m, i: (m[:i], m[i:])),
+            patch.object(mw._summarization, "_create_summary", return_value="Summary."),
+            patch.object(mw._summarization, "_offload_to_backend", return_value=None),
+        ):
+            result = mw._run_compact(runtime)
+        assert "_summarization_event" in result.update
+
+    def test_dict_trigger_constructs_with_unreleased_langchain_support(self) -> None:
+        """Dict trigger input should not require LangChain's new trigger support."""
+        mw = _make_middleware_with_trigger({"tokens": 100_000, "messages": 6})
+        assert mw._summarization._lc_helper._trigger_conditions == [{"tokens": 100_000, "messages": 6}]
+
+    def test_dict_clause_list_uses_or_semantics(self) -> None:
+        """Multiple dict trigger clauses use OR semantics for compact eligibility."""
+        mw = _make_middleware_with_trigger(("tokens", 100_000))
+        mw._summarization._lc_helper._trigger_conditions = [
+            {"tokens": 100_000, "messages": 10},
+            {"tokens": 200_000, "messages": 2},
+        ]
+        messages = [HumanMessage(content="hi"), _ai_message_with_usage(110_000)]
+        runtime = _make_runtime(messages)
+        with (
+            patch.object(mw._summarization, "_determine_cutoff_index", return_value=1),
+            patch.object(mw._summarization, "_partition_messages", side_effect=lambda m, i: (m[:i], m[i:])),
+            patch.object(mw._summarization, "_create_summary", return_value="Summary."),
+            patch.object(mw._summarization, "_offload_to_backend", return_value=None),
+        ):
+            result = mw._run_compact(runtime)
+        assert "_summarization_event" in result.update
+
+    def test_messages_trigger_uses_message_count(self) -> None:
+        """Message trigger eligibility uses half the configured message count."""
+        mw = _make_middleware_with_trigger(("messages", 4))
+        messages = [HumanMessage(content="one")]
+        runtime = _make_runtime(messages)
+        result = mw._run_compact(runtime)
+        assert "Nothing to compact" in result.update["messages"][0].content
+
+        messages.append(HumanMessage(content="two"))
+        runtime = _make_runtime(messages)
+        with (
+            patch.object(mw._summarization, "_determine_cutoff_index", return_value=1),
+            patch.object(mw._summarization, "_partition_messages", side_effect=lambda m, i: (m[:i], m[i:])),
+            patch.object(mw._summarization, "_create_summary", return_value="Summary."),
+            patch.object(mw._summarization, "_offload_to_backend", return_value=None),
+        ):
+            result = mw._run_compact(runtime)
+        assert "_summarization_event" in result.update
+
     def test_no_usage_metadata_falls_through(self) -> None:
         """No usage metadata → not eligible → falls through to cutoff check."""
         mw = _make_middleware_with_trigger(("tokens", 100_000))


### PR DESCRIPTION
This adds a temporary compatibility shim for the upcoming LangChain `SummarizationMiddleware` trigger-clause changes.

LangChain is moving `_trigger_conditions` from tuple thresholds to dict clauses so triggers can support AND semantics within a clause and OR semantics across clauses. Deep Agents already needs to handle that new shape for compact-tool eligibility, but the currently released LangChain wheel still rejects dict trigger inputs during middleware construction.

This keeps Deep Agents compatible with both versions by normalizing triggers locally, passing old tuple-style triggers into older LangChain during construction, and preserving the dict-clause shape for Deep Agents' own summarization and compact-tool checks.

This is intended to unblock the LangChain release. Once Deep Agents can raise its minimum LangChain version to a release that includes native trigger-clause support, this shim can be simplified or removed.