### PR TITLE
chore(sdk): update summarization trigger compatibility

### DIFF
--- a/examples/async-subagent-server/uv.lock
+++ b/examples/async-subagent-server/uv.lock
@@ -363,7 +363,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.6,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -637,16 +637,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.5"
+version = "1.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/16/c77e6d87cb580e2eb15d117de3494647a7198380703c72fecb1ab585d84d/langchain-1.3.6.tar.gz", hash = "sha256:c36a5ab3ad3149636a55fa0e5e237fb28ec4dbd40f6fd08c5a5e9494f0b16411", size = 614499, upload-time = "2026-06-10T00:53:02.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/647a72e9ed690bce49212ea9ee9dc01d874e73932045d69116cc6d34fc75/langchain-1.3.6-py3-none-any.whl", hash = "sha256:5c8c70deeb18326d5348039ac5ba778135ff29faf4ea003342fd199e3d7ec9ef", size = 127124, upload-time = "2026-06-10T00:53:01.186Z" },
 ]
 
 [[package]]

--- a/examples/async-subagent-server/uv.lock
+++ b/examples/async-subagent-server/uv.lock
@@ -363,7 +363,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -637,16 +637,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3f/034eb6cbef90bfccc89b7f8ed0c1d853dc9cb0bea17c7a269534c647ba3a/langchain-1.3.4.tar.gz", hash = "sha256:d6e0654c22848925534f5c0a706f9be481bb09a619ec60a738fbd1e5502e457a", size = 606617, upload-time = "2026-06-02T20:04:49.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/29/9ffe99c7dc4891a0215ec59c423bea320f943c08a231bc5bae392a438a83/langchain-1.3.4-py3-none-any.whl", hash = "sha256:e51b05ab23d056bc6bf2d97d8c694fb92d6d5765126fef74565d007c27581672", size = 125286, upload-time = "2026-06-02T20:04:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
 ]
 
 [[package]]

--- a/examples/llm-wiki/uv.lock
+++ b/examples/llm-wiki/uv.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.6,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -548,16 +548,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.5"
+version = "1.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/16/c77e6d87cb580e2eb15d117de3494647a7198380703c72fecb1ab585d84d/langchain-1.3.6.tar.gz", hash = "sha256:c36a5ab3ad3149636a55fa0e5e237fb28ec4dbd40f6fd08c5a5e9494f0b16411", size = 614499, upload-time = "2026-06-10T00:53:02.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/647a72e9ed690bce49212ea9ee9dc01d874e73932045d69116cc6d34fc75/langchain-1.3.6-py3-none-any.whl", hash = "sha256:5c8c70deeb18326d5348039ac5ba778135ff29faf4ea003342fd199e3d7ec9ef", size = 127124, upload-time = "2026-06-10T00:53:01.186Z" },
 ]
 
 [[package]]

--- a/examples/llm-wiki/uv.lock
+++ b/examples/llm-wiki/uv.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -548,16 +548,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3f/034eb6cbef90bfccc89b7f8ed0c1d853dc9cb0bea17c7a269534c647ba3a/langchain-1.3.4.tar.gz", hash = "sha256:d6e0654c22848925534f5c0a706f9be481bb09a619ec60a738fbd1e5502e457a", size = 606617, upload-time = "2026-06-02T20:04:49.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/29/9ffe99c7dc4891a0215ec59c423bea320f943c08a231bc5bae392a438a83/langchain-1.3.4-py3-none-any.whl", hash = "sha256:e51b05ab23d056bc6bf2d97d8c694fb92d6d5765126fef74565d007c27581672", size = 125286, upload-time = "2026-06-02T20:04:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
 ]
 
 [[package]]

--- a/examples/repl_swarm/uv.lock
+++ b/examples/repl_swarm/uv.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.6,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -548,16 +548,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.5"
+version = "1.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/16/c77e6d87cb580e2eb15d117de3494647a7198380703c72fecb1ab585d84d/langchain-1.3.6.tar.gz", hash = "sha256:c36a5ab3ad3149636a55fa0e5e237fb28ec4dbd40f6fd08c5a5e9494f0b16411", size = 614499, upload-time = "2026-06-10T00:53:02.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/647a72e9ed690bce49212ea9ee9dc01d874e73932045d69116cc6d34fc75/langchain-1.3.6-py3-none-any.whl", hash = "sha256:5c8c70deeb18326d5348039ac5ba778135ff29faf4ea003342fd199e3d7ec9ef", size = 127124, upload-time = "2026-06-10T00:53:01.186Z" },
 ]
 
 [[package]]

--- a/examples/repl_swarm/uv.lock
+++ b/examples/repl_swarm/uv.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -548,16 +548,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3f/034eb6cbef90bfccc89b7f8ed0c1d853dc9cb0bea17c7a269534c647ba3a/langchain-1.3.4.tar.gz", hash = "sha256:d6e0654c22848925534f5c0a706f9be481bb09a619ec60a738fbd1e5502e457a", size = 606617, upload-time = "2026-06-02T20:04:49.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/29/9ffe99c7dc4891a0215ec59c423bea320f943c08a231bc5bae392a438a83/langchain-1.3.4-py3-none-any.whl", hash = "sha256:e51b05ab23d056bc6bf2d97d8c694fb92d6d5765126fef74565d007c27581672", size = 125286, upload-time = "2026-06-02T20:04:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
 ]
 
 [[package]]

--- a/examples/rlm_agent/uv.lock
+++ b/examples/rlm_agent/uv.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.6,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -548,16 +548,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.5"
+version = "1.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/16/c77e6d87cb580e2eb15d117de3494647a7198380703c72fecb1ab585d84d/langchain-1.3.6.tar.gz", hash = "sha256:c36a5ab3ad3149636a55fa0e5e237fb28ec4dbd40f6fd08c5a5e9494f0b16411", size = 614499, upload-time = "2026-06-10T00:53:02.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/647a72e9ed690bce49212ea9ee9dc01d874e73932045d69116cc6d34fc75/langchain-1.3.6-py3-none-any.whl", hash = "sha256:5c8c70deeb18326d5348039ac5ba778135ff29faf4ea003342fd199e3d7ec9ef", size = 127124, upload-time = "2026-06-10T00:53:01.186Z" },
 ]
 
 [[package]]

--- a/examples/rlm_agent/uv.lock
+++ b/examples/rlm_agent/uv.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -548,16 +548,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3f/034eb6cbef90bfccc89b7f8ed0c1d853dc9cb0bea17c7a269534c647ba3a/langchain-1.3.4.tar.gz", hash = "sha256:d6e0654c22848925534f5c0a706f9be481bb09a619ec60a738fbd1e5502e457a", size = 606617, upload-time = "2026-06-02T20:04:49.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/29/9ffe99c7dc4891a0215ec59c423bea320f943c08a231bc5bae392a438a83/langchain-1.3.4-py3-none-any.whl", hash = "sha256:e51b05ab23d056bc6bf2d97d8c694fb92d6d5765126fef74565d007c27581672", size = 125286, upload-time = "2026-06-02T20:04:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
 ]
 
 [[package]]

--- a/libs/acp/uv.lock
+++ b/libs/acp/uv.lock
@@ -443,7 +443,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -752,16 +752,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3f/034eb6cbef90bfccc89b7f8ed0c1d853dc9cb0bea17c7a269534c647ba3a/langchain-1.3.4.tar.gz", hash = "sha256:d6e0654c22848925534f5c0a706f9be481bb09a619ec60a738fbd1e5502e457a", size = 606617, upload-time = "2026-06-02T20:04:49.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/29/9ffe99c7dc4891a0215ec59c423bea320f943c08a231bc5bae392a438a83/langchain-1.3.4-py3-none-any.whl", hash = "sha256:e51b05ab23d056bc6bf2d97d8c694fb92d6d5765126fef74565d007c27581672", size = 125286, upload-time = "2026-06-02T20:04:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
 ]
 
 [[package]]

--- a/libs/acp/uv.lock
+++ b/libs/acp/uv.lock
@@ -443,7 +443,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.6,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -752,16 +752,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.5"
+version = "1.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/16/c77e6d87cb580e2eb15d117de3494647a7198380703c72fecb1ab585d84d/langchain-1.3.6.tar.gz", hash = "sha256:c36a5ab3ad3149636a55fa0e5e237fb28ec4dbd40f6fd08c5a5e9494f0b16411", size = 614499, upload-time = "2026-06-10T00:53:02.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/647a72e9ed690bce49212ea9ee9dc01d874e73932045d69116cc6d34fc75/langchain-1.3.6-py3-none-any.whl", hash = "sha256:5c8c70deeb18326d5348039ac5ba778135ff29faf4ea003342fd199e3d7ec9ef", size = 127124, upload-time = "2026-06-10T00:53:01.186Z" },
 ]
 
 [[package]]

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -420,7 +420,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.6,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -842,16 +842,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.5"
+version = "1.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/16/c77e6d87cb580e2eb15d117de3494647a7198380703c72fecb1ab585d84d/langchain-1.3.6.tar.gz", hash = "sha256:c36a5ab3ad3149636a55fa0e5e237fb28ec4dbd40f6fd08c5a5e9494f0b16411", size = 614499, upload-time = "2026-06-10T00:53:02.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/647a72e9ed690bce49212ea9ee9dc01d874e73932045d69116cc6d34fc75/langchain-1.3.6-py3-none-any.whl", hash = "sha256:5c8c70deeb18326d5348039ac5ba778135ff29faf4ea003342fd199e3d7ec9ef", size = 127124, upload-time = "2026-06-10T00:53:01.186Z" },
 ]
 
 [[package]]

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -420,7 +420,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -842,16 +842,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3f/034eb6cbef90bfccc89b7f8ed0c1d853dc9cb0bea17c7a269534c647ba3a/langchain-1.3.4.tar.gz", hash = "sha256:d6e0654c22848925534f5c0a706f9be481bb09a619ec60a738fbd1e5502e457a", size = 606617, upload-time = "2026-06-02T20:04:49.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/29/9ffe99c7dc4891a0215ec59c423bea320f943c08a231bc5bae392a438a83/langchain-1.3.4-py3-none-any.whl", hash = "sha256:e51b05ab23d056bc6bf2d97d8c694fb92d6d5765126fef74565d007c27581672", size = 125286, upload-time = "2026-06-02T20:04:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
 ]
 
 [[package]]

--- a/libs/code/uv.lock
+++ b/libs/code/uv.lock
@@ -983,7 +983,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -2537,16 +2537,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3f/034eb6cbef90bfccc89b7f8ed0c1d853dc9cb0bea17c7a269534c647ba3a/langchain-1.3.4.tar.gz", hash = "sha256:d6e0654c22848925534f5c0a706f9be481bb09a619ec60a738fbd1e5502e457a", size = 606617, upload-time = "2026-06-02T20:04:49.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/29/9ffe99c7dc4891a0215ec59c423bea320f943c08a231bc5bae392a438a83/langchain-1.3.4-py3-none-any.whl", hash = "sha256:e51b05ab23d056bc6bf2d97d8c694fb92d6d5765126fef74565d007c27581672", size = 125286, upload-time = "2026-06-02T20:04:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
 ]
 
 [[package]]

--- a/libs/code/uv.lock
+++ b/libs/code/uv.lock
@@ -983,7 +983,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.6,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -2537,16 +2537,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.5"
+version = "1.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/16/c77e6d87cb580e2eb15d117de3494647a7198380703c72fecb1ab585d84d/langchain-1.3.6.tar.gz", hash = "sha256:c36a5ab3ad3149636a55fa0e5e237fb28ec4dbd40f6fd08c5a5e9494f0b16411", size = 614499, upload-time = "2026-06-10T00:53:02.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/647a72e9ed690bce49212ea9ee9dc01d874e73932045d69116cc6d34fc75/langchain-1.3.6-py3-none-any.whl", hash = "sha256:5c8c70deeb18326d5348039ac5ba778135ff29faf4ea003342fd199e3d7ec9ef", size = 127124, upload-time = "2026-06-10T00:53:01.186Z" },
 ]
 
 [[package]]

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -1576,6 +1576,11 @@ class SummarizationToolMiddleware(AgentMiddleware):
                 return False
         return True
 
+    def _compact_trigger_conditions(self) -> list[object]:
+        """Return LangChain's canonical trigger clauses, falling back for older versions."""
+        lc = self._summarization._lc_helper
+        return cast("list[object]", getattr(lc, "_trigger_clauses", lc._trigger_conditions))
+
     def _is_eligible_for_compaction(self, messages: list[AnyMessage]) -> bool:
         """Check if manual compaction is currently allowed.
 
@@ -1591,7 +1596,7 @@ class SummarizationToolMiddleware(AgentMiddleware):
 
         Uses reported usage metadata when available.
         """
-        trigger_conditions = self._summarization._lc_helper._trigger_conditions
+        trigger_conditions = self._compact_trigger_conditions()
         if not trigger_conditions:
             return False
         return any(self._is_compaction_clause_met(self._compact_trigger_clause(condition), messages) for condition in trigger_conditions)

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -1576,11 +1576,6 @@ class SummarizationToolMiddleware(AgentMiddleware):
                 return False
         return True
 
-    def _compact_trigger_conditions(self) -> list[object]:
-        """Return LangChain's canonical trigger clauses, falling back for older versions."""
-        lc = self._summarization._lc_helper
-        return cast("list[object]", getattr(lc, "_trigger_clauses", lc._trigger_conditions))
-
     def _is_eligible_for_compaction(self, messages: list[AnyMessage]) -> bool:
         """Check if manual compaction is currently allowed.
 
@@ -1596,7 +1591,7 @@ class SummarizationToolMiddleware(AgentMiddleware):
 
         Uses reported usage metadata when available.
         """
-        trigger_conditions = self._compact_trigger_conditions()
+        trigger_conditions = self._summarization._lc_helper._trigger_clauses
         if not trigger_conditions:
             return False
         return any(self._is_compaction_clause_met(self._compact_trigger_clause(condition), messages) for condition in trigger_conditions)

--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -316,23 +316,16 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
                 package="deepagents",
             )
 
-        lc_trigger = self._trigger_for_lc_constructor(trigger)
-
         # Initialize langchain helper for core summarization logic
         self._lc_helper = LCSummarizationMiddleware(
             model=model,
-            trigger=lc_trigger,
+            trigger=trigger,
             keep=keep,
             token_counter=token_counter,
             summary_prompt=summary_prompt,
             trim_tokens_to_summarize=trim_tokens_to_summarize,
             **deprecated_kwargs,
         )
-        self.trigger = self._copy_trigger(trigger)
-        self._trigger_conditions = self._normalize_trigger(trigger)
-        lc_helper = cast("Any", self._lc_helper)
-        lc_helper.trigger = self.trigger
-        lc_helper._trigger_conditions = self._trigger_conditions
 
         # Deep Agents specific attributes
         self._backend = backend
@@ -357,106 +350,6 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
             self._max_arg_length = truncate_args_settings.get("max_length", 2000)
             self._truncation_text = truncate_args_settings.get("truncation_text", "...(argument truncated)")
 
-    @staticmethod
-    def _copy_trigger(
-        trigger: ContextSize | TriggerClause | list[ContextSize | TriggerClause] | None,
-    ) -> ContextSize | TriggerClause | list[ContextSize | TriggerClause] | None:
-        """Copy mutable trigger containers so caller mutations do not affect this instance."""
-        if isinstance(trigger, Mapping):
-            return cast("TriggerClause", dict(trigger))
-        if isinstance(trigger, list):
-            return [cast("TriggerClause", dict(item)) if isinstance(item, Mapping) else item for item in trigger]
-        return trigger
-
-    @staticmethod
-    def _validate_trigger_clause(clause: Mapping[str, Any]) -> TriggerClause:
-        """Validate a dict trigger clause and return a typed shallow copy."""
-        if not clause:
-            msg = "trigger clause must specify at least one of 'tokens', 'messages', 'fraction'"
-            raise ValueError(msg)
-
-        validated: dict[str, int | float] = {}
-        for kind, value in clause.items():
-            if kind not in {"tokens", "messages", "fraction"}:
-                msg = f"Unsupported trigger metric: {kind!r}"
-                raise ValueError(msg)
-            if isinstance(value, bool):
-                msg = f"{kind} trigger value must be numeric, got {value!r}"
-                raise ValueError(msg)  # noqa: TRY004
-            if kind == "fraction":
-                if not isinstance(value, (int, float)):
-                    msg = f"Fraction trigger values must be numeric, got {value!r}"
-                    raise ValueError(msg)
-            elif not isinstance(value, int):
-                msg = f"{kind} trigger values must be integers, got {value!r}"
-                raise ValueError(msg)
-            LCSummarizationMiddleware._validate_context_size(cast("ContextSize", (kind, value)), "trigger")
-            validated[kind] = value
-        return cast("TriggerClause", validated)
-
-    @classmethod
-    def _normalize_trigger(
-        cls,
-        trigger: ContextSize | TriggerClause | list[ContextSize | TriggerClause] | None,
-    ) -> list[TriggerClause]:
-        """Normalize supported trigger inputs into dict clauses."""
-        if trigger is None:
-            return []
-
-        def _tuple_to_clause(context: ContextSize) -> TriggerClause:
-            kind, value = LCSummarizationMiddleware._validate_context_size(context, "trigger")
-            return cast("TriggerClause", {kind: value})
-
-        subject: Any = trigger
-        if isinstance(subject, Mapping):
-            return [cls._validate_trigger_clause(subject)]
-        if isinstance(subject, tuple):
-            return [_tuple_to_clause(cast("ContextSize", subject))]
-        if isinstance(subject, list):
-            clauses: list[TriggerClause] = []
-            for item in subject:
-                if isinstance(item, Mapping):
-                    clauses.append(cls._validate_trigger_clause(item))
-                elif isinstance(item, tuple):
-                    clauses.append(_tuple_to_clause(cast("ContextSize", item)))
-                else:
-                    msg = f"Unsupported trigger item type: {type(item)}"
-                    raise TypeError(msg)
-            return clauses
-
-        msg = f"Unsupported trigger type: {type(subject)}"
-        raise TypeError(msg)
-
-    @classmethod
-    def _trigger_for_lc_constructor(
-        cls,
-        trigger: ContextSize | TriggerClause | list[ContextSize | TriggerClause] | None,
-    ) -> ContextSize | list[ContextSize] | None:
-        """Convert dict trigger clauses into tuple triggers accepted by old LangChain."""
-        if trigger is None or isinstance(trigger, tuple):
-            return trigger
-
-        contexts: list[ContextSize] = []
-        subject: Any = trigger
-        if isinstance(subject, Mapping):
-            clause = cls._validate_trigger_clause(subject)
-            contexts.extend(cast("ContextSize", (kind, value)) for kind, value in clause.items())
-            return contexts
-        if isinstance(subject, list):
-            for item in subject:
-                if isinstance(item, Mapping):
-                    clause = cls._validate_trigger_clause(item)
-                    contexts.extend(cast("ContextSize", (kind, value)) for kind, value in clause.items())
-                elif isinstance(item, tuple):
-                    contexts.append(LCSummarizationMiddleware._validate_context_size(cast("ContextSize", item), "trigger"))
-                else:
-                    msg = f"Unsupported trigger item type: {type(item)}"
-                    raise TypeError(msg)
-            return contexts
-
-        msg = f"Unsupported trigger type: {type(subject)}"
-        raise TypeError(msg)
-
     # Delegated properties and methods from langchain helper
     @property
     def model(self) -> BaseChatModel:
@@ -474,39 +367,7 @@ class _DeepAgentsSummarizationMiddleware(AgentMiddleware):
 
     def _should_summarize(self, messages: list[AnyMessage], total_tokens: int) -> bool:
         """Determine whether summarization should run for the current token usage."""
-        if not self._trigger_conditions:
-            return False
-        return any(self._is_summarization_clause_met(clause, messages, total_tokens) for clause in self._trigger_conditions)
-
-    def _is_summarization_clause_met(
-        self,
-        clause: TriggerClause,
-        messages: list[AnyMessage],
-        total_tokens: int,
-    ) -> bool:
-        """Check whether all thresholds in a summarization trigger clause are met."""
-        return all(self._is_summarization_condition_met(kind, cast("float", value), messages, total_tokens) for kind, value in clause.items())
-
-    def _is_summarization_condition_met(
-        self,
-        kind: str,
-        value: float,
-        messages: list[AnyMessage],
-        total_tokens: int,
-    ) -> bool:
-        """Check whether one summarization trigger threshold is met."""
-        if kind == "messages":
-            return len(messages) >= cast("int", value)
-        if kind == "tokens":
-            threshold = cast("int", value)
-            return total_tokens >= threshold or self._lc_helper._should_summarize_based_on_reported_tokens(messages, threshold)
-        if kind == "fraction":
-            max_input_tokens = self._get_profile_limits()
-            if max_input_tokens is None:
-                return False
-            threshold = max(1, int(max_input_tokens * value))
-            return total_tokens >= threshold or self._lc_helper._should_summarize_based_on_reported_tokens(messages, threshold)
-        return False
+        return self._lc_helper._should_summarize(messages, total_tokens)
 
     def _determine_cutoff_index(self, messages: list[AnyMessage]) -> int:
         """Choose cutoff index respecting retention configuration."""

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "langchain-core>=1.4.2,<2.0.0",
     "langsmith>=0.8.11",
-    "langchain>=1.3.4,<2.0.0",
+    "langchain>=1.3.5,<2.0.0",
     "langchain-anthropic>=1.4.4,<2.0.0",
     "langchain-google-genai>=4.2.4,<5.0.0",
     "wcmatch",

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "langchain-core>=1.4.2,<2.0.0",
     "langsmith>=0.8.11",
-    "langchain>=1.3.5,<2.0.0",
+    "langchain>=1.3.6,<2.0.0",
     "langchain-anthropic>=1.4.4,<2.0.0",
     "langchain-google-genai>=4.2.4,<5.0.0",
     "wcmatch",

--- a/libs/deepagents/tests/unit_tests/middleware/test_compact_tool.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_compact_tool.py
@@ -639,7 +639,7 @@ class TestIsEligibleForCompaction:
     def test_dict_clause_requires_all_thresholds(self) -> None:
         """Dict trigger clauses use AND semantics for compact eligibility."""
         mw = _make_middleware_with_trigger(("tokens", 100_000))
-        mw._summarization._lc_helper._trigger_conditions = [{"tokens": 100_000, "messages": 6}]
+        mw._summarization._lc_helper._trigger_clauses = [{"tokens": 100_000, "messages": 6}]
         messages = [HumanMessage(content="hi"), _ai_message_with_usage(60_000)]
         runtime = _make_runtime(messages)
         result = mw._run_compact(runtime)
@@ -685,7 +685,7 @@ class TestIsEligibleForCompaction:
     def test_dict_clause_list_uses_or_semantics(self) -> None:
         """Multiple dict trigger clauses use OR semantics for compact eligibility."""
         mw = _make_middleware_with_trigger(("tokens", 100_000))
-        mw._summarization._lc_helper._trigger_conditions = [
+        mw._summarization._lc_helper._trigger_clauses = [
             {"tokens": 100_000, "messages": 10},
             {"tokens": 200_000, "messages": 2},
         ]

--- a/libs/deepagents/tests/unit_tests/middleware/test_compact_tool.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_compact_tool.py
@@ -656,10 +656,31 @@ class TestIsEligibleForCompaction:
             result = mw._run_compact(runtime)
         assert "_summarization_event" in result.update
 
-    def test_dict_trigger_constructs_with_unreleased_langchain_support(self) -> None:
-        """Dict trigger input should not require LangChain's new trigger support."""
+    def test_trigger_clauses_are_preferred_over_legacy_conditions(self) -> None:
+        """LangChain's canonical `_trigger_clauses` attr wins when available."""
+        mw = _make_middleware_with_trigger(("tokens", 100_000))
+        mw._summarization._lc_helper._trigger_clauses = [{"tokens": 100_000, "messages": 6}]
+        mw._summarization._lc_helper._trigger_conditions = [("tokens", 100_000)]
+        messages = [HumanMessage(content="hi"), _ai_message_with_usage(60_000)]
+        runtime = _make_runtime(messages)
+        result = mw._run_compact(runtime)
+        assert "Nothing to compact" in result.update["messages"][0].content
+
+        messages.append(HumanMessage(content="more context"))
+        runtime = _make_runtime(messages)
+        with (
+            patch.object(mw._summarization, "_determine_cutoff_index", return_value=1),
+            patch.object(mw._summarization, "_partition_messages", side_effect=lambda m, i: (m[:i], m[i:])),
+            patch.object(mw._summarization, "_create_summary", return_value="Summary."),
+            patch.object(mw._summarization, "_offload_to_backend", return_value=None),
+        ):
+            result = mw._run_compact(runtime)
+        assert "_summarization_event" in result.update
+
+    def test_dict_trigger_constructs_langchain_trigger_clauses(self) -> None:
+        """Dict trigger input should populate LangChain's canonical trigger clauses."""
         mw = _make_middleware_with_trigger({"tokens": 100_000, "messages": 6})
-        assert mw._summarization._lc_helper._trigger_conditions == [{"tokens": 100_000, "messages": 6}]
+        assert mw._summarization._lc_helper._trigger_clauses == [{"tokens": 100_000, "messages": 6}]
 
     def test_dict_clause_list_uses_or_semantics(self) -> None:
         """Multiple dict trigger clauses use OR semantics for compact eligibility."""

--- a/libs/deepagents/uv.lock
+++ b/libs/deepagents/uv.lock
@@ -449,7 +449,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -812,16 +812,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3f/034eb6cbef90bfccc89b7f8ed0c1d853dc9cb0bea17c7a269534c647ba3a/langchain-1.3.4.tar.gz", hash = "sha256:d6e0654c22848925534f5c0a706f9be481bb09a619ec60a738fbd1e5502e457a", size = 606617, upload-time = "2026-06-02T20:04:49.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/29/9ffe99c7dc4891a0215ec59c423bea320f943c08a231bc5bae392a438a83/langchain-1.3.4-py3-none-any.whl", hash = "sha256:e51b05ab23d056bc6bf2d97d8c694fb92d6d5765126fef74565d007c27581672", size = 125286, upload-time = "2026-06-02T20:04:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
 ]
 
 [[package]]

--- a/libs/deepagents/uv.lock
+++ b/libs/deepagents/uv.lock
@@ -449,7 +449,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.6,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -812,16 +812,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.5"
+version = "1.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/16/c77e6d87cb580e2eb15d117de3494647a7198380703c72fecb1ab585d84d/langchain-1.3.6.tar.gz", hash = "sha256:c36a5ab3ad3149636a55fa0e5e237fb28ec4dbd40f6fd08c5a5e9494f0b16411", size = 614499, upload-time = "2026-06-10T00:53:02.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/647a72e9ed690bce49212ea9ee9dc01d874e73932045d69116cc6d34fc75/langchain-1.3.6-py3-none-any.whl", hash = "sha256:5c8c70deeb18326d5348039ac5ba778135ff29faf4ea003342fd199e3d7ec9ef", size = 127124, upload-time = "2026-06-10T00:53:01.186Z" },
 ]
 
 [[package]]

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -430,7 +430,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.6,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -1331,16 +1331,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.5"
+version = "1.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "langgraph", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/16/c77e6d87cb580e2eb15d117de3494647a7198380703c72fecb1ab585d84d/langchain-1.3.6.tar.gz", hash = "sha256:c36a5ab3ad3149636a55fa0e5e237fb28ec4dbd40f6fd08c5a5e9494f0b16411", size = 614499, upload-time = "2026-06-10T00:53:02.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/647a72e9ed690bce49212ea9ee9dc01d874e73932045d69116cc6d34fc75/langchain-1.3.6-py3-none-any.whl", hash = "sha256:5c8c70deeb18326d5348039ac5ba778135ff29faf4ea003342fd199e3d7ec9ef", size = 127124, upload-time = "2026-06-10T00:53:01.186Z" },
 ]
 
 [[package]]

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -430,7 +430,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -1331,16 +1331,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "langgraph", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3f/034eb6cbef90bfccc89b7f8ed0c1d853dc9cb0bea17c7a269534c647ba3a/langchain-1.3.4.tar.gz", hash = "sha256:d6e0654c22848925534f5c0a706f9be481bb09a619ec60a738fbd1e5502e457a", size = 606617, upload-time = "2026-06-02T20:04:49.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/29/9ffe99c7dc4891a0215ec59c423bea320f943c08a231bc5bae392a438a83/langchain-1.3.4-py3-none-any.whl", hash = "sha256:e51b05ab23d056bc6bf2d97d8c694fb92d6d5765126fef74565d007c27581672", size = 125286, upload-time = "2026-06-02T20:04:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
 ]
 
 [[package]]

--- a/libs/partners/daytona/uv.lock
+++ b/libs/partners/daytona/uv.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.6,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -1078,16 +1078,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.5"
+version = "1.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/16/c77e6d87cb580e2eb15d117de3494647a7198380703c72fecb1ab585d84d/langchain-1.3.6.tar.gz", hash = "sha256:c36a5ab3ad3149636a55fa0e5e237fb28ec4dbd40f6fd08c5a5e9494f0b16411", size = 614499, upload-time = "2026-06-10T00:53:02.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/647a72e9ed690bce49212ea9ee9dc01d874e73932045d69116cc6d34fc75/langchain-1.3.6-py3-none-any.whl", hash = "sha256:5c8c70deeb18326d5348039ac5ba778135ff29faf4ea003342fd199e3d7ec9ef", size = 127124, upload-time = "2026-06-10T00:53:01.186Z" },
 ]
 
 [[package]]

--- a/libs/partners/daytona/uv.lock
+++ b/libs/partners/daytona/uv.lock
@@ -657,7 +657,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -1078,16 +1078,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3f/034eb6cbef90bfccc89b7f8ed0c1d853dc9cb0bea17c7a269534c647ba3a/langchain-1.3.4.tar.gz", hash = "sha256:d6e0654c22848925534f5c0a706f9be481bb09a619ec60a738fbd1e5502e457a", size = 606617, upload-time = "2026-06-02T20:04:49.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/29/9ffe99c7dc4891a0215ec59c423bea320f943c08a231bc5bae392a438a83/langchain-1.3.4-py3-none-any.whl", hash = "sha256:e51b05ab23d056bc6bf2d97d8c694fb92d6d5765126fef74565d007c27581672", size = 125286, upload-time = "2026-06-02T20:04:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
 ]
 
 [[package]]

--- a/libs/partners/modal/uv.lock
+++ b/libs/partners/modal/uv.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.6,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -1019,16 +1019,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.5"
+version = "1.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/16/c77e6d87cb580e2eb15d117de3494647a7198380703c72fecb1ab585d84d/langchain-1.3.6.tar.gz", hash = "sha256:c36a5ab3ad3149636a55fa0e5e237fb28ec4dbd40f6fd08c5a5e9494f0b16411", size = 614499, upload-time = "2026-06-10T00:53:02.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/647a72e9ed690bce49212ea9ee9dc01d874e73932045d69116cc6d34fc75/langchain-1.3.6-py3-none-any.whl", hash = "sha256:5c8c70deeb18326d5348039ac5ba778135ff29faf4ea003342fd199e3d7ec9ef", size = 127124, upload-time = "2026-06-10T00:53:01.186Z" },
 ]
 
 [[package]]

--- a/libs/partners/modal/uv.lock
+++ b/libs/partners/modal/uv.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -1019,16 +1019,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3f/034eb6cbef90bfccc89b7f8ed0c1d853dc9cb0bea17c7a269534c647ba3a/langchain-1.3.4.tar.gz", hash = "sha256:d6e0654c22848925534f5c0a706f9be481bb09a619ec60a738fbd1e5502e457a", size = 606617, upload-time = "2026-06-02T20:04:49.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/29/9ffe99c7dc4891a0215ec59c423bea320f943c08a231bc5bae392a438a83/langchain-1.3.4-py3-none-any.whl", hash = "sha256:e51b05ab23d056bc6bf2d97d8c694fb92d6d5765126fef74565d007c27581672", size = 125286, upload-time = "2026-06-02T20:04:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
 ]
 
 [[package]]

--- a/libs/partners/quickjs/uv.lock
+++ b/libs/partners/quickjs/uv.lock
@@ -430,7 +430,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.6,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -812,16 +812,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.5"
+version = "1.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/16/c77e6d87cb580e2eb15d117de3494647a7198380703c72fecb1ab585d84d/langchain-1.3.6.tar.gz", hash = "sha256:c36a5ab3ad3149636a55fa0e5e237fb28ec4dbd40f6fd08c5a5e9494f0b16411", size = 614499, upload-time = "2026-06-10T00:53:02.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/647a72e9ed690bce49212ea9ee9dc01d874e73932045d69116cc6d34fc75/langchain-1.3.6-py3-none-any.whl", hash = "sha256:5c8c70deeb18326d5348039ac5ba778135ff29faf4ea003342fd199e3d7ec9ef", size = 127124, upload-time = "2026-06-10T00:53:01.186Z" },
 ]
 
 [[package]]

--- a/libs/partners/quickjs/uv.lock
+++ b/libs/partners/quickjs/uv.lock
@@ -430,7 +430,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -812,16 +812,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3f/034eb6cbef90bfccc89b7f8ed0c1d853dc9cb0bea17c7a269534c647ba3a/langchain-1.3.4.tar.gz", hash = "sha256:d6e0654c22848925534f5c0a706f9be481bb09a619ec60a738fbd1e5502e457a", size = 606617, upload-time = "2026-06-02T20:04:49.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/29/9ffe99c7dc4891a0215ec59c423bea320f943c08a231bc5bae392a438a83/langchain-1.3.4-py3-none-any.whl", hash = "sha256:e51b05ab23d056bc6bf2d97d8c694fb92d6d5765126fef74565d007c27581672", size = 125286, upload-time = "2026-06-02T20:04:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
 ]
 
 [[package]]

--- a/libs/partners/runloop/uv.lock
+++ b/libs/partners/runloop/uv.lock
@@ -395,7 +395,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -662,16 +662,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3f/034eb6cbef90bfccc89b7f8ed0c1d853dc9cb0bea17c7a269534c647ba3a/langchain-1.3.4.tar.gz", hash = "sha256:d6e0654c22848925534f5c0a706f9be481bb09a619ec60a738fbd1e5502e457a", size = 606617, upload-time = "2026-06-02T20:04:49.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/29/9ffe99c7dc4891a0215ec59c423bea320f943c08a231bc5bae392a438a83/langchain-1.3.4-py3-none-any.whl", hash = "sha256:e51b05ab23d056bc6bf2d97d8c694fb92d6d5765126fef74565d007c27581672", size = 125286, upload-time = "2026-06-02T20:04:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
 ]
 
 [[package]]

--- a/libs/partners/runloop/uv.lock
+++ b/libs/partners/runloop/uv.lock
@@ -395,7 +395,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.6,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -662,16 +662,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.5"
+version = "1.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/16/c77e6d87cb580e2eb15d117de3494647a7198380703c72fecb1ab585d84d/langchain-1.3.6.tar.gz", hash = "sha256:c36a5ab3ad3149636a55fa0e5e237fb28ec4dbd40f6fd08c5a5e9494f0b16411", size = 614499, upload-time = "2026-06-10T00:53:02.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/647a72e9ed690bce49212ea9ee9dc01d874e73932045d69116cc6d34fc75/langchain-1.3.6-py3-none-any.whl", hash = "sha256:5c8c70deeb18326d5348039ac5ba778135ff29faf4ea003342fd199e3d7ec9ef", size = 127124, upload-time = "2026-06-10T00:53:01.186Z" },
 ]
 
 [[package]]

--- a/libs/talon/uv.lock
+++ b/libs/talon/uv.lock
@@ -684,7 +684,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.4,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -1508,16 +1508,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.4"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3f/034eb6cbef90bfccc89b7f8ed0c1d853dc9cb0bea17c7a269534c647ba3a/langchain-1.3.4.tar.gz", hash = "sha256:d6e0654c22848925534f5c0a706f9be481bb09a619ec60a738fbd1e5502e457a", size = 606617, upload-time = "2026-06-02T20:04:49.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/29/9ffe99c7dc4891a0215ec59c423bea320f943c08a231bc5bae392a438a83/langchain-1.3.4-py3-none-any.whl", hash = "sha256:e51b05ab23d056bc6bf2d97d8c694fb92d6d5765126fef74565d007c27581672", size = 125286, upload-time = "2026-06-02T20:04:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
 ]
 
 [[package]]

--- a/libs/talon/uv.lock
+++ b/libs/talon/uv.lock
@@ -684,7 +684,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain", specifier = ">=1.3.5,<2.0.0" },
+    { name = "langchain", specifier = ">=1.3.6,<2.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.4,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.2,<2.0.0" },
     { name = "langchain-google-genai", specifier = ">=4.2.4,<5.0.0" },
@@ -1508,16 +1508,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.5"
+version = "1.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/1e/0f817205ab2e077a1ab258b0dcae9f3f425f50de990964ad861900dc95fa/langchain-1.3.5.tar.gz", hash = "sha256:3185cd0e831539f3ddac542b0650bbdf1273872d925f4d8fcc3b1cfb90289c2f", size = 613910, upload-time = "2026-06-10T00:15:21.608Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/16/c77e6d87cb580e2eb15d117de3494647a7198380703c72fecb1ab585d84d/langchain-1.3.6.tar.gz", hash = "sha256:c36a5ab3ad3149636a55fa0e5e237fb28ec4dbd40f6fd08c5a5e9494f0b16411", size = 614499, upload-time = "2026-06-10T00:53:02.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/c4/a93a76d80a50aa41d8b8d3e88d666a7be35d6f148f7e03adcd2ac0d78dbe/langchain-1.3.5-py3-none-any.whl", hash = "sha256:49fc95b2c03ee18f0c137c1a652079a9a1c9800279b9b77352386ac5bd1a64b3", size = 126849, upload-time = "2026-06-10T00:15:20.041Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/647a72e9ed690bce49212ea9ee9dc01d874e73932045d69116cc6d34fc75/langchain-1.3.6-py3-none-any.whl", hash = "sha256:5c8c70deeb18326d5348039ac5ba778135ff29faf4ea003342fd199e3d7ec9ef", size = 127124, upload-time = "2026-06-10T00:53:01.186Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Deep Agents now pins to the LangChain release that owns the updated summarization trigger representation used by the underlying `LCSummarizationMiddleware`. This is primarily a compatibility update for the Deep Agents summarization wrapper and compact-tool eligibility, not a broad new public configuration surface for `create_deep_agent`.

## Changes
- Raised the SDK's minimum `langchain` dependency to `>=1.3.6`, where LangChain stores and evaluates summarization triggers as dict clauses.
- Kept `LCSummarizationMiddleware` as the source of truth for validating `trigger`/`keep`, storing `_trigger_clauses`, token counting setup, and deciding when automatic summarization should run.
- Passed `trigger` directly through `SummarizationMiddleware` so direct wrapper users can use LangChain's supported trigger shapes without Deep Agents mirroring that logic.
- Removed the temporary SDK-side trigger normalization and evaluation shim that was only needed while the LangChain release was blocked on Deep Agents tests.
