### PR TITLE
fix(code): surface cached MCP errors as failed tool messages

### DIFF
--- a/.github/scripts/check_lockfiles_pre_commit.py
+++ b/.github/scripts/check_lockfiles_pre_commit.py
@@ -43,7 +43,7 @@ def _touches_talon(paths: list[str]) -> bool:
 
 
 def main(paths: list[str]) -> int:
-    include_talon = _touches_talon(paths)
+    include_talon = not paths or _touches_talon(paths)
     for package in _package_dirs(include_talon=include_talon):
         print(f"🔍 Checking {_label(package)}")
         result = subprocess.run(

--- a/.github/scripts/check_lockfiles_pre_commit.py
+++ b/.github/scripts/check_lockfiles_pre_commit.py
@@ -1,0 +1,65 @@
+"""Run the lockfile check for pre-commit without unrelated Talon churn."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIBS_ROOT = REPO_ROOT / "libs"
+EXAMPLES_ROOT = REPO_ROOT / "examples"
+TALON_DIR = LIBS_ROOT / "talon"
+
+
+def _package_dirs(*, include_talon: bool) -> list[Path]:
+    libs = [path.parent for path in LIBS_ROOT.glob("*/Makefile")]
+    partners = [path.parent for path in (LIBS_ROOT / "partners").glob("*/Makefile")]
+    examples = [path.parent for path in EXAMPLES_ROOT.glob("*/pyproject.toml")]
+    packages = [*libs, *partners, *examples]
+    if not include_talon:
+        packages = [package for package in packages if package != TALON_DIR]
+    return sorted(packages, key=lambda path: path.relative_to(REPO_ROOT).as_posix())
+
+
+def _python_version(package: Path) -> str:
+    if package == LIBS_ROOT / "acp":
+        return "3.14"
+    return "3.12"
+
+
+def _label(package: Path) -> str:
+    try:
+        return package.relative_to(LIBS_ROOT).as_posix()
+    except ValueError:
+        return f"../{package.relative_to(REPO_ROOT).as_posix()}"
+
+
+def _touches_talon(paths: list[str]) -> bool:
+    return any(Path(path).parts[:2] == ("libs", "talon") for path in paths)
+
+
+def main(paths: list[str]) -> int:
+    include_talon = _touches_talon(paths)
+    for package in _package_dirs(include_talon=include_talon):
+        print(f"🔍 Checking {_label(package)}")
+        result = subprocess.run(
+            [
+                "uv",
+                "lock",
+                "--check",
+                "--directory",
+                str(package),
+                "--python",
+                _python_version(package),
+            ],
+            check=False,
+        )
+        if result.returncode != 0:
+            return result.returncode
+    print("✅ All applicable lockfiles are up-to-date!")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/scripts/check_lockfiles_pre_commit.py
+++ b/.github/scripts/check_lockfiles_pre_commit.py
@@ -36,7 +36,10 @@ def _label(package: Path) -> str:
 
 
 def _touches_talon(paths: list[str]) -> bool:
-    return any(Path(path).parts[:2] == ("libs", "talon") for path in paths)
+    return any(
+        Path(path).parts[:2] == ("libs", "talon") and Path(path).name != "uv.lock"
+        for path in paths
+    )
 
 
 def main(paths: list[str]) -> int:

--- a/.github/workflows/check_lockfiles.yml
+++ b/.github/workflows/check_lockfiles.yml
@@ -25,12 +25,15 @@ jobs:
     steps:
       - name: "📋 Checkout Code"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
 
       - name: "🐍 Set up Python and uv"
         uses: "./.github/actions/uv_setup"
         with:
           python-version: "3.14"
 
-      - name: "🔍 Check all lockfiles"
-        run: make lock-check
-        working-directory: libs
+      - name: "🔍 Check changed lockfiles"
+        run: |
+          mapfile -t changed < <(git diff --name-only HEAD^ HEAD)
+          python3 .github/scripts/check_lockfiles_pre_commit.py "${changed[@]}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,9 +86,8 @@ repos:
       - id: lock-check
         name: check lockfiles are up-to-date
         language: system
-        entry: make -C libs lock-check
+        entry: python3 .github/scripts/check_lockfiles_pre_commit.py
         files: (^libs/.*/pyproject\.toml|^libs/.*/uv\.lock)$
-        pass_filenames: false
       - id: extras-sync
         name: check extras sync with required deps
         language: system

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -203,16 +203,13 @@ class _ToolExceptionRecoveryMiddleware(AgentMiddleware):
     """Convert expected tool failures into recoverable tool messages.
 
     A `ToolException` signals a tool-side failure that the model should see and
-    work around (e.g. an MCP server returning `isError`, which
-    `langchain-mcp-adapters` surfaces as a raised `ToolException`) rather than a
-    bug that should abort the run. LangGraph's default tool-error handling
-    re-raises plain `ToolException`, so without this shim such a failure would
-    propagate and crash the entire agent run. Catching it here turns it into an
-    error `ToolMessage` the model can recover from. Only `ToolException` is
+    work around rather than a bug that should abort the run. Current
+    `langchain-mcp-adapters` tools handle MCP `CallToolResult(isError=True)` at
+    the tool level and return `ToolMessage(status="error")` by default, so this
+    middleware remains for Deep Agents/tool-originated `ToolException`s,
+    older adapter versions, and other backwards-compatible tool paths that do
+    not install their own `handle_tool_error` callback. Only `ToolException` is
     caught; every other exception propagates so genuine bugs surface.
-
-    Temporary workaround shim while we determine whether an upstream change to
-    `langchain-mcp-adapters` is sensible.
     """
 
     @staticmethod

--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -18,7 +18,7 @@ import shutil
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -1052,6 +1052,57 @@ def _build_cached_mcp_tool(
         _convert_call_tool_result,  # noqa: PLC2701
     )
 
+    try:
+        from langchain_mcp_adapters.tools import (
+            _handle_mcp_tool_error,
+        )
+    except ImportError:  # pragma: no cover - remove once PR #540 is released
+        from langchain_mcp_adapters.tools import (
+            _convert_mcp_content_to_lc_block,  # noqa: PLC2701
+            create_text_block,
+        )
+
+        def _summarize_tool_error(tool_content: list[Any]) -> str:
+            error_parts = [
+                block["text"]
+                for block in tool_content
+                if isinstance(block, dict) and block.get("type") == "text"
+            ]
+            if error_parts:
+                return "\n".join(error_parts)
+            if tool_content:
+                return (
+                    "MCP tool returned an error with no text content "
+                    f"({len(tool_content)} non-text content block(s))."
+                )
+            return "MCP tool returned an error with empty content."
+
+        class _MCPToolExecutionError(ToolException):
+            def __init__(self, tool_content: list[Any]) -> None:
+                super().__init__(_summarize_tool_error(tool_content))
+                self.tool_content = tool_content
+
+        def _handle_mcp_tool_error(error: ToolException) -> list[Any]:
+            if isinstance(error, _MCPToolExecutionError):
+                if error.tool_content:
+                    return error.tool_content
+                return [create_text_block(text=str(error))]
+            raise error
+
+        def _convert_cached_call_tool_result(result: Any) -> Any:  # noqa: ANN401
+            if getattr(result, "isError", False):
+                tool_content = [
+                    _convert_mcp_content_to_lc_block(content)
+                    for content in result.content
+                ]
+                raise _MCPToolExecutionError(tool_content)
+            return _convert_call_tool_result(result)
+
+    else:
+
+        def _convert_cached_call_tool_result(result: Any) -> Any:  # noqa: ANN401
+            return _convert_call_tool_result(result)
+
     original_tool_name = mcp_tool.name
     lc_tool_name = (
         f"{server_name}_{original_tool_name}"
@@ -1150,12 +1201,12 @@ def _build_cached_mcp_tool(
                             exc_info=True,
                         )
 
-        # `_convert_call_tool_result` raises ToolException when the MCP server
-        # returns a result flagged isError=True. That ToolException propagates
-        # up through ToolNode, whose default handler re-raises everything except
-        # ToolInvocationError — so it aborts the turn unless a wrap_tool_call
-        # middleware converts it to a recoverable ToolMessage.
-        return _convert_call_tool_result(result)
+        # MCP `isError=True` results become `_MCPToolExecutionError`; the
+        # StructuredTool error handler below returns the converted MCP content
+        # blocks so LangChain emits a `ToolMessage(status="error")` instead of
+        # aborting the run. Transport/session failures and non-MCP
+        # `ToolException`s still propagate.
+        return _convert_cached_call_tool_result(result)
 
     return StructuredTool(
         name=lc_tool_name,
@@ -1164,6 +1215,7 @@ def _build_cached_mcp_tool(
         coroutine=coroutine,
         response_format="content_and_artifact",
         metadata=metadata,
+        handle_tool_error=cast("Any", _handle_mcp_tool_error),
     )
 
 

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
     "tomli-w>=1.2.0,<2.0.0",
 
     # MCP
-    "langchain-mcp-adapters>=0.2.2,<1.0.0",
+    "langchain-mcp-adapters>=0.3.0,<1.0.0",
 
     # ACP
     "deepagents-acp>=0.0.8,<1.0.0",

--- a/libs/code/tests/unit_tests/test_mcp_tools.py
+++ b/libs/code/tests/unit_tests/test_mcp_tools.py
@@ -1944,8 +1944,8 @@ class TestCachedSessionProxy:
         self,
         write_config: Callable[..., str],
     ) -> None:
-        """A logical tool failure propagates without retrying the session."""
-        from langchain_core.tools import ToolException
+        """MCP `isError=True` returns a failed `ToolMessage` without retrying."""
+        from langchain_core.messages import ToolMessage
         from mcp.types import CallToolResult, TextContent
 
         path = write_config(
@@ -1983,12 +1983,70 @@ class TestCachedSessionProxy:
 
         with patch("langchain_mcp_adapters.sessions.create_session", _fake):
             tools, manager, _ = await get_mcp_tools(path)
-            with pytest.raises(ToolException, match="boom"):
-                await tools[0].ainvoke({})  # ty: ignore
+            result = await tools[0].ainvoke(
+                {"args": {}, "id": "call-1", "type": "tool_call"}
+            )  # ty: ignore
 
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert result.tool_call_id == "call-1"
+        assert result.content_blocks[0]["type"] == "text"
+        assert result.content_blocks[0]["text"] == "boom"
         assert call_counter["n"] == 2
         assert runtime_session is not None
         assert runtime_session.call_tool.await_count == 1
+        await manager.cleanup()
+
+    async def test_empty_mcp_error_content_uses_placeholder_tool_message(
+        self,
+        write_config: Callable[..., str],
+    ) -> None:
+        """Empty MCP error content gets the adapter placeholder text block."""
+        from langchain_core.messages import ToolMessage
+        from mcp.types import CallToolResult
+
+        path = write_config(
+            {"mcpServers": {"srv": {"command": "node", "args": ["s.js"]}}}
+        )
+        runtime_session: AsyncMock | None = None
+
+        def _new_session() -> AsyncMock:
+            nonlocal runtime_session
+            session = AsyncMock()
+            session.initialize = AsyncMock()
+            session.list_tools = AsyncMock(
+                return_value=_make_tool_page([_make_mcp_tool("echo")])
+            )
+            session.call_tool = AsyncMock(
+                return_value=CallToolResult(content=[], isError=True)
+            )
+            runtime_session = session
+            return session
+
+        @asynccontextmanager
+        async def _fake(
+            _connection: dict[str, Any],
+            *,
+            _mcp_callbacks: object | None = None,
+        ) -> AsyncIterator[AsyncMock]:
+            await asyncio.sleep(0)
+            yield _new_session()
+
+        with patch("langchain_mcp_adapters.sessions.create_session", _fake):
+            tools, manager, _ = await get_mcp_tools(path)
+            result = await tools[0].ainvoke(
+                {"args": {}, "id": "call-1", "type": "tool_call"}
+            )  # ty: ignore
+
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert result.content_blocks[0]["type"] == "text"
+        assert result.content_blocks[0]["text"] == (
+            "MCP tool returned an error with empty content."
+        )
+        assert runtime_session is not None
+        assert runtime_session.call_tool.await_count == 1
+        assert manager is not None
         await manager.cleanup()
 
     async def test_reauth_signal_surfaces_tool_exception_without_retry(

--- a/libs/code/uv.lock
+++ b/libs/code/uv.lock
@@ -1213,7 +1213,7 @@ requires-dist = [
     { name = "langchain-huggingface", marker = "extra == 'huggingface'", specifier = ">=1.2.2,<2.0.0" },
     { name = "langchain-ibm", marker = "extra == 'ibm'", specifier = ">=1.1.0,<2.0.0" },
     { name = "langchain-litellm", marker = "extra == 'litellm'", specifier = ">=0.6.6,<2.0.0" },
-    { name = "langchain-mcp-adapters", specifier = ">=0.2.2,<1.0.0" },
+    { name = "langchain-mcp-adapters", specifier = ">=0.3.0,<1.0.0" },
     { name = "langchain-mistralai", marker = "extra == 'mistralai'", specifier = ">=1.1.4,<2.0.0" },
     { name = "langchain-modal", marker = "extra == 'modal'", editable = "../partners/modal" },
     { name = "langchain-nvidia-ai-endpoints", marker = "extra == 'nvidia'", specifier = ">=1.4.1,<2.0.0" },
@@ -2795,16 +2795,16 @@ wheels = [
 
 [[package]]
 name = "langchain-mcp-adapters"
-version = "0.2.2"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "mcp" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/66/1cc7039e2daaddcdea9d8887851fe6eb67401925999b2aa394aa855c7132/langchain_mcp_adapters-0.2.2.tar.gz", hash = "sha256:12d39e91ae4389c54b61b221094e53850b6e152934d8bc10c80665d600e76530", size = 37942, upload-time = "2026-03-16T17:13:30.35Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/1c/b179d8650d2349a342bc1fd1aab41b34154e79c7fc86fc42bdf0bb110d6f/langchain_mcp_adapters-0.3.0.tar.gz", hash = "sha256:fa6c9497015eb2807de5d0c341a36e1d2445cecbae1f4a24e922fc5b94f1a36c", size = 42774, upload-time = "2026-06-10T01:10:28.552Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/2f/15d5e6c1765d8404a9cce38d8c81d7b33fb3392f9db5b992c000dddbd2a3/langchain_mcp_adapters-0.2.2-py3-none-any.whl", hash = "sha256:d08e64954e86281002653071b7430e0377c9a577cb4ac3143abfeb3e24ef8797", size = 23288, upload-time = "2026-03-16T17:13:29.073Z" },
+    { url = "https://files.pythonhosted.org/packages/66/89/b4869db84ce529de6c7548319197df50c24d0f8a7412f74f889e22324036/langchain_mcp_adapters-0.3.0-py3-none-any.whl", hash = "sha256:1af511a95e028d9546502e360f95698ae8b691dbc07981fc48170c2cb1ebd7a9", size = 25855, upload-time = "2026-06-10T01:10:27.524Z" },
 ]
 
 [[package]]

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -534,7 +534,7 @@ requires-dist = [
     { name = "langchain-huggingface", marker = "extra == 'huggingface'", specifier = ">=1.2.2,<2.0.0" },
     { name = "langchain-ibm", marker = "extra == 'ibm'", specifier = ">=1.1.0,<2.0.0" },
     { name = "langchain-litellm", marker = "extra == 'litellm'", specifier = ">=0.6.6,<2.0.0" },
-    { name = "langchain-mcp-adapters", specifier = ">=0.2.2,<1.0.0" },
+    { name = "langchain-mcp-adapters", specifier = ">=0.3.0,<1.0.0" },
     { name = "langchain-mistralai", marker = "extra == 'mistralai'", specifier = ">=1.1.4,<2.0.0" },
     { name = "langchain-modal", marker = "extra == 'modal'", editable = "../partners/modal" },
     { name = "langchain-nvidia-ai-endpoints", marker = "extra == 'nvidia'", specifier = ">=1.4.1,<2.0.0" },
@@ -1450,16 +1450,16 @@ wheels = [
 
 [[package]]
 name = "langchain-mcp-adapters"
-version = "0.2.2"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "mcp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/66/1cc7039e2daaddcdea9d8887851fe6eb67401925999b2aa394aa855c7132/langchain_mcp_adapters-0.2.2.tar.gz", hash = "sha256:12d39e91ae4389c54b61b221094e53850b6e152934d8bc10c80665d600e76530", size = 37942, upload-time = "2026-03-16T17:13:30.35Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/1c/b179d8650d2349a342bc1fd1aab41b34154e79c7fc86fc42bdf0bb110d6f/langchain_mcp_adapters-0.3.0.tar.gz", hash = "sha256:fa6c9497015eb2807de5d0c341a36e1d2445cecbae1f4a24e922fc5b94f1a36c", size = 42774, upload-time = "2026-06-10T01:10:28.552Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/2f/15d5e6c1765d8404a9cce38d8c81d7b33fb3392f9db5b992c000dddbd2a3/langchain_mcp_adapters-0.2.2-py3-none-any.whl", hash = "sha256:d08e64954e86281002653071b7430e0377c9a577cb4ac3143abfeb3e24ef8797", size = 23288, upload-time = "2026-03-16T17:13:29.073Z" },
+    { url = "https://files.pythonhosted.org/packages/66/89/b4869db84ce529de6c7548319197df50c24d0f8a7412f74f889e22324036/langchain_mcp_adapters-0.3.0-py3-none-any.whl", hash = "sha256:1af511a95e028d9546502e360f95698ae8b691dbc07981fc48170c2cb1ebd7a9", size = 25855, upload-time = "2026-06-10T01:10:27.524Z" },
 ]
 
 [[package]]

--- a/libs/talon/uv.lock
+++ b/libs/talon/uv.lock
@@ -788,7 +788,7 @@ requires-dist = [
     { name = "langchain-huggingface", marker = "extra == 'huggingface'", specifier = ">=1.2.2,<2.0.0" },
     { name = "langchain-ibm", marker = "extra == 'ibm'", specifier = ">=1.1.0,<2.0.0" },
     { name = "langchain-litellm", marker = "extra == 'litellm'", specifier = ">=0.6.6,<2.0.0" },
-    { name = "langchain-mcp-adapters", specifier = ">=0.3.0,<1.0.0" },
+    { name = "langchain-mcp-adapters", specifier = ">=0.2.2,<1.0.0" },
     { name = "langchain-mistralai", marker = "extra == 'mistralai'", specifier = ">=1.1.4,<2.0.0" },
     { name = "langchain-modal", marker = "extra == 'modal'", editable = "../partners/modal" },
     { name = "langchain-nvidia-ai-endpoints", marker = "extra == 'nvidia'", specifier = ">=1.4.1,<2.0.0" },
@@ -1571,16 +1571,16 @@ wheels = [
 
 [[package]]
 name = "langchain-mcp-adapters"
-version = "0.3.0"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "mcp" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/1c/b179d8650d2349a342bc1fd1aab41b34154e79c7fc86fc42bdf0bb110d6f/langchain_mcp_adapters-0.3.0.tar.gz", hash = "sha256:fa6c9497015eb2807de5d0c341a36e1d2445cecbae1f4a24e922fc5b94f1a36c", size = 42774, upload-time = "2026-06-10T01:10:28.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/66/1cc7039e2daaddcdea9d8887851fe6eb67401925999b2aa394aa855c7132/langchain_mcp_adapters-0.2.2.tar.gz", hash = "sha256:12d39e91ae4389c54b61b221094e53850b6e152934d8bc10c80665d600e76530", size = 37942, upload-time = "2026-03-16T17:13:30.35Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/89/b4869db84ce529de6c7548319197df50c24d0f8a7412f74f889e22324036/langchain_mcp_adapters-0.3.0-py3-none-any.whl", hash = "sha256:1af511a95e028d9546502e360f95698ae8b691dbc07981fc48170c2cb1ebd7a9", size = 25855, upload-time = "2026-06-10T01:10:27.524Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/2f/15d5e6c1765d8404a9cce38d8c81d7b33fb3392f9db5b992c000dddbd2a3/langchain_mcp_adapters-0.2.2-py3-none-any.whl", hash = "sha256:d08e64954e86281002653071b7430e0377c9a577cb4ac3143abfeb3e24ef8797", size = 23288, upload-time = "2026-03-16T17:13:29.073Z" },
 ]
 
 [[package]]

--- a/libs/talon/uv.lock
+++ b/libs/talon/uv.lock
@@ -788,7 +788,7 @@ requires-dist = [
     { name = "langchain-huggingface", marker = "extra == 'huggingface'", specifier = ">=1.2.2,<2.0.0" },
     { name = "langchain-ibm", marker = "extra == 'ibm'", specifier = ">=1.1.0,<2.0.0" },
     { name = "langchain-litellm", marker = "extra == 'litellm'", specifier = ">=0.6.6,<2.0.0" },
-    { name = "langchain-mcp-adapters", specifier = ">=0.2.2,<1.0.0" },
+    { name = "langchain-mcp-adapters", specifier = ">=0.3.0,<1.0.0" },
     { name = "langchain-mistralai", marker = "extra == 'mistralai'", specifier = ">=1.1.4,<2.0.0" },
     { name = "langchain-modal", marker = "extra == 'modal'", editable = "../partners/modal" },
     { name = "langchain-nvidia-ai-endpoints", marker = "extra == 'nvidia'", specifier = ">=1.4.1,<2.0.0" },
@@ -1571,16 +1571,16 @@ wheels = [
 
 [[package]]
 name = "langchain-mcp-adapters"
-version = "0.2.2"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "mcp" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/66/1cc7039e2daaddcdea9d8887851fe6eb67401925999b2aa394aa855c7132/langchain_mcp_adapters-0.2.2.tar.gz", hash = "sha256:12d39e91ae4389c54b61b221094e53850b6e152934d8bc10c80665d600e76530", size = 37942, upload-time = "2026-03-16T17:13:30.35Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/1c/b179d8650d2349a342bc1fd1aab41b34154e79c7fc86fc42bdf0bb110d6f/langchain_mcp_adapters-0.3.0.tar.gz", hash = "sha256:fa6c9497015eb2807de5d0c341a36e1d2445cecbae1f4a24e922fc5b94f1a36c", size = 42774, upload-time = "2026-06-10T01:10:28.552Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/2f/15d5e6c1765d8404a9cce38d8c81d7b33fb3392f9db5b992c000dddbd2a3/langchain_mcp_adapters-0.2.2-py3-none-any.whl", hash = "sha256:d08e64954e86281002653071b7430e0377c9a577cb4ac3143abfeb3e24ef8797", size = 23288, upload-time = "2026-03-16T17:13:29.073Z" },
+    { url = "https://files.pythonhosted.org/packages/66/89/b4869db84ce529de6c7548319197df50c24d0f8a7412f74f889e22324036/langchain_mcp_adapters-0.3.0-py3-none-any.whl", hash = "sha256:1af511a95e028d9546502e360f95698ae8b691dbc07981fc48170c2cb1ebd7a9", size = 25855, upload-time = "2026-06-10T01:10:27.524Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Cached-session MCP tools now match `langchain-mcp-adapters` 0.3 behavior for MCP execution errors: `CallToolResult(isError=True)` is returned to the model as a failed tool result instead of escaping as a raised `ToolException`. Transport, session, retry, and reauth failures keep their existing exception paths, while the generic recovery middleware remains documented as a compatibility fallback for non-MCP/tool-originated `ToolException`s.