### PR TITLE
fix(code): handle MCP tool errors locally

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -199,98 +199,6 @@ class ShellAllowListMiddleware(AgentMiddleware):
         return await handler(request)
 
 
-class _ToolExceptionRecoveryMiddleware(AgentMiddleware):
-    """Convert expected tool failures into recoverable tool messages.
-
-    A `ToolException` signals a tool-side failure that the model should see and
-    work around rather than a bug that should abort the run. Current
-    `langchain-mcp-adapters` tools handle MCP `CallToolResult(isError=True)` at
-    the tool level and return `ToolMessage(status="error")` by default, so this
-    middleware remains for Deep Agents/tool-originated `ToolException`s,
-    older adapter versions, and other backwards-compatible tool paths that do
-    not install their own `handle_tool_error` callback. Only `ToolException` is
-    caught; every other exception propagates so genuine bugs surface.
-    """
-
-    @staticmethod
-    def _error_message(request: ToolCallRequest, exc: Exception) -> ToolMessage:
-        """Build an error-status `ToolMessage` from a caught exception.
-
-        Args:
-            request: The tool call request whose handler raised.
-            exc: The recoverable exception to surface to the model.
-
-        Returns:
-            A `ToolMessage` with `status="error"` carrying the exception text,
-                or a tool-named fallback when the exception has no message.
-        """
-        from langchain_core.messages import ToolMessage as LCToolMessage
-
-        tool_call = request.tool_call
-        return LCToolMessage(
-            content=str(exc) or f"{tool_call['name']} failed with no error detail",
-            name=tool_call["name"],
-            tool_call_id=tool_call["id"],
-            status="error",
-        )
-
-    def wrap_tool_call(
-        self,
-        request: ToolCallRequest,
-        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
-    ) -> ToolMessage | Command[Any]:
-        """Convert a recoverable `ToolException` into an error `ToolMessage`.
-
-        Args:
-            request: The tool call request being processed.
-            handler: The next handler in the middleware chain.
-
-        Returns:
-            The tool execution result, or an error `ToolMessage` when the tool
-                raised a `ToolException`. Other exceptions propagate unchanged.
-        """
-        from langchain_core.tools import ToolException
-
-        try:
-            return handler(request)
-        except ToolException as exc:
-            logger.warning(
-                "Tool %r failed with recoverable ToolException: %s",
-                request.tool_call.get("name"),
-                exc,
-                exc_info=True,
-            )
-            return self._error_message(request, exc)
-
-    async def awrap_tool_call(
-        self,
-        request: ToolCallRequest,
-        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
-    ) -> ToolMessage | Command[Any]:
-        """Convert a recoverable `ToolException` into an error `ToolMessage`.
-
-        Args:
-            request: The tool call request being processed.
-            handler: The next handler in the middleware chain.
-
-        Returns:
-            The tool execution result, or an error `ToolMessage` when the tool
-                raised a `ToolException`. Other exceptions propagate unchanged.
-        """
-        from langchain_core.tools import ToolException
-
-        try:
-            return await handler(request)
-        except ToolException as exc:
-            logger.warning(
-                "Tool %r failed with recoverable ToolException: %s",
-                request.tool_call.get("name"),
-                exc,
-                exc_info=True,
-            )
-            return self._error_message(request, exc)
-
-
 _INTERPRETER_WRITE_TOOLS: frozenset[str] = frozenset(
     {"execute", "write_file", "edit_file"}
 )
@@ -1315,11 +1223,6 @@ def create_cli_agent(
                     [settings.get_user_agent_md_path(assistant_id)]
                 )
             )
-        # Recovery sits last so it is the innermost tool-call wrapper, matching
-        # the main agent stack: it then wraps tool execution as tightly as
-        # possible and only intercepts `ToolException`s from the tool itself,
-        # not from sibling middleware (which return error messages, not raise).
-        middleware.append(_ToolExceptionRecoveryMiddleware())
         return middleware
 
     for subagent_meta in list_subagents(
@@ -1366,7 +1269,6 @@ def create_cli_agent(
     agent_middleware: list[AgentMiddleware[Any, Any]] = [
         ConfigurableModelMiddleware(),
         _FilesystemEmptyResultMiddleware(),
-        _ToolExceptionRecoveryMiddleware(),
     ]
 
     # Resume state: declares the `_context_tokens` and `_model_spec` channels

--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -1050,58 +1050,8 @@ def _build_cached_mcp_tool(
     from langchain_core.tools import StructuredTool, ToolException
     from langchain_mcp_adapters.tools import (
         _convert_call_tool_result,  # noqa: PLC2701
+        _handle_mcp_tool_error,  # noqa: PLC2701
     )
-
-    try:
-        from langchain_mcp_adapters.tools import (
-            _handle_mcp_tool_error,
-        )
-    except ImportError:  # pragma: no cover - remove once PR #540 is released
-        from langchain_mcp_adapters.tools import (
-            _convert_mcp_content_to_lc_block,  # noqa: PLC2701
-            create_text_block,
-        )
-
-        def _summarize_tool_error(tool_content: list[Any]) -> str:
-            error_parts = [
-                block["text"]
-                for block in tool_content
-                if isinstance(block, dict) and block.get("type") == "text"
-            ]
-            if error_parts:
-                return "\n".join(error_parts)
-            if tool_content:
-                return (
-                    "MCP tool returned an error with no text content "
-                    f"({len(tool_content)} non-text content block(s))."
-                )
-            return "MCP tool returned an error with empty content."
-
-        class _MCPToolExecutionError(ToolException):
-            def __init__(self, tool_content: list[Any]) -> None:
-                super().__init__(_summarize_tool_error(tool_content))
-                self.tool_content = tool_content
-
-        def _handle_mcp_tool_error(error: ToolException) -> list[Any]:
-            if isinstance(error, _MCPToolExecutionError):
-                if error.tool_content:
-                    return error.tool_content
-                return [create_text_block(text=str(error))]
-            raise error
-
-        def _convert_cached_call_tool_result(result: Any) -> Any:  # noqa: ANN401
-            if getattr(result, "isError", False):
-                tool_content = [
-                    _convert_mcp_content_to_lc_block(content)
-                    for content in result.content
-                ]
-                raise _MCPToolExecutionError(tool_content)
-            return _convert_call_tool_result(result)
-
-    else:
-
-        def _convert_cached_call_tool_result(result: Any) -> Any:  # noqa: ANN401
-            return _convert_call_tool_result(result)
 
     original_tool_name = mcp_tool.name
     lc_tool_name = (
@@ -1116,6 +1066,18 @@ def _build_cached_mcp_tool(
     )
     wrapped_meta = {"_meta": meta} if meta is not None else {}
     metadata = {**base_meta, **wrapped_meta} or None
+
+    def _handle_cached_mcp_tool_error(error: ToolException) -> Any:  # noqa: ANN401
+        try:
+            return _handle_mcp_tool_error(error)
+        except ToolException:
+            logger.warning(
+                "MCP tool %r failed with recoverable ToolException: %s",
+                lc_tool_name,
+                error,
+                exc_info=True,
+            )
+            return str(error) or f"{lc_tool_name} failed with no error detail"
 
     async def coroutine(
         # `runtime` is injected by LangChain's tool-calling plumbing.
@@ -1133,9 +1095,9 @@ def _build_cached_mcp_tool(
         # Re-raise control-flow/shutdown signals (CancelledError,
         # KeyboardInterrupt, SystemExit) and ToolException unchanged. Wrapping a
         # ToolException here would bury its actionable message (e.g. an MCP
-        # `isError` instruction like "use the X tool instead") under a
-        # generic retry wrapper; re-raising preserves it for the tool-error
-        # handling layer and the model.
+        # `isError` instruction like "use the X tool instead") under a generic
+        # retry wrapper; re-raising preserves it for the tool-local error
+        # handler and the model.
         except (asyncio.CancelledError, KeyboardInterrupt, SystemExit, ToolException):
             raise
         except Exception as exc:
@@ -1201,12 +1163,12 @@ def _build_cached_mcp_tool(
                             exc_info=True,
                         )
 
-        # MCP `isError=True` results become `_MCPToolExecutionError`; the
-        # StructuredTool error handler below returns the converted MCP content
-        # blocks so LangChain emits a `ToolMessage(status="error")` instead of
-        # aborting the run. Transport/session failures and non-MCP
-        # `ToolException`s still propagate.
-        return _convert_cached_call_tool_result(result)
+        # On an MCP `isError=True` result the adapter's `_convert_call_tool_result`
+        # raises, and the `handle_tool_error` callback registered below converts
+        # the MCP content blocks into a `ToolMessage(status="error")`. Other
+        # expected `ToolException`s raised by this wrapper are formatted by that
+        # same tool-local handler.
+        return _convert_call_tool_result(result)
 
     return StructuredTool(
         name=lc_tool_name,
@@ -1215,7 +1177,7 @@ def _build_cached_mcp_tool(
         coroutine=coroutine,
         response_format="content_and_artifact",
         metadata=metadata,
-        handle_tool_error=cast("Any", _handle_mcp_tool_error),
+        handle_tool_error=cast("Any", _handle_cached_mcp_tool_error),
     )
 
 

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -22,7 +22,6 @@ from deepagents_code.agent import (
     _format_task_description,
     _format_web_search_description,
     _format_write_file_description,
-    _ToolExceptionRecoveryMiddleware,
     build_model_identity_section,
     create_cli_agent,
     get_available_agent_names,
@@ -1872,138 +1871,6 @@ class TestLoadAsyncSubagents:
         assert result == []
 
 
-class TestToolExceptionRecoveryMiddleware:
-    """Tests for converting tool exceptions into recoverable tool messages."""
-
-    @staticmethod
-    def _request(tool_call_id: str) -> Mock:
-        """Build a minimal tool-call request the middleware can read."""
-        request = Mock()
-        request.tool_call = {
-            "name": "langsmith_fetch_runs",
-            "args": {},
-            "id": tool_call_id,
-        }
-        return request
-
-    def test_converts_tool_exception_sync(self) -> None:
-        from langchain_core.messages import ToolMessage
-        from langchain_core.tools import ToolException
-
-        middleware = _ToolExceptionRecoveryMiddleware()
-        request = self._request("tc1")
-        handler = Mock(side_effect=ToolException('no project found with name "abc"'))
-
-        result = middleware.wrap_tool_call(request, handler)
-
-        handler.assert_called_once_with(request)
-        assert isinstance(result, ToolMessage)
-        assert result.status == "error"
-        assert result.name == "langsmith_fetch_runs"
-        assert result.tool_call_id == "tc1"
-        assert 'no project found with name "abc"' in result.content
-
-    async def test_converts_tool_exception_async(self) -> None:
-        from unittest.mock import AsyncMock
-
-        from langchain_core.messages import ToolMessage
-        from langchain_core.tools import ToolException
-
-        middleware = _ToolExceptionRecoveryMiddleware()
-        request = self._request("tc2")
-        handler = AsyncMock(
-            side_effect=ToolException('no project found with name "abc"')
-        )
-
-        result = await middleware.awrap_tool_call(request, handler)
-
-        handler.assert_awaited_once_with(request)
-        assert isinstance(result, ToolMessage)
-        assert result.status == "error"
-        assert result.name == "langsmith_fetch_runs"
-        assert result.tool_call_id == "tc2"
-        assert 'no project found with name "abc"' in result.content
-
-    def test_passes_through_success_sync(self) -> None:
-        """A successful handler result is returned unchanged (sync)."""
-        from langchain_core.messages import ToolMessage
-
-        middleware = _ToolExceptionRecoveryMiddleware()
-        request = self._request("tc3")
-        sentinel = ToolMessage(content="ok", name="x", tool_call_id="tc3")
-
-        result = middleware.wrap_tool_call(request, lambda _req: sentinel)
-
-        assert result is sentinel
-
-    async def test_passes_through_success_async(self) -> None:
-        """A successful handler result is returned unchanged (async)."""
-        from unittest.mock import AsyncMock
-
-        from langgraph.types import Command
-
-        middleware = _ToolExceptionRecoveryMiddleware()
-        request = self._request("tc4")
-        sentinel = Command(update={"messages": []})
-        handler = AsyncMock(return_value=sentinel)
-
-        result = await middleware.awrap_tool_call(request, handler)
-
-        handler.assert_awaited_once_with(request)
-        assert result is sentinel
-
-    def test_propagates_non_tool_exception_sync(self) -> None:
-        """Non-`ToolException` errors propagate rather than being swallowed."""
-        middleware = _ToolExceptionRecoveryMiddleware()
-        request = self._request("tc5")
-        handler = Mock(side_effect=ValueError("boom"))
-
-        with pytest.raises(ValueError, match="boom"):
-            middleware.wrap_tool_call(request, handler)
-
-    async def test_propagates_non_tool_exception_async(self) -> None:
-        """Non-`ToolException` errors propagate rather than being swallowed."""
-        from unittest.mock import AsyncMock
-
-        middleware = _ToolExceptionRecoveryMiddleware()
-        request = self._request("tc6")
-        handler = AsyncMock(side_effect=ValueError("boom"))
-
-        with pytest.raises(ValueError, match="boom"):
-            await middleware.awrap_tool_call(request, handler)
-
-    def test_empty_exception_message_falls_back_to_tool_name(self) -> None:
-        """An exception with no message yields an informative fallback."""
-        from langchain_core.tools import ToolException
-
-        middleware = _ToolExceptionRecoveryMiddleware()
-        request = self._request("tc7")
-        handler = Mock(side_effect=ToolException())
-
-        result = middleware.wrap_tool_call(request, handler)
-
-        assert result.content == "langsmith_fetch_runs failed with no error detail"
-
-    def test_logs_warning_with_traceback(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """The recovered failure is logged at WARNING with a traceback."""
-        import logging
-
-        from langchain_core.tools import ToolException
-
-        middleware = _ToolExceptionRecoveryMiddleware()
-        request = self._request("tc8")
-        handler = Mock(side_effect=ToolException("kaboom"))
-
-        with caplog.at_level(logging.WARNING, logger="deepagents_code.agent"):
-            middleware.wrap_tool_call(request, handler)
-
-        records = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert any("langsmith_fetch_runs" in r.getMessage() for r in records)
-        assert any(r.exc_info is not None for r in records)
-
-
 class TestShellAllowListMiddleware:
     """Tests for inline shell command validation middleware."""
 
@@ -2255,8 +2122,6 @@ class TestCreateCliAgentShellMiddlewareWiring:
         assert kwargs["interrupt_on"] == {}
         middleware_types = [type(m) for m in kwargs["middleware"]]
         assert ShellAllowListMiddleware in middleware_types
-        # Recovery middleware is wired onto the main agent, not just subagents.
-        assert _ToolExceptionRecoveryMiddleware in middleware_types
 
     def test_interrupt_shell_only_skipped_when_auto_approve(
         self, tmp_path: Path
@@ -2586,10 +2451,9 @@ class TestCreateCliAgentShellMiddlewareWiring:
         }
 
         # Implicit-model subagents (and the general-purpose fallback) get
-        # configurable-model, shell, and recovery middlewares, with the
-        # configurable-model swap ordered before the shell gate so a runtime
-        # `/model` switch applies before tools are filtered, and recovery last
-        # so it wraps tool execution innermost (matching the main agent stack).
+        # configurable-model and shell middlewares, with the configurable-model
+        # swap ordered before the shell gate so a runtime `/model` switch applies
+        # before tools are filtered.
         for name in ("researcher", "general-purpose"):
             middleware_types = [
                 type(mw) for mw in subagents_by_name[name]["middleware"]
@@ -2597,7 +2461,6 @@ class TestCreateCliAgentShellMiddlewareWiring:
             assert middleware_types == [
                 ConfigurableModelMiddleware,
                 ShellAllowListMiddleware,
-                _ToolExceptionRecoveryMiddleware,
             ], f"Unexpected middleware on subagent {name!r}: {middleware_types}"
 
         # The pinned subagent keeps shell restriction but is NOT given the

--- a/libs/code/tests/unit_tests/test_mcp_tools.py
+++ b/libs/code/tests/unit_tests/test_mcp_tools.py
@@ -1852,13 +1852,13 @@ class TestCachedSessionProxy:
         sessions[2].call_tool.assert_awaited_once()
         await manager.cleanup()
 
-    async def test_repeated_transient_error_surfaces_tool_exception(
+    async def test_repeated_transient_error_surfaces_tool_message(
         self,
         write_config: Callable[..., str],
     ) -> None:
-        """A second transient failure becomes a `ToolException`."""
+        """A second transient failure becomes a tool-local error message."""
         from anyio import ClosedResourceError
-        from langchain_core.tools import ToolException
+        from langchain_core.messages import ToolMessage
 
         path = write_config(
             {"mcpServers": {"srv": {"command": "node", "args": ["s.js"]}}}
@@ -1888,9 +1888,13 @@ class TestCachedSessionProxy:
 
         with patch("langchain_mcp_adapters.sessions.create_session", _fake):
             tools, manager, _ = await get_mcp_tools(path)
-            with pytest.raises(ToolException, match="failed after one retry"):
-                await tools[0].ainvoke({})  # ty: ignore
+            result = await tools[0].ainvoke(
+                {"args": {}, "id": "call-1", "type": "tool_call"}
+            )  # ty: ignore
 
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert "failed after one retry" in result.content
         assert call_counter["n"] == 3
         await manager.cleanup()
 
@@ -1900,7 +1904,7 @@ class TestCachedSessionProxy:
         fake_tool_result: Any,  # noqa: ANN401
     ) -> None:
         """Generic `OSError`s do not trigger session invalidation and retry."""
-        from langchain_core.tools import ToolException
+        from langchain_core.messages import ToolMessage
 
         path = write_config(
             {"mcpServers": {"srv": {"command": "node", "args": ["s.js"]}}}
@@ -1932,11 +1936,13 @@ class TestCachedSessionProxy:
 
         with patch("langchain_mcp_adapters.sessions.create_session", _fake):
             tools, manager, _ = await get_mcp_tools(path)
-            # Non-transient exceptions now surface as `ToolException` so the
-            # agent sees a structured error instead of a raw `OSError`.
-            with pytest.raises(ToolException, match="socket glitch"):
-                await tools[0].ainvoke({})  # ty: ignore
+            result = await tools[0].ainvoke(
+                {"args": {}, "id": "call-1", "type": "tool_call"}
+            )  # ty: ignore
 
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert "socket glitch" in result.content
         assert call_counter["n"] == 2
         await manager.cleanup()
 
@@ -2049,12 +2055,12 @@ class TestCachedSessionProxy:
         assert manager is not None
         await manager.cleanup()
 
-    async def test_reauth_signal_surfaces_tool_exception_without_retry(
+    async def test_reauth_signal_surfaces_tool_message_without_retry(
         self,
         write_config: Callable[..., str],
     ) -> None:
-        """Runtime re-auth signals surface as actionable `ToolException`s."""
-        from langchain_core.tools import ToolException
+        """Runtime re-auth signals surface as actionable tool messages."""
+        from langchain_core.messages import ToolMessage
 
         path = write_config(
             {
@@ -2095,9 +2101,13 @@ class TestCachedSessionProxy:
 
         with patch("langchain_mcp_adapters.sessions.create_session", _fake):
             tools, manager, _ = await get_mcp_tools(path)
-            with pytest.raises(ToolException, match="re-authentication"):
-                await tools[0].ainvoke({})  # ty: ignore
+            result = await tools[0].ainvoke(
+                {"args": {}, "id": "call-1", "type": "tool_call"}
+            )  # ty: ignore
 
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert "re-authentication" in result.content
         assert call_counter["n"] == 2
         await manager.cleanup()
 


### PR DESCRIPTION
Undo earlier `_ToolExceptionRecoveryMiddleware`.

Recoverable MCP tool failures now stay inside the `StructuredTool` error handler instead of relying on global agent middleware. This keeps MCP `isError` results, transient retry failures, and re-auth signals visible to the model as `ToolMessage(status="error")` while avoiding broad agent-level `ToolException` recovery.

## Changes
- Removed `_ToolExceptionRecoveryMiddleware` from the main agent and implicit subagent middleware stacks, so agent-level tool execution no longer catches every `ToolException`.
- Wired cached MCP tools to use adapter-owned `_handle_mcp_tool_error` directly through `_handle_cached_mcp_tool_error`, with warning logs and fallback text for recoverable wrapper failures the adapter does not format.
- Simplified cached MCP result conversion to call `_convert_call_tool_result`, leaving MCP `isError=True` handling in the tool-local `handle_tool_error` callback.
- Updated MCP session failure behavior so repeated transient failures, generic wrapper failures, and re-auth signals return error-status `ToolMessage`s when invoked as tool calls.