### PR TITLE
chore(ci): validate Talon when `libs/talon/uv.lock` is directly changed

### DIFF
--- a/.github/scripts/check_lockfiles_pre_commit.py
+++ b/.github/scripts/check_lockfiles_pre_commit.py
@@ -36,14 +36,15 @@ def _label(package: Path) -> str:
 
 
 def _touches_talon(paths: list[str]) -> bool:
-    return any(
-        Path(path).parts[:2] == ("libs", "talon") and Path(path).name != "uv.lock"
-        for path in paths
-    )
+    return any(Path(path).parts[:2] == ("libs", "talon") for path in paths)
+
+
+def _include_talon(paths: list[str]) -> bool:
+    return not paths or _touches_talon(paths)
 
 
 def main(paths: list[str]) -> int:
-    include_talon = not paths or _touches_talon(paths)
+    include_talon = _include_talon(paths)
     for package in _package_dirs(include_talon=include_talon):
         print(f"🔍 Checking {_label(package)}")
         result = subprocess.run(

--- a/.github/scripts/test_check_lockfiles_pre_commit.py
+++ b/.github/scripts/test_check_lockfiles_pre_commit.py
@@ -1,0 +1,25 @@
+"""Tests for check_lockfiles_pre_commit (pre-commit Talon path selection)."""
+
+from check_lockfiles_pre_commit import _include_talon
+
+
+def test_unrelated_paths_skip_talon() -> None:
+    """Changes to other packages never force Talon validation."""
+    paths = ["libs/deepagents/deepagents/graph.py", "libs/cli/uv.lock"]
+    assert _include_talon(paths) is False
+
+
+def test_talon_source_includes_talon() -> None:
+    """A Talon source/config edit forces Talon validation."""
+    assert _include_talon(["libs/talon/deepagents_talon/__init__.py"]) is True
+    assert _include_talon(["libs/talon/pyproject.toml"]) is True
+
+
+def test_talon_lockfile_includes_talon() -> None:
+    """A direct edit to libs/talon/uv.lock forces Talon validation."""
+    assert _include_talon(["libs/talon/uv.lock"]) is True
+
+
+def test_empty_paths_include_talon() -> None:
+    """No paths preserves the full-check behavior (Talon included)."""
+    assert _include_talon([]) is True


### PR DESCRIPTION
`_touches_talon()` excluded `libs/talon/uv.lock`, so a PR changing only that lockfile skipped Talon's `uv lock --check`, allowing a stale/malformed lockfile to pass pre-commit. Now any `libs/talon` path (including `uv.lock`) counts as touching Talon, while unrelated changes still skip Talon to preserve the optimization.

Made by [Open SWE](https://openswe.vercel.app)