### PR TITLE
fix(code): ignore stale cwd warmers in file autocomplete cache

### DIFF
--- a/libs/code/deepagents_code/widgets/autocomplete.py
+++ b/libs/code/deepagents_code/widgets/autocomplete.py
@@ -514,6 +514,7 @@ class FuzzyFileController:
         # `set_cwd`) and the real project root is resolved off the event loop in
         # `warm_cache`. See `set_cwd` for why discovery is deferred.
         self._project_root_pending = False
+        self._cache_generation = 0
 
     def _get_files(self) -> list[str]:
         """Get cached file list or refresh.
@@ -527,6 +528,7 @@ class FuzzyFileController:
 
     def refresh_cache(self) -> None:
         """Force refresh of file cache."""
+        self._cache_generation += 1
         self._file_cache = None
 
     def set_cwd(self, cwd: Path) -> None:
@@ -538,6 +540,7 @@ class FuzzyFileController:
         run here on the event loop. Until then `cwd` is used as a provisional
         root, which is a safe narrower scope.
         """
+        self._cache_generation += 1
         self._cwd = cwd
         self._project_root = cwd
         self._project_root_pending = True
@@ -550,16 +553,17 @@ class FuzzyFileController:
         Also resolves a project root deferred by `set_cwd`, so the blocking
         filesystem walk runs in a worker thread instead of on the event loop.
 
-        Warmers are scheduled non-exclusively, so two quick cwd switches can run
-        concurrently. The cwd is snapshotted before each await and re-checked
-        after, so a warmer for a superseded cwd cannot overwrite controller
-        state belonging to a newer cwd.
+        Warmers are scheduled non-exclusively, so quick cwd/cache invalidations
+        can run concurrently. A monotonic generation is snapshotted before each
+        await and re-checked after, so a warmer for a superseded state cannot
+        overwrite controller state belonging to a newer generation.
         """
         cwd = self._cwd
+        generation = self._cache_generation
         if self._project_root_pending:
             root = await asyncio.to_thread(find_project_root, cwd)
-            if cwd != self._cwd:
-                # A newer cwd switch superseded this warmer; drop stale results.
+            if generation != self._cache_generation:
+                # A newer cwd/cache invalidation superseded this warmer.
                 return
             resolved = root or cwd
             if resolved != self._project_root:
@@ -574,7 +578,7 @@ class FuzzyFileController:
         # Best-effort; _get_files() falls back to sync on failure.
         with contextlib.suppress(Exception):
             files = await asyncio.to_thread(_get_project_files, project_root)
-            if cwd == self._cwd:
+            if generation == self._cache_generation:
                 self._file_cache = files
 
     @staticmethod

--- a/libs/code/deepagents_code/widgets/autocomplete.py
+++ b/libs/code/deepagents_code/widgets/autocomplete.py
@@ -554,9 +554,12 @@ class FuzzyFileController:
         filesystem walk runs in a worker thread instead of on the event loop.
 
         Warmers are scheduled non-exclusively, so quick cwd/cache invalidations
-        can run concurrently. A monotonic generation is snapshotted before each
-        await and re-checked after, so a warmer for a superseded state cannot
-        overwrite controller state belonging to a newer generation.
+        can run concurrently. The generation is snapshotted once before the first
+        await and re-checked after each await, so a warmer whose generation has
+        been superseded drops its results instead of overwriting controller state
+        belonging to a newer generation. (Snapshotting again before the second
+        await would defeat the guard: it would match the post-supersession
+        generation and let a stale-root file walk win.)
         """
         cwd = self._cwd
         generation = self._cache_generation

--- a/libs/code/deepagents_code/widgets/autocomplete.py
+++ b/libs/code/deepagents_code/widgets/autocomplete.py
@@ -549,10 +549,19 @@ class FuzzyFileController:
 
         Also resolves a project root deferred by `set_cwd`, so the blocking
         filesystem walk runs in a worker thread instead of on the event loop.
+
+        Warmers are scheduled non-exclusively, so two quick cwd switches can run
+        concurrently. The cwd is snapshotted before each await and re-checked
+        after, so a warmer for a superseded cwd cannot overwrite controller
+        state belonging to a newer cwd.
         """
+        cwd = self._cwd
         if self._project_root_pending:
-            root = await asyncio.to_thread(find_project_root, self._cwd)
-            resolved = root or self._cwd
+            root = await asyncio.to_thread(find_project_root, cwd)
+            if cwd != self._cwd:
+                # A newer cwd switch superseded this warmer; drop stale results.
+                return
+            resolved = root or cwd
             if resolved != self._project_root:
                 # The real root differs from the provisional `cwd`; drop any
                 # cache built against the narrower scope.
@@ -561,11 +570,12 @@ class FuzzyFileController:
             self._project_root_pending = False
         if self._file_cache is not None:
             return
+        project_root = self._project_root
         # Best-effort; _get_files() falls back to sync on failure.
         with contextlib.suppress(Exception):
-            self._file_cache = await asyncio.to_thread(
-                _get_project_files, self._project_root
-            )
+            files = await asyncio.to_thread(_get_project_files, project_root)
+            if cwd == self._cwd:
+                self._file_cache = files
 
     @staticmethod
     def can_handle(text: str, cursor_index: int) -> bool:

--- a/libs/code/tests/unit_tests/test_autocomplete.py
+++ b/libs/code/tests/unit_tests/test_autocomplete.py
@@ -720,3 +720,53 @@ class TestFuzzyFileControllerWarmCacheRace:
 
         assert controller._project_root == sub_b
         assert controller._file_cache == ["b/file.py"]
+
+    async def test_aba_stale_warmer_does_not_overwrite_file_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An older A warmer must not win after an A-to-B-to-A switch."""
+        sub_a = tmp_path / "a"
+        sub_a.mkdir()
+        sub_b = tmp_path / "b"
+        sub_b.mkdir()
+
+        entered_old_a = threading.Event()
+        release_old_a = threading.Event()
+        lock = threading.Lock()
+        a_calls = 0
+
+        def fake_files(root: Path) -> list[str]:
+            nonlocal a_calls
+
+            if root == sub_a:
+                with lock:
+                    a_calls += 1
+                    call = a_calls
+                if call == 1:
+                    entered_old_a.set()
+                    release_old_a.wait(timeout=5)
+                    return ["a/old.py"]
+                return ["a/new.py"]
+            return ["b/file.py"]
+
+        monkeypatch.setattr(autocomplete_module, "find_project_root", lambda _: None)
+        monkeypatch.setattr(autocomplete_module, "_get_project_files", fake_files)
+
+        controller = FuzzyFileController(MagicMock(), cwd=tmp_path)
+
+        controller.set_cwd(sub_a)
+        old_task_a = asyncio.create_task(controller.warm_cache())
+        await asyncio.to_thread(entered_old_a.wait, 5)
+
+        controller.set_cwd(sub_b)
+        await controller.warm_cache()
+
+        controller.set_cwd(sub_a)
+        await controller.warm_cache()
+        assert controller._file_cache == ["a/new.py"]
+
+        release_old_a.set()
+        await old_task_a
+
+        assert controller._project_root == sub_a
+        assert controller._file_cache == ["a/new.py"]

--- a/libs/code/tests/unit_tests/test_autocomplete.py
+++ b/libs/code/tests/unit_tests/test_autocomplete.py
@@ -677,9 +677,15 @@ class TestFuzzyFileControllerWarmCacheRace:
         controller.set_cwd(sub_b)
         await controller.warm_cache()
 
+        # The newer warmer fully resolved before the stale one is released.
+        assert controller._project_root == proj_b
+        assert controller._project_root_pending is False
+        assert controller._file_cache == ["b/file.py"]
+
         release_a.set()
         await task_a
 
+        # The stale warmer finished last but left the newer state untouched.
         assert controller._project_root == proj_b
         assert controller._project_root_pending is False
         assert controller._file_cache == ["b/file.py"]
@@ -715,10 +721,17 @@ class TestFuzzyFileControllerWarmCacheRace:
         controller.set_cwd(sub_b)
         await controller.warm_cache()
 
+        # The newer warmer fully resolved before the stale one is released.
+        assert controller._project_root == sub_b
+        assert controller._project_root_pending is False
+        assert controller._file_cache == ["b/file.py"]
+
         release_a.set()
         await task_a
 
+        # The stale warmer finished last but left the newer state untouched.
         assert controller._project_root == sub_b
+        assert controller._project_root_pending is False
         assert controller._file_cache == ["b/file.py"]
 
     async def test_aba_stale_warmer_does_not_overwrite_file_cache(
@@ -769,4 +782,5 @@ class TestFuzzyFileControllerWarmCacheRace:
         await old_task_a
 
         assert controller._project_root == sub_a
+        assert controller._project_root_pending is False
         assert controller._file_cache == ["a/new.py"]

--- a/libs/code/tests/unit_tests/test_autocomplete.py
+++ b/libs/code/tests/unit_tests/test_autocomplete.py
@@ -1,11 +1,15 @@
 """Tests for autocomplete fuzzy search functionality."""
 
+import asyncio
+import threading
+from pathlib import Path
 from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
 
 from deepagents_code.command_registry import SLASH_COMMANDS, CommandEntry
+from deepagents_code.widgets import autocomplete as autocomplete_module
 from deepagents_code.widgets.autocomplete import (
     MAX_SUGGESTIONS,
     CompletionController,
@@ -624,3 +628,95 @@ class TestFuzzyFileControllerSetCwd:
 
         assert controller._project_root == proj.resolve()
         assert controller._project_root_pending is False
+
+
+class TestFuzzyFileControllerWarmCacheRace:
+    """Overlapping cwd warmers must not let stale results win.
+
+    Warmers are scheduled with `exclusive=False`, so a slow warmer for an old
+    cwd can finish after a newer cwd switch. These tests force that ordering and
+    assert the controller stays rooted/cache-warmed for the newest cwd.
+    """
+
+    async def test_stale_warmer_does_not_overwrite_project_root(
+        self, tmp_path, monkeypatch
+    ):
+        """An older project-root lookup finishing last must not win."""
+        proj_a = tmp_path / "a"
+        sub_a = proj_a / "sub"
+        sub_a.mkdir(parents=True)
+        proj_b = tmp_path / "b"
+        sub_b = proj_b / "sub"
+        sub_b.mkdir(parents=True)
+
+        entered_a = threading.Event()
+        release_a = threading.Event()
+
+        def fake_find(path: Path) -> Path | None:
+            if path == sub_a:
+                entered_a.set()
+                release_a.wait(timeout=5)
+                return proj_a
+            if path == sub_b:
+                return proj_b
+            return None
+
+        monkeypatch.setattr(autocomplete_module, "find_project_root", fake_find)
+        monkeypatch.setattr(
+            autocomplete_module,
+            "_get_project_files",
+            lambda root: [f"{root.name}/file.py"],
+        )
+
+        controller = FuzzyFileController(MagicMock(), cwd=tmp_path)
+
+        controller.set_cwd(sub_a)
+        task_a = asyncio.create_task(controller.warm_cache())
+        await asyncio.to_thread(entered_a.wait, 5)
+
+        controller.set_cwd(sub_b)
+        await controller.warm_cache()
+
+        release_a.set()
+        await task_a
+
+        assert controller._project_root == proj_b
+        assert controller._project_root_pending is False
+        assert controller._file_cache == ["b/file.py"]
+
+    async def test_stale_warmer_does_not_overwrite_file_cache(
+        self, tmp_path, monkeypatch
+    ):
+        """An older file-cache warm finishing last must not win."""
+        sub_a = tmp_path / "a"
+        sub_a.mkdir()
+        sub_b = tmp_path / "b"
+        sub_b.mkdir()
+
+        entered_a = threading.Event()
+        release_a = threading.Event()
+
+        def fake_files(root: Path) -> list[str]:
+            if root == sub_a:
+                entered_a.set()
+                release_a.wait(timeout=5)
+                return ["a/file.py"]
+            return ["b/file.py"]
+
+        monkeypatch.setattr(autocomplete_module, "find_project_root", lambda _: None)
+        monkeypatch.setattr(autocomplete_module, "_get_project_files", fake_files)
+
+        controller = FuzzyFileController(MagicMock(), cwd=tmp_path)
+
+        controller.set_cwd(sub_a)
+        task_a = asyncio.create_task(controller.warm_cache())
+        await asyncio.to_thread(entered_a.wait, 5)
+
+        controller.set_cwd(sub_b)
+        await controller.warm_cache()
+
+        release_a.set()
+        await task_a
+
+        assert controller._project_root == sub_b
+        assert controller._file_cache == ["b/file.py"]


### PR DESCRIPTION
`FuzzyFileController.warm_cache` is scheduled non-exclusively, so two quick cwd switches can run concurrently. Because the warmer awaited `find_project_root` and `_get_project_files` against the mutable `_cwd`, an older warmer finishing after a newer cwd switch could overwrite `_project_root`, `_project_root_pending`, or `_file_cache` with stale data — leaving `@file` autocomplete rooted at the previous project until the next cwd change or cache refresh.

The fix snapshots `cwd` before each await and re-checks `cwd == self._cwd` before mutating controller state. A superseded warmer now drops its results instead of clobbering the newer cwd's root/cache. The provisional-root behavior in `set_cwd` is unchanged, and the single-cwd path is unaffected.

New unit tests force the race by making the older warmer's project-root lookup and file-cache warm complete last; both fail before the fix and pass after.

Made by [Open SWE](https://openswe.vercel.app)