### PR TITLE
feat(sdk): add structured subagent payloads

### DIFF
--- a/libs/deepagents/README.md
+++ b/libs/deepagents/README.md
@@ -51,6 +51,36 @@ result = agent.invoke({"messages": "Research LangGraph and write a summary"})
 
 The agent can plan, read/write files, and manage its own context. Add your own tools, swap models, customize prompts, configure sub-agents, and more. For a full overview and quickstart of Deep Agents, the best resource is our [docs](https://docs.langchain.com/oss/python/deepagents/overview).
 
+### Structured sub-agent input
+
+Sub-agents can declare an `input_schema` to require structured `task` payloads from the supervisor before they run.
+
+```python
+from pydantic import BaseModel, Field
+
+from deepagents import create_deep_agent
+
+
+class ResearchInput(BaseModel):
+    topic: str = Field(description="Research topic")
+    depth: str = Field(description="Requested depth, such as 'brief' or 'deep'")
+
+
+agent = create_deep_agent(
+    model=...,
+    subagents=[
+        {
+            "name": "researcher",
+            "description": "Researches a topic from a structured payload.",
+            "system_prompt": "Use the JSON payload from the user message to research the topic.",
+            "input_schema": ResearchInput,
+        }
+    ],
+)
+```
+
+When a supervisor invokes `researcher`, the `task` call must include a `payload` matching `ResearchInput`. Invalid or missing payloads are rejected before the sub-agent is invoked.
+
 **Acknowledgements: This project was primarily inspired by Claude Code, and initially was largely an attempt to see what made Claude Code general purpose, and make it even more so.**
 
 ## ❓ FAQ

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -17,7 +17,7 @@ from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import StructuredTool
 from langgraph.types import Command
 from langsmith.run_helpers import get_tracing_context, tracing_context
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError as PydanticValidationError
 
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
 from deepagents.middleware._utils import append_to_system_message
@@ -66,6 +66,10 @@ class SubAgent(TypedDict):
             replaces the parent agent's rules entirely for this subagent.
 
             Rules are evaluated in declaration order; the first match wins.
+        input_schema: Structured payload schema for task tool calls to this subagent.
+
+            When provided, `task` calls targeting this subagent must include
+            `payload`, and the payload is validated before the subagent is invoked.
     """
 
     name: str
@@ -110,6 +114,17 @@ class SubAgent(TypedDict):
     Rules are evaluated in declaration order; the first match wins.
     `FilesystemMiddleware` enforces these rules for the built-in filesystem
     tools on the subagent stack.
+    """
+
+    input_schema: NotRequired[type]
+    """Structured payload schema for task tool calls to this subagent.
+
+    When specified, the main agent must provide `payload` when invoking this
+    subagent through the `task` tool. Payloads are validated before invocation
+    and forwarded to the subagent in the initial user message.
+
+    The schema must be a Python `type` accepted by Pydantic's `TypeAdapter`,
+    such as a Pydantic `BaseModel`, dataclass, or `TypedDict` class.
     """
 
     response_format: NotRequired[ResponseFormat[Any] | type | dict[str, Any]]
@@ -231,6 +246,14 @@ class CompiledSubAgent(TypedDict):
     results back to the main agent.
     """
 
+    input_schema: NotRequired[type]
+    """Structured payload schema for task tool calls to this subagent.
+
+    When specified, the main agent must provide `payload` when invoking this
+    subagent through the `task` tool. Payloads are validated before invocation
+    and forwarded to the subagent in the initial user message.
+    """
+
 
 DEFAULT_SUBAGENT_PROMPT = """In order to complete the objective that the user asks of you, you have access to a number of standard tools.
 
@@ -269,6 +292,14 @@ class TaskToolSchema(BaseModel):
 
     subagent_type: str = Field(description=("The type of subagent to use. Must be one of the available agent types listed in the tool description."))
 
+    payload: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Optional structured payload to send to the subagent. Required when the selected subagent declares an input schema. "
+            "Must match that subagent's input schema."
+        ),
+    )
+
 
 TASK_TOOL_DESCRIPTION = """Launch an ephemeral subagent to handle complex, multi-step independent tasks with isolated context windows.
 
@@ -276,6 +307,8 @@ Available agent types and the tools they have access to:
 {available_agents}
 
 When using the Task tool, you must specify a subagent_type parameter to select which agent type to use.
+Use description for natural-language instructions and payload for structured inputs.
+If a subagent lists an input payload schema, include a payload matching that schema.
 
 ## Usage notes:
 1. Launch multiple agents concurrently whenever possible, to maximize performance; to do that, use a single message with multiple tool uses
@@ -432,6 +465,8 @@ class _SubagentSpec(TypedDict):
 
     runnable: Runnable
 
+    input_schema: NotRequired[type]
+
 
 @contextlib.contextmanager
 def _subagent_tracing_context() -> Generator[None, None, None]:
@@ -477,8 +512,15 @@ def _build_task_tool(  # noqa: C901, PLR0915
     """
     # Build the graphs dict and descriptions from the unified spec list
     subagent_graphs: dict[str, Runnable] = {spec["name"]: spec["runnable"] for spec in subagents}
+    subagent_input_schemas: dict[str, type | None] = {spec["name"]: spec.get("input_schema") for spec in subagents}
 
-    subagent_description_str = "\n".join(f"- {s['name']}: {s['description']}" for s in subagents)
+    subagent_descriptions: list[str] = []
+    for spec in subagents:
+        subagent_descriptions.append(f"- {spec['name']}: {spec['description']}")
+        if "input_schema" in spec:
+            schema = TypeAdapter(spec["input_schema"]).json_schema()
+            subagent_descriptions.append(f"  Input payload schema: {json.dumps(schema, sort_keys=True)}")
+    subagent_description_str = "\n".join(subagent_descriptions)
 
     # Use custom description if provided, otherwise use default template
     if task_description is None:
@@ -528,19 +570,40 @@ def _build_task_tool(  # noqa: C901, PLR0915
             }
         )
 
-    def _validate_and_prepare_state(subagent_type: str, description: str, runtime: ToolRuntime) -> tuple[Runnable, dict]:
+    def _validate_and_prepare_state(
+        subagent_type: str,
+        description: str,
+        payload: dict[str, Any] | None,
+        runtime: ToolRuntime,
+    ) -> tuple[Runnable, dict] | str:
         """Prepare state for invocation."""
         subagent = subagent_graphs[subagent_type]
+        input_schema = subagent_input_schemas[subagent_type]
+
+        if input_schema is None:
+            content = description if payload is None else json.dumps({"description": description, "payload": payload})
+        else:
+            if payload is None:
+                return f"`payload` is required for subagent `{subagent_type}` because it declares an input schema."
+            try:
+                adapter = TypeAdapter(input_schema)
+                validated = adapter.validate_python(payload)
+                content = json.dumps({"description": description, "payload": adapter.dump_python(validated, mode="json")})
+            except PydanticValidationError as e:
+                return f"Invalid `payload` for subagent `{subagent_type}`: {e}"
+
         # Create a new state dict to avoid mutating the original
         subagent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS}
         subagent_state = {k: v for k, v in subagent_state.items() if k not in private_state_keys}
-        subagent_state["messages"] = [HumanMessage(content=description)]
+
+        subagent_state["messages"] = [HumanMessage(content=content)]
         return subagent, subagent_state
 
     def task(
         description: str,
         subagent_type: str,
         runtime: ToolRuntime,
+        payload: dict[str, Any] | None = None,
     ) -> str | Command:
         if subagent_type not in subagent_graphs:
             allowed_types = ", ".join([f"`{k}`" for k in subagent_graphs])
@@ -548,7 +611,10 @@ def _build_task_tool(  # noqa: C901, PLR0915
         if not runtime.tool_call_id:
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
-        subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
+        prepared = _validate_and_prepare_state(subagent_type, description, payload, runtime)
+        if isinstance(prepared, str):
+            return prepared
+        subagent, subagent_state = prepared
         # The parent's callbacks, tags and configurable reach the subagent
         # automatically: langgraph's `ensure_config` seeds each run from the
         # ambient parent config and (as of langgraph#7926) merges it per-key, so
@@ -565,6 +631,7 @@ def _build_task_tool(  # noqa: C901, PLR0915
         description: str,
         subagent_type: str,
         runtime: ToolRuntime,
+        payload: dict[str, Any] | None = None,
     ) -> str | Command:
         if subagent_type not in subagent_graphs:
             allowed_types = ", ".join([f"`{k}`" for k in subagent_graphs])
@@ -572,7 +639,10 @@ def _build_task_tool(  # noqa: C901, PLR0915
         if not runtime.tool_call_id:
             value_error_msg = "Tool call ID is required for subagent invocation"
             raise ValueError(value_error_msg)
-        subagent, subagent_state = _validate_and_prepare_state(subagent_type, description, runtime)
+        prepared = _validate_and_prepare_state(subagent_type, description, payload, runtime)
+        if isinstance(prepared, str):
+            return prepared
+        subagent, subagent_state = prepared
         # The parent's callbacks, tags and configurable reach the subagent
         # automatically: langgraph's `ensure_config` seeds each run from the
         # ambient parent config and (as of langgraph#7926) merges it per-key, so
@@ -723,7 +793,14 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
                 # untouched and a shared instance can be registered under multiple names.
                 compiled = cast("CompiledSubAgent", spec)
                 runnable = compiled["runnable"].with_config({"metadata": {"lc_agent_name": compiled["name"]}, "run_name": compiled["name"]})
-                specs.append({"name": compiled["name"], "description": compiled["description"], "runnable": runnable})
+                compiled_spec: _SubagentSpec = {
+                    "name": compiled["name"],
+                    "description": compiled["description"],
+                    "runnable": runnable,
+                }
+                if "input_schema" in compiled:
+                    compiled_spec["input_schema"] = compiled["input_schema"]
+                specs.append(compiled_spec)
                 continue
 
             # SubAgent - validate required fields
@@ -755,13 +832,14 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
             }
             if self._state_schema is not None:
                 create_agent_kwargs["state_schema"] = self._state_schema
-            specs.append(
-                {
-                    "name": spec["name"],
-                    "description": spec["description"],
-                    "runnable": create_agent(model, **create_agent_kwargs),
-                }
-            )
+            subagent_spec: _SubagentSpec = {
+                "name": spec["name"],
+                "description": spec["description"],
+                "runnable": create_agent(model, **create_agent_kwargs),
+            }
+            if "input_schema" in spec:
+                subagent_spec["input_schema"] = spec["input_schema"]
+            specs.append(subagent_spec)
 
         return specs
 

--- a/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
@@ -7,6 +7,7 @@ from langchain.agents import create_agent
 from langchain_core.messages import AIMessage
 from langchain_core.tools import tool
 from langgraph.graph import START, MessagesState, StateGraph
+from pydantic import BaseModel
 
 from deepagents.backends.state import StateBackend
 from deepagents.middleware.subagents import (
@@ -71,6 +72,54 @@ class TestSubagentMiddlewareInit:
         # System prompt includes TASK_SYSTEM_PROMPT plus available subagent types
         assert middleware.system_prompt.startswith(TASK_SYSTEM_PROMPT)
         assert "weather" in middleware.system_prompt
+
+    def test_task_tool_schema_exposes_payload_argument(self) -> None:
+        """The task tool accepts an optional structured payload."""
+        middleware = SubAgentMiddleware(
+            backend=StateBackend(),
+            subagents=[
+                {
+                    "name": "weather",
+                    "description": "Weather subagent",
+                    "system_prompt": "Get weather.",
+                    "model": "openai:gpt-5.5",
+                    "tools": [],
+                }
+            ],
+        )
+
+        schema = middleware.tools[0].tool_call_schema.model_json_schema()
+        payload_schema = schema["properties"]["payload"]
+
+        assert payload_schema["default"] is None
+        assert {"type": "null"} in payload_schema["anyOf"]
+        assert "structured payload" in payload_schema["description"]
+
+    def test_task_tool_description_includes_subagent_input_schema(self) -> None:
+        """Input schemas should be visible in the supervisor-facing tool description."""
+
+        class WeatherInput(BaseModel):
+            city: str
+
+        middleware = SubAgentMiddleware(
+            backend=StateBackend(),
+            subagents=[
+                {
+                    "name": "weather",
+                    "description": "Weather subagent",
+                    "system_prompt": "Get weather.",
+                    "model": "openai:gpt-5.5",
+                    "tools": [],
+                    "input_schema": WeatherInput,
+                }
+            ],
+        )
+
+        description = middleware.tools[0].description
+
+        assert "Input payload schema" in description
+        assert "city" in description
+        assert "payload matching that schema" in description
 
     def test_subagent_middleware_custom_system_prompt(self) -> None:
         """Test SubAgentMiddleware with a custom system prompt."""
@@ -162,6 +211,39 @@ class TestSubagentMiddlewareInit:
         assert runnable.config is not None
         assert runnable.config.get("metadata", {}).get("lc_agent_name") == "my-subagent"
         assert runnable.config.get("run_name") == "my-subagent"
+
+    def test_input_schema_preserved_for_declarative_and_compiled_subagents(self) -> None:
+        """_get_subagents keeps input schemas for both subagent spec types."""
+
+        class WeatherInput(BaseModel):
+            city: str
+
+        graph = self._make_echo_graph()
+
+        middleware = SubAgentMiddleware(
+            backend=StateBackend(),
+            subagents=[
+                {
+                    "name": "declarative-weather",
+                    "description": "Declarative weather subagent",
+                    "system_prompt": "Get weather.",
+                    "model": "openai:gpt-5.5",
+                    "tools": [],
+                    "input_schema": WeatherInput,
+                },
+                {
+                    "name": "compiled-weather",
+                    "description": "Compiled weather subagent",
+                    "runnable": graph,
+                    "input_schema": WeatherInput,
+                },
+            ],
+        )
+
+        schemas = {spec["name"]: spec.get("input_schema") for spec in middleware._get_subagents()}
+
+        assert schemas["declarative-weather"] is WeatherInput
+        assert schemas["compiled-weather"] is WeatherInput
 
     def test_compiled_subagent_does_not_mutate_original_runnable(self) -> None:
         """_get_subagents must not mutate the original runnable passed by the caller."""

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -32,9 +32,10 @@ from langsmith.run_helpers import tracing_context
 from pydantic import BaseModel, Field
 
 from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.backends.state import StateBackend
 from deepagents.graph import create_deep_agent
 from deepagents.middleware.skills import SkillsMiddleware
-from deepagents.middleware.subagents import CompiledSubAgent, SubAgent
+from deepagents.middleware.subagents import CompiledSubAgent, SubAgent, SubAgentMiddleware
 from tests.unit_tests.chat_model import GenericFakeChatModel
 
 
@@ -89,8 +90,42 @@ class _ScriptedChatModel(BaseChatModel):
         return self
 
 
+class _WeatherInput(BaseModel):
+    city: str
+    days: int = Field(default=1, ge=1)
+
+
 class TestSubAgents:
     """Tests for sub-agent middleware functionality."""
+
+    @staticmethod
+    def _tool_runtime(*, tool_call_id: str = "call_task") -> ToolRuntime:
+        return ToolRuntime(
+            state={"messages": [HumanMessage(content="Parent message.")]},
+            context=None,
+            config={},
+            stream_writer=lambda _: None,
+            tool_call_id=tool_call_id,
+            store=None,
+        )
+
+    @staticmethod
+    def _weather_middleware(captured_states: list[dict[str, Any]]) -> SubAgentMiddleware:
+        def worker(state: dict[str, Any]) -> dict[str, Any]:
+            captured_states.append(state)
+            return {"messages": [AIMessage(content="Weather complete.")]}
+
+        return SubAgentMiddleware(
+            backend=StateBackend(),
+            subagents=[
+                CompiledSubAgent(
+                    name="weather-worker",
+                    description="Handles weather requests.",
+                    runnable=RunnableLambda(worker),
+                    input_schema=_WeatherInput,
+                )
+            ],
+        )
 
     def test_create_deep_agent_routes_async_subagents_from_subagents_param(self) -> None:
         agent = create_deep_agent(
@@ -208,6 +243,156 @@ class TestSubAgents:
         # Verify the ToolMessage contains the subagent's final response
         subagent_tool_message = tool_messages[0]
         assert "The sum of 2 and 3 is 5." in subagent_tool_message.content, "ToolMessage should contain subagent's final message content"
+
+    def test_parent_task_tool_call_accepts_payload_argument(self) -> None:
+        """ToolNode invocation should pass model-provided payload into `task`."""
+        captured_states: list[dict[str, Any]] = []
+
+        def worker(state: dict[str, Any]) -> dict[str, Any]:
+            captured_states.append(state)
+            return {"messages": [AIMessage(content="Weather complete.")]}
+
+        parent_model = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "task",
+                                "args": {
+                                    "description": "Fetch weather.",
+                                    "subagent_type": "weather-worker",
+                                    "payload": {"city": "Seoul", "days": "3"},
+                                },
+                                "id": "call_weather",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(
+            model=parent_model,
+            subagents=[
+                CompiledSubAgent(
+                    name="weather-worker",
+                    description="Handles weather requests.",
+                    runnable=RunnableLambda(worker),
+                    input_schema=_WeatherInput,
+                )
+            ],
+        )
+
+        agent.invoke({"messages": [HumanMessage(content="What is the weather in Seoul?")]})
+
+        content = json.loads(captured_states[0]["messages"][0].content)
+        assert content == {
+            "description": "Fetch weather.",
+            "payload": {"city": "Seoul", "days": 3},
+        }
+
+    def test_subagent_input_schema_requires_payload(self) -> None:
+        """A schema-backed subagent should not be invoked without payload."""
+        captured_states: list[dict[str, Any]] = []
+        middleware = self._weather_middleware(captured_states)
+
+        result = middleware.tools[0].func(
+            description="Fetch weather.",
+            subagent_type="weather-worker",
+            runtime=self._tool_runtime(),
+        )
+
+        assert isinstance(result, str)
+        assert "`payload` is required" in result
+        assert captured_states == []
+
+    def test_subagent_input_schema_rejects_invalid_payload(self) -> None:
+        """Invalid schema-backed payloads should return a retryable tool error."""
+        captured_states: list[dict[str, Any]] = []
+        middleware = self._weather_middleware(captured_states)
+
+        result = middleware.tools[0].func(
+            description="Fetch weather.",
+            subagent_type="weather-worker",
+            payload={"city": "Seoul", "days": 0},
+            runtime=self._tool_runtime(),
+        )
+
+        assert isinstance(result, str)
+        assert "Invalid `payload` for subagent `weather-worker`" in result
+        assert captured_states == []
+
+    def test_subagent_without_input_schema_forwards_raw_payload(self) -> None:
+        """Payloads remain available even when a subagent does not declare a schema."""
+        captured_states: list[dict[str, Any]] = []
+
+        def worker(state: dict[str, Any]) -> dict[str, Any]:
+            captured_states.append(state)
+            return {"messages": [AIMessage(content="Weather complete.")]}
+
+        middleware = SubAgentMiddleware(
+            backend=StateBackend(),
+            subagents=[
+                CompiledSubAgent(
+                    name="weather-worker",
+                    description="Handles weather requests.",
+                    runnable=RunnableLambda(worker),
+                )
+            ],
+        )
+
+        result = middleware.tools[0].func(
+            description="Fetch weather.",
+            subagent_type="weather-worker",
+            payload={"city": "Seoul", "days": "3"},
+            runtime=self._tool_runtime(),
+        )
+
+        assert not isinstance(result, str)
+        content = json.loads(captured_states[0]["messages"][0].content)
+        assert content == {
+            "description": "Fetch weather.",
+            "payload": {"city": "Seoul", "days": "3"},
+        }
+
+    async def test_async_task_input_schema_validates_and_forwards_payload(self) -> None:
+        """The async task path should use the same input schema validation."""
+        captured_states: list[dict[str, Any]] = []
+
+        async def worker(state: dict[str, Any]) -> dict[str, Any]:
+            captured_states.append(state)
+            return {"messages": [AIMessage(content="Async weather complete.")]}
+
+        middleware = SubAgentMiddleware(
+            backend=StateBackend(),
+            subagents=[
+                CompiledSubAgent(
+                    name="weather-worker",
+                    description="Handles weather requests.",
+                    runnable=RunnableLambda(worker),
+                    input_schema=_WeatherInput,
+                )
+            ],
+        )
+
+        result = await middleware.tools[0].coroutine(
+            description="Fetch weather.",
+            subagent_type="weather-worker",
+            payload={"city": "Seoul"},
+            runtime=self._tool_runtime(),
+        )
+
+        assert not isinstance(result, str)
+        assert result.update["messages"][0].content == "Async weather complete."
+        content = json.loads(captured_states[0]["messages"][0].content)
+        assert content == {
+            "description": "Fetch weather.",
+            "payload": {"city": "Seoul", "days": 1},
+        }
 
     def test_multiple_subagents_invoked_in_parallel(self) -> None:
         """Test that multiple different subagents can be launched in parallel.


### PR DESCRIPTION
Fixes #3838 

---

This adds optional `input_schema` support for subagents.

The task tool now accepts `payload`, and when the selected subagent has `input_schema`, it validates the payload before invoking the subagent. The validated payload is forwarded together with the normal task description.

The task tool still stays generic, so this does not create a custom task tool schema for each subagent.

I verified this with:

- related unit tests: `56 passed, 1 xfailed`
- `ruff check`
- `ty check deepagents/middleware/subagents.py`
- `make lint_package`
- format check

I used generative AI to help with implementation and review.