### PR TITLE
feat(code): confirm modal for `/install --package`

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3643,6 +3643,9 @@ class DeepAgentsApp(App):
         parts = command.split()
         force = "--force" in parts[1:]
         package_mode = "--package" in parts[1:]
+        # `--yes` is an undocumented alias for `--force` in package mode,
+        # mirroring the CLI's `--yes` confirmation bypass.
+        yes = "--yes" in parts[1:]
         names = [p for p in parts[1:] if not p.startswith("-")]
         if not names:
             from deepagents_code.extras_info import format_known_extras
@@ -3668,7 +3671,7 @@ class DeepAgentsApp(App):
         await self._mount_message(UserMessage(command))
 
         if package_mode:
-            await self._handle_install_package(names[0], force=force)
+            await self._handle_install_package(names[0], force=force or yes)
             return
 
         extra = names[0].lower()
@@ -3801,11 +3804,12 @@ class DeepAgentsApp(App):
         Backs `/install <package> --package`, the escape hatch for a provider
         whose package is not a `deepagents-code` extra (e.g. a custom
         `class_path` model). Arbitrary packages have no curated allowlist, so a
-        `--force` token is required to confirm pulling in third-party code.
+        non-blocking confirmation modal gates pulling in third-party code.
+        `--force` (or `--yes`) bypasses the prompt.
 
         Args:
             package: The package name to install.
-            force: Whether the user passed `--force` to confirm the install.
+            force: Whether the user passed `--force`/`--yes` to skip the prompt.
         """
         try:
             from deepagents_code.config import _is_editable_install
@@ -3840,13 +3844,9 @@ class DeepAgentsApp(App):
             )
             return
 
-        if not force:
+        if not force and not await self._confirm_install_package(package):
             await self._mount_message(
-                AppMessage(
-                    f"Installing the package '{package}' runs third-party code. "
-                    "Re-run with `--force` to proceed: "
-                    f"`/install {package} --package --force`",
-                ),
+                AppMessage(f"Cancelled install of package '{package}'."),
             )
             return
 
@@ -3883,6 +3883,40 @@ class DeepAgentsApp(App):
             ),
         )
         await self._offer_restart_after_install(package)
+
+    async def _confirm_install_package(self, package: str) -> bool:
+        """Ask the user to confirm installing an arbitrary package.
+
+        Pushes a non-blocking Textual modal explaining that the install runs
+        third-party code. A watchdog bounds the wait so a modal that never
+        resolves can't wedge command handling; a timeout or mount failure is
+        treated as a cancel.
+
+        Args:
+            package: The package name to confirm, surfaced in the modal.
+
+        Returns:
+            Whether the user confirmed the install.
+        """
+        from deepagents_code.widgets.install_confirm import (
+            InstallPackageConfirmScreen,
+        )
+
+        try:
+            confirmed = await asyncio.wait_for(
+                self._push_screen_wait(InstallPackageConfirmScreen(package)),
+                timeout=600.0,
+            )
+        except TimeoutError:
+            logger.warning(
+                "Install confirmation for %r timed out; treating as cancel",
+                package,
+            )
+            return False
+        except Exception:
+            logger.exception("Failed to mount install confirmation for %r", package)
+            return False
+        return bool(confirmed)
 
     async def _handle_version_command(self) -> None:
         """Handle the `/version` slash command — show versions and update status.

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -216,6 +216,16 @@ backend cannot trap the user inside a finished onboarding modal forever.
 _UPDATE_RECHECK_INTERVAL_SECONDS = 60 * 60
 """How often long-running TUI sessions quietly re-check for app updates."""
 
+_MODAL_WATCHDOG_TIMEOUT_SECONDS = 600.0
+"""Upper bound on awaiting a confirmation modal's dismissal.
+
+Bounds command/worker handling against a modal that never resolves (compose
+crash, programmatic teardown that skips the dismiss callback). 10 minutes is
+well past any human latency but stops a genuinely broken modal from wedging
+the caller. Shared by the install-confirm, MCP-reconnect, and restart-prompt
+watchdogs so the three stay in lockstep.
+"""
+
 
 def _resolve_theme_name(value: object) -> str | None:
     """Resolve a user-supplied theme name to a canonical registry key.
@@ -3844,10 +3854,11 @@ class DeepAgentsApp(App):
             )
             return
 
+        # `_confirm_install_package` mounts its own outcome message (cancel,
+        # timeout, or mount failure), so the caller just aborts on a falsy
+        # result rather than mounting a generic — and possibly inaccurate —
+        # "Cancelled" line.
         if not force and not await self._confirm_install_package(package):
-            await self._mount_message(
-                AppMessage(f"Cancelled install of package '{package}'."),
-            )
             return
 
         log_path = create_update_log_path()
@@ -3890,13 +3901,16 @@ class DeepAgentsApp(App):
         Pushes a non-blocking Textual modal explaining that the install runs
         third-party code. A watchdog bounds the wait so a modal that never
         resolves can't wedge command handling; a timeout or mount failure is
-        treated as a cancel.
+        treated as a cancel. Each non-confirming outcome mounts its own
+        message so the user is told what actually happened rather than being
+        told they "cancelled" a prompt that timed out or failed to appear.
 
         Args:
             package: The package name to confirm, surfaced in the modal.
 
         Returns:
-            Whether the user confirmed the install.
+            `True` only when the user explicitly confirmed; `False` on cancel,
+                timeout, or mount failure.
         """
         from deepagents_code.widgets.install_confirm import (
             InstallPackageConfirmScreen,
@@ -3905,18 +3919,39 @@ class DeepAgentsApp(App):
         try:
             confirmed = await asyncio.wait_for(
                 self._push_screen_wait(InstallPackageConfirmScreen(package)),
-                timeout=600.0,
+                timeout=_MODAL_WATCHDOG_TIMEOUT_SECONDS,
             )
         except TimeoutError:
             logger.warning(
                 "Install confirmation for %r timed out; treating as cancel",
                 package,
             )
+            await self._mount_message(
+                AppMessage(
+                    f"Install confirmation for '{package}' timed out; not "
+                    "installed. Re-run with `--force` to skip the prompt.",
+                ),
+            )
             return False
         except Exception:
             logger.exception("Failed to mount install confirmation for %r", package)
+            await self._mount_message(
+                ErrorMessage(
+                    f"Could not show the install confirmation for '{package}'; "
+                    "not installed. Re-run with `--force` to skip the prompt.",
+                ),
+            )
             return False
-        return bool(confirmed)
+
+        # Fail closed: a programmatic dismiss yields `None`, so only an
+        # explicit `True` proceeds — anything else is treated as "do not
+        # install".
+        if confirmed is not True:
+            await self._mount_message(
+                AppMessage(f"Cancelled install of package '{package}'."),
+            )
+            return False
+        return True
 
     async def _handle_version_command(self) -> None:
         """Handle the `/version` slash command — show versions and update status.
@@ -10150,9 +10185,10 @@ class DeepAgentsApp(App):
             try:
                 # Watchdog: guard against a screen that never resolves
                 # (compose crash, programmatic teardown that skips the
-                # callback). 10 minutes is well past any human latency
-                # but bounds the worker if the modal is genuinely broken.
-                choice = await asyncio.wait_for(choice_future, timeout=600.0)
+                # callback).
+                choice = await asyncio.wait_for(
+                    choice_future, timeout=_MODAL_WATCHDOG_TIMEOUT_SECONDS
+                )
             except TimeoutError:
                 logger.warning(
                     "MCP reconnect prompt for %r timed out; defaulting to defer",
@@ -10279,12 +10315,10 @@ class DeepAgentsApp(App):
         try:
             # Watchdog: bound the handler against a screen that never resolves
             # (compose crash, programmatic teardown that skips the dismiss
-            # callback). 10 minutes is well past any human latency but stops a
-            # genuinely broken modal from wedging command handling. Mirrors the
-            # MCP reconnect prompt's watchdog.
+            # callback).
             choice = await asyncio.wait_for(
                 self._push_screen_wait(RestartPromptScreen(label)),
-                timeout=600.0,
+                timeout=_MODAL_WATCHDOG_TIMEOUT_SECONDS,
             )
         except TimeoutError:
             logger.warning(

--- a/libs/code/deepagents_code/widgets/install_confirm.py
+++ b/libs/code/deepagents_code/widgets/install_confirm.py
@@ -109,5 +109,12 @@ class InstallPackageConfirmScreen(ModalScreen[bool]):
         self.dismiss(True)
 
     def action_cancel(self) -> None:
-        """Dismiss with `False`."""
+        """Dismiss with `False`.
+
+        The method name must stay `cancel`: the app owns a priority `escape`
+        binding that, for an active `ModalScreen`, dispatches to
+        `action_cancel` if present and otherwise falls through to
+        `dismiss(None)`. Renaming this would silently regress Esc to a
+        `None` dismiss instead of an explicit cancel.
+        """
         self.dismiss(False)

--- a/libs/code/deepagents_code/widgets/install_confirm.py
+++ b/libs/code/deepagents_code/widgets/install_confirm.py
@@ -1,0 +1,113 @@
+"""Confirmation modal for `/install <package> --package` in the TUI.
+
+Arbitrary packages have no curated allowlist to vet against, so installing
+one pulls in third-party code. Rather than forcing the user to re-run with
+`--force`, this non-blocking modal asks for explicit confirmation before the
+install runs. `--force` (or `--yes`) still bypasses the prompt.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.content import Content
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+
+class InstallPackageConfirmScreen(ModalScreen[bool]):
+    """Confirmation overlay for installing an arbitrary `--package`.
+
+    Dismisses with `True` when the user confirms and `False` when the user
+    cancels. Esc is treated as cancel so the user is never forced into an
+    install they did not explicitly choose.
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("enter", "confirm", "Install", show=False, priority=True),
+        Binding("escape", "cancel", "Cancel", show=False, priority=True),
+    ]
+
+    CSS = """
+    InstallPackageConfirmScreen {
+        align: center middle;
+    }
+
+    InstallPackageConfirmScreen > Vertical {
+        width: 64;
+        max-width: 90%;
+        height: auto;
+        background: $surface;
+        border: solid $warning;
+        padding: 1 2;
+    }
+
+    InstallPackageConfirmScreen .install-confirm-title {
+        text-style: bold;
+        color: $warning;
+        text-align: center;
+        margin-bottom: 1;
+    }
+
+    InstallPackageConfirmScreen .install-confirm-body {
+        height: auto;
+        color: $text;
+        margin-bottom: 1;
+    }
+
+    InstallPackageConfirmScreen .install-confirm-help {
+        height: 1;
+        color: $text-muted;
+        text-style: italic;
+        text-align: center;
+    }
+    """
+
+    def __init__(self, package: str) -> None:
+        """Initialize the prompt.
+
+        Args:
+            package: The package name to install, surfaced in the body.
+        """
+        super().__init__()
+        self._package = package
+
+    def compose(self) -> ComposeResult:
+        """Compose the install confirmation dialog.
+
+        Yields:
+            Title, body, and help-row widgets parented inside a `Vertical`.
+        """
+        with Vertical():
+            yield Static(
+                "Install package?",
+                classes="install-confirm-title",
+                markup=False,
+            )
+            yield Static(
+                Content.from_markup(
+                    "Installing [bold]$name[/bold] runs third-party code in "
+                    "the Deep Agents Code environment.",
+                    name=self._package,
+                ),
+                classes="install-confirm-body",
+                markup=False,
+            )
+            yield Static(
+                "Enter to install, Esc to cancel",
+                classes="install-confirm-help",
+                markup=False,
+            )
+
+    def action_confirm(self) -> None:
+        """Dismiss with `True`."""
+        self.dismiss(True)
+
+    def action_cancel(self) -> None:
+        """Dismiss with `False`."""
+        self.dismiss(False)

--- a/libs/code/tests/unit_tests/test_install_command.py
+++ b/libs/code/tests/unit_tests/test_install_command.py
@@ -299,6 +299,60 @@ async def test_install_slash_package_cancel_aborts() -> None:
         assert "uv tool" not in joined
 
 
+async def test_install_slash_package_prompt_timeout_aborts() -> None:
+    """A timed-out prompt aborts the install and reports the timeout."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_package",
+                new_callable=AsyncMock,
+            ) as perform_mock,
+            patch.object(
+                app,
+                "_push_screen_wait",
+                new=AsyncMock(side_effect=TimeoutError()),
+            ) as prompt,
+        ):
+            await app._handle_command("/install langchain-custom --package")
+            await pilot.pause()
+        prompt.assert_awaited_once()
+        perform_mock.assert_not_awaited()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        joined = "\n".join(str(m._content) for m in app_msgs)
+        assert "timed out" in joined
+        # A timeout is not a user cancel and must not be reported as one.
+        assert "Cancelled install" not in joined
+
+
+async def test_install_slash_package_prompt_mount_failure_aborts() -> None:
+    """A modal that fails to mount aborts the install and surfaces an error."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_package",
+                new_callable=AsyncMock,
+            ) as perform_mock,
+            patch.object(
+                app,
+                "_push_screen_wait",
+                new=AsyncMock(side_effect=RuntimeError("no screen stack")),
+            ) as prompt,
+        ):
+            await app._handle_command("/install langchain-custom --package")
+            await pilot.pause()
+        prompt.assert_awaited_once()
+        perform_mock.assert_not_awaited()
+        err_msgs = [str(m._content) for m in app.query(ErrorMessage)]
+        joined = "\n".join(err_msgs)
+        assert "Could not show the install confirmation" in joined
+
+
 async def test_install_slash_package_force_skips_prompt() -> None:
     """`--package --force` must not open the confirmation prompt."""
     app = DeepAgentsApp()

--- a/libs/code/tests/unit_tests/test_install_command.py
+++ b/libs/code/tests/unit_tests/test_install_command.py
@@ -247,8 +247,34 @@ async def test_install_slash_editable_install_refuses() -> None:
         assert any("Editable install detected" in str(m._content) for m in app_msgs)
 
 
-async def test_install_slash_package_requires_force() -> None:
-    """`--package` without `--force` must not call `perform_install_package`."""
+async def test_install_slash_package_confirm_runs() -> None:
+    """`--package` without `--force` prompts; confirming runs the install."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_package",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as perform_mock,
+            patch.object(
+                app, "_push_screen_wait", new=AsyncMock(return_value=True)
+            ) as prompt,
+        ):
+            await app._handle_command("/install langchain-custom --package")
+            await pilot.pause()
+        prompt.assert_awaited_once()
+        perform_mock.assert_awaited_once()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        assert any(
+            "Installed package 'langchain-custom'" in str(m._content) for m in app_msgs
+        )
+
+
+async def test_install_slash_package_cancel_aborts() -> None:
+    """Cancelling the prompt must not call `perform_install_package`."""
     app = DeepAgentsApp()
     async with app.run_test() as pilot:
         await pilot.pause()
@@ -258,16 +284,59 @@ async def test_install_slash_package_requires_force() -> None:
                 "deepagents_code.update_check.perform_install_package",
                 new_callable=AsyncMock,
             ) as perform_mock,
+            patch.object(
+                app, "_push_screen_wait", new=AsyncMock(return_value=False)
+            ) as prompt,
         ):
             await app._handle_command("/install langchain-custom --package")
             await pilot.pause()
+        prompt.assert_awaited_once()
         perform_mock.assert_not_awaited()
         app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
         joined = "\n".join(str(m._content) for m in app_msgs)
-        assert "--force" in joined
-        assert "third-party code" in joined
+        assert "Cancelled install" in joined
         # The raw `uv tool` command is never surfaced to the user.
         assert "uv tool" not in joined
+
+
+async def test_install_slash_package_force_skips_prompt() -> None:
+    """`--package --force` must not open the confirmation prompt."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_package",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as perform_mock,
+            patch.object(app, "_push_screen_wait", new=AsyncMock()) as prompt,
+        ):
+            await app._handle_command("/install langchain-custom --package --force")
+            await pilot.pause()
+        prompt.assert_not_awaited()
+        perform_mock.assert_awaited_once()
+
+
+async def test_install_slash_package_yes_alias_skips_prompt() -> None:
+    """`--package --yes` is an alias for `--force` and skips the prompt."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.perform_install_package",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as perform_mock,
+            patch.object(app, "_push_screen_wait", new=AsyncMock()) as prompt,
+        ):
+            await app._handle_command("/install langchain-custom --package --yes")
+            await pilot.pause()
+        prompt.assert_not_awaited()
+        perform_mock.assert_awaited_once()
 
 
 async def test_install_slash_package_with_force_runs() -> None:

--- a/libs/code/tests/unit_tests/test_install_confirm.py
+++ b/libs/code/tests/unit_tests/test_install_confirm.py
@@ -1,0 +1,88 @@
+"""Tests for the `/install --package` confirmation modal."""
+
+from __future__ import annotations
+
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from deepagents_code.widgets.install_confirm import InstallPackageConfirmScreen
+
+
+class _InstallConfirmTestApp(App[None]):
+    def compose(self) -> ComposeResult:
+        yield Static("base")
+
+
+class TestInstallPackageConfirmScreen:
+    """Behavior tests for `InstallPackageConfirmScreen`."""
+
+    async def test_enter_dismisses_with_true(self) -> None:
+        """Pressing Enter confirms the install."""
+        app = _InstallConfirmTestApp()
+        async with app.run_test() as pilot:
+            outcomes: list[bool | None] = []
+
+            def on_dismiss(result: bool | None) -> None:
+                outcomes.append(result)
+
+            app.push_screen(InstallPackageConfirmScreen("langchain-custom"), on_dismiss)
+            await pilot.pause()
+
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert outcomes == [True]
+
+    async def test_escape_dismisses_with_false(self) -> None:
+        """Pressing Esc cancels (no implicit install)."""
+        app = _InstallConfirmTestApp()
+        async with app.run_test() as pilot:
+            outcomes: list[bool | None] = []
+
+            def on_dismiss(result: bool | None) -> None:
+                outcomes.append(result)
+
+            app.push_screen(InstallPackageConfirmScreen("langchain-custom"), on_dismiss)
+            await pilot.pause()
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert outcomes == [False]
+
+    async def test_action_cancel_dismisses_with_false(self) -> None:
+        """`action_cancel` cancels — the path taken by the app's Esc handler.
+
+        `DeepAgentsApp.action_interrupt` (a priority `escape` binding) fires
+        before the modal's own `escape` binding. When the active screen is a
+        `ModalScreen`, it dispatches to `action_cancel` if present, else falls
+        through to `dismiss(None)`. Without an `action_cancel` that returns
+        `False`, real-app Esc would silently None-dismiss, which the caller
+        cannot distinguish from a programmatic dismiss.
+        """
+        app = _InstallConfirmTestApp()
+        async with app.run_test() as pilot:
+            outcomes: list[bool | None] = []
+
+            def on_dismiss(result: bool | None) -> None:
+                outcomes.append(result)
+
+            screen = InstallPackageConfirmScreen("langchain-custom")
+            app.push_screen(screen, on_dismiss)
+            await pilot.pause()
+
+            screen.action_cancel()
+            await pilot.pause()
+
+            assert outcomes == [False]
+
+    async def test_renders_package_name(self) -> None:
+        """The package name is surfaced in the modal body."""
+        app = _InstallConfirmTestApp()
+        async with app.run_test() as pilot:
+            app.push_screen(InstallPackageConfirmScreen("langchain-custom"))
+            await pilot.pause()
+
+            bodies = app.screen.query(".install-confirm-body")
+            assert len(bodies) == 1
+            assert "langchain-custom" in str(bodies.first().render())


### PR DESCRIPTION
In the TUI, `/install <pkg> --package` previously refused to install unless the user re-ran with `--force`. That was inconsistent with the CLI, which prompts interactively. This makes the TUI prompt too: it opens a non-blocking Textual confirmation modal (`InstallPackageConfirmScreen`) explaining that installing an arbitrary package runs third-party code.

Confirming runs the same install path `--force` used; cancelling shows a "Cancelled install" message and never calls `perform_install_package`. `--force` (and a new undocumented `--yes` alias) still bypass the prompt. Invalid package names and editable installs are still rejected before any confirmation. The CLI `--install <pkg> --package` flow and its `--yes` behavior are unchanged.

The new modal reuses the existing confirm-screen pattern (mirrors `MCPReconnectForceConfirmScreen`/`RestartPromptScreen`), and the wait is bounded by a watchdog so a stuck modal can't wedge command handling.

Made by [Open SWE](https://openswe.vercel.app)