### PR TITLE
feat(code): copy focused input selection on `Ctrl+C`

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7799,12 +7799,14 @@ class DeepAgentsApp(App):
         """Handle Ctrl+C - interrupt agent, reject approval, or quit on double press.
 
         Priority order:
-        1. If a focused input has a non-empty selection, copy it
+        1. If a focused input has a non-empty selection, copy it (a failed
+            copy falls through to the branches below)
         2. If shell command is running, kill it
         3. If approval menu is active, reject it
-        4. If agent is running, interrupt it (preserve input)
-        5. If double press (quit_pending), quit
-        6. Otherwise show quit hint
+        4. If ask_user menu is active, cancel it
+        5. If agent is running, interrupt it (preserve input)
+        6. If double press (quit_pending), quit
+        7. Otherwise show quit hint
         """
         # If a focused input widget has selected text, copy it instead of
         # quitting/interrupting so Ctrl+C matches standard terminal behavior.
@@ -7850,8 +7852,12 @@ class DeepAgentsApp(App):
         """Copy the focused input's selection to the clipboard, if any.
 
         Returns:
-            `True` when a non-empty selection was copied (so the caller should
-            skip quit/interrupt), `False` otherwise.
+            `True` when a non-empty selection was copied to the clipboard, so
+                the caller should treat the keypress as handled and skip
+                quit/interrupt. `False` when there was nothing to copy or every
+                clipboard backend failed, so the caller should fall through to
+                its normal quit/interrupt handling (a failed copy already
+                notifies the user).
         """
         from textual.widgets import Input, TextArea
 
@@ -7877,7 +7883,7 @@ class DeepAgentsApp(App):
                 timeout=3,
                 markup=False,
             )
-        return True
+        return success
 
     def _arm_quit_pending(self, shortcut: str) -> None:
         """Set the pending-quit flag and show a matching hint.

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7858,6 +7858,8 @@ class DeepAgentsApp(App):
         widget = self.focused
         if not isinstance(widget, (TextArea, Input)):
             return False
+        if isinstance(widget, Input) and widget.password:
+            return False
 
         selected_text = widget.selected_text
         if not selected_text:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7799,12 +7799,19 @@ class DeepAgentsApp(App):
         """Handle Ctrl+C - interrupt agent, reject approval, or quit on double press.
 
         Priority order:
-        1. If shell command is running, kill it
-        2. If approval menu is active, reject it
-        3. If agent is running, interrupt it (preserve input)
-        4. If double press (quit_pending), quit
-        5. Otherwise show quit hint
+        1. If a focused input has a non-empty selection, copy it
+        2. If shell command is running, kill it
+        3. If approval menu is active, reject it
+        4. If agent is running, interrupt it (preserve input)
+        5. If double press (quit_pending), quit
+        6. Otherwise show quit hint
         """
+        # If a focused input widget has selected text, copy it instead of
+        # quitting/interrupting so Ctrl+C matches standard terminal behavior.
+        if self._copy_focused_selection():
+            self._quit_pending = False
+            return
+
         # If shell command is running, cancel the worker
         if self._shell_running and self._shell_worker:
             self._cancel_worker(self._shell_worker)
@@ -7838,6 +7845,37 @@ class DeepAgentsApp(App):
             self.exit()
         else:
             self._arm_quit_pending("Ctrl+C")
+
+    def _copy_focused_selection(self) -> bool:
+        """Copy the focused input's selection to the clipboard, if any.
+
+        Returns:
+            `True` when a non-empty selection was copied (so the caller should
+            skip quit/interrupt), `False` otherwise.
+        """
+        from textual.widgets import Input, TextArea
+
+        widget = self.focused
+        if not isinstance(widget, (TextArea, Input)):
+            return False
+
+        selected_text = widget.selected_text
+        if not selected_text:
+            return False
+
+        from deepagents_code.clipboard import copy_text_to_clipboard
+
+        success, error = copy_text_to_clipboard(self, selected_text)
+        if not success:
+            self.notify(
+                f"Failed to copy selection: {error}"
+                if error
+                else "Failed to copy selection - no clipboard method available",
+                severity="warning",
+                timeout=3,
+                markup=False,
+            )
+        return True
 
     def _arm_quit_pending(self, shortcut: str) -> None:
         """Set the pending-quit flag and show a matching hint.

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -1418,6 +1418,11 @@ class TestCtrlCCopySelection:
 
             assert text_area.selected_text == "hello world"
 
+            # Arm quit first so the post-copy assertion that `_quit_pending` is
+            # reset is load-bearing (it defaults to False, so without arming it
+            # the assertion would pass even if the reset were removed).
+            app._quit_pending = True
+
             with (
                 patch(
                     "deepagents_code.clipboard.copy_text_to_clipboard",
@@ -1484,6 +1489,9 @@ class TestCtrlCCopySelection:
 
             assert test_input.selected_text == "abc123"
 
+            # Arm quit so the post-copy reset assertion is load-bearing.
+            app._quit_pending = True
+
             with (
                 patch(
                     "deepagents_code.clipboard.copy_text_to_clipboard",
@@ -1530,6 +1538,142 @@ class TestCtrlCCopySelection:
                 timeout=3,
                 markup=False,
             )
+
+    async def test_ctrl_c_copy_takes_precedence_over_agent_interrupt(self) -> None:
+        """A successful copy wins over interrupting a running agent."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            chat_input = app.query_one(ChatInput)
+            text_area = chat_input.input_widget
+            assert text_area is not None
+            text_area.text = "hello world"
+            await pilot.pause()
+            text_area.focus()
+            await pilot.pause()
+            text_area.select_all()
+            await pilot.pause()
+
+            assert text_area.selected_text == "hello world"
+
+            app._agent_running = True
+            mock_worker = MagicMock()
+            app._agent_worker = mock_worker
+
+            with (
+                patch(
+                    "deepagents_code.clipboard.copy_text_to_clipboard",
+                    return_value=(True, None),
+                ) as copy_mock,
+                patch.object(app, "exit") as exit_mock,
+            ):
+                app.action_quit_or_interrupt()
+
+            copy_mock.assert_called_once_with(app, "hello world")
+            # Copy consumed the keypress, so the agent worker is left running.
+            mock_worker.cancel.assert_not_called()
+            exit_mock.assert_not_called()
+            assert app._quit_pending is False
+
+    async def test_ctrl_c_copy_failure_falls_through_to_interrupt(self) -> None:
+        """When the copy fails, Ctrl+C still interrupts the running agent.
+
+        Returning `True` unconditionally would swallow the keypress and leave
+        the agent running with only a transient warning, making interrupt
+        unreachable while a selection lingers. The copy must degrade to the
+        safety-critical interrupt path on failure.
+        """
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            chat_input = app.query_one(ChatInput)
+            text_area = chat_input.input_widget
+            assert text_area is not None
+            text_area.text = "hello world"
+            await pilot.pause()
+            text_area.focus()
+            await pilot.pause()
+            text_area.select_all()
+            await pilot.pause()
+
+            assert text_area.selected_text == "hello world"
+
+            app._agent_running = True
+            mock_worker = MagicMock()
+            app._agent_worker = mock_worker
+
+            with (
+                patch(
+                    "deepagents_code.clipboard.copy_text_to_clipboard",
+                    return_value=(False, "boom"),
+                ) as copy_mock,
+                patch.object(app, "notify") as notify_mock,
+                patch.object(app, "exit") as exit_mock,
+            ):
+                app.action_quit_or_interrupt()
+
+            copy_mock.assert_called_once_with(app, "hello world")
+            notify_mock.assert_called_once_with(
+                "Failed to copy selection: boom",
+                severity="warning",
+                timeout=3,
+                markup=False,
+            )
+            # Fell through to the agent-interrupt branch instead of quitting.
+            mock_worker.cancel.assert_called_once()
+            exit_mock.assert_not_called()
+            assert app._quit_pending is False
+
+    async def test_ctrl_c_non_input_focus_falls_through(self) -> None:
+        """Ctrl+C with a non-Input/TextArea widget focused never copies."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            checkbox = Checkbox()
+            await app.mount(checkbox)
+            checkbox.focus()
+            await pilot.pause()
+
+            assert app.focused is checkbox
+
+            with (
+                patch(
+                    "deepagents_code.clipboard.copy_text_to_clipboard",
+                    return_value=(True, None),
+                ) as copy_mock,
+                patch.object(app, "exit") as exit_mock,
+            ):
+                app.action_quit_or_interrupt()
+
+            copy_mock.assert_not_called()
+            exit_mock.assert_not_called()
+            assert app._quit_pending is True
+
+    async def test_ctrl_c_no_focus_falls_through(self) -> None:
+        """Ctrl+C with nothing focused never copies and does not crash."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app.set_focus(None)
+            await pilot.pause()
+            assert app.focused is None
+
+            with (
+                patch(
+                    "deepagents_code.clipboard.copy_text_to_clipboard",
+                    return_value=(True, None),
+                ) as copy_mock,
+                patch.object(app, "exit") as exit_mock,
+            ):
+                app.action_quit_or_interrupt()
+
+            copy_mock.assert_not_called()
+            exit_mock.assert_not_called()
+            assert app._quit_pending is True
 
 
 class TestModalScreenEscapeDismissal:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -1397,6 +1397,107 @@ class TestAppBindings:
         assert "ctrl+e" not in bindings_by_key
 
 
+class TestCtrlCCopySelection:
+    """Test Ctrl+C copying a focused input's selection instead of quitting."""
+
+    async def test_ctrl_c_copies_chat_text_area_selection(self) -> None:
+        """Ctrl+C with a selection in ChatTextArea copies it, no quit/interrupt."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            chat_input = app.query_one(ChatInput)
+            text_area = chat_input.input_widget
+            assert text_area is not None
+            text_area.text = "hello world"
+            await pilot.pause()
+            text_area.focus()
+            await pilot.pause()
+            text_area.select_all()
+            await pilot.pause()
+
+            assert text_area.selected_text == "hello world"
+
+            with (
+                patch(
+                    "deepagents_code.clipboard.copy_text_to_clipboard",
+                    return_value=(True, None),
+                ) as copy_mock,
+                patch.object(app, "exit") as exit_mock,
+            ):
+                app.action_quit_or_interrupt()
+
+            copy_mock.assert_called_once_with(app, "hello world")
+            exit_mock.assert_not_called()
+            assert app._quit_pending is False
+
+    async def test_ctrl_c_without_selection_still_quits(self) -> None:
+        """Ctrl+C with no selection in ChatTextArea falls through to quit hint."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            chat_input = app.query_one(ChatInput)
+            text_area = chat_input.input_widget
+            assert text_area is not None
+            text_area.text = "hello world"
+            await pilot.pause()
+            text_area.focus()
+            await pilot.pause()
+
+            assert text_area.selected_text == ""
+
+            with (
+                patch(
+                    "deepagents_code.clipboard.copy_text_to_clipboard",
+                    return_value=(True, None),
+                ) as copy_mock,
+                patch.object(app, "notify") as notify_mock,
+                patch.object(app, "exit") as exit_mock,
+            ):
+                app.action_quit_or_interrupt()
+
+                copy_mock.assert_not_called()
+                exit_mock.assert_not_called()
+                assert app._quit_pending is True
+                notify_mock.assert_called_once_with(
+                    "Press Ctrl+C again to quit",
+                    timeout=3,
+                    markup=False,
+                )
+
+                app.action_quit_or_interrupt()
+                exit_mock.assert_called_once()
+
+    async def test_ctrl_c_copies_input_selection(self) -> None:
+        """Ctrl+C with a selection in a focused Input copies it, no quit."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            test_input = Input(value="abc123")
+            await app.mount(test_input)
+            test_input.focus()
+            await pilot.pause()
+            test_input.select_all()
+            await pilot.pause()
+
+            assert test_input.selected_text == "abc123"
+
+            with (
+                patch(
+                    "deepagents_code.clipboard.copy_text_to_clipboard",
+                    return_value=(True, None),
+                ) as copy_mock,
+                patch.object(app, "exit") as exit_mock,
+            ):
+                app.action_quit_or_interrupt()
+
+            copy_mock.assert_called_once_with(app, "abc123")
+            exit_mock.assert_not_called()
+            assert app._quit_pending is False
+
+
 class TestModalScreenEscapeDismissal:
     """Test that escape key dismisses modal screens."""
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -1497,6 +1497,40 @@ class TestCtrlCCopySelection:
             exit_mock.assert_not_called()
             assert app._quit_pending is False
 
+    async def test_ctrl_c_skips_password_input_selection(self) -> None:
+        """Ctrl+C must not copy selected text from masked password inputs."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            test_input = Input(value="secret-api-key", password=True)
+            await app.mount(test_input)
+            test_input.focus()
+            await pilot.pause()
+            test_input.select_all()
+            await pilot.pause()
+
+            assert test_input.selected_text == "secret-api-key"
+
+            with (
+                patch(
+                    "deepagents_code.clipboard.copy_text_to_clipboard",
+                    return_value=(True, None),
+                ) as copy_mock,
+                patch.object(app, "notify") as notify_mock,
+                patch.object(app, "exit") as exit_mock,
+            ):
+                app.action_quit_or_interrupt()
+
+            copy_mock.assert_not_called()
+            exit_mock.assert_not_called()
+            assert app._quit_pending is True
+            notify_mock.assert_called_once_with(
+                "Press Ctrl+C again to quit",
+                timeout=3,
+                markup=False,
+            )
+
 
 class TestModalScreenEscapeDismissal:
     """Test that escape key dismisses modal screens."""


### PR DESCRIPTION
`Ctrl+C` now copies the selected text in a focused input instead of quitting when there is an active selection.

---

dcode's global priority `ctrl+c` binding (`quit_or_interrupt`) shadowed Textual's built-in copy binding on focused inputs, so selected text in the chat input could never be copied with `Ctrl+C`. This adds a selection check at the top of `action_quit_or_interrupt`: when the focused widget is a `TextArea`/`ChatTextArea` or `Input` with a non-empty selection, the selection is copied via the existing `copy_text_to_clipboard` helper and quit/interrupt is skipped. With no selection, all existing behavior is preserved, so `Ctrl+C` can still quit while an input is focused.

Made by [Open SWE](https://openswe.vercel.app)