### PR TITLE
fix(code): resolve interpreter PTC allowlist against the runtime tool registry

### DIFF
--- a/libs/code/deepagents_code/_server_config.py
+++ b/libs/code/deepagents_code/_server_config.py
@@ -164,7 +164,9 @@ class ServerConfig:
 
     `None` means "fall through to whatever `settings.interpreter_ptc` resolves
     to from `~/.deepagents/config.toml`". A string is one of `"safe"`/`"all"`;
-    a list is an explicit allowlist of tool names.
+    a list is an explicit allowlist of tool names that may also include the
+    `"safe"` preset (expanded at agent-build time); `"all"` is rejected inside
+    a list.
     """
 
     interpreter_ptc_acknowledge_unsafe: bool = False

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -294,7 +294,8 @@ def _resolve_ptc_option(
             # `all` can only enumerate the tools passed to `create_cli_agent`;
             # SDK runtime built-ins (filesystem, `task`, …) are injected later
             # and are not enumerable here. Exposing them under `all` needs an
-            # "expose everything" sentinel in `CodeInterpreterMiddleware`.
+            # "expose everything" sentinel in `CodeInterpreterMiddleware`
+            # (tracked in langchain-ai/deepagents#3847).
             included = sorted(live_set)
             write_included = sorted(_INTERPRETER_WRITE_TOOLS & live_set)
             if write_included:

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -222,7 +222,9 @@ def _resolve_ptc_option(
 
     Args:
         ptc: Raw `interpreter_ptc` value from settings or CLI. Accepts
-            `False`/`[]`, `"safe"`, `"all"`, or a list of names.
+            `False`/`[]`, `"safe"`, `"all"`, or a list of names. A list may
+            include `"safe"`, which expands to the live intersection of
+            `INTERPRETER_PTC_SAFE_PRESET`; `"all"` is rejected inside a list.
         tools: Live tool list given to `create_cli_agent`. Used to validate
             explicit names, intersect the `"safe"` preset, and enumerate
             `"all"`.
@@ -237,8 +239,9 @@ def _resolve_ptc_option(
         suitable for `CodeInterpreterMiddleware(ptc=...)`.
 
     Raises:
-        ValueError: For unknown names in an explicit list, or for `"all"`
-            without `acknowledge_unsafe` outside of `auto_approve`.
+        ValueError: For unknown names in an explicit list, for `"all"` inside
+            a list, or for `"all"` without `acknowledge_unsafe` outside of
+            `auto_approve`.
     """
     from langchain.tools import BaseTool as _BaseTool
 
@@ -298,7 +301,35 @@ def _resolve_ptc_option(
         raise ValueError(msg)
 
     if isinstance(ptc, list):
-        unknown = [name for name in ptc if name not in live_set]
+        from deepagents_code.config import INTERPRETER_PTC_SAFE_PRESET
+
+        if any(name.strip().lower() == "all" for name in ptc):
+            msg = (
+                "interpreter_ptc list entries cannot include 'all'; use 'all' "
+                "as a standalone value or list explicit tool names (optionally "
+                "with the 'safe' preset)."
+            )
+            raise ValueError(msg)
+
+        resolved: list[str] = []
+        seen: set[str] = set()
+
+        def _add(name: str) -> None:
+            if name not in seen:
+                seen.add(name)
+                resolved.append(name)
+
+        unknown: list[str] = []
+        for name in ptc:
+            if name.strip().lower() == "safe":
+                for member in sorted(INTERPRETER_PTC_SAFE_PRESET & live_set):
+                    _add(member)
+                continue
+            if name not in live_set:
+                unknown.append(name)
+                continue
+            _add(name)
+
         if unknown:
             available = ", ".join(sorted(live_set)) or "<none>"
             msg = (
@@ -306,7 +337,7 @@ def _resolve_ptc_option(
                 f"{sorted(set(unknown))}. Available tools: {available}."
             )
             raise ValueError(msg)
-        return list(ptc)
+        return resolved
 
     msg = (
         "interpreter_ptc must be False, 'safe', 'all', or a list of tool names; "

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -324,6 +324,13 @@ def _resolve_ptc_option(
             if name.strip().lower() == "safe":
                 for member in sorted(INTERPRETER_PTC_SAFE_PRESET & live_set):
                     _add(member)
+                dropped = sorted(INTERPRETER_PTC_SAFE_PRESET - live_set)
+                if dropped:
+                    logger.debug(
+                        "interpreter_ptc 'safe' preset members not present in "
+                        "toolset: %s",
+                        dropped,
+                    )
                 continue
             if name not in live_set:
                 unknown.append(name)

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -220,14 +220,23 @@ def _resolve_ptc_option(
 ) -> list[str] | None:
     """Resolve the configured PTC allowlist to a concrete list of tool names.
 
+    Names are *not* validated against `tools`. The Deep Agents SDK injects the
+    filesystem, `task`, `write_todos`, and `execute` tools via middleware in
+    `create_deep_agent` — *after* this point — so they are absent from `tools`
+    here, and the SDK exposes no importable list of them. `CodeInterpreterMiddleware`
+    matches the resolved names against the live runtime registry and silently
+    ignores any that are absent, so resolution passes names through and lets
+    runtime decide. (Names that match nothing at runtime are dropped, so a typo
+    silently exposes no tool rather than raising.)
+
     Args:
         ptc: Raw `interpreter_ptc` value from settings or CLI. Accepts
             `False`/`[]`, `"safe"`, `"all"`, or a list of names. A list may
-            include `"safe"`, which expands to the live intersection of
-            `INTERPRETER_PTC_SAFE_PRESET`; `"all"` is rejected inside a list.
-        tools: Live tool list given to `create_cli_agent`. Used to validate
-            explicit names, intersect the `"safe"` preset, and enumerate
-            `"all"`.
+            include `"safe"`, which expands to `INTERPRETER_PTC_SAFE_PRESET`;
+            `"all"` is rejected inside a list.
+        tools: Tools passed to `create_cli_agent`. Used only to enumerate
+            `"all"`, which is therefore limited to these explicitly-passed
+            tools (the SDK runtime built-ins cannot be enumerated here).
         acknowledge_unsafe: Mirrors `settings.interpreter_ptc_acknowledge_unsafe`;
             required when `ptc="all"` and `auto_approve` is `False`.
         auto_approve: Whether HITL approval is globally disabled. When `True`,
@@ -239,9 +248,9 @@ def _resolve_ptc_option(
         suitable for `CodeInterpreterMiddleware(ptc=...)`.
 
     Raises:
-        ValueError: For unknown names in an explicit list, for `"all"` inside
-            a list, or for `"all"` without `acknowledge_unsafe` outside of
-            `auto_approve`.
+        ValueError: For `"all"` inside a list, for `"all"` without
+            `acknowledge_unsafe` outside of `auto_approve`, or for an invalid
+            `ptc` type or string.
     """
     from langchain.tools import BaseTool as _BaseTool
 
@@ -269,14 +278,10 @@ def _resolve_ptc_option(
         if normalized == "safe":
             from deepagents_code.config import INTERPRETER_PTC_SAFE_PRESET
 
-            selected = sorted(INTERPRETER_PTC_SAFE_PRESET & live_set)
-            dropped = sorted(INTERPRETER_PTC_SAFE_PRESET - live_set)
-            if dropped:
-                logger.debug(
-                    "interpreter_ptc='safe' preset members not present in toolset: %s",
-                    dropped,
-                )
-            return selected
+            # Return the preset as-is; the middleware exposes whichever members
+            # exist in the live registry at runtime (they are SDK built-ins not
+            # present in `tools` here).
+            return sorted(INTERPRETER_PTC_SAFE_PRESET)
         if normalized == "all":
             if not auto_approve and not acknowledge_unsafe:
                 msg = (
@@ -286,6 +291,10 @@ def _resolve_ptc_option(
                     "auto_approve=True) to opt in."
                 )
                 raise ValueError(msg)
+            # `all` can only enumerate the tools passed to `create_cli_agent`;
+            # SDK runtime built-ins (filesystem, `task`, …) are injected later
+            # and are not enumerable here. Exposing them under `all` needs an
+            # "expose everything" sentinel in `CodeInterpreterMiddleware`.
             included = sorted(live_set)
             write_included = sorted(_INTERPRETER_WRITE_TOOLS & live_set)
             if write_included:
@@ -319,31 +328,23 @@ def _resolve_ptc_option(
                 seen.add(name)
                 resolved.append(name)
 
-        unknown: list[str] = []
         for name in ptc:
             if name.strip().lower() == "safe":
-                for member in sorted(INTERPRETER_PTC_SAFE_PRESET & live_set):
+                for member in sorted(INTERPRETER_PTC_SAFE_PRESET):
                     _add(member)
-                dropped = sorted(INTERPRETER_PTC_SAFE_PRESET - live_set)
-                if dropped:
-                    logger.debug(
-                        "interpreter_ptc 'safe' preset members not present in "
-                        "toolset: %s",
-                        dropped,
-                    )
-                continue
-            if name not in live_set:
-                unknown.append(name)
                 continue
             _add(name)
 
-        if unknown:
-            available = ", ".join(sorted(live_set)) or "<none>"
-            msg = (
-                "Unknown tool names in interpreter_ptc: "
-                f"{sorted(set(unknown))}. Available tools: {available}."
+        # Explicit names are passed through unvalidated: the middleware resolves
+        # them against the live runtime registry (which includes the SDK
+        # built-ins absent from `tools`) and drops any that match nothing.
+        absent = sorted(n for n in resolved if n not in live_set)
+        if absent:
+            logger.debug(
+                "interpreter_ptc names not in the build-time toolset (resolved "
+                "at runtime if present): %s",
+                absent,
             )
-            raise ValueError(msg)
         return resolved
 
     msg = (

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -983,10 +983,12 @@ def _parse_interpreter_ptc(
     Returns:
         `False` for `False`/`None`/`[]`, the string `"safe"`/`"all"` when
         either sentinel is given, otherwise a validated list of tool names.
+        A list may include the `"safe"` preset (expanded at agent-build time)
+        but never `"all"`.
 
     Raises:
-        ValueError: If `raw` is a list with empty or non-string entries, or
-            a string other than `"safe"`/`"all"`.
+        ValueError: If `raw` is a list with empty or non-string entries, a
+            list containing `"all"`, or a string other than `"safe"`/`"all"`.
     """
     if raw is None or raw is False:
         return False
@@ -1016,7 +1018,15 @@ def _parse_interpreter_ptc(
                     f"got {entry!r}."
                 )
                 raise ValueError(msg)
-            names.append(entry.strip())
+            cleaned = entry.strip()
+            if cleaned.lower() == INTERPRETER_PTC_ALL_SENTINEL:
+                msg = (
+                    "`interpreter_ptc` list entries cannot include 'all'; use "
+                    "'all' as a standalone value or list explicit tool names "
+                    "(optionally with the 'safe' preset)."
+                )
+                raise ValueError(msg)
+            names.append(cleaned)
         return names
     msg = (
         f"`interpreter_ptc` must be False, 'safe', 'all', or a list of tool "

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -1318,14 +1318,13 @@ class Settings:
     Accepted values:
 
     - `False` or `[]`: pure REPL, no `tools.*` bridge.
-    - `"safe"`: expand to `INTERPRETER_PTC_SAFE_PRESET` intersected with the
-        live toolset.
-    - `"all"`: every live tool is exposed. Requires
+    - `"safe"`: expand to `INTERPRETER_PTC_SAFE_PRESET`.
+    - `"all"`: every tool passed to `create_cli_agent` is exposed. Requires
         `interpreter_ptc_acknowledge_unsafe=True` when `auto_approve` is `False`.
-    - `list[str]`: explicit tool names, validated at agent-build time. The list
-        may also include the `"safe"` preset (expanded to
-        `INTERPRETER_PTC_SAFE_PRESET` intersected with the live toolset);
-        `"all"` is rejected inside a list.
+    - `list[str]`: explicit tool names. The list may also include the `"safe"`
+        preset (expanded to `INTERPRETER_PTC_SAFE_PRESET`); `"all"` is rejected
+        inside a list. Names are matched against the live tool registry at
+        runtime, so names not present are simply not exposed.
     """
 
     interpreter_ptc_acknowledge_unsafe: bool = False

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -1322,7 +1322,10 @@ class Settings:
         live toolset.
     - `"all"`: every live tool is exposed. Requires
         `interpreter_ptc_acknowledge_unsafe=True` when `auto_approve` is `False`.
-    - `list[str]`: explicit tool names, validated at agent-build time.
+    - `list[str]`: explicit tool names, validated at agent-build time. The list
+        may also include the `"safe"` preset (expanded to
+        `INTERPRETER_PTC_SAFE_PRESET` intersected with the live toolset);
+        `"all"` is rejected inside a list.
     """
 
     interpreter_ptc_acknowledge_unsafe: bool = False

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -247,10 +247,12 @@ def _parse_interpreter_tools_flag(
 
     Returns:
         `None` when the flag is absent, the literal string `"safe"`/`"all"`,
-        or a list of trimmed tool names.
+        or a list of trimmed tool names. The list may contain `"safe"` as an
+        expandable preset (e.g. `"safe,task"` → `["safe", "task"]`).
 
-        Calls `sys.exit(2)` when the value is empty or contains only blank
-        tokens — the CLI treats that as a usage error.
+        Calls `sys.exit(2)` when the value is empty, contains only blank
+        tokens, or includes `"all"` inside a list — the CLI treats those as
+        usage errors.
     """
     if raw is None:
         return None
@@ -269,6 +271,13 @@ def _parse_interpreter_tools_flag(
         sys.stderr.write(
             "Error: --interpreter-tools list must contain at least one "
             "non-empty tool name.\n"
+        )
+        sys.exit(2)
+    if any(name.lower() == "all" for name in names):
+        sys.stderr.write(
+            "Error: --interpreter-tools 'all' cannot be combined with other "
+            "tools; use 'all' on its own or list explicit tool names "
+            "(optionally with the 'safe' preset).\n"
         )
         sys.exit(2)
     return names
@@ -1086,7 +1095,8 @@ def parse_args() -> argparse.Namespace:
         dest="interpreter_tools",
         metavar="VALUE",
         help="PTC allowlist for `js_eval`: 'safe', 'all', or a comma-separated "
-        "list of tool names. Default is no PTC (pure REPL).",
+        "list of tool names (which may include the 'safe' preset, e.g. "
+        "'safe,task'). Default is no PTC (pure REPL).",
     )
 
     try:

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -138,7 +138,7 @@ def show_help() -> None:
     )
     console.print(
         "  --interpreter-tools VALUE  PTC allowlist: 'safe', 'all', or comma-separated "
-        "tool names"
+        "tool names (may include 'safe')"
     )
     console.print("  -n, --non-interactive MSG  Run a single task and exit")
     console.print("  -q, --quiet                Clean output for piping (needs -n)")

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -2895,8 +2895,16 @@ class TestCreateCliAgentInterpreterWiring:
                 sandbox=fake_sandbox,
             )
 
-    def test_raises_on_unknown_ptc_tool_name(self, tmp_path: Path) -> None:
+    def test_unknown_ptc_names_pass_through_to_middleware(self, tmp_path: Path) -> None:
+        """Names absent from `tools` are forwarded, not rejected.
+
+        The middleware matches `ptc` names against the live runtime registry and
+        silently drops unmatched ones, so an unrecognized name (a typo, or a
+        runtime-injected built-in) is passed through rather than raising at
+        build time.
+        """
         from langchain_core.tools import tool
+        from langchain_quickjs import CodeInterpreterMiddleware
 
         mock_settings = self._build_mock_settings(tmp_path)
         mock_settings.interpreter_ptc = ["nope", "grep"]
@@ -2907,15 +2915,20 @@ class TestCreateCliAgentInterpreterWiring:
             """Search for a pattern."""
             return ""
 
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
         with (
             patch("deepagents_code.agent.settings", mock_settings),
             patch("deepagents_code.agent.SkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
             patch(
+                "deepagents_code.agent.create_deep_agent",
+                return_value=mock_agent,
+            ) as mock_create,
+            patch(
                 "deepagents._models.init_chat_model",
                 return_value=fake_model,
             ),
-            pytest.raises(ValueError, match="nope") as exc_info,
         ):
             create_cli_agent(
                 model="fake-model",
@@ -2927,7 +2940,12 @@ class TestCreateCliAgentInterpreterWiring:
                 tools=[grep],
             )
 
-        assert "Unknown tool names" in str(exc_info.value)
+        _, kwargs = mock_create.call_args
+        middlewares = [
+            m for m in kwargs["middleware"] if isinstance(m, CodeInterpreterMiddleware)
+        ]
+        assert len(middlewares) == 1
+        assert middlewares[0]._ptc == ["nope", "grep"]
 
     def test_raises_on_ptc_all_without_acknowledge(self, tmp_path: Path) -> None:
         from langchain_core.tools import tool
@@ -2963,8 +2981,15 @@ class TestCreateCliAgentInterpreterWiring:
                 tools=[grep],
             )
 
-    def test_safe_preset_drops_unknown_members(self, tmp_path: Path) -> None:
-        """`'safe'` ∩ live toolset; missing preset members are silently dropped."""
+    def test_safe_preset_includes_runtime_builtins(self, tmp_path: Path) -> None:
+        """`'safe'` resolves to the full preset including SDK-injected built-ins.
+
+        `glob` is not in the passed `tools`, but `create_deep_agent` injects it
+        at runtime, so the `ptc` list handed to `CodeInterpreterMiddleware` must
+        include all three preset members — not just the ones in `tools`. This is
+        the regression guard for the server/non-interactive path, where the
+        filesystem tools are never members of the `tools` sequence.
+        """
         from langchain_core.tools import tool
         from langchain_quickjs import CodeInterpreterMiddleware
 
@@ -3012,8 +3037,9 @@ class TestCreateCliAgentInterpreterWiring:
             m for m in kwargs["middleware"] if isinstance(m, CodeInterpreterMiddleware)
         ]
         assert len(middlewares) == 1
-        # Names beyond the live set should be dropped, leaving exactly grep+read_file
-        assert sorted(middlewares[0]._ptc) == ["grep", "read_file"]
+        # `glob` is absent from `tools` but is a runtime built-in, so the safe
+        # preset resolves to all three members rather than dropping it.
+        assert sorted(middlewares[0]._ptc) == ["glob", "grep", "read_file"]
 
 
 class TestResolvePtcOption:
@@ -3066,7 +3092,13 @@ class TestResolvePtcOption:
             is None
         )
 
-    def test_safe_intersects_with_live_toolset(self) -> None:
+    def test_safe_includes_builtin_preset_members(self) -> None:
+        """`"safe"` resolves to the full preset even when members are SDK built-ins.
+
+        `glob` is not in the passed `tools` here, but it is a Deep Agents
+        built-in injected at runtime, so the resolved allowlist must still
+        include it — the middleware bridges it against the live registry.
+        """
         from deepagents_code.agent import _resolve_ptc_option
 
         result = _resolve_ptc_option(
@@ -3075,7 +3107,7 @@ class TestResolvePtcOption:
             acknowledge_unsafe=False,
             auto_approve=False,
         )
-        assert result == ["grep", "read_file"]
+        assert result == ["glob", "grep", "read_file"]
 
     def test_all_with_auto_approve_skips_ack_check(self) -> None:
         from deepagents_code.agent import _resolve_ptc_option
@@ -3087,6 +3119,8 @@ class TestResolvePtcOption:
             auto_approve=True,
         )
         assert result is not None
+        # `all` enumerates only the tools passed to `create_cli_agent`; SDK
+        # runtime built-ins are injected later and are not enumerable here.
         assert sorted(result) == ["grep", "read_file", "write_file"]
 
     @staticmethod
@@ -3148,16 +3182,22 @@ class TestResolvePtcOption:
                 auto_approve=False,
             )
 
-    def test_unknown_name_in_list_with_safe_raises(self) -> None:
+    def test_unknown_name_in_list_passes_through(self) -> None:
+        """Unrecognized names are forwarded, not rejected.
+
+        A name absent from `tools` may still match an SDK built-in injected at
+        runtime (or be a genuine typo the middleware drops), so the resolver
+        passes it through after expanding `"safe"`.
+        """
         from deepagents_code.agent import _resolve_ptc_option
 
-        with pytest.raises(ValueError, match="Unknown tool names"):
-            _resolve_ptc_option(
-                ["safe", "nope"],
-                tools=self._tools_with_task(),
-                acknowledge_unsafe=False,
-                auto_approve=False,
-            )
+        result = _resolve_ptc_option(
+            ["safe", "nope"],
+            tools=self._tools_with_task(),
+            acknowledge_unsafe=False,
+            auto_approve=False,
+        )
+        assert result == ["glob", "grep", "read_file", "nope"]
 
     def test_safe_alone_in_list_equals_standalone(self) -> None:
         """`["safe"]` must resolve identically to the standalone `"safe"`."""
@@ -3193,41 +3233,49 @@ class TestResolvePtcOption:
         )
         assert result == ["glob", "grep", "read_file", "task"]
 
-    def test_explicit_names_are_not_whitespace_stripped(self) -> None:
-        """Only sentinels are normalized; explicit names match `live_set` exactly.
+    def test_explicit_names_are_not_normalized(self) -> None:
+        """Only the `"safe"`/`"all"` sentinels are normalized; names pass verbatim.
 
-        The CLI and config layers strip whitespace before this layer sees the
-        names, so a padded explicit name reaching `_resolve_ptc_option` is a
-        genuine mismatch and must be reported rather than silently trimmed.
+        The CLI and config layers strip whitespace before this layer, so a
+        padded explicit name should never reach here in practice. If one does,
+        it is forwarded verbatim (not trimmed) and the middleware resolves it
+        against the runtime registry.
         """
         from deepagents_code.agent import _resolve_ptc_option
 
-        with pytest.raises(ValueError, match="Unknown tool names"):
-            _resolve_ptc_option(
-                ["safe", " task "],
-                tools=self._tools_with_task(),
-                acknowledge_unsafe=False,
-                auto_approve=False,
-            )
+        result = _resolve_ptc_option(
+            ["safe", " task "],
+            tools=self._tools_with_task(),
+            acknowledge_unsafe=False,
+            auto_approve=False,
+        )
+        assert result == ["glob", "grep", "read_file", " task "]
 
-    def test_safe_in_list_empty_when_preset_absent(self) -> None:
-        """`["safe"]` resolves to `[]` when no preset members are live."""
+    def test_resolves_builtins_absent_from_passed_tools(self) -> None:
+        """Reproduce the server path: built-in names resolve without being in `tools`.
+
+        In server/non-interactive mode `create_cli_agent` only receives custom
+        tools (e.g. `fetch_url` + MCP); the filesystem and `task` tools are
+        injected by `create_deep_agent` middleware. The PTC allowlist must
+        still resolve `safe`/`task` against those runtime built-ins rather than
+        raising "Unknown tool names".
+        """
         from langchain_core.tools import tool
 
         from deepagents_code.agent import _resolve_ptc_option
 
         @tool
-        def task(prompt: str) -> str:  # noqa: ARG001
-            """Dispatch a subagent."""
+        def fetch_url(url: str) -> str:  # noqa: ARG001
+            """Fetch a URL (a custom, non-built-in tool)."""
             return ""
 
         result = _resolve_ptc_option(
-            ["safe"],
-            tools=[task],
+            ["safe", "task"],
+            tools=[fetch_url],
             acknowledge_unsafe=False,
             auto_approve=False,
         )
-        assert result == []
+        assert result == ["glob", "grep", "read_file", "task"]
 
     def test_duplicate_safe_tokens_dedupe(self) -> None:
         """Repeated `"safe"` tokens expand once; members are not duplicated."""

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -3089,6 +3089,76 @@ class TestResolvePtcOption:
         assert result is not None
         assert sorted(result) == ["grep", "read_file", "write_file"]
 
+    @staticmethod
+    def _tools_with_task() -> list:
+        from langchain_core.tools import tool
+
+        @tool
+        def read_file(path: str) -> str:  # noqa: ARG001
+            """Read."""
+            return ""
+
+        @tool
+        def glob(pattern: str) -> str:  # noqa: ARG001
+            """Glob."""
+            return ""
+
+        @tool
+        def grep(pattern: str) -> str:  # noqa: ARG001
+            """Search."""
+            return ""
+
+        @tool
+        def task(prompt: str) -> str:  # noqa: ARG001
+            """Dispatch a subagent."""
+            return ""
+
+        return [read_file, glob, grep, task]
+
+    def test_safe_in_list_expands_with_explicit_tool(self) -> None:
+        from deepagents_code.agent import _resolve_ptc_option
+
+        result = _resolve_ptc_option(
+            ["safe", "task"],
+            tools=self._tools_with_task(),
+            acknowledge_unsafe=False,
+            auto_approve=False,
+        )
+        assert result == ["glob", "grep", "read_file", "task"]
+
+    def test_safe_in_list_dedupes_preserving_order(self) -> None:
+        from deepagents_code.agent import _resolve_ptc_option
+
+        result = _resolve_ptc_option(
+            ["grep", "safe", "task", "grep"],
+            tools=self._tools_with_task(),
+            acknowledge_unsafe=False,
+            auto_approve=False,
+        )
+        assert result == ["grep", "glob", "read_file", "task"]
+
+    def test_all_in_list_raises(self) -> None:
+        from deepagents_code.agent import _resolve_ptc_option
+
+        with pytest.raises(ValueError, match="cannot include 'all'"):
+            _resolve_ptc_option(
+                ["all", "task"],
+                tools=self._tools_with_task(),
+                acknowledge_unsafe=False,
+                auto_approve=False,
+            )
+
+    def test_unknown_name_in_list_with_safe_raises(self) -> None:
+        from deepagents_code.agent import _resolve_ptc_option
+
+        with pytest.raises(ValueError, match="Unknown tool names"):
+            _resolve_ptc_option(
+                ["safe", "nope"],
+                tools=self._tools_with_task(),
+                acknowledge_unsafe=False,
+                auto_approve=False,
+            )
+
     def test_safe_excludes_hitl_gated_tools(self) -> None:
         """`"safe"` must never expose tools that are HITL-gated outside the REPL.
 

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -3159,6 +3159,88 @@ class TestResolvePtcOption:
                 auto_approve=False,
             )
 
+    def test_safe_alone_in_list_equals_standalone(self) -> None:
+        """`["safe"]` must resolve identically to the standalone `"safe"`."""
+        from deepagents_code.agent import _resolve_ptc_option
+
+        tools = self._tools_with_task()
+        kwargs = {"acknowledge_unsafe": False, "auto_approve": False}
+        as_list = _resolve_ptc_option(["safe"], tools=tools, **kwargs)
+        standalone = _resolve_ptc_option("safe", tools=tools, **kwargs)
+        assert as_list == standalone == ["glob", "grep", "read_file"]
+
+    def test_safe_in_list_is_case_insensitive(self) -> None:
+        """The `"safe"` sentinel is matched case-insensitively inside a list."""
+        from deepagents_code.agent import _resolve_ptc_option
+
+        result = _resolve_ptc_option(
+            ["SAFE", "task"],
+            tools=self._tools_with_task(),
+            acknowledge_unsafe=False,
+            auto_approve=False,
+        )
+        assert result == ["glob", "grep", "read_file", "task"]
+
+    def test_safe_sentinel_is_whitespace_tolerant(self) -> None:
+        """Whitespace around the `"safe"` sentinel is tolerated and expanded."""
+        from deepagents_code.agent import _resolve_ptc_option
+
+        result = _resolve_ptc_option(
+            [" safe ", "task"],
+            tools=self._tools_with_task(),
+            acknowledge_unsafe=False,
+            auto_approve=False,
+        )
+        assert result == ["glob", "grep", "read_file", "task"]
+
+    def test_explicit_names_are_not_whitespace_stripped(self) -> None:
+        """Only sentinels are normalized; explicit names match `live_set` exactly.
+
+        The CLI and config layers strip whitespace before this layer sees the
+        names, so a padded explicit name reaching `_resolve_ptc_option` is a
+        genuine mismatch and must be reported rather than silently trimmed.
+        """
+        from deepagents_code.agent import _resolve_ptc_option
+
+        with pytest.raises(ValueError, match="Unknown tool names"):
+            _resolve_ptc_option(
+                ["safe", " task "],
+                tools=self._tools_with_task(),
+                acknowledge_unsafe=False,
+                auto_approve=False,
+            )
+
+    def test_safe_in_list_empty_when_preset_absent(self) -> None:
+        """`["safe"]` resolves to `[]` when no preset members are live."""
+        from langchain_core.tools import tool
+
+        from deepagents_code.agent import _resolve_ptc_option
+
+        @tool
+        def task(prompt: str) -> str:  # noqa: ARG001
+            """Dispatch a subagent."""
+            return ""
+
+        result = _resolve_ptc_option(
+            ["safe"],
+            tools=[task],
+            acknowledge_unsafe=False,
+            auto_approve=False,
+        )
+        assert result == []
+
+    def test_duplicate_safe_tokens_dedupe(self) -> None:
+        """Repeated `"safe"` tokens expand once; members are not duplicated."""
+        from deepagents_code.agent import _resolve_ptc_option
+
+        result = _resolve_ptc_option(
+            ["safe", "safe", "task"],
+            tools=self._tools_with_task(),
+            acknowledge_unsafe=False,
+            auto_approve=False,
+        )
+        assert result == ["glob", "grep", "read_file", "task"]
+
     def test_safe_excludes_hitl_gated_tools(self) -> None:
         """`"safe"` must never expose tools that are HITL-gated outside the REPL.
 

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -3295,3 +3295,31 @@ ptc = [""]
             settings_obj = Settings.from_environment(start_path=tmp_path)
 
         assert settings_obj.interpreter_ptc is False
+
+    def test_ptc_list_with_safe_preset_round_trip(self, tmp_path: Path) -> None:
+        """`"safe"` is preserved as a list entry until agent-build expansion."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            """
+[interpreter]
+ptc = ["safe", "task"]
+"""
+        )
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            settings_obj = Settings.from_environment(start_path=tmp_path)
+
+        assert settings_obj.interpreter_ptc == ["safe", "task"]
+
+    def test_ptc_list_with_all_falls_back(self, tmp_path: Path) -> None:
+        """`"all"` inside a list is rejected, falling back to the default."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            """
+[interpreter]
+ptc = ["all", "task"]
+"""
+        )
+        with patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path):
+            settings_obj = Settings.from_environment(start_path=tmp_path)
+
+        assert settings_obj.interpreter_ptc is False

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -1602,3 +1602,51 @@ class TestInstallPackageSubcommand:
         code, perform_mock, _console = self._run_install_package("-rreqs.txt", yes=True)
         assert code == 2
         perform_mock.assert_not_awaited()
+
+
+class TestParseInterpreterToolsFlag:
+    """Tests for `_parse_interpreter_tools_flag`."""
+
+    def test_none_returns_none(self) -> None:
+        from deepagents_code.main import _parse_interpreter_tools_flag
+
+        assert _parse_interpreter_tools_flag(None) is None
+
+    def test_safe_sentinel(self) -> None:
+        from deepagents_code.main import _parse_interpreter_tools_flag
+
+        assert _parse_interpreter_tools_flag("safe") == "safe"
+
+    def test_all_sentinel(self) -> None:
+        from deepagents_code.main import _parse_interpreter_tools_flag
+
+        assert _parse_interpreter_tools_flag("all") == "all"
+
+    def test_explicit_list(self) -> None:
+        from deepagents_code.main import _parse_interpreter_tools_flag
+
+        assert _parse_interpreter_tools_flag("read_file,glob,grep,task") == [
+            "read_file",
+            "glob",
+            "grep",
+            "task",
+        ]
+
+    def test_safe_inside_list(self) -> None:
+        from deepagents_code.main import _parse_interpreter_tools_flag
+
+        assert _parse_interpreter_tools_flag("safe,task") == ["safe", "task"]
+
+    def test_all_inside_list_exits(self) -> None:
+        from deepagents_code.main import _parse_interpreter_tools_flag
+
+        with pytest.raises(SystemExit) as exc_info:
+            _parse_interpreter_tools_flag("all,task")
+        assert exc_info.value.code == 2
+
+    def test_empty_value_exits(self) -> None:
+        from deepagents_code.main import _parse_interpreter_tools_flag
+
+        with pytest.raises(SystemExit) as exc_info:
+            _parse_interpreter_tools_flag("   ")
+        assert exc_info.value.code == 2


### PR DESCRIPTION
The interpreter PTC allowlist (`interpreter_ptc`, set via `--interpreter-tools` or `[interpreter].ptc`) lets `js_eval` call a subset of the agent's tools by name. Resolution ran while the agent was being built and validated the configured names against the tool list handed to `create_cli_agent`. That list does **not** contain the Deep Agents built-ins (`read_file`, `glob`, `grep`, `write_file`, `edit_file`, `execute`, `write_todos`, `task`) — those are injected a step later by SDK middleware. In server and non-interactive mode the handed-in list is only `fetch_url`/`web_search`/MCP tools, so two things broke:

- Naming a built-in (e.g. `--interpreter-tools read_file,grep,task`) failed validation and **aborted server startup** with `Unknown tool names: [...]` (exit code 3).
- `interpreter_ptc="safe"` intersected its read-only preset against that list, matched none of its members, and silently resolved to an empty allowlist — exposing nothing.

`CodeInterpreterMiddleware` already resolves PTC names against the live runtime registry and silently drops names that match nothing, so build-time validation was both unnecessary and wrong. This change stops validating names at build time: `"safe"` resolves to its preset directly, explicit names pass through to the middleware, and runtime decides what is exposed. The SDK exposes no importable list of built-in tool names, so there is deliberately no hardcoded mirror that could drift.

While here, the `"safe"` preset can now be combined with explicit names in a list — `--interpreter-tools safe,task` or `ptc = ["safe", "task"]` — deduplicated with order preserved. `"all"` stays a standalone, acknowledgement-gated sentinel (it can expose write/shell tools without HITL prompts) and is now rejected early, with a clear message, if placed inside a list — at the CLI, `config.toml`, and agent-build layers.

## Notes

- `"safe"` now genuinely exposes `read_file`/`glob`/`grep` in server and non-interactive mode (previously empty). The preset stays locked to read-only, non-HITL-gated tools, enforced by a test against the live interrupt map.
- Build-time "unknown tool name" errors are gone; a mistyped explicit name now silently exposes nothing (logged at debug). Recovering that feedback at the layer that can distinguish a typo from an absent tool — plus an "expose-all" sentinel so `interpreter_ptc="all"` can include the SDK built-ins — is tracked in #3847.
- `interpreter_ptc="all"` enumeration is unchanged from `main`: still scoped to the tools passed to `create_cli_agent`, since the runtime built-ins are not enumerable at build time (see #3847).

Made by [Open SWE](https://openswe.vercel.app)
