### PR TITLE
feat(sdk): warn when langgraph lacks `DeltaChannel` support

### DIFF
--- a/libs/deepagents/deepagents/_delta_channel.py
+++ b/libs/deepagents/deepagents/_delta_channel.py
@@ -1,0 +1,60 @@
+"""Feature detection for langgraph's `DeltaChannel`.
+
+`DeltaChannel` landed in `langgraph>=1.2.0`. On older installs the import
+fails, so deep agents fall back to `add_messages` for the `messages` channel
+and warn the user to upgrade — without it, checkpoint storage grows O(N^2)
+with conversation length instead of O(N).
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING
+
+from langgraph.graph.message import add_messages
+
+from deepagents._messages_reducer import _messages_delta_reducer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from langgraph.channels.base import BaseChannel
+
+try:
+    from langgraph.channels.delta import DeltaChannel
+
+    _DELTA_CHANNEL_SUPPORTED = True
+except ImportError:
+    _DELTA_CHANNEL_SUPPORTED = False
+
+_MESSAGES_SNAPSHOT_FREQUENCY = 50
+
+_UNSUPPORTED_MESSAGE = (
+    "The installed `langgraph` version does not support `DeltaChannel` "
+    "(added in `langgraph>=1.2.0`). Deep agents fall back to `add_messages` "
+    "for the `messages` channel, which grows checkpoint storage O(N^2) with "
+    "conversation length. Upgrade langgraph (e.g. `pip install -U langgraph`) "
+    "to enable O(N) checkpoint growth."
+)
+
+
+def delta_channel_supported() -> bool:
+    """`True` if the installed `langgraph` exposes `DeltaChannel`."""
+    return _DELTA_CHANNEL_SUPPORTED
+
+
+def messages_channel_reducer() -> BaseChannel | Callable:
+    """Reducer for the `messages` channel.
+
+    Returns a `DeltaChannel` when supported, otherwise `add_messages`.
+    """
+    if _DELTA_CHANNEL_SUPPORTED:
+        return DeltaChannel(_messages_delta_reducer, snapshot_frequency=_MESSAGES_SNAPSHOT_FREQUENCY)  # ty: ignore[invalid-argument-type]
+    return add_messages
+
+
+def warn_if_delta_channel_unsupported(*, stacklevel: int = 2) -> None:
+    """Warn (once per call site) when langgraph predates `DeltaChannel`."""
+    if _DELTA_CHANNEL_SUPPORTED:
+        return
+    warnings.warn(_UNSUPPORTED_MESSAGE, UserWarning, stacklevel=stacklevel + 1)

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -19,19 +19,21 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AnyMessage, SystemMessage
 from langchain_core.tools import BaseTool
 from langgraph.cache.base import BaseCache
-from langgraph.channels.delta import DeltaChannel
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.store.base import BaseStore
 from langgraph.types import Checkpointer
 from langgraph.typing import ContextT
 
 from deepagents._api.deprecation import deprecated, warn_deprecated
+from deepagents._delta_channel import (
+    messages_channel_reducer,
+    warn_if_delta_channel_unsupported,
+)
 from deepagents._excluded_middleware import (
     _apply_excluded_middleware,
     _validate_excluded_middleware_config,
     _verify_excluded_middleware_coverage,
 )
-from deepagents._messages_reducer import _messages_delta_reducer
 from deepagents._models import resolve_model
 from deepagents._tools import _apply_tool_description_overrides
 from deepagents._version import __version__
@@ -62,9 +64,13 @@ logger = logging.getLogger(__name__)
 
 
 class DeepAgentState(AgentState):
-    """AgentState with DeltaChannel on messages to reduce checkpoint growth from O(N²) to O(N)."""
+    """AgentState with DeltaChannel on messages to reduce checkpoint growth from O(N²) to O(N).
 
-    messages: Required[Annotated[list[AnyMessage], DeltaChannel(_messages_delta_reducer, snapshot_frequency=50)]]  # ty: ignore[invalid-argument-type]
+    Falls back to `add_messages` when the installed `langgraph` predates
+    `DeltaChannel` (`langgraph>=1.2.0`); `create_deep_agent` warns in that case.
+    """
+
+    messages: Required[Annotated[list[AnyMessage], messages_channel_reducer()]]
 
 
 BASE_AGENT_PROMPT = """You are a deep agent, an AI assistant that helps users accomplish tasks using tools. You respond with text and tool calls. The user can see your responses and tool outputs in real time.
@@ -544,6 +550,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     # `DeepAgentState` is a `TypedDict`; TypedDicts disallow `issubclass`, so the
     # subclass constraint on `state_schema` is enforced by typing alone and not
     # validated at runtime.
+
+    warn_if_delta_channel_unsupported()
 
     _model_spec: str | None = model if isinstance(model, str) else None
 

--- a/libs/deepagents/tests/unit_tests/test_delta_channel.py
+++ b/libs/deepagents/tests/unit_tests/test_delta_channel.py
@@ -1,0 +1,45 @@
+"""Tests for langgraph `DeltaChannel` feature detection."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import warnings
+
+from langgraph.channels.delta import DeltaChannel
+from langgraph.graph.message import add_messages
+
+import deepagents._delta_channel as dc
+
+
+def test_supported_returns_delta_channel() -> None:
+    """When langgraph supports it, the reducer is a `DeltaChannel`."""
+    assert dc.delta_channel_supported() is True
+    assert isinstance(dc.messages_channel_reducer(), DeltaChannel)
+
+
+def test_no_warning_when_supported() -> None:
+    """No warning is emitted on a supported langgraph install."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        dc.warn_if_delta_channel_unsupported()
+
+
+def test_unsupported_falls_back_and_warns(monkeypatch) -> None:
+    """Simulate an old langgraph (no `DeltaChannel`): fall back + warn."""
+    real_delta = sys.modules.pop("langgraph.channels.delta", None)
+    monkeypatch.setitem(sys.modules, "langgraph.channels.delta", None)
+    try:
+        reloaded = importlib.reload(dc)
+        assert reloaded.delta_channel_supported() is False
+        assert reloaded.messages_channel_reducer() is add_messages
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            reloaded.warn_if_delta_channel_unsupported()
+        assert len(captured) == 1
+        assert issubclass(captured[0].category, UserWarning)
+        assert "DeltaChannel" in str(captured[0].message)
+    finally:
+        if real_delta is not None:
+            sys.modules["langgraph.channels.delta"] = real_delta
+        importlib.reload(dc)


### PR DESCRIPTION
`DeepAgentState` imported `DeltaChannel` (added in `langgraph>=1.2.0`) at module level, so deep agents hard-fail with an `ImportError` on older langgraph installs. This adds feature detection: when `DeltaChannel` is unavailable, the `messages` channel falls back to `add_messages` and `create_deep_agent` emits a `UserWarning` explaining that checkpoint storage grows O(N²) until langgraph is upgraded.

## Self-Hosted Release Note
Deep agents now degrade gracefully on `langgraph<1.2.0` (falling back to `add_messages`) and warn to upgrade for O(N) checkpoint storage instead of failing to import.

## Test Plan
- [ ] With an older langgraph (no `langgraph.channels.delta`), `create_deep_agent` constructs successfully and emits the upgrade `UserWarning`.

Made by [Open SWE](https://openswe.vercel.app)