### PR TITLE
fix(code): add debug-log guidance for truncated startup errors

### DIFF
--- a/libs/code/deepagents_code/_debug.py
+++ b/libs/code/deepagents_code/_debug.py
@@ -74,3 +74,23 @@ def configure_debug_logging(target: logging.Logger) -> None:
     handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(message)s"))
     target.addHandler(handler)
     target.setLevel(logging.DEBUG)
+
+
+def installed_debug_log_path() -> Path | None:
+    """Return the path of the active debug log file, or `None` if not logging.
+
+    Reflects the file handler actually attached by `configure_debug_logging`,
+    not the current `DEEPAGENTS_CODE_DEBUG` env value. The two diverge when the
+    variable is set after import — e.g. via a project/global `.env` loaded during
+    settings bootstrap — in which case the variable reads truthy but no handler
+    was installed and no log file exists. Callers that surface "full error in
+    <path>" hints must use this rather than the env var to avoid pointing users
+    at a file that was never created.
+    """
+    package_logger = logging.getLogger(__package__ or "deepagents_code")
+    for handler in package_logger.handlers:
+        if isinstance(handler, logging.FileHandler) and getattr(
+            handler, _DEBUG_HANDLER_ATTR, False
+        ):
+            return Path(handler.baseFilename)
+    return None

--- a/libs/code/deepagents_code/_debug.py
+++ b/libs/code/deepagents_code/_debug.py
@@ -13,7 +13,12 @@ import os
 import sys
 from pathlib import Path
 
-from deepagents_code._env_vars import DEBUG, DEBUG_FILE, is_env_truthy
+from deepagents_code._env_vars import (
+    DEBUG,
+    DEBUG_FILE,
+    DEFAULT_DEBUG_FILE,
+    is_env_truthy,
+)
 
 _DEBUG_HANDLER_ATTR = "_deepagents_code_debug_handler"
 
@@ -25,8 +30,8 @@ def configure_debug_logging(target: logging.Logger) -> None:
     module loggers reach the same file via propagation, so individual modules do
     not configure logging themselves.
 
-    The log file defaults to `'/tmp/deepagents_debug.log'` but can be overridden
-    with `DEEPAGENTS_CODE_DEBUG_FILE`. The handler appends (`mode='a'`) so logs
+    The log file defaults to `DEFAULT_DEBUG_FILE` but can be overridden with
+    `DEEPAGENTS_CODE_DEBUG_FILE`. The handler appends (`mode='a'`) so logs
     are preserved across separate process runs. Calling this again with the same
     resolved path is a no-op: the existing tagged handler is reused rather than
     stacking duplicates. If the resolved path changes, the stale handler is
@@ -40,12 +45,7 @@ def configure_debug_logging(target: logging.Logger) -> None:
     if not is_env_truthy(DEBUG):
         return
 
-    debug_path = Path(
-        os.environ.get(
-            DEBUG_FILE,
-            "/tmp/deepagents_debug.log",  # noqa: S108
-        )
-    )
+    debug_path = Path(os.environ.get(DEBUG_FILE, DEFAULT_DEBUG_FILE))
     for existing in list(target.handlers):
         if not (
             isinstance(existing, logging.FileHandler)

--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -46,7 +46,10 @@ as enabled, and `0`, `false`, `no`, `off`, empty string, or unset as disabled.
 """
 
 DEBUG_FILE = "DEEPAGENTS_CODE_DEBUG_FILE"
-"""Path for the debug log file (default: `/tmp/deepagents_debug.log`)."""
+"""Path for the debug log file (default: `DEFAULT_DEBUG_FILE`)."""
+
+DEFAULT_DEBUG_FILE = "/tmp/deepagents_debug.log"  # noqa: S108  # opt-in debug log
+"""Default path for the debug log when `DEBUG_FILE` is unset."""
 
 DEBUG_MCP_PROJECT_TRUST = "DEEPAGENTS_CODE_DEBUG_MCP_PROJECT_TRUST"
 """Force the project MCP approval prompt for manual UI testing.

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1230,6 +1230,31 @@ def _build_whats_new_message(heading: str) -> Content:
     )
 
 
+_STARTUP_ERROR_HEADLINE_LIMIT = 300
+"""Max characters of a startup-error headline shown in chat before truncation.
+
+Long single-line errors (e.g. the `interpreter_ptc` "Available tools: ..." list)
+overflow this. `on_deep_agents_app_server_start_failed` appends a pointer to the
+full error in the debug log when the headline is clipped, since the truncated
+tail is often the actionable part.
+"""
+
+
+def _startup_error_headline(error: BaseException) -> str:
+    """Return the untruncated single-line `Type: message` startup headline.
+
+    Args:
+        error: The exception raised during server startup.
+
+    Returns:
+        A single-line `Type: message` summary (may exceed the banner width).
+    """
+    first_line = str(error).splitlines()[0].strip() if str(error) else ""
+    if not first_line:
+        first_line = error.__class__.__name__
+    return f"{type(error).__name__}: {first_line}"
+
+
 def _format_startup_error(error: BaseException) -> str:
     """Format a server-startup exception for the welcome banner.
 
@@ -1245,10 +1270,9 @@ def _format_startup_error(error: BaseException) -> str:
     Returns:
         A single-line `Type: message` summary suitable for the banner.
     """
-    first_line = str(error).splitlines()[0].strip() if str(error) else ""
-    if not first_line:
-        first_line = error.__class__.__name__
-    return f"{type(error).__name__}: {_truncate(first_line, limit=300)}"
+    return _truncate(
+        _startup_error_headline(error), limit=_STARTUP_ERROR_HEADLINE_LIMIT
+    )
 
 
 class TextualSessionState:
@@ -3083,11 +3107,18 @@ class DeepAgentsApp(App):
 
         self._connecting = False
         self._connection_ready_event.set()
+        headline_truncated = False
         if isinstance(event.error, MCPConfigError):
             # Already carries the path + hint; showing the class name is noise.
             self._server_startup_error = str(event.error)
         else:
             self._server_startup_error = _format_startup_error(event.error)
+            # A clipped headline drops the actionable tail (e.g. the
+            # `interpreter_ptc` available-tools list), so point at the full log.
+            headline_truncated = (
+                len(_startup_error_headline(event.error))
+                > _STARTUP_ERROR_HEADLINE_LIMIT
+            )
 
         # Stash the provider for the `/model` recovery hint. Reset on every
         # failure so a non-credentials retry-failure clears the prior flag.
@@ -3162,6 +3193,24 @@ class DeepAgentsApp(App):
                     f"\n\nHint: {install_hint}, then run "
                     f"`/model {missing.provider}:<model>` "
                     "to retry. Or pick a different provider with `/model`."
+                )
+
+        if headline_truncated:
+            from deepagents_code._env_vars import (
+                DEBUG,
+                DEBUG_FILE,
+                DEFAULT_DEBUG_FILE,
+                is_env_truthy,
+            )
+
+            if is_env_truthy(DEBUG):
+                debug_path = os.environ.get(DEBUG_FILE, DEFAULT_DEBUG_FILE)
+                text += f"\n\nNote: error truncated — full error in {debug_path}."
+            else:
+                text += (
+                    "\n\nNote: error truncated. Re-run with "
+                    "`DEEPAGENTS_CODE_DEBUG=1` to write the full error to the "
+                    "debug log."
                 )
 
         async def _mount_failure() -> None:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3196,15 +3196,14 @@ class DeepAgentsApp(App):
                 )
 
         if headline_truncated:
-            from deepagents_code._env_vars import (
-                DEBUG,
-                DEBUG_FILE,
-                DEFAULT_DEBUG_FILE,
-                is_env_truthy,
-            )
+            from deepagents_code._debug import installed_debug_log_path
 
-            if is_env_truthy(DEBUG):
-                debug_path = os.environ.get(DEBUG_FILE, DEFAULT_DEBUG_FILE)
+            # Base the pointer on the handler that was actually installed, not on
+            # `DEEPAGENTS_CODE_DEBUG`: the var can read truthy (e.g. set in a
+            # `.env`) while no log file exists, which would point users at a
+            # nonexistent path.
+            debug_path = installed_debug_log_path()
+            if debug_path is not None:
                 text += f"\n\nNote: error truncated — full error in {debug_path}."
             else:
                 text += (

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -302,6 +302,14 @@ def _ensure_bootstrap() -> None:
             _bootstrap_start_path = ctx.user_cwd if ctx else None
             _load_dotenv(start_path=_bootstrap_start_path)
 
+            # `configure_debug_logging` already ran at import, before the `.env`
+            # above was loaded. Re-run it so a `DEEPAGENTS_CODE_DEBUG` set only in
+            # `.env` installs the file handler now (idempotent for the same path),
+            # ensuring later failures are actually written to the debug log.
+            from deepagents_code._debug import configure_debug_logging
+
+            configure_debug_logging(logging.getLogger("deepagents_code"))
+
             # Capture AFTER dotenv loading so .env-only values are visible,
             # but BEFORE the override below replaces it.
             _original_langsmith_project = os.environ.get("LANGSMITH_PROJECT")

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -6734,6 +6734,175 @@ class TestDeferredActions:
             assert "Server process exited with code 3" in stored
             assert len(stored) < 400
 
+    async def test_server_failure_truncated_headline_notes_debug_rerun(self) -> None:
+        """A clipped headline appends a re-run hint when debug logging is off.
+
+        The full error (e.g. the `interpreter_ptc` available-tools list) only
+        reaches disk under `DEEPAGENTS_CODE_DEBUG`; without it the note tells
+        the user how to capture it on the next run.
+        """
+        from deepagents_code._env_vars import DEBUG, DEBUG_FILE
+        from deepagents_code.widgets.messages import ErrorMessage
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # Single-line message long enough to overflow the headline limit.
+            long_message = "Unknown tool names: " + ", ".join(
+                f"tool_{i}" for i in range(80)
+            )
+            with patch.dict(os.environ, {DEBUG: "0"}, clear=False):
+                os.environ.pop(DEBUG_FILE, None)
+                app.on_deep_agents_app_server_start_failed(
+                    DeepAgentsApp.ServerStartFailed(error=RuntimeError(long_message))
+                )
+                await pilot.pause()
+
+            widget = app._startup_failure_widget
+            assert isinstance(widget, ErrorMessage)
+            rendered = str(widget._content)
+            assert "error truncated" in rendered
+            assert "DEEPAGENTS_CODE_DEBUG=1" in rendered
+            # The note stays on the displayed message, not in stored state.
+            assert app._server_startup_error is not None
+            assert "error truncated" not in app._server_startup_error
+
+    async def test_server_failure_truncated_headline_points_to_debug_file(
+        self,
+    ) -> None:
+        """With debug logging on, the note points at the resolved log path."""
+        from deepagents_code._env_vars import DEBUG, DEBUG_FILE
+        from deepagents_code.widgets.messages import ErrorMessage
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            long_message = "Unknown tool names: " + ", ".join(
+                f"tool_{i}" for i in range(80)
+            )
+            with patch.dict(
+                os.environ,
+                {DEBUG: "1", DEBUG_FILE: "/tmp/custom_debug.log"},
+                clear=False,
+            ):
+                app.on_deep_agents_app_server_start_failed(
+                    DeepAgentsApp.ServerStartFailed(error=RuntimeError(long_message))
+                )
+                await pilot.pause()
+
+            widget = app._startup_failure_widget
+            assert isinstance(widget, ErrorMessage)
+            rendered = str(widget._content)
+            assert "error truncated" in rendered
+            assert "/tmp/custom_debug.log" in rendered
+
+    async def test_server_failure_short_headline_omits_truncation_note(self) -> None:
+        """A headline within the limit renders no truncation note."""
+        from deepagents_code.widgets.messages import ErrorMessage
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.on_deep_agents_app_server_start_failed(
+                DeepAgentsApp.ServerStartFailed(error=RuntimeError("short boom"))
+            )
+            await pilot.pause()
+
+            widget = app._startup_failure_widget
+            assert isinstance(widget, ErrorMessage)
+            assert "error truncated" not in str(widget._content)
+
+    async def test_server_failure_long_mcp_config_error_omits_truncation_note(
+        self,
+    ) -> None:
+        """A long `MCPConfigError` never gets a truncation note.
+
+        That branch sets `_server_startup_error` to the full (untruncated)
+        message and leaves `headline_truncated` False, so the note logic must
+        not fire even when the rendered text far exceeds the headline limit.
+        Locks the branch against a refactor that hoists the truncation check.
+        """
+        from deepagents_code.mcp_tools import MCPConfigError
+        from deepagents_code.widgets.messages import ErrorMessage
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            long_message = "Invalid MCP config at /tmp/x.json: " + "x" * 400
+            app.on_deep_agents_app_server_start_failed(
+                DeepAgentsApp.ServerStartFailed(error=MCPConfigError(long_message))
+            )
+            await pilot.pause()
+
+            widget = app._startup_failure_widget
+            assert isinstance(widget, ErrorMessage)
+            assert "error truncated" not in str(widget._content)
+
+    async def test_server_failure_truncation_note_boundary(self) -> None:
+        """The note fires only when the headline strictly exceeds the limit.
+
+        `_startup_error_headline` prepends `"RuntimeError: "` (14 chars), so a
+        286-char body yields a 300-char headline (no note) and a 287-char body
+        yields 301 (note) — pinning the `>` vs `>=` boundary against off-by-one.
+        """
+        from deepagents_code.app import _STARTUP_ERROR_HEADLINE_LIMIT
+        from deepagents_code.widgets.messages import ErrorMessage
+
+        prefix_len = len("RuntimeError: ")
+        at_limit = "a" * (_STARTUP_ERROR_HEADLINE_LIMIT - prefix_len)
+        over_limit = "a" * (_STARTUP_ERROR_HEADLINE_LIMIT - prefix_len + 1)
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.on_deep_agents_app_server_start_failed(
+                DeepAgentsApp.ServerStartFailed(error=RuntimeError(at_limit))
+            )
+            await pilot.pause()
+            widget = app._startup_failure_widget
+            assert isinstance(widget, ErrorMessage)
+            assert "error truncated" not in str(widget._content)
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.on_deep_agents_app_server_start_failed(
+                DeepAgentsApp.ServerStartFailed(error=RuntimeError(over_limit))
+            )
+            await pilot.pause()
+            widget = app._startup_failure_widget
+            assert isinstance(widget, ErrorMessage)
+            assert "error truncated" in str(widget._content)
+
+    async def test_server_failure_truncated_headline_uses_default_debug_path(
+        self,
+    ) -> None:
+        """With debug on and `DEBUG_FILE` unset, the note names the default path.
+
+        Guards the `DEFAULT_DEBUG_FILE` fallback this change extracted — a
+        regression in the `os.environ.get(..., DEFAULT_DEBUG_FILE)` default
+        would otherwise go uncaught.
+        """
+        from deepagents_code._env_vars import DEBUG, DEBUG_FILE, DEFAULT_DEBUG_FILE
+        from deepagents_code.widgets.messages import ErrorMessage
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            long_message = "Unknown tool names: " + ", ".join(
+                f"tool_{i}" for i in range(80)
+            )
+            with patch.dict(os.environ, {DEBUG: "1"}, clear=False):
+                os.environ.pop(DEBUG_FILE, None)
+                app.on_deep_agents_app_server_start_failed(
+                    DeepAgentsApp.ServerStartFailed(error=RuntimeError(long_message))
+                )
+                await pilot.pause()
+
+            widget = app._startup_failure_widget
+            assert isinstance(widget, ErrorMessage)
+            assert DEFAULT_DEBUG_FILE in str(widget._content)
+
     async def test_server_failure_mcp_config_error_omits_class_prefix(self) -> None:
         """`MCPConfigError` banner shows the path and reason without class prefix."""
         from deepagents_code.mcp_tools import MCPConfigError

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -6735,66 +6735,99 @@ class TestDeferredActions:
             assert len(stored) < 400
 
     async def test_server_failure_truncated_headline_notes_debug_rerun(self) -> None:
-        """A clipped headline appends a re-run hint when debug logging is off.
+        """A clipped headline appends a re-run hint when no debug log is active.
 
         The full error (e.g. the `interpreter_ptc` available-tools list) only
-        reaches disk under `DEEPAGENTS_CODE_DEBUG`; without it the note tells
-        the user how to capture it on the next run.
+        reaches disk when a debug file handler is installed; absent one the note
+        tells the user how to capture it on the next run.
         """
-        from deepagents_code._env_vars import DEBUG, DEBUG_FILE
+        import logging
+
         from deepagents_code.widgets.messages import ErrorMessage
 
-        app = DeepAgentsApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            # Single-line message long enough to overflow the headline limit.
-            long_message = "Unknown tool names: " + ", ".join(
-                f"tool_{i}" for i in range(80)
-            )
-            with patch.dict(os.environ, {DEBUG: "0"}, clear=False):
-                os.environ.pop(DEBUG_FILE, None)
+        # Strip any installed debug handler so the helper reports "no log file"
+        # deterministically — a developer may run the suite with
+        # `DEEPAGENTS_CODE_DEBUG` exported, which installs one at import.
+        package_logger = logging.getLogger("deepagents_code")
+        stripped = [
+            h
+            for h in package_logger.handlers
+            if getattr(h, "_deepagents_code_debug_handler", False)
+        ]
+        for h in stripped:
+            package_logger.removeHandler(h)
+        try:
+            app = DeepAgentsApp()
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                # Single-line message long enough to overflow the headline limit.
+                long_message = "Unknown tool names: " + ", ".join(
+                    f"tool_{i}" for i in range(80)
+                )
                 app.on_deep_agents_app_server_start_failed(
                     DeepAgentsApp.ServerStartFailed(error=RuntimeError(long_message))
                 )
                 await pilot.pause()
 
-            widget = app._startup_failure_widget
-            assert isinstance(widget, ErrorMessage)
-            rendered = str(widget._content)
-            assert "error truncated" in rendered
-            assert "DEEPAGENTS_CODE_DEBUG=1" in rendered
-            # The note stays on the displayed message, not in stored state.
-            assert app._server_startup_error is not None
-            assert "error truncated" not in app._server_startup_error
+                widget = app._startup_failure_widget
+                assert isinstance(widget, ErrorMessage)
+                rendered = str(widget._content)
+                assert "error truncated" in rendered
+                assert "DEEPAGENTS_CODE_DEBUG=1" in rendered
+                # The note stays on the displayed message, not in stored state.
+                assert app._server_startup_error is not None
+                assert "error truncated" not in app._server_startup_error
+        finally:
+            for h in stripped:
+                package_logger.addHandler(h)
 
     async def test_server_failure_truncated_headline_points_to_debug_file(
-        self,
+        self, tmp_path
     ) -> None:
-        """With debug logging on, the note points at the resolved log path."""
+        """The note points at the path of the handler that was actually installed.
+
+        The pointer reflects the file handler attached by
+        `configure_debug_logging`, not the `DEEPAGENTS_CODE_DEBUG` env value: a
+        var set only after import (e.g. via a project `.env`) never installs a
+        handler, so the note must never advertise a file that was never created.
+        """
+        import logging
+
+        from deepagents_code._debug import configure_debug_logging
         from deepagents_code._env_vars import DEBUG, DEBUG_FILE
         from deepagents_code.widgets.messages import ErrorMessage
 
-        app = DeepAgentsApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            long_message = "Unknown tool names: " + ", ".join(
-                f"tool_{i}" for i in range(80)
-            )
-            with patch.dict(
-                os.environ,
-                {DEBUG: "1", DEBUG_FILE: "/tmp/custom_debug.log"},
-                clear=False,
-            ):
+        package_logger = logging.getLogger("deepagents_code")
+        log_path = tmp_path / "custom_debug.log"
+        pre_existing = list(package_logger.handlers)
+        with patch.dict(
+            os.environ,
+            {DEBUG: "1", DEBUG_FILE: str(log_path)},
+            clear=False,
+        ):
+            configure_debug_logging(package_logger)
+        added = [h for h in package_logger.handlers if h not in pre_existing]
+        try:
+            app = DeepAgentsApp()
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                long_message = "Unknown tool names: " + ", ".join(
+                    f"tool_{i}" for i in range(80)
+                )
                 app.on_deep_agents_app_server_start_failed(
                     DeepAgentsApp.ServerStartFailed(error=RuntimeError(long_message))
                 )
                 await pilot.pause()
 
-            widget = app._startup_failure_widget
-            assert isinstance(widget, ErrorMessage)
-            rendered = str(widget._content)
-            assert "error truncated" in rendered
-            assert "/tmp/custom_debug.log" in rendered
+                widget = app._startup_failure_widget
+                assert isinstance(widget, ErrorMessage)
+                rendered = str(widget._content)
+                assert "error truncated" in rendered
+                assert str(log_path) in rendered
+        finally:
+            for h in added:
+                h.close()
+                package_logger.removeHandler(h)
 
     async def test_server_failure_short_headline_omits_truncation_note(self) -> None:
         """A headline within the limit renders no truncation note."""
@@ -6877,31 +6910,43 @@ class TestDeferredActions:
     async def test_server_failure_truncated_headline_uses_default_debug_path(
         self,
     ) -> None:
-        """With debug on and `DEBUG_FILE` unset, the note names the default path.
+        """With `DEBUG_FILE` unset, a handler at the default path is named.
 
-        Guards the `DEFAULT_DEBUG_FILE` fallback this change extracted — a
-        regression in the `os.environ.get(..., DEFAULT_DEBUG_FILE)` default
-        would otherwise go uncaught.
+        Guards the `DEFAULT_DEBUG_FILE` fallback — a regression in the default
+        resolution would otherwise go uncaught. The handler is installed at the
+        default path so `installed_debug_log_path` reports it.
         """
+        import logging
+
+        from deepagents_code._debug import configure_debug_logging
         from deepagents_code._env_vars import DEBUG, DEBUG_FILE, DEFAULT_DEBUG_FILE
         from deepagents_code.widgets.messages import ErrorMessage
 
-        app = DeepAgentsApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-            long_message = "Unknown tool names: " + ", ".join(
-                f"tool_{i}" for i in range(80)
-            )
-            with patch.dict(os.environ, {DEBUG: "1"}, clear=False):
-                os.environ.pop(DEBUG_FILE, None)
+        package_logger = logging.getLogger("deepagents_code")
+        pre_existing = list(package_logger.handlers)
+        with patch.dict(os.environ, {DEBUG: "1"}, clear=False):
+            os.environ.pop(DEBUG_FILE, None)
+            configure_debug_logging(package_logger)
+        added = [h for h in package_logger.handlers if h not in pre_existing]
+        try:
+            app = DeepAgentsApp()
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                long_message = "Unknown tool names: " + ", ".join(
+                    f"tool_{i}" for i in range(80)
+                )
                 app.on_deep_agents_app_server_start_failed(
                     DeepAgentsApp.ServerStartFailed(error=RuntimeError(long_message))
                 )
                 await pilot.pause()
 
-            widget = app._startup_failure_widget
-            assert isinstance(widget, ErrorMessage)
-            assert DEFAULT_DEBUG_FILE in str(widget._content)
+                widget = app._startup_failure_widget
+                assert isinstance(widget, ErrorMessage)
+                assert DEFAULT_DEBUG_FILE in str(widget._content)
+        finally:
+            for h in added:
+                h.close()
+                package_logger.removeHandler(h)
 
     async def test_server_failure_mcp_config_error_omits_class_prefix(self) -> None:
         """`MCPConfigError` banner shows the path and reason without class prefix."""

--- a/libs/code/tests/unit_tests/test_debug.py
+++ b/libs/code/tests/unit_tests/test_debug.py
@@ -8,7 +8,10 @@ import os
 from unittest.mock import patch
 
 import deepagents_code
-from deepagents_code._debug import configure_debug_logging
+from deepagents_code._debug import (
+    configure_debug_logging,
+    installed_debug_log_path,
+)
 
 
 class TestConfigureDebugLogging:
@@ -166,6 +169,74 @@ class TestConfigureDebugLogging:
         assert len(logger.handlers) == original_count
         captured = capsys.readouterr()
         assert "Warning" in captured.err
+
+
+class TestInstalledDebugLogPath:
+    def test_returns_none_when_no_handler(self) -> None:
+        """Absent a tagged handler, the helper reports no log file."""
+        logger = logging.getLogger("deepagents_code")
+        original = list(logger.handlers)
+        for h in logger.handlers[:]:
+            if getattr(h, "_deepagents_code_debug_handler", False):
+                logger.removeHandler(h)
+        try:
+            assert installed_debug_log_path() is None
+        finally:
+            for h in logger.handlers[:]:
+                if h not in original:
+                    logger.removeHandler(h)
+            for h in original:
+                if h not in logger.handlers:
+                    logger.addHandler(h)
+
+    def test_returns_path_when_handler_installed(self, tmp_path) -> None:
+        """The helper returns the path of the actually-installed handler."""
+        logger = logging.getLogger("deepagents_code")
+        log_file = tmp_path / "installed.log"
+        with patch.dict(
+            os.environ,
+            {"DEEPAGENTS_CODE_DEBUG": "1", "DEEPAGENTS_CODE_DEBUG_FILE": str(log_file)},
+        ):
+            configure_debug_logging(logger)
+        installed = [
+            h
+            for h in logger.handlers
+            if getattr(h, "_deepagents_code_debug_handler", False)
+        ]
+        try:
+            assert installed_debug_log_path() == log_file
+        finally:
+            for h in installed:
+                h.close()
+                logger.removeHandler(h)
+
+    def test_ignores_untagged_file_handler(self, tmp_path) -> None:
+        """A foreign FileHandler does not count as an installed debug log.
+
+        Mirrors the divergence the helper exists to catch: a truthy
+        `DEEPAGENTS_CODE_DEBUG` set after import (e.g. via `.env`) never installs
+        our tagged handler, so the helper must report `None` regardless of any
+        unrelated handlers present.
+        """
+        logger = logging.getLogger("deepagents_code")
+        pre_existing = [
+            h
+            for h in logger.handlers
+            if getattr(h, "_deepagents_code_debug_handler", False)
+        ]
+        for h in pre_existing:
+            logger.removeHandler(h)
+        foreign = logging.FileHandler(str(tmp_path / "foreign.log"), mode="a")
+        logger.addHandler(foreign)
+        try:
+            with patch.dict(os.environ, {"DEEPAGENTS_CODE_DEBUG": "1"}, clear=True):
+                # Env is truthy but no tagged handler was installed.
+                assert installed_debug_log_path() is None
+        finally:
+            foreign.close()
+            logger.removeHandler(foreign)
+            for h in pre_existing:
+                logger.addHandler(h)
 
     def test_package_import_configures_package_logger(self, tmp_path) -> None:
         logger = logging.getLogger("deepagents_code")


### PR DESCRIPTION
Long server startup failures can exceed the chat banner limit and hide the actionable part of the exception. Truncated startup errors now keep the UI readable while pointing users at the debug log path, or telling them how to re-run with debug logging enabled.