### PR TITLE
feat(quickjs)!: add default `subagent` bridge

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/_prompt.py
+++ b/libs/partners/quickjs/langchain_quickjs/_prompt.py
@@ -30,6 +30,210 @@ _REPL_SYSTEM_PROMPT_TEMPLATE = (
     "- Timeout: {timeout}s per call. Memory: {memory_limit_mb} MB total.\n"
     "- `console.log` output is captured and returned alongside the result."
 )
+_SUBAGENT_SYSTEM_PROMPT_TEMPLATE = """
+
+### Dispatching Subagents with `subagent`
+
+`subagent` is your primitive for running configured subagents from inside the
+JavaScript REPL. You orchestrate everything else - fan-out, filtering,
+deduplication, multi-stage flow, and synthesis - in plain JavaScript.
+
+#### The primitive
+
+```javascript
+await subagent({
+  description,      // full autonomous task prompt
+  subagent_type,    // configured subagent name
+  response_schema,  // optional JSON Schema for structured output
+}); // -> Promise<unknown>
+```
+
+`subagent` runs a full agentic loop for the selected configured subagent. The
+subagent can use whatever tools it was configured with, iterate, inspect
+context, and return one final result. `subagent_type` is required; use one of
+the configured subagent names.
+
+`description` is the only prompt the subagent receives for this dispatch. Make
+it complete: include the goal, constraints, relevant context, what to inspect,
+and the exact shape or level of detail you expect back. Each dispatch is
+stateless from the caller's perspective; you cannot send follow-up messages to
+the same subagent run.
+
+`response_schema` is optional. When provided, the resolved value is already a
+typed JavaScript value matching the schema. Do not call `JSON.parse` unless the
+subagent intentionally returned a JSON string. Dynamic schemas work for
+declarative subagents; runnable-backed subagents reject dynamic schemas because
+their runnable is already compiled.
+
+#### Approval model
+
+`subagent` dispatches from inside the already-running `{tool_name}` call. It
+does not route through the parent agent's `ToolNode`-managed `task` tool and
+does not trigger parent-level `interrupt_on` / HITL approval for each dispatch.
+Declarative subagents still honor approval middleware configured inside their
+own spec. If you need approval before launching a subagent from the parent, use
+the normal `task` tool outside JavaScript or ensure the `{tool_name}` call
+itself is approval-gated.
+
+#### Mental model
+
+Hold your work in JS: an array of items in, an array of results out. Merge each
+dispatch result back onto its item. Multi-stage analysis means: run a pass,
+filter or regroup the array in JS, then run another pass over the survivors.
+
+Prefer one `{tool_name}` call that performs the whole workflow. Splitting the
+workflow across multiple `{tool_name}` calls costs model turns and forces you to
+re-establish state.
+
+#### Fan out with bounded concurrency
+
+Dispatch independent work in parallel with `Promise.all`, but in explicit
+batches around 10 so you do not launch hundreds of subagents at once. The bridge
+enforces a hard per-REPL cap of 32 concurrent subagent calls.
+
+```javascript
+const batchSize = 10;
+const reviewed = [];
+for (let i = 0; i < items.length; i += batchSize) {
+  const batch = items.slice(i, i + batchSize);
+  reviewed.push(...(await Promise.all(batch.map(async (it) => {
+    const result = await subagent({
+      description: "Review " + it.file + " for SQL injection. Cite line numbers.",
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: {
+          vulnerabilities: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                type: { type: "string" },
+                line: { type: "number" },
+                evidence: { type: "string" },
+              },
+              required: ["type", "line", "evidence"],
+            },
+          },
+        },
+        required: ["vulnerabilities"],
+      },
+    });
+    return { ...it, ...result };
+  }))));
+}
+```
+
+#### Use parent JS for cheap work; use subagents for agentic work
+
+Use JavaScript in the parent REPL for deterministic orchestration: joining
+arrays, deduping, sorting, filtering, grouping, batching, and merging results.
+If the `tools.*` namespace is exposed, also use it to pre-read files or collect
+shared data once, then pass only the relevant content to each subagent in
+`description`.
+
+Use `subagent` for work that benefits from an autonomous agentic loop: reading
+or searching with the subagent's own tools, inspecting multiple files, following
+leads, making judgment calls, or producing a final synthesized report.
+
+#### Pre-read shared context in the parent when useful
+
+If many subagents need the same source list or file content and `tools.*` is
+available, gather that context once in the parent REPL before dispatching:
+
+```javascript
+const files = (await tools.glob({ pattern: "src/**/*.ts" }))
+  .split("\\n")
+  .filter(Boolean);
+
+const items = await Promise.all(files.map(async (file) => {
+  const content = await tools.readFile({ file_path: file });
+  return { file, content };
+}));
+
+const batchSize = 10;
+const results = [];
+for (let i = 0; i < items.length; i += batchSize) {
+  const batch = items.slice(i, i + batchSize);
+  results.push(...(await Promise.all(batch.map(async (it) => {
+    const finding = await subagent({
+      description:
+        "Review this file for auth bypasses. Return concrete findings only.\\n\\n" +
+        "File: " + it.file + "\\n\\n" +
+        it.content,
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: {
+          findings: { type: "array", items: { type: "object" } },
+        },
+        required: ["findings"],
+      },
+    });
+    return { ...it, ...finding };
+  }))));
+}
+```
+
+#### Compose multiple stages
+
+Filter the array in JS between passes. For example: first ask subagents for a
+cheap classification, filter to the risky items, then dispatch deeper reviews
+only for those items.
+
+```javascript
+const tagged = [];
+for (let i = 0; i < items.length; i += 10) {
+  const batch = items.slice(i, i + 10);
+  tagged.push(...(await Promise.all(batch.map(async (it) => {
+    const tag = await subagent({
+      description: "Classify " + it.file + " as handler, util, test, or config.",
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: { kind: { type: "string" }, risky: { type: "boolean" } },
+        required: ["kind", "risky"],
+      },
+    });
+    return { ...it, ...tag };
+  }))));
+}
+
+const riskyHandlers = tagged.filter((it) => it.kind === "handler" && it.risky);
+const deepReviews = [];
+for (let i = 0; i < riskyHandlers.length; i += 10) {
+  const batch = riskyHandlers.slice(i, i + 10);
+  deepReviews.push(...(await Promise.all(batch.map(async (it) => {
+    const review = await subagent({
+      description: "Deep security review of " + it.file + ". Cite line numbers.",
+      subagent_type: "reviewer",
+    });
+    return { ...it, review };
+  }))));
+}
+```
+
+#### Get results out without flooding your context
+
+Keep large result sets in JS variables. Do not `console.log` the full result set.
+If `tools.writeFile` is exposed, persist structured output from inside the eval:
+
+```javascript
+await tools.writeFile({
+  file_path: "/results/subagent-output.json",
+  content: JSON.stringify(deepReviews),
+});
+```
+
+Otherwise return a compact summary or a small slice of the results, not the
+entire intermediate dataset.
+
+#### Across evals
+
+Variables persist according to the interpreter persistence mode above, but
+re-establish what you need in each eval. Doing the whole workflow in one
+`{tool_name}` call is usually simplest.
+"""
 
 
 def render_repl_system_prompt(
@@ -73,6 +277,11 @@ def render_repl_system_prompt(
         timeout=timeout,
         memory_limit_mb=memory_limit_mb,
     )
+
+
+def render_subagent_system_prompt(*, tool_name: str = "eval") -> str:
+    """Render guidance for the top-level QuickJS `subagent` global."""
+    return _SUBAGENT_SYSTEM_PROMPT_TEMPLATE.replace("{tool_name}", tool_name)
 
 
 def render_eval_tool_code_doc(*, mode: Literal["thread", "turn", "call"]) -> str:

--- a/libs/partners/quickjs/langchain_quickjs/_prompt.py
+++ b/libs/partners/quickjs/langchain_quickjs/_prompt.py
@@ -32,23 +32,23 @@ _REPL_SYSTEM_PROMPT_TEMPLATE = (
 )
 _SUBAGENT_SYSTEM_PROMPT_TEMPLATE = """
 
-### Dispatching Subagents with `subagent`
+### Dispatching Subagents with `task`
 
-`subagent` is your primitive for running configured subagents from inside the
+`task` is your primitive for running configured subagents from inside the
 JavaScript REPL. You orchestrate everything else - fan-out, filtering,
 deduplication, multi-stage flow, and synthesis - in plain JavaScript.
 
 #### The primitive
 
 ```javascript
-await subagent({
+await task({
   description,      // full autonomous task prompt
   subagent_type,    // configured subagent name
   response_schema,  // optional JSON Schema for structured output
 }); // -> Promise<unknown>
 ```
 
-`subagent` runs a full agentic loop for the selected configured subagent. The
+`task` runs a full agentic loop for the selected configured subagent. The
 subagent can use whatever tools it was configured with, iterate, inspect
 context, and return one final result. `subagent_type` is required; use one of
 the configured subagent names.
@@ -67,7 +67,7 @@ their runnable is already compiled.
 
 #### Approval model
 
-`subagent` dispatches from inside the already-running `{tool_name}` call. It
+`task` dispatches from inside the already-running `{tool_name}` call. It
 does not route through the parent agent's `ToolNode`-managed `task` tool and
 does not trigger parent-level `interrupt_on` / HITL approval for each dispatch.
 Declarative subagents still honor approval middleware configured inside their
@@ -89,7 +89,7 @@ re-establish state.
 
 Dispatch independent work in parallel with `Promise.all`, but in explicit
 batches around 10 so you do not launch hundreds of subagents at once. The bridge
-enforces a hard per-REPL cap of 32 concurrent subagent calls.
+enforces a hard per-REPL cap of 32 concurrent `task` calls.
 
 ```javascript
 const batchSize = 10;
@@ -97,7 +97,7 @@ const reviewed = [];
 for (let i = 0; i < items.length; i += batchSize) {
   const batch = items.slice(i, i + batchSize);
   reviewed.push(...(await Promise.all(batch.map(async (it) => {
-    const result = await subagent({
+    const result = await task({
       description: "Review " + it.file + " for SQL injection. Cite line numbers.",
       subagent_type: "reviewer",
       response_schema: {
@@ -132,7 +132,7 @@ If the `tools.*` namespace is exposed, also use it to pre-read files or collect
 shared data once, then pass only the relevant content to each subagent in
 `description`.
 
-Use `subagent` for work that benefits from an autonomous agentic loop: reading
+Use `task` for work that benefits from an autonomous agentic loop: reading
 or searching with the subagent's own tools, inspecting multiple files, following
 leads, making judgment calls, or producing a final synthesized report.
 
@@ -156,7 +156,7 @@ const results = [];
 for (let i = 0; i < items.length; i += batchSize) {
   const batch = items.slice(i, i + batchSize);
   results.push(...(await Promise.all(batch.map(async (it) => {
-    const finding = await subagent({
+    const finding = await task({
       description:
         "Review this file for auth bypasses. Return concrete findings only.\\n\\n" +
         "File: " + it.file + "\\n\\n" +
@@ -186,7 +186,7 @@ const tagged = [];
 for (let i = 0; i < items.length; i += 10) {
   const batch = items.slice(i, i + 10);
   tagged.push(...(await Promise.all(batch.map(async (it) => {
-    const tag = await subagent({
+    const tag = await task({
       description: "Classify " + it.file + " as handler, util, test, or config.",
       subagent_type: "reviewer",
       response_schema: {
@@ -204,7 +204,7 @@ const deepReviews = [];
 for (let i = 0; i < riskyHandlers.length; i += 10) {
   const batch = riskyHandlers.slice(i, i + 10);
   deepReviews.push(...(await Promise.all(batch.map(async (it) => {
-    const review = await subagent({
+    const review = await task({
       description: "Deep security review of " + it.file + ". Cite line numbers.",
       subagent_type: "reviewer",
     });
@@ -280,7 +280,7 @@ def render_repl_system_prompt(
 
 
 def render_subagent_system_prompt(*, tool_name: str = "eval") -> str:
-    """Render guidance for the top-level QuickJS `subagent` global."""
+    """Render guidance for the top-level QuickJS `task` global."""
     return _SUBAGENT_SYSTEM_PROMPT_TEMPLATE.replace("{tool_name}", tool_name)
 
 

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -52,8 +52,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_MAX_SUBAGENT_CALLS_PER_THREAD = 32
-_SUBAGENT_FUNCTION_NAME = "subagent"
+_MAX_TASK_CALLS_PER_THREAD = 32
+_TASK_FUNCTION_NAME = "task"
 
 
 def _clear_exception_references(exc: BaseException) -> None:
@@ -107,8 +107,8 @@ class _PTCCallBudgetExceededError(RuntimeError):
         )
 
 
-class _SubagentBridgeError(RuntimeError):
-    """Wrap errors from the top-level `subagent()` host function."""
+class _TaskBridgeError(RuntimeError):
+    """Wrap errors from the top-level `task()` host function."""
 
     def __init__(self, exc: Exception) -> None:
         self.error_type = type(exc).__name__
@@ -394,7 +394,7 @@ class _ThreadREPL:
         # at eval start and cleared in finally so bridge calls can't run
         # outside the current eval.
         self._ptc_state: _PTCState | None = None
-        self._subagent_calls: asyncio.Semaphore | None = None
+        self._task_calls: asyncio.Semaphore | None = None
         # Context creation + console install must happen on the worker
         # thread. Block caller here so the REPL is ready to use when
         # __init__ returns.
@@ -405,8 +405,8 @@ class _ThreadREPL:
         if self._capture_console:
             self._install_console()
         if self._subagents_enabled:
-            self._subagent_calls = asyncio.Semaphore(_MAX_SUBAGENT_CALLS_PER_THREAD)
-            self._register_subagent_bridge()
+            self._task_calls = asyncio.Semaphore(_MAX_TASK_CALLS_PER_THREAD)
+            self._register_task_bridge()
 
     def _require_ctx(self) -> Context:
         """Return the live QuickJS context or raise if this REPL is closed."""
@@ -497,13 +497,13 @@ class _ThreadREPL:
         self._active_tool_names = target_names
         self._tools_installed = True
 
-    async def _ainvoke_subagent_on_outer_loop(
+    async def _ainvoke_task_on_outer_loop(
         self,
         payload: dict[str, Any],
         *,
         state: _PTCState,
     ) -> Any:
-        """Validate JS `subagent()` input and invoke the runner on the right loop.
+        """Validate JS `task()` input and invoke the runner on the right loop.
 
         The QuickJS host call runs on the REPL worker loop, but subagent runnables
         should execute on the parent LangGraph loop when one exists so callbacks,
@@ -511,27 +511,27 @@ class _ThreadREPL:
         """
         description = payload.get("description")
         if not isinstance(description, str) or not description:
-            msg = "subagent() requires non-empty string field `description`"
+            msg = "task() requires non-empty string field `description`"
             raise ValueError(msg)
 
         subagent_type = payload.get("subagent_type")
         if not isinstance(subagent_type, str) or not subagent_type:
-            msg = "subagent() requires non-empty string field `subagent_type`"
+            msg = "task() requires non-empty string field `subagent_type`"
             raise ValueError(msg)
 
         response_schema = payload.get("response_schema")
         if response_schema is not None and not isinstance(response_schema, dict):
-            msg = "subagent() field `response_schema` must be an object when provided"
+            msg = "task() field `response_schema` must be an object when provided"
             raise ValueError(msg)
 
         async def _call() -> Any:
             runtime = state.outer_runtime
             if runtime is None:
-                msg = "subagent() requires an active ToolRuntime"
+                msg = "task() requires an active ToolRuntime"
                 raise RuntimeError(msg)
             task_tool = find_subagent_task_tool(getattr(runtime, "tools", ()) or ())
             if task_tool is None:
-                msg = "subagent task tool not configured for this eval"
+                msg = "task tool not configured for this eval"
                 raise RuntimeError(msg)
             return await call_subagent_task_tool(
                 task_tool,
@@ -554,24 +554,24 @@ class _ThreadREPL:
             future.cancel()
             raise
 
-    def _register_subagent_bridge(self) -> None:
-        """Install the async host function backing top-level ``subagent()``."""
+    def _register_task_bridge(self) -> None:
+        """Install the async host function backing top-level ``task()``."""
         ctx = self._require_ctx()
 
         async def _bridge(raw_input: Any = None) -> Any:
             state = self._ptc_state
             if state is None:
-                msg = "subagent bridge called outside active eval"
+                msg = "task bridge called outside active eval"
                 raise ConcurrentEvalError(msg)
-            subagent_calls = self._subagent_calls
-            if subagent_calls is None:
-                msg = "subagent call limiter not initialized"
+            task_calls = self._task_calls
+            if task_calls is None:
+                msg = "task call limiter not initialized"
                 raise RuntimeError(msg)
 
             payload = _normalize_tool_input(raw_input)
-            async with subagent_calls:
+            async with task_calls:
                 try:
-                    result = await self._ainvoke_subagent_on_outer_loop(
+                    result = await self._ainvoke_task_on_outer_loop(
                         payload,
                         state=state,
                     )
@@ -579,14 +579,14 @@ class _ThreadREPL:
                     # Subagent dispatches are part of the eval language, not
                     # PTC calls. Surface their validation/runtime failures as
                     # eval errors without changing normal `tools.*` semantics.
-                    raise _SubagentBridgeError(e) from e
+                    raise _TaskBridgeError(e) from e
             return coerce_tool_output_for_ptc(result)
 
-        ctx.register(_SUBAGENT_FUNCTION_NAME, _bridge, is_async=True)
+        ctx.register(_TASK_FUNCTION_NAME, _bridge, is_async=True)
         ctx.eval(
-            "Object.freeze(globalThis.subagent);"
-            "Object.defineProperty(globalThis, 'subagent', {"
-            " value: globalThis.subagent,"
+            "Object.freeze(globalThis.task);"
+            "Object.defineProperty(globalThis, 'task', {"
+            " value: globalThis.task,"
             " writable: false,"
             " configurable: false,"
             "}); undefined"
@@ -836,7 +836,7 @@ class _ThreadREPL:
             outcome.error_type = "OutOfMemory"
             outcome.error_message = str(e)
             _clear_exception_references(e)
-        except _SubagentBridgeError as e:
+        except _TaskBridgeError as e:
             outcome.error_type = e.error_type
             outcome.error_message = e.error_message
             _clear_exception_references(e)

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -39,6 +39,10 @@ from langchain_quickjs._format import (
     stringify,
 )
 from langchain_quickjs._ptc import is_valid_js_identifier, to_camel_case
+from langchain_quickjs._subagent import (
+    call_subagent_task_tool,
+    find_subagent_task_tool,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -47,6 +51,9 @@ if TYPE_CHECKING:
     from langgraph.prebuilt import ToolRuntime
 
 logger = logging.getLogger(__name__)
+
+_MAX_SUBAGENT_CALLS_PER_THREAD = 32
+_SUBAGENT_FUNCTION_NAME = "subagent"
 
 
 def _clear_exception_references(exc: BaseException) -> None:
@@ -98,6 +105,15 @@ class _PTCCallBudgetExceededError(RuntimeError):
             f"(limit={self.limit}, attempted={self.attempted}, "
             f"function={self.function_name})"
         )
+
+
+class _SubagentBridgeError(RuntimeError):
+    """Wrap errors from the top-level `subagent()` host function."""
+
+    def __init__(self, exc: Exception) -> None:
+        self.error_type = type(exc).__name__
+        self.error_message = str(exc)
+        super().__init__(self.error_message)
 
 
 @dataclass(frozen=True, slots=True)
@@ -343,6 +359,7 @@ class _ThreadREPL:
         capture_console: bool,
         max_stdout_chars: int,
         max_ptc_calls: int | None = 256,
+        subagents_enabled: bool = True,
     ) -> None:
         self._worker = worker
         self._runtime = runtime
@@ -354,6 +371,7 @@ class _ThreadREPL:
         self._capture_console = capture_console
         # Static budget config; mutable counters live in ``_ptc_state``.
         self._max_ptc_calls = max_ptc_calls
+        self._subagents_enabled = subagents_enabled
         self._console = _ConsoleBuffer(max_stdout_chars)
         self._ctx: Context | None = None
         # PTC state. ``_registered_tools`` tracks which camel-case names
@@ -376,6 +394,7 @@ class _ThreadREPL:
         # at eval start and cleared in finally so bridge calls can't run
         # outside the current eval.
         self._ptc_state: _PTCState | None = None
+        self._subagent_calls: asyncio.Semaphore | None = None
         # Context creation + console install must happen on the worker
         # thread. Block caller here so the REPL is ready to use when
         # __init__ returns.
@@ -385,6 +404,9 @@ class _ThreadREPL:
         self._ctx = self._runtime.new_context(timeout=self._per_call_timeout)
         if self._capture_console:
             self._install_console()
+        if self._subagents_enabled:
+            self._subagent_calls = asyncio.Semaphore(_MAX_SUBAGENT_CALLS_PER_THREAD)
+            self._register_subagent_bridge()
 
     def _require_ctx(self) -> Context:
         """Return the live QuickJS context or raise if this REPL is closed."""
@@ -474,6 +496,101 @@ class _ThreadREPL:
         ctx.eval(_render_tools_namespace_assignment(bridges))
         self._active_tool_names = target_names
         self._tools_installed = True
+
+    async def _ainvoke_subagent_on_outer_loop(
+        self,
+        payload: dict[str, Any],
+        *,
+        state: _PTCState,
+    ) -> Any:
+        """Validate JS `subagent()` input and invoke the runner on the right loop.
+
+        The QuickJS host call runs on the REPL worker loop, but subagent runnables
+        should execute on the parent LangGraph loop when one exists so callbacks,
+        context, and async loop affinity match normal tool execution.
+        """
+        description = payload.get("description")
+        if not isinstance(description, str) or not description:
+            msg = "subagent() requires non-empty string field `description`"
+            raise ValueError(msg)
+
+        subagent_type = payload.get("subagent_type")
+        if not isinstance(subagent_type, str) or not subagent_type:
+            msg = "subagent() requires non-empty string field `subagent_type`"
+            raise ValueError(msg)
+
+        response_schema = payload.get("response_schema")
+        if response_schema is not None and not isinstance(response_schema, dict):
+            msg = "subagent() field `response_schema` must be an object when provided"
+            raise ValueError(msg)
+
+        async def _call() -> Any:
+            runtime = state.outer_runtime
+            if runtime is None:
+                msg = "subagent() requires an active ToolRuntime"
+                raise RuntimeError(msg)
+            task_tool = find_subagent_task_tool(getattr(runtime, "tools", ()) or ())
+            if task_tool is None:
+                msg = "subagent task tool not configured for this eval"
+                raise RuntimeError(msg)
+            return await call_subagent_task_tool(
+                task_tool,
+                description=description,
+                subagent_type=subagent_type,
+                response_schema=response_schema,
+                runtime=runtime,
+            )
+
+        outer_loop = state.outer_loop
+        if outer_loop is None:
+            return await _call()
+        current_loop = asyncio.get_running_loop()
+        if current_loop is outer_loop:
+            return await _call()
+        future = asyncio.run_coroutine_threadsafe(_call(), outer_loop)
+        try:
+            return await asyncio.wrap_future(future)
+        except asyncio.CancelledError:
+            future.cancel()
+            raise
+
+    def _register_subagent_bridge(self) -> None:
+        """Install the async host function backing top-level ``subagent()``."""
+        ctx = self._require_ctx()
+
+        async def _bridge(raw_input: Any = None) -> Any:
+            state = self._ptc_state
+            if state is None:
+                msg = "subagent bridge called outside active eval"
+                raise ConcurrentEvalError(msg)
+            subagent_calls = self._subagent_calls
+            if subagent_calls is None:
+                msg = "subagent call limiter not initialized"
+                raise RuntimeError(msg)
+
+            payload = _normalize_tool_input(raw_input)
+            async with subagent_calls:
+                try:
+                    result = await self._ainvoke_subagent_on_outer_loop(
+                        payload,
+                        state=state,
+                    )
+                except Exception as e:
+                    # Subagent dispatches are part of the eval language, not
+                    # PTC calls. Surface their validation/runtime failures as
+                    # eval errors without changing normal `tools.*` semantics.
+                    raise _SubagentBridgeError(e) from e
+            return coerce_tool_output_for_ptc(result)
+
+        ctx.register(_SUBAGENT_FUNCTION_NAME, _bridge, is_async=True)
+        ctx.eval(
+            "Object.freeze(globalThis.subagent);"
+            "Object.defineProperty(globalThis, 'subagent', {"
+            " value: globalThis.subagent,"
+            " writable: false,"
+            " configurable: false,"
+            "}); undefined"
+        )
 
     async def _ainvoke_tool_on_outer_loop(
         self,
@@ -719,6 +836,10 @@ class _ThreadREPL:
             outcome.error_type = "OutOfMemory"
             outcome.error_message = str(e)
             _clear_exception_references(e)
+        except _SubagentBridgeError as e:
+            outcome.error_type = e.error_type
+            outcome.error_message = e.error_message
+            _clear_exception_references(e)
         finally:
             self._ptc_state = prev_ptc_state
             outcome.stdout, outcome.stdout_truncated_chars = self._console.drain()
@@ -769,6 +890,7 @@ class _Registry:
     capture_console: bool
     max_stdout_chars: int
     max_ptc_calls: int | None = 256
+    subagents_enabled: bool = True
     _slots: dict[str, _Slot] = field(default_factory=dict)
     _lock: threading.Lock = field(default_factory=threading.Lock)
 
@@ -816,6 +938,7 @@ class _Registry:
             capture_console=self.capture_console,
             max_stdout_chars=self.max_stdout_chars,
             max_ptc_calls=self.max_ptc_calls,
+            subagents_enabled=self.subagents_enabled,
         )
 
         with self._lock:
@@ -838,6 +961,7 @@ class _Registry:
             capture_console=self.capture_console,
             max_stdout_chars=self.max_stdout_chars,
             max_ptc_calls=self.max_ptc_calls,
+            subagents_enabled=self.subagents_enabled,
         )
         return _Slot(worker=worker, runtime=runtime, repl=repl)
 

--- a/libs/partners/quickjs/langchain_quickjs/_subagent.py
+++ b/libs/partners/quickjs/langchain_quickjs/_subagent.py
@@ -29,7 +29,7 @@ _SUBAGENT_TASK_TOOL_FIELDS = frozenset({"description", "subagent_type"})
 
 
 def find_subagent_task_tool(tools: Sequence[BaseTool]) -> BaseTool | None:
-    """Return the Deep Agents task tool that backs top-level `subagent()`."""
+    """Return the Deep Agents task tool that backs top-level `task()`."""
     for tool in tools:
         if (
             getattr(tool, "name", None) == "task"
@@ -64,7 +64,7 @@ async def call_subagent_task_tool(
 ) -> Any:
     """Call the Deep Agents task tool and return a JavaScript-friendly value."""
     if runtime is None:
-        msg = "subagent() requires an active ToolRuntime"
+        msg = "task() requires an active ToolRuntime"
         raise RuntimeError(msg)
 
     parse_json_output = response_schema is not None

--- a/libs/partners/quickjs/langchain_quickjs/_subagent.py
+++ b/libs/partners/quickjs/langchain_quickjs/_subagent.py
@@ -1,0 +1,153 @@
+"""QuickJS adapter for the Deep Agents `task` subagent tool."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+from langchain.agents.structured_output import AutoStrategy
+
+from langchain_quickjs._format import coerce_tool_output_for_ptc
+
+try:
+    from deepagents.middleware.subagents import SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY
+except ImportError:  # pragma: no cover - compatibility with older deepagents
+    SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY = "__deepagents_subagent_response_format"
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from langchain_core.tools import BaseTool
+
+_SCHEMA_MAX_BYTES = 4096
+_SCHEMA_MAX_DEPTH = 5
+_SCHEMA_MAX_PROPERTIES = 32
+_SUBAGENT_TASK_TOOL_FIELDS = frozenset({"description", "subagent_type"})
+
+
+def find_subagent_task_tool(tools: Sequence[BaseTool]) -> BaseTool | None:
+    """Return the Deep Agents task tool that backs top-level `subagent()`."""
+    for tool in tools:
+        if (
+            getattr(tool, "name", None) == "task"
+            and _tool_input_field_names(tool) >= _SUBAGENT_TASK_TOOL_FIELDS
+        ):
+            return tool
+    return None
+
+
+def _tool_input_field_names(tool: BaseTool) -> frozenset[str]:
+    """Return input field names from a LangChain tool's public schema."""
+    schema = getattr(tool, "args_schema", None)
+    fields = getattr(schema, "model_fields", None)
+    if isinstance(fields, dict):
+        return frozenset(str(name) for name in fields)
+    fields = getattr(schema, "__fields__", None)
+    if isinstance(fields, dict):
+        return frozenset(str(name) for name in fields)
+    args = getattr(tool, "args", None)
+    if isinstance(args, dict):
+        return frozenset(str(name) for name in args)
+    return frozenset()
+
+
+async def call_subagent_task_tool(
+    task_tool: BaseTool,
+    *,
+    description: str,
+    subagent_type: str,
+    response_schema: dict[str, Any] | None,
+    runtime: Any,
+) -> Any:
+    """Call the Deep Agents task tool and return a JavaScript-friendly value."""
+    if runtime is None:
+        msg = "subagent() requires an active ToolRuntime"
+        raise RuntimeError(msg)
+
+    parse_json_output = response_schema is not None
+    if response_schema is not None:
+        _validate_response_schema(response_schema)
+        runtime = _runtime_with_response_format(runtime, response_schema)
+
+    runtime = _runtime_with_tool_call_id(
+        runtime,
+        f"ptc_{task_tool.name}_{uuid.uuid4().hex[:8]}",
+    )
+    result = await task_tool.arun(
+        {
+            "description": description,
+            "subagent_type": subagent_type,
+            "runtime": runtime,
+        }
+    )
+    return _extract_task_tool_output(result, parse_json_output=parse_json_output)
+
+
+def _validate_response_schema(schema: dict[str, Any]) -> None:
+    """Reject schemas that exceed size, depth, or property-count limits."""
+    serialized = json.dumps(schema)
+    if len(serialized) > _SCHEMA_MAX_BYTES:
+        msg = (
+            f"response_schema exceeds {_SCHEMA_MAX_BYTES}"
+            f" byte limit ({len(serialized)} bytes)"
+        )
+        raise ValueError(msg)
+
+    def _check(node: dict[str, Any], depth: int, prop_count: list[int]) -> None:
+        if depth > _SCHEMA_MAX_DEPTH:
+            msg = (
+                f"response_schema exceeds maximum nesting depth of {_SCHEMA_MAX_DEPTH}"
+            )
+            raise ValueError(msg)
+        props = node.get("properties")
+        if isinstance(props, dict):
+            prop_count[0] += len(props)
+            if prop_count[0] > _SCHEMA_MAX_PROPERTIES:
+                msg = (
+                    "response_schema exceeds maximum of"
+                    f" {_SCHEMA_MAX_PROPERTIES} properties"
+                )
+                raise ValueError(msg)
+            for value in props.values():
+                if isinstance(value, dict):
+                    _check(value, depth + 1, prop_count)
+        items = node.get("items")
+        if isinstance(items, dict):
+            _check(items, depth + 1, prop_count)
+
+    _check(schema, 0, [0])
+
+
+def _runtime_with_response_format(
+    runtime: Any,
+    response_schema: dict[str, Any],
+) -> Any:
+    """Return a per-dispatch runtime carrying response format in configurable."""
+    config = getattr(runtime, "config", None)
+    updated_config = dict(config) if isinstance(config, dict) else {}
+    configurable = updated_config.get("configurable")
+    if not isinstance(configurable, dict):
+        configurable = {}
+    updated_config["configurable"] = {
+        **configurable,
+        SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY: AutoStrategy(response_schema),
+    }
+    return replace(runtime, config=updated_config)
+
+
+def _runtime_with_tool_call_id(runtime: Any, tool_call_id: str) -> Any:
+    """Return a per-dispatch runtime for the nested task tool call."""
+    return replace(runtime, tool_call_id=tool_call_id)
+
+
+def _extract_task_tool_output(result: Any, *, parse_json_output: bool) -> Any:
+    output = coerce_tool_output_for_ptc(result)
+    if not parse_json_output or not isinstance(output, str):
+        return output
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError:
+        return output

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -33,6 +33,7 @@ from langchain_quickjs._prompt import (
     render_eval_tool_code_doc,
     render_eval_tool_description,
     render_repl_system_prompt,
+    render_subagent_system_prompt,
 )
 from langchain_quickjs._ptc import (
     PTCOption,
@@ -40,6 +41,7 @@ from langchain_quickjs._ptc import (
     render_ptc_prompt,
 )
 from langchain_quickjs._repl import _Registry
+from langchain_quickjs._subagent import find_subagent_task_tool
 
 logger = logging.getLogger(__name__)
 
@@ -163,6 +165,17 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         capture_console: If `True`, install a `console` object that
             buffers `console.log/warn/error` calls and emits them in
             `<stdout>` blocks alongside the result. Default `True`.
+        subagents: If `True`, expose the top-level `subagent(...)`
+            JavaScript API when the current agent has a Deep Agents `task`
+            tool. Set to `False` to require subagent dispatch through the
+            normal parent `task` tool path instead.
+
+            !!! warning
+                `subagent(...)` calls run inside an already-approved `eval`
+                invocation and do not trigger parent-level `interrupt_on` /
+                HITL approval per dispatch. Gate the `eval` tool itself, add
+                approval middleware inside subagent specs, or set
+                `subagents=False` if per-dispatch parent approval is required.
         ptc: Programmatic tool calling — expose agent tools inside the
             REPL as `tools.<camelCase>(input) => Promise<string>`. One
             `eval` call can then orchestrate many tool calls (loops,
@@ -228,6 +241,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         tool_name: str = _DEFAULT_TOOL_NAME,
         max_result_chars: int = _DEFAULT_MAX_RESULT_CHARS,
         capture_console: bool = True,
+        subagents: bool = True,
         ptc: PTCOption | None = None,
         mode: Literal["thread", "turn", "call"] | None = None,
         snapshot_between_turns: bool | None = None,
@@ -247,6 +261,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         self._tool_name = tool_name
         self._max_result_chars = max_result_chars
         self._capture_console = capture_console
+        self._subagents = subagents
         self._ptc = ptc
         (
             self._mode,
@@ -265,6 +280,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
             capture_console=capture_console,
             max_stdout_chars=max_result_chars,
             max_ptc_calls=max_ptc_calls,
+            subagents_enabled=subagents,
         )
         self._base_system_prompt = render_repl_system_prompt(
             tool_name=tool_name,
@@ -437,17 +453,22 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         )
 
     def _prepare_for_call(self, request: ModelRequest[ContextT]) -> str:
-        """Install PTC bindings for this turn and return the system-prompt addendum.
+        """Install PTC bindings for this turn and return the prompt addendum.
 
         Called from both sync and async model-call wrappers. Reads the
         live tool list off the request (middlewares upstream may have
-        filtered it), decides what PTC exposes this turn, registers any
-        missing host-function bridges on the current thread's REPL, and
-        rebuilds `globalThis.tools` if the exposed name set changed.
+        filtered it), installs PTC bridges on the current thread's REPL,
+        and renders matching API-reference text.
         """
-        if self._ptc is None:
-            return self._base_system_prompt
         request_tools: list[BaseTool] = list(getattr(request, "tools", []) or [])
+        prompt = self._base_system_prompt
+
+        if self._subagents and find_subagent_task_tool(request_tools) is not None:
+            prompt += render_subagent_system_prompt(tool_name=self._tool_name)
+
+        if self._ptc is None:
+            return prompt
+
         exposed = filter_tools_for_ptc(
             request_tools,
             self._ptc,
@@ -473,7 +494,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
                 exposed_names,
                 render_ptc_prompt(exposed, tool_name=self._tool_name),
             )
-        return self._base_system_prompt + self._ptc_prompt_cache[1]
+        return prompt + self._ptc_prompt_cache[1]
 
     def _extend(
         self, system_message: SystemMessage | None, prompt: str

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -165,13 +165,13 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         capture_console: If `True`, install a `console` object that
             buffers `console.log/warn/error` calls and emits them in
             `<stdout>` blocks alongside the result. Default `True`.
-        subagents: If `True`, expose the top-level `subagent(...)`
+        subagents: If `True`, expose the top-level `task(...)`
             JavaScript API when the current agent has a Deep Agents `task`
             tool. Set to `False` to require subagent dispatch through the
             normal parent `task` tool path instead.
 
             !!! warning
-                `subagent(...)` calls run inside an already-approved `eval`
+                `task(...)` calls run inside an already-approved `eval`
                 invocation and do not trigger parent-level `interrupt_on` /
                 HITL approval per dispatch. Gate the `eval` tool itself, add
                 approval middleware inside subagent specs, or set

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions.md
@@ -128,6 +128,209 @@ An `eval` tool is available. It runs JavaScript in a persistent REPL.
 - Timeout: 5.0s per call. Memory: 64 MB total.
 - `console.log` output is captured and returned alongside the result.
 
+### Dispatching Subagents with `subagent`
+
+`subagent` is your primitive for running configured subagents from inside the
+JavaScript REPL. You orchestrate everything else - fan-out, filtering,
+deduplication, multi-stage flow, and synthesis - in plain JavaScript.
+
+#### The primitive
+
+```javascript
+await subagent({
+  description,      // full autonomous task prompt
+  subagent_type,    // configured subagent name
+  response_schema,  // optional JSON Schema for structured output
+}); // -> Promise<unknown>
+```
+
+`subagent` runs a full agentic loop for the selected configured subagent. The
+subagent can use whatever tools it was configured with, iterate, inspect
+context, and return one final result. `subagent_type` is required; use one of
+the configured subagent names.
+
+`description` is the only prompt the subagent receives for this dispatch. Make
+it complete: include the goal, constraints, relevant context, what to inspect,
+and the exact shape or level of detail you expect back. Each dispatch is
+stateless from the caller's perspective; you cannot send follow-up messages to
+the same subagent run.
+
+`response_schema` is optional. When provided, the resolved value is already a
+typed JavaScript value matching the schema. Do not call `JSON.parse` unless the
+subagent intentionally returned a JSON string. Dynamic schemas work for
+declarative subagents; runnable-backed subagents reject dynamic schemas because
+their runnable is already compiled.
+
+#### Approval model
+
+`subagent` dispatches from inside the already-running `eval` call. It
+does not route through the parent agent's `ToolNode`-managed `task` tool and
+does not trigger parent-level `interrupt_on` / HITL approval for each dispatch.
+Declarative subagents still honor approval middleware configured inside their
+own spec. If you need approval before launching a subagent from the parent, use
+the normal `task` tool outside JavaScript or ensure the `eval` call
+itself is approval-gated.
+
+#### Mental model
+
+Hold your work in JS: an array of items in, an array of results out. Merge each
+dispatch result back onto its item. Multi-stage analysis means: run a pass,
+filter or regroup the array in JS, then run another pass over the survivors.
+
+Prefer one `eval` call that performs the whole workflow. Splitting the
+workflow across multiple `eval` calls costs model turns and forces you to
+re-establish state.
+
+#### Fan out with bounded concurrency
+
+Dispatch independent work in parallel with `Promise.all`, but in explicit
+batches around 10 so you do not launch hundreds of subagents at once. The bridge
+enforces a hard per-REPL cap of 32 concurrent subagent calls.
+
+```javascript
+const batchSize = 10;
+const reviewed = [];
+for (let i = 0; i < items.length; i += batchSize) {
+  const batch = items.slice(i, i + batchSize);
+  reviewed.push(...(await Promise.all(batch.map(async (it) => {
+    const result = await subagent({
+      description: "Review " + it.file + " for SQL injection. Cite line numbers.",
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: {
+          vulnerabilities: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                type: { type: "string" },
+                line: { type: "number" },
+                evidence: { type: "string" },
+              },
+              required: ["type", "line", "evidence"],
+            },
+          },
+        },
+        required: ["vulnerabilities"],
+      },
+    });
+    return { ...it, ...result };
+  }))));
+}
+```
+
+#### Use parent JS for cheap work; use subagents for agentic work
+
+Use JavaScript in the parent REPL for deterministic orchestration: joining
+arrays, deduping, sorting, filtering, grouping, batching, and merging results.
+If the `tools.*` namespace is exposed, also use it to pre-read files or collect
+shared data once, then pass only the relevant content to each subagent in
+`description`.
+
+Use `subagent` for work that benefits from an autonomous agentic loop: reading
+or searching with the subagent's own tools, inspecting multiple files, following
+leads, making judgment calls, or producing a final synthesized report.
+
+#### Pre-read shared context in the parent when useful
+
+If many subagents need the same source list or file content and `tools.*` is
+available, gather that context once in the parent REPL before dispatching:
+
+```javascript
+const files = (await tools.glob({ pattern: "src/**/*.ts" }))
+  .split("\n")
+  .filter(Boolean);
+
+const items = await Promise.all(files.map(async (file) => {
+  const content = await tools.readFile({ file_path: file });
+  return { file, content };
+}));
+
+const batchSize = 10;
+const results = [];
+for (let i = 0; i < items.length; i += batchSize) {
+  const batch = items.slice(i, i + batchSize);
+  results.push(...(await Promise.all(batch.map(async (it) => {
+    const finding = await subagent({
+      description:
+        "Review this file for auth bypasses. Return concrete findings only.\n\n" +
+        "File: " + it.file + "\n\n" +
+        it.content,
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: {
+          findings: { type: "array", items: { type: "object" } },
+        },
+        required: ["findings"],
+      },
+    });
+    return { ...it, ...finding };
+  }))));
+}
+```
+
+#### Compose multiple stages
+
+Filter the array in JS between passes. For example: first ask subagents for a
+cheap classification, filter to the risky items, then dispatch deeper reviews
+only for those items.
+
+```javascript
+const tagged = [];
+for (let i = 0; i < items.length; i += 10) {
+  const batch = items.slice(i, i + 10);
+  tagged.push(...(await Promise.all(batch.map(async (it) => {
+    const tag = await subagent({
+      description: "Classify " + it.file + " as handler, util, test, or config.",
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: { kind: { type: "string" }, risky: { type: "boolean" } },
+        required: ["kind", "risky"],
+      },
+    });
+    return { ...it, ...tag };
+  }))));
+}
+
+const riskyHandlers = tagged.filter((it) => it.kind === "handler" && it.risky);
+const deepReviews = [];
+for (let i = 0; i < riskyHandlers.length; i += 10) {
+  const batch = riskyHandlers.slice(i, i + 10);
+  deepReviews.push(...(await Promise.all(batch.map(async (it) => {
+    const review = await subagent({
+      description: "Deep security review of " + it.file + ". Cite line numbers.",
+      subagent_type: "reviewer",
+    });
+    return { ...it, review };
+  }))));
+}
+```
+
+#### Get results out without flooding your context
+
+Keep large result sets in JS variables. Do not `console.log` the full result set.
+If `tools.writeFile` is exposed, persist structured output from inside the eval:
+
+```javascript
+await tools.writeFile({
+  file_path: "/results/subagent-output.json",
+  content: JSON.stringify(deepReviews),
+});
+```
+
+Otherwise return a compact summary or a small slice of the results, not the
+entire intermediate dataset.
+
+#### Across evals
+
+Variables persist according to the interpreter persistence mode above, but
+re-establish what you need in each eval. Doing the whole workflow in one
+`eval` call is usually simplest.
+
+
 ### API Reference — `tools` namespace
 
 The agent tools listed below are exposed on the global object at `globalThis.tools` (also reachable as `tools`). Each takes a single object argument and returns a Promise that resolves to the tool's native value: strings as strings, numbers as numbers, lists as arrays, dicts as objects, and `None` as `null`. You do NOT need to `JSON.parse` results — they are already typed.

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions.md
@@ -128,23 +128,23 @@ An `eval` tool is available. It runs JavaScript in a persistent REPL.
 - Timeout: 5.0s per call. Memory: 64 MB total.
 - `console.log` output is captured and returned alongside the result.
 
-### Dispatching Subagents with `subagent`
+### Dispatching Subagents with `task`
 
-`subagent` is your primitive for running configured subagents from inside the
+`task` is your primitive for running configured subagents from inside the
 JavaScript REPL. You orchestrate everything else - fan-out, filtering,
 deduplication, multi-stage flow, and synthesis - in plain JavaScript.
 
 #### The primitive
 
 ```javascript
-await subagent({
+await task({
   description,      // full autonomous task prompt
   subagent_type,    // configured subagent name
   response_schema,  // optional JSON Schema for structured output
 }); // -> Promise<unknown>
 ```
 
-`subagent` runs a full agentic loop for the selected configured subagent. The
+`task` runs a full agentic loop for the selected configured subagent. The
 subagent can use whatever tools it was configured with, iterate, inspect
 context, and return one final result. `subagent_type` is required; use one of
 the configured subagent names.
@@ -163,7 +163,7 @@ their runnable is already compiled.
 
 #### Approval model
 
-`subagent` dispatches from inside the already-running `eval` call. It
+`task` dispatches from inside the already-running `eval` call. It
 does not route through the parent agent's `ToolNode`-managed `task` tool and
 does not trigger parent-level `interrupt_on` / HITL approval for each dispatch.
 Declarative subagents still honor approval middleware configured inside their
@@ -185,7 +185,7 @@ re-establish state.
 
 Dispatch independent work in parallel with `Promise.all`, but in explicit
 batches around 10 so you do not launch hundreds of subagents at once. The bridge
-enforces a hard per-REPL cap of 32 concurrent subagent calls.
+enforces a hard per-REPL cap of 32 concurrent `task` calls.
 
 ```javascript
 const batchSize = 10;
@@ -193,7 +193,7 @@ const reviewed = [];
 for (let i = 0; i < items.length; i += batchSize) {
   const batch = items.slice(i, i + batchSize);
   reviewed.push(...(await Promise.all(batch.map(async (it) => {
-    const result = await subagent({
+    const result = await task({
       description: "Review " + it.file + " for SQL injection. Cite line numbers.",
       subagent_type: "reviewer",
       response_schema: {
@@ -228,7 +228,7 @@ If the `tools.*` namespace is exposed, also use it to pre-read files or collect
 shared data once, then pass only the relevant content to each subagent in
 `description`.
 
-Use `subagent` for work that benefits from an autonomous agentic loop: reading
+Use `task` for work that benefits from an autonomous agentic loop: reading
 or searching with the subagent's own tools, inspecting multiple files, following
 leads, making judgment calls, or producing a final synthesized report.
 
@@ -252,7 +252,7 @@ const results = [];
 for (let i = 0; i < items.length; i += batchSize) {
   const batch = items.slice(i, i + batchSize);
   results.push(...(await Promise.all(batch.map(async (it) => {
-    const finding = await subagent({
+    const finding = await task({
       description:
         "Review this file for auth bypasses. Return concrete findings only.\n\n" +
         "File: " + it.file + "\n\n" +
@@ -282,7 +282,7 @@ const tagged = [];
 for (let i = 0; i < items.length; i += 10) {
   const batch = items.slice(i, i + 10);
   tagged.push(...(await Promise.all(batch.map(async (it) => {
-    const tag = await subagent({
+    const tag = await task({
       description: "Classify " + it.file + " as handler, util, test, or config.",
       subagent_type: "reviewer",
       response_schema: {
@@ -300,7 +300,7 @@ const deepReviews = [];
 for (let i = 0; i < riskyHandlers.length; i += 10) {
   const batch = riskyHandlers.slice(i, i + 10);
   deepReviews.push(...(await Promise.all(batch.map(async (it) => {
-    const review = await subagent({
+    const review = await task({
       description: "Deep security review of " + it.file + ". Cite line numbers.",
       subagent_type: "reviewer",
     });

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_call.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_call.md
@@ -128,6 +128,209 @@ An `eval` tool is available. It runs JavaScript in a fresh sandboxed REPL for ea
 - Timeout: 5.0s per call. Memory: 64 MB total.
 - `console.log` output is captured and returned alongside the result.
 
+### Dispatching Subagents with `subagent`
+
+`subagent` is your primitive for running configured subagents from inside the
+JavaScript REPL. You orchestrate everything else - fan-out, filtering,
+deduplication, multi-stage flow, and synthesis - in plain JavaScript.
+
+#### The primitive
+
+```javascript
+await subagent({
+  description,      // full autonomous task prompt
+  subagent_type,    // configured subagent name
+  response_schema,  // optional JSON Schema for structured output
+}); // -> Promise<unknown>
+```
+
+`subagent` runs a full agentic loop for the selected configured subagent. The
+subagent can use whatever tools it was configured with, iterate, inspect
+context, and return one final result. `subagent_type` is required; use one of
+the configured subagent names.
+
+`description` is the only prompt the subagent receives for this dispatch. Make
+it complete: include the goal, constraints, relevant context, what to inspect,
+and the exact shape or level of detail you expect back. Each dispatch is
+stateless from the caller's perspective; you cannot send follow-up messages to
+the same subagent run.
+
+`response_schema` is optional. When provided, the resolved value is already a
+typed JavaScript value matching the schema. Do not call `JSON.parse` unless the
+subagent intentionally returned a JSON string. Dynamic schemas work for
+declarative subagents; runnable-backed subagents reject dynamic schemas because
+their runnable is already compiled.
+
+#### Approval model
+
+`subagent` dispatches from inside the already-running `eval` call. It
+does not route through the parent agent's `ToolNode`-managed `task` tool and
+does not trigger parent-level `interrupt_on` / HITL approval for each dispatch.
+Declarative subagents still honor approval middleware configured inside their
+own spec. If you need approval before launching a subagent from the parent, use
+the normal `task` tool outside JavaScript or ensure the `eval` call
+itself is approval-gated.
+
+#### Mental model
+
+Hold your work in JS: an array of items in, an array of results out. Merge each
+dispatch result back onto its item. Multi-stage analysis means: run a pass,
+filter or regroup the array in JS, then run another pass over the survivors.
+
+Prefer one `eval` call that performs the whole workflow. Splitting the
+workflow across multiple `eval` calls costs model turns and forces you to
+re-establish state.
+
+#### Fan out with bounded concurrency
+
+Dispatch independent work in parallel with `Promise.all`, but in explicit
+batches around 10 so you do not launch hundreds of subagents at once. The bridge
+enforces a hard per-REPL cap of 32 concurrent subagent calls.
+
+```javascript
+const batchSize = 10;
+const reviewed = [];
+for (let i = 0; i < items.length; i += batchSize) {
+  const batch = items.slice(i, i + batchSize);
+  reviewed.push(...(await Promise.all(batch.map(async (it) => {
+    const result = await subagent({
+      description: "Review " + it.file + " for SQL injection. Cite line numbers.",
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: {
+          vulnerabilities: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                type: { type: "string" },
+                line: { type: "number" },
+                evidence: { type: "string" },
+              },
+              required: ["type", "line", "evidence"],
+            },
+          },
+        },
+        required: ["vulnerabilities"],
+      },
+    });
+    return { ...it, ...result };
+  }))));
+}
+```
+
+#### Use parent JS for cheap work; use subagents for agentic work
+
+Use JavaScript in the parent REPL for deterministic orchestration: joining
+arrays, deduping, sorting, filtering, grouping, batching, and merging results.
+If the `tools.*` namespace is exposed, also use it to pre-read files or collect
+shared data once, then pass only the relevant content to each subagent in
+`description`.
+
+Use `subagent` for work that benefits from an autonomous agentic loop: reading
+or searching with the subagent's own tools, inspecting multiple files, following
+leads, making judgment calls, or producing a final synthesized report.
+
+#### Pre-read shared context in the parent when useful
+
+If many subagents need the same source list or file content and `tools.*` is
+available, gather that context once in the parent REPL before dispatching:
+
+```javascript
+const files = (await tools.glob({ pattern: "src/**/*.ts" }))
+  .split("\n")
+  .filter(Boolean);
+
+const items = await Promise.all(files.map(async (file) => {
+  const content = await tools.readFile({ file_path: file });
+  return { file, content };
+}));
+
+const batchSize = 10;
+const results = [];
+for (let i = 0; i < items.length; i += batchSize) {
+  const batch = items.slice(i, i + batchSize);
+  results.push(...(await Promise.all(batch.map(async (it) => {
+    const finding = await subagent({
+      description:
+        "Review this file for auth bypasses. Return concrete findings only.\n\n" +
+        "File: " + it.file + "\n\n" +
+        it.content,
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: {
+          findings: { type: "array", items: { type: "object" } },
+        },
+        required: ["findings"],
+      },
+    });
+    return { ...it, ...finding };
+  }))));
+}
+```
+
+#### Compose multiple stages
+
+Filter the array in JS between passes. For example: first ask subagents for a
+cheap classification, filter to the risky items, then dispatch deeper reviews
+only for those items.
+
+```javascript
+const tagged = [];
+for (let i = 0; i < items.length; i += 10) {
+  const batch = items.slice(i, i + 10);
+  tagged.push(...(await Promise.all(batch.map(async (it) => {
+    const tag = await subagent({
+      description: "Classify " + it.file + " as handler, util, test, or config.",
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: { kind: { type: "string" }, risky: { type: "boolean" } },
+        required: ["kind", "risky"],
+      },
+    });
+    return { ...it, ...tag };
+  }))));
+}
+
+const riskyHandlers = tagged.filter((it) => it.kind === "handler" && it.risky);
+const deepReviews = [];
+for (let i = 0; i < riskyHandlers.length; i += 10) {
+  const batch = riskyHandlers.slice(i, i + 10);
+  deepReviews.push(...(await Promise.all(batch.map(async (it) => {
+    const review = await subagent({
+      description: "Deep security review of " + it.file + ". Cite line numbers.",
+      subagent_type: "reviewer",
+    });
+    return { ...it, review };
+  }))));
+}
+```
+
+#### Get results out without flooding your context
+
+Keep large result sets in JS variables. Do not `console.log` the full result set.
+If `tools.writeFile` is exposed, persist structured output from inside the eval:
+
+```javascript
+await tools.writeFile({
+  file_path: "/results/subagent-output.json",
+  content: JSON.stringify(deepReviews),
+});
+```
+
+Otherwise return a compact summary or a small slice of the results, not the
+entire intermediate dataset.
+
+#### Across evals
+
+Variables persist according to the interpreter persistence mode above, but
+re-establish what you need in each eval. Doing the whole workflow in one
+`eval` call is usually simplest.
+
+
 ### API Reference — `tools` namespace
 
 The agent tools listed below are exposed on the global object at `globalThis.tools` (also reachable as `tools`). Each takes a single object argument and returns a Promise that resolves to the tool's native value: strings as strings, numbers as numbers, lists as arrays, dicts as objects, and `None` as `null`. You do NOT need to `JSON.parse` results — they are already typed.

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_call.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_call.md
@@ -128,23 +128,23 @@ An `eval` tool is available. It runs JavaScript in a fresh sandboxed REPL for ea
 - Timeout: 5.0s per call. Memory: 64 MB total.
 - `console.log` output is captured and returned alongside the result.
 
-### Dispatching Subagents with `subagent`
+### Dispatching Subagents with `task`
 
-`subagent` is your primitive for running configured subagents from inside the
+`task` is your primitive for running configured subagents from inside the
 JavaScript REPL. You orchestrate everything else - fan-out, filtering,
 deduplication, multi-stage flow, and synthesis - in plain JavaScript.
 
 #### The primitive
 
 ```javascript
-await subagent({
+await task({
   description,      // full autonomous task prompt
   subagent_type,    // configured subagent name
   response_schema,  // optional JSON Schema for structured output
 }); // -> Promise<unknown>
 ```
 
-`subagent` runs a full agentic loop for the selected configured subagent. The
+`task` runs a full agentic loop for the selected configured subagent. The
 subagent can use whatever tools it was configured with, iterate, inspect
 context, and return one final result. `subagent_type` is required; use one of
 the configured subagent names.
@@ -163,7 +163,7 @@ their runnable is already compiled.
 
 #### Approval model
 
-`subagent` dispatches from inside the already-running `eval` call. It
+`task` dispatches from inside the already-running `eval` call. It
 does not route through the parent agent's `ToolNode`-managed `task` tool and
 does not trigger parent-level `interrupt_on` / HITL approval for each dispatch.
 Declarative subagents still honor approval middleware configured inside their
@@ -185,7 +185,7 @@ re-establish state.
 
 Dispatch independent work in parallel with `Promise.all`, but in explicit
 batches around 10 so you do not launch hundreds of subagents at once. The bridge
-enforces a hard per-REPL cap of 32 concurrent subagent calls.
+enforces a hard per-REPL cap of 32 concurrent `task` calls.
 
 ```javascript
 const batchSize = 10;
@@ -193,7 +193,7 @@ const reviewed = [];
 for (let i = 0; i < items.length; i += batchSize) {
   const batch = items.slice(i, i + batchSize);
   reviewed.push(...(await Promise.all(batch.map(async (it) => {
-    const result = await subagent({
+    const result = await task({
       description: "Review " + it.file + " for SQL injection. Cite line numbers.",
       subagent_type: "reviewer",
       response_schema: {
@@ -228,7 +228,7 @@ If the `tools.*` namespace is exposed, also use it to pre-read files or collect
 shared data once, then pass only the relevant content to each subagent in
 `description`.
 
-Use `subagent` for work that benefits from an autonomous agentic loop: reading
+Use `task` for work that benefits from an autonomous agentic loop: reading
 or searching with the subagent's own tools, inspecting multiple files, following
 leads, making judgment calls, or producing a final synthesized report.
 
@@ -252,7 +252,7 @@ const results = [];
 for (let i = 0; i < items.length; i += batchSize) {
   const batch = items.slice(i, i + batchSize);
   results.push(...(await Promise.all(batch.map(async (it) => {
-    const finding = await subagent({
+    const finding = await task({
       description:
         "Review this file for auth bypasses. Return concrete findings only.\n\n" +
         "File: " + it.file + "\n\n" +
@@ -282,7 +282,7 @@ const tagged = [];
 for (let i = 0; i < items.length; i += 10) {
   const batch = items.slice(i, i + 10);
   tagged.push(...(await Promise.all(batch.map(async (it) => {
-    const tag = await subagent({
+    const tag = await task({
       description: "Classify " + it.file + " as handler, util, test, or config.",
       subagent_type: "reviewer",
       response_schema: {
@@ -300,7 +300,7 @@ const deepReviews = [];
 for (let i = 0; i < riskyHandlers.length; i += 10) {
   const batch = riskyHandlers.slice(i, i + 10);
   deepReviews.push(...(await Promise.all(batch.map(async (it) => {
-    const review = await subagent({
+    const review = await task({
       description: "Deep security review of " + it.file + ". Cite line numbers.",
       subagent_type: "reviewer",
     });

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_turn.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_turn.md
@@ -128,6 +128,209 @@ An `eval` tool is available. It runs JavaScript in a persistent REPL.
 - Timeout: 5.0s per call. Memory: 64 MB total.
 - `console.log` output is captured and returned alongside the result.
 
+### Dispatching Subagents with `subagent`
+
+`subagent` is your primitive for running configured subagents from inside the
+JavaScript REPL. You orchestrate everything else - fan-out, filtering,
+deduplication, multi-stage flow, and synthesis - in plain JavaScript.
+
+#### The primitive
+
+```javascript
+await subagent({
+  description,      // full autonomous task prompt
+  subagent_type,    // configured subagent name
+  response_schema,  // optional JSON Schema for structured output
+}); // -> Promise<unknown>
+```
+
+`subagent` runs a full agentic loop for the selected configured subagent. The
+subagent can use whatever tools it was configured with, iterate, inspect
+context, and return one final result. `subagent_type` is required; use one of
+the configured subagent names.
+
+`description` is the only prompt the subagent receives for this dispatch. Make
+it complete: include the goal, constraints, relevant context, what to inspect,
+and the exact shape or level of detail you expect back. Each dispatch is
+stateless from the caller's perspective; you cannot send follow-up messages to
+the same subagent run.
+
+`response_schema` is optional. When provided, the resolved value is already a
+typed JavaScript value matching the schema. Do not call `JSON.parse` unless the
+subagent intentionally returned a JSON string. Dynamic schemas work for
+declarative subagents; runnable-backed subagents reject dynamic schemas because
+their runnable is already compiled.
+
+#### Approval model
+
+`subagent` dispatches from inside the already-running `eval` call. It
+does not route through the parent agent's `ToolNode`-managed `task` tool and
+does not trigger parent-level `interrupt_on` / HITL approval for each dispatch.
+Declarative subagents still honor approval middleware configured inside their
+own spec. If you need approval before launching a subagent from the parent, use
+the normal `task` tool outside JavaScript or ensure the `eval` call
+itself is approval-gated.
+
+#### Mental model
+
+Hold your work in JS: an array of items in, an array of results out. Merge each
+dispatch result back onto its item. Multi-stage analysis means: run a pass,
+filter or regroup the array in JS, then run another pass over the survivors.
+
+Prefer one `eval` call that performs the whole workflow. Splitting the
+workflow across multiple `eval` calls costs model turns and forces you to
+re-establish state.
+
+#### Fan out with bounded concurrency
+
+Dispatch independent work in parallel with `Promise.all`, but in explicit
+batches around 10 so you do not launch hundreds of subagents at once. The bridge
+enforces a hard per-REPL cap of 32 concurrent subagent calls.
+
+```javascript
+const batchSize = 10;
+const reviewed = [];
+for (let i = 0; i < items.length; i += batchSize) {
+  const batch = items.slice(i, i + batchSize);
+  reviewed.push(...(await Promise.all(batch.map(async (it) => {
+    const result = await subagent({
+      description: "Review " + it.file + " for SQL injection. Cite line numbers.",
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: {
+          vulnerabilities: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                type: { type: "string" },
+                line: { type: "number" },
+                evidence: { type: "string" },
+              },
+              required: ["type", "line", "evidence"],
+            },
+          },
+        },
+        required: ["vulnerabilities"],
+      },
+    });
+    return { ...it, ...result };
+  }))));
+}
+```
+
+#### Use parent JS for cheap work; use subagents for agentic work
+
+Use JavaScript in the parent REPL for deterministic orchestration: joining
+arrays, deduping, sorting, filtering, grouping, batching, and merging results.
+If the `tools.*` namespace is exposed, also use it to pre-read files or collect
+shared data once, then pass only the relevant content to each subagent in
+`description`.
+
+Use `subagent` for work that benefits from an autonomous agentic loop: reading
+or searching with the subagent's own tools, inspecting multiple files, following
+leads, making judgment calls, or producing a final synthesized report.
+
+#### Pre-read shared context in the parent when useful
+
+If many subagents need the same source list or file content and `tools.*` is
+available, gather that context once in the parent REPL before dispatching:
+
+```javascript
+const files = (await tools.glob({ pattern: "src/**/*.ts" }))
+  .split("\n")
+  .filter(Boolean);
+
+const items = await Promise.all(files.map(async (file) => {
+  const content = await tools.readFile({ file_path: file });
+  return { file, content };
+}));
+
+const batchSize = 10;
+const results = [];
+for (let i = 0; i < items.length; i += batchSize) {
+  const batch = items.slice(i, i + batchSize);
+  results.push(...(await Promise.all(batch.map(async (it) => {
+    const finding = await subagent({
+      description:
+        "Review this file for auth bypasses. Return concrete findings only.\n\n" +
+        "File: " + it.file + "\n\n" +
+        it.content,
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: {
+          findings: { type: "array", items: { type: "object" } },
+        },
+        required: ["findings"],
+      },
+    });
+    return { ...it, ...finding };
+  }))));
+}
+```
+
+#### Compose multiple stages
+
+Filter the array in JS between passes. For example: first ask subagents for a
+cheap classification, filter to the risky items, then dispatch deeper reviews
+only for those items.
+
+```javascript
+const tagged = [];
+for (let i = 0; i < items.length; i += 10) {
+  const batch = items.slice(i, i + 10);
+  tagged.push(...(await Promise.all(batch.map(async (it) => {
+    const tag = await subagent({
+      description: "Classify " + it.file + " as handler, util, test, or config.",
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: { kind: { type: "string" }, risky: { type: "boolean" } },
+        required: ["kind", "risky"],
+      },
+    });
+    return { ...it, ...tag };
+  }))));
+}
+
+const riskyHandlers = tagged.filter((it) => it.kind === "handler" && it.risky);
+const deepReviews = [];
+for (let i = 0; i < riskyHandlers.length; i += 10) {
+  const batch = riskyHandlers.slice(i, i + 10);
+  deepReviews.push(...(await Promise.all(batch.map(async (it) => {
+    const review = await subagent({
+      description: "Deep security review of " + it.file + ". Cite line numbers.",
+      subagent_type: "reviewer",
+    });
+    return { ...it, review };
+  }))));
+}
+```
+
+#### Get results out without flooding your context
+
+Keep large result sets in JS variables. Do not `console.log` the full result set.
+If `tools.writeFile` is exposed, persist structured output from inside the eval:
+
+```javascript
+await tools.writeFile({
+  file_path: "/results/subagent-output.json",
+  content: JSON.stringify(deepReviews),
+});
+```
+
+Otherwise return a compact summary or a small slice of the results, not the
+entire intermediate dataset.
+
+#### Across evals
+
+Variables persist according to the interpreter persistence mode above, but
+re-establish what you need in each eval. Doing the whole workflow in one
+`eval` call is usually simplest.
+
+
 ### API Reference — `tools` namespace
 
 The agent tools listed below are exposed on the global object at `globalThis.tools` (also reachable as `tools`). Each takes a single object argument and returns a Promise that resolves to the tool's native value: strings as strings, numbers as numbers, lists as arrays, dicts as objects, and `None` as `null`. You do NOT need to `JSON.parse` results — they are already typed.

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_turn.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_turn.md
@@ -128,23 +128,23 @@ An `eval` tool is available. It runs JavaScript in a persistent REPL.
 - Timeout: 5.0s per call. Memory: 64 MB total.
 - `console.log` output is captured and returned alongside the result.
 
-### Dispatching Subagents with `subagent`
+### Dispatching Subagents with `task`
 
-`subagent` is your primitive for running configured subagents from inside the
+`task` is your primitive for running configured subagents from inside the
 JavaScript REPL. You orchestrate everything else - fan-out, filtering,
 deduplication, multi-stage flow, and synthesis - in plain JavaScript.
 
 #### The primitive
 
 ```javascript
-await subagent({
+await task({
   description,      // full autonomous task prompt
   subagent_type,    // configured subagent name
   response_schema,  // optional JSON Schema for structured output
 }); // -> Promise<unknown>
 ```
 
-`subagent` runs a full agentic loop for the selected configured subagent. The
+`task` runs a full agentic loop for the selected configured subagent. The
 subagent can use whatever tools it was configured with, iterate, inspect
 context, and return one final result. `subagent_type` is required; use one of
 the configured subagent names.
@@ -163,7 +163,7 @@ their runnable is already compiled.
 
 #### Approval model
 
-`subagent` dispatches from inside the already-running `eval` call. It
+`task` dispatches from inside the already-running `eval` call. It
 does not route through the parent agent's `ToolNode`-managed `task` tool and
 does not trigger parent-level `interrupt_on` / HITL approval for each dispatch.
 Declarative subagents still honor approval middleware configured inside their
@@ -185,7 +185,7 @@ re-establish state.
 
 Dispatch independent work in parallel with `Promise.all`, but in explicit
 batches around 10 so you do not launch hundreds of subagents at once. The bridge
-enforces a hard per-REPL cap of 32 concurrent subagent calls.
+enforces a hard per-REPL cap of 32 concurrent `task` calls.
 
 ```javascript
 const batchSize = 10;
@@ -193,7 +193,7 @@ const reviewed = [];
 for (let i = 0; i < items.length; i += batchSize) {
   const batch = items.slice(i, i + batchSize);
   reviewed.push(...(await Promise.all(batch.map(async (it) => {
-    const result = await subagent({
+    const result = await task({
       description: "Review " + it.file + " for SQL injection. Cite line numbers.",
       subagent_type: "reviewer",
       response_schema: {
@@ -228,7 +228,7 @@ If the `tools.*` namespace is exposed, also use it to pre-read files or collect
 shared data once, then pass only the relevant content to each subagent in
 `description`.
 
-Use `subagent` for work that benefits from an autonomous agentic loop: reading
+Use `task` for work that benefits from an autonomous agentic loop: reading
 or searching with the subagent's own tools, inspecting multiple files, following
 leads, making judgment calls, or producing a final synthesized report.
 
@@ -252,7 +252,7 @@ const results = [];
 for (let i = 0; i < items.length; i += batchSize) {
   const batch = items.slice(i, i + batchSize);
   results.push(...(await Promise.all(batch.map(async (it) => {
-    const finding = await subagent({
+    const finding = await task({
       description:
         "Review this file for auth bypasses. Return concrete findings only.\n\n" +
         "File: " + it.file + "\n\n" +
@@ -282,7 +282,7 @@ const tagged = [];
 for (let i = 0; i < items.length; i += 10) {
   const batch = items.slice(i, i + 10);
   tagged.push(...(await Promise.all(batch.map(async (it) => {
-    const tag = await subagent({
+    const tag = await task({
       description: "Classify " + it.file + " as handler, util, test, or config.",
       subagent_type: "reviewer",
       response_schema: {
@@ -300,7 +300,7 @@ const deepReviews = [];
 for (let i = 0; i < riskyHandlers.length; i += 10) {
   const batch = riskyHandlers.slice(i, i + 10);
   deepReviews.push(...(await Promise.all(batch.map(async (it) => {
-    const review = await subagent({
+    const review = await task({
       description: "Deep security review of " + it.file + ". Cite line numbers.",
       subagent_type: "reviewer",
     });

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools.md
@@ -127,3 +127,205 @@ An `eval` tool is available. It runs JavaScript in a persistent REPL.
 - Runtime sandbox: no built-in filesystem, network, stdlib, or wall-clock APIs (`fetch`, `require`, `fs`, `process`, real `Date.now()` are unavailable or stubbed). External side effects from inside the REPL are only reachable via the `tools.*` namespace when it is exposed (see below); without it, the REPL is pure computation.
 - Timeout: 5.0s per call. Memory: 64 MB total.
 - `console.log` output is captured and returned alongside the result.
+
+### Dispatching Subagents with `subagent`
+
+`subagent` is your primitive for running configured subagents from inside the
+JavaScript REPL. You orchestrate everything else - fan-out, filtering,
+deduplication, multi-stage flow, and synthesis - in plain JavaScript.
+
+#### The primitive
+
+```javascript
+await subagent({
+  description,      // full autonomous task prompt
+  subagent_type,    // configured subagent name
+  response_schema,  // optional JSON Schema for structured output
+}); // -> Promise<unknown>
+```
+
+`subagent` runs a full agentic loop for the selected configured subagent. The
+subagent can use whatever tools it was configured with, iterate, inspect
+context, and return one final result. `subagent_type` is required; use one of
+the configured subagent names.
+
+`description` is the only prompt the subagent receives for this dispatch. Make
+it complete: include the goal, constraints, relevant context, what to inspect,
+and the exact shape or level of detail you expect back. Each dispatch is
+stateless from the caller's perspective; you cannot send follow-up messages to
+the same subagent run.
+
+`response_schema` is optional. When provided, the resolved value is already a
+typed JavaScript value matching the schema. Do not call `JSON.parse` unless the
+subagent intentionally returned a JSON string. Dynamic schemas work for
+declarative subagents; runnable-backed subagents reject dynamic schemas because
+their runnable is already compiled.
+
+#### Approval model
+
+`subagent` dispatches from inside the already-running `eval` call. It
+does not route through the parent agent's `ToolNode`-managed `task` tool and
+does not trigger parent-level `interrupt_on` / HITL approval for each dispatch.
+Declarative subagents still honor approval middleware configured inside their
+own spec. If you need approval before launching a subagent from the parent, use
+the normal `task` tool outside JavaScript or ensure the `eval` call
+itself is approval-gated.
+
+#### Mental model
+
+Hold your work in JS: an array of items in, an array of results out. Merge each
+dispatch result back onto its item. Multi-stage analysis means: run a pass,
+filter or regroup the array in JS, then run another pass over the survivors.
+
+Prefer one `eval` call that performs the whole workflow. Splitting the
+workflow across multiple `eval` calls costs model turns and forces you to
+re-establish state.
+
+#### Fan out with bounded concurrency
+
+Dispatch independent work in parallel with `Promise.all`, but in explicit
+batches around 10 so you do not launch hundreds of subagents at once. The bridge
+enforces a hard per-REPL cap of 32 concurrent subagent calls.
+
+```javascript
+const batchSize = 10;
+const reviewed = [];
+for (let i = 0; i < items.length; i += batchSize) {
+  const batch = items.slice(i, i + batchSize);
+  reviewed.push(...(await Promise.all(batch.map(async (it) => {
+    const result = await subagent({
+      description: "Review " + it.file + " for SQL injection. Cite line numbers.",
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: {
+          vulnerabilities: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                type: { type: "string" },
+                line: { type: "number" },
+                evidence: { type: "string" },
+              },
+              required: ["type", "line", "evidence"],
+            },
+          },
+        },
+        required: ["vulnerabilities"],
+      },
+    });
+    return { ...it, ...result };
+  }))));
+}
+```
+
+#### Use parent JS for cheap work; use subagents for agentic work
+
+Use JavaScript in the parent REPL for deterministic orchestration: joining
+arrays, deduping, sorting, filtering, grouping, batching, and merging results.
+If the `tools.*` namespace is exposed, also use it to pre-read files or collect
+shared data once, then pass only the relevant content to each subagent in
+`description`.
+
+Use `subagent` for work that benefits from an autonomous agentic loop: reading
+or searching with the subagent's own tools, inspecting multiple files, following
+leads, making judgment calls, or producing a final synthesized report.
+
+#### Pre-read shared context in the parent when useful
+
+If many subagents need the same source list or file content and `tools.*` is
+available, gather that context once in the parent REPL before dispatching:
+
+```javascript
+const files = (await tools.glob({ pattern: "src/**/*.ts" }))
+  .split("\n")
+  .filter(Boolean);
+
+const items = await Promise.all(files.map(async (file) => {
+  const content = await tools.readFile({ file_path: file });
+  return { file, content };
+}));
+
+const batchSize = 10;
+const results = [];
+for (let i = 0; i < items.length; i += batchSize) {
+  const batch = items.slice(i, i + batchSize);
+  results.push(...(await Promise.all(batch.map(async (it) => {
+    const finding = await subagent({
+      description:
+        "Review this file for auth bypasses. Return concrete findings only.\n\n" +
+        "File: " + it.file + "\n\n" +
+        it.content,
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: {
+          findings: { type: "array", items: { type: "object" } },
+        },
+        required: ["findings"],
+      },
+    });
+    return { ...it, ...finding };
+  }))));
+}
+```
+
+#### Compose multiple stages
+
+Filter the array in JS between passes. For example: first ask subagents for a
+cheap classification, filter to the risky items, then dispatch deeper reviews
+only for those items.
+
+```javascript
+const tagged = [];
+for (let i = 0; i < items.length; i += 10) {
+  const batch = items.slice(i, i + 10);
+  tagged.push(...(await Promise.all(batch.map(async (it) => {
+    const tag = await subagent({
+      description: "Classify " + it.file + " as handler, util, test, or config.",
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: { kind: { type: "string" }, risky: { type: "boolean" } },
+        required: ["kind", "risky"],
+      },
+    });
+    return { ...it, ...tag };
+  }))));
+}
+
+const riskyHandlers = tagged.filter((it) => it.kind === "handler" && it.risky);
+const deepReviews = [];
+for (let i = 0; i < riskyHandlers.length; i += 10) {
+  const batch = riskyHandlers.slice(i, i + 10);
+  deepReviews.push(...(await Promise.all(batch.map(async (it) => {
+    const review = await subagent({
+      description: "Deep security review of " + it.file + ". Cite line numbers.",
+      subagent_type: "reviewer",
+    });
+    return { ...it, review };
+  }))));
+}
+```
+
+#### Get results out without flooding your context
+
+Keep large result sets in JS variables. Do not `console.log` the full result set.
+If `tools.writeFile` is exposed, persist structured output from inside the eval:
+
+```javascript
+await tools.writeFile({
+  file_path: "/results/subagent-output.json",
+  content: JSON.stringify(deepReviews),
+});
+```
+
+Otherwise return a compact summary or a small slice of the results, not the
+entire intermediate dataset.
+
+#### Across evals
+
+Variables persist according to the interpreter persistence mode above, but
+re-establish what you need in each eval. Doing the whole workflow in one
+`eval` call is usually simplest.

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools.md
@@ -128,23 +128,23 @@ An `eval` tool is available. It runs JavaScript in a persistent REPL.
 - Timeout: 5.0s per call. Memory: 64 MB total.
 - `console.log` output is captured and returned alongside the result.
 
-### Dispatching Subagents with `subagent`
+### Dispatching Subagents with `task`
 
-`subagent` is your primitive for running configured subagents from inside the
+`task` is your primitive for running configured subagents from inside the
 JavaScript REPL. You orchestrate everything else - fan-out, filtering,
 deduplication, multi-stage flow, and synthesis - in plain JavaScript.
 
 #### The primitive
 
 ```javascript
-await subagent({
+await task({
   description,      // full autonomous task prompt
   subagent_type,    // configured subagent name
   response_schema,  // optional JSON Schema for structured output
 }); // -> Promise<unknown>
 ```
 
-`subagent` runs a full agentic loop for the selected configured subagent. The
+`task` runs a full agentic loop for the selected configured subagent. The
 subagent can use whatever tools it was configured with, iterate, inspect
 context, and return one final result. `subagent_type` is required; use one of
 the configured subagent names.
@@ -163,7 +163,7 @@ their runnable is already compiled.
 
 #### Approval model
 
-`subagent` dispatches from inside the already-running `eval` call. It
+`task` dispatches from inside the already-running `eval` call. It
 does not route through the parent agent's `ToolNode`-managed `task` tool and
 does not trigger parent-level `interrupt_on` / HITL approval for each dispatch.
 Declarative subagents still honor approval middleware configured inside their
@@ -185,7 +185,7 @@ re-establish state.
 
 Dispatch independent work in parallel with `Promise.all`, but in explicit
 batches around 10 so you do not launch hundreds of subagents at once. The bridge
-enforces a hard per-REPL cap of 32 concurrent subagent calls.
+enforces a hard per-REPL cap of 32 concurrent `task` calls.
 
 ```javascript
 const batchSize = 10;
@@ -193,7 +193,7 @@ const reviewed = [];
 for (let i = 0; i < items.length; i += batchSize) {
   const batch = items.slice(i, i + batchSize);
   reviewed.push(...(await Promise.all(batch.map(async (it) => {
-    const result = await subagent({
+    const result = await task({
       description: "Review " + it.file + " for SQL injection. Cite line numbers.",
       subagent_type: "reviewer",
       response_schema: {
@@ -228,7 +228,7 @@ If the `tools.*` namespace is exposed, also use it to pre-read files or collect
 shared data once, then pass only the relevant content to each subagent in
 `description`.
 
-Use `subagent` for work that benefits from an autonomous agentic loop: reading
+Use `task` for work that benefits from an autonomous agentic loop: reading
 or searching with the subagent's own tools, inspecting multiple files, following
 leads, making judgment calls, or producing a final synthesized report.
 
@@ -252,7 +252,7 @@ const results = [];
 for (let i = 0; i < items.length; i += batchSize) {
   const batch = items.slice(i, i + batchSize);
   results.push(...(await Promise.all(batch.map(async (it) => {
-    const finding = await subagent({
+    const finding = await task({
       description:
         "Review this file for auth bypasses. Return concrete findings only.\n\n" +
         "File: " + it.file + "\n\n" +
@@ -282,7 +282,7 @@ const tagged = [];
 for (let i = 0; i < items.length; i += 10) {
   const batch = items.slice(i, i + 10);
   tagged.push(...(await Promise.all(batch.map(async (it) => {
-    const tag = await subagent({
+    const tag = await task({
       description: "Classify " + it.file + " as handler, util, test, or config.",
       subagent_type: "reviewer",
       response_schema: {
@@ -300,7 +300,7 @@ const deepReviews = [];
 for (let i = 0; i < riskyHandlers.length; i += 10) {
   const batch = riskyHandlers.slice(i, i + 10);
   deepReviews.push(...(await Promise.all(batch.map(async (it) => {
-    const review = await subagent({
+    const review = await task({
       description: "Deep security review of " + it.file + ". Cite line numbers.",
       subagent_type: "reviewer",
     });

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools_call.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools_call.md
@@ -127,3 +127,205 @@ An `eval` tool is available. It runs JavaScript in a fresh sandboxed REPL for ea
 - Runtime sandbox: no built-in filesystem, network, stdlib, or wall-clock APIs (`fetch`, `require`, `fs`, `process`, real `Date.now()` are unavailable or stubbed). External side effects from inside the REPL are only reachable via the `tools.*` namespace when it is exposed (see below); without it, the REPL is pure computation.
 - Timeout: 5.0s per call. Memory: 64 MB total.
 - `console.log` output is captured and returned alongside the result.
+
+### Dispatching Subagents with `subagent`
+
+`subagent` is your primitive for running configured subagents from inside the
+JavaScript REPL. You orchestrate everything else - fan-out, filtering,
+deduplication, multi-stage flow, and synthesis - in plain JavaScript.
+
+#### The primitive
+
+```javascript
+await subagent({
+  description,      // full autonomous task prompt
+  subagent_type,    // configured subagent name
+  response_schema,  // optional JSON Schema for structured output
+}); // -> Promise<unknown>
+```
+
+`subagent` runs a full agentic loop for the selected configured subagent. The
+subagent can use whatever tools it was configured with, iterate, inspect
+context, and return one final result. `subagent_type` is required; use one of
+the configured subagent names.
+
+`description` is the only prompt the subagent receives for this dispatch. Make
+it complete: include the goal, constraints, relevant context, what to inspect,
+and the exact shape or level of detail you expect back. Each dispatch is
+stateless from the caller's perspective; you cannot send follow-up messages to
+the same subagent run.
+
+`response_schema` is optional. When provided, the resolved value is already a
+typed JavaScript value matching the schema. Do not call `JSON.parse` unless the
+subagent intentionally returned a JSON string. Dynamic schemas work for
+declarative subagents; runnable-backed subagents reject dynamic schemas because
+their runnable is already compiled.
+
+#### Approval model
+
+`subagent` dispatches from inside the already-running `eval` call. It
+does not route through the parent agent's `ToolNode`-managed `task` tool and
+does not trigger parent-level `interrupt_on` / HITL approval for each dispatch.
+Declarative subagents still honor approval middleware configured inside their
+own spec. If you need approval before launching a subagent from the parent, use
+the normal `task` tool outside JavaScript or ensure the `eval` call
+itself is approval-gated.
+
+#### Mental model
+
+Hold your work in JS: an array of items in, an array of results out. Merge each
+dispatch result back onto its item. Multi-stage analysis means: run a pass,
+filter or regroup the array in JS, then run another pass over the survivors.
+
+Prefer one `eval` call that performs the whole workflow. Splitting the
+workflow across multiple `eval` calls costs model turns and forces you to
+re-establish state.
+
+#### Fan out with bounded concurrency
+
+Dispatch independent work in parallel with `Promise.all`, but in explicit
+batches around 10 so you do not launch hundreds of subagents at once. The bridge
+enforces a hard per-REPL cap of 32 concurrent subagent calls.
+
+```javascript
+const batchSize = 10;
+const reviewed = [];
+for (let i = 0; i < items.length; i += batchSize) {
+  const batch = items.slice(i, i + batchSize);
+  reviewed.push(...(await Promise.all(batch.map(async (it) => {
+    const result = await subagent({
+      description: "Review " + it.file + " for SQL injection. Cite line numbers.",
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: {
+          vulnerabilities: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                type: { type: "string" },
+                line: { type: "number" },
+                evidence: { type: "string" },
+              },
+              required: ["type", "line", "evidence"],
+            },
+          },
+        },
+        required: ["vulnerabilities"],
+      },
+    });
+    return { ...it, ...result };
+  }))));
+}
+```
+
+#### Use parent JS for cheap work; use subagents for agentic work
+
+Use JavaScript in the parent REPL for deterministic orchestration: joining
+arrays, deduping, sorting, filtering, grouping, batching, and merging results.
+If the `tools.*` namespace is exposed, also use it to pre-read files or collect
+shared data once, then pass only the relevant content to each subagent in
+`description`.
+
+Use `subagent` for work that benefits from an autonomous agentic loop: reading
+or searching with the subagent's own tools, inspecting multiple files, following
+leads, making judgment calls, or producing a final synthesized report.
+
+#### Pre-read shared context in the parent when useful
+
+If many subagents need the same source list or file content and `tools.*` is
+available, gather that context once in the parent REPL before dispatching:
+
+```javascript
+const files = (await tools.glob({ pattern: "src/**/*.ts" }))
+  .split("\n")
+  .filter(Boolean);
+
+const items = await Promise.all(files.map(async (file) => {
+  const content = await tools.readFile({ file_path: file });
+  return { file, content };
+}));
+
+const batchSize = 10;
+const results = [];
+for (let i = 0; i < items.length; i += batchSize) {
+  const batch = items.slice(i, i + batchSize);
+  results.push(...(await Promise.all(batch.map(async (it) => {
+    const finding = await subagent({
+      description:
+        "Review this file for auth bypasses. Return concrete findings only.\n\n" +
+        "File: " + it.file + "\n\n" +
+        it.content,
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: {
+          findings: { type: "array", items: { type: "object" } },
+        },
+        required: ["findings"],
+      },
+    });
+    return { ...it, ...finding };
+  }))));
+}
+```
+
+#### Compose multiple stages
+
+Filter the array in JS between passes. For example: first ask subagents for a
+cheap classification, filter to the risky items, then dispatch deeper reviews
+only for those items.
+
+```javascript
+const tagged = [];
+for (let i = 0; i < items.length; i += 10) {
+  const batch = items.slice(i, i + 10);
+  tagged.push(...(await Promise.all(batch.map(async (it) => {
+    const tag = await subagent({
+      description: "Classify " + it.file + " as handler, util, test, or config.",
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: { kind: { type: "string" }, risky: { type: "boolean" } },
+        required: ["kind", "risky"],
+      },
+    });
+    return { ...it, ...tag };
+  }))));
+}
+
+const riskyHandlers = tagged.filter((it) => it.kind === "handler" && it.risky);
+const deepReviews = [];
+for (let i = 0; i < riskyHandlers.length; i += 10) {
+  const batch = riskyHandlers.slice(i, i + 10);
+  deepReviews.push(...(await Promise.all(batch.map(async (it) => {
+    const review = await subagent({
+      description: "Deep security review of " + it.file + ". Cite line numbers.",
+      subagent_type: "reviewer",
+    });
+    return { ...it, review };
+  }))));
+}
+```
+
+#### Get results out without flooding your context
+
+Keep large result sets in JS variables. Do not `console.log` the full result set.
+If `tools.writeFile` is exposed, persist structured output from inside the eval:
+
+```javascript
+await tools.writeFile({
+  file_path: "/results/subagent-output.json",
+  content: JSON.stringify(deepReviews),
+});
+```
+
+Otherwise return a compact summary or a small slice of the results, not the
+entire intermediate dataset.
+
+#### Across evals
+
+Variables persist according to the interpreter persistence mode above, but
+re-establish what you need in each eval. Doing the whole workflow in one
+`eval` call is usually simplest.

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools_call.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools_call.md
@@ -128,23 +128,23 @@ An `eval` tool is available. It runs JavaScript in a fresh sandboxed REPL for ea
 - Timeout: 5.0s per call. Memory: 64 MB total.
 - `console.log` output is captured and returned alongside the result.
 
-### Dispatching Subagents with `subagent`
+### Dispatching Subagents with `task`
 
-`subagent` is your primitive for running configured subagents from inside the
+`task` is your primitive for running configured subagents from inside the
 JavaScript REPL. You orchestrate everything else - fan-out, filtering,
 deduplication, multi-stage flow, and synthesis - in plain JavaScript.
 
 #### The primitive
 
 ```javascript
-await subagent({
+await task({
   description,      // full autonomous task prompt
   subagent_type,    // configured subagent name
   response_schema,  // optional JSON Schema for structured output
 }); // -> Promise<unknown>
 ```
 
-`subagent` runs a full agentic loop for the selected configured subagent. The
+`task` runs a full agentic loop for the selected configured subagent. The
 subagent can use whatever tools it was configured with, iterate, inspect
 context, and return one final result. `subagent_type` is required; use one of
 the configured subagent names.
@@ -163,7 +163,7 @@ their runnable is already compiled.
 
 #### Approval model
 
-`subagent` dispatches from inside the already-running `eval` call. It
+`task` dispatches from inside the already-running `eval` call. It
 does not route through the parent agent's `ToolNode`-managed `task` tool and
 does not trigger parent-level `interrupt_on` / HITL approval for each dispatch.
 Declarative subagents still honor approval middleware configured inside their
@@ -185,7 +185,7 @@ re-establish state.
 
 Dispatch independent work in parallel with `Promise.all`, but in explicit
 batches around 10 so you do not launch hundreds of subagents at once. The bridge
-enforces a hard per-REPL cap of 32 concurrent subagent calls.
+enforces a hard per-REPL cap of 32 concurrent `task` calls.
 
 ```javascript
 const batchSize = 10;
@@ -193,7 +193,7 @@ const reviewed = [];
 for (let i = 0; i < items.length; i += batchSize) {
   const batch = items.slice(i, i + batchSize);
   reviewed.push(...(await Promise.all(batch.map(async (it) => {
-    const result = await subagent({
+    const result = await task({
       description: "Review " + it.file + " for SQL injection. Cite line numbers.",
       subagent_type: "reviewer",
       response_schema: {
@@ -228,7 +228,7 @@ If the `tools.*` namespace is exposed, also use it to pre-read files or collect
 shared data once, then pass only the relevant content to each subagent in
 `description`.
 
-Use `subagent` for work that benefits from an autonomous agentic loop: reading
+Use `task` for work that benefits from an autonomous agentic loop: reading
 or searching with the subagent's own tools, inspecting multiple files, following
 leads, making judgment calls, or producing a final synthesized report.
 
@@ -252,7 +252,7 @@ const results = [];
 for (let i = 0; i < items.length; i += batchSize) {
   const batch = items.slice(i, i + batchSize);
   results.push(...(await Promise.all(batch.map(async (it) => {
-    const finding = await subagent({
+    const finding = await task({
       description:
         "Review this file for auth bypasses. Return concrete findings only.\n\n" +
         "File: " + it.file + "\n\n" +
@@ -282,7 +282,7 @@ const tagged = [];
 for (let i = 0; i < items.length; i += 10) {
   const batch = items.slice(i, i + 10);
   tagged.push(...(await Promise.all(batch.map(async (it) => {
-    const tag = await subagent({
+    const tag = await task({
       description: "Classify " + it.file + " as handler, util, test, or config.",
       subagent_type: "reviewer",
       response_schema: {
@@ -300,7 +300,7 @@ const deepReviews = [];
 for (let i = 0; i < riskyHandlers.length; i += 10) {
   const batch = riskyHandlers.slice(i, i + 10);
   deepReviews.push(...(await Promise.all(batch.map(async (it) => {
-    const review = await subagent({
+    const review = await task({
       description: "Deep security review of " + it.file + ". Cite line numbers.",
       subagent_type: "reviewer",
     });

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools_turn.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools_turn.md
@@ -127,3 +127,205 @@ An `eval` tool is available. It runs JavaScript in a persistent REPL.
 - Runtime sandbox: no built-in filesystem, network, stdlib, or wall-clock APIs (`fetch`, `require`, `fs`, `process`, real `Date.now()` are unavailable or stubbed). External side effects from inside the REPL are only reachable via the `tools.*` namespace when it is exposed (see below); without it, the REPL is pure computation.
 - Timeout: 5.0s per call. Memory: 64 MB total.
 - `console.log` output is captured and returned alongside the result.
+
+### Dispatching Subagents with `subagent`
+
+`subagent` is your primitive for running configured subagents from inside the
+JavaScript REPL. You orchestrate everything else - fan-out, filtering,
+deduplication, multi-stage flow, and synthesis - in plain JavaScript.
+
+#### The primitive
+
+```javascript
+await subagent({
+  description,      // full autonomous task prompt
+  subagent_type,    // configured subagent name
+  response_schema,  // optional JSON Schema for structured output
+}); // -> Promise<unknown>
+```
+
+`subagent` runs a full agentic loop for the selected configured subagent. The
+subagent can use whatever tools it was configured with, iterate, inspect
+context, and return one final result. `subagent_type` is required; use one of
+the configured subagent names.
+
+`description` is the only prompt the subagent receives for this dispatch. Make
+it complete: include the goal, constraints, relevant context, what to inspect,
+and the exact shape or level of detail you expect back. Each dispatch is
+stateless from the caller's perspective; you cannot send follow-up messages to
+the same subagent run.
+
+`response_schema` is optional. When provided, the resolved value is already a
+typed JavaScript value matching the schema. Do not call `JSON.parse` unless the
+subagent intentionally returned a JSON string. Dynamic schemas work for
+declarative subagents; runnable-backed subagents reject dynamic schemas because
+their runnable is already compiled.
+
+#### Approval model
+
+`subagent` dispatches from inside the already-running `eval` call. It
+does not route through the parent agent's `ToolNode`-managed `task` tool and
+does not trigger parent-level `interrupt_on` / HITL approval for each dispatch.
+Declarative subagents still honor approval middleware configured inside their
+own spec. If you need approval before launching a subagent from the parent, use
+the normal `task` tool outside JavaScript or ensure the `eval` call
+itself is approval-gated.
+
+#### Mental model
+
+Hold your work in JS: an array of items in, an array of results out. Merge each
+dispatch result back onto its item. Multi-stage analysis means: run a pass,
+filter or regroup the array in JS, then run another pass over the survivors.
+
+Prefer one `eval` call that performs the whole workflow. Splitting the
+workflow across multiple `eval` calls costs model turns and forces you to
+re-establish state.
+
+#### Fan out with bounded concurrency
+
+Dispatch independent work in parallel with `Promise.all`, but in explicit
+batches around 10 so you do not launch hundreds of subagents at once. The bridge
+enforces a hard per-REPL cap of 32 concurrent subagent calls.
+
+```javascript
+const batchSize = 10;
+const reviewed = [];
+for (let i = 0; i < items.length; i += batchSize) {
+  const batch = items.slice(i, i + batchSize);
+  reviewed.push(...(await Promise.all(batch.map(async (it) => {
+    const result = await subagent({
+      description: "Review " + it.file + " for SQL injection. Cite line numbers.",
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: {
+          vulnerabilities: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                type: { type: "string" },
+                line: { type: "number" },
+                evidence: { type: "string" },
+              },
+              required: ["type", "line", "evidence"],
+            },
+          },
+        },
+        required: ["vulnerabilities"],
+      },
+    });
+    return { ...it, ...result };
+  }))));
+}
+```
+
+#### Use parent JS for cheap work; use subagents for agentic work
+
+Use JavaScript in the parent REPL for deterministic orchestration: joining
+arrays, deduping, sorting, filtering, grouping, batching, and merging results.
+If the `tools.*` namespace is exposed, also use it to pre-read files or collect
+shared data once, then pass only the relevant content to each subagent in
+`description`.
+
+Use `subagent` for work that benefits from an autonomous agentic loop: reading
+or searching with the subagent's own tools, inspecting multiple files, following
+leads, making judgment calls, or producing a final synthesized report.
+
+#### Pre-read shared context in the parent when useful
+
+If many subagents need the same source list or file content and `tools.*` is
+available, gather that context once in the parent REPL before dispatching:
+
+```javascript
+const files = (await tools.glob({ pattern: "src/**/*.ts" }))
+  .split("\n")
+  .filter(Boolean);
+
+const items = await Promise.all(files.map(async (file) => {
+  const content = await tools.readFile({ file_path: file });
+  return { file, content };
+}));
+
+const batchSize = 10;
+const results = [];
+for (let i = 0; i < items.length; i += batchSize) {
+  const batch = items.slice(i, i + batchSize);
+  results.push(...(await Promise.all(batch.map(async (it) => {
+    const finding = await subagent({
+      description:
+        "Review this file for auth bypasses. Return concrete findings only.\n\n" +
+        "File: " + it.file + "\n\n" +
+        it.content,
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: {
+          findings: { type: "array", items: { type: "object" } },
+        },
+        required: ["findings"],
+      },
+    });
+    return { ...it, ...finding };
+  }))));
+}
+```
+
+#### Compose multiple stages
+
+Filter the array in JS between passes. For example: first ask subagents for a
+cheap classification, filter to the risky items, then dispatch deeper reviews
+only for those items.
+
+```javascript
+const tagged = [];
+for (let i = 0; i < items.length; i += 10) {
+  const batch = items.slice(i, i + 10);
+  tagged.push(...(await Promise.all(batch.map(async (it) => {
+    const tag = await subagent({
+      description: "Classify " + it.file + " as handler, util, test, or config.",
+      subagent_type: "reviewer",
+      response_schema: {
+        type: "object",
+        properties: { kind: { type: "string" }, risky: { type: "boolean" } },
+        required: ["kind", "risky"],
+      },
+    });
+    return { ...it, ...tag };
+  }))));
+}
+
+const riskyHandlers = tagged.filter((it) => it.kind === "handler" && it.risky);
+const deepReviews = [];
+for (let i = 0; i < riskyHandlers.length; i += 10) {
+  const batch = riskyHandlers.slice(i, i + 10);
+  deepReviews.push(...(await Promise.all(batch.map(async (it) => {
+    const review = await subagent({
+      description: "Deep security review of " + it.file + ". Cite line numbers.",
+      subagent_type: "reviewer",
+    });
+    return { ...it, review };
+  }))));
+}
+```
+
+#### Get results out without flooding your context
+
+Keep large result sets in JS variables. Do not `console.log` the full result set.
+If `tools.writeFile` is exposed, persist structured output from inside the eval:
+
+```javascript
+await tools.writeFile({
+  file_path: "/results/subagent-output.json",
+  content: JSON.stringify(deepReviews),
+});
+```
+
+Otherwise return a compact summary or a small slice of the results, not the
+entire intermediate dataset.
+
+#### Across evals
+
+Variables persist according to the interpreter persistence mode above, but
+re-establish what you need in each eval. Doing the whole workflow in one
+`eval` call is usually simplest.

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools_turn.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools_turn.md
@@ -128,23 +128,23 @@ An `eval` tool is available. It runs JavaScript in a persistent REPL.
 - Timeout: 5.0s per call. Memory: 64 MB total.
 - `console.log` output is captured and returned alongside the result.
 
-### Dispatching Subagents with `subagent`
+### Dispatching Subagents with `task`
 
-`subagent` is your primitive for running configured subagents from inside the
+`task` is your primitive for running configured subagents from inside the
 JavaScript REPL. You orchestrate everything else - fan-out, filtering,
 deduplication, multi-stage flow, and synthesis - in plain JavaScript.
 
 #### The primitive
 
 ```javascript
-await subagent({
+await task({
   description,      // full autonomous task prompt
   subagent_type,    // configured subagent name
   response_schema,  // optional JSON Schema for structured output
 }); // -> Promise<unknown>
 ```
 
-`subagent` runs a full agentic loop for the selected configured subagent. The
+`task` runs a full agentic loop for the selected configured subagent. The
 subagent can use whatever tools it was configured with, iterate, inspect
 context, and return one final result. `subagent_type` is required; use one of
 the configured subagent names.
@@ -163,7 +163,7 @@ their runnable is already compiled.
 
 #### Approval model
 
-`subagent` dispatches from inside the already-running `eval` call. It
+`task` dispatches from inside the already-running `eval` call. It
 does not route through the parent agent's `ToolNode`-managed `task` tool and
 does not trigger parent-level `interrupt_on` / HITL approval for each dispatch.
 Declarative subagents still honor approval middleware configured inside their
@@ -185,7 +185,7 @@ re-establish state.
 
 Dispatch independent work in parallel with `Promise.all`, but in explicit
 batches around 10 so you do not launch hundreds of subagents at once. The bridge
-enforces a hard per-REPL cap of 32 concurrent subagent calls.
+enforces a hard per-REPL cap of 32 concurrent `task` calls.
 
 ```javascript
 const batchSize = 10;
@@ -193,7 +193,7 @@ const reviewed = [];
 for (let i = 0; i < items.length; i += batchSize) {
   const batch = items.slice(i, i + batchSize);
   reviewed.push(...(await Promise.all(batch.map(async (it) => {
-    const result = await subagent({
+    const result = await task({
       description: "Review " + it.file + " for SQL injection. Cite line numbers.",
       subagent_type: "reviewer",
       response_schema: {
@@ -228,7 +228,7 @@ If the `tools.*` namespace is exposed, also use it to pre-read files or collect
 shared data once, then pass only the relevant content to each subagent in
 `description`.
 
-Use `subagent` for work that benefits from an autonomous agentic loop: reading
+Use `task` for work that benefits from an autonomous agentic loop: reading
 or searching with the subagent's own tools, inspecting multiple files, following
 leads, making judgment calls, or producing a final synthesized report.
 
@@ -252,7 +252,7 @@ const results = [];
 for (let i = 0; i < items.length; i += batchSize) {
   const batch = items.slice(i, i + batchSize);
   results.push(...(await Promise.all(batch.map(async (it) => {
-    const finding = await subagent({
+    const finding = await task({
       description:
         "Review this file for auth bypasses. Return concrete findings only.\n\n" +
         "File: " + it.file + "\n\n" +
@@ -282,7 +282,7 @@ const tagged = [];
 for (let i = 0; i < items.length; i += 10) {
   const batch = items.slice(i, i + 10);
   tagged.push(...(await Promise.all(batch.map(async (it) => {
-    const tag = await subagent({
+    const tag = await task({
       description: "Classify " + it.file + " as handler, util, test, or config.",
       subagent_type: "reviewer",
       response_schema: {
@@ -300,7 +300,7 @@ const deepReviews = [];
 for (let i = 0; i < riskyHandlers.length; i += 10) {
   const batch = riskyHandlers.slice(i, i + 10);
   deepReviews.push(...(await Promise.all(batch.map(async (it) => {
-    const review = await subagent({
+    const review = await task({
       description: "Deep security review of " + it.file + ". Cite line numbers.",
       subagent_type: "reviewer",
     });

--- a/libs/partners/quickjs/tests/unit_tests/test_prompt_modes.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_prompt_modes.py
@@ -40,6 +40,7 @@ def test_render_repl_system_prompt_mode_specific(
     )
     assert expected_fragment in prompt
     assert "Timeout: 5.0s per call. Memory: 64 MB total." in prompt
+    assert "### Dispatching Subagents with `subagent`" not in prompt
 
 
 @pytest.mark.parametrize(

--- a/libs/partners/quickjs/tests/unit_tests/test_prompt_modes.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_prompt_modes.py
@@ -40,7 +40,7 @@ def test_render_repl_system_prompt_mode_specific(
     )
     assert expected_fragment in prompt
     assert "Timeout: 5.0s per call. Memory: 64 MB total." in prompt
-    assert "### Dispatching Subagents with `subagent`" not in prompt
+    assert "### Dispatching Subagents with `task`" not in prompt
 
 
 @pytest.mark.parametrize(

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -181,7 +181,7 @@ def test_system_prompt_injected_once() -> None:
     assert "7.0s per call" in sys_text
     assert "32 MB total" in sys_text
     assert "across multiple turns for this conversation thread" in sys_text
-    assert "### Dispatching Subagents with `subagent`" not in sys_text
+    assert "### Dispatching Subagents with `task`" not in sys_text
 
 
 def test_system_prompt_includes_subagent_guidance_when_specs_configured() -> None:
@@ -220,8 +220,8 @@ def test_system_prompt_includes_subagent_guidance_when_specs_configured() -> Non
         for block in seen[0].system_message.content_blocks
         if block["type"] == "text"
     )
-    assert "### Dispatching Subagents with `subagent`" in sys_text
-    assert "await subagent({" in sys_text
+    assert "### Dispatching Subagents with `task`" in sys_text
+    assert "await task({" in sys_text
 
 
 def test_system_prompt_omits_subagent_guidance_when_disabled() -> None:
@@ -260,8 +260,8 @@ def test_system_prompt_omits_subagent_guidance_when_disabled() -> None:
         for block in seen[0].system_message.content_blocks
         if block["type"] == "text"
     )
-    assert "### Dispatching Subagents with `subagent`" not in sys_text
-    assert "await subagent({" not in sys_text
+    assert "### Dispatching Subagents with `task`" not in sys_text
+    assert "await task({" not in sys_text
 
 
 def test_system_prompt_mentions_single_turn_when_snapshots_disabled() -> None:
@@ -1103,14 +1103,14 @@ async def test_eval_tool_does_not_install_subagent_when_disabled() -> None:
             )
         )
 
-        result = await tool.coroutine(runtime=runtime, code="typeof subagent")
+        result = await tool.coroutine(runtime=runtime, code="typeof task")
 
         assert "<result>undefined</result>" in result.content
     finally:
         mw._registry.close()
 
 
-async def test_async_subagent_global_invokes_runner(repl: _ThreadREPL) -> None:
+async def test_async_task_global_invokes_runner(repl: _ThreadREPL) -> None:
     calls: list[dict[str, Any]] = []
 
     def _sync(state: dict[str, Any], config: Any) -> dict[str, Any]:
@@ -1124,13 +1124,13 @@ async def test_async_subagent_global_invokes_runner(repl: _ThreadREPL) -> None:
     runnable = RunnableLambda(_sync, afunc=_async)
 
     outcome = await repl.eval_async(
-        "globalThis.subagent = null;"
-        "delete globalThis.subagent;"
-        "subagent.extra = 1;"
-        "if (!Object.isFrozen(subagent) || subagent.extra !== undefined) {"
-        "  throw new Error('subagent binding is mutable');"
+        "globalThis.task = null;"
+        "delete globalThis.task;"
+        "task.extra = 1;"
+        "if (!Object.isFrozen(task) || task.extra !== undefined) {"
+        "  throw new Error('task binding is mutable');"
         "}"
-        "JSON.stringify(await subagent({"
+        "JSON.stringify(await task({"
         "description: 'work', "
         "subagent_type: 'worker'"
         "}))",
@@ -1144,7 +1144,7 @@ async def test_async_subagent_global_invokes_runner(repl: _ThreadREPL) -> None:
     assert calls[0]["config"]["configurable"]["ls_agent_type"] == "subagent"
 
 
-async def test_async_subagent_global_not_installed_when_disabled(
+async def test_async_task_global_not_installed_when_disabled(
     worker: ThreadWorker,
     runtime: Runtime,
 ) -> None:
@@ -1157,7 +1157,7 @@ async def test_async_subagent_global_not_installed_when_disabled(
         subagents_enabled=False,
     )
 
-    outcome = await disabled.eval_async("typeof subagent")
+    outcome = await disabled.eval_async("typeof task")
 
     assert outcome.error_type is None
     assert outcome.result == "undefined"
@@ -1167,24 +1167,24 @@ async def test_async_subagent_global_not_installed_when_disabled(
     ("code", "message"),
     [
         (
-            "await subagent({subagent_type: 'worker'})",
-            "subagent() requires non-empty string field `description`",
+            "await task({subagent_type: 'worker'})",
+            "task() requires non-empty string field `description`",
         ),
         (
-            "await subagent({description: 'work'})",
-            "subagent() requires non-empty string field `subagent_type`",
+            "await task({description: 'work'})",
+            "task() requires non-empty string field `subagent_type`",
         ),
         (
-            "await subagent({"
+            "await task({"
             "description: 'work', "
             "subagent_type: 'worker', "
             "response_schema: 'bad'"
             "})",
-            "subagent() field `response_schema` must be an object when provided",
+            "task() field `response_schema` must be an object when provided",
         ),
     ],
 )
-async def test_async_subagent_global_validation_errors_surface_as_eval_errors(
+async def test_async_task_global_validation_errors_surface_as_eval_errors(
     repl: _ThreadREPL, code: str, message: str
 ) -> None:
     runnable = RunnableLambda(
@@ -1200,7 +1200,7 @@ async def test_async_subagent_global_validation_errors_surface_as_eval_errors(
     assert message in formatted
 
 
-async def test_async_subagent_global_missing_task_tool_surfaces_as_eval_error(
+async def test_async_task_global_missing_task_tool_surfaces_as_eval_error(
     repl: _ThreadREPL,
 ) -> None:
     runtime = ToolRuntime(
@@ -1214,15 +1214,15 @@ async def test_async_subagent_global_missing_task_tool_surfaces_as_eval_error(
     )
 
     outcome = await repl.eval_async(
-        "await subagent({description: 'work', subagent_type: 'worker'})",
+        "await task({description: 'work', subagent_type: 'worker'})",
         outer_runtime=runtime,
     )
 
     assert outcome.error_type == "RuntimeError"
-    assert "subagent task tool not configured for this eval" in outcome.error_message
+    assert "task tool not configured for this eval" in outcome.error_message
 
 
-async def test_async_subagent_global_returns_declarative_structured_response_object(
+async def test_async_task_global_returns_declarative_structured_response_object(
     repl: _ThreadREPL,
 ) -> None:
     outcome = await repl.eval_async(
@@ -1231,12 +1231,12 @@ async def test_async_subagent_global_returns_declarative_structured_response_obj
         "properties: {label: {type: 'string'}, score: {type: 'number'}}, "
         "required: ['label', 'score']"
         "};"
-        "const first = await subagent({"
+        "const first = await task({"
         "description: 'work', "
         "subagent_type: 'worker', "
         "response_schema: schema"
         "});"
-        "const second = await subagent({"
+        "const second = await task({"
         "description: 'work again', "
         "subagent_type: 'worker', "
         "response_schema: schema"
@@ -1256,7 +1256,7 @@ async def test_async_subagent_global_returns_declarative_structured_response_obj
     )
 
 
-async def test_async_subagent_global_rejects_compiled_response_schema(
+async def test_async_task_global_rejects_compiled_response_schema(
     repl: _ThreadREPL,
 ) -> None:
     runnable = RunnableLambda(
@@ -1264,7 +1264,7 @@ async def test_async_subagent_global_rejects_compiled_response_schema(
     )
 
     outcome = await repl.eval_async(
-        "await subagent({"
+        "await task({"
         "description: 'work', "
         "subagent_type: 'worker', "
         "response_schema: {"
@@ -1283,7 +1283,7 @@ async def test_async_subagent_global_rejects_compiled_response_schema(
     )
 
 
-async def test_async_subagent_global_uses_last_non_empty_ai_message(
+async def test_async_task_global_uses_last_non_empty_ai_message(
     repl: _ThreadREPL,
 ) -> None:
     async def _async(state: dict[str, Any], config: Any) -> dict[str, Any]:
@@ -1296,10 +1296,7 @@ async def test_async_subagent_global_uses_last_non_empty_ai_message(
     )
 
     outcome = await repl.eval_async(
-        "JSON.stringify(await subagent({"
-        "description: 'work', "
-        "subagent_type: 'worker'"
-        "}))",
+        "JSON.stringify(await task({description: 'work', subagent_type: 'worker'}))",
         outer_runtime=_subagent_runtime(runnable),
     )
 
@@ -1307,7 +1304,7 @@ async def test_async_subagent_global_uses_last_non_empty_ai_message(
     assert outcome.result == '"final"'
 
 
-async def test_async_subagent_global_rejects_state_without_messages(
+async def test_async_task_global_rejects_state_without_messages(
     repl: _ThreadREPL,
 ) -> None:
     async def _async(state: dict[str, Any], config: Any) -> dict[str, Any]:
@@ -1320,7 +1317,7 @@ async def test_async_subagent_global_rejects_state_without_messages(
     )
 
     outcome = await repl.eval_async(
-        "await subagent({description: 'work', subagent_type: 'worker'})",
+        "await task({description: 'work', subagent_type: 'worker'})",
         outer_runtime=_subagent_runtime(runnable),
     )
 
@@ -1328,7 +1325,7 @@ async def test_async_subagent_global_rejects_state_without_messages(
     assert "messages" in outcome.error_message
 
 
-async def test_async_subagent_global_limits_concurrency_per_repl(
+async def test_async_task_global_limits_concurrency_per_repl(
     repl: _ThreadREPL,
 ) -> None:
     class _CountingRunner:
@@ -1372,7 +1369,7 @@ async def test_async_subagent_global_limits_concurrency_per_repl(
     outcome = await repl.eval_async(
         "const calls = [];"
         "for (let i = 0; i < 64; i++) {"
-        "  calls.push(subagent({description: String(i), subagent_type: 'worker'}));"
+        "  calls.push(task({description: String(i), subagent_type: 'worker'}));"
         "}"
         "(await Promise.all(calls)).length",
         outer_runtime=_subagent_runtime(runnable),

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -3,21 +3,37 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+import threading
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from deepagents.backends.state import StateBackend
+from deepagents.middleware.subagents import (
+    SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY,
+    SubAgentMiddleware,
+    _build_task_tool,
+)
 from langchain.agents import create_agent
 from langchain.agents.middleware.types import ModelRequest
+from langchain.agents.structured_output import AutoStrategy
 from langchain.tools import ToolRuntime
-from langchain_core.messages import SystemMessage
-from langchain_core.tools import StructuredTool
-from pydantic import BaseModel
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, SystemMessage
+from langchain_core.runnables import RunnableLambda
+from langchain_core.tools import BaseTool, StructuredTool
+from pydantic import BaseModel, Field
 from quickjs_rs import Runtime, ThreadWorker
 
 from langchain_quickjs import CodeInterpreterMiddleware
 from langchain_quickjs._format import format_outcome
 from langchain_quickjs._repl import _clear_exception_references, _Registry, _ThreadREPL
+from langchain_quickjs._subagent import _runtime_with_response_format
+
+if TYPE_CHECKING:
+    from langchain_core.callbacks import CallbackManagerForLLMRun
+    from langchain_core.messages import BaseMessage
+    from langchain_core.outputs import ChatResult
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -165,6 +181,87 @@ def test_system_prompt_injected_once() -> None:
     assert "7.0s per call" in sys_text
     assert "32 MB total" in sys_text
     assert "across multiple turns for this conversation thread" in sys_text
+    assert "### Dispatching Subagents with `subagent`" not in sys_text
+
+
+def test_system_prompt_includes_subagent_guidance_when_specs_configured() -> None:
+    mw = CodeInterpreterMiddleware()
+    seen: list[ModelRequest] = []
+
+    def handler(req: ModelRequest):
+        seen.append(req)
+        from langchain.agents.middleware.types import ModelResponse
+        from langchain_core.messages import AIMessage
+
+        return ModelResponse(result=[AIMessage(content="ok")])
+
+    req = MagicMock(spec=ModelRequest)
+    req.system_message = SystemMessage(content="base")
+    req.tools = [
+        _task_tool_for_runnable(
+            RunnableLambda(
+                lambda _state, _config: {"messages": [AIMessage(content="ok")]}
+            )
+        )
+    ]
+
+    def _override(**kwargs):
+        new = MagicMock(spec=ModelRequest)
+        new.system_message = kwargs.get("system_message", req.system_message)
+        return new
+
+    req.override = _override
+
+    mw.wrap_model_call(req, handler)
+
+    assert len(seen) == 1
+    sys_text = "\n".join(
+        block["text"]
+        for block in seen[0].system_message.content_blocks
+        if block["type"] == "text"
+    )
+    assert "### Dispatching Subagents with `subagent`" in sys_text
+    assert "await subagent({" in sys_text
+
+
+def test_system_prompt_omits_subagent_guidance_when_disabled() -> None:
+    mw = CodeInterpreterMiddleware(subagents=False)
+    seen: list[ModelRequest] = []
+
+    def handler(req: ModelRequest):
+        seen.append(req)
+        from langchain.agents.middleware.types import ModelResponse
+        from langchain_core.messages import AIMessage
+
+        return ModelResponse(result=[AIMessage(content="ok")])
+
+    req = MagicMock(spec=ModelRequest)
+    req.system_message = SystemMessage(content="base")
+    req.tools = [
+        _task_tool_for_runnable(
+            RunnableLambda(
+                lambda _state, _config: {"messages": [AIMessage(content="ok")]}
+            )
+        )
+    ]
+
+    def _override(**kwargs):
+        new = MagicMock(spec=ModelRequest)
+        new.system_message = kwargs.get("system_message", req.system_message)
+        return new
+
+    req.override = _override
+
+    mw.wrap_model_call(req, handler)
+
+    assert len(seen) == 1
+    sys_text = "\n".join(
+        block["text"]
+        for block in seen[0].system_message.content_blocks
+        if block["type"] == "text"
+    )
+    assert "### Dispatching Subagents with `subagent`" not in sys_text
+    assert "await subagent({" not in sys_text
 
 
 def test_system_prompt_mentions_single_turn_when_snapshots_disabled() -> None:
@@ -880,6 +977,411 @@ async def test_async_top_level_await(repl: _ThreadREPL) -> None:
     outcome = await repl.eval_async("await new Promise(resolve => resolve(42))")
     assert outcome.error_type is None
     assert outcome.result == "42"
+
+
+def _task_tool_for_runnable(
+    runnable: Any,
+) -> BaseTool:
+    spec: dict[str, Any] = {
+        "name": "worker",
+        "description": "Does work.",
+        "runnable": runnable,
+    }
+    return _build_task_tool([spec])
+
+
+def _subagent_runtime_from_task_tool(task_tool: BaseTool) -> ToolRuntime:
+    return ToolRuntime(
+        state={},
+        context={},
+        config={"configurable": {}},
+        stream_writer=lambda _chunk: None,
+        tools=[task_tool],
+        tool_call_id="outer_eval_call",
+        store=None,
+    )
+
+
+def _subagent_runtime(
+    runnable: Any,
+) -> ToolRuntime:
+    return _subagent_runtime_from_task_tool(_task_tool_for_runnable(runnable))
+
+
+def test_runtime_with_response_format_uses_configurable() -> None:
+    runtime = _subagent_runtime(
+        RunnableLambda(lambda _state, _config: {"messages": [AIMessage(content="ok")]})
+    )
+    schema = {
+        "type": "object",
+        "properties": {"label": {"type": "string"}},
+        "required": ["label"],
+    }
+
+    updated = _runtime_with_response_format(runtime, schema)
+
+    assert updated.context is runtime.context
+    assert SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY not in runtime.config["configurable"]
+    strategy = updated.config["configurable"][SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY]
+    assert isinstance(strategy, AutoStrategy)
+    assert strategy.schema == schema
+
+
+class _StructuredSubagentModel(GenericFakeChatModel):
+    """Fake subagent model that calls the currently bound response-format tool."""
+
+    messages: Any = Field(exclude=True)
+    tools: Any = ()
+
+    def bind_tools(
+        self,
+        tools: Any,
+        **_: Any,
+    ) -> _StructuredSubagentModel:
+        self.tools = tools
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        tool_name = getattr(self.tools[-1], "name", None)
+        if not isinstance(tool_name, str):
+            msg = "Expected a response-format tool to be bound"
+            raise TypeError(msg)
+        self.messages = iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": tool_name,
+                            "args": {"label": "positive", "score": 0.95},
+                            "id": "call_structured",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        )
+        return super()._generate(
+            messages,
+            stop=stop,
+            run_manager=run_manager,
+            **kwargs,
+        )
+
+
+def _declarative_subagent_runtime() -> ToolRuntime:
+    middleware = SubAgentMiddleware(
+        backend=StateBackend(),
+        subagents=[
+            {
+                "name": "worker",
+                "description": "Does work.",
+                "system_prompt": "Return structured data.",
+                "model": _StructuredSubagentModel(messages=iter(())),
+                "tools": [],
+            }
+        ],
+        system_prompt=None,
+    )
+    return _subagent_runtime_from_task_tool(middleware.tools[0])
+
+
+async def test_eval_tool_does_not_install_subagent_when_disabled() -> None:
+    mw = CodeInterpreterMiddleware(subagents=False)
+    try:
+        tool = mw.tools[0]
+        assert tool.coroutine is not None
+        runtime = _subagent_runtime(
+            RunnableLambda(
+                lambda _state, _config: {"messages": [AIMessage(content="ok")]}
+            )
+        )
+
+        result = await tool.coroutine(runtime=runtime, code="typeof subagent")
+
+        assert "<result>undefined</result>" in result.content
+    finally:
+        mw._registry.close()
+
+
+async def test_async_subagent_global_invokes_runner(repl: _ThreadREPL) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def _sync(state: dict[str, Any], config: Any) -> dict[str, Any]:
+        del state, config
+        return {"messages": [AIMessage(content="sync")]}
+
+    async def _async(state: dict[str, Any], config: Any) -> dict[str, Any]:
+        calls.append({"state": state, "config": config})
+        return {"messages": [AIMessage(content="ok")]}
+
+    runnable = RunnableLambda(_sync, afunc=_async)
+
+    outcome = await repl.eval_async(
+        "globalThis.subagent = null;"
+        "delete globalThis.subagent;"
+        "subagent.extra = 1;"
+        "if (!Object.isFrozen(subagent) || subagent.extra !== undefined) {"
+        "  throw new Error('subagent binding is mutable');"
+        "}"
+        "JSON.stringify(await subagent({"
+        "description: 'work', "
+        "subagent_type: 'worker'"
+        "}))",
+        outer_runtime=_subagent_runtime(runnable),
+    )
+
+    assert outcome.error_type is None
+    assert outcome.result == '"ok"'
+    assert calls
+    assert calls[0]["state"]["messages"][0].content == "work"
+    assert calls[0]["config"]["configurable"]["ls_agent_type"] == "subagent"
+
+
+async def test_async_subagent_global_not_installed_when_disabled(
+    worker: ThreadWorker,
+    runtime: Runtime,
+) -> None:
+    disabled = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+        subagents_enabled=False,
+    )
+
+    outcome = await disabled.eval_async("typeof subagent")
+
+    assert outcome.error_type is None
+    assert outcome.result == "undefined"
+
+
+@pytest.mark.parametrize(
+    ("code", "message"),
+    [
+        (
+            "await subagent({subagent_type: 'worker'})",
+            "subagent() requires non-empty string field `description`",
+        ),
+        (
+            "await subagent({description: 'work'})",
+            "subagent() requires non-empty string field `subagent_type`",
+        ),
+        (
+            "await subagent({"
+            "description: 'work', "
+            "subagent_type: 'worker', "
+            "response_schema: 'bad'"
+            "})",
+            "subagent() field `response_schema` must be an object when provided",
+        ),
+    ],
+)
+async def test_async_subagent_global_validation_errors_surface_as_eval_errors(
+    repl: _ThreadREPL, code: str, message: str
+) -> None:
+    runnable = RunnableLambda(
+        lambda state, config: {"messages": [AIMessage(content="sync")]},
+    )
+
+    outcome = await repl.eval_async(code, outer_runtime=_subagent_runtime(runnable))
+
+    assert outcome.error_type == "ValueError"
+    assert message in outcome.error_message
+    formatted = format_outcome(outcome, max_result_chars=1000)
+    assert '<error type="ValueError">' in formatted
+    assert message in formatted
+
+
+async def test_async_subagent_global_missing_task_tool_surfaces_as_eval_error(
+    repl: _ThreadREPL,
+) -> None:
+    runtime = ToolRuntime(
+        state={},
+        context={},
+        config={"configurable": {}},
+        stream_writer=lambda _chunk: None,
+        tools=[],
+        tool_call_id="outer_eval_call",
+        store=None,
+    )
+
+    outcome = await repl.eval_async(
+        "await subagent({description: 'work', subagent_type: 'worker'})",
+        outer_runtime=runtime,
+    )
+
+    assert outcome.error_type == "RuntimeError"
+    assert "subagent task tool not configured for this eval" in outcome.error_message
+
+
+async def test_async_subagent_global_returns_declarative_structured_response_object(
+    repl: _ThreadREPL,
+) -> None:
+    outcome = await repl.eval_async(
+        "const schema = {"
+        "type: 'object', "
+        "properties: {label: {type: 'string'}, score: {type: 'number'}}, "
+        "required: ['label', 'score']"
+        "};"
+        "const first = await subagent({"
+        "description: 'work', "
+        "subagent_type: 'worker', "
+        "response_schema: schema"
+        "});"
+        "const second = await subagent({"
+        "description: 'work again', "
+        "subagent_type: 'worker', "
+        "response_schema: schema"
+        "});"
+        "JSON.stringify({"
+        "label: first.label, "
+        "score: first.score, "
+        "type: typeof first, "
+        "secondLabel: second.label"
+        "})",
+        outer_runtime=_declarative_subagent_runtime(),
+    )
+
+    assert outcome.error_type is None
+    assert outcome.result == (
+        '{"label":"positive","score":0.95,"type":"object","secondLabel":"positive"}'
+    )
+
+
+async def test_async_subagent_global_rejects_compiled_response_schema(
+    repl: _ThreadREPL,
+) -> None:
+    runnable = RunnableLambda(
+        lambda state, config: {"messages": [AIMessage(content="sync")]},
+    )
+
+    outcome = await repl.eval_async(
+        "await subagent({"
+        "description: 'work', "
+        "subagent_type: 'worker', "
+        "response_schema: {"
+        "type: 'object', "
+        "properties: {ok: {type: 'boolean'}}, "
+        "required: ['ok']"
+        "}"
+        "})",
+        outer_runtime=_subagent_runtime(runnable),
+    )
+
+    assert outcome.error_type == "ValueError"
+    assert (
+        'response_schema cannot be used with compiled subagent "worker"'
+        in outcome.error_message
+    )
+
+
+async def test_async_subagent_global_uses_last_non_empty_ai_message(
+    repl: _ThreadREPL,
+) -> None:
+    async def _async(state: dict[str, Any], config: Any) -> dict[str, Any]:
+        del state, config
+        return {"messages": [AIMessage(content="final"), AIMessage(content="")]}
+
+    runnable = RunnableLambda(
+        lambda state, config: {"messages": [AIMessage(content="sync")]},
+        afunc=_async,
+    )
+
+    outcome = await repl.eval_async(
+        "JSON.stringify(await subagent({"
+        "description: 'work', "
+        "subagent_type: 'worker'"
+        "}))",
+        outer_runtime=_subagent_runtime(runnable),
+    )
+
+    assert outcome.error_type is None
+    assert outcome.result == '"final"'
+
+
+async def test_async_subagent_global_rejects_state_without_messages(
+    repl: _ThreadREPL,
+) -> None:
+    async def _async(state: dict[str, Any], config: Any) -> dict[str, Any]:
+        del state, config
+        return {"structured_response": {"ok": True}}
+
+    runnable = RunnableLambda(
+        lambda state, config: {"messages": [AIMessage(content="sync")]},
+        afunc=_async,
+    )
+
+    outcome = await repl.eval_async(
+        "await subagent({description: 'work', subagent_type: 'worker'})",
+        outer_runtime=_subagent_runtime(runnable),
+    )
+
+    assert outcome.error_type == "ValueError"
+    assert "messages" in outcome.error_message
+
+
+async def test_async_subagent_global_limits_concurrency_per_repl(
+    repl: _ThreadREPL,
+) -> None:
+    class _CountingRunner:
+        def __init__(self) -> None:
+            self.active = 0
+            self.max_active = 0
+            self.lock = threading.Lock()
+
+        async def ainvoke(
+            self,
+            *,
+            description: str,
+            subagent_type: str,
+            response_schema: dict[str, Any] | None = None,
+            runtime: ToolRuntime | None = None,
+        ) -> str:
+            del subagent_type, response_schema, runtime
+            with self.lock:
+                self.active += 1
+                self.max_active = max(self.max_active, self.active)
+            await asyncio.sleep(0.01)
+            with self.lock:
+                self.active -= 1
+            return description
+
+    runner = _CountingRunner()
+
+    async def _counting_async(state: dict[str, Any], config: Any) -> dict[str, Any]:
+        del config
+        content = await runner.ainvoke(
+            description=state["messages"][0].content,
+            subagent_type="worker",
+        )
+        return {"messages": [AIMessage(content=content)]}
+
+    runnable = RunnableLambda(
+        lambda state, config: {"messages": [AIMessage(content="sync")]},
+        afunc=_counting_async,
+    )
+
+    outcome = await repl.eval_async(
+        "const calls = [];"
+        "for (let i = 0; i < 64; i++) {"
+        "  calls.push(subagent({description: String(i), subagent_type: 'worker'}));"
+        "}"
+        "(await Promise.all(calls)).length",
+        outer_runtime=_subagent_runtime(runnable),
+    )
+
+    assert outcome.error_type is None
+    assert outcome.result == "64"
+    assert runner.max_active <= 32
+    assert runner.max_active > 1
 
 
 async def test_async_promise_chain(repl: _ThreadREPL) -> None:

--- a/libs/partners/quickjs/tests/unit_tests/test_thread_affinity.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_thread_affinity.py
@@ -160,8 +160,8 @@ async def test_quickjs_async_ptc_task_subagent_loop_affinity_e2e() -> None:
     assert all(loop_id == outer_loop_id for loop_id in subagent_loop_ids)
 
 
-async def test_quickjs_subagent_global_available_without_ptc_e2e() -> None:
-    """E2E: top-level `subagent()` works without exposing PTC tools."""
+async def test_quickjs_task_global_available_without_ptc_e2e() -> None:
+    """E2E: top-level `task()` works without exposing PTC tools."""
 
     def _subagent_sync(state: dict[str, Any], config: Any) -> dict[str, Any]:
         del state, config
@@ -175,7 +175,7 @@ async def test_quickjs_subagent_global_available_without_ptc_e2e() -> None:
     agent = create_deep_agent(
         model=_FakeChatModel(
             messages=_script(
-                "await subagent({description: 'say hi', subagent_type: 'researcher'})",
+                "await task({description: 'say hi', subagent_type: 'researcher'})",
                 final_message="done",
             )
         ),
@@ -194,12 +194,10 @@ async def test_quickjs_subagent_global_available_without_ptc_e2e() -> None:
     result = await agent.ainvoke(
         {
             "messages": [
-                HumanMessage(
-                    content="Use eval and call the researcher through subagent."
-                )
+                HumanMessage(content="Use eval and call the researcher through task.")
             ]
         },
-        config={"configurable": {"thread_id": "subagent-global-no-ptc"}},
+        config={"configurable": {"thread_id": "task-global-no-ptc"}},
     )
     tool_message = _eval_tool_message(result)
     _assert_result_contains(tool_message.content, "subagent-ok")

--- a/libs/partners/quickjs/tests/unit_tests/test_thread_affinity.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_thread_affinity.py
@@ -158,3 +158,48 @@ async def test_quickjs_async_ptc_task_subagent_loop_affinity_e2e() -> None:
     _assert_result_contains(tool_message.content, "subagent-ok")
     assert subagent_loop_ids
     assert all(loop_id == outer_loop_id for loop_id in subagent_loop_ids)
+
+
+async def test_quickjs_subagent_global_available_without_ptc_e2e() -> None:
+    """E2E: top-level `subagent()` works without exposing PTC tools."""
+
+    def _subagent_sync(state: dict[str, Any], config: Any) -> dict[str, Any]:
+        del state, config
+        return {"messages": [AIMessage(content="subagent-ok")]}
+
+    async def _subagent_async(state: dict[str, Any], config: Any) -> dict[str, Any]:
+        del state, config
+        return {"messages": [AIMessage(content="subagent-ok")]}
+
+    subagent_runnable = RunnableLambda(_subagent_sync, afunc=_subagent_async)
+    agent = create_deep_agent(
+        model=_FakeChatModel(
+            messages=_script(
+                "await subagent({description: 'say hi', subagent_type: 'researcher'})",
+                final_message="done",
+            )
+        ),
+        subagents=[
+            {
+                "name": "researcher",
+                "description": "returns one short answer",
+                "runnable": subagent_runnable,
+            }
+        ],
+        middleware=[
+            CodeInterpreterMiddleware(),
+        ],
+    )
+
+    result = await agent.ainvoke(
+        {
+            "messages": [
+                HumanMessage(
+                    content="Use eval and call the researcher through subagent."
+                )
+            ]
+        },
+        config={"configurable": {"thread_id": "subagent-global-no-ptc"}},
+    )
+    tool_message = _eval_tool_message(result)
+    _assert_result_contains(tool_message.content, "subagent-ok")


### PR DESCRIPTION
Adds a default QuickJS `subagent()` global backed by the subagents configured on `create_deep_agent`. The bridge recreates subagents inside the REPL from a private configurable payload, keeps subagent spec handling out of middleware dispatcher state, and preserves private-state filtering when invoking child agents.

Changes:

- Expose `create_sub_agent` as the shared helper for compiling declarative subagent specs, so the task tool path and QuickJS bridge use the same construction path.
- Expose normalized subagent specs from `SubAgentMiddleware` through `RunnableConfig.configurable` when constructing a deep agent.
- Add a per-REPL `SubagentRunner` that resolves configured subagents, prepares child state, invokes the runnable on the parent LangGraph loop when available, and normalizes structured responses for JavaScript.
- Install `subagent` as a frozen top-level QuickJS binding with a per-REPL concurrency cap of 32 calls.
- Support dynamic response schemas for declarative subagent specs and reject dynamic schemas for runnable-backed subagents.
- Add a dedicated `subagent` prompt carve-out adapted from the previous `swarmTask` guidance, covering the top-level API, structured return semantics, explicit batched fan-out, parent-side pre-reading, multi-stage array workflows, context-safe result handling, and across-eval behavior.
- Keep QuickJS middleware focused on REPL/PTC setup rather than middleware-side subagent dispatcher maps or prompt-time spec plumbing.
- Add unit and end-to-end coverage for `subagent()` invocation, structured output, malformed subagent states, last-message fallback behavior, concurrency limits, prompt guidance, and availability without PTC.
