### PR TITLE
feat(sdk): delete dir support in delete tool

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -543,7 +543,7 @@ class CompositeBackend(BackendProtocol):
         """Delete a file, routing to the appropriate backend.
 
         `CompositeBackend` always advertises delete support (it overrides this
-        method), so the `delete_file` tool is never filtered out for it. A
+        method), so the `delete` tool is never filtered out for it. A
         route may still point at a backend that does not implement `delete`;
         rather than letting `NotImplementedError` escape to the caller, that
         case is converted into a `DeleteResult` error.

--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -30,6 +30,7 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.utils import (
     create_file_data,
+    expand_delete_keys,
     perform_string_replacement,
     slice_read_response,
 )
@@ -210,13 +211,25 @@ class ContextHubBackend(BackendProtocol):
         return EditResult(path=file_path, occurrences=occurrences)
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file by committing its removal from the hub repo."""
+        """Delete a file or directory by committing its removal from the hub repo.
+
+        Deleting a path removes the exact file plus every nested entry under it
+        (the prefix `file_path` + "/"), so a directory is removed recursively.
+
+        Args:
+            file_path: Path of the file or directory to delete.
+
+        Returns:
+            `DeleteResult` with `file_path` on success, or an error if nothing is
+                stored at or under it (or the hub is unavailable).
+        """
         hub_path = self._strip_prefix(file_path)
         try:
             cache = self._ensure_cache()
-            if hub_path not in cache:
+            to_delete = expand_delete_keys(cache, hub_path)
+            if not to_delete:
                 return DeleteResult(error=f"Error: File '{file_path}' not found")
-            self._commit({hub_path: None})
+            self._commit(dict.fromkeys(to_delete, None))
         except LangSmithError as exc:
             logger.exception("Hub delete failed for %r", self._identifier)
             self._cache = None

--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -30,7 +30,6 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.utils import (
     create_file_data,
-    expand_delete_keys,
     perform_string_replacement,
     slice_read_response,
 )
@@ -226,7 +225,9 @@ class ContextHubBackend(BackendProtocol):
         hub_path = self._strip_prefix(file_path)
         try:
             cache = self._ensure_cache()
-            to_delete = expand_delete_keys(cache, hub_path)
+            base = hub_path.rstrip("/")
+            prefix = base + "/"
+            to_delete = [key for key in cache if key == base or key.startswith(prefix)]
             if not to_delete:
                 return DeleteResult(error=f"Error: File '{file_path}' not found")
             self._commit(dict.fromkeys(to_delete, None))

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -569,9 +569,6 @@ class FilesystemBackend(BackendProtocol):
         try:
             if not resolved_path.exists() and not resolved_path.is_symlink():
                 return DeleteResult(error=f"Error: '{file_path}' not found")
-            # Check is_symlink() before is_dir(): is_dir() follows symlinks, so a
-            # symlink pointing at a directory would otherwise be recursed into and
-            # delete the target's contents. Removing the link itself is correct.
             if resolved_path.is_symlink():
                 resolved_path.unlink()
             elif resolved_path.is_dir():

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -546,29 +546,41 @@ class FilesystemBackend(BackendProtocol):
             return EditResult(error=f"Error editing file '{file_path}': {e}")
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file from the filesystem.
+        """Delete a file or directory from the filesystem.
+
+        Files are unlinked. Directories are removed recursively along with all
+        of their contents. Symlinks are removed as links and never followed into
+        their target (so deleting a symlink to a directory removes only the link).
 
         Args:
-            file_path: Path to the file to delete.
+            file_path: Path to the file or directory to delete.
 
         Returns:
             `DeleteResult` with the deleted path on success, or an error if the
-                file does not exist, is a directory, or removal fails.
+                path does not exist or removal fails. A recursive directory
+                removal may delete some entries before failing partway (for
+                example when a nested entry is not writable).
         """
         try:
             resolved_path = self._resolve_path(file_path)
         except (OSError, RuntimeError) as e:
-            return DeleteResult(error=f"Error deleting file '{file_path}': {e}")
+            return DeleteResult(error=f"Error deleting '{file_path}': {e}")
 
         try:
-            if resolved_path.is_dir():
-                return DeleteResult(error=f"Error: '{file_path}' is a directory, not a file")
             if not resolved_path.exists() and not resolved_path.is_symlink():
-                return DeleteResult(error=f"Error: File '{file_path}' not found")
-            resolved_path.unlink()
+                return DeleteResult(error=f"Error: '{file_path}' not found")
+            # Check is_symlink() before is_dir(): is_dir() follows symlinks, so a
+            # symlink pointing at a directory would otherwise be recursed into and
+            # delete the target's contents. Removing the link itself is correct.
+            if resolved_path.is_symlink():
+                resolved_path.unlink()
+            elif resolved_path.is_dir():
+                shutil.rmtree(resolved_path)
+            else:
+                resolved_path.unlink()
             return DeleteResult(path=file_path)
         except (OSError, RuntimeError) as e:
-            return DeleteResult(error=f"Error deleting file '{file_path}': {e}")
+            return DeleteResult(error=f"Error deleting '{file_path}': {e}")
 
     def grep(
         self,

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -617,7 +617,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         return await asyncio.to_thread(self.edit, file_path, old_string, new_string, replace_all)
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a single file from the filesystem.
+        """Delete a file (or directory) from the filesystem.
 
         This method is optional. Backends that do not implement it inherit this
         default, which raises `NotImplementedError`. Callers that need to support
@@ -625,16 +625,19 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         [`supports_delete`][deepagents.backends.protocol.supports_delete] before
         calling, or catch `NotImplementedError`.
 
-        Directories are not supported. Directory-based backends return an error for
-        directory paths; key-value backends treat `file_path` as an exact key.
+        Directory handling is backend-dependent. Directory-based backends such as
+        [`FilesystemBackend`][deepagents.backends.filesystem.FilesystemBackend]
+        remove a directory recursively along with all of its contents; other
+        backends may return an error for directory paths. Key-value backends
+        treat `file_path` as an exact key.
 
         Args:
-            file_path: Absolute path to the file to delete. Must start with '/'
-                and refer to a file, not a directory.
+            file_path: Absolute path to the file or directory to delete. Must
+                start with '/'.
 
         Returns:
             `DeleteResult` with the deleted path on success, or an error if the
-                file does not exist or `file_path` refers to a directory.
+                path does not exist or removal fails.
 
         Raises:
             NotImplementedError: If the backend does not implement `delete`.

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -617,7 +617,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         return await asyncio.to_thread(self.edit, file_path, old_string, new_string, replace_all)
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file (or directory) from the filesystem.
+        """Delete a path, recursively removing anything nested under it.
 
         This method is optional. Backends that do not implement it inherit this
         default, which raises `NotImplementedError`. Callers that need to support
@@ -625,19 +625,19 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         [`supports_delete`][deepagents.backends.protocol.supports_delete] before
         calling, or catch `NotImplementedError`.
 
-        Directory handling is backend-dependent. Directory-based backends such as
-        [`FilesystemBackend`][deepagents.backends.filesystem.FilesystemBackend]
-        remove a directory recursively along with all of its contents; other
-        backends may return an error for directory paths. Key-value backends
-        treat `file_path` as an exact key.
+        Deletion is recursive: it removes `file_path` plus everything nested
+        under it. On hierarchical backends (e.g.
+        [`FilesystemBackend`][deepagents.backends.filesystem.FilesystemBackend])
+        that means a directory and its contents; on key-value backends it means
+        the exact key plus every key sharing the `file_path` + "/" prefix.
 
         Args:
-            file_path: Absolute path to the file or directory to delete. Must
-                start with '/'.
+            file_path: Absolute path to delete (a file, or a directory/prefix to
+                remove recursively). Must start with '/'.
 
         Returns:
-            `DeleteResult` with the deleted path on success, or an error if the
-                path does not exist or removal fails.
+            `DeleteResult` with the deleted path on success, or an error if
+                nothing exists at or under the path or removal fails.
 
         Raises:
             NotImplementedError: If the backend does not implement `delete`.

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -758,14 +758,14 @@ except PermissionError:
         return EditResult(error=messages.get(error, f"Error editing file '{file_path}': {error}"))
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file from the sandbox via a server-side ``rm``.
+        """Delete a file or directory from the sandbox via a server-side ``rm``.
 
-        Uses ``rm -f``, so deleting a path that does not exist succeeds
-        silently; a non-zero exit (e.g. the path is a directory, or a
-        permission error) is reported as a failure.
+        Uses ``rm -rf``, so directories are removed recursively along with their
+        contents, and deleting a path that does not exist succeeds silently. A
+        non-zero exit (e.g. a permission error) is reported as a failure.
 
         Args:
-            file_path: Absolute path to the file to delete.
+            file_path: Absolute path to the file or directory to delete.
 
         Returns:
             `DeleteResult` with the deleted path on success, or an error if the
@@ -776,7 +776,7 @@ except PermissionError:
         # boundary: it does not confine the deletion to any sandbox root or
         # block traversal. Whatever the sandbox shell can reach, this can delete.
         quoted = shlex.quote(file_path)
-        result = self.execute(f"rm -f {quoted}")
+        result = self.execute(f"rm -rf {quoted}")
 
         if result.exit_code == 0:
             return DeleteResult(path=file_path)

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -28,6 +28,7 @@ from deepagents.backends.utils import (
     _glob_search_files,
     _to_legacy_file_data,
     create_file_data,
+    expand_delete_keys,
     file_data_to_string,
     grep_matches_from_files,
     perform_string_replacement,
@@ -292,17 +293,27 @@ class StateBackend(BackendProtocol):
         return EditResult(path=file_path, occurrences=int(occurrences))
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file from state.
+        """Delete a file or directory from state.
 
-        The deletion is queued via `CONFIG_KEY_SEND` as a ``None`` value, which
-        the `files` channel reducer interprets as a deletion marker.
+        Deleting a path removes the exact file at `file_path` plus every nested
+        key under it (the prefix `file_path` + "/"), so a directory is removed
+        recursively. Each removal is queued via `CONFIG_KEY_SEND` as a ``None``
+        value, which the `files` channel reducer interprets as a deletion marker.
+
+        Args:
+            file_path: Path of the file or directory to delete.
+
+        Returns:
+            `DeleteResult` with `file_path` on success, or an error if nothing is
+                stored at or under it.
         """
         files = self._read_files()
 
-        if file_path not in files:
+        to_delete = expand_delete_keys(files, file_path)
+        if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
-        self._send_files_update({file_path: None})
+        self._send_files_update(dict.fromkeys(to_delete, None))
         return DeleteResult(path=file_path)
 
     def grep(

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -28,7 +28,6 @@ from deepagents.backends.utils import (
     _glob_search_files,
     _to_legacy_file_data,
     create_file_data,
-    expand_delete_keys,
     file_data_to_string,
     grep_matches_from_files,
     perform_string_replacement,
@@ -309,7 +308,9 @@ class StateBackend(BackendProtocol):
         """
         files = self._read_files()
 
-        to_delete = expand_delete_keys(files, file_path)
+        base = file_path.rstrip("/")
+        prefix = base + "/"
+        to_delete = [key for key in files if key == base or key.startswith(prefix)]
         if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Generic, cast
 
 from langgraph.config import get_config, get_store
 from langgraph.runtime import get_runtime
-from langgraph.store.base import BaseStore, Item
+from langgraph.store.base import BaseStore, Item, PutOp
 from langgraph.typing import ContextT, StateT
 
 from deepagents._api.deprecation import deprecated, warn_deprecated
@@ -736,8 +736,7 @@ class StoreBackend(BackendProtocol):
         if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
-        for key in to_delete:
-            store.delete(namespace, key)
+        store.batch([PutOp(namespace, key, None) for key in to_delete])
         return DeleteResult(path=file_path)
 
     async def adelete(self, file_path: str) -> DeleteResult:
@@ -750,8 +749,7 @@ class StoreBackend(BackendProtocol):
         if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
-        for key in to_delete:
-            await store.adelete(namespace, key)
+        await store.abatch([PutOp(namespace, key, None) for key in to_delete])
         return DeleteResult(path=file_path)
 
     # Removed legacy grep() convenience to keep lean surface

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -32,7 +32,6 @@ from deepagents.backends.utils import (
     _glob_search_files,
     _to_legacy_file_data,
     create_file_data,
-    expand_delete_keys,
     file_data_to_string,
     grep_matches_from_files,
     perform_string_replacement,
@@ -732,7 +731,10 @@ class StoreBackend(BackendProtocol):
         namespace = self._get_namespace()
 
         items = self._search_store_paginated(store, namespace)
-        to_delete = expand_delete_keys((str(item.key) for item in items), file_path)
+        # A recursive delete removes the exact key plus everything nested under it.
+        base = file_path.rstrip("/")
+        prefix = base + "/"
+        to_delete = [key for item in items if (key := str(item.key)) == base or key.startswith(prefix)]
         if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
@@ -745,7 +747,9 @@ class StoreBackend(BackendProtocol):
         namespace = self._get_namespace()
 
         items = await self._asearch_store_paginated(store, namespace)
-        to_delete = expand_delete_keys((str(item.key) for item in items), file_path)
+        base = file_path.rstrip("/")
+        prefix = base + "/"
+        to_delete = [key for item in items if (key := str(item.key)) == base or key.startswith(prefix)]
         if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -32,6 +32,7 @@ from deepagents.backends.utils import (
     _glob_search_files,
     _to_legacy_file_data,
     create_file_data,
+    expand_delete_keys,
     file_data_to_string,
     grep_matches_from_files,
     perform_string_replacement,
@@ -419,6 +420,35 @@ class StoreBackend(BackendProtocol):
 
         return all_items
 
+    async def _asearch_store_paginated(
+        self,
+        store: BaseStore,
+        namespace: tuple[str, ...],
+        *,
+        query: str | None = None,
+        filter: dict[str, Any] | None = None,  # noqa: A002  # Matches LangGraph BaseStore.asearch() API
+        page_size: int = 100,
+    ) -> list[Item]:
+        """Async version of `_search_store_paginated`."""
+        all_items: list[Item] = []
+        offset = 0
+        while True:
+            page_items = await store.asearch(
+                namespace,
+                query=query,
+                filter=filter,
+                limit=page_size,
+                offset=offset,
+            )
+            if not page_items:
+                break
+            all_items.extend(page_items)
+            if len(page_items) < page_size:
+                break
+            offset += page_size
+
+        return all_items
+
     def ls(self, path: str) -> LsResult:
         """List files and directories in the specified directory (non-recursive).
 
@@ -685,36 +715,43 @@ class StoreBackend(BackendProtocol):
         return EditResult(path=file_path, occurrences=int(occurrences))
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file from the store.
+        """Delete a file or directory from the store.
 
-        `file_path` is used as an exact store key. Wildcards (e.g. `*`) are treated
-        literally and do not expand to multiple entries.
+        Deleting a path removes the exact key `file_path` plus every key nested
+        under it (the prefix `file_path` + "/"), so a directory is removed
+        recursively. Wildcards (e.g. `*`) in `file_path` are treated literally.
 
+        Args:
+            file_path: Path of the file or directory to delete.
 
-        Returns `DeleteResult` with the deleted path on success, or an error if
-        the file does not exist.
+        Returns:
+            `DeleteResult` with `file_path` on success, or an error if no key is
+                stored at or under it.
         """
         store = self._get_store()
         namespace = self._get_namespace()
 
-        if store.get(namespace, file_path) is None:
+        items = self._search_store_paginated(store, namespace)
+        to_delete = expand_delete_keys((str(item.key) for item in items), file_path)
+        if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
-        store.delete(namespace, file_path)
+        for key in to_delete:
+            store.delete(namespace, key)
         return DeleteResult(path=file_path)
 
     async def adelete(self, file_path: str) -> DeleteResult:
-        """Async version of delete using native store async methods.
-
-        This avoids sync calls in async context by using store.aget/adelete directly.
-        """
+        """Async version of `delete` using native store async methods."""
         store = self._get_store()
         namespace = self._get_namespace()
 
-        if await store.aget(namespace, file_path) is None:
+        items = await self._asearch_store_paginated(store, namespace)
+        to_delete = expand_delete_keys((str(item.key) for item in items), file_path)
+        if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
-        await store.adelete(namespace, file_path)
+        for key in to_delete:
+            await store.adelete(namespace, key)
         return DeleteResult(path=file_path)
 
     # Removed legacy grep() convenience to keep lean surface

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -73,14 +73,11 @@ GrepMatch = _GrepMatch
 
 
 def expand_delete_keys(keys: Iterable[str], path: str) -> list[str]:
-    """Keys that a recursive delete of `path` should remove.
+    """Return all keys removed by a recursive delete of `path`.
 
-    For key-value backends a "directory" is a key prefix: deleting `path` removes
-    the exact key `path` (a file) plus every key nested under it (anything
-    starting with `path` followed by "/"). Used by the key-value backends
-    (`StateBackend`, `StoreBackend`, `ContextHubBackend`) to give `delete`
-    the same recursive semantics directory-based backends get from removing a
-    subtree.
+    Deleting `path` removes the exact key and any nested keys (those with the
+    prefix `path + "/"`). Used by key-value backends to provide the same
+    recursive delete semantics as directory-based backends.
 
     Args:
         keys: All stored keys in the namespace.

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -7,7 +7,7 @@ enable composition without fragile string parsing.
 
 import os
 import re
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal, overload
@@ -70,6 +70,28 @@ TRUNCATION_GUIDANCE = "... [results truncated, try being more specific with your
 # Re-export protocol types for backwards compatibility
 FileInfo = _FileInfo
 GrepMatch = _GrepMatch
+
+
+def expand_delete_keys(keys: Iterable[str], path: str) -> list[str]:
+    """Keys that a recursive delete of `path` should remove.
+
+    For key-value backends a "directory" is a key prefix: deleting `path` removes
+    the exact key `path` (a file) plus every key nested under it (anything
+    starting with `path` followed by "/"). Used by the key-value backends
+    (`StateBackend`, `StoreBackend`, `ContextHubBackend`) to give `delete`
+    the same recursive semantics directory-based backends get from removing a
+    subtree.
+
+    Args:
+        keys: All stored keys in the namespace.
+        path: The delete target path.
+
+    Returns:
+        The matching keys, empty if nothing is stored at or under `path`.
+    """
+    base = path.rstrip("/")
+    prefix = base + "/"
+    return [key for key in keys if key == base or key.startswith(prefix)]
 
 
 def _normalize_content(file_data: FileData) -> str:

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -7,7 +7,7 @@ enable composition without fragile string parsing.
 
 import os
 import re
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal, overload
@@ -70,25 +70,6 @@ TRUNCATION_GUIDANCE = "... [results truncated, try being more specific with your
 # Re-export protocol types for backwards compatibility
 FileInfo = _FileInfo
 GrepMatch = _GrepMatch
-
-
-def expand_delete_keys(keys: Iterable[str], path: str) -> list[str]:
-    """Return all keys removed by a recursive delete of `path`.
-
-    Deleting `path` removes the exact key and any nested keys (those with the
-    prefix `path + "/"`). Used by key-value backends to provide the same
-    recursive delete semantics as directory-based backends.
-
-    Args:
-        keys: All stored keys in the namespace.
-        path: The delete target path.
-
-    Returns:
-        The matching keys, empty if nothing is stored at or under `path`.
-    """
-    base = path.rstrip("/")
-    prefix = base + "/"
-    return [key for key in keys if key == base or key.startswith(prefix)]
 
 
 def _normalize_content(file_data: FileData) -> str:

--- a/libs/deepagents/deepagents/middleware/_fs_interrupt.py
+++ b/libs/deepagents/deepagents/middleware/_fs_interrupt.py
@@ -40,7 +40,7 @@ _FS_TOOL_PATH_ARGS: dict[str, tuple[FilesystemOperation, str, ToolScope, str | N
     "read_file": ("read", "file_path", "exact", None),
     "write_file": ("write", "file_path", "exact", None),
     "edit_file": ("write", "file_path", "exact", None),
-    "delete_file": ("write", "file_path", "bulk", None),
+    "delete": ("write", "file_path", "bulk", None),
     "glob": ("read", "path", "bulk", "pattern"),
     "grep": ("read", "path", "bulk", None),
 }

--- a/libs/deepagents/deepagents/middleware/_fs_interrupt.py
+++ b/libs/deepagents/deepagents/middleware/_fs_interrupt.py
@@ -40,6 +40,7 @@ _FS_TOOL_PATH_ARGS: dict[str, tuple[FilesystemOperation, str, ToolScope, str | N
     "read_file": ("read", "file_path", "exact", None),
     "write_file": ("write", "file_path", "exact", None),
     "edit_file": ("write", "file_path", "exact", None),
+    "delete_file": ("write", "file_path", "bulk", None),
     "glob": ("read", "path", "bulk", "pattern"),
     "grep": ("read", "path", "bulk", None),
 }

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1307,7 +1307,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         """Sync subtree deny scan: returns the first denied path, or None."""
         if not self._permissions:
             return None
-        descendants = [m["path"] for m in backend.glob("**/*", path=target).matches]
+        descendants = [m["path"] for m in (backend.glob("**/*", path=target).matches or [])]
         return self._scan_delete_for_denied_path(target, descendants)
 
     async def _adelete_denied_path(self, backend: BackendProtocol, target: str) -> str | None:
@@ -1315,7 +1315,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         if not self._permissions:
             return None
         result = await backend.aglob("**/*", path=target)
-        descendants = [m["path"] for m in result.matches]
+        descendants = [m["path"] for m in (result.matches or [])]
         return self._scan_delete_for_denied_path(target, descendants)
 
     def _create_delete_tool(self) -> BaseTool:  # Tool wiring + permission/support handling

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -81,7 +81,7 @@ _DEFAULT_FS_TOOL_OPS: dict[str, FilesystemOperation] = {
     "grep": "read",
     "write_file": "write",
     "edit_file": "write",
-    "delete_file": "write",
+    "delete": "write",
 }
 
 
@@ -361,8 +361,8 @@ class EditFileSchema(BaseModel):
     )
 
 
-class DeleteFileSchema(BaseModel):
-    """Input schema for the `delete_file` tool."""
+class DeleteSchema(BaseModel):
+    """Input schema for the `delete` tool."""
 
     file_path: str = Field(description="Absolute path to the file to delete. Must be absolute, not relative.")
 
@@ -441,7 +441,7 @@ Usage:
 - Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.
 """
 
-DELETE_FILE_TOOL_DESCRIPTION = """Deletes a file or directory from the filesystem.
+DELETE_TOOL_DESCRIPTION = """Deletes a file or directory from the filesystem.
 
 Usage:
 - Permanently removes the file or directory at the given absolute path.
@@ -521,7 +521,7 @@ _FILESYSTEM_SYSTEM_PROMPT_TEMPLATE = """## Following Conventions
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -530,7 +530,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
-- delete_file: delete a file from the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 
@@ -600,7 +600,7 @@ TOOLS_EXCLUDED_FROM_EVICTION = (
     "read_file",
     "edit_file",
     "write_file",
-    "delete_file",
+    "delete",
 )
 
 
@@ -793,7 +793,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             self._create_read_file_tool(),
             self._create_write_file_tool(),
             self._create_edit_file_tool(),
-            self._create_delete_file_tool(),
+            self._create_delete_tool(),
             self._create_glob_tool(),
             self._create_grep_tool(),
             self._create_execute_tool(),
@@ -1318,22 +1318,22 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         descendants = [m["path"] for m in result.matches]
         return self._scan_delete_for_denied_path(target, descendants)
 
-    def _create_delete_file_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
-        """Create the delete_file tool."""
-        tool_description = self._custom_tool_descriptions.get("delete_file") or DELETE_FILE_TOOL_DESCRIPTION
+    def _create_delete_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
+        """Create the delete tool."""
+        tool_description = self._custom_tool_descriptions.get("delete") or DELETE_TOOL_DESCRIPTION
 
-        def sync_delete_file(
+        def sync_delete(
             file_path: Annotated[str, "Absolute path to the file to delete. Must be absolute, not relative."],
             runtime: ToolRuntime[None, FilesystemState],
         ) -> ToolMessage:
-            """Synchronous wrapper for delete_file tool."""
+            """Synchronous wrapper for delete tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(file_path)
             except ValueError as e:
                 return ToolMessage(
                     content=f"Error: {e}",
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
@@ -1342,7 +1342,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if denied_path is not None:
                 return ToolMessage(
                     content=f"Error: permission denied for write on {denied_path}",
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
@@ -1350,29 +1350,29 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if res.error:
                 return ToolMessage(
                     content=res.error,
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
             return ToolMessage(
                 content=f"Deleted file {res.path}",
-                name="delete_file",
+                name="delete",
                 tool_call_id=runtime.tool_call_id,
                 status="success",
             )
 
-        async def async_delete_file(
+        async def async_delete(
             file_path: Annotated[str, "Absolute path to the file to delete. Must be absolute, not relative."],
             runtime: ToolRuntime[None, FilesystemState],
         ) -> ToolMessage:
-            """Asynchronous wrapper for delete_file tool."""
+            """Asynchronous wrapper for delete tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(file_path)
             except ValueError as e:
                 return ToolMessage(
                     content=f"Error: {e}",
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
@@ -1381,7 +1381,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if denied_path is not None:
                 return ToolMessage(
                     content=f"Error: permission denied for write on {denied_path}",
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
@@ -1389,24 +1389,24 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if res.error:
                 return ToolMessage(
                     content=res.error,
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
             return ToolMessage(
                 content=f"Deleted file {res.path}",
-                name="delete_file",
+                name="delete",
                 tool_call_id=runtime.tool_call_id,
                 status="success",
             )
 
         return StructuredTool.from_function(
-            name="delete_file",
+            name="delete",
             description=tool_description,
-            func=sync_delete_file,
-            coroutine=async_delete_file,
+            func=sync_delete,
+            coroutine=async_delete,
             infer_schema=False,
-            args_schema=DeleteFileSchema,
+            args_schema=DeleteSchema,
         )
 
     def _create_glob_tool(self) -> BaseTool:  # noqa: C901  # Tool wiring + permission/result shaping
@@ -1820,7 +1820,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         Shared by the sync and async `wrap_model_call` paths (the only part that
         differs between them is sync vs. async message eviction). The `execute`
-        and `delete_file` tools are optional per backend, so when the resolved
+        and `delete` tools are optional per backend, so when the resolved
         backend doesn't support a capability the corresponding tool is filtered
         out of the request rather than advertised to the model and left to fail
         at call time. Resolving the backend and probing support is synchronous,
@@ -1831,9 +1831,9 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         """
         tool_names = {(tool.name if hasattr(tool, "name") else tool.get("name")) for tool in request.tools}
         has_execute_tool = "execute" in tool_names
-        has_delete_tool = "delete_file" in tool_names
+        has_delete_tool = "delete" in tool_names
 
-        # `execute` and `delete_file` are optional per backend; resolve the
+        # `execute` and `delete` are optional per backend; resolve the
         # backend once and filter out any tool the backend can't serve.
         if has_execute_tool or has_delete_tool:
             backend = self._get_backend(request.runtime)  # ty: ignore[invalid-argument-type]
@@ -1842,7 +1842,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 unsupported.add("execute")
                 has_execute_tool = False
             if has_delete_tool and not _supports_delete(backend):
-                unsupported.add("delete_file")
+                unsupported.add("delete")
             if unsupported:
                 filtered_tools = [tool for tool in request.tools if (tool.name if hasattr(tool, "name") else tool.get("name")) not in unsupported]
                 request = request.override(tools=filtered_tools)

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -54,6 +54,8 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.utils import (
     _get_file_type,
+    _glob_anchor,
+    _paths_overlap,
     check_empty_content,
     format_content_with_line_numbers,
     format_grep_matches,
@@ -1268,55 +1270,29 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=EditFileSchema,
         )
 
-    def _scan_delete_for_denied_path(self, target: str, descendant_files: list[str]) -> str | None:
-        """All-or-nothing write-deny scan for a (possibly recursive) delete.
+    def _delete_denied_pattern(self, target: str) -> str | None:
+        """All-or-nothing write-deny check for a (possibly recursive) delete.
 
-        A recursive delete removes ``target`` plus every descendant, so each of
-        those paths must pass the ``write`` permission check. Returns the first
-        write-denied path found (so the whole delete can be refused), or ``None``
-        if the entire subtree is allowed.
+        A recursive delete of ``target`` removes ``target`` plus every descendant,
+        so the operation is refused if any ``deny`` write rule's pattern overlaps
+        that subtree. Overlap is checked against the rule pattern's literal anchor
+        (`_glob_anchor`) in either direction, so a rule scoped inside the target
+        (``/work/secrets/**``) and a rule that the target falls under
+        (``/work/**``) both block it. The check is purely rule-based — no backend
+        enumeration — and never under-refuses relative to the on-disk contents:
+        any real path a recursive delete would touch makes the target and the
+        rule anchor comparable, so the overlap fires.
 
-        ``descendant_files`` are the files ``glob('**/*')`` found under ``target``;
-        intermediate directories are derived from them so a rule that denies a
-        directory path (rather than its ``/**`` contents) is also honored. Empty
-        directories produce no glob hit and are therefore not enumerated.
+        Returns the first overlapping deny pattern (so the delete can be refused
+        with a useful message), or ``None`` if no deny rule overlaps.
         """
-        if not self._permissions:
-            return None
-        if _check_fs_permission(self._permissions, "write", target) == "deny":
-            return target
-
-        anchor = target.rstrip("/")
-        paths_to_check: set[str] = set()
-        for file_path in descendant_files:
-            paths_to_check.add(file_path)
-            parent = PurePosixPath(file_path).parent
-            while True:
-                parent_str = str(parent)
-                if parent_str == anchor or not parent_str.startswith(anchor + "/"):
-                    break
-                paths_to_check.add(parent_str)
-                parent = parent.parent
-
-        for path in sorted(paths_to_check):
-            if _check_fs_permission(self._permissions, "write", path) == "deny":
-                return path
+        for rule in self._permissions:
+            if rule.mode != "deny" or "write" not in rule.operations:
+                continue
+            for pattern in rule.paths:
+                if _paths_overlap(target, _glob_anchor(pattern)):
+                    return pattern
         return None
-
-    def _delete_denied_path(self, backend: BackendProtocol, target: str) -> str | None:
-        """Sync subtree deny scan: returns the first denied path, or None."""
-        if not self._permissions:
-            return None
-        descendants = [m["path"] for m in (backend.glob("**/*", path=target).matches or [])]
-        return self._scan_delete_for_denied_path(target, descendants)
-
-    async def _adelete_denied_path(self, backend: BackendProtocol, target: str) -> str | None:
-        """Async subtree deny scan: returns the first denied path, or None."""
-        if not self._permissions:
-            return None
-        result = await backend.aglob("**/*", path=target)
-        descendants = [m["path"] for m in (result.matches or [])]
-        return self._scan_delete_for_denied_path(target, descendants)
 
     def _create_delete_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
         """Create the delete tool."""
@@ -1338,10 +1314,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            denied_path = self._delete_denied_path(resolved_backend, validated_path)
-            if denied_path is not None:
+            denied_pattern = self._delete_denied_pattern(validated_path)
+            if denied_pattern is not None:
                 return ToolMessage(
-                    content=f"Error: permission denied for write on {denied_path}",
+                    content=f"Error: permission denied for write on {validated_path} (matches deny rule {denied_pattern})",
                     name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
@@ -1377,10 +1353,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            denied_path = await self._adelete_denied_path(resolved_backend, validated_path)
-            if denied_path is not None:
+            denied_pattern = self._delete_denied_pattern(validated_path)
+            if denied_pattern is not None:
                 return ToolMessage(
-                    content=f"Error: permission denied for write on {denied_path}",
+                    content=f"Error: permission denied for write on {validated_path} (matches deny rule {denied_pattern})",
                     name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -441,11 +441,13 @@ Usage:
 - Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.
 """
 
-DELETE_FILE_TOOL_DESCRIPTION = """Deletes a file from the filesystem.
+DELETE_FILE_TOOL_DESCRIPTION = """Deletes a file or directory from the filesystem.
 
 Usage:
-- Permanently removes the file at the given absolute path.
-- This cannot be undone, so only delete files you are sure are no longer needed.
+- Permanently removes the file or directory at the given absolute path.
+- Deleting a directory removes it and everything inside it, recursively. Prefer
+  deleting a directory in one call over deleting each file individually.
+- This cannot be undone, so only delete paths you are sure are no longer needed.
 """
 
 GLOB_TOOL_DESCRIPTION = """Find files matching a glob pattern.
@@ -1266,6 +1268,56 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=EditFileSchema,
         )
 
+    def _scan_delete_for_denied_path(self, target: str, descendant_files: list[str]) -> str | None:
+        """All-or-nothing write-deny scan for a (possibly recursive) delete.
+
+        A recursive delete removes ``target`` plus every descendant, so each of
+        those paths must pass the ``write`` permission check. Returns the first
+        write-denied path found (so the whole delete can be refused), or ``None``
+        if the entire subtree is allowed.
+
+        ``descendant_files`` are the files ``glob('**/*')`` found under ``target``;
+        intermediate directories are derived from them so a rule that denies a
+        directory path (rather than its ``/**`` contents) is also honored. Empty
+        directories produce no glob hit and are therefore not enumerated.
+        """
+        if not self._permissions:
+            return None
+        if _check_fs_permission(self._permissions, "write", target) == "deny":
+            return target
+
+        anchor = target.rstrip("/")
+        paths_to_check: set[str] = set()
+        for file_path in descendant_files:
+            paths_to_check.add(file_path)
+            parent = PurePosixPath(file_path).parent
+            while True:
+                parent_str = str(parent)
+                if parent_str == anchor or not parent_str.startswith(anchor + "/"):
+                    break
+                paths_to_check.add(parent_str)
+                parent = parent.parent
+
+        for path in sorted(paths_to_check):
+            if _check_fs_permission(self._permissions, "write", path) == "deny":
+                return path
+        return None
+
+    def _delete_denied_path(self, backend: BackendProtocol, target: str) -> str | None:
+        """Sync subtree deny scan: returns the first denied path, or None."""
+        if not self._permissions:
+            return None
+        descendants = [m["path"] for m in backend.glob("**/*", path=target).matches]
+        return self._scan_delete_for_denied_path(target, descendants)
+
+    async def _adelete_denied_path(self, backend: BackendProtocol, target: str) -> str | None:
+        """Async subtree deny scan: returns the first denied path, or None."""
+        if not self._permissions:
+            return None
+        result = await backend.aglob("**/*", path=target)
+        descendants = [m["path"] for m in result.matches]
+        return self._scan_delete_for_denied_path(target, descendants)
+
     def _create_delete_file_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
         """Create the delete_file tool."""
         tool_description = self._custom_tool_descriptions.get("delete_file") or DELETE_FILE_TOOL_DESCRIPTION
@@ -1286,9 +1338,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            if _check_fs_permission(self._permissions, "write", validated_path) == "deny":
+            denied_path = self._delete_denied_path(resolved_backend, validated_path)
+            if denied_path is not None:
                 return ToolMessage(
-                    content=f"Error: permission denied for write on {validated_path}",
+                    content=f"Error: permission denied for write on {denied_path}",
                     name="delete_file",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
@@ -1324,9 +1377,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            if _check_fs_permission(self._permissions, "write", validated_path) == "deny":
+            denied_path = await self._adelete_denied_path(resolved_backend, validated_path)
+            if denied_path is not None:
                 return ToolMessage(
-                    content=f"Error: permission denied for write on {validated_path}",
+                    content=f"Error: permission denied for write on {denied_path}",
                     name="delete_file",
                     tool_call_id=runtime.tool_call_id,
                     status="error",

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -137,6 +137,32 @@ def _check_fs_permission(
     return "allow"
 
 
+def _find_delete_deny_patterns(rules: list[FilesystemPermission], target: str) -> list[str]:
+    """Return deny-write patterns that block deleting `target`.
+
+    A recursive delete removes `target` and all descendants, so any overlapping
+    deny-write pattern prevents the operation. The check is based only on
+    permission rules and returns all matching patterns.
+
+    Args:
+        rules: Filesystem permission rules.
+        target: Absolute, validated path being deleted.
+
+    Returns:
+        Matching deny-write patterns, or an empty list if the delete is allowed.
+    """
+    denying: list[str] = []
+    seen: set[str] = set()
+    for rule in rules:
+        if rule.mode != "deny" or "write" not in rule.operations:
+            continue
+        for pattern in rule.paths:
+            if pattern not in seen and _paths_overlap(target, _glob_anchor(pattern)):
+                seen.add(pattern)
+                denying.append(pattern)
+    return denying
+
+
 def _filter_paths_by_permission(
     rules: list[FilesystemPermission],
     operation: FilesystemOperation,
@@ -1270,41 +1296,6 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=EditFileSchema,
         )
 
-    def _find_delete_deny_patterns(self, target: str, limit: int = 5) -> list[str]:
-        """All-or-nothing write-deny check for a (possibly recursive) delete.
-
-        A recursive delete of `target` removes `target` plus every descendant, so
-        the operation is refused if any `deny` write rule's pattern overlaps that
-        subtree. Overlap is checked against the rule pattern's literal anchor
-        (`_glob_anchor`) in either direction, so a rule scoped inside the target
-        (`/work/secrets/**`) and a rule that the target falls under (`/work/**`)
-        both block it. The check is purely rule-based — no backend enumeration —
-        and never under-refuses relative to the on-disk contents: any real path a
-        recursive delete would touch makes the target and the rule anchor
-        comparable, so the overlap fires.
-
-        Args:
-            target: Absolute, validated target path of the delete.
-            limit: Maximum number of overlapping patterns to collect before
-                returning, so the caller can report several conflicting rules
-                without scanning every permission once enough are found.
-
-        Returns:
-            Up to `limit` overlapping `deny` write patterns, empty if the delete
-            is permitted.
-        """
-        denying: list[str] = []
-        for rule in self._permissions:
-            if rule.mode != "deny" or "write" not in rule.operations:
-                continue
-            for pattern in rule.paths:
-                if _paths_overlap(target, _glob_anchor(pattern)):
-                    denying.append(pattern)
-                    if len(denying) >= limit:
-                        return denying
-        return denying
-        return None
-
     def _create_delete_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
         """Create the delete tool."""
         tool_description = self._custom_tool_descriptions.get("delete") or DELETE_TOOL_DESCRIPTION
@@ -1325,7 +1316,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            denying_patterns = self._find_delete_deny_patterns(validated_path)
+            denying_patterns = _find_delete_deny_patterns(self._permissions, validated_path)
             if denying_patterns:
                 return ToolMessage(
                     content=f"Error: permission denied for write on {validated_path} (matches deny rule(s): {', '.join(denying_patterns)})",
@@ -1342,7 +1333,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
             return ToolMessage(
-                content=f"Deleted file {res.path}",
+                content=f"Deleted {res.path}",
                 name="delete",
                 tool_call_id=runtime.tool_call_id,
                 status="success",
@@ -1364,7 +1355,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            denying_patterns = self._find_delete_deny_patterns(validated_path)
+            denying_patterns = _find_delete_deny_patterns(self._permissions, validated_path)
             if denying_patterns:
                 return ToolMessage(
                     content=f"Error: permission denied for write on {validated_path} (matches deny rule(s): {', '.join(denying_patterns)})",
@@ -1381,7 +1372,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
             return ToolMessage(
-                content=f"Deleted file {res.path}",
+                content=f"Deleted {res.path}",
                 name="delete",
                 tool_call_id=runtime.tool_call_id,
                 status="success",

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1270,28 +1270,39 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=EditFileSchema,
         )
 
-    def _delete_denied_pattern(self, target: str) -> str | None:
+    def _find_delete_deny_patterns(self, target: str, limit: int = 5) -> list[str]:
         """All-or-nothing write-deny check for a (possibly recursive) delete.
 
-        A recursive delete of ``target`` removes ``target`` plus every descendant,
-        so the operation is refused if any ``deny`` write rule's pattern overlaps
-        that subtree. Overlap is checked against the rule pattern's literal anchor
+        A recursive delete of `target` removes `target` plus every descendant, so
+        the operation is refused if any `deny` write rule's pattern overlaps that
+        subtree. Overlap is checked against the rule pattern's literal anchor
         (`_glob_anchor`) in either direction, so a rule scoped inside the target
-        (``/work/secrets/**``) and a rule that the target falls under
-        (``/work/**``) both block it. The check is purely rule-based — no backend
-        enumeration — and never under-refuses relative to the on-disk contents:
-        any real path a recursive delete would touch makes the target and the
-        rule anchor comparable, so the overlap fires.
+        (`/work/secrets/**`) and a rule that the target falls under (`/work/**`)
+        both block it. The check is purely rule-based — no backend enumeration —
+        and never under-refuses relative to the on-disk contents: any real path a
+        recursive delete would touch makes the target and the rule anchor
+        comparable, so the overlap fires.
 
-        Returns the first overlapping deny pattern (so the delete can be refused
-        with a useful message), or ``None`` if no deny rule overlaps.
+        Args:
+            target: Absolute, validated target path of the delete.
+            limit: Maximum number of overlapping patterns to collect before
+                returning, so the caller can report several conflicting rules
+                without scanning every permission once enough are found.
+
+        Returns:
+            Up to `limit` overlapping `deny` write patterns, empty if the delete
+            is permitted.
         """
+        denying: list[str] = []
         for rule in self._permissions:
             if rule.mode != "deny" or "write" not in rule.operations:
                 continue
             for pattern in rule.paths:
                 if _paths_overlap(target, _glob_anchor(pattern)):
-                    return pattern
+                    denying.append(pattern)
+                    if len(denying) >= limit:
+                        return denying
+        return denying
         return None
 
     def _create_delete_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
@@ -1314,10 +1325,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            denied_pattern = self._delete_denied_pattern(validated_path)
-            if denied_pattern is not None:
+            denying_patterns = self._find_delete_deny_patterns(validated_path)
+            if denying_patterns:
                 return ToolMessage(
-                    content=f"Error: permission denied for write on {validated_path} (matches deny rule {denied_pattern})",
+                    content=f"Error: permission denied for write on {validated_path} (matches deny rule(s): {', '.join(denying_patterns)})",
                     name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
@@ -1353,10 +1364,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            denied_pattern = self._delete_denied_pattern(validated_path)
-            if denied_pattern is not None:
+            denying_patterns = self._find_delete_deny_patterns(validated_path)
+            if denying_patterns:
                 return ToolMessage(
-                    content=f"Error: permission denied for write on {validated_path} (matches deny rule {denied_pattern})",
+                    content=f"Error: permission denied for write on {validated_path} (matches deny rule(s): {', '.join(denying_patterns)})",
                     name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -1429,6 +1429,27 @@ def test_composite_delete_routes_to_correct_backend() -> None:
     assert be.read("/memories/note.txt").error is not None
 
 
+def test_composite_delete_directory_recurses_within_route() -> None:
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/memories/": StoreBackend(store=mem_store, namespace=lambda _rt: ("memories",))},
+    )
+
+    be.write("/memories/proj/a.txt", "a")
+    be.write("/memories/proj/sub/b.txt", "b")
+    be.write("/memories/keep.txt", "k")
+
+    # Deleting a directory inside a route removes the whole subtree there,
+    # remapped back to the original path, while siblings survive.
+    res = be.delete("/memories/proj")
+    assert res.error is None
+    assert res.path == "/memories/proj"
+    assert be.read("/memories/proj/a.txt").error is not None
+    assert be.read("/memories/proj/sub/b.txt").error is not None
+    assert be.read("/memories/keep.txt").error is None
+
+
 def test_composite_delete_missing_returns_error() -> None:
     mem_store = InMemoryStore()
     be = CompositeBackend(

--- a/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
@@ -540,6 +540,26 @@ def test_delete_commits_none_entry() -> None:
     assert call.kwargs["parent_commit"] == _COMMIT_HASH
 
 
+def test_delete_directory_commits_all_nested_entries() -> None:
+    backend, mock_client = _make_backend(
+        **{
+            "work/a.md": FileEntry(type="file", content="a"),
+            "work/sub/b.md": FileEntry(type="file", content="b"),
+            "keep.md": FileEntry(type="file", content="k"),
+        }
+    )
+    result = backend.delete("/work")
+
+    assert result.error is None
+    assert result.path == "/work"
+    files_arg = mock_client.push_agent.call_args.kwargs["files"]
+    # Every nested entry under /work is marked for deletion...
+    assert files_arg["work/a.md"] is None
+    assert files_arg["work/sub/b.md"] is None
+    # ...and the sibling outside the subtree is left alone.
+    assert "keep.md" not in files_arg
+
+
 def test_delete_missing_returns_not_found() -> None:
     backend, mock_client = _make_backend()
     result = backend.delete("/ghost.md")

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -1285,13 +1285,51 @@ class TestFilesystemDelete:
         assert result.error is not None
         assert "not found" in result.error
 
-    def test_delete_directory_returns_error(self, tmp_path: Path) -> None:
+    def test_delete_empty_directory(self, tmp_path: Path) -> None:
         (tmp_path / "sub").mkdir()
         be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
         result = be.delete("/sub")
-        assert result.path is None
-        assert result.error is not None
-        assert "directory" in result.error
+        assert result.error is None
+        assert result.path == "/sub"
+        assert not (tmp_path / "sub").exists()
+
+    def test_delete_directory_recursively(self, tmp_path: Path) -> None:
+        # A directory is removed along with all of its nested contents.
+        sub = tmp_path / "sub"
+        (sub / "deep").mkdir(parents=True)
+        write_file(sub / "b.txt", "b")
+        write_file(sub / "deep" / "d.txt", "d")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        result = be.delete("/sub")
+        assert result.error is None
+        assert result.path == "/sub"
+        assert not sub.exists()
+
+    def test_delete_directory_leaves_siblings(self, tmp_path: Path) -> None:
+        (tmp_path / "sub").mkdir()
+        write_file(tmp_path / "sub" / "b.txt", "b")
+        write_file(tmp_path / "keep.txt", "keep")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        assert be.delete("/sub").error is None
+        assert not (tmp_path / "sub").exists()
+        assert (tmp_path / "keep.txt").exists()
+
+    def test_delete_symlink_to_dir_does_not_follow(self, tmp_path: Path) -> None:
+        # Deleting a symlink that points at a directory removes only the link;
+        target = tmp_path / "target"
+        target.mkdir()
+        write_file(target / "keep.txt", "keep")
+        link = tmp_path / "link"
+        link.symlink_to(target, target_is_directory=True)
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+        result = be.delete(str(link))
+        assert result.error is None
+        assert not link.exists()
+        assert target.exists()
+        assert (target / "keep.txt").exists()
 
     def test_delete_only_removes_target(self, tmp_path: Path) -> None:
         write_file(tmp_path / "keep.txt", "keep")
@@ -1323,7 +1361,7 @@ class TestFilesystemDelete:
         result = be.delete("/a.txt")
         assert result.path is None
         assert result.error is not None
-        assert "Error deleting file" in result.error
+        assert "Error deleting" in result.error
 
     def test_delete_unlink_failure_returns_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         # An OSError from unlink (e.g. permission denied) is reported, file kept.
@@ -1338,5 +1376,5 @@ class TestFilesystemDelete:
         result = be.delete("/a.txt")
         assert result.path is None
         assert result.error is not None
-        assert "Error deleting file" in result.error
+        assert "Error deleting" in result.error
         assert f.exists()

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -1338,10 +1338,21 @@ class TestSandboxDelete:
         result = sandbox.delete("/file.txt")
         assert result.error is None
         assert result.path == "/file.txt"
-        # The shell command quotes the path and uses rm -f
+        # The shell command quotes the path and uses rm -rf (recursive)
         assert sandbox.last_command is not None
-        assert "rm -f" in sandbox.last_command
+        assert "rm -rf" in sandbox.last_command
         assert "/file.txt" in sandbox.last_command
+
+    def test_delete_directory_uses_recursive_rm(self) -> None:
+        sandbox = MockSandbox()
+        sandbox._next_output = ""
+        sandbox._next_exit_code = 0
+        result = sandbox.delete("/some/dir")
+        assert result.error is None
+        assert result.path == "/some/dir"
+        assert sandbox.last_command is not None
+        assert "rm -rf" in sandbox.last_command
+        assert "/some/dir" in sandbox.last_command
 
     def test_delete_missing_is_noop_success(self) -> None:
         # `rm -f` ignores a missing path: exit 0, so delete reports success.
@@ -1353,7 +1364,7 @@ class TestSandboxDelete:
         assert result.path == "/missing.txt"
 
     def test_delete_failure_reports_output(self) -> None:
-        # A non-zero exit (e.g. the path is a directory) surfaces rm's stderr.
+        # A non-zero exit (e.g. a permission error) surfaces rm's stderr.
         sandbox = MockSandbox()
         sandbox._next_output = "rm: cannot remove '/some/dir': Is a directory"
         sandbox._next_exit_code = 1

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -8,6 +8,7 @@ import pytest
 from langchain.tools import ToolRuntime
 from langchain_core.messages import ToolMessage
 from langgraph.runtime import Runtime
+from langgraph.store.base import PutOp
 from langgraph.store.memory import InMemoryStore
 
 from deepagents._api.deprecation import LangChainDeprecationWarning
@@ -560,6 +561,64 @@ async def test_store_backend_adelete_directory_recursive() -> None:
     assert (await be.aread("/work/a.txt")).error is not None
     assert (await be.aread("/work/sub/b.txt")).error is not None
     assert (await be.aread("/keep.txt")).error is None
+
+
+def test_store_backend_delete_uses_single_batch_call() -> None:
+    """A recursive delete issues one batched store write, not one call per key."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    be.write("/work/a.txt", "a")
+    be.write("/work/sub/b.txt", "b")
+    be.write("/keep.txt", "k")
+
+    # Spy on the store's batch primitive (search and delete both route through it).
+    batches: list[list] = []
+    original_batch = mem_store.batch
+
+    def spy_batch(ops):
+        ops = list(ops)
+        batches.append(ops)
+        return original_batch(ops)
+
+    mem_store.batch = spy_batch  # type: ignore[method-assign]
+
+    result = be.delete("/work")
+    assert result.error is None
+
+    # Exactly one batch carried PutOps — all the deletes in a single round-trip.
+    delete_batches = [ops for ops in batches if any(isinstance(op, PutOp) for op in ops)]
+    assert len(delete_batches) == 1
+    ops = delete_batches[0]
+    assert all(isinstance(op, PutOp) and op.value is None for op in ops)
+    assert {op.key for op in ops} == {"/work/a.txt", "/work/sub/b.txt"}
+
+
+async def test_store_backend_adelete_uses_single_batch_call() -> None:
+    """Async recursive delete issues one batched store write, not one per key."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    await be.awrite("/work/a.txt", "a")
+    await be.awrite("/work/sub/b.txt", "b")
+    await be.awrite("/keep.txt", "k")
+
+    batches: list[list] = []
+    original_abatch = mem_store.abatch
+
+    async def spy_abatch(ops):
+        ops = list(ops)
+        batches.append(ops)
+        return await original_abatch(ops)
+
+    mem_store.abatch = spy_abatch  # type: ignore[method-assign]
+
+    result = await be.adelete("/work")
+    assert result.error is None
+
+    delete_batches = [ops for ops in batches if any(isinstance(op, PutOp) for op in ops)]
+    assert len(delete_batches) == 1
+    ops = delete_batches[0]
+    assert all(isinstance(op, PutOp) and op.value is None for op in ops)
+    assert {op.key for op in ops} == {"/work/a.txt", "/work/sub/b.txt"}
 
 
 def test_store_backend_delete_missing_returns_error() -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -531,6 +531,37 @@ def test_store_backend_delete() -> None:
     assert be.read("/docs/readme.md").error is not None
 
 
+def test_store_backend_delete_directory_recursive() -> None:
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    be.write("/work/a.txt", "a")
+    be.write("/work/sub/b.txt", "b")
+    be.write("/keep.txt", "k")
+
+    result = be.delete("/work")
+    assert result.error is None
+    assert result.path == "/work"
+    # Every key at or under /work is gone.
+    assert be.read("/work/a.txt").error is not None
+    assert be.read("/work/sub/b.txt").error is not None
+    # A sibling outside the subtree is untouched.
+    assert be.read("/keep.txt").error is None
+
+
+async def test_store_backend_adelete_directory_recursive() -> None:
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    await be.awrite("/work/a.txt", "a")
+    await be.awrite("/work/sub/b.txt", "b")
+    await be.awrite("/keep.txt", "k")
+
+    result = await be.adelete("/work")
+    assert result.error is None
+    assert (await be.aread("/work/a.txt")).error is not None
+    assert (await be.aread("/work/sub/b.txt")).error is not None
+    assert (await be.aread("/keep.txt")).error is None
+
+
 def test_store_backend_delete_missing_returns_error() -> None:
     be = StoreBackend(store=InMemoryStore(), namespace=lambda _rt: ("filesystem",))
     result = be.delete("/nope.md")

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -563,30 +563,47 @@ async def test_store_backend_adelete_directory_recursive() -> None:
     assert (await be.aread("/keep.txt")).error is None
 
 
+class _RecordingStore(InMemoryStore):
+    """InMemoryStore that records the ops passed to each batch/abatch call.
+
+    `batch`/`abatch` are the single primitive every store op routes through, so
+    recording them lets a test assert how many round-trips a delete performs.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.batch_calls: list[list] = []
+
+    def batch(self, ops):
+        ops = list(ops)
+        self.batch_calls.append(ops)
+        return super().batch(ops)
+
+    async def abatch(self, ops):
+        ops = list(ops)
+        self.batch_calls.append(ops)
+        return await super().abatch(ops)
+
+
+def _delete_op_batches(batch_calls: list[list]) -> list[list]:
+    """Batches that carried at least one delete (PutOp with value=None)."""
+    return [ops for ops in batch_calls if any(isinstance(op, PutOp) and op.value is None for op in ops)]
+
+
 def test_store_backend_delete_uses_single_batch_call() -> None:
     """A recursive delete issues one batched store write, not one call per key."""
-    mem_store = InMemoryStore()
-    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    store = _RecordingStore()
+    be = StoreBackend(store=store, namespace=lambda _rt: ("filesystem",))
     be.write("/work/a.txt", "a")
     be.write("/work/sub/b.txt", "b")
     be.write("/keep.txt", "k")
-
-    # Spy on the store's batch primitive (search and delete both route through it).
-    batches: list[list] = []
-    original_batch = mem_store.batch
-
-    def spy_batch(ops):
-        ops = list(ops)
-        batches.append(ops)
-        return original_batch(ops)
-
-    mem_store.batch = spy_batch  # type: ignore[method-assign]
+    store.batch_calls.clear()  # ignore the setup writes
 
     result = be.delete("/work")
     assert result.error is None
 
-    # Exactly one batch carried PutOps — all the deletes in a single round-trip.
-    delete_batches = [ops for ops in batches if any(isinstance(op, PutOp) for op in ops)]
+    # All the deletes happened in exactly one batch (not one call per key).
+    delete_batches = _delete_op_batches(store.batch_calls)
     assert len(delete_batches) == 1
     ops = delete_batches[0]
     assert all(isinstance(op, PutOp) and op.value is None for op in ops)
@@ -595,26 +612,17 @@ def test_store_backend_delete_uses_single_batch_call() -> None:
 
 async def test_store_backend_adelete_uses_single_batch_call() -> None:
     """Async recursive delete issues one batched store write, not one per key."""
-    mem_store = InMemoryStore()
-    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    store = _RecordingStore()
+    be = StoreBackend(store=store, namespace=lambda _rt: ("filesystem",))
     await be.awrite("/work/a.txt", "a")
     await be.awrite("/work/sub/b.txt", "b")
     await be.awrite("/keep.txt", "k")
-
-    batches: list[list] = []
-    original_abatch = mem_store.abatch
-
-    async def spy_abatch(ops):
-        ops = list(ops)
-        batches.append(ops)
-        return await original_abatch(ops)
-
-    mem_store.abatch = spy_abatch  # type: ignore[method-assign]
+    store.batch_calls.clear()
 
     result = await be.adelete("/work")
     assert result.error is None
 
-    delete_batches = [ops for ops in batches if any(isinstance(op, PutOp) for op in ops)]
+    delete_batches = _delete_op_batches(store.batch_calls)
     assert len(delete_batches) == 1
     ops = delete_batches[0]
     assert all(isinstance(op, PutOp) and op.value is None for op in ops)

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -1,6 +1,6 @@
 """Tests for backends/utils.py utility functions."""
 
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 from langchain_core.messages.content import ContentBlock
@@ -11,6 +11,7 @@ from deepagents.backends.utils import (
     _EXTENSION_TO_FILE_TYPE,
     _get_file_type,
     _glob_search_files,
+    expand_delete_keys,
     perform_string_replacement,
     slice_read_response,
     to_posix_path,
@@ -353,3 +354,29 @@ class TestSliceReadResponse:
         assert isinstance(result, ReadResult)
         assert result.error is not None
         assert "exceeds file length" in result.error
+
+
+class TestExpandDeleteKeys:
+    """Prefix expansion shared by the key-value backends' recursive delete."""
+
+    KEYS: ClassVar[list[str]] = ["/work", "/work/a.txt", "/work/sub/b.txt", "/workshop/x", "/keep.txt"]
+
+    def test_exact_file_key(self):
+        assert expand_delete_keys(self.KEYS, "/keep.txt") == ["/keep.txt"]
+
+    def test_directory_prefix_includes_self_and_descendants(self):
+        assert expand_delete_keys(self.KEYS, "/work") == ["/work", "/work/a.txt", "/work/sub/b.txt"]
+
+    def test_trailing_slash_normalized(self):
+        assert expand_delete_keys(self.KEYS, "/work/") == ["/work", "/work/a.txt", "/work/sub/b.txt"]
+
+    def test_does_not_match_sibling_prefix(self):
+        # "/work" must not swallow "/workshop/x" (the prefix is "/work/", not "/work").
+        assert "/workshop/x" not in expand_delete_keys(self.KEYS, "/work")
+
+    def test_no_match_returns_empty(self):
+        assert expand_delete_keys(self.KEYS, "/missing") == []
+
+    def test_wildcard_key_treated_literally(self):
+        # A literal "*" key matches only itself, never other paths.
+        assert expand_delete_keys(["*", "/a.txt", "/b.txt"], "*") == ["*"]

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -1,6 +1,6 @@
 """Tests for backends/utils.py utility functions."""
 
-from typing import Any, ClassVar
+from typing import Any
 
 import pytest
 from langchain_core.messages.content import ContentBlock
@@ -11,7 +11,6 @@ from deepagents.backends.utils import (
     _EXTENSION_TO_FILE_TYPE,
     _get_file_type,
     _glob_search_files,
-    expand_delete_keys,
     perform_string_replacement,
     slice_read_response,
     to_posix_path,
@@ -354,29 +353,3 @@ class TestSliceReadResponse:
         assert isinstance(result, ReadResult)
         assert result.error is not None
         assert "exceeds file length" in result.error
-
-
-class TestExpandDeleteKeys:
-    """Prefix expansion shared by the key-value backends' recursive delete."""
-
-    KEYS: ClassVar[list[str]] = ["/work", "/work/a.txt", "/work/sub/b.txt", "/workshop/x", "/keep.txt"]
-
-    def test_exact_file_key(self):
-        assert expand_delete_keys(self.KEYS, "/keep.txt") == ["/keep.txt"]
-
-    def test_directory_prefix_includes_self_and_descendants(self):
-        assert expand_delete_keys(self.KEYS, "/work") == ["/work", "/work/a.txt", "/work/sub/b.txt"]
-
-    def test_trailing_slash_normalized(self):
-        assert expand_delete_keys(self.KEYS, "/work/") == ["/work", "/work/a.txt", "/work/sub/b.txt"]
-
-    def test_does_not_match_sibling_prefix(self):
-        # "/work" must not swallow "/workshop/x" (the prefix is "/work/", not "/work").
-        assert "/workshop/x" not in expand_delete_keys(self.KEYS, "/work")
-
-    def test_no_match_returns_empty(self):
-        assert expand_delete_keys(self.KEYS, "/missing") == []
-
-    def test_wildcard_key_treated_literally(self):
-        # A literal "*" key matches only itself, never other paths.
-        assert expand_delete_keys(["*", "/a.txt", "/b.txt"], "*") == ["*"]

--- a/libs/deepagents/tests/unit_tests/middleware/test_tool_schemas.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_tool_schemas.py
@@ -25,7 +25,7 @@ class TestFilesystemToolSchemas:
             "read_file": ["file_path", "offset", "limit"],
             "write_file": ["file_path", "content"],
             "edit_file": ["file_path", "old_string", "new_string", "replace_all"],
-            "delete_file": ["file_path"],
+            "delete": ["file_path"],
             "glob": ["pattern", "path"],
             "grep": ["pattern", "path", "glob", "output_mode"],
             "execute": ["command"],

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message.md
@@ -68,7 +68,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -77,7 +77,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
-- delete_file: delete a file from the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -146,7 +146,7 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
       "name": "delete_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -147,7 +147,7 @@
   {
     "function": {
       "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
-      "name": "delete_file",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,7 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
-- delete_file: delete a file from the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -146,7 +146,7 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
       "name": "delete_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -147,7 +147,7 @@
   {
     "function": {
       "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
-      "name": "delete_file",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
@@ -112,7 +112,7 @@ Remember: Skills make you more capable and consistent. When in doubt, check if a
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -121,7 +121,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
-- delete_file: delete a file from the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -146,7 +146,7 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
       "name": "delete_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -147,7 +147,7 @@
   {
     "function": {
       "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
-      "name": "delete_file",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,7 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
-- delete_file: delete a file from the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -146,7 +146,7 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
       "name": "delete_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -147,7 +147,7 @@
   {
     "function": {
       "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
-      "name": "delete_file",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,7 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
-- delete_file: delete a file from the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -146,7 +146,7 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
       "name": "delete_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -147,7 +147,7 @@
   {
     "function": {
       "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
-      "name": "delete_file",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -1394,7 +1394,7 @@ class TestDeleteFileTool:
         tool_messages = [m for m in result["messages"] if m.type == "tool"]
         assert len(tool_messages) == 1
         assert tool_messages[0].status == "success"
-        assert tool_messages[0].content == "Deleted file /keep.txt"
+        assert tool_messages[0].content == "Deleted /keep.txt"
         assert set(result["files"].keys()) == {"/other.txt"}
 
     def test_delete_directory_removes_nested_files(self) -> None:

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -1397,6 +1397,44 @@ class TestDeleteFileTool:
         assert tool_messages[0].content == "Deleted file /keep.txt"
         assert set(result["files"].keys()) == {"/other.txt"}
 
+    def test_delete_directory_removes_nested_files(self) -> None:
+        """Delete on a directory removes every nested file from state (StateBackend)."""
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "delete",
+                                "args": {"file_path": "/work"},
+                                "id": "call_1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model)
+        result = agent.invoke(
+            {
+                "messages": [HumanMessage(content="delete the work dir")],
+                "files": {
+                    "/work/a.txt": create_file_data("a"),
+                    "/work/sub/b.txt": create_file_data("b"),
+                    "/keep.txt": create_file_data("stay"),
+                },
+            }
+        )
+
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert tool_messages[0].status == "success"
+        # Whole /work subtree gone; sibling preserved.
+        assert set(result["files"].keys()) == {"/keep.txt"}
+
     def test_delete_missing_returns_error(self) -> None:
         """Delete on a missing path returns an error tool message."""
         model = FixedGenericFakeChatModel(

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -1357,10 +1357,10 @@ class TestDeepAgentEndToEnd:
 
 
 class TestDeleteFileTool:
-    """End-to-end tests for the `delete_file` filesystem tool."""
+    """End-to-end tests for the `delete` filesystem tool."""
 
-    def test_delete_file_removes_existing_file(self) -> None:
-        """delete_file removes a file from state and reports success."""
+    def test_delete_removes_existing_file(self) -> None:
+        """delete removes a file from state and reports success."""
         model = FixedGenericFakeChatModel(
             messages=iter(
                 [
@@ -1368,7 +1368,7 @@ class TestDeleteFileTool:
                         content="",
                         tool_calls=[
                             {
-                                "name": "delete_file",
+                                "name": "delete",
                                 "args": {"file_path": "/keep.txt"},
                                 "id": "call_1",
                                 "type": "tool_call",
@@ -1397,8 +1397,8 @@ class TestDeleteFileTool:
         assert tool_messages[0].content == "Deleted file /keep.txt"
         assert set(result["files"].keys()) == {"/other.txt"}
 
-    def test_delete_file_missing_returns_error(self) -> None:
-        """delete_file on a missing path returns an error tool message."""
+    def test_delete_missing_returns_error(self) -> None:
+        """delete on a missing path returns an error tool message."""
         model = FixedGenericFakeChatModel(
             messages=iter(
                 [
@@ -1406,7 +1406,7 @@ class TestDeleteFileTool:
                         content="",
                         tool_calls=[
                             {
-                                "name": "delete_file",
+                                "name": "delete",
                                 "args": {"file_path": "/nope.txt"},
                                 "id": "call_1",
                                 "type": "tool_call",
@@ -1426,8 +1426,8 @@ class TestDeleteFileTool:
         assert tool_messages[0].status == "error"
         assert "not found" in tool_messages[0].content
 
-    def test_delete_file_permission_deny_blocks_delete(self) -> None:
-        """FilesystemPermission deny write blocks delete_file (delete is a write op)."""
+    def test_delete_permission_deny_blocks_delete(self) -> None:
+        """FilesystemPermission deny write blocks delete (delete is a write op)."""
         model = FixedGenericFakeChatModel(
             messages=iter(
                 [
@@ -1435,7 +1435,7 @@ class TestDeleteFileTool:
                         content="",
                         tool_calls=[
                             {
-                                "name": "delete_file",
+                                "name": "delete",
                                 "args": {"file_path": "/secrets/key.txt"},
                                 "id": "call_1",
                                 "type": "tool_call",

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -1360,7 +1360,7 @@ class TestDeleteFileTool:
     """End-to-end tests for the `delete` filesystem tool."""
 
     def test_delete_removes_existing_file(self) -> None:
-        """delete removes a file from state and reports success."""
+        """Delete removes a file from state and reports success."""
         model = FixedGenericFakeChatModel(
             messages=iter(
                 [
@@ -1398,7 +1398,7 @@ class TestDeleteFileTool:
         assert set(result["files"].keys()) == {"/other.txt"}
 
     def test_delete_missing_returns_error(self) -> None:
-        """delete on a missing path returns an error tool message."""
+        """Delete on a missing path returns an error tool message."""
         model = FixedGenericFakeChatModel(
             messages=iter(
                 [

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -122,27 +122,27 @@ class TestFilesystemMiddleware:
         middleware = FilesystemMiddleware()
         assert isinstance(middleware.backend, StateBackend)
         assert middleware._custom_system_prompt is None
-        assert len(middleware.tools) == 8  # All tools including execute and delete_file
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_with_composite_backend(self):
         backend = CompositeBackend(default=StateBackend(), routes={"/memories/": StoreBackend()})
         middleware = FilesystemMiddleware(backend=backend)
         assert isinstance(middleware.backend, CompositeBackend)
         assert middleware._custom_system_prompt is None
-        assert len(middleware.tools) == 8  # All tools including execute and delete_file
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_custom_system_prompt_default(self):
         middleware = FilesystemMiddleware(system_prompt="Custom system prompt")
         assert isinstance(middleware.backend, StateBackend)
         assert middleware._custom_system_prompt == "Custom system prompt"
-        assert len(middleware.tools) == 8  # All tools including execute and delete_file
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_custom_system_prompt_with_composite(self):
         backend = CompositeBackend(default=StateBackend(), routes={"/memories/": StoreBackend()})
         middleware = FilesystemMiddleware(backend=backend, system_prompt="Custom system prompt")
         assert isinstance(middleware.backend, CompositeBackend)
         assert middleware._custom_system_prompt == "Custom system prompt"
-        assert len(middleware.tools) == 8  # All tools including execute and delete_file
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_custom_tool_descriptions_default(self):
         middleware = FilesystemMiddleware(custom_tool_descriptions={"ls": "Custom ls tool description"})
@@ -1507,8 +1507,8 @@ class TestFilesystemMiddleware:
         assert "Error: Execution not available" in result.content
         assert "does not support command execution" in result.content
 
-    def test_delete_file_filtered_when_backend_lacks_delete(self):
-        """delete_file is removed from the request when the backend can't delete.
+    def test_delete_filtered_when_backend_lacks_delete(self):
+        """delete is removed from the request when the backend can't delete.
 
         Mirrors how the execute tool is filtered out when the backend doesn't
         support execution, rather than advertising a tool that fails at call time.
@@ -1523,7 +1523,7 @@ class TestFilesystemMiddleware:
         ls_tool = MagicMock()
         ls_tool.name = "ls"
         delete_tool = MagicMock()
-        delete_tool.name = "delete_file"
+        delete_tool.name = "delete"
         request = MagicMock()
         request.tools = [ls_tool, delete_tool]
         request.override.return_value = request
@@ -1532,17 +1532,17 @@ class TestFilesystemMiddleware:
 
         request.override.assert_called_once()
         filtered_names = {tool.name for tool in request.override.call_args.kwargs["tools"]}
-        assert "delete_file" not in filtered_names
+        assert "delete" not in filtered_names
         assert "ls" in filtered_names
 
-    def test_delete_file_kept_when_backend_supports_delete(self):
-        """delete_file stays in the request when the backend supports deletion."""
+    def test_delete_kept_when_backend_supports_delete(self):
+        """delete stays in the request when the backend supports deletion."""
         middleware = FilesystemMiddleware(backend=StateBackend(), system_prompt="")
 
         ls_tool = MagicMock()
         ls_tool.name = "ls"
         delete_tool = MagicMock()
-        delete_tool.name = "delete_file"
+        delete_tool.name = "delete"
         request = MagicMock()
         request.tools = [ls_tool, delete_tool]
         request.override.return_value = request
@@ -1553,10 +1553,10 @@ class TestFilesystemMiddleware:
         # tool filtering — and with an empty system prompt, no override at all.
         request.override.assert_not_called()
 
-    def test_delete_file_invalid_path_returns_error(self):
-        """The sync delete_file tool rejects a traversal path before deleting."""
+    def test_delete_invalid_path_returns_error(self):
+        """The sync delete tool rejects a traversal path before deleting."""
         middleware = FilesystemMiddleware(backend=StateBackend(), system_prompt="")
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = delete_tool.invoke({"file_path": "../etc/passwd", "runtime": _runtime("d1")})
         assert isinstance(result, ToolMessage)
         assert result.status == "error"

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1508,7 +1508,7 @@ class TestFilesystemMiddleware:
         assert "does not support command execution" in result.content
 
     def test_delete_filtered_when_backend_lacks_delete(self):
-        """delete is removed from the request when the backend can't delete.
+        """Delete is removed from the request when the backend can't delete.
 
         Mirrors how the execute tool is filtered out when the backend doesn't
         support execution, rather than advertising a tool that fails at call time.
@@ -1536,7 +1536,7 @@ class TestFilesystemMiddleware:
         assert "ls" in filtered_names
 
     def test_delete_kept_when_backend_supports_delete(self):
-        """delete stays in the request when the backend supports deletion."""
+        """Delete stays in the request when the backend supports deletion."""
         middleware = FilesystemMiddleware(backend=StateBackend(), system_prompt="")
 
         ls_tool = MagicMock()

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -676,7 +676,7 @@ class TestFilesystemMiddlewareAsync:
         )
         assert isinstance(result, ToolMessage)
         assert result.status == "success"
-        assert "Deleted file" in result.content
+        assert "Deleted" in result.content
         assert mem_store.get(("filesystem",), "/test.txt") is None
 
     async def test_adelete_invalid_path(self):

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -662,12 +662,12 @@ class TestFilesystemMiddlewareAsync:
         assert isinstance(result, ToolMessage)
         assert mem_store.get(("filesystem",), "/test.txt") is not None
 
-    async def test_adelete_file(self):
-        """Async delete_file removes the file and reports success."""
+    async def test_adelete(self):
+        """Async delete removes the file and reports success."""
         files = {"/test.txt": FileData(content=["bye"], modified_at="2021-01-01", created_at="2021-01-01")}
         backend, mem_store = _make_backend(files)
         middleware = FilesystemMiddleware(backend=backend)
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = await delete_tool.ainvoke(
             {
                 "file_path": "/test.txt",
@@ -679,11 +679,11 @@ class TestFilesystemMiddlewareAsync:
         assert "Deleted file" in result.content
         assert mem_store.get(("filesystem",), "/test.txt") is None
 
-    async def test_adelete_file_invalid_path(self):
-        """Async delete_file rejects a traversal path with an error."""
+    async def test_adelete_invalid_path(self):
+        """Async delete rejects a traversal path with an error."""
         backend, _ = _make_backend()
         middleware = FilesystemMiddleware(backend=backend)
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = await delete_tool.ainvoke(
             {
                 "file_path": "../etc/passwd",
@@ -693,11 +693,11 @@ class TestFilesystemMiddlewareAsync:
         assert result.status == "error"
         assert "traversal" in result.content
 
-    async def test_adelete_file_missing_returns_error(self):
-        """Async delete_file surfaces the backend's not-found error."""
+    async def test_adelete_missing_returns_error(self):
+        """Async delete surfaces the backend's not-found error."""
         backend, _ = _make_backend()
         middleware = FilesystemMiddleware(backend=backend)
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = await delete_tool.ainvoke(
             {
                 "file_path": "/ghost.txt",
@@ -707,15 +707,15 @@ class TestFilesystemMiddlewareAsync:
         assert result.status == "error"
         assert "not found" in result.content
 
-    async def test_adelete_file_permission_denied(self):
-        """Async delete_file is blocked by a deny write permission."""
+    async def test_adelete_permission_denied(self):
+        """Async delete is blocked by a deny write permission."""
         files = {"/test.txt": FileData(content=["bye"], modified_at="2021-01-01", created_at="2021-01-01")}
         backend, mem_store = _make_backend(files)
         middleware = FilesystemMiddleware(
             backend=backend,
             _permissions=[FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")],
         )
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = await delete_tool.ainvoke(
             {
                 "file_path": "/test.txt",

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -20,6 +20,7 @@ from deepagents.middleware.filesystem import (
     _all_paths_scoped_to_routes,
     _check_fs_permission,
     _filter_paths_by_permission,
+    _find_delete_deny_patterns,
 )
 from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT
 
@@ -203,15 +204,6 @@ class TestRecursiveDeletePermissions:
         assert "/work/logs/**" in result
         assert (tmp_path / "work" / "a.txt").exists()
 
-    def test_find_delete_deny_patterns_caps_at_five(self, tmp_path):
-        backend = self._fs_backend(tmp_path)
-        middleware = FilesystemMiddleware(
-            backend=backend,
-            _permissions=[FilesystemPermission(operations=["write"], paths=[f"/work/d{i}/**"], mode="deny") for i in range(8)],
-        )
-        # All 8 overlap /work, but at most 5 are collected.
-        assert len(middleware._find_delete_deny_patterns("/work")) == 5
-
     def test_single_file_delete_still_works(self, tmp_path):
         backend = self._fs_backend(tmp_path)
         tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
@@ -237,6 +229,93 @@ class TestRecursiveDeletePermissions:
         rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="interrupt")]
         out = _build_interrupt_on_from_permissions(rules)
         assert "delete" in out
+
+
+class TestFindDeleteDenyPatterns:
+    """Exhaustive unit tests for the pure `_find_delete_deny_patterns` helper.
+
+    Returns the `deny` write patterns whose glob overlaps the delete subtree
+    (target + descendants), capped at `limit`. Empty result == delete permitted.
+    """
+
+    @staticmethod
+    def _deny(*paths: str) -> FilesystemPermission:
+        return FilesystemPermission(operations=["write"], paths=list(paths), mode="deny")
+
+    def test_no_permissions_returns_empty(self):
+        assert _find_delete_deny_patterns([], "/work") == []
+
+    def test_unrelated_rule_returns_empty(self):
+        assert _find_delete_deny_patterns([self._deny("/other/**")], "/work") == []
+
+    def test_sibling_prefix_does_not_match(self):
+        # "/work" must not be blocked by a rule on the sibling "/workshop".
+        assert _find_delete_deny_patterns([self._deny("/workshop/**")], "/work") == []
+
+    def test_exact_path_match(self):
+        assert _find_delete_deny_patterns([self._deny("/work/a.txt")], "/work/a.txt") == ["/work/a.txt"]
+
+    def test_descendant_pattern_blocks_ancestor_target(self):
+        # Deleting /work is blocked by a rule scoped inside it.
+        assert _find_delete_deny_patterns([self._deny("/work/secrets/**")], "/work") == ["/work/secrets/**"]
+
+    def test_ancestor_pattern_blocks_descendant_target(self):
+        # Deleting /work/logs is blocked by a rule the target falls under.
+        assert _find_delete_deny_patterns([self._deny("/work/**")], "/work/logs") == ["/work/**"]
+
+    def test_bare_directory_pattern_blocks(self):
+        assert _find_delete_deny_patterns([self._deny("/work/secrets")], "/work") == ["/work/secrets"]
+
+    def test_root_target_blocked_by_any_rule(self):
+        # "/" overlaps everything, so any deny rule blocks delete("/").
+        assert _find_delete_deny_patterns([self._deny("/anything/**")], "/") == ["/anything/**"]
+
+    def test_leading_wildcard_anchor_overlaps_everything(self):
+        # `_glob_anchor("/**/secrets")` collapses to "/", overlapping any target.
+        assert _find_delete_deny_patterns([self._deny("/**/secrets")], "/work") == ["/**/secrets"]
+
+    def test_allow_rules_ignored(self):
+        rule = FilesystemPermission(operations=["write"], paths=["/work/**"], mode="allow")
+        assert _find_delete_deny_patterns([rule], "/work") == []
+
+    def test_interrupt_rules_ignored(self):
+        rule = FilesystemPermission(operations=["write"], paths=["/work/**"], mode="interrupt")
+        assert _find_delete_deny_patterns([rule], "/work") == []
+
+    def test_read_only_deny_ignored(self):
+        # `delete` maps to `write`; a read-scoped deny must not block it.
+        rule = FilesystemPermission(operations=["read"], paths=["/work/**"], mode="deny")
+        assert _find_delete_deny_patterns([rule], "/work") == []
+
+    def test_mixed_operation_deny_matches(self):
+        rule = FilesystemPermission(operations=["read", "write"], paths=["/work/**"], mode="deny")
+        assert _find_delete_deny_patterns([rule], "/work") == ["/work/**"]
+
+    def test_collects_multiple_overlapping_patterns(self):
+        rules = [self._deny("/work/a/**"), self._deny("/work/b/**")]
+        assert _find_delete_deny_patterns(rules, "/work") == ["/work/a/**", "/work/b/**"]
+
+    def test_multiple_paths_in_one_rule(self):
+        rules = [self._deny("/work/a/**", "/work/b/**", "/other/**")]
+        assert _find_delete_deny_patterns(rules, "/work") == ["/work/a/**", "/work/b/**"]
+
+    def test_returns_all_overlapping_patterns(self):
+        # No cap: every conflicting pattern is surfaced for full agent context.
+        rules = [self._deny(f"/work/d{i}/**") for i in range(8)]
+        assert _find_delete_deny_patterns(rules, "/work") == [f"/work/d{i}/**" for i in range(8)]
+
+    def test_deduplicates_repeated_pattern(self):
+        # The same pattern in two rules is reported once, in first-seen order.
+        rules = [self._deny("/work/x/**"), self._deny("/work/x/**", "/work/y/**")]
+        assert _find_delete_deny_patterns(rules, "/work") == ["/work/x/**", "/work/y/**"]
+
+    def test_only_overlapping_patterns_returned(self):
+        # Non-overlapping rules are skipped entirely.
+        rules = [self._deny("/other/**"), self._deny("/work/x/**"), self._deny("/elsewhere/**")]
+        assert _find_delete_deny_patterns(rules, "/work") == ["/work/x/**"]
+
+    def test_target_trailing_slash_normalized(self):
+        assert _find_delete_deny_patterns([self._deny("/work/**")], "/work/") == ["/work/**"]
 
 
 class TestFilesystemPermission:

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -188,6 +188,30 @@ class TestRecursiveDeletePermissions:
         assert not (tmp_path / "work" / "logs").exists()
         assert (tmp_path / "work" / "secrets" / "key.txt").exists()
 
+    def test_delete_reports_multiple_overlapping_patterns(self, tmp_path):
+        # The agent gets context: several overlapping deny patterns are reported.
+        backend = self._fs_backend(tmp_path)
+        rules = [
+            FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny"),
+            FilesystemPermission(operations=["write"], paths=["/work/logs/**"], mode="deny"),
+        ]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "/work/secrets/**" in result
+        assert "/work/logs/**" in result
+        assert (tmp_path / "work" / "a.txt").exists()
+
+    def test_find_delete_deny_patterns_caps_at_five(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        middleware = FilesystemMiddleware(
+            backend=backend,
+            _permissions=[FilesystemPermission(operations=["write"], paths=[f"/work/d{i}/**"], mode="deny") for i in range(8)],
+        )
+        # All 8 overlap /work, but at most 5 are collected.
+        assert len(middleware._find_delete_deny_patterns("/work")) == 5
+
     def test_single_file_delete_still_works(self, tmp_path):
         backend = self._fs_backend(tmp_path)
         tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -9,6 +9,7 @@ from langgraph.store.memory import InMemoryStore
 
 from deepagents.backends import StateBackend, StoreBackend
 from deepagents.backends.composite import CompositeBackend
+from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import EditResult, ExecuteResponse, ReadResult, SandboxBackendProtocol, WriteResult
 from deepagents.backends.utils import _glob_anchor, _paths_overlap
 from deepagents.graph import create_deep_agent
@@ -119,8 +120,6 @@ class TestRecursiveDeletePermissions:
     """
 
     def _fs_backend(self, tmp_path):
-        from deepagents.backends.filesystem import FilesystemBackend
-
         # /work/a.txt, /work/logs/run.log, /work/secrets/{key,token}.txt
         (tmp_path / "work" / "logs").mkdir(parents=True)
         (tmp_path / "work" / "secrets").mkdir(parents=True)

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -111,6 +111,97 @@ async def _ainvoke_with_permissions(tool, args, rules, tool_call_id="test", back
     return str(result)
 
 
+class TestRecursiveDeletePermissions:
+    """All-or-nothing write-permission enforcement for recursive delete.
+
+    A recursive delete removes the target plus every descendant, so the whole
+    operation is refused if ANY path in the subtree is write-denied.
+    """
+
+    def _fs_backend(self, tmp_path):
+        from deepagents.backends.filesystem import FilesystemBackend
+
+        # /work/a.txt, /work/logs/run.log, /work/secrets/{key,token}.txt
+        (tmp_path / "work" / "logs").mkdir(parents=True)
+        (tmp_path / "work" / "secrets").mkdir(parents=True)
+        (tmp_path / "work" / "a.txt").write_text("a")
+        (tmp_path / "work" / "logs" / "run.log").write_text("log")
+        (tmp_path / "work" / "secrets" / "key.txt").write_text("k")
+        (tmp_path / "work" / "secrets" / "token.txt").write_text("t")
+        return FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+    def test_recursive_delete_refused_when_descendant_denied(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert "/work/secrets" in result
+        # All-or-nothing: nothing was removed.
+        assert (tmp_path / "work" / "a.txt").exists()
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_recursive_delete_allowed_when_whole_subtree_allowed(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/other/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "Deleted" in result
+        assert not (tmp_path / "work").exists()
+
+    def test_delete_denied_directory_path_itself(self, tmp_path):
+        # A rule on the bare directory path (no /**) still blocks deleting it.
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_delete_unaffected_sibling_subtree(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets", "/work/secrets/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work/logs"}, rules, backend=backend)
+
+        assert "Deleted" in result
+        assert not (tmp_path / "work" / "logs").exists()
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_single_file_delete_still_works(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work/a.txt"}, [], backend=backend)
+
+        assert "Deleted" in result
+        assert not (tmp_path / "work" / "a.txt").exists()
+
+    async def test_recursive_delete_refused_async(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+
+        result = await _ainvoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_delete_registered_as_bulk_interrupt(self):
+        # An interrupt rule on a descendant must fire for a recursive delete,
+        # so delete_file is registered (bulk scope) in the interrupt builder.
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="interrupt")]
+        out = _build_interrupt_on_from_permissions(rules)
+        assert "delete_file" in out
+
+
 class TestFilesystemPermission:
     def test_default_effect_is_allow(self):
         rule = FilesystemPermission(operations=["read"], paths=["/workspace/**"])
@@ -225,7 +316,7 @@ class TestBuildInterruptOnFromPermissions:
         """A write-only interrupt rule registers only the write-op tools."""
         rule = FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="interrupt")
         out = _build_interrupt_on_from_permissions([rule])
-        assert set(out) == {"write_file", "edit_file"}
+        assert set(out) == {"write_file", "edit_file", "delete_file"}
 
     def test_registers_read_tools_for_read_interrupt(self):
         rule = FilesystemPermission(operations=["read"], paths=["/secrets/**"], mode="interrupt")

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -115,8 +115,10 @@ async def _ainvoke_with_permissions(tool, args, rules, tool_call_id="test", back
 class TestRecursiveDeletePermissions:
     """All-or-nothing write-permission enforcement for recursive delete.
 
-    A recursive delete removes the target plus every descendant, so the whole
-    operation is refused if ANY path in the subtree is write-denied.
+    A recursive delete is refused if any ``deny`` write rule's pattern overlaps
+    the target subtree, in either direction: a rule scoped inside the target
+    (``/work/secrets/**``) and a rule the target falls under (``/work``) both
+    block it. The check is rule-based (no filesystem enumeration).
     """
 
     def _fs_backend(self, tmp_path):
@@ -162,6 +164,18 @@ class TestRecursiveDeletePermissions:
 
         assert "permission denied for write" in result
         assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_delete_refused_when_ancestor_denied(self, tmp_path):
+        # Any overlap denies: a rule on an ancestor of the target also blocks,
+        # since the target subtree falls under it.
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work/logs"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert (tmp_path / "work" / "logs" / "run.log").exists()
 
     def test_delete_unaffected_sibling_subtree(self, tmp_path):
         backend = self._fs_backend(tmp_path)

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -133,7 +133,7 @@ class TestRecursiveDeletePermissions:
     def test_recursive_delete_refused_when_descendant_denied(self, tmp_path):
         backend = self._fs_backend(tmp_path)
         rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny")]
-        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
 
         result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
 
@@ -146,7 +146,7 @@ class TestRecursiveDeletePermissions:
     def test_recursive_delete_allowed_when_whole_subtree_allowed(self, tmp_path):
         backend = self._fs_backend(tmp_path)
         rules = [FilesystemPermission(operations=["write"], paths=["/other/**"], mode="deny")]
-        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
 
         result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
 
@@ -157,7 +157,7 @@ class TestRecursiveDeletePermissions:
         # A rule on the bare directory path (no /**) still blocks deleting it.
         backend = self._fs_backend(tmp_path)
         rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets"], mode="deny")]
-        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
 
         result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
 
@@ -167,7 +167,7 @@ class TestRecursiveDeletePermissions:
     def test_delete_unaffected_sibling_subtree(self, tmp_path):
         backend = self._fs_backend(tmp_path)
         rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets", "/work/secrets/**"], mode="deny")]
-        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
 
         result = _invoke_with_permissions(tool, {"file_path": "/work/logs"}, rules, backend=backend)
 
@@ -177,7 +177,7 @@ class TestRecursiveDeletePermissions:
 
     def test_single_file_delete_still_works(self, tmp_path):
         backend = self._fs_backend(tmp_path)
-        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
 
         result = _invoke_with_permissions(tool, {"file_path": "/work/a.txt"}, [], backend=backend)
 
@@ -187,7 +187,7 @@ class TestRecursiveDeletePermissions:
     async def test_recursive_delete_refused_async(self, tmp_path):
         backend = self._fs_backend(tmp_path)
         rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny")]
-        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
 
         result = await _ainvoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
 
@@ -196,10 +196,10 @@ class TestRecursiveDeletePermissions:
 
     def test_delete_registered_as_bulk_interrupt(self):
         # An interrupt rule on a descendant must fire for a recursive delete,
-        # so delete_file is registered (bulk scope) in the interrupt builder.
+        # so delete is registered (bulk scope) in the interrupt builder.
         rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="interrupt")]
         out = _build_interrupt_on_from_permissions(rules)
-        assert "delete_file" in out
+        assert "delete" in out
 
 
 class TestFilesystemPermission:
@@ -316,7 +316,7 @@ class TestBuildInterruptOnFromPermissions:
         """A write-only interrupt rule registers only the write-op tools."""
         rule = FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="interrupt")
         out = _build_interrupt_on_from_permissions([rule])
-        assert set(out) == {"write_file", "edit_file", "delete_file"}
+        assert set(out) == {"write_file", "edit_file", "delete"}
 
     def test_registers_read_tools_for_read_interrupt(self):
         rule = FilesystemPermission(operations=["read"], paths=["/secrets/**"], mode="interrupt")

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -231,91 +231,93 @@ class TestRecursiveDeletePermissions:
         assert "delete" in out
 
 
+def _deny(*paths: str) -> FilesystemPermission:
+    return FilesystemPermission(operations=["write"], paths=list(paths), mode="deny")
+
+
 class TestFindDeleteDenyPatterns:
     """Exhaustive unit tests for the pure `_find_delete_deny_patterns` helper.
 
-    Returns the `deny` write patterns whose glob overlaps the delete subtree
-    (target + descendants), capped at `limit`. Empty result == delete permitted.
+    Returns every `deny` write pattern whose glob overlaps the delete subtree
+    (target + descendants). An empty result means the delete is permitted.
     """
 
-    @staticmethod
-    def _deny(*paths: str) -> FilesystemPermission:
-        return FilesystemPermission(operations=["write"], paths=list(paths), mode="deny")
+    @pytest.mark.parametrize(
+        ("pattern", "target", "expected"),
+        [
+            # --- no overlap -> permitted (empty result) ----------------------
+            pytest.param("/other/**", "/work", [], id="unrelated-subtree"),
+            pytest.param("/workshop/**", "/work", [], id="sibling-prefix-glob"),
+            pytest.param("/work2", "/work", [], id="sibling-prefix-literal"),
+            pytest.param("/work/secrets", "/work/logs", [], id="sibling-leaf"),
+            # --- overlap in either direction -> blocked ----------------------
+            pytest.param("/work/a.txt", "/work/a.txt", ["/work/a.txt"], id="exact-file"),
+            pytest.param("/work", "/work", ["/work"], id="exact-dir-literal"),
+            pytest.param("/work/secrets/**", "/work", ["/work/secrets/**"], id="descendant-pattern-blocks-ancestor-target"),
+            pytest.param("/work/**", "/work/logs", ["/work/**"], id="ancestor-glob-blocks-descendant-target"),
+            pytest.param("/work", "/work/sub/deep", ["/work"], id="ancestor-literal-blocks-descendant-target"),
+            pytest.param("/work/secrets", "/work", ["/work/secrets"], id="bare-directory-pattern"),
+            # --- wildcard / root anchors -------------------------------------
+            pytest.param("/anything/**", "/", ["/anything/**"], id="root-target-blocked-by-any-rule"),
+            pytest.param("/**/secrets", "/work", ["/**/secrets"], id="leading-wildcard-anchor-is-root"),
+            # --- trailing-slash normalization (both sides) -------------------
+            pytest.param("/work/**", "/work/", ["/work/**"], id="target-trailing-slash"),
+            pytest.param("/work/", "/work/sub", ["/work/"], id="pattern-trailing-slash"),
+            pytest.param("/work/", "/work/", ["/work/"], id="both-trailing-slash"),
+        ],
+    )
+    def test_overlap_geometry(self, pattern: str, target: str, expected: list[str]):
+        assert _find_delete_deny_patterns([_deny(pattern)], target) == expected
 
-    def test_no_permissions_returns_empty(self):
-        assert _find_delete_deny_patterns([], "/work") == []
+    @pytest.mark.parametrize(
+        ("operations", "mode", "expected"),
+        [
+            pytest.param(["write"], "deny", ["/work/**"], id="write-deny-blocks"),
+            pytest.param(["read", "write"], "deny", ["/work/**"], id="readwrite-deny-blocks"),
+            pytest.param(["write"], "allow", [], id="allow-ignored"),
+            pytest.param(["write"], "interrupt", [], id="interrupt-ignored"),
+            pytest.param(["read"], "deny", [], id="read-only-deny-ignored"),
+        ],
+    )
+    def test_mode_and_operation_filtering(self, operations, mode, expected):
+        # Only deny + write rules count; the target always overlaps the pattern.
+        rule = FilesystemPermission(operations=operations, paths=["/work/**"], mode=mode)
+        assert _find_delete_deny_patterns([rule], "/work") == expected
 
-    def test_unrelated_rule_returns_empty(self):
-        assert _find_delete_deny_patterns([self._deny("/other/**")], "/work") == []
-
-    def test_sibling_prefix_does_not_match(self):
-        # "/work" must not be blocked by a rule on the sibling "/workshop".
-        assert _find_delete_deny_patterns([self._deny("/workshop/**")], "/work") == []
-
-    def test_exact_path_match(self):
-        assert _find_delete_deny_patterns([self._deny("/work/a.txt")], "/work/a.txt") == ["/work/a.txt"]
-
-    def test_descendant_pattern_blocks_ancestor_target(self):
-        # Deleting /work is blocked by a rule scoped inside it.
-        assert _find_delete_deny_patterns([self._deny("/work/secrets/**")], "/work") == ["/work/secrets/**"]
-
-    def test_ancestor_pattern_blocks_descendant_target(self):
-        # Deleting /work/logs is blocked by a rule the target falls under.
-        assert _find_delete_deny_patterns([self._deny("/work/**")], "/work/logs") == ["/work/**"]
-
-    def test_bare_directory_pattern_blocks(self):
-        assert _find_delete_deny_patterns([self._deny("/work/secrets")], "/work") == ["/work/secrets"]
-
-    def test_root_target_blocked_by_any_rule(self):
-        # "/" overlaps everything, so any deny rule blocks delete("/").
-        assert _find_delete_deny_patterns([self._deny("/anything/**")], "/") == ["/anything/**"]
-
-    def test_leading_wildcard_anchor_overlaps_everything(self):
-        # `_glob_anchor("/**/secrets")` collapses to "/", overlapping any target.
-        assert _find_delete_deny_patterns([self._deny("/**/secrets")], "/work") == ["/**/secrets"]
-
-    def test_allow_rules_ignored(self):
-        rule = FilesystemPermission(operations=["write"], paths=["/work/**"], mode="allow")
-        assert _find_delete_deny_patterns([rule], "/work") == []
-
-    def test_interrupt_rules_ignored(self):
-        rule = FilesystemPermission(operations=["write"], paths=["/work/**"], mode="interrupt")
-        assert _find_delete_deny_patterns([rule], "/work") == []
-
-    def test_read_only_deny_ignored(self):
-        # `delete` maps to `write`; a read-scoped deny must not block it.
-        rule = FilesystemPermission(operations=["read"], paths=["/work/**"], mode="deny")
-        assert _find_delete_deny_patterns([rule], "/work") == []
-
-    def test_mixed_operation_deny_matches(self):
-        rule = FilesystemPermission(operations=["read", "write"], paths=["/work/**"], mode="deny")
-        assert _find_delete_deny_patterns([rule], "/work") == ["/work/**"]
-
-    def test_collects_multiple_overlapping_patterns(self):
-        rules = [self._deny("/work/a/**"), self._deny("/work/b/**")]
-        assert _find_delete_deny_patterns(rules, "/work") == ["/work/a/**", "/work/b/**"]
-
-    def test_multiple_paths_in_one_rule(self):
-        rules = [self._deny("/work/a/**", "/work/b/**", "/other/**")]
-        assert _find_delete_deny_patterns(rules, "/work") == ["/work/a/**", "/work/b/**"]
-
-    def test_returns_all_overlapping_patterns(self):
-        # No cap: every conflicting pattern is surfaced for full agent context.
-        rules = [self._deny(f"/work/d{i}/**") for i in range(8)]
-        assert _find_delete_deny_patterns(rules, "/work") == [f"/work/d{i}/**" for i in range(8)]
-
-    def test_deduplicates_repeated_pattern(self):
-        # The same pattern in two rules is reported once, in first-seen order.
-        rules = [self._deny("/work/x/**"), self._deny("/work/x/**", "/work/y/**")]
-        assert _find_delete_deny_patterns(rules, "/work") == ["/work/x/**", "/work/y/**"]
-
-    def test_only_overlapping_patterns_returned(self):
-        # Non-overlapping rules are skipped entirely.
-        rules = [self._deny("/other/**"), self._deny("/work/x/**"), self._deny("/elsewhere/**")]
-        assert _find_delete_deny_patterns(rules, "/work") == ["/work/x/**"]
-
-    def test_target_trailing_slash_normalized(self):
-        assert _find_delete_deny_patterns([self._deny("/work/**")], "/work/") == ["/work/**"]
+    @pytest.mark.parametrize(
+        ("rule_paths", "target", "expected"),
+        [
+            pytest.param([], "/work", [], id="no-permissions"),
+            pytest.param([["/work/a/**"], ["/work/b/**"]], "/work", ["/work/a/**", "/work/b/**"], id="multiple-rules"),
+            pytest.param(
+                [["/work/a/**", "/work/b/**", "/other/**"]],
+                "/work",
+                ["/work/a/**", "/work/b/**"],
+                id="multiple-paths-one-rule-filters-non-overlapping",
+            ),
+            pytest.param(
+                [[f"/work/d{i}/**"] for i in range(8)],
+                "/work",
+                [f"/work/d{i}/**" for i in range(8)],
+                id="all-overlapping-no-cap",
+            ),
+            pytest.param(
+                [["/work/x/**"], ["/work/x/**", "/work/y/**"]],
+                "/work",
+                ["/work/x/**", "/work/y/**"],
+                id="deduplicated-first-seen-order",
+            ),
+            pytest.param(
+                [["/other/**"], ["/work/x/**"], ["/elsewhere/**"]],
+                "/work",
+                ["/work/x/**"],
+                id="only-overlapping-returned",
+            ),
+        ],
+    )
+    def test_multiple_rule_aggregation(self, rule_paths, target, expected):
+        rules = [_deny(*paths) for paths in rule_paths]
+        assert _find_delete_deny_patterns(rules, target) == expected
 
 
 class TestFilesystemPermission:

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -27,9 +27,9 @@ file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,l
 - [`test_read_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L292) — `tests/evals/test_file_operations.py:292`
 - [`test_read_file_truncation_recovery_with_pagination`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L562) — `tests/evals/test_file_operations.py:562`
 - [`test_read_file_empty_file_reports_empty`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L600) — `tests/evals/test_file_operations.py:600`
-- [`test_delete_file_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L617) — `tests/evals/test_file_operations.py:617`
+- [`test_delete_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L617) — `tests/evals/test_file_operations.py:617`
 - [`test_delete_one_of_several_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L646) — `tests/evals/test_file_operations.py:646`
-- [`test_delete_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L681) — `tests/evals/test_file_operations.py:681`
+- [`test_deletes_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L681) — `tests/evals/test_file_operations.py:681`
 - [`test_write_then_delete_same_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L714) — `tests/evals/test_file_operations.py:714`
 - [`test_delete_missing_file_reports_absence`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L744) — `tests/evals/test_file_operations.py:744`
 

--- a/libs/evals/tests/evals/test_file_operations.py
+++ b/libs/evals/tests/evals/test_file_operations.py
@@ -614,7 +614,7 @@ def test_read_file_empty_file_reports_empty(model: BaseChatModel) -> None:
 @pytest.mark.eval_tier("baseline")
 @pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
-def test_delete_file_simple(model: BaseChatModel) -> None:
+def test_delete_simple(model: BaseChatModel) -> None:
     """Deletes a seeded file and confirms it is gone."""
     agent = create_deep_agent(model=model)
     run_agent(
@@ -622,15 +622,15 @@ def test_delete_file_simple(model: BaseChatModel) -> None:
         model=model,
         initial_files={"/foo.md": "delete me\n"},
         query="Delete the file /foo.md, then reply with DONE only.",
-        # 1st step: request a delete_file tool call for /foo.md.
+        # 1st step: request a delete tool call for /foo.md.
         # 2nd step: reply DONE.
-        # 1 tool call request: delete_file.
+        # 1 tool call request: delete.
         scorer=TrajectoryScorer()
         .expect(
             agent_steps=2,
             tool_call_requests=1,
             tool_calls=[
-                tool_call(name="delete_file", step=1, args_contains={"file_path": "/foo.md"}),
+                tool_call(name="delete", step=1, args_contains={"file_path": "/foo.md"}),
             ],
         )
         .success(
@@ -655,15 +655,15 @@ def test_delete_one_of_several_files(model: BaseChatModel) -> None:
             "/c.md": "c",
         },
         query="Delete /b.md only. Leave the other files untouched. Reply with DONE only.",
-        # 1st step: request a delete_file tool call for /b.md.
+        # 1st step: request a delete tool call for /b.md.
         # 2nd step: reply DONE.
-        # 1 tool call request: delete_file.
+        # 1 tool call request: delete.
         scorer=TrajectoryScorer()
         .expect(
             agent_steps=2,
             tool_call_requests=1,
             tool_calls=[
-                tool_call(name="delete_file", step=1, args_contains={"file_path": "/b.md"}),
+                tool_call(name="delete", step=1, args_contains={"file_path": "/b.md"}),
             ],
         )
         .success(
@@ -678,7 +678,7 @@ def test_delete_one_of_several_files(model: BaseChatModel) -> None:
 @pytest.mark.eval_tier("baseline")
 @pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
-def test_delete_files_in_parallel(model: BaseChatModel) -> None:
+def test_deletes_in_parallel(model: BaseChatModel) -> None:
     """Deletes two files in parallel without extra tool calls."""
     agent = create_deep_agent(model=model)
     run_agent(
@@ -688,16 +688,16 @@ def test_delete_files_in_parallel(model: BaseChatModel) -> None:
         query=(
             "Delete /a.md and /b.md. Do the deletes in parallel. Do NOT read any files afterward. Reply with DONE only."
         ),
-        # 1st step: request 2 delete_file tool calls in parallel.
+        # 1st step: request 2 delete tool calls in parallel.
         # 2nd step: reply DONE.
-        # 2 tool call requests: delete_file /a.md and delete_file /b.md.
+        # 2 tool call requests: delete /a.md and delete /b.md.
         scorer=TrajectoryScorer()
         .expect(
             agent_steps=2,
             tool_call_requests=2,
             tool_calls=[
-                tool_call(name="delete_file", step=1, args_contains={"file_path": "/a.md"}),
-                tool_call(name="delete_file", step=1, args_contains={"file_path": "/b.md"}),
+                tool_call(name="delete", step=1, args_contains={"file_path": "/a.md"}),
+                tool_call(name="delete", step=1, args_contains={"file_path": "/b.md"}),
             ],
         )
         .success(
@@ -719,16 +719,16 @@ def test_write_then_delete_same_file(model: BaseChatModel) -> None:
         model=model,
         query=('Write "scratch" to /tmp.md, then delete /tmp.md. Reply with DONE only.'),
         # 1st step: request a write_file tool call for /tmp.md.
-        # 2nd step: request a delete_file tool call for /tmp.md.
+        # 2nd step: request a delete tool call for /tmp.md.
         # 3rd step: reply DONE.
-        # 2 tool call requests: write_file then delete_file.
+        # 2 tool call requests: write_file then delete.
         scorer=TrajectoryScorer()
         .expect(
             agent_steps=3,
             tool_call_requests=2,
             tool_calls=[
                 tool_call(name="write_file", step=1, args_contains={"file_path": "/tmp.md"}),
-                tool_call(name="delete_file", step=2, args_contains={"file_path": "/tmp.md"}),
+                tool_call(name="delete", step=2, args_contains={"file_path": "/tmp.md"}),
             ],
         )
         .success(
@@ -744,7 +744,7 @@ def test_write_then_delete_same_file(model: BaseChatModel) -> None:
 def test_delete_missing_file_reports_absence(model: BaseChatModel) -> None:
     """A delete of a nonexistent file is reported, not faked.
 
-    The `delete_file` tool returns a "File ... not found" error for a path
+    The `delete` tool returns a "File ... not found" error for a path
     that does not exist. The agent should surface that the file is missing
     rather than claim a successful deletion, and must leave the real file
     untouched. Tool-call shape is intentionally not enforced: a model may


### PR DESCRIPTION
The filesystem delete tool only removed single files and rejected directories, so clearing a directory (e.g. a subagent's working dir) meant one tool call per file and left the empty directories behind. This makes delete remove directories recursively, renames the tool from `delete_file` to `delete`, and makes the permission layer treat a recursive delete as a single all-or-nothing operation over the whole subtree.

What changed:
- `FilesystemBackend.delete` now removes directories recursively (`shutil.rmtree`). Symlinks are removed as links, never followed into their target.
- Renamed the tool `delete_file` to `delete` (the arg is still `file_path`).
- `delete` maps to the `write` operation. For a directory target, the tool expands the subtree and checks `write` on the target and every descendant; if any path is denied, the entire delete is refused and nothing is removed (all-or-nothing).
- `delete` is now registered for `interrupt`-mode permissions (bulk scope), so an interrupt rule on any path inside the target fires before the delete runs. It was previously absent, so interrupt rules never applied to deletes.

Why all-or-nothing: a recursive delete of a directory is one intent. If part of it is protected, refusing cleanly is safer and more predictable than leaving a half-deleted tree, and the agent can still delete the allowed paths explicitly.