### PR TITLE
fix(code): keep terminal-default theme on Esc in `/theme` selector

### DIFF
--- a/libs/code/deepagents_code/widgets/theme_selector.py
+++ b/libs/code/deepagents_code/widgets/theme_selector.py
@@ -114,6 +114,7 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
         self._original_theme = current_theme
         self._terminal_default = terminal_default
         self._session_terminal_default: str | None = None
+        self._cancel_kept_terminal_default: str | None = None
         self._show_keys = False
 
     def _sync_terminal_background(self) -> None:
@@ -235,6 +236,8 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
         restores the theme that was active when the picker opened.
         """
         keep = self._session_terminal_default
+        if keep is not None:
+            self._cancel_kept_terminal_default = keep
         target = keep if keep is not None else self._original_theme
         try:
             self.app.theme = target
@@ -246,6 +249,25 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
                 "Failed to apply theme '%s' on cancel", target, exc_info=True
             )
         self.dismiss(None)
+
+    def _discard_failed_terminal_default_save(self, name: str) -> None:
+        if self._session_terminal_default != name:
+            return
+        self._session_terminal_default = None
+        if self._cancel_kept_terminal_default != name:
+            return
+        self._cancel_kept_terminal_default = None
+        if self.app.theme != name:
+            return
+        try:
+            self.app.theme = self._original_theme
+            self._sync_terminal_background()
+        except Exception:
+            logger.warning(
+                "Failed to restore original theme '%s' after terminal save failure",
+                self._original_theme,
+                exc_info=True,
+            )
 
     def action_cursor_down(self) -> None:
         """Move the option list cursor down (Tab)."""
@@ -308,10 +330,7 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
                 )
             except Exception as exc:
                 logger.exception("Failed to persist terminal theme mapping")
-                # Guard against clobbering a newer `t` selection whose write
-                # is still in flight; only clear if this save is still current.
-                if self._session_terminal_default == name:
-                    self._session_terminal_default = None
+                self._discard_failed_terminal_default_save(name)
                 self.app.notify(
                     f"Could not save terminal mapping ({type(exc).__name__}).",
                     severity="error",
@@ -320,8 +339,7 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
                 )
                 return
             if not status.ok:
-                if self._session_terminal_default == name:
-                    self._session_terminal_default = None
+                self._discard_failed_terminal_default_save(name)
                 self.app.notify(
                     status.message or "Could not save terminal mapping.",
                     severity=status.severity,

--- a/libs/code/deepagents_code/widgets/theme_selector.py
+++ b/libs/code/deepagents_code/widgets/theme_selector.py
@@ -35,7 +35,9 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
 
     Displays available themes in an `OptionList`. Navigating the option list
     applies a live preview by swapping the app theme. Returns the selected
-    theme name on Enter, or `None` on Esc (restoring the original theme).
+    theme name on Enter, or `None` on Esc. Esc normally restores the original
+    theme, but if the user set a per-terminal default with `t` this session,
+    Esc keeps that theme active instead of reverting.
     """
 
     BINDINGS: ClassVar[list[BindingType]] = [
@@ -47,7 +49,8 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
     ]
     """Key bindings for the selector.
 
-    Esc dismisses and restores the original theme. Arrow keys and Enter are
+    Esc dismisses, restoring the original theme unless `t` set a per-terminal
+    default this session (in which case that theme is kept). Arrow keys and Enter are
     handled natively by the embedded `OptionList`; Tab / Shift+Tab are bound
     here to advance the option list cursor for consistency with other
     selector screens (where Tab cycles focus across multiple widgets).
@@ -109,6 +112,7 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
         self._current_theme = current_theme
         self._original_theme = current_theme
         self._terminal_default = terminal_default
+        self._session_terminal_default: str | None = None
         self._show_keys = False
 
     def _sync_terminal_background(self) -> None:
@@ -218,8 +222,17 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
             self.dismiss(None)
 
     def action_cancel(self) -> None:
-        """Restore the original theme and dismiss."""
-        self.app.theme = self._original_theme
+        """Dismiss, keeping a terminal default set this session or restoring.
+
+        Pressing `t` saves a per-terminal default and is treated as a
+        deliberate choice, so Esc keeps that theme active instead of
+        reverting. `dismiss(None)` skips the global `[ui].theme` write — the
+        per-terminal mapping was already persisted by `action_set_for_terminal`.
+        Without a `t` press, Esc restores the original theme as before.
+        """
+        keep = self._session_terminal_default
+        target = keep if keep is not None else self._original_theme
+        self.app.theme = target
         self._sync_terminal_background()
         self.dismiss(None)
 
@@ -268,6 +281,11 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
                 "action_set_for_terminal got unregistered option id '%s'", name
             )
             return
+
+        # Record the deliberate choice synchronously so a subsequent Esc keeps
+        # this theme rather than reverting, regardless of when the async write
+        # finishes. The persisted mapping is the source of truth either way.
+        self._session_terminal_default = name
 
         async def _persist() -> None:
             try:

--- a/libs/code/deepagents_code/widgets/theme_selector.py
+++ b/libs/code/deepagents_code/widgets/theme_selector.py
@@ -282,11 +282,6 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
             )
             return
 
-        # Record the deliberate choice synchronously so a subsequent Esc keeps
-        # this theme rather than reverting, regardless of when the async write
-        # finishes. The persisted mapping is the source of truth either way.
-        self._session_terminal_default = name
-
         async def _persist() -> None:
             try:
                 from deepagents_code.app import _save_terminal_theme_mapping_result
@@ -311,6 +306,9 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
                     timeout=6,
                 )
                 return
+            # Esc should only preserve a previewed theme after the terminal
+            # default has actually been saved.
+            self._session_terminal_default = name
             if status.message is not None:
                 self.app.notify(
                     status.message,

--- a/libs/code/deepagents_code/widgets/theme_selector.py
+++ b/libs/code/deepagents_code/widgets/theme_selector.py
@@ -36,8 +36,8 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
     Displays available themes in an `OptionList`. Navigating the option list
     applies a live preview by swapping the app theme. Returns the selected
     theme name on Enter, or `None` on Esc. Esc normally restores the original
-    theme, but if the user set a per-terminal default with `t` this session,
-    Esc keeps that theme active instead of reverting.
+    theme, but if a per-terminal default was saved with `t` this session, Esc
+    keeps that theme active instead of reverting.
     """
 
     BINDINGS: ClassVar[list[BindingType]] = [
@@ -49,9 +49,10 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
     ]
     """Key bindings for the selector.
 
-    Esc dismisses, restoring the original theme unless `t` set a per-terminal
-    default this session (in which case that theme is kept). Arrow keys and Enter are
-    handled natively by the embedded `OptionList`; Tab / Shift+Tab are bound
+    Esc dismisses, restoring the original theme unless a `t` save set a
+    per-terminal default this session (in which case that theme is kept).
+    Arrow keys and Enter are handled natively by the embedded `OptionList`;
+    Tab / Shift+Tab are bound
     here to advance the option list cursor for consistency with other
     selector screens (where Tab cycles focus across multiple widgets).
     `action_toggle_names` toggles between human-readable labels and canonical
@@ -222,18 +223,27 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
             self.dismiss(None)
 
     def action_cancel(self) -> None:
-        """Dismiss, keeping a terminal default set this session or restoring.
+        """Dismiss, keeping a saved terminal default or restoring the original.
 
-        Pressing `t` saves a per-terminal default and is treated as a
-        deliberate choice, so Esc keeps that theme active instead of
-        reverting. `dismiss(None)` skips the global `[ui].theme` write — the
-        per-terminal mapping was already persisted by `action_set_for_terminal`.
-        Without a `t` press, Esc restores the original theme as before.
+        Pressing `t` to save a per-terminal default is a deliberate choice, so
+        Esc keeps that theme instead of reverting. `_session_terminal_default`
+        is set only after the save succeeds (see `action_set_for_terminal`), so
+        reaching the keep branch means the per-terminal mapping was written this
+        session; `dismiss(None)` then intentionally skips the global `[ui].theme`
+        write. Without a successful `t` save, Esc restores the theme that was
+        active when the picker opened.
         """
         keep = self._session_terminal_default
         target = keep if keep is not None else self._original_theme
-        self.app.theme = target
-        self._sync_terminal_background()
+        try:
+            self.app.theme = target
+            self._sync_terminal_background()
+        except Exception:
+            # A theme can be unregistered mid-session; never trap the user in
+            # the modal. Log and dismiss regardless so Esc always closes.
+            logger.warning(
+                "Failed to apply theme '%s' on cancel", target, exc_info=True
+            )
         self.dismiss(None)
 
     def action_cursor_down(self) -> None:

--- a/libs/code/deepagents_code/widgets/theme_selector.py
+++ b/libs/code/deepagents_code/widgets/theme_selector.py
@@ -223,15 +223,16 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
             self.dismiss(None)
 
     def action_cancel(self) -> None:
-        """Dismiss, keeping a saved terminal default or restoring the original.
+        """Dismiss, keeping a terminal default chosen this session or restoring.
 
         Pressing `t` to save a per-terminal default is a deliberate choice, so
-        Esc keeps that theme instead of reverting. `_session_terminal_default`
-        is set only after the save succeeds (see `action_set_for_terminal`), so
-        reaching the keep branch means the per-terminal mapping was written this
-        session; `dismiss(None)` then intentionally skips the global `[ui].theme`
-        write. Without a successful `t` save, Esc restores the theme that was
-        active when the picker opened.
+        Esc keeps that theme instead of reverting. `action_set_for_terminal`
+        records the choice synchronously (and clears it only if the async save
+        fails), so Esc keeps the theme even when the write is still in flight;
+        the persisted `[ui.terminal_themes]` mapping is the source of truth
+        across sessions. `dismiss(None)` intentionally skips the global
+        `[ui].theme` write. Without a `t` press — or after a failed save — Esc
+        restores the theme that was active when the picker opened.
         """
         keep = self._session_terminal_default
         target = keep if keep is not None else self._original_theme
@@ -292,6 +293,12 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
             )
             return
 
+        # Record the deliberate choice synchronously so Esc keeps this theme
+        # even if the user dismisses before the async write returns (otherwise
+        # a slow write would race the cancel path and revert). The failure
+        # branches below clear it so a save that errors still reverts on Esc.
+        self._session_terminal_default = name
+
         async def _persist() -> None:
             try:
                 from deepagents_code.app import _save_terminal_theme_mapping_result
@@ -301,6 +308,10 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
                 )
             except Exception as exc:
                 logger.exception("Failed to persist terminal theme mapping")
+                # Guard against clobbering a newer `t` selection whose write
+                # is still in flight; only clear if this save is still current.
+                if self._session_terminal_default == name:
+                    self._session_terminal_default = None
                 self.app.notify(
                     f"Could not save terminal mapping ({type(exc).__name__}).",
                     severity="error",
@@ -309,6 +320,8 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
                 )
                 return
             if not status.ok:
+                if self._session_terminal_default == name:
+                    self._session_terminal_default = None
                 self.app.notify(
                     status.message or "Could not save terminal mapping.",
                     severity=status.severity,
@@ -316,9 +329,6 @@ class ThemeSelectorScreen(ModalScreen[str | None]):
                     timeout=6,
                 )
                 return
-            # Esc should only preserve a previewed theme after the terminal
-            # default has actually been saved.
-            self._session_terminal_default = name
             if status.message is not None:
                 self.app.notify(
                     status.message,

--- a/libs/code/tests/unit_tests/test_theme.py
+++ b/libs/code/tests/unit_tests/test_theme.py
@@ -2542,3 +2542,93 @@ class TestThemeSelectorScreen:
                 str(option_list.get_option_at_index(other_index).prompt) == other_label
             )
             assert option_list.highlighted == other_index
+
+    async def test_escape_keeps_theme_set_for_terminal_this_session(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Esc keeps a theme set with `t` instead of reverting to the original.
+
+        Pressing `t` is a deliberate choice, so Esc should preserve it rather
+        than rolling back to the theme that was active when the picker opened.
+        """
+        from textual.app import App
+        from textual.theme import Theme as TextualTheme
+        from textual.widgets import OptionList
+
+        from deepagents_code.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        results: list[str | None] = []
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            c = theme.LIGHT_COLORS
+            app.register_theme(
+                TextualTheme(
+                    name="langchain-light",
+                    primary=c.primary,
+                    secondary=c.secondary,
+                    accent=c.accent,
+                    foreground=c.foreground,
+                    background=c.background,
+                    surface=c.surface,
+                    panel=c.panel,
+                    warning=c.warning,
+                    error=c.error,
+                    success=c.success,
+                    dark=False,
+                )
+            )
+
+            def on_result(result: str | None) -> None:
+                results.append(result)
+
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen, on_result)
+            await pilot.pause()
+
+            target_key = "langchain-light"
+            target_index = list(theme.get_registry()).index(target_key)
+
+            option_list = screen.query_one("#theme-options", OptionList)
+            option_list.highlighted = target_index
+            await pilot.pause()
+            await pilot.press("t")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+        assert app.theme == target_key
+        assert results == [None]
+
+    async def test_escape_restores_original_when_no_terminal_default_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without a `t` press, Esc still reverts the previewed theme."""
+        from textual.app import App
+
+        from deepagents_code.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            await pilot.press("down")
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+
+        assert app.theme == "langchain"

--- a/libs/code/tests/unit_tests/test_theme.py
+++ b/libs/code/tests/unit_tests/test_theme.py
@@ -2868,3 +2868,65 @@ class TestThemeSelectorScreen:
 
         # The modal dismissed (no exception bubbled, user not trapped).
         assert results == [None]
+
+    async def test_escape_keeps_theme_when_save_still_in_flight(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Esc keeps the `t` theme even if the config write hasn't returned.
+
+        Regression test for the race where the per-terminal save is slow
+        (disk/lock contention): pressing `t` then Esc before the write
+        completes must still keep the chosen theme, because the choice is
+        recorded synchronously rather than only after the worker resolves.
+        """
+        import asyncio
+        import threading
+
+        from textual.app import App
+        from textual.widgets import OptionList
+
+        from deepagents_code.app import _ConfigWriteResult
+        from deepagents_code.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def _slow_save(*_args: object, **_kwargs: object) -> _ConfigWriteResult:
+            started.set()
+            release.wait(timeout=1)
+            return _ConfigWriteResult(True)
+
+        monkeypatch.setattr(
+            "deepagents_code.app._save_terminal_theme_mapping_result", _slow_save
+        )
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            _register_lc_light_theme(app)
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            option_list = screen.query_one("#theme-options", OptionList)
+            option_list.highlighted = list(theme.get_registry()).index(
+                "langchain-light"
+            )
+            await pilot.pause()
+
+            await pilot.press("t")
+            # Wait until the worker is blocked inside the (still-unfinished) save.
+            assert await asyncio.to_thread(started.wait, 1)
+
+            # Cancel while the write is in flight — must keep, not revert.
+            await pilot.press("escape")
+            await pilot.pause()
+
+            release.set()
+            await app.workers.wait_for_complete()
+
+        assert app.theme == "langchain-light"

--- a/libs/code/tests/unit_tests/test_theme.py
+++ b/libs/code/tests/unit_tests/test_theme.py
@@ -2679,3 +2679,192 @@ class TestThemeSelectorScreen:
             await pilot.pause()
 
         assert app.theme == "langchain"
+
+    async def test_escape_keeps_last_terminal_default_after_multiple_t(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The last successful `t` wins; Esc keeps it over earlier saves.
+
+        Pressing `t` on a second theme supersedes the first, and a later
+        preview (without `t`) does not override the saved default — Esc
+        restores the most recently saved per-terminal theme.
+        """
+        from textual.app import App
+        from textual.widgets import OptionList
+
+        from deepagents_code.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            _register_lc_light_theme(app)
+            # `textual-light` is a Textual builtin, registered on every App and
+            # present in the deepagents registry — usable as a second target.
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            registry = list(theme.get_registry())
+            option_list = screen.query_one("#theme-options", OptionList)
+
+            # First `t`: save langchain-light.
+            option_list.highlighted = registry.index("langchain-light")
+            await pilot.pause()
+            await pilot.press("t")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+            # Second `t`: save textual-light, superseding the first.
+            option_list.highlighted = registry.index("textual-light")
+            await pilot.pause()
+            await pilot.press("t")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+            # Preview the original (no `t`) — this must not win on Esc.
+            option_list.highlighted = registry.index("langchain")
+            await pilot.pause()
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+        assert app.theme == "textual-light"
+
+    async def test_escape_keeps_terminal_default_over_later_preview(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Esc restores the `t`-saved theme even after previewing another.
+
+        After `t` saves a default, browsing to a different theme live-previews
+        it; Esc must roll back to the saved default, not the last preview.
+        """
+        from textual.app import App
+        from textual.widgets import OptionList
+
+        from deepagents_code.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            _register_lc_light_theme(app)
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            registry = list(theme.get_registry())
+            option_list = screen.query_one("#theme-options", OptionList)
+
+            option_list.highlighted = registry.index("langchain-light")
+            await pilot.pause()
+            await pilot.press("t")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+            # Preview a different, registered theme without pressing `t`.
+            option_list.highlighted = registry.index("textual-light")
+            await pilot.pause()
+            assert app.theme == "textual-light"
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+        assert app.theme == "langchain-light"
+
+    async def test_escape_restores_original_when_t_with_term_program_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`t` no-ops without `TERM_PROGRAM`, so Esc reverts the preview.
+
+        The early return in `action_set_for_terminal` never arms the
+        keep-on-Esc behavior, so Esc restores the original theme and nothing
+        is persisted.
+        """
+        from textual.app import App
+        from textual.widgets import OptionList
+
+        from deepagents_code.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.delenv("TERM_PROGRAM", raising=False)
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            _register_lc_light_theme(app)
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            registry = list(theme.get_registry())
+            option_list = screen.query_one("#theme-options", OptionList)
+            option_list.highlighted = registry.index("langchain-light")
+            await pilot.pause()
+            assert app.theme == "langchain-light"
+
+            await pilot.press("t")
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+
+        assert app.theme == "langchain"
+        assert not config.exists()
+
+    async def test_escape_dismisses_when_kept_theme_unregistered_midsession(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Esc never traps the user even if the kept theme can't be applied.
+
+        If the saved per-terminal theme is unregistered after `t` (so
+        reapplying it raises `InvalidThemeError`), `action_cancel` logs and
+        still dismisses rather than leaving the modal stuck open.
+        """
+        from textual.app import App
+        from textual.widgets import OptionList
+
+        from deepagents_code.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        results: list[str | None] = []
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            _register_lc_light_theme(app)
+
+            def on_result(result: str | None) -> None:
+                results.append(result)
+
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen, on_result)
+            await pilot.pause()
+
+            registry = list(theme.get_registry())
+            option_list = screen.query_one("#theme-options", OptionList)
+            option_list.highlighted = registry.index("langchain-light")
+            await pilot.pause()
+            await pilot.press("t")
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+
+            # Move off the saved theme, then pull it out from under Esc.
+            option_list.highlighted = registry.index("langchain")
+            await pilot.pause()
+            app.unregister_theme("langchain-light")
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+        # The modal dismissed (no exception bubbled, user not trapped).
+        assert results == [None]

--- a/libs/code/tests/unit_tests/test_theme.py
+++ b/libs/code/tests/unit_tests/test_theme.py
@@ -2935,3 +2935,65 @@ class TestThemeSelectorScreen:
             await app.workers.wait_for_complete()
 
         assert app.theme == "langchain-light"
+
+    @pytest.mark.parametrize("failure_mode", ["status", "exception"])
+    async def test_escape_restores_theme_when_in_flight_save_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure_mode: str
+    ) -> None:
+        """Esc reverts once a terminal-default save kept by cancel fails."""
+        import asyncio
+        import threading
+
+        from textual.app import App
+        from textual.widgets import OptionList
+
+        from deepagents_code.app import _ConfigWriteResult
+        from deepagents_code.widgets.theme_selector import ThemeSelectorScreen
+
+        config = tmp_path / "config.toml"
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def _slow_failing_save(*_args: object, **_kwargs: object) -> _ConfigWriteResult:
+            started.set()
+            release.wait(timeout=1)
+            if failure_mode == "exception":
+                msg = "simulated"
+                raise OSError(msg)
+            return _ConfigWriteResult(
+                False, "Could not save terminal mapping.", "error"
+            )
+
+        monkeypatch.setattr(
+            "deepagents_code.app._save_terminal_theme_mapping_result",
+            _slow_failing_save,
+        )
+
+        app = App()
+        async with app.run_test() as pilot:
+            _register_lc_theme(app)
+            _register_lc_light_theme(app)
+            screen = ThemeSelectorScreen(current_theme="langchain")
+            app.push_screen(screen)
+            await pilot.pause()
+
+            option_list = screen.query_one("#theme-options", OptionList)
+            option_list.highlighted = list(theme.get_registry()).index(
+                "langchain-light"
+            )
+            await pilot.pause()
+
+            await pilot.press("t")
+            assert await asyncio.to_thread(started.wait, 1)
+
+            await pilot.press("escape")
+            await pilot.pause()
+            assert app.theme == "langchain-light"
+
+            release.set()
+            await app.workers.wait_for_complete()
+
+        assert app.theme == "langchain"

--- a/libs/code/tests/unit_tests/test_theme.py
+++ b/libs/code/tests/unit_tests/test_theme.py
@@ -1861,6 +1861,29 @@ def _register_lc_theme(app: object) -> None:
     app_any.theme = "langchain"
 
 
+def _register_lc_light_theme(app: object) -> None:
+    """Register the light LangChain theme for preview tests."""
+    from textual.theme import Theme as TextualTheme
+
+    c = LIGHT_COLORS
+    app.register_theme(  # ty: ignore
+        TextualTheme(
+            name="langchain-light",
+            primary=c.primary,
+            secondary=c.secondary,
+            accent=c.accent,
+            foreground=c.foreground,
+            background=c.background,
+            surface=c.surface,
+            panel=c.panel,
+            warning=c.warning,
+            error=c.error,
+            success=c.success,
+            dark=False,
+        )
+    )
+
+
 class TestThemeSelectorScreen:
     """ThemeSelectorScreen widget tests."""
 
@@ -2277,6 +2300,7 @@ class TestThemeSelectorScreen:
         silent no-op.
         """
         from textual.app import App
+        from textual.widgets import OptionList
 
         from deepagents_code.app import _ConfigWriteResult
         from deepagents_code.widgets.theme_selector import ThemeSelectorScreen
@@ -2298,6 +2322,7 @@ class TestThemeSelectorScreen:
         app = App()
         async with app.run_test() as pilot:
             _register_lc_theme(app)
+            _register_lc_light_theme(app)
 
             def _capture(
                 message: str, *, severity: str = "information", **_kwargs: object
@@ -2309,13 +2334,23 @@ class TestThemeSelectorScreen:
             screen = ThemeSelectorScreen(current_theme="langchain")
             app.push_screen(screen)
             await pilot.pause()
+
+            target_key = "langchain-light"
+            target_index = list(theme.get_registry()).index(target_key)
+            option_list = screen.query_one("#theme-options", OptionList)
+            option_list.highlighted = target_index
+            await pilot.pause()
+
             await pilot.press("t")
             await app.workers.wait_for_complete()
+            await pilot.pause()
+            await pilot.press("escape")
             await pilot.pause()
 
         assert any(
             sev == "error" and "terminal mapping" in msg for sev, msg in notifications
         )
+        assert app.theme == "langchain"
 
     async def test_t_notifies_on_save_exception(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -2326,6 +2361,7 @@ class TestThemeSelectorScreen:
         name (e.g., `OSError`) tells the user where to look.
         """
         from textual.app import App
+        from textual.widgets import OptionList
 
         from deepagents_code.widgets.theme_selector import ThemeSelectorScreen
 
@@ -2346,6 +2382,7 @@ class TestThemeSelectorScreen:
         app = App()
         async with app.run_test() as pilot:
             _register_lc_theme(app)
+            _register_lc_light_theme(app)
 
             def _capture(
                 message: str, *, severity: str = "information", **_kwargs: object
@@ -2357,11 +2394,21 @@ class TestThemeSelectorScreen:
             screen = ThemeSelectorScreen(current_theme="langchain")
             app.push_screen(screen)
             await pilot.pause()
+
+            target_key = "langchain-light"
+            target_index = list(theme.get_registry()).index(target_key)
+            option_list = screen.query_one("#theme-options", OptionList)
+            option_list.highlighted = target_index
+            await pilot.pause()
+
             await pilot.press("t")
             await app.workers.wait_for_complete()
             await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
 
         assert any(sev == "error" and "OSError" in msg for sev, msg in notifications)
+        assert app.theme == "langchain"
 
     async def test_t_write_skips_rerender_after_screen_unmount(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_theme.py
+++ b/libs/code/tests/unit_tests/test_theme.py
@@ -2925,7 +2925,12 @@ class TestThemeSelectorScreen:
             # Cancel while the write is in flight — must keep, not revert.
             await pilot.press("escape")
             await pilot.pause()
+            assert app.theme == "langchain-light"
 
+            # Let the still-blocked save finish. The screen is already
+            # dismissed, so suppress the badge rerender (its option list is
+            # gone) to mirror real mid-write teardown before draining workers.
+            screen._is_mounted = False
             release.set()
             await app.workers.wait_for_complete()
 


### PR DESCRIPTION
`/theme`: pressing Esc after setting a terminal default with `t` now keeps that theme instead of reverting.

---

In the `/theme` selector, pressing `t` to set a per-terminal default is a deliberate choice. Previously Esc reverted to the theme that was active when the picker opened, discarding that preview. Now Esc keeps the theme set with `t` this session while still restoring the original when no terminal default was set. The persisted `[ui.terminal_themes]` mapping remains the source of truth, so no extra `[ui].theme` write happens.

Made by [Open SWE](https://openswe.vercel.app)