### PR TITLE
style(code): say "Agent has a question for you" for single question

### DIFF
--- a/libs/code/deepagents_code/widgets/ask_user.py
+++ b/libs/code/deepagents_code/widgets/ask_user.py
@@ -176,9 +176,12 @@ class AskUserMenu(Container):
     def compose(self) -> ComposeResult:  # noqa: D102
         glyphs = get_glyphs()
         count = len(self._questions)
-        label = "Question" if count == 1 else "Questions"
+        if count == 1:
+            title = "Agent has a question for you"
+        else:
+            title = f"Agent has {count} Questions for you"
         yield Static(
-            f"{glyphs.cursor} Agent has {count} {label} for you",
+            f"{glyphs.cursor} {title}",
             classes="ask-user-title",
         )
         yield Static("")


### PR DESCRIPTION
The ask-user widget title read "Agent has 1 Question for you" for a single question. This now reads "Agent has a question for you" while keeping the pluralized count form for multiple questions.

Made by [Open SWE](https://openswe.vercel.app)