### PR TITLE
style(code): reword auto-update restart toast for clarity

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3472,7 +3472,7 @@ class DeepAgentsApp(App):
                 self.notify(
                     f"Update available: v{latest}{release_age}. "
                     f"Currently installed: {cli_version}{installed_age}. "
-                    "Restart dcode to auto-update before startup.",
+                    "Restart dcode to install the update automatically.",
                     severity="information",
                     timeout=12,
                     markup=False,


### PR DESCRIPTION
The update-available toast read "Restart dcode to auto-update before startup," which is awkward from a UX perspective. Reworded to "Restart dcode to install the update automatically."

Made by [Open SWE](https://openswe.vercel.app)