### PR TITLE
ci(infra): fail release early if version already on PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,13 +290,51 @@ jobs:
         run: |
           import os
           import re
+          import sys
           import tomllib
+          import urllib.error
+          import urllib.request
           with open("pyproject.toml", "rb") as f:
               data = tomllib.load(f)
           pkg_name = data["project"]["name"]
           version = data["project"]["version"]
           # PEP 440 pre-release: contains a/b/rc/dev suffix or dash separator
           is_pre = bool(re.search(r"(a|b|rc|\.dev)\d", version) or "-" in version)
+
+          # Query the per-version endpoint so PyPI applies PEP 440 normalization
+          # (e.g. `0.1.0-rc1` and `0.1.0rc1` resolve to the same release): HTTP 200
+          # means the version is already published, 404 means it's available
+          # (including the first-ever release of a new package). Only the status
+          # code is used, so a malicious or malformed response body can't mislead us.
+          url = f"https://pypi.org/pypi/{pkg_name}/{version}/json"
+          try:
+              with urllib.request.urlopen(url, timeout=10):
+                  already_published = True
+          except urllib.error.HTTPError as err:
+              if err.code == 404:
+                  already_published = False
+              else:
+                  # Fail closed: an unexpected status means we can't verify.
+                  print(
+                      f"::error::PyPI returned HTTP {err.code} checking whether "
+                      f"{pkg_name}=={version} exists; cannot verify, aborting."
+                  )
+                  sys.exit(1)
+          except urllib.error.URLError as err:
+              # Fail closed: if PyPI is unreachable we must not assume the version
+              # is free, or we risk re-publishing an existing release.
+              print(
+                  f"::error::Could not reach PyPI to verify {pkg_name}=={version} "
+                  f"({err.reason}); cannot verify, aborting."
+              )
+              sys.exit(1)
+
+          if already_published:
+              print(f"::error::{pkg_name}=={version} already exists on PyPI.")
+              sys.exit(1)
+
+          print(f"::notice::{pkg_name}=={version} is not yet on PyPI; proceeding.")
+
           with open(os.environ["GITHUB_OUTPUT"], "a") as f:
               f.write(f"pkg-name={pkg_name}\n")
               f.write(f"version={version}\n")


### PR DESCRIPTION
Ported from langchain-ai/langchain#38055

---

- Check the PyPI per-version JSON endpoint during the release workflow's build job.
- Abort before publishing when the package version already exists on PyPI.
- Fail closed if PyPI is unreachable or returns an unexpected status.