### PR TITLE
fix(evals): preserve LangSmith sandbox workdir

### DIFF
--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -361,7 +361,12 @@ jobs:
             n_tasks_flag="--n-tasks $HARBOR_N_TASKS"
           fi
 
-          env_flag="--env $HARBOR_SANDBOX_ENV"
+          # Keep LangSmith on our adapter so commands run from the image's Dockerfile WORKDIR.
+          if [ "$HARBOR_SANDBOX_ENV" = "langsmith" ]; then
+            env_flag="--environment-import-path deepagents_harbor.langsmith_environment:LangSmithEnvironment"
+          else
+            env_flag="--env $HARBOR_SANDBOX_ENV"
+          fi
 
           uv run harbor run \
             --agent-import-path deepagents_harbor:DeepAgentsWrapper \

--- a/libs/evals/deepagents_harbor/langsmith_environment.py
+++ b/libs/evals/deepagents_harbor/langsmith_environment.py
@@ -1,0 +1,576 @@
+"""Harbor environment backed by LangSmith sandboxes."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import shlex
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from dockerfile_parse import DockerfileParser
+from harbor.environments.base import BaseEnvironment, ExecResult
+from harbor.environments.capabilities import EnvironmentCapabilities
+from harbor.models.task.config import NetworkMode
+from harbor.models.trial.paths import EnvironmentPaths, TrialPaths
+from harbor.utils.logger import logger
+from langsmith.sandbox import AsyncSandboxClient
+
+from deepagents_harbor.langsmith import resolve_langsmith_api_key
+
+if TYPE_CHECKING:
+    from harbor.models.environment_type import EnvironmentType
+    from harbor.models.task.config import EnvironmentConfig
+    from langsmith.sandbox import AsyncSandbox
+
+
+_DEFAULT_EXEC_TIMEOUT_SEC = 30 * 60
+
+
+def _list_files_recursive(source: Path) -> list[Path]:
+    """Materialize every regular file under `source` (sync; for use inside `asyncio.to_thread`)."""
+    return [p for p in source.rglob("*") if p.is_file()]
+
+
+_BYTES_PER_MB = 1024 * 1024
+_MAX_NAME_LEN = 63
+
+
+class LangSmithEnvironment(BaseEnvironment):
+    r"""Harbor environment backed by LangSmith sandboxes.
+
+    Uses `--environment-import-path` because harbor's `EnvironmentType` enum
+    does not include `langsmith` yet. Example:
+
+        harbor run --environment-import-path \
+            deepagents_harbor.langsmith_environment:LangSmithEnvironment ...
+
+    The environment reads the task's Dockerfile to extract the base image,
+    ensures a LangSmith snapshot exists for that image (building it on first
+    use), and boots a sandbox from it with the task's resource config applied
+    at `create_sandbox` time.
+
+    Snapshots are keyed purely by image and are **shared across trials**.
+    They are intentionally never deleted on `stop()` — rebuilding the same
+    image for every trial would be wasteful, and the LangSmith workspace is
+    the canonical place to prune them manually. Per-trial vCPU / memory /
+    filesystem sizing lives on `create_sandbox`, not on the snapshot, so
+    sharing is safe.
+    """
+
+    def __init__(
+        self,
+        environment_dir: Path,
+        environment_name: str,
+        session_id: str,
+        trial_paths: TrialPaths,
+        task_env_config: EnvironmentConfig,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize a LangSmith harbor environment.
+
+        Args:
+            environment_dir: Path to the task's environment directory.
+            environment_name: Logical name for this environment.
+            session_id: Unique trial session identifier.
+            trial_paths: Local paths for trial artifacts.
+            task_env_config: Resource and network configuration.
+            **kwargs: Forwarded to `BaseEnvironment` (e.g. `logger`,
+                `override_cpus`, `override_memory_mb`).
+        """
+        self._session_id = session_id
+        self._sandbox: AsyncSandbox | None = None
+        self._client: AsyncSandboxClient | None = None
+        self._snapshot_name: str | None = None
+        self._default_cwd: str | None = None
+        super().__init__(
+            environment_dir,
+            environment_name,
+            session_id,
+            trial_paths,
+            task_env_config,
+            **kwargs,
+        )
+
+    # -- Required abstract properties / methods --------------------------------
+
+    @staticmethod
+    def type() -> EnvironmentType:
+        """Not applicable — this environment is loaded via import path."""
+        msg = (
+            "LangSmithEnvironment is used via --environment-import-path, "
+            "not --env. It has no EnvironmentType enum member."
+        )
+        raise NotImplementedError(msg)
+
+    @property
+    def capabilities(self) -> EnvironmentCapabilities:
+        """Capabilities supported by LangSmith sandboxes."""
+        return EnvironmentCapabilities(disable_internet=True, network_allowlist=True)
+
+    # -- Validation overrides --------------------------------------------------
+    # Override base-class validators so they never call self.type(), which
+    # would raise NotImplementedError.
+
+    def _validate_definition(self) -> None:
+        """Validate that the task provides a usable image source.
+
+        Accepts either a prebuilt `docker_image` in the task config or a
+        Dockerfile in the environment directory.
+
+        Raises:
+            FileNotFoundError: If neither a Dockerfile nor `docker_image`
+                is available.
+        """
+        if self.task_env_config.docker_image:
+            return
+        dockerfile_path = self.environment_dir / "Dockerfile"
+        if not dockerfile_path.exists():
+            msg = (
+                f"LangSmith environment requires either a Dockerfile at "
+                f"'{dockerfile_path}' or a 'docker_image' in the task config."
+            )
+            raise FileNotFoundError(msg)
+
+    def _validate_gpu_support(self) -> None:
+        """Override base to avoid calling `self.type()`."""
+        if (self.task_env_config.gpus or 0) > 0:
+            msg = "LangSmith sandbox does not support GPU allocation."
+            raise RuntimeError(msg)
+
+    def _validate_network_policy_support(self) -> None:
+        """LangSmith supports no-network and allowlist policies via proxy config."""
+        return
+
+    def _validate_internet_config(self) -> None:
+        """Deprecated validation hook kept for compatibility with older Harbor."""
+        return
+
+    def _network_proxy_config(self) -> dict[str, Any] | None:
+        """Build LangSmith proxy_config for Harbor's network policy."""
+        network_mode = self.network_policy.network_mode
+        allowed_hosts = list(self.network_policy.allowed_hosts)
+        legacy_allow_internet = getattr(self.task_env_config, "allow_internet", None)
+
+        if network_mode == NetworkMode.NO_NETWORK or legacy_allow_internet is False:
+            return {"access_control": {"deny_list": ["*"]}}
+        if network_mode == NetworkMode.ALLOWLIST:
+            return {"access_control": {"allow_list": allowed_hosts}}
+        return None
+
+    # -- Image resolution ------------------------------------------------------
+
+    def _resolve_image(self) -> str:
+        """Return the container image for the LangSmith template.
+
+        Prefers `docker_image` from the task config; falls back to parsing
+        the `FROM` instruction in the environment Dockerfile.
+        """
+        if self.task_env_config.docker_image:
+            return self.task_env_config.docker_image
+
+        dockerfile_path = self.environment_dir / "Dockerfile"
+        parser = DockerfileParser(path=str(dockerfile_path))
+        base = parser.baseimage
+        if not base:
+            msg = f"Could not extract FROM image from {dockerfile_path}"
+            raise ValueError(msg)
+        return base
+
+    # -- Name helpers ----------------------------------------------------------
+
+    @staticmethod
+    def _sanitize_name(raw: str) -> str:
+        """Sanitize a string for use as a LangSmith resource name.
+
+        LangSmith requires names that start with a lowercase letter, contain
+        only lowercase letters, numbers, and hyphens, and do not end with a
+        hyphen. Max 63 characters.
+        """
+        name = raw.lower()
+        name = re.sub(r"[^a-z0-9-]", "-", name)
+        name = re.sub(r"-{2,}", "-", name)
+        name = name.strip("-")
+        if not name or not name[0].isalpha():
+            name = f"h-{name}"
+        return name[:_MAX_NAME_LEN].rstrip("-")
+
+    # -- Snapshot naming -------------------------------------------------------
+
+    @staticmethod
+    def _build_snapshot_name(image: str) -> str:
+        """Build a deterministic LangSmith snapshot name for `image`.
+
+        Snapshots are shared across trials in the new model, so the name is
+        derived solely from the (sanitized) image reference — no session hash.
+        Multiple concurrent trials that resolve to the same image will reuse
+        the same snapshot.
+
+        Args:
+            image: Container image reference (e.g. `python:3.12-slim` or
+                `alexgshaw/foo:tag`).
+
+        Returns:
+            A sanitized name of the form ``harbor-{sanitized_image}``, at most
+            63 characters, suitable for a LangSmith snapshot name.
+        """
+        sanitized_image = LangSmithEnvironment._sanitize_name(image)
+        max_image_len = _MAX_NAME_LEN - len("harbor-")
+        truncated_image = sanitized_image[:max_image_len].rstrip("-")
+        return f"harbor-{truncated_image}"
+
+    # -- Lifecycle -------------------------------------------------------------
+
+    async def start(self, force_build: bool) -> None:  # noqa: ARG002  # required by BaseEnvironment interface
+        """Provision a LangSmith sandbox from the task's Dockerfile image.
+
+        Ensures a shared snapshot exists for the resolved image, then boots a
+        sandbox from it with per-trial resource limits applied at
+        `create_sandbox` time.
+
+        Args:
+            force_build: Accepted for interface compatibility but unused.
+                Snapshots are shared across trials; the first trial to touch
+                a given image builds it, every subsequent trial reuses it.
+        """
+        image = self._resolve_image()
+
+        resolved = resolve_langsmith_api_key()
+        if not resolved:
+            msg = (
+                "No LangSmith API key found. Set one of: "
+                "LANGSMITH_SANDBOX_API_KEY, LANGSMITH_API_KEY, LANGCHAIN_API_KEY."
+            )
+            raise ValueError(msg)
+
+        api_key, key_source = resolved
+        if key_source == "LANGSMITH_SANDBOX_API_KEY":
+            logger.info("Using LangSmith API key from %s", key_source)
+
+        client = AsyncSandboxClient(api_key=api_key)
+        self._client = client
+
+        snapshot_name = self._build_snapshot_name(image)
+
+        vcpus = self.task_env_config.cpus
+        memory_mb = self.task_env_config.memory_mb
+        storage_mb = self.task_env_config.storage_mb
+        if memory_mb is None or storage_mb is None:
+            msg = "LangSmith sandbox requires memory_mb and storage_mb to be configured."
+            raise ValueError(msg)
+        mem_bytes = memory_mb * _BYTES_PER_MB
+        fs_capacity_bytes = storage_mb * _BYTES_PER_MB
+
+        await self._ensure_snapshot(client, snapshot_name, image, fs_capacity_bytes)
+        self._snapshot_name = snapshot_name
+
+        proxy_config = self._network_proxy_config()
+        create_sandbox_kwargs: dict[str, Any] = {
+            "snapshot_name": snapshot_name,
+            "vcpus": vcpus,
+            "mem_bytes": mem_bytes,
+            "fs_capacity_bytes": fs_capacity_bytes,
+            "timeout": 120,
+        }
+        if proxy_config is not None:
+            create_sandbox_kwargs["proxy_config"] = proxy_config
+
+        sandbox = await client.create_sandbox(**create_sandbox_kwargs)
+        self._sandbox = sandbox
+        logger.info(
+            "Created LangSmith sandbox '%s' from snapshot '%s' "
+            "(vcpus=%s, mem_bytes=%s, fs_capacity_bytes=%s)",
+            sandbox.name,
+            snapshot_name,
+            vcpus,
+            mem_bytes,
+            fs_capacity_bytes,
+        )
+
+        await sandbox.run(
+            f"mkdir -p {EnvironmentPaths.agent_dir} {EnvironmentPaths.verifier_dir}",
+            timeout=30,
+        )
+
+        self._default_cwd = await self._detect_workdir(sandbox)
+        logger.info(
+            "LangSmith sandbox '%s' default cwd resolved to '%s'",
+            sandbox.name,
+            self._default_cwd,
+        )
+
+    @staticmethod
+    async def _ensure_snapshot(
+        client: AsyncSandboxClient,
+        snapshot_name: str,
+        image: str,
+        fs_capacity_bytes: int,
+    ) -> None:
+        """Guarantee a ready LangSmith snapshot named ``snapshot_name`` exists.
+
+        Uses the server-side ``name_contains`` filter to keep the lookup cheap
+        even when the workspace accumulates many snapshots, then matches the
+        exact name client-side (``name_contains`` is a case-insensitive
+        substring match, so it can return unrelated entries).
+
+        Behavior:
+            - If a snapshot with the exact name is ``ready`` -> return.
+            - If it exists but is in any other state -> raise ``RuntimeError``
+                with a clear instruction to wait for it to finish or delete it.
+            - Otherwise -> build it via ``create_snapshot`` (blocks until ready).
+
+        The helper does not return an ID: downstream callers pass
+        ``snapshot_name`` straight to ``create_sandbox``.
+
+        Args:
+            client: Async LangSmith sandbox client.
+            snapshot_name: Name of the snapshot to ensure.
+            image: Docker image reference to build from if missing.
+            fs_capacity_bytes: Filesystem capacity used when building.
+
+        Raises:
+            RuntimeError: If a snapshot with the same name exists but is not
+                ready, or if ``create_snapshot`` fails.
+        """
+        snapshots = await client.list_snapshots(
+            name_contains=snapshot_name,
+        )
+        for snap in snapshots:
+            if snap.name != snapshot_name:
+                continue
+            if snap.status == "ready":
+                logger.debug("Reusing existing LangSmith snapshot '%s'", snapshot_name)
+                return
+            msg = (
+                f"LangSmith snapshot '{snapshot_name}' exists but is in state "
+                f"'{snap.status}'. Wait for it to finish building, or delete "
+                f"it to rebuild."
+            )
+            raise RuntimeError(msg)
+
+        logger.info(
+            "Building LangSmith snapshot '%s' from image '%s' "
+            "(first run for this image may take a few minutes)",
+            snapshot_name,
+            image,
+        )
+        try:
+            await client.create_snapshot(
+                name=snapshot_name,
+                docker_image=image,
+                fs_capacity_bytes=fs_capacity_bytes,
+            )
+        except Exception as create_err:
+            msg = f"Failed to build LangSmith snapshot '{snapshot_name}': {create_err}"
+            raise RuntimeError(msg) from create_err
+
+    @staticmethod
+    async def _detect_workdir(sandbox: AsyncSandbox) -> str:
+        """Resolve the container's Dockerfile ``WORKDIR`` at runtime.
+
+        LangSmith's `sandbox.run(cwd=None)` spawns each command from the
+        dataplane daemon's cwd, not the image's `WORKDIR`. Terminal-bench
+        verifier scripts rely on `WORKDIR` (e.g. `/app`) — many include
+        `if [ "$PWD" = "/" ]; then exit 1; fi` as a guard and abort without
+        writing `/logs/verifier/reward.txt` when this assumption is violated.
+
+        PID 1 (the container entrypoint) inherits the image's `WORKDIR` as
+        its cwd, so `readlink /proc/1/cwd` yields the correct directory
+        without requiring access to the image metadata. Falls back to `/app`
+        (terminal-bench convention) when the probe is inconclusive.
+
+        Args:
+            sandbox: The active LangSmith sandbox.
+
+        Returns:
+            Absolute path to use as the default working directory for
+            subsequent command execution.
+        """
+        try:
+            result = await sandbox.run("readlink /proc/1/cwd", timeout=15)
+        except Exception:  # noqa: BLE001
+            logger.warning("Failed to probe /proc/1/cwd; falling back to '/app'", exc_info=True)
+            return "/app"
+
+        candidate = (result.stdout or "").strip()
+        if result.exit_code == 0 and candidate and candidate != "/":
+            return candidate
+
+        probe = await sandbox.run(
+            "[ -d /app ] && echo /app || echo /",
+            timeout=15,
+        )
+        fallback = (probe.stdout or "").strip() or "/"
+        return fallback if fallback != "/" else "/app"
+
+    async def stop(self, delete: bool) -> None:
+        """Tear down the LangSmith sandbox.
+
+        The backing snapshot is **never** deleted here: snapshots are shared
+        across trials and are only cleaned up manually in the LangSmith
+        workspace.
+
+        Args:
+            delete: If True, delete the sandbox before closing the client.
+        """
+        if self._sandbox and self._client and delete:
+            try:
+                await self._client.delete_sandbox(self._sandbox.name)
+                logger.info("Deleted LangSmith sandbox '%s'", self._sandbox.name)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to delete sandbox '%s' -- resource may be leaked",
+                    self._sandbox.name,
+                    exc_info=True,
+                )
+        if self._client:
+            await self._client.aclose()
+        self._sandbox = None
+        self._client = None
+        self._snapshot_name = None
+        self._default_cwd = None
+
+    # -- Command execution -----------------------------------------------------
+
+    def _require_sandbox(self) -> AsyncSandbox:
+        """Return the active sandbox or raise if not started.
+
+        Raises:
+            RuntimeError: If `start()` has not been called.
+        """
+        if self._sandbox is None:
+            msg = "Sandbox not started. Call start() first."
+            raise RuntimeError(msg)
+        return self._sandbox
+
+    async def exec(  # ty: ignore[invalid-method-override]  # harbor API drift, tracked separately
+        self,
+        command: str,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_sec: int | None = None,
+    ) -> ExecResult:
+        """Execute a command inside the LangSmith sandbox.
+
+        When `cwd` is not provided, defaults to the container's
+        `WORKDIR` (resolved at `start()`) rather than LangSmith's
+        dataplane default of `/`. This preserves the semantics that
+        terminal-bench verifier scripts assume when they probe `$PWD`.
+
+        Args:
+            command: Shell command string to execute.
+            cwd: Working directory for command execution. Overrides the
+                detected default when provided.
+            env: Environment variables to set.
+            timeout_sec: Timeout in seconds.
+
+        Returns:
+            Execution result containing stdout, stderr, and return code.
+        """
+        sandbox = self._require_sandbox()
+        effective_timeout = timeout_sec if timeout_sec is not None else _DEFAULT_EXEC_TIMEOUT_SEC
+        effective_cwd = cwd if cwd is not None else self._default_cwd
+
+        result = await sandbox.run(
+            command,
+            timeout=effective_timeout,
+            cwd=effective_cwd,
+            env=env,
+        )
+        return ExecResult(
+            stdout=result.stdout or "",
+            stderr=result.stderr or "",
+            return_code=result.exit_code,
+        )
+
+    # -- File operations -------------------------------------------------------
+
+    async def upload_file(self, source_path: Path | str, target_path: str) -> None:
+        """Upload a local file to the sandbox.
+
+        Args:
+            source_path: Local file path.
+            target_path: Destination path inside the sandbox.
+        """
+        sandbox = self._require_sandbox()
+        content = await asyncio.to_thread(Path(source_path).read_bytes)
+
+        parent = str(Path(target_path).parent)
+        if parent != "/":
+            await sandbox.run(f"mkdir -p {shlex.quote(parent)}", timeout=30)
+
+        await sandbox.write(target_path, content)
+
+    async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
+        """Upload a local directory to the sandbox recursively.
+
+        Args:
+            source_dir: Local directory path.
+            target_dir: Destination directory inside the sandbox.
+        """
+        self._require_sandbox()
+        source = Path(source_dir)
+        files = await asyncio.to_thread(_list_files_recursive, source)
+        for file_path in files:
+            relative = file_path.relative_to(source)
+            target = str(Path(target_dir) / relative)
+            await self.upload_file(file_path, target)
+
+    async def download_file(self, source_path: str, target_path: Path | str) -> None:
+        """Download a file from the sandbox to the local machine.
+
+        Args:
+            source_path: File path inside the sandbox.
+            target_path: Local destination path.
+        """
+        sandbox = self._require_sandbox()
+        data = await sandbox.read(source_path)
+        local = Path(target_path)
+        local.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(local.write_bytes, data)
+
+    async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
+        """Download a directory from the sandbox to the local machine.
+
+        Args:
+            source_dir: Directory path inside the sandbox.
+            target_dir: Local destination directory.
+        """
+        local_dir = Path(target_dir)
+        await asyncio.to_thread(local_dir.mkdir, parents=True, exist_ok=True)
+
+        result = await self.exec(
+            f"find {shlex.quote(source_dir)} -type f",
+            timeout_sec=60,
+        )
+        if result.return_code != 0:
+            logger.warning(
+                "Failed to list files in '%s': exit_code=%d, stderr=%s",
+                source_dir,
+                result.return_code,
+                result.stderr,
+            )
+            return
+
+        if not result.stdout or not result.stdout.strip():
+            logger.info("No files found in '%s'", source_dir)
+            return
+
+        files = [f for f in result.stdout.strip().split("\n") if f]
+        failures: list[str] = []
+        for file_path in files:
+            relative = Path(file_path).relative_to(source_dir)
+            local_file = local_dir / relative
+            try:
+                await self.download_file(file_path, local_file)
+            except Exception:  # noqa: BLE001
+                logger.warning("Failed to download '%s'", file_path, exc_info=True)
+                failures.append(file_path)
+
+        if failures:
+            logger.warning(
+                "download_dir('%s') completed with %d/%d file failures",
+                source_dir,
+                len(failures),
+                len(files),
+            )

--- a/libs/evals/pyproject.toml
+++ b/libs/evals/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "deepagents>=0.6.8",
     "langchain>=1.3.4,<2.0.0",
     "deepagents-code>=0.1.11",
-    # Harbor runtime, with the built-in LangSmith sandbox env (`-e langsmith`, harbor>=0.13.2)
+    # Harbor runtime, including LangSmith sandbox dependencies for our WORKDIR-preserving adapter.
     "harbor[langsmith]>=0.13.2,<0.14.0",
     # LangSmith for observability
     "langsmith>=0.8.11,<0.9.0",

--- a/libs/evals/tests/unit_tests/test_langsmith_environment.py
+++ b/libs/evals/tests/unit_tests/test_langsmith_environment.py
@@ -1,0 +1,1028 @@
+"""Tests for the LangSmith harbor environment adapter."""
+
+from __future__ import annotations
+
+import logging
+import textwrap
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from harbor.models.task.config import EnvironmentConfig, NetworkMode, NetworkPolicy
+from harbor.models.trial.paths import TrialPaths
+
+from deepagents_harbor.langsmith_environment import (
+    LangSmithEnvironment,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _fake_langsmith_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide a fake API key so unit tests never require real credentials."""
+    monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2-test-fake-key")
+
+
+@dataclass
+class _FakeExecResult:
+    """Minimal stand-in for langsmith ExecutionResult."""
+
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int = 0
+
+
+@dataclass
+class _FakeSandbox:
+    """Minimal stand-in for langsmith AsyncSandbox."""
+
+    name: str = "test-sandbox"
+    _run_calls: list[tuple] = field(default_factory=list)
+    _written_files: dict[str, bytes] = field(default_factory=dict)
+    _read_files: dict[str, bytes] = field(default_factory=dict)
+
+    async def run(
+        self,
+        command: str,
+        *,
+        timeout: int = 60,  # noqa: ASYNC109 -- mirrors AsyncSandbox.run() signature
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> _FakeExecResult:
+        self._run_calls.append((command, timeout, cwd, env))
+        return _FakeExecResult()
+
+    async def write(self, path: str, content: str | bytes) -> None:
+        if isinstance(content, str):
+            content = content.encode()
+        self._written_files[path] = content
+
+    async def read(self, path: str) -> bytes:
+        return self._read_files.get(path, b"")
+
+
+def _make_env(
+    tmp_path: Path,
+    *,
+    docker_image: str | None = None,
+    dockerfile_content: str | None = None,
+    cpus: int = 1,
+    memory_mb: int = 2048,
+    storage_mb: int = 10240,
+    network_policy: NetworkPolicy | None = None,
+    allow_internet: bool | None = None,
+) -> LangSmithEnvironment:
+    """Create a LangSmithEnvironment with a temp directory.
+
+    Args:
+        tmp_path: Temporary directory for environment files.
+        docker_image: Prebuilt image name (skips Dockerfile).
+        dockerfile_content: Dockerfile content to write.
+        cpus: CPU count for the task.
+        memory_mb: Memory in MB for the task.
+        storage_mb: Storage in MB for the task.
+        network_policy: Network policy to pass to the environment.
+        allow_internet: Deprecated Harbor internet access flag.
+    """
+    env_dir = tmp_path / "environment"
+    env_dir.mkdir()
+    if dockerfile_content:
+        (env_dir / "Dockerfile").write_text(dockerfile_content)
+    elif not docker_image:
+        (env_dir / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+
+    trial_dir = tmp_path / "trial"
+    trial_dir.mkdir()
+
+    config_kwargs: dict[str, Any] = {
+        "docker_image": docker_image,
+        "cpus": cpus,
+        "memory_mb": memory_mb,
+        "storage_mb": storage_mb,
+    }
+    if allow_internet is not None:
+        config_kwargs["allow_internet"] = allow_internet
+    config = EnvironmentConfig(**config_kwargs)
+    trial_paths = TrialPaths(trial_dir=trial_dir)
+    trial_paths.mkdir()
+
+    return LangSmithEnvironment(
+        environment_dir=env_dir,
+        environment_name="test-task",
+        session_id="test-session-001",
+        trial_paths=trial_paths,
+        task_env_config=config,
+        network_policy=network_policy,
+    )
+
+
+@dataclass
+class _FakeSnapshot:
+    """Stand-in for langsmith Snapshot with a safe ``name`` attribute.
+
+    MagicMock reserves ``.name`` as a descriptor for the mock itself, so we
+    use a plain dataclass here to make assertions on ``snap.name`` behave
+    normally.
+    """
+
+    name: str
+    status: str = "ready"
+    id: str = "snap-id-test"
+
+
+def _mock_async_client(*, existing_snapshots: list[Any] | None = None) -> AsyncMock:
+    """Build a mock AsyncSandboxClient wired for start() tests.
+
+    Defaults mirror the "happy path": no existing snapshot → `create_snapshot`
+    will be invoked → `create_sandbox` returns a fake sandbox. Tests can
+    override by passing `existing_snapshots` or reassigning the individual
+    method mocks.
+    """
+    mock = AsyncMock()
+    fake_sb = _FakeSandbox()
+    mock.create_sandbox.return_value = fake_sb
+    mock.list_snapshots = AsyncMock(return_value=existing_snapshots or [])
+    mock.create_snapshot = AsyncMock(return_value=_FakeSnapshot(name="snap-test", status="ready"))
+    return mock
+
+
+class TestValidation:
+    """Tests for __init__-time validation."""
+
+    def test_valid_dockerfile(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        assert env is not None
+
+    def test_valid_docker_image(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path, docker_image="python:3.12-slim")
+        assert env is not None
+
+    def test_missing_dockerfile_and_image_raises(self, tmp_path: Path) -> None:
+        env_dir = tmp_path / "environment"
+        env_dir.mkdir()
+
+        trial_dir = tmp_path / "trial"
+        trial_dir.mkdir()
+        config = EnvironmentConfig()
+        trial_paths = TrialPaths(trial_dir=trial_dir)
+        trial_paths.mkdir()
+
+        with pytest.raises(FileNotFoundError, match="LangSmith environment requires"):
+            LangSmithEnvironment(
+                environment_dir=env_dir,
+                environment_name="test",
+                session_id="s1",
+                trial_paths=trial_paths,
+                task_env_config=config,
+            )
+
+    def test_gpu_requirement_raises(self, tmp_path: Path) -> None:
+        env_dir = tmp_path / "environment"
+        env_dir.mkdir()
+        (env_dir / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+
+        trial_dir = tmp_path / "trial"
+        trial_dir.mkdir()
+        config = EnvironmentConfig(gpus=1)
+        trial_paths = TrialPaths(trial_dir=trial_dir)
+        trial_paths.mkdir()
+
+        with pytest.raises(RuntimeError, match="GPU"):
+            LangSmithEnvironment(
+                environment_dir=env_dir,
+                environment_name="test",
+                session_id="s1",
+                trial_paths=trial_paths,
+                task_env_config=config,
+            )
+
+    def test_no_network_config_is_accepted(self, tmp_path: Path) -> None:
+        env_dir = tmp_path / "environment"
+        env_dir.mkdir()
+        (env_dir / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+
+        trial_dir = tmp_path / "trial"
+        trial_dir.mkdir()
+        config = EnvironmentConfig()
+        trial_paths = TrialPaths(trial_dir=trial_dir)
+        trial_paths.mkdir()
+
+        env = LangSmithEnvironment(
+            environment_dir=env_dir,
+            environment_name="test",
+            session_id="s1",
+            trial_paths=trial_paths,
+            task_env_config=config,
+            network_policy=NetworkPolicy(network_mode=NetworkMode.NO_NETWORK),
+        )
+
+        assert env._network_proxy_config() == {"access_control": {"deny_list": ["*"]}}
+
+    def test_accepts_factory_kwargs(self, tmp_path: Path) -> None:
+        """Harbor's EnvironmentFactory passes logger, override_* kwargs."""
+        env_dir = tmp_path / "environment"
+        env_dir.mkdir()
+        (env_dir / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+
+        trial_dir = tmp_path / "trial"
+        trial_dir.mkdir()
+        config = EnvironmentConfig()
+        trial_paths = TrialPaths(trial_dir=trial_dir)
+        trial_paths.mkdir()
+
+        test_logger = logging.getLogger("test.harbor")
+        env = LangSmithEnvironment(
+            environment_dir=env_dir,
+            environment_name="test",
+            session_id="s1",
+            trial_paths=trial_paths,
+            task_env_config=config,
+            logger=test_logger,
+            override_cpus=4,
+            override_memory_mb=8192,
+            override_storage_mb=20480,
+            override_gpus=0,
+        )
+        assert env is not None
+        assert env.task_env_config.cpus == 4
+        assert env.task_env_config.memory_mb == 8192
+
+
+class TestResolveImage:
+    """Tests for image resolution from Dockerfile or config."""
+
+    def test_prefers_docker_image(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path, docker_image="my-custom:latest")
+        assert env._resolve_image() == "my-custom:latest"
+
+    def test_parses_from_dockerfile(self, tmp_path: Path) -> None:
+        env = _make_env(
+            tmp_path,
+            dockerfile_content=textwrap.dedent("""\
+                FROM python:3.12-slim
+                RUN apt-get update
+                WORKDIR /app
+            """),
+        )
+        assert env._resolve_image() == "python:3.12-slim"
+
+    def test_empty_from_raises(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path, dockerfile_content="# no FROM\n")
+        with pytest.raises(ValueError, match="Could not extract FROM"):
+            env._resolve_image()
+
+
+class TestProperties:
+    """Tests for static properties."""
+
+    def test_capabilities(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        assert env.capabilities.mounted is False
+        assert env.capabilities.gpus is False
+        assert env.capabilities.disable_internet is True
+        assert env.capabilities.network_allowlist is True
+
+    def test_no_network_policy_builds_deny_all_proxy_config(self, tmp_path: Path) -> None:
+        env = _make_env(
+            tmp_path,
+            network_policy=NetworkPolicy(network_mode=NetworkMode.NO_NETWORK),
+        )
+
+        assert env._network_proxy_config() == {"access_control": {"deny_list": ["*"]}}
+
+    def test_legacy_allow_internet_false_builds_deny_all_proxy_config(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path, allow_internet=False)
+
+        assert env._network_proxy_config() == {"access_control": {"deny_list": ["*"]}}
+
+    def test_allowlist_policy_builds_allowlist_proxy_config(self, tmp_path: Path) -> None:
+        env = _make_env(
+            tmp_path,
+            network_policy=NetworkPolicy(
+                network_mode=NetworkMode.ALLOWLIST,
+                allowed_hosts=["api.openai.com", "github.com"],
+            ),
+        )
+
+        assert env._network_proxy_config() == {
+            "access_control": {"allow_list": ["api.openai.com", "github.com"]}
+        }
+
+    def test_public_network_policy_omits_proxy_config(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+
+        assert env._network_proxy_config() is None
+
+    def test_type_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(NotImplementedError):
+            LangSmithEnvironment.type()
+
+
+class TestSanitizeName:
+    """Tests for LangSmith resource name sanitization."""
+
+    def test_lowercase_and_replace_underscores(self) -> None:
+        assert (
+            LangSmithEnvironment._sanitize_name("gpt2-codegolf__UxLAidb") == "gpt2-codegolf-uxlaidb"
+        )
+
+    def test_replaces_special_chars(self) -> None:
+        assert LangSmithEnvironment._sanitize_name("my/image:3.12-slim") == "my-image-3-12-slim"
+
+    def test_collapses_consecutive_hyphens(self) -> None:
+        assert LangSmithEnvironment._sanitize_name("a___b---c") == "a-b-c"
+
+    def test_strips_leading_trailing_hyphens(self) -> None:
+        assert LangSmithEnvironment._sanitize_name("--hello--") == "hello"
+
+    def test_prepends_prefix_if_starts_with_number(self) -> None:
+        result = LangSmithEnvironment._sanitize_name("123abc")
+        assert result[0].isalpha()
+        assert result == "h-123abc"
+
+    def test_truncates_to_63_chars(self) -> None:
+        long_name = "a" * 100
+        assert len(LangSmithEnvironment._sanitize_name(long_name)) == 63
+
+    def test_empty_string(self) -> None:
+        result = LangSmithEnvironment._sanitize_name("")
+        assert result[0].isalpha()
+        assert not result.endswith("-")
+
+    def test_no_trailing_hyphen_after_truncation(self) -> None:
+        """Truncation at 63 chars must not leave a trailing hyphen."""
+        raw = "a" * 62 + ":b"
+        result = LangSmithEnvironment._sanitize_name(raw)
+        assert not result.endswith("-")
+        assert len(result) <= 63
+
+
+class TestResourceConversion:
+    """Tests for task resource config → LangSmith create_sandbox/create_snapshot kwargs.
+
+    Memory and CPU live on ``create_sandbox`` (vcpus/mem_bytes). Filesystem
+    capacity is passed to both ``create_snapshot`` (when building) and
+    ``create_sandbox`` so per-trial disk sizing takes effect.
+    """
+
+    async def test_memory_under_1gb(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path, memory_mb=512)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client()
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=True)
+
+            assert mock_client.create_sandbox.call_args.kwargs["mem_bytes"] == 512 * 1024 * 1024
+
+    async def test_memory_over_1gb(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path, memory_mb=2048)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client()
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=True)
+
+            assert mock_client.create_sandbox.call_args.kwargs["mem_bytes"] == 2048 * 1024 * 1024
+
+    async def test_cpu_conversion(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path, cpus=2)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client()
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=True)
+
+            assert mock_client.create_sandbox.call_args.kwargs["vcpus"] == 2
+
+    async def test_storage_bytes_on_snapshot_and_sandbox(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path, storage_mb=10240)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client()
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=True)
+
+            expected_bytes = 10240 * 1024 * 1024
+            assert (
+                mock_client.create_snapshot.call_args.kwargs["fs_capacity_bytes"] == expected_bytes
+            )
+            assert (
+                mock_client.create_sandbox.call_args.kwargs["fs_capacity_bytes"] == expected_bytes
+            )
+
+    async def test_storage_passes_exact_bytes(self, tmp_path: Path) -> None:
+        """No more Gi rounding -- we forward whatever the task requested, byte-for-byte."""
+        env = _make_env(tmp_path, storage_mb=1500)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client()
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=True)
+
+            expected_bytes = 1500 * 1024 * 1024
+            assert (
+                mock_client.create_snapshot.call_args.kwargs["fs_capacity_bytes"] == expected_bytes
+            )
+            assert (
+                mock_client.create_sandbox.call_args.kwargs["fs_capacity_bytes"] == expected_bytes
+            )
+
+
+class TestStartSnapshotProvisioning:
+    """Tests for shared-per-image snapshot provisioning in start().
+
+    Snapshots are keyed purely by image and reused across trials; trial-local
+    resource sizing moves onto ``create_sandbox``.
+    """
+
+    async def test_builds_snapshot_when_missing(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client(existing_snapshots=[])
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+            expected_name = LangSmithEnvironment._build_snapshot_name("ubuntu:24.04")
+            mock_client.create_snapshot.assert_called_once()
+            kwargs = mock_client.create_snapshot.call_args.kwargs
+            assert kwargs["name"] == expected_name
+            assert kwargs["docker_image"] == "ubuntu:24.04"
+
+    async def test_reuses_existing_ready_snapshot(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        expected_name = LangSmithEnvironment._build_snapshot_name("ubuntu:24.04")
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client(
+                existing_snapshots=[_FakeSnapshot(name=expected_name, status="ready")]
+            )
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+            mock_client.create_snapshot.assert_not_called()
+            create_kwargs = mock_client.create_sandbox.call_args.kwargs
+            assert create_kwargs["snapshot_name"] == expected_name
+            assert "snapshot_id" not in create_kwargs
+            assert "template_name" not in create_kwargs
+
+    async def test_raises_when_existing_snapshot_not_ready(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        expected_name = LangSmithEnvironment._build_snapshot_name("ubuntu:24.04")
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client(
+                existing_snapshots=[_FakeSnapshot(name=expected_name, status="building")]
+            )
+            mock_cls.return_value = mock_client
+
+            with pytest.raises(RuntimeError, match="building"):
+                await env.start(force_build=False)
+
+            mock_client.create_snapshot.assert_not_called()
+            mock_client.create_sandbox.assert_not_called()
+
+    async def test_list_snapshots_called_with_name_contains(self, tmp_path: Path) -> None:
+        """Readiness check must use the server-side ``name_contains`` filter."""
+        env = _make_env(tmp_path)
+        expected_name = LangSmithEnvironment._build_snapshot_name("ubuntu:24.04")
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client()
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+            mock_client.list_snapshots.assert_awaited_once_with(name_contains=expected_name)
+
+    async def test_creates_sandbox_from_snapshot(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client()
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+            expected_name = LangSmithEnvironment._build_snapshot_name("ubuntu:24.04")
+            mock_client.create_sandbox.assert_called_once()
+            kwargs = mock_client.create_sandbox.call_args.kwargs
+            assert kwargs["snapshot_name"] == expected_name
+            assert kwargs["vcpus"] == 1
+            assert kwargs["mem_bytes"] == 2048 * 1024 * 1024
+            assert kwargs["fs_capacity_bytes"] == 10240 * 1024 * 1024
+            assert kwargs["timeout"] == 120
+            assert "proxy_config" not in kwargs
+            assert "template_name" not in kwargs
+            assert "snapshot_id" not in kwargs
+
+    async def test_create_sandbox_passes_no_network_proxy_config(self, tmp_path: Path) -> None:
+        env = _make_env(
+            tmp_path,
+            network_policy=NetworkPolicy(network_mode=NetworkMode.NO_NETWORK),
+        )
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client()
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+            assert mock_client.create_sandbox.call_args.kwargs["proxy_config"] == {
+                "access_control": {"deny_list": ["*"]}
+            }
+
+    async def test_create_sandbox_passes_legacy_allow_internet_proxy_config(
+        self, tmp_path: Path
+    ) -> None:
+        env = _make_env(tmp_path, allow_internet=False)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client()
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+            assert mock_client.create_sandbox.call_args.kwargs["proxy_config"] == {
+                "access_control": {"deny_list": ["*"]}
+            }
+
+    async def test_create_sandbox_passes_allowlist_proxy_config(self, tmp_path: Path) -> None:
+        env = _make_env(
+            tmp_path,
+            network_policy=NetworkPolicy(
+                network_mode=NetworkMode.ALLOWLIST,
+                allowed_hosts=["api.openai.com", "github.com"],
+            ),
+        )
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client()
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+            assert mock_client.create_sandbox.call_args.kwargs["proxy_config"] == {
+                "access_control": {"allow_list": ["api.openai.com", "github.com"]}
+            }
+
+    async def test_force_build_is_noop(self, tmp_path: Path) -> None:
+        """force_build accepted for interface compat but does not change calls."""
+        (tmp_path / "a").mkdir()
+        (tmp_path / "b").mkdir()
+        env_a = _make_env(tmp_path / "a")
+        env_b = _make_env(tmp_path / "b")
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_a = _mock_async_client()
+            mock_cls.return_value = mock_a
+            await env_a.start(force_build=False)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_b = _mock_async_client()
+            mock_cls.return_value = mock_b
+            await env_b.start(force_build=True)
+
+        assert mock_a.create_sandbox.call_count == mock_b.create_sandbox.call_count == 1
+
+
+class TestBuildSnapshotName:
+    """Tests for _build_snapshot_name shape and sharing contract."""
+
+    def test_starts_with_harbor_prefix(self) -> None:
+        name = LangSmithEnvironment._build_snapshot_name("ubuntu:24.04")
+        assert name.startswith("harbor-")
+        assert len(name) <= 63
+
+    def test_long_image_stays_within_limit(self) -> None:
+        long_image = "alexgshaw/log-summary-date-ranges:20251031"
+        name = LangSmithEnvironment._build_snapshot_name(long_image)
+        assert len(name) <= 63
+
+    def test_deterministic(self) -> None:
+        a = LangSmithEnvironment._build_snapshot_name("img:v1")
+        b = LangSmithEnvironment._build_snapshot_name("img:v1")
+        assert a == b
+
+    def test_same_image_different_sessions_share_name(self) -> None:
+        """Snapshots are shared across trials: name depends on image alone."""
+        image = "alexgshaw/log-summary-date-ranges:20251031"
+        # _build_snapshot_name takes no session_id; calling it from multiple
+        # "trials" must produce the exact same name.
+        names = {LangSmithEnvironment._build_snapshot_name(image) for _ in range(5)}
+        assert len(names) == 1
+
+    def test_name_starts_with_letter(self) -> None:
+        name = LangSmithEnvironment._build_snapshot_name("123image:latest")
+        assert name[0].isalpha()
+
+
+class TestExec:
+    """Tests for command execution."""
+
+    async def test_exec_delegates_to_sandbox(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        sandbox = _FakeSandbox()
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
+
+        result = await env.exec("echo hello")
+
+        assert result.return_code == 0
+        assert sandbox._run_calls[0][0] == "echo hello"
+
+    async def test_exec_passes_cwd_and_env(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        sandbox = _FakeSandbox()
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
+
+        await env.exec("ls", cwd="/app", env={"FOO": "bar"})
+
+        _, _, cwd, cmd_env = sandbox._run_calls[0]
+        assert cwd == "/app"
+        assert cmd_env == {"FOO": "bar"}
+
+    async def test_exec_uses_default_cwd_when_none_provided(self, tmp_path: Path) -> None:
+        """Regression: without this, LangSmith's dataplane defaults to "/",
+        which causes terminal-bench verifier scripts to abort early without
+        writing /logs/verifier/reward.txt.
+        """
+        env = _make_env(tmp_path)
+        sandbox = _FakeSandbox()
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
+        env._default_cwd = "/app"
+
+        await env.exec("ls")
+
+        _, _, cwd, _ = sandbox._run_calls[0]
+        assert cwd == "/app"
+
+    async def test_exec_explicit_cwd_overrides_default(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        sandbox = _FakeSandbox()
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
+        env._default_cwd = "/app"
+
+        await env.exec("ls", cwd="/tmp")
+
+        _, _, cwd, _ = sandbox._run_calls[0]
+        assert cwd == "/tmp"
+
+    async def test_exec_uses_default_timeout(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        sandbox = _FakeSandbox()
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
+
+        await env.exec("echo hello")
+
+        assert sandbox._run_calls[0][1] == 30 * 60
+
+    async def test_exec_forwards_custom_timeout(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        sandbox = _FakeSandbox()
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
+
+        await env.exec("echo hello", timeout_sec=10)
+
+        assert sandbox._run_calls[0][1] == 10
+
+    async def test_exec_without_start_raises(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        with pytest.raises(RuntimeError, match="start"):
+            await env.exec("echo fail")
+
+
+class TestWorkdirDetection:
+    """Tests for container WORKDIR detection at start()."""
+
+    @staticmethod
+    def _install_probe_sandbox(
+        mock_client: MagicMock,
+        *,
+        readlink_stdout: str = "",
+        readlink_exit_code: int = 0,
+        dir_probe_stdout: str = "",
+    ) -> _FakeSandbox:
+        """Install a sandbox whose `run()` answers the workdir probes.
+
+        Both probes (`readlink /proc/1/cwd` and the `/app`-existence fallback)
+        are dispatched from the same method so assertions stay simple.
+        """
+        sandbox = _FakeSandbox()
+
+        async def _run(
+            command: str,
+            *,
+            timeout: int = 60,  # noqa: ASYNC109
+            cwd: str | None = None,
+            env: dict[str, str] | None = None,
+        ) -> _FakeExecResult:
+            sandbox._run_calls.append((command, timeout, cwd, env))
+            if "readlink /proc/1/cwd" in command:
+                return _FakeExecResult(stdout=readlink_stdout, exit_code=readlink_exit_code)
+            if "-d /app" in command:
+                return _FakeExecResult(stdout=dir_probe_stdout)
+            return _FakeExecResult()
+
+        sandbox.run = _run  # ty: ignore[invalid-assignment]
+        mock_client.create_sandbox.return_value = sandbox
+        return sandbox
+
+    async def test_detects_workdir_from_pid1(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = AsyncMock()
+            self._install_probe_sandbox(mock_client, readlink_stdout="/app\n")
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+        assert env._default_cwd == "/app"
+
+    async def test_detects_non_app_workdir(self, tmp_path: Path) -> None:
+        """Images with non-standard WORKDIRs (e.g. /workspace) must be honored."""
+        env = _make_env(tmp_path)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = AsyncMock()
+            self._install_probe_sandbox(mock_client, readlink_stdout="/workspace\n")
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+        assert env._default_cwd == "/workspace"
+
+    async def test_falls_back_to_app_when_root(self, tmp_path: Path) -> None:
+        """When the container has no WORKDIR, prefer /app if it exists."""
+        env = _make_env(tmp_path)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = AsyncMock()
+            self._install_probe_sandbox(
+                mock_client,
+                readlink_stdout="/\n",
+                dir_probe_stdout="/app\n",
+            )
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+        assert env._default_cwd == "/app"
+
+    async def test_falls_back_to_app_on_probe_failure(self, tmp_path: Path) -> None:
+        """A broken readlink probe must not prevent start()."""
+        env = _make_env(tmp_path)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = AsyncMock()
+            sandbox = _FakeSandbox()
+
+            async def _run(
+                command: str,
+                *,
+                timeout: int = 60,  # noqa: ASYNC109
+                cwd: str | None = None,
+                env: dict[str, str] | None = None,
+            ) -> _FakeExecResult:
+                sandbox._run_calls.append((command, timeout, cwd, env))
+                if "readlink /proc/1/cwd" in command:
+                    msg = "connection reset"
+                    raise RuntimeError(msg)
+                return _FakeExecResult()
+
+            sandbox.run = _run  # ty: ignore[invalid-assignment]
+            mock_client.create_sandbox.return_value = sandbox
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+        assert env._default_cwd == "/app"
+
+    async def test_falls_back_to_app_when_nothing_resolves(self, tmp_path: Path) -> None:
+        """When /app doesn't exist either, still default to /app rather
+        than "/" to preserve terminal-bench verifier PWD semantics."""
+        env = _make_env(tmp_path)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = AsyncMock()
+            self._install_probe_sandbox(
+                mock_client,
+                readlink_stdout="/\n",
+                dir_probe_stdout="/\n",
+            )
+            mock_cls.return_value = mock_client
+
+            await env.start(force_build=False)
+
+        assert env._default_cwd == "/app"
+
+    async def test_stop_clears_default_cwd(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        env._sandbox = _FakeSandbox()  # ty: ignore[invalid-assignment]
+        env._client = AsyncMock()
+        env._snapshot_name = "snap-tmpl"
+        env._default_cwd = "/app"
+
+        await env.stop(delete=False)
+
+        assert env._default_cwd is None
+
+
+class TestFileOps:
+    """Tests for file upload/download operations."""
+
+    async def test_upload_file(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        sandbox = _FakeSandbox()
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
+
+        src = tmp_path / "local.txt"
+        src.write_text("hello world")
+
+        await env.upload_file(src, "/app/remote.txt")
+
+        assert sandbox._written_files["/app/remote.txt"] == b"hello world"
+
+    async def test_download_file(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        sandbox = _FakeSandbox()
+        sandbox._read_files["/app/data.txt"] = b"file content"
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
+
+        dest = tmp_path / "downloaded.txt"
+        await env.download_file("/app/data.txt", dest)
+
+        assert dest.read_bytes() == b"file content"
+
+    async def test_upload_dir(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        sandbox = _FakeSandbox()
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
+
+        src_dir = tmp_path / "mydir"
+        src_dir.mkdir()
+        (src_dir / "a.txt").write_text("aaa")
+        sub = src_dir / "sub"
+        sub.mkdir()
+        (sub / "b.txt").write_text("bbb")
+
+        await env.upload_dir(src_dir, "/app/dest")
+
+        assert sandbox._written_files["/app/dest/a.txt"] == b"aaa"
+        assert sandbox._written_files["/app/dest/sub/b.txt"] == b"bbb"
+
+    async def test_download_dir(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        sandbox = _FakeSandbox()
+        sandbox._read_files["/remote/a.txt"] = b"aaa"
+        sandbox._read_files["/remote/sub/b.txt"] = b"bbb"
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
+
+        async def _fake_run(_cmd: str, **_kw: Any) -> _FakeExecResult:
+            return _FakeExecResult(stdout="/remote/a.txt\n/remote/sub/b.txt\n")
+
+        sandbox.run = _fake_run  # ty: ignore[invalid-assignment]
+
+        dest = tmp_path / "downloaded"
+        await env.download_dir("/remote", dest)
+
+        assert (dest / "a.txt").read_bytes() == b"aaa"
+        assert (dest / "sub" / "b.txt").read_bytes() == b"bbb"
+
+    async def test_download_dir_partial_failure(self, tmp_path: Path) -> None:
+        """Files that fail to download are skipped; successful ones are kept."""
+        env = _make_env(tmp_path)
+        sandbox = _FakeSandbox()
+        sandbox._read_files["/remote/good.txt"] = b"ok"
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
+
+        async def _fake_run(_cmd: str, **_kw: Any) -> _FakeExecResult:
+            return _FakeExecResult(stdout="/remote/good.txt\n/remote/bad.txt\n")
+
+        sandbox.run = _fake_run  # ty: ignore[invalid-assignment]
+
+        # bad.txt is not in _read_files, so download_file → sandbox.read
+        # returns b"" by default, but we override read to raise for bad.txt.
+        original_read = sandbox.read
+
+        async def _failing_read(path: str) -> bytes:
+            if path == "/remote/bad.txt":
+                msg = "not found"
+                raise FileNotFoundError(msg)
+            return await original_read(path)
+
+        sandbox.read = _failing_read  # ty: ignore[invalid-assignment]
+
+        dest = tmp_path / "downloaded"
+        await env.download_dir("/remote", dest)
+
+        assert (dest / "good.txt").read_bytes() == b"ok"
+        assert not (dest / "bad.txt").exists()
+
+    async def test_upload_dir_without_start_raises(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        src_dir = tmp_path / "mydir"
+        src_dir.mkdir()
+        with pytest.raises(RuntimeError, match="start"):
+            await env.upload_dir(src_dir, "/app/dest")
+
+    async def test_download_dir_empty(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        sandbox = _FakeSandbox()
+        env._sandbox = sandbox  # ty: ignore[invalid-assignment]
+
+        async def _fake_run(_cmd: str, **_kw: Any) -> _FakeExecResult:
+            return _FakeExecResult(exit_code=1, stderr="No such file or directory")
+
+        sandbox.run = _fake_run  # ty: ignore[invalid-assignment]
+
+        dest = tmp_path / "downloaded"
+        await env.download_dir("/nonexistent", dest)
+
+        assert dest.exists()
+        assert list(dest.iterdir()) == []
+
+
+class TestStop:
+    """Tests for teardown.
+
+    Snapshots are shared resources — ``stop()`` must never delete them,
+    regardless of the ``delete`` flag.
+    """
+
+    async def test_stop_deletes_sandbox_but_not_snapshot(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        mock_client = AsyncMock()
+        mock_sandbox = _FakeSandbox(name="my-sandbox")
+        env._sandbox = mock_sandbox  # ty: ignore[invalid-assignment]
+        env._client = mock_client
+        env._snapshot_name = "harbor-ubuntu-24-04"
+
+        await env.stop(delete=True)
+
+        mock_client.delete_sandbox.assert_called_once_with("my-sandbox")
+        mock_client.delete_snapshot.assert_not_called()
+        mock_client.aclose.assert_called_once()
+        assert env._sandbox is None
+        assert env._client is None
+        assert env._snapshot_name is None
+
+    async def test_stop_no_delete_skips_cleanup(self, tmp_path: Path) -> None:
+        env = _make_env(tmp_path)
+        mock_client = AsyncMock()
+        env._sandbox = _FakeSandbox()  # ty: ignore[invalid-assignment]
+        env._client = mock_client
+        env._snapshot_name = "snap-tmpl"
+
+        await env.stop(delete=False)
+
+        mock_client.delete_sandbox.assert_not_called()
+        mock_client.delete_snapshot.assert_not_called()
+        mock_client.aclose.assert_called_once()
+
+    async def test_stop_continues_after_sandbox_delete_fails(self, tmp_path: Path) -> None:
+        """If sandbox deletion fails, aclose still runs and snapshot is untouched."""
+        env = _make_env(tmp_path)
+        mock_client = AsyncMock()
+        mock_client.delete_sandbox.side_effect = RuntimeError("API timeout")
+        env._sandbox = _FakeSandbox(name="my-sandbox")  # ty: ignore[invalid-assignment]
+        env._client = mock_client
+        env._snapshot_name = "harbor-my-image"
+
+        await env.stop(delete=True)
+
+        mock_client.delete_sandbox.assert_called_once_with("my-sandbox")
+        mock_client.delete_snapshot.assert_not_called()
+        mock_client.aclose.assert_called_once()
+        assert env._sandbox is None
+        assert env._client is None
+        assert env._snapshot_name is None
+
+    async def test_stop_clean_after_failed_start(self, tmp_path: Path) -> None:
+        """If create_snapshot fails, _snapshot_name stays None and stop is safe."""
+        env = _make_env(tmp_path)
+
+        with patch("deepagents_harbor.langsmith_environment.AsyncSandboxClient") as mock_cls:
+            mock_client = _mock_async_client()
+            mock_client.create_snapshot = AsyncMock(side_effect=RuntimeError("API 422"))
+            mock_cls.return_value = mock_client
+
+            with pytest.raises(RuntimeError, match="API 422"):
+                await env.start(force_build=False)
+
+        assert env._snapshot_name is None
+        assert env._sandbox is None
+
+        await env.stop(delete=True)
+        mock_client.delete_snapshot.assert_not_called()


### PR DESCRIPTION
Restores the custom LangSmith Harbor environment adapter for eval runs so commands execute from the Docker image's `WORKDIR`, matching terminal-bench expectations. Harbor's built-in `langsmith` environment covers sandbox creation, but it does not preserve the image workdir when commands omit an explicit `cwd`, which can make verifier scripts run from the wrong directory.

## Changes
- Route only `sandbox_env=langsmith` Harbor workflow runs through `deepagents_harbor.langsmith_environment:LangSmithEnvironment` while leaving other sandbox providers on `--env`.
- Restore `LangSmithEnvironment` as a compatibility adapter between Harbor task configs and LangSmith sandboxes, including resource mapping, proxy config mapping, snapshot reuse, file transfer, and default cwd detection.
- Keep the `harbor[langsmith]` dependency so the adapter continues to use Harbor's LangSmith sandbox dependencies.