### PR TITLE
hotfix(code): honor `DEEPAGENTS_CODE_` prefix for `UI_CHARSET_MODE`

### DIFF
--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -629,7 +629,9 @@ def _detect_charset_mode() -> CharsetMode:
     Returns:
         The detected CharsetMode based on environment and terminal encoding.
     """
-    env_mode = os.environ.get("UI_CHARSET_MODE", "auto").lower()
+    from deepagents_code.model_config import resolve_env_var
+
+    env_mode = (resolve_env_var("UI_CHARSET_MODE") or "auto").lower()
     if env_mode == "unicode":
         return CharsetMode.UNICODE
     if env_mode == "ascii":

--- a/libs/code/tests/unit_tests/test_charset.py
+++ b/libs/code/tests/unit_tests/test_charset.py
@@ -1,5 +1,6 @@
 """Tests for charset mode configuration and glyph selection."""
 
+import os
 import sys
 from unittest.mock import Mock, patch
 
@@ -204,6 +205,22 @@ class TestDetectCharsetMode:
             with patch.object(sys, "stdout", mock_stdout):
                 mode = _detect_charset_mode()
         assert mode == CharsetMode.UNICODE
+
+    @patch.dict("os.environ", {"DEEPAGENTS_CODE_UI_CHARSET_MODE": "ascii"}, clear=False)
+    def test_prefixed_env_var_is_honored(self) -> None:
+        """The `DEEPAGENTS_CODE_` prefixed variant resolves the mode."""
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("UI_CHARSET_MODE", None)
+            assert _detect_charset_mode() == CharsetMode.ASCII
+
+    @patch.dict(
+        "os.environ",
+        {"UI_CHARSET_MODE": "ascii", "DEEPAGENTS_CODE_UI_CHARSET_MODE": "unicode"},
+        clear=False,
+    )
+    def test_prefixed_env_var_overrides_canonical(self) -> None:
+        """The prefixed variant wins over the canonical one, matching runtime."""
+        assert _detect_charset_mode() == CharsetMode.UNICODE
 
 
 class TestGetGlyphs:


### PR DESCRIPTION
Fixed `dcode config get display.charset` disagreeing with the runtime when both `UI_CHARSET_MODE` and `DEEPAGENTS_CODE_UI_CHARSET_MODE` are set.

---

`_detect_charset_mode` read `UI_CHARSET_MODE` directly from the environment, bypassing the `DEEPAGENTS_CODE_` prefix-override convention that the rest of the config system follows. Meanwhile, `config get display.charset` reports the option's value and source through `resolved_env_var_name`, which *does* honor the prefix.

The result: with both `UI_CHARSET_MODE` and `DEEPAGENTS_CODE_UI_CHARSET_MODE` set, the new config introspection command reported the prefixed value while the app actually rendered using the canonical one. This change routes the runtime lookup through `resolve_env_var`, so the runtime and the introspection command agree on which variable wins.

Made by [Open SWE](https://openswe.vercel.app)