### PR TITLE
fix(code): surface untracked files in `@` completion

### DIFF
--- a/libs/code/deepagents_code/widgets/autocomplete.py
+++ b/libs/code/deepagents_code/widgets/autocomplete.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 import shutil
 
 # S404: subprocess is required for git ls-files to get project file list
@@ -18,6 +19,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
 from deepagents_code.project_utils import find_project_root
+
+logger = logging.getLogger(__name__)
 
 
 def _get_git_executable() -> str | None:
@@ -351,11 +354,20 @@ def _run_git_ls_files(
 ) -> tuple[bool, list[str]]:
     """Run `git ls-files` with the given arguments and return file paths.
 
+    Args:
+        git_path: Full path to the git executable.
+        root: Directory to run the command in.
+        extra_args: Flags appended after `ls-files`, e.g.
+            `["--others", "--exclude-standard"]`.
+
     Returns:
-        Tuple of success status and relative file paths.
+        Tuple of success status and relative file paths. Success is `False`
+            when git could not be run or exited non-zero, signalling the caller
+            to fall back to a glob walk.
     """
     try:
-        # S603: git_path is validated via shutil.which(), args are hardcoded
+        # S603: git_path validated via shutil.which(); ls-files args are
+        # caller-supplied literals.
         result = subprocess.run(  # noqa: S603
             [git_path, "ls-files", *extra_args],
             cwd=root,
@@ -365,8 +377,10 @@ def _run_git_ls_files(
             check=False,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        logger.debug("git ls-files %s failed to run", extra_args, exc_info=True)
         return False, []
     if result.returncode != 0:
+        logger.debug("git ls-files %s exited with %d", extra_args, result.returncode)
         return False, []
     return True, [f for f in result.stdout.strip().split("\n") if f]
 
@@ -408,7 +422,7 @@ def _get_project_files(root: Path) -> list[str]:
             if len(files) >= _MAX_FALLBACK_FILES:
                 break
     except OSError:
-        pass
+        logger.debug("glob fallback failed for %s", root, exc_info=True)
     return files
 
 

--- a/libs/code/deepagents_code/widgets/autocomplete.py
+++ b/libs/code/deepagents_code/widgets/autocomplete.py
@@ -346,29 +346,53 @@ _MIN_FUZZY_RATIO = 0.4
 """SequenceMatcher threshold for filename-only fuzzy matches."""
 
 
+def _run_git_ls_files(git_path: str, root: Path, extra_args: list[str]) -> list[str]:
+    """Run `git ls-files` with the given arguments and return file paths.
+
+    Returns:
+        List of relative file paths, or empty list on failure.
+    """
+    try:
+        # S603: git_path is validated via shutil.which(), args are hardcoded
+        result = subprocess.run(  # noqa: S603
+            [git_path, "ls-files", *extra_args],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+    return [f for f in result.stdout.strip().split("\n") if f]
+
+
 def _get_project_files(root: Path) -> list[str]:
     """Get project files using git ls-files or fallback to glob.
+
+    Includes both tracked files and untracked files that are not ignored
+    (via `--others --exclude-standard`), so freshly created files surface
+    in `@` completion without needing to be committed first.
 
     Returns:
         List of relative file paths from project root.
     """
     git_path = _get_git_executable()
     if git_path:
-        try:
-            # S603: git_path is validated via shutil.which(), args are hardcoded
-            result = subprocess.run(  # noqa: S603
-                [git_path, "ls-files"],
-                cwd=root,
-                capture_output=True,
-                text=True,
-                timeout=5,
-                check=False,
-            )
-            if result.returncode == 0:
-                files = result.stdout.strip().split("\n")
-                return [f for f in files if f]  # Filter empty strings
-        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-            pass
+        tracked = _run_git_ls_files(git_path, root, [])
+        untracked = _run_git_ls_files(
+            git_path, root, ["--others", "--exclude-standard"]
+        )
+        if tracked or untracked:
+            seen: set[str] = set()
+            files: list[str] = []
+            for f in (*tracked, *untracked):
+                if f not in seen:
+                    seen.add(f)
+                    files.append(f)
+            return files
 
     # Fallback: simple glob (limited depth to avoid slowness)
     files = []

--- a/libs/code/deepagents_code/widgets/autocomplete.py
+++ b/libs/code/deepagents_code/widgets/autocomplete.py
@@ -346,11 +346,13 @@ _MIN_FUZZY_RATIO = 0.4
 """SequenceMatcher threshold for filename-only fuzzy matches."""
 
 
-def _run_git_ls_files(git_path: str, root: Path, extra_args: list[str]) -> list[str]:
+def _run_git_ls_files(
+    git_path: str, root: Path, extra_args: list[str]
+) -> tuple[bool, list[str]]:
     """Run `git ls-files` with the given arguments and return file paths.
 
     Returns:
-        List of relative file paths, or empty list on failure.
+        Tuple of success status and relative file paths.
     """
     try:
         # S603: git_path is validated via shutil.which(), args are hardcoded
@@ -363,10 +365,10 @@ def _run_git_ls_files(git_path: str, root: Path, extra_args: list[str]) -> list[
             check=False,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        return []
+        return False, []
     if result.returncode != 0:
-        return []
-    return [f for f in result.stdout.strip().split("\n") if f]
+        return False, []
+    return True, [f for f in result.stdout.strip().split("\n") if f]
 
 
 def _get_project_files(root: Path) -> list[str]:
@@ -381,11 +383,11 @@ def _get_project_files(root: Path) -> list[str]:
     """
     git_path = _get_git_executable()
     if git_path:
-        tracked = _run_git_ls_files(git_path, root, [])
-        untracked = _run_git_ls_files(
+        tracked_ok, tracked = _run_git_ls_files(git_path, root, [])
+        untracked_ok, untracked = _run_git_ls_files(
             git_path, root, ["--others", "--exclude-standard"]
         )
-        if tracked or untracked:
+        if tracked_ok and untracked_ok:
             seen: set[str] = set()
             files: list[str] = []
             for f in (*tracked, *untracked):

--- a/libs/code/tests/unit_tests/test_autocomplete.py
+++ b/libs/code/tests/unit_tests/test_autocomplete.py
@@ -19,6 +19,7 @@ from deepagents_code.widgets.autocomplete import (
     SlashCommandController,
     _fuzzy_score,
     _fuzzy_search,
+    _get_project_files,
     _is_dotpath,
     _path_depth,
 )
@@ -784,3 +785,62 @@ class TestFuzzyFileControllerWarmCacheRace:
         assert controller._project_root == sub_a
         assert controller._project_root_pending is False
         assert controller._file_cache == ["a/new.py"]
+
+
+class TestGetProjectFiles:
+    """Tests for _get_project_files."""
+
+    @staticmethod
+    def _init_repo(root: Path) -> None:
+        import subprocess
+
+        for args in (
+            ["init"],
+            ["config", "user.email", "test@example.com"],
+            ["config", "user.name", "Test"],
+        ):
+            subprocess.run(["git", *args], cwd=root, check=True, capture_output=True)
+
+    def test_includes_tracked_and_untracked_files(self, tmp_path: Path) -> None:
+        """Both committed and untracked-but-not-ignored files are returned."""
+        import subprocess
+
+        self._init_repo(tmp_path)
+        (tmp_path / "tracked.py").write_text("x = 1\n")
+        subprocess.run(
+            ["git", "add", "tracked.py"], cwd=tmp_path, check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "init"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        (tmp_path / "untracked.py").write_text("y = 2\n")
+
+        files = _get_project_files(tmp_path)
+
+        assert "tracked.py" in files
+        assert "untracked.py" in files
+
+    def test_excludes_ignored_files(self, tmp_path: Path) -> None:
+        """Files matched by .gitignore are not returned."""
+        self._init_repo(tmp_path)
+        (tmp_path / ".gitignore").write_text("ignored.py\n")
+        (tmp_path / "ignored.py").write_text("z = 3\n")
+        (tmp_path / "visible.py").write_text("a = 4\n")
+
+        files = _get_project_files(tmp_path)
+
+        assert "visible.py" in files
+        assert "ignored.py" not in files
+
+    def test_no_duplicate_entries(self, tmp_path: Path) -> None:
+        """A file does not appear twice across tracked/untracked sources."""
+        self._init_repo(tmp_path)
+        (tmp_path / "only.py").write_text("b = 5\n")
+
+        files = _get_project_files(tmp_path)
+
+        assert files.count("only.py") == 1

--- a/libs/code/tests/unit_tests/test_autocomplete.py
+++ b/libs/code/tests/unit_tests/test_autocomplete.py
@@ -837,6 +837,16 @@ class TestGetProjectFiles:
         assert "visible.py" in files
         assert "ignored.py" not in files
 
+    def test_empty_git_listing_does_not_fall_back_to_glob(self, tmp_path: Path) -> None:
+        """Successful empty git output is authoritative."""
+        self._init_repo(tmp_path)
+        (tmp_path / ".git" / "info" / "exclude").write_text("ignored.py\n")
+        (tmp_path / "ignored.py").write_text("z = 3\n")
+
+        files = _get_project_files(tmp_path)
+
+        assert files == []
+
     def test_no_duplicate_entries(self, tmp_path: Path) -> None:
         """A file does not appear twice across tracked/untracked sources."""
         self._init_repo(tmp_path)

--- a/libs/code/tests/unit_tests/test_autocomplete.py
+++ b/libs/code/tests/unit_tests/test_autocomplete.py
@@ -1,6 +1,7 @@
 """Tests for autocomplete fuzzy search functionality."""
 
 import asyncio
+import subprocess
 import threading
 from pathlib import Path
 from typing import cast
@@ -19,9 +20,11 @@ from deepagents_code.widgets.autocomplete import (
     SlashCommandController,
     _fuzzy_score,
     _fuzzy_search,
+    _get_git_executable,
     _get_project_files,
     _is_dotpath,
     _path_depth,
+    _run_git_ls_files,
     _scope_files_to_cwd,
 )
 
@@ -793,8 +796,7 @@ class TestGetProjectFiles:
 
     @staticmethod
     def _init_repo(root: Path) -> None:
-        import subprocess
-
+        """Initialize a throwaway git repo with a test identity."""
         for args in (
             ["init"],
             ["config", "user.email", "test@example.com"],
@@ -803,9 +805,11 @@ class TestGetProjectFiles:
             subprocess.run(["git", *args], cwd=root, check=True, capture_output=True)
 
     def test_includes_tracked_and_untracked_files(self, tmp_path: Path) -> None:
-        """Both committed and untracked-but-not-ignored files are returned."""
-        import subprocess
+        """Both committed and untracked-but-not-ignored files are returned.
 
+        Tracked files are listed before untracked ones so they rank ahead in
+        completion results.
+        """
         self._init_repo(tmp_path)
         (tmp_path / "tracked.py").write_text("x = 1\n")
         subprocess.run(
@@ -824,6 +828,7 @@ class TestGetProjectFiles:
 
         assert "tracked.py" in files
         assert "untracked.py" in files
+        assert files.index("tracked.py") < files.index("untracked.py")
 
     def test_excludes_ignored_files(self, tmp_path: Path) -> None:
         """Files matched by .gitignore are not returned."""
@@ -847,14 +852,95 @@ class TestGetProjectFiles:
 
         assert files == []
 
-    def test_no_duplicate_entries(self, tmp_path: Path) -> None:
-        """A file does not appear twice across tracked/untracked sources."""
+    def test_deduplicates_repeated_paths(self, tmp_path: Path) -> None:
+        """A path emitted more than once by git ls-files appears only once.
+
+        An unmerged (conflicted) file is reported once per merge stage by
+        `git ls-files`, which is the real source of the duplicate entries the
+        de-duplication guards against.
+        """
         self._init_repo(tmp_path)
-        (tmp_path / "only.py").write_text("b = 5\n")
+        conflict = tmp_path / "conflict.py"
+        conflict.write_text("base\n")
+        subprocess.run(
+            ["git", "add", "conflict.py"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "base"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        base_branch = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "checkout", "-b", "other"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        conflict.write_text("theirs\n")
+        subprocess.run(
+            ["git", "commit", "-am", "theirs"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "checkout", base_branch],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        conflict.write_text("ours\n")
+        subprocess.run(
+            ["git", "commit", "-am", "ours"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        # The merge fails with a conflict; the conflicted state is the point.
+        subprocess.run(
+            ["git", "merge", "other"],
+            cwd=tmp_path,
+            check=False,
+            capture_output=True,
+        )
+
+        git_path = _get_git_executable()
+        assert git_path is not None
+        _, raw = _run_git_ls_files(git_path, tmp_path, [])
+        # Premise: the conflicted path is reported more than once.
+        assert raw.count("conflict.py") > 1
 
         files = _get_project_files(tmp_path)
 
-        assert files.count("only.py") == 1
+        assert files.count("conflict.py") == 1
+
+    def test_glob_fallback_when_git_unavailable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without git, files are discovered via glob, excluding dotpaths."""
+        monkeypatch.setattr(autocomplete_module, "_get_git_executable", lambda: None)
+        (tmp_path / "visible.py").write_text("a = 1\n")
+        (tmp_path / ".hidden.py").write_text("secret = 1\n")
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "mod.py").write_text("b = 2\n")
+
+        files = _get_project_files(tmp_path)
+
+        assert "visible.py" in files
+        assert "pkg/mod.py" in files
+        assert ".hidden.py" not in files
 
 
 class TestFuzzyFileControllerScope:


### PR DESCRIPTION
Closes #1615

---

The `@` file-mention autocomplete only listed git-tracked files because `_get_project_files` relied solely on `git ls-files`, which reads the index. Files created in the working tree but not yet committed never appeared in completion results.

This augments the file list with `git ls-files --others --exclude-standard`, which returns untracked files that are not ignored, and de-duplicates the combined result. Tracked files still come first. The glob fallback (used when git is unavailable) is unchanged.

## Self-Hosted Release Note
The `@` file picker now surfaces untracked (uncommitted, non-ignored) files in addition to tracked ones.

Made by [Open SWE](https://openswe.vercel.app)