### PR TITLE
fix(code): warn on misconfigured subagent files

### DIFF
--- a/libs/code/deepagents_code/subagents.py
+++ b/libs/code/deepagents_code/subagents.py
@@ -173,8 +173,8 @@ def _load_subagents_from_dir(
         # Look for {folder_name}/AGENTS.md
         subagent_file = entry / "AGENTS.md"
         if not subagent_file.exists():
-            # Warn when the folder looks like a misconfigured subagent (e.g. a
-            # Claude Code style `agent.md`/`<name>.md` instead of `AGENTS.md`).
+            # The folder exists but holds a differently-named markdown file
+            # (e.g. agent.md or {name}.md) instead of the required AGENTS.md.
             stray_md = [p.name for p in entry.glob("*.md")]
             if stray_md:
                 logger.warning(
@@ -189,6 +189,22 @@ def _load_subagents_from_dir(
         subagent = _parse_subagent_file(subagent_file)
         if subagent:
             subagent["source"] = source
+            # The folder name and the frontmatter `name` are independent, so two
+            # folders can declare the same `name` and silently collapse to one
+            # entry. Iteration order is filesystem-dependent, so warn rather than
+            # let a definition vanish without explanation.
+            existing = subagents.get(subagent["name"])
+            if existing is not None:
+                logger.warning(
+                    "Subagent name collision in %s: %s and %s both declare "
+                    "name=%r. Using %s; give each subagent a unique 'name' in "
+                    "its frontmatter.",
+                    agents_dir,
+                    existing["path"],
+                    subagent["path"],
+                    subagent["name"],
+                    subagent["path"],
+                )
             subagents[subagent["name"]] = subagent
 
     return subagents

--- a/libs/code/deepagents_code/subagents.py
+++ b/libs/code/deepagents_code/subagents.py
@@ -22,6 +22,7 @@ Example file (researcher/AGENTS.md):
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import TYPE_CHECKING, TypedDict
 
@@ -29,6 +30,8 @@ import yaml
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class SubagentMetadata(TypedDict):
@@ -67,21 +70,35 @@ def _parse_subagent_file(file_path: Path) -> SubagentMetadata | None:
     """
     try:
         content = file_path.read_text(encoding="utf-8")
-    except OSError:
+    except OSError as exc:
+        logger.warning("Skipping subagent %s: could not read file (%s)", file_path, exc)
         return None
 
     # Extract YAML frontmatter (--- delimited)
     match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
     if not match:
+        logger.warning(
+            "Skipping subagent %s: missing YAML frontmatter. The file must start "
+            "with a '---' delimited block containing 'name' and 'description'.",
+            file_path,
+        )
         return None
 
     try:
         frontmatter = yaml.safe_load(match.group(1))
-    except yaml.YAMLError:
+    except yaml.YAMLError as exc:
+        logger.warning(
+            "Skipping subagent %s: invalid YAML frontmatter (%s)", file_path, exc
+        )
         return None
 
     # Validate frontmatter structure and required fields
     if not isinstance(frontmatter, dict):
+        logger.warning(
+            "Skipping subagent %s: frontmatter must be a mapping with 'name' and "
+            "'description' fields.",
+            file_path,
+        )
         return None
 
     name = frontmatter.get("name")
@@ -95,6 +112,18 @@ def _parse_subagent_file(file_path: Path) -> SubagentMetadata | None:
     model_valid = model is None or isinstance(model, str)
 
     if not (name_valid and description_valid and model_valid):
+        invalid_fields: list[str] = []
+        if not name_valid:
+            invalid_fields.append("name (non-empty string required)")
+        if not description_valid:
+            invalid_fields.append("description (non-empty string required)")
+        if not model_valid:
+            invalid_fields.append("model (string required when present)")
+        logger.warning(
+            "Skipping subagent %s: invalid or missing frontmatter field(s): %s",
+            file_path,
+            ", ".join(invalid_fields),
+        )
         return None
 
     return {
@@ -126,13 +155,35 @@ def _load_subagents_from_dir(
     if not agents_dir.exists() or not agents_dir.is_dir():
         return subagents
 
-    for folder in agents_dir.iterdir():
-        if not folder.is_dir():
+    for entry in agents_dir.iterdir():
+        if not entry.is_dir():
+            # A stray file directly under agents/ is a common mistake: subagents
+            # must live at agents/{name}/AGENTS.md, not agents/{name}.md.
+            if entry.suffix.lower() == ".md":
+                logger.warning(
+                    "Ignoring %s subagent file %s: subagents must be defined at "
+                    "%s/{subagent-name}/AGENTS.md, not as a file directly in the "
+                    "agents directory.",
+                    source,
+                    entry,
+                    agents_dir,
+                )
             continue
 
         # Look for {folder_name}/AGENTS.md
-        subagent_file = folder / "AGENTS.md"
+        subagent_file = entry / "AGENTS.md"
         if not subagent_file.exists():
+            # Warn when the folder looks like a misconfigured subagent (e.g. a
+            # Claude Code style `agent.md`/`<name>.md` instead of `AGENTS.md`).
+            stray_md = [p.name for p in entry.glob("*.md")]
+            if stray_md:
+                logger.warning(
+                    "Ignoring %s subagent folder %s: expected an AGENTS.md file "
+                    "but found %s. Rename the definition to AGENTS.md.",
+                    source,
+                    entry,
+                    ", ".join(sorted(stray_md)),
+                )
             continue
 
         subagent = _parse_subagent_file(subagent_file)

--- a/libs/code/tests/unit_tests/test_subagents.py
+++ b/libs/code/tests/unit_tests/test_subagents.py
@@ -449,22 +449,78 @@ class TestDiagnostics:
 
         assert "missing YAML frontmatter" in caplog.text
 
-    def test_warns_on_invalid_fields(
+    def test_warns_on_unreadable_file(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Missing required fields are named in the warning."""
-        subagent_file = tmp_path / "AGENTS.md"
-        subagent_file.write_text("""---
-name: helper
----
+        """A file that cannot be read (here, a directory) logs a warning."""
+        # Reading a directory with read_text raises OSError deterministically,
+        # without relying on chmod (which is a no-op for root in CI).
+        with caplog.at_level(logging.WARNING):
+            assert _parse_subagent_file(tmp_path) is None
 
-Content
-""")
+        assert "could not read file" in caplog.text
+
+    def test_warns_on_invalid_yaml(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Frontmatter that is not valid YAML logs a warning."""
+        subagent_file = tmp_path / "AGENTS.md"
+        subagent_file.write_text("---\nname: [unclosed\n---\n\nContent\n")
 
         with caplog.at_level(logging.WARNING):
             assert _parse_subagent_file(subagent_file) is None
 
-        assert "description" in caplog.text
+        assert "invalid YAML frontmatter" in caplog.text
+
+    def test_warns_on_non_dict_frontmatter(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Frontmatter that parses to a non-mapping (a list) logs a warning."""
+        subagent_file = tmp_path / "AGENTS.md"
+        subagent_file.write_text("---\n- just\n- a\n- list\n---\n\nContent\n")
+
+        with caplog.at_level(logging.WARNING):
+            assert _parse_subagent_file(subagent_file) is None
+
+        assert "must be a mapping" in caplog.text
+
+    def test_warns_on_missing_description_field(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A missing description names the description field in the warning."""
+        subagent_file = tmp_path / "AGENTS.md"
+        subagent_file.write_text("---\nname: helper\n---\n\nContent\n")
+
+        with caplog.at_level(logging.WARNING):
+            assert _parse_subagent_file(subagent_file) is None
+
+        assert "description (non-empty string required)" in caplog.text
+
+    def test_warns_on_missing_name_field(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A missing name names the name field in the warning."""
+        subagent_file = tmp_path / "AGENTS.md"
+        subagent_file.write_text("---\ndescription: A helper\n---\n\nContent\n")
+
+        with caplog.at_level(logging.WARNING):
+            assert _parse_subagent_file(subagent_file) is None
+
+        assert "name (non-empty string required)" in caplog.text
+
+    def test_warns_on_non_string_model_field(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A non-string model names the model field in the warning."""
+        subagent_file = tmp_path / "AGENTS.md"
+        subagent_file.write_text(
+            "---\nname: helper\ndescription: A helper\nmodel: 42\n---\n\nContent\n"
+        )
+
+        with caplog.at_level(logging.WARNING):
+            assert _parse_subagent_file(subagent_file) is None
+
+        assert "model (string required when present)" in caplog.text
 
     def test_warns_on_stray_file_in_agents_dir(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
@@ -486,7 +542,7 @@ Content
     def test_warns_on_folder_without_agents_md(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A Claude Code style folder (agent.md instead of AGENTS.md) is flagged."""
+        """A folder with a misnamed definition (agent.md, not AGENTS.md) is flagged."""
         agents_dir = tmp_path / "agents"
         folder = agents_dir / "researcher"
         folder.mkdir(parents=True)
@@ -500,3 +556,44 @@ Content
         assert result == {}
         assert "agent.md" in caplog.text
         assert "AGENTS.md" in caplog.text
+
+    def test_warns_on_name_collision(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Two folders declaring the same frontmatter name are flagged."""
+        agents_dir = tmp_path / "agents"
+        for folder_name in ("researcher", "web-researcher"):
+            folder = agents_dir / folder_name
+            folder.mkdir(parents=True)
+            # Both folders declare the same frontmatter `name`, so one silently
+            # shadows the other without this warning.
+            (folder / "AGENTS.md").write_text(
+                make_subagent_content("researcher", f"Defined in {folder_name}")
+            )
+
+        with caplog.at_level(logging.WARNING):
+            result = _load_subagents_from_dir(agents_dir, "project")
+
+        # One definition wins (collapsed to a single entry); the collision warns.
+        assert len(result) == 1
+        assert "name collision" in caplog.text
+        assert "researcher" in caplog.text
+
+    def test_no_warning_for_valid_or_unrelated_entries(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A valid subagent alongside an unrelated non-markdown file stays silent."""
+        agents_dir = tmp_path / "agents"
+        folder = agents_dir / "researcher"
+        folder.mkdir(parents=True)
+        (folder / "AGENTS.md").write_text(
+            make_subagent_content("researcher", "Research assistant")
+        )
+        # An unrelated file (not .md) directly under agents/ must not be flagged.
+        (agents_dir / "notes.txt").write_text("just some notes")
+
+        with caplog.at_level(logging.WARNING):
+            result = _load_subagents_from_dir(agents_dir, "project")
+
+        assert len(result) == 1
+        assert caplog.records == []

--- a/libs/code/tests/unit_tests/test_subagents.py
+++ b/libs/code/tests/unit_tests/test_subagents.py
@@ -1,6 +1,9 @@
 """Unit tests for subagent loading functionality."""
 
+import logging
 from pathlib import Path
+
+import pytest
 
 from deepagents_code.subagents import (
     _load_subagents_from_dir,
@@ -429,3 +432,71 @@ class TestListSubagents:
 
         assert len(result) == 1
         assert result[0]["model"] == "anthropic:claude-haiku-4-5-20251001"
+
+
+class TestDiagnostics:
+    """Test that discovery surfaces warnings for misconfigured subagents."""
+
+    def test_warns_on_missing_frontmatter(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A file without frontmatter logs an explanatory warning."""
+        subagent_file = tmp_path / "AGENTS.md"
+        subagent_file.write_text("# Just markdown\n\nNo frontmatter.")
+
+        with caplog.at_level(logging.WARNING):
+            assert _parse_subagent_file(subagent_file) is None
+
+        assert "missing YAML frontmatter" in caplog.text
+
+    def test_warns_on_invalid_fields(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Missing required fields are named in the warning."""
+        subagent_file = tmp_path / "AGENTS.md"
+        subagent_file.write_text("""---
+name: helper
+---
+
+Content
+""")
+
+        with caplog.at_level(logging.WARNING):
+            assert _parse_subagent_file(subagent_file) is None
+
+        assert "description" in caplog.text
+
+    def test_warns_on_stray_file_in_agents_dir(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A markdown file placed directly in agents/ is flagged."""
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "researcher.md").write_text(
+            make_subagent_content("researcher", "Research assistant")
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = _load_subagents_from_dir(agents_dir, "project")
+
+        assert result == {}
+        assert "researcher.md" in caplog.text
+        assert "AGENTS.md" in caplog.text
+
+    def test_warns_on_folder_without_agents_md(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A Claude Code style folder (agent.md instead of AGENTS.md) is flagged."""
+        agents_dir = tmp_path / "agents"
+        folder = agents_dir / "researcher"
+        folder.mkdir(parents=True)
+        (folder / "agent.md").write_text(
+            make_subagent_content("researcher", "Research assistant")
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = _load_subagents_from_dir(agents_dir, "user")
+
+        assert result == {}
+        assert "agent.md" in caplog.text
+        assert "AGENTS.md" in caplog.text


### PR DESCRIPTION
Fixes #2322

Deep Agents Code now warns when a custom subagent file is malformed or placed at an unexpected path instead of silently ignoring it.

---

Project- and user-level subagent discovery silently ignored files that were malformed or in the wrong location, so users migrating from a Claude Code structure (`agent.md` / `<name>.md` instead of `<name>/AGENTS.md`) got no feedback. Discovery now logs explanatory warnings naming the file and the specific problem (missing frontmatter, invalid/missing `name`/`description`/`model`, stray file in `agents/`, or a folder missing `AGENTS.md`).

Made by [Open SWE](https://openswe.vercel.app)