### PR TITLE
fix(code): scope `@` file completion to current cwd

### DIFF
--- a/libs/code/deepagents_code/widgets/autocomplete.py
+++ b/libs/code/deepagents_code/widgets/autocomplete.py
@@ -491,18 +491,28 @@ def _fuzzy_search(
 
 
 def _scope_files_to_cwd(files: list[str], project_root: Path, cwd: Path) -> list[str]:
-    """Scope a repo-relative file list to paths under `cwd`.
+    """Scope a project-root-relative file list to paths under `cwd`.
+
+    Args:
+        files: File paths relative to `project_root` (as produced by
+            `_get_project_files`).
+        project_root: Directory the `files` paths are relative to.
+        cwd: Directory to scope suggestions to.
 
     Returns:
-        Paths relative to `cwd` when `cwd` is nested under `project_root`,
-        otherwise the original list unchanged.
+        Paths rewritten relative to `cwd`, filtered to that subtree (possibly
+        empty), when `cwd` is nested under `project_root`. The input list
+        unchanged when `cwd` equals `project_root`. An empty list when `cwd` is
+        not under `project_root`: the paths are project-root-relative and would
+        resolve to the wrong base from `cwd`, so fail closed rather than offer
+        misleading suggestions.
     """
     if cwd == project_root:
         return files
     try:
         relative_cwd = cwd.relative_to(project_root).as_posix()
     except ValueError:
-        return files
+        return []
     prefix = f"{relative_cwd}/"
     return [path[len(prefix) :] for path in files if path.startswith(prefix)]
 

--- a/libs/code/deepagents_code/widgets/autocomplete.py
+++ b/libs/code/deepagents_code/widgets/autocomplete.py
@@ -332,7 +332,7 @@ class SlashCommandController:
 
 
 # ============================================================================
-# Fuzzy File Completion (from project root)
+# Fuzzy File Completion (scoped to current working directory)
 # ============================================================================
 
 # Constants for fuzzy file completion
@@ -490,8 +490,25 @@ def _fuzzy_search(
     return [c for _, c in scored[:limit]]
 
 
+def _scope_files_to_cwd(files: list[str], project_root: Path, cwd: Path) -> list[str]:
+    """Scope a repo-relative file list to paths under `cwd`.
+
+    Returns:
+        Paths relative to `cwd` when `cwd` is nested under `project_root`,
+        otherwise the original list unchanged.
+    """
+    if cwd == project_root:
+        return files
+    try:
+        relative_cwd = cwd.relative_to(project_root).as_posix()
+    except ValueError:
+        return files
+    prefix = f"{relative_cwd}/"
+    return [path[len(prefix) :] for path in files if path.startswith(prefix)]
+
+
 class FuzzyFileController:
-    """Controller for @ file completion with fuzzy matching from project root."""
+    """Controller for @ file completion with fuzzy matching from current cwd."""
 
     def __init__(
         self,
@@ -502,10 +519,10 @@ class FuzzyFileController:
 
         Args:
             view: View to render suggestions to
-            cwd: Starting directory to find project root from
+            cwd: Current working directory for file completion scope
         """
         self._view = view
-        self._cwd = cwd or Path.cwd()
+        self._cwd = (cwd or Path.cwd()).resolve()
         self._project_root = find_project_root(self._cwd) or self._cwd
         self._suggestions: list[tuple[str, str]] = []
         self._selected_index = 0
@@ -523,7 +540,8 @@ class FuzzyFileController:
             List of project file paths.
         """
         if self._file_cache is None:
-            self._file_cache = _get_project_files(self._project_root)
+            files = _get_project_files(self._project_root)
+            self._file_cache = _scope_files_to_cwd(files, self._project_root, self._cwd)
         return self._file_cache
 
     def refresh_cache(self) -> None:
@@ -541,8 +559,8 @@ class FuzzyFileController:
         root, which is a safe narrower scope.
         """
         self._cache_generation += 1
-        self._cwd = cwd
-        self._project_root = cwd
+        self._cwd = cwd.resolve()
+        self._project_root = self._cwd
         self._project_root_pending = True
         self._file_cache = None
         self.reset()
@@ -582,7 +600,7 @@ class FuzzyFileController:
         with contextlib.suppress(Exception):
             files = await asyncio.to_thread(_get_project_files, project_root)
             if generation == self._cache_generation:
-                self._file_cache = files
+                self._file_cache = _scope_files_to_cwd(files, project_root, cwd)
 
     @staticmethod
     def can_handle(text: str, cursor_index: int) -> bool:

--- a/libs/code/tests/unit_tests/test_autocomplete.py
+++ b/libs/code/tests/unit_tests/test_autocomplete.py
@@ -21,6 +21,7 @@ from deepagents_code.widgets.autocomplete import (
     _fuzzy_search,
     _is_dotpath,
     _path_depth,
+    _scope_files_to_cwd,
 )
 
 
@@ -884,3 +885,82 @@ class TestFuzzyFileControllerScope:
         await controller.warm_cache()
 
         assert controller._file_cache == ["main.py"]
+
+    def test_excludes_sibling_with_shared_prefix(
+        self, mock_view, monkeypatch, tmp_path
+    ):
+        """A sibling sharing a name prefix (apps/cli vs apps/cli-tools) is excluded.
+
+        Guards the trailing slash in the scope prefix: without it, `apps/cli`
+        would also match `apps/cli-tools/...`.
+        """
+        project_root = tmp_path
+        (project_root / ".git").mkdir()
+        cwd = project_root / "apps" / "cli"
+        cwd.mkdir(parents=True)
+
+        mock_files = [
+            "apps/cli/main.py",
+            "apps/cli-tools/runner.py",
+        ]
+        monkeypatch.setattr(
+            autocomplete_module, "_get_project_files", lambda _root: mock_files
+        )
+
+        controller = FuzzyFileController(mock_view, cwd=cwd)
+        assert controller._get_files() == ["main.py"]
+
+    def test_empty_when_cwd_subtree_has_no_files(
+        self, mock_view, monkeypatch, tmp_path
+    ):
+        """A nested cwd with no files under it yields an empty suggestion list."""
+        project_root = tmp_path
+        (project_root / ".git").mkdir()
+        cwd = project_root / "apps" / "empty"
+        cwd.mkdir(parents=True)
+
+        mock_files = ["README.md", "apps/cli/main.py"]
+        monkeypatch.setattr(
+            autocomplete_module, "_get_project_files", lambda _root: mock_files
+        )
+
+        controller = FuzzyFileController(mock_view, cwd=cwd)
+        assert controller._get_files() == []
+
+    def test_refresh_cache_rescopes_to_cwd(self, mock_view, monkeypatch, tmp_path):
+        """refresh_cache re-runs scoping against the latest file list."""
+        project_root = tmp_path
+        (project_root / ".git").mkdir()
+        cwd = project_root / "apps" / "cli"
+        cwd.mkdir(parents=True)
+
+        files = ["apps/cli/main.py"]
+        monkeypatch.setattr(
+            autocomplete_module, "_get_project_files", lambda _root: files
+        )
+
+        controller = FuzzyFileController(mock_view, cwd=cwd)
+        assert controller._get_files() == ["main.py"]
+
+        files.append("apps/cli/added.py")
+        controller.refresh_cache()
+        assert controller._get_files() == ["main.py", "added.py"]
+
+    def test_scope_helper_fails_closed_when_cwd_outside_root(self):
+        """A cwd outside project_root returns [] rather than wrong-base paths.
+
+        The input paths are project-root-relative; if cwd is not under the root
+        they would resolve to the wrong base, so the helper fails closed.
+        """
+        files = ["src/main.py", "src/utils.py"]
+        project_root = Path("/repo")
+        cwd = Path("/elsewhere")
+
+        assert _scope_files_to_cwd(files, project_root, cwd) == []
+
+    def test_scope_helper_returns_unchanged_when_cwd_is_root(self):
+        """A cwd equal to project_root leaves the repo-relative list unchanged."""
+        files = ["src/main.py", "README.md"]
+        root = Path("/repo")
+
+        assert _scope_files_to_cwd(files, root, root) == files

--- a/libs/code/tests/unit_tests/test_autocomplete.py
+++ b/libs/code/tests/unit_tests/test_autocomplete.py
@@ -665,7 +665,7 @@ class TestFuzzyFileControllerWarmCacheRace:
         monkeypatch.setattr(
             autocomplete_module,
             "_get_project_files",
-            lambda root: [f"{root.name}/file.py"],
+            lambda root: [f"sub/{root.name}.py"],
         )
 
         controller = FuzzyFileController(MagicMock(), cwd=tmp_path)
@@ -680,7 +680,7 @@ class TestFuzzyFileControllerWarmCacheRace:
         # The newer warmer fully resolved before the stale one is released.
         assert controller._project_root == proj_b
         assert controller._project_root_pending is False
-        assert controller._file_cache == ["b/file.py"]
+        assert controller._file_cache == ["b.py"]
 
         release_a.set()
         await task_a
@@ -688,7 +688,7 @@ class TestFuzzyFileControllerWarmCacheRace:
         # The stale warmer finished last but left the newer state untouched.
         assert controller._project_root == proj_b
         assert controller._project_root_pending is False
-        assert controller._file_cache == ["b/file.py"]
+        assert controller._file_cache == ["b.py"]
 
     async def test_stale_warmer_does_not_overwrite_file_cache(
         self, tmp_path, monkeypatch
@@ -784,3 +784,103 @@ class TestFuzzyFileControllerWarmCacheRace:
         assert controller._project_root == sub_a
         assert controller._project_root_pending is False
         assert controller._file_cache == ["a/new.py"]
+
+
+class TestFuzzyFileControllerScope:
+    """Tests for cwd-scoped file completion behavior."""
+
+    @pytest.fixture
+    def mock_view(self):
+        """Create a mock CompletionView."""
+        return MagicMock()
+
+    def test_scopes_git_file_list_to_cwd(self, mock_view, monkeypatch, tmp_path):
+        """When cwd is nested, suggestions are scoped to that subtree."""
+        project_root = tmp_path
+        (project_root / ".git").mkdir()
+        cwd = project_root / "apps" / "cli"
+        cwd.mkdir(parents=True)
+
+        mock_files = [
+            "README.md",
+            "apps/cli/main.py",
+            "apps/cli/utils/helpers.py",
+            "apps/web/index.ts",
+        ]
+        monkeypatch.setattr(
+            autocomplete_module, "_get_project_files", lambda _root: mock_files
+        )
+
+        controller = FuzzyFileController(mock_view, cwd=cwd)
+        assert controller._get_files() == ["main.py", "utils/helpers.py"]
+
+        controller.on_text_changed("@", 1)
+        suggestions = mock_view.render_completion_suggestions.call_args[0][0]
+        labels = [label for label, _ in suggestions]
+        assert "@main.py" in labels
+        assert "@utils/helpers.py" in labels
+        assert not any("apps/web" in label for label in labels)
+
+    def test_keeps_project_root_scope_when_cwd_is_root(
+        self, mock_view, monkeypatch, tmp_path
+    ):
+        """When cwd is project root, file list remains repo-relative."""
+        (tmp_path / ".git").mkdir()
+        mock_files = ["README.md", "apps/cli/main.py"]
+        monkeypatch.setattr(
+            autocomplete_module, "_get_project_files", lambda _root: mock_files
+        )
+
+        controller = FuzzyFileController(mock_view, cwd=tmp_path)
+        assert controller._get_files() == mock_files
+
+    def test_scopes_git_file_list_with_symlinked_cwd(
+        self, mock_view, monkeypatch, tmp_path
+    ):
+        """Symlinked cwd should still scope suggestions to the resolved subtree."""
+        project_root = tmp_path
+        (project_root / ".git").mkdir()
+        real_cwd = project_root / "apps" / "cli"
+        real_cwd.mkdir(parents=True)
+        symlink_cwd = project_root / "APPS_CLI_LINK"
+        try:
+            symlink_cwd.symlink_to(real_cwd, target_is_directory=True)
+        except OSError:  # pragma: no cover - platform/permission dependent
+            return
+
+        mock_files = [
+            "README.md",
+            "apps/cli/main.py",
+            "apps/cli/utils/helpers.py",
+            "apps/web/index.ts",
+        ]
+        monkeypatch.setattr(
+            autocomplete_module, "_get_project_files", lambda _root: mock_files
+        )
+
+        controller = FuzzyFileController(mock_view, cwd=symlink_cwd)
+        assert controller._get_files() == ["main.py", "utils/helpers.py"]
+
+    async def test_warm_cache_scopes_file_list_to_cwd(
+        self, mock_view, monkeypatch, tmp_path
+    ):
+        """warm_cache scopes the cached file list to the resolved cwd subtree."""
+        project_root = tmp_path
+        (project_root / ".git").mkdir()
+        cwd = project_root / "apps" / "cli"
+        cwd.mkdir(parents=True)
+
+        mock_files = [
+            "README.md",
+            "apps/cli/main.py",
+            "apps/web/index.ts",
+        ]
+        monkeypatch.setattr(
+            autocomplete_module, "_get_project_files", lambda _root: mock_files
+        )
+
+        controller = FuzzyFileController(mock_view, cwd=project_root)
+        controller.set_cwd(cwd)
+        await controller.warm_cache()
+
+        assert controller._file_cache == ["main.py"]


### PR DESCRIPTION
Fixes #1093

`@` file completion now suggests files relative to the current working directory instead of the repository root.

---

`@` file completion listed candidates from the git/project root even when the app was launched in a nested subdirectory. This scopes the cached candidate list to the current working directory subtree and displays suggestions relative to that cwd (e.g. `@main.py` instead of `@apps/cli/main.py`). Scoping is applied in both the synchronous `_get_files()` path and the off-event-loop `warm_cache()` path.

Made by [Open SWE](https://openswe.vercel.app)