### PR TITLE
fix(evals): make `DeepAgentsWrapper` temperature optional + fix langsmith make target

### DIFF
--- a/libs/evals/Makefile
+++ b/libs/evals/Makefile
@@ -65,9 +65,9 @@ run-terminal-bench-runloop: ## Run terminal-bench on Runloop (10 concurrent)
 	@mkdir -p jobs/terminal-bench
 	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 10 --jobs-dir jobs/terminal-bench --env runloop $(AGENT_KWARG)
 
-run-terminal-bench-langsmith: ## Run terminal-bench on LangSmith prod sandboxes (sequential)
+run-terminal-bench-langsmith: ## Run terminal-bench on LangSmith prod sandboxes (sequential; override with MODEL=<id>)
 	@mkdir -p jobs/terminal-bench
-	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 1 --jobs-dir jobs/terminal-bench --env langsmith $(AGENT_KWARG)
+	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 --model $(or $(MODEL),anthropic:claude-opus-4-8) -n 1 --jobs-dir jobs/terminal-bench --env langsmith $(AGENT_KWARG)
 
 ######################
 # CHARTS

--- a/libs/evals/deepagents_harbor/deepagents_wrapper.py
+++ b/libs/evals/deepagents_harbor/deepagents_wrapper.py
@@ -92,7 +92,7 @@ class DeepAgentsWrapper(BaseAgent):
         self,
         logs_dir: Path,
         model_name: str,
-        temperature: float = 0.0,
+        temperature: float | None = None,
         verbose: bool = True,
         use_cli_agent: bool = True,
         openrouter_provider: str | None = None,
@@ -105,7 +105,7 @@ class DeepAgentsWrapper(BaseAgent):
         Args:
             logs_dir: Directory for storing logs.
             model_name: Name of the LLM model to use.
-            temperature: Temperature setting for the model.
+            temperature: Optional sampling temperature; omitted when None (the default).
             verbose: Enable verbose output.
             use_cli_agent: If `True`, use `create_cli_agent` from
                 `deepagents-code` (default). If `False`, use
@@ -154,7 +154,9 @@ class DeepAgentsWrapper(BaseAgent):
                 "only": providers,
                 "allow_fallbacks": openrouter_allow_fallbacks,
             }
-        self._model = init_chat_model(model_name, temperature=temperature, **model_kwargs)
+        if temperature is not None:
+            model_kwargs["temperature"] = temperature
+        self._model = init_chat_model(model_name, **model_kwargs)
 
         self._temperature = temperature
         self._verbose = verbose

--- a/libs/evals/tests/unit_tests/test_deepagents_wrapper.py
+++ b/libs/evals/tests/unit_tests/test_deepagents_wrapper.py
@@ -54,7 +54,43 @@ class TestHappyPathConstruction:
 
         assert wrapper._model_name == "claude-sonnet-4-6"
         assert wrapper._model is not None
-        assert wrapper._temperature == 0.0
+        assert wrapper._temperature is None
+
+
+class TestTemperatureKwarg:
+    """`temperature` is omitted from `init_chat_model` unless explicitly set."""
+
+    @staticmethod
+    def _capture_init(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+        captured: list[dict[str, object]] = []
+
+        def fake_init(model: str, **kwargs: object) -> object:  # noqa: ARG001
+            captured.append(kwargs)
+            return object()
+
+        monkeypatch.setattr(
+            "deepagents_harbor.deepagents_wrapper.init_chat_model",
+            fake_init,
+        )
+        return captured
+
+    def test_temperature_omitted_by_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = self._capture_init(monkeypatch)
+        DeepAgentsWrapper(logs_dir=tmp_path, model_name="claude-opus-4-8")
+        assert "temperature" not in captured[0]
+
+    def test_temperature_forwarded_when_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = self._capture_init(monkeypatch)
+        DeepAgentsWrapper(
+            logs_dir=tmp_path,
+            model_name="claude-sonnet-4-6",
+            temperature=0.0,
+        )
+        assert captured[0]["temperature"] == 0.0
 
 
 class TestParseOpenrouterProviders:


### PR DESCRIPTION
## Problem

`DeepAgentsWrapper` passes `temperature=0.0` to `init_chat_model` unconditionally:

```python
self._model = init_chat_model(model_name, temperature=temperature, **model_kwargs)
```

Anthropic **Opus 4.7+ and Fable** removed sampling parameters and reject `temperature` with:

```
anthropic.BadRequestError: 400 - {'type': 'invalid_request_error',
  'message': '`temperature` is deprecated for this model.'}
```

So those models fail at the **first model call**. This includes `anthropic:claude-opus-4-7`, which is in the `.github/workflows/harbor.yml` model matrix — meaning Opus runs in CI hit this too.

Surfaced while running terminal-bench on the LangSmith Harbor environment with `--model anthropic:claude-opus-4-8`.

## Fix

Default `temperature` to `None` and forward it to `init_chat_model` only when explicitly set:

```python
if temperature is not None:
    model_kwargs["temperature"] = temperature
self._model = init_chat_model(model_name, **model_kwargs)
```

- Models that accept `temperature` can still pass it (`--agent-kwarg temperature=0.0`).
- Models that reject it are no longer sent an invalid parameter.

Added unit tests covering omit-by-default and forward-when-set; updated the existing happy-path assertion (`_temperature` now defaults to `None`). `ruff`, `ty`, and the wrapper unit tests pass.

## 🙏 Looking for OSS input on the default

This changes the default from `temperature=0.0` → omitted. The upside is broad model support out of the box (Opus 4.7+/Fable just work). The tradeoff: models that *do* accept `temperature` (e.g. Sonnet) are no longer pinned to `0.0`, so they fall back to the provider default — a small **eval-reproducibility** shift.

Alternatives considered:
1. **This PR** — default `None` (omit), opt in per-run. Simple, model-agnostic.
2. Keep `0.0` default but skip `temperature` for known-incompatible model families. More brittle (hardcodes model lists).
3. Catch the 400 and retry without `temperature`. Hides the issue, costs a round-trip.

Preference / concerns welcome — happy to switch approaches.