### PR TITLE
fix(evals): pass `--model` to `run-terminal-bench-langsmith` target

### DIFF
--- a/libs/evals/Makefile
+++ b/libs/evals/Makefile
@@ -67,7 +67,7 @@ run-terminal-bench-runloop: ## Run terminal-bench on Runloop (10 concurrent)
 
 run-terminal-bench-langsmith: ## Run terminal-bench on LangSmith prod sandboxes (sequential)
 	@mkdir -p jobs/terminal-bench
-	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 1 --jobs-dir jobs/terminal-bench --env langsmith $(AGENT_KWARG)
+	harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 --model anthropic:claude-opus-4-8 -n 1 --jobs-dir jobs/terminal-bench --env langsmith $(AGENT_KWARG)
 
 ######################
 # CHARTS


### PR DESCRIPTION
## Problem

The `run-terminal-bench-langsmith` Make target invokes `harbor run` without `--model`:

```make
harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 -n 1 --jobs-dir jobs/terminal-bench --env langsmith $(AGENT_KWARG)
```

`DeepAgentsWrapper` requires a model, so the target fails immediately with `ValueError: model_name must be a non-empty string`.

## Fix

Add `--model anthropic:claude-opus-4-8` so the target runs as-is:

```make
harbor run --agent-import-path deepagents_harbor:DeepAgentsWrapper --dataset terminal-bench@2.0 --model anthropic:claude-opus-4-8 -n 1 --jobs-dir jobs/terminal-bench --env langsmith $(AGENT_KWARG)
```

Verified: `anthropic:claude-opus-4-8` runs end-to-end through the wrapper on the LangSmith Harbor environment (requires the `temperature` fix in #3876, since Opus 4.7+ rejects `temperature`).

> Note: the sibling `run-terminal-bench-{modal,docker,daytona,runloop}` targets have the same missing-`--model` gap. Left out of this PR to keep it focused — a shared `MODEL`/`TB_MODEL` variable across all of them would be a reasonable follow-up. Happy to fold that in if preferred.