### PR TITLE
perf(sdk): speed up grep/read hot path, cache dynamic prompt

### DIFF
--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import fnmatch
 import logging
+import os
 import re
 from typing import TYPE_CHECKING
 
@@ -253,10 +254,12 @@ class ContextHubBackend(BackendProtocol):
 
         prefix = self._strip_prefix(path).rstrip("/") if path else ""
 
+        glob_re = re.compile(fnmatch.translate(os.path.normcase(glob))) if glob else None
+
         for file_path, content in cache.items():
             if prefix and not file_path.startswith(prefix):
                 continue
-            if glob and not fnmatch.fnmatch(file_path, glob):
+            if glob_re is not None and not glob_re.match(os.path.normcase(file_path)):
                 continue
             for i, line in enumerate(content.splitlines(), start=1):
                 if regex.search(line):

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -6,7 +6,6 @@ import functools
 import json
 import logging
 import os
-import re
 import shutil
 import subprocess
 import time
@@ -582,8 +581,8 @@ class FilesystemBackend(BackendProtocol):
         results = self._ripgrep_search(pattern, base_full, glob)
         partial_error: str | None = None
         if results is None:
-            # Python fallback needs escaped pattern for literal search
-            results, partial_error = self._python_search(re.escape(pattern), base_full, glob)
+            # Python fallback does literal substring matching on the raw pattern.
+            results, partial_error = self._python_search(pattern, base_full, glob)
 
         matches: list[GrepMatch] = []
         for fpath, items in results.items():
@@ -729,7 +728,7 @@ class FilesystemBackend(BackendProtocol):
         and a wall-clock timeout.
 
         Args:
-            pattern: Escaped regex pattern (from re.escape) for literal search.
+            pattern: Literal string to search for (substring match, not regex).
             base_full: Resolved base path to search in.
             include_glob: Optional glob pattern to filter files by name.
             timeout: Maximum wall-clock seconds before the search is aborted.
@@ -744,53 +743,62 @@ class FilesystemBackend(BackendProtocol):
                 should treat such results as incomplete.
         """
         deadline = time.monotonic() + timeout
-        regex = re.compile(pattern)
+        glob_matcher = wcglob.compile(include_glob, flags=wcglob.BRACE | wcglob.GLOBSTAR) if include_glob else None
 
         results: dict[str, list[tuple[int, str]]] = {}
         root = base_full if base_full.is_dir() else base_full.parent
 
+        def _timed_out_msg() -> str:
+            msg = (
+                f"Grep of '{base_full}' timed out after {timeout}s "
+                f"with {len(results)} matching file(s); try a more "
+                f"specific pattern or a narrower path."
+            )
+            logger.warning("%s", msg)
+            return msg
+
         try:
             for fp in root.rglob("*"):
                 if time.monotonic() > deadline:
-                    msg = (
-                        f"Grep of '{base_full}' timed out after {timeout}s "
-                        f"with {len(results)} matching file(s); try a more "
-                        f"specific pattern or a narrower path."
-                    )
-                    logger.warning("%s", msg)
-                    return results, msg
+                    return results, _timed_out_msg()
                 try:
                     if not fp.is_file():
                         continue
                 except (PermissionError, OSError, RuntimeError):
                     continue
-                if include_glob:
+                if glob_matcher is not None:
                     rel_path = str(fp.relative_to(root))
-                    if not wcglob.globmatch(rel_path, include_glob, flags=wcglob.BRACE | wcglob.GLOBSTAR):
+                    if not glob_matcher.match(rel_path):
                         continue
                 try:
                     if fp.stat().st_size > self.max_file_size_bytes:
                         continue
                 except (OSError, RuntimeError):
                     continue
+                # Stream the file line-by-line so a single huge file neither
+                # blows peak memory nor monopolizes the wall-clock budget.
                 try:
-                    content = fp.read_text()
+                    with fp.open(encoding="utf-8", errors="strict") as handle:
+                        for line_num, raw_line in enumerate(handle, 1):
+                            if line_num % 2048 == 0 and time.monotonic() > deadline:
+                                return results, _timed_out_msg()
+                            if pattern not in raw_line:
+                                continue
+                            line = raw_line.rstrip("\n")
+                            if self.virtual_mode:
+                                try:
+                                    virt_path = self._to_virtual_path(fp)
+                                except ValueError:
+                                    logger.debug("Skipping grep result outside root: %s", fp)
+                                    break
+                                except (OSError, RuntimeError):
+                                    logger.warning("Could not resolve grep result path: %s", fp, exc_info=True)
+                                    break
+                            else:
+                                virt_path = str(fp)
+                            results.setdefault(virt_path, []).append((line_num, line))
                 except (UnicodeDecodeError, PermissionError, OSError, RuntimeError):
                     continue
-                for line_num, line in enumerate(content.splitlines(), 1):
-                    if regex.search(line):
-                        if self.virtual_mode:
-                            try:
-                                virt_path = self._to_virtual_path(fp)
-                            except ValueError:
-                                logger.debug("Skipping grep result outside root: %s", fp)
-                                continue
-                            except (OSError, RuntimeError):
-                                logger.warning("Could not resolve grep result path: %s", fp, exc_info=True)
-                                continue
-                        else:
-                            virt_path = str(fp)
-                        results.setdefault(virt_path, []).append((line_num, line))
         except (OSError, RuntimeError) as e:
             # `rglob` raised mid-iteration. `OSError` covers the common case
             # where a directory entry is unlinked or renamed during the walk

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -714,7 +714,7 @@ class FilesystemBackend(BackendProtocol):
 
         return results
 
-    def _python_search(  # noqa: C901, PLR0912
+    def _python_search(  # noqa: C901, PLR0912, PLR0915
         self,
         pattern: str,
         base_full: Path,
@@ -738,14 +738,16 @@ class FilesystemBackend(BackendProtocol):
 
                 `partial_error` is `None` on a clean walk, otherwise a
                 human-readable message indicating the walk was incomplete:
-                either the wall-clock `timeout` elapsed or the walk aborted
-                early (e.g., a directory entry was removed mid-walk). Callers
+                either the wall-clock `timeout` elapsed, at least one file
+                failed after scanning started, or the walk aborted early
+                (e.g., a directory entry was removed mid-walk). Callers
                 should treat such results as incomplete.
         """
         deadline = time.monotonic() + timeout
         glob_matcher = wcglob.compile(include_glob, flags=wcglob.BRACE | wcglob.GLOBSTAR) if include_glob else None
 
         results: dict[str, list[tuple[int, str]]] = {}
+        file_errors: list[str] = []
         root = base_full if base_full.is_dir() else base_full.parent
 
         def _timed_out_msg() -> str:
@@ -756,6 +758,11 @@ class FilesystemBackend(BackendProtocol):
             )
             logger.warning("%s", msg)
             return msg
+
+        def _file_errors_msg() -> str | None:
+            if not file_errors:
+                return None
+            return "One or more files could not be fully searched:\n" + "\n".join(file_errors)
 
         try:
             for fp in root.rglob("*"):
@@ -777,27 +784,31 @@ class FilesystemBackend(BackendProtocol):
                     continue
                 # Stream the file line-by-line so a single huge file neither
                 # blows peak memory nor monopolizes the wall-clock budget.
+                scanned_lines = 0
                 try:
+                    if self.virtual_mode:
+                        try:
+                            virt_path = self._to_virtual_path(fp)
+                        except ValueError:
+                            logger.debug("Skipping grep result outside root: %s", fp)
+                            continue
+                        except (OSError, RuntimeError):
+                            logger.warning("Could not resolve grep result path: %s", fp, exc_info=True)
+                            continue
+                    else:
+                        virt_path = str(fp)
                     with fp.open(encoding="utf-8", errors="strict") as handle:
                         for line_num, raw_line in enumerate(handle, 1):
+                            scanned_lines = line_num
                             if line_num % 2048 == 0 and time.monotonic() > deadline:
                                 return results, _timed_out_msg()
                             if pattern not in raw_line:
                                 continue
                             line = raw_line.rstrip("\n")
-                            if self.virtual_mode:
-                                try:
-                                    virt_path = self._to_virtual_path(fp)
-                                except ValueError:
-                                    logger.debug("Skipping grep result outside root: %s", fp)
-                                    break
-                                except (OSError, RuntimeError):
-                                    logger.warning("Could not resolve grep result path: %s", fp, exc_info=True)
-                                    break
-                            else:
-                                virt_path = str(fp)
                             results.setdefault(virt_path, []).append((line_num, line))
-                except (UnicodeDecodeError, PermissionError, OSError, RuntimeError):
+                except (UnicodeDecodeError, PermissionError, OSError, RuntimeError) as e:
+                    if scanned_lines > 0 or virt_path in results:
+                        file_errors.append(f"- {virt_path}: {type(e).__name__} while reading file")
                     continue
         except (OSError, RuntimeError) as e:
             # `rglob` raised mid-iteration. `OSError` covers the common case
@@ -810,7 +821,7 @@ class FilesystemBackend(BackendProtocol):
             logger.warning("%s", msg, exc_info=True)
             return results, msg
 
-        return results, None
+        return results, _file_errors_msg()
 
     def glob(self, pattern: str, path: str | None = None) -> GlobResult:  # noqa: C901, PLR0912, PLR0915  # Complex virtual_mode logic
         """Find files matching a glob pattern.

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -5,6 +5,7 @@ helpers used by backends and the composite router. Structured helpers
 enable composition without fragile string parsing.
 """
 
+import functools
 import os
 import re
 from collections.abc import Sequence
@@ -70,6 +71,12 @@ TRUNCATION_GUIDANCE = "... [results truncated, try being more specific with your
 # Re-export protocol types for backwards compatibility
 FileInfo = _FileInfo
 GrepMatch = _GrepMatch
+
+
+@functools.lru_cache(maxsize=256)
+def _compile_glob(pattern: str) -> wcglob.WcMatcher:
+    """Compile a glob pattern once and cache it (BRACE flag)."""
+    return wcglob.compile(pattern, flags=wcglob.BRACE)
 
 
 def _normalize_content(file_data: FileData) -> str:
@@ -291,15 +298,12 @@ def slice_read_response(
     if not content or content.strip() == "":
         return content
 
-    # Normalize line endings to LF before slicing. State/Store backends may
-    # carry CRLF or CR content as written; downstream tooling (edit match,
-    # grep, format) assumes LF.
-    content = content.replace("\r\n", "\n").replace("\r", "\n")
-
     # `splitlines(keepends=True)` retains each line's terminator, including
     # the absence of one on the final line. Joining with `""` therefore
     # round-trips the trailing-newline state of the file faithfully —
-    # required so `edit()` can report EOF-newline mismatches accurately.
+    # required so `edit()` can report EOF-newline mismatches accurately. It
+    # also splits on CR / CRLF, so line indexing matches the LF-normalized
+    # form without first rewriting the whole (potentially huge) string.
     lines = content.splitlines(keepends=True)
     start_idx = offset
     end_idx = min(start_idx + limit, len(lines))
@@ -307,7 +311,10 @@ def slice_read_response(
     if start_idx >= len(lines):
         return ReadResult(error=f"Line offset {offset} exceeds file length ({len(lines)} lines)")
 
-    return "".join(lines[start_idx:end_idx])
+    # Normalize line endings to LF, but only across the requested window.
+    # State/Store backends may carry CRLF or CR content as written;
+    # downstream tooling (edit match, grep, format) assumes LF.
+    return "".join(lines[start_idx:end_idx]).replace("\r\n", "\n").replace("\r", "\n")
 
 
 def perform_string_replacement(
@@ -712,7 +719,8 @@ def _grep_search_files(
     filtered = _filter_files_by_path(files, normalized_path)
 
     if glob:
-        filtered = {fp: fd for fp, fd in filtered.items() if wcglob.globmatch(Path(fp).name, glob, flags=wcglob.BRACE)}
+        matcher = _compile_glob(glob)
+        filtered = {fp: fd for fp, fd in filtered.items() if matcher.match(Path(fp).name)}
 
     results: dict[str, list[tuple[int, str]]] = {}
     for file_path, file_data in filtered.items():
@@ -753,7 +761,8 @@ def grep_matches_from_files(
     filtered = _filter_files_by_path(files, normalized_path)
 
     if glob:
-        filtered = {fp: fd for fp, fd in filtered.items() if wcglob.globmatch(Path(fp).name, glob, flags=wcglob.BRACE)}
+        matcher = _compile_glob(glob)
+        filtered = {fp: fd for fp, fd in filtered.items() if matcher.match(Path(fp).name)}
 
     matches: list[GrepMatch] = []
     for file_path, file_data in filtered.items():

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -774,6 +774,11 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         self._large_tool_results_prefix = f"{_root}/large_tool_results"
         self._conversation_history_prefix = f"{_root}/conversation_history"
 
+        # Cache for dynamic system prompts keyed on whether the execute tool
+        # is both present and supported. The text depends only on that flag
+        # and immutable config, so it is computed at most twice per instance.
+        self._dynamic_system_prompt_cache: dict[bool, str] = {}
+
         # Store configuration (private - internal implementation details)
         self._custom_system_prompt = system_prompt
         self._custom_tool_descriptions = custom_tool_descriptions or {}
@@ -800,6 +805,22 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             self._create_grep_tool(),
             self._create_execute_tool(),
         ]
+
+    def _build_dynamic_system_prompt(self, *, include_execution: bool) -> str:
+        """Build (and memoize) the dynamic system prompt.
+
+        The result depends only on `include_execution` and immutable config,
+        so it is cached per instance to avoid rebuilding on every model call.
+        """
+        cached = self._dynamic_system_prompt_cache.get(include_execution)
+        if cached is not None:
+            return cached
+        prompt_parts = [_FILESYSTEM_SYSTEM_PROMPT_TEMPLATE.format(large_tool_results_prefix=self._large_tool_results_prefix)]
+        if include_execution:
+            prompt_parts.append(EXECUTION_SYSTEM_PROMPT)
+        system_prompt = "\n\n".join(prompt_parts).strip()
+        self._dynamic_system_prompt_cache[include_execution] = system_prompt
+        return system_prompt
 
     def _get_backend(self, runtime: ToolRuntime[Any, Any]) -> BackendProtocol:
         """Get the resolved backend instance from backend or factory.
@@ -1776,18 +1797,9 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         if self._custom_system_prompt is not None:
             system_prompt = self._custom_system_prompt
         else:
-            # Build dynamic system prompt based on available tools
-            prompt_parts = [
-                _FILESYSTEM_SYSTEM_PROMPT_TEMPLATE.format(
-                    large_tool_results_prefix=self._large_tool_results_prefix,
-                )
-            ]
-
-            # Add execution instructions if execute tool is available
-            if has_execute_tool and backend_supports_execution:
-                prompt_parts.append(EXECUTION_SYSTEM_PROMPT)
-
-            system_prompt = "\n\n".join(prompt_parts).strip()
+            system_prompt = self._build_dynamic_system_prompt(
+                include_execution=has_execute_tool and backend_supports_execution,
+            )
 
         if system_prompt:
             new_system_message = append_to_system_message(request.system_message, system_prompt)
@@ -1841,18 +1853,9 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         if self._custom_system_prompt is not None:
             system_prompt = self._custom_system_prompt
         else:
-            # Build dynamic system prompt based on available tools
-            prompt_parts = [
-                _FILESYSTEM_SYSTEM_PROMPT_TEMPLATE.format(
-                    large_tool_results_prefix=self._large_tool_results_prefix,
-                )
-            ]
-
-            # Add execution instructions if execute tool is available
-            if has_execute_tool and backend_supports_execution:
-                prompt_parts.append(EXECUTION_SYSTEM_PROMPT)
-
-            system_prompt = "\n\n".join(prompt_parts).strip()
+            system_prompt = self._build_dynamic_system_prompt(
+                include_execution=has_execute_tool and backend_supports_execution,
+            )
 
         if system_prompt:
             new_system_message = append_to_system_message(request.system_message, system_prompt)

--- a/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
@@ -303,6 +303,20 @@ def test_grep_with_path_prefix() -> None:
     assert paths == {"/memories/a.md"}
 
 
+def test_grep_with_glob_filter() -> None:
+    """`grep` honors the glob filter via the precompiled, hoisted matcher."""
+    backend, _ = _make_backend(
+        **{
+            "src/main.py": FileEntry(type="file", content="import os"),
+            "src/notes.md": FileEntry(type="file", content="import os"),
+        }
+    )
+    result = backend.grep("import", glob="*.py")
+    assert result.matches is not None
+    paths = {m["path"] for m in result.matches}
+    assert paths == {"/src/main.py"}
+
+
 def test_grep_invalid_regex() -> None:
     backend, _ = _make_backend()
     result = backend.grep("[unclosed")

--- a/libs/deepagents/tests/unit_tests/backends/test_file_format.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_file_format.py
@@ -264,6 +264,30 @@ def test_grep_new_format():
 # ---------------------------------------------------------------------------
 
 
+def test_grep_glob_filters_by_filename():
+    """`grep_matches_from_files` honors the glob filter (cached compile path)."""
+    files = {
+        "/src/main.py": create_file_data("import os"),
+        "/src/notes.txt": create_file_data("import os"),
+    }
+    result = grep_matches_from_files(files, "import", path="/", glob="*.py")
+    assert result.matches is not None
+    assert len(result.matches) == 1
+    assert result.matches[0]["path"] == "/src/main.py"
+
+
+def test_grep_glob_brace_expansion():
+    """Brace-expansion globs match either extension via the cached matcher."""
+    files = {
+        "/a.py": create_file_data("hit"),
+        "/b.md": create_file_data("hit"),
+        "/c.txt": create_file_data("hit"),
+    }
+    result = grep_matches_from_files(files, "hit", path="/", glob="*.{py,md}")
+    paths = sorted(m["path"] for m in result.matches)
+    assert paths == ["/a.py", "/b.md"]
+
+
 def test_grep_legacy_format():
     legacy_fd = {
         "content": ["def foo():", "    return 42", "def bar():", "    return 0"],

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -4,6 +4,7 @@ import subprocess
 import warnings
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Self
 
 import pytest
 from langchain.tools import ToolRuntime
@@ -1031,6 +1032,53 @@ class TestGrepPythonFallbackTimeout:
         _results, partial_error = be._python_search("needle", tmp_path, None, timeout=0)
         assert partial_error is not None
         assert "timed out" in partial_error
+
+    def test_python_search_reports_file_error_after_partial_scan(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A per-file read error after scanning starts is surfaced with partial matches."""
+        bad = tmp_path / "bad.txt"
+        bad.write_text("")
+
+        class BrokenHandle:
+            def __init__(self) -> None:
+                self._first = True
+
+            def __enter__(self) -> Self:
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            def __iter__(self) -> Self:
+                return self
+
+            def __next__(self) -> str:
+                if self._first:
+                    self._first = False
+                    return "needle before failure\n"
+                encoding = "utf-8"
+                data = b"\xff"
+                reason = "invalid start byte"
+                raise UnicodeDecodeError(encoding, data, 0, 1, reason)
+
+        original_open = Path.open
+
+        def fake_open(path: Path, *args: object, **kwargs: object) -> BrokenHandle | object:
+            if path == bad:
+                return BrokenHandle()
+            return original_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "open", fake_open)
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        results, partial_error = be._python_search("needle", tmp_path, None)
+
+        assert results == {"/bad.txt": [(1, "needle before failure")]}
+        assert partial_error is not None
+        assert "One or more files could not be fully searched" in partial_error
+        assert "- /bad.txt: UnicodeDecodeError while reading file" in partial_error
 
     def test_grep_surfaces_timeout_with_partial_results(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """`grep` surfaces the timeout as a partial error while still returning matches found so far."""

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -1024,14 +1024,83 @@ class TestGrepPythonFallbackTimeout:
         all_lines = [text for items in results.values() for _, text in items]
         assert any("[a-z]" in line for line in all_lines)
 
-    def test_python_search_streams_large_file_with_per_line_timeout(self, tmp_path: Path) -> None:
-        """A single large file is interrupted by the wall-clock deadline mid-file."""
-        big = "\n".join(f"line {i}" for i in range(200_000)) + "\nneedle\n"
-        (tmp_path / "big.txt").write_text(big)
+    def test_python_search_streams_large_file_with_per_line_timeout(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The per-line deadline check interrupts a single large file mid-stream.
+
+        `time.monotonic` is stubbed to advance 1s per call. Inside
+        `_python_search` it is called once to set the deadline, once for the
+        outer per-file check, then once every 2048 lines. With the deadline
+        1.5s out, the outer check passes (so the file is opened) and the first
+        in-file check at line 2048 trips. This proves the mid-file branch runs
+        rather than the outer guard short-circuiting before any read — which is
+        what a `timeout=0` test (see `test_python_search_times_out_with_zero_timeout`)
+        cannot distinguish.
+        """
+        lines = [f"line {i}" for i in range(1, 2501)]
+        lines[0] = "needle"  # line 1 — scanned before the in-file timeout
+        lines[2499] = "needle"  # line 2500 — never reached
+        (tmp_path / "big.txt").write_text("\n".join(lines) + "\n")
         be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
-        _results, partial_error = be._python_search("needle", tmp_path, None, timeout=0)
+
+        clock = {"t": 1000.0}
+
+        def fake_monotonic() -> float:
+            t = clock["t"]
+            clock["t"] += 1.0
+            return t
+
+        monkeypatch.setattr(fs_module.time, "monotonic", fake_monotonic)
+        results, partial_error = be._python_search("needle", tmp_path, None, timeout=1.5)
+
         assert partial_error is not None
         assert "timed out" in partial_error
+        collected = results.get("/big.txt", [])
+        assert (1, "needle") in collected
+        assert all(line_num != 2500 for line_num, _ in collected)
+
+    def test_python_search_does_not_match_regex_metacharacters(self, tmp_path: Path) -> None:
+        """The fallback is a literal substring search: regex metacharacters are inert.
+
+        Both patterns would match via `re.search` but must not match literally,
+        which is the load-bearing distinction now that the regex compile is gone.
+        """
+        (tmp_path / "code.py").write_text("axb\nab\n")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        no_dot, err_dot = be._python_search("a.b", tmp_path, None)  # regex would match "axb"
+        assert err_dot is None
+        assert no_dot == {}
+
+        no_star, err_star = be._python_search("a*b", tmp_path, None)  # regex would match "ab"
+        assert err_star is None
+        assert no_star == {}
+
+    def test_python_search_strips_carriage_returns(self, tmp_path: Path) -> None:
+        """CRLF files yield clean match text via universal-newline translation on read."""
+        (tmp_path / "crlf.txt").write_bytes(b"hit me\r\nother\r\n")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        results, partial_error = be._python_search("hit", tmp_path, None)
+        assert partial_error is None
+        matches = results.get("/crlf.txt", [])
+        assert matches == [(1, "hit me")]
+
+    def test_python_search_skips_non_utf8_file(self, tmp_path: Path) -> None:
+        """A wholly-undecodable file is skipped silently while valid files still match.
+
+        The decode fails on the first byte, so no lines are scanned and the file
+        is not reported as a partial read — mirroring ripgrep's binary-file skip.
+        """
+        (tmp_path / "good.txt").write_text("needle here\n")
+        (tmp_path / "bad.bin").write_bytes(b"\xff\xfe needle \x00\x80")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        results, partial_error = be._python_search("needle", tmp_path, None)
+        assert partial_error is None
+        assert results.get("/good.txt") == [(1, "needle here")]
+        assert "/bad.bin" not in results
 
     def test_python_search_reports_file_error_after_partial_scan(
         self,

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -1014,6 +1014,24 @@ class TestGrepPythonFallbackTimeout:
         assert partial_error is not None
         assert "timed out" in partial_error
 
+    def test_python_search_matches_literal_substrings(self, tmp_path: Path) -> None:
+        """The Python fallback does literal substring matching (no regex)."""
+        (tmp_path / "code.py").write_text("def __init__(self):\n    return [a-z]\n")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        results, partial_error = be._python_search("[a-z]", tmp_path, None)
+        assert partial_error is None
+        all_lines = [text for items in results.values() for _, text in items]
+        assert any("[a-z]" in line for line in all_lines)
+
+    def test_python_search_streams_large_file_with_per_line_timeout(self, tmp_path: Path) -> None:
+        """A single large file is interrupted by the wall-clock deadline mid-file."""
+        big = "\n".join(f"line {i}" for i in range(200_000)) + "\nneedle\n"
+        (tmp_path / "big.txt").write_text(big)
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        _results, partial_error = be._python_search("needle", tmp_path, None, timeout=0)
+        assert partial_error is not None
+        assert "timed out" in partial_error
+
     def test_grep_surfaces_timeout_with_partial_results(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """`grep` surfaces the timeout as a partial error while still returning matches found so far."""
         (tmp_path / "file.txt").write_text("hello")

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -343,6 +343,12 @@ class TestSliceReadResponse:
         result = slice_read_response(self._file("a\nb\nc\nd\n"), offset=1, limit=2)
         assert result == "b\nc\n"
 
+    def test_partial_window_normalizes_crlf(self) -> None:
+        """An internal CRLF slice is LF-normalized even though only the window is rewritten."""
+        result = slice_read_response(self._file("a\r\nb\r\nc\r\nd\r\n"), offset=1, limit=2)
+        assert result == "b\nc\n"
+        assert "\r" not in result
+
     def test_partial_window_ending_on_unterminated_last_line(self) -> None:
         """A window covering the last line keeps that line's missing-terminator state."""
         result = slice_read_response(self._file("a\nb\nc"), offset=2, limit=1)

--- a/libs/deepagents/tests/unit_tests/middleware/test_filesystem_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_filesystem_middleware_init.py
@@ -8,6 +8,7 @@ from langgraph.store.memory import InMemoryStore
 
 from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
 from deepagents.middleware.filesystem import (
+    EXECUTION_SYSTEM_PROMPT,
     WRITE_FILE_TOOL_DESCRIPTION,
     FilesystemMiddleware,
 )
@@ -15,6 +16,24 @@ from deepagents.middleware.filesystem import (
 
 def build_composite_state_backend(*, routes: dict[str, Any]) -> CompositeBackend:
     return CompositeBackend(default=StateBackend(), routes=routes)
+
+
+class TestDynamicSystemPromptCache:
+    """`_build_dynamic_system_prompt` caches per `include_execution` flag."""
+
+    def test_returns_identical_cached_object(self) -> None:
+        mw = FilesystemMiddleware(backend=StateBackend())
+        first = mw._build_dynamic_system_prompt(include_execution=False)
+        second = mw._build_dynamic_system_prompt(include_execution=False)
+        assert first is second
+
+    def test_execution_flag_changes_output(self) -> None:
+        mw = FilesystemMiddleware(backend=StateBackend())
+        without = mw._build_dynamic_system_prompt(include_execution=False)
+        with_exec = mw._build_dynamic_system_prompt(include_execution=True)
+        assert without != with_exec
+        assert EXECUTION_SYSTEM_PROMPT not in without
+        assert EXECUTION_SYSTEM_PROMPT in with_exec
 
 
 class TestFilesystemMiddlewareInit:


### PR DESCRIPTION
Targeted performance improvements in `libs/deepagents` hot paths, with no public signature changes.

- The Python `grep` fallback (`FilesystemBackend._python_search`) now streams each file line-by-line instead of loading the whole file via `read_text().splitlines()`, does literal substring matching instead of compiling/running a regex over an `re.escape`d pattern, and checks the wall-clock deadline *within* long files so a single huge file can't blow the timeout or peak memory. Per-file read failures encountered mid-scan are now surfaced as a partial error instead of being silently dropped.
- Glob filters in the in-memory grep helpers (`_grep_search_files`, `grep_matches_from_files`) are compiled once via a cached `_compile_glob` instead of recompiling per file; the Context Hub `grep` hoists its `fnmatch` translation out of the loop.
- `slice_read_response` normalizes line endings only across the requested window rather than rewriting the entire (potentially huge) file before slicing.
- The filesystem middleware memoizes its dynamic system prompt (keyed on whether the execute tool is present and supported) instead of rebuilding it on every model call.

### Behavioral notes

The in-memory grep helpers, `slice_read_response`, and the middleware cache are byte-for-byte behavior-preserving. The Python `grep` fallback (exercised only when `ripgrep` is unavailable) has two intentional, non-breaking changes that bring it in line with both the sibling `read()` method and the `ripgrep` primary path:

- **Decoding is pinned to UTF-8** (`errors="strict"`) instead of the platform locale default. Every other read/write path in the backends already pins UTF-8; the fallback was the lone outlier since the original experimental backend. On a non-UTF-8 locale, fallback decoding now matches `read()` and `ripgrep` rather than the host locale.
- **Line splitting is narrower**: lines now break only on `\n` / `\r` / `\r\n` (matching `ripgrep`), not on the exotic separators that `str.splitlines()` also breaks on (form feed, vertical tab, file/group/record separators, NEL, and the Unicode line/paragraph separators). CRLF / CR match text is unchanged, since universal-newline translation still applies on read.

### Benchmarks

Focused local microbenchmarks compared this branch against `main` on Python 3.14.2:

- Normal `FilesystemBackend.grep` with `ripgrep` installed: no meaningful change (`main`: 0.022466s, PR: 0.022572s median; ~0.5% slower, effectively noise).
- Forced Python grep fallback: **1.06x faster** (`main`: 0.030186s, PR: 0.028388s median; ~6.0% improvement).
- State backend `_grep_search_files` with glob filtering: **3.50x faster** (`main`: 0.045913s, PR: 0.013116s median; ~71.4% improvement).
- State backend `grep_matches_from_files` with glob filtering: **3.71x faster** (`main`: 0.044786s, PR: 0.012071s median; ~73.0% improvement).
- `slice_read_response` on large CRLF content: **2.55x faster** for both first-window and late-window reads (~60.8% improvement), with **~29.2% lower peak memory**.

Takeaway: the common filesystem grep path remains dominated by `ripgrep`, while this PR substantially improves in-memory/state backend grep with glob filters and large-content read slicing.

### Tests

Added unit coverage for literal substring matching (including a negative case proving regex metacharacters stay inert), the mid-file per-line timeout (driven by a stubbed clock so it provably reaches the in-file branch rather than the outer guard), CRLF match-text stripping, non-UTF-8 file skipping, partial-read error surfacing, Context Hub `grep` glob filtering, glob filtering with brace expansion, a partial-window CRLF slice in `slice_read_response`, and the dynamic-prompt cache.

## Self-Hosted Release Note
Faster file `grep`/`read` operations and reduced per-request overhead in the filesystem middleware.
