### PR TITLE
perf(evals): cut redundant I/O and serialized round-trips

### DIFF
--- a/libs/evals/deepagents_harbor/langsmith.py
+++ b/libs/evals/deepagents_harbor/langsmith.py
@@ -20,6 +20,7 @@ import tempfile
 import urllib.parse
 import uuid
 from collections.abc import Awaitable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, Protocol, cast
 
@@ -37,6 +38,9 @@ LANGSMITH_API_URL = os.getenv("LANGSMITH_ENDPOINT", "https://api.smith.langchain
 
 _API_KEY_ENV_VARS = ("LANGSMITH_SANDBOX_API_KEY", "LANGSMITH_API_KEY", "LANGCHAIN_API_KEY")
 """Environment variables checked (in priority order) when resolving an API key."""
+
+_FEEDBACK_MAX_WORKERS = 8
+"""Upper bound on concurrent trial-feedback workers in `add_feedback`."""
 
 
 class _RegistryClient(Protocol):
@@ -656,15 +660,30 @@ def add_feedback(job_folder: Path, project_name: str, dry_run: bool = False) -> 
     results = {"success": 0, "fallback": 0, "skipped": 0, "error": 0}
     client = Client()
 
-    for i, trial_dir in enumerate(trial_dirs, 1):
-        print(f"[{i}/{len(trial_dirs)}] Processing {trial_dir.name}...")
+    # Each trial issues up to three independent, blocking LangSmith calls. Process
+    # trials concurrently with a bounded thread pool instead of serializing them.
+    max_workers = min(_FEEDBACK_MAX_WORKERS, len(trial_dirs)) or 1
+    processed: list[dict[str, str]] = [{}] * len(trial_dirs)
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {
+            executor.submit(
+                _process_trial,
+                trial_dir=trial_dir,
+                project_name=project_name,
+                client=client,
+                dry_run=dry_run,
+            ): idx
+            for idx, trial_dir in enumerate(trial_dirs)
+        }
+        for future in as_completed(futures):
+            idx = futures[future]
+            try:
+                processed[idx] = future.result()
+            except Exception as exc:  # noqa: BLE001  # surface unexpected errors per-trial
+                processed[idx] = {"status": "error", "message": f"Unexpected error: {exc}"}
 
-        result = _process_trial(
-            trial_dir=trial_dir,
-            project_name=project_name,
-            client=client,
-            dry_run=dry_run,
-        )
+    for i, (trial_dir, result) in enumerate(zip(trial_dirs, processed, strict=True), 1):
+        print(f"[{i}/{len(trial_dirs)}] Processing {trial_dir.name}...")
 
         status = result["status"]
         message = result["message"]

--- a/libs/evals/deepagents_harbor/langsmith.py
+++ b/libs/evals/deepagents_harbor/langsmith.py
@@ -660,10 +660,15 @@ def add_feedback(job_folder: Path, project_name: str, dry_run: bool = False) -> 
     results = {"success": 0, "fallback": 0, "skipped": 0, "error": 0}
     client = Client()
 
-    # Each trial issues up to three independent, blocking LangSmith calls. Process
-    # trials concurrently with a bounded thread pool instead of serializing them.
+    # Each trial issues up to three blocking, data-dependent LangSmith calls
+    # (list runs -> list feedback -> create feedback). The trials themselves are
+    # independent, so process them concurrently with a bounded thread pool instead
+    # of serializing them. Pre-fill with a valid-shaped sentinel so the consumer
+    # below never sees a slot missing the "status"/"message" keys.
     max_workers = min(_FEEDBACK_MAX_WORKERS, len(trial_dirs)) or 1
-    processed: list[dict[str, str]] = [{}] * len(trial_dirs)
+    processed: list[dict[str, str]] = [
+        {"status": "error", "message": "Trial was not processed"} for _ in trial_dirs
+    ]
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = {
             executor.submit(

--- a/libs/evals/deepagents_harbor/metadata.py
+++ b/libs/evals/deepagents_harbor/metadata.py
@@ -104,8 +104,8 @@ async def collect_sandbox_metadata(backend: SandboxLike) -> InfraMetadata:
     meta.host_python_version = host["host_python_version"]
 
     # Collect sandbox info via shell commands (best-effort — must never abort a trial).
-    # The four probes are independent, so run them concurrently to avoid serializing
-    # four sandbox round-trips per trial.
+    # The probes are independent, so run them concurrently to avoid serializing one
+    # sandbox round-trip each.
     async def _probe(command: str) -> str | None:
         try:
             result = await backend.aexecute(command, timeout=10)

--- a/libs/evals/deepagents_harbor/metadata.py
+++ b/libs/evals/deepagents_harbor/metadata.py
@@ -6,6 +6,7 @@ post-hoc analysis of infrastructure noise in eval results.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import platform
@@ -102,54 +103,51 @@ async def collect_sandbox_metadata(backend: SandboxLike) -> InfraMetadata:
     meta.host_platform = host["host_platform"]
     meta.host_python_version = host["host_python_version"]
 
-    # Collect sandbox info via shell commands (best-effort — must never abort a trial)
-    try:
-        cpu_result = await backend.aexecute(
-            "nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 0", timeout=10
-        )
-        cpu_str = cpu_result.output.strip().split("\n")[0]
+    # Collect sandbox info via shell commands (best-effort — must never abort a trial).
+    # The four probes are independent, so run them concurrently to avoid serializing
+    # four sandbox round-trips per trial.
+    async def _probe(command: str) -> str | None:
+        try:
+            result = await backend.aexecute(command, timeout=10)
+            return result.output.strip().split("\n")[0]
+        except Exception:  # noqa: BLE001  # best-effort metadata collection
+            logger.debug("Sandbox probe failed: %s", command, exc_info=True)
+            return None
+
+    mem_cmd = (
+        "grep MemTotal /proc/meminfo 2>/dev/null | awk '{print int($2/1024)}' "
+        "|| sysctl -n hw.memsize 2>/dev/null | awk '{print int($1/1048576)}' "
+        "|| echo 0"
+    )
+    avail_cmd = "grep MemAvailable /proc/meminfo 2>/dev/null | awk '{print int($2/1024)}' || echo 0"
+
+    cpu_str, mem_str, avail_str, os_str = await asyncio.gather(
+        _probe("nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 0"),
+        _probe(mem_cmd),
+        _probe(avail_cmd),
+        _probe("uname -s -r 2>/dev/null || echo unknown"),
+    )
+
+    if cpu_str is not None:
         if cpu_str.isdigit():
             meta.sandbox_cpu_count = int(cpu_str)
         else:
             logger.debug("Sandbox CPU count returned non-numeric: %r", cpu_str)
-    except Exception:  # noqa: BLE001  # best-effort metadata collection
-        logger.debug("Failed to collect sandbox CPU count", exc_info=True)
 
-    try:
-        # Linux: /proc/meminfo, fallback to macOS sysctl
-        mem_cmd = (
-            "grep MemTotal /proc/meminfo 2>/dev/null | awk '{print int($2/1024)}' "
-            "|| sysctl -n hw.memsize 2>/dev/null | awk '{print int($1/1048576)}' "
-            "|| echo 0"
-        )
-        mem_result = await backend.aexecute(mem_cmd, timeout=10)
-        mem_str = mem_result.output.strip().split("\n")[0]
+    if mem_str is not None:
         if mem_str.isdigit():
             meta.sandbox_memory_total_mb = int(mem_str)
         else:
             logger.debug("Sandbox memory total returned non-numeric: %r", mem_str)
-    except Exception:  # noqa: BLE001  # best-effort metadata collection
-        logger.debug("Failed to collect sandbox memory total", exc_info=True)
 
-    try:
-        # Available memory (Linux only via /proc/meminfo)
-        avail_cmd = (
-            "grep MemAvailable /proc/meminfo 2>/dev/null | awk '{print int($2/1024)}' || echo 0"
-        )
-        avail_result = await backend.aexecute(avail_cmd, timeout=10)
-        avail_str = avail_result.output.strip().split("\n")[0]
+    if avail_str is not None:
         if avail_str.isdigit():
             avail = int(avail_str)
             meta.sandbox_memory_available_mb = avail if avail > 0 else None
         else:
             logger.debug("Sandbox memory available returned non-numeric: %r", avail_str)
-    except Exception:  # noqa: BLE001  # best-effort metadata collection
-        logger.debug("Failed to collect sandbox available memory", exc_info=True)
 
-    try:
-        os_result = await backend.aexecute("uname -s -r 2>/dev/null || echo unknown", timeout=10)
-        meta.sandbox_os = os_result.output.strip().split("\n")[0]
-    except Exception:  # noqa: BLE001  # best-effort metadata collection
-        logger.debug("Failed to collect sandbox OS info", exc_info=True)
+    if os_str is not None:
+        meta.sandbox_os = os_str
 
     return meta

--- a/libs/evals/scripts/analyze.py
+++ b/libs/evals/scripts/analyze.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 from dataclasses import dataclass
 from enum import Enum
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
@@ -58,6 +59,30 @@ def scan_dataset_for_solutions(dataset_path: Path) -> dict[str, Path]:
     return task_to_solution
 
 
+def _read_json(path: Path) -> Optional[dict]:
+    """Read and parse a JSON file, returning None on any error."""
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+@lru_cache(maxsize=None)
+def _task_dir_index(task_source_dir: Path) -> dict[str, Path]:
+    """Map task_name -> task directory for a task source, scanning the tree once."""
+    index: dict[str, Path] = {}
+    if not task_source_dir.exists():
+        return index
+    for hash_dir in task_source_dir.iterdir():
+        if not hash_dir.is_dir():
+            continue
+        for task_dir in hash_dir.iterdir():
+            if task_dir.is_dir():
+                index[task_dir.name] = task_dir
+    return index
+
+
 def find_task_directory(trial_dir: Path, task_name: str, task_source: str) -> Optional[Path]:
     """Find the task directory for a given trial.
 
@@ -69,24 +94,11 @@ def find_task_directory(trial_dir: Path, task_name: str, task_source: str) -> Op
     Returns:
         Path to the task directory if found, None otherwise
     """
-    # Start from the trial directory and search for the task directory
-    # The structure is typically: {task_source}/{hash}/{task_name}
-
-    # Go up to find the task source directory
-    current = trial_dir.parent.parent  # Go up from trial to jobs root
-    task_source_dir = current / task_source
-
-    if not task_source_dir.exists():
-        return None
-
-    # Search for the task in any hash subdirectory
-    for hash_dir in task_source_dir.iterdir():
-        if hash_dir.is_dir():
-            task_dir = hash_dir / task_name
-            if task_dir.exists():
-                return task_dir
-
-    return None
+    # The structure is typically: {task_source}/{hash}/{task_name}.
+    # Build (and cache) a task_name -> dir index per source so repeated trials
+    # don't re-scan the same tree.
+    task_source_dir = trial_dir.parent.parent / task_source
+    return _task_dir_index(task_source_dir).get(task_name)
 
 
 class TrialStatus(Enum):
@@ -120,114 +132,62 @@ async def parse_reward(reward_path: Path) -> bool:
     return reward_value == "1"
 
 
-def extract_task_metadata(trial_dir: Path) -> dict:
+def extract_task_metadata(trial_dir: Path, config: Optional[dict] = None) -> dict:
     """Extract task metadata from config.json and other files.
 
     Args:
         trial_dir: Path to the trial directory
+        config: Pre-parsed config.json contents, if already loaded
 
     Returns:
         Dictionary containing task metadata
     """
-    metadata = {}
+    metadata: dict = {}
 
-    # Read config.json
-    config_path = trial_dir / "config.json"
-    if config_path.exists():
-        try:
-            with open(config_path, "r") as f:
-                config = json.load(f)
-                metadata["task_name"] = config.get("task", {}).get("path", "")
-                metadata["task_source"] = config.get("task", {}).get("source", "")
-                metadata["git_url"] = config.get("task", {}).get("git_url", "")
-                metadata["git_commit_id"] = config.get("task", {}).get("git_commit_id", "")
-        except Exception:
-            pass
+    if config is None:
+        config = _read_json(trial_dir / "config.json")
+    if config:
+        task = config.get("task", {})
+        metadata["task_name"] = task.get("path", "")
+        metadata["task_source"] = task.get("source", "")
+        metadata["git_url"] = task.get("git_url", "")
+        metadata["git_commit_id"] = task.get("git_commit_id", "")
 
     # Read result.json for additional metadata
-    result_path = trial_dir / "result.json"
-    if result_path.exists():
-        try:
-            with open(result_path, "r") as f:
-                result = json.load(f)
-                metadata["reward"] = (
-                    result.get("verifier_result", {}).get("rewards", {}).get("reward", 0.0)
-                )
-                metadata["started_at"] = result.get("started_at", "")
-                metadata["finished_at"] = result.get("finished_at", "")
-        except Exception:
-            pass
+    result = _read_json(trial_dir / "result.json")
+    if result:
+        metadata["reward"] = result.get("verifier_result", {}).get("rewards", {}).get("reward", 0.0)
+        metadata["started_at"] = result.get("started_at", "")
+        metadata["finished_at"] = result.get("finished_at", "")
 
     return metadata
 
 
-def extract_task_instructions(trajectory_path: Path) -> Optional[str]:
-    """Extract the task instructions from the trajectory file.
+def extract_task_instructions(trajectory_data: dict) -> Optional[str]:
+    """Extract the task instructions from parsed trajectory data.
 
     Looks for the user message in the trajectory steps.
     """
-    try:
-        with open(trajectory_path, "r") as f:
-            trajectory_data = json.load(f)
-
-        # Find the user message in the steps
-        for step in trajectory_data.get("steps", []):
-            if step.get("source") == "user":
-                return step.get("message", "")
-
-        return None
-    except Exception:
-        return None
+    for step in trajectory_data.get("steps", []):
+        if step.get("source") == "user":
+            return step.get("message", "")
+    return None
 
 
-def count_tool_usage(trajectory_path: Path) -> dict[str, int]:
-    """Count tool usage across all steps in a trajectory.
-
-    Args:
-        trajectory_path: Path to the trajectory.json file in ATIF format
+def count_tool_usage(trajectory_data: dict) -> dict[str, int]:
+    """Count tool usage across all steps in parsed trajectory data (ATIF format).
 
     Returns:
         Dictionary mapping tool names to their usage counts
     """
     tool_counts: dict[str, int] = {}
-
-    try:
-        with open(trajectory_path, "r") as f:
-            trajectory_data = json.load(f)
-
-        # Iterate through all steps
-        for step in trajectory_data.get("steps", []):
-            # Check if this step has tool calls
-            tool_calls = step.get("tool_calls")
-            if tool_calls:
-                # Count each tool call
-                for tool_call in tool_calls:
-                    tool_name = tool_call.get("function_name", "unknown")
-                    tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
-
-        return tool_counts
-    except Exception:
-        return {}
-
-
-def get_task_name_from_trial(trial_dir: Path) -> Optional[str]:
-    """Extract the task name from a trial's config.json.
-
-    Args:
-        trial_dir: Path to the trial directory
-
-    Returns:
-        Task name if found, None otherwise
-    """
-    config_path = trial_dir / "config.json"
-    if config_path.exists():
-        try:
-            with open(config_path, "r") as f:
-                config = json.load(f)
-                return config.get("task", {}).get("path", "")
-        except Exception:
-            pass
-    return None
+    for step in trajectory_data.get("steps", []):
+        tool_calls = step.get("tool_calls")
+        if tool_calls:
+            for tool_call in tool_calls:
+                tool_name = tool_call.get("function_name", "unknown")
+                tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
+    return tool_counts
 
 
 def enrich_trials_with_solutions(
@@ -244,13 +204,14 @@ def enrich_trials_with_solutions(
     """
     for trial in trials:
         if trial.trial_dir:
-            task_name = get_task_name_from_trial(trial.trial_dir)
+            config = _read_json(trial.trial_dir / "config.json")
+            task_name = config.get("task", {}).get("path", "") if config else None
             if task_name and task_name in solution_mapping:
                 trial.solution_path = solution_mapping[task_name]
     return trials
 
 
-async def analyze_trial(
+def analyze_trial(
     trial_dir: Path, solution_mapping: Optional[dict[str, Path]] = None
 ) -> Optional[Trial]:
     """Analyze a single trial directory.
@@ -267,29 +228,22 @@ async def analyze_trial(
     reward_path = trial_dir / "verifier" / "reward.txt"
     exception_path = trial_dir / "exception.txt"
 
-    # Read config to find the task directory for the solution
-    config_path = trial_dir / "config.json"
+    # Read config once and reuse for both the mapping lookup and the fallback search.
+    config = _read_json(trial_dir / "config.json")
+    task = config.get("task", {}) if config else {}
+    task_name = task.get("path", "")
+    task_source = task.get("source", "")
     solution_path = None
 
     # First try to use the solution_mapping if provided
-    if solution_mapping:
-        task_name = get_task_name_from_trial(trial_dir)
-        if task_name and task_name in solution_mapping:
-            solution_path = solution_mapping[task_name]
+    if solution_mapping and task_name and task_name in solution_mapping:
+        solution_path = solution_mapping[task_name]
 
     # Fall back to searching for the task directory
-    if not solution_path and config_path.exists():
-        try:
-            with open(config_path, "r") as f:
-                config = json.load(f)
-                task_name = config.get("task", {}).get("path", "")
-                task_source = config.get("task", {}).get("source", "")
-                if task_name and task_source:
-                    task_dir = find_task_directory(trial_dir, task_name, task_source)
-                    if task_dir:
-                        solution_path = task_dir / "solution" / "solve.sh"
-        except Exception:
-            pass
+    if not solution_path and task_name and task_source:
+        task_dir = find_task_directory(trial_dir, task_name, task_source)
+        if task_dir:
+            solution_path = task_dir / "solution" / "solve.sh"
 
     traj_exists = trajectory_path.exists()
     reward_exists = reward_path.exists()
@@ -312,12 +266,16 @@ async def analyze_trial(
     else:
         status = TrialStatus.PENDING
 
-    # Count tool usage if trajectory exists
+    # Count tool usage if trajectory exists. Read the file once and reuse both the
+    # raw text (for exit-code extraction) and the parsed data (for tool counts).
     tool_usage = None
     trajectory_text = None
     if traj_exists:
-        tool_usage = count_tool_usage(trajectory_path)
-        trajectory_text = trajectory_path.read_text()
+        try:
+            trajectory_text = trajectory_path.read_text()
+            tool_usage = count_tool_usage(json.loads(trajectory_text))
+        except Exception:
+            tool_usage = {}
 
     # Classify failure category for non-completed trials
     failure_category = None
@@ -376,11 +334,12 @@ async def scan_jobs_directory(
 
     print(f"Found {len(trial_dirs)} trial directories")
 
-    trials: list[Trial] = []
-    for trial_dir in trial_dirs:
-        trial = await analyze_trial(trial_dir, solution_mapping=solution_mapping)
-        trials.append(trial)
-    return trials
+    # Analyze trials concurrently; each call is blocking file I/O, so run them in
+    # threads to overlap the reads.
+    trials = await asyncio.gather(
+        *(asyncio.to_thread(analyze_trial, trial_dir, solution_mapping) for trial_dir in trial_dirs)
+    )
+    return list(trials)
 
 
 def print_summary(trials: list[Trial]) -> None:
@@ -614,13 +573,18 @@ If clear from the trajectory, suggest:
 """  # noqa: E501
 
 
-async def analyze_failed_trial(trial: Trial, analyze_pending: bool = False) -> Optional[str]:
+async def analyze_failed_trial(
+    trial: Trial,
+    analyze_pending: bool = False,
+    trajectory_data: Optional[dict] = None,
+) -> Optional[str]:
     """
     Run deep agent analysis on a failed or pending trial trajectory.
 
     Args:
         trial: The trial to analyze
         analyze_pending: If True, analyze pending trials in addition to failed ones
+        trajectory_data: Pre-parsed trajectory contents, if already loaded
 
     Returns:
         Analysis result as a string, or None if trajectory cannot be read
@@ -636,12 +600,12 @@ async def analyze_failed_trial(trial: Trial, analyze_pending: bool = False) -> O
     if trial.status == TrialStatus.PENDING and not analyze_pending:
         return None
 
-    if not trial.trajectory_path or not trial.trajectory_path.exists():
-        return None
-
-    # Read the trajectory file
-    with open(trial.trajectory_path, "r") as f:
-        trajectory_data = json.load(f)
+    if trajectory_data is None:
+        if not trial.trajectory_path or not trial.trajectory_path.exists():
+            return None
+        trajectory_data = _read_json(trial.trajectory_path)
+        if trajectory_data is None:
+            return None
 
     # Format trajectory as JSON string for the prompt
     trajectory_json = json.dumps(trajectory_data, indent=2)
@@ -704,18 +668,26 @@ async def write_trial_analysis(
     if trial.status == TrialStatus.PENDING and not analyze_pending:
         return None
 
-    # Extract metadata
-    metadata = extract_task_metadata(trial_dir)
+    # Extract metadata (parse config.json once)
+    config = _read_json(trial_dir / "config.json")
+    metadata = extract_task_metadata(trial_dir, config=config)
+
+    # Parse the trajectory once and reuse for instructions + LLM analysis.
+    trajectory_data = None
+    if trial.trajectory_path and trial.trajectory_path.exists():
+        trajectory_data = _read_json(trial.trajectory_path)
 
     # Extract task instructions
     task_instructions = None
-    if trial.trajectory_path:
-        task_instructions = extract_task_instructions(trial.trajectory_path)
+    if trajectory_data is not None:
+        task_instructions = extract_task_instructions(trajectory_data)
 
     # Run the LLM analysis unless summary_only is True
     analysis = None
     if not summary_only:
-        analysis = await analyze_failed_trial(trial, analyze_pending=analyze_pending)
+        analysis = await analyze_failed_trial(
+            trial, analyze_pending=analyze_pending, trajectory_data=trajectory_data
+        )
         if not analysis:
             # If we couldn't get analysis (e.g., missing trajectory), skip this trial
             return None

--- a/libs/evals/scripts/analyze.py
+++ b/libs/evals/scripts/analyze.py
@@ -60,17 +60,49 @@ def scan_dataset_for_solutions(dataset_path: Path) -> dict[str, Path]:
 
 
 def _read_json(path: Path) -> Optional[dict]:
-    """Read and parse a JSON file, returning None on any error."""
+    """Read and parse a JSON object from a file.
+
+    Args:
+        path: Path to the JSON file.
+
+    Returns:
+        The parsed object, or None if the file is missing, unreadable, not valid
+        JSON, or does not contain a top-level object. A present-but-malformed file
+        emits a warning so a corrupt input is distinguishable from an absent one.
+    """
     try:
         with open(path, "r") as f:
-            return json.load(f)
-    except Exception:
+            data = json.load(f)
+    except FileNotFoundError:
+        # Missing files are expected (e.g. optional config.json/result.json).
         return None
+    except OSError as exc:
+        print(f"  Warning: could not read {path}: {exc}")
+        return None
+    except json.JSONDecodeError as exc:
+        print(f"  Warning: malformed JSON in {path}: {exc}")
+        return None
+    if not isinstance(data, dict):
+        print(f"  Warning: expected a JSON object in {path}, got {type(data).__name__}")
+        return None
+    return data
 
 
 @lru_cache(maxsize=None)
 def _task_dir_index(task_source_dir: Path) -> dict[str, Path]:
-    """Map task_name -> task directory for a task source, scanning the tree once."""
+    """Map task_name -> task directory for a task source, scanning the tree once.
+
+    Results are cached for the lifetime of the process (the analysis tool is a
+    short-lived, single-pass script), so the task tree is assumed immutable during
+    a run. If a task name appears under multiple hash directories, the first one
+    encountered wins, matching the prior first-match search behavior.
+
+    Args:
+        task_source_dir: Path to the `{task_source}` directory.
+
+    Returns:
+        Mapping from task name to its directory; empty if the source is absent.
+    """
     index: dict[str, Path] = {}
     if not task_source_dir.exists():
         return index
@@ -79,7 +111,7 @@ def _task_dir_index(task_source_dir: Path) -> dict[str, Path]:
             continue
         for task_dir in hash_dir.iterdir():
             if task_dir.is_dir():
-                index[task_dir.name] = task_dir
+                index.setdefault(task_dir.name, task_dir)
     return index
 
 
@@ -137,7 +169,8 @@ def extract_task_metadata(trial_dir: Path, config: Optional[dict] = None) -> dic
 
     Args:
         trial_dir: Path to the trial directory
-        config: Pre-parsed config.json contents, if already loaded
+        config: Pre-parsed config.json contents to reuse instead of re-reading.
+            Only config.json is reusable here; result.json is always read fresh.
 
     Returns:
         Dictionary containing task metadata
@@ -166,7 +199,14 @@ def extract_task_metadata(trial_dir: Path, config: Optional[dict] = None) -> dic
 def extract_task_instructions(trajectory_data: dict) -> Optional[str]:
     """Extract the task instructions from parsed trajectory data.
 
-    Looks for the user message in the trajectory steps.
+    Looks for the first user message in the trajectory steps.
+
+    Args:
+        trajectory_data: Parsed trajectory contents (ATIF format).
+
+    Returns:
+        The first user step's message (possibly an empty string), or None if no
+        user step is present.
     """
     for step in trajectory_data.get("steps", []):
         if step.get("source") == "user":

--- a/libs/evals/tests/evals/llm_judge.py
+++ b/libs/evals/tests/evals/llm_judge.py
@@ -12,6 +12,7 @@ delegated to openevals (https://github.com/langchain-ai/openevals).
 from __future__ import annotations
 
 import warnings
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -159,20 +160,45 @@ class LLMJudge(SuccessAssertion):
             model=self.judge_model,
         )
 
+        def _evaluate(criterion: str) -> dict[str, Any]:
+            return evaluator(outputs=conversation, criterion=criterion)
+
+        # The per-criterion judge calls are independent network calls, so run them
+        # concurrently rather than serializing one round-trip per criterion. Results
+        # are collected in criterion order so error messages stay deterministic.
+        total = len(self.criteria)
+        raw_results: list[Any] = [None] * total
+        if total > 1:
+            with ThreadPoolExecutor(max_workers=total) as executor:
+                futures = {
+                    executor.submit(_evaluate, criterion): idx
+                    for idx, criterion in enumerate(self.criteria)
+                }
+                for future in as_completed(futures):
+                    idx = futures[future]
+                    try:
+                        raw_results[idx] = future.result()
+                    except Exception as exc:  # noqa: BLE001
+                        raw_results[idx] = exc
+        else:
+            for idx, criterion in enumerate(self.criteria):
+                try:
+                    raw_results[idx] = _evaluate(criterion)
+                except Exception as exc:  # noqa: BLE001
+                    raw_results[idx] = exc
+
         results: list[dict[str, Any]] = []
-        for i, criterion in enumerate(self.criteria, 1):
-            try:
-                result = evaluator(outputs=conversation, criterion=criterion)
-            except Exception as exc:
+        for i, (criterion, result) in enumerate(zip(self.criteria, raw_results, strict=True), 1):
+            if isinstance(result, BaseException):
                 msg = (
-                    f"LLM judge failed on criterion {i}/{len(self.criteria)} "
+                    f"LLM judge failed on criterion {i}/{total} "
                     f"(model={self.judge_model!r}): {criterion!r}"
                 )
-                raise RuntimeError(msg) from exc
+                raise RuntimeError(msg) from result  # noqa: TRY004
             if not isinstance(result, dict) or "score" not in result:
                 msg = (
                     f"openevals returned unexpected result for criterion "
-                    f"{i}/{len(self.criteria)} {criterion!r}: {result!r}"
+                    f"{i}/{total} {criterion!r}: {result!r}"
                 )
                 raise ValueError(msg)
             results.append(result)

--- a/libs/evals/tests/evals/llm_judge.py
+++ b/libs/evals/tests/evals/llm_judge.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextvars import copy_context
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -22,6 +23,7 @@ from openevals.llm import create_llm_as_judge
 from tests.evals.utils import AgentTrajectory, SuccessAssertion
 
 _DEFAULT_JUDGE_MODEL = "claude-sonnet-4-6"
+_MAX_JUDGE_WORKERS = 8
 
 _RESPONSES_PROMPT = """You are a strict grading assistant. You will receive a
 series of agent responses and a single criterion. Decide whether the agent's
@@ -164,16 +166,18 @@ class LLMJudge(SuccessAssertion):
             return evaluator(outputs=conversation, criterion=criterion)
 
         # The per-criterion judge calls are independent network calls, so run them
-        # concurrently rather than serializing one round-trip per criterion. Results
-        # are collected in criterion order so error messages stay deterministic.
+        # concurrently rather than serializing one round-trip per criterion. Every
+        # criterion is evaluated (there is no early short-circuit on the first
+        # failure); results are stored by criterion index and consumed in order, so
+        # the surfaced error stays deterministic regardless of completion order.
         total = len(self.criteria)
         raw_results: list[Any] = [None] * total
         if total > 1:
-            with ThreadPoolExecutor(max_workers=total) as executor:
-                futures = {
-                    executor.submit(_evaluate, criterion): idx
-                    for idx, criterion in enumerate(self.criteria)
-                }
+            with ThreadPoolExecutor(max_workers=min(total, _MAX_JUDGE_WORKERS)) as executor:
+                futures = {}
+                for idx, criterion in enumerate(self.criteria):
+                    ctx = copy_context()
+                    futures[executor.submit(ctx.run, _evaluate, criterion)] = idx
                 for future in as_completed(futures):
                     idx = futures[future]
                     try:

--- a/libs/evals/tests/unit_tests/test_analyze.py
+++ b/libs/evals/tests/unit_tests/test_analyze.py
@@ -1,0 +1,253 @@
+"""Tests for the trial analysis script (`scripts/analyze.py`).
+
+The script lives outside any importable package, so it is loaded by path. These
+tests pin the I/O-reuse refactor: that helpers tolerate missing/corrupt inputs
+without crashing, that the task-dir index is first-match and cached, and that a
+malformed trajectory still yields exit-code-based failure classification (the
+raw text must survive a JSON parse failure).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from types import ModuleType
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "analyze.py"
+_MODULE_NAME = "_analyze_under_test"
+
+
+def _load_analyze() -> ModuleType:
+    """Import `scripts/analyze.py` as a module without polluting `sys.path`."""
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, _SCRIPT)
+    if spec is None or spec.loader is None:
+        msg = f"could not load spec for {_SCRIPT}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+analyze = _load_analyze()
+
+
+@pytest.fixture(autouse=True)
+def _clear_index_cache() -> Iterator[None]:
+    """Clear the process-lifetime `_task_dir_index` cache between tests."""
+    analyze._task_dir_index.cache_clear()
+    yield
+    analyze._task_dir_index.cache_clear()
+
+
+class TestReadJson:
+    """Tests for `_read_json`."""
+
+    def test_valid_object(self, tmp_path: Path) -> None:
+        path = tmp_path / "data.json"
+        path.write_text(json.dumps({"a": 1}))
+        assert analyze._read_json(path) == {"a": 1}
+
+    def test_missing_file_is_silent_none(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        assert analyze._read_json(tmp_path / "absent.json") is None
+        # Missing files are expected; no warning should be emitted.
+        assert capsys.readouterr().out == ""
+
+    def test_corrupt_json_warns_and_returns_none(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text("{not valid json")
+        assert analyze._read_json(path) is None
+        assert "malformed JSON" in capsys.readouterr().out
+
+    def test_non_object_json_returns_none(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A valid-but-non-object JSON (e.g. a list) must not crash callers that
+        # immediately call `.get(...)` on the result.
+        path = tmp_path / "list.json"
+        path.write_text("[1, 2, 3]")
+        assert analyze._read_json(path) is None
+        assert "expected a JSON object" in capsys.readouterr().out
+
+
+class TestTaskDirIndex:
+    """Tests for `_task_dir_index` and `find_task_directory`."""
+
+    def test_indexes_all_tasks(self, tmp_path: Path) -> None:
+        source = tmp_path / "src"
+        (source / "hashA" / "task-1").mkdir(parents=True)
+        (source / "hashB" / "task-2").mkdir(parents=True)
+
+        index = analyze._task_dir_index(source)
+
+        assert set(index) == {"task-1", "task-2"}
+        assert index["task-1"] == source / "hashA" / "task-1"
+
+    def test_missing_source_returns_empty(self, tmp_path: Path) -> None:
+        assert analyze._task_dir_index(tmp_path / "nope") == {}
+
+    def test_duplicate_task_name_keeps_single_first_match(self, tmp_path: Path) -> None:
+        source = tmp_path / "src"
+        (source / "hashA" / "dup").mkdir(parents=True)
+        (source / "hashB" / "dup").mkdir(parents=True)
+
+        index = analyze._task_dir_index(source)
+
+        # First match wins (one entry, pointing at a real candidate directory).
+        assert list(index) == ["dup"]
+        assert index["dup"] in {source / "hashA" / "dup", source / "hashB" / "dup"}
+        # Cached: a second call returns the identical mapping.
+        assert analyze._task_dir_index(source)["dup"] == index["dup"]
+
+    def test_find_task_directory(self, tmp_path: Path) -> None:
+        # trial_dir.parent.parent is the jobs root; task source sits beside jobs.
+        (tmp_path / "src" / "hashA" / "my-task").mkdir(parents=True)
+        trial_dir = tmp_path / "jobs" / "trial-1"
+        trial_dir.mkdir(parents=True)
+
+        found = analyze.find_task_directory(trial_dir, "my-task", "src")
+
+        assert found == tmp_path / "src" / "hashA" / "my-task"
+
+    def test_find_task_directory_absent(self, tmp_path: Path) -> None:
+        trial_dir = tmp_path / "jobs" / "trial-1"
+        trial_dir.mkdir(parents=True)
+        assert analyze.find_task_directory(trial_dir, "missing", "src") is None
+
+
+class TestCountToolUsage:
+    """Tests for `count_tool_usage`."""
+
+    def test_counts_by_function_name(self) -> None:
+        data = {
+            "steps": [
+                {"tool_calls": [{"function_name": "read"}, {"function_name": "read"}]},
+                {"tool_calls": [{"function_name": "write"}]},
+                {"tool_calls": [{}]},  # missing name defaults to "unknown"
+                {"source": "assistant"},  # no tool_calls
+            ]
+        }
+        assert analyze.count_tool_usage(data) == {"read": 2, "write": 1, "unknown": 1}
+
+    def test_empty_trajectory(self) -> None:
+        assert analyze.count_tool_usage({}) == {}
+
+
+class TestExtractTaskInstructions:
+    """Tests for `extract_task_instructions`."""
+
+    def test_returns_first_user_message(self) -> None:
+        data = {
+            "steps": [
+                {"source": "system", "message": "sys"},
+                {"source": "user", "message": "do the thing"},
+                {"source": "user", "message": "ignored"},
+            ]
+        }
+        assert analyze.extract_task_instructions(data) == "do the thing"
+
+    def test_user_step_without_message_returns_empty_string(self) -> None:
+        assert analyze.extract_task_instructions({"steps": [{"source": "user"}]}) == ""
+
+    def test_no_user_step_returns_none(self) -> None:
+        assert analyze.extract_task_instructions({"steps": [{"source": "assistant"}]}) is None
+
+
+def _make_trial(
+    trial_dir: Path,
+    *,
+    trajectory: str | None = None,
+    reward: str | None = None,
+    config: dict | None = None,
+) -> None:
+    """Write a minimal trial directory layout for `analyze_trial`."""
+    trial_dir.mkdir(parents=True, exist_ok=True)
+    if config is not None:
+        (trial_dir / "config.json").write_text(json.dumps(config))
+    if trajectory is not None:
+        (trial_dir / "agent").mkdir(parents=True, exist_ok=True)
+        (trial_dir / "agent" / "trajectory.json").write_text(trajectory)
+    if reward is not None:
+        (trial_dir / "verifier").mkdir(parents=True, exist_ok=True)
+        (trial_dir / "verifier" / "reward.txt").write_text(reward)
+
+
+class TestAnalyzeTrial:
+    """Tests for `analyze_trial`."""
+
+    def test_completed_trial_counts_tools(self, tmp_path: Path) -> None:
+        trajectory = json.dumps(
+            {"steps": [{"tool_calls": [{"function_name": "bash"}, {"function_name": "bash"}]}]}
+        )
+        _make_trial(tmp_path, trajectory=trajectory, reward="1", config={"task": {"path": "t"}})
+
+        trial = analyze.analyze_trial(tmp_path)
+
+        assert trial.status is analyze.TrialStatus.COMPLETED
+        assert trial.reward is True
+        assert trial.tool_usage == {"bash": 2}
+
+    def test_corrupt_trajectory_preserves_exit_code_classification(self, tmp_path: Path) -> None:
+        # Regression guard: a malformed trajectory.json must not poison the raw
+        # text used for exit-code extraction. The exit code 137 (OOM) is only
+        # recoverable from the raw text via regex fallback, so failure_category
+        # must be INFRA_OOM — not CAPABILITY (which is what an empty exit-code
+        # list would produce here, since there is no exception.txt).
+        corrupt = 'this is not valid json {"exit_code": 137}'
+        _make_trial(tmp_path, trajectory=corrupt, reward="0", config={"task": {"path": "t"}})
+
+        trial = analyze.analyze_trial(tmp_path)
+
+        assert trial.status is analyze.TrialStatus.FAILED
+        assert trial.tool_usage == {}  # parse failed, counted nothing
+        assert trial.failure_category is analyze.FailureCategory.INFRA_OOM
+
+    def test_pending_trial_when_no_reward_or_exception(self, tmp_path: Path) -> None:
+        _make_trial(tmp_path, trajectory=json.dumps({"steps": []}), config={"task": {"path": "t"}})
+
+        trial = analyze.analyze_trial(tmp_path)
+
+        assert trial.status is analyze.TrialStatus.PENDING
+        assert trial.reward is None
+
+    def test_uses_solution_mapping(self, tmp_path: Path) -> None:
+        solution = tmp_path / "solve.sh"
+        solution.write_text("#!/bin/sh\n")
+        _make_trial(tmp_path, trajectory=json.dumps({"steps": []}), config={"task": {"path": "t"}})
+
+        trial = analyze.analyze_trial(tmp_path, solution_mapping={"t": solution})
+
+        assert trial.solution_path == solution
+
+
+class TestScanJobsDirectory:
+    """Tests for `scan_jobs_directory` (concurrent analysis entry point)."""
+
+    async def test_scans_all_trials_concurrently(self, tmp_path: Path) -> None:
+        for name in ("trial-a", "trial-b", "trial-c"):
+            _make_trial(
+                tmp_path / name,
+                trajectory=json.dumps({"steps": []}),
+                reward="1",
+                config={"task": {"path": name}},
+            )
+
+        trials = await analyze.scan_jobs_directory(tmp_path)
+
+        assert len(trials) == 3
+        assert {t.trial_id for t in trials} == {"trial-a", "trial-b", "trial-c"}
+
+    async def test_missing_jobs_directory_returns_empty(self, tmp_path: Path) -> None:
+        assert await analyze.scan_jobs_directory(tmp_path / "absent") == []

--- a/libs/evals/tests/unit_tests/test_infra.py
+++ b/libs/evals/tests/unit_tests/test_infra.py
@@ -382,28 +382,42 @@ class _FakeEnvironment:
 
 
 class _FakeBackend(SandboxLike):
-    """Minimal fake for HarborSandbox used by collect_sandbox_metadata."""
+    """Minimal fake for HarborSandbox used by collect_sandbox_metadata.
+
+    Responses are keyed by a distinctive substring of each probe command so they
+    map to the correct probe regardless of execution order — the probes run
+    concurrently via `asyncio.gather`, so a call-index-based fake would be a
+    scheduling-order assumption rather than a behavioral one.
+    """
 
     environment: Any
 
-    def __init__(self, responses: list[str | Exception]) -> None:
+    def __init__(self, responses: dict[str, str | Exception]) -> None:
         self._responses = responses
-        self._idx = 0
         self.environment = _FakeEnvironment()
 
     async def aexecute(self, command: str, *, timeout: int | None = None) -> _FakeExecResult:  # noqa: ASYNC109
-        resp = self._responses[self._idx]
-        self._idx += 1
-        if isinstance(resp, Exception):
-            raise resp
-        return _FakeExecResult(output=resp)
+        for key, resp in self._responses.items():
+            if key in command:
+                if isinstance(resp, Exception):
+                    raise resp
+                return _FakeExecResult(output=resp)
+        msg = f"No fake response configured for command: {command!r}"
+        raise AssertionError(msg)
 
 
 class TestCollectSandboxMetadata:
     """Tests for sandbox metadata collection."""
 
     async def test_happy_path(self):
-        backend = _FakeBackend(["4\n", "8192\n", "4096\n", "Linux 6.1.0\n"])
+        backend = _FakeBackend(
+            {
+                "nproc": "4\n",
+                "MemTotal": "8192\n",
+                "MemAvailable": "4096\n",
+                "uname": "Linux 6.1.0\n",
+            }
+        )
         meta = await collect_sandbox_metadata(backend)
 
         assert meta.sandbox_cpu_count == 4
@@ -415,12 +429,12 @@ class TestCollectSandboxMetadata:
 
     async def test_non_numeric_output_sets_none(self):
         backend = _FakeBackend(
-            [
-                "nproc: command not found\n",
-                "unknown\n",
-                "unknown\n",
-                "Linux 6.1.0\n",
-            ]
+            {
+                "nproc": "nproc: command not found\n",
+                "MemTotal": "unknown\n",
+                "MemAvailable": "unknown\n",
+                "uname": "Linux 6.1.0\n",
+            }
         )
         meta = await collect_sandbox_metadata(backend)
 
@@ -431,12 +445,12 @@ class TestCollectSandboxMetadata:
 
     async def test_partial_failure_still_collects(self):
         backend = _FakeBackend(
-            [
-                RuntimeError("sandbox down"),  # CPU fails
-                "8192\n",  # memory succeeds
-                "4096\n",  # avail succeeds
-                ConnectionError("reset"),  # OS fails
-            ]
+            {
+                "nproc": RuntimeError("sandbox down"),  # CPU fails
+                "MemTotal": "8192\n",  # memory succeeds
+                "MemAvailable": "4096\n",  # avail succeeds
+                "uname": ConnectionError("reset"),  # OS fails
+            }
         )
         meta = await collect_sandbox_metadata(backend)
 
@@ -447,12 +461,12 @@ class TestCollectSandboxMetadata:
 
     async def test_all_commands_fail(self):
         backend = _FakeBackend(
-            [
-                TimeoutError(),
-                RuntimeError(),
-                ConnectionError(),
-                OSError(),
-            ]
+            {
+                "nproc": TimeoutError(),
+                "MemTotal": RuntimeError(),
+                "MemAvailable": ConnectionError(),
+                "uname": OSError(),
+            }
         )
         meta = await collect_sandbox_metadata(backend)
 

--- a/libs/evals/tests/unit_tests/test_langsmith.py
+++ b/libs/evals/tests/unit_tests/test_langsmith.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -12,6 +13,8 @@ from deepagents_harbor.langsmith import (
     _download_dataset,
     _extract_reward,
     _headers,
+    _process_trial,
+    add_feedback,
     resolve_langsmith_api_key,
 )
 
@@ -280,3 +283,177 @@ class TestExtractReward:
         with pytest.raises(ValueError, match="malformed JSON") as exc_info:
             _extract_reward(trial_dir)
         assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)
+
+
+class _FakeRun:
+    """Minimal stand-in for a LangSmith run object."""
+
+    def __init__(self, run_id: str) -> None:
+        self.id = run_id
+
+
+class _FakeFeedback:
+    """Minimal stand-in for a LangSmith feedback object."""
+
+    def __init__(self, key: str) -> None:
+        self.key = key
+
+
+class _FakeClient:
+    """Offline fake for the LangSmith `Client` used by `_process_trial`.
+
+    `list_runs` returns `runs` (or raises it, if it is an exception) and
+    `list_feedback` returns `feedback`. Every `create_feedback` call is recorded.
+    """
+
+    def __init__(
+        self,
+        *,
+        runs: list[Any] | Exception,
+        feedback: list[Any] | None = None,
+    ) -> None:
+        self._runs = runs
+        self._feedback = feedback or []
+        self.created: list[dict[str, Any]] = []
+
+    def list_runs(self, *, project_name, filter, is_root):  # noqa: A002  # mirrors Client API
+        if isinstance(self._runs, Exception):
+            raise self._runs
+        return iter(self._runs)
+
+    def list_feedback(self, *, run_ids):
+        return iter(self._feedback)
+
+    def create_feedback(self, *, run_id, key, score, comment=None):
+        self.created.append({"run_id": run_id, "key": key, "score": score, "comment": comment})
+
+
+class TestProcessTrial:
+    """Tests for `_process_trial` status mapping (offline)."""
+
+    def test_success(self, trial_dir: Path) -> None:
+        _write_result(trial_dir, {"verifier_result": {"rewards": {"reward": 1.0}}})
+        client: Any = _FakeClient(runs=[_FakeRun("run-1")])
+
+        result = _process_trial(client=client, trial_dir=trial_dir, project_name="proj")
+
+        assert result["status"] == "success"
+        assert len(client.created) == 1
+        assert client.created[0]["run_id"] == "run-1"
+        assert client.created[0]["score"] == 1.0
+
+    def test_fallback_when_no_verifier_result(self, trial_dir: Path) -> None:
+        _write_result(trial_dir, {"some_other_key": True})
+        client: Any = _FakeClient(runs=[_FakeRun("run-1")])
+
+        result = _process_trial(client=client, trial_dir=trial_dir, project_name="proj")
+
+        assert result["status"] == "fallback"
+        assert client.created[0]["score"] == 0.0
+
+    def test_skipped_when_feedback_exists(self, trial_dir: Path) -> None:
+        _write_result(trial_dir, {"verifier_result": {"rewards": {"reward": 1.0}}})
+        client: Any = _FakeClient(
+            runs=[_FakeRun("run-1")], feedback=[_FakeFeedback("harbor_reward")]
+        )
+
+        result = _process_trial(client=client, trial_dir=trial_dir, project_name="proj")
+
+        assert result["status"] == "skipped"
+        assert client.created == []
+
+    def test_error_when_no_trace(self, trial_dir: Path) -> None:
+        client: Any = _FakeClient(runs=[])
+
+        result = _process_trial(client=client, trial_dir=trial_dir, project_name="proj")
+
+        assert result["status"] == "error"
+        assert "No trace found" in result["message"]
+
+    def test_error_when_multiple_traces(self, trial_dir: Path) -> None:
+        client: Any = _FakeClient(runs=[_FakeRun("run-1"), _FakeRun("run-2")])
+
+        result = _process_trial(client=client, trial_dir=trial_dir, project_name="proj")
+
+        assert result["status"] == "error"
+        assert "Multiple traces" in result["message"]
+
+    def test_error_when_fetch_fails(self, trial_dir: Path) -> None:
+        client: Any = _FakeClient(runs=ValueError("bad filter"))
+
+        result = _process_trial(client=client, trial_dir=trial_dir, project_name="proj")
+
+        assert result["status"] == "error"
+        assert "Failed to fetch trace" in result["message"]
+
+    def test_dry_run_does_not_create_feedback(self, trial_dir: Path) -> None:
+        _write_result(trial_dir, {"verifier_result": {"rewards": {"reward": 1.0}}})
+        client: Any = _FakeClient(runs=[_FakeRun("run-1")])
+
+        result = _process_trial(
+            client=client, trial_dir=trial_dir, project_name="proj", dry_run=True
+        )
+
+        assert result["status"] == "success"
+        assert "Would add" in result["message"]
+        assert client.created == []
+
+
+class _RoutingClient:
+    """Fake `Client` that routes per trial by reading the trial name from the filter.
+
+    Lets `add_feedback` run many trials concurrently while each resolves to a
+    distinct, deterministic outcome, so we can assert results map back to the
+    correct trial regardless of completion order.
+    """
+
+    def __init__(self, statuses: dict[str, str]) -> None:
+        self._statuses = statuses
+        self.created: list[dict[str, Any]] = []
+
+    @staticmethod
+    def _trial_name(filter_query: str) -> str:
+        match = re.search(r'eq\(metadata_value, "([^"]+)"\)', filter_query)
+        return match.group(1) if match else ""
+
+    def list_runs(self, *, project_name, filter, is_root):  # noqa: A002  # mirrors Client API
+        name = self._trial_name(filter)
+        if self._statuses.get(name) == "none":
+            return iter([])
+        return iter([_FakeRun(f"run-{name}")])
+
+    def list_feedback(self, *, run_ids):
+        name = run_ids[0].removeprefix("run-")
+        if self._statuses.get(name) == "skipped":
+            return iter([_FakeFeedback("harbor_reward")])
+        return iter([])
+
+    def create_feedback(self, *, run_id, key, score, comment=None):
+        self.created.append({"run_id": run_id, "key": key, "score": score, "comment": comment})
+
+
+class TestAddFeedbackOrdering:
+    """End-to-end ordering/reassembly check for `add_feedback`."""
+
+    def test_results_map_to_correct_trial(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Three trials with distinct intended outcomes.
+        statuses = {"good": "success", "dupe": "skipped", "missing": "none"}
+        for name in statuses:
+            d = tmp_path / name
+            d.mkdir()
+            _write_result(d, {"verifier_result": {"rewards": {"reward": 1.0}}})
+
+        routing = _RoutingClient(statuses)
+        monkeypatch.setattr("deepagents_harbor.langsmith.Client", lambda: routing)
+
+        add_feedback(tmp_path, project_name="proj")
+
+        # Only the "good" trial should have feedback created (skipped/missing must not).
+        assert [c["run_id"] for c in routing.created] == ["run-good"]
+
+        out = capsys.readouterr().out
+        assert "Successfully updated: 1" in out
+        assert "Skipped (already has feedback): 1" in out
+        assert "Errors: 1" in out

--- a/libs/evals/tests/unit_tests/test_llm_judge.py
+++ b/libs/evals/tests/unit_tests/test_llm_judge.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+from threading import Lock
+from typing import TYPE_CHECKING
+
+from langchain_core.messages import AIMessage
+
+from tests.evals import llm_judge as llm_judge_module
+from tests.evals.llm_judge import LLMJudge
+from tests.evals.utils import AgentStep, AgentTrajectory
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _make_trajectory(answer: str) -> AgentTrajectory:
+    return AgentTrajectory(
+        steps=[AgentStep(index=1, action=AIMessage(content=answer), observations=[])],
+        files={},
+    )
+
+
+def test_threaded_judge_preserves_caller_contextvars(monkeypatch) -> None:
+    active_run: ContextVar[str | None] = ContextVar("active_run", default=None)
+    seen: list[tuple[str, str | None]] = []
+    lock = Lock()
+
+    def fake_create_llm_as_judge(**_kwargs: object) -> Callable[..., dict[str, object]]:
+        def evaluator(*, outputs: str, criterion: str) -> dict[str, object]:
+            with lock:
+                seen.append((criterion, active_run.get()))
+            return {"score": True, "comment": outputs}
+
+        return evaluator
+
+    monkeypatch.setattr(llm_judge_module, "create_llm_as_judge", fake_create_llm_as_judge)
+    monkeypatch.setattr(llm_judge_module.t, "log_feedback", lambda **_kwargs: None)
+
+    token = active_run.set("langsmith-test-context")
+    try:
+        results = LLMJudge(criteria=("correctness", "safety"))._grade(
+            _make_trajectory("final answer")
+        )
+    finally:
+        active_run.reset(token)
+
+    assert [result["score"] for result in results] == [True, True]
+    assert sorted(seen) == [
+        ("correctness", "langsmith-test-context"),
+        ("safety", "langsmith-test-context"),
+    ]

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -436,7 +436,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.2.5,<5.0.0" },
     { name = "langchain-quickjs", marker = "extra == 'quickjs'" },
     { name = "langsmith", specifier = ">=0.8.11" },
-    { name = "wcmatch" },
+    { name = "wcmatch", specifier = ">=10.1" },
 ]
 provides-extras = ["quickjs"]
 


### PR DESCRIPTION
Eliminates redundant per-trial file reads/parses and replaces serialized blocking round-trips with concurrent ones, without changing behavior.

- `scripts/analyze.py`: read each `trajectory.json`/`config.json` once per trial (was 2-4x), cache the task-directory index instead of re-globbing per trial, and analyze trials concurrently via a thread pool.
- `deepagents_harbor/metadata.py`: run the four independent sandbox probes concurrently instead of one at a time.
- `deepagents_harbor/langsmith.py`: process per-trial feedback with a bounded thread pool instead of serially.
- `tests/evals/llm_judge.py`: grade criteria concurrently rather than one LLM call at a time.


Made by [Open SWE](https://openswe.vercel.app)