### PR TITLE
fix(ci): only strip release deps requiring the unpublished same-PR bump

### DIFF
--- a/.github/scripts/check_release_deps.py
+++ b/.github/scripts/check_release_deps.py
@@ -2,8 +2,9 @@
 
 Release-please PRs can bump several packages in one coordinated change. The
 newly bumped wheels do not exist on PyPI until merge, so dependency resolution
-must ignore only the intra-PR pins that the PR itself satisfies while still
-checking every other runtime dependency against the real index.
+must ignore only the intra-PR pins that *require* the unpublished bump (i.e. the
+currently-published base version cannot satisfy them) while still checking every
+other runtime dependency against the real index.
 
 This validates only direct pins on same-PR-bumped packages. A bumped package
 that introduces a brand-new transitive dependency is not exercised here, since
@@ -48,6 +49,7 @@ class PackageBump:
 
     name: str
     version: str
+    base_version: str
     path: str
 
 
@@ -179,12 +181,19 @@ def detect_package_bumps(paths: list[str], base_sha: str) -> dict[str, PackageBu
         bumped[canonical] = PackageBump(
             name=current_name,
             version=current_version,
+            base_version=base_version,
             path=path,
         )
     return bumped
 
 
-def _requirement_is_satisfied_by_bump(dep: str, bumped: dict[str, PackageBump]) -> bool:
+def _requirement_requires_same_pr_bump(dep: str, bumped: dict[str, PackageBump]) -> bool:
+    """Report whether a dependency can only be satisfied by an unpublished same-PR bump.
+
+    A pin is stripped only when the same-PR bumped version satisfies it but the
+    currently-published (base) version does not. Broad ranges that the published
+    version already satisfies are left in place so they resolve against PyPI.
+    """
     try:
         requirement = Requirement(dep)
     except InvalidRequirement as err:
@@ -193,7 +202,10 @@ def _requirement_is_satisfied_by_bump(dep: str, bumped: dict[str, PackageBump]) 
     bump = bumped.get(canonicalize_name(requirement.name))
     if bump is None:
         return False
-    return requirement.specifier.contains(bump.version, prereleases=True)
+    specifier = requirement.specifier
+    if not specifier.contains(bump.version, prereleases=True):
+        return False
+    return not specifier.contains(bump.base_version, prereleases=True)
 
 
 def _filter_dep_list(deps: Any, bumped: dict[str, PackageBump]) -> tuple[Any, list[str]]:
@@ -202,7 +214,7 @@ def _filter_dep_list(deps: Any, bumped: dict[str, PackageBump]) -> tuple[Any, li
     kept: list[Any] = []
     skipped: list[str] = []
     for dep in deps:
-        if isinstance(dep, str) and _requirement_is_satisfied_by_bump(dep, bumped):
+        if isinstance(dep, str) and _requirement_requires_same_pr_bump(dep, bumped):
             skipped.append(dep)
         else:
             kept.append(dep)

--- a/.github/scripts/test_check_release_deps.py
+++ b/.github/scripts/test_check_release_deps.py
@@ -64,6 +64,7 @@ dependencies = []
     assert bumps["deepagents"] == PackageBump(
         name="deepagents",
         version="0.7.0",
+        base_version="0.6.8",
         path="pyproject.toml",
     )
 
@@ -94,10 +95,11 @@ def test_filtered_manifest_removes_only_satisfied_same_pr_pins_and_preserves_uv_
         },
     }
     bumped = {
-        "deepagents": PackageBump("deepagents", "0.7.0", "libs/deepagents/pyproject.toml"),
+        "deepagents": PackageBump("deepagents", "0.7.0", "0.6.8", "libs/deepagents/pyproject.toml"),
         "langchain-daytona": PackageBump(
             "langchain-daytona",
             "0.0.8",
+            "0.0.7",
             "libs/partners/daytona/pyproject.toml",
         ),
     }
@@ -213,13 +215,63 @@ def test_filtered_manifest_keeps_pin_not_satisfied_by_bump() -> None:
             "dependencies": ["deepagents==0.6.8"],
         },
     }
-    bumped = {"deepagents": PackageBump("deepagents", "0.7.0", "libs/deepagents/pyproject.toml")}
+    bumped = {
+        "deepagents": PackageBump("deepagents", "0.7.0", "0.6.7", "libs/deepagents/pyproject.toml")
+    }
 
     filtered = build_filtered_manifest(data, bumped)
     parsed = tomllib.loads(filtered.content)
 
     assert parsed["project"]["dependencies"] == ["deepagents==0.6.8"]
     assert filtered.skipped == ()
+
+
+def test_filtered_manifest_keeps_broad_range_satisfied_by_published_base() -> None:
+    """A broad range that the currently-published base version satisfies is kept.
+
+    Bumping ``deepagents-code`` to 0.1.13 must not strip ``>=0.1.11,<1.0.0``,
+    because the published 0.1.12 still satisfies it and resolves from PyPI.
+    """
+    data = {
+        "project": {
+            "name": "example",
+            "version": "0.1.0",
+            "dependencies": ["deepagents-code>=0.1.11,<1.0.0"],
+        },
+    }
+    bumped = {
+        "deepagents-code": PackageBump(
+            "deepagents-code", "0.1.13", "0.1.12", "libs/code/pyproject.toml"
+        )
+    }
+
+    filtered = build_filtered_manifest(data, bumped)
+    parsed = tomllib.loads(filtered.content)
+
+    assert parsed["project"]["dependencies"] == ["deepagents-code>=0.1.11,<1.0.0"]
+    assert filtered.skipped == ()
+
+
+def test_filtered_manifest_strips_range_requiring_unpublished_bump() -> None:
+    """A range only the unpublished same-PR bump satisfies is stripped."""
+    data = {
+        "project": {
+            "name": "example",
+            "version": "0.1.0",
+            "dependencies": ["deepagents-code>=0.1.13,<1.0.0"],
+        },
+    }
+    bumped = {
+        "deepagents-code": PackageBump(
+            "deepagents-code", "0.1.13", "0.1.12", "libs/code/pyproject.toml"
+        )
+    }
+
+    filtered = build_filtered_manifest(data, bumped)
+    parsed = tomllib.loads(filtered.content)
+
+    assert parsed["project"]["dependencies"] == []
+    assert filtered.skipped == ("deepagents-code>=0.1.13,<1.0.0",)
 
 
 def test_filtered_manifest_keeps_unparseable_requirement() -> None:
@@ -231,7 +283,9 @@ def test_filtered_manifest_keeps_unparseable_requirement() -> None:
             "dependencies": ["deepagents @@@ broken"],
         },
     }
-    bumped = {"deepagents": PackageBump("deepagents", "0.7.0", "libs/deepagents/pyproject.toml")}
+    bumped = {
+        "deepagents": PackageBump("deepagents", "0.7.0", "0.6.8", "libs/deepagents/pyproject.toml")
+    }
 
     filtered = build_filtered_manifest(data, bumped)
     parsed = tomllib.loads(filtered.content)


### PR DESCRIPTION
The release-dep check stripped any dependency whose range contained the newly bumped version, so broad in-repo ranges (e.g. `deepagents-code>=0.1.11,<1.0.0` while bumping to `0.1.13`) were dropped entirely even though the published `0.1.12` already satisfies them. A pin is now stripped only when the same-PR bump satisfies it *and* the currently-published base version does not, so broad ranges still resolve against PyPI.

Made by [Open SWE](https://openswe.vercel.app)