### PR TITLE
refactor(ci): simplify release dep check to direct PyPI resolution

### DIFF
--- a/.github/scripts/check_release_deps.py
+++ b/.github/scripts/check_release_deps.py
@@ -1,31 +1,24 @@
-"""Resolve release PR dependencies against PyPI without same-PR package bumps.
+"""Resolve release PR runtime dependencies against real PyPI.
 
-Release-please PRs can bump several packages in one coordinated change. The
-newly bumped wheels do not exist on PyPI until merge, so dependency resolution
-must ignore only the intra-PR pins that the PR itself satisfies while still
-checking every other runtime dependency against the real index.
-
-This validates only direct pins on same-PR-bumped packages. A bumped package
-that introduces a brand-new transitive dependency is not exercised here, since
-its own pin is stripped and the currently-published version is resolved instead;
-that case is covered once the bumped package itself reaches PyPI.
+A release PR bumps a single package's version. Local development installs the
+sibling packages as editable path dependencies via `[tool.uv.sources]`, which
+hides whether a package's *published* dependencies actually resolve. This check
+strips those local sources and resolves each changed release manifest against
+the real index (`uv pip compile --no-sources`), so an unsatisfiable or
+not-yet-published runtime dependency fails before merge/publish instead of at
+user install time.
 """
 
 from __future__ import annotations
 
-import copy
 import json
 import os
 import re
 import subprocess
 import tempfile
 import tomllib
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-
-from packaging.requirements import InvalidRequirement, Requirement
-from packaging.utils import canonicalize_name
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONFIG = REPO_ROOT / "release-please-config.json"
@@ -40,23 +33,6 @@ TRANSIENT_PATTERNS = re.compile(
     r"http (?:429|5\d\d)|status code: (?:429|5\d\d))",
     re.IGNORECASE,
 )
-
-
-@dataclass(frozen=True)
-class PackageBump:
-    """A package whose own version was bumped by this PR."""
-
-    name: str
-    version: str
-    path: str
-
-
-@dataclass(frozen=True)
-class FilteredManifest:
-    """Filtered manifest content plus dependency pins removed from it."""
-
-    content: str
-    skipped: tuple[str, ...]
 
 
 def _notice(message: str) -> None:
@@ -81,17 +57,6 @@ def _run_git(args: list[str], *, check: bool = True) -> subprocess.CompletedProc
     )
 
 
-def _git_show(ref: str, path: str) -> str | None:
-    proc = _run_git(["show", f"{ref}:{path}"], check=False)
-    if proc.returncode != 0:
-        _warning(
-            f"Could not read {path} at base SHA; assuming it is new or unavailable "
-            "and skipping same-PR bump detection for that package."
-        )
-        return None
-    return proc.stdout
-
-
 def load_release_packages(config_path: Path = DEFAULT_CONFIG) -> dict[str, str]:
     """Return release-please package paths mapped to component/package labels."""
     config = json.loads(config_path.read_text(encoding="utf-8"))
@@ -112,101 +77,6 @@ def changed_manifests(base_sha: str, head_sha: str, package_paths: list[str]) ->
     proc = _run_git(["diff", "--name-only", base_sha, head_sha, "--", *manifest_paths])
     changed = {line.strip() for line in proc.stdout.splitlines() if line.strip()}
     return [path for path in manifest_paths if path in changed]
-
-
-def _parse_toml(content: str, path: str) -> dict[str, Any] | None:
-    try:
-        return tomllib.loads(content)
-    except tomllib.TOMLDecodeError as err:
-        _warning(f"Could not parse {path}: {err}; skipping same-PR bump detection.")
-        return None
-
-
-def _project_name_version(data: dict[str, Any], path: str) -> tuple[str, str] | None:
-    project = data.get("project")
-    if not isinstance(project, dict):
-        _warning(f"{path} has no [project] table; skipping same-PR bump detection.")
-        return None
-    dynamic = project.get("dynamic", [])
-    if isinstance(dynamic, list) and ({"name", "version"} & set(dynamic)):
-        _warning(f"{path} has dynamic project name/version; skipping same-PR bump detection.")
-        return None
-    name = project.get("name")
-    version = project.get("version")
-    if not isinstance(name, str) or not name:
-        _warning(f"{path} has no static [project].name; skipping same-PR bump detection.")
-        return None
-    if not isinstance(version, str) or not version:
-        _warning(f"{path} has no static [project].version; skipping same-PR bump detection.")
-        return None
-    return name, version
-
-
-def detect_package_bumps(paths: list[str], base_sha: str) -> dict[str, PackageBump]:
-    """Return packages whose own project version changed in this PR."""
-    bumped: dict[str, PackageBump] = {}
-    for path in paths:
-        current_path = REPO_ROOT / path
-        current = _parse_toml(current_path.read_text(encoding="utf-8"), path)
-        if current is None:
-            continue
-        current_identity = _project_name_version(current, path)
-        if current_identity is None:
-            continue
-
-        base_content = _git_show(base_sha, path)
-        if base_content is None:
-            continue
-        base = _parse_toml(base_content, f"{base_sha}:{path}")
-        if base is None:
-            continue
-        base_identity = _project_name_version(base, f"{base_sha}:{path}")
-        if base_identity is None:
-            continue
-
-        current_name, current_version = current_identity
-        base_name, base_version = base_identity
-        if canonicalize_name(current_name) != canonicalize_name(base_name):
-            _warning(
-                f"{path} renamed package {base_name!r} -> {current_name!r}; "
-                "skipping same-PR bump detection for that manifest."
-            )
-            continue
-        if current_version == base_version:
-            continue
-
-        canonical = canonicalize_name(current_name)
-        bumped[canonical] = PackageBump(
-            name=current_name,
-            version=current_version,
-            path=path,
-        )
-    return bumped
-
-
-def _requirement_is_satisfied_by_bump(dep: str, bumped: dict[str, PackageBump]) -> bool:
-    try:
-        requirement = Requirement(dep)
-    except InvalidRequirement as err:
-        _warning(f"Could not parse dependency {dep!r}: {err}; leaving it in place.")
-        return False
-    bump = bumped.get(canonicalize_name(requirement.name))
-    if bump is None:
-        return False
-    return requirement.specifier.contains(bump.version, prereleases=True)
-
-
-def _filter_dep_list(deps: Any, bumped: dict[str, PackageBump]) -> tuple[Any, list[str]]:
-    if not isinstance(deps, list):
-        return deps, []
-    kept: list[Any] = []
-    skipped: list[str] = []
-    for dep in deps:
-        if isinstance(dep, str) and _requirement_is_satisfied_by_bump(dep, bumped):
-            skipped.append(dep)
-        else:
-            kept.append(dep)
-    return kept, skipped
 
 
 def _quote(value: str) -> str:
@@ -235,31 +105,18 @@ def _toml_value(value: Any) -> str:
     raise TypeError(msg)
 
 
-def build_filtered_manifest(data: dict[str, Any], bumped: dict[str, PackageBump]) -> FilteredManifest:
-    """Build a resolver-equivalent pyproject with same-PR dependency pins removed.
+def build_resolver_manifest(data: dict[str, Any]) -> str:
+    """Build a resolver-equivalent pyproject that drops local path sources.
 
     The result is a minimal manifest holding only resolver-relevant fields:
-    `name`, `version`, `requires-python`, (optional) dependencies, and the
-    `RESOLVER_UV_KEYS` subset of `[tool.uv]`. Notably it drops `[tool.uv.sources]`
+    `name`, `version`, `requires-python`, dependencies, optional-dependencies,
+    and the `RESOLVER_UV_KEYS` subset of `[tool.uv]`. It omits `[tool.uv.sources]`
     so resolution runs against real PyPI (paired with `--no-sources`).
     """
-    filtered = copy.deepcopy(data)
-    project = filtered.get("project", {})
+    project = data.get("project", {})
     if not isinstance(project, dict):
         msg = "manifest has no [project] table"
         raise ValueError(msg)
-
-    skipped: list[str] = []
-    dependencies, skipped_dependencies = _filter_dep_list(project.get("dependencies", []), bumped)
-    project["dependencies"] = dependencies
-    skipped.extend(skipped_dependencies)
-
-    optional_dependencies = project.get("optional-dependencies", {})
-    if isinstance(optional_dependencies, dict):
-        for extra, deps in list(optional_dependencies.items()):
-            filtered_deps, skipped_extra = _filter_dep_list(deps, bumped)
-            optional_dependencies[extra] = filtered_deps
-            skipped.extend(f"{extra}: {dep}" for dep in skipped_extra)
 
     lines: list[str] = ["[project]"]
     for key in ("name", "version", "requires-python"):
@@ -268,24 +125,21 @@ def build_filtered_manifest(data: dict[str, Any], bumped: dict[str, PackageBump]
             lines.append(f"{key} = {_toml_value(value)}")
     lines.append(f"dependencies = {_toml_value(project.get('dependencies', []))}")
 
+    optional_dependencies = project.get("optional-dependencies", {})
     if isinstance(optional_dependencies, dict) and optional_dependencies:
         lines.extend(["", "[project.optional-dependencies]"])
         for extra, deps in optional_dependencies.items():
             lines.append(f"{extra} = {_toml_value(deps)}")
 
-    tool = filtered.get("tool", {})
+    tool = data.get("tool", {})
     uv = tool.get("uv", {}) if isinstance(tool, dict) else {}
-    preserved = {
-        key: uv[key]
-        for key in RESOLVER_UV_KEYS
-        if isinstance(uv, dict) and key in uv
-    }
+    preserved = {key: uv[key] for key in RESOLVER_UV_KEYS if isinstance(uv, dict) and key in uv}
     if preserved:
         lines.extend(["", "[tool.uv]"])
         for key, value in preserved.items():
             lines.append(f"{key} = {_toml_value(value)}")
 
-    return FilteredManifest(content="\n".join(lines) + "\n", skipped=tuple(skipped))
+    return "\n".join(lines) + "\n"
 
 
 def is_transient_resolver_error(log: str) -> bool:
@@ -294,7 +148,7 @@ def is_transient_resolver_error(log: str) -> bool:
 
 
 def run_resolver(manifest: Path, log: Path) -> bool:
-    """Resolve a filtered manifest against real PyPI and write combined output to log.
+    """Resolve a manifest against real PyPI and write combined output to log.
 
     Resolution ignores local path sources (`--no-sources`), spans every extra
     (`--all-extras`), allows prereleases (`--prerelease allow`), and is universal
@@ -330,10 +184,9 @@ def run_resolver(manifest: Path, log: Path) -> bool:
         )
     else:
         _error(
-            "Dependency resolution failed. If the failing dependency is another package "
-            "bumped by this same release PR, this check removes only pins satisfied by "
-            "that same-PR bump before resolving the rest. If the remaining pin is "
-            f"intentional, apply the `{BYPASS_LABEL}` label."
+            "Dependency resolution failed against PyPI. A declared runtime dependency "
+            "could not be satisfied by published packages (e.g. a pin on a version that "
+            f"is not on PyPI yet). If the pin is intentional, apply the `{BYPASS_LABEL}` label."
         )
     return False
 
@@ -347,35 +200,19 @@ def check_release_dependencies(base_sha: str, head_sha: str) -> int:
         return 0
 
     _notice(f"Changed package manifests: {', '.join(manifests)}")
-    bumped = detect_package_bumps(manifests, base_sha)
-    if bumped:
-        introduced = ", ".join(
-            f"{bump.name}=={bump.version} ({bump.path})"
-            for bump in sorted(bumped.values(), key=lambda item: item.name)
-        )
-        _notice(f"Packages introduced by this PR: {introduced}")
-    else:
-        _notice("No same-PR package version bumps detected.")
 
     ok = True
     with tempfile.TemporaryDirectory(prefix="release-deps-") as tmp:
         tmpdir = Path(tmp)
         for index, manifest_path in enumerate(manifests):
             data = tomllib.loads((REPO_ROOT / manifest_path).read_text(encoding="utf-8"))
-            filtered = build_filtered_manifest(data, bumped)
-            if filtered.skipped:
-                _notice(
-                    f"{manifest_path}: skipped same-PR dependency pins: "
-                    + "; ".join(filtered.skipped)
-                )
-            else:
-                _notice(f"{manifest_path}: no same-PR dependency pins skipped.")
+            content = build_resolver_manifest(data)
 
             manifest_label = manifest_path.removesuffix("/pyproject.toml").replace("/", "__")
             manifest_dir = tmpdir / f"{index}-{manifest_label}"
             manifest_dir.mkdir()
             temp_manifest = manifest_dir / "pyproject.toml"
-            temp_manifest.write_text(filtered.content, encoding="utf-8")
+            temp_manifest.write_text(content, encoding="utf-8")
             log = tmpdir / f"{manifest_dir.name}.log"
             _notice(
                 f"Resolving {manifest_path} against PyPI with "

--- a/.github/scripts/test_check_release_deps.py
+++ b/.github/scripts/test_check_release_deps.py
@@ -6,12 +6,9 @@ import tomllib
 
 import pytest
 from check_release_deps import (
-    FilteredManifest,
-    PackageBump,
     _toml_value,
-    build_filtered_manifest,
+    build_resolver_manifest,
     check_release_dependencies,
-    detect_package_bumps,
     is_transient_resolver_error,
     load_release_packages,
     main,
@@ -19,56 +16,7 @@ from check_release_deps import (
 )
 
 
-def test_detect_package_bumps_skips_new_manifest(monkeypatch, tmp_path) -> None:
-    manifest = tmp_path / "pyproject.toml"
-    manifest.write_text(
-        """
-[project]
-name = "deepagents"
-version = "0.7.0"
-dependencies = []
-""".strip(),
-        encoding="utf-8",
-    )
-
-    monkeypatch.setattr("check_release_deps.REPO_ROOT", tmp_path)
-    monkeypatch.setattr("check_release_deps._git_show", lambda _base, _path: None)
-
-    assert detect_package_bumps(["pyproject.toml"], "base-sha") == {}
-
-
-def test_detect_package_bumps_returns_changed_static_versions(monkeypatch, tmp_path) -> None:
-    manifest = tmp_path / "pyproject.toml"
-    manifest.write_text(
-        """
-[project]
-name = "deepagents"
-version = "0.7.0"
-dependencies = []
-""".strip(),
-        encoding="utf-8",
-    )
-
-    base_manifest = """
-[project]
-name = "deepagents"
-version = "0.6.8"
-dependencies = []
-""".strip()
-
-    monkeypatch.setattr("check_release_deps.REPO_ROOT", tmp_path)
-    monkeypatch.setattr("check_release_deps._git_show", lambda _base, _path: base_manifest)
-
-    bumps = detect_package_bumps(["pyproject.toml"], "base-sha")
-
-    assert bumps["deepagents"] == PackageBump(
-        name="deepagents",
-        version="0.7.0",
-        path="pyproject.toml",
-    )
-
-
-def test_filtered_manifest_removes_only_satisfied_same_pr_pins_and_preserves_uv_keys() -> None:
+def test_build_resolver_manifest_drops_sources_and_preserves_uv_keys() -> None:
     data = {
         "project": {
             "name": "deepagents-code",
@@ -93,37 +41,33 @@ def test_filtered_manifest_removes_only_satisfied_same_pr_pins_and_preserves_uv_
             }
         },
     }
-    bumped = {
-        "deepagents": PackageBump("deepagents", "0.7.0", "libs/deepagents/pyproject.toml"),
-        "langchain-daytona": PackageBump(
-            "langchain-daytona",
-            "0.0.8",
-            "libs/partners/daytona/pyproject.toml",
-        ),
-    }
 
-    filtered = build_filtered_manifest(data, bumped)
-    parsed = tomllib.loads(filtered.content)
+    parsed = tomllib.loads(build_resolver_manifest(data))
 
     assert parsed["project"]["dependencies"] == [
+        "deepagents==0.7.0",
         "langchain>=1.0,<2.0",
         "deepagents-acp>=0.0.8,<0.0.9",
     ]
-    assert parsed["project"]["optional-dependencies"]["sandbox"] == []
+    assert parsed["project"]["optional-dependencies"]["sandbox"] == [
+        "langchain-daytona>=0.0.8,<0.1.0"
+    ]
     assert parsed["project"]["optional-dependencies"]["quickjs"] == [
         "langchain-quickjs>=0.1.4,<0.2.0"
     ]
+    assert parsed["project"]["requires-python"] == ">=3.11,<4.0"
     assert parsed["tool"]["uv"]["prerelease"] == "allow"
     assert parsed["tool"]["uv"]["constraint-dependencies"] == ["example<2"]
     assert parsed["tool"]["uv"]["override-dependencies"] == ["other==1.0"]
     assert "sources" not in parsed["tool"]["uv"]
-    assert filtered.skipped == (
-        "deepagents==0.7.0",
-        "sandbox: langchain-daytona>=0.0.8,<0.1.0",
-    )
 
 
-def test_check_release_dependencies_writes_each_filtered_manifest_as_pyproject(
+def test_build_resolver_manifest_requires_project_table() -> None:
+    with pytest.raises(ValueError, match="no \\[project\\] table"):
+        build_resolver_manifest({"project": "not-a-table"})
+
+
+def test_check_release_dependencies_writes_each_manifest_as_pyproject(
     monkeypatch,
     tmp_path,
 ) -> None:
@@ -156,17 +100,29 @@ dependencies = []
         "check_release_deps.load_release_packages",
         lambda: {"libs/code": "deepagents-code", "libs/partners/daytona": "langchain-daytona"},
     )
-    monkeypatch.setattr("check_release_deps.changed_manifests", lambda _base, _head, _packages: manifests)
-    monkeypatch.setattr("check_release_deps.detect_package_bumps", lambda _manifests, _base: {})
     monkeypatch.setattr(
-        "check_release_deps.build_filtered_manifest",
-        lambda _data, _bumped: FilteredManifest(content=content, skipped=()),
+        "check_release_deps.changed_manifests", lambda _base, _head, _packages: manifests
     )
+    monkeypatch.setattr("check_release_deps.build_resolver_manifest", lambda _data: content)
     monkeypatch.setattr("check_release_deps.run_resolver", run_resolver)
 
     assert check_release_dependencies("base-sha", "head-sha") == 0
     assert len(resolver_paths) == len(manifests)
     assert len({path.parent for path in resolver_paths}) == len(manifests)
+
+
+def test_check_release_dependencies_noop_when_no_manifests_changed(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "check_release_deps.load_release_packages", lambda: {"libs/code": "deepagents-code"}
+    )
+    monkeypatch.setattr("check_release_deps.changed_manifests", lambda _base, _head, _packages: [])
+
+    def run_resolver(_manifest, _log) -> bool:
+        pytest.fail("resolver should not run when nothing changed")
+
+    monkeypatch.setattr("check_release_deps.run_resolver", run_resolver)
+
+    assert check_release_dependencies("base-sha", "head-sha") == 0
 
 
 def test_run_resolver_allows_prereleases_for_all_extras(monkeypatch, tmp_path) -> None:
@@ -193,113 +149,11 @@ dependencies = []
 
     command = commands[0]
     assert command[:3] == ["uv", "pip", "compile"]
+    assert "--no-sources" in command
     assert "--all-extras" in command
     assert command[command.index("--prerelease") + 1] == "allow"
     assert command[-1] == str(manifest)
     assert log.read_text(encoding="utf-8") == "resolved\n"
-
-
-def test_filtered_manifest_keeps_pin_not_satisfied_by_bump() -> None:
-    """A pin on a bumped package that the bump does NOT satisfy must be kept.
-
-    This is the core safety guarantee: stripping only happens when the same-PR
-    bump actually satisfies the specifier, so a stale pin still reaches the
-    resolver and fails.
-    """
-    data = {
-        "project": {
-            "name": "deepagents-code",
-            "version": "0.2.0",
-            "dependencies": ["deepagents==0.6.8"],
-        },
-    }
-    bumped = {"deepagents": PackageBump("deepagents", "0.7.0", "libs/deepagents/pyproject.toml")}
-
-    filtered = build_filtered_manifest(data, bumped)
-    parsed = tomllib.loads(filtered.content)
-
-    assert parsed["project"]["dependencies"] == ["deepagents==0.6.8"]
-    assert filtered.skipped == ()
-
-
-def test_filtered_manifest_keeps_unparseable_requirement() -> None:
-    """An unparseable dependency string is left in place, never silently dropped."""
-    data = {
-        "project": {
-            "name": "deepagents-code",
-            "version": "0.2.0",
-            "dependencies": ["deepagents @@@ broken"],
-        },
-    }
-    bumped = {"deepagents": PackageBump("deepagents", "0.7.0", "libs/deepagents/pyproject.toml")}
-
-    filtered = build_filtered_manifest(data, bumped)
-    parsed = tomllib.loads(filtered.content)
-
-    assert parsed["project"]["dependencies"] == ["deepagents @@@ broken"]
-    assert filtered.skipped == ()
-
-
-def test_detect_package_bumps_skips_unchanged_version(monkeypatch, tmp_path) -> None:
-    manifest = tmp_path / "pyproject.toml"
-    body = """
-[project]
-name = "deepagents"
-version = "0.7.0"
-dependencies = []
-""".strip()
-    manifest.write_text(body, encoding="utf-8")
-
-    monkeypatch.setattr("check_release_deps.REPO_ROOT", tmp_path)
-    monkeypatch.setattr("check_release_deps._git_show", lambda _base, _path: body)
-
-    assert detect_package_bumps(["pyproject.toml"], "base-sha") == {}
-
-
-def test_detect_package_bumps_skips_renamed_package(monkeypatch, tmp_path) -> None:
-    manifest = tmp_path / "pyproject.toml"
-    manifest.write_text(
-        """
-[project]
-name = "deepagents-code"
-version = "0.7.0"
-dependencies = []
-""".strip(),
-        encoding="utf-8",
-    )
-    base_manifest = """
-[project]
-name = "deepagents"
-version = "0.6.8"
-dependencies = []
-""".strip()
-
-    monkeypatch.setattr("check_release_deps.REPO_ROOT", tmp_path)
-    monkeypatch.setattr("check_release_deps._git_show", lambda _base, _path: base_manifest)
-
-    assert detect_package_bumps(["pyproject.toml"], "base-sha") == {}
-
-
-def test_detect_package_bumps_skips_dynamic_version(monkeypatch, tmp_path) -> None:
-    manifest = tmp_path / "pyproject.toml"
-    manifest.write_text(
-        """
-[project]
-name = "deepagents"
-dynamic = ["version"]
-dependencies = []
-""".strip(),
-        encoding="utf-8",
-    )
-
-    monkeypatch.setattr("check_release_deps.REPO_ROOT", tmp_path)
-    # _git_show should never be consulted once the dynamic head manifest is skipped.
-    monkeypatch.setattr(
-        "check_release_deps._git_show",
-        lambda _base, _path: pytest.fail("base manifest should not be read"),
-    )
-
-    assert detect_package_bumps(["pyproject.toml"], "base-sha") == {}
 
 
 def test_load_release_packages_resolves_name_then_component_then_path(tmp_path) -> None:

--- a/.github/workflows/check_release_deps.yml
+++ b/.github/workflows/check_release_deps.yml
@@ -1,9 +1,10 @@
 # Resolve release PR runtime dependencies against real PyPI.
 #
-# Coordinated release-please bumps can update multiple packages in one PR. The
-# bumped wheels are not on PyPI until merge, so the helper strips only the
-# dependency pins satisfied by packages bumped in this same PR, then resolves the
-# rest with `uv pip compile --no-sources --universal --prerelease allow --all-extras`.
+# Local development installs sibling packages as editable path dependencies via
+# `[tool.uv.sources]`, which hides whether a package's published dependencies
+# actually resolve. The helper strips those local sources and resolves each
+# changed release manifest against the real index with
+# `uv pip compile --no-sources --universal --prerelease allow --all-extras`.
 
 name: "📦 Check Release Dependencies"
 


### PR DESCRIPTION
Because `release-please-config.json` sets `separate-pull-requests: true`, a release PR only ever bumps a single package, so the same-PR-bump detection and dependency-pin stripping never fired (the bump set was always just the released package, which can't depend on itself). This removes that dead machinery (`detect_package_bumps`, `PackageBump`, the requirement/pin filtering) and resolves each changed release manifest directly against real PyPI after stripping local `[tool.uv.sources]`. Supersedes #3885.

Note: the `.github/workflows/check_release_deps.yml` header comment still describes the old behavior; it couldn't be updated here because the bot lacks `workflows` push permission.

## Test Plan
- [ ] `build_resolver_manifest` keeps all deps and drops `[tool.uv.sources]` while preserving resolver `[tool.uv]` keys
- [ ] `check_release_dependencies` resolves each changed manifest and is a no-op when none changed

Made by [Open SWE](https://openswe.vercel.app)