### PR TITLE
fix(ci): scope lockfile checks to touched packages

### DIFF
--- a/.github/scripts/check_lockfiles_pre_commit.py
+++ b/.github/scripts/check_lockfiles_pre_commit.py
@@ -1,4 +1,4 @@
-"""Run the lockfile check for pre-commit without unrelated Talon churn."""
+"""Run lockfile checks only for packages touched by changed paths."""
 
 from __future__ import annotations
 
@@ -9,17 +9,17 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LIBS_ROOT = REPO_ROOT / "libs"
 EXAMPLES_ROOT = REPO_ROOT / "examples"
-TALON_DIR = LIBS_ROOT / "talon"
 
 
-def _package_dirs(*, include_talon: bool) -> list[Path]:
+def _package_dirs() -> list[Path]:
     libs = [path.parent for path in LIBS_ROOT.glob("*/Makefile")]
     partners = [path.parent for path in (LIBS_ROOT / "partners").glob("*/Makefile")]
     examples = [path.parent for path in EXAMPLES_ROOT.glob("*/pyproject.toml")]
-    packages = [*libs, *partners, *examples]
-    if not include_talon:
-        packages = [package for package in packages if package != TALON_DIR]
-    return sorted(packages, key=lambda path: path.relative_to(REPO_ROOT).as_posix())
+    return sorted([*libs, *partners, *examples], key=_repo_path)
+
+
+def _repo_path(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
 
 
 def _python_version(package: Path) -> str:
@@ -35,17 +35,29 @@ def _label(package: Path) -> str:
         return f"../{package.relative_to(REPO_ROOT).as_posix()}"
 
 
-def _touches_talon(paths: list[str]) -> bool:
-    return any(Path(path).parts[:2] == ("libs", "talon") for path in paths)
+def _touches_package(path: str, package: Path) -> bool:
+    package_path = _repo_path(package)
+    return path == package_path or path.startswith(f"{package_path}/")
 
 
-def _include_talon(paths: list[str]) -> bool:
-    return not paths or _touches_talon(paths)
+def _packages_for_paths(paths: list[str]) -> list[Path]:
+    packages = _package_dirs()
+    if not paths:
+        return packages
+    return [
+        package
+        for package in packages
+        if any(_touches_package(path, package) for path in paths)
+    ]
 
 
 def main(paths: list[str]) -> int:
-    include_talon = _include_talon(paths)
-    for package in _package_dirs(include_talon=include_talon):
+    """Check lockfiles for packages touched by `paths`, or every package if empty."""
+    packages = _packages_for_paths(paths)
+    if not packages:
+        print("✅ No package lockfiles need checking.")
+        return 0
+    for package in packages:
         print(f"🔍 Checking {_label(package)}")
         result = subprocess.run(
             [

--- a/.github/scripts/test_check_lockfiles_pre_commit.py
+++ b/.github/scripts/test_check_lockfiles_pre_commit.py
@@ -1,25 +1,63 @@
-"""Tests for check_lockfiles_pre_commit (pre-commit Talon path selection)."""
+"""Tests for check_lockfiles_pre_commit changed path selection."""
 
-from check_lockfiles_pre_commit import _include_talon
+from pathlib import Path
+
+from check_lockfiles_pre_commit import REPO_ROOT, _packages_for_paths
+
+
+def _paths(packages: list[Path]) -> list[str]:
+    return [package.relative_to(REPO_ROOT).as_posix() for package in packages]
 
 
 def test_unrelated_paths_skip_talon() -> None:
-    """Changes to other packages never force Talon validation."""
-    paths = ["libs/deepagents/deepagents/graph.py", "libs/cli/uv.lock"]
-    assert _include_talon(paths) is False
+    """Unrelated multi-package changes select only those packages, never Talon."""
+    packages = _paths(
+        _packages_for_paths(["libs/deepagents/deepagents/graph.py", "libs/cli/uv.lock"])
+    )
+    assert packages == ["libs/cli", "libs/deepagents"]
+    assert "libs/talon" not in packages
 
 
 def test_talon_source_includes_talon() -> None:
-    """A Talon source/config edit forces Talon validation."""
-    assert _include_talon(["libs/talon/deepagents_talon/__init__.py"]) is True
-    assert _include_talon(["libs/talon/pyproject.toml"]) is True
+    """A Talon source/config edit selects Talon for validation."""
+    assert _paths(_packages_for_paths(["libs/talon/deepagents_talon/__init__.py"])) == [
+        "libs/talon"
+    ]
+    assert _paths(_packages_for_paths(["libs/talon/pyproject.toml"])) == ["libs/talon"]
 
 
 def test_talon_lockfile_includes_talon() -> None:
-    """A direct edit to libs/talon/uv.lock forces Talon validation."""
-    assert _include_talon(["libs/talon/uv.lock"]) is True
+    """A direct edit to libs/talon/uv.lock selects Talon."""
+    assert _paths(_packages_for_paths(["libs/talon/uv.lock"])) == ["libs/talon"]
 
 
-def test_empty_paths_include_talon() -> None:
-    """No paths preserves the full-check behavior (Talon included)."""
-    assert _include_talon([]) is True
+def test_empty_paths_check_all_packages() -> None:
+    """No paths preserves full-check behavior for manual runs."""
+    packages = _paths(_packages_for_paths([]))
+    assert "libs/deepagents" in packages
+    assert "libs/talon" in packages
+    assert "examples/async-subagent-server" in packages
+
+
+def test_changed_paths_check_only_touched_packages() -> None:
+    """Changed paths do not force unrelated lockfile updates."""
+    packages = _paths(
+        _packages_for_paths(
+            [
+                "libs/deepagents/deepagents/graph.py",
+                "libs/deepagents/uv.lock",
+            ]
+        )
+    )
+    assert packages == ["libs/deepagents"]
+
+
+def test_changed_partner_path_checks_only_that_partner() -> None:
+    """Nested partner paths match the owning partner package only."""
+    packages = _paths(_packages_for_paths(["libs/partners/daytona/pyproject.toml"]))
+    assert packages == ["libs/partners/daytona"]
+
+
+def test_unowned_paths_skip_lock_check() -> None:
+    """Non-package edits should not run repo-wide lock checks in PR mode."""
+    assert _packages_for_paths([".github/workflows/check_lockfiles.yml"]) == []


### PR DESCRIPTION
Lockfile validation now follows the same package boundary as the PR diff instead of treating every package in the repo as in scope. That keeps unrelated stale lockfiles from blocking scoped work or forcing extra path changes that release-please may interpret as release-relevant.