### PR TITLE
fix(code): label `-r` resume as `"Resuming..."` in the status bar

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1941,6 +1941,14 @@ class DeepAgentsApp(App):
         the meaningless `(_connecting=False, _reconnecting=True)` state.
         """
 
+        self._resuming = self._connecting and self._resume_thread_intent is not None
+        """True while the initial connect is resuming a thread (`-r`).
+
+        Lets the status bar label the spinner "Resuming" instead of the generic
+        "Connecting" during `-r` startup. Only meaningful while `_connecting` is
+        `True`; cleared whenever `_connecting` is cleared.
+        """
+
         self._server_startup_error: str | None = None
         """Set when the background server fails to start; persists for the
         session lifetime (server failure is terminal).
@@ -4292,6 +4300,7 @@ class DeepAgentsApp(App):
             self._reconnecting = False
         if not self._connecting:
             self._defer_connection_status_display = False
+            self._resuming = False
             self._cancel_connection_status_reveal_timer()
             self._status_bar.set_connection("")
         elif self._defer_connection_status_display:
@@ -4299,6 +4308,8 @@ class DeepAgentsApp(App):
             self._schedule_connection_status_reveal_timer()
         elif self._reconnecting:
             self._status_bar.set_connection("reconnecting")
+        elif self._resuming:
+            self._status_bar.set_connection("resuming")
         else:
             self._status_bar.set_connection("connecting")
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1946,7 +1946,12 @@ class DeepAgentsApp(App):
 
         Lets the status bar label the spinner "Resuming" instead of the generic
         "Connecting" during `-r` startup. Only meaningful while `_connecting` is
-        `True`; cleared whenever `_connecting` is cleared.
+        `True`; `_sync_status_connection` resets it to `False` whenever it
+        observes `_connecting` cleared.
+
+        Set once at init and never re-armed, since `_resume_thread_intent` is
+        consumed on the first connect — so unlike `_reconnecting` it needs no
+        caller-side reset discipline.
         """
 
         self._server_startup_error: str | None = None

--- a/libs/code/deepagents_code/widgets/status.py
+++ b/libs/code/deepagents_code/widgets/status.py
@@ -33,7 +33,7 @@ PROVIDER_PREFIX_STRIPS: dict[str, tuple[str, ...]] = {
 `accounts/fireworks/models/...` that crowd out the rest of the status bar;
 strip the registered prefixes before display."""
 
-ConnectionState = Literal["", "connecting", "reconnecting"]
+ConnectionState = Literal["", "connecting", "reconnecting", "resuming"]
 """Connection states the status bar can display (`''` means cleared)."""
 
 CONNECTION_STATES = frozenset(get_args(ConnectionState))
@@ -369,7 +369,7 @@ class StatusBar(Horizontal):
 
     def watch_connection_state(self, new_value: ConnectionState) -> None:
         """Start or stop the spinner and re-render when connection state changes."""
-        if new_value in {"connecting", "reconnecting"}:
+        if new_value in {"connecting", "reconnecting", "resuming"}:
             self._start_spinner()
         else:
             self._stop_spinner()
@@ -413,6 +413,8 @@ class StatusBar(Horizontal):
         parts: list[str] = []
         if self.connection_state == "reconnecting":
             parts.append(f"{self._spinner.current_frame()} Reconnecting")
+        elif self.connection_state == "resuming":
+            parts.append(f"{self._spinner.current_frame()} Resuming")
         elif self.connection_state == "connecting":
             parts.append(f"{self._spinner.current_frame()} Connecting")
         if self.queued_count > 0:
@@ -429,7 +431,8 @@ class StatusBar(Horizontal):
         """Set the connection indicator state.
 
         Args:
-            state: One of `''` (clear), `'connecting'`, or `'reconnecting'`.
+            state: One of `''` (clear), `'connecting'`, `'reconnecting'`, or
+                `'resuming'`.
 
         Raises:
             ValueError: If `state` is not a recognized connection state.

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -12811,6 +12811,49 @@ class TestStatusBarConnectionMirroring:
             assert app._status_bar is not None
             assert app._status_bar.connection_state == "connecting"
 
+    async def test_sync_reflects_resuming(self) -> None:
+        """A `-r` initial connect reads as resuming, not the generic connecting."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+        async with app.run_test():
+            app._connecting = True
+            app._reconnecting = False
+            app._resuming = True
+            app._sync_status_connection()
+            assert app._status_bar is not None
+            assert app._status_bar.connection_state == "resuming"
+
+    async def test_resume_intent_arms_resuming_flag(self) -> None:
+        """A `-r` resume intent with a pending connect should arm `_resuming`."""
+        app = DeepAgentsApp(
+            thread_id="thread-123",
+            resume_thread="thread-123",
+            server_kwargs={"assistant_id": "agent", "model_name": None},
+        )
+        assert app._connecting is True
+        assert app._resuming is True
+
+    async def test_no_resume_intent_leaves_resuming_unset(self) -> None:
+        """A plain connect (no `-r`) should not arm `_resuming`."""
+        app = DeepAgentsApp(
+            thread_id="thread-123",
+            server_kwargs={"assistant_id": "agent", "model_name": None},
+        )
+        assert app._connecting is True
+        assert app._resuming is False
+
+    async def test_sync_clears_resuming_when_connected(self) -> None:
+        """Clearing `_connecting` should also drop the resuming flag."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+        async with app.run_test():
+            app._connecting = True
+            app._resuming = True
+            app._sync_status_connection()
+            app._connecting = False
+            app._sync_status_connection()
+            assert app._resuming is False
+            assert app._status_bar is not None
+            assert app._status_bar.connection_state == ""
+
     async def test_sync_clears_when_connected(self) -> None:
         """Clearing `_connecting` should empty the connection indicator."""
         app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -12822,6 +12822,22 @@ class TestStatusBarConnectionMirroring:
             assert app._status_bar is not None
             assert app._status_bar.connection_state == "resuming"
 
+    async def test_sync_prefers_reconnecting_over_resuming(self) -> None:
+        """A reconnect of a resumed thread labels as reconnecting, not resuming.
+
+        Locks the precedence in `_sync_status_connection` (reconnect checked
+        before resume) so a future reorder of the branch chain can't surface
+        "Resuming" while a reconnect is in flight.
+        """
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+        async with app.run_test():
+            app._connecting = True
+            app._reconnecting = True
+            app._resuming = True
+            app._sync_status_connection()
+            assert app._status_bar is not None
+            assert app._status_bar.connection_state == "reconnecting"
+
     async def test_resume_intent_arms_resuming_flag(self) -> None:
         """A `-r` resume intent with a pending connect should arm `_resuming`."""
         app = DeepAgentsApp(

--- a/libs/code/tests/unit_tests/test_status.py
+++ b/libs/code/tests/unit_tests/test_status.py
@@ -456,6 +456,15 @@ class TestConnectionIndicator:
             indicator = pilot.app.query_one("#connection-indicator", Static)
             assert "Reconnecting" in str(indicator.render())
 
+    async def test_set_resuming_shows_message(self) -> None:
+        """`set_connection('resuming')` should surface a Resuming message."""
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_connection("resuming")
+            await pilot.pause()
+            indicator = pilot.app.query_one("#connection-indicator", Static)
+            assert "Resuming" in str(indicator.render())
+
     async def test_clearing_connection_clears_indicator(self) -> None:
         """Returning to the empty state should clear the indicator text."""
         async with StatusBarApp().run_test() as pilot:


### PR DESCRIPTION
`deepagents code -r` once again shows a "Resuming" status while resuming a thread instead of a generic "Connecting".

---

When connection progress moved from the welcome banner into the bottom status bar, the resume-specific footer was lost. As a result `dcode -r` rendered the generic "Connecting" spinner instead of the previous "Resuming" label.

This reintroduces a dedicated `resuming` connection state on the `StatusBar` and arms a new `_resuming` flag from the `-r` resume intent during the initial connect, mirroring how `_reconnecting` is handled. The flag is cleared whenever the connection clears, and reconnect labeling continues to take priority.

Made by [Open SWE](https://openswe.vercel.app)