### PR TITLE
fix(code): don't move cursor on click that re-focuses terminal

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -8612,7 +8612,7 @@ class DeepAgentsApp(App):
         """
         if self._chat_input is None:
             return
-        self._chat_input.notify_app_focus()
+        self._chat_input._notify_app_focus()
         self._chat_input.set_cursor_blink(blink=self._cursor_blink_enabled)
         if isinstance(self.screen, ModalScreen):
             return
@@ -8629,7 +8629,7 @@ class DeepAgentsApp(App):
         """
         if self._chat_input is None:
             return
-        self._chat_input.notify_app_blur()
+        self._chat_input._notify_app_blur()
         self._chat_input.set_cursor_blink(blink=False)
 
     def on_click(self, event: Click) -> None:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -8612,6 +8612,7 @@ class DeepAgentsApp(App):
         """
         if self._chat_input is None:
             return
+        self._chat_input.notify_app_focus()
         self._chat_input.set_cursor_blink(blink=self._cursor_blink_enabled)
         if isinstance(self.screen, ModalScreen):
             return
@@ -8628,6 +8629,7 @@ class DeepAgentsApp(App):
         """
         if self._chat_input is None:
             return
+        self._chat_input.notify_app_blur()
         self._chat_input.set_cursor_blink(blink=False)
 
     def on_click(self, event: Click) -> None:

--- a/libs/code/deepagents_code/widgets/chat_input.py
+++ b/libs/code/deepagents_code/widgets/chat_input.py
@@ -104,10 +104,18 @@ have a much larger gap."""
 _REFOCUS_CLICK_SUPPRESS_WINDOW_SECONDS = 0.3
 """Window after a terminal focus regain during which a click only refocuses.
 
-When the terminal window is unfocused and the user clicks back in, the OS
-delivers a `FocusIn` (Textual `AppFocus`) just before the mouse report. A
+When the terminal window is unfocused and the user clicks back in, we rely on
+the OS delivering a `FocusIn` (Textual `AppFocus`) before the mouse report —
+the same FocusIn support `on_app_focus` documents. Terminals without it never
+arm suppression, so clicks just behave normally (the cursor moves). A
 mouse-down landing within this window after the focus regain is treated as
 focus-only so the cursor stays put instead of jumping to the click location.
+
+The window trades off two failure modes: too small and a genuine refocus click
+leaks through and moves the cursor (the bug this guards against); too large and
+an intentional click made shortly after refocusing is wrongly suppressed. 0.3s
+comfortably covers the FocusIn-to-mouse-report latency while staying below a
+deliberate click-pause-click interaction.
 """
 
 if TYPE_CHECKING:
@@ -628,11 +636,11 @@ class ChatTextArea(TextArea):
         if has_focus and not self.has_focus:
             self.call_after_refresh(self.focus)
 
-    def notify_app_blur(self) -> None:
+    def _notify_app_blur(self) -> None:
         """Record that the terminal window lost OS focus."""
         self._app_blurred = True
 
-    def notify_app_focus(self) -> None:
+    def _notify_app_focus(self) -> None:
         """Record that the terminal window regained OS focus via a focus event.
 
         Stamps the regain time so the click that re-focused the window (which
@@ -643,7 +651,13 @@ class ChatTextArea(TextArea):
             self._app_blurred = False
 
     def _consume_refocus_click(self) -> bool:
-        """Return whether the current mouse-down only re-focuses the window."""
+        """Return whether the current mouse-down only re-focuses the window.
+
+        `_refocus_time` is only cleared here, so a focus regain that is never
+        followed by a text-area click leaves the stamp set. The gap check
+        bounds that staleness: an old stamp exceeds the window and returns
+        `False` (clearing it), so a much later click is never suppressed.
+        """
         refocus_time = self._refocus_time
         if refocus_time is None:
             return False
@@ -656,6 +670,11 @@ class ChatTextArea(TextArea):
 
         A mouse-down landing within a short window after a terminal focus
         regain only restores focus and leaves the cursor where it was.
+
+        Deliberately shadows Textual's private `TextArea._on_mouse_down` to gate
+        cursor positioning; verified against Textual 8.2.7. If the base handler
+        changes, re-verify that early-returning before `super()` still leaves no
+        selection/capture state set.
         """
         if self._consume_refocus_click():
             event.stop()
@@ -2320,15 +2339,15 @@ class ChatInput(Vertical):
         if self._text_area is not None:
             self._text_area.cursor_blink = blink
 
-    def notify_app_blur(self) -> None:
+    def _notify_app_blur(self) -> None:
         """Tell the text area the terminal window lost OS focus."""
         if self._text_area is not None:
-            self._text_area.notify_app_blur()
+            self._text_area._notify_app_blur()
 
-    def notify_app_focus(self) -> None:
+    def _notify_app_focus(self) -> None:
         """Tell the text area the terminal window regained OS focus."""
         if self._text_area is not None:
-            self._text_area.notify_app_focus()
+            self._text_area._notify_app_focus()
 
     def exit_mode(self) -> bool:
         """Exit the current input mode (command/shell) back to normal.

--- a/libs/code/deepagents_code/widgets/chat_input.py
+++ b/libs/code/deepagents_code/widgets/chat_input.py
@@ -101,6 +101,15 @@ generous (150 ms) because the terminal emits both characters nearly
 simultaneously; a human deliberately typing `\\` then pressing Enter would
 have a much larger gap."""
 
+_REFOCUS_CLICK_SUPPRESS_WINDOW_SECONDS = 0.3
+"""Window after a terminal focus regain during which a click only refocuses.
+
+When the terminal window is unfocused and the user clicks back in, the OS
+delivers a `FocusIn` (Textual `AppFocus`) just before the mouse report. A
+mouse-down landing within this window after the focus regain is treated as
+focus-only so the cursor stays put instead of jumping to the click location.
+"""
+
 if TYPE_CHECKING:
     from textual import events
     from textual.app import ComposeResult
@@ -453,6 +462,11 @@ class ChatTextArea(TextArea):
         self._paste_burst_window_until: float | None = None
         # See _BACKSLASH_ENTER_GAP_SECONDS for context.
         self._backslash_pending_time: float | None = None
+        # Tracks terminal focus so a click that re-focuses the window only
+        # restores focus instead of also moving the cursor. See
+        # `_REFOCUS_CLICK_SUPPRESS_WINDOW_SECONDS`.
+        self._app_blurred = False
+        self._refocus_time: float | None = None
 
     def render_line(self, y: int) -> Strip:
         """Render a single line, appending any argument hint at line end.
@@ -613,6 +627,41 @@ class ChatTextArea(TextArea):
         self._backslash_pending_time = None
         if has_focus and not self.has_focus:
             self.call_after_refresh(self.focus)
+
+    def notify_app_blur(self) -> None:
+        """Record that the terminal window lost OS focus."""
+        self._app_blurred = True
+
+    def notify_app_focus(self) -> None:
+        """Record that the terminal window regained OS focus via a focus event.
+
+        Stamps the regain time so the click that re-focused the window (which
+        arrives just after the focus event) can be treated as focus-only.
+        """
+        if self._app_blurred:
+            self._refocus_time = time.monotonic()
+            self._app_blurred = False
+
+    def _consume_refocus_click(self) -> bool:
+        """Return whether the current mouse-down only re-focuses the window."""
+        refocus_time = self._refocus_time
+        if refocus_time is None:
+            return False
+        self._refocus_time = None
+        gap = time.monotonic() - refocus_time
+        return gap <= _REFOCUS_CLICK_SUPPRESS_WINDOW_SECONDS
+
+    async def _on_mouse_down(self, event: events.MouseDown) -> None:
+        """Position the cursor on click, except when the click re-focuses the app.
+
+        A mouse-down landing within a short window after a terminal focus
+        regain only restores focus and leaves the cursor where it was.
+        """
+        if self._consume_refocus_click():
+            event.stop()
+            event.prevent_default()
+            return
+        await super()._on_mouse_down(event)
 
     def set_completion_active(self, *, active: bool) -> None:
         """Set whether completion suggestions are visible."""
@@ -2270,6 +2319,16 @@ class ChatInput(Vertical):
         """
         if self._text_area is not None:
             self._text_area.cursor_blink = blink
+
+    def notify_app_blur(self) -> None:
+        """Tell the text area the terminal window lost OS focus."""
+        if self._text_area is not None:
+            self._text_area.notify_app_blur()
+
+    def notify_app_focus(self) -> None:
+        """Tell the text area the terminal window regained OS focus."""
+        if self._text_area is not None:
+            self._text_area.notify_app_focus()
 
     def exit_mode(self) -> bool:
         """Exit the current input mode (command/shell) back to normal.

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -3991,6 +3991,29 @@ class TestAppFocusRestoresChatInput:
 
             assert app._chat_input._text_area.cursor_blink is True
 
+    async def test_app_blur_then_focus_arms_refocus_suppression(self) -> None:
+        """`on_app_blur`/`on_app_focus` forward terminal focus state to the input.
+
+        Guards the wiring between the app's focus handlers and the text area:
+        without these forwarded calls the refocus-click suppression never arms,
+        so the cursor-jump fix would silently break while its own unit tests
+        (which poke the text area directly) keep passing.
+        """
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._chat_input is not None
+            text_area = app._chat_input._text_area
+            assert text_area is not None
+
+            app.on_app_blur()
+            assert text_area._app_blurred is True
+
+            app.on_app_focus()
+            await pilot.pause()
+            assert text_area._app_blurred is False
+            assert text_area._refocus_time is not None
+
 
 class TestChatScrollKeepsInputFocus:
     """Clicking a chat message must not steal focus from the chat input."""

--- a/libs/code/tests/unit_tests/test_chat_input.py
+++ b/libs/code/tests/unit_tests/test_chat_input.py
@@ -568,6 +568,62 @@ class TestSetValueAtEnd:
             assert text_area.cursor_location == (1, len("second"))
 
 
+class TestRefocusClickSuppression:
+    """Clicks that re-focus the terminal window should not move the cursor."""
+
+    async def test_refocus_click_does_not_move_cursor(self) -> None:
+        """A click within the refocus window only restores focus."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            text_area = chat._text_area
+            assert text_area is not None
+
+            text_area.insert("hello world")
+            text_area.move_cursor((0, 0))
+            await pilot.pause()
+            assert text_area.cursor_location == (0, 0)
+
+            chat.notify_app_blur()
+            chat.notify_app_focus()
+            await pilot.click(ChatTextArea, offset=(6, 0))
+            await pilot.pause()
+
+            assert text_area.cursor_location == (0, 0)
+
+    async def test_click_while_focused_moves_cursor(self) -> None:
+        """A click without a preceding refocus moves the cursor normally."""
+        app = _ChatInputTestApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            text_area = chat._text_area
+            assert text_area is not None
+
+            text_area.insert("hello world")
+            text_area.move_cursor((0, 0))
+            await pilot.pause()
+            assert text_area.cursor_location == (0, 0)
+
+            await pilot.click(ChatTextArea, offset=(6, 0))
+            await pilot.pause()
+
+            assert text_area.cursor_location != (0, 0)
+
+    def test_consume_refocus_click_requires_blur(self) -> None:
+        """Without a preceding blur, focus does not arm click suppression."""
+        text_area = ChatTextArea()
+        text_area.notify_app_focus()
+        assert text_area._consume_refocus_click() is False
+
+    def test_consume_refocus_click_fires_once(self) -> None:
+        """Only the first click after a refocus is suppressed."""
+        text_area = ChatTextArea()
+        text_area.notify_app_blur()
+        text_area.notify_app_focus()
+        assert text_area._consume_refocus_click() is True
+        assert text_area._consume_refocus_click() is False
+
+
 class TestHistoryBoundaryNavigation:
     """Test that history navigation only triggers at input boundaries."""
 

--- a/libs/code/tests/unit_tests/test_chat_input.py
+++ b/libs/code/tests/unit_tests/test_chat_input.py
@@ -571,8 +571,15 @@ class TestSetValueAtEnd:
 class TestRefocusClickSuppression:
     """Clicks that re-focus the terminal window should not move the cursor."""
 
-    async def test_refocus_click_does_not_move_cursor(self) -> None:
+    async def test_refocus_click_does_not_move_cursor(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A click within the refocus window only restores focus."""
+        # Widen the window so the test never depends on how fast the event loop
+        # delivers the click after the refocus stamp (avoids wall-clock flake).
+        monkeypatch.setattr(
+            chat_input_module, "_REFOCUS_CLICK_SUPPRESS_WINDOW_SECONDS", 60.0
+        )
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
@@ -584,8 +591,8 @@ class TestRefocusClickSuppression:
             await pilot.pause()
             assert text_area.cursor_location == (0, 0)
 
-            chat.notify_app_blur()
-            chat.notify_app_focus()
+            chat._notify_app_blur()
+            chat._notify_app_focus()
             await pilot.click(ChatTextArea, offset=(6, 0))
             await pilot.pause()
 
@@ -612,16 +619,40 @@ class TestRefocusClickSuppression:
     def test_consume_refocus_click_requires_blur(self) -> None:
         """Without a preceding blur, focus does not arm click suppression."""
         text_area = ChatTextArea()
-        text_area.notify_app_focus()
+        text_area._notify_app_focus()
         assert text_area._consume_refocus_click() is False
 
     def test_consume_refocus_click_fires_once(self) -> None:
         """Only the first click after a refocus is suppressed."""
         text_area = ChatTextArea()
-        text_area.notify_app_blur()
-        text_area.notify_app_focus()
+        text_area._notify_app_blur()
+        text_area._notify_app_focus()
         assert text_area._consume_refocus_click() is True
         assert text_area._consume_refocus_click() is False
+
+    def test_consume_refocus_click_expires_after_window(self) -> None:
+        """A click landing after the window elapses moves the cursor normally."""
+        text_area = ChatTextArea()
+        text_area._notify_app_blur()
+        text_area._notify_app_focus()
+        # Backdate the refocus stamp past the window so the gap check fails.
+        text_area._refocus_time = (
+            chat_input_module.time.monotonic()
+            - chat_input_module._REFOCUS_CLICK_SUPPRESS_WINDOW_SECONDS
+            - 0.01
+        )
+        assert text_area._consume_refocus_click() is False
+
+    def test_consume_refocus_click_rearms_each_cycle(self) -> None:
+        """Suppression re-arms on every blur/focus cycle, not just the first."""
+        text_area = ChatTextArea()
+        text_area._notify_app_blur()
+        text_area._notify_app_focus()
+        assert text_area._consume_refocus_click() is True
+        # A second cycle must arm suppression again.
+        text_area._notify_app_blur()
+        text_area._notify_app_focus()
+        assert text_area._consume_refocus_click() is True
 
 
 class TestHistoryBoundaryNavigation:

--- a/libs/code/uv.lock
+++ b/libs/code/uv.lock
@@ -989,7 +989,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.2.5,<5.0.0" },
     { name = "langchain-quickjs", marker = "extra == 'quickjs'" },
     { name = "langsmith", specifier = ">=0.8.11" },
-    { name = "wcmatch" },
+    { name = "wcmatch", specifier = ">=10.1" },
 ]
 provides-extras = ["quickjs"]
 


### PR DESCRIPTION
Clicking back into the terminal to refocus no longer moves the chat input cursor.

---

When the terminal window is unfocused and the user clicks back into the chat input, that click previously both restored focus and moved the cursor to the click location. The `ChatTextArea` now tracks `AppBlur`/`AppFocus` and treats a mouse-down landing within a short window after a focus regain as focus-only, leaving the cursor where it was. Clicks while the window is already focused behave normally.

Made by [Open SWE](https://openswe.vercel.app)