### PR TITLE
fix(ci): report actionable lockfile check failures

### DIFF
--- a/.github/scripts/check_lockfiles_pre_commit.py
+++ b/.github/scripts/check_lockfiles_pre_commit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -51,6 +52,30 @@ def _packages_for_paths(paths: list[str]) -> list[Path]:
     ]
 
 
+def _lock_command(package: Path, *, check: bool) -> list[str]:
+    command = ["uv", "lock"]
+    if check:
+        command.append("--check")
+    return [
+        *command,
+        "--directory",
+        package.relative_to(REPO_ROOT).as_posix(),
+        "--python",
+        _python_version(package),
+    ]
+
+
+def _lockfile_error(package: Path) -> str:
+    package_path = package.relative_to(REPO_ROOT).as_posix()
+    lockfile = f"{package_path}/uv.lock"
+    command = shlex.join(_lock_command(package, check=False))
+    return (
+        f"::error file={lockfile},title=Out-of-date uv.lock::"
+        f"{lockfile} is out of sync with {package_path}/pyproject.toml. "
+        f"From the repository root, run `{command}` and commit the updated lockfile."
+    )
+
+
 def main(paths: list[str]) -> int:
     """Check lockfiles for packages touched by `paths`, or every package if empty."""
     packages = _packages_for_paths(paths)
@@ -60,18 +85,12 @@ def main(paths: list[str]) -> int:
     for package in packages:
         print(f"🔍 Checking {_label(package)}")
         result = subprocess.run(
-            [
-                "uv",
-                "lock",
-                "--check",
-                "--directory",
-                str(package),
-                "--python",
-                _python_version(package),
-            ],
+            _lock_command(package, check=True),
             check=False,
+            cwd=REPO_ROOT,
         )
         if result.returncode != 0:
+            print(_lockfile_error(package), file=sys.stderr)
             return result.returncode
     print("✅ All applicable lockfiles are up-to-date!")
     return 0

--- a/.github/scripts/test_check_lockfiles_pre_commit.py
+++ b/.github/scripts/test_check_lockfiles_pre_commit.py
@@ -1,8 +1,17 @@
 """Tests for check_lockfiles_pre_commit changed path selection."""
 
 from pathlib import Path
+from types import SimpleNamespace
 
-from check_lockfiles_pre_commit import REPO_ROOT, _packages_for_paths
+import check_lockfiles_pre_commit
+from check_lockfiles_pre_commit import (
+    LIBS_ROOT,
+    REPO_ROOT,
+    _lock_command,
+    _lockfile_error,
+    _packages_for_paths,
+    main,
+)
 
 
 def _paths(packages: list[Path]) -> list[str]:
@@ -61,3 +70,67 @@ def test_changed_partner_path_checks_only_that_partner() -> None:
 def test_unowned_paths_skip_lock_check() -> None:
     """Non-package edits should not run repo-wide lock checks in PR mode."""
     assert _packages_for_paths([".github/workflows/check_lockfiles.yml"]) == []
+
+
+def test_lock_command_uses_package_specific_python_version() -> None:
+    """The suggested and checked commands preserve package Python requirements."""
+    assert _lock_command(LIBS_ROOT / "evals", check=True) == [
+        "uv",
+        "lock",
+        "--check",
+        "--directory",
+        "libs/evals",
+        "--python",
+        "3.12",
+    ]
+    assert _lock_command(LIBS_ROOT / "acp", check=False) == [
+        "uv",
+        "lock",
+        "--directory",
+        "libs/acp",
+        "--python",
+        "3.14",
+    ]
+
+
+def test_lockfile_error_names_package_and_fix_command() -> None:
+    """Failure output points at the stale lockfile and the exact relock command."""
+    assert _lockfile_error(LIBS_ROOT / "evals") == (
+        "::error file=libs/evals/uv.lock,title=Out-of-date uv.lock::"
+        "libs/evals/uv.lock is out of sync with libs/evals/pyproject.toml. "
+        "From the repository root, run `uv lock --directory libs/evals "
+        "--python 3.12` and commit the updated lockfile."
+    )
+
+
+def test_main_prints_actionable_error_on_lock_failure(monkeypatch, capsys) -> None:
+    """A stale lockfile failure includes the package path and exact fix command."""
+    package = LIBS_ROOT / "evals"
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], *, check: bool, cwd: Path) -> SimpleNamespace:
+        commands.append(command)
+        assert check is False
+        assert cwd == REPO_ROOT
+        return SimpleNamespace(returncode=1)
+
+    monkeypatch.setattr(check_lockfiles_pre_commit, "_package_dirs", lambda: [package])
+    monkeypatch.setattr(check_lockfiles_pre_commit.subprocess, "run", fake_run)
+
+    assert main(["libs/evals/pyproject.toml"]) == 1
+    captured = capsys.readouterr()
+
+    assert commands == [
+        [
+            "uv",
+            "lock",
+            "--check",
+            "--directory",
+            "libs/evals",
+            "--python",
+            "3.12",
+        ]
+    ]
+    assert "🔍 Checking evals" in captured.out
+    assert "libs/evals/uv.lock is out of sync" in captured.err
+    assert "uv lock --directory libs/evals --python 3.12" in captured.err


### PR DESCRIPTION
Lockfile validation now uses a single command builder for both the `uv lock --check` invocation and the recovery command shown to contributors. Failures point at the stale `uv.lock` with a GitHub annotation and the exact repo-root command needed to regenerate it.