### PR TITLE
refactor(code): stop reinjecting SDK version metadata

### DIFF
--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -826,19 +826,10 @@ def build_stream_config(
 ) -> RunnableConfig:
     """Build the LangGraph stream config dict.
 
-    Injects dcode and SDK versions into `metadata["versions"]` so LangSmith traces
-    can be correlated with specific releases.
-
-    Why dcode sets *both* versions:
-
-    * `create_deep_agent` bakes `versions: {"deepagents": "X.Y.Z"}` into the
-        compiled graph via `with_config`. At stream time, LangGraph merges
-        the graph config with the runtime config passed here. Because the
-        metadata merge is shallow (effectively `{**graph_meta, **runtime_meta}`
-        for top-level keys), both configs containing a `versions` key means
-        the runtime dict **replaces** the graph dict entirely — the SDK
-        version would be lost.
-    * Including the SDK version here ensures it survives the merge.
+    Injects the dcode version into `metadata["versions"]` so LangSmith traces
+    can be correlated with specific releases. `create_deep_agent` supplies the
+    SDK version through the compiled graph config, and LangChain merges nested
+    metadata dictionaries so both versions survive at stream time.
 
     Includes `ls_integration` metadata so LangSmith traces originating from
     the app are distinguishable from bare SDK usage.
@@ -852,8 +843,6 @@ def build_stream_config(
     Returns:
         Config dict with `configurable` and `metadata` keys.
     """
-    import contextlib
-    import importlib.metadata as importlib_metadata
     from datetime import UTC, datetime
 
     try:
@@ -862,13 +851,8 @@ def build_stream_config(
         logger.warning("Could not determine working directory", exc_info=True)
         cwd = ""
 
-    # Include SDK version alongside dcode version — see docstring for why.
-    versions: dict[str, str] = {"deepagents-code": __version__}
-    with contextlib.suppress(importlib_metadata.PackageNotFoundError):
-        versions["deepagents"] = importlib_metadata.version("deepagents")
-
     metadata: dict[str, Any] = {
-        "versions": versions,
+        "versions": {"deepagents-code": __version__},
         "ls_integration": "deepagents-code",
     }
     from deepagents_code._env_vars import USER_ID

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -611,29 +611,6 @@ class TestBuildStreamConfig:
         config = build_stream_config("t-ver", assistant_id=None)
         assert config["metadata"]["versions"]["deepagents-code"] == __version__
 
-    def test_versions_contains_sdk_version_when_installed(self) -> None:
-        """SDK version should be in versions when deepagents is installed."""
-        with patch(
-            "importlib.metadata.version",
-            return_value="0.5.0",
-        ):
-            config = build_stream_config("t-sdk", assistant_id=None)
-        assert config["metadata"]["versions"]["deepagents"] == "0.5.0"
-
-    def test_versions_omits_sdk_when_not_installed(self) -> None:
-        """SDK version key should be absent when deepagents is not installed."""
-        from importlib.metadata import PackageNotFoundError
-
-        with patch(
-            "importlib.metadata.version",
-            side_effect=PackageNotFoundError("deepagents"),
-        ):
-            config = build_stream_config("t-nosdk", assistant_id=None)
-        assert "deepagents" not in config["metadata"]["versions"]
-        from deepagents_code._version import __version__
-
-        assert config["metadata"]["versions"]["deepagents-code"] == __version__
-
     def test_user_id_included_when_set(self) -> None:
         """DEEPAGENTS_CODE_USER_ID should appear in metadata when set."""
         with patch.dict("os.environ", {"DEEPAGENTS_CODE_USER_ID": "mason"}):


### PR DESCRIPTION
With LangChain's nested metadata merge available in the supported `langchain-core` range, dcode no longer needs to duplicate SDK version metadata at stream time. Runtime configs now report the dcode version only, while the compiled deep agent graph remains responsible for contributing the SDK version.