### PR TITLE
feat(code): surface editable mode and core deps in `/version`

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -4171,6 +4171,10 @@ class DeepAgentsApp(App):
         then persists the result so subsequent calls stay local. The
         update-available hint reads `self._update_available`, which
         reflects the last completed background check.
+
+        Editable installs additionally surface the source path and the
+        resolved versions of the core LangChain-ecosystem dependencies, which
+        helps diagnose local checkouts.
         """
         from importlib.metadata import (
             PackageNotFoundError,
@@ -4204,6 +4208,22 @@ class DeepAgentsApp(App):
             logger.warning("Unexpected error looking up SDK version", exc_info=True)
             lines.append("deepagents (SDK) version: unknown")
 
+        editable = False
+        try:
+            from deepagents_code.config import (
+                _get_editable_install_path,
+                _is_editable_install,
+            )
+
+            editable = await asyncio.to_thread(_is_editable_install)
+            if editable:
+                path = _get_editable_install_path()
+                lines.append(
+                    f"Editable install: {path}" if path else "Editable install"
+                )
+        except Exception:
+            logger.warning("Unexpected error detecting editable install", exc_info=True)
+
         available, latest = self._update_available
         if available and latest:
             try:
@@ -4222,6 +4242,19 @@ class DeepAgentsApp(App):
             lines.extend(("", f"Update available: v{latest}. Run: {cmd}"))
 
         await self._mount_message(AppMessage("\n".join(lines)))
+
+        if editable:
+            try:
+                from deepagents_code.extras_info import format_core_dependencies
+
+                core_markdown = format_core_dependencies()
+            except Exception:
+                logger.warning(
+                    "Failed to collect core dependency versions", exc_info=True
+                )
+                core_markdown = ""
+            if core_markdown:
+                await self._mount_message(AppMessage(core_markdown, markdown=True))
 
         try:
             from deepagents_code.extras_info import (

--- a/libs/code/deepagents_code/extras_info.py
+++ b/libs/code/deepagents_code/extras_info.py
@@ -409,6 +409,65 @@ def format_extras_status_plain(status: ExtrasStatus) -> str:
     return "\n".join(lines)
 
 
+CORE_DEPENDENCIES: tuple[str, ...] = (
+    "langchain",
+    "langchain-core",
+    "langgraph",
+    "langgraph-checkpoint",
+    "langgraph-prebuilt",
+    "langgraph-sdk",
+    "langsmith",
+)
+"""Core LangChain-ecosystem packages surfaced for editable installs.
+
+The deepagents SDK is reported separately by `/version`, so it is omitted
+here. These are the packages a local checkout is most likely to pin or
+override, so their resolved versions help diagnose editable environments.
+"""
+
+
+def get_core_dependency_versions() -> list[tuple[str, str | None]]:
+    """Return `(package, version)` pairs for the core ecosystem dependencies.
+
+    Returns:
+        One entry per package in `CORE_DEPENDENCIES`, in declaration order.
+            The version is `None` when the package is not installed.
+    """
+    versions: list[tuple[str, str | None]] = []
+    for name in CORE_DEPENDENCIES:
+        try:
+            versions.append((name, pkg_version(name)))
+        except PackageNotFoundError:
+            versions.append((name, None))
+    return versions
+
+
+def format_core_dependencies() -> str:
+    """Render core ecosystem dependency versions as a markdown fragment.
+
+    Returns:
+        Multi-line markdown string with a heading and a pipe table listing
+            each core package and its resolved version (or `not installed`).
+    """
+    rows = [
+        (name, version or "not installed")
+        for name, version in get_core_dependency_versions()
+    ]
+    headers = ("Package", "Version")
+
+    def _row(cells: tuple[str, str]) -> str:
+        return "| " + " | ".join(cells) + " |"
+
+    lines = [
+        "### Core dependencies",
+        "",
+        _row(headers),
+        "| " + " | ".join("---" for _ in headers) + " |",
+        *(_row(row) for row in rows),
+    ]
+    return "\n".join(lines)
+
+
 def format_extras_status(status: ExtrasStatus) -> str:
     """Render an `ExtrasStatus` mapping as a markdown fragment.
 

--- a/libs/code/deepagents_code/extras_info.py
+++ b/libs/code/deepagents_code/extras_info.py
@@ -442,6 +442,26 @@ def get_core_dependency_versions() -> list[tuple[str, str | None]]:
     return versions
 
 
+def format_core_dependencies_plain() -> str:
+    """Render core ecosystem dependency versions as column-aligned plain text.
+
+    Suitable for stdout in non-interactive contexts (e.g. the `--version`
+    CLI flag) where a markdown renderer is unavailable.
+
+    Returns:
+        Multi-line string with a heading and one `package  version` row per
+            core dependency. Missing packages are reported as `not installed`.
+    """
+    rows = [
+        (name, version or "not installed")
+        for name, version in get_core_dependency_versions()
+    ]
+    package_width = max(len(name) for name, _ in rows)
+    lines = ["Core dependencies:"]
+    lines.extend(f"  {name.ljust(package_width)}  {version}" for name, version in rows)
+    return "\n".join(lines)
+
+
 def format_core_dependencies() -> str:
     """Render core ecosystem dependency versions as a markdown fragment.
 

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -40,6 +40,74 @@ _SANDBOX_DEFAULT_SENTINEL = "\x00default"
 """Marker stored by `--sandbox` with no value, resolved to `[sandboxes].default`."""
 
 
+def build_version_text() -> str:
+    """Build the plain-text output for the `--version` CLI flag.
+
+    Includes the CLI and SDK versions and any installed optional
+    dependencies. For editable installs it also reports the source path and
+    the resolved versions of the core LangChain-ecosystem dependencies,
+    mirroring the `/version` slash command.
+
+    Returns:
+        Multi-line version string suitable for stdout.
+    """
+    from importlib.metadata import (
+        PackageNotFoundError,
+        version as _pkg_version,
+    )
+
+    try:
+        sdk_version = _pkg_version("deepagents")
+    except PackageNotFoundError:
+        logger.debug("deepagents SDK package not found in environment")
+        sdk_version = "unknown"
+    except Exception:  # Best-effort SDK version lookup
+        logger.warning("Unexpected error looking up SDK version", exc_info=True)
+        sdk_version = "unknown"
+
+    text = f"deepagents-code {__version__}\ndeepagents (SDK) {sdk_version}"
+
+    editable = False
+    try:
+        from deepagents_code.config import (
+            _get_editable_install_path,
+            _is_editable_install,
+        )
+
+        editable = _is_editable_install()
+        if editable:
+            path = _get_editable_install_path()
+            text += f"\nEditable install: {path}" if path else "\nEditable install"
+    except Exception:
+        logger.warning("Unexpected error detecting editable install", exc_info=True)
+
+    try:
+        from deepagents_code.extras_info import (
+            format_extras_status_plain,
+            get_extras_status,
+        )
+
+        extras_text = format_extras_status_plain(get_extras_status())
+    except Exception:
+        logger.warning("Unexpected error collecting optional deps", exc_info=True)
+        extras_text = ""
+    if extras_text:
+        text = f"{text}\n\n{extras_text}"
+
+    if editable:
+        try:
+            from deepagents_code.extras_info import format_core_dependencies_plain
+
+            core_text = format_core_dependencies_plain()
+        except Exception:
+            logger.warning("Failed to collect core dependency versions", exc_info=True)
+            core_text = ""
+        if core_text:
+            text = f"{text}\n\n{core_text}"
+
+    return text
+
+
 def _restart_current_process() -> NoReturn:
     """Replace the current process with a fresh `deepagents_code` invocation.
 
@@ -1197,19 +1265,6 @@ def parse_args() -> argparse.Namespace:
         "'safe,task'). Default is no PTC (pure REPL).",
     )
 
-    try:
-        from importlib.metadata import (
-            PackageNotFoundError,
-            version as _pkg_version,
-        )
-
-        sdk_version = _pkg_version("deepagents")
-    except PackageNotFoundError:
-        logger.debug("deepagents SDK package not found in environment")
-        sdk_version = "unknown"
-    except Exception:
-        logger.warning("Unexpected error looking up SDK version", exc_info=True)
-        sdk_version = "unknown"
     parser.add_argument(
         "--update",
         action="store_true",
@@ -1244,22 +1299,12 @@ def parse_args() -> argparse.Namespace:
         help="Run as an ACP server over stdio instead of launching the Textual UI",
     )
 
-    version_text = f"deepagents-code {__version__}\ndeepagents (SDK) {sdk_version}"
     # `parse_args` runs on every invocation; keep the import-heavy metadata
     # scan off the hot path unless the user explicitly asked for --version.
     if any(arg in {"-v", "--version"} for arg in sys.argv[1:]):
-        try:
-            from deepagents_code.extras_info import (
-                format_extras_status_plain,
-                get_extras_status,
-            )
-
-            extras_text = format_extras_status_plain(get_extras_status())
-        except Exception:
-            logger.warning("Unexpected error collecting optional deps", exc_info=True)
-            extras_text = ""
-        if extras_text:
-            version_text = f"{version_text}\n\n{extras_text}"
+        version_text = build_version_text()
+    else:
+        version_text = f"deepagents-code {__version__}"
     parser.add_argument(
         "-v",
         "--version",
@@ -2014,32 +2059,7 @@ def cli_main() -> None:
 
     # Fast path: print version without loading heavy dependencies
     if len(sys.argv) == 2 and sys.argv[1] in {"-v", "--version"}:  # noqa: PLR2004  # argv length check for fast-path
-        try:
-            from importlib.metadata import (
-                PackageNotFoundError,
-                version as _pkg_version,
-            )
-
-            sdk_version = _pkg_version("deepagents")
-        except PackageNotFoundError:
-            sdk_version = "unknown"
-        except Exception:  # Best-effort SDK version lookup
-            logger.debug("Unexpected error looking up SDK version", exc_info=True)
-            sdk_version = "unknown"
-        output = f"deepagents-code {__version__}\ndeepagents (SDK) {sdk_version}"
-        try:
-            from deepagents_code.extras_info import (
-                format_extras_status_plain,
-                get_extras_status,
-            )
-
-            extras_text = format_extras_status_plain(get_extras_status())
-        except Exception:
-            logger.warning("Unexpected error collecting optional deps", exc_info=True)
-            extras_text = ""
-        if extras_text:
-            output = f"{output}\n\n{extras_text}"
-        print(output)  # noqa: T201  # Version output
+        print(build_version_text())  # noqa: T201  # Version output
         sys.exit(0)
 
     # ACP mode does not require Textual, so skip UI dependency checks when

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -45,8 +45,12 @@ def build_version_text() -> str:
 
     Includes the CLI and SDK versions and any installed optional
     dependencies. For editable installs it also reports the source path and
-    the resolved versions of the core LangChain-ecosystem dependencies,
-    mirroring the `/version` slash command.
+    the resolved versions of the core LangChain-ecosystem dependencies.
+
+    Reports the same version facts as the `/version` slash command, in the
+    same section order (versions, editable path, core dependencies, optional
+    dependencies), but omits its network-dependent release-age suffixes and
+    update-available hint so `--version` stays offline.
 
     Returns:
         Multi-line version string suitable for stdout.
@@ -81,6 +85,19 @@ def build_version_text() -> str:
     except Exception:
         logger.warning("Unexpected error detecting editable install", exc_info=True)
 
+    # Core dependencies precede optional dependencies to match the section
+    # order of the `/version` slash command (see `_handle_version_command`).
+    if editable:
+        try:
+            from deepagents_code.extras_info import format_core_dependencies_plain
+
+            core_text = format_core_dependencies_plain()
+        except Exception:
+            logger.warning("Failed to collect core dependency versions", exc_info=True)
+            core_text = ""
+        if core_text:
+            text = f"{text}\n\n{core_text}"
+
     try:
         from deepagents_code.extras_info import (
             format_extras_status_plain,
@@ -93,17 +110,6 @@ def build_version_text() -> str:
         extras_text = ""
     if extras_text:
         text = f"{text}\n\n{extras_text}"
-
-    if editable:
-        try:
-            from deepagents_code.extras_info import format_core_dependencies_plain
-
-            core_text = format_core_dependencies_plain()
-        except Exception:
-            logger.warning("Failed to collect core dependency versions", exc_info=True)
-            core_text = ""
-        if core_text:
-            text = f"{text}\n\n{core_text}"
 
     return text
 
@@ -1304,6 +1310,9 @@ def parse_args() -> argparse.Namespace:
     if any(arg in {"-v", "--version"} for arg in sys.argv[1:]):
         version_text = build_version_text()
     else:
+        # Never surfaced: argparse only emits `version=` when the flag is
+        # actually passed, which takes the `build_version_text()` branch above.
+        # This placeholder only exists because `version=` requires a value.
         version_text = f"deepagents-code {__version__}"
     parser.add_argument(
         "-v",

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -264,6 +264,92 @@ async def test_version_slash_command_omits_update_hint_when_up_to_date() -> None
         assert "Update available" not in content
 
 
+async def test_version_slash_command_indicates_editable_install() -> None:
+    """Verify `/version` reports editable mode and lists core dependencies."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch(
+                "deepagents_code.config._is_editable_install",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.config._get_editable_install_path",
+                return_value="~/src/deepagents/libs/code",
+            ),
+        ):
+            await app._handle_command("/version")
+        await pilot.pause()
+
+        msgs = app.query(AppMessage)
+        plain = str([m for m in msgs if not m._is_markdown][-1]._content)
+        assert "Editable install: ~/src/deepagents/libs/code" in plain
+
+        md_sources = [str(m._content) for m in msgs if m._is_markdown]
+        core = [s for s in md_sources if "### Core dependencies" in s]
+        assert core
+        assert "langchain-core" in core[-1]
+        assert "langgraph" in core[-1]
+        assert "langsmith" in core[-1]
+
+
+async def test_version_slash_command_omits_editable_info_when_not_editable() -> None:
+    """Verify `/version` hides editable info and core deps for normal installs."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with patch(
+            "deepagents_code.config._is_editable_install",
+            return_value=False,
+        ):
+            await app._handle_command("/version")
+        await pilot.pause()
+
+        msgs = app.query(AppMessage)
+        plain = str([m for m in msgs if not m._is_markdown][-1]._content)
+        assert "Editable install" not in plain
+        md_sources = [str(m._content) for m in msgs if m._is_markdown]
+        assert not any("### Core dependencies" in s for s in md_sources)
+
+
+def test_format_core_dependencies_lists_known_packages() -> None:
+    """Verify `format_core_dependencies` renders a row for each core package."""
+    from deepagents_code.extras_info import (
+        CORE_DEPENDENCIES,
+        format_core_dependencies,
+    )
+
+    rendered = format_core_dependencies()
+    assert rendered.startswith("### Core dependencies")
+    for name in CORE_DEPENDENCIES:
+        assert f"| {name} |" in rendered
+
+
+def test_get_core_dependency_versions_marks_missing_as_none() -> None:
+    """Verify missing core packages resolve to `None` rather than raising."""
+    from importlib.metadata import PackageNotFoundError
+
+    from deepagents_code.extras_info import get_core_dependency_versions
+
+    def patched_version(name: str) -> str:
+        if name == "langgraph-sdk":
+            raise PackageNotFoundError(name)
+        return "1.2.3"
+
+    with patch("deepagents_code.extras_info.pkg_version", side_effect=patched_version):
+        result = dict(get_core_dependency_versions())
+
+    assert result["langgraph-sdk"] is None
+    assert result["langchain"] == "1.2.3"
+
+
 async def test_update_slash_command_editable_install_short_circuits() -> None:
     """Editable install must not invoke `perform_upgrade` from the TUI.
 

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -319,6 +319,43 @@ async def test_version_slash_command_omits_editable_info_when_not_editable() -> 
         assert not any("### Core dependencies" in s for s in md_sources)
 
 
+def test_build_version_text_includes_editable_core_deps() -> None:
+    """Verify the `--version` text reports editable mode and core deps."""
+    from deepagents_code.main import build_version_text
+
+    with (
+        patch(
+            "deepagents_code.config._is_editable_install",
+            return_value=True,
+        ),
+        patch(
+            "deepagents_code.config._get_editable_install_path",
+            return_value="~/src/deepagents/libs/code",
+        ),
+    ):
+        text = build_version_text()
+
+    assert f"deepagents-code {__version__}" in text
+    assert "Editable install: ~/src/deepagents/libs/code" in text
+    assert "Core dependencies:" in text
+    assert "langchain-core" in text
+    assert "langsmith" in text
+
+
+def test_build_version_text_omits_core_deps_when_not_editable() -> None:
+    """Verify the `--version` text hides editable info for normal installs."""
+    from deepagents_code.main import build_version_text
+
+    with patch(
+        "deepagents_code.config._is_editable_install",
+        return_value=False,
+    ):
+        text = build_version_text()
+
+    assert "Editable install" not in text
+    assert "Core dependencies:" not in text
+
+
 def test_format_core_dependencies_lists_known_packages() -> None:
     """Verify `format_core_dependencies` renders a row for each core package."""
     from deepagents_code.extras_info import (


### PR DESCRIPTION
`/version` and `dcode -v` now report editable-install status and core LangChain dependency versions when running from a local checkout.

---

When `deepagents-code` runs from an editable install, both the `/version` slash command and the `dcode -v` / `--version` CLI flag now indicate editable mode (including the contracted source path) and list the resolved versions of the core LangChain-ecosystem dependencies — `langchain`, `langchain-core`, `langgraph`, `langgraph-checkpoint`, `langgraph-prebuilt`, `langgraph-sdk`, and `langsmith`.

Local checkouts frequently pin or override these packages, so surfacing them makes editable environments much easier to diagnose. Non-editable installs are unchanged. A new `build_version_text` helper centralizes the CLI version string so the fast path and the argparse `version` action stay in sync, and a plain-text core-dependency formatter sits alongside the existing extras helpers (missing packages render as `not installed`). Both surfaces emit sections in the same order (versions, editable path, core dependencies, optional dependencies); `--version` omits the network-dependent release-age suffixes and update hint so it stays offline.

One behavior change worth calling out: consolidating the three former `--version` code paths into `build_version_text` means an *unexpected* error while looking up the SDK version (i.e. anything other than `PackageNotFoundError`) is now logged at `warning` rather than `debug`, matching how the `/version` slash command already logs it.

Made by [Open SWE](https://openswe.vercel.app)