### PR TITLE
fix(code): set dcode agent names in trace metadata

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1567,5 +1567,6 @@ def create_cli_agent(
         interrupt_on=interrupt_on,
         checkpointer=checkpointer,
         subagents=all_subagents or None,
+        name=assistant_id,
     ).with_config(config)
     return agent, composite_backend

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -88,6 +88,19 @@ REQUIRE_COMPACT_TOOL_APPROVAL: bool = True
 """When `True`, `compact_conversation` requires HITL approval like other gated tools."""
 
 
+def _sanitize_agent_message_name(agent_name: str) -> str:
+    """Return a provider-safe message name for a user-facing agent name.
+
+    Args:
+        agent_name: Display/storage name for the selected agent.
+
+    Returns:
+        Name containing only alphanumerics, underscores, and hyphens.
+    """
+    sanitized = re.sub(r"[^a-zA-Z0-9_-]+", "_", agent_name).strip("_")
+    return sanitized or DEFAULT_AGENT_NAME
+
+
 class ShellAllowListMiddleware(AgentMiddleware):
     """Validate shell commands against an allow-list without HITL interrupts.
 
@@ -1567,6 +1580,6 @@ def create_cli_agent(
         interrupt_on=interrupt_on,
         checkpointer=checkpointer,
         subagents=all_subagents or None,
-        name=assistant_id,
+        name=_sanitize_agent_message_name(assistant_id),
     ).with_config(config)
     return agent, composite_backend

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -836,7 +836,7 @@ def build_stream_config(
 
     Args:
         thread_id: The app session thread identifier.
-        assistant_id: The agent/assistant identifier, if any.
+        assistant_id: The dcode agent identifier, if any.
         sandbox_type: Sandbox provider name for trace metadata, or `None` if no
             sandbox is active.
 
@@ -865,7 +865,7 @@ def build_stream_config(
     if assistant_id:
         metadata.update(
             {
-                "assistant_id": assistant_id,
+                "dcode_agent_name": assistant_id,
                 "agent_name": assistant_id,
                 "updated_at": datetime.now(UTC).isoformat(),
             }

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -836,7 +836,9 @@ def build_stream_config(
 
     Args:
         thread_id: The app session thread identifier.
-        assistant_id: The dcode agent identifier, if any.
+        assistant_id: The dcode agent identifier, if any. When set, it is
+            surfaced in trace metadata under `dcode_agent_name` and
+            `agent_name`.
         sandbox_type: Sandbox provider name for trace metadata, or `None` if no
             sandbox is active.
 

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -741,7 +741,9 @@ class TestCreateCliAgentInteractiveForwarding:
             patch("deepagents_code.agent.settings", mock_settings),
             patch("deepagents_code.agent.SkillsMiddleware"),
             patch("deepagents_code.agent.MemoryMiddleware"),
-            patch("deepagents_code.agent.create_deep_agent", return_value=mock_agent),
+            patch(
+                "deepagents_code.agent.create_deep_agent", return_value=mock_agent
+            ) as mock_create_deep_agent,
             patch(
                 "deepagents._models.init_chat_model",
                 return_value=fake_model,
@@ -761,6 +763,7 @@ class TestCreateCliAgentInteractiveForwarding:
         mock_get_prompt.assert_called_once()
         _, kwargs = mock_get_prompt.call_args
         assert kwargs["interactive"] is False
+        assert mock_create_deep_agent.call_args.kwargs["name"] == "test"
 
     def test_explicit_system_prompt_ignores_interactive(self, tmp_path: Path) -> None:
         """Explicit system_prompt should be used verbatim, ignoring interactive."""

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -23,6 +23,7 @@ from deepagents_code.agent import (
     _format_task_description,
     _format_web_search_description,
     _format_write_file_description,
+    _sanitize_agent_message_name,
     build_model_identity_section,
     create_cli_agent,
     get_available_agent_names,
@@ -47,6 +48,14 @@ def test_add_interrupt_on_gates_async_task_tools() -> None:
 
     for tool_name in ("start_async_task", "update_async_task", "cancel_async_task"):
         assert tool_name in interrupt_on
+
+
+def test_sanitize_agent_message_name_replaces_provider_unsafe_chars() -> None:
+    """Agent display names with spaces must become valid message names."""
+    assert _sanitize_agent_message_name("my agent") == "my_agent"
+    assert _sanitize_agent_message_name("  my\tagent  ") == "my_agent"
+    assert _sanitize_agent_message_name("my-agent_2") == "my-agent_2"
+    assert _sanitize_agent_message_name("  ") == DEFAULT_AGENT_NAME
 
 
 def test_format_write_file_description_create_new_file(tmp_path: Path) -> None:
@@ -753,7 +762,7 @@ class TestCreateCliAgentInteractiveForwarding:
             mock_get_prompt.return_value = "mocked prompt"
             create_cli_agent(
                 model="fake-model",
-                assistant_id="test",
+                assistant_id="my agent",
                 enable_memory=False,
                 enable_skills=False,
                 enable_shell=False,
@@ -763,7 +772,7 @@ class TestCreateCliAgentInteractiveForwarding:
         mock_get_prompt.assert_called_once()
         _, kwargs = mock_get_prompt.call_args
         assert kwargs["interactive"] is False
-        assert mock_create_deep_agent.call_args.kwargs["name"] == "test"
+        assert mock_create_deep_agent.call_args.kwargs["name"] == "my_agent"
 
     def test_explicit_system_prompt_ignores_interactive(self, tmp_path: Path) -> None:
         """Explicit system_prompt should be used verbatim, ignoring interactive."""

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -526,10 +526,11 @@ class TestBuildStreamConfig:
         """Clear the git-branch cache between tests."""
         config_module._git_branch_cache.clear()
 
-    def test_assistant_fields_present(self) -> None:
-        """Assistant-specific metadata should be present when `assistant_id` is set."""
+    def test_dcode_agent_fields_present(self) -> None:
+        """Selected dcode agent metadata should be present."""
         config = build_stream_config("t-456", assistant_id="my-agent")
-        assert config["metadata"]["assistant_id"] == "my-agent"
+        assert "assistant_id" not in config["metadata"]
+        assert config["metadata"]["dcode_agent_name"] == "my-agent"
         assert config["metadata"]["agent_name"] == "my-agent"
         assert "updated_at" in config["metadata"]
         assert "cwd" in config["metadata"]
@@ -542,20 +543,22 @@ class TestBuildStreamConfig:
         parsed = datetime.fromisoformat(raw)
         assert parsed.tzinfo is not None
 
-    def test_no_assistant_fields_when_none(self) -> None:
-        """Assistant-specific fields should be absent when `assistant_id` is `None`."""
+    def test_no_dcode_agent_fields_when_none(self) -> None:
+        """Selected dcode agent fields should be absent when unset."""
         config = build_stream_config("t-789", assistant_id=None)
         metadata = config["metadata"]
         assert "assistant_id" not in metadata
+        assert "dcode_agent_name" not in metadata
         assert "agent_name" not in metadata
         assert "updated_at" not in metadata
         assert "cwd" in metadata
 
-    def test_no_assistant_fields_when_empty_string(self) -> None:
+    def test_no_dcode_agent_fields_when_empty_string(self) -> None:
         """Empty-string `assistant_id` should be treated as absent."""
         config = build_stream_config("t-000", assistant_id="")
         metadata = config["metadata"]
         assert "assistant_id" not in metadata
+        assert "dcode_agent_name" not in metadata
         assert "agent_name" not in metadata
         assert "updated_at" not in metadata
         assert "cwd" in metadata


### PR DESCRIPTION
LangSmith trace metadata now separates dcode's selected agent name from Agent Server's `assistant_id`, avoiding collisions with the UUID assigned by LangSmith. Root dcode runs also pass the selected agent name into `create_deep_agent`, so `lc_agent_name` is populated consistently with LangChain's agent naming metadata.

## Changes
- Set `create_deep_agent(..., name=assistant_id)` in `create_cli_agent` so root runs report the selected dcode agent through `lc_agent_name`.
- Replace dcode's custom `metadata["assistant_id"]` value with `metadata["dcode_agent_name"]`, leaving LangSmith/Agent Server ownership of `assistant_id` intact.
- Keep `metadata["agent_name"]` for compatibility while adding the more explicit dcode-specific metadata key.
- Clarify `build_stream_config` docs so `assistant_id` is described as the dcode agent identifier in this code path.