### PR TITLE
fix(sdk): make ContextHub grep treat pattern as literal text

### DIFF
--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -246,10 +246,9 @@ class ContextHubBackend(BackendProtocol):
             return GrepResult(error=f"Hub unavailable: {exc}")
         matches: list[GrepMatch] = []
 
-        try:
-            regex = re.compile(pattern)
-        except re.error as e:
-            return GrepResult(error=f"Invalid regex pattern: {e}")
+        # The grep contract is a literal text pattern (see BackendProtocol.grep);
+        # escape so metacharacters in the query match themselves.
+        regex = re.compile(re.escape(pattern))
 
         prefix = self._strip_prefix(path).rstrip("/") if path else ""
 

--- a/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
@@ -303,11 +303,19 @@ def test_grep_with_path_prefix() -> None:
     assert paths == {"/memories/a.md"}
 
 
-def test_grep_invalid_regex() -> None:
-    backend, _ = _make_backend()
-    result = backend.grep("[unclosed")
-    assert result.error is not None
-    assert "Invalid regex" in result.error
+def test_grep_literal_special_chars() -> None:
+    backend, _ = _make_backend(
+        **{
+            "code.py": FileEntry(type="file", content="def __init__(self):\n    pat = '[unclosed'\n    api_key = 1"),
+        }
+    )
+    # Metacharacters match themselves (grep takes a literal pattern).
+    for pattern, line in [("def __init__(", 1), ("[unclosed", 2)]:
+        result = backend.grep(pattern)
+        assert result.error is None
+        assert [m["line"] for m in result.matches] == [line]
+    # Dot is not a regex wildcard: 'api.key' must not match 'api_key'.
+    assert backend.grep("api.key").matches == []
 
 
 def test_glob_matches_pattern() -> None:


### PR DESCRIPTION
Fixes #3902

---

The backend protocol defines grep's pattern as literal text and the state/store/filesystem backends match literally, but `ContextHubBackend.grep` compiled the raw pattern as a regex — erroring on `(`, over-matching on `.`, and silently missing on `$`. Escape the pattern before compiling (mirroring `FilesystemBackend`) and update the one test that asserted the regex behavior.

Verified with `make format`, `make lint`, `make test` (1762 passed) from `libs/deepagents`.

Disclaimer: written with AI assistance (Claude Code); fix and tests reviewed and run by me.