### PR TITLE
hotfix(code): keep tracked files when untracked scan fails

### DIFF
--- a/libs/code/deepagents_code/widgets/autocomplete.py
+++ b/libs/code/deepagents_code/widgets/autocomplete.py
@@ -398,10 +398,13 @@ def _get_project_files(root: Path) -> list[str]:
     git_path = _get_git_executable()
     if git_path:
         tracked_ok, tracked = _run_git_ls_files(git_path, root, [])
-        untracked_ok, untracked = _run_git_ls_files(
-            git_path, root, ["--others", "--exclude-standard"]
-        )
-        if tracked_ok and untracked_ok:
+        if tracked_ok:
+            # The untracked scan is optional; if it fails or times out, keep the
+            # already-successful tracked list rather than dropping to the glob
+            # fallback (which only walks a few levels deep).
+            _, untracked = _run_git_ls_files(
+                git_path, root, ["--others", "--exclude-standard"]
+            )
             seen: set[str] = set()
             files: list[str] = []
             for f in (*tracked, *untracked):

--- a/libs/code/tests/unit_tests/test_autocomplete.py
+++ b/libs/code/tests/unit_tests/test_autocomplete.py
@@ -925,6 +925,45 @@ class TestGetProjectFiles:
 
         assert files.count("conflict.py") == 1
 
+    def test_untracked_failure_keeps_tracked_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed untracked scan must not discard the tracked list.
+
+        When the optional `--others --exclude-standard` call fails or times
+        out, the already-successful tracked listing stays authoritative instead
+        of falling back to the shallow glob walk.
+        """
+        self._init_repo(tmp_path)
+        nested = tmp_path / "a" / "b" / "c" / "d" / "e"
+        nested.mkdir(parents=True)
+        deep = nested / "deep.py"
+        deep.write_text("x = 1\n")
+        subprocess.run(
+            ["git", "add", "a"], cwd=tmp_path, check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "init"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        real_run = autocomplete_module._run_git_ls_files
+
+        def fake_run(
+            git_path: str, root: Path, extra_args: list[str]
+        ) -> tuple[bool, list[str]]:
+            if "--others" in extra_args:
+                return False, []
+            return real_run(git_path, root, extra_args)
+
+        monkeypatch.setattr(autocomplete_module, "_run_git_ls_files", fake_run)
+
+        files = _get_project_files(tmp_path)
+
+        assert "a/b/c/d/e/deep.py" in files
+
     def test_glob_fallback_when_git_unavailable(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Fixed `@` file completion dropping deeply-nested tracked files when the untracked-file scan timed out in large repositories.

---

`_get_project_files` built `@`-completion results from two `git ls-files` calls and only returned the git-backed list when *both* succeeded. That made the optional untracked scan (`--others --exclude-standard`) a hard dependency: if it failed or exceeded the 5s timeout in a large repo, the already-successful tracked listing was thrown away and completion fell back to a glob walk that only descends a few levels — silently dropping deep tracked files.

The tracked listing is now authoritative. The untracked scan only augments it, and its failure no longer triggers the glob fallback.

Made by [Open SWE](https://openswe.vercel.app)