### PR TITLE
feat(code): `skills install` for prebuilt LangChain/LangSmith skills

### DIFF
--- a/libs/code/deepagents_code/skills/commands.py
+++ b/libs/code/deepagents_code/skills/commands.py
@@ -388,6 +388,126 @@ description: "{description}"
 """
 
 
+def _resolve_install_dir(agent: str, *, project: bool) -> Path:
+    """Resolve the target skills directory for `skills install`.
+
+    Args:
+        agent: Agent identifier for user-level skills.
+        project: Install into the project skills directory instead of the user one.
+
+    Returns:
+        The skills directory to install into.
+
+    Raises:
+        SystemExit: If a project install is requested outside a project.
+    """
+    from deepagents_code.config import Settings, console
+
+    settings = Settings.from_environment()
+    if project:
+        if not settings.project_root:
+            console.print("[bold red]Error:[/bold red] Not in a project directory.")
+            console.print(
+                "[dim]Project skills require a .git directory "
+                "in the project root.[/dim]",
+                style=theme.MUTED,
+            )
+            raise SystemExit(1)
+        skills_dir = settings.ensure_project_skills_dir()
+        if skills_dir is None:
+            console.print(
+                "[bold red]Error:[/bold red] Could not create project skills directory."
+            )
+            raise SystemExit(1)
+        return skills_dir
+    return settings.ensure_user_skills_dir(agent)
+
+
+def _install(
+    collections: list[str],
+    *,
+    agent: str = "agent",
+    project: bool = False,
+    force: bool = False,
+    output_format: OutputFormat = "text",
+) -> None:
+    """Install prebuilt LangChain/LangSmith skill collections.
+
+    Args:
+        collections: Collection keys to install (`langchain`, `langsmith`, `all`).
+        agent: Agent identifier for user-level skills.
+        project: Install into the project skills directory instead of the user one.
+        force: Overwrite skills that already exist.
+        output_format: Output format — `'text'` (Rich) or `'json'`.
+
+    Raises:
+        SystemExit: If an unknown collection is requested or a download fails.
+    """
+    from deepagents_code.config import console, get_glyphs
+    from deepagents_code.skills.prebuilt import (
+        PrebuiltSkillsError,
+        install_collection,
+        resolve_collections,
+    )
+
+    try:
+        targets = resolve_collections(collections)
+    except PrebuiltSkillsError as exc:
+        console.print(f"[bold red]Error:[/bold red] {exc}")
+        raise SystemExit(1) from exc
+
+    skills_dir = _resolve_install_dir(agent, project=project)
+
+    results = []
+    for collection in targets:
+        if output_format != "json":
+            source = f"{collection.owner}/{collection.repo}"
+            console.print(
+                f"Fetching {collection.name} from {source}…",
+                style=theme.MUTED,
+            )
+        try:
+            results.append(install_collection(collection, skills_dir, force=force))
+        except PrebuiltSkillsError as exc:
+            console.print(f"[bold red]Error:[/bold red] {exc}")
+            raise SystemExit(1) from exc
+
+    if output_format == "json":
+        from deepagents_code.output import write_json
+
+        write_json(
+            "skills install",
+            {
+                "path": str(skills_dir),
+                "project": project,
+                "collections": [
+                    {
+                        "key": r.collection.key,
+                        "installed": r.installed,
+                        "skipped": r.skipped,
+                    }
+                    for r in results
+                ],
+            },
+        )
+        return
+
+    checkmark = get_glyphs().checkmark
+    for result in results:
+        console.print(
+            f"\n[bold]{checkmark} {result.collection.name}[/bold]",
+            style=theme.PRIMARY,
+        )
+        for name in result.installed:
+            console.print(f"  {checkmark} {name}", style=theme.PRIMARY)
+        for name in result.skipped:
+            console.print(
+                f"  - {name} (already exists, use --force to overwrite)",
+                style=theme.MUTED,
+            )
+    console.print(f"\nLocation: {skills_dir}\n", style=theme.MUTED)
+
+
 def _create(
     skill_name: str,
     agent: str,
@@ -958,6 +1078,42 @@ def setup_skills_parser(
         help="Create skill in project directory instead of user directory",
     )
 
+    # Skills install
+    install_parser = skills_subparsers.add_parser(
+        "install",
+        help="Install prebuilt LangChain/LangSmith skill collections",
+        description=(
+            "Download and install curated skill collections from "
+            "langchain-ai/langchain-skills and langchain-ai/langsmith-skills."
+        ),
+        add_help=False,
+        parents=help_parent(_lazy_help("show_skills_install_help")),
+    )
+    if add_output_args is not None:
+        add_output_args(install_parser)
+    install_parser.add_argument(
+        "collections",
+        nargs="*",
+        default=["all"],
+        help="Collections to install: langchain, langsmith, or all (default: all)",
+    )
+    install_parser.add_argument(
+        "--agent",
+        default="agent",
+        help="Agent identifier for skills (default: agent)",
+    )
+    install_parser.add_argument(
+        "--project",
+        action="store_true",
+        help="Install into the project skills directory instead of the user one",
+    )
+    install_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Overwrite skills that already exist",
+    )
+
     # Skills info
     info_parser = skills_subparsers.add_parser(
         "info",
@@ -1051,6 +1207,14 @@ def execute_skills_command(args: argparse.Namespace) -> None:
             args.name,
             agent=args.agent,
             project=args.project,
+            output_format=output_format,
+        )
+    elif args.skills_command == "install":
+        _install(
+            args.collections,
+            agent=args.agent,
+            project=args.project,
+            force=args.force,
             output_format=output_format,
         )
     elif args.skills_command == "info":

--- a/libs/code/deepagents_code/skills/prebuilt.py
+++ b/libs/code/deepagents_code/skills/prebuilt.py
@@ -1,0 +1,233 @@
+"""Install prebuilt LangChain/LangSmith skill collections.
+
+The LangChain and LangSmith teams publish curated agent-skill collections at
+`langchain-ai/langchain-skills` and `langchain-ai/langsmith-skills`. This module
+fetches those collections (as GitHub source tarballs, no `git`/`npx` required)
+and installs the individual skills into a local skills directory so they show up
+in skill discovery.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import httpx
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Skills live under this prefix inside each collection repo.
+_SKILLS_SUBPATH = "config/skills"
+
+# Network timeout (seconds) for the tarball download.
+_DOWNLOAD_TIMEOUT = 60.0
+
+
+@dataclass(frozen=True)
+class PrebuiltCollection:
+    """A curated, remotely hosted collection of agent skills.
+
+    Attributes:
+        key: Short identifier used on the command line (e.g. `langchain`).
+        name: Human-readable collection name.
+        owner: GitHub owner/org.
+        repo: GitHub repository name.
+        ref: Git ref (branch or tag) to download.
+        description: One-line summary for help/listing output.
+    """
+
+    key: str
+    name: str
+    owner: str
+    repo: str
+    description: str
+    ref: str = "main"
+
+    @property
+    def url(self) -> str:
+        """GitHub source tarball URL for the configured ref."""
+        return (
+            f"https://github.com/{self.owner}/{self.repo}"
+            f"/archive/refs/heads/{self.ref}.tar.gz"
+        )
+
+
+PREBUILT_COLLECTIONS: dict[str, PrebuiltCollection] = {
+    "langchain": PrebuiltCollection(
+        key="langchain",
+        name="LangChain Skills",
+        owner="langchain-ai",
+        repo="langchain-skills",
+        description="Build agents with LangChain, LangGraph, and Deep Agents",
+    ),
+    "langsmith": PrebuiltCollection(
+        key="langsmith",
+        name="LangSmith Skills",
+        owner="langchain-ai",
+        repo="langsmith-skills",
+        description="Observe and evaluate LLM apps with LangSmith",
+    ),
+}
+"""Known prebuilt collections, keyed by their command-line identifier."""
+
+
+@dataclass
+class InstallResult:
+    """Outcome of installing a single collection.
+
+    Attributes:
+        collection: The collection that was processed.
+        installed: Names of skills newly written to disk.
+        skipped: Names of skills skipped because they already existed.
+    """
+
+    collection: PrebuiltCollection
+    installed: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+
+
+class PrebuiltSkillsError(Exception):
+    """Raised when a prebuilt collection cannot be downloaded or extracted."""
+
+
+def _safe_members(
+    tar: tarfile.TarFile, skills_prefix: str
+) -> dict[str, list[tarfile.TarInfo]]:
+    """Group tar members by skill name, rejecting unsafe paths.
+
+    Args:
+        tar: Opened tar archive for a collection.
+        skills_prefix: Archive path prefix that contains the skills
+            (e.g. `repo-main/config/skills/`).
+
+    Returns:
+        Mapping of skill name to the member entries that belong to it.
+
+    Raises:
+        PrebuiltSkillsError: If a member escapes the skills prefix.
+    """
+    grouped: dict[str, list[tarfile.TarInfo]] = {}
+    for member in tar.getmembers():
+        if not member.name.startswith(skills_prefix):
+            continue
+        relative = member.name[len(skills_prefix) :]
+        if not relative:
+            continue
+        if relative.startswith("/") or ".." in relative.split("/"):
+            msg = f"Unsafe path in archive: {member.name}"
+            raise PrebuiltSkillsError(msg)
+        skill_name = relative.lstrip("/").split("/", 1)[0]
+        grouped.setdefault(skill_name, []).append(member)
+    return grouped
+
+
+def install_collection(
+    collection: PrebuiltCollection,
+    dest_dir: Path,
+    *,
+    force: bool = False,
+) -> InstallResult:
+    """Download a collection and install its skills into `dest_dir`.
+
+    Args:
+        collection: The collection to install.
+        dest_dir: Target skills directory (created if missing).
+        force: Overwrite skills that already exist instead of skipping them.
+
+    Returns:
+        An `InstallResult` describing what was installed or skipped.
+
+    Raises:
+        PrebuiltSkillsError: If the download fails or the archive is malformed.
+    """
+    try:
+        response = httpx.get(
+            collection.url, follow_redirects=True, timeout=_DOWNLOAD_TIMEOUT
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        msg = f"Failed to download {collection.name}: {exc}"
+        raise PrebuiltSkillsError(msg) from exc
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    result = InstallResult(collection=collection)
+
+    try:
+        with tarfile.open(fileobj=io.BytesIO(response.content), mode="r:gz") as tar:
+            root = tar.getmembers()[0].name.split("/", 1)[0]
+            skills_prefix = f"{root}/{_SKILLS_SUBPATH}/"
+            grouped = _safe_members(tar, skills_prefix)
+            if not grouped:
+                msg = f"No skills found in {collection.name} ({_SKILLS_SUBPATH})"
+                raise PrebuiltSkillsError(msg)
+
+            for skill_name in sorted(grouped):
+                skill_dir = dest_dir / skill_name
+                if skill_dir.exists() and not force:
+                    result.skipped.append(skill_name)
+                    continue
+                _extract_skill(tar, grouped[skill_name], skills_prefix, dest_dir)
+                result.installed.append(skill_name)
+    except tarfile.TarError as exc:
+        msg = f"Failed to extract {collection.name}: {exc}"
+        raise PrebuiltSkillsError(msg) from exc
+
+    return result
+
+
+def _extract_skill(
+    tar: tarfile.TarFile,
+    members: list[tarfile.TarInfo],
+    skills_prefix: str,
+    dest_dir: Path,
+) -> None:
+    """Write the files of one skill into `dest_dir`, stripping the prefix.
+
+    Args:
+        tar: Opened tar archive.
+        members: Member entries belonging to a single skill.
+        skills_prefix: Archive prefix to strip from member names.
+        dest_dir: Target skills directory.
+    """
+    for member in members:
+        relative = member.name[len(skills_prefix) :].lstrip("/")
+        target = dest_dir / relative
+        if member.isdir():
+            target.mkdir(parents=True, exist_ok=True)
+        elif member.isfile():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            extracted = tar.extractfile(member)
+            if extracted is None:
+                continue
+            with extracted, target.open("wb") as out:
+                out.write(extracted.read())
+
+
+def resolve_collections(keys: list[str]) -> list[PrebuiltCollection]:
+    """Resolve user-supplied collection keys to `PrebuiltCollection` objects.
+
+    Args:
+        keys: Collection keys, where `all` expands to every known collection.
+
+    Returns:
+        Ordered, de-duplicated list of matching collections.
+
+    Raises:
+        PrebuiltSkillsError: If a key does not match a known collection.
+    """
+    if not keys or "all" in keys:
+        return list(PREBUILT_COLLECTIONS.values())
+
+    resolved: list[PrebuiltCollection] = []
+    for key in keys:
+        collection = PREBUILT_COLLECTIONS.get(key.lower())
+        if collection is None:
+            known = ", ".join([*PREBUILT_COLLECTIONS, "all"])
+            msg = f"Unknown skill collection '{key}'. Choose from: {known}"
+            raise PrebuiltSkillsError(msg)
+        if collection not in resolved:
+            resolved.append(collection)
+    return resolved

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -320,6 +320,7 @@ def show_skills_help() -> None:
     console.print("[bold]Commands:[/bold]", style=theme.PRIMARY)
     console.print("  list|ls           List all available skills")
     console.print("  create <name>     Create a new skill")
+    console.print("  install <names>   Install prebuilt LangChain/LangSmith skills")
     console.print("  info <name>       Show detailed information about a skill")
     console.print("  delete <name>     Delete a skill")
     console.print()
@@ -386,6 +387,36 @@ def show_skills_create_help() -> None:
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
     console.print("  dcode skills create web-research")
     console.print("  dcode skills create my-skill --project")
+    console.print()
+
+
+def show_skills_install_help() -> None:
+    """Show help information for the `skills install` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=theme.PRIMARY)
+    console.print("  dcode skills install [collections] [options]")
+    console.print()
+    console.print(
+        "Download curated skill collections from langchain-ai/langchain-skills\n"
+        "and langchain-ai/langsmith-skills and install them locally.",
+    )
+    console.print()
+    console.print("[bold]Collections:[/bold]", style=theme.PRIMARY)
+    console.print("  langchain   Build agents with LangChain, LangGraph, Deep Agents")
+    console.print("  langsmith   Observe and evaluate LLM apps with LangSmith")
+    console.print("  all         Both collections (default)")
+    console.print()
+    _print_option_section(
+        "  --agent NAME            Agent identifier (default: agent)",
+        "  --project               Install into project skills instead of user skills",
+        "  -f, --force             Overwrite skills that already exist",
+    )
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
+    console.print("  dcode skills install")
+    console.print("  dcode skills install langchain")
+    console.print("  dcode skills install langchain langsmith --force")
+    console.print("  dcode skills install all --project")
     console.print()
 
 

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -20,6 +20,11 @@
 #                             "ollama,groq", or "daytona"
 #                             (see pyproject.toml for available extras)
 #   DEEPAGENTS_CODE_PYTHON  — Python version to use (default: 3.13)
+#   DEEPAGENTS_CODE_SKILLS  — prebuilt skill collections to install
+#                             non-interactively: "all", "langchain",
+#                             "langsmith", "langchain,langsmith", or "none"
+#                             to skip. When unset, you are prompted (and the
+#                             prompt is skipped on non-interactive installs).
 #   DEEPAGENTS_CODE_SKIP_OPTIONAL — set to 1 to skip optional tool checks
 #   DEEPAGENTS_CODE_VERBOSE — set to 1 to show uv's raw stderr (timing
 #                             lines, unfiltered package diff) and the
@@ -204,6 +209,13 @@ EXTRAS="${DEEPAGENTS_CODE_EXTRAS:-}"
 PYTHON_VERSION="${DEEPAGENTS_CODE_PYTHON:-3.13}"
 SKIP_OPTIONAL="${DEEPAGENTS_CODE_SKIP_OPTIONAL:-0}"
 VERBOSE="${DEEPAGENTS_CODE_VERBOSE:-0}"
+SKILLS="${DEEPAGENTS_CODE_SKILLS:-}"
+
+# Validate prebuilt-skills selection: comma-separated collection names or "none".
+if [[ -n "$SKILLS" ]] && [[ ! "$SKILLS" =~ ^[a-z]+(,[a-z]+)*$ ]]; then
+  log_error "DEEPAGENTS_CODE_SKILLS must be comma-separated collection names (e.g. 'langchain,langsmith'), 'all', or 'none'"
+  exit 1
+fi
 
 # Validate and normalize extras: accept bare CSV, wrap in brackets for pip
 if [[ -n "$EXTRAS" ]]; then
@@ -604,6 +616,32 @@ if [ "$SKIP_OPTIONAL" != "1" ]; then
       fi
     else
       ripgrep_manual_hint
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Prebuilt skills — offer the curated LangChain/LangSmith skill collections.
+# Controlled by DEEPAGENTS_CODE_SKILLS (non-interactive) or a prompt otherwise.
+# ---------------------------------------------------------------------------
+if [ -n "$DCODE_BIN" ] && [ "$VERIFY_OK" = true ]; then
+  skills_to_install=""
+  if [ -n "$SKILLS" ]; then
+    [ "$SKILLS" != "none" ] && skills_to_install="$SKILLS"
+  elif prompt_yn "  Install prebuilt LangChain & LangSmith skills?"; then
+    skills_to_install="all"
+  fi
+
+  if [ -n "$skills_to_install" ]; then
+    echo ""
+    log_info "Installing prebuilt skills (${skills_to_install})..."
+    # shellcheck disable=SC2086
+    if "$DCODE_BIN" skills install ${skills_to_install//,/ }; then
+      [ -d "${HOME}/.deepagents" ] && fix_owner "${HOME}/.deepagents"
+      log_success "Prebuilt skills installed."
+    else
+      log_warn "Could not install prebuilt skills."
+      log_warn "  Install later with: dcode skills install"
     fi
   fi
 fi

--- a/libs/code/tests/unit_tests/skills/test_prebuilt.py
+++ b/libs/code/tests/unit_tests/skills/test_prebuilt.py
@@ -1,0 +1,161 @@
+"""Tests for prebuilt LangChain/LangSmith skill installation."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from deepagents_code.skills.prebuilt import (
+    PREBUILT_COLLECTIONS,
+    PrebuiltSkillsError,
+    install_collection,
+    resolve_collections,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_tarball(
+    files: dict[str, str], *, root: str = "langchain-skills-main"
+) -> bytes:
+    """Build an in-memory `.tar.gz` mirroring a GitHub source tarball.
+
+    Args:
+        files: Mapping of archive-relative path to file contents.
+        root: Top-level directory GitHub wraps the source in.
+
+    Returns:
+        Gzipped tar bytes.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for path, content in files.items():
+            data = content.encode()
+            info = tarfile.TarInfo(name=f"{root}/{path}")
+            info.size = len(data)
+            info.mtime = int(time.time())
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+class _FakeResponse:
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+def _patch_download(monkeypatch: pytest.MonkeyPatch, content: bytes) -> None:
+    monkeypatch.setattr(httpx, "get", lambda *_args, **_kwargs: _FakeResponse(content))
+
+
+class TestResolveCollections:
+    def test_default_returns_all(self) -> None:
+        assert resolve_collections([]) == list(PREBUILT_COLLECTIONS.values())
+
+    def test_all_keyword_returns_all(self) -> None:
+        assert resolve_collections(["all"]) == list(PREBUILT_COLLECTIONS.values())
+
+    def test_specific_key(self) -> None:
+        resolved = resolve_collections(["langchain"])
+        assert [c.key for c in resolved] == ["langchain"]
+
+    def test_case_insensitive_and_deduped(self) -> None:
+        resolved = resolve_collections(["LangChain", "langchain"])
+        assert [c.key for c in resolved] == ["langchain"]
+
+    def test_unknown_raises(self) -> None:
+        with pytest.raises(PrebuiltSkillsError, match="Unknown skill collection"):
+            resolve_collections(["nope"])
+
+
+class TestInstallCollection:
+    def test_installs_skills(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        content = _make_tarball(
+            {
+                "config/skills/skill-a/SKILL.md": "A",
+                "config/skills/skill-b/SKILL.md": "B",
+                "config/skills/skill-b/scripts/run.py": "print('x')",
+                "README.md": "ignored",
+            }
+        )
+        _patch_download(monkeypatch, content)
+
+        result = install_collection(
+            PREBUILT_COLLECTIONS["langchain"], tmp_path, force=False
+        )
+
+        assert result.installed == ["skill-a", "skill-b"]
+        assert result.skipped == []
+        assert (tmp_path / "skill-a" / "SKILL.md").read_text() == "A"
+        assert (tmp_path / "skill-b" / "scripts" / "run.py").exists()
+
+    def test_skips_existing_without_force(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "skill-a").mkdir()
+        (tmp_path / "skill-a" / "SKILL.md").write_text("OLD")
+        content = _make_tarball({"config/skills/skill-a/SKILL.md": "NEW"})
+        _patch_download(monkeypatch, content)
+
+        result = install_collection(
+            PREBUILT_COLLECTIONS["langchain"], tmp_path, force=False
+        )
+
+        assert result.installed == []
+        assert result.skipped == ["skill-a"]
+        assert (tmp_path / "skill-a" / "SKILL.md").read_text() == "OLD"
+
+    def test_force_overwrites(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "skill-a").mkdir()
+        (tmp_path / "skill-a" / "SKILL.md").write_text("OLD")
+        content = _make_tarball({"config/skills/skill-a/SKILL.md": "NEW"})
+        _patch_download(monkeypatch, content)
+
+        result = install_collection(
+            PREBUILT_COLLECTIONS["langchain"], tmp_path, force=True
+        )
+
+        assert result.installed == ["skill-a"]
+        assert (tmp_path / "skill-a" / "SKILL.md").read_text() == "NEW"
+
+    def test_no_skills_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        content = _make_tarball({"README.md": "nothing here"})
+        _patch_download(monkeypatch, content)
+
+        with pytest.raises(PrebuiltSkillsError, match="No skills found"):
+            install_collection(PREBUILT_COLLECTIONS["langchain"], tmp_path)
+
+    def test_unsafe_path_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        content = _make_tarball({"config/skills/../evil/SKILL.md": "bad"})
+        _patch_download(monkeypatch, content)
+
+        with pytest.raises(PrebuiltSkillsError, match="Unsafe path"):
+            install_collection(PREBUILT_COLLECTIONS["langchain"], tmp_path)
+
+    def test_download_error_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(*_args: object, **_kwargs: object) -> None:
+            msg = "nope"
+            raise httpx.ConnectError(msg)
+
+        monkeypatch.setattr(httpx, "get", _boom)
+
+        with pytest.raises(PrebuiltSkillsError, match="Failed to download"):
+            install_collection(PREBUILT_COLLECTIONS["langchain"], tmp_path)


### PR DESCRIPTION
Closes #2081

Add `dcode skills install` to fetch the prebuilt LangChain/LangSmith skill collections, and offer them during install.

---

The LangChain and LangSmith teams publish curated agent-skill collections at `langchain-ai/langchain-skills` and `langchain-ai/langsmith-skills`, but there was no first-class way to pull them into `deepagents-code`. This adds one.

- New `dcode skills install [langchain|langsmith|all]` subcommand. It fetches each collection as a GitHub source tarball over `httpx` (no `git` or `npx` dependency), extracts the skills under `config/skills/`, and writes them into the user skills dir (or the project dir with `--project`). Existing skills are skipped unless `--force` is passed. Supports `--json`.
- The curl-bash installer (`scripts/install.sh`) now offers to seed these collections after install. It prompts interactively and can be driven non-interactively via the new `DEEPAGENTS_CODE_SKILLS` env var (`all`, `langchain`, `langsmith`, `langchain,langsmith`, or `none`).
- Extraction validates archive member paths to reject traversal outside the skills prefix.

The in-REPL `/skills install` slash command requested in the issue is intentionally left out of this PR — it touches the larger TUI surface (command registry, drift tests, autocomplete, help screen, async worker) and warrants its own design pass. Installed skills already surface automatically as `/skill:<name>` once present.

## Test Plan
- [ ] `dcode skills install langchain --force` populates `~/.deepagents/agent/skills/` and the skills appear in `dcode skills list`.
- [ ] `DEEPAGENTS_CODE_SKILLS=all curl -LsSf https://langch.in/dcode | bash` installs the collections non-interactively.

Made by [Open SWE](https://openswe.vercel.app)