### PR TITLE
chore(code): remove retries config tip from welcome footer

### DIFF
--- a/libs/code/deepagents_code/widgets/welcome.py
+++ b/libs/code/deepagents_code/widgets/welcome.py
@@ -58,7 +58,6 @@ _TIPS: dict[str, int] = {
     "In /agents, press Ctrl+S to set the highlighted agent as your default": 1,
     "Press Shift+Tab to toggle auto-approve mode": 2,
     "Use --startup-cmd to run a shell command before the first prompt": 1,
-    "Set [retries] in ~/.deepagents/config.toml for resilience to transient errors": 1,
     "Use !! for incognito shell commands that stay out of model context": 1,
     "Deep Agents can explain its own features and look up its docs. Ask it how to use.": 3,  # noqa: E501
 }


### PR DESCRIPTION
Removes the rotating welcome footer tip about setting `[retries]` in `~/.deepagents/config.toml`.

Made by [Open SWE](https://openswe.vercel.app)