### PR TITLE
fix(code): skip startup auto-update when already updated in-session

### DIFF
--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -151,6 +151,7 @@ def _run_startup_auto_update(console: "Console") -> None:
         format_release_age_parenthetical,
         get_cached_update_available,
         is_auto_update_enabled,
+        is_installed_version_at_least,
         perform_upgrade,
         upgrade_command,
     )
@@ -162,6 +163,12 @@ def _run_startup_auto_update(console: "Console") -> None:
         restarted_for = os.environ.pop(RESTARTED_AFTER_UPDATE, None)
         available, latest = get_cached_update_available()
         if not available or latest is None:
+            return
+        if is_installed_version_at_least(latest):
+            # The on-disk install already satisfies `latest` (e.g. the user ran
+            # `/update` in-session). `get_cached_update_available` compares the
+            # baked-in `__version__`, which lags an in-session upgrade, so
+            # re-running the upgrade here would be a redundant no-op and restart.
             return
         if restarted_for == latest:
             # Already restarted after upgrading to this version, yet it still

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -178,6 +178,38 @@ class TestStartupAutoUpdate:
         restart.assert_not_called()
         console.print.assert_not_called()
 
+    def test_in_session_update_already_installed_skips(self) -> None:
+        """An in-session `/update` already on disk must not re-upgrade.
+
+        The cache reports a newer version than the baked-in `__version__`,
+        but the on-disk install already satisfies it, so the upgrade and
+        restart are skipped silently.
+        """
+        console = MagicMock()
+
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.update_check.get_cached_update_available",
+                return_value=(True, "9.9.9"),
+            ),
+            patch(
+                "deepagents_code.update_check.is_installed_version_at_least",
+                return_value=True,
+            ),
+            patch("deepagents_code.update_check.perform_upgrade") as upgrade,
+            patch("deepagents_code.main._restart_current_process") as restart,
+        ):
+            _run_startup_auto_update(console)
+
+        upgrade.assert_not_called()
+        restart.assert_not_called()
+        console.print.assert_not_called()
+
     def test_debug_update_skips_install(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """DEBUG_UPDATE announces the update but skips the actual install."""
         console = MagicMock()


### PR DESCRIPTION
Fixed a spurious "Auto-updating ... before startup" message/restart on launch after updating via `/update` in the same session.

---

After running `/update` inside the TUI, the on-disk install advances but the running process keeps its baked-in `__version__`. The startup auto-update compares the cache against `__version__`, so on the next launch it redundantly re-ran the upgrade and restarted ("Auto-updating ... before startup ... Restarting..."). This adds an `is_installed_version_at_least(latest)` guard to `_run_startup_auto_update`, mirroring the existing exit-banner check, so an already-installed version is skipped.

Made by [Open SWE](https://openswe.vercel.app)