### PR TITLE
fix(sdk): validate `read_file` image payloads

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -2,6 +2,8 @@
 # ruff: noqa: E501
 
 import asyncio
+import base64
+import binascii
 import concurrent.futures
 import contextlib
 import contextvars
@@ -73,6 +75,7 @@ from deepagents.middleware._utils import append_to_system_message
 
 _FS_WCMATCH_FLAGS = wcglob.BRACE | wcglob.GLOBSTAR
 _SYNC_GLOB_WORKERS = 4
+_MAX_IMAGE_BYTES = 5 * 1024 * 1024
 
 FilesystemOperation = Literal["read", "write"]
 
@@ -152,6 +155,21 @@ def _filter_paths_by_permission(
     if not rules:
         return paths
     return [p for p in paths if _check_fs_permission(rules, operation, p) != "deny"]
+
+
+def _validate_image_payload(content: str, path: str) -> str | None:
+    try:
+        decoded = base64.b64decode(content, validate=True)
+    except (binascii.Error, ValueError):
+        return f"Error: image file '{path}' did not contain valid base64 data"
+
+    if not decoded:
+        return f"Error: image file '{path}' decoded to empty content"
+
+    if len(decoded) > _MAX_IMAGE_BYTES:
+        return f"Error: image file '{path}' exceeds the {_MAX_IMAGE_BYTES} byte limit"
+
+    return None
 
 
 def _all_paths_scoped_to_routes(
@@ -984,17 +1002,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="success",
                 )
 
-            if read_result.error:
+            if read_result.error or read_result.file_data is None:
+                error = f"Error: {read_result.error}" if read_result.error else f"Error: no data returned for '{validated_path}'"
                 return ToolMessage(
-                    content=f"Error: {read_result.error}",
-                    name="read_file",
-                    tool_call_id=tool_call_id,
-                    status="error",
-                )
-
-            if read_result.file_data is None:
-                return ToolMessage(
-                    content=f"Error: no data returned for '{validated_path}'",
+                    content=error,
                     name="read_file",
                     tool_call_id=tool_call_id,
                     status="error",
@@ -1003,6 +1014,16 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             file_type = _get_file_type(validated_path)
             encoding = read_result.file_data.get("encoding", "utf-8")
             content = read_result.file_data["content"]
+
+            if file_type == "image":
+                image_error = _validate_image_payload(content, validated_path)
+                if image_error:
+                    return ToolMessage(
+                        content=image_error,
+                        name="read_file",
+                        tool_call_id=tool_call_id,
+                        status="error",
+                    )
 
             # Empty files get a uniform warning regardless of encoding/type, so
             # check before routing to avoid a degenerate empty content block for

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1,3 +1,4 @@
+import base64
 import mimetypes
 import time
 from unittest.mock import patch
@@ -1424,7 +1425,7 @@ class TestFilesystemMiddleware:
             def read(self, path, *, offset=0, limit=100):
                 return ReadResult(
                     file_data={
-                        "content": "<base64_data>",
+                        "content": base64.b64encode(b"image bytes").decode(),
                         "encoding": "base64",
                     }
                 )
@@ -1451,7 +1452,46 @@ class TestFilesystemMiddleware:
         assert isinstance(result.content, list)
         assert result.content[0]["type"] == "image"
         assert result.content[0]["mime_type"] == "image/png"
-        assert result.content[0]["base64"] == "<base64_data>"
+        assert result.content[0]["base64"] == base64.b64encode(b"image bytes").decode()
+
+    @pytest.mark.parametrize(
+        ("content", "expected_error"),
+        [
+            pytest.param("not valid base64!", "valid base64", id="invalid-base64"),
+            pytest.param(base64.b64encode(b"").decode(), "empty", id="empty-decoded-bytes"),
+            pytest.param(base64.b64encode(b"x" * (5 * 1024 * 1024 + 1)).decode(), "exceeds", id="oversized-image"),
+        ],
+    )
+    def test_read_file_image_returns_error_for_invalid_payloads(self, content, expected_error):
+        """Image reads must reject payloads providers cannot accept (#3864)."""
+
+        class ImageBackend(StateBackend):
+            def read(self, path, *, offset=0, limit=100):
+                return ReadResult(
+                    file_data={
+                        "content": content,
+                        "encoding": "base64",
+                    }
+                )
+
+        middleware = FilesystemMiddleware(backend=ImageBackend())
+        state = FilesystemState(messages=[], files={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="img-read-invalid",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
+
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+        result = read_file_tool.invoke({"file_path": "/app/screenshot.png", "runtime": runtime})
+
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert isinstance(result.content, str)
+        assert expected_error in result.content
 
     def test_read_file_base64_unknown_extension_returns_file_block(self):
         """Binary reads route on `encoding`, not the extension map (#3657).


### PR DESCRIPTION
Fixes #3864

---

This updates `read_file` image handling so image content blocks are only emitted after the base64 payload is validated. Invalid base64, empty decoded image data, and decoded images larger than 5 MiB now return an error `ToolMessage` instead of checkpointing a provider-rejected successful tool result.

The fix is scoped to image payloads so existing generic binary file handling remains unchanged.

Validated with:

- `uv run --group test pytest tests/unit_tests/test_middleware.py --no-cov`
- `uv run --group test ruff check deepagents/middleware/filesystem.py tests/unit_tests/test_middleware.py`