### PR TITLE
feat(sdk): add context_lines parameter to grep

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -50,6 +50,16 @@ def _remap_grep_path(m: GrepMatch, route_prefix: str) -> GrepMatch:
     )
 
 
+def _ctx_kwargs(context_lines: int) -> dict[str, int]:
+    """Build optional grep kwargs for delegate calls.
+
+    Forwards `context_lines` only when set, so routed backends that still
+    use the older 3-argument `grep` signature keep working when no context
+    is requested.
+    """
+    return {"context_lines": context_lines} if context_lines else {}
+
+
 def _strip_route_from_pattern(pattern: str, route_prefix: str) -> str:
     """Strip a route prefix from a glob pattern when the pattern targets that route.
 
@@ -308,6 +318,7 @@ class CompositeBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,
     ) -> GrepResult:
         """Search files for literal text pattern.
 
@@ -319,6 +330,8 @@ class CompositeBackend(BackendProtocol):
             path: Directory to search. None searches all backends.
             glob: Glob pattern to filter files (e.g., "*.py", "**/*.txt").
                 Filters by filename, not content.
+            context_lines: Lines of surrounding context to include with each
+                match, forwarded to the routed backend(s). Defaults to 0.
 
         Returns:
             GrepResult with matches or error.
@@ -337,7 +350,7 @@ class CompositeBackend(BackendProtocol):
                 path=path,
             )
             if route_prefix is not None:
-                grep_result = self._coerce_grep_result(backend.grep(pattern, backend_path, glob))
+                grep_result = self._coerce_grep_result(backend.grep(pattern, backend_path, glob, **_ctx_kwargs(context_lines)))
                 if grep_result.error:
                     return grep_result
                 return GrepResult(matches=[_remap_grep_path(m, route_prefix) for m in (grep_result.matches or [])])
@@ -346,26 +359,27 @@ class CompositeBackend(BackendProtocol):
         # Otherwise, search only the default backend
         if path is None or path == "/":
             all_matches: list[GrepMatch] = []
-            default_result = self._coerce_grep_result(self.default.grep(pattern, path, glob))
+            default_result = self._coerce_grep_result(self.default.grep(pattern, path, glob, **_ctx_kwargs(context_lines)))
             if default_result.error:
                 return default_result
             all_matches.extend(default_result.matches or [])
 
             for route_prefix, backend in self.routes.items():
-                grep_result = self._coerce_grep_result(backend.grep(pattern, "/", glob))
+                grep_result = self._coerce_grep_result(backend.grep(pattern, "/", glob, **_ctx_kwargs(context_lines)))
                 if grep_result.error:
                     return grep_result
                 all_matches.extend(_remap_grep_path(m, route_prefix) for m in (grep_result.matches or []))
 
             return GrepResult(matches=all_matches)
         # Path specified but doesn't match a route - search only default
-        return self._coerce_grep_result(self.default.grep(pattern, path, glob))
+        return self._coerce_grep_result(self.default.grep(pattern, path, glob, **_ctx_kwargs(context_lines)))
 
     async def agrep(
         self,
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,
     ) -> GrepResult:
         """Async version of grep.
 
@@ -378,7 +392,7 @@ class CompositeBackend(BackendProtocol):
                 path=path,
             )
             if route_prefix is not None:
-                grep_result = self._coerce_grep_result(await backend.agrep(pattern, backend_path, glob))
+                grep_result = self._coerce_grep_result(await backend.agrep(pattern, backend_path, glob, **_ctx_kwargs(context_lines)))
                 if grep_result.error:
                     return grep_result
                 return GrepResult(matches=[_remap_grep_path(m, route_prefix) for m in (grep_result.matches or [])])
@@ -387,20 +401,20 @@ class CompositeBackend(BackendProtocol):
         # Otherwise, search only the default backend
         if path is None or path == "/":
             all_matches: list[GrepMatch] = []
-            default_result = self._coerce_grep_result(await self.default.agrep(pattern, path, glob))
+            default_result = self._coerce_grep_result(await self.default.agrep(pattern, path, glob, **_ctx_kwargs(context_lines)))
             if default_result.error:
                 return default_result
             all_matches.extend(default_result.matches or [])
 
             for route_prefix, backend in self.routes.items():
-                grep_result = self._coerce_grep_result(await backend.agrep(pattern, "/", glob))
+                grep_result = self._coerce_grep_result(await backend.agrep(pattern, "/", glob, **_ctx_kwargs(context_lines)))
                 if grep_result.error:
                     return grep_result
                 all_matches.extend(_remap_grep_path(m, route_prefix) for m in (grep_result.matches or []))
 
             return GrepResult(matches=all_matches)
         # Path specified but doesn't match a route - search only default
-        return self._coerce_grep_result(await self.default.agrep(pattern, path, glob))
+        return self._coerce_grep_result(await self.default.agrep(pattern, path, glob, **_ctx_kwargs(context_lines)))
 
     def glob(self, pattern: str, path: str | None = None) -> GlobResult:
         """Find files matching a glob pattern, routing by path prefix."""

--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -29,6 +29,8 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from deepagents.backends.utils import (
+    clamp_context_lines,
+    context_window_from_lines,
     create_file_data,
     perform_string_replacement,
     slice_read_response,
@@ -238,6 +240,7 @@ class ContextHubBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,
     ) -> GrepResult:
         """Search contents for `pattern` (optional `path` / `glob` filters)."""
         try:
@@ -256,14 +259,21 @@ class ContextHubBackend(BackendProtocol):
 
         glob_re = re.compile(fnmatch.translate(os.path.normcase(glob))) if glob else None
 
+        context_lines = clamp_context_lines(context_lines)
         for file_path, content in cache.items():
             if prefix and not file_path.startswith(prefix):
                 continue
             if glob_re is not None and not glob_re.match(os.path.normcase(file_path)):
                 continue
-            for i, line in enumerate(content.splitlines(), start=1):
+            lines = content.splitlines()
+            for i, line in enumerate(lines, start=1):
                 if regex.search(line):
-                    matches.append(GrepMatch(path=f"/{file_path}", line=i, text=line))
+                    match = GrepMatch(path=f"/{file_path}", line=i, text=line)
+                    if context_lines:
+                        before, after = context_window_from_lines(lines, i, context_lines)
+                        match["context_before"] = before
+                        match["context_after"] = after
+                    matches.append(match)
 
         return GrepResult(matches=matches)
 

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -38,6 +38,8 @@ from deepagents.backends.protocol import (
 from deepagents.backends.utils import (
     _get_file_type,
     check_empty_content,
+    clamp_context_lines,
+    context_window_from_lines,
     perform_string_replacement,
 )
 
@@ -571,6 +573,7 @@ class FilesystemBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,
     ) -> GrepResult:
         """Search for a literal text pattern in files.
 
@@ -580,6 +583,8 @@ class FilesystemBackend(BackendProtocol):
             pattern: Literal string to search for (NOT regex).
             path: Directory or file path to search in. Defaults to current directory.
             glob: Optional glob pattern to filter which files to search.
+            context_lines: Lines of surrounding context to attach to each
+                match (clamped to `MAX_GREP_CONTEXT_LINES`). Defaults to 0.
 
         Returns:
             GrepResult with matches or error.
@@ -611,7 +616,32 @@ class FilesystemBackend(BackendProtocol):
         for fpath, items in results.items():
             for line_num, line_text in items:
                 matches.append({"path": fpath, "line": int(line_num), "text": line_text})
+        if context_lines:
+            self._attach_context(matches, context_lines)
         return GrepResult(error=partial_error, matches=matches)
+
+    def _attach_context(self, matches: list[GrepMatch], context_lines: int) -> None:
+        """Attach surrounding lines to matches by re-reading each matched file.
+
+        Reading the file once per matched path (rather than parsing ripgrep's
+        interleaved `context` JSON events) keeps behavior identical between
+        the ripgrep and Python-fallback paths. Files that can no longer be
+        read (deleted/renamed/binary) simply yield matches without context.
+        """
+        context_lines = clamp_context_lines(context_lines)
+        by_path: dict[str, list[GrepMatch]] = {}
+        for m in matches:
+            by_path.setdefault(m["path"], []).append(m)
+        for fpath, file_matches in by_path.items():
+            try:
+                resolved = self._resolve_path(fpath)
+                lines = resolved.read_text(encoding="utf-8", errors="replace").split("\n")
+            except (OSError, ValueError, RuntimeError):
+                continue
+            for m in file_matches:
+                before, after = context_window_from_lines(lines, m["line"], context_lines)
+                m["context_before"] = before
+                m["context_after"] = after
 
     def _ripgrep_search(self, pattern: str, base_full: Path, include_glob: str | None) -> dict[str, list[tuple[int, str]]] | None:  # noqa: C901, PLR0912, PLR0915  # except clauses split per-exception for targeted logging (timeout vs exec-race vs ripgrep hard-error)
         """Search using ripgrep with fixed-string (literal) mode.

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -11,7 +11,7 @@ import inspect
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import lru_cache, partial
 from typing import Any, Final, Literal, NotRequired, TypeAlias
 
 from langchain.tools import ToolRuntime
@@ -162,6 +162,19 @@ class GrepMatch(TypedDict):
 
     text: str
     """Content of the matching line."""
+
+    context_before: NotRequired[list[str]]
+    """Lines immediately preceding the match, in file order.
+
+    Only present when the search was performed with `context_lines > 0`.
+    Line numbers are inferable: the first entry is line `line - len(context_before)`.
+    """
+
+    context_after: NotRequired[list[str]]
+    """Lines immediately following the match, in file order.
+
+    Only present when the search was performed with `context_lines > 0`.
+    """
 
 
 class FileData(TypedDict):
@@ -412,6 +425,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,  # noqa: ARG002 -- consumed by overrides; legacy grep_raw fallback has no context support
     ) -> "GrepResult":
         """Search for a literal text pattern in files.
 
@@ -427,6 +441,16 @@ class BackendProtocol(abc.ABC):  # noqa: B024
                 If None, searches in current working directory.
 
                 Example: `'/workspace/src'`
+
+            context_lines: Number of lines of surrounding context to include
+                with each match (like `grep -C`).
+
+                When greater than 0, each `GrepMatch` includes
+                `context_before` / `context_after` with up to that many lines
+                on each side, clamped at file boundaries. Defaults to `0`
+                (no context, current behavior). Backends that cannot read
+                surrounding lines may ignore this and return matches without
+                context. Not supported on the deprecated `grep_raw` fallback.
 
             glob: Optional glob pattern to filter which FILES to search.
 
@@ -471,6 +495,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,
     ) -> "GrepResult":
         """Async version of `grep`.
 
@@ -478,9 +503,13 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         bounds how long the caller waits; it does not stop the worker thread
         created by `asyncio.to_thread`.
         """
+        # Only forward `context_lines` when set, so custom backends that
+        # override `grep` with the older 3-argument signature keep working
+        # as long as no context is requested.
+        sync_call = partial(self.grep, pattern, path, glob, context_lines) if context_lines else partial(self.grep, pattern, path, glob)
         try:
             return await asyncio.wait_for(
-                asyncio.to_thread(self.grep, pattern, path, glob),
+                asyncio.to_thread(sync_call),
                 timeout=ASYNC_GREP_TIMEOUT,
             )
         except TimeoutError:

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -761,6 +761,7 @@ except PermissionError:
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,  # noqa: ARG002
     ) -> GrepResult:
         """Search file contents for a literal string using `grep -F`.
 
@@ -771,6 +772,10 @@ except PermissionError:
                 Defaults to `"."`.
             glob: Optional file-name glob to restrict the search
                 (e.g. `'*.py'`).
+            context_lines: Accepted for protocol compatibility but not yet
+                supported on sandbox backends — fetching surrounding lines
+                would require an extra remote round-trip per matched file.
+                Matches are returned without context.
 
         Returns:
             `GrepResult` with a list of `GrepMatch` dicts, or `error` on failure.

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -295,10 +295,11 @@ class StateBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,
     ) -> GrepResult:
         """Search state files for a literal text pattern."""
         files = self._read_files()
-        return grep_matches_from_files(files, pattern, path if path is not None else "/", glob)
+        return grep_matches_from_files(files, pattern, path if path is not None else "/", glob, context_lines)
 
     def glob(self, pattern: str, path: str | None = None) -> GlobResult:
         """Get FileInfo for files matching glob pattern."""

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -690,6 +690,7 @@ class StoreBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        context_lines: int = 0,
     ) -> GrepResult:
         """Search store files for a literal text pattern."""
         store = self._get_store()
@@ -701,7 +702,7 @@ class StoreBackend(BackendProtocol):
                 files[item.key] = self._convert_store_item_to_file_data(item)
             except ValueError:
                 continue
-        return grep_matches_from_files(files, pattern, path, glob)
+        return grep_matches_from_files(files, pattern, path, glob, context_lines)
 
     def glob(self, pattern: str, path: str | None = None) -> GlobResult:
         """Find files matching a glob pattern in the store."""

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -683,15 +683,42 @@ def _format_grep_results(
 # -------- Structured helpers for composition --------
 
 
+MAX_GREP_CONTEXT_LINES = 10
+"""Upper bound for grep `context_lines`, keeping tool results bounded."""
+
+
+def clamp_context_lines(context_lines: int) -> int:
+    """Clamp a user-supplied `context_lines` value to `[0, MAX_GREP_CONTEXT_LINES]`."""
+    return max(0, min(int(context_lines), MAX_GREP_CONTEXT_LINES))
+
+
+def context_window_from_lines(
+    lines: list[str],
+    match_line: int,
+    context_lines: int,
+) -> tuple[list[str], list[str]]:
+    """Slice the context window around a 1-indexed `match_line`.
+
+    Returns `(context_before, context_after)`, clamped at file boundaries.
+    """
+    idx = match_line - 1
+    start = max(0, idx - context_lines)
+    return lines[start:idx], lines[idx + 1 : idx + 1 + context_lines]
+
+
 def grep_matches_from_files(
     files: dict[str, Any],
     pattern: str,
     path: str | None = None,
     glob: str | None = None,
+    context_lines: int = 0,
 ) -> GrepResult:
     """Return structured grep matches from an in-memory files mapping.
 
     Performs literal text search (not regex).
+
+    When `context_lines > 0`, each match carries `context_before` /
+    `context_after` with up to that many surrounding lines.
 
     Returns a GrepResult with matches on success.
     We deliberately do not raise here to keep backends non-throwing in tool
@@ -708,12 +735,19 @@ def grep_matches_from_files(
         matcher = _compile_glob(glob)
         filtered = {fp: fd for fp, fd in filtered.items() if matcher.match(Path(fp).name)}
 
+    context_lines = clamp_context_lines(context_lines)
     matches: list[GrepMatch] = []
     for file_path, file_data in filtered.items():
         content_str = _normalize_content(file_data)
-        for line_num, line in enumerate(content_str.split("\n"), 1):
+        lines = content_str.split("\n")
+        for line_num, line in enumerate(lines, 1):
             if pattern in line:  # Simple substring search for literal matching
-                matches.append({"path": file_path, "line": int(line_num), "text": line})
+                match: GrepMatch = {"path": file_path, "line": int(line_num), "text": line}
+                if context_lines:
+                    before, after = context_window_from_lines(lines, line_num, context_lines)
+                    match["context_before"] = before
+                    match["context_after"] = after
+                matches.append(match)
     return GrepResult(matches=matches)
 
 
@@ -732,4 +766,31 @@ def format_grep_matches(
     """Format structured grep matches using existing formatting logic."""
     if not matches:
         return "No matches found"
+    if output_mode == "content" and any("context_before" in m or "context_after" in m for m in matches):
+        return _format_grep_content_with_context(matches)
     return _format_grep_results(build_grep_results_dict(matches), output_mode)
+
+
+def _format_grep_content_with_context(matches: list[GrepMatch]) -> str:
+    """Render content mode with surrounding context lines.
+
+    Match lines keep the existing `  LINENO: text` shape; context lines use
+    `-` as the separator (mirroring `grep -C`), and match groups within the
+    same file are separated by `--`.
+    """
+    by_file: dict[str, list[GrepMatch]] = {}
+    for m in matches:
+        by_file.setdefault(m["path"], []).append(m)
+    lines: list[str] = []
+    for file_path in sorted(by_file):
+        lines.append(f"{file_path}:")
+        for i, m in enumerate(sorted(by_file[file_path], key=lambda m: m["line"])):
+            if i:
+                lines.append("  --")
+            before = m.get("context_before", [])
+            for offset, text in enumerate(before, start=m["line"] - len(before)):
+                lines.append(f"  {offset}- {text}")
+            lines.append(f"  {m['line']}: {m['text']}")
+            for offset, text in enumerate(m.get("context_after", []), start=m["line"] + 1):
+                lines.append(f"  {offset}- {text}")
+    return "\n".join(lines)

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -389,6 +389,12 @@ class GrepSchema(BaseModel):
         default="files_with_matches",
         description="Output format: 'files_with_matches' (file paths only, default), 'content' (matching lines with context), 'count' (match counts per file).",
     )
+    context_lines: int = Field(
+        default=0,
+        ge=0,
+        le=10,
+        description="Number of lines of surrounding context to include with each match in 'content' mode (like grep -C). Defaults to 0 (no context).",
+    )
 
 
 class ExecuteSchema(BaseModel):
@@ -465,6 +471,7 @@ Examples:
 - Search all files: `grep(pattern="TODO")`
 - Search Python files only: `grep(pattern="import", glob="*.py")`
 - Show matching lines: `grep(pattern="error", output_mode="content")`
+- Show matching lines with 3 lines of surrounding context: `grep(pattern="error", output_mode="content", context_lines=3)`
 - Search for code with special chars: `grep(pattern="def __init__(self):")`"""
 
 EXECUTE_TOOL_DESCRIPTION = """Executes a shell command in an isolated sandbox environment.
@@ -1480,6 +1487,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 Literal["files_with_matches", "content", "count"],
                 "Output format: 'files_with_matches' (file paths only, default), 'content' (matching lines with context), 'count' (match counts per file).",
             ] = "files_with_matches",
+            context_lines: Annotated[
+                int,
+                "Number of lines of surrounding context to include with each match in 'content' mode (like grep -C). 0-10. Defaults to 0 (no context).",
+            ] = 0,
         ) -> ToolMessage:
             """Synchronous wrapper for grep tool."""
             if path is not None:
@@ -1500,7 +1511,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                         status="error",
                     )
             resolved_backend = self._get_backend(runtime)
-            grep_result = resolved_backend.grep(pattern, path=path, glob=glob)
+            grep_result = resolved_backend.grep(pattern, path=path, glob=glob, context_lines=context_lines)
             matches = grep_result.matches or []
             filtered_matches = _filter_grep_matches_by_permission(self._permissions, matches, operation="read")
             formatted, status = _format_grep_tool_result(
@@ -1523,6 +1534,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 Literal["files_with_matches", "content", "count"],
                 "Output format: 'files_with_matches' (file paths only, default), 'content' (matching lines with context), 'count' (match counts per file).",
             ] = "files_with_matches",
+            context_lines: Annotated[
+                int,
+                "Number of lines of surrounding context to include with each match in 'content' mode (like grep -C). 0-10. Defaults to 0 (no context).",
+            ] = 0,
         ) -> ToolMessage:
             """Asynchronous wrapper for grep tool."""
             if path is not None:
@@ -1543,7 +1558,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                         status="error",
                     )
             resolved_backend = self._get_backend(runtime)
-            grep_result = await resolved_backend.agrep(pattern, path=path, glob=glob)
+            grep_result = await resolved_backend.agrep(pattern, path=path, glob=glob, context_lines=context_lines)
             matches = grep_result.matches or []
             filtered_matches = _filter_grep_matches_by_permission(self._permissions, matches, operation="read")
             formatted, status = _format_grep_tool_result(

--- a/libs/deepagents/tests/unit_tests/backends/test_grep_context_lines.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_grep_context_lines.py
@@ -1,0 +1,95 @@
+"""Tests for the `context_lines` parameter on grep (#3109)."""
+
+from pathlib import Path
+
+import pytest
+
+from deepagents.backends import filesystem as filesystem_module
+from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.backends.utils import (
+    MAX_GREP_CONTEXT_LINES,
+    clamp_context_lines,
+    context_window_from_lines,
+    format_grep_matches,
+    grep_matches_from_files,
+)
+
+FILE_CONTENT = "line one\nline two\ntarget line\nline four\nline five"
+
+
+def _files() -> dict[str, dict[str, str]]:
+    return {"/notes.txt": {"content": FILE_CONTENT, "encoding": "utf-8"}}
+
+
+def test_grep_matches_from_files_default_has_no_context_keys() -> None:
+    matches = grep_matches_from_files(_files(), "target").matches
+    assert matches is not None and len(matches) == 1
+    assert "context_before" not in matches[0]
+    assert "context_after" not in matches[0]
+
+
+def test_grep_matches_from_files_with_context() -> None:
+    matches = grep_matches_from_files(_files(), "target", context_lines=2).matches
+    assert matches is not None and len(matches) == 1
+    match = matches[0]
+    assert match["line"] == 3
+    assert match["context_before"] == ["line one", "line two"]
+    assert match["context_after"] == ["line four", "line five"]
+
+
+def test_grep_context_clamped_at_file_boundaries() -> None:
+    files = {"/short.txt": {"content": "only\ntwo", "encoding": "utf-8"}}
+    matches = grep_matches_from_files(files, "only", context_lines=5).matches
+    assert matches is not None and len(matches) == 1
+    assert matches[0]["context_before"] == []
+    assert matches[0]["context_after"] == ["two"]
+
+
+def test_clamp_context_lines_bounds() -> None:
+    assert clamp_context_lines(-3) == 0
+    assert clamp_context_lines(0) == 0
+    assert clamp_context_lines(MAX_GREP_CONTEXT_LINES + 50) == MAX_GREP_CONTEXT_LINES
+
+
+def test_context_window_from_lines_first_and_last_line() -> None:
+    lines = ["a", "b", "c"]
+    assert context_window_from_lines(lines, 1, 2) == ([], ["b", "c"])
+    assert context_window_from_lines(lines, 3, 2) == (["a", "b"], [])
+
+
+@pytest.mark.parametrize("force_python_fallback", [False, True])
+def test_filesystem_backend_grep_context(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, force_python_fallback: bool) -> None:
+    """Context attaches identically on the ripgrep path and the Python fallback."""
+    if force_python_fallback:
+        monkeypatch.setattr(filesystem_module, "_resolve_ripgrep_path", lambda: None)
+
+    (tmp_path / "code.py").write_text(FILE_CONTENT)
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+    matches = be.grep("target", path="/", context_lines=1).matches
+    assert matches is not None and len(matches) == 1
+    assert matches[0]["context_before"] == ["line two"]
+    assert matches[0]["context_after"] == ["line four"]
+
+    # default stays context-free
+    plain = be.grep("target", path="/").matches
+    assert plain is not None and "context_before" not in plain[0]
+
+
+def test_format_grep_matches_content_mode_with_context() -> None:
+    matches = grep_matches_from_files(_files(), "target", context_lines=1).matches
+    assert matches is not None
+    formatted = format_grep_matches(matches, "content")
+    assert formatted.splitlines() == [
+        "/notes.txt:",
+        "  2- line two",
+        "  3: target line",
+        "  4- line four",
+    ]
+
+
+def test_format_grep_matches_without_context_unchanged() -> None:
+    matches = grep_matches_from_files(_files(), "target").matches
+    assert matches is not None
+    assert format_grep_matches(matches, "content") == "/notes.txt:\n  3: target line"
+    assert format_grep_matches(matches, "files_with_matches") == "/notes.txt"

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -177,10 +177,17 @@
   },
   {
     "function": {
-      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
+      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Show matching lines with 3 lines of surrounding context: `grep(pattern=\"error\", output_mode=\"content\", context_lines=3)`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
       "name": "grep",
       "parameters": {
         "properties": {
+          "context_lines": {
+            "default": 0,
+            "description": "Number of lines of surrounding context to include with each match in 'content' mode (like grep -C). Defaults to 0 (no context).",
+            "maximum": 10,
+            "minimum": 0,
+            "type": "integer"
+          },
           "glob": {
             "anyOf": [
               {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -177,10 +177,17 @@
   },
   {
     "function": {
-      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
+      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Show matching lines with 3 lines of surrounding context: `grep(pattern=\"error\", output_mode=\"content\", context_lines=3)`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
       "name": "grep",
       "parameters": {
         "properties": {
+          "context_lines": {
+            "default": 0,
+            "description": "Number of lines of surrounding context to include with each match in 'content' mode (like grep -C). Defaults to 0 (no context).",
+            "maximum": 10,
+            "minimum": 0,
+            "type": "integer"
+          },
           "glob": {
             "anyOf": [
               {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -177,10 +177,17 @@
   },
   {
     "function": {
-      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
+      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Show matching lines with 3 lines of surrounding context: `grep(pattern=\"error\", output_mode=\"content\", context_lines=3)`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
       "name": "grep",
       "parameters": {
         "properties": {
+          "context_lines": {
+            "default": 0,
+            "description": "Number of lines of surrounding context to include with each match in 'content' mode (like grep -C). Defaults to 0 (no context).",
+            "maximum": 10,
+            "minimum": 0,
+            "type": "integer"
+          },
           "glob": {
             "anyOf": [
               {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -177,10 +177,17 @@
   },
   {
     "function": {
-      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
+      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Show matching lines with 3 lines of surrounding context: `grep(pattern=\"error\", output_mode=\"content\", context_lines=3)`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
       "name": "grep",
       "parameters": {
         "properties": {
+          "context_lines": {
+            "default": 0,
+            "description": "Number of lines of surrounding context to include with each match in 'content' mode (like grep -C). Defaults to 0 (no context).",
+            "maximum": 10,
+            "minimum": 0,
+            "type": "integer"
+          },
           "glob": {
             "anyOf": [
               {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -177,10 +177,17 @@
   },
   {
     "function": {
-      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
+      "description": "Search for a text pattern across files.\n\nSearches for literal text (not regex) and returns matching files or content based on output_mode.\nSpecial characters like parentheses, brackets, pipes, etc. are treated as literal characters, not regex operators.\n\nExamples:\n- Search all files: `grep(pattern=\"TODO\")`\n- Search Python files only: `grep(pattern=\"import\", glob=\"*.py\")`\n- Show matching lines: `grep(pattern=\"error\", output_mode=\"content\")`\n- Show matching lines with 3 lines of surrounding context: `grep(pattern=\"error\", output_mode=\"content\", context_lines=3)`\n- Search for code with special chars: `grep(pattern=\"def __init__(self):\")`",
       "name": "grep",
       "parameters": {
         "properties": {
+          "context_lines": {
+            "default": 0,
+            "description": "Number of lines of surrounding context to include with each match in 'content' mode (like grep -C). Defaults to 0 (no context).",
+            "maximum": 10,
+            "minimum": 0,
+            "type": "integer"
+          },
           "glob": {
             "anyOf": [
               {


### PR DESCRIPTION
Fixes #3109

Adds an opt-in `context_lines: int = 0` parameter to the `grep` capability so each match can include up to N lines of surrounding context — saving the follow-up `read_file` round-trip the issue describes. Default `0` preserves current behavior exactly (existing matches/output are byte-identical; `GrepMatch` only gains `context_before`/`context_after` keys when context is requested).

**Design**

- Context is attached by re-reading each matched file once and slicing windows in Python, rather than parsing ripgrep's interleaved `"type":"context"` JSON events — so the ripgrep path, the Python fallback, and the in-memory backends (state, store, context-hub) behave identically. Values are clamped to `[0, 10]`.
- `CompositeBackend` forwards the parameter to routed backends only when set, so custom backends that still override the older 3-argument `grep` keep working as long as no context is requested (same guard in `BackendProtocol.agrep`).
- Sandbox backends accept the parameter but return matches without context (documented) — honoring it would cost an extra remote round-trip per matched file; can be a follow-up if desired.
- The `grep` tool schema exposes `context_lines` (0–10), and `content` output mode renders context grep `-C` style: context lines use `LINENO-`, matches keep the existing `LINENO:` shape, `--` separates match groups within a file.

**Testing**

- New `tests/unit_tests/backends/test_grep_context_lines.py` (9 tests): in-memory backend context before/after, file-boundary clamping, clamp bounds, local backend on both the ripgrep path and the forced Python fallback, formatter rendering with context, and no-context output unchanged.
- Tool-schema snapshots regenerated (`--update-snapshots`) since the grep tool gains a parameter.
- `make format`, `make lint` (ruff + ty) clean; full unit suite: 1807 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)