### PR TITLE
fix(sdk): unify grep glob semantics across backends (ripgrep-style)

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -12,8 +12,6 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-import wcmatch.glob as wcglob
-
 from deepagents._api.deprecation import warn_deprecated
 from deepagents.backends.protocol import (
     DEFAULT_GREP_TIMEOUT,
@@ -38,6 +36,7 @@ from deepagents.backends.protocol import (
 from deepagents.backends.utils import (
     _get_file_type,
     check_empty_content,
+    compile_grep_include_glob,
     perform_string_replacement,
 )
 
@@ -767,7 +766,7 @@ class FilesystemBackend(BackendProtocol):
                 should treat such results as incomplete.
         """
         deadline = time.monotonic() + timeout
-        glob_matcher = wcglob.compile(include_glob, flags=wcglob.BRACE | wcglob.GLOBSTAR) if include_glob else None
+        glob_match = compile_grep_include_glob(include_glob) if include_glob else None
 
         results: dict[str, list[tuple[int, str]]] = {}
         file_errors: list[str] = []
@@ -811,10 +810,8 @@ class FilesystemBackend(BackendProtocol):
                         continue
                 except (PermissionError, OSError, RuntimeError):
                     continue
-                if glob_matcher is not None:
-                    rel_path = str(fp.relative_to(root))
-                    if not glob_matcher.match(rel_path):
-                        continue
+                if glob_match is not None and not glob_match(str(fp.relative_to(root))):
+                    continue
                 try:
                     if fp.stat().st_size > self.max_file_size_bytes:
                         continue

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -8,7 +8,7 @@ enable composition without fragile string parsing.
 import functools
 import os
 import re
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal, overload
@@ -77,6 +77,21 @@ GrepMatch = _GrepMatch
 def _compile_glob(pattern: str) -> wcglob.WcMatcher:
     """Compile a glob pattern once and cache it (BRACE flag)."""
     return wcglob.compile(pattern, flags=wcglob.BRACE)
+
+
+def compile_grep_include_glob(glob: str) -> Callable[[str], bool]:
+    """Compile a grep `glob` filter with ripgrep-like semantics.
+
+    Mirrors how ripgrep interprets `--glob`: a pattern without `/` matches
+    file basenames at any depth; a pattern containing `/` matches the path
+    relative to the search root, with `**` support. Returns a predicate
+    applied to a root-relative path (no leading slash).
+    """
+    if "/" not in glob:
+        matcher = wcglob.compile(glob, flags=wcglob.BRACE)
+        return lambda rel_path: bool(matcher.match(Path(rel_path).name))
+    path_matcher = wcglob.compile(glob.lstrip("/"), flags=wcglob.BRACE | wcglob.GLOBSTAR)
+    return lambda rel_path: bool(path_matcher.match(rel_path))
 
 
 def _normalize_content(file_data: FileData) -> str:
@@ -705,8 +720,9 @@ def grep_matches_from_files(
     filtered = _filter_files_by_path(files, normalized_path)
 
     if glob:
-        matcher = _compile_glob(glob)
-        filtered = {fp: fd for fp, fd in filtered.items() if matcher.match(Path(fp).name)}
+        glob_match = compile_grep_include_glob(glob)
+        root = normalized_path.rstrip("/")
+        filtered = {fp: fd for fp, fd in filtered.items() if glob_match((fp[len(root) :] if root and fp.startswith(root) else fp).lstrip("/"))}
 
     matches: list[GrepMatch] = []
     for file_path, file_data in filtered.items():

--- a/libs/deepagents/tests/unit_tests/backends/test_grep_glob_semantics.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_grep_glob_semantics.py
@@ -1,0 +1,52 @@
+"""Cross-backend glob semantics for grep (ripgrep-style everywhere)."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import deepagents.backends.filesystem as fsmod
+from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.backends.utils import compile_grep_include_glob, grep_matches_from_files
+
+FILES = {
+    "/src/app/main.py": {"content": "import os", "encoding": "utf-8"},
+    "/readme.md": {"content": "import nothing", "encoding": "utf-8"},
+}
+
+CASES = [
+    ("src/**/*.py", ["/src/app/main.py"]),
+    ("**/*.py", ["/src/app/main.py"]),
+    ("*.py", ["/src/app/main.py"]),  # slashless: basename at any depth (rg semantics)
+    ("*.md", ["/readme.md"]),
+    ("app/*.py", []),  # path patterns are root-relative, like rg
+]
+
+
+@pytest.mark.parametrize(("glob", "expected"), CASES)
+def test_in_memory_backend_glob(glob: str, expected: list[str]) -> None:
+    matches = grep_matches_from_files(FILES, "import", "/", glob=glob).matches
+    assert sorted(m["path"] for m in (matches or [])) == expected
+
+
+@pytest.mark.parametrize(("glob", "expected"), CASES)
+def test_python_fallback_glob(tmp_path: Path, glob: str, expected: list[str]) -> None:
+    (tmp_path / "src" / "app").mkdir(parents=True)
+    (tmp_path / "src" / "app" / "main.py").write_text("import os")
+    (tmp_path / "readme.md").write_text("import nothing")
+    with patch.object(fsmod, "_resolve_ripgrep_path", lambda: None):
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        matches = be.grep("import", path="/", glob=glob).matches
+    assert sorted(m["path"] for m in (matches or [])) == expected
+
+
+def test_in_memory_glob_with_search_root() -> None:
+    # path patterns are relative to the search root, matching rg's cwd behavior
+    matches = grep_matches_from_files(FILES, "import", "/src", glob="app/*.py").matches
+    assert [m["path"] for m in (matches or [])] == ["/src/app/main.py"]
+
+
+def test_compile_grep_include_glob_basename_vs_path() -> None:
+    assert compile_grep_include_glob("*.py")("src/app/main.py")
+    assert not compile_grep_include_glob("app/*.py")("src/app/main.py")
+    assert compile_grep_include_glob("src/**/*.py")("src/app/main.py")


### PR DESCRIPTION
Fixes #3922

The `glob` parameter of `grep` meant a different thing on every code path — there was no pattern that behaved the same on the default `StateBackend` and on `FilesystemBackend`, and local behavior changed between hosts depending on whether ripgrep happened to be installed:

| glob | State/Store (basename-only) | Filesystem + rg (gitignore-style) | Filesystem Python fallback (path-anchored) |
|---|---|---|---|
| `src/**/*.py` | ❌ no match | ✅ | ✅ |
| `**/*.py` (the tool description's own example) | ❌ no match | ✅ | ✅ |
| `*.py` (nested file) | ✅ | ✅ | ❌ no match |

Since `StateBackend` is the default in `create_deep_agent`, an agent following the grep tool's own documentation gets zero matches with `status="success"` and concludes the code doesn't exist.

**Fix.** One shared helper, `compile_grep_include_glob` (in `backends/utils.py`), implementing ripgrep's semantics — a pattern without `/` matches basenames at any depth; a pattern containing `/` matches the search-root-relative path with `**` support — now used by both `grep_matches_from_files` (StateBackend/StoreBackend, and CompositeBackend via them) and `_python_search` (the local fallback). The ripgrep path is unchanged: it already had the target behavior, so all paths now agree with it.

**Testing.** New `tests/unit_tests/backends/test_grep_glob_semantics.py` (12 tests): the full pattern matrix (`src/**/*.py`, `**/*.py`, `*.py`, `*.md`, root-relative `app/*.py`) on both the in-memory path and the forced Python fallback, plus search-root relativity and the helper's basename-vs-path split. `make format` / `make lint` (ruff + ty) clean; full unit suite: 1810 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)