### PR TITLE
hotfix(ci): make CodSpeed benchmarks advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,8 +398,6 @@ jobs:
       - test-modal
       - test-runloop
       - test-quickjs
-      - benchmark-deepagents
-      - benchmark-code
       - check-release-options
     if: always()
     runs-on: ubuntu-latest


### PR DESCRIPTION
CodSpeed benchmark jobs still run for relevant package changes, but their failures no longer block merges through the required aggregate CI check.