### PR TITLE
fix(sdk,code): rename trace version metadata to `lc_versions`

### DIFF
--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -826,7 +826,7 @@ def build_stream_config(
 ) -> RunnableConfig:
     """Build the LangGraph stream config dict.
 
-    Injects the dcode version into `metadata["versions"]` so LangSmith traces
+    Injects the dcode version into `metadata["lc_versions"]` so LangSmith traces
     can be correlated with specific releases. `create_deep_agent` supplies the
     SDK version through the compiled graph config, and LangChain merges nested
     metadata dictionaries so both versions survive at stream time.
@@ -854,7 +854,7 @@ def build_stream_config(
         cwd = ""
 
     metadata: dict[str, Any] = {
-        "versions": {"deepagents-code": __version__},
+        "lc_versions": {"deepagents-code": __version__},
         "ls_integration": "deepagents-code",
     }
     from deepagents_code._env_vars import USER_ID

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -608,11 +608,11 @@ class TestBuildStreamConfig:
         assert "model_params" not in config["configurable"]
 
     def test_versions_contains_cli_version(self) -> None:
-        """CLI version should always be present in metadata.versions."""
+        """CLI version should always be present in metadata.lc_versions."""
         from deepagents_code._version import __version__
 
         config = build_stream_config("t-ver", assistant_id=None)
-        assert config["metadata"]["versions"]["deepagents-code"] == __version__
+        assert config["metadata"]["lc_versions"]["deepagents-code"] == __version__
 
     def test_user_id_included_when_set(self) -> None:
         """DEEPAGENTS_CODE_USER_ID should appear in metadata when set."""

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -859,7 +859,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             "recursion_limit": 9_999,
             "metadata": {
                 "ls_integration": "deepagents",
-                "versions": {"deepagents": __version__},
+                "lc_versions": {"deepagents": __version__},
                 "lc_agent_name": name,
             },
         }

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -251,7 +251,7 @@ class TestDeepAgentEndToEnd:
         assert captured_config["tags"] == ["tool-tag", "tool-session-456"]
         assert captured_config["metadata"]["ls_integration"] == "deepagents"
         assert captured_config["metadata"]["lc_agent_name"] == "supervisor"
-        assert "deepagents" in captured_config["metadata"]["versions"]
+        assert "deepagents" in captured_config["metadata"]["lc_versions"]
 
     def test_deep_agent_with_fake_llm_with_tools(self) -> None:
         """Test deepagent with tools using a fake LLM model.

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -61,11 +61,11 @@ class TestCreateDeepAgentMetadata:
     """Tests for metadata on the compiled graph."""
 
     def test_versions_metadata_contains_sdk_version(self) -> None:
-        """`create_deep_agent` should attach SDK version in metadata.versions."""
+        """`create_deep_agent` should attach SDK version in metadata.lc_versions."""
         model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
         agent = create_deep_agent(model=model)
         assert agent.config is not None
-        versions = agent.config["metadata"]["versions"]
+        versions = agent.config["metadata"]["lc_versions"]
         assert versions["deepagents"] == __version__
 
     def test_ls_integration_metadata_preserved(self) -> None:


### PR DESCRIPTION
Package-version trace metadata is now reported under `metadata["lc_versions"]` instead of `metadata["versions"]`.

---

Follows langchain-ai/langchain#38110, which moved package-version trace metadata from the user-owned `metadata["versions"]` key to the LangChain-owned `metadata["lc_versions"]` key.

`langchain-core` now only accumulates nested mappings under `lc_versions` when merging metadata (generic keys are last-writer-wins). The SDK (`create_deep_agent`) and the `dcode` CLI (`build_stream_config`) both seed package versions into trace metadata, so they must use `lc_versions` for those entries to survive the merge and coexist with core/partner versions.

Made by [Open SWE](https://openswe.vercel.app)