### PR TITLE
docs(repo): refresh `README.md` resources and install commands

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -27,7 +27,7 @@
 #   * hotfix     — urgent fix that won't trigger a release
 #
 # Allowed Scope(s) (required):
-#   acp, ci, cli, cli-gha, code, daytona, deepagents, deepagents-acp, deepagents-cli,
+#   acp, ci, cli, code, daytona, dcode-gha, deepagents, deepagents-acp, deepagents-cli,
 #   deepagents-code, deepagents-talon, deps, deps-dev, evals, examples, harbor, infra, langchain-daytona, langchain-modal,
 #   langchain-quickjs, langchain-runloop, langsmith-sandbox, modal,
 #   quickjs, runloop, sdk, talon
@@ -110,8 +110,8 @@ jobs:
             acp
             ci
             cli
-            cli-gha
             code
+            dcode-gha
             daytona
             deepagents
             deepagents-acp

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -30,7 +30,7 @@
 #   acp, ci, cli, code, daytona, dcode-gha, deepagents, deepagents-acp, deepagents-cli,
 #   deepagents-code, deepagents-talon, deps, deps-dev, evals, examples, harbor, infra, langchain-daytona, langchain-modal,
 #   langchain-quickjs, langchain-runloop, langsmith-sandbox, modal,
-#   quickjs, runloop, sdk, talon
+#   quickjs, repo, runloop, sdk, talon
 #
 # Multiple scopes can be used by separating them with a comma.
 #
@@ -131,6 +131,7 @@ jobs:
             langsmith-sandbox
             modal
             quickjs
+            repo
             runloop
             sdk
             talon

--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ Deep Agents is an open source agent harness — an opinionated agent that runs o
 - **Skills** — reusable behaviors the agent can load on demand
 - **Tools** — bring your own functions or any MCP server
 
+Deep Agents is available as a JavaScript/TypeScript library — see [deepagents.js](https://github.com/langchain-ai/deepagentsjs).
+
 > [!NOTE]
-> Deep Agents is available as a JavaScript/TypeScript library — see [deepagents.js](https://github.com/langchain-ai/deepagentsjs).
+> **Deep Agents Code** — a pre-built coding agent in your terminal, similar to Claude Code or Cursor, powered by any LLM. Install with `curl -LsSf https://langch.in/dcode | bash`. See the [documentation](https://docs.langchain.com/deepagents-code) for the full feature set.
 
 ## Quickstart
 
@@ -65,9 +67,6 @@ The agent can plan, read/write files, and manage its own context. Add your own t
 
 > [!TIP]
 > For developing, debugging, and deploying AI agents and LLM applications, see [LangSmith](https://docs.langchain.com/langsmith/home).
-
-> [!NOTE]
-> **Deep Agents Code** — a pre-built coding agent in your terminal, similar to Claude Code or Cursor, powered by any LLM. Install with `curl -LsSf https://langch.in/dcode | bash`. See the [documentation](https://docs.langchain.com/deepagents-code) for the full feature set.
 
 ## FAQ
 
@@ -98,6 +97,7 @@ The layers compose: any LangGraph `CompiledStateGraph` can be passed in as a sub
 - [LangChain ecosystem overview](https://docs.langchain.com/oss/python/concepts/products) — how Deep Agents, LangChain, LangGraph, and LangSmith fit together
 - [API reference](https://reference.langchain.com/python/deepagents/) — complete reference for all public classes, functions, and types
 - [Discussions](https://forum.langchain.com/c/oss-product-help-lc-and-lg/deep-agents/18) — community forum for technical questions, ideas, and feedback
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview) — how to contribute and find good first issues
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The layers compose: any LangGraph `CompiledStateGraph` can be passed in as a sub
 - [LangChain ecosystem overview](https://docs.langchain.com/oss/python/concepts/products) — how Deep Agents, LangChain, LangGraph, and LangSmith fit together
 - [API reference](https://reference.langchain.com/python/deepagents/) — complete reference for all public classes, functions, and types
 - [Discussions](https://forum.langchain.com/c/oss-product-help-lc-and-lg/deep-agents/18) — community forum for technical questions, ideas, and feedback
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview) — how to contribute and find good first issues
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -116,5 +116,5 @@ When adding a new example:
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/README.md
+++ b/examples/README.md
@@ -113,3 +113,8 @@ When adding a new example:
 - **Follow the structure** of existing examples (see `deep_research/` or `text-to-sql-agent/` as references)
 
 </details>
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/async-subagent-server/README.md
+++ b/examples/async-subagent-server/README.md
@@ -79,3 +79,8 @@ _agent = create_deep_agent(
 ## ⚠️ For demonstration purposes only
 
 This example is intended to illustrate the self-hosted async subagent pattern. It does not feature authentication, rate limiting, or other features required for production use.
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/async-subagent-server/README.md
+++ b/examples/async-subagent-server/README.md
@@ -82,5 +82,5 @@ This example is intended to illustrate the self-hosted async subagent pattern. I
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/better-harness/README.md
+++ b/examples/better-harness/README.md
@@ -202,3 +202,8 @@ Supported splits:
 Local artifacts are the source of truth.
 
 If pytest or Harbor logs include trace links, `better-harness` saves them into the run directory. LangSmith is supported the same way: if trace URLs are present in logs or summaries, they are captured and written with the run.
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/better-harness/README.md
+++ b/examples/better-harness/README.md
@@ -205,5 +205,5 @@ If pytest or Harbor logs include trace links, `better-harness` saves them into t
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/content-builder-agent/README.md
+++ b/examples/content-builder-agent/README.md
@@ -147,5 +147,5 @@ This agent has filesystem access and can read, write, and delete files on your m
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/content-builder-agent/README.md
+++ b/examples/content-builder-agent/README.md
@@ -144,3 +144,8 @@ This agent has filesystem access and can read, write, and delete files on your m
 - `ANTHROPIC_API_KEY` - For the main agent
 - `GOOGLE_API_KEY` - For image generation (uses Gemini's [Imagen / "nano banana"](https://ai.google.dev/gemini-api/docs/image-generation) via `gemini-2.5-flash-image`)
 - `TAVILY_API_KEY` - For web search (optional, research still works without it)
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/deep_research/README.md
+++ b/examples/deep_research/README.md
@@ -71,7 +71,6 @@ This provides a user-friendly chat interface and visualization of files in state
 ## 📚 Resources
 
 - **[Deep Research Course](https://academy.langchain.com/courses/deep-research-with-langgraph)** - Full course on deep research with LangGraph
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards
 
 ### Custom Model

--- a/examples/deep_research/README.md
+++ b/examples/deep_research/README.md
@@ -71,6 +71,8 @@ This provides a user-friendly chat interface and visualization of files in state
 ## 📚 Resources
 
 - **[Deep Research Course](https://academy.langchain.com/courses/deep-research-with-langgraph)** - Full course on deep research with LangGraph
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards
 
 ### Custom Model
 

--- a/examples/deploy-coding-agent/README.md
+++ b/examples/deploy-coding-agent/README.md
@@ -65,3 +65,6 @@ Find your deployment URL in LangSmith under **Deployments**. See the [LangGraph 
 
 - [deepagents deploy docs](https://docs.langchain.com/deepagents/deploy)
 - [LangSmith sandbox docs](https://docs.langchain.com/deepagents/sandbox)
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/deploy-coding-agent/README.md
+++ b/examples/deploy-coding-agent/README.md
@@ -65,6 +65,5 @@ Find your deployment URL in LangSmith under **Deployments**. See the [LangGraph 
 
 - [deepagents deploy docs](https://docs.langchain.com/deepagents/deploy)
 - [LangSmith sandbox docs](https://docs.langchain.com/deepagents/sandbox)
-
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/deploy-content-writer/README.md
+++ b/examples/deploy-content-writer/README.md
@@ -80,3 +80,6 @@ deploy-content-writer/
 - [deepagents deploy docs](https://docs.langchain.com/deepagents/deploy)
 - [Custom auth docs](https://docs.langchain.com/deepagents/auth)
 - [Per-user memory docs](https://docs.langchain.com/deepagents/memory)
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/deploy-content-writer/README.md
+++ b/examples/deploy-content-writer/README.md
@@ -80,6 +80,5 @@ deploy-content-writer/
 - [deepagents deploy docs](https://docs.langchain.com/deepagents/deploy)
 - [Custom auth docs](https://docs.langchain.com/deepagents/auth)
 - [Per-user memory docs](https://docs.langchain.com/deepagents/memory)
-
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/deploy-gtm-agent/README.md
+++ b/examples/deploy-gtm-agent/README.md
@@ -70,6 +70,5 @@ deploy-gtm-agent/
 
 - [deepagents deploy docs](https://docs.langchain.com/deepagents/deploy)
 - [Subagents docs](https://docs.langchain.com/deepagents/subagents)
-
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/deploy-gtm-agent/README.md
+++ b/examples/deploy-gtm-agent/README.md
@@ -70,3 +70,6 @@ deploy-gtm-agent/
 
 - [deepagents deploy docs](https://docs.langchain.com/deepagents/deploy)
 - [Subagents docs](https://docs.langchain.com/deepagents/subagents)
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/deploy-mcp-docs-agent/README.md
+++ b/examples/deploy-mcp-docs-agent/README.md
@@ -62,3 +62,6 @@ deploy-mcp-docs-agent/
 
 - [deepagents deploy docs](https://docs.langchain.com/deepagents/deploy)
 - [MCP server docs](https://docs.langchain.com/deepagents/mcp)
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/deploy-mcp-docs-agent/README.md
+++ b/examples/deploy-mcp-docs-agent/README.md
@@ -62,6 +62,5 @@ deploy-mcp-docs-agent/
 
 - [deepagents deploy docs](https://docs.langchain.com/deepagents/deploy)
 - [MCP server docs](https://docs.langchain.com/deepagents/mcp)
-
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/downloading_agents/README.md
+++ b/examples/downloading_agents/README.md
@@ -45,3 +45,8 @@ deepagents
 ```bash
 git init && curl -L https://raw.githubusercontent.com/langchain-ai/deepagents/main/examples/downloading_agents/content-writer.zip -o agent.zip && unzip agent.zip -d .deepagents && rm agent.zip && deepagents
 ```
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/downloading_agents/README.md
+++ b/examples/downloading_agents/README.md
@@ -48,5 +48,5 @@ git init && curl -L https://raw.githubusercontent.com/langchain-ai/deepagents/ma
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/llm-wiki/README.md
+++ b/examples/llm-wiki/README.md
@@ -155,5 +155,5 @@ grep "^## \\[.*\\] query.review \\|" log.md | tail -10
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/llm-wiki/README.md
+++ b/examples/llm-wiki/README.md
@@ -152,3 +152,8 @@ grep "^## \\[" log.md | tail -5
 # Show the latest query review outcomes.
 grep "^## \\[.*\\] query.review \\|" log.md | tail -10
 ```
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/nvidia_deep_agent/README.md
+++ b/examples/nvidia_deep_agent/README.md
@@ -197,3 +197,6 @@ For a full enterprise deployment with NeMo Agent Toolkit, evaluation harnesses, 
 - [NVIDIA NIM](https://build.nvidia.com/)
 - [Modal](https://modal.com)
 - [The Two Patterns for Agent Sandboxes](https://blog.langchain.com/the-two-patterns-by-which-agents-connect-sandboxes/)
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/nvidia_deep_agent/README.md
+++ b/examples/nvidia_deep_agent/README.md
@@ -197,6 +197,5 @@ For a full enterprise deployment with NeMo Agent Toolkit, evaluation harnesses, 
 - [NVIDIA NIM](https://build.nvidia.com/)
 - [Modal](https://modal.com)
 - [The Two Patterns for Agent Sandboxes](https://blog.langchain.com/the-two-patterns-by-which-agents-connect-sandboxes/)
-
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/ralph_mode/README.md
+++ b/examples/ralph_mode/README.md
@@ -25,7 +25,7 @@ uv venv
 source .venv/bin/activate
 
 # Install the CLI
-uv add deepagents-cli
+uv pip install deepagents-cli
 
 # Download the script (or copy from examples/ralph_mode/ if you have the repo)
 curl -O https://raw.githubusercontent.com/langchain-ai/deepagents/main/examples/ralph_mode/ralph_mode.py
@@ -93,5 +93,5 @@ Supported providers: **AgentCore**, **Modal**, **Daytona**, **Runloop**.
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/ralph_mode/README.md
+++ b/examples/ralph_mode/README.md
@@ -25,7 +25,7 @@ uv venv
 source .venv/bin/activate
 
 # Install the CLI
-uv pip install deepagents-cli
+uv add deepagents-cli
 
 # Download the script (or copy from examples/ralph_mode/ if you have the repo)
 curl -O https://raw.githubusercontent.com/langchain-ai/deepagents/main/examples/ralph_mode/ralph_mode.py
@@ -90,3 +90,8 @@ Supported providers: **AgentCore**, **Modal**, **Daytona**, **Runloop**.
 
 - Original Ralph concept by [Geoff Huntley](https://ghuntley.com)
 - [Brief History of Ralph](https://www.humanlayer.dev/blog/brief-history-of-ralph) by HumanLayer
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/repl_swarm/README.md
+++ b/examples/repl_swarm/README.md
@@ -74,5 +74,5 @@ actually runs.
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/repl_swarm/README.md
+++ b/examples/repl_swarm/README.md
@@ -71,3 +71,8 @@ actually runs.
 - **Hundreds of tasks.** The default `concurrency=5` cap (hard-max 10)
   is intentional — subagent invocations aren't free. For mass fan-out
   at thousands of tasks, batch them in a job queue, not a REPL call.
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/rlm_agent/README.md
+++ b/examples/rlm_agent/README.md
@@ -108,5 +108,5 @@ uv run python rlm_agent.py --max-depth 2
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/rlm_agent/README.md
+++ b/examples/rlm_agent/README.md
@@ -105,3 +105,8 @@ uv run python rlm_agent.py --max-depth 2
 - **Only the root agent has REPL at each level.** If you want REPL
   on a non-`general-purpose` subagent too, add `CodeInterpreterMiddleware` to
   its `middleware` list yourself when you define it.
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/talon-whatsapp/README.md
+++ b/examples/talon-whatsapp/README.md
@@ -55,3 +55,8 @@ WhatsApp exposure:
 - `DEEPAGENTS_TALON_WHATSAPP_EXPOSURE=open` allows every inbound WhatsApp message.
 
 Cron jobs are stored in the assistant state directory at `cron/jobs.json`. Scheduler ticks, dispatch, success/failure, and delivery outcomes are logged as `talon_event` JSON records.
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/talon-whatsapp/README.md
+++ b/examples/talon-whatsapp/README.md
@@ -58,5 +58,5 @@ Cron jobs are stored in the assistant state directory at `cron/jobs.json`. Sched
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/examples/text-to-sql-agent/README.md
+++ b/examples/text-to-sql-agent/README.md
@@ -45,7 +45,7 @@ curl -L -o chinook.db https://github.com/lerocha/chinook-database/raw/master/Chi
 # Using uv (recommended)
 uv venv --python 3.11
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-uv add --editable .
+uv sync
 ```
 
 1. Set up your environment variables:
@@ -259,8 +259,7 @@ View your traces at: <https://smith.langchain.com/>
 - [LangChain](https://www.langchain.com/)
 - [Claude Sonnet 4.5](https://www.anthropic.com/claude)
 - [Chinook Database](https://github.com/lerocha/chinook-database)
-
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards
 
 ## License

--- a/examples/text-to-sql-agent/README.md
+++ b/examples/text-to-sql-agent/README.md
@@ -45,7 +45,7 @@ curl -L -o chinook.db https://github.com/lerocha/chinook-database/raw/master/Chi
 # Using uv (recommended)
 uv venv --python 3.11
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-uv pip install -e .
+uv add --editable .
 ```
 
 1. Set up your environment variables:
@@ -259,6 +259,9 @@ View your traces at: <https://smith.langchain.com/>
 - [LangChain](https://www.langchain.com/)
 - [Claude Sonnet 4.5](https://www.anthropic.com/claude)
 - [Chinook Database](https://github.com/lerocha/chinook-database)
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards
 
 ## License
 

--- a/libs/acp/README.md
+++ b/libs/acp/README.md
@@ -152,5 +152,5 @@ You can see a full example [here](./examples/demo_agent.py) with LangChain's mod
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/acp/README.md
+++ b/libs/acp/README.md
@@ -149,3 +149,8 @@ server = AgentServerACP(agent=build_agent, models=models)
 ```
 
 You can see a full example [here](./examples/demo_agent.py) with LangChain's model profile feature.
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -114,6 +114,9 @@ ignoring case and trailing slash).
 - **[Deep Agents SDK](https://github.com/langchain-ai/deepagents)** — underlying agent harness
 - **[Deep Agents Code](https://pypi.org/project/deepagents-code/)** — coding agent
 
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards
+
 ## 📕 Releases & Versioning
 
 See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Versioning](https://docs.langchain.com/oss/python/versioning) policies.

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -113,8 +113,7 @@ ignoring case and trailing slash).
 - **[Source code](https://github.com/langchain-ai/deepagents/tree/main/libs/cli)**
 - **[Deep Agents SDK](https://github.com/langchain-ai/deepagents)** — underlying agent harness
 - **[Deep Agents Code](https://pypi.org/project/deepagents-code/)** — coding agent
-
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards
 
 ## 📕 Releases & Versioning

--- a/libs/code/README.md
+++ b/libs/code/README.md
@@ -48,8 +48,7 @@ The fastest way to start using Deep Agents. `deepagents-code` is a pre-built cod
 - **[Changelog](https://github.com/langchain-ai/deepagents/blob/main/libs/code/CHANGELOG.md)**
 - **[Source code](https://github.com/langchain-ai/deepagents/tree/main/libs/code)**
 - **[Deep Agents SDK](https://github.com/langchain-ai/deepagents)** — underlying agent harness
-
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards
 
 ## 📕 Releases & Versioning

--- a/libs/code/README.md
+++ b/libs/code/README.md
@@ -49,6 +49,9 @@ The fastest way to start using Deep Agents. `deepagents-code` is a pre-built cod
 - **[Source code](https://github.com/langchain-ai/deepagents/tree/main/libs/code)**
 - **[Deep Agents SDK](https://github.com/langchain-ai/deepagents)** — underlying agent harness
 
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards
+
 ## 📕 Releases & Versioning
 
 See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Versioning](https://docs.langchain.com/oss/python/versioning) policies.

--- a/libs/deepagents/README.md
+++ b/libs/deepagents/README.md
@@ -80,8 +80,7 @@ The layers compose: any LangGraph `CompiledStateGraph` can be passed in as a sub
 - **[API Reference](https://reference.langchain.com/python/deepagents/)** — Full SDK reference documentation
 - **[Examples](https://github.com/langchain-ai/deepagents/tree/main/examples)** — Working agents and patterns
 - **[Discussions](https://forum.langchain.com/c/oss-product-help-lc-and-lg/deep-agents/18)** — Community forum for technical questions, ideas, and feedback
-
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards
 
 ## 📕 Releases & Versioning

--- a/libs/deepagents/README.md
+++ b/libs/deepagents/README.md
@@ -80,7 +80,9 @@ The layers compose: any LangGraph `CompiledStateGraph` can be passed in as a sub
 - **[API Reference](https://reference.langchain.com/python/deepagents/)** — Full SDK reference documentation
 - **[Examples](https://github.com/langchain-ai/deepagents/tree/main/examples)** — Working agents and patterns
 - **[Discussions](https://forum.langchain.com/c/oss-product-help-lc-and-lg/deep-agents/18)** — Community forum for technical questions, ideas, and feedback
-- **[Chat LangChain](https://chat.langchain.com)** — Chat interactively with the docs
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards
 
 ## 📕 Releases & Versioning
 

--- a/libs/evals/README.md
+++ b/libs/evals/README.md
@@ -19,5 +19,5 @@ Architecture, writing new evals, category system, Harbor setup, and LangSmith in
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/evals/README.md
+++ b/libs/evals/README.md
@@ -16,3 +16,8 @@ The suite also includes [Harbor](https://github.com/laude-institute/harbor) inte
 ## Contributing
 
 Architecture, writing new evals, category system, Harbor setup, and LangSmith integration are all documented in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/daytona/README.md
+++ b/libs/partners/daytona/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain_daytona
+uv add langchain_daytona
 ```
 
 ```python
@@ -41,3 +41,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/daytona/README.md
+++ b/libs/partners/daytona/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-uv add langchain_daytona
+uv add langchain-daytona
 ```
 
 ```python
@@ -44,5 +44,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/modal/README.md
+++ b/libs/partners/modal/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-uv add langchain-modal
+uv pip install langchain-modal
 ```
 
 ```python
@@ -39,5 +39,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/modal/README.md
+++ b/libs/partners/modal/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-uv pip install langchain-modal
+uv add langchain-modal
 ```
 
 ```python

--- a/libs/partners/modal/README.md
+++ b/libs/partners/modal/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-modal
+uv add langchain-modal
 ```
 
 ```python
@@ -36,3 +36,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/quickjs/CHANGELOG.md
+++ b/libs/partners/quickjs/CHANGELOG.md
@@ -4,20 +4,18 @@
 
 ## [0.2.0](https://github.com/langchain-ai/deepagents/compare/langchain-quickjs==0.1.4...langchain-quickjs==0.2.0) (2026-06-12)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **quickjs:** add default `subagent` bridge ([#3850](https://github.com/langchain-ai/deepagents/issues/3850))
-* **quickjs:** remove `skills_backend` ([#3843](https://github.com/langchain-ai/deepagents/issues/3843))
+* Add default `subagent` bridge ([#3850](https://github.com/langchain-ai/deepagents/issues/3850))
+* Remove `skills_backend` ([#3843](https://github.com/langchain-ai/deepagents/issues/3843))
 
 ### Features
 
-* **quickjs:** add default `subagent` bridge ([#3850](https://github.com/langchain-ai/deepagents/issues/3850)) ([85fd7c2](https://github.com/langchain-ai/deepagents/commit/85fd7c283da6744e403a01861e17e99e13e0f481))
-
+* Add default `subagent` bridge ([#3850](https://github.com/langchain-ai/deepagents/issues/3850)) ([85fd7c2](https://github.com/langchain-ai/deepagents/commit/85fd7c283da6744e403a01861e17e99e13e0f481))
 
 ### Bug Fixes
 
-* **quickjs:** remove `skills_backend` ([#3843](https://github.com/langchain-ai/deepagents/issues/3843)) ([1159e50](https://github.com/langchain-ai/deepagents/commit/1159e504abaeec4f81d5e777ecde6a6cee641edb))
+* Remove `skills_backend` ([#3843](https://github.com/langchain-ai/deepagents/issues/3843)) ([1159e50](https://github.com/langchain-ai/deepagents/commit/1159e504abaeec4f81d5e777ecde6a6cee641edb))
 
 ## [0.1.4](https://github.com/langchain-ai/deepagents/compare/langchain-quickjs==0.1.3...langchain-quickjs==0.1.4) (2026-06-03)
 

--- a/libs/partners/quickjs/README.md
+++ b/libs/partners/quickjs/README.md
@@ -237,3 +237,8 @@ CodeInterpreterMiddleware(
 ## License
 
 MIT. See [`LICENSE`](LICENSE)
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/quickjs/README.md
+++ b/libs/partners/quickjs/README.md
@@ -240,5 +240,5 @@ MIT. See [`LICENSE`](LICENSE)
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/runloop/README.md
+++ b/libs/partners/runloop/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-runloop
+uv add langchain-runloop
 ```
 
 ```python
@@ -51,3 +51,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/runloop/README.md
+++ b/libs/partners/runloop/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-uv add langchain-runloop
+uv pip install langchain-runloop
 ```
 
 ```python
@@ -54,5 +54,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/runloop/README.md
+++ b/libs/partners/runloop/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-uv pip install langchain-runloop
+uv add langchain-runloop
 ```
 
 ```python

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -164,5 +164,5 @@ make test
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -161,3 +161,8 @@ Focused verification:
 make lint
 make test
 ```
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards


### PR DESCRIPTION
`README.md` guidance now points readers toward the shared LangChain learning and community resources across the repo. Python install snippets also use `uv add` consistently instead of `pip install` or `uv pip install`.

## Changes
- Added LangChain Academy and Code of Conduct links across package and example READMEs, using existing Resources sections where available and adding a short Resources section where needed.
- Updated partner package quick-install snippets for Daytona, Modal, and Runloop to use `uv add`.
- Updated example setup instructions to use `uv add deepagents-cli` and `uv add --editable .` for local installs.
- Refreshed the root README intro so the JavaScript/TypeScript library link sits in the main overview and the Deep Agents Code install callout appears before Quickstart.