### PR TITLE
feat(code): add Deep Agents client version metadata

### DIFF
--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -13,7 +13,7 @@ import sys
 import threading
 from dataclasses import dataclass
 from enum import StrEnum
-from importlib.metadata import PackageNotFoundError, distribution
+from importlib.metadata import PackageNotFoundError, distribution, version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote, urlparse
@@ -568,6 +568,23 @@ Kept short so tracing metadata can never stall app flows.
 """
 
 
+def _get_deepagents_version() -> str | None:
+    """Read the installed Deep Agents SDK version from package metadata.
+
+    Returns:
+        The installed Deep Agents SDK version, or `None` when package metadata
+        is unavailable.
+    """
+    try:
+        return version("deepagents")
+    except PackageNotFoundError:
+        logger.debug(
+            "Failed to read deepagents version from package metadata",
+            exc_info=True,
+        )
+        return None
+
+
 def _resolve_editable_info() -> tuple[bool, str | None]:
     """Parse PEP 610 `direct_url.json` once and cache both results.
 
@@ -831,6 +848,10 @@ def build_stream_config(
     SDK version through the compiled graph config, and LangChain merges nested
     metadata dictionaries so both versions survive at stream time.
 
+    Also records `dcode_client_deepagents_version` as a dcode-client diagnostic.
+    This describes the Deep Agents package installed alongside the TUI, which
+    can differ from a remote graph's Deep Agents runtime version.
+
     Includes `ls_integration` metadata so LangSmith traces originating from
     the app are distinguishable from bare SDK usage.
 
@@ -857,6 +878,10 @@ def build_stream_config(
         "lc_versions": {"deepagents-code": __version__},
         "ls_integration": "deepagents-code",
     }
+    deepagents_version = _get_deepagents_version()
+    if deepagents_version is not None:
+        metadata["dcode_client_deepagents_version"] = deepagents_version
+
     from deepagents_code._env_vars import USER_ID
 
     user_id = os.environ.get(USER_ID)

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -1,9 +1,11 @@
 """Unit tests for textual_adapter functions."""
 
 import asyncio
+import sys
 from asyncio import Future
 from collections.abc import AsyncIterator, Generator
 from datetime import datetime
+from importlib.metadata import PackageNotFoundError
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
@@ -612,7 +614,43 @@ class TestBuildStreamConfig:
         from deepagents_code._version import __version__
 
         config = build_stream_config("t-ver", assistant_id=None)
-        assert config["metadata"]["lc_versions"]["deepagents-code"] == __version__
+        assert config["metadata"]["lc_versions"] == {"deepagents-code": __version__}
+
+    def test_dcode_client_deepagents_version_is_diagnostic_metadata(self) -> None:
+        """Client-side SDK version should not be reported as graph instrumentation."""
+        with patch("deepagents_code.config.version", return_value="1.2.3"):
+            config = build_stream_config("t-sdk", assistant_id=None)
+        assert config["metadata"]["dcode_client_deepagents_version"] == "1.2.3"
+        assert "deepagents" not in config["metadata"]["lc_versions"]
+
+    def test_dcode_client_deepagents_version_absent_when_metadata_missing(
+        self,
+    ) -> None:
+        """Missing SDK metadata should not prevent stream config construction."""
+        with patch(
+            "deepagents_code.config.version",
+            side_effect=PackageNotFoundError("deepagents"),
+        ):
+            config = build_stream_config("t-missing-sdk", assistant_id=None)
+
+        assert "dcode_client_deepagents_version" not in config["metadata"]
+
+    def test_dcode_client_deepagents_version_does_not_import_sdk(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """SDK version metadata lookup should not import the SDK package."""
+        for module in list(sys.modules):
+            if module == "deepagents" or module.startswith("deepagents."):
+                monkeypatch.delitem(sys.modules, module, raising=False)
+
+        with patch("deepagents_code.config.version", return_value="1.2.3"):
+            build_stream_config("t-no-sdk-import", assistant_id=None)
+
+        assert not any(
+            module == "deepagents" or module.startswith("deepagents.")
+            for module in sys.modules
+        )
 
     def test_user_id_included_when_set(self) -> None:
         """DEEPAGENTS_CODE_USER_ID should appear in metadata when set."""


### PR DESCRIPTION
Stream config metadata now separates dcode's bundled SDK version from graph instrumentation so LangSmith traces can distinguish the TUI client from the remote runtime. Missing package metadata is treated as a diagnostic miss instead of blocking config construction.