### PR TITLE
fix(sdk): remove excluded tools from prompts

### DIFF
--- a/libs/deepagents/deepagents/middleware/_tool_exclusion.py
+++ b/libs/deepagents/deepagents/middleware/_tool_exclusion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import SystemMessage
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -18,6 +19,8 @@ if TYPE_CHECKING:
     from langchain_core.messages import AIMessage
     from langchain_core.tools import BaseTool
 
+_FILESYSTEM_TOOL_NAMES = frozenset({"ls", "read_file", "write_file", "edit_file", "glob", "grep"})
+
 
 def _tool_name(tool: BaseTool | dict[str, str]) -> str | None:
     """Extract tool name from a `BaseTool` or dict tool."""
@@ -26,6 +29,70 @@ def _tool_name(tool: BaseTool | dict[str, str]) -> str | None:
         return name if isinstance(name, str) else None
     name = getattr(tool, "name", None)
     return name if isinstance(name, str) else None
+
+
+def _remove_markdown_section(text: str, heading: str) -> str:
+    """Remove a markdown section by exact heading."""
+    start = text.find(heading)
+    if start == -1:
+        return text
+    next_section = text.find("\n\n## ", start + len(heading))
+    if next_section == -1:
+        return text[:start].rstrip()
+    return (text[:start].rstrip() + "\n\n" + text[next_section:].lstrip()).strip()
+
+
+def _remove_filesystem_tool_prompt_entries(text: str, excluded: frozenset[str]) -> str:
+    """Remove excluded filesystem tools from the filesystem prompt block."""
+    filesystem_excluded = excluded & _FILESYSTEM_TOOL_NAMES
+    if not filesystem_excluded:
+        return text
+
+    lines: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("## Filesystem Tools "):
+            available = [name for name in ("ls", "read_file", "write_file", "edit_file", "glob", "grep") if name not in filesystem_excluded]
+            if not available:
+                continue
+            tools = ", ".join(f"`{name}`" for name in available)
+            lines.append(f"## Filesystem Tools {tools}")
+            continue
+        if any(line.startswith(f"- {name}:") for name in filesystem_excluded):
+            continue
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _filter_system_prompt(system_message: SystemMessage | None, excluded: frozenset[str]) -> SystemMessage | None:
+    """Remove built-in tool instructions for tools hidden from the model."""
+    if system_message is None or not excluded:
+        return system_message
+
+    changed = False
+    content_blocks: list[Any] = []
+    for block in system_message.content_blocks:
+        block_data: Any = block
+        if not isinstance(block_data, dict) or block_data.get("type") != "text" or not isinstance(block_data.get("text"), str):
+            content_blocks.append(block)
+            continue
+
+        text = block_data["text"]
+        filtered_text = _remove_filesystem_tool_prompt_entries(text, excluded)
+        if "execute" in excluded:
+            filtered_text = _remove_markdown_section(filtered_text, "## Execute Tool `execute`")
+        if "task" in excluded:
+            filtered_text = _remove_markdown_section(filtered_text, "## `task` (subagent spawner)")
+
+        if filtered_text != text:
+            changed = True
+        if filtered_text.strip():
+            content_blocks.append({**block_data, "text": filtered_text})
+        else:
+            changed = True
+
+    if not changed:
+        return system_message
+    return SystemMessage(content_blocks=content_blocks)
 
 
 class _ToolExclusionMiddleware(AgentMiddleware[Any, Any, Any]):
@@ -50,7 +117,10 @@ class _ToolExclusionMiddleware(AgentMiddleware[Any, Any, Any]):
         """Filter excluded tools before they reach the model."""
         if self._excluded:
             filtered = [t for t in request.tools if _tool_name(t) not in self._excluded]
-            request = request.override(tools=filtered)
+            request = request.override(
+                tools=filtered,
+                system_message=_filter_system_prompt(request.system_message, self._excluded),
+            )
         return handler(request)
 
     async def awrap_model_call(
@@ -61,5 +131,8 @@ class _ToolExclusionMiddleware(AgentMiddleware[Any, Any, Any]):
         """Async variant of `wrap_model_call`."""
         if self._excluded:
             filtered = [t for t in request.tools if _tool_name(t) not in self._excluded]
-            request = request.override(tools=filtered)
+            request = request.override(
+                tools=filtered,
+                system_message=_filter_system_prompt(request.system_message, self._excluded),
+            )
         return await handler(request)

--- a/libs/deepagents/tests/unit_tests/middleware/test_tool_exclusion.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_tool_exclusion.py
@@ -1,0 +1,97 @@
+"""Tests for tool exclusion middleware."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
+from tests.unit_tests.chat_model import GenericFakeChatModel
+
+
+def _request_with_prompt(prompt: str) -> ModelRequest:
+    return ModelRequest(
+        model=GenericFakeChatModel(messages=iter([AIMessage(content="ok")])),
+        messages=[HumanMessage(content="hi")],
+        system_message=SystemMessage(content=prompt),
+        tools=[
+            {"name": "ls"},
+            {"name": "read_file"},
+            {"name": "write_file"},
+            {"name": "edit_file"},
+            {"name": "glob"},
+            {"name": "grep"},
+            {"name": "execute"},
+            {"name": "task"},
+        ],
+    )
+
+
+def test_excluded_tools_are_removed_from_tools_and_system_prompt() -> None:
+    middleware = _ToolExclusionMiddleware(excluded=frozenset({"write_file", "edit_file", "execute", "task"}))
+    request = _request_with_prompt(
+        """## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+
+- ls: list files in a directory
+- read_file: read a file from the filesystem
+- write_file: write to a file in the filesystem
+- edit_file: edit a file in the filesystem
+- glob: find files matching a pattern
+- grep: search for text within files
+
+## Execute Tool `execute`
+
+Run shell commands.
+
+## `task` (subagent spawner)
+
+Use subagents.
+
+## Keep Me
+
+Other instructions."""
+    )
+    captured: list[ModelRequest] = []
+
+    def handler(request: ModelRequest) -> ModelResponse:
+        captured.append(request)
+        return ModelResponse(result=[AIMessage(content="ok")])
+
+    middleware.wrap_model_call(request, handler)
+
+    assert [_tool["name"] for _tool in captured[0].tools] == ["ls", "read_file", "glob", "grep"]
+    assert captured[0].system_message is not None
+    prompt = captured[0].system_message.text
+    assert "write_file" not in prompt
+    assert "edit_file" not in prompt
+    assert "Execute Tool" not in prompt
+    assert "subagent spawner" not in prompt
+    assert "## Keep Me" in prompt
+
+
+@pytest.mark.asyncio
+async def test_async_excluded_tools_are_removed_from_tools_and_system_prompt() -> None:
+    middleware = _ToolExclusionMiddleware(excluded=frozenset({"write_file"}))
+    request = _request_with_prompt(
+        """## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+
+- ls: list files in a directory
+- write_file: write to a file in the filesystem
+- edit_file: edit a file in the filesystem"""
+    )
+    captured: list[ModelRequest] = []
+
+    async def handler(request: ModelRequest[Any]) -> ModelResponse:
+        captured.append(request)
+        return ModelResponse(result=[AIMessage(content="ok")])
+
+    await middleware.awrap_model_call(request, handler)
+
+    assert [_tool["name"] for _tool in captured[0].tools] == ["ls", "read_file", "edit_file", "glob", "grep", "execute", "task"]
+    assert captured[0].system_message is not None
+    prompt = captured[0].system_message.text
+    assert "write_file" not in prompt
+    assert "edit_file" in prompt


### PR DESCRIPTION
Fixes #3948

Keep `excluded_tools` consistent with the system prompt by removing hidden built-in tool instructions for filesystem, execute, and task tools.

Verified with `uv run --group test pytest tests/unit_tests/middleware/test_tool_exclusion.py -q`, targeted ruff format/check, and `uv run --all-groups ty check deepagents`.

AI assistance disclosure: I used Codex while preparing this change and reviewed the implementation and tests before submitting.