### PR TITLE
feat(code): add model switcher to command palette

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, cast
 from textual import on
 from textual.app import App, ScreenStackError
 from textual.binding import Binding, BindingType
+from textual.command import DiscoveryHit, Hit, Hits, Provider
 from textual.containers import Container, VerticalScroll
 from textual.content import Content
 from textual.css.query import NoMatches
@@ -1401,6 +1402,59 @@ class _ChatScroll(VerticalScroll):
     FOCUS_ON_CLICK = False
 
 
+class ModelProvider(Provider):
+    """Command palette provider for switching models."""
+
+    async def startup(self) -> None:
+        """Load available model specs before palette search begins."""
+        from deepagents_code.widgets.model_selector import ModelSelectorScreen
+
+        cli_override = getattr(self.app, "_profile_override", None)
+        all_models, _, _, _ = await asyncio.to_thread(
+            ModelSelectorScreen._load_model_data,
+            cli_override,
+        )
+        self._models = all_models
+
+    def _switch_model(self, model_spec: str) -> None:
+        """Request a model switch from the owning app.
+
+        Args:
+            model_spec: Model spec in `provider:model` format.
+        """
+        request = getattr(self.app, "_request_model_switch", None)
+        if callable(request):
+            request(model_spec)
+
+    async def discover(self) -> Hits:
+        """Yield model-switching commands for an empty palette query."""
+        for model_spec, _ in self._models:
+            command_text = f"Switch model: {model_spec}"
+            yield DiscoveryHit(
+                command_text,
+                lambda model_spec=model_spec: self._switch_model(model_spec),
+                text=command_text,
+            )
+
+    async def search(self, query: str) -> Hits:
+        """Yield matching model-switching commands.
+
+        Args:
+            query: Palette search query.
+        """
+        matcher = self.matcher(query)
+        for model_spec, _ in self._models:
+            command_text = f"Switch model: {model_spec}"
+            score = matcher.match(command_text)
+            if score > 0:
+                yield Hit(
+                    score,
+                    matcher.highlight(command_text),
+                    lambda model_spec=model_spec: self._switch_model(model_spec),
+                    text=command_text,
+                )
+
+
 class DeepAgentsApp(App):
     """Main Textual application for deepagents-code."""
 
@@ -1410,9 +1464,14 @@ class DeepAgentsApp(App):
     CSS_PATH = "app.tcss"
     """Path to the Textual CSS stylesheet for the app layout."""
 
-    ENABLE_COMMAND_PALETTE = False
-    """Disable Textual's built-in command palette in favor of the custom slash
-    command system."""
+    ENABLE_COMMAND_PALETTE = True
+    """Enable Textual's command palette for non-destructive quick actions."""
+
+    COMMANDS: ClassVar[set[type[Provider] | Callable[[], type[Provider]]]] = {
+        *App.COMMANDS,
+        ModelProvider,
+    }
+    """Custom Textual command palette providers."""
 
     SCROLL_SENSITIVITY_Y = 1.0
     """Vertical scroll speed (reduced from Textual default for finer control)."""
@@ -8767,6 +8826,44 @@ class DeepAgentsApp(App):
         result = await self._push_screen_wait(screen)
         return result if result is None or isinstance(result, tuple) else None
 
+    def _request_model_switch(
+        self,
+        model_spec: str,
+        *,
+        extra_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        """Schedule or defer a model switch without disturbing chat input.
+
+        Args:
+            model_spec: Model spec in `provider:model` format.
+            extra_kwargs: Extra constructor kwargs from `--model-params`.
+        """
+        from functools import partial
+
+        if self._agent_running or self._shell_running or self._connecting:
+            self._defer_action(
+                DeferredAction(
+                    kind="model_switch",
+                    execute=partial(
+                        self._switch_model,
+                        model_spec,
+                        extra_kwargs=extra_kwargs,
+                    ),
+                ),
+            )
+            self.notify(
+                "Model will switch after current task completes.",
+                timeout=3,
+            )
+        else:
+            self.call_later(
+                partial(
+                    self._switch_model,
+                    model_spec,
+                    extra_kwargs=extra_kwargs,
+                ),
+            )
+
     async def _show_model_selector(
         self,
         *,
@@ -8777,35 +8874,12 @@ class DeepAgentsApp(App):
         Args:
             extra_kwargs: Extra constructor kwargs from `--model-params`.
         """
-        from functools import partial
 
         def handle_result(result: tuple[str, str] | None) -> None:
             """Handle the model selector result."""
             if result is not None:
                 model_spec, _ = result
-                if self._agent_running or self._shell_running or self._connecting:
-                    self._defer_action(
-                        DeferredAction(
-                            kind="model_switch",
-                            execute=partial(
-                                self._switch_model,
-                                model_spec,
-                                extra_kwargs=extra_kwargs,
-                            ),
-                        ),
-                    )
-                    self.notify(
-                        "Model will switch after current task completes.",
-                        timeout=3,
-                    )
-                else:
-                    self.call_later(
-                        partial(
-                            self._switch_model,
-                            model_spec,
-                            extra_kwargs=extra_kwargs,
-                        ),
-                    )
+                self._request_model_switch(model_spec, extra_kwargs=extra_kwargs)
             # Refocus input after modal closes
             if self._chat_input:
                 self._chat_input.focus_input()

--- a/libs/code/tests/unit_tests/test_command_palette.py
+++ b/libs/code/tests/unit_tests/test_command_palette.py
@@ -1,0 +1,119 @@
+"""Tests for the Textual command palette integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from deepagents_code.app import DeepAgentsApp, ModelProvider
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class TestCommandPalette:
+    """Tests for the Textual command palette integration."""
+
+    def test_command_palette_is_enabled_with_model_provider(self) -> None:
+        """The app should expose the model-switching provider to Textual."""
+        assert DeepAgentsApp.ENABLE_COMMAND_PALETTE is True
+        assert ModelProvider in DeepAgentsApp.COMMANDS
+
+    async def test_model_provider_keeps_existing_input_when_switching(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Palette model switches should not submit or clear draft input."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+
+        monkeypatch.setattr(
+            "deepagents_code.widgets.model_selector.ModelSelectorScreen._load_model_data",
+            staticmethod(
+                lambda _override: (
+                    [("openai:test-gpt", "openai")],
+                    None,
+                    {},
+                    [],
+                )
+            ),
+        )
+
+        async with app.run_test():
+            assert app._chat_input is not None
+            app._chat_input.value = "draft prompt"
+            provider = ModelProvider(app.screen)
+            await provider.startup()
+            hits = [hit async for hit in provider.search("gpt")]
+
+            hits[0].command()
+
+            assert app._chat_input.value == "draft prompt"
+
+    async def test_model_provider_search_switches_matching_model(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Choosing a model palette hit should request that model switch."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+        requested: list[str] = []
+
+        monkeypatch.setattr(
+            "deepagents_code.widgets.model_selector.ModelSelectorScreen._load_model_data",
+            staticmethod(
+                lambda _override: (
+                    [
+                        ("anthropic:test-sonnet", "anthropic"),
+                        ("openai:test-gpt", "openai"),
+                    ],
+                    None,
+                    {},
+                    [],
+                )
+            ),
+        )
+
+        def record_model_switch(
+            model_spec: str,
+            *,
+            extra_kwargs: dict[str, object] | None = None,
+        ) -> None:
+            del extra_kwargs
+            requested.append(model_spec)
+
+        monkeypatch.setattr(app, "_request_model_switch", record_model_switch)
+
+        async with app.run_test():
+            provider = ModelProvider(app.screen)
+            await provider.startup()
+            hits = [hit async for hit in provider.search("gpt")]
+
+            assert [hit.text for hit in hits] == ["Switch model: openai:test-gpt"]
+            hits[0].command()
+
+        assert requested == ["openai:test-gpt"]
+
+    async def test_model_provider_discovery_lists_models(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An empty palette query should discover switchable models."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+
+        monkeypatch.setattr(
+            "deepagents_code.widgets.model_selector.ModelSelectorScreen._load_model_data",
+            staticmethod(
+                lambda _override: (
+                    [("openai:test-gpt", "openai")],
+                    None,
+                    {},
+                    [],
+                )
+            ),
+        )
+
+        async with app.run_test():
+            provider = ModelProvider(app.screen)
+            await provider.startup()
+            hits = [hit async for hit in provider.discover()]
+
+        assert [hit.text for hit in hits] == ["Switch model: openai:test-gpt"]


### PR DESCRIPTION
Closes #1418

---

Adds a Textual command palette provider for model switching in `deepagents-code`.

The provider reuses the existing model selector catalog and routes selections through the same scheduling path as the modal selector, so model changes still defer while an agent, shell command, or connection is running. This keeps the feature narrow: the command palette exposes model switching without changing slash-command behavior or model construction.

The regression coverage exercises three user-visible behaviors:
- the app registers the Textual command palette provider
- searching the palette requests the selected model switch
- switching from the palette preserves draft chat input instead of submitting or clearing it

Verification:
- `uv run --group test pytest tests/unit_tests/test_command_palette.py tests/unit_tests/test_model_selector.py tests/unit_tests/test_model_switch.py -q`
- `uv run ruff check deepagents_code/app.py tests/unit_tests/test_command_palette.py`
- `uv run ruff format deepagents_code/app.py tests/unit_tests/test_command_palette.py --diff`
- `uv run ty check deepagents_code/app.py tests/unit_tests/test_command_palette.py`
- reviewer pass: CLEAN, including headless Textual command-palette smoke check

Review note: the issue thread mentions maintainers planned to handle implementation. I kept this as a draft and intentionally limited the diff to the command palette/model-switch path so maintainers can either take it directly or use it as a tested reference.