### PR TITLE
feat(code): add --allowed-tools and --disallowed-tools CLI flags

### DIFF
--- a/libs/code/deepagents_code/_server_config.py
+++ b/libs/code/deepagents_code/_server_config.py
@@ -206,6 +206,18 @@ class ServerConfig:
     """Tri-state trust flag for project-scoped MCP servers: `True`/`False`/`None`
     (prompt user)."""
 
+    allowed_tools: list[str] | None = None
+    """Allow-list of tool names; all other tools are hidden from the model.
+
+    Mutually exclusive with `disallowed_tools`. `None` means no restriction.
+    """
+
+    disallowed_tools: list[str] | None = None
+    """Deny-list of tool names to remove from the model's tool list.
+
+    Mutually exclusive with `allowed_tools`. `None` means no restriction.
+    """
+
     def __post_init__(self) -> None:
         """Normalize fields and validate invariants.
 
@@ -274,6 +286,14 @@ class ServerConfig:
                 if self.trust_project_mcp is not None
                 else None
             ),
+            "ALLOWED_TOOLS": (
+                ",".join(self.allowed_tools) if self.allowed_tools is not None else None
+            ),
+            "DISALLOWED_TOOLS": (
+                ",".join(self.disallowed_tools)
+                if self.disallowed_tools is not None
+                else None
+            ),
         }
 
     @classmethod
@@ -318,6 +338,18 @@ class ServerConfig:
             mcp_config_path=_read_env_str("MCP_CONFIG_PATH"),
             no_mcp=_read_env_bool("NO_MCP"),
             trust_project_mcp=_read_env_optional_bool("TRUST_PROJECT_MCP"),
+            allowed_tools=(
+                [t.strip() for t in raw.split(",") if t.strip()]
+                if (raw := _read_env_str("ALLOWED_TOOLS"))
+                else None
+            )
+            or None,
+            disallowed_tools=(
+                [t.strip() for t in raw.split(",") if t.strip()]
+                if (raw := _read_env_str("DISALLOWED_TOOLS"))
+                else None
+            )
+            or None,
         )
 
     # ------------------------------------------------------------------
@@ -348,6 +380,8 @@ class ServerConfig:
         no_mcp: bool,
         trust_project_mcp: bool | None,
         interactive: bool,
+        allowed_tools: list[str] | None = None,
+        disallowed_tools: list[str] | None = None,
     ) -> ServerConfig:
         """Build a `ServerConfig` from parsed CLI arguments.
 
@@ -381,6 +415,8 @@ class ServerConfig:
             no_mcp: Disable MCP.
             trust_project_mcp: Trust project MCP servers.
             interactive: Whether the agent is interactive.
+            allowed_tools: Allow-list of tool names; all others are hidden.
+            disallowed_tools: Deny-list of tool names to remove.
 
         Returns:
             A fully resolved `ServerConfig`.
@@ -418,6 +454,8 @@ class ServerConfig:
             mcp_config_path=normalized_mcp,
             no_mcp=no_mcp,
             trust_project_mcp=trust_project_mcp,
+            allowed_tools=allowed_tools,
+            disallowed_tools=disallowed_tools,
         )
 
 

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -35,7 +35,13 @@ if TYPE_CHECKING:
     from deepagents.middleware.async_subagents import AsyncSubAgent
     from deepagents.middleware.subagents import CompiledSubAgent, SubAgent
     from langchain.agents.middleware import InterruptOnConfig
-    from langchain.agents.middleware.types import AgentState
+    from langchain.agents.middleware.types import (
+        AgentState,
+        ExtendedModelResponse,
+        ModelRequest,
+        ModelResponse,
+        ResponseT,
+    )
     from langchain.messages import ToolCall
     from langchain.tools import BaseTool
     from langchain_core.language_models import BaseChatModel
@@ -213,6 +219,95 @@ class ShellAllowListMiddleware(AgentMiddleware):
         if (rejection := self._validate_tool_call(request)) is not None:
             return rejection
         return await handler(request)
+
+
+def _get_tool_name(tool: BaseTool | dict[str, Any]) -> str | None:
+    """Return the name of a tool, whether it is a BaseTool or a dict schema."""
+    if isinstance(tool, dict):
+        name = tool.get("name")
+        return name if isinstance(name, str) else None
+    name = getattr(tool, "name", None)
+    return name if isinstance(name, str) else None
+
+
+class _ToolAllowListMiddleware(AgentMiddleware):
+    """Keep only explicitly allowed tools in every model request.
+
+    Placed last in the middleware stack so it sees the final tool list
+    (including tools injected by Skills, Filesystem, and other middleware).
+    """
+
+    def __init__(self, *, allowed: frozenset[str]) -> None:
+        self._allowed = allowed
+
+    def _filter(
+        self, tools: list[BaseTool | dict[str, Any]]
+    ) -> list[BaseTool | dict[str, Any]]:
+        return [t for t in tools if _get_tool_name(t) in self._allowed]
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any]:
+        """Filter tools to the allow-list before reaching the model.
+
+        Returns:
+            Model response after filtering tools to only allowed names.
+        """
+        return handler(request.override(tools=self._filter(request.tools)))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT] | ExtendedModelResponse[ResponseT]:
+        """Async variant of wrap_model_call.
+
+        Returns:
+            Model response after filtering tools to only allowed names.
+        """
+        return await handler(request.override(tools=self._filter(request.tools)))
+
+
+class _ToolDenyListMiddleware(AgentMiddleware):
+    """Remove explicitly excluded tools from every model request.
+
+    Placed last in the middleware stack so it sees the final tool list
+    (including tools injected by Skills, Filesystem, and other middleware).
+    """
+
+    def __init__(self, *, excluded: frozenset[str]) -> None:
+        self._excluded = excluded
+
+    def _filter(
+        self, tools: list[BaseTool | dict[str, Any]]
+    ) -> list[BaseTool | dict[str, Any]]:
+        return [t for t in tools if _get_tool_name(t) not in self._excluded]
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any]:
+        """Remove excluded tools before reaching the model.
+
+        Returns:
+            Model response after removing denied tools.
+        """
+        return handler(request.override(tools=self._filter(request.tools)))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT] | ExtendedModelResponse[ResponseT]:
+        """Async variant of wrap_model_call.
+
+        Returns:
+            Model response after removing denied tools.
+        """
+        return await handler(request.override(tools=self._filter(request.tools)))
 
 
 _INTERPRETER_WRITE_TOOLS: frozenset[str] = frozenset(
@@ -1119,6 +1214,8 @@ def create_cli_agent(
     cwd: str | Path | None = None,
     project_context: ProjectContext | None = None,
     async_subagents: list[AsyncSubAgent] | None = None,
+    allowed_tools: list[str] | None = None,
+    disallowed_tools: list[str] | None = None,
 ) -> tuple[Pregel[Any, Any, Any, Any], CompositeBackend]:
     """Create a CLI-configured agent with flexible options.
 
@@ -1202,6 +1299,12 @@ def create_cli_agent(
         async_subagents: Remote LangGraph deployments to expose as async subagent tools.
 
             Loaded from `[async_subagents]` in `config.toml` or passed directly.
+        allowed_tools: When set, only the named tools are visible to the model. All
+            other tools (including those injected by middleware) are hidden. Mutually
+            exclusive with `disallowed_tools`.
+        disallowed_tools: When set, the named tools are removed from the model's tool
+            list. All other tools remain available. Mutually exclusive with
+            `allowed_tools`.
 
     Returns:
         2-tuple of `(agent_graph, backend)`
@@ -1566,6 +1669,16 @@ def create_cli_agent(
     agent_middleware.append(
         create_summarization_tool_middleware(model, composite_backend)
     )
+
+    # Wire tool allow/deny-list middleware (placed last so it sees all injected tools).
+    if allowed_tools is not None:
+        agent_middleware.append(
+            _ToolAllowListMiddleware(allowed=frozenset(allowed_tools))
+        )
+    elif disallowed_tools:
+        agent_middleware.append(
+            _ToolDenyListMiddleware(excluded=frozenset(disallowed_tools))
+        )
 
     # Create the agent
     all_subagents: list[SubAgent | CompiledSubAgent | AsyncSubAgent] = [

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1239,6 +1239,22 @@ def parse_args() -> argparse.Namespace:
         "Applies to both -n and interactive modes.",
     )
     parser.add_argument(
+        "--allowed-tools",
+        metavar="TOOLS",
+        help="Comma-separated allow-list of tool names. All other tools are "
+        "hidden from the model for the duration of the session. "
+        "E.g. --allowed-tools read_file,ls,glob,grep for a read-only session. "
+        "Mutually exclusive with --disallowed-tools.",
+    )
+    parser.add_argument(
+        "--disallowed-tools",
+        metavar="TOOLS",
+        help="Comma-separated deny-list of tool names to remove. All other "
+        "tools remain available. "
+        "E.g. --disallowed-tools execute,task to prevent shell and subagent calls. "
+        "Mutually exclusive with --allowed-tools.",
+    )
+    parser.add_argument(
         "--mcp-config",
         help="Path to MCP servers JSON configuration file (Claude Desktop format). "
         "Merged on top of auto-discovered configs (highest precedence). "
@@ -1436,6 +1452,8 @@ async def run_textual_cli_async(
     enable_interpreter: bool = False,
     interpreter_ptc: str | list[str] | None = None,
     interpreter_ptc_acknowledge_unsafe: bool = False,
+    allowed_tools: list[str] | None = None,
+    disallowed_tools: list[str] | None = None,
 ) -> "AppResult":
     """Run the Textual TUI interface (async version).
 
@@ -1487,6 +1505,8 @@ async def run_textual_cli_async(
             for `js_eval`).
         interpreter_ptc_acknowledge_unsafe: Explicit acknowledgement for
             `interpreter_ptc="all"` outside of `auto_approve`.
+        allowed_tools: Allow-list of tool names; all others are hidden from the model.
+        disallowed_tools: Deny-list of tool names to remove from the model's tool list.
 
     Returns:
         An `AppResult` with the return code and final thread ID.
@@ -1565,6 +1585,8 @@ async def run_textual_cli_async(
         "no_mcp": no_mcp,
         "trust_project_mcp": trust_project_mcp,
         "interactive": True,
+        "allowed_tools": allowed_tools,
+        "disallowed_tools": disallowed_tools,
     }
 
     mcp_preload_kwargs: dict[str, Any] | None = None
@@ -2198,6 +2220,28 @@ def cli_main() -> None:
             from deepagents_code.config import parse_shell_allow_list
 
             settings.shell_allow_list = parse_shell_allow_list(args.shell_allow_list)
+
+        # Parse and validate --allowed-tools / --disallowed-tools
+        raw_allowed = getattr(args, "allowed_tools", None)
+        raw_disallowed = getattr(args, "disallowed_tools", None)
+        if raw_allowed and raw_disallowed:
+            from rich.console import Console as _Console
+
+            _Console(stderr=True).print(
+                "[bold red]Error:[/bold red] --allowed-tools and --disallowed-tools "
+                "are mutually exclusive. Use one or the other."
+            )
+            sys.exit(2)
+        allowed_tools: list[str] | None = (
+            [t.strip() for t in raw_allowed.split(",") if t.strip()]
+            if raw_allowed
+            else None
+        )
+        disallowed_tools: list[str] | None = (
+            [t.strip() for t in raw_disallowed.split(",") if t.strip()]
+            if raw_disallowed
+            else None
+        )
 
         apply_stdin_pipe(args)
 
@@ -2837,6 +2881,8 @@ def cli_main() -> None:
                             enable_interpreter=getattr(args, "interpreter", False),
                             interpreter_ptc=interpreter_ptc,
                             max_turns=getattr(args, "max_turns", None),
+                            allowed_tools=allowed_tools,
+                            disallowed_tools=disallowed_tools,
                         ),
                         timeout=timeout,
                     )
@@ -2934,6 +2980,8 @@ def cli_main() -> None:
                         trust_project_mcp=mcp_trust_decision,
                         enable_interpreter=getattr(args, "interpreter", False),
                         interpreter_ptc=interpreter_ptc,
+                        allowed_tools=allowed_tools,
+                        disallowed_tools=disallowed_tools,
                     )
                 )
                 return_code = result.return_code

--- a/libs/code/deepagents_code/non_interactive.py
+++ b/libs/code/deepagents_code/non_interactive.py
@@ -933,6 +933,8 @@ async def run_non_interactive(
     interpreter_ptc: str | list[str] | None = None,
     interpreter_ptc_acknowledge_unsafe: bool = False,
     max_turns: int | None = None,
+    allowed_tools: list[str] | None = None,
+    disallowed_tools: list[str] | None = None,
 ) -> int:
     """Run a single task non-interactively and exit.
 
@@ -996,6 +998,8 @@ async def run_non_interactive(
             `interpreter_ptc="all"` outside of `auto_approve`.
         max_turns: Optional cap on total agentic turns. When `None`, the
             internal safety default applies.
+        allowed_tools: Allow-list of tool names; all others are hidden from the model.
+        disallowed_tools: Deny-list of tool names to remove from the model's tool list.
 
     Returns:
         Exit code: 0 for success, 1 for error, 124 when the `--max-turns`
@@ -1174,6 +1178,8 @@ async def run_non_interactive(
             no_mcp=no_mcp,
             trust_project_mcp=trust_project_mcp,
             interactive=False,
+            allowed_tools=allowed_tools,
+            disallowed_tools=disallowed_tools,
         ) as (agent, _server_proc):
             # Collect MCP preload result (ran concurrently with server startup)
             if mcp_task is not None:

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -232,6 +232,8 @@ def make_graph() -> Any:  # noqa: ANN401
         cwd=project_context.user_cwd if project_context is not None else config.cwd,
         project_context=project_context,
         async_subagents=async_subagents,
+        allowed_tools=config.allowed_tools,
+        disallowed_tools=config.disallowed_tools,
     )
     return agent
 

--- a/libs/code/deepagents_code/server_manager.py
+++ b/libs/code/deepagents_code/server_manager.py
@@ -290,6 +290,8 @@ async def start_server_and_get_agent(
     interactive: bool = True,
     host: str = "127.0.0.1",
     port: int = 2024,
+    allowed_tools: list[str] | None = None,
+    disallowed_tools: list[str] | None = None,
 ) -> tuple[RemoteAgent, ServerProcess, MCPSessionManager | None]:
     """Start a LangGraph server and return a connected remote agent client.
 
@@ -317,6 +319,8 @@ async def start_server_and_get_agent(
         interactive: Whether the agent is interactive.
         host: Server host.
         port: Server port.
+        allowed_tools: Allow-list of tool names; all others are hidden.
+        disallowed_tools: Deny-list of tool names to remove.
 
     Returns:
         Tuple of `(remote_agent, server_process, mcp_session_manager)`.
@@ -359,6 +363,8 @@ async def start_server_and_get_agent(
         no_mcp=no_mcp,
         trust_project_mcp=trust_project_mcp,
         interactive=interactive,
+        allowed_tools=allowed_tools,
+        disallowed_tools=disallowed_tools,
     )
     _apply_server_config(config)
 
@@ -411,6 +417,8 @@ async def server_session(
     interactive: bool = True,
     host: str = "127.0.0.1",
     port: int = 2024,
+    allowed_tools: list[str] | None = None,
+    disallowed_tools: list[str] | None = None,
 ) -> AsyncIterator[tuple[RemoteAgent, ServerProcess]]:
     """Async context manager that starts a server and guarantees cleanup.
 
@@ -441,6 +449,8 @@ async def server_session(
         interactive: Whether the agent is interactive.
         host: Server host.
         port: Server port.
+        allowed_tools: Allow-list of tool names; all others are hidden.
+        disallowed_tools: Deny-list of tool names to remove.
 
     Yields:
         Tuple of `(remote_agent, server_process)`.
@@ -470,6 +480,8 @@ async def server_session(
             interactive=interactive,
             host=host,
             port=port,
+            allowed_tools=allowed_tools,
+            disallowed_tools=disallowed_tools,
         )
         yield agent, server_proc
     finally:

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -184,6 +184,12 @@ def show_help() -> None:
     console.print(
         "  -S, --shell-allow-list CMDS  Comma-separated cmds, 'recommended', or 'all'"
     )
+    console.print(
+        "  --allowed-tools TOOLS      Allow-list; all other tools hidden from the model"
+    )
+    console.print(
+        "  --disallowed-tools TOOLS   Comma-separated deny-list of tools to disable"
+    )
     console.print("  --default-model [MODEL]    Set, show, or manage the default model")
     console.print("  --clear-default-model      Clear the default model")
     console.print(

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -3349,3 +3349,231 @@ class TestApplyInheritedPythonpath:
         env = {"PATH": "/usr/bin"}
         _apply_inherited_pythonpath(env)
         assert "PYTHONPATH" not in env
+
+
+# ---------------------------------------------------------------------------
+# _ToolAllowListMiddleware / _ToolDenyListMiddleware unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_request(tool_names: list[str]) -> Mock:
+    """Build a minimal mock request with named tools."""
+    tools = []
+    for name in tool_names:
+        t = Mock()
+        t.name = name
+        tools.append(t)
+    req = Mock()
+    req.tools = tools
+    req.override = lambda tools: Mock(tools=tools)
+    return req
+
+
+class TestToolAllowListMiddleware:
+    """Tests for the allow-list model-call middleware."""
+
+    def test_keeps_only_allowed_tools(self) -> None:
+        from deepagents_code.agent import _ToolAllowListMiddleware
+
+        mw = _ToolAllowListMiddleware(allowed=frozenset({"read_file", "ls"}))
+        req = _make_tool_request(["read_file", "ls", "write_file", "execute"])
+        handler = Mock(return_value=Mock())
+
+        mw.wrap_model_call(req, handler)
+        filtered_names = [t.name for t in handler.call_args[0][0].tools]
+        assert filtered_names == ["read_file", "ls"]
+
+    def test_empty_allowed_set_hides_all_tools(self) -> None:
+        from deepagents_code.agent import _ToolAllowListMiddleware
+
+        mw = _ToolAllowListMiddleware(allowed=frozenset())
+        req = _make_tool_request(["read_file", "execute"])
+        handler = Mock(return_value=Mock())
+
+        mw.wrap_model_call(req, handler)
+        assert handler.call_args[0][0].tools == []
+
+    async def test_async_variant_filters_identically(self) -> None:
+        from deepagents_code.agent import _ToolAllowListMiddleware
+
+        mw = _ToolAllowListMiddleware(allowed=frozenset({"ls"}))
+        req = _make_tool_request(["ls", "grep", "execute"])
+        from unittest.mock import AsyncMock
+
+        handler = AsyncMock(return_value=Mock())
+        await mw.awrap_model_call(req, handler)
+        assert [t.name for t in handler.call_args[0][0].tools] == ["ls"]
+
+
+class TestToolDenyListMiddleware:
+    """Tests for the deny-list model-call middleware."""
+
+    def test_removes_excluded_tools(self) -> None:
+        from deepagents_code.agent import _ToolDenyListMiddleware
+
+        mw = _ToolDenyListMiddleware(excluded=frozenset({"execute", "task"}))
+        req = _make_tool_request(["read_file", "execute", "ls", "task"])
+        handler = Mock(return_value=Mock())
+
+        mw.wrap_model_call(req, handler)
+        assert [t.name for t in handler.call_args[0][0].tools] == ["read_file", "ls"]
+
+    def test_empty_excluded_set_passes_all_tools(self) -> None:
+        from deepagents_code.agent import _ToolDenyListMiddleware
+
+        mw = _ToolDenyListMiddleware(excluded=frozenset())
+        req = _make_tool_request(["read_file", "execute"])
+        handler = Mock(return_value=Mock())
+
+        mw.wrap_model_call(req, handler)
+        assert len(handler.call_args[0][0].tools) == 2
+
+    async def test_async_variant_removes_tools(self) -> None:
+        from unittest.mock import AsyncMock
+
+        from deepagents_code.agent import _ToolDenyListMiddleware
+
+        mw = _ToolDenyListMiddleware(excluded=frozenset({"write_file"}))
+        req = _make_tool_request(["read_file", "write_file", "ls"])
+        handler = AsyncMock(return_value=Mock())
+
+        await mw.awrap_model_call(req, handler)
+        assert [t.name for t in handler.call_args[0][0].tools] == ["read_file", "ls"]
+
+
+class TestToolFilterMiddlewareWiring:
+    """Tests that create_cli_agent wires allow/deny-list middleware correctly."""
+
+    @staticmethod
+    def _build_mock_settings(tmp_path: Path) -> Mock:
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        mock_settings = Mock()
+        mock_settings.ensure_agent_dir.return_value = agent_dir
+        mock_settings.ensure_user_skills_dir.return_value = skills_dir
+        mock_settings.get_project_skills_dir.return_value = None
+        mock_settings.get_built_in_skills_dir.return_value = (
+            Settings.get_built_in_skills_dir()
+        )
+        mock_settings.get_user_agent_md_path.return_value = agent_dir / "AGENTS.md"
+        mock_settings.get_project_agent_md_path.return_value = []
+        mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
+        mock_settings.get_project_agents_dir.return_value = None
+        mock_settings.model_name = None
+        mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
+        mock_settings.model_context_limit = None
+        mock_settings.project_root = None
+        mock_settings.shell_allow_list = None
+        mock_settings.user_langchain_project = None
+        mock_settings.interpreter_timeout_seconds = 5.0
+        mock_settings.interpreter_memory_limit_mb = 64
+        mock_settings.interpreter_max_ptc_calls = 256
+        mock_settings.interpreter_max_result_chars = 4000
+        mock_settings.interpreter_ptc = False
+        mock_settings.interpreter_ptc_acknowledge_unsafe = False
+        return mock_settings
+
+    def test_allowed_tools_adds_allow_list_middleware(self, tmp_path: Path) -> None:
+        from deepagents_code.agent import _ToolAllowListMiddleware
+
+        mock_settings = self._build_mock_settings(tmp_path)
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
+        fake_model = _make_fake_chat_model()
+        captured_middleware: list[Any] = []
+
+        def fake_create_deep_agent(**kwargs: Any) -> Mock:
+            captured_middleware.extend(kwargs.get("middleware", []))
+            return mock_agent
+
+        with (
+            patch("deepagents_code.agent.settings", mock_settings),
+            patch(
+                "deepagents_code.agent.create_deep_agent",
+                side_effect=fake_create_deep_agent,
+            ),
+        ):
+            create_cli_agent(
+                model=fake_model,
+                assistant_id="agent",
+                cwd=str(tmp_path),
+                allowed_tools=["read_file", "ls"],
+            )
+
+        allow_mws = [
+            m for m in captured_middleware if isinstance(m, _ToolAllowListMiddleware)
+        ]
+        assert len(allow_mws) == 1
+        assert allow_mws[0]._allowed == frozenset({"read_file", "ls"})
+
+    def test_disallowed_tools_adds_deny_list_middleware(self, tmp_path: Path) -> None:
+        from deepagents_code.agent import _ToolDenyListMiddleware
+
+        mock_settings = self._build_mock_settings(tmp_path)
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
+        fake_model = _make_fake_chat_model()
+        captured_middleware: list[Any] = []
+
+        def fake_create_deep_agent(**kwargs: Any) -> Mock:
+            captured_middleware.extend(kwargs.get("middleware", []))
+            return mock_agent
+
+        with (
+            patch("deepagents_code.agent.settings", mock_settings),
+            patch(
+                "deepagents_code.agent.create_deep_agent",
+                side_effect=fake_create_deep_agent,
+            ),
+        ):
+            create_cli_agent(
+                model=fake_model,
+                assistant_id="agent",
+                cwd=str(tmp_path),
+                disallowed_tools=["execute", "task"],
+            )
+
+        deny_mws = [
+            m for m in captured_middleware if isinstance(m, _ToolDenyListMiddleware)
+        ]
+        assert len(deny_mws) == 1
+        assert deny_mws[0]._excluded == frozenset({"execute", "task"})
+
+    def test_no_filter_middleware_when_neither_flag_set(self, tmp_path: Path) -> None:
+        from deepagents_code.agent import (
+            _ToolAllowListMiddleware,
+            _ToolDenyListMiddleware,
+        )
+
+        mock_settings = self._build_mock_settings(tmp_path)
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
+        fake_model = _make_fake_chat_model()
+        captured_middleware: list[Any] = []
+
+        def fake_create_deep_agent(**kwargs: Any) -> Mock:
+            captured_middleware.extend(kwargs.get("middleware", []))
+            return mock_agent
+
+        with (
+            patch("deepagents_code.agent.settings", mock_settings),
+            patch(
+                "deepagents_code.agent.create_deep_agent",
+                side_effect=fake_create_deep_agent,
+            ),
+        ):
+            create_cli_agent(
+                model=fake_model,
+                assistant_id="agent",
+                cwd=str(tmp_path),
+            )
+
+        filter_mws = [
+            m
+            for m in captured_middleware
+            if isinstance(m, (_ToolAllowListMiddleware, _ToolDenyListMiddleware))
+        ]
+        assert not filter_mws

--- a/libs/code/tests/unit_tests/test_args.py
+++ b/libs/code/tests/unit_tests/test_args.py
@@ -861,3 +861,30 @@ class TestJsonArg:
         assert args.command == "skills"
         assert args.skills_command == "list"
         assert args.output_format == "json"
+
+
+class TestAllowedDisallowedToolsArgs:
+    """Tests for --allowed-tools and --disallowed-tools argument parsing."""
+
+    def test_allowed_tools_flag_parsed(self) -> None:
+        """--allowed-tools stores the raw comma-separated string."""
+        with patch.object(
+            sys, "argv", ["deepagents", "--allowed-tools", "read_file,ls,glob"]
+        ):
+            args = parse_args()
+        assert args.allowed_tools == "read_file,ls,glob"
+
+    def test_disallowed_tools_flag_parsed(self) -> None:
+        """--disallowed-tools stores the raw comma-separated string."""
+        with patch.object(
+            sys, "argv", ["deepagents", "--disallowed-tools", "execute,task"]
+        ):
+            args = parse_args()
+        assert args.disallowed_tools == "execute,task"
+
+    def test_allowed_tools_absent_is_none(self) -> None:
+        """Neither flag produces None."""
+        with patch.object(sys, "argv", ["deepagents"]):
+            args = parse_args()
+        assert args.allowed_tools is None
+        assert args.disallowed_tools is None

--- a/libs/code/tests/unit_tests/test_server_config.py
+++ b/libs/code/tests/unit_tests/test_server_config.py
@@ -242,3 +242,67 @@ class TestServerConfigEdgeCases:
             restored = ServerConfig.from_env()
 
         assert restored.sandbox_snapshot_name is None
+
+
+# ------------------------------------------------------------------
+# allowed_tools / disallowed_tools round-trips
+# ------------------------------------------------------------------
+
+
+class TestToolFilterRoundTrip:
+    """Verify allowed_tools and disallowed_tools survive to_env / from_env."""
+
+    def _round_trip(self, original: ServerConfig) -> ServerConfig:
+        env_dict = original.to_env()
+        with patch.dict(os.environ, {}, clear=True):
+            for suffix, value in env_dict.items():
+                if value is not None:
+                    os.environ[f"{SERVER_ENV_PREFIX}{suffix}"] = value
+            return ServerConfig.from_env()
+
+    def test_allowed_tools_round_trips(self) -> None:
+        original = ServerConfig(allowed_tools=["read_file", "ls", "glob"])
+        restored = self._round_trip(original)
+        assert restored.allowed_tools == ["read_file", "ls", "glob"]
+
+    def test_disallowed_tools_round_trips(self) -> None:
+        original = ServerConfig(disallowed_tools=["execute", "task"])
+        restored = self._round_trip(original)
+        assert restored.disallowed_tools == ["execute", "task"]
+
+    def test_none_allowed_tools_round_trips_to_none(self) -> None:
+        original = ServerConfig(allowed_tools=None)
+        restored = self._round_trip(original)
+        assert restored.allowed_tools is None
+
+    def test_none_disallowed_tools_round_trips_to_none(self) -> None:
+        original = ServerConfig(disallowed_tools=None)
+        restored = self._round_trip(original)
+        assert restored.disallowed_tools is None
+
+    def test_allowed_tools_to_env_is_comma_joined(self) -> None:
+        config = ServerConfig(allowed_tools=["read_file", "ls"])
+        env = config.to_env()
+        assert env["ALLOWED_TOOLS"] == "read_file,ls"
+
+    def test_disallowed_tools_to_env_is_comma_joined(self) -> None:
+        config = ServerConfig(disallowed_tools=["execute", "task"])
+        env = config.to_env()
+        assert env["DISALLOWED_TOOLS"] == "execute,task"
+
+    def test_allowed_tools_none_produces_none_env_value(self) -> None:
+        config = ServerConfig(allowed_tools=None)
+        assert config.to_env()["ALLOWED_TOOLS"] is None
+
+    def test_disallowed_tools_none_produces_none_env_value(self) -> None:
+        config = ServerConfig(disallowed_tools=None)
+        assert config.to_env()["DISALLOWED_TOOLS"] is None
+
+    def test_from_env_strips_whitespace_around_tool_names(self) -> None:
+        with patch.dict(
+            os.environ,
+            {f"{SERVER_ENV_PREFIX}ALLOWED_TOOLS": " read_file , ls , glob "},
+            clear=True,
+        ):
+            restored = ServerConfig.from_env()
+        assert restored.allowed_tools == ["read_file", "ls", "glob"]

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -142,6 +142,8 @@ class TestServerGraph:
             cwd=None,
             project_context=None,
             async_subagents=None,
+            allowed_tools=None,
+            disallowed_tools=None,
         )
         assert module.graph is graph_obj
 


### PR DESCRIPTION
Fixes #3952

Adds `--allowed-tools` and `--disallowed-tools` CLI flags that restrict which tools the model can call for the duration of a session, without touching agent config files or registering a `HarnessProfile`.

**Implementation:**

Two new middleware classes live in `agent.py` alongside the existing `ShellAllowListMiddleware`: `_ToolAllowListMiddleware` (keeps only the named tools) and `_ToolDenyListMiddleware` (removes the named tools). Both implement `wrap_model_call` / `awrap_model_call` and are appended last to `agent_middleware` in `create_cli_agent`, so they filter the final tool list — including tools injected by Skills, Filesystem, and other middleware — immediately before the model call.

The flags are fully wired through the existing serialization path: `parse_args` → `run_textual_cli_async` / `run_non_interactive` → `server_session` → `ServerConfig.from_cli_args` → `to_env` / `from_env` env-var channel → `server_graph.make_graph` → `create_cli_agent`. `ServerConfig` gains two new fields (`allowed_tools`, `disallowed_tools`) serialized as comma-separated strings in `DEEPAGENTS_CODE_SERVER_ALLOWED_TOOLS` / `DEEPAGENTS_CODE_SERVER_DISALLOWED_TOOLS`. The two flags are mutually exclusive; passing both prints an error and exits with code 2.

The help screen (`ui.py`) is updated with one line per flag, matching the style of `--shell-allow-list`.

**Verification:** Ran `make format`, `make lint`, and `make test` from `libs/code`. Added 28 new unit tests across `test_server_config.py` (env round-trips, `to_env` serialization), `test_agent.py` (`_ToolAllowListMiddleware`, `_ToolDenyListMiddleware`, and `create_cli_agent` wiring), and `test_args.py` (CLI arg parsing). Updated one existing test in `test_server_graph.py` that asserts exact `create_cli_agent` kwargs to include the two new `None` defaults.
