### PR TITLE
fix(sdk): allow backend-supplied file content blocks

### DIFF
--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -15,6 +15,7 @@ from functools import lru_cache
 from typing import Any, Final, Literal, NotRequired, TypeAlias
 
 from langchain.tools import ToolRuntime
+from langchain_core.messages.content import ContentBlock
 from typing_extensions import TypedDict
 
 from deepagents._api.deprecation import deprecated, warn_deprecated
@@ -187,10 +188,13 @@ class ReadResult:
     Attributes:
         error: Error message on failure, None on success.
         file_data: FileData dict on success, None on failure.
+        content_blocks: Provider-ready content blocks on success, None when the
+            middleware should derive blocks from `file_data`.
     """
 
     error: str | None = None
     file_data: FileData | None = None
+    content_blocks: list[ContentBlock] | None = None
 
 
 class _Unset:
@@ -383,7 +387,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         offset: int = 0,
         limit: int = 2000,
     ) -> ReadResult:
-        """Read file content with line numbers.
+        """Read file content.
 
         Args:
             file_path: Absolute path to the file to read. Must start with '/'.
@@ -391,10 +395,8 @@ class BackendProtocol(abc.ABC):  # noqa: B024
             limit: Maximum number of lines to read. Default: 2000.
 
         Returns:
-            String containing file content formatted with line numbers (cat -n format),
-            starting at line 1. Lines longer than 2000 characters are truncated.
-
-            Returns an error string if the file doesn't exist or can't be read.
+            `ReadResult` containing file data, provider-ready content blocks,
+            or an error if the file doesn't exist or can't be read.
         """
         raise NotImplementedError
 

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -958,7 +958,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
             return content
 
-        def _handle_read_result(
+        def _handle_read_result(  # noqa: PLR0911  # explicit returns keep each read-result shape isolated
             read_result: ReadResult | str,
             validated_path: str,
             tool_call_id: str | None,
@@ -990,6 +990,22 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     name="read_file",
                     tool_call_id=tool_call_id,
                     status="error",
+                )
+
+            if read_result.content_blocks is not None:
+                media_type = next(
+                    (block.get("mime_type") for block in read_result.content_blocks if block.get("mime_type")),
+                    None,
+                )
+                return ToolMessage(
+                    content_blocks=read_result.content_blocks,
+                    name="read_file",
+                    tool_call_id=tool_call_id,
+                    additional_kwargs={
+                        "read_file_path": validated_path,
+                        "read_file_media_type": media_type,
+                    },
+                    status="success",
                 )
 
             if read_result.file_data is None:

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1500,6 +1500,46 @@ class TestFilesystemMiddleware:
         expected_mime = mimetypes.guess_type("file.docx")[0] or "application/octet-stream"
         assert result.content[0]["mime_type"] == expected_mime
 
+    def test_read_file_uses_backend_supplied_content_blocks(self):
+        """Provider upload backends can return native file refs without inline bytes (#2630)."""
+
+        class UploadedFileBackend(StateBackend):
+            def read(self, path, *, offset=0, limit=100):
+                return ReadResult(
+                    content_blocks=[
+                        {
+                            "type": "file",
+                            "file_id": "file-abc123",
+                            "mime_type": "application/pdf",
+                        }
+                    ]
+                )
+
+        middleware = FilesystemMiddleware(backend=UploadedFileBackend())
+        state = FilesystemState(messages=[], files={})
+        runtime = ToolRuntime(
+            state=state,
+            context=None,
+            tool_call_id="uploaded-pdf-1",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
+
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+        result = read_file_tool.invoke({"file_path": "/docs/report.pdf", "runtime": runtime})
+
+        assert isinstance(result, ToolMessage)
+        assert result.status == "success"
+        assert result.tool_call_id == "uploaded-pdf-1"
+        assert isinstance(result.content, list)
+        assert result.content[0]["type"] == "file"
+        assert result.content[0]["file_id"] == "file-abc123"
+        assert result.content[0]["mime_type"] == "application/pdf"
+        assert "base64" not in result.content[0]
+        assert result.additional_kwargs["read_file_path"] == "/docs/report.pdf"
+        assert result.additional_kwargs["read_file_media_type"] == "application/pdf"
+
     def test_read_file_empty_mapped_binary_returns_empty_content_warning(self):
         """Empty reads of mapped binary extensions (e.g. .pdf) return the empty-file warning (#3664)."""
 


### PR DESCRIPTION
Closes #2630

---

Adds a narrow `ReadResult.content_blocks` escape hatch so filesystem backends can return provider-native content blocks from `read_file` directly.

Why:
- some providers can consume uploaded file references more efficiently than base64 payloads
- backend implementations may already own upload/cache lifecycles
- `FilesystemMiddleware` should not force those backends to re-inline bytes after `read()`

What changed:
- `ReadResult` now accepts optional provider-ready `content_blocks`
- `read_file` returns those blocks directly with `read_file_path` and `read_file_media_type` metadata
- existing `file_data` text/base64 behavior is unchanged
- regression coverage verifies a backend-supplied PDF file reference is preserved without a `base64` payload

Verification:
- `make test TEST_FILE=tests/unit_tests/test_middleware.py PYTEST_EXTRA=-q`
- `uv run --all-groups ruff check deepagents/backends/protocol.py deepagents/middleware/filesystem.py tests/unit_tests/test_middleware.py`
- `uv run --all-groups ruff format deepagents/backends/protocol.py deepagents/middleware/filesystem.py tests/unit_tests/test_middleware.py --diff`
- `uv run --all-groups ty check deepagents`
- local reviewer pass: CLEAN
