### PR TITLE
feat(code): add pre-release update support

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3759,19 +3759,44 @@ class DeepAgentsApp(App):
         except Exception:
             logger.warning("Failed to persist seen-version marker", exc_info=True)
 
-    async def _handle_update_command(self) -> None:
-        """Handle the `/update` slash command — check for and install updates."""
-        await self._mount_message(UserMessage("/update"))
+    async def _handle_update_command(self, command: str = "/update") -> None:
+        """Handle the `/update` slash command — check for and install updates.
+
+        Parses an optional `--prerelease` flag from the raw command line; any
+        other option is rejected with a usage message.
+
+        Args:
+            command: The raw slash-command line as typed, including any options.
+        """
+        parts = command.split()
+        await self._mount_message(UserMessage(command))
+        # Reject typo'd/miscased options (e.g. `--prereleases`, `--PRERELEASE`)
+        # loudly instead of silently downgrading to a stable update — mirroring
+        # the headless path, which also refuses unknown options rather than
+        # silently ignoring them.
+        unknown = [opt for opt in parts[1:] if opt != "--prerelease"]
+        if unknown:
+            await self._mount_message(
+                AppMessage(
+                    f"Unknown option(s) for /update: {' '.join(unknown)}. "
+                    "Usage: /update [--prerelease]",
+                ),
+            )
+            return
+        prerelease_requested = "--prerelease" in parts[1:]
+        include_prereleases = True if prerelease_requested else None
         try:
             from deepagents_code._env_vars import DEBUG_UPDATE
             from deepagents_code._version import __version__ as cli_version
             from deepagents_code.config import _is_editable_install
             from deepagents_code.update_check import (
+                _PRERELEASE_UNSUPPORTED_MESSAGE,
                 format_age_suffix,
                 format_installed_age_suffix,
                 format_release_age_parenthetical,
                 is_update_available,
                 perform_upgrade,
+                prerelease_upgrade_supported,
                 upgrade_command,
             )
 
@@ -3785,10 +3810,23 @@ class DeepAgentsApp(App):
                 )
                 return
 
+            # Refuse pre-release upgrades the install method can't honor before
+            # promising an upgrade or hitting PyPI.
+            if prerelease_requested:
+                supported, reason = await asyncio.to_thread(
+                    prerelease_upgrade_supported,
+                )
+                if not supported:
+                    await self._mount_message(
+                        AppMessage(reason or _PRERELEASE_UNSUPPORTED_MESSAGE),
+                    )
+                    return
+
             await self._mount_message(AppMessage("Checking for updates..."))
             available, latest = await asyncio.to_thread(
                 is_update_available,
                 bypass_cache=True,
+                include_prereleases=include_prereleases,
             )
             if latest is None:
                 await self._mount_message(
@@ -3827,7 +3865,9 @@ class DeepAgentsApp(App):
                     AppMessage("Skipped update install (debug mode)."),
                 )
                 return
-            success, output = await perform_upgrade()
+            success, output = await perform_upgrade(
+                include_prereleases=include_prereleases,
+            )
             if success:
                 self._update_available = (False, None)
                 await self._mount_message(
@@ -3836,7 +3876,7 @@ class DeepAgentsApp(App):
                     ),
                 )
             else:
-                cmd = upgrade_command()
+                cmd = upgrade_command(include_prereleases=include_prereleases)
                 detail = f": {output[:200]}" if output else ""
                 await self._mount_message(
                     AppMessage(f"Auto-update failed{detail}\nRun manually: {cmd}"),
@@ -6500,8 +6540,8 @@ class DeepAgentsApp(App):
             await self._show_thread_selector()
         elif cmd == "/trace":
             await self._handle_trace_command(command)
-        elif cmd == "/update":
-            await self._handle_update_command()
+        elif cmd == "/update" or cmd.startswith("/update "):
+            await self._handle_update_command(command)
         elif cmd == "/auto-update":
             await self._handle_auto_update_toggle()
         elif cmd == "/install" or cmd.startswith("/install "):

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1026,6 +1026,12 @@ def parse_args() -> argparse.Namespace:
         add_help=False,
         parents=help_parent(_lazy_help("show_update_help")),
     )
+    update_parser.add_argument(
+        "--prerelease",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Include alpha/beta/rc releases when checking for updates",
+    )
     add_json_output_arg(update_parser)
 
     # Default interactive mode — argument order here determines the
@@ -1274,6 +1280,11 @@ def parse_args() -> argparse.Namespace:
         "--update",
         action="store_true",
         help="Check for and install updates, then exit",
+    )
+    parser.add_argument(
+        "--prerelease",
+        action="store_true",
+        help="With --update, include alpha/beta/rc releases",
     )
     parser.add_argument(
         "--auto-update",
@@ -2269,6 +2280,15 @@ def cli_main() -> None:
             )
             sys.exit(2)
 
+        if args.prerelease and not (args.update or args.command == "update"):
+            from rich.console import Console as _Console
+
+            _Console(stderr=True).print(
+                "[bold red]Error:[/bold red] --prerelease requires --update "
+                "or the update subcommand"
+            )
+            sys.exit(2)
+
         # Handle --update flag or `update` subcommand (headless, no session)
         if args.update or args.command == "update":
             try:
@@ -2278,12 +2298,14 @@ def cli_main() -> None:
                 from deepagents_code._version import __version__ as cli_version
                 from deepagents_code.config import _is_editable_install
                 from deepagents_code.update_check import (
+                    _PRERELEASE_UNSUPPORTED_MESSAGE,
                     create_update_log_path,
                     format_age_suffix,
                     format_installed_age_suffix,
                     format_release_age_parenthetical,
                     is_update_available,
                     perform_upgrade,
+                    prerelease_upgrade_supported,
                     upgrade_command,
                 )
 
@@ -2296,8 +2318,24 @@ def cli_main() -> None:
                     )
                     sys.exit(0)
 
+                include_prereleases = True if args.prerelease else None
+
+                # Refuse pre-release upgrades the install method can't honor
+                # before promising an upgrade or hitting PyPI.
+                if args.prerelease:
+                    supported, reason = prerelease_upgrade_supported()
+                    if not supported:
+                        console.print(
+                            "[bold red]Error:[/bold red] "
+                            f"{reason or _PRERELEASE_UNSUPPORTED_MESSAGE}"
+                        )
+                        sys.exit(1)
+
                 console.print("Checking for updates...", style="dim")
-                available, latest = is_update_available(bypass_cache=True)
+                available, latest = is_update_available(
+                    bypass_cache=True,
+                    include_prereleases=include_prereleases,
+                )
                 if latest is None:
                     console.print(
                         "[bold yellow]Warning:[/bold yellow] Could not "
@@ -2329,11 +2367,16 @@ def cli_main() -> None:
                     highlight=False,
                     markup=False,
                 )
-                success, output = asyncio.run(perform_upgrade(log_path=log_path))
+                success, output = asyncio.run(
+                    perform_upgrade(
+                        log_path=log_path,
+                        include_prereleases=include_prereleases,
+                    )
+                )
                 if success:
                     console.print(f"[green]Updated to v{latest}.[/green]")
                 else:
-                    cmd = upgrade_command()
+                    cmd = upgrade_command(include_prereleases=include_prereleases)
                     detail = f": {escape(output[:200])}" if output else ""
                     console.print(
                         f"[bold red]Auto-update failed{detail}[/bold red]\n"
@@ -2343,10 +2386,24 @@ def cli_main() -> None:
                 sys.exit(0)
             except Exception:
                 logger.warning("--update failed", exc_info=True)
+                # Preserve the user's pre-release intent in the manual fallback:
+                # a `--prerelease` request that crashes unexpectedly must not
+                # suggest a stable-only command, which would silently downgrade
+                # the channel. Both are module-level string constants, so this
+                # import can't fail inside the last-resort handler.
+                from deepagents_code.update_check import (
+                    _UV_PRERELEASE_UPGRADE_COMMAND,
+                    FALLBACK_UPGRADE_COMMAND,
+                )
+
+                manual_cmd = (
+                    _UV_PRERELEASE_UPGRADE_COMMAND
+                    if args.prerelease
+                    else FALLBACK_UPGRADE_COMMAND
+                )
                 console.print(
                     "[bold red]Error:[/bold red] Update failed.\n"
-                    "Run manually: [cyan]uv tool upgrade "
-                    "deepagents-code[/cyan]"
+                    f"Run manually: [cyan]{manual_cmd}[/cyan]"
                 )
                 sys.exit(1)
 

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -190,6 +190,9 @@ def show_help() -> None:
         "  --update                   Check for and install updates, then exit"
     )
     console.print(
+        "  --prerelease               With --update, include alpha/beta/rc releases"
+    )
+    console.print(
         "  --auto-update              Toggle automatic updates on or off, then exit"
     )
     console.print(
@@ -435,10 +438,13 @@ def show_update_help() -> None:
         "Check for and install updates from PyPI.",
     )
     console.print()
-    _print_option_section()
+    _print_option_section(
+        "  --prerelease            Include alpha/beta/rc releases",
+    )
     console.print()
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
     console.print("  dcode update")
+    console.print("  dcode update --prerelease")
     console.print("  dcode update --json")
     console.print()
 

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -94,6 +94,20 @@ upgraded with a different package manager, because that can update a separate
 environment from the one currently providing `dcode`.
 """
 
+_UV_PRERELEASE_UPGRADE_COMMAND = "uv tool upgrade deepagents-code --prerelease allow"
+"""uv upgrade command that opts into alpha/beta/rc release resolution."""
+
+_PRERELEASE_UNSUPPORTED_MESSAGE = (
+    "Pre-release updates aren't supported for this install. Reinstall with "
+    "pre-releases enabled:\n"
+    '  curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_PRERELEASE="allow" bash'
+)
+"""User-facing reason a pre-release upgrade is refused on non-uv installs.
+
+Points at the install script (uv under the hood) rather than raw uv commands,
+since that one-liner is the path we promote.
+"""
+
 _UPGRADE_TIMEOUT = 120  # seconds
 """Wall-clock cap for `perform_upgrade` and `perform_install_extra`."""
 
@@ -650,16 +664,23 @@ def clear_update_notified() -> None:
     _write_update_state({}, remove_keys=("notified_at", "notified_version"))
 
 
-def is_update_available(*, bypass_cache: bool = False) -> tuple[bool, str | None]:
+def is_update_available(
+    *,
+    bypass_cache: bool = False,
+    include_prereleases: bool | None = None,
+) -> tuple[bool, str | None]:
     """Check whether a newer version of deepagents-code is available.
 
     When the installed version is a pre-release (e.g. `0.0.35a1`),
     pre-release versions on PyPI are included in the comparison so alpha
     testers are notified of newer alphas and the eventual stable release.
-    Stable installs only compare against stable PyPI releases.
+    Stable installs only compare against stable PyPI releases unless
+    `include_prereleases` is explicitly set.
 
     Args:
         bypass_cache: Skip the cache and always hit PyPI.
+        include_prereleases: Override whether alpha/beta/rc releases are
+            considered. When `None`, this follows the installed version.
 
     Returns:
         A `(available, latest)` tuple.
@@ -682,7 +703,10 @@ def is_update_available(*, bypass_cache: bool = False) -> tuple[bool, str | None
         )
         return False, None
 
-    include_prereleases = installed.is_prerelease
+    include_prereleases = _resolve_include_prereleases(
+        include_prereleases,
+        installed=installed,
+    )
     latest = get_latest_version(
         bypass_cache=bypass_cache,
         include_prereleases=include_prereleases,
@@ -700,6 +724,37 @@ def is_update_available(*, bypass_cache: bool = False) -> tuple[bool, str | None
 # ---------------------------------------------------------------------------
 # Install method detection
 # ---------------------------------------------------------------------------
+
+
+def _resolve_include_prereleases(
+    include_prereleases: bool | None,
+    *,
+    installed: Version | None = None,
+) -> bool:
+    """Resolve update channel preference from the requested or installed channel.
+
+    Args:
+        include_prereleases: Explicit channel preference, or `None` to infer
+            from the installed version.
+        installed: Parsed installed version to reuse when the caller already
+            has one.
+
+    Returns:
+        `True` when pre-release versions should be considered.
+    """
+    if include_prereleases is not None:
+        return include_prereleases
+    if installed is None:
+        try:
+            installed = _parse_version(__version__)
+        except InvalidVersion:
+            logger.warning(
+                "Installed version %r is not PEP 440 compliant; "
+                "defaulting to stable-only upgrades",
+                __version__,
+            )
+            return False
+    return installed.is_prerelease
 
 
 def detect_install_method() -> InstallMethod:
@@ -729,7 +784,11 @@ def detect_install_method() -> InstallMethod:
     return "other"
 
 
-def upgrade_command(method: InstallMethod | None = None) -> str:
+def upgrade_command(
+    method: InstallMethod | None = None,
+    *,
+    include_prereleases: bool | None = None,
+) -> str:
     """Return the shell command to upgrade `deepagents-code`.
 
     Falls back to the documented uv command for display-only guidance.
@@ -738,10 +797,43 @@ def upgrade_command(method: InstallMethod | None = None) -> str:
         method: Install method override.
 
             Auto-detected if `None`.
+        include_prereleases: Whether to include alpha/beta/rc releases. When
+            `None`, follows the installed version's channel. When `True`,
+            returns the uv pre-release command regardless of `method`, since
+            only uv can be steered onto the pre-release channel.
     """
+    include_prereleases = _resolve_include_prereleases(include_prereleases)
+    if include_prereleases:
+        return _UV_PRERELEASE_UPGRADE_COMMAND
     if method is None:
         method = detect_install_method()
     return _UPGRADE_COMMANDS.get(method, FALLBACK_UPGRADE_COMMAND)
+
+
+def prerelease_upgrade_supported(
+    method: InstallMethod | None = None,
+) -> tuple[bool, str | None]:
+    """Return whether pre-release upgrades are supported for the install method.
+
+    Pre-release channel switching is only safe for `uv tool` installs, where
+    `uv tool upgrade --prerelease allow` re-resolves against the pre-release
+    feed. Other package managers can't be steered onto that channel, so callers
+    should refuse before promising an upgrade.
+
+    Args:
+        method: Install method override.
+
+            Auto-detected if `None`.
+
+    Returns:
+        A `(supported, reason)` tuple. `reason` is `None` when supported, else a
+        user-facing explanation of why the pre-release upgrade is refused.
+    """
+    if method is None:
+        method = detect_install_method()
+    if method != "uv":
+        return False, _PRERELEASE_UNSUPPORTED_MESSAGE
+    return True, None
 
 
 def cleanup_update_logs(
@@ -921,6 +1013,7 @@ async def perform_upgrade(
     *,
     progress: UpgradeProgressCallback | None = None,
     log_path: Path | None = None,
+    include_prereleases: bool | None = None,
 ) -> tuple[bool, str]:
     """Attempt to upgrade `deepagents-code` using the detected install method.
 
@@ -930,6 +1023,9 @@ async def perform_upgrade(
     Args:
         progress: Optional callback invoked for each output line.
         log_path: Optional path to persist command output.
+        include_prereleases: Whether to include alpha/beta/rc releases. When
+            `None`, follows the installed version's channel. Pre-release
+            upgrades require the uv install method; returns failure otherwise.
 
     Returns:
         `(success, output)` — *output* is the combined stdout/stderr.
@@ -944,10 +1040,13 @@ async def perform_upgrade(
             "`uv tool install -U deepagents-code` or upgrade with the package "
             "manager originally used for this install."
         )
+    resolved_include_prereleases = _resolve_include_prereleases(include_prereleases)
+    if resolved_include_prereleases:
+        supported, reason = prerelease_upgrade_supported(method)
+        if not supported:
+            return False, reason or _PRERELEASE_UNSUPPORTED_MESSAGE
 
-    cmd = _UPGRADE_COMMANDS.get(method)
-    if cmd is None:
-        return False, f"No upgrade command for install method: {method}"
+    cmd = upgrade_command(method, include_prereleases=resolved_include_prereleases)
 
     # Skip brew if binary not on PATH
     if method == "brew" and not shutil.which("brew"):

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -1425,19 +1425,38 @@ class TestUpdateSubcommand:
         editable: bool,
         is_update_available_return: tuple[bool, str | None],
         log_path: str = "/tmp/deepagents-update.log",
+        prerelease: bool = False,
+        flag_style: bool = False,
+        prerelease_before_command: bool = False,
+        install_method: str = "uv",
     ) -> tuple[int, MagicMock, MagicMock]:
-        """Invoke `cli_main()` with `update` subcommand; return exit code + mocks."""
+        """Invoke `cli_main()` with `update`; return exit code + mocks."""
         from deepagents_code._env_vars import DEBUG_UPDATE
         from deepagents_code.main import cli_main
 
         mock_stdin = MagicMock()
         mock_stdin.isatty.return_value = True
+        if prerelease_before_command:
+            argv = ["deepagents", "--prerelease", "update"]
+        elif flag_style:
+            argv = ["deepagents", "--update"]
+        else:
+            argv = ["deepagents", "update"]
+        if prerelease:
+            argv.append("--prerelease")
         with (
             patch.dict(os.environ, {DEBUG_UPDATE: "1" if debug else ""}),
-            patch.object(sys, "argv", ["deepagents", "update"]),
+            patch.object(sys, "argv", argv),
             patch.object(sys, "stdin", mock_stdin),
             patch("deepagents_code.main.check_cli_dependencies"),
             patch("deepagents_code.config._is_editable_install", return_value=editable),
+            # `--prerelease` is only honored on uv installs; pin the detected
+            # method so the precheck's outcome is driven by the test rather than
+            # the test runner's own environment.
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value=install_method,
+            ),
             patch(
                 "deepagents_code.update_check.is_update_available",
                 return_value=is_update_available_return,
@@ -1510,12 +1529,153 @@ class TestUpdateSubcommand:
 
     def test_update_available_runs_upgrade(self) -> None:
         """`(True, "x.y.z")` triggers `perform_upgrade` and exits 0 on success."""
-        code, _, perform_upgrade_mock = self._run_update(
+        code, is_update_mock, perform_upgrade_mock = self._run_update(
             editable=False,
             is_update_available_return=(True, "99.0.0"),
         )
         assert code == 0
-        perform_upgrade_mock.assert_awaited_once()
+        is_update_mock.assert_called_once_with(
+            bypass_cache=True,
+            include_prereleases=None,
+        )
+        perform_upgrade_mock.assert_awaited_once_with(
+            log_path="/tmp/deepagents-update.log",
+            include_prereleases=None,
+        )
+
+    def test_prerelease_update_includes_prereleases(self) -> None:
+        """`dcode update --prerelease` opts into alpha/beta/rc releases."""
+        code, is_update_mock, perform_upgrade_mock = self._run_update(
+            editable=False,
+            is_update_available_return=(True, "99.0.0rc1"),
+            prerelease=True,
+        )
+
+        assert code == 0
+        is_update_mock.assert_called_once_with(
+            bypass_cache=True,
+            include_prereleases=True,
+        )
+        perform_upgrade_mock.assert_awaited_once_with(
+            log_path="/tmp/deepagents-update.log",
+            include_prereleases=True,
+        )
+
+    def test_prerelease_update_flag_includes_prereleases(self) -> None:
+        """`dcode --update --prerelease` uses the same prerelease path."""
+        code, is_update_mock, perform_upgrade_mock = self._run_update(
+            editable=False,
+            is_update_available_return=(True, "99.0.0rc1"),
+            prerelease=True,
+            flag_style=True,
+        )
+
+        assert code == 0
+        is_update_mock.assert_called_once_with(
+            bypass_cache=True,
+            include_prereleases=True,
+        )
+        perform_upgrade_mock.assert_awaited_once_with(
+            log_path="/tmp/deepagents-update.log",
+            include_prereleases=True,
+        )
+
+    def test_prerelease_before_update_includes_prereleases(self) -> None:
+        """`dcode --prerelease update` preserves the top-level prerelease flag."""
+        code, is_update_mock, perform_upgrade_mock = self._run_update(
+            editable=False,
+            is_update_available_return=(True, "99.0.0rc1"),
+            prerelease_before_command=True,
+        )
+
+        assert code == 0
+        is_update_mock.assert_called_once_with(
+            bypass_cache=True,
+            include_prereleases=True,
+        )
+        perform_upgrade_mock.assert_awaited_once_with(
+            log_path="/tmp/deepagents-update.log",
+            include_prereleases=True,
+        )
+
+    def test_prerelease_unsupported_install_refuses_before_pypi(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """`--prerelease` on a non-uv install refuses before hitting PyPI.
+
+        A regression that dropped the guard would let a brew/other install fall
+        through to a stable update (or an unsupported upgrade attempt), so the
+        refusal must short-circuit before `is_update_available`/`perform_upgrade`.
+        """
+        code, is_update_mock, perform_upgrade_mock = self._run_update(
+            editable=False,
+            is_update_available_return=(True, "99.0.0rc1"),
+            prerelease=True,
+            install_method="brew",
+        )
+
+        assert code == 1
+        is_update_mock.assert_not_called()
+        perform_upgrade_mock.assert_not_called()
+        captured = capsys.readouterr()
+        assert "aren't supported for this install" in (captured.out + captured.err)
+
+    def test_unexpected_error_manual_command_keeps_prerelease(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An unexpected crash during `--prerelease` keeps the pre-release hint.
+
+        The last-resort handler prints a manual upgrade command. A regression
+        that hardcoded the stable command would nudge a user who requested a
+        pre-release onto the stable channel — the exact silent downgrade this
+        flag guards against, via an error side-door.
+        """
+        from deepagents_code.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(sys, "argv", ["deepagents", "update", "--prerelease"]),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_code.main.check_cli_dependencies"),
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            # Crash after the pre-release support check passes but before the
+            # upgrade completes, exercising the catch-all fallback path.
+            patch(
+                "deepagents_code.update_check.is_update_available",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "--prerelease allow" in (captured.out + captured.err)
+
+    def test_prerelease_without_update_exits_usage_error(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """`--prerelease` only applies to the update command."""
+        from deepagents_code.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(sys, "argv", ["deepagents", "--prerelease"]),
+            patch.object(sys, "stdin", mock_stdin),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+
+        assert exc_info.value.code == 2
+        assert "--prerelease requires --update or the update subcommand" in (
+            capsys.readouterr().err
+        )
 
 
 class TestInstallExtraSubcommand:

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -9,7 +9,7 @@ import time
 import tomllib
 from collections.abc import Mapping, Sequence  # noqa: TC003
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
 from packaging.version import InvalidVersion, Version
@@ -21,6 +21,7 @@ from deepagents_code._version import __version__
 from deepagents_code.extras_info import ExtrasIntrospectionError, installed_extra_names
 from deepagents_code.update_check import (
     CACHE_TTL,
+    InstallMethod,
     _extract_release_times,
     _latest_from_releases,
     _parse_version,
@@ -54,8 +55,10 @@ from deepagents_code.update_check import (
     perform_install_extra,
     perform_install_package,
     perform_upgrade,
+    prerelease_upgrade_supported,
     set_auto_update,
     should_notify_update,
+    upgrade_command,
 )
 
 
@@ -568,6 +571,32 @@ class TestIsUpdateAvailable:
 
         mock_get.assert_called_once_with(bypass_cache=False, include_prereleases=False)
 
+    def test_explicit_include_prereleases_overrides_stable_install(self) -> None:
+        """Explicit `include_prereleases=True` beats a stable installed version."""
+        with (
+            patch(
+                "deepagents_code.update_check.get_latest_version",
+                return_value=None,
+            ) as mock_get,
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+        ):
+            is_update_available(include_prereleases=True)
+
+        mock_get.assert_called_once_with(bypass_cache=False, include_prereleases=True)
+
+    def test_explicit_exclude_prereleases_overrides_prerelease_install(self) -> None:
+        """Explicit `include_prereleases=False` beats a pre-release install."""
+        with (
+            patch(
+                "deepagents_code.update_check.get_latest_version",
+                return_value=None,
+            ) as mock_get,
+            patch("deepagents_code.update_check.__version__", "1.0.0a1"),
+        ):
+            is_update_available(include_prereleases=False)
+
+        mock_get.assert_called_once_with(bypass_cache=False, include_prereleases=False)
+
     def test_invalid_installed_version(self) -> None:
         """Non-PEP 440 installed version disables update check gracefully."""
         with patch("deepagents_code.update_check.__version__", "not-a-version"):
@@ -973,6 +1002,125 @@ class TestUpdateLogs:
 
         assert success is False
         assert "Unsupported install method" in output
+
+    async def test_perform_upgrade_uses_uv_prerelease_command(self) -> None:
+        """Pre-release upgrades pass uv's explicit pre-release strategy."""
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as run_mock,
+        ):
+            success, _output = await perform_upgrade(include_prereleases=True)
+
+        assert success is True
+        run_mock.assert_awaited_once()
+        await_args = run_mock.await_args
+        assert await_args is not None
+        assert await_args.args[0] == (
+            "uv tool upgrade deepagents-code --prerelease allow"
+        )
+
+    async def test_perform_upgrade_follows_installed_prerelease_channel(self) -> None:
+        """Omitted pre-release preference follows an installed pre-release."""
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0rc1"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as run_mock,
+        ):
+            success, _output = await perform_upgrade()
+
+        assert success is True
+        run_mock.assert_awaited_once()
+        await_args = run_mock.await_args
+        assert await_args is not None
+        assert await_args.args[0] == (
+            "uv tool upgrade deepagents-code --prerelease allow"
+        )
+
+    async def test_perform_upgrade_uses_plain_uv_command_by_default(self) -> None:
+        """Stable upgrades shell out to uv without the pre-release strategy.
+
+        `perform_upgrade` routes through `upgrade_command(method, ...)`, so a
+        regression that always opted into the pre-release channel would slip
+        past the default-path tests that override `_UPGRADE_COMMANDS`.
+        """
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as run_mock,
+        ):
+            success, _output = await perform_upgrade()
+
+        assert success is True
+        run_mock.assert_awaited_once()
+        await_args = run_mock.await_args
+        assert await_args is not None
+        assert await_args.args[0] == "uv tool upgrade deepagents-code"
+
+    async def test_perform_upgrade_refuses_prerelease_for_brew(self) -> None:
+        """Pre-release channel switching is only safe for uv tool installs."""
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="brew",
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+            ) as run_mock,
+        ):
+            success, output = await perform_upgrade(include_prereleases=True)
+
+        assert success is False
+        assert "Pre-release updates aren't supported for this install" in output
+        # The refusal must short-circuit before shelling out to `brew`.
+        run_mock.assert_not_awaited()
+
+    def test_upgrade_command_prerelease(self) -> None:
+        """Manual fallback command includes uv's pre-release strategy."""
+        assert (
+            upgrade_command(include_prereleases=True)
+            == "uv tool upgrade deepagents-code --prerelease allow"
+        )
+
+    def test_prerelease_upgrade_supported_for_uv(self) -> None:
+        """The uv install method can be steered onto the pre-release channel."""
+        supported, reason = prerelease_upgrade_supported("uv")
+
+        assert supported is True
+        assert reason is None
+
+    @pytest.mark.parametrize("method", ["brew", "other", "unknown"])
+    def test_prerelease_upgrade_unsupported_for_non_uv(
+        self,
+        method: InstallMethod,
+    ) -> None:
+        """Non-uv installs are refused with a user-facing reason."""
+        supported, reason = prerelease_upgrade_supported(method)
+
+        assert supported is False
+        assert reason is not None
+        assert "aren't supported for this install" in reason
 
 
 class TestInstallExtraCommand:

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -8,7 +8,7 @@ import tomllib
 from importlib.metadata import version as pkg_version
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -393,8 +393,6 @@ async def test_update_slash_command_editable_install_short_circuits() -> None:
     A regression here would run `uv tool upgrade deepagents-code` on an
     editable dev checkout and clobber the local install with a PyPI copy.
     """
-    from unittest.mock import AsyncMock
-
     from deepagents_code.app import DeepAgentsApp
     from deepagents_code.widgets.messages import AppMessage
 
@@ -429,8 +427,6 @@ async def test_update_slash_command_pypi_unreachable_short_circuits() -> None:
     Regression guard: collapsing this branch into the up-to-date message
     would tell users they're current when the check actually failed.
     """
-    from unittest.mock import AsyncMock
-
     from deepagents_code.app import DeepAgentsApp
     from deepagents_code.widgets.messages import AppMessage
 
@@ -445,7 +441,7 @@ async def test_update_slash_command_pypi_unreachable_short_circuits() -> None:
             patch(
                 "deepagents_code.update_check.is_update_available",
                 return_value=(False, None),
-            ),
+            ) as is_update_mock,
             patch(
                 "deepagents_code.update_check.perform_upgrade",
                 new_callable=AsyncMock,
@@ -454,10 +450,153 @@ async def test_update_slash_command_pypi_unreachable_short_circuits() -> None:
             await app._handle_command("/update")
             await pilot.pause()
 
+        is_update_mock.assert_called_once_with(
+            bypass_cache=True,
+            include_prereleases=None,
+        )
         perform_upgrade_mock.assert_not_awaited()
         app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
         content = str(app_msgs[-1]._content)
         assert "Could not determine the latest version" in content
+
+
+async def test_update_slash_command_omitted_prerelease_preserves_channel() -> None:
+    """`/update` lets update helpers infer the channel from the installed version."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch(
+                "deepagents_code.config._is_editable_install",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_code.update_check.is_update_available",
+                return_value=(True, "99.0.0"),
+            ) as is_update_mock,
+            patch(
+                "deepagents_code.update_check.perform_upgrade",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as perform_upgrade_mock,
+        ):
+            await app._handle_command("/update")
+            await pilot.pause()
+
+        is_update_mock.assert_called_once_with(
+            bypass_cache=True,
+            include_prereleases=None,
+        )
+        perform_upgrade_mock.assert_awaited_once_with(include_prereleases=None)
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        assert "Updated to v99.0.0" in str(app_msgs[-1]._content)
+
+
+async def test_update_slash_command_prerelease_updates_channel() -> None:
+    """`/update --prerelease` opts into alpha/beta/rc releases."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.widgets.messages import AppMessage, UserMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch(
+                "deepagents_code.config._is_editable_install",
+                return_value=False,
+            ),
+            # `--prerelease` is only honored on uv installs; pin the detected
+            # method so the precheck doesn't refuse based on the test runner's
+            # own environment.
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.update_check.is_update_available",
+                return_value=(True, "99.0.0rc1"),
+            ) as is_update_mock,
+            patch(
+                "deepagents_code.update_check.perform_upgrade",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as perform_upgrade_mock,
+        ):
+            await app._handle_command("/update --prerelease")
+            await pilot.pause()
+
+        is_update_mock.assert_called_once_with(
+            bypass_cache=True,
+            include_prereleases=True,
+        )
+        perform_upgrade_mock.assert_awaited_once_with(include_prereleases=True)
+        user_msgs = list(app.query(UserMessage))
+        assert str(user_msgs[-1]._content) == "/update --prerelease"
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        assert "Updated to v99.0.0rc1" in str(app_msgs[-1]._content)
+
+
+async def test_update_slash_command_prerelease_unsupported_install_refuses() -> None:
+    """`/update --prerelease` refuses on a non-uv install before hitting PyPI."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch(
+                "deepagents_code.config._is_editable_install",
+                return_value=False,
+            ),
+            # Pin a non-uv install so the precheck's refusal is driven by the
+            # test rather than the test runner's own environment.
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="brew",
+            ),
+            patch(
+                "deepagents_code.update_check.is_update_available",
+            ) as is_update_mock,
+            patch(
+                "deepagents_code.update_check.perform_upgrade",
+                new_callable=AsyncMock,
+            ) as perform_upgrade_mock,
+        ):
+            await app._handle_command("/update --prerelease")
+            await pilot.pause()
+
+        # The refusal must short-circuit before promising or attempting an
+        # upgrade the install method can't honor.
+        is_update_mock.assert_not_called()
+        perform_upgrade_mock.assert_not_awaited()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        assert "aren't supported for this install" in str(app_msgs[-1]._content)
+
+
+async def test_update_slash_command_rejects_unknown_option() -> None:
+    """`/update` surfaces typo'd options instead of silently running stable."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with patch(
+            "deepagents_code.update_check.is_update_available",
+        ) as is_update_mock:
+            await app._handle_command("/update --prereleases")
+            await pilot.pause()
+
+        # A discarded flag must never silently fall through to an update check.
+        is_update_mock.assert_not_called()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        assert "Unknown option(s) for /update: --prereleases" in str(
+            app_msgs[-1]._content
+        )
 
 
 def test_help_mentions_version_flag() -> None:


### PR DESCRIPTION
Stable `dcode` installs can now opt into alpha/beta/rc updates from both headless CLI flows and the interactive `/update` command. Pre-release upgrade attempts are limited to `uv tool` installs so users do not get silently routed through an installer that cannot honor the requested release channel.