### PR TITLE
refactor(code): remove superseded thread-population helpers

### DIFF
--- a/libs/code/deepagents_code/sessions.py
+++ b/libs/code/deepagents_code/sessions.py
@@ -405,26 +405,6 @@ async def list_threads(
         return threads
 
 
-async def populate_thread_message_counts(threads: list[ThreadInfo]) -> list[ThreadInfo]:
-    """Populate `message_count` for an existing thread list.
-
-    This is used by the `/threads` modal to render rows quickly, then backfill
-    counts in the background without issuing a second thread-list query.
-
-    Args:
-        threads: Thread rows to enrich in place.
-
-    Returns:
-        The same list object with `message_count` values populated.
-    """
-    if not threads:
-        return threads
-
-    async with _connect() as conn:
-        await _populate_message_counts(conn, threads)
-    return threads
-
-
 async def populate_thread_checkpoint_details(
     threads: list[ThreadInfo],
     *,
@@ -677,43 +657,6 @@ def _cache_recent_threads(
 def _copy_threads(threads: list[ThreadInfo]) -> list[ThreadInfo]:
     """Return shallow-copied thread rows."""
     return [ThreadInfo(**thread) for thread in threads]
-
-
-async def _extract_initial_prompt(
-    conn: aiosqlite.Connection,
-    thread_id: str,
-    serde: JsonPlusSerializer,
-) -> str | None:
-    """Extract the first human message from the latest checkpoint.
-
-    Args:
-        conn: Database connection.
-        thread_id: The thread ID to extract from.
-        serde: Serializer for decoding checkpoint data.
-
-    Returns:
-        First human message content, or None if not found.
-    """
-    summary = await _load_latest_checkpoint_summary(conn, thread_id, serde)
-    return summary.initial_prompt
-
-
-async def populate_thread_initial_prompts(threads: list[ThreadInfo]) -> None:
-    """Populate `initial_prompt` for thread rows in the background.
-
-    Args:
-        threads: Thread rows to enrich in place.
-    """
-    if not threads:
-        return
-
-    async with _connect() as conn:
-        await _populate_checkpoint_fields(
-            conn,
-            threads,
-            include_message_count=False,
-            include_initial_prompt=True,
-        )
 
 
 async def _populate_checkpoint_fields(
@@ -1052,43 +995,6 @@ async def _load_message_counts_from_writes_batch(
                 continue
 
     return {tid: len(messages) for tid, messages in reduced.items()}
-
-
-async def _load_latest_checkpoint_summary(
-    conn: aiosqlite.Connection,
-    thread_id: str,
-    serde: JsonPlusSerializer,
-) -> _CheckpointSummary:
-    """Load checkpoint-derived summary data from the latest checkpoint row.
-
-    Returns:
-        Message-count and prompt data extracted from the latest checkpoint row.
-    """
-    query = """
-        SELECT type, checkpoint
-        FROM checkpoints
-        WHERE thread_id = ?
-        ORDER BY checkpoint_id DESC
-        LIMIT 1
-    """
-    async with conn.execute(query, (thread_id,)) as cursor:
-        row = await cursor.fetchone()
-        if not row or not row[0] or not row[1]:
-            return _CheckpointSummary(message_count=None, initial_prompt=None)
-
-        type_str, checkpoint_blob = row
-        try:
-            data = serde.loads_typed((type_str, checkpoint_blob))
-        except (ValueError, TypeError, KeyError, AttributeError):
-            logger.warning(
-                "Failed to deserialize checkpoint for thread %s; "
-                "message count and initial prompt may be incomplete",
-                thread_id,
-                exc_info=True,
-            )
-            return _CheckpointSummary(message_count=None, initial_prompt=None)
-
-    return _summarize_checkpoint(data)
 
 
 def _summarize_checkpoint(data: object) -> _CheckpointSummary:


### PR DESCRIPTION
Removes three unused functions in `sessions.py` (`populate_thread_message_counts`, `populate_thread_initial_prompts`, `_extract_initial_prompt`) plus a private helper (`_load_latest_checkpoint_summary`) that only the removed code used.

How we know it's dead: the `/threads` modal now enriches rows through the newer batched `populate_thread_checkpoint_details` / `_populate_checkpoint_fields` path. A search across the whole package, tests, and examples found no remaining callers of any of these — only their own definitions. The shared lower-level helpers they relied on are still used by the batched path, so nothing else is affected.

Made by [Open SWE](https://openswe.vercel.app)