### PR TITLE
docs(infra): add architecture and development onboarding guides

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,168 @@
+# Architecture
+
+This document is a map of how a Deep Agent is assembled and how a single
+request flows through the stack. It is aimed at contributors who need to trace
+behavior or find the right place to make a change. For setup and day-to-day
+commands, see [`DEVELOPMENT.md`](./DEVELOPMENT.md).
+
+## The three layers
+
+Deep Agents is the top layer of a three-layer stack. Each layer owns a
+different concern, and understanding which layer a behavior lives in is the
+fastest way to find the code responsible for it.
+
+```txt
+┌─────────────────────────────────────────────────────────────┐
+│ deepagents          opinionated harness                      │
+│                     create_deep_agent() assembles a default   │
+│                     middleware stack, backends, subagents,    │
+│                     skills, and profiles.                     │
+├─────────────────────────────────────────────────────────────┤
+│ langchain           agent loop                                │
+│ create_agent()      turns a model + tools + middleware into a │
+│                     runnable agent graph.                     │
+├─────────────────────────────────────────────────────────────┤
+│ langgraph           runtime                                   │
+│                     state channels, checkpointing, streaming, │
+│                     persistence, interrupts.                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- **LangGraph** is the runtime. It owns the compiled state graph, state
+  channels, checkpointing, streaming, and human-in-the-loop interrupts. Deep
+  Agents never re-implements any of this.
+- **LangChain `create_agent`** is the agent loop. It takes a model, a tool
+  list, and a list of middleware and produces a `CompiledStateGraph` that runs
+  the model/tool loop.
+- **Deep Agents** is an opinionated harness *on top of* `create_agent`. It does
+  not introduce a new runtime; instead, `create_deep_agent()` assembles a
+  curated middleware stack, wires in pluggable backends, and configures
+  subagents, skills, memory, and profiles, then hands all of it to
+  `create_agent`.
+
+The practical consequence: most Deep Agents behavior is implemented as
+**middleware** and **backends**, not as bespoke graph code. When debugging,
+ask "which middleware owns this?" before reaching for the runtime.
+
+## Request flow
+
+There are two distinct phases: **construction** (once, when you call
+`create_deep_agent`) and **execution** (every turn, when the agent runs).
+
+### Construction
+
+`create_deep_agent()` (in `deepagents/graph.py`) does the assembly:
+
+1. Resolves the model and the active harness/provider **profile**.
+2. Resolves the **backend** (filesystem / shell / store) used by the
+   filesystem, skills, and memory middleware.
+3. Builds the **middleware stack** (see ordering below).
+4. Builds the general-purpose subagent (and any inline subagents) with their
+   own middleware stacks.
+5. Composes the final system prompt (caller prompt + base prompt + profile
+   suffix).
+6. Calls `create_agent(...)`, which compiles everything into a LangGraph
+   `CompiledStateGraph`.
+
+The return value is a LangGraph `CompiledStateGraph`. That means you invoke,
+stream, checkpoint, and resume it exactly like any other LangGraph graph.
+
+### Execution
+
+On each turn, LangGraph drives the agent loop. Middleware participate via
+hooks; the most important is `wrap_model_call()`, which **intercepts every LLM
+request** before it is sent. This is how middleware can:
+
+- filter the tool list per call (e.g. `FilesystemMiddleware` drops the
+  `execute` tool when the backend has no shell),
+- inject system-prompt context (e.g. `MemoryMiddleware`, `SkillsMiddleware`),
+- transform message history (e.g. `SummarizationMiddleware` truncates or
+  summarizes when the context window fills), and
+- read/write typed state that persists across turns.
+
+A plain tool in the `tools=[]` list cannot do any of this — it is only invoked
+*by* the model, never *before* the model call. That distinction (middleware vs.
+plain tool) is the core extensibility decision and is documented inline in
+`deepagents/middleware/__init__.py`.
+
+## Middleware stack ordering
+
+`create_deep_agent` assembles the stack in a fixed order. User-supplied
+`middleware` is inserted between the base stack and the tail stack. This
+ordering is authoritative and is kept in sync with the `create_deep_agent`
+docstring (the source of truth):
+
+Base stack:
+
+- `TodoListMiddleware`
+- `SkillsMiddleware` (if `skills` is provided)
+- `FilesystemMiddleware`
+- `SubAgentMiddleware` (if inline subagents are available)
+- `SummarizationMiddleware`
+- `PatchToolCallsMiddleware`
+- `AsyncSubAgentMiddleware` (if async subagents are provided)
+
+*User-supplied `middleware` is inserted here.*
+
+Tail stack:
+
+- Harness profile `extra_middleware` (if any)
+- tool-exclusion middleware (if the profile excludes tools)
+- `AnthropicPromptCachingMiddleware` (unconditional; no-ops for non-Anthropic
+  models)
+- `MemoryMiddleware` (if `memory` is provided)
+- `HumanInTheLoopMiddleware` (if `interrupt_on` is provided)
+
+After assembly, any entries listed in the profile's `excluded_middleware` are
+filtered out. A scaffolding subset (e.g. `FilesystemMiddleware`,
+`SubAgentMiddleware`) is protected and cannot be excluded.
+
+## State and persistence
+
+State lives in LangGraph, not in Deep Agents. `DeepAgentState` extends
+LangChain's `AgentState` and wraps `messages` in a `DeltaChannel` so checkpoint
+growth stays O(N) instead of O(N^2) across a long thread. Middleware contribute
+additional typed state fields via their `state_schema`; private fields are
+tracked so subagents don't leak internal state.
+
+## Extension points
+
+These are the supported, public ways to customize a Deep Agent without forking.
+Anything exported from a package's `__init__.py` is public; modules and symbols
+prefixed with an underscore (`_tools.py`, `_models.py`, `_api/`, `_state.py`,
+etc.) are internal and may change without notice.
+
+| Want to change... | Use | Where |
+| --- | --- | --- |
+| The model | `model=` | `create_deep_agent` |
+| Add capabilities the model calls | `tools=` (plain tools) | `create_deep_agent` |
+| Intercept/transform requests | `middleware=` (`AgentMiddleware`) | `deepagents.middleware` |
+| Delegate to isolated agents | `subagents=` (`SubAgent`, `CompiledSubAgent`, `AsyncSubAgent`) | `deepagents` |
+| Where files/shell/state live | `backend=` (`BackendProtocol`) | `deepagents.backends` |
+| Reusable loadable behaviors | `skills=` | `deepagents.middleware.skills` |
+| Cross-session recall | `memory=` | `deepagents.middleware.memory` |
+| Approve/edit/reject tool calls | `interrupt_on=` / `permissions=` | `create_deep_agent` |
+| Model/harness defaults | profiles | `deepagents.profiles` |
+
+Backends are pluggable via `BackendProtocol`; built-ins include
+`StateBackend`, `FilesystemBackend`, `StoreBackend`, `LocalShellBackend`,
+`CompositeBackend`, `ContextHubBackend`, and `LangSmithSandbox`. Sandbox
+providers (Daytona, Modal, Vercel, Runloop, QuickJS) ship as separate partner
+packages under `libs/partners/`.
+
+## Where things live
+
+```txt
+libs/deepagents/deepagents/
+├── graph.py            # create_deep_agent: assembly + middleware ordering
+├── __init__.py         # public SDK surface
+├── middleware/         # the default middleware stack (+ overview docstring)
+├── backends/           # pluggable file/shell/state backends + BackendProtocol
+├── profiles/           # harness and provider profiles (defaults per model)
+├── _tools.py           # internal helpers (underscore = not public)
+├── _models.py          # internal model resolution
+└── _api/               # internal deprecation helpers
+```
+
+For the relationship between Deep Agents, LangChain, and LangGraph, see the
+[LangChain ecosystem overview](https://docs.langchain.com/oss/python/concepts/products).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -96,7 +96,7 @@ uv run --group test pytest tests/unit_tests/test_specific.py
 
 ### Repo-wide commands
 
-Run these from the `libs/` directory to fan out across packages:
+Run these from the repository root to fan out across packages:
 
 | Command | What it does |
 | --- | --- |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,143 @@
+# Development
+
+A single starting point for working in the Deep Agents monorepo: how to set up,
+which commands to run, and where the rules live. For how the code is structured
+at runtime, see [`ARCHITECTURE.md`](./ARCHITECTURE.md).
+
+> [!IMPORTANT]
+> Before opening a pull request, read the
+> [LangChain contributing guide](https://docs.langchain.com/oss/python/contributing/overview).
+> External PRs must link to an issue or discussion that a maintainer has
+> approved, and the contributor must be assigned to it before the PR is opened.
+
+## Prerequisites
+
+- [`uv`](https://docs.astral.sh/uv/) — manages interpreters, virtual
+  environments, and dependencies. Do not use `pip`, `poetry`, or `conda`.
+- `make` — task runner. Every package's `Makefile` is the source of truth for
+  its commands; run `make help` in any package directory to list targets.
+
+`uv` provisions the right Python interpreter automatically, so there is no
+global Python version to install or pin.
+
+## Repository layout
+
+This is a monorepo of independently versioned packages under `libs/`:
+
+```txt
+libs/
+├── deepagents/     # Core SDK — create_deep_agent, middleware, backends
+├── cli/            # Deployment CLI (init / dev / deploy)
+├── code/           # Coding agent with an interactive Textual TUI
+├── acp/            # Agent Client Protocol integration
+├── evals/          # Evaluation suite and Harbor integration
+├── talon/          # ACP-related package
+└── partners/       # Provider/sandbox integrations
+    ├── daytona/
+    ├── modal/
+    ├── vercel/
+    ├── runloop/
+    └── quickjs/
+```
+
+Each package has its own `pyproject.toml`, `uv.lock`, `Makefile`, and
+`README.md`. There is no root `pyproject.toml`; you work inside the package you
+are changing. Local cross-package dependencies are wired as editable installs
+via `[tool.uv.sources]`, so a change in `libs/deepagents` is picked up by
+`libs/cli` without reinstalling.
+
+## Setup
+
+Work inside the package you are changing. `uv` creates and manages the virtual
+environment for you — no manual `activate` needed.
+
+```bash
+cd libs/deepagents
+uv sync --all-groups      # install the package + all dependency groups
+```
+
+Then run commands with `uv run ...` or via the package's `make` targets.
+
+## Python versions
+
+Runtime support is declared per package via `requires-python` in each
+`pyproject.toml`. For dependency **locking**, the monorepo pins one interpreter
+per package: `acp` resolves against Python 3.14 and every other package against
+3.12. That mapping lives in the `python_version` function in
+[`libs/Makefile`](./libs/Makefile) and is the source of truth for `make lock`,
+`make lock-check`, and `make lock-bump`.
+
+## Common commands
+
+Run these from inside a package directory (e.g. `libs/deepagents`). They are
+consistent across the SDK packages:
+
+| Command | What it does |
+| --- | --- |
+| `make help` | List the package's available targets |
+| `make test` | Run unit tests (no network) with coverage |
+| `make test TEST_FILE=tests/unit_tests/test_foo.py` | Run a single test file |
+| `make integration_test` | Run integration tests (network allowed) |
+| `make lint` | Run `ruff` checks + `ty` type checking |
+| `make format` | Auto-format and apply safe `ruff` fixes |
+| `make type` | Run the `ty` type checker only |
+| `make coverage` | Unit tests with a coverage report |
+| `make bench` | Run benchmarks under CodSpeed instrumentation |
+
+You can also run a specific test directly:
+
+```bash
+uv run --group test pytest tests/unit_tests/test_specific.py
+```
+
+> [!NOTE]
+> Do not add `@pytest.mark.asyncio` to async tests — every package sets
+> `asyncio_mode = "auto"`, so they are discovered automatically.
+
+### Repo-wide commands
+
+Run these from the `libs/` directory to fan out across packages:
+
+| Command | What it does |
+| --- | --- |
+| `make -C libs lint` | Lint every package |
+| `make -C libs format` | Format every package |
+| `make -C libs lock` | Update all lockfiles |
+| `make -C libs lock-check` | Verify all lockfiles are up to date |
+| `make -C libs lock-bump DEP=<pkg>` | Bump one dependency across all lockfiles |
+
+## Pre-commit hooks
+
+The repo uses [`pre-commit`](https://pre-commit.com/) for formatting, linting,
+lockfile checks, and Conventional Commit message validation:
+
+```bash
+uv tool install pre-commit   # or: pipx install pre-commit
+pre-commit install --install-hooks
+```
+
+The hooks run `make format lint` for changed packages and validate commit
+messages, so most CI lint failures are caught before you push.
+
+## Contributing conventions
+
+The full conventions live in [`AGENTS.md`](./AGENTS.md) at the repo root. The
+points most likely to trip up a first PR:
+
+- **Conventional Commits with a mandatory scope.** Titles look like
+  `type(scope): description` — e.g. `fix(cli): resolve type hinting issue`.
+  Allowed types and scopes are defined in `.github/workflows/pr_lint.yml`.
+- **Branch naming:** `<github-username>/<scope>/<short-description>`
+  (e.g. `mdrxy/docs/architecture-guide`).
+- **Tests required.** Every feature or bugfix needs unit tests under
+  `tests/unit_tests/` (no network); integration tests go in
+  `tests/integration_tests/`.
+- **Stable public interfaces.** Avoid breaking exported signatures; add new
+  parameters as keyword-only with defaults.
+- **PRs must link an approved issue/discussion** (see the contributing guide
+  linked above), and the PR description fills in the repository template.
+
+CI runs a number of gates beyond tests — Conventional Commit linting,
+lockfile freshness, version/extras consistency, and SDK-pin checks among them.
+Running `make format lint` and `make -C libs lock-check` locally before pushing
+clears the most common ones.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ The layers compose: any LangGraph `CompiledStateGraph` can be passed in as a sub
 
 ## Resources
 
+- [Architecture](ARCHITECTURE.md) — how a request flows through the stack and where to extend it
+- [Development](DEVELOPMENT.md) — monorepo setup and command reference for contributors
 - [Examples](examples/) — working agents and patterns
 - [Documentation](https://docs.langchain.com/oss/python/deepagents/overview) — conceptual overviews and guides
 - [LangChain ecosystem overview](https://docs.langchain.com/oss/python/concepts/products) — how Deep Agents, LangChain, LangGraph, and LangSmith fit together

--- a/libs/README.md
+++ b/libs/README.md
@@ -15,3 +15,5 @@ partners/            # Provider integrations
 ```
 
 (Each package contains its own `README.md` file with specific details about that package.)
+
+For monorepo setup and the command reference, see [`DEVELOPMENT.md`](../DEVELOPMENT.md). For how a request flows through the stack at runtime, see [`ARCHITECTURE.md`](../ARCHITECTURE.md).


### PR DESCRIPTION
New-contributor onboarding requires stitching knowledge together from `AGENTS.md`, per-package `Makefile`s, and external docs, and the request flow across the `deepagents` -> `create_agent` -> LangGraph layers isn't mapped anywhere in the repo. This adds two root-level guides to close those gaps (the architecture/request-flow map and a single bootstrap + command reference), cross-linked from `README.md` and `libs/README.md`.

`ARCHITECTURE.md` mirrors the authoritative middleware ordering from the `create_deep_agent` docstring; `DEVELOPMENT.md` derives commands from the package `Makefile`s and the `python_version` lock map in `libs/Makefile`.

Made by [Open SWE](https://openswe.vercel.app)