### PR TITLE
refactor(code): remove orphaned unused helper methods

### DIFF
--- a/libs/code/deepagents_code/input.py
+++ b/libs/code/deepagents_code/input.py
@@ -162,19 +162,6 @@ class MediaTracker:
         """
         return self.add_media(video_data, "video")
 
-    def get_media(self, kind: MediaKind) -> list[ImageData] | list[VideoData]:
-        """Get all tracked media of a given type.
-
-        Args:
-            kind: Media type key.
-
-        Returns:
-            Copy of the list of tracked media items.
-        """
-        if kind == "image":
-            return list(self.images)
-        return list(self.videos)
-
     def get_images(self) -> list[ImageData]:
         """Get all tracked images.
 

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -187,15 +187,6 @@ def _get_registry() -> SandboxRegistry:
     return SandboxRegistry.load()
 
 
-def _get_available_sandbox_types() -> list[str]:
-    """Get list of available sandbox provider types (internal).
-
-    Returns:
-        List of available sandbox provider type names
-    """
-    return _get_registry().available_providers()
-
-
 def get_default_working_dir(provider: str) -> str:
     """Get the default working directory for a given sandbox provider.
 

--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -137,10 +137,6 @@ class MCPServerInfo:
                 )
                 raise ValueError(msg)
 
-    def is_loaded(self) -> bool:
-        """Return whether this server has successfully loaded tools."""
-        return self.status == "ok"
-
     def needs_attention(self) -> bool:
         """Return whether this server is blocked on user login."""
         return self.status == "unauthenticated"

--- a/libs/code/deepagents_code/widgets/message_store.py
+++ b/libs/code/deepagents_code/widgets/message_store.py
@@ -515,19 +515,6 @@ class MessageStore:
         """
         return self._index.get(message_id)
 
-    def get_message_at_index(self, index: int) -> MessageData | None:
-        """Get a message by its index.
-
-        Args:
-            index: The index of the message.
-
-        Returns:
-            The message data, or None if index is out of bounds.
-        """
-        if 0 <= index < len(self._messages):
-            return self._messages[index]
-        return None
-
     def update_message(self, message_id: str, **updates: Any) -> bool:
         """Update a message's data.
 


### PR DESCRIPTION
Removes four small helper functions/methods that are defined but never called:
- `_get_available_sandbox_types` (`integrations/sandbox_factory.py`)
- `MCPServerInfo.is_loaded` (`mcp_tools.py`)
- `MessageStore.get_message_at_index` (`widgets/message_store.py`)
- `InputState.get_media` (`input.py`)

How we know it's dead: each one has exactly one match in the whole package, tests, and examples — its own definition. Their sibling helpers that are actually used (e.g. `needs_attention`, `get_images`/`get_videos`) are left in place.

Made by [Open SWE](https://openswe.vercel.app)