### PR TITLE
feat(code): auto-qualify bare Fireworks model IDs

### DIFF
--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -2967,6 +2967,7 @@ def create_model(
         >>> model = create_model()  # Uses environment defaults
     """
     from deepagents_code.model_config import (
+        FIREWORKS_PROVIDER,
         IMPLICIT_AUTH_PROVIDERS,
         ModelConfig,
         ModelConfigError,
@@ -2974,6 +2975,7 @@ def create_model(
         apply_stored_credentials,
         get_credential_env_var,
         has_provider_credentials,
+        normalize_fireworks_model,
         warn_on_split_credential_source,
     )
 
@@ -3004,6 +3006,12 @@ def create_model(
         # Bare model name — auto-detect provider or let init_chat_model infer
         model_name = model_spec
         provider = detect_provider(model_spec) or ""
+
+    # Fireworks routes by fully-qualified resource path; qualify bare ids with
+    # the account/model prefix while leaving custom-account models, deployment
+    # suffixes, and already-qualified ids untouched.
+    if provider == FIREWORKS_PROVIDER:
+        model_name = normalize_fireworks_model(model_name)
 
     # Stored API keys (added via `/auth`) take effect by being copied onto
     # the env var name LangChain reads. Apply before the credential check so

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -556,6 +556,36 @@ the full `openai` API, so mirroring every openai model would surface specs the
 backend rejects at call time.
 """
 
+FIREWORKS_PROVIDER = "fireworks"
+"""Provider name for Fireworks AI models served via `langchain-fireworks`."""
+
+FIREWORKS_MODEL_PREFIX = "accounts/fireworks/models/"
+"""Fully-qualified prefix Fireworks expects for its first-party model IDs.
+
+Fireworks routes by resource path (`accounts/<account>/models/<model>`), so a
+bare id like `kimi-k2p6` resolves only once this prefix is prepended. The
+status bar strips this same prefix for display (see `PROVIDER_PREFIX_STRIPS`).
+"""
+
+
+def normalize_fireworks_model(model_name: str) -> str:
+    """Qualify a bare Fireworks model id with the account/model prefix.
+
+    Any id that already carries an `accounts/...` path is returned unchanged so
+    custom-account models, on-demand deployment suffixes (`...#<deployment>`),
+    and already-qualified ids are preserved verbatim.
+
+    Args:
+        model_name: The Fireworks model identifier as supplied by the user.
+
+    Returns:
+        The id prefixed with `accounts/fireworks/models/` when it is a bare
+        name, otherwise the original id unchanged.
+    """
+    if not model_name or model_name.startswith("accounts/"):
+        return model_name
+    return f"{FIREWORKS_MODEL_PREFIX}{model_name}"
+
 
 RETRY_PARAM_BY_PROVIDER: dict[str, str] = {
     "anthropic": "max_retries",

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -3053,6 +3053,68 @@ class TestCreateModelEdgeCaseParsing:
         mock_default.assert_called_once()
 
 
+class TestCreateModelFireworksPrefix:
+    """Tests for Fireworks model-id normalization in create_model()."""
+
+    @pytest.fixture(autouse=True)
+    def _bypass_credential_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "deepagents_code.model_config.has_provider_credentials", lambda _: True
+        )
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_bare_name_is_qualified(self, mock_init_chat_model: Mock) -> None:
+        """A bare fireworks model id is prefixed before model creation."""
+        mock_model = Mock()
+        mock_model.profile = None
+        mock_init_chat_model.return_value = mock_model
+
+        result = create_model("fireworks:kimi-k2p6")
+
+        args, kwargs = mock_init_chat_model.call_args
+        assert args[0] == "accounts/fireworks/models/kimi-k2p6"
+        assert kwargs["model_provider"] == "fireworks"
+        assert result.model_name == "accounts/fireworks/models/kimi-k2p6"
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_qualified_id_unchanged(self, mock_init_chat_model: Mock) -> None:
+        """An already-qualified fireworks id is left untouched."""
+        mock_model = Mock()
+        mock_model.profile = None
+        mock_init_chat_model.return_value = mock_model
+
+        create_model("fireworks:accounts/fireworks/models/kimi-k2p6")
+
+        args, _ = mock_init_chat_model.call_args
+        assert args[0] == "accounts/fireworks/models/kimi-k2p6"
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_custom_account_not_clobbered(self, mock_init_chat_model: Mock) -> None:
+        """A custom-account fireworks path is preserved verbatim."""
+        mock_model = Mock()
+        mock_model.profile = None
+        mock_init_chat_model.return_value = mock_model
+
+        create_model("fireworks:accounts/my-org/models/my-tune")
+
+        args, _ = mock_init_chat_model.call_args
+        assert args[0] == "accounts/my-org/models/my-tune"
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_non_fireworks_provider_unaffected(
+        self, mock_init_chat_model: Mock
+    ) -> None:
+        """Non-fireworks providers never receive the fireworks prefix."""
+        mock_model = Mock()
+        mock_model.profile = None
+        mock_init_chat_model.return_value = mock_model
+
+        create_model("openai:gpt-5.5")
+
+        args, _ = mock_init_chat_model.call_args
+        assert args[0] == "gpt-5.5"
+
+
 class TestCreateModelViaInitImportError:
     """Tests for _create_model_via_init() ImportError handling."""
 

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -12,6 +12,7 @@ import pytest
 
 from deepagents_code import model_config
 from deepagents_code.model_config import (
+    FIREWORKS_MODEL_PREFIX,
     IMPLICIT_AUTH_PROVIDERS,
     NO_AUTH_REQUIRED_PROVIDERS,
     PROVIDER_API_KEY_ENV,
@@ -41,6 +42,7 @@ from deepagents_code.model_config import (
     load_recent_agent,
     load_recent_models,
     load_thread_columns,
+    normalize_fireworks_model,
     save_default_agent,
     save_recent_agent,
     save_recent_model,
@@ -77,6 +79,43 @@ class TestRetryParamByProvider:
         assert RETRY_PARAM_BY_PROVIDER["bedrock"] == "max_retries"
         assert RETRY_PARAM_BY_PROVIDER["fireworks"] == "max_retries"
         assert RETRY_PARAM_BY_PROVIDER["openai"] == "max_retries"
+
+
+class TestNormalizeFireworksModel:
+    """Tests for `normalize_fireworks_model`."""
+
+    def test_prepends_prefix_to_bare_name(self) -> None:
+        """A bare model id is qualified with the account/model prefix."""
+        assert (
+            normalize_fireworks_model("kimi-k2p6")
+            == f"{FIREWORKS_MODEL_PREFIX}kimi-k2p6"
+        )
+
+    def test_qualified_first_party_id_unchanged(self) -> None:
+        """An already-qualified first-party id is returned verbatim."""
+        qualified = f"{FIREWORKS_MODEL_PREFIX}kimi-k2p6"
+        assert normalize_fireworks_model(qualified) == qualified
+
+    def test_custom_account_id_preserved(self) -> None:
+        """A custom-account path is not clobbered by the fireworks prefix."""
+        custom = "accounts/my-org/models/my-tune"
+        assert normalize_fireworks_model(custom) == custom
+
+    def test_deployment_suffix_on_bare_name_prefixed(self) -> None:
+        """A bare id with a deployment suffix keeps the suffix after prefixing."""
+        assert (
+            normalize_fireworks_model("gpt-oss-120b#my-deploy")
+            == f"{FIREWORKS_MODEL_PREFIX}gpt-oss-120b#my-deploy"
+        )
+
+    def test_deployment_suffix_on_qualified_id_preserved(self) -> None:
+        """A qualified id with a deployment suffix is returned verbatim."""
+        qualified = f"{FIREWORKS_MODEL_PREFIX}gpt-oss-120b#my-deploy"
+        assert normalize_fireworks_model(qualified) == qualified
+
+    def test_empty_name_unchanged(self) -> None:
+        """An empty model id is returned unchanged."""
+        assert normalize_fireworks_model("") == ""
 
 
 class TestModelSpec:


### PR DESCRIPTION
Fireworks model ids supplied without the `accounts/fireworks/models/` prefix are now auto-qualified.

---

Fireworks routes requests by fully-qualified resource path (`accounts/<account>/models/<model>`), so a bare id like `kimi-k2p6` only resolves once the `accounts/fireworks/models/` prefix is prepended. `create_model` now qualifies bare Fireworks model ids automatically.

The normalization keys off the `accounts/` prefix rather than the full `accounts/fireworks/models/` literal, so it does **not** clobber other Fireworks-specific info: custom-account models (`accounts/<acct>/models/…`), on-demand deployment suffixes (`…#<deployment>`), and already-qualified ids pass through verbatim. This mirrors the canonical form already used in the model catalog and the prefix the status bar strips for display.

Made by [Open SWE](https://openswe.vercel.app)