### PR TITLE
feat(code): warn on `--interpreter-tools` without `--interpreter`

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2357,6 +2357,34 @@ class DeepAgentsApp(App):
         )
         self._maybe_start_external_event_source()
 
+        # Non-essential advisory: defer past first paint so it never delays
+        # the initial frame.
+        self.call_after_refresh(self._notify_interpreter_tools_without_interpreter)
+
+    def _notify_interpreter_tools_without_interpreter(self) -> None:
+        """Toast when `--interpreter-tools` was set without `--interpreter`.
+
+        The PTC allowlist applies only when the interpreter middleware is
+        enabled, so the flag is a no-op on its own. This is the TUI counterpart
+        of the non-interactive stderr warning emitted in
+        `main._warn_if_interpreter_tools_without_interpreter`: a stderr line is
+        invisible behind the alternate screen, so the same advisory is surfaced
+        as a startup notification here.
+
+        Reads the values from `self._server_kwargs` (which already carries them
+        for server startup); no extra plumbing is required.
+        """
+        server_kwargs = self._server_kwargs or {}
+        if server_kwargs.get("interpreter_ptc") is None:
+            return
+        if server_kwargs.get("enable_interpreter"):
+            return
+        self.notify(
+            "--interpreter-tools has no effect unless --interpreter is set.",
+            severity="warning",
+            markup=False,
+        )
+
     def _maybe_start_external_event_source(self) -> None:
         """Start the external event listener when explicitly enabled."""
         from deepagents_code._env_vars import (

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -366,6 +366,25 @@ def _parse_interpreter_tools_flag(
     return names
 
 
+def _warn_if_interpreter_tools_without_interpreter(args: argparse.Namespace) -> None:
+    """Warn when the `--interpreter-tools` flag is set without `--interpreter`.
+
+    The PTC allowlist only takes effect once the interpreter middleware is
+    enabled, so the flag is a silent no-op on its own. Only the CLI flag is
+    checked here, never `[interpreter]` config values.
+    """
+    if getattr(args, "interpreter_tools", None) is None:
+        return
+    if getattr(args, "interpreter", False):
+        return
+    from rich.console import Console as _Console
+
+    _Console(stderr=True).print(
+        "[yellow]Warning:[/yellow] --interpreter-tools has no effect "
+        "unless --interpreter is set."
+    )
+
+
 def _recent_agent_is_valid(name: str) -> bool:
     """Return `True` when `~/.deepagents/<name>/` still exists on disk.
 
@@ -2888,6 +2907,7 @@ def cli_main() -> None:
             interpreter_ptc = _parse_interpreter_tools_flag(
                 getattr(args, "interpreter_tools", None)
             )
+            _warn_if_interpreter_tools_without_interpreter(args)
 
             timeout = getattr(args, "timeout", None)
             try:
@@ -2988,6 +3008,7 @@ def cli_main() -> None:
                 interpreter_ptc = _parse_interpreter_tools_flag(
                     getattr(args, "interpreter_tools", None)
                 )
+                _warn_if_interpreter_tools_without_interpreter(args)
 
                 result = asyncio.run(
                     run_textual_cli_async(

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -367,15 +367,25 @@ def _parse_interpreter_tools_flag(
 
 
 def _warn_if_interpreter_tools_without_interpreter(args: argparse.Namespace) -> None:
-    """Warn when the `--interpreter-tools` flag is set without `--interpreter`.
+    """Warn that `--interpreter-tools` is a no-op without `--interpreter`.
 
-    The PTC allowlist only takes effect once the interpreter middleware is
-    enabled, so the flag is a silent no-op on its own. Only the CLI flag is
-    checked here, never `[interpreter]` config values.
+    The PTC allowlist applies only when the interpreter middleware is enabled,
+    and on the CLI that gate is the `--interpreter` flag alone (`args.interpreter`).
+    `[interpreter]` config is not consulted: `config.toml`'s `enable_interpreter`
+    does not currently enable the middleware on this path, so a missing
+    `--interpreter` always means the flag has no effect. If that ever changes,
+    this check must consider config to avoid a false-positive warning.
+
+    This drives the non-interactive (`-n`) path and prints to stderr. The
+    interactive TUI surfaces the same advisory as a startup notification (see
+    `DeepAgentsApp._notify_interpreter_tools_without_interpreter`).
+
+    Attributes are accessed directly (not via `getattr` defaults) so an argparse
+    `dest` rename fails loudly in tests rather than silently disabling the warning.
     """
-    if getattr(args, "interpreter_tools", None) is None:
+    if args.interpreter_tools is None:
         return
-    if getattr(args, "interpreter", False):
+    if args.interpreter:
         return
     from rich.console import Console as _Console
 
@@ -3008,7 +3018,10 @@ def cli_main() -> None:
                 interpreter_ptc = _parse_interpreter_tools_flag(
                     getattr(args, "interpreter_tools", None)
                 )
-                _warn_if_interpreter_tools_without_interpreter(args)
+                # A stderr warning here would be clobbered by the alternate
+                # screen the moment the TUI launches; the app surfaces the
+                # advisory as a startup notification instead (see
+                # `DeepAgentsApp._notify_interpreter_tools_without_interpreter`).
 
                 result = asyncio.run(
                     run_textual_cli_async(

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -14073,3 +14073,74 @@ class TestEnsureManagedRipgrep:
             await app._start_server_background()
 
         assert call_order[:2] == ["ensure", "start_server"], call_order
+
+
+class TestNotifyInterpreterToolsWithoutInterpreter:
+    """Tests for `_notify_interpreter_tools_without_interpreter` (TUI advisory)."""
+
+    def test_toasts_when_tools_set_without_interpreter(self) -> None:
+        """`interpreter_ptc` set with the interpreter disabled warns once."""
+        app = DeepAgentsApp(
+            server_kwargs={
+                "assistant_id": "agent",
+                "model_name": None,
+                "interpreter_ptc": "safe",
+                "enable_interpreter": False,
+            },
+        )
+        notify_mock = MagicMock()
+        app.notify = notify_mock  # ty: ignore
+
+        app._notify_interpreter_tools_without_interpreter()
+
+        notify_mock.assert_called_once()
+        assert (
+            "--interpreter-tools has no effect unless --interpreter is set"
+            in notify_mock.call_args.args[0]
+        )
+        assert notify_mock.call_args.kwargs.get("severity") == "warning"
+        assert notify_mock.call_args.kwargs.get("markup") is False
+
+    def test_no_toast_when_interpreter_enabled(self) -> None:
+        """The allowlist takes effect with `--interpreter`, so no warning."""
+        app = DeepAgentsApp(
+            server_kwargs={
+                "assistant_id": "agent",
+                "model_name": None,
+                "interpreter_ptc": "safe",
+                "enable_interpreter": True,
+            },
+        )
+        notify_mock = MagicMock()
+        app.notify = notify_mock  # ty: ignore
+
+        app._notify_interpreter_tools_without_interpreter()
+
+        notify_mock.assert_not_called()
+
+    def test_no_toast_without_interpreter_tools(self) -> None:
+        """Absent `interpreter_ptc` does not warn."""
+        app = DeepAgentsApp(
+            server_kwargs={
+                "assistant_id": "agent",
+                "model_name": None,
+                "interpreter_ptc": None,
+                "enable_interpreter": False,
+            },
+        )
+        notify_mock = MagicMock()
+        app.notify = notify_mock  # ty: ignore
+
+        app._notify_interpreter_tools_without_interpreter()
+
+        notify_mock.assert_not_called()
+
+    def test_no_toast_when_server_kwargs_absent(self) -> None:
+        """An agent-backed app with no `server_kwargs` does not warn."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+        notify_mock = MagicMock()
+        app.notify = notify_mock  # ty: ignore
+
+        app._notify_interpreter_tools_without_interpreter()
+
+        notify_mock.assert_not_called()

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -2124,3 +2124,49 @@ class TestParseInterpreterToolsFlag:
         with pytest.raises(SystemExit) as exc_info:
             _parse_interpreter_tools_flag("   ")
         assert exc_info.value.code == 2
+
+
+class TestWarnInterpreterToolsWithoutInterpreter:
+    """Tests for `_warn_if_interpreter_tools_without_interpreter`."""
+
+    def test_warns_without_interpreter(
+        self, mock_argv: MockArgvType, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--interpreter-tools without --interpreter warns and does not exit."""
+        from deepagents_code.main import (
+            _warn_if_interpreter_tools_without_interpreter,
+        )
+
+        with mock_argv("-n", "task", "--interpreter-tools", "safe"):
+            args = parse_args()
+        _warn_if_interpreter_tools_without_interpreter(args)
+        assert (
+            "--interpreter-tools has no effect unless --interpreter is set"
+            in capsys.readouterr().err
+        )
+
+    def test_no_warning_with_interpreter(
+        self, mock_argv: MockArgvType, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--interpreter --interpreter-tools does not warn."""
+        from deepagents_code.main import (
+            _warn_if_interpreter_tools_without_interpreter,
+        )
+
+        with mock_argv("-n", "task", "--interpreter", "--interpreter-tools", "safe"):
+            args = parse_args()
+        _warn_if_interpreter_tools_without_interpreter(args)
+        assert capsys.readouterr().err == ""
+
+    def test_no_warning_without_flag(
+        self, mock_argv: MockArgvType, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Absent --interpreter-tools does not warn."""
+        from deepagents_code.main import (
+            _warn_if_interpreter_tools_without_interpreter,
+        )
+
+        with mock_argv("-n", "task"):
+            args = parse_args()
+        _warn_if_interpreter_tools_without_interpreter(args)
+        assert capsys.readouterr().err == ""

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -2170,3 +2170,40 @@ class TestWarnInterpreterToolsWithoutInterpreter:
             args = parse_args()
         _warn_if_interpreter_tools_without_interpreter(args)
         assert capsys.readouterr().err == ""
+
+    def test_cli_main_emits_warning_on_non_interactive_path(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """End-to-end: `-n --interpreter-tools` without `--interpreter` warns.
+
+        Guards the wiring (not just the helper): a dropped or misplaced call
+        site, or an earlier `sys.exit` swallowing the warning, fails here.
+        """
+        from deepagents_code.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        with (
+            patch.object(
+                sys, "argv", ["deepagents", "-n", "task", "--interpreter-tools", "safe"]
+            ),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_code.main.check_optional_tools", return_value=[]),
+            patch(
+                "deepagents_code.main._should_ensure_managed_ripgrep",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_code.non_interactive.run_non_interactive",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+
+        assert exc_info.value.code == 0
+        assert (
+            "--interpreter-tools has no effect unless --interpreter is set"
+            in capsys.readouterr().err
+        )


### PR DESCRIPTION
The CLI now warns when `--interpreter-tools` is passed without `--interpreter`, since the flag has no effect on its own.

---

Passing `--interpreter-tools` configures the PTC allowlist for the `js_eval` interpreter, but that allowlist only takes effect when the interpreter middleware is enabled via `--interpreter`. Previously the flag was silently parsed and ignored in that case, leaving users with no feedback.

The advisory is surfaced on whichever path the user is on:

- **Non-interactive (`-n`):** a one-line stderr warning — `--interpreter-tools has no effect unless --interpreter is set.` — emitted after argument validation. It does not exit nonzero and does not trigger interpreter dependency verification.
- **Interactive (TUI):** the same advisory as a startup notification. A stderr line printed just before the TUI launches is clobbered by the alternate screen and never seen, so the app emits a `warning`-severity toast on mount instead. This reuses the interpreter values already handed to the app, so no new plumbing or signature changes are needed.

Only the `--interpreter` CLI flag gates the advisory. `[interpreter]` config values are untouched, and invalid `--interpreter-tools` values keep their existing usage-error behavior — those errors take precedence over the advisory.

**Known limitation:** `--interpreter-tools` is a top-level flag, so passing it alongside a management subcommand (`threads`, `mcp`, `agents`, `skills`) does not warn — those paths exit before a session launches. Combining an interpreter flag with a management subcommand is an obvious no-op with no correctness impact.
