### PR TITLE
fix(code): treat gateway-provisioned providers as authenticated

### DIFF
--- a/libs/code/deepagents_code/auth_commands.py
+++ b/libs/code/deepagents_code/auth_commands.py
@@ -192,6 +192,8 @@ def _resolution_label(status: ProviderAuthStatus) -> str:
     if state is ProviderAuthState.CONFIGURED:
         if status.source is ProviderAuthSource.STORED:
             return "stored"
+        if status.source is ProviderAuthSource.GATEWAY:
+            return "gateway"
         if status.source is ProviderAuthSource.ENV and status.env_var:
             return f"env: {resolved_env_var_name(status.env_var)}"
         return "configured"

--- a/libs/code/deepagents_code/auth_display.py
+++ b/libs/code/deepagents_code/auth_display.py
@@ -160,7 +160,8 @@ def _format_configured_badge(status: ProviderAuthStatus) -> Content:
         status: A `CONFIGURED` provider auth status.
 
     Returns:
-        A styled badge naming the credential source (`[stored]` or `[env: …]`).
+        A styled badge naming the credential source (`[stored]`, `[gateway]`,
+            or `[env: …]`).
 
     Raises:
         ValueError: If the status carries no source. `ProviderAuthStatus`
@@ -170,6 +171,8 @@ def _format_configured_badge(status: ProviderAuthStatus) -> Content:
     match status.source:
         case ProviderAuthSource.STORED:
             return Content.styled("[stored]", "bold $success")
+        case ProviderAuthSource.GATEWAY:
+            return Content.styled("[gateway]", "bold $success")
         case ProviderAuthSource.ENV:
             if status.env_var:
                 return Content.assemble(

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -244,6 +244,14 @@ class ProviderAuthSource(StrEnum):
     ENV = "env"
     """Resolved from an environment variable."""
 
+    GATEWAY = "gateway"
+    """Authenticated through a managed gateway (e.g. the LangSmith gateway).
+
+    The provider's own API-key env var is unset, but its endpoint is the
+    gateway and a gateway key is present, so requests authenticate via the
+    gateway rather than a provider-native key.
+    """
+
 
 @dataclass(frozen=True)
 class ProviderAuthStatus:
@@ -696,6 +704,17 @@ NO_AUTH_REQUIRED_PROVIDERS: frozenset[str] = frozenset({"ollama"})
 
 OPTIONAL_AUTH_ENV: dict[str, str] = {"ollama": "OLLAMA_API_KEY"}
 """Optional env vars that enable authenticated provider modes when present."""
+
+LANGSMITH_GATEWAY_HOST = "smith.langchain.com"
+"""Host substring identifying a LangSmith gateway endpoint.
+
+When a provider's resolved base URL points here, requests are routed through
+the LangSmith gateway, which authenticates with a LangSmith key rather than the
+provider's own API key.
+"""
+
+LANGSMITH_GATEWAY_KEY_ENVS: tuple[str, ...] = ("LANGSMITH_API_KEY", "LANGCHAIN_API_KEY")
+"""Env vars that may hold the LangSmith key used to authenticate the gateway."""
 
 PROVIDER_HOST_ENV: dict[str, str] = {"ollama": "OLLAMA_HOST"}
 """Provider-specific env vars that can point a local provider at a remote host."""
@@ -1705,6 +1724,51 @@ def _resolve_configured(provider: str, env_var: str) -> ProviderAuthStatus | Non
     return None
 
 
+def _resolve_langsmith_gateway_key() -> str | None:
+    """Return the LangSmith key authenticating the gateway, if any.
+
+    Checks `LANGSMITH_API_KEY` then `LANGCHAIN_API_KEY` via `resolve_env_var`
+    (so `DEEPAGENTS_CODE_` prefixes apply). The secret value is never logged.
+    """
+    for name in LANGSMITH_GATEWAY_KEY_ENVS:
+        key = resolve_env_var(name)
+        if key:
+            return key
+    return None
+
+
+def _resolve_gateway_auth(
+    provider: str, config: ModelConfig
+) -> ProviderAuthStatus | None:
+    """Return a `CONFIGURED` status when `provider` authenticates via a gateway.
+
+    A machine provisioned with the LangSmith gateway exports the provider's
+    endpoint variable (e.g. `ANTHROPIC_BASE_URL`) and a gateway key together,
+    leaving the provider's own API-key env var unset. In that case the provider
+    is authenticated through the gateway, so it must not be reported as missing
+    credentials.
+
+    Args:
+        provider: Provider name (e.g., `"anthropic"`).
+        config: Loaded model configuration used to resolve the endpoint.
+
+    Returns:
+        A `CONFIGURED` / `GATEWAY` status when the provider's endpoint is the
+            LangSmith gateway and a LangSmith key is set, else `None`.
+    """
+    endpoint = _get_provider_endpoint(provider, config)
+    if not endpoint or LANGSMITH_GATEWAY_HOST not in endpoint:
+        return None
+    if not _resolve_langsmith_gateway_key():
+        return None
+    return ProviderAuthStatus(
+        state=ProviderAuthState.CONFIGURED,
+        provider=provider,
+        source=ProviderAuthSource.GATEWAY,
+        detail="via LangSmith gateway",
+    )
+
+
 def _get_codex_auth_status() -> ProviderAuthStatus:
     """Translate the ChatGPT OAuth on-disk state into a `ProviderAuthStatus`.
 
@@ -1771,6 +1835,11 @@ def get_provider_auth_status(provider: str) -> ProviderAuthStatus:
         via `resolve_env_var()`.
     3. **Implicit auth providers** (e.g., Vertex AI ADC): a missing env var is
         not treated as missing credentials.
+
+    Before reporting a missing key, providers whose endpoint resolves to the
+    LangSmith gateway are treated as configured when a LangSmith gateway key is
+    set: the gateway authenticates the request, so the provider's own key env
+    var is not required (see `_resolve_gateway_auth`).
     4. **Optional auth env vars** (`OPTIONAL_AUTH_ENV`): when present, mark
         the provider as configured for hosted/cloud use.
     5. **No-auth-required providers** (`NO_AUTH_REQUIRED_PROVIDERS`): default
@@ -1806,6 +1875,9 @@ def get_provider_auth_status(provider: str) -> ProviderAuthStatus:
             configured = _resolve_configured(provider, env_var)
             if configured:
                 return configured
+            gateway = _resolve_gateway_auth(provider, config)
+            if gateway:
+                return gateway
             return ProviderAuthStatus(
                 state=ProviderAuthState.MISSING,
                 provider=provider,
@@ -1836,6 +1908,9 @@ def get_provider_auth_status(provider: str) -> ProviderAuthStatus:
                 env_var=env_var,
                 detail="implicit auth",
             )
+        gateway = _resolve_gateway_auth(provider, config)
+        if gateway:
+            return gateway
         return ProviderAuthStatus(
             state=ProviderAuthState.MISSING,
             provider=provider,

--- a/libs/code/tests/unit_tests/test_auth_commands.py
+++ b/libs/code/tests/unit_tests/test_auth_commands.py
@@ -442,6 +442,20 @@ class TestStatus:
         assert code == 0
         assert "missing" in capsys.readouterr().out
 
+    def test_status_gateway(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A gateway-provisioned provider reports `gateway`, not `missing`."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("DEEPAGENTS_CODE_ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv(
+            "ANTHROPIC_BASE_URL", "https://gateway.smith.langchain.com/anthropic"
+        )
+        monkeypatch.setenv("LANGSMITH_API_KEY", "lsv2_test")
+        code = run_auth_command(_ns(auth_command="status", provider="anthropic"))
+        assert code == 0
+        assert "gateway" in capsys.readouterr().out
+
     def test_status_requires_provider(self, capsys: pytest.CaptureFixture[str]) -> None:
         """`status` without a provider points users at `list` instead."""
         code = run_auth_command(_ns(auth_command="status", provider=None))

--- a/libs/code/tests/unit_tests/test_auth_display.py
+++ b/libs/code/tests/unit_tests/test_auth_display.py
@@ -51,6 +51,16 @@ _AUTH_STATUS_CASES = [
     ),
     (
         ProviderAuthStatus(
+            state=ProviderAuthState.CONFIGURED,
+            provider="anthropic",
+            source=ProviderAuthSource.GATEWAY,
+            detail="via LangSmith gateway",
+        ),
+        "[gateway]",
+        "",
+    ),
+    (
+        ProviderAuthStatus(
             state=ProviderAuthState.MISSING,
             provider="anthropic",
             env_var="ANTHROPIC_API_KEY",

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -3389,6 +3389,111 @@ models = ["llama3"]
         assert status.env_var == "OLLAMA_API_KEY"
 
 
+class TestProviderAuthStatusGateway:
+    """Gateway-provisioned providers are configured, not missing."""
+
+    _GATEWAY_URL = "https://gateway.smith.langchain.com/anthropic"
+
+    def test_gateway_endpoint_and_key_reports_configured(self) -> None:
+        """A gateway endpoint + LangSmith key authenticates without a provider key."""
+        with patch.dict(
+            "os.environ",
+            {
+                "ANTHROPIC_BASE_URL": self._GATEWAY_URL,
+                "LANGSMITH_API_KEY": "lsv2_test",
+            },
+            clear=True,
+        ):
+            status = get_provider_auth_status("anthropic")
+            legacy = has_provider_credentials("anthropic")
+
+        assert status.state is ProviderAuthState.CONFIGURED
+        assert status.source is ProviderAuthSource.GATEWAY
+        assert status.blocks_start is False
+        assert legacy is True
+
+    def test_gateway_accepts_langchain_api_key(self) -> None:
+        """`LANGCHAIN_API_KEY` is honored as the gateway key alias."""
+        with patch.dict(
+            "os.environ",
+            {
+                "ANTHROPIC_BASE_URL": self._GATEWAY_URL,
+                "LANGCHAIN_API_KEY": "lsv2_test",
+            },
+            clear=True,
+        ):
+            status = get_provider_auth_status("anthropic")
+
+        assert status.state is ProviderAuthState.CONFIGURED
+        assert status.source is ProviderAuthSource.GATEWAY
+
+    def test_gateway_endpoint_without_key_reports_missing(self) -> None:
+        """A gateway endpoint with no LangSmith key stays MISSING."""
+        with patch.dict(
+            "os.environ",
+            {"ANTHROPIC_BASE_URL": self._GATEWAY_URL},
+            clear=True,
+        ):
+            status = get_provider_auth_status("anthropic")
+
+        assert status.state is ProviderAuthState.MISSING
+        assert status.env_var == "ANTHROPIC_API_KEY"
+
+    def test_langsmith_key_without_gateway_endpoint_reports_missing(self) -> None:
+        """A LangSmith key alone (no gateway endpoint) does not satisfy auth."""
+        with patch.dict(
+            "os.environ",
+            {"LANGSMITH_API_KEY": "lsv2_test"},
+            clear=True,
+        ):
+            status = get_provider_auth_status("anthropic")
+
+        assert status.state is ProviderAuthState.MISSING
+        assert status.env_var == "ANTHROPIC_API_KEY"
+
+    def test_provider_key_beats_gateway_source(self) -> None:
+        """A provider-native key wins, reporting an ENV source over GATEWAY."""
+        with patch.dict(
+            "os.environ",
+            {
+                "ANTHROPIC_BASE_URL": self._GATEWAY_URL,
+                "LANGSMITH_API_KEY": "lsv2_test",
+                "ANTHROPIC_API_KEY": "sk-ant-test",
+            },
+            clear=True,
+        ):
+            status = get_provider_auth_status("anthropic")
+
+        assert status.state is ProviderAuthState.CONFIGURED
+        assert status.source is ProviderAuthSource.ENV
+
+    def test_config_provider_gateway_reports_configured(
+        self, tmp_path: Path
+    ) -> None:
+        """A config-file provider with an unset key still resolves via the gateway."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.openai]
+models = ["gpt-5.5"]
+api_key_env = "OPENAI_API_KEY"
+""")
+        with (
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            patch.dict(
+                "os.environ",
+                {
+                    "OPENAI_BASE_URL": "https://gateway.smith.langchain.com/openai/v1",
+                    "LANGSMITH_API_KEY": "lsv2_test",
+                },
+                clear=True,
+            ),
+        ):
+            status = get_provider_auth_status("openai")
+
+        assert status.state is ProviderAuthState.CONFIGURED
+        assert status.source is ProviderAuthSource.GATEWAY
+
+
 class TestProviderAuthStatusMissingDetail:
     """Tests for ProviderAuthStatus.missing_detail() rendering."""
 

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -3467,9 +3467,7 @@ class TestProviderAuthStatusGateway:
         assert status.state is ProviderAuthState.CONFIGURED
         assert status.source is ProviderAuthSource.ENV
 
-    def test_config_provider_gateway_reports_configured(
-        self, tmp_path: Path
-    ) -> None:
+    def test_config_provider_gateway_reports_configured(self, tmp_path: Path) -> None:
         """A config-file provider with an unset key still resolves via the gateway."""
         config_path = tmp_path / "config.toml"
         config_path.write_text("""


### PR DESCRIPTION
Providers reachable through a managed LangSmith gateway are no longer incorrectly reported as unauthenticated when their own API key is unset.

---

On a machine provisioned with the LangSmith gateway, the provider's endpoint variable (e.g. `ANTHROPIC_BASE_URL`) and a gateway key are exported together while the provider's own API-key env var stays unset. `get_provider_auth_status` only inspected the provider's own key, so it wrongly reported these providers as missing credentials (blocking model creation and showing `[missing]` in `/auth` and `/model`). It now detects a provider whose resolved endpoint is the LangSmith gateway plus a LangSmith key (`LANGSMITH_API_KEY`/`LANGCHAIN_API_KEY`) and reports it as `CONFIGURED` via a new `GATEWAY` source.

## Test Plan
- [ ] With `ANTHROPIC_BASE_URL` pointing at the LangSmith gateway and `LANGSMITH_API_KEY` set (no `ANTHROPIC_API_KEY`), confirm `/auth` shows `[gateway]` and the model starts.

Made by [Open SWE](https://openswe.vercel.app)