### PR TITLE
fix(code): guard restart-prompt import against in-place self-upgrade

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -10684,19 +10684,24 @@ class DeepAgentsApp(App):
         rewrites deepagents-code's own on-disk package tree while this process
         is running. Modules already in `sys.modules` keep working from memory,
         but a *first* import after the rewrite reads the mutated (or
-        partially-written) tree and can raise `ModuleNotFoundError`.
+        partially-written) tree and raises `ModuleNotFoundError`.
         `restart_prompt` is imported only on the post-install path, so import
         it now — before the mutation — so the later import in
-        `_offer_restart_after_install` is a cache hit served from memory. The
-        import is still defended there for the genuine upgrade case where the
-        on-disk module legitimately differs from what is resident.
+        `_offer_restart_after_install` resolves from `sys.modules` without
+        re-reading disk. That import is still defended there for the genuine
+        upgrade case where the on-disk module legitimately differs from what is
+        resident.
+
+        Catches only `ModuleNotFoundError` (the missing-tree failure), not the
+        broader `ImportError`, so a genuine name-binding bug in `restart_prompt`
+        still surfaces instead of being mistaken for an upgrade race.
 
         Best-effort: a failure here just means the post-install import falls
         back to its own guard, so swallow it rather than crash the install.
         """
         try:
-            from deepagents_code.widgets import restart_prompt  # noqa: F401
-        except ImportError:
+            import deepagents_code.widgets.restart_prompt  # noqa: F401
+        except ModuleNotFoundError:
             logger.warning("Could not preload restart_prompt modal", exc_info=True)
 
     async def _offer_restart_after_install(self, label: str) -> None:
@@ -10722,12 +10727,15 @@ class DeepAgentsApp(App):
 
         try:
             from deepagents_code.widgets.restart_prompt import RestartPromptScreen
-        except ImportError:
+        except ModuleNotFoundError:
             # `/install` runs `uv tool install -U 'deepagents-code[...]'`, which
             # can rewrite deepagents-code's own on-disk package tree mid-session
             # (see `_ensure_restart_prompt_loaded`). A first import of the modal
-            # here may then fail. The manual `/restart` hint was already mounted
-            # by the caller, so degrade to that instead of crashing the TUI.
+            # here may then fail with `ModuleNotFoundError`. The manual
+            # `/restart` hint was already mounted by the caller, so degrade to
+            # that instead of crashing the TUI. The catch is deliberately
+            # narrow — a genuine `ImportError` from a broken modal still
+            # propagates rather than being mistaken for an upgrade race.
             logger.warning(
                 "restart_prompt unavailable after installing %r; leaving the "
                 "manual /restart hint in place",

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -205,6 +205,7 @@ if TYPE_CHECKING:
     from deepagents_code.widgets.notification_center import (
         NotificationSuppressRequested,
     )
+    from deepagents_code.widgets.restart_prompt import RestartChoice
     from deepagents_code.widgets.update_progress import UpdateProgressScreen
 
 _LAUNCH_INIT_CONNECTION_TIMEOUT_SECONDS = 60.0
@@ -4003,6 +4004,9 @@ class DeepAgentsApp(App):
             return
 
         log_path = create_update_log_path()
+        # Load the restart modal before the upgrade rewrites our own package
+        # tree; the post-install import then hits the in-memory cache.
+        self._ensure_restart_prompt_loaded()
         await self._mount_message(
             AppMessage(f"Installing extra '{extra}'..."),
         )
@@ -4114,6 +4118,9 @@ class DeepAgentsApp(App):
             return
 
         log_path = create_update_log_path()
+        # Load the restart modal before the upgrade rewrites our own package
+        # tree; the post-install import then hits the in-memory cache.
+        self._ensure_restart_prompt_loaded()
         await self._mount_message(
             AppMessage(f"Installing package '{package}'..."),
         )
@@ -10669,6 +10676,29 @@ class DeepAgentsApp(App):
             ),
         )
 
+    @staticmethod
+    def _ensure_restart_prompt_loaded() -> None:
+        """Load the restart-prompt modal before any in-place self-upgrade.
+
+        `/install` runs `uv tool install -U 'deepagents-code[...]'`, which
+        rewrites deepagents-code's own on-disk package tree while this process
+        is running. Modules already in `sys.modules` keep working from memory,
+        but a *first* import after the rewrite reads the mutated (or
+        partially-written) tree and can raise `ModuleNotFoundError`.
+        `restart_prompt` is imported only on the post-install path, so import
+        it now — before the mutation — so the later import in
+        `_offer_restart_after_install` is a cache hit served from memory. The
+        import is still defended there for the genuine upgrade case where the
+        on-disk module legitimately differs from what is resident.
+
+        Best-effort: a failure here just means the post-install import falls
+        back to its own guard, so swallow it rather than crash the install.
+        """
+        try:
+            from deepagents_code.widgets import restart_prompt  # noqa: F401
+        except ImportError:
+            logger.warning("Could not preload restart_prompt modal", exc_info=True)
+
     async def _offer_restart_after_install(self, label: str) -> None:
         """Offer a one-keypress restart after a restart-capable install.
 
@@ -10690,10 +10720,21 @@ class DeepAgentsApp(App):
         if self._agent_running or self._connecting:
             return
 
-        from deepagents_code.widgets.restart_prompt import (
-            RestartChoice,
-            RestartPromptScreen,
-        )
+        try:
+            from deepagents_code.widgets.restart_prompt import RestartPromptScreen
+        except ImportError:
+            # `/install` runs `uv tool install -U 'deepagents-code[...]'`, which
+            # can rewrite deepagents-code's own on-disk package tree mid-session
+            # (see `_ensure_restart_prompt_loaded`). A first import of the modal
+            # here may then fail. The manual `/restart` hint was already mounted
+            # by the caller, so degrade to that instead of crashing the TUI.
+            logger.warning(
+                "restart_prompt unavailable after installing %r; leaving the "
+                "manual /restart hint in place",
+                label,
+                exc_info=True,
+            )
+            return
 
         choice: RestartChoice | None
         try:

--- a/libs/code/tests/unit_tests/test_install_command.py
+++ b/libs/code/tests/unit_tests/test_install_command.py
@@ -508,6 +508,7 @@ async def test_install_restart_capable_extra_offers_restart_when_idle() -> None:
                 new_callable=AsyncMock,
                 return_value=(True, ""),
             ),
+            patch.object(app, "_ensure_restart_prompt_loaded") as preload,
             patch.object(
                 app, "_push_screen_wait", new=AsyncMock(return_value="restart")
             ) as prompt,
@@ -521,6 +522,8 @@ async def test_install_restart_capable_extra_offers_restart_when_idle() -> None:
         ):
             await app._handle_command("/install fireworks")
             await pilot.pause()
+        # The modal is preloaded before the upgrade can rewrite our own tree.
+        preload.assert_called_once()
         prompt.assert_awaited_once()
         restart.assert_awaited_once()
         assert calls == ["reload", "clear", "restart"]
@@ -648,6 +651,7 @@ async def test_install_package_offers_restart_when_idle() -> None:
                 new_callable=AsyncMock,
                 return_value=(True, ""),
             ),
+            patch.object(app, "_ensure_restart_prompt_loaded") as preload,
             patch.object(
                 app, "_push_screen_wait", new=AsyncMock(return_value="restart")
             ) as prompt,
@@ -661,6 +665,8 @@ async def test_install_package_offers_restart_when_idle() -> None:
         ):
             await app._handle_command("/install langchain-custom --package --force")
             await pilot.pause()
+        # The modal is preloaded before the upgrade can rewrite our own tree.
+        preload.assert_called_once()
         prompt.assert_awaited_once()
         restart.assert_awaited_once()
         assert calls == ["reload", "clear", "restart"]
@@ -790,9 +796,10 @@ async def test_offer_restart_survives_missing_restart_prompt_module() -> None:
 
     `/install` runs `uv tool install -U 'deepagents-code[...]'`, which rewrites
     deepagents-code's own on-disk tree mid-session. A first import of the
-    restart modal on the post-install path can then raise `ModuleNotFoundError`
-    (observed in the field). The handler must fall back to the already-mounted
-    manual `/restart` hint instead of letting the import crash the app.
+    restart modal on the post-install path then reads the half-replaced tree
+    and raises `ModuleNotFoundError`. The handler must fall back to the
+    already-mounted manual `/restart` hint instead of letting the import crash
+    the app.
     """
     app = DeepAgentsApp()
     async with app.run_test() as pilot:
@@ -803,8 +810,9 @@ async def test_offer_restart_survives_missing_restart_prompt_module() -> None:
         app._connecting = False
         push = AsyncMock(return_value="restart")
         with (
-            # `None` in sys.modules forces `import` to raise ImportError,
-            # reproducing the half-replaced on-disk tree after a self-upgrade.
+            # `None` in sys.modules makes the `from`-import raise
+            # `ModuleNotFoundError` — a deterministic stand-in for the import
+            # failure a half-replaced on-disk tree causes after a self-upgrade.
             patch.dict(
                 sys.modules,
                 {"deepagents_code.widgets.restart_prompt": None},
@@ -820,3 +828,33 @@ async def test_offer_restart_survives_missing_restart_prompt_module() -> None:
         # The modal was never mounted and no restart was attempted.
         push.assert_not_awaited()
         restart.assert_not_awaited()
+
+
+def test_ensure_restart_prompt_loaded_caches_module() -> None:
+    """Preloading leaves the restart modal resident in `sys.modules`.
+
+    This is the actual fix: importing the modal before the self-upgrade
+    rewrites the on-disk tree means the post-install import in
+    `_offer_restart_after_install` resolves from `sys.modules` rather than the
+    mutated tree. Dropping the resident copy first forces a real import.
+    """
+    with patch.dict(sys.modules):
+        sys.modules.pop("deepagents_code.widgets.restart_prompt", None)
+        DeepAgentsApp._ensure_restart_prompt_loaded()
+        assert "deepagents_code.widgets.restart_prompt" in sys.modules
+
+
+def test_ensure_restart_prompt_loaded_swallows_missing_module() -> None:
+    """A failed preload is best-effort and must not raise.
+
+    `None` in `sys.modules` makes `import deepagents_code.widgets.restart_prompt`
+    raise `ModuleNotFoundError`, standing in for the half-replaced tree left by
+    a self-upgrade. The preload swallows it so the install continues; the
+    post-install import then falls back to its own guard.
+    """
+    with patch.dict(
+        sys.modules,
+        {"deepagents_code.widgets.restart_prompt": None},
+    ):
+        # Must not raise despite the unimportable module.
+        DeepAgentsApp._ensure_restart_prompt_loaded()

--- a/libs/code/tests/unit_tests/test_install_command.py
+++ b/libs/code/tests/unit_tests/test_install_command.py
@@ -6,6 +6,7 @@ this module focuses on the in-app slash dispatch in `DeepAgentsApp`.
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from deepagents_code.app import DeepAgentsApp
@@ -782,3 +783,40 @@ async def test_install_restart_failure_omits_complete_message() -> None:
         ]
         assert any("Restarting server..." in m for m in app_msgs)
         assert not any("Restart complete." in m for m in app_msgs)
+
+
+async def test_offer_restart_survives_missing_restart_prompt_module() -> None:
+    """A missing `restart_prompt` module must degrade, not crash the TUI.
+
+    `/install` runs `uv tool install -U 'deepagents-code[...]'`, which rewrites
+    deepagents-code's own on-disk tree mid-session. A first import of the
+    restart modal on the post-install path can then raise `ModuleNotFoundError`
+    (observed in the field). The handler must fall back to the already-mounted
+    manual `/restart` hint instead of letting the import crash the app.
+    """
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._server_proc = MagicMock()
+        app._server_kwargs = {"model_name": "fireworks:fake"}
+        app._agent_running = False
+        app._connecting = False
+        push = AsyncMock(return_value="restart")
+        with (
+            # `None` in sys.modules forces `import` to raise ImportError,
+            # reproducing the half-replaced on-disk tree after a self-upgrade.
+            patch.dict(
+                sys.modules,
+                {"deepagents_code.widgets.restart_prompt": None},
+            ),
+            patch.object(app, "_push_screen_wait", new=push),
+            patch.object(
+                app, "_restart_server_manual", new=AsyncMock(return_value=True)
+            ) as restart,
+        ):
+            # Must not raise despite the unimportable modal.
+            await app._offer_restart_after_install("fireworks")
+            await pilot.pause()
+        # The modal was never mounted and no restart was attempted.
+        push.assert_not_awaited()
+        restart.assert_not_awaited()


### PR DESCRIPTION
Running `/install` could crash the whole TUI with `ModuleNotFoundError: No module named 'deepagents_code.widgets.restart_prompt'`. The install command runs `uv tool install -U 'deepagents-code[...]'`, which reinstalls deepagents-code and rewrites its own on-disk package tree *while the process is running*. The post-install restart prompt was then imported for the first time off that just-mutated tree, so the import failed and took the app down. Modules already resident in `sys.modules` survived from memory, which is why `app.py` ran fine right up to the failing lazy import.

## Changes
- Load the `restart_prompt` modal into memory *before* `perform_install_extra`/`perform_install_package` rewrite the package tree, via `_ensure_restart_prompt_loaded()`, so the later import in `_offer_restart_after_install` is served from cache.
- Wrap the post-install import in `_offer_restart_after_install` in a guard that degrades to the already-mounted manual `/restart` hint instead of crashing when the module can't be loaded (e.g. a genuine version upgrade mid-session). `RestartChoice` moves to the `TYPE_CHECKING` block to keep the annotation valid.