### PR TITLE
docs(ci): annotate non-default branch releases

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -296,14 +296,16 @@ release-please is SemVer-only internally. Its `prerelease` versioning strategy p
 
 Alpha releases use a **throwaway branch** + [manual release](#manual-release). This keeps `main`, the release-please manifest, and any pending release PR completely untouched.
 
-1. **Create a branch from `main`:**
+1. **Create a branch from the version line you are releasing:**
 
    ```bash
-   git checkout main && git pull
+   git checkout <BASE_BRANCH> && git pull
    git checkout -b alpha/<PACKAGE>-<VERSION>
    ```
 
-   Replace `<PACKAGE>` with the PyPI name (e.g., `deepagents-cli`) and `<VERSION>` with the alpha version using hyphens instead of periods (e.g., `0-0-35a1`).
+   Replace `<BASE_BRANCH>` with `main` for normal pre-releases, or the relevant `vX.Y` branch when staging or maintaining a separate version line. Replace `<PACKAGE>` with the PyPI name (e.g., `deepagents-cli`) and `<VERSION>` with the alpha version using hyphens instead of periods (e.g., `0-0-35a1`).
+
+   For example, when staging `deepagents` `0.7.0` on `v0.7` while `main` still tracks `0.6.x` and you need an installable alpha for validation, branch from `v0.7`, not `main`, so the artifact contains the staged `0.7` work — the PEP 440 version `0.7.0a1` becomes `alpha/deepagents-0-7-0a1` (hyphens instead of periods) as the branch name.
 
 2. **Bump the version** in both files to a [PEP 440 pre-release](https://peps.python.org/pep-0440/#pre-releases) (e.g., `0.0.35a1`):
 
@@ -327,7 +329,7 @@ Alpha releases use a **throwaway branch** + [manual release](#manual-release). T
    - Enable `dangerous-nonmain-release` ✓
    - For `deepagents-code`: leave `dangerous-skip-sdk-pin-check` unchecked (unless the SDK pin is intentionally behind)
 
-5. **Verify the GitHub release** — the workflow automatically detects PEP 440 pre-release versions (`a`, `b`, `rc`, `.dev`) and marks the GitHub release as a **pre-release**. Pre-releases are never set as the repository's "Latest" release. The release body will contain a warning banner and contributor shoutouts (no changelog or git log).
+5. **Verify the GitHub release** — the workflow automatically detects PEP 440 pre-release versions (`a`, `b`, `rc`, `.dev`) and marks the GitHub release as a **pre-release**. Pre-releases are never set as the repository's "Latest" release. The release body will contain a warning banner, contributor shoutouts (no changelog or git log), and — because the branch is not `main` — a "Released from" line linking the originating branch and the release commit.
 
 6. **Clean up** — delete the branch after the workflow succeeds:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,6 +467,9 @@ jobs:
           PREV_TAG: ${{ steps.resolve-refs.outputs.prev-tag }}
           RELEASE_COMMIT: ${{ steps.resolve-refs.outputs.release-commit }}
           IS_PRERELEASE: ${{ needs.build.outputs.is-prerelease }}
+          BASE_BRANCH: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           if [ -z "$RELEASE_COMMIT" ]; then
             echo "::error::RELEASE_COMMIT is empty — resolve-refs step may have failed"
@@ -647,6 +650,19 @@ jobs:
           # Prepend pre-release banner
           if [ "$IS_PRERELEASE" = "true" ]; then
             RELEASE_BODY=$(printf "> [!WARNING]\n> This is a pre-release version. Install with: \`pip install %s==%s\`\n\n%s" "$PKG_NAME" "$VERSION" "$RELEASE_BODY")
+          fi
+
+          # Annotate releases cut from a non-default branch (a vX.Y version line
+          # or an alpha/* throwaway branch) with the originating branch and the
+          # immutable release commit. Skipped for normal default-branch releases,
+          # where the branch carries no signal. The branch is rendered as plain
+          # text and the link targets the commit SHA, never tree/<branch>: alpha
+          # branches are deleted after release, so a branch link would 404, and
+          # the commit is the exact code that shipped even when release-sha points
+          # somewhere other than the branch tip.
+          DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+          if [ -n "$BASE_BRANCH" ] && [ "$BASE_BRANCH" != "$DEFAULT_BRANCH" ]; then
+            RELEASE_BODY=$(printf "%s\n\nReleased from \`%s\` at commit [\`%s\`](https://github.com/%s/commit/%s)" "$RELEASE_BODY" "$BASE_BRANCH" "${RELEASE_COMMIT:0:7}" "$REPOSITORY" "$RELEASE_COMMIT")
           fi
 
           # Append contributor shoutouts


### PR DESCRIPTION
Manual releases now carry clearer provenance when they are cut from a version-line or alpha branch instead of the repository default branch. The alpha release runbook also now points maintainers at the version line they are actually releasing from, so validation artifacts include the intended staged code.

## Changes
- Added release workflow inputs for `BASE_BRANCH`, `DEFAULT_BRANCH`, and `REPOSITORY` so the release body can identify non-default-branch releases.
- Added a `Released from` line to non-default-branch release notes that names the source branch and links to the immutable release commit, avoiding links to throwaway alpha branches that may be deleted.
- Updated the alpha release instructions to branch from the relevant `vX.Y` version line when staging or maintaining a separate release line, while keeping `main` as the normal default.
- Documented the expected release-note behavior for pre-releases, including the new source-branch provenance line.