### PR TITLE
fix(code): hide `[SYSTEM]` interrupt notices from `/threads` prompt

### DIFF
--- a/libs/code/deepagents_code/_constants.py
+++ b/libs/code/deepagents_code/_constants.py
@@ -12,3 +12,12 @@ from typing import Final
 
 DEFAULT_AGENT_NAME: Final[str] = "agent"
 """Default agent / assistant identifier when no `-a` flag is given."""
+
+SYSTEM_MESSAGE_PREFIX: Final[str] = "[SYSTEM]"
+"""Prefix for synthetic human messages (e.g. interrupt cancellation notices).
+
+Such messages are written to the `messages` channel for the agent's benefit on
+resume but are not user-authored, so they are filtered out of both the rendered
+transcript and a thread's initial prompt. Shared here so the single producer
+(`textual_adapter`) and its consumers (`app`, `sessions`) agree on one literal.
+"""

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -42,7 +42,10 @@ from deepagents_code import (
     theme,
 )
 from deepagents_code._cli_context import CLIContext
-from deepagents_code._constants import DEFAULT_AGENT_NAME as DEFAULT_ASSISTANT_ID
+from deepagents_code._constants import (
+    DEFAULT_AGENT_NAME as DEFAULT_ASSISTANT_ID,
+    SYSTEM_MESSAGE_PREFIX,
+)
 from deepagents_code._git import (
     read_git_branch_from_filesystem,
     read_git_branch_via_subprocess,
@@ -7408,7 +7411,7 @@ class DeepAgentsApp(App):
                 content = (
                     msg.content if isinstance(msg.content, str) else str(msg.content)
                 )
-                if content.startswith("[SYSTEM]"):
+                if content.startswith(SYSTEM_MESSAGE_PREFIX):
                     continue
 
                 # Detect skill invocations persisted via additional_kwargs

--- a/libs/code/deepagents_code/sessions.py
+++ b/libs/code/deepagents_code/sessions.py
@@ -30,6 +30,9 @@ _initial_prompt_cache: dict[str, tuple[str | None, str | None]] = {}
 _MAX_INITIAL_PROMPT_CACHE = 4096
 _recent_threads_cache: dict[tuple[str | None, int], list[ThreadInfo]] = {}
 _MAX_RECENT_THREADS_CACHE_KEYS = 16
+_SYSTEM_MESSAGE_PREFIX = "[SYSTEM]"
+"""Prefix for synthetic human messages (e.g. interrupt cancellation notices)
+that should never be displayed as a thread's initial prompt."""
 
 
 def _patch_aiosqlite() -> None:
@@ -1130,23 +1133,32 @@ def _checkpoint_messages(data: object) -> list[object] | None:
 
 
 def _initial_prompt_from_messages(messages: list[object]) -> str | None:
-    """Return the first human message content from a message list.
+    """Return the first non-system human message content from a message list.
 
     Accepts both LangChain `HumanMessage` objects (with `type == "human"`) and
     plain dicts in OpenAI chat shape (`{"role": "user", "content": ...}`). The
     first write to the `messages` channel is the raw user input passed to the
     agent, which is preserved verbatim as a dict; subsequent writes are
     serialized `BaseMessage` instances produced after the model runs.
+
+    Synthetic `[SYSTEM]`-prefixed human messages (e.g. the interrupt
+    cancellation notice) are skipped so they never surface as a thread's prompt.
     """
     for msg in messages:
         if getattr(msg, "type", None) == "human":
-            return _coerce_prompt_text(getattr(msg, "content", None))
-        if isinstance(msg, dict):
+            prompt = _coerce_prompt_text(getattr(msg, "content", None))
+        elif isinstance(msg, dict):
             msg_dict = cast("dict[str, object]", msg)
             role = msg_dict.get("role")
             type_ = msg_dict.get("type")
-            if role in {"user", "human"} or type_ == "human":
-                return _coerce_prompt_text(msg_dict.get("content"))
+            if role not in {"user", "human"} and type_ != "human":
+                continue
+            prompt = _coerce_prompt_text(msg_dict.get("content"))
+        else:
+            continue
+        if prompt is not None and prompt.startswith(_SYSTEM_MESSAGE_PREFIX):
+            continue
+        return prompt
     return None
 
 

--- a/libs/code/deepagents_code/sessions.py
+++ b/libs/code/deepagents_code/sessions.py
@@ -11,6 +11,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple, NotRequired, TypedDict, cast
 
+from deepagents_code._constants import SYSTEM_MESSAGE_PREFIX
+
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
@@ -30,9 +32,6 @@ _initial_prompt_cache: dict[str, tuple[str | None, str | None]] = {}
 _MAX_INITIAL_PROMPT_CACHE = 4096
 _recent_threads_cache: dict[tuple[str | None, int], list[ThreadInfo]] = {}
 _MAX_RECENT_THREADS_CACHE_KEYS = 16
-_SYSTEM_MESSAGE_PREFIX = "[SYSTEM]"
-"""Prefix for synthetic human messages (e.g. interrupt cancellation notices)
-that should never be displayed as a thread's initial prompt."""
 
 
 def _patch_aiosqlite() -> None:
@@ -1141,7 +1140,7 @@ def _initial_prompt_from_messages(messages: list[object]) -> str | None:
     agent, which is preserved verbatim as a dict; subsequent writes are
     serialized `BaseMessage` instances produced after the model runs.
 
-    Synthetic `[SYSTEM]`-prefixed human messages (e.g. the interrupt
+    Synthetic `[SYSTEM]`-prefixed human messages (e.g. an interrupt
     cancellation notice) are skipped so they never surface as a thread's prompt.
     """
     for msg in messages:
@@ -1156,7 +1155,7 @@ def _initial_prompt_from_messages(messages: list[object]) -> str | None:
             prompt = _coerce_prompt_text(msg_dict.get("content"))
         else:
             continue
-        if prompt is not None and prompt.startswith(_SYSTEM_MESSAGE_PREFIX):
+        if prompt is not None and prompt.startswith(SYSTEM_MESSAGE_PREFIX):
             continue
         return prompt
     return None

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 
 from deepagents_code._ask_user_types import AskUserRequest
 from deepagents_code._cli_context import CLIContext  # noqa: TC001
+from deepagents_code._constants import SYSTEM_MESSAGE_PREFIX
 from deepagents_code._session_stats import (
     ModelStats as ModelStats,
     SessionStats as SessionStats,
@@ -1499,7 +1500,7 @@ async def _handle_interrupt_cleanup(
                 await agent.aupdate_state(config, {"messages": [interrupted_msg]})
 
             cancellation_msg = HumanMessage(
-                content="[SYSTEM] Task interrupted by user. "
+                content=f"{SYSTEM_MESSAGE_PREFIX} Task interrupted by user. "
                 "Previous operation was cancelled."
             )
             cancellation_values: dict[str, Any] = {"messages": [cancellation_msg]}

--- a/libs/code/tests/unit_tests/test_sessions.py
+++ b/libs/code/tests/unit_tests/test_sessions.py
@@ -2655,3 +2655,37 @@ class TestInitialPromptFromMessages:
             [{"role": "assistant", "content": "ack"}]
         )
         assert result is None
+
+    def test_skips_system_prefixed_human_message(self) -> None:
+        """Synthetic `[SYSTEM]` interrupt notices are not used as the prompt."""
+        from langchain_core.messages import HumanMessage
+
+        result = sessions._initial_prompt_from_messages(  # pyright: ignore[reportPrivateUsage]
+            [
+                HumanMessage(
+                    content="[SYSTEM] Task interrupted by user. "
+                    "Previous operation was cancelled."
+                ),
+                HumanMessage(content="real prompt"),
+            ]
+        )
+        assert result == "real prompt"
+
+    def test_skips_system_prefixed_dict_message(self) -> None:
+        """`[SYSTEM]`-prefixed OpenAI-shape dicts are skipped too."""
+        result = sessions._initial_prompt_from_messages(  # pyright: ignore[reportPrivateUsage]
+            [
+                {"role": "user", "content": "[SYSTEM] Task interrupted by user."},
+                {"role": "user", "content": "real prompt"},
+            ]
+        )
+        assert result == "real prompt"
+
+    def test_returns_none_when_only_system_message(self) -> None:
+        """A lone `[SYSTEM]` message yields no displayable prompt."""
+        from langchain_core.messages import HumanMessage
+
+        result = sessions._initial_prompt_from_messages(  # pyright: ignore[reportPrivateUsage]
+            [HumanMessage(content="[SYSTEM] Task interrupted by user.")]
+        )
+        assert result is None

--- a/libs/code/tests/unit_tests/test_sessions.py
+++ b/libs/code/tests/unit_tests/test_sessions.py
@@ -2689,3 +2689,60 @@ class TestInitialPromptFromMessages:
             [HumanMessage(content="[SYSTEM] Task interrupted by user.")]
         )
         assert result is None
+
+    def test_skips_system_message_across_mixed_shapes(self) -> None:
+        """Skipping advances across object/dict shapes, not just within one.
+
+        The first write to `messages` is a raw dict; later writes are serialized
+        `BaseMessage` instances, so a real thread mixes the two shapes. The skip
+        must carry over from a `[SYSTEM]` dict to a real `HumanMessage` object
+        and vice versa.
+        """
+        from langchain_core.messages import HumanMessage
+
+        dict_then_object = sessions._initial_prompt_from_messages(  # pyright: ignore[reportPrivateUsage]
+            [
+                {"role": "user", "content": "[SYSTEM] Task interrupted by user."},
+                HumanMessage(content="real prompt"),
+            ]
+        )
+        assert dict_then_object == "real prompt"
+
+        object_then_dict = sessions._initial_prompt_from_messages(  # pyright: ignore[reportPrivateUsage]
+            [
+                HumanMessage(content="[SYSTEM] Task interrupted by user."),
+                {"role": "user", "content": "real prompt"},
+            ]
+        )
+        assert object_then_dict == "real prompt"
+
+    def test_skips_consecutive_system_messages(self) -> None:
+        """A run of several `[SYSTEM]` messages is skipped, not just the first."""
+        from langchain_core.messages import HumanMessage
+
+        result = sessions._initial_prompt_from_messages(  # pyright: ignore[reportPrivateUsage]
+            [
+                HumanMessage(content="[SYSTEM] first notice"),
+                HumanMessage(content="[SYSTEM] second notice"),
+                HumanMessage(content="real prompt"),
+            ]
+        )
+        assert result == "real prompt"
+
+    def test_empty_first_content_returns_without_falling_through(self) -> None:
+        """Empty (non-`[SYSTEM]`) first content returns as-is, not skipped.
+
+        Only `[SYSTEM]`-prefixed content is skipped; an empty-string first human
+        message is returned verbatim (`""`) rather than falling through to a
+        later message. This pins the `prompt is not None` guard so a future
+        "skip empties" change cannot silently alter behavior.
+        """
+        from langchain_core.messages import HumanMessage
+
+        result = sessions._initial_prompt_from_messages(  # pyright: ignore[reportPrivateUsage]
+            [
+                HumanMessage(content=""),
+                HumanMessage(content="real prompt"),
+            ]
+        )
+        assert result == ""


### PR DESCRIPTION
When a task is interrupted, dcode persists a synthetic `[SYSTEM] Task interrupted by user.` `HumanMessage` into the thread's `messages` channel. Because `_initial_prompt_from_messages` returned the first human-typed message verbatim, this notice could surface as a thread's prompt in the `/threads` selector instead of the user's real request.

The parser now skips `[SYSTEM]`-prefixed human messages and falls through to the next genuine human message, mirroring the existing `[SYSTEM]` filtering already done when rendering a loaded thread's messages.

Made by [Open SWE](https://openswe.vercel.app)