### PR TITLE
feat(code): `/uninstall` and `--uninstall` for optional extras

### DIFF
--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -6,7 +6,7 @@ Canonical list of slash commands for `deepagents-code`, derived from
 regenerate after editing the registry.
 
 
-## Public (28)
+## Public (29)
 
 | Command | Aliases | Description |
 | --- | --- | --- |
@@ -36,6 +36,7 @@ regenerate after editing the registry.
 | `/timestamps` |  | Toggle message timestamp footers |
 | `/tokens` |  | Token usage |
 | `/trace` |  | Open current thread in LangSmith |
+| `/uninstall` |  | Remove an installed optional extra |
 | `/update` |  | Check for and install updates |
 | `/version` | `/about` | Show version |
 

--- a/libs/code/README.md
+++ b/libs/code/README.md
@@ -21,6 +21,19 @@ curl -LsSf https://langch.in/dcode | bash
 DEEPAGENTS_CODE_EXTRAS="nvidia,ollama" curl -LsSf https://langch.in/dcode | bash
 ```
 
+Add or remove an optional extra after installing, from the shell or inside the
+TUI:
+
+```bash
+dcode --install ollama     # or /install ollama in the TUI
+dcode --uninstall ollama   # or /uninstall ollama in the TUI
+```
+
+`--uninstall` rebuilds the tool environment with your remaining extras (and
+reinstalls plain `deepagents-code` once none are left). The default OpenAI,
+Anthropic, and Gemini providers are base dependencies, so they can't be removed
+via extras.
+
 Run:
 
 ```bash

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -4110,6 +4110,170 @@ class DeepAgentsApp(App):
         if restart_capable:
             await self._offer_restart_after_install(extra)
 
+    async def _handle_uninstall_command(self, command: str) -> None:
+        """Handle the `/uninstall <extra>` slash command.
+
+        Removes an installed optional extra by rebuilding the uv tool
+        environment with the remaining extras (`uv tool install -U
+        'deepagents-code[<remaining>]'`). When no extras remain, plain
+        `deepagents-code` is reinstalled. Absent extras are reported without
+        invoking uv.
+
+        Args:
+            command: The full slash command line (e.g. `'/uninstall ollama'`).
+        """
+        parts = command.split()
+        names = [p for p in parts[1:] if not p.startswith("-")]
+        if not names:
+            from deepagents_code.extras_info import installed_extra_names
+
+            try:
+                installed = await asyncio.to_thread(
+                    installed_extra_names, "deepagents-code", strict=False
+                )
+            except Exception:  # noqa: BLE001  # display-only; degrade gracefully
+                installed = set()
+            listing = (
+                f"Installed extras: {', '.join(sorted(installed))}"
+                if installed
+                else "No optional extras are currently installed."
+            )
+            await self._mount_message(
+                AppMessage(
+                    "Usage: /uninstall <extra>\n"
+                    "Example: /uninstall ollama\n\n" + listing,
+                ),
+            )
+            return
+        if len(names) > 1:
+            await self._mount_message(
+                AppMessage(
+                    "Only one extra may be uninstalled per /uninstall command. "
+                    f"Got: {', '.join(names)}",
+                ),
+            )
+            return
+        await self._mount_message(UserMessage(command))
+
+        extra = names[0].lower()
+
+        try:
+            from deepagents_code.config import _is_editable_install
+            from deepagents_code.extras_info import (
+                MODEL_PROVIDER_EXTRAS,
+                SANDBOX_EXTRAS,
+                ExtrasIntrospectionError,
+                installed_extra_names,
+            )
+            from deepagents_code.update_check import (
+                ExtraNotInstalledError,
+                create_update_log_path,
+                editable_extra_removal_hint,
+                is_valid_extra_name,
+                perform_uninstall_extra,
+                uninstall_extra_command,
+            )
+        except ImportError as exc:
+            logger.warning("/uninstall command import failed", exc_info=True)
+            await self._mount_message(
+                ErrorMessage(f"Uninstall failed: {type(exc).__name__}: {exc}"),
+            )
+            return
+
+        if not is_valid_extra_name(extra):
+            await self._mount_message(
+                AppMessage(
+                    "Invalid extra name. Extra names must be "
+                    "alphanumeric with `-`, `_`, or `.` (PEP 508).",
+                ),
+            )
+            return
+
+        if await asyncio.to_thread(_is_editable_install):
+            await self._mount_message(
+                AppMessage(
+                    "Editable install detected — cannot remove extras.\n"
+                    + editable_extra_removal_hint(extra),
+                ),
+            )
+            return
+
+        try:
+            installed = await asyncio.to_thread(
+                installed_extra_names, "deepagents-code", strict=True
+            )
+        except ExtrasIntrospectionError as exc:
+            logger.warning("/uninstall command failed", exc_info=True)
+            await self._mount_message(
+                ErrorMessage(f"Uninstall failed: {type(exc).__name__}: {exc}"),
+            )
+            return
+
+        if extra not in installed:
+            await self._mount_message(
+                AppMessage(f"Extra '{extra}' is not installed."),
+            )
+            return
+
+        log_path = create_update_log_path()
+        # Load the restart modal before the reinstall rewrites our own package
+        # tree; the post-uninstall import then hits the in-memory cache.
+        self._ensure_restart_prompt_loaded()
+        await self._mount_message(
+            AppMessage(f"Uninstalling extra '{extra}'..."),
+        )
+        try:
+            manual_cmd = await asyncio.to_thread(uninstall_extra_command, extra)
+        except (ExtrasIntrospectionError, ExtraNotInstalledError, ValueError) as exc:
+            logger.warning("/uninstall command failed", exc_info=True)
+            await self._mount_message(
+                ErrorMessage(
+                    f"Uninstall failed: {type(exc).__name__}: {exc}\nLog: {log_path}",
+                ),
+            )
+            return
+        try:
+            success, output = await perform_uninstall_extra(extra, log_path=log_path)
+        except (OSError, asyncio.CancelledError) as exc:
+            logger.warning("/uninstall command failed", exc_info=True)
+            await self._mount_message(
+                ErrorMessage(
+                    f"Uninstall failed: {type(exc).__name__}: {exc}\n"
+                    f"Log: {log_path}\n"
+                    f"Run manually: {manual_cmd}",
+                ),
+            )
+            return
+
+        if not success:
+            # Tail the last 200 chars — uv resolver prints the resolved
+            # error at the end, not the beginning.
+            detail = f": {output[-200:]}" if output else ""
+            await self._mount_message(
+                ErrorMessage(
+                    f"Uninstall failed{detail}\n"
+                    f"Log: {log_path}\n"
+                    f"Run manually: {manual_cmd}",
+                ),
+            )
+            return
+
+        # Mirror /install: provider/sandbox extras are imported by the langgraph
+        # server subprocess, so `/restart` picks up their removal without exiting
+        # the TUI. Other extras (e.g. quickjs) are wired into the parent process
+        # at startup, so a full relaunch is required.
+        restart_capable = extra in MODEL_PROVIDER_EXTRAS or extra in SANDBOX_EXTRAS
+        if restart_capable:
+            next_step = "Run `/restart` to apply now, or relaunch dcode."
+        else:
+            next_step = "Exit and relaunch dcode to apply the change."
+
+        await self._mount_message(
+            AppMessage(f"Uninstalled extra '{extra}'. {next_step}"),
+        )
+        if restart_capable:
+            await self._offer_restart_after_install(extra)
+
     async def _handle_install_package(self, package: str, *, force: bool) -> None:
         """Install an arbitrary package into the dcode tool env via `uv --with`.
 
@@ -6480,8 +6644,8 @@ class DeepAgentsApp(App):
                 "/mcp, /model [--model-params JSON] [--default], "
                 "/notifications, /reload, /restart, /skill:<name>, /remember, "
                 "/skill-creator, /theme, /timestamps, /tokens, /threads, /trace, "
-                "/update, /auto-update, /install, /changelog, /docs, "
-                "/feedback, /help\n\n"
+                "/update, /auto-update, /install, /uninstall, /changelog, "
+                "/docs, /feedback, /help\n\n"
                 "Interactive Features:\n"
                 "  Enter           Submit your message\n"
                 f"  {newline_shortcut():<15} Insert newline\n"
@@ -6594,6 +6758,8 @@ class DeepAgentsApp(App):
             await self._handle_auto_update_toggle()
         elif cmd == "/install" or cmd.startswith("/install "):
             await self._handle_install_command(command)
+        elif cmd == "/uninstall" or cmd.startswith("/uninstall "):
+            await self._handle_uninstall_command(command)
         elif cmd == "/timestamps":
             await self._mount_message(UserMessage(command))
             await self._toggle_message_timestamp_footers()

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -203,6 +203,13 @@ COMMANDS: tuple[SlashCommand, ...] = (
         argument_hint="<extra> [--force]",
     ),
     SlashCommand(
+        name="/uninstall",
+        description="Remove an installed optional extra",
+        bypass_tier=BypassTier.QUEUED,
+        hidden_keywords="extra extras remove delete provider sandbox dependency",
+        argument_hint="<extra>",
+    ),
+    SlashCommand(
         name="/auto-update",
         description="Toggle automatic updates on or off",
         bypass_tier=BypassTier.SIDE_EFFECT_FREE,

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1370,10 +1370,16 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Toggle automatic updates on or off, then exit",
     )
-    parser.add_argument(
+    extra_group = parser.add_mutually_exclusive_group()
+    extra_group.add_argument(
         "--install",
         metavar="NAME",
         help="Install an optional extra (e.g. quickjs, daytona, fireworks), then exit",
+    )
+    extra_group.add_argument(
+        "--uninstall",
+        metavar="NAME",
+        help="Remove an installed optional extra, then exit",
     )
     parser.add_argument(
         "--package",
@@ -2698,6 +2704,120 @@ def cli_main() -> None:
                 log_line = f"\nLog: {log_path}" if log_path else ""
                 fallback_cmd = (
                     manual_cmd or f"uv tool install -U 'deepagents-code[{extra}]'"
+                )
+                console.print(
+                    f"[bold red]Error:[/bold red] "
+                    f"{type(exc).__name__}: {escape(str(exc))}"
+                    f"{escape(log_line)}\n"
+                    f"Run manually: [cyan]{escape(fallback_cmd)}[/cyan]",
+                    markup=True,
+                    highlight=False,
+                )
+                sys.exit(1)
+
+        # Handle --uninstall <extra> flag (headless, no session)
+        if args.uninstall:
+            from rich.markup import escape
+
+            from deepagents_code.config import _is_editable_install
+            from deepagents_code.extras_info import (
+                ExtrasIntrospectionError,
+                installed_extra_names,
+            )
+            from deepagents_code.update_check import (
+                create_update_log_path,
+                editable_extra_removal_hint,
+                is_valid_extra_name,
+                perform_uninstall_extra,
+                uninstall_extra_command,
+            )
+
+            uninstall_extra: str = args.uninstall
+            uninstall_log_path: Path | None = None
+            uninstall_manual_cmd: str | None = None
+            try:
+                if not is_valid_extra_name(uninstall_extra):
+                    # Defense in depth — the extra is interpolated into a
+                    # shell command. Reject malformed names before any uv call.
+                    console.print(
+                        f"[bold red]Error:[/bold red] "
+                        f"Invalid extra name '{escape(uninstall_extra)}'. "
+                        "Extra names must be alphanumeric with `-`, `_`, "
+                        "or `.` (PEP 508).",
+                        highlight=False,
+                    )
+                    sys.exit(2)
+                if _is_editable_install():
+                    console.print(
+                        "[bold yellow]Warning:[/bold yellow] "
+                        "--uninstall is not supported on editable installs.\n"
+                        + escape(editable_extra_removal_hint(uninstall_extra)),
+                        highlight=False,
+                    )
+                    sys.exit(1)
+
+                # The absent-extra case is a no-op: report it clearly and never
+                # invoke uv.
+                try:
+                    installed = installed_extra_names(
+                        "deepagents-code", strict=True
+                    )
+                except ExtrasIntrospectionError as exc:
+                    console.print(
+                        f"[bold red]Error:[/bold red] "
+                        f"{type(exc).__name__}: {escape(str(exc))}",
+                        markup=True,
+                        highlight=False,
+                    )
+                    sys.exit(1)
+                if uninstall_extra not in installed:
+                    console.print(
+                        f"Extra '{escape(uninstall_extra)}' is not installed.",
+                        highlight=False,
+                    )
+                    sys.exit(0)
+
+                uninstall_manual_cmd = uninstall_extra_command(uninstall_extra)
+                console.print(f"Uninstalling extra '{uninstall_extra}'...")
+                uninstall_log_path = create_update_log_path()
+                console.print(
+                    f"Uninstall log: {uninstall_log_path}\n"
+                    f"Tail progress: tail -f {uninstall_log_path}",
+                    style="dim",
+                    highlight=False,
+                    markup=False,
+                )
+                success, output = asyncio.run(
+                    perform_uninstall_extra(
+                        uninstall_extra, log_path=uninstall_log_path
+                    )
+                )
+                if success:
+                    console.print(
+                        f"[green]Uninstalled extra '{uninstall_extra}'.[/green]"
+                    )
+                    sys.exit(0)
+                # Tail the last 200 chars — uv resolver prints the resolved
+                # error at the end, not the beginning.
+                detail = f": {output[-200:]}" if output else ""
+                console.print(
+                    f"[bold red]Uninstall failed[/bold red]{escape(detail)}\n"
+                    f"Log: {uninstall_log_path}\n"
+                    f"Run manually: [cyan]{uninstall_manual_cmd}[/cyan]",
+                    markup=True,
+                    highlight=False,
+                )
+                sys.exit(1)
+            except KeyboardInterrupt:
+                console.print("\nAborted.", style="dim")
+                sys.exit(130)
+            except Exception as exc:
+                logger.warning("--uninstall failed", exc_info=True)
+                log_line = (
+                    f"\nLog: {uninstall_log_path}" if uninstall_log_path else ""
+                )
+                fallback_cmd = uninstall_manual_cmd or (
+                    "uv tool install -U deepagents-code"
                 )
                 console.print(
                     f"[bold red]Error:[/bold red] "

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2759,9 +2759,7 @@ def cli_main() -> None:
                 # The absent-extra case is a no-op: report it clearly and never
                 # invoke uv.
                 try:
-                    installed = installed_extra_names(
-                        "deepagents-code", strict=True
-                    )
+                    installed = installed_extra_names("deepagents-code", strict=True)
                 except ExtrasIntrospectionError as exc:
                     console.print(
                         f"[bold red]Error:[/bold red] "
@@ -2813,9 +2811,7 @@ def cli_main() -> None:
                 sys.exit(130)
             except Exception as exc:
                 logger.warning("--uninstall failed", exc_info=True)
-                log_line = (
-                    f"\nLog: {uninstall_log_path}" if uninstall_log_path else ""
-                )
+                log_line = f"\nLog: {uninstall_log_path}" if uninstall_log_path else ""
                 fallback_cmd = uninstall_manual_cmd or (
                     "uv tool install -U deepagents-code"
                 )

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -1248,6 +1248,60 @@ def install_extra_command(
     return install_extras_command(extras)
 
 
+class ExtraNotInstalledError(RuntimeError):
+    """Raised when an uninstall targets an extra that is not installed."""
+
+
+def uninstall_extra_command(
+    extra: str,
+    *,
+    distribution_name: str = "deepagents-code",
+) -> str:
+    """Return the shell command that removes `extra` from the installed dcode tool.
+
+    Rebuilds the uv tool environment with the remaining installed extras (the
+    inverse of `install_extra_command`). When no optional extras remain, the
+    command reinstalls plain `deepagents-code`.
+
+    Args:
+        extra: The extra name to remove. Validated internally against PEP 508
+            grammar before any metadata read.
+        distribution_name: Name of the installed distribution to inspect for
+            already-installed extras.
+
+    Returns:
+        Shell command string suitable for display in error messages and
+            for execution via `perform_uninstall_extra`.
+
+    Raises:
+        ExtrasIntrospectionError: If installed extras cannot be determined
+            safely from distribution metadata.
+        ExtraNotInstalledError: If `extra` is not currently installed.
+        ValueError: If `extra` or any remaining extra fails PEP 508 validation.
+    """
+    from deepagents_code.extras_info import (
+        ExtrasIntrospectionError,
+        installed_extra_names,
+    )
+
+    if not is_valid_extra_name(extra):
+        msg = (
+            f"Invalid extra name {extra!r}: must match PEP 508 "
+            f"({_EXTRA_NAME_RE.pattern})"
+        )
+        raise ValueError(msg)
+    try:
+        extras = installed_extra_names(distribution_name, strict=True)
+    except ExtrasIntrospectionError as exc:
+        msg = str(exc)
+        raise ExtrasIntrospectionError(msg) from exc
+    if extra not in extras:
+        msg = f"Extra {extra!r} is not installed."
+        raise ExtraNotInstalledError(msg)
+    extras.discard(extra)
+    return install_extras_command(extras)
+
+
 def editable_extra_hint(extra: str) -> str:
     """Return the canonical action hint for editable installs missing an extra.
 
@@ -1259,6 +1313,20 @@ def editable_extra_hint(extra: str) -> str:
     return (
         "Rerun your `uv tool install --editable` command with "
         f"`--with 'deepagents-code[{extra}]'` added so the extra is "
+        "resolved against the editable source."
+    )
+
+
+def editable_extra_removal_hint(extra: str) -> str:
+    """Return the canonical action hint for removing an extra on editable installs.
+
+    Mirrors `editable_extra_hint` for the uninstall direction: editable installs
+    can't have extras rebuilt automatically, so point the user at re-running
+    their own `uv tool install --editable` command without the extra.
+    """
+    return (
+        "Rerun your `uv tool install --editable` command without "
+        f"`--with 'deepagents-code[{extra}]'` so the extra is no longer "
         "resolved against the editable source."
     )
 
@@ -1339,6 +1407,74 @@ async def perform_install_extra(
 
     try:
         cmd = install_extra_command(extra)
+    except (ExtrasIntrospectionError, ValueError) as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+    return await _run_install_subprocess(cmd, progress=progress, log_path=log_path)
+
+
+async def perform_uninstall_extra(
+    extra: str,
+    *,
+    progress: UpgradeProgressCallback | None = None,
+    log_path: Path | None = None,
+) -> tuple[bool, str]:
+    """Remove `extra` from the installed dcode tool environment.
+
+    Rebuilds the tool with `uv tool install -U 'deepagents-code[<remaining>]'`,
+    dropping only `extra` and preserving the other installed extras. When no
+    optional extras remain, plain `deepagents-code` is reinstalled. Editable,
+    Homebrew, and unrecognized installs are refused — the same set of methods
+    `perform_install_extra` refuses — because the running environment can't be
+    rebuilt safely.
+
+    Args:
+        extra: The extra name to remove. Must satisfy `is_valid_extra_name`;
+            invalid names are rejected without invoking uv (defense in depth
+            against shell injection).
+        progress: Optional callback invoked for each output line.
+        log_path: Optional path to persist command output.
+
+    Returns:
+        `(success, output)` — *output* is the combined stdout/stderr, or an
+            explanatory error message when the install method is unsupported,
+            `extra` is malformed, or `extra` is not installed.
+    """
+    if not is_valid_extra_name(extra):
+        return False, (
+            f"Invalid extra name {extra!r}: must match {_EXTRA_NAME_RE.pattern}"
+        )
+    method = detect_install_method()
+    if method == "unknown":
+        return False, (
+            "Editable install detected — cannot remove extras automatically.\n"
+            + editable_extra_removal_hint(extra)
+        )
+    if method == "brew":
+        return False, (
+            "Homebrew install detected — extras are not managed via brew. "
+            "Reinstall with `uv tool install -U deepagents-code` to switch to a "
+            "uv-managed tool install whose extras can be rebuilt."
+        )
+    if method == "other":
+        return False, (
+            "Unsupported install method detected — cannot remove extras without "
+            "knowing which environment provides `dcode`. Reinstall with "
+            "`uv tool install -U deepagents-code` to switch to a uv-managed "
+            "tool install whose extras can be rebuilt."
+        )
+
+    if not shutil.which("uv"):
+        return False, (
+            "`uv` not found on PATH. Reinstall dcode following the docs, or "
+            "install uv (https://docs.astral.sh/uv/) so extras can be removed."
+        )
+
+    from deepagents_code.extras_info import ExtrasIntrospectionError
+
+    try:
+        cmd = uninstall_extra_command(extra)
+    except ExtraNotInstalledError as exc:
+        return False, str(exc)
     except (ExtrasIntrospectionError, ValueError) as exc:
         return False, f"{type(exc).__name__}: {exc}"
     return await _run_install_subprocess(cmd, progress=progress, log_path=log_path)

--- a/libs/code/tests/unit_tests/test_uninstall_command.py
+++ b/libs/code/tests/unit_tests/test_uninstall_command.py
@@ -121,9 +121,7 @@ class TestUninstallExtraSubcommand:
             patch.object(sys, "stdin", mock_stdin),
             patch("deepagents_code.main.check_cli_dependencies"),
             patch("deepagents_code.config.console", console_mock, create=True),
-            patch(
-                "deepagents_code.config._is_editable_install", return_value=editable
-            ),
+            patch("deepagents_code.config._is_editable_install", return_value=editable),
             patch(
                 "deepagents_code.extras_info.installed_extra_names",
                 return_value=set(installed),
@@ -304,6 +302,4 @@ async def test_uninstall_slash_editable_install_refuses() -> None:
             await pilot.pause()
         perform_mock.assert_not_awaited()
         app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
-        assert any(
-            "Editable install detected" in str(m._content) for m in app_msgs
-        )
+        assert any("Editable install detected" in str(m._content) for m in app_msgs)

--- a/libs/code/tests/unit_tests/test_uninstall_command.py
+++ b/libs/code/tests/unit_tests/test_uninstall_command.py
@@ -1,0 +1,309 @@
+"""Tests for `/uninstall <extra>` and `--uninstall <extra>` extra removal.
+
+Covers the `uninstall_extra_command` generator, the `cli_main` `--uninstall`
+flow, and the in-app `/uninstall` slash dispatch in `DeepAgentsApp`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deepagents_code.app import DeepAgentsApp
+from deepagents_code.extras_info import ExtrasIntrospectionError
+from deepagents_code.update_check import (
+    ExtraNotInstalledError,
+    uninstall_extra_command,
+)
+from deepagents_code.widgets.messages import AppMessage
+
+
+def _write_dist_info(
+    root: Path,
+    name: str,
+    *,
+    version: str = "1.0.0",
+    requires: tuple[str, ...] = (),
+) -> None:
+    normalized = name.replace("-", "_")
+    dist_info = root / f"{normalized}-{version}.dist-info"
+    dist_info.mkdir()
+    metadata = ["Metadata-Version: 2.1", f"Name: {name}", f"Version: {version}"]
+    metadata.extend(f"Requires-Dist: {req}" for req in requires)
+    dist_info.joinpath("METADATA").write_text("\n".join(metadata), encoding="utf-8")
+
+
+class TestUninstallExtraCommand:
+    """`uninstall_extra_command` rebuilds the tool with the remaining extras."""
+
+    def test_drops_one_keeps_remaining(self, tmp_path, monkeypatch) -> None:
+        _write_dist_info(tmp_path, "definitely-present-dcode-test-ollama")
+        _write_dist_info(tmp_path, "definitely-present-dcode-test-quickjs")
+        _write_dist_info(
+            tmp_path,
+            "deepagents-code",
+            requires=(
+                'definitely-present-dcode-test-ollama; extra == "ollama"',
+                'definitely-present-dcode-test-quickjs; extra == "quickjs"',
+            ),
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        assert (
+            uninstall_extra_command("ollama", distribution_name="deepagents-code")
+            == "uv tool install -U 'deepagents-code[quickjs]'"
+        )
+
+    def test_last_extra_returns_plain_package(self, tmp_path, monkeypatch) -> None:
+        _write_dist_info(tmp_path, "definitely-present-dcode-test-ollama")
+        _write_dist_info(
+            tmp_path,
+            "deepagents-code",
+            requires=('definitely-present-dcode-test-ollama; extra == "ollama"',),
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        assert (
+            uninstall_extra_command("ollama", distribution_name="deepagents-code")
+            == "uv tool install -U deepagents-code"
+        )
+
+    def test_absent_extra_raises(self, tmp_path, monkeypatch) -> None:
+        _write_dist_info(tmp_path, "definitely-present-dcode-test-ollama")
+        _write_dist_info(
+            tmp_path,
+            "deepagents-code",
+            requires=('definitely-present-dcode-test-ollama; extra == "ollama"',),
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        with pytest.raises(ExtraNotInstalledError, match="not installed"):
+            uninstall_extra_command("quickjs", distribution_name="deepagents-code")
+
+    def test_invalid_name_raises_before_metadata(self) -> None:
+        with pytest.raises(ValueError, match="Invalid extra name"):
+            uninstall_extra_command(
+                "quickjs']; touch /tmp/pwned; '",
+                distribution_name="missing-dcode-test",
+            )
+
+    def test_missing_distribution_raises(self) -> None:
+        with pytest.raises(ExtrasIntrospectionError, match="cannot preserve"):
+            uninstall_extra_command(
+                "ollama", distribution_name="missing-dcode-test-xyz"
+            )
+
+
+class TestUninstallExtraSubcommand:
+    """Control-flow tests for `dcode --uninstall <extra>`."""
+
+    @staticmethod
+    def _run(
+        extra: str,
+        *,
+        editable: bool = False,
+        installed: tuple[str, ...] = ("ollama",),
+        perform_return: tuple[bool, str] = (True, ""),
+    ) -> tuple[int, MagicMock, MagicMock]:
+        from deepagents_code.main import cli_main
+
+        argv = ["deepagents", "--uninstall", extra]
+        console_mock = MagicMock()
+        perform_mock = AsyncMock(return_value=perform_return)
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = False
+        mock_stdin.read.return_value = ""
+        with (
+            patch.object(sys, "argv", argv),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_code.main.check_cli_dependencies"),
+            patch("deepagents_code.config.console", console_mock, create=True),
+            patch(
+                "deepagents_code.config._is_editable_install", return_value=editable
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=set(installed),
+            ),
+            patch(
+                "deepagents_code.update_check.create_update_log_path",
+                return_value=Path("/tmp/deepagents-uninstall.log"),
+            ),
+            patch(
+                "deepagents_code.update_check.uninstall_extra_command",
+                return_value="uv tool install -U deepagents-code",
+            ),
+            patch(
+                "deepagents_code.update_check.perform_uninstall_extra",
+                perform_mock,
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+        return int(exc_info.value.code or 0), perform_mock, console_mock
+
+    @staticmethod
+    def _text(console_mock: MagicMock) -> str:
+        chunks: list[str] = []
+        for call in console_mock.print.call_args_list:
+            chunks.extend(str(arg) for arg in call.args)
+        return "\n".join(chunks)
+
+    def test_installed_extra_runs(self) -> None:
+        code, perform, console = self._run("ollama", installed=("ollama",))
+        assert code == 0
+        perform.assert_awaited_once()
+        assert "Uninstalled extra 'ollama'" in self._text(console)
+
+    def test_absent_extra_skips_uv(self) -> None:
+        code, perform, console = self._run("quickjs", installed=("ollama",))
+        assert code == 0
+        perform.assert_not_awaited()
+        assert "Extra 'quickjs' is not installed." in self._text(console)
+
+    def test_editable_install_refuses(self) -> None:
+        code, perform, _console = self._run("ollama", editable=True)
+        assert code == 1
+        perform.assert_not_awaited()
+
+    def test_invalid_name_refuses(self) -> None:
+        code, perform, _console = self._run("bad;name")
+        assert code == 2
+        perform.assert_not_awaited()
+
+    def test_failure_surfaces_log_and_manual_command(self) -> None:
+        code, _perform, console = self._run(
+            "ollama", perform_return=(False, "resolver: conflict")
+        )
+        assert code == 1
+        text = self._text(console)
+        assert "Uninstall failed" in text
+        assert "/tmp/deepagents-uninstall.log" in text
+
+
+async def test_uninstall_slash_usage_when_no_extra() -> None:
+    """`/uninstall` with no argument prints a usage hint and does not run uv."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with patch(
+            "deepagents_code.update_check.perform_uninstall_extra",
+            new_callable=AsyncMock,
+        ) as perform_mock:
+            await app._handle_command("/uninstall")
+            await pilot.pause()
+        perform_mock.assert_not_awaited()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        assert any("Usage: /uninstall" in str(m._content) for m in app_msgs)
+
+
+async def test_uninstall_slash_provider_extra_recommends_restart_slash() -> None:
+    """Provider extras advertise `/restart`, not a full relaunch."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value={"ollama"},
+            ),
+            patch(
+                "deepagents_code.update_check.uninstall_extra_command",
+                return_value="uv tool install -U deepagents-code",
+            ),
+            patch(
+                "deepagents_code.update_check.perform_uninstall_extra",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as perform_mock,
+        ):
+            await app._handle_command("/uninstall ollama")
+            await pilot.pause()
+        perform_mock.assert_awaited_once()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        success = next(
+            m for m in app_msgs if "Uninstalled extra 'ollama'" in str(m._content)
+        )
+        assert "/restart" in str(success._content)
+
+
+async def test_uninstall_slash_standalone_extra_recommends_full_relaunch() -> None:
+    """Standalone extras (e.g. quickjs) require a full relaunch, not `/restart`."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value={"quickjs"},
+            ),
+            patch(
+                "deepagents_code.update_check.uninstall_extra_command",
+                return_value="uv tool install -U deepagents-code",
+            ),
+            patch(
+                "deepagents_code.update_check.perform_uninstall_extra",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+        ):
+            await app._handle_command("/uninstall quickjs")
+            await pilot.pause()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        success = next(
+            m for m in app_msgs if "Uninstalled extra 'quickjs'" in str(m._content)
+        )
+        rendered = str(success._content)
+        assert "/restart" not in rendered
+        assert "relaunch dcode" in rendered
+
+
+async def test_uninstall_slash_absent_extra_reports_and_skips_uv() -> None:
+    """An extra that is not installed is reported without invoking uv."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value={"ollama"},
+            ),
+            patch(
+                "deepagents_code.update_check.perform_uninstall_extra",
+                new_callable=AsyncMock,
+            ) as perform_mock,
+        ):
+            await app._handle_command("/uninstall quickjs")
+            await pilot.pause()
+        perform_mock.assert_not_awaited()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        assert any(
+            "Extra 'quickjs' is not installed." in str(m._content) for m in app_msgs
+        )
+
+
+async def test_uninstall_slash_editable_install_refuses() -> None:
+    """Editable installs refuse and never call the performer."""
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=True),
+            patch(
+                "deepagents_code.update_check.perform_uninstall_extra",
+                new_callable=AsyncMock,
+            ) as perform_mock,
+        ):
+            await app._handle_command("/uninstall ollama")
+            await pilot.pause()
+        perform_mock.assert_not_awaited()
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        assert any(
+            "Editable install detected" in str(m._content) for m in app_msgs
+        )


### PR DESCRIPTION
Add `dcode --uninstall <extra>` and the `/uninstall <extra>` slash command to remove an installed optional extra.

---

Adds first-class removal of an installed `deepagents-code` optional extra, mirroring the existing `/install` / `--install` flow. Removal rebuilds the uv tool environment with the remaining installed extras (`uv tool install -U 'deepagents-code[<remaining>]'`), and reinstalls plain `deepagents-code` when none remain. Absent extras are reported without invoking uv; editable installs are refused with guidance analogous to `/install`; successful removals show the same restart/relaunch guidance.

Default providers (OpenAI, Anthropic, Gemini) are base dependencies and are not removable via extras — documented in the README.

## Test Plan
- [ ] `dcode --uninstall <extra>` removes an installed extra and reports a clear message when the extra is not installed

Made by [Open SWE](https://openswe.vercel.app)