### PR TITLE
fix(code): exclude prompt prefix from `UserMessage` selection

### DIFF
--- a/libs/code/deepagents_code/widgets/messages.py
+++ b/libs/code/deepagents_code/widgets/messages.py
@@ -36,6 +36,7 @@ from deepagents_code.widgets.diff import compose_diff_lines
 if TYPE_CHECKING:
     from rich.console import Console as RichConsole, ConsoleOptions, RenderResult
     from textual.app import ComposeResult
+    from textual.selection import Selection
     from textual.timer import Timer
     from textual.widgets import Markdown
     from textual.widgets._markdown import MarkdownStream
@@ -125,6 +126,39 @@ def _strip_success_exit_line(text: str) -> str:
     return _SUCCESS_EXIT_RE.sub("", text)
 
 
+# Visual width of the prompt prefix (glyph + trailing space, e.g. "> ", "$ ").
+# Glyphs are single characters, so the prefix is always two columns wide.
+_PROMPT_PREFIX_WIDTH = 2
+
+
+def _strip_prompt_prefix(
+    result: tuple[str, str] | None,
+    selection: Selection,
+) -> tuple[str, str] | None:
+    """Drop the leading prompt prefix glyph from a selected range.
+
+    The prefix is only rendered on the first row, so it is stripped only when
+    the selection begins there. This keeps triple-click / select-all copies to
+    the message body instead of the decorative `"> "` (or mode glyph) prefix.
+
+    Args:
+        result: The `(text, ending)` tuple returned by `Static.get_selection`.
+        selection: The active selection geometry.
+
+    Returns:
+        The selection with the prefix removed from row 0, or `result` unchanged.
+    """
+    if result is None:
+        return None
+    text, ending = result
+    start = selection.start
+    if start is not None and start.y != 0:
+        return result
+    start_x = 0 if start is None else start.x
+    prefix_chars = max(0, _PROMPT_PREFIX_WIDTH - start_x)
+    return text[prefix_chars:], ending
+
+
 class UserMessage(Static):
     """Widget displaying a user message."""
 
@@ -157,6 +191,17 @@ class UserMessage(Static):
     def set_cancelled(self) -> None:
         """Dim the message to mark its turn as interrupted by the user."""
         self.add_class("-cancelled")
+
+    def get_selection(self, selection: Selection) -> tuple[str, str] | None:
+        """Exclude the prompt prefix glyph from copied text.
+
+        Args:
+            selection: The active selection geometry.
+
+        Returns:
+            The `(text, ending)` selection with the prefix removed, or `None`.
+        """
+        return _strip_prompt_prefix(super().get_selection(selection), selection)
 
     def on_mount(self) -> None:
         """Add CSS classes for mode-specific border and ASCII border type."""
@@ -254,6 +299,17 @@ class QueuedUserMessage(Static):
         """Add ASCII border class when in ASCII mode."""
         if is_ascii_mode():
             self.add_class("-ascii")
+
+    def get_selection(self, selection: Selection) -> tuple[str, str] | None:
+        """Exclude the prompt prefix glyph from copied text.
+
+        Args:
+            selection: The active selection geometry.
+
+        Returns:
+            The `(text, ending)` selection with the prefix removed, or `None`.
+        """
+        return _strip_prompt_prefix(super().get_selection(selection), selection)
 
     def render(self) -> Content:
         """Render the queued user message (greyed out).

--- a/libs/code/deepagents_code/widgets/messages.py
+++ b/libs/code/deepagents_code/widgets/messages.py
@@ -16,8 +16,10 @@ from textual import on
 from textual.containers import Horizontal, Vertical
 from textual.content import Content
 from textual.events import Click
+from textual.geometry import Offset
 from textual.message_pump import NoActiveAppError
 from textual.reactive import var
+from textual.selection import Selection
 from textual.widgets import Static
 
 from deepagents_code import theme
@@ -36,7 +38,6 @@ from deepagents_code.widgets.diff import compose_diff_lines
 if TYPE_CHECKING:
     from rich.console import Console as RichConsole, ConsoleOptions, RenderResult
     from textual.app import ComposeResult
-    from textual.selection import Selection
     from textual.timer import Timer
     from textual.widgets import Markdown
     from textual.widgets._markdown import MarkdownStream
@@ -159,6 +160,17 @@ def _strip_prompt_prefix(
     return text[prefix_chars:], ending
 
 
+def _select_prompt_body(widget: Static) -> None:
+    """Select the user message body without its decorative prompt glyph.
+
+    Args:
+        widget: User message widget whose body should be selected.
+    """
+    widget.screen.selections = {  # ty: ignore[invalid-assignment]  # Textual reactive descriptor assignment updates selection watchers; `set_reactive` would skip them.
+        widget: Selection(Offset(_PROMPT_PREFIX_WIDTH, 0), None),
+    }
+
+
 class UserMessage(Static):
     """Widget displaying a user message."""
 
@@ -202,6 +214,10 @@ class UserMessage(Static):
             The `(text, ending)` selection with the prefix removed, or `None`.
         """
         return _strip_prompt_prefix(super().get_selection(selection), selection)
+
+    def text_select_all(self) -> None:
+        """Select the message body without the prompt prefix glyph."""
+        _select_prompt_body(self)
 
     def on_mount(self) -> None:
         """Add CSS classes for mode-specific border and ASCII border type."""
@@ -310,6 +326,10 @@ class QueuedUserMessage(Static):
             The `(text, ending)` selection with the prefix removed, or `None`.
         """
         return _strip_prompt_prefix(super().get_selection(selection), selection)
+
+    def text_select_all(self) -> None:
+        """Select the message body without the prompt prefix glyph."""
+        _select_prompt_body(self)
 
     def render(self) -> Content:
         """Render the queued user message (greyed out).

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -2006,7 +2006,9 @@ class _SelectionApp(App[None]):
 
     def compose(self) -> ComposeResult:
         yield UserMessage("hello world", id="user")
+        yield UserMessage("!ls", id="shell-user")
         yield QueuedUserMessage("hi there", id="queued")
+        yield QueuedUserMessage("!pwd", id="shell-queued")
 
 
 class TestUserMessageGetSelection:
@@ -2040,6 +2042,48 @@ class TestUserMessageGetSelection:
             result = widget.get_selection(selection)
             assert result is not None
             assert result[0] == "world"
+
+    async def test_user_message_select_all_starts_after_prompt_prefix(self) -> None:
+        from textual.geometry import Offset
+        from textual.selection import Selection
+
+        async with _SelectionApp().run_test() as pilot:
+            widget = pilot.app.query_one("#user", UserMessage)
+            widget.text_select_all()
+            assert pilot.app.screen.selections[widget] == Selection(Offset(2, 0), None)
+
+    async def test_shell_user_select_all_starts_after_prompt_prefix(self) -> None:
+        from textual.geometry import Offset
+        from textual.selection import Selection
+
+        async with _SelectionApp().run_test() as pilot:
+            widget = pilot.app.query_one("#shell-user", UserMessage)
+            widget.text_select_all()
+            assert pilot.app.screen.selections[widget] == Selection(Offset(2, 0), None)
+            result = widget.get_selection(pilot.app.screen.selections[widget])
+            assert result is not None
+            assert result[0] == "ls"
+
+    async def test_queued_message_select_all_starts_after_prompt_prefix(self) -> None:
+        from textual.geometry import Offset
+        from textual.selection import Selection
+
+        async with _SelectionApp().run_test() as pilot:
+            widget = pilot.app.query_one("#queued", QueuedUserMessage)
+            widget.text_select_all()
+            assert pilot.app.screen.selections[widget] == Selection(Offset(2, 0), None)
+
+    async def test_shell_queued_select_all_starts_after_prompt_prefix(self) -> None:
+        from textual.geometry import Offset
+        from textual.selection import Selection
+
+        async with _SelectionApp().run_test() as pilot:
+            widget = pilot.app.query_one("#shell-queued", QueuedUserMessage)
+            widget.text_select_all()
+            assert pilot.app.screen.selections[widget] == Selection(Offset(2, 0), None)
+            result = widget.get_selection(pilot.app.screen.selections[widget])
+            assert result is not None
+            assert result[0] == "pwd"
 
 
 class TestAppMessageAutoLinksDisabled:

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -22,6 +22,7 @@ from deepagents_code.widgets.messages import (
     UserMessage,
     _MutedRichMarkdown,
     _strip_frontmatter,
+    _strip_prompt_prefix,
     _strip_success_exit_line,
 )
 
@@ -1947,6 +1948,98 @@ class TestQueuedUserMessageModeRendering:
         """`QueuedUserMessage('')` should not crash and should render `'> '`."""
         content = _render_content(QueuedUserMessage(""))
         assert content.plain == "> "
+
+
+class TestStripPromptPrefix:
+    """Unit tests for `_strip_prompt_prefix` selection trimming."""
+
+    def test_passes_through_none(self) -> None:
+        """A `None` result (no extractable text) stays `None`."""
+        from textual.selection import SELECT_ALL
+
+        assert _strip_prompt_prefix(None, SELECT_ALL) is None
+
+    def test_select_all_drops_prefix(self) -> None:
+        """Select-all (`Selection(None, None)`) trims the two-column prefix."""
+        from textual.selection import SELECT_ALL
+
+        assert _strip_prompt_prefix(("> hello", "\n"), SELECT_ALL) == (
+            "hello",
+            "\n",
+        )
+
+    def test_selection_from_row_zero_drops_prefix(self) -> None:
+        """A row-0 selection starting at column 0 trims the prefix."""
+        from textual.geometry import Offset
+        from textual.selection import Selection
+
+        selection = Selection(Offset(0, 0), Offset(7, 0))
+        assert _strip_prompt_prefix(("> hello", "\n"), selection) == ("hello", "\n")
+
+    def test_partial_prefix_selection_trims_remaining_glyph(self) -> None:
+        """Starting inside the prefix trims only the still-included columns."""
+        from textual.geometry import Offset
+        from textual.selection import Selection
+
+        selection = Selection(Offset(1, 0), Offset(7, 0))
+        assert _strip_prompt_prefix((" hello", "\n"), selection) == ("hello", "\n")
+
+    def test_selection_starting_in_body_is_untouched(self) -> None:
+        """A selection beginning past the prefix keeps the body verbatim."""
+        from textual.geometry import Offset
+        from textual.selection import Selection
+
+        selection = Selection(Offset(4, 0), Offset(7, 0))
+        assert _strip_prompt_prefix(("llo", "\n"), selection) == ("llo", "\n")
+
+    def test_selection_starting_below_row_zero_is_untouched(self) -> None:
+        """Selections that begin on later rows carry no prefix to strip."""
+        from textual.geometry import Offset
+        from textual.selection import Selection
+
+        selection = Selection(Offset(0, 1), Offset(5, 1))
+        assert _strip_prompt_prefix(("world", "\n"), selection) == ("world", "\n")
+
+
+class _SelectionApp(App[None]):
+    """Mount user-message widgets so `get_selection` has an active app."""
+
+    def compose(self) -> ComposeResult:
+        yield UserMessage("hello world", id="user")
+        yield QueuedUserMessage("hi there", id="queued")
+
+
+class TestUserMessageGetSelection:
+    """Triple-click / select-all should copy the body, not the prefix glyph."""
+
+    async def test_user_message_select_all_excludes_prefix(self) -> None:
+        from textual.selection import SELECT_ALL
+
+        async with _SelectionApp().run_test() as pilot:
+            widget = pilot.app.query_one("#user", UserMessage)
+            result = widget.get_selection(SELECT_ALL)
+            assert result is not None
+            assert result[0] == "hello world"
+
+    async def test_queued_message_select_all_excludes_prefix(self) -> None:
+        from textual.selection import SELECT_ALL
+
+        async with _SelectionApp().run_test() as pilot:
+            widget = pilot.app.query_one("#queued", QueuedUserMessage)
+            result = widget.get_selection(SELECT_ALL)
+            assert result is not None
+            assert result[0] == "hi there"
+
+    async def test_body_selection_preserved(self) -> None:
+        from textual.geometry import Offset
+        from textual.selection import Selection
+
+        async with _SelectionApp().run_test() as pilot:
+            widget = pilot.app.query_one("#user", UserMessage)
+            selection = Selection(Offset(8, 0), Offset(13, 0))
+            result = widget.get_selection(selection)
+            assert result is not None
+            assert result[0] == "world"
 
 
 class TestAppMessageAutoLinksDisabled:


### PR DESCRIPTION
Selecting a user message no longer copies the leading prompt prefix — `> `, or the mode glyph `$ ` / `/ ` — into the clipboard. That prefix is purely decorative.

On these `Static`-based message widgets, both double-click and triple-click select the entire message (Textual maps double-click to `text_select_all`, and triple-click escalates to the scroll container's select-all); previously both pulled the prefix into the copied text.

`UserMessage` and `QueuedUserMessage` now override `get_selection` to drop the two-column prefix from row 0 of any selection that starts there, leaving body-only and later-row selections untouched. This is the actual fix and applies to every gesture — double-click, triple-click, and drag-from-start.

They also override `text_select_all` so the double-click highlight begins after the glyph. This affects the highlight only on double-click; triple-click routes through the container and still renders the glyph as highlighted, though it is never copied.

Made by [Open SWE](https://openswe.vercel.app)
