### PR TITLE
fix(quickjs): nest PTC tool calls under the eval run in traces

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -16,6 +16,7 @@ import uuid
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 
+from langchain_core.runnables.config import ensure_config
 from quickjs_rs import (
     UNDEFINED,
     ConcurrentEvalError,
@@ -47,6 +48,7 @@ from langchain_quickjs._subagent import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from langchain_core.runnables import RunnableConfig
     from langchain_core.tools import BaseTool
     from langgraph.prebuilt import ToolRuntime
 
@@ -123,6 +125,9 @@ class _PTCState:
     remaining_calls: int | None
     outer_runtime: ToolRuntime | None = None
     outer_loop: asyncio.AbstractEventLoop | None = None
+    # The ``eval`` invocation's run-scoped RunnableConfig, captured while its
+    # callback context is live so PTC tool calls nest under the eval run.
+    eval_config: RunnableConfig | None = None
 
     def consume_call_budget(
         self, *, function_name: str, max_ptc_calls: int | None
@@ -598,6 +603,7 @@ class _ThreadREPL:
         tool_call: dict[str, Any],
         *,
         outer_loop: asyncio.AbstractEventLoop | None,
+        config: RunnableConfig | None = None,
     ) -> Any:
         """Run the tool on the outer runtime's loop when available.
 
@@ -606,14 +612,23 @@ class _ThreadREPL:
         value rather than a string-coerced ``ToolMessage``. We only pass
         ``tool_call_id`` when the tool declares ``InjectedToolCallId`` —
         otherwise ``_format_output`` would wrap the result anyway.
+
+        ``config`` carries the active ``eval`` invocation's callback context.
+        Its callback manager is forwarded via ``BaseTool.arun(callbacks=...)``
+        — the ``callbacks`` argument (not ``config["callbacks"]``, which
+        ``arun`` does not use for parenting) is what makes the tool's run a
+        child of the ``eval`` run. Without it the tool starts a fresh root run
+        and tracing back-ends orphan its span at the top level instead of
+        nesting it under ``eval`` (#3991).
         """
         args = tool_call["args"]
         tool_call_id = (
             tool_call.get("id") if _tool_uses_injected_tool_call_id(tool) else None
         )
+        callbacks = config.get("callbacks") if config else None
 
         async def _call() -> Any:
-            return await tool.arun(args, tool_call_id=tool_call_id)
+            return await tool.arun(args, tool_call_id=tool_call_id, callbacks=callbacks)
 
         if outer_loop is None:
             return await _call()
@@ -670,6 +685,7 @@ class _ThreadREPL:
                 tool,
                 {"name": tool.name, "args": args, "id": call_id, "type": "tool_call"},
                 outer_loop=state.outer_loop,
+                config=state.eval_config,
             )
             return coerce_tool_output_for_ptc(result)
 
@@ -687,10 +703,16 @@ class _ThreadREPL:
         # the worker loop. Sync ctx.eval can't dispatch async host functions
         # (PTC bridges are is_async=True), so routing sync callers through
         # the async path is required for PTC to work under sync invocation.
+        #
+        # Capture the eval invocation's run-scoped config here, on the calling
+        # thread where the callback context is live; the worker loop it runs on
+        # does not inherit it. PTC tools are then invoked under this config so
+        # their runs nest under the eval run (#3991).
         return self._worker.run_sync(
             self._aeval_async(
                 code,
                 outer_runtime=outer_runtime,
+                eval_config=ensure_config(),
             )
         )
 
@@ -701,11 +723,15 @@ class _ThreadREPL:
         outer_runtime: ToolRuntime | None = None,
         outer_loop: asyncio.AbstractEventLoop | None = None,
     ) -> EvalOutcome:
+        # Capture the eval invocation's run-scoped config on this (calling)
+        # task, where its callback context is live; the worker loop the eval
+        # body runs on does not inherit it. See ``eval_sync`` for why (#3991).
         return await self._worker.run_async(
             self._aeval_async(
                 code,
                 outer_runtime=outer_runtime,
                 outer_loop=outer_loop,
+                eval_config=ensure_config(),
             )
         )
 
@@ -751,6 +777,7 @@ class _ThreadREPL:
         *,
         outer_runtime: ToolRuntime | None = None,
         outer_loop: asyncio.AbstractEventLoop | None = None,
+        eval_config: RunnableConfig | None = None,
     ) -> EvalOutcome:
         """Uses ``ctx.eval_async`` directly.
 
@@ -770,6 +797,7 @@ class _ThreadREPL:
             remaining_calls=self._max_ptc_calls,
             outer_runtime=outer_runtime,
             outer_loop=outer_loop,
+            eval_config=eval_config,
         )
         try:
             # Drive any final-expression Promise (e.g. a bare async

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -342,6 +342,92 @@ async def test_tool_invocation_from_repl(repl: _ThreadREPL) -> None:
     assert calls == [{"name": "world", "times": 2}]
 
 
+async def test_ptc_tool_run_nests_under_eval() -> None:
+    """A PTC tool call must nest under the ``eval`` run in the callback tree.
+
+    Regression for #3991: a tool invoked from JS via ``tools.x()`` during an
+    ``eval`` was run without the eval's callback context, so its run had no
+    parent. Tracing back-ends (e.g. OpenInference) then orphaned the tool's
+    span at the top level instead of nesting it under the ``eval`` span. We
+    assert the run tree directly through a callback handler so the test needs
+    no tracing-backend dependency — span nesting is downstream of this tree.
+    """
+    from uuid import UUID  # noqa: TC003 — used in a nested-class annotation
+
+    from langchain_core.callbacks import BaseCallbackHandler
+    from langchain_core.messages import AIMessage
+    from langchain_core.tools import tool
+    from langgraph._internal._constants import (
+        CONF,
+        CONFIG_KEY_RUNTIME,
+    )
+    from langgraph.prebuilt import ToolNode
+    from langgraph.runtime import Runtime as AgentRuntime
+
+    class _RunTreeRecorder(BaseCallbackHandler):
+        """Record every tool-start with its run id and parent run id."""
+
+        def __init__(self) -> None:
+            self.tool_starts: list[dict[str, Any]] = []
+
+        def on_tool_start(
+            self,
+            serialized: dict[str, Any],
+            input_str: str,
+            *,
+            run_id: UUID,
+            parent_run_id: UUID | None = None,
+            **kwargs: Any,
+        ) -> None:
+            name = (serialized or {}).get("name") or kwargs.get("name")
+            self.tool_starts.append(
+                {"name": name, "run_id": run_id, "parent_run_id": parent_run_id}
+            )
+
+    @tool
+    def stub_tool(x: int) -> int:
+        """Return x doubled."""
+        return x * 2
+
+    middleware = CodeInterpreterMiddleware(ptc=["stub_tool"], mode="thread")
+    eval_tool = middleware.tools[0]
+    repl = middleware._registry.get(middleware._fallback_thread_id)
+    repl.install_tools([stub_tool])
+
+    node = ToolNode([eval_tool, stub_tool])
+    msg = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "eval",
+                "args": {"code": "await tools.stubTool({ x: 21 })"},
+                "id": "call_eval_1",
+                "type": "tool_call",
+            }
+        ],
+    )
+    runtime = AgentRuntime(context=None, store=None, stream_writer=lambda _: None)
+    recorder = _RunTreeRecorder()
+    config = {CONF: {CONFIG_KEY_RUNTIME: runtime}, "callbacks": [recorder]}
+
+    try:
+        await node.ainvoke({"messages": [msg]}, config=config)
+    finally:
+        # Close the REPL worker explicitly; otherwise the middleware's
+        # __del__ tries to close it synchronously during GC and blocks.
+        middleware._registry.close()
+
+    eval_starts = [t for t in recorder.tool_starts if t["name"] == "eval"]
+    stub_starts = [t for t in recorder.tool_starts if t["name"] == "stub_tool"]
+    assert eval_starts, "expected an eval tool-start in the run tree"
+    assert stub_starts, "expected a stub_tool tool-start from the PTC bridge"
+    assert stub_starts[0]["parent_run_id"] == eval_starts[0]["run_id"], (
+        "PTC stub_tool run must nest under the eval run "
+        f"(eval={eval_starts[0]['run_id']}, "
+        f"stub parent={stub_starts[0]['parent_run_id']})"
+    )
+
+
 async def test_promise_all_runs_tools_concurrently(repl: _ThreadREPL) -> None:
     """``Promise.all`` on two tool calls resolves both before returning."""
     calls: list[dict] = []


### PR DESCRIPTION
Fixes #3991

## Problem

With `CodeInterpreterMiddleware` and PTC enabled, a tool invoked from JS via `tools.x()` during an `eval` produces a trace where the PTC tool span is **not** nested under the `eval` tool span — it's orphaned at the top level of the turn's trace.

Root cause: the PTC bridge invoked the tool via `BaseTool.arun(...)` without the `eval` invocation's callback context, so the tool started a fresh root run (no parent). Tracing back-ends (e.g. OpenInference) nest spans off the run tree, so the tool span had no `eval` parent to attach to.

## Fix

- Capture the `eval` invocation's run-scoped config via `ensure_config()` on the **calling thread**, where its callback context is live — the worker loop the eval body runs on does not inherit it.
- Forward that callback context to the PTC tool through `BaseTool.arun(callbacks=...)`. The `callbacks=` argument (not `config["callbacks"]`, which `arun` does not use for parenting) is what makes the tool's run a child of the `eval` run.

## Test

Added `test_ptc_tool_run_nests_under_eval`, which drives a PTC tool call through `ToolNode` → `eval` and asserts via a callback handler that the PTC tool's run nests under the `eval` run (`parent_run_id == eval run_id`). The assertion is on the callback run tree directly, so the test needs no tracing-backend dependency (span nesting is downstream of the run tree).

Verified locally: the new test fails before the fix and passes after; the full `quickjs` unit suite (148 tests) passes; `ruff check`, `ruff format`, and `ty check` are clean.