### PR TITLE
chore(code): bump langchain-quickjs to 0.2.0

### DIFF
--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -117,7 +117,7 @@ all-sandboxes = [
 ]
 
 # Standalone integrations (not part of any composite extra)
-quickjs = ["langchain-quickjs>=0.1.4,<0.2.0"]
+quickjs = ["langchain-quickjs>=0.2.0,<0.3.0"]
 
 
 [project.scripts]
@@ -140,7 +140,7 @@ test = [
     "build>=1.5.0,<2.0.0",
     "ruff>=0.15.17,<1.0.0",
     "ty>=0.0.49,<1.0.0",
-    "langchain-quickjs>=0.1.4,<0.2.0",
+    "langchain-quickjs>=0.2.0,<0.3.0",
     "pytest>=9.0.3,<10.0.0",
     "pytest-asyncio>=1.4.0,<2.0.0",
     "pytest-benchmark>=5.2.3,<6.0.0",


### PR DESCRIPTION
Bumps the `langchain-quickjs` dependency constraint in `deepagents-code` from `>=0.1.4,<0.2.0` to `>=0.2.0,<0.3.0`. `langchain-quickjs` is the JavaScript REPL interpreter behind the dcode `--interpreter` flag.

The `langchain-quickjs` partner package was already released at `0.2.0` on `main`, but the published `deepagents-code` constraint (`<0.2.0`) excluded it. This bump aligns dcode with the released interpreter so that, once a new `deepagents-code` is published, `/install quickjs` (and `dcode --install quickjs`) pulls in `langchain-quickjs` 0.2.x.