### PR TITLE
feat(code): note minimum OpenAI key permissions in `/auth`

### DIFF
--- a/libs/code/deepagents_code/widgets/auth.py
+++ b/libs/code/deepagents_code/widgets/auth.py
@@ -718,6 +718,15 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
                 "Keys and Endpoint page, then paste it below. ",
                 (label, self._link_style(url)),
             )
+        elif self._provider == "openai":
+            instructions = Content.assemble(
+                f"Sign in to {provider}, create or copy an API key, "
+                "then paste it below. A Restricted key is enough: grant "
+                "Write access to Responses (/v1/responses), and add Chat "
+                "completions (/v1/chat/completions) only if you use a "
+                "completions model. ",
+                (label, self._link_style(url)),
+            )
         else:
             instructions = Content.assemble(
                 f"Sign in to {provider}, create or copy an API key, "

--- a/libs/code/deepagents_code/widgets/auth.py
+++ b/libs/code/deepagents_code/widgets/auth.py
@@ -720,11 +720,11 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
             )
         elif self._provider == "openai":
             instructions = Content.assemble(
-                f"Sign in to {provider}, create or copy an API key, "
-                "then paste it below. A Restricted key is enough: grant "
-                "Write access to Responses (/v1/responses), and add Chat "
-                "completions (/v1/chat/completions) only if you use a "
-                "completions model. ",
+                f"Sign in to {provider}, create or copy an API key, then "
+                "paste it below. Minimum permissions needed: "
+                "under Model capabilities, grant Write access to Responses "
+                "(/v1/responses). For older models, you may also need "
+                "Request access to Chat completions (/v1/chat/completions). ",
                 (label, self._link_style(url)),
             )
         else:

--- a/libs/code/tests/unit_tests/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/test_auth_widgets.py
@@ -302,9 +302,12 @@ class TestAuthPromptScreen:
             instructions = app.screen.query_one("#auth-prompt-key-instructions", Static)
             text = str(instructions.content)
             assert "Sign in to OpenAI" in text
-            assert "Restricted key is enough" in text
-            assert "Responses (/v1/responses)" in text
-            assert "Chat completions (/v1/chat/completions)" in text
+            assert "create or copy an API key" in text
+            assert "Minimum permissions needed" in text
+            assert "in Model capabilities" in text
+            assert "Write access to Responses (/v1/responses)" in text
+            assert "For older models" in text
+            assert "Request access to Chat completions (/v1/chat/completions)" in text
 
     async def test_provider_instructions_use_config_metadata(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/test_auth_widgets.py
@@ -304,7 +304,7 @@ class TestAuthPromptScreen:
             assert "Sign in to OpenAI" in text
             assert "create or copy an API key" in text
             assert "Minimum permissions needed" in text
-            assert "in Model capabilities" in text
+            assert "under Model capabilities" in text
             assert "Write access to Responses (/v1/responses)" in text
             assert "For older models" in text
             assert "Request access to Chat completions (/v1/chat/completions)" in text

--- a/libs/code/tests/unit_tests/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/test_auth_widgets.py
@@ -293,6 +293,19 @@ class TestAuthPromptScreen:
             assert "Keys and Endpoint page" in text
             assert "Sign in to Azure OpenAI" not in text
 
+    async def test_openai_instructions_name_minimum_key_permissions(self) -> None:
+        """OpenAI keys note the minimum Restricted scopes Deep Agents Code needs."""
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_prompt("openai", "OPENAI_API_KEY")
+            await pilot.pause()
+            instructions = app.screen.query_one("#auth-prompt-key-instructions", Static)
+            text = str(instructions.content)
+            assert "Sign in to OpenAI" in text
+            assert "Restricted key is enough" in text
+            assert "Responses (/v1/responses)" in text
+            assert "Chat completions (/v1/chat/completions)" in text
+
     async def test_provider_instructions_use_config_metadata(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
The OpenAI `/auth` prompt now documents the minimum Restricted key permissions Deep Agents Code needs.

---

When acquiring an OpenAI API key, users can pick `all`, `restricted`, or `read only` scopes. Deep Agents Code doesn't use any OpenAI provider tools, so a `restricted` key with `write` on Responses (`/v1/responses`) is sufficient — plus `request` on Chat completions (`/v1/chat/completions`) only when a completions model is used. The `/auth` prompt now surfaces this so users don't over-provision an `all` key. This follows the existing per-provider special-casing in the key-acquisition instructions (e.g. Azure OpenAI).

Made by [Open SWE](https://openswe.vercel.app/agents/5e320e33-7cc7-c2c4-4b91-ec46eda94a74)