### PR TITLE
fix(code): clarify post-update restart semantics

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3684,7 +3684,8 @@ class DeepAgentsApp(App):
                 self.notify(
                     f"Update available: v{latest}{release_age}. "
                     f"Currently installed: {cli_version}{installed_age}. "
-                    "Restart dcode to install the update automatically.",
+                    "Quit and relaunch dcode to install the update "
+                    "automatically.",
                     severity="information",
                     timeout=12,
                     markup=False,
@@ -3924,7 +3925,9 @@ class DeepAgentsApp(App):
                 self._update_available = (False, None)
                 await self._mount_message(
                     AppMessage(
-                        f"Updated to v{latest}. Restart to use the new version."
+                        f"Updated to v{latest}. Quit and relaunch dcode to use "
+                        "the new version (`/restart` only restarts the server, "
+                        "not the CLI)."
                     ),
                 )
             else:
@@ -10058,7 +10061,8 @@ class DeepAgentsApp(App):
                     if not progress_modal_visible:
                         self.notify(
                             f"Updated to v{payload.latest}. "
-                            "Restart to use the new version.",
+                            "Quit and relaunch dcode to use the new version "
+                            "(/restart only restarts the server, not the CLI).",
                             severity="information",
                             timeout=10,
                             markup=False,

--- a/libs/code/deepagents_code/widgets/update_progress.py
+++ b/libs/code/deepagents_code/widgets/update_progress.py
@@ -197,7 +197,8 @@ class UpdateProgressScreen(ModalScreen[None]):
         """Render the completed-success state."""
         self._done = True
         self._status = (
-            f"Update complete. Restart Deep Agents Code to use v{self._latest}."
+            f"Update complete. Quit and relaunch Deep Agents Code to use "
+            f"v{self._latest}."
         )
         self._stop_spinner_timer()
         self._refresh_status()


### PR DESCRIPTION
Update messages now clearly tell users to quit and relaunch dcode (not `/restart`) to load a newly installed version.

---

The post-update copy said "Restart to use the new version," which users naturally interpreted as the `/restart` slash command. But `/restart` only respawns the server subprocess — it doesn't reload the running CLI, so the new version never took effect. Reworded the update success/availability messages to instruct quitting and relaunching `dcode`, and clarified that `/restart` is server-only.

Made by [Open SWE](https://openswe.vercel.app/agents/f99c0bcd-6536-1db7-816f-0b4bae8fbb73)

BEGIN_COMMIT_OVERRIDE
fix(code): clarify post-update restart semantics
END_COMMIT_OVERRIDE