### PR TITLE
fix(code): keep install-required `/model` rows dimmed after navigation

### DIFF
--- a/libs/code/deepagents_code/widgets/model_selector.py
+++ b/libs/code/deepagents_code/widgets/model_selector.py
@@ -1306,6 +1306,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 auth_status=old_widget.auth_status,
                 is_default=old_widget.model_spec == self._default_spec,
                 status=self._get_model_status(old_widget.model_spec),
+                install_required=old_widget.provider in self._install_extras,
             )
         )
 
@@ -1320,6 +1321,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 auth_status=new_widget.auth_status,
                 is_default=new_widget.model_spec == self._default_spec,
                 status=self._get_model_status(new_widget.model_spec),
+                install_required=new_widget.provider in self._install_extras,
             )
         )
 

--- a/libs/code/deepagents_code/widgets/model_selector.py
+++ b/libs/code/deepagents_code/widgets/model_selector.py
@@ -958,14 +958,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 if is_current:
                     classes += " model-option-current"
 
-                label = self._format_option_label(
-                    model_spec,
-                    selected=is_selected,
-                    current=is_current,
-                    auth_status=auth_status,
-                    is_default=model_spec == self._default_spec,
-                    status=self._get_model_status(model_spec),
-                    install_required=real_provider in self._install_extras,
+                label = self._build_option_label(
+                    model_spec, real_provider, auth_status, selected=is_selected
                 )
                 widget = ModelOption(
                     label=label,
@@ -1011,14 +1005,8 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 if is_current:
                     classes += " model-option-current"
 
-                label = self._format_option_label(
-                    model_spec,
-                    selected=is_selected,
-                    current=is_current,
-                    auth_status=auth_status,
-                    is_default=model_spec == self._default_spec,
-                    status=self._get_model_status(model_spec),
-                    install_required=provider in self._install_extras,
+                label = self._build_option_label(
+                    model_spec, provider, auth_status, selected=is_selected
                 )
                 widget = ModelOption(
                     label=label,
@@ -1071,6 +1059,43 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
     def _install_indicator() -> str:
         """Return the provider-header text for an uninstalled provider."""
         return "not installed"
+
+    def _build_option_label(
+        self,
+        model_spec: str,
+        provider: str,
+        auth_status: ProviderAuthStatus,
+        *,
+        selected: bool,
+    ) -> Content:
+        """Build a model-option label from the current screen state.
+
+        Centralizes the per-row flag derivation (current/default/status/
+        `install_required`) shared by the full rebuild in `_update_display`
+        and the incremental relabel in `_move_selection`, so the two paths
+        cannot drift. The original `/model` dim-persistence bug came from
+        exactly such drift: `_move_selection` omitted `install_required`,
+        so uninstalled rows stopped rendering dimmed after navigation.
+
+        Args:
+            model_spec: The `provider:model` string for the row.
+            provider: The row's provider key, tested against the
+                install-required set.
+            auth_status: Provider auth/readiness status for the row.
+            selected: Whether this row is the highlighted one.
+
+        Returns:
+            Styled `Content` label.
+        """
+        return self._format_option_label(
+            model_spec,
+            selected=selected,
+            current=model_spec == self._current_spec,
+            auth_status=auth_status,
+            is_default=model_spec == self._default_spec,
+            status=self._get_model_status(model_spec),
+            install_required=provider in self._install_extras,
+        )
 
     @staticmethod
     def _format_option_label(
@@ -1299,14 +1324,11 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         old_widget = self._option_widgets[old_index]
         old_widget.remove_class("model-option-selected")
         old_widget.update(
-            self._format_option_label(
+            self._build_option_label(
                 old_widget.model_spec,
+                old_widget.provider,
+                old_widget.auth_status,
                 selected=False,
-                current=old_widget.model_spec == self._current_spec,
-                auth_status=old_widget.auth_status,
-                is_default=old_widget.model_spec == self._default_spec,
-                status=self._get_model_status(old_widget.model_spec),
-                install_required=old_widget.provider in self._install_extras,
             )
         )
 
@@ -1314,14 +1336,11 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         new_widget = self._option_widgets[new_index]
         new_widget.add_class("model-option-selected")
         new_widget.update(
-            self._format_option_label(
+            self._build_option_label(
                 new_widget.model_spec,
+                new_widget.provider,
+                new_widget.auth_status,
                 selected=True,
-                current=new_widget.model_spec == self._current_spec,
-                auth_status=new_widget.auth_status,
-                is_default=new_widget.model_spec == self._default_spec,
-                status=self._get_model_status(new_widget.model_spec),
-                install_required=new_widget.provider in self._install_extras,
             )
         )
 

--- a/libs/code/tests/unit_tests/test_model_selector.py
+++ b/libs/code/tests/unit_tests/test_model_selector.py
@@ -2119,7 +2119,64 @@ enabled = false
             screen._move_selection(1)
             await pilot.pause()
             assert screen._selected_index == 1
+            # While highlighted the row is intentionally bright: CSS owns the
+            # selected row and `_format_option_label` only dims when
+            # `not selected`. This guards the selected-row relabel so it keeps
+            # threading the correct state.
+            assert "dim" not in install_widget.content.markup
             screen._move_selection(-1)
             await pilot.pause()
 
             assert "dim" in install_widget.content.markup
+
+    async def test_navigation_preserves_install_required_dim_in_recent(self) -> None:
+        """The Recent-section copy of an install-required row stays dimmed too.
+
+        `_move_selection` is section-agnostic, but the Recent section builds
+        its rows through a separate call site than the provider groups. An
+        install-required model also surfaces at the top as a recent pick, so
+        cursoring onto then off that Recent row must re-dim it just the same.
+        """
+        install_spec = "baseten:moonshotai/Kimi-K2.6"
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            app.show_selector()
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, ModelSelectorScreen)
+
+            screen._curated = False
+            screen._recommended_only = False
+            screen._install_extras = {"baseten": "baseten"}
+            screen._unfiltered_models = [
+                ("openai:gpt-5.5", "openai"),
+                (install_spec, "baseten"),
+            ]
+            screen._all_models = list(screen._unfiltered_models)
+            screen._filtered_models = list(screen._unfiltered_models)
+            # The install-required model is also a recent pick, so it renders
+            # both at the top (Recent) and in its provider group.
+            screen._recent_specs = [install_spec]
+            screen._filter_text = ""
+            screen._selected_index = 0
+            await screen._update_display()
+            await pilot.pause()
+
+            # Recents render first; index 0 is the Recent-section install row.
+            recent_install = screen._option_widgets[0]
+            assert recent_install.model_spec == install_spec
+            assert "dim" in recent_install.content.markup
+            # `_update_display` keeps the openai row highlighted (rendered
+            # order: recent install, openai, provider-group install).
+            assert screen._selected_index == 1
+
+            # Move the cursor onto the Recent install row, then back off it.
+            screen._move_selection(-1)
+            await pilot.pause()
+            assert screen._selected_index == 0
+            assert "dim" not in recent_install.content.markup
+            screen._move_selection(1)
+            await pilot.pause()
+            assert screen._selected_index == 1
+
+            assert "dim" in recent_install.content.markup

--- a/libs/code/tests/unit_tests/test_model_selector.py
+++ b/libs/code/tests/unit_tests/test_model_selector.py
@@ -2080,3 +2080,46 @@ enabled = false
             assert "openai" in providers
             assert "baseten" in providers
             assert providers.index("openai") < providers.index("baseten")
+
+    async def test_navigation_preserves_install_required_dim(self) -> None:
+        """Cursoring onto then off an install-required row keeps it dimmed.
+
+        Regression: `_move_selection` re-rendered the deselected row without
+        the `install_required` flag, so uninstalled rows turned bright after
+        the cursor passed over them and never reverted.
+        """
+        install_spec = "baseten:moonshotai/Kimi-K2.6"
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            app.show_selector()
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, ModelSelectorScreen)
+
+            screen._curated = False
+            screen._recommended_only = False
+            screen._install_extras = {"baseten": "baseten"}
+            screen._unfiltered_models = [
+                ("openai:gpt-5.5", "openai"),
+                (install_spec, "baseten"),
+            ]
+            screen._all_models = list(screen._unfiltered_models)
+            screen._filtered_models = list(screen._unfiltered_models)
+            screen._filter_text = ""
+            screen._selected_index = 0
+            await screen._update_display()
+            await pilot.pause()
+
+            install_widget = next(
+                w for w in screen._option_widgets if w.model_spec == install_spec
+            )
+            assert "dim" in install_widget.content.markup
+
+            # Move the cursor onto the install-required row, then back off it.
+            screen._move_selection(1)
+            await pilot.pause()
+            assert screen._selected_index == 1
+            screen._move_selection(-1)
+            await pilot.pause()
+
+            assert "dim" in install_widget.content.markup


### PR DESCRIPTION
Fix `/model` selector so install-required models stay dimmed after the cursor moves over them.

---

In the `/model` selector, install-required (greyed-out) models render dimmed, but `_move_selection` rebuilt the deselected row's label without the `install_required` flag — so once the cursor passed over an uninstalled row it turned bright (its provider's warning color) and never reverted, making the list inconsistent. The fix threads `install_required` through both label rebuilds in `_move_selection`.

Made by [Open SWE](https://openswe.vercel.app/agents/40830357-a2db-0a33-29c5-284f3af973eb)