### PR TITLE
feat(code): show provider in usage stats table

### DIFF
--- a/libs/code/deepagents_code/_session_stats.py
+++ b/libs/code/deepagents_code/_session_stats.py
@@ -23,11 +23,14 @@ class ModelStats:
         request_count: Number of LLM API requests made to this model.
         input_tokens: Cumulative input tokens sent to this model.
         output_tokens: Cumulative output tokens received from this model.
+        provider: Provider that served this model (e.g. `openai`), or `""`
+            when unknown.
     """
 
     request_count: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
+    provider: str = ""
 
 
 @dataclass
@@ -58,6 +61,7 @@ class SessionStats:
         model_name: str,
         input_toks: int,
         output_toks: int,
+        provider: str = "",
     ) -> None:
         """Accumulate token counts for one completed LLM request.
 
@@ -69,6 +73,8 @@ class SessionStats:
                 breakdown for this request.
             input_toks: Input tokens for this request.
             output_toks: Output tokens for this request.
+            provider: Provider that served the model (e.g. `openai`). Recorded
+                on the per-model entry for display alongside the model name.
         """
         self.request_count += 1
         self.input_tokens += input_toks
@@ -78,6 +84,8 @@ class SessionStats:
             entry.request_count += 1
             entry.input_tokens += input_toks
             entry.output_tokens += output_toks
+            if provider:
+                entry.provider = provider
 
     def merge(self, other: SessionStats) -> None:
         """Merge another `SessionStats` into this one (mutates *self*).
@@ -96,6 +104,8 @@ class SessionStats:
             entry.request_count += ms.request_count
             entry.input_tokens += ms.input_tokens
             entry.output_tokens += ms.output_tokens
+            if ms.provider:
+                entry.provider = ms.provider
 
 
 def format_token_count(count: int) -> str:

--- a/libs/code/deepagents_code/_session_stats.py
+++ b/libs/code/deepagents_code/_session_stats.py
@@ -36,6 +36,13 @@ class ModelStats:
 
 
 ModelStatsKey = tuple[str, str]
+"""Per-model dict key: the `(provider, model_name)` pair.
+
+Pairing the provider with the model name keeps the same model served by
+different providers (e.g. `gpt-5.5` via `openai` vs `azure`) in separate rows
+instead of collapsing them. The key is always built from the same values stored
+on the corresponding `ModelStats`, so key and fields never diverge.
+"""
 
 
 @dataclass
@@ -77,13 +84,14 @@ class SessionStats:
         Updates both the session totals and the per-model breakdown.
 
         Args:
-            model_name: The model that served this request (used as the
-                per-model key). Pass an empty string to skip the per-model
-                breakdown for this request.
+            model_name: The model that served this request. Combined with
+                `provider` to form the per-model key. Pass an empty string to
+                skip the per-model breakdown for this request.
             input_toks: Input tokens for this request.
             output_toks: Output tokens for this request.
-            provider: Provider that served the model (e.g. `openai`). Recorded
-                on the per-model entry for display alongside the model name.
+            provider: Provider that served the model (e.g. `openai`). Combined
+                with `model_name` to form the per-model key, so the same model
+                served by different providers is tracked separately.
         """
         self.request_count += 1
         self.input_tokens += input_toks

--- a/libs/code/deepagents_code/_session_stats.py
+++ b/libs/code/deepagents_code/_session_stats.py
@@ -17,44 +17,53 @@ SpinnerStatus = Literal["Thinking", "Offloading", "Loading thread"] | None
 
 @dataclass
 class ModelStats:
-    """Token stats for a single model within a session.
-
-    Attributes:
-        request_count: Number of LLM API requests made to this model.
-        input_tokens: Cumulative input tokens sent to this model.
-        output_tokens: Cumulative output tokens received from this model.
-        provider: Provider that served this model (e.g. `openai`), or `""`
-            when unknown.
-    """
+    """Token stats for a single model within a session."""
 
     request_count: int = 0
+    """Number of LLM API requests made to this model."""
+
     input_tokens: int = 0
+    """Cumulative input tokens sent to this model."""
+
     output_tokens: int = 0
+    """Cumulative output tokens received from this model."""
+
     provider: str = ""
+    """Provider that served this model (e.g. `openai`), or `""` when unknown."""
+
+    model_name: str = ""
+    """Model name displayed in usage output."""
+
+
+ModelStatsKey = tuple[str, str]
 
 
 @dataclass
 class SessionStats:
-    """Stats accumulated over a single agent turn (or full session).
-
-    Attributes:
-        request_count: Total LLM API requests made (each chunk with
-            usage_metadata counts as one completed request).
-        input_tokens: Cumulative input tokens across all LLM requests.
-        output_tokens: Cumulative output tokens across all LLM requests.
-        wall_time_seconds: Wall-clock duration from stream start to end.
-        per_model: Per-model breakdown keyed by model name.
-            Populated only when `record_request` receives a non-empty
-            `model_name`. Empty dict means no named-model requests were
-            recorded; `print_usage_table` omits the model table in that case and
-            shows only the wall-time line (if applicable).
-    """
+    """Stats accumulated over a single agent turn (or full session)."""
 
     request_count: int = 0
+    """Total LLM API requests made.
+
+    Each chunk with `usage_metadata` counts as one completed request.
+    """
+
     input_tokens: int = 0
+    """Cumulative input tokens across all LLM requests."""
+
     output_tokens: int = 0
+    """Cumulative output tokens across all LLM requests."""
+
     wall_time_seconds: float = 0.0
-    per_model: dict[str, ModelStats] = field(default_factory=dict)
+    """Wall-clock duration from stream start to end."""
+
+    per_model: dict[ModelStatsKey, ModelStats] = field(default_factory=dict)
+    """Per-model breakdown keyed by `(provider, model_name)`.
+
+    Populated only when `record_request` receives a non-empty `model_name`. Empty
+    dict means no named-model requests were recorded; `print_usage_table` omits
+    the model table in that case and shows only the wall-time line (if applicable).
+    """
 
     def record_request(
         self,
@@ -80,12 +89,14 @@ class SessionStats:
         self.input_tokens += input_toks
         self.output_tokens += output_toks
         if model_name:
-            entry = self.per_model.setdefault(model_name, ModelStats())
+            key = (provider, model_name)
+            entry = self.per_model.setdefault(
+                key,
+                ModelStats(provider=provider, model_name=model_name),
+            )
             entry.request_count += 1
             entry.input_tokens += input_toks
             entry.output_tokens += output_toks
-            if provider:
-                entry.provider = provider
 
     def merge(self, other: SessionStats) -> None:
         """Merge another `SessionStats` into this one (mutates *self*).
@@ -99,13 +110,14 @@ class SessionStats:
         self.input_tokens += other.input_tokens
         self.output_tokens += other.output_tokens
         self.wall_time_seconds += other.wall_time_seconds
-        for model, ms in other.per_model.items():
-            entry = self.per_model.setdefault(model, ModelStats())
+        for key, ms in other.per_model.items():
+            entry = self.per_model.setdefault(
+                key,
+                ModelStats(provider=ms.provider, model_name=ms.model_name),
+            )
             entry.request_count += ms.request_count
             entry.input_tokens += ms.input_tokens
             entry.output_tokens += ms.output_tokens
-            if ms.provider:
-                entry.provider = ms.provider
 
 
 def format_token_count(count: int) -> str:

--- a/libs/code/deepagents_code/non_interactive.py
+++ b/libs/code/deepagents_code/non_interactive.py
@@ -380,10 +380,13 @@ def _process_ai_message(
         output_toks = usage.get("output_tokens", 0)
         total_toks = usage.get("total_tokens", 0)
         active_model = settings.model_name or ""
+        active_provider = settings.model_provider or ""
         if input_toks or output_toks:
-            state.stats.record_request(active_model, input_toks, output_toks)
+            state.stats.record_request(
+                active_model, input_toks, output_toks, active_provider
+            )
         elif total_toks:
-            state.stats.record_request(active_model, total_toks, 0)
+            state.stats.record_request(active_model, total_toks, 0, active_provider)
 
     if not hasattr(message_obj, "content_blocks"):
         logger.debug("AIMessage missing content_blocks attribute, skipping")

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -107,8 +107,9 @@ def print_usage_table(
 ) -> None:
     """Print a model-usage stats table to a Rich console.
 
-    When the session spans multiple models each gets its own row with a
-    totals row appended; single-model sessions show one row.
+    Each row shows the serving provider alongside the model name. When the
+    session spans multiple models each gets its own row with a totals row
+    appended; single-model sessions show one row.
 
     Args:
         stats: Cumulative session stats.
@@ -131,6 +132,7 @@ def print_usage_table(
             padding=(0, 2, 0, 0),
             show_edge=False,
         )
+        table.add_column("Provider", style="dim")
         table.add_column("Model", style="dim")
         table.add_column("Reqs", justify="right", style="dim")
         table.add_column("InputTok", justify="right", style="dim")
@@ -139,12 +141,14 @@ def print_usage_table(
         if multi_model:
             for model_name, ms in stats.per_model.items():
                 table.add_row(
+                    ms.provider,
                     model_name,
                     str(ms.request_count),
                     format_token_count(ms.input_tokens),
                     format_token_count(ms.output_tokens),
                 )
             table.add_row(
+                "",
                 "Total",
                 str(stats.request_count),
                 format_token_count(stats.input_tokens),
@@ -153,6 +157,7 @@ def print_usage_table(
         else:
             model_label = next(iter(stats.per_model))
             table.add_row(
+                stats.per_model[model_label].provider,
                 model_label,
                 str(stats.request_count),
                 format_token_count(stats.input_tokens),
@@ -768,17 +773,23 @@ async def execute_task_textual(
                             from deepagents_code.config import settings
 
                             active_model = settings.model_name or ""
+                            active_provider = settings.model_provider or ""
                             if input_toks or output_toks:
                                 # Model gives split counts — preferred path
                                 turn_stats.record_request(
-                                    active_model, input_toks, output_toks
+                                    active_model,
+                                    input_toks,
+                                    output_toks,
+                                    active_provider,
                                 )
                                 captured_input_tokens = max(
                                     captured_input_tokens, input_toks + output_toks
                                 )
                             elif total_toks:
                                 # Fallback: model gives only total (no split)
-                                turn_stats.record_request(active_model, total_toks, 0)
+                                turn_stats.record_request(
+                                    active_model, total_toks, 0, active_provider
+                                )
                                 captured_input_tokens = max(
                                     captured_input_tokens, total_toks
                                 )

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -139,10 +139,10 @@ def print_usage_table(
         table.add_column("OutputTok", justify="right", style="dim")
 
         if multi_model:
-            for model_name, ms in stats.per_model.items():
+            for (_provider, model_name), ms in stats.per_model.items():
                 table.add_row(
                     ms.provider,
-                    model_name,
+                    ms.model_name or model_name,
                     str(ms.request_count),
                     format_token_count(ms.input_tokens),
                     format_token_count(ms.output_tokens),
@@ -155,10 +155,10 @@ def print_usage_table(
                 format_token_count(stats.output_tokens),
             )
         else:
-            model_label = next(iter(stats.per_model))
+            (_provider, model_name), ms = next(iter(stats.per_model.items()))
             table.add_row(
-                stats.per_model[model_label].provider,
-                model_label,
+                ms.provider,
+                ms.model_name or model_name,
                 str(stats.request_count),
                 format_token_count(stats.input_tokens),
                 format_token_count(stats.output_tokens),

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -50,6 +50,7 @@ from deepagents_code._ask_user_types import AskUserRequest
 from deepagents_code._cli_context import CLIContext  # noqa: TC001
 from deepagents_code._session_stats import (
     ModelStats as ModelStats,
+    ModelStatsKey as ModelStatsKey,
     SessionStats as SessionStats,
     SpinnerStatus as SpinnerStatus,
     format_token_count as format_token_count,
@@ -139,10 +140,10 @@ def print_usage_table(
         table.add_column("OutputTok", justify="right", style="dim")
 
         if multi_model:
-            for (_provider, model_name), ms in stats.per_model.items():
+            for ms in stats.per_model.values():
                 table.add_row(
                     ms.provider,
-                    ms.model_name or model_name,
+                    ms.model_name,
                     str(ms.request_count),
                     format_token_count(ms.input_tokens),
                     format_token_count(ms.output_tokens),
@@ -155,10 +156,10 @@ def print_usage_table(
                 format_token_count(stats.output_tokens),
             )
         else:
-            (_provider, model_name), ms = next(iter(stats.per_model.items()))
+            ms = next(iter(stats.per_model.values()))
             table.add_row(
                 ms.provider,
-                ms.model_name or model_name,
+                ms.model_name,
                 str(stats.request_count),
                 format_token_count(stats.input_tokens),
                 format_token_count(stats.output_tokens),

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -21,10 +21,12 @@ from deepagents_code.config import SHELL_ALLOW_ALL, ModelResult
 from deepagents_code.non_interactive import (
     _MAX_HITL_ITERATIONS,
     HITLIterationLimitError,
+    StreamState,
     ThreadUrlLookupState,
     _build_non_interactive_header,
     _collect_action_request_warnings,
     _make_hitl_decision,
+    _process_ai_message,
     _run_agent_loop,
     _run_startup_command,
     _start_langsmith_thread_url_lookup,
@@ -1625,6 +1627,53 @@ class TestRunStartupCommand:
 
         mock_spawn.assert_not_called()
         assert buf.getvalue() == ""
+
+
+class TestProcessAiMessageStats:
+    """`_process_ai_message` threads the active provider into usage stats.
+
+    Guards the wiring between `settings.model_provider` and
+    `SessionStats.record_request` — the per-model API is unit-tested in
+    isolation elsewhere, but these confirm the call site actually forwards the
+    configured provider.
+    """
+
+    def test_records_provider_from_settings(self, console: Console) -> None:
+        """Split input/output usage records the configured provider."""
+        state = StreamState()
+        message = AIMessage(
+            content="",
+            usage_metadata={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            },
+        )
+        with patch("deepagents_code.non_interactive.settings") as mock_settings:
+            mock_settings.model_name = "gpt-5.5"
+            mock_settings.model_provider = "openai"
+            _process_ai_message(message, state, console)
+
+        assert state.stats.per_model["openai", "gpt-5.5"].input_tokens == 100
+        assert state.stats.per_model["openai", "gpt-5.5"].output_tokens == 50
+
+    def test_records_provider_on_total_only_fallback(self, console: Console) -> None:
+        """Total-only usage (no split) still forwards the provider."""
+        state = StreamState()
+        message = AIMessage(
+            content="",
+            usage_metadata={
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 150,
+            },
+        )
+        with patch("deepagents_code.non_interactive.settings") as mock_settings:
+            mock_settings.model_name = "gpt-5.5"
+            mock_settings.model_provider = "openai"
+            _process_ai_message(message, state, console)
+
+        assert state.stats.per_model["openai", "gpt-5.5"].input_tokens == 150
 
 
 async def _async_iter(items: Sequence[object]) -> AsyncIterator[object]:  # noqa: RUF029

--- a/libs/code/tests/unit_tests/test_session_stats.py
+++ b/libs/code/tests/unit_tests/test_session_stats.py
@@ -57,6 +57,7 @@ class TestModelStats:
         assert stats.request_count == 0
         assert stats.input_tokens == 0
         assert stats.output_tokens == 0
+        assert stats.provider == ""
 
 
 class TestSessionStats:
@@ -104,6 +105,11 @@ class TestSessionStats:
         assert stats.request_count == 2
         assert stats.input_tokens == 300
 
+    def test_record_request_records_provider(self) -> None:
+        stats = SessionStats()
+        stats.record_request("gpt-5.5", 100, 50, provider="openai")
+        assert stats.per_model["gpt-5.5"].provider == "openai"
+
     def test_record_request_empty_model_skips_per_model(self) -> None:
         stats = SessionStats()
         stats.record_request("", 100, 50)
@@ -142,6 +148,14 @@ class TestSessionStats:
         assert a.per_model["gpt-5.5"].input_tokens == 300
         assert a.per_model["gpt-5.5"].request_count == 2
         assert a.per_model["claude-sonnet-4-5"].input_tokens == 300
+
+    def test_merge_carries_provider(self) -> None:
+        a = SessionStats()
+        b = SessionStats()
+        b.record_request("gpt-5.5", 200, 75, provider="openai")
+
+        a.merge(b)
+        assert a.per_model["gpt-5.5"].provider == "openai"
 
     def test_merge_empty_into_populated(self) -> None:
         a = SessionStats(request_count=5, input_tokens=500)

--- a/libs/code/tests/unit_tests/test_session_stats.py
+++ b/libs/code/tests/unit_tests/test_session_stats.py
@@ -89,26 +89,36 @@ class TestSessionStats:
     def test_record_request_populates_per_model(self) -> None:
         stats = SessionStats()
         stats.record_request("gpt-5.5", 100, 50)
-        assert "gpt-5.5" in stats.per_model
-        model = stats.per_model["gpt-5.5"]
+        assert ("", "gpt-5.5") in stats.per_model
+        model = stats.per_model["", "gpt-5.5"]
         assert model.request_count == 1
         assert model.input_tokens == 100
         assert model.output_tokens == 50
+        assert model.model_name == "gpt-5.5"
 
     def test_record_request_multiple_models(self) -> None:
         stats = SessionStats()
         stats.record_request("gpt-5.5", 100, 50)
         stats.record_request("claude-sonnet-4-5", 200, 75)
         assert len(stats.per_model) == 2
-        assert stats.per_model["gpt-5.5"].input_tokens == 100
-        assert stats.per_model["claude-sonnet-4-5"].input_tokens == 200
+        assert stats.per_model["", "gpt-5.5"].input_tokens == 100
+        assert stats.per_model["", "claude-sonnet-4-5"].input_tokens == 200
         assert stats.request_count == 2
         assert stats.input_tokens == 300
 
     def test_record_request_records_provider(self) -> None:
         stats = SessionStats()
         stats.record_request("gpt-5.5", 100, 50, provider="openai")
-        assert stats.per_model["gpt-5.5"].provider == "openai"
+        assert stats.per_model["openai", "gpt-5.5"].provider == "openai"
+
+    def test_record_request_splits_same_model_by_provider(self) -> None:
+        stats = SessionStats()
+        stats.record_request("gpt-5.5", 100, 50, provider="openai")
+        stats.record_request("gpt-5.5", 200, 75, provider="azure")
+
+        assert len(stats.per_model) == 2
+        assert stats.per_model["openai", "gpt-5.5"].input_tokens == 100
+        assert stats.per_model["azure", "gpt-5.5"].input_tokens == 200
 
     def test_record_request_empty_model_skips_per_model(self) -> None:
         stats = SessionStats()
@@ -145,9 +155,9 @@ class TestSessionStats:
         b.record_request("claude-sonnet-4-5", 300, 100)
 
         a.merge(b)
-        assert a.per_model["gpt-5.5"].input_tokens == 300
-        assert a.per_model["gpt-5.5"].request_count == 2
-        assert a.per_model["claude-sonnet-4-5"].input_tokens == 300
+        assert a.per_model["", "gpt-5.5"].input_tokens == 300
+        assert a.per_model["", "gpt-5.5"].request_count == 2
+        assert a.per_model["", "claude-sonnet-4-5"].input_tokens == 300
 
     def test_merge_carries_provider(self) -> None:
         a = SessionStats()
@@ -155,7 +165,19 @@ class TestSessionStats:
         b.record_request("gpt-5.5", 200, 75, provider="openai")
 
         a.merge(b)
-        assert a.per_model["gpt-5.5"].provider == "openai"
+        assert a.per_model["openai", "gpt-5.5"].provider == "openai"
+
+    def test_merge_splits_same_model_by_provider(self) -> None:
+        a = SessionStats()
+        a.record_request("gpt-5.5", 100, 50, provider="openai")
+
+        b = SessionStats()
+        b.record_request("gpt-5.5", 200, 75, provider="azure")
+
+        a.merge(b)
+        assert len(a.per_model) == 2
+        assert a.per_model["openai", "gpt-5.5"].input_tokens == 100
+        assert a.per_model["azure", "gpt-5.5"].input_tokens == 200
 
     def test_merge_empty_into_populated(self) -> None:
         a = SessionStats(request_count=5, input_tokens=500)

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -822,6 +822,58 @@ def _tool_chunk(
     return ((), "messages", (message, {}))
 
 
+def _usage_chunk(*, input_tokens: int, output_tokens: int) -> tuple[Any, ...]:
+    """Build a `messages`-stream chunk carrying only `usage_metadata`."""
+    from langchain_core.messages import AIMessageChunk
+
+    message = AIMessageChunk(
+        content="",
+        usage_metadata={
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        },
+    )
+    return ((), "messages", (message, {}))
+
+
+class TestExecuteTaskTextualUsageStats:
+    """`execute_task_textual` forwards the active provider into usage stats.
+
+    The per-model recording API is unit-tested directly elsewhere; this guards
+    the call site actually reading `settings.model_provider` and threading it
+    through `record_request`.
+    """
+
+    async def test_records_provider_from_settings(self) -> None:
+        """A usage chunk records the configured provider on `turn_stats`."""
+
+        async def mount_message(_: object) -> None:
+            await asyncio.sleep(0)
+
+        turn_stats = SessionStats()
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+
+        with patch("deepagents_code.config.settings") as mock_settings:
+            mock_settings.model_name = "gpt-5.5"
+            mock_settings.model_provider = "openai"
+            await execute_task_textual(
+                user_input="hello",
+                agent=_FakeAgent([_usage_chunk(input_tokens=100, output_tokens=50)]),
+                assistant_id="assistant",
+                session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+                adapter=adapter,
+                turn_stats=turn_stats,
+            )
+
+        assert turn_stats.per_model["openai", "gpt-5.5"].input_tokens == 100
+        assert turn_stats.per_model["openai", "gpt-5.5"].output_tokens == 50
+
+
 class TestExecuteTaskTextualToolCallStreaming:
     """Tests for incremental tool-call argument accumulation."""
 
@@ -2997,6 +3049,12 @@ class TestPrintUsageTable:
         assert "openai" in output
         assert "azure" in output
         assert "Total" in output
+        # Two distinct rows, not a collapsed one: each provider's per-row token
+        # counts must appear (100/50 and 200/80), alongside the 300/130 totals.
+        assert "100" in output
+        assert "50" in output
+        assert "200" in output
+        assert "80" in output
 
     def test_tokens_with_no_wall_time_omits_timing_line(self) -> None:
         """Token table should print but timing line should be absent."""

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -2807,10 +2807,10 @@ class TestSessionStats:
         assert stats.request_count == 1
         assert stats.input_tokens == 100
         assert stats.output_tokens == 50
-        assert "gpt-4" in stats.per_model
-        assert stats.per_model["gpt-4"].request_count == 1
-        assert stats.per_model["gpt-4"].input_tokens == 100
-        assert stats.per_model["gpt-4"].output_tokens == 50
+        assert ("", "gpt-4") in stats.per_model
+        assert stats.per_model["", "gpt-4"].request_count == 1
+        assert stats.per_model["", "gpt-4"].input_tokens == 100
+        assert stats.per_model["", "gpt-4"].output_tokens == 50
 
     def test_record_request_empty_model(self) -> None:
         """record_request with empty model skips per_model entry."""
@@ -2832,23 +2832,36 @@ class TestSessionStats:
         assert stats.input_tokens == 300
         assert stats.output_tokens == 130
         assert len(stats.per_model) == 2
-        assert stats.per_model["gpt-4"].request_count == 1
-        assert stats.per_model["claude-opus-4-6"].request_count == 1
+        assert stats.per_model["", "gpt-4"].request_count == 1
+        assert stats.per_model["", "claude-opus-4-6"].request_count == 1
+
+    def test_record_request_splits_same_model_by_provider(self) -> None:
+        """Provider-specific model names should not collapse into one entry."""
+        stats = SessionStats()
+        stats.record_request("gpt-4", 100, 50, provider="openai")
+        stats.record_request("gpt-4", 200, 80, provider="azure")
+
+        assert len(stats.per_model) == 2
+        assert stats.per_model["openai", "gpt-4"].request_count == 1
+        assert stats.per_model["azure", "gpt-4"].request_count == 1
 
     def test_merge(self) -> None:
         """merge() folds another SessionStats into self."""
         a = SessionStats(
             request_count=1, input_tokens=100, output_tokens=50, wall_time_seconds=1.0
         )
-        a.per_model["gpt-4"] = ModelStats(
-            request_count=1, input_tokens=100, output_tokens=50
+        a.per_model["", "gpt-4"] = ModelStats(
+            request_count=1, input_tokens=100, output_tokens=50, model_name="gpt-4"
         )
 
         b = SessionStats(
             request_count=2, input_tokens=300, output_tokens=120, wall_time_seconds=2.5
         )
-        b.per_model["claude-opus-4-6"] = ModelStats(
-            request_count=2, input_tokens=300, output_tokens=120
+        b.per_model["", "claude-opus-4-6"] = ModelStats(
+            request_count=2,
+            input_tokens=300,
+            output_tokens=120,
+            model_name="claude-opus-4-6",
         )
 
         a.merge(b)
@@ -2858,7 +2871,7 @@ class TestSessionStats:
         assert a.output_tokens == 170
         assert a.wall_time_seconds == pytest.approx(3.5)
         assert len(a.per_model) == 2
-        assert a.per_model["claude-opus-4-6"].request_count == 2
+        assert a.per_model["", "claude-opus-4-6"].request_count == 2
 
     def test_merge_overlapping_models(self) -> None:
         """merge() combines per_model entries for the same model."""
@@ -2873,9 +2886,23 @@ class TestSessionStats:
         assert a.request_count == 2
         assert a.input_tokens == 300
         assert a.output_tokens == 130
-        assert a.per_model["gpt-4"].request_count == 2
-        assert a.per_model["gpt-4"].input_tokens == 300
-        assert a.per_model["gpt-4"].output_tokens == 130
+        assert a.per_model["", "gpt-4"].request_count == 2
+        assert a.per_model["", "gpt-4"].input_tokens == 300
+        assert a.per_model["", "gpt-4"].output_tokens == 130
+
+    def test_merge_splits_same_model_by_provider(self) -> None:
+        """merge() preserves provider-specific entries for the same model."""
+        a = SessionStats()
+        a.record_request("gpt-4", 100, 50, provider="openai")
+
+        b = SessionStats()
+        b.record_request("gpt-4", 200, 80, provider="azure")
+
+        a.merge(b)
+
+        assert len(a.per_model) == 2
+        assert a.per_model["openai", "gpt-4"].input_tokens == 100
+        assert a.per_model["azure", "gpt-4"].input_tokens == 200
 
 
 # ---------------------------------------------------------------------------
@@ -2957,6 +2984,19 @@ class TestPrintUsageTable:
         assert "claude-opus-4-6" in output
         assert "Total" in output
         assert "unknown" not in output
+
+    def test_same_model_with_different_providers_shows_separate_rows(self) -> None:
+        """Same-name models from different providers should render separately."""
+        stats = SessionStats()
+        stats.record_request("gpt-4", 100, 50, provider="openai")
+        stats.record_request("gpt-4", 200, 80, provider="azure")
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True)
+        print_usage_table(stats, wall_time=2.0, console=console)
+        output = buf.getvalue()
+        assert "openai" in output
+        assert "azure" in output
+        assert "Total" in output
 
     def test_tokens_with_no_wall_time_omits_timing_line(self) -> None:
         """Token table should print but timing line should be absent."""

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -2932,6 +2932,18 @@ class TestPrintUsageTable:
         assert "gpt-4" in output
         assert "unknown" not in output
 
+    def test_shows_provider_name(self) -> None:
+        """The table should include the provider for each model."""
+        stats = SessionStats()
+        stats.record_request("gpt-4", 100, 50, provider="openai")
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True)
+        print_usage_table(stats, wall_time=2.0, console=console)
+        output = buf.getvalue()
+        assert "Provider" in output
+        assert "openai" in output
+        assert "gpt-4" in output
+
     def test_multi_model_shows_all_names_and_total(self) -> None:
         """Multi-model session should show each model and a Total row."""
         stats = SessionStats()


### PR DESCRIPTION
## Description
The session teardown usage stats table listed only the model name, so multi-provider sessions were ambiguous. This adds the serving provider, sourced from `settings.model_provider` and threaded through `record_request` at both usage call sites (`non_interactive` and the Textual streaming loop).

The per-model breakdown is now keyed by the `(provider, model_name)` pair rather than the model name alone, so the same model served by two providers (e.g. `gpt-5.5` via `openai` vs `azure`) renders as separate rows instead of collapsing into one. A new `Provider` column displays the value, with totals in a trailing row for multi-model sessions.

## Release Note
The model usage stats table shown on exit now includes the provider name alongside the model name.

## Tests
Coverage is automated, so no manual verification is needed:
- The recording API (`SessionStats.record_request` / `merge`) is unit-tested for provider capture and same-model/different-provider splitting.
- Call-site wiring is covered end-to-end — both `non_interactive` and `execute_task_textual` are exercised to confirm `settings.model_provider` actually reaches `record_request`, including the `total_tokens`-only fallback path.
- `print_usage_table` rendering asserts the `Provider` column and that same-name models from different providers produce distinct rows with their own per-row token counts.

Made by [Open SWE](https://openswe.vercel.app/agents/98964857-39db-630c-b2b6-40b8fd726bc3)