### PR TITLE
fix(code): rescaffold server workspace on `/restart` when config is missing

### DIFF
--- a/libs/code/deepagents_code/server.py
+++ b/libs/code/deepagents_code/server.py
@@ -367,6 +367,7 @@ class ServerProcess:
         port: int = _DEFAULT_PORT,
         config_dir: str | Path | None = None,
         owns_config_dir: bool = False,
+        scaffold: Callable[[Path], None] | None = None,
     ) -> None:
         """Initialize server process manager.
 
@@ -379,11 +380,17 @@ class ServerProcess:
             config_dir: Directory containing `langgraph.json`.
             owns_config_dir: When `True`, the server will delete `config_dir`
                 on `stop()`.
+            scaffold: Optional callable that (re)generates the working
+                directory's `langgraph.json` and supporting files. When the
+                config is missing at `start()` (e.g. the temp dir was purged
+                between the initial boot and a later `/restart`), it is invoked
+                to rebuild the workspace instead of failing.
         """
         self.host = host
         self.port = port
         self.config_dir = Path(config_dir) if config_dir else None
         self._owns_config_dir = owns_config_dir
+        self._scaffold = scaffold
         self._process: subprocess.Popen | None = None
         self._temp_dir: tempfile.TemporaryDirectory | None = None
         self._log_file: tempfile.NamedTemporaryFile | None = None  # ty: ignore[invalid-type-form]
@@ -442,6 +449,13 @@ class ServerProcess:
             work_dir = Path(self._temp_dir.name)
 
         config_path = work_dir / "langgraph.json"
+        if not config_path.exists() and self._scaffold is not None:
+            # The config can vanish between the initial boot and a later
+            # `/restart` (e.g. the OS tmp reaper purging the temp work dir).
+            # Rebuild it rather than failing the restart.
+            logger.info("langgraph.json missing in %s; rescaffolding", work_dir)
+            work_dir.mkdir(parents=True, exist_ok=True)
+            self._scaffold(work_dir)
         if not config_path.exists():
             msg = (
                 f"langgraph.json not found in {work_dir}. "

--- a/libs/code/deepagents_code/server.py
+++ b/libs/code/deepagents_code/server.py
@@ -454,13 +454,32 @@ class ServerProcess:
             # `/restart` (e.g. the OS tmp reaper purging the temp work dir).
             # Rebuild it rather than failing the restart.
             logger.info("langgraph.json missing in %s; rescaffolding", work_dir)
-            work_dir.mkdir(parents=True, exist_ok=True)
-            self._scaffold(work_dir)
+            try:
+                work_dir.mkdir(parents=True, exist_ok=True)
+                self._scaffold(work_dir)
+            except OSError as exc:
+                # Surface the failure with restart context instead of letting a
+                # bare OSError (e.g. ENOSPC/EACCES on a degraded temp fs) escape
+                # stripped of the recovery framing. Chained so the root cause
+                # stays in the traceback.
+                msg = f"Failed to rescaffold server workspace at {work_dir}: {exc}"
+                raise RuntimeError(msg) from exc
         if not config_path.exists():
-            msg = (
-                f"langgraph.json not found in {work_dir}. "
-                "Call generate_langgraph_json() first."
-            )
+            if self._scaffold is not None:
+                # The scaffold hook ran but produced no langgraph.json (a silent
+                # no-op or a write to the wrong path). The "call
+                # generate_langgraph_json() first" advice below would misdirect,
+                # since the scaffold is exactly that call run internally.
+                contents = sorted(p.name for p in work_dir.iterdir())
+                msg = (
+                    f"Rescaffolding {work_dir} did not produce langgraph.json "
+                    f"(directory contents: {contents})."
+                )
+            else:
+                msg = (
+                    f"langgraph.json not found in {work_dir}. "
+                    "Call generate_langgraph_json() first."
+                )
             raise RuntimeError(msg)
 
         if _port_in_use(self.host, self.port):

--- a/libs/code/deepagents_code/server_manager.py
+++ b/libs/code/deepagents_code/server_manager.py
@@ -366,7 +366,11 @@ async def start_server_and_get_agent(
     _scaffold_workspace(work_dir)
 
     server = ServerProcess(
-        host=host, port=port, config_dir=work_dir, owns_config_dir=True
+        host=host,
+        port=port,
+        config_dir=work_dir,
+        owns_config_dir=True,
+        scaffold=_scaffold_workspace,
     )
     try:
         await server.start()

--- a/libs/code/tests/unit_tests/test_server.py
+++ b/libs/code/tests/unit_tests/test_server.py
@@ -247,6 +247,54 @@ class TestServerProcess:
         assert not config_dir.exists()
         assert not log_path.exists()
 
+    async def test_start_rescaffolds_when_config_missing(self, tmp_path: Path) -> None:
+        """A missing langgraph.json should be rebuilt via the scaffold hook."""
+        config_dir = tmp_path / "runtime"
+        config_dir.mkdir()
+
+        def scaffold(work_dir: Path) -> None:
+            (work_dir / "langgraph.json").write_text("{}")
+
+        scaffold_mock = MagicMock(side_effect=scaffold)
+
+        process = MagicMock()
+        process.pid = 1234
+        process.poll.return_value = None
+
+        log_file = MagicMock()
+        log_file.name = str(tmp_path / "server.log")
+
+        server = ServerProcess(config_dir=config_dir, scaffold=scaffold_mock)
+
+        with (
+            patch("deepagents_code.server._port_in_use", return_value=False),
+            patch(
+                "deepagents_code.server.tempfile.NamedTemporaryFile",
+                return_value=log_file,
+            ),
+            patch("deepagents_code.server.subprocess.Popen", return_value=process),
+            patch(
+                "deepagents_code.server.wait_for_server_healthy",
+                new=AsyncMock(),
+            ),
+        ):
+            await server.start()
+
+        scaffold_mock.assert_called_once_with(config_dir)
+        assert (config_dir / "langgraph.json").exists()
+
+    async def test_start_raises_when_scaffold_does_not_restore_config(
+        self, tmp_path: Path
+    ) -> None:
+        """If the scaffold hook fails to recreate the config, start still raises."""
+        config_dir = tmp_path / "runtime"
+        config_dir.mkdir()
+
+        server = ServerProcess(config_dir=config_dir, scaffold=MagicMock())
+
+        with pytest.raises(RuntimeError, match=r"langgraph\.json not found"):
+            await server.start()
+
     async def test_update_env_and_restart(self, tmp_path: Path) -> None:
         """update_env stages overrides that restart() applies."""
         config_dir = tmp_path / "runtime"

--- a/libs/code/tests/unit_tests/test_server.py
+++ b/libs/code/tests/unit_tests/test_server.py
@@ -286,14 +286,177 @@ class TestServerProcess:
     async def test_start_raises_when_scaffold_does_not_restore_config(
         self, tmp_path: Path
     ) -> None:
-        """If the scaffold hook fails to recreate the config, start still raises."""
+        """A scaffold hook that runs but produces no config still raises.
+
+        The error must report the failed rescaffold (not the misleading
+        "call generate_langgraph_json() first") and the hook must have run.
+        """
         config_dir = tmp_path / "runtime"
         config_dir.mkdir()
 
-        server = ServerProcess(config_dir=config_dir, scaffold=MagicMock())
+        scaffold_mock = MagicMock()
+        server = ServerProcess(config_dir=config_dir, scaffold=scaffold_mock)
+
+        with pytest.raises(RuntimeError, match=r"did not produce langgraph\.json"):
+            await server.start()
+
+        scaffold_mock.assert_called_once_with(config_dir)
+
+    async def test_start_raises_without_scaffold_when_config_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """With no scaffold hook, a missing config raises the original error."""
+        config_dir = tmp_path / "runtime"
+        config_dir.mkdir()
+
+        server = ServerProcess(config_dir=config_dir)
 
         with pytest.raises(RuntimeError, match=r"langgraph\.json not found"):
             await server.start()
+
+    async def test_start_wraps_scaffold_oserror(self, tmp_path: Path) -> None:
+        """An OSError raised mid-scaffold surfaces as RuntimeError, cause kept."""
+        config_dir = tmp_path / "runtime"
+        config_dir.mkdir()
+
+        boom = OSError("No space left on device")
+        server = ServerProcess(
+            config_dir=config_dir, scaffold=MagicMock(side_effect=boom)
+        )
+
+        with pytest.raises(RuntimeError, match=r"Failed to rescaffold") as exc_info:
+            await server.start()
+
+        assert exc_info.value.__cause__ is boom
+
+    async def test_start_creates_work_dir_when_purged(self, tmp_path: Path) -> None:
+        """A fully purged work dir is recreated before the scaffold runs.
+
+        Exercises the `mkdir(parents=True)` recovery: the directory itself —
+        not just `langgraph.json` — is gone (the OS tmp reaper removing the
+        whole temp dir), so the scaffold would fail without the mkdir.
+        """
+        # Deliberately not created: the directory is missing entirely.
+        config_dir = tmp_path / "runtime"
+
+        def scaffold(work_dir: Path) -> None:
+            (work_dir / "langgraph.json").write_text("{}")
+
+        scaffold_mock = MagicMock(side_effect=scaffold)
+
+        process = MagicMock()
+        process.pid = 1234
+        process.poll.return_value = None
+
+        log_file = MagicMock()
+        log_file.name = str(tmp_path / "server.log")
+
+        server = ServerProcess(config_dir=config_dir, scaffold=scaffold_mock)
+
+        with (
+            patch("deepagents_code.server._port_in_use", return_value=False),
+            patch(
+                "deepagents_code.server.tempfile.NamedTemporaryFile",
+                return_value=log_file,
+            ),
+            patch("deepagents_code.server.subprocess.Popen", return_value=process),
+            patch(
+                "deepagents_code.server.wait_for_server_healthy",
+                new=AsyncMock(),
+            ),
+        ):
+            await server.start()
+
+        scaffold_mock.assert_called_once_with(config_dir)
+        assert config_dir.is_dir()
+        assert (config_dir / "langgraph.json").exists()
+
+    async def test_start_does_not_rescaffold_when_config_present(
+        self, tmp_path: Path
+    ) -> None:
+        """The scaffold hook is a recovery path only; skip it when config exists."""
+        config_dir = tmp_path / "runtime"
+        config_dir.mkdir()
+        (config_dir / "langgraph.json").write_text("{}")
+
+        scaffold_mock = MagicMock()
+
+        process = MagicMock()
+        process.pid = 1234
+        process.poll.return_value = None
+
+        log_file = MagicMock()
+        log_file.name = str(tmp_path / "server.log")
+
+        server = ServerProcess(config_dir=config_dir, scaffold=scaffold_mock)
+
+        with (
+            patch("deepagents_code.server._port_in_use", return_value=False),
+            patch(
+                "deepagents_code.server.tempfile.NamedTemporaryFile",
+                return_value=log_file,
+            ),
+            patch("deepagents_code.server.subprocess.Popen", return_value=process),
+            patch(
+                "deepagents_code.server.wait_for_server_healthy",
+                new=AsyncMock(),
+            ),
+        ):
+            await server.start()
+
+        scaffold_mock.assert_not_called()
+
+    async def test_restart_rescaffolds_after_config_purged(
+        self, tmp_path: Path
+    ) -> None:
+        """restart() rebuilds a config purged between boot and the restart.
+
+        This is the motivating scenario: the server boots with config present,
+        the work dir is purged externally, and a later `/restart` recovers via
+        the scaffold hook rather than failing.
+        """
+        config_dir = tmp_path / "runtime"
+        config_dir.mkdir()
+        config_path = config_dir / "langgraph.json"
+        config_path.write_text("{}")
+
+        def scaffold(work_dir: Path) -> None:
+            (work_dir / "langgraph.json").write_text("{}")
+
+        scaffold_mock = MagicMock(side_effect=scaffold)
+
+        process = MagicMock()
+        process.pid = 1234
+        process.poll.return_value = None
+
+        log_file = MagicMock()
+        log_file.name = str(tmp_path / "server.log")
+
+        server = ServerProcess(config_dir=config_dir, scaffold=scaffold_mock)
+
+        with (
+            patch("deepagents_code.server._port_in_use", return_value=False),
+            patch(
+                "deepagents_code.server.tempfile.NamedTemporaryFile",
+                return_value=log_file,
+            ),
+            patch("deepagents_code.server.subprocess.Popen", return_value=process),
+            patch(
+                "deepagents_code.server.wait_for_server_healthy",
+                new=AsyncMock(),
+            ),
+        ):
+            await server.start()
+            # Config present on boot: the scaffold hook must not have fired yet.
+            scaffold_mock.assert_not_called()
+
+            # Simulate the OS tmp reaper purging the work dir.
+            config_path.unlink()
+
+            await server.restart()
+
+        scaffold_mock.assert_called_once_with(config_dir)
+        assert config_path.exists()
 
     async def test_update_env_and_restart(self, tmp_path: Path) -> None:
         """update_env stages overrides that restart() applies."""

--- a/libs/code/tests/unit_tests/test_server_manager.py
+++ b/libs/code/tests/unit_tests/test_server_manager.py
@@ -180,6 +180,42 @@ class TestStartServerAndGetAgent:
         assert kwargs["graph_ref"] == "./server_graph.py:graph"
         assert kwargs["checkpointer_path"] == "./checkpointer.py:create_checkpointer"
 
+    async def test_passes_scaffold_hook_to_server_process(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """ServerProcess should receive the scaffold hook for restart recovery."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        monkeypatch.chdir(project_root)
+
+        work_dir = tmp_path / "runtime"
+        work_dir.mkdir()
+
+        mock_server = MagicMock()
+        mock_server.start = AsyncMock()
+        mock_server.url = "http://127.0.0.1:2024"
+
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch(
+                "deepagents_code.server_manager.tempfile.mkdtemp",
+                return_value=str(work_dir),
+            ),
+            patch(
+                "deepagents_code.server_manager._scaffold_workspace"
+            ) as mock_scaffold,
+            patch(
+                "deepagents_code.server.ServerProcess", return_value=mock_server
+            ) as mock_server_process,
+            patch("deepagents_code.remote_client.RemoteAgent", return_value=object()),
+        ):
+            await start_server_and_get_agent(
+                assistant_id="agent",
+                mcp_config_path=None,
+            )
+
+        assert mock_server_process.call_args.kwargs["scaffold"] is mock_scaffold
+
     def test_relative_paths_written_verbatim_to_langgraph_json(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Fix `/restart` failing with "langgraph.json not found" when the server's temp working directory was purged.

---

The `langgraph dev` server runs from a temp work dir scaffolded at boot. If that dir's `langgraph.json` vanishes before a later `/restart` (e.g. the OS tmp reaper purging `$TMPDIR`), the restart failed with `RuntimeError: langgraph.json not found ... Call generate_langgraph_json() first` — exactly the error users hit after `/install <extra>` auto-restarts. `ServerProcess` now takes a scaffold hook and rebuilds the workspace when the config is missing instead of failing.

Made by [Open SWE](https://openswe.vercel.app/agents/3bf48cdb-540d-2913-5fe1-8846646f7ab8)