### PR TITLE
fix(code): read `LANGSMITH_PROJECT` for `tracing.langsmith_project` + show default

### DIFF
--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -2378,6 +2378,7 @@ def get_langsmith_project_name() -> str | None:
     Returns:
         Project name string when LangSmith tracing is active, None otherwise.
     """
+    from deepagents_code.config_manifest import LANGSMITH_PROJECT_DEFAULT
     from deepagents_code.model_config import resolve_env_var
 
     langsmith_key = resolve_env_var("LANGSMITH_API_KEY") or resolve_env_var(
@@ -2392,7 +2393,7 @@ def get_langsmith_project_name() -> str | None:
     return (
         _get_settings().deepagents_langchain_project
         or os.environ.get("LANGSMITH_PROJECT")
-        or "deepagents-code"
+        or LANGSMITH_PROJECT_DEFAULT
     )
 
 

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -221,9 +221,24 @@ class ConfigOption:
         `resolve_scalar`. Catching it here fails the import (and the test suite).
 
         Raises:
-            TypeError: When `default` is mutable, a `STRUCTURED` option declares
-                a default, or a scalar option's default has the wrong type.
+            TypeError: When `fallback_env_vars` is not a tuple of non-empty
+                strings, `default` is mutable, a `STRUCTURED` option declares a
+                default, or a scalar option's default has the wrong type.
         """
+        # Guard `fallback_env_vars` independently of `default` (which has its own
+        # early-return path below): like `default`, it is shared by reference
+        # through the `get_config_options` `lru_cache`, so a mutable value (a
+        # `list`) would reintroduce the aliasing hazard the default guard exists
+        # to prevent. Empty names never match any env var, so reject those too.
+        if not isinstance(self.fallback_env_vars, tuple) or any(
+            not isinstance(name, str) or not name for name in self.fallback_env_vars
+        ):
+            msg = (
+                f"{self.key}: fallback_env_vars must be a tuple of non-empty "
+                f"strings, got {self.fallback_env_vars!r}"
+            )
+            raise TypeError(msg)
+
         default = self.default
         if default is None:
             if self.invert_toml_bool:
@@ -512,14 +527,19 @@ def resolve_scalar(
         option: The option to resolve.
         toml_data: Parsed `config.toml` mapping (see `load_config_toml`).
 
+    Resolution order is: the prefixed primary `env_var`, then each
+    `fallback_env_vars` name in declaration order, then `config.toml`, then the
+    typed `default`.
+
     Returns:
         `(value, source)`, where `source` is `env (<name>)`, `config.toml`, or
         `default`. A malformed `int`/`float`/list/PTC value, an unrecognized
         boolean token, or any TOML value of the wrong type is logged and skipped
         so the next layer (or the typed default) applies. An empty env value is
         treated as unset (mirroring `resolve_env_var`), so it falls through to
-        `config.toml`/`default` rather than counting as set. Theme resolution
-        (`THEME_DELEGATE`) reports its own richer `config.toml [ui.*]` sources.
+        the next env var, then `config.toml`/`default`, rather than counting as
+        set. Theme resolution (`THEME_DELEGATE`) reports its own richer
+        `config.toml [ui.*]` sources.
     """
     if option.kind is OptionKind.THEME_DELEGATE:
         return _resolve_theme(toml_data)
@@ -531,10 +551,12 @@ def resolve_scalar(
         if option.env_var:
             names.append(resolved_env_var_name(option.env_var))
         names.extend(option.fallback_env_vars)
-        # An empty string counts as unset, matching `resolve_env_var`: this
-        # keeps `config show`/`get` aligned with what the runtime reads (and
-        # lets a prefixed empty var suppress a canonical one). Fallbacks are
-        # tried in order so a bare `LANGSMITH_PROJECT` still resolves.
+        # An empty string counts as unset, matching `resolve_env_var`, so it is
+        # skipped and the loop continues to the next name. This keeps
+        # `config show`/`get` aligned with what the runtime reads: e.g. an empty
+        # prefixed `DEEPAGENTS_CODE_LANGSMITH_PROJECT` falls through to a bare
+        # `LANGSMITH_PROJECT`, mirroring `get_langsmith_project_name`. Names are
+        # tried in order, so the primary `env_var` wins over any fallback.
         for name in names:
             raw = os.environ.get(name)
             if not raw:

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -58,6 +58,12 @@ INTERPRETER_MAX_RESULT_CHARS_DEFAULT = 4000
 INTERPRETER_PTC_DEFAULT: str | bool | list[str] = False
 INTERPRETER_PTC_ACKNOWLEDGE_UNSAFE_DEFAULT = False
 
+LANGSMITH_PROJECT_DEFAULT = "deepagents-code"
+"""Project agent traces fall back to when no project env var is set.
+
+Single source of truth shared by the `tracing.langsmith_project` option and
+`config.get_langsmith_project_name`."""
+
 
 class OptionKind(Enum):
     """How an option's raw env/TOML value is coerced to a typed value.
@@ -161,6 +167,14 @@ class ConfigOption:
 
     For provider credentials this is the canonical name; the
     `DEEPAGENTS_CODE_` prefix override is applied dynamically at resolution time.
+    """
+
+    fallback_env_vars: tuple[str, ...] = ()
+    """Secondary env vars read (in order) when `env_var` is unset.
+
+    Read literally — no `DEEPAGENTS_CODE_` prefix logic — so `config show`/`get`
+    mirror runtime fallbacks such as `get_langsmith_project_name` reading bare
+    `LANGSMITH_PROJECT`.
     """
 
     toml_keys: tuple[str, ...] | None = None
@@ -510,15 +524,21 @@ def resolve_scalar(
     if option.kind is OptionKind.THEME_DELEGATE:
         return _resolve_theme(toml_data)
 
-    if option.env_var:
+    if option.env_var or option.fallback_env_vars:
         from deepagents_code.model_config import resolved_env_var_name
 
-        name = resolved_env_var_name(option.env_var)
+        names: list[str] = []
+        if option.env_var:
+            names.append(resolved_env_var_name(option.env_var))
+        names.extend(option.fallback_env_vars)
         # An empty string counts as unset, matching `resolve_env_var`: this
         # keeps `config show`/`get` aligned with what the runtime reads (and
-        # lets a prefixed empty var suppress a canonical one).
-        raw = os.environ.get(name)
-        if raw:
+        # lets a prefixed empty var suppress a canonical one). Fallbacks are
+        # tried in order so a bare `LANGSMITH_PROJECT` still resolves.
+        for name in names:
+            raw = os.environ.get(name)
+            if not raw:
+                continue
             value = _coerce_env(option, raw, name)
             if value is not _INVALID:
                 return value, f"env ({name})"
@@ -819,7 +839,9 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         group="Models",
         summary="LangSmith project name for deepagents agent traces.",
         kind=OptionKind.STR,
+        default=LANGSMITH_PROJECT_DEFAULT,
         env_var=_env_vars.LANGSMITH_PROJECT,
+        fallback_env_vars=("LANGSMITH_PROJECT",),
         settings_field="deepagents_langchain_project",
     ),
     ConfigOption(

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -1785,7 +1785,9 @@ class TestGetLangsmithProjectName:
             assert get_langsmith_project_name() == "env-project"
 
     def test_falls_back_to_default(self) -> None:
-        """Should fall back to 'deepagents-code' when no project name configured."""
+        """Should fall back to the default project when none is configured."""
+        from deepagents_code.config_manifest import LANGSMITH_PROJECT_DEFAULT
+
         env = {
             "LANGSMITH_API_KEY": "lsv2_test",
             "LANGSMITH_TRACING": "true",
@@ -1795,10 +1797,12 @@ class TestGetLangsmithProjectName:
             patch("deepagents_code.config.settings") as mock_settings,
         ):
             mock_settings.deepagents_langchain_project = None
-            assert get_langsmith_project_name() == "deepagents-code"
+            assert get_langsmith_project_name() == LANGSMITH_PROJECT_DEFAULT
 
     def test_accepts_langchain_api_key(self) -> None:
         """Should accept LANGCHAIN_API_KEY as alternative to LANGSMITH_API_KEY."""
+        from deepagents_code.config_manifest import LANGSMITH_PROJECT_DEFAULT
+
         env = {
             "LANGSMITH_API_KEY": "",
             "LANGCHAIN_API_KEY": "lsv2_test",
@@ -1809,7 +1813,58 @@ class TestGetLangsmithProjectName:
             patch("deepagents_code.config.settings") as mock_settings,
         ):
             mock_settings.deepagents_langchain_project = None
-            assert get_langsmith_project_name() == "deepagents-code"
+            assert get_langsmith_project_name() == LANGSMITH_PROJECT_DEFAULT
+
+    def test_agrees_with_config_manifest_resolution(self) -> None:
+        """`get_langsmith_project_name` and `resolve_scalar` agree on the project.
+
+        The `fallback_env_vars` mechanism exists so `config show`/`get` report
+        the project agent traces actually route to. This pins that parity for
+        the bare-env and unset cases, catching future drift between the two
+        resolution paths.
+        """
+        from deepagents_code.config_manifest import (
+            LANGSMITH_PROJECT_DEFAULT,
+            get_option,
+            resolve_scalar,
+        )
+
+        opt = get_option("tracing.langsmith_project")
+        assert opt is not None
+
+        # Bare `LANGSMITH_PROJECT` set, no prefixed override, no settings value.
+        bare_env = {
+            "LANGSMITH_API_KEY": "lsv2_test",
+            "LANGSMITH_TRACING": "true",
+            "LANGSMITH_PROJECT": "parity-bare",
+            "DEEPAGENTS_CODE_LANGSMITH_PROJECT": "",
+        }
+        with (
+            patch.dict("os.environ", bare_env, clear=False),
+            patch("deepagents_code.config.settings") as mock_settings,
+        ):
+            mock_settings.deepagents_langchain_project = None
+            manifest_value, _ = resolve_scalar(opt, toml_data={})
+            assert get_langsmith_project_name() == manifest_value == "parity-bare"
+
+        # Nothing configured: both fall back to the shared default.
+        default_env = {
+            "LANGSMITH_API_KEY": "lsv2_test",
+            "LANGSMITH_TRACING": "true",
+            "LANGSMITH_PROJECT": "",
+            "DEEPAGENTS_CODE_LANGSMITH_PROJECT": "",
+        }
+        with (
+            patch.dict("os.environ", default_env, clear=False),
+            patch("deepagents_code.config.settings") as mock_settings,
+        ):
+            mock_settings.deepagents_langchain_project = None
+            manifest_value, _ = resolve_scalar(opt, toml_data={})
+            assert (
+                get_langsmith_project_name()
+                == manifest_value
+                == LANGSMITH_PROJECT_DEFAULT
+            )
 
 
 class TestDisableOrphanedTracing:

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -284,6 +284,41 @@ def test_resolve_empty_env_is_unset_matching_resolve_env_var(monkeypatch) -> Non
     assert value is None
 
 
+def test_langsmith_project_prefers_prefixed_env(monkeypatch) -> None:
+    """The prefixed project env var wins over a bare `LANGSMITH_PROJECT`."""
+    opt = get_option("tracing.langsmith_project")
+    assert opt is not None
+    monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_PROJECT", "prefixed")
+    monkeypatch.setenv("LANGSMITH_PROJECT", "bare")
+    value, source = resolve_scalar(opt, toml_data={})
+    assert (value, source) == ("prefixed", "env (DEEPAGENTS_CODE_LANGSMITH_PROJECT)")
+
+
+def test_langsmith_project_falls_back_to_bare_env(monkeypatch) -> None:
+    """A bare `LANGSMITH_PROJECT` resolves when the prefixed var is unset.
+
+    Mirrors `get_langsmith_project_name`, so `config show`/`get` report the
+    project agent traces actually route to.
+    """
+    opt = get_option("tracing.langsmith_project")
+    assert opt is not None
+    monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_PROJECT", raising=False)
+    monkeypatch.setenv("LANGSMITH_PROJECT", "bare")
+    value, source = resolve_scalar(opt, toml_data={})
+    assert (value, source) == ("bare", "env (LANGSMITH_PROJECT)")
+
+
+def test_langsmith_project_default_when_unset(monkeypatch) -> None:
+    """With no project env var set, the default project name is rendered."""
+    from deepagents_code.config_manifest import LANGSMITH_PROJECT_DEFAULT
+
+    opt = get_option("tracing.langsmith_project")
+    assert opt is not None
+    monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_PROJECT", raising=False)
+    monkeypatch.delenv("LANGSMITH_PROJECT", raising=False)
+    assert resolve_scalar(opt, toml_data={}) == (LANGSMITH_PROJECT_DEFAULT, "default")
+
+
 def test_run_show_json_redacts_every_secret(monkeypatch, capsys) -> None:
     """The `config show` aggregate (separate path from `get`) never leaks a secret."""
     import json

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -319,6 +319,82 @@ def test_langsmith_project_default_when_unset(monkeypatch) -> None:
     assert resolve_scalar(opt, toml_data={}) == (LANGSMITH_PROJECT_DEFAULT, "default")
 
 
+def test_langsmith_project_empty_prefixed_falls_through_to_bare(monkeypatch) -> None:
+    """An empty prefixed var is skipped, so a set bare `LANGSMITH_PROJECT` wins.
+
+    This is the opposite of the single-name credential path
+    (`test_resolve_empty_env_is_unset_matching_resolve_env_var`): with a
+    fallback declared, an empty prefixed var does not suppress resolution — it
+    falls through to the next name, matching `get_langsmith_project_name`.
+    """
+    opt = get_option("tracing.langsmith_project")
+    assert opt is not None
+    monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_PROJECT", "")
+    monkeypatch.setenv("LANGSMITH_PROJECT", "bare")
+    value, source = resolve_scalar(opt, toml_data={})
+    assert (value, source) == ("bare", "env (LANGSMITH_PROJECT)")
+
+
+def test_langsmith_project_empty_bare_is_default(monkeypatch) -> None:
+    """An empty bare `LANGSMITH_PROJECT` is unset, so the default applies."""
+    from deepagents_code.config_manifest import LANGSMITH_PROJECT_DEFAULT
+
+    opt = get_option("tracing.langsmith_project")
+    assert opt is not None
+    monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_PROJECT", raising=False)
+    monkeypatch.setenv("LANGSMITH_PROJECT", "")
+    assert resolve_scalar(opt, toml_data={}) == (LANGSMITH_PROJECT_DEFAULT, "default")
+
+
+def test_fallback_env_vars_yield_to_toml_when_env_unset(monkeypatch) -> None:
+    """A synthetic option exercises the empty-fallback → `config.toml` path.
+
+    No shipping option both declares `fallback_env_vars` and has `toml_keys`,
+    so this guards the generic resolver: an empty fallback env var must fall
+    through to `config.toml`, while a set one still wins over it.
+    """
+    opt = ConfigOption(
+        key="synthetic.fallback_toml",
+        group="Synthetic",
+        summary="Synthetic option for fallback + TOML precedence.",
+        kind=OptionKind.STR,
+        env_var=_env_vars.LANGSMITH_PROJECT,
+        fallback_env_vars=("SYNTHETIC_FALLBACK",),
+        toml_keys=("synthetic", "value"),
+    )
+    monkeypatch.delenv("DEEPAGENTS_CODE_LANGSMITH_PROJECT", raising=False)
+    toml_data = {"synthetic": {"value": "from-toml"}}
+
+    monkeypatch.setenv("SYNTHETIC_FALLBACK", "")
+    assert resolve_scalar(opt, toml_data=toml_data) == ("from-toml", "config.toml")
+
+    monkeypatch.setenv("SYNTHETIC_FALLBACK", "from-env")
+    assert resolve_scalar(opt, toml_data=toml_data) == (
+        "from-env",
+        "env (SYNTHETIC_FALLBACK)",
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_fallback",
+    [
+        ["LANGSMITH_PROJECT"],  # mutable list reintroduces the lru_cache hazard
+        ("",),  # empty name never matches any env var
+        ("LANGSMITH_PROJECT", ""),  # one valid, one empty
+    ],
+)
+def test_fallback_env_vars_rejects_invalid(bad_fallback) -> None:
+    """`__post_init__` rejects non-tuple or empty/non-str `fallback_env_vars`."""
+    with pytest.raises(TypeError, match="fallback_env_vars must be a tuple"):
+        ConfigOption(
+            key="synthetic.bad_fallback",
+            group="Synthetic",
+            summary="Synthetic option with an invalid fallback.",
+            kind=OptionKind.STR,
+            fallback_env_vars=bad_fallback,
+        )
+
+
 def test_run_show_json_redacts_every_secret(monkeypatch, capsys) -> None:
     """The `config show` aggregate (separate path from `get`) never leaks a secret."""
     import json


### PR DESCRIPTION
`dcode config show`/`get`/`ls` now reflect a bare `LANGSMITH_PROJECT` and display the default `deepagents-code` project when unset.

---

`dcode config show`/`get`/`ls` resolved `tracing.langsmith_project` only from `DEEPAGENTS_CODE_LANGSMITH_PROJECT`, so a user relying on a bare `LANGSMITH_PROJECT` saw `(unset)` even though agent traces actually routed there via `get_langsmith_project_name`. This adds a generic `fallback_env_vars` mechanism to `ConfigOption`/`resolve_scalar` (read literally, after the prefixed primary) and wires `LANGSMITH_PROJECT` as the fallback, plus gives the option its real default (`deepagents-code`) so it renders when unset. The default now lives in one shared constant used by both the manifest and `get_langsmith_project_name`.