### PR TITLE
test(sdk): cover LangGraph API Overwrite serde

### DIFF
--- a/libs/deepagents/tests/integration_tests/test_langgraph_api_overwrite.py
+++ b/libs/deepagents/tests/integration_tests/test_langgraph_api_overwrite.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolCall
+from langgraph._internal._constants import OVERWRITE
+from langgraph._internal._typing import MISSING
+from langgraph.channels.delta import DeltaChannel
+from langgraph.graph.message import _messages_delta_reducer
+
+from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
+
+
+def test_patch_tool_calls_overwrite_survives_langgraph_api_json_serde() -> None:
+    orjson = pytest.importorskip("orjson")
+    api_serde = pytest.importorskip("langgraph_api.serde")
+
+    messages = [
+        HumanMessage(content="hi", id="h1"),
+        AIMessage(
+            content="",
+            id="a1",
+            tool_calls=[ToolCall(id="tc1", name="lookup", args={})],
+        ),
+    ]
+    update = PatchToolCallsMiddleware().before_agent({"messages": messages}, None)
+    assert update is not None
+
+    payload = orjson.loads(api_serde.json_dumpb(update["messages"]))
+    assert OVERWRITE in payload
+    assert "value" not in payload
+
+    channel = DeltaChannel(_messages_delta_reducer, list).from_checkpoint(MISSING)
+    channel.update([payload])
+
+    patched = channel.get()
+    assert len(patched) == 3
+    assert patched[-1]["type"] == "tool"
+    assert patched[-1]["tool_call_id"] == "tc1"


### PR DESCRIPTION
Adds an optional integration regression for the LangGraph API `Overwrite` serialization fix.

The test:
- invokes `PatchToolCallsMiddleware` on a dangling tool call;
- serializes the returned `Overwrite` with `langgraph_api.serde.json_dumpb` when `langgraph_api` is installed;
- verifies the API JSON shape uses the `__overwrite__` sentinel instead of the ambiguous `value` field;
- applies that payload to a DeltaChannel messages channel to confirm it does not trigger the message coercion failure.

This complements langchain-ai/langgraph-api#3571, which contains the platform-side fix and an end-to-end API `/state` regression.

Tests:
- `make -C /tmp/deepagents-overwrite-api/libs/deepagents format`
- `make -C /tmp/deepagents-overwrite-api/libs/deepagents test` (default unit suite)
- `cd /tmp/deepagents-overwrite-api/libs/deepagents && uv run --group test pytest tests/integration_tests/test_langgraph_api_overwrite.py -q` (skips without `langgraph_api`)
- `cd /tmp/deepagents-overwrite-api/libs/deepagents && uv run --group test --with /Users/sydney_runkle/oss/langgraph-api/api pytest tests/integration_tests/test_langgraph_api_overwrite.py -q`