### PR TITLE
docs(sdk): add `permissions` and `response_format` to `subagents=` docstring

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -378,9 +378,9 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
             `SubAgent` entries are invoked through the `task` tool. They should
             provide `name`, `description`, and `system_prompt`, and may also
-            override `tools`, `model`, `middleware`, `interrupt_on`, and
-            `skills`. See `interrupt_on` below for inheritance and override
-            behavior.
+            override `tools`, `model`, `middleware`, `interrupt_on`, `skills`,
+            `permissions`, and `response_format`. See `interrupt_on` below for
+            inheritance and override behavior.
 
             `CompiledSubAgent` entries are also exposed through the `task` tool,
             but provide a pre-built `runnable` instead of a declarative prompt


### PR DESCRIPTION
Fixes #3970

---

The `subagents=` parameter docstring listed `tools`, `model`, `middleware`, `interrupt_on`, and `skills` as overridable `SubAgent` fields but omitted `permissions` and `response_format`, both of which are fully supported. Updated the docstring to include them.

Doc-only change. Ran make format and make lint — both passed clean.

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
Twitter: @kavishkarth31
LinkedIn: https://linkedin.com/in/kavish-kartha
