### PR TITLE
feat(code): manage Tavily web-search API key in `/auth`

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -10017,7 +10017,43 @@ class DeepAgentsApp(App):
                     markup=False,
                 )
             return
+        if action_id == ActionId.ENTER_API_KEY:
+            await self._enter_service_api_key(entry, payload)
+            return
         self._log_unknown_action(entry, action_id)
+
+    async def _enter_service_api_key(
+        self,
+        entry: PendingNotification,
+        payload: MissingDepPayload,
+    ) -> None:
+        """Open the `/auth` prompt so the user can store a service API key.
+
+        Args:
+            entry: The missing-dependency notification entry.
+            payload: Typed payload carrying the service (tool) name.
+        """
+        from deepagents_code.model_config import SERVICE_API_KEY_ENV, is_service
+
+        service = payload.tool
+        env_var = SERVICE_API_KEY_ENV.get(service)
+        if not is_service(service) or env_var is None:
+            self._log_unknown_action(entry, ActionId.ENTER_API_KEY)
+            return
+
+        from deepagents_code.widgets.auth import AuthPromptScreen, AuthResult
+
+        result = await self._push_screen_wait(
+            AuthPromptScreen(service, env_var),
+        )
+        if result == AuthResult.SAVED:
+            self._notice_registry.remove(entry.key)
+            self.notify(
+                f"Saved {service} API key. Restart to enable web search.",
+                severity="information",
+                timeout=6,
+                markup=False,
+            )
 
     async def _handle_update_action(
         self,

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -10093,17 +10093,22 @@ class DeepAgentsApp(App):
         entry: PendingNotification,
         payload: MissingDepPayload,
     ) -> None:
-        """Open the `/auth` prompt so the user can store a service API key.
+        """Open the API-key entry prompt (the one `/auth` uses) for a service.
+
+        Lets the user store a service API key inline instead of exporting an
+        env var before launch.
 
         Args:
             entry: The missing-dependency notification entry.
             payload: Typed payload carrying the service (tool) name.
         """
-        from deepagents_code.model_config import SERVICE_API_KEY_ENV, is_service
+        from deepagents_code.model_config import SERVICE_API_KEY_ENV
 
         service = payload.tool
+        # `env_var is None` covers any non-service tool, since `is_service` is
+        # exactly membership in `SERVICE_API_KEY_ENV`.
         env_var = SERVICE_API_KEY_ENV.get(service)
-        if not is_service(service) or env_var is None:
+        if env_var is None:
             self._log_unknown_action(entry, ActionId.ENTER_API_KEY)
             return
 
@@ -10115,7 +10120,7 @@ class DeepAgentsApp(App):
         if result == AuthResult.SAVED:
             self._notice_registry.remove(entry.key)
             self.notify(
-                f"Saved {service} API key. Restart to enable web search.",
+                f"Saved {service} API key. Restart to apply.",
                 severity="information",
                 timeout=6,
                 markup=False,

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -549,6 +549,13 @@ def _ensure_bootstrap() -> None:
             # Tracing enabled without a key floods the TUI with 401 ingest
             # errors; disable it before any traced run starts.
             _disable_orphaned_tracing()
+
+            # Bridge stored service keys (e.g. Tavily web search, entered via
+            # `/auth`) onto their canonical env vars before settings detection,
+            # so a stored key activates the feature without exporting the var.
+            from deepagents_code.model_config import apply_stored_service_credentials
+
+            apply_stored_service_credentials()
         except Exception:
             logger.exception(
                 "Bootstrap failed; .env values and LANGSMITH_PROJECT override "

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -704,13 +704,15 @@ def build_missing_tool_notification(tool: str) -> "PendingNotification":
             key="dep:tavily",
             title="Web search disabled",
             body=(
-                "TAVILY_API_KEY is not set, so web search is disabled.\n\n"
-                "Get a key at https://tavily.com"
+                "No Tavily API key is set, so web search is disabled.\n\n"
+                "Enter a key to store it (takes effect next launch), or get one "
+                "at https://tavily.com"
             ),
             actions=(
                 NotificationAction(
-                    ActionId.OPEN_WEBSITE, "Open tavily.com", primary=True
+                    ActionId.ENTER_API_KEY, "Enter API key", primary=True
                 ),
+                NotificationAction(ActionId.OPEN_WEBSITE, "Open tavily.com"),
                 suppress_action,
             ),
             payload=MissingDepPayload(tool="tavily", url="https://tavily.com"),

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -558,11 +558,6 @@ they appear in the `/auth` manager and can be entered directly in the TUI
 instead of being exported as environment variables before launch.
 """
 
-SERVICE_DOCS_URL: dict[str, str] = {
-    "tavily": "https://tavily.com",
-}
-"""Sign-up / docs URL for each service in `SERVICE_API_KEY_ENV`."""
-
 CODEX_PROVIDER = "openai_codex"
 """Provider name for `_ChatOpenAICodex` models authenticated via ChatGPT OAuth.
 
@@ -2055,7 +2050,11 @@ def apply_stored_service_credentials() -> None:
         try:
             stored = auth_store.get_stored_key(service)
         except RuntimeError:
-            logger.warning("Could not read stored credentials for service %s", service)
+            logger.warning(
+                "Could not read stored credentials for service %s; the credential "
+                "file may be corrupt. Re-add the key via /auth.",
+                service,
+            )
             continue
         if stored and os.environ.get(env_var) != stored:
             os.environ[env_var] = stored

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -547,6 +547,22 @@ Providers not listed here fall through to the config-file check or the langchain
 registry fallback.
 """
 
+SERVICE_API_KEY_ENV: dict[str, str] = {
+    "tavily": "TAVILY_API_KEY",
+}
+"""Non-model services configurable via `/auth`, mapped to their API-key env var.
+
+These are not LLM providers — they back features such as web search — but
+their credentials follow the same store-on-disk model as model providers, so
+they appear in the `/auth` manager and can be entered directly in the TUI
+instead of being exported as environment variables before launch.
+"""
+
+SERVICE_DOCS_URL: dict[str, str] = {
+    "tavily": "https://tavily.com",
+}
+"""Sign-up / docs URL for each service in `SERVICE_API_KEY_ENV`."""
+
 CODEX_PROVIDER = "openai_codex"
 """Provider name for `_ChatOpenAICodex` models authenticated via ChatGPT OAuth.
 
@@ -1994,6 +2010,55 @@ def get_default_base_url_env(provider: str) -> str | None:
         return None
     prefixed = f"{_ENV_PREFIX}{env_var}"
     return prefixed if os.environ.get(prefixed) else None
+
+
+def is_service(name: str) -> bool:
+    """Return whether `name` is a non-model service configurable via `/auth`."""
+    return name in SERVICE_API_KEY_ENV
+
+
+def get_service_auth_status(service: str) -> ProviderAuthStatus:
+    """Return credential readiness for a non-model service (e.g. `"tavily"`).
+
+    Mirrors `get_provider_auth_status` but is scoped to `SERVICE_API_KEY_ENV`,
+    so a stored key beats the env var and the `/auth` manager can render the
+    same `[stored]` / `[env: ...]` / `[missing]` badges.
+
+    Args:
+        service: Service name (e.g. `"tavily"`).
+
+    Returns:
+        `CONFIGURED` when a stored or env credential is set, else `MISSING`.
+    """
+    env_var = SERVICE_API_KEY_ENV[service]
+    configured = _resolve_configured(service, env_var)
+    if configured:
+        return configured
+    return ProviderAuthStatus(
+        state=ProviderAuthState.MISSING,
+        provider=service,
+        env_var=env_var,
+        detail=f"{env_var} is not set or is empty",
+    )
+
+
+def apply_stored_service_credentials() -> None:
+    """Export every stored service key into `os.environ`.
+
+    Services (e.g. web search via Tavily) have no base URL to reconcile, so
+    this is a plain key copy onto the canonical env var name the underlying
+    SDK reads. A stored key takes precedence over an existing env var, matching
+    `apply_stored_credentials`. Only the unprefixed canonical name is written,
+    so a `DEEPAGENTS_CODE_`-prefixed override still wins via `resolve_env_var`.
+    """
+    for service, env_var in SERVICE_API_KEY_ENV.items():
+        try:
+            stored = auth_store.get_stored_key(service)
+        except RuntimeError:
+            logger.warning("Could not read stored credentials for service %s", service)
+            continue
+        if stored and os.environ.get(env_var) != stored:
+            os.environ[env_var] = stored
 
 
 def apply_stored_credentials(provider: str) -> bool:

--- a/libs/code/deepagents_code/notifications.py
+++ b/libs/code/deepagents_code/notifications.py
@@ -26,6 +26,9 @@ class ActionId(StrEnum):
     OPEN_WEBSITE = "open_website"
     """Open the associated URL in the user's browser."""
 
+    ENTER_API_KEY = "enter_api_key"
+    """Open the `/auth` manager so the user can store an API key."""
+
     INSTALL = "install"
     """Run the upgrade command via `perform_upgrade`."""
 

--- a/libs/code/deepagents_code/widgets/auth.py
+++ b/libs/code/deepagents_code/widgets/auth.py
@@ -1304,7 +1304,7 @@ class AuthManagerScreen(ModalScreen[None]):
         # enter it the same way they enter a model-provider key.
         options.extend(
             Option(self._format_label(service), id=service)
-            for service in sorted(SERVICE_API_KEY_ENV)
+            for service in sorted(set(SERVICE_API_KEY_ENV) - set(providers))
         )
         return options, warning
 

--- a/libs/code/deepagents_code/widgets/auth.py
+++ b/libs/code/deepagents_code/widgets/auth.py
@@ -45,6 +45,7 @@ from deepagents_code.model_config import (
     CODEX_PROVIDER,
     PROVIDER_API_KEY_ENV,
     PROVIDERS_DOCS_URL as _PROVIDERS_DOCS_URL,
+    SERVICE_API_KEY_ENV,
     ModelConfig,
     ProviderAuthSource,
     ProviderAuthState,
@@ -55,6 +56,8 @@ from deepagents_code.model_config import (
     get_credential_env_var,
     get_default_base_url_env,
     get_provider_auth_status,
+    get_service_auth_status,
+    is_service,
     resolved_env_var_name,
 )
 from deepagents_code.widgets._links import open_style_link
@@ -107,6 +110,7 @@ PROVIDER_API_KEY_URLS: dict[str, str] = {
     "openai": "https://platform.openai.com/api-keys",
     "openrouter": "https://openrouter.ai/workspaces/default/keys",
     "perplexity": "https://www.perplexity.ai/settings/api",
+    "tavily": "https://app.tavily.com",
     "together": "https://api.together.ai/settings/api-keys",
     "xai": "https://console.x.ai/team/default/api-keys",
 }
@@ -481,7 +485,11 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
         # cached instance instead of reloading outside this crash-safety guard.
         try:
             self._config = ModelConfig.load()
-            self._auth_status = get_provider_auth_status(provider)
+            self._auth_status = (
+                get_service_auth_status(provider)
+                if is_service(provider)
+                else get_provider_auth_status(provider)
+            )
             self._has_existing = auth_store.get_stored_key(provider) is not None
             self._existing_base_url = auth_store.get_stored_base_url(provider) or ""
             self._advanced_visible = bool(self._existing_base_url)
@@ -1049,9 +1057,9 @@ class AuthManagerScreen(ModalScreen[None]):
             )
         )
         return Content.assemble(
-            "Lists installed providers and any you've configured in "
-            "~/.deepagents/config.toml. Install more via "
-            "`/install <provider>`. ",
+            "Lists installed model providers, services like web search, and any "
+            "providers you've configured in ~/.deepagents/config.toml. Install "
+            "more via `/install <provider>`. ",
             ("Docs", link_style),
         )
 
@@ -1086,6 +1094,14 @@ class AuthManagerScreen(ModalScreen[None]):
             # users can still paste it manually) and run the loopback
             # callback wait on a worker.
             self._open_codex_screen()
+            return
+        if is_service(provider):
+            # Services (e.g. Tavily web search) use a plain API key, stored the
+            # same way as a model-provider key.
+            self.app.push_screen(
+                AuthPromptScreen(provider, SERVICE_API_KEY_ENV[provider]),
+                self._on_prompt_closed,
+            )
             return
         env_var = get_credential_env_var(provider)
         self.app.push_screen(
@@ -1216,6 +1232,14 @@ class AuthManagerScreen(ModalScreen[None]):
         options = [
             Option(self._format_label(provider), id=provider) for provider in providers
         ]
+        # Append non-model services (e.g. Tavily web search) after the model
+        # providers. These are always shown — their key is configurable here
+        # regardless of whether the backing package is installed — so users can
+        # enter it the same way they enter a model-provider key.
+        options.extend(
+            Option(self._format_label(service), id=service)
+            for service in sorted(SERVICE_API_KEY_ENV)
+        )
         return options, warning
 
     @staticmethod
@@ -1225,7 +1249,11 @@ class AuthManagerScreen(ModalScreen[None]):
         Returns:
             A composed `Content` with the provider label and a status badge.
         """
-        status = get_provider_auth_status(provider)
+        status = (
+            get_service_auth_status(provider)
+            if is_service(provider)
+            else get_provider_auth_status(provider)
+        )
         badge = format_auth_badge(status)
         return Content.assemble(
             Content.from_markup("$provider", provider=_provider_display_name(provider)),

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -9238,6 +9238,59 @@ class TestNotificationCenterIntegration:
         mock_suppress.assert_called_once_with("ripgrep")
         assert app._notice_registry.get("dep:ripgrep") is None
 
+    async def test_enter_api_key_saved_removes_entry_and_notifies(self) -> None:
+        """Saving a service key clears the notice and confirms the restart."""
+        from deepagents_code.notifications import ActionId
+        from deepagents_code.widgets.auth import AuthPromptScreen, AuthResult
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        entry = _missing_dep_entry("tavily", url="https://tavily.com")
+        app._notice_registry.add(entry)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._push_screen_wait = AsyncMock(return_value=AuthResult.SAVED)  # ty: ignore
+            messages: list[str] = []
+            app.notify = lambda message, **_: messages.append(message)  # ty: ignore
+            await app._dispatch_notification_action(entry.key, ActionId.ENTER_API_KEY)
+            await pilot.pause()
+
+        # The prompt is opened for the service's canonical env var ...
+        app._push_screen_wait.assert_awaited_once()  # ty: ignore
+        screen = app._push_screen_wait.await_args.args[0]  # ty: ignore
+        assert isinstance(screen, AuthPromptScreen)
+        assert screen._provider == "tavily"
+        assert screen._env_var == "TAVILY_API_KEY"
+        # ... and on save the stale notice is gone and the user is told to restart.
+        assert app._notice_registry.get("dep:tavily") is None
+        assert any("Restart to apply." in m for m in messages)
+
+    async def test_enter_api_key_unknown_service_is_a_noop(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """ENTER_API_KEY on a non-service tool logs and opens nothing."""
+        import logging
+
+        from deepagents_code.notifications import ActionId
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        entry = _missing_dep_entry("ripgrep")
+        app._notice_registry.add(entry)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._push_screen_wait = AsyncMock()  # ty: ignore
+            with caplog.at_level(logging.WARNING):
+                await app._dispatch_notification_action(
+                    entry.key, ActionId.ENTER_API_KEY
+                )
+            await pilot.pause()
+
+        app._push_screen_wait.assert_not_awaited()  # ty: ignore
+        # Non-service tool: nothing opened, entry untouched, dev-facing log only.
+        assert app._notice_registry.get("dep:ripgrep") is entry
+        assert "Unknown action_id" in caplog.text
+
     async def test_suppress_message_reloads_center_in_place(self) -> None:
         """Posting NotificationSuppressRequested refreshes the open center."""
         from deepagents_code.widgets.notification_center import (

--- a/libs/code/tests/unit_tests/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/test_auth_widgets.py
@@ -136,7 +136,11 @@ class TestAuthPromptScreen:
         known = set(model_config.PROVIDER_API_KEY_ENV) | {model_config.CODEX_PROVIDER}
         assert set(PROVIDER_DISPLAY_NAMES) <= known
         # Codex uses ChatGPT login, not an API-key page, so it has no key URL.
-        assert set(PROVIDER_API_KEY_URLS) <= set(model_config.PROVIDER_API_KEY_ENV)
+        # Services (e.g. Tavily) carry a key URL but live in SERVICE_API_KEY_ENV.
+        assert set(PROVIDER_API_KEY_URLS) <= (
+            set(model_config.PROVIDER_API_KEY_ENV)
+            | set(model_config.SERVICE_API_KEY_ENV)
+        )
 
     def test_every_known_provider_has_a_display_name(self) -> None:
         """A new provider can't ship without a branded `/auth` label.
@@ -950,7 +954,8 @@ api_key_env = "MY_GATEWAY_API_KEY"
             ids = {
                 options.get_option_at_index(i).id for i in range(options.option_count)
             }
-        assert ids == {"openai", "openai_codex", "anthropic"}
+        # Non-model services (e.g. Tavily) are always listed for key entry.
+        assert ids == {"openai", "openai_codex", "anthropic", "tavily"}
 
     async def test_stored_provider_shown_even_when_uninstalled(
         self, monkeypatch: pytest.MonkeyPatch
@@ -984,7 +989,7 @@ api_key_env = "MY_GATEWAY_API_KEY"
             await pilot.pause()
             copy = app.screen.query_one(".auth-manager-copy", Static)
             content = str(copy.content)
-        assert "Lists installed providers" in content
+        assert "Lists installed model providers" in content
         assert "Docs" in content
         # URL is embedded as a Textual link style — assert the link target
         # surfaces in the rendered span representation.

--- a/libs/code/tests/unit_tests/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/test_auth_widgets.py
@@ -978,6 +978,56 @@ api_key_env = "MY_GATEWAY_API_KEY"
         # Non-model services (e.g. Tavily) are always listed for key entry.
         assert ids == {"openai", "openai_codex", "anthropic", "tavily"}
 
+    async def test_selecting_service_opens_prompt_for_its_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Selecting a service routes to the key prompt bound to its env var.
+
+        Services must not fall through to the model-provider branch, which
+        would look up a credential env var the service doesn't have.
+        """
+        monkeypatch.setattr(
+            "deepagents_code.widgets.auth.get_available_models",
+            lambda: {"openai": ["gpt-5.4"]},
+        )
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_manager()
+            await pilot.pause()
+            screen = cast("AuthManagerScreen", app.screen)
+            event = SimpleNamespace(option=SimpleNamespace(id="tavily"))
+            screen.on_option_list_option_selected(cast("Any", event))
+            await pilot.pause()
+            prompt = app.screen
+            assert isinstance(prompt, AuthPromptScreen)
+            assert prompt._provider == "tavily"
+            assert prompt._env_var == "TAVILY_API_KEY"
+
+    async def test_service_row_shows_stored_badge(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stored service key renders the `[stored]` badge on its row.
+
+        Confirms the service-aware status branch in `_format_label` is wired
+        up — a regression to `get_provider_auth_status` would `KeyError`.
+        """
+        auth_store.set_stored_key("tavily", "k")
+        monkeypatch.setattr(
+            "deepagents_code.widgets.auth.get_available_models",
+            lambda: {"openai": ["gpt-5.4"]},
+        )
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_manager()
+            await pilot.pause()
+            options = app.screen.query_one("#auth-manager-options", OptionList)
+            label = next(
+                str(options.get_option_at_index(i).prompt)
+                for i in range(options.option_count)
+                if options.get_option_at_index(i).id == "tavily"
+            )
+        assert "stored" in label
+
     async def test_stored_provider_shown_even_when_uninstalled(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/test_auth_widgets.py
@@ -878,6 +878,19 @@ api_key_env = "MY_GATEWAY_API_KEY"
         assert label is not None
         assert "stored" in str(label)
 
+    async def test_stored_service_is_not_duplicated(self) -> None:
+        """Stored non-model services appear once in the manager list."""
+        auth_store.set_stored_key("tavily", "k")
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_manager()
+            await pilot.pause()
+            options = app.screen.query_one("#auth-manager-options", OptionList)
+            ids = [
+                options.get_option_at_index(i).id for i in range(options.option_count)
+            ]
+        assert ids.count("tavily") == 1
+
     async def test_env_badge_shows_canonical_when_only_canonical_set(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -1420,8 +1420,8 @@ class TestBuildMissingToolNotification:
         action_ids = [a.action_id for a in entry.actions]
         assert action_ids == [ActionId.OPEN_WEBSITE, ActionId.SUPPRESS]
 
-    def test_tavily_offers_website_and_suppress(self) -> None:
-        """Tavily entry links to tavily.com and offers suppression."""
+    def test_tavily_offers_enter_key_website_and_suppress(self) -> None:
+        """Tavily entry offers entering a key, the website, and suppression."""
         from deepagents_code.notifications import ActionId, MissingDepPayload
 
         entry = build_missing_tool_notification("tavily")
@@ -1431,8 +1431,13 @@ class TestBuildMissingToolNotification:
         assert entry.payload.url == "https://tavily.com"
         assert entry.payload.install_command is None
         action_ids = [a.action_id for a in entry.actions]
-        assert action_ids == [ActionId.OPEN_WEBSITE, ActionId.SUPPRESS]
-        assert "TAVILY_API_KEY" in entry.body
+        assert action_ids == [
+            ActionId.ENTER_API_KEY,
+            ActionId.OPEN_WEBSITE,
+            ActionId.SUPPRESS,
+        ]
+        assert entry.actions[0].primary is True
+        assert "Tavily API key" in entry.body
 
     def test_unknown_tool_only_suppresses_and_logs(
         self, caplog: pytest.LogCaptureFixture

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -499,6 +499,27 @@ class TestServiceCredentials:
         apply_stored_service_credentials()
         assert os.environ["TAVILY_API_KEY"] == "from-env"
 
+    def test_apply_stored_key_overrides_existing_env(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A stored key wins over a conflicting existing env var.
+
+        Guards the documented precedence (matching `apply_stored_credentials`):
+        a key entered via `/auth` must beat a plain `TAVILY_API_KEY` already in
+        the environment, otherwise the stored key would be silently ignored.
+        """
+        import os
+
+        from deepagents_code import auth_store
+        from deepagents_code.model_config import apply_stored_service_credentials
+
+        monkeypatch.setenv("TAVILY_API_KEY", "from-env")
+        auth_store.set_stored_key("tavily", "from-store")
+        apply_stored_service_credentials()
+        assert os.environ["TAVILY_API_KEY"] == "from-store"
+
 
 class TestSplitCredentialSource:
     """`warn_on_split_credential_source` flags key/endpoint env-tier mismatches."""

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -418,6 +418,88 @@ models = ["m1"]
         assert status.source is ProviderAuthSource.ENV
 
 
+class TestServiceCredentials:
+    """Non-model services (e.g. Tavily) resolve and apply stored keys."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_tavily_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Strip Tavily env vars so each test controls its own state."""
+        for var in ("TAVILY_API_KEY", "DEEPAGENTS_CODE_TAVILY_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_is_service(self) -> None:
+        """`is_service` recognizes registered services, not model providers."""
+        from deepagents_code.model_config import is_service
+
+        assert is_service("tavily") is True
+        assert is_service("anthropic") is False
+
+    def test_status_missing_when_unset(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+    ) -> None:
+        """No stored or env key reports MISSING with the canonical env var."""
+        from deepagents_code.model_config import get_service_auth_status
+
+        status = get_service_auth_status("tavily")
+        assert status.state is ProviderAuthState.MISSING
+        assert status.env_var == "TAVILY_API_KEY"
+
+    def test_status_configured_from_env(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An env var reports CONFIGURED from the env source."""
+        from deepagents_code.model_config import get_service_auth_status
+
+        monkeypatch.setenv("TAVILY_API_KEY", "from-env")
+        status = get_service_auth_status("tavily")
+        assert status.state is ProviderAuthState.CONFIGURED
+        assert status.source is ProviderAuthSource.ENV
+
+    def test_status_configured_from_store(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+    ) -> None:
+        """A stored key reports CONFIGURED from the stored source."""
+        from deepagents_code import auth_store
+        from deepagents_code.model_config import get_service_auth_status
+
+        auth_store.set_stored_key("tavily", "from-store")
+        status = get_service_auth_status("tavily")
+        assert status.state is ProviderAuthState.CONFIGURED
+        assert status.source is ProviderAuthSource.STORED
+
+    def test_apply_exports_stored_key(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+    ) -> None:
+        """`apply_stored_service_credentials` copies the stored key to env."""
+        import os
+
+        from deepagents_code import auth_store
+        from deepagents_code.model_config import apply_stored_service_credentials
+
+        auth_store.set_stored_key("tavily", "from-store")
+        apply_stored_service_credentials()
+        assert os.environ["TAVILY_API_KEY"] == "from-store"
+
+    def test_apply_noop_without_stored_key(
+        self,
+        fake_state_dir: Path,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No stored key leaves an existing env var untouched."""
+        import os
+
+        from deepagents_code.model_config import apply_stored_service_credentials
+
+        monkeypatch.setenv("TAVILY_API_KEY", "from-env")
+        apply_stored_service_credentials()
+        assert os.environ["TAVILY_API_KEY"] == "from-env"
+
+
 class TestSplitCredentialSource:
     """`warn_on_split_credential_source` flags key/endpoint env-tier mismatches."""
 


### PR DESCRIPTION
Tavily web-search API keys can now be entered and managed from the `/auth` Manage API keys screen instead of only via the `TAVILY_API_KEY` environment variable.

---

Setting up Tavily web search was a dead end: the only path was a notification that pointed at `tavily.com`, with no way to enter a key the way model-provider keys are entered. This surfaces non-model services (starting with Tavily) in the `/auth` Manage API keys screen so a key can be entered and stored on disk like any provider key.

- A new `SERVICE_API_KEY_ENV` registry (currently just `tavily` → `TAVILY_API_KEY`) drives a service-aware `get_service_auth_status`, so Tavily renders the same `[stored]` / `[env: …]` / `[missing]` badges and reuses the existing `AuthPromptScreen`.
- `apply_stored_service_credentials` bridges a stored key onto its canonical env var during bootstrap, so a key entered in the TUI activates web search on the next launch without exporting anything.
- The "Web search disabled" notification now offers a primary `Enter API key` action that opens the prompt directly.

Note: web search tools are wired at server start from `settings.has_tavily`, so a freshly entered key takes effect on the next launch/restart rather than mid-session — called out in the notification copy.

Made by [Open SWE](https://openswe.vercel.app/agents/cbecdb67-7ab2-8ada-6cf3-8e619c734f59)