### PR TITLE
Use overwrite sentinel for messages updates

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -31,6 +31,7 @@ from langchain.tools.tool_node import ToolCallRequest
 from langchain_core.messages import AnyMessage, HumanMessage, ToolMessage
 from langchain_core.messages.content import ContentBlock
 from langchain_core.tools import BaseTool, StructuredTool
+from langgraph._internal._constants import OVERWRITE
 from langgraph.channels.delta import DeltaChannel
 from langgraph.runtime import Runtime
 from langgraph.types import Command, Overwrite
@@ -2124,8 +2125,9 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
     ) -> tuple[list[AnyMessage], Command | None]:
         """Tag a newly evicted message and truncate all tagged messages.
 
-        When a new eviction fires, uses `Overwrite` to atomically replace
-        the messages channel with a fully-identified list. A plain append of
+        When a new eviction fires, uses the `__overwrite__` sentinel to
+        atomically replace the messages channel with a fully-identified list.
+        A plain append of
         the tagged message would not survive DeltaChannel replay: the original
         `HumanMessage(id=None)` write gets a fresh UUID on replay that
         doesn't match the eviction Command's ID, producing a duplicate.
@@ -2152,7 +2154,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     },
                 }
             )
-            state_command = Command(update={"messages": Overwrite([*messages[:-1], tagged])})
+            state_command = Command(update={"messages": {OVERWRITE: [*messages[:-1], tagged]}})
             messages = [*messages[:-1], tagged]
 
         processed: list[AnyMessage] = []
@@ -2223,17 +2225,24 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
     @staticmethod
     def _unwrap_command_messages(update: Mapping[str, Any]) -> tuple[Any, bool]:
-        """Return a Command messages update and whether it used Overwrite."""
+        """Return a Command messages update and whether it used the overwrite sentinel.
+
+        Recognizes both the typed `Overwrite(...)` form and the JSON-safe
+        `{"__overwrite__": value}` dict form so the helper survives JSON
+        roundtrips through `langgraph-api` serializers.
+        """
         command_messages = update.get("messages", [])
         if isinstance(command_messages, Overwrite):
             return command_messages.value, True
+        if isinstance(command_messages, dict) and len(command_messages) == 1 and OVERWRITE in command_messages:
+            return command_messages[OVERWRITE], True
         return command_messages, False
 
     @staticmethod
-    def _rewrap_command_messages(messages: list[AnyMessage], *, wrapped: bool) -> list[AnyMessage] | Overwrite:
-        """Restore Overwrite semantics when the original messages update used them."""
+    def _rewrap_command_messages(messages: list[AnyMessage], *, wrapped: bool) -> list[AnyMessage] | dict[str, list[AnyMessage]]:
+        """Restore overwrite semantics when the original messages update used them."""
         if wrapped:
-            return Overwrite(messages)
+            return {OVERWRITE: messages}
         return messages
 
     def _intercept_large_tool_result(self, tool_result: ToolMessage | Command, runtime: ToolRuntime) -> ToolMessage | Command:

--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -4,8 +4,8 @@ from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware, AgentState
 from langchain_core.messages import AIMessage, AnyMessage, ToolMessage
+from langgraph._internal._constants import OVERWRITE
 from langgraph.runtime import Runtime
-from langgraph.types import Overwrite
 
 
 class PatchToolCallsMiddleware(AgentMiddleware):
@@ -43,4 +43,4 @@ class PatchToolCallsMiddleware(AgentMiddleware):
                     content = f"Tool call {name} with id {tool_call_id} was cancelled - another message came in before it could be completed."
                 patched_messages.append(ToolMessage(content=content, name=name, tool_call_id=tool_call_id))
 
-        return {"messages": Overwrite(patched_messages)}
+        return {"messages": {OVERWRITE: patched_messages}}

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -2,6 +2,7 @@ import mimetypes
 import time
 from unittest.mock import patch
 
+import orjson
 import pytest
 from langchain.agents import create_agent
 from langchain.agents.middleware.types import ToolCallRequest
@@ -13,6 +14,8 @@ from langchain_core.messages import (
     ToolCall,
     ToolMessage,
 )
+from langgraph._internal._constants import OVERWRITE
+from langgraph.channels.binop import _get_overwrite
 from langgraph.store.memory import InMemoryStore
 from langgraph.types import Command, Overwrite
 
@@ -1148,9 +1151,10 @@ class TestFilesystemMiddleware:
         result = middleware._intercept_large_tool_result(command, runtime)
 
         assert isinstance(result, Command)
-        assert isinstance(result.update["messages"], Overwrite)
+        assert isinstance(result.update["messages"], dict)
+        assert set(result.update["messages"]) == {OVERWRITE}
         assert mem_store.get(("filesystem",), "/large_tool_results/test_123") is not None
-        assert "Tool result too large" in result.update["messages"].value[0].content
+        assert "Tool result too large" in result.update["messages"][OVERWRITE][0].content
 
     async def test_aintercept_command_with_overwrite_messages(self):
         """Test that the async path handles Overwrite-wrapped messages."""
@@ -1164,9 +1168,10 @@ class TestFilesystemMiddleware:
         result = await middleware._aintercept_large_tool_result(command, runtime)
 
         assert isinstance(result, Command)
-        assert isinstance(result.update["messages"], Overwrite)
+        assert isinstance(result.update["messages"], dict)
+        assert set(result.update["messages"]) == {OVERWRITE}
         assert mem_store.get(("filesystem",), "/large_tool_results/test_123") is not None
-        assert "Tool result too large" in result.update["messages"].value[0].content
+        assert "Tool result too large" in result.update["messages"][OVERWRITE][0].content
 
     def test_intercept_command_with_short_overwrite_messages(self):
         """A small ToolMessage stays wrapped and unchanged."""
@@ -1186,8 +1191,8 @@ class TestFilesystemMiddleware:
         result = middleware._intercept_large_tool_result(command, runtime)
 
         assert isinstance(result, Command)
-        assert isinstance(result.update["messages"], Overwrite)
-        assert result.update["messages"].value == [tool_message]
+        assert isinstance(result.update["messages"], dict)
+        assert result.update["messages"] == {OVERWRITE: [tool_message]}
         assert result.update["custom_key"] == "custom_value"
         assert mem_store.get(("filesystem",), "/large_tool_results/test_123") is None
 
@@ -1211,8 +1216,9 @@ class TestFilesystemMiddleware:
         result = middleware._intercept_large_tool_result(command, runtime)
 
         assert isinstance(result, Command)
-        assert isinstance(result.update["messages"], Overwrite)
-        messages = result.update["messages"].value
+        assert isinstance(result.update["messages"], dict)
+        assert set(result.update["messages"]) == {OVERWRITE}
+        messages = result.update["messages"][OVERWRITE]
         assert messages[0] == ai_message
         assert "Tool result too large" in messages[1].content
         assert messages[2] == final_message
@@ -1232,8 +1238,9 @@ class TestFilesystemMiddleware:
         result = await middleware._aintercept_large_tool_result(command, runtime)
 
         assert isinstance(result, Command)
-        assert isinstance(result.update["messages"], Overwrite)
-        messages = result.update["messages"].value
+        assert isinstance(result.update["messages"], dict)
+        assert set(result.update["messages"]) == {OVERWRITE}
+        messages = result.update["messages"][OVERWRITE]
         assert messages[0] == ai_message
         assert "Tool result too large" in messages[1].content
         assert mem_store.get(("filesystem",), "/large_tool_results/test_123") is not None
@@ -1248,8 +1255,8 @@ class TestFilesystemMiddleware:
         result = middleware._intercept_large_tool_result(command, runtime)
 
         assert isinstance(result, Command)
-        assert isinstance(result.update["messages"], Overwrite)
-        assert result.update["messages"].value == []
+        assert isinstance(result.update["messages"], dict)
+        assert result.update["messages"] == {OVERWRITE: []}
         assert result.update["custom_key"] == "custom_value"
 
     def test_sanitize_tool_call_id(self):
@@ -2058,8 +2065,9 @@ class TestPatchToolCallsMiddleware:
         middleware = PatchToolCallsMiddleware()
         state_update = middleware.before_agent({"messages": input_messages}, None)
         assert state_update is not None
-        assert isinstance(state_update["messages"], Overwrite)
-        patched_messages = state_update["messages"].value
+        assert isinstance(state_update["messages"], dict)
+        assert set(state_update["messages"]) == {OVERWRITE}
+        patched_messages = state_update["messages"][OVERWRITE]
         assert len(patched_messages) == 5
         assert patched_messages[0].type == "system"
         assert patched_messages[0].content == "You are a helpful assistant."
@@ -2112,8 +2120,9 @@ class TestPatchToolCallsMiddleware:
         middleware = PatchToolCallsMiddleware()
         state_update = middleware.before_agent({"messages": input_messages}, None)
         assert state_update is not None
-        assert isinstance(state_update["messages"], Overwrite)
-        patched_messages = state_update["messages"].value
+        assert isinstance(state_update["messages"], dict)
+        assert set(state_update["messages"]) == {OVERWRITE}
+        patched_messages = state_update["messages"][OVERWRITE]
         assert len(patched_messages) == 8
         assert patched_messages[0].type == "system"
         assert patched_messages[0].content == "You are a helpful assistant."
@@ -2139,6 +2148,44 @@ class TestPatchToolCallsMiddleware:
         assert patched_messages[6].tool_call_id == "456"
         assert patched_messages[7].type == "human"
         assert patched_messages[7].content == "What is the weather in Tokyo?"
+
+    def test_overwrite_sentinel_survives_json_roundtrip(self) -> None:
+        """Regression: the overwrite sentinel survives `orjson` serialization.
+
+        The deployed LangGraph runtime JSON-encodes state updates across
+        worker boundaries. Producing a `langgraph.types.Overwrite` dataclass
+        gets type-erased to `{"value": [...]}` after `orjson.dumps`, which
+        the reducer no longer recognizes as an overwrite. Emitting the
+        canonical `{"__overwrite__": value}` dict sentinel survives the
+        roundtrip and is recognized by `_get_overwrite()` downstream.
+        """
+        input_messages = [
+            SystemMessage(content="You are a helpful assistant.", id="1"),
+            HumanMessage(content="Hello, how are you?", id="2"),
+            AIMessage(
+                content="I'm doing well, thank you!",
+                tool_calls=[ToolCall(id="123", name="get_events_for_days", args={"date_str": "2025-01-01"})],
+                id="3",
+            ),
+            HumanMessage(content="What is the weather in Tokyo?", id="4"),
+        ]
+        middleware = PatchToolCallsMiddleware()
+        state_update = middleware.before_agent({"messages": input_messages}, None)
+        assert state_update is not None
+
+        def _default(obj):
+            # Mirror langgraph-api's serde.default(): convert pydantic models
+            # to dicts so orjson can encode message objects nested inside the
+            # state update.
+            if hasattr(obj, "model_dump") and callable(obj.model_dump):
+                return obj.model_dump()
+            msg = f"Type is not JSON serializable: {type(obj).__name__}"
+            raise TypeError(msg)
+
+        roundtripped = orjson.loads(orjson.dumps(state_update["messages"], default=_default))
+        is_overwrite, unwrapped = _get_overwrite(roundtripped)
+        assert is_overwrite
+        assert isinstance(unwrapped, list)
 
 
 class TestTruncation:


### PR DESCRIPTION
Produce `{"__overwrite__": value}` in `PatchToolCallsMiddleware` and `FilesystemMiddleware` instead of `langgraph.types.Overwrite(...)`. The dataclass form gets type-erased to `{"value": [...]}` across any JSON serialization boundary (e.g. `langgraph-api.serde.json_dumpb`), which the channel reducer does not recognize and which permanently wedges threads on subsequent state reads.\n\nThe dict sentinel is the canonical wire form already recognized by `langgraph.channels.binop._get_overwrite`, so it survives JSON roundtrips and remains compatible with the typed `Overwrite` form for backward compatibility in `_unwrap_command_messages`.\n\nRefs langchain-ai/deepagents#3789