### PR TITLE
docs(code): note Tavily key management via `/auth`

### DIFF
--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -11,7 +11,7 @@ regenerate after editing the registry.
 | Command | Aliases | Description |
 | --- | --- | --- |
 | `/agents` |  | Browse and switch between available agents |
-| `/auth` | `/connect` | Manage stored API keys for model providers |
+| `/auth` | `/connect` | Manage stored API keys for model providers and services |
 | `/auto-update` |  | Toggle automatic updates on or off |
 | `/changelog` |  | Open changelog in browser |
 | `/clear` |  | Clear chat and start new thread |

--- a/libs/code/README.md
+++ b/libs/code/README.md
@@ -35,7 +35,7 @@ The fastest way to start using Deep Agents. `deepagents-code` is a pre-built cod
 
 - **Interactive TUI** — rich terminal interface with streaming responses
 - **Conversation resume** — pick up where you left off across sessions
-- **Web search** — ground responses in live information
+- **Web search** — ground responses in live information (add a Tavily key in `/auth`)
 - **Remote sandboxes** — run code in isolated environments (LangSmith, AgentCore, Daytona, Modal, Runloop, & more)
 - **Persistent memory** — agent remembers context across conversations
 - **Custom skills** — extend the agent with your own slash commands

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -80,9 +80,11 @@ COMMANDS: tuple[SlashCommand, ...] = (
     ),
     SlashCommand(
         name="/auth",
-        description="Manage stored API keys for model providers",
+        description="Manage stored API keys for model providers and services",
         bypass_tier=BypassTier.IMMEDIATE_UI,
-        hidden_keywords="key keys credential credentials login token api",
+        hidden_keywords=(
+            "key keys credential credentials login token api tavily web search service"
+        ),
         aliases=("/connect",),
     ),
     SlashCommand(


### PR DESCRIPTION
## Description

#4062 surfaced Tavily web search in the `/auth` Manage API keys screen. This updates the docs to match: the `/auth` command description now covers services (not just model providers), the README web-search bullet points users at `/auth`, and the command catalog is regenerated.

## Release Note
none

## Test Plan
- [ ] `make commands-catalog --check` passes (COMMANDS.md in sync)

Made by [Open SWE](https://openswe.vercel.app/agents/e7cba2e6-9cc6-1ffd-ebf0-b9bfa4292406)