### PR TITLE
chore(code): bump langchain-quickjs pin to >=0.3.0,<0.4.0

### DIFF
--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -117,7 +117,7 @@ all-sandboxes = [
 ]
 
 # Standalone integrations (not part of any composite extra)
-quickjs = ["langchain-quickjs>=0.2.0,<0.3.0"]
+quickjs = ["langchain-quickjs>=0.3.0,<0.4.0"]
 
 
 [project.scripts]


### PR DESCRIPTION
Bumps the `langchain-quickjs` constraint in `deepagents-code` (both the `quickjs` extra and the `test` dependency group) from `>=0.2.0,<0.3.0` to `>=0.3.0,<0.4.0` to track the latest `langchain-quickjs` release.

The lockfile already resolved to `0.3.0` via the editable in-repo partner path, so no `uv.lock` changes are needed.