### PR TITLE
refactor(sdk): use `RemoveMessage` sentinel in FS and patch tool calls middleware

### DIFF
--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -28,12 +28,13 @@ from langchain.agents.middleware.types import (
 )
 from langchain.tools import ToolRuntime
 from langchain.tools.tool_node import ToolCallRequest
-from langchain_core.messages import AnyMessage, HumanMessage, ToolMessage
+from langchain_core.messages import AnyMessage, HumanMessage, RemoveMessage, ToolMessage
 from langchain_core.messages.content import ContentBlock
 from langchain_core.tools import BaseTool, StructuredTool
 from langgraph.channels.delta import DeltaChannel
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.runtime import Runtime
-from langgraph.types import Command, Overwrite
+from langgraph.types import Command
 from pydantic import BaseModel, Field
 
 from deepagents._api.deprecation import warn_deprecated
@@ -2124,11 +2125,12 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
     ) -> tuple[list[AnyMessage], Command | None]:
         """Tag a newly evicted message and truncate all tagged messages.
 
-        When a new eviction fires, uses `Overwrite` to atomically replace
-        the messages channel with a fully-identified list. A plain append of
-        the tagged message would not survive DeltaChannel replay: the original
-        `HumanMessage(id=None)` write gets a fresh UUID on replay that
-        doesn't match the eviction Command's ID, producing a duplicate.
+        When a new eviction fires, emits a `RemoveMessage(REMOVE_ALL_MESSAGES)`
+        sentinel followed by the fully-identified list to atomically replace
+        the messages channel. A plain append of the tagged message would not
+        survive DeltaChannel replay: the original `HumanMessage(id=None)`
+        write gets a fresh UUID on replay that doesn't match the eviction
+        Command's ID, producing a duplicate.
 
         Args:
             messages: The message list (may be modified if write succeeded).
@@ -2152,8 +2154,9 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     },
                 }
             )
-            state_command = Command(update={"messages": Overwrite([*messages[:-1], tagged])})
-            messages = [*messages[:-1], tagged]
+            replacement: list[AnyMessage] = [*messages[:-1], tagged]
+            state_command = Command(update={"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *replacement]})
+            messages = replacement
 
         processed: list[AnyMessage] = []
         for msg in messages:
@@ -2223,18 +2226,28 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
     @staticmethod
     def _unwrap_command_messages(update: Mapping[str, Any]) -> tuple[Any, bool]:
-        """Return a Command messages update and whether it used Overwrite."""
+        """Return the message list from a Command update and whether it was prefixed with a `REMOVE_ALL_MESSAGES` sentinel.
+
+        Tools that want to atomically replace the messages channel emit
+        `[RemoveMessage(REMOVE_ALL_MESSAGES), *messages]`. Detect that
+        sentinel so we can preserve it after processing.
+        """
         command_messages = update.get("messages", [])
-        if isinstance(command_messages, Overwrite):
-            return command_messages.value, True
+        if (
+            isinstance(command_messages, list)
+            and command_messages
+            and isinstance(command_messages[0], RemoveMessage)
+            and command_messages[0].id == REMOVE_ALL_MESSAGES
+        ):
+            return command_messages[1:], True
         return command_messages, False
 
     @staticmethod
-    def _rewrap_command_messages(messages: list[AnyMessage], *, wrapped: bool) -> list[AnyMessage] | Overwrite:
-        """Restore Overwrite semantics when the original messages update used them."""
+    def _rewrap_command_messages(messages: list[AnyMessage], *, wrapped: bool) -> list[AnyMessage | RemoveMessage]:
+        """Restore the `REMOVE_ALL_MESSAGES` sentinel when the original update used one."""
         if wrapped:
-            return Overwrite(messages)
-        return messages
+            return [RemoveMessage(id=REMOVE_ALL_MESSAGES), *messages]
+        return list(messages)
 
     def _intercept_large_tool_result(self, tool_result: ToolMessage | Command, runtime: ToolRuntime) -> ToolMessage | Command:
         """Intercept and process large tool results before they're added to state.

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -2125,12 +2125,13 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
     ) -> tuple[list[AnyMessage], Command | None]:
         """Tag a newly evicted message and truncate all tagged messages.
 
-        When a new eviction fires, emits a `RemoveMessage(REMOVE_ALL_MESSAGES)`
-        sentinel followed by the fully-identified list to atomically replace
-        the messages channel. A plain append of the tagged message would not
-        survive DeltaChannel replay: the original `HumanMessage(id=None)`
-        write gets a fresh UUID on replay that doesn't match the eviction
-        Command's ID, producing a duplicate.
+        When a new eviction fires, emits a `Command` whose messages update
+        contains only the tagged `HumanMessage`. Because `ensure_message_ids`
+        stamps a stable UUID onto the original write before it is checkpointed,
+        the tagged copy (which reuses that ID) is deduped in-place by the
+        `DeltaChannel` reducer — no `REMOVE_ALL_MESSAGES` sentinel is needed.
+        Using a sentinel would also clobber the `AIMessage` that the model node
+        writes in the same super-step.
 
         Args:
             messages: The message list (may be modified if write succeeded).
@@ -2154,9 +2155,8 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     },
                 }
             )
-            replacement: list[AnyMessage] = [*messages[:-1], tagged]
-            state_command = Command(update={"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *replacement]})
-            messages = replacement
+            state_command = Command(update={"messages": [tagged]})
+            messages = [*messages[:-1], tagged]
 
         processed: list[AnyMessage] = []
         for msg in messages:

--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -3,9 +3,9 @@
 from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware, AgentState
-from langchain_core.messages import AIMessage, AnyMessage, ToolMessage
+from langchain_core.messages import AIMessage, AnyMessage, RemoveMessage, ToolMessage
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.runtime import Runtime
-from langgraph.types import Overwrite
 
 
 class PatchToolCallsMiddleware(AgentMiddleware):
@@ -43,4 +43,4 @@ class PatchToolCallsMiddleware(AgentMiddleware):
                     content = f"Tool call {name} with id {tool_call_id} was cancelled - another message came in before it could be completed."
                 patched_messages.append(ToolMessage(content=content, name=name, tool_call_id=tool_call_id))
 
-        return {"messages": Overwrite(patched_messages)}
+        return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *patched_messages]}

--- a/libs/deepagents/tests/unit_tests/test_eviction_replay.py
+++ b/libs/deepagents/tests/unit_tests/test_eviction_replay.py
@@ -20,16 +20,16 @@ class _FakeModel:
 
     name = "fake"
 
-    def bind_tools(self, *args, **kwargs):
+    def bind_tools(self, *args, **kwargs):  # noqa: ANN002, ANN003
         return self
 
-    def with_structured_output(self, *args, **kwargs):
+    def with_structured_output(self, *args, **kwargs):  # noqa: ANN002, ANN003
         return self
 
-    def invoke(self, messages, config=None, **kw):
+    def invoke(self, messages, config=None, **kw):  # noqa: ANN003
         return AIMessage(content="ok")
 
-    async def ainvoke(self, messages, config=None, **kw):
+    async def ainvoke(self, messages, config=None, **kw):  # noqa: ANN003
         return AIMessage(content="ok")
 
 
@@ -46,7 +46,7 @@ def _build_agent():
         middleware=[middleware],
         checkpointer=checkpointer,
     )
-    return agent
+    return agent  # noqa: RET504  # clearer than inlining the create_agent call
 
 
 def _state_messages(agent, thread_id):

--- a/libs/deepagents/tests/unit_tests/test_eviction_replay.py
+++ b/libs/deepagents/tests/unit_tests/test_eviction_replay.py
@@ -1,0 +1,83 @@
+"""Tests for HumanMessage eviction with DeltaChannel replay.
+
+Verifies that emitting only ``[tagged]`` (reusing the original message's
+ID) correctly deduplicates on DeltaChannel replay — without needing a
+``REMOVE_ALL_MESSAGES`` sentinel that would clobber the AIMessage written
+in the same super-step.
+"""
+
+from langchain.agents import create_agent
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.store.memory import InMemoryStore
+
+from deepagents.backends import StoreBackend
+from deepagents.middleware.filesystem import FilesystemMiddleware
+
+
+class _FakeModel:
+    """Minimal fake model that always responds with a short AIMessage."""
+
+    name = "fake"
+
+    def bind_tools(self, *args, **kwargs):
+        return self
+
+    def with_structured_output(self, *args, **kwargs):
+        return self
+
+    def invoke(self, messages, config=None, **kw):
+        return AIMessage(content="ok")
+
+    async def ainvoke(self, messages, config=None, **kw):
+        return AIMessage(content="ok")
+
+
+def _build_agent():
+    checkpointer = InMemorySaver()
+    store = InMemoryStore()
+    backend = StoreBackend(store=store, namespace=lambda _rt: ("filesystem",))
+    middleware = FilesystemMiddleware(
+        backend=backend,
+        human_message_token_limit_before_evict=100,
+    )
+    agent = create_agent(
+        model=_FakeModel(),
+        middleware=[middleware],
+        checkpointer=checkpointer,
+    )
+    return agent
+
+
+def _state_messages(agent, thread_id):
+    return agent.get_state({"configurable": {"thread_id": thread_id}}).values["messages"]
+
+
+def test_eviction_preserves_ai_response_and_no_duplicates():
+    """Eviction emits only [tagged]; no duplicates on replay, AI response preserved."""
+    agent = _build_agent()
+    cfg = {"configurable": {"thread_id": "t1"}}
+
+    large_content = "x" * 401  # 401 chars > 100 tokens * 4 chars/token
+    agent.invoke({"messages": [HumanMessage(content=large_content)]}, cfg)
+
+    msgs = _state_messages(agent, "t1")
+    # Should have both the tagged HumanMessage AND the AIMessage.
+    # A REMOVE_ALL_MESSAGES sentinel would have clobbered the AIMessage.
+    assert len(msgs) == 2, f"Expected 2 messages after first invoke, got {len(msgs)}"
+    assert isinstance(msgs[0], HumanMessage)
+    assert msgs[0].additional_kwargs.get("lc_evicted_to") is not None
+    assert isinstance(msgs[1], AIMessage)
+
+    # Second invoke triggers checkpoint replay — verify no duplicates.
+    agent.invoke({"messages": [HumanMessage(content="hello")]}, cfg)
+    msgs = _state_messages(agent, "t1")
+    assert len(msgs) == 4, f"Expected 4 messages after second invoke, got {len(msgs)}"
+
+    ids = [m.id for m in msgs if m.id is not None]
+    assert len(ids) == len(set(ids)), f"Duplicate message IDs: {ids}"
+
+    human_msgs = [m for m in msgs if isinstance(m, HumanMessage)]
+    assert len(human_msgs) == 2
+    evicted = [m for m in human_msgs if m.additional_kwargs.get("lc_evicted_to")]
+    assert len(evicted) == 1

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -9,12 +9,14 @@ from langchain.tools import ToolRuntime
 from langchain_core.messages import (
     AIMessage,
     HumanMessage,
+    RemoveMessage,
     SystemMessage,
     ToolCall,
     ToolMessage,
 )
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.store.memory import InMemoryStore
-from langgraph.types import Command, Overwrite
+from langgraph.types import Command
 
 import deepagents.middleware.filesystem as filesystem_middleware
 from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
@@ -1136,40 +1138,56 @@ class TestFilesystemMiddleware:
         assert mem_store.get(("filesystem",), "/large_tool_results/test_123") is not None
         assert result.update["custom_key"] == "custom_value"
 
-    def test_intercept_command_with_overwrite_messages(self):
-        """Test that Commands wrapping messages in Overwrite are handled."""
+    def test_intercept_command_with_remove_all_sentinel(self):
+        """Commands prefixed with a `REMOVE_ALL_MESSAGES` sentinel are handled."""
         backend, mem_store = _make_backend()
         middleware = FilesystemMiddleware(backend=backend, tool_token_limit_before_evict=1000)
         runtime = _runtime("test_123")
 
         large_content = "y" * 5000
         tool_message = ToolMessage(content=large_content, tool_call_id="test_123")
-        command = Command(update={"messages": Overwrite([tool_message]), "files": {}})
+        command = Command(
+            update={
+                "messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), tool_message],
+                "files": {},
+            }
+        )
         result = middleware._intercept_large_tool_result(command, runtime)
 
         assert isinstance(result, Command)
-        assert isinstance(result.update["messages"], Overwrite)
+        messages = result.update["messages"]
+        assert isinstance(messages, list)
+        assert isinstance(messages[0], RemoveMessage)
+        assert messages[0].id == REMOVE_ALL_MESSAGES
         assert mem_store.get(("filesystem",), "/large_tool_results/test_123") is not None
-        assert "Tool result too large" in result.update["messages"].value[0].content
+        assert "Tool result too large" in messages[1].content
 
-    async def test_aintercept_command_with_overwrite_messages(self):
-        """Test that the async path handles Overwrite-wrapped messages."""
+    async def test_aintercept_command_with_remove_all_sentinel(self):
+        """Async path handles `REMOVE_ALL_MESSAGES`-prefixed message lists."""
         backend, mem_store = _make_backend()
         middleware = FilesystemMiddleware(backend=backend, tool_token_limit_before_evict=1000)
         runtime = _runtime("test_123")
 
         large_content = "y" * 5000
         tool_message = ToolMessage(content=large_content, tool_call_id="test_123")
-        command = Command(update={"messages": Overwrite([tool_message]), "files": {}})
+        command = Command(
+            update={
+                "messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), tool_message],
+                "files": {},
+            }
+        )
         result = await middleware._aintercept_large_tool_result(command, runtime)
 
         assert isinstance(result, Command)
-        assert isinstance(result.update["messages"], Overwrite)
+        messages = result.update["messages"]
+        assert isinstance(messages, list)
+        assert isinstance(messages[0], RemoveMessage)
+        assert messages[0].id == REMOVE_ALL_MESSAGES
         assert mem_store.get(("filesystem",), "/large_tool_results/test_123") is not None
-        assert "Tool result too large" in result.update["messages"].value[0].content
+        assert "Tool result too large" in messages[1].content
 
-    def test_intercept_command_with_short_overwrite_messages(self):
-        """A small ToolMessage stays wrapped and unchanged."""
+    def test_intercept_command_with_short_sentinel_messages(self):
+        """A small ToolMessage stays prefixed with the sentinel and unchanged."""
         backend, mem_store = _make_backend()
         middleware = FilesystemMiddleware(backend=backend, tool_token_limit_before_evict=1000)
         runtime = _runtime("test_123")
@@ -1178,7 +1196,7 @@ class TestFilesystemMiddleware:
         tool_message = ToolMessage(content=small_content, tool_call_id="test_123")
         command = Command(
             update={
-                "messages": Overwrite([tool_message]),
+                "messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), tool_message],
                 "files": {},
                 "custom_key": "custom_value",
             }
@@ -1186,13 +1204,16 @@ class TestFilesystemMiddleware:
         result = middleware._intercept_large_tool_result(command, runtime)
 
         assert isinstance(result, Command)
-        assert isinstance(result.update["messages"], Overwrite)
-        assert result.update["messages"].value == [tool_message]
+        messages = result.update["messages"]
+        assert isinstance(messages, list)
+        assert isinstance(messages[0], RemoveMessage)
+        assert messages[0].id == REMOVE_ALL_MESSAGES
+        assert messages[1:] == [tool_message]
         assert result.update["custom_key"] == "custom_value"
         assert mem_store.get(("filesystem",), "/large_tool_results/test_123") is None
 
-    def test_intercept_command_with_mixed_overwrite_messages(self):
-        """Non-tool messages in an Overwrite update survive in order."""
+    def test_intercept_command_with_mixed_sentinel_messages(self):
+        """Non-tool messages in a sentinel-prefixed update survive in order."""
         backend, mem_store = _make_backend()
         middleware = FilesystemMiddleware(backend=backend, tool_token_limit_before_evict=1000)
         runtime = _runtime("test_123")
@@ -1203,7 +1224,12 @@ class TestFilesystemMiddleware:
         final_message = AIMessage(content="Done")
         command = Command(
             update={
-                "messages": Overwrite([ai_message, tool_message, final_message]),
+                "messages": [
+                    RemoveMessage(id=REMOVE_ALL_MESSAGES),
+                    ai_message,
+                    tool_message,
+                    final_message,
+                ],
                 "files": {},
                 "custom_key": "custom_value",
             }
@@ -1211,16 +1237,18 @@ class TestFilesystemMiddleware:
         result = middleware._intercept_large_tool_result(command, runtime)
 
         assert isinstance(result, Command)
-        assert isinstance(result.update["messages"], Overwrite)
-        messages = result.update["messages"].value
-        assert messages[0] == ai_message
-        assert "Tool result too large" in messages[1].content
-        assert messages[2] == final_message
+        messages = result.update["messages"]
+        assert isinstance(messages, list)
+        assert isinstance(messages[0], RemoveMessage)
+        assert messages[0].id == REMOVE_ALL_MESSAGES
+        assert messages[1] == ai_message
+        assert "Tool result too large" in messages[2].content
+        assert messages[3] == final_message
         assert result.update["custom_key"] == "custom_value"
         assert mem_store.get(("filesystem",), "/large_tool_results/test_123") is not None
 
-    async def test_aintercept_command_with_mixed_overwrite_messages(self):
-        """The async path preserves non-tool messages in Overwrite updates."""
+    async def test_aintercept_command_with_mixed_sentinel_messages(self):
+        """Async path preserves non-tool messages in sentinel-prefixed updates."""
         backend, mem_store = _make_backend()
         middleware = FilesystemMiddleware(backend=backend, tool_token_limit_before_evict=1000)
         runtime = _runtime("test_123")
@@ -1228,28 +1256,42 @@ class TestFilesystemMiddleware:
         ai_message = AIMessage(content="Use a tool")
         large_content = "y" * 5000
         tool_message = ToolMessage(content=large_content, tool_call_id="test_123")
-        command = Command(update={"messages": Overwrite([ai_message, tool_message])})
+        command = Command(
+            update={
+                "messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), ai_message, tool_message],
+            }
+        )
         result = await middleware._aintercept_large_tool_result(command, runtime)
 
         assert isinstance(result, Command)
-        assert isinstance(result.update["messages"], Overwrite)
-        messages = result.update["messages"].value
-        assert messages[0] == ai_message
-        assert "Tool result too large" in messages[1].content
+        messages = result.update["messages"]
+        assert isinstance(messages, list)
+        assert isinstance(messages[0], RemoveMessage)
+        assert messages[0].id == REMOVE_ALL_MESSAGES
+        assert messages[1] == ai_message
+        assert "Tool result too large" in messages[2].content
         assert mem_store.get(("filesystem",), "/large_tool_results/test_123") is not None
 
-    def test_intercept_command_with_empty_overwrite_messages(self):
-        """An empty Overwrite remains an empty Overwrite."""
+    def test_intercept_command_with_empty_sentinel_messages(self):
+        """A sentinel-only message list stays as just the sentinel."""
         backend, _ = _make_backend()
         middleware = FilesystemMiddleware(backend=backend, tool_token_limit_before_evict=1000)
         runtime = _runtime("test_123")
 
-        command = Command(update={"messages": Overwrite([]), "custom_key": "custom_value"})
+        command = Command(
+            update={
+                "messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES)],
+                "custom_key": "custom_value",
+            }
+        )
         result = middleware._intercept_large_tool_result(command, runtime)
 
         assert isinstance(result, Command)
-        assert isinstance(result.update["messages"], Overwrite)
-        assert result.update["messages"].value == []
+        messages = result.update["messages"]
+        assert isinstance(messages, list)
+        assert len(messages) == 1
+        assert isinstance(messages[0], RemoveMessage)
+        assert messages[0].id == REMOVE_ALL_MESSAGES
         assert result.update["custom_key"] == "custom_value"
 
     def test_sanitize_tool_call_id(self):
@@ -2058,8 +2100,11 @@ class TestPatchToolCallsMiddleware:
         middleware = PatchToolCallsMiddleware()
         state_update = middleware.before_agent({"messages": input_messages}, None)
         assert state_update is not None
-        assert isinstance(state_update["messages"], Overwrite)
-        patched_messages = state_update["messages"].value
+        messages = state_update["messages"]
+        assert isinstance(messages, list)
+        assert isinstance(messages[0], RemoveMessage)
+        assert messages[0].id == REMOVE_ALL_MESSAGES
+        patched_messages = messages[1:]
         assert len(patched_messages) == 5
         assert patched_messages[0].type == "system"
         assert patched_messages[0].content == "You are a helpful assistant."
@@ -2112,8 +2157,11 @@ class TestPatchToolCallsMiddleware:
         middleware = PatchToolCallsMiddleware()
         state_update = middleware.before_agent({"messages": input_messages}, None)
         assert state_update is not None
-        assert isinstance(state_update["messages"], Overwrite)
-        patched_messages = state_update["messages"].value
+        messages = state_update["messages"]
+        assert isinstance(messages, list)
+        assert isinstance(messages[0], RemoveMessage)
+        assert messages[0].id == REMOVE_ALL_MESSAGES
+        patched_messages = messages[1:]
         assert len(patched_messages) == 8
         assert patched_messages[0].type == "system"
         assert patched_messages[0].content == "You are a helpful assistant."


### PR DESCRIPTION
`FilesystemMiddleware` and `PatchToolCallsMiddleware` previously emitted `Overwrite(...)` to atomically replace the `messages` channel. With the local `_messages_delta_reducer` and `DeltaChannel`, the same semantics are expressible as a `RemoveMessage(REMOVE_ALL_MESSAGES)` sentinel followed by the desired message list — which is the standard `add_messages`-compatible idiom and avoids depending on `Overwrite`.

Three call sites change:

- `PatchToolCallsMiddleware.before_agent` now returns `[RemoveMessage(id=REMOVE_ALL_MESSAGES), *patched_messages]`.
- `FilesystemMiddleware._apply_eviction_and_truncate` emits the same sentinel-prefixed list when tagging a newly evicted `HumanMessage`, preserving the "atomic replace so DeltaChannel replay doesn't duplicate the `id=None` write" property.
- `FilesystemMiddleware._intercept_large_tool_result` (and its async sibling) now detect a leading `REMOVE_ALL_MESSAGES` sentinel on incoming tool `Command` updates instead of an `Overwrite` wrapper, and re-emit the sentinel after eviction processing.

`Overwrite` is no longer imported by either middleware. Unit tests covering both middlewares are updated to assert the new sentinel-prefixed list shape.