### PR TITLE
fix(quickjs): ptc tools in tools namespace are rendered without prepended `tools.` in system prompt and task as ptc duplicated task global

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/_prompt.py
+++ b/libs/partners/quickjs/langchain_quickjs/_prompt.py
@@ -10,8 +10,6 @@ from typing import TYPE_CHECKING, Any, Literal, get_type_hints
 
 from pydantic import TypeAdapter
 
-from langchain_quickjs._subagent import is_subagent_task_tool
-
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -386,8 +384,6 @@ def render_ptc_prompt(tools: Sequence[BaseTool], *, tool_name: str = "eval") -> 
     for tool in tools:
         camel = to_camel_case(tool.name)
         schema = _safe_json_schema(tool)
-        if is_subagent_task_tool(tool):
-            schema = _camelize_schema_fields(schema)
         return_type = _render_return_type(tool)
         signature = _render_signature(camel, schema, return_type=return_type)
         description = (
@@ -451,24 +447,6 @@ def _safe_json_schema(tool: BaseTool) -> dict[str, Any] | None:
     return None
 
 
-def _camelize_schema_fields(schema: dict[str, Any] | None) -> dict[str, Any] | None:
-    """Return a copy of `schema` with property keys camelCased.
-
-    Only top-level keys are remapped: the bridge reads the top-level keys and
-    passes nested values through unchanged, so nested keys must stay verbatim.
-    """
-    if not schema or not isinstance(schema.get("properties"), dict):
-        return schema
-    camelized = dict(schema)
-    camelized["properties"] = {
-        to_camel_case(key): prop for key, prop in schema["properties"].items()
-    }
-    required = schema.get("required")
-    if isinstance(required, list):
-        camelized["required"] = [to_camel_case(key) for key in required]
-    return camelized
-
-
 def _render_signature(
     fn_name: str,
     schema: dict[str, Any] | None,
@@ -477,7 +455,7 @@ def _render_signature(
 ) -> str:
     return_clause = f"Promise<{return_type}>"
     default_signature = (
-        f"async function {fn_name}(input: Record<string, unknown>): {return_clause}"
+        f"tools.{fn_name}(input: Record<string, unknown>): {return_clause}"
     )
     if not schema or not isinstance(schema.get("properties"), dict):
         return default_signature
@@ -493,7 +471,7 @@ def _render_signature(
     body = "\n".join(fields) if fields else ""
     if not body:
         return default_signature
-    return f"async function {fn_name}(input: {{\n{body}\n}}): {return_clause}"
+    return f"tools.{fn_name}(input: {{\n{body}\n}}): {return_clause}"
 
 
 # Return types come from the tool's underlying function annotation. We feed

--- a/libs/partners/quickjs/langchain_quickjs/_prompt.py
+++ b/libs/partners/quickjs/langchain_quickjs/_prompt.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any, Literal, get_type_hints
 
 from pydantic import TypeAdapter
 
+from langchain_quickjs._subagent import is_subagent_task_tool
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -384,6 +386,8 @@ def render_ptc_prompt(tools: Sequence[BaseTool], *, tool_name: str = "eval") -> 
     for tool in tools:
         camel = to_camel_case(tool.name)
         schema = _safe_json_schema(tool)
+        if is_subagent_task_tool(tool):
+            schema = _camelize_schema_fields(schema)
         return_type = _render_return_type(tool)
         signature = _render_signature(camel, schema, return_type=return_type)
         description = (
@@ -445,6 +449,24 @@ def _safe_json_schema(tool: BaseTool) -> dict[str, Any] | None:
     except Exception:  # noqa: BLE001 — prompt rendering is best-effort
         return None
     return None
+
+
+def _camelize_schema_fields(schema: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return a copy of `schema` with property keys camelCased.
+
+    Only top-level keys are remapped: the bridge reads the top-level keys and
+    passes nested values through unchanged, so nested keys must stay verbatim.
+    """
+    if not schema or not isinstance(schema.get("properties"), dict):
+        return schema
+    camelized = dict(schema)
+    camelized["properties"] = {
+        to_camel_case(key): prop for key, prop in schema["properties"].items()
+    }
+    required = schema.get("required")
+    if isinstance(required, list):
+        camelized["required"] = [to_camel_case(key) for key in required]
+    return camelized
 
 
 def _render_signature(

--- a/libs/partners/quickjs/langchain_quickjs/_ptc.py
+++ b/libs/partners/quickjs/langchain_quickjs/_ptc.py
@@ -34,9 +34,6 @@ if TYPE_CHECKING:
 
 PTCOption = list[str | BaseTool]
 
-# The subagent dispatch tool. It is reserved: it is always available as the
-# top-level `task()` global in the REPL, so it must never be exposed through
-# the `tools.*` PTC namespace (see `filter_tools_for_ptc`).
 _RESERVED_SUBAGENT_TASK_NAME = "task"
 
 _TASK_IN_PTC_MSG = (

--- a/libs/partners/quickjs/langchain_quickjs/_ptc.py
+++ b/libs/partners/quickjs/langchain_quickjs/_ptc.py
@@ -34,6 +34,19 @@ if TYPE_CHECKING:
 
 PTCOption = list[str | BaseTool]
 
+# The subagent dispatch tool. It is reserved: it is always available as the
+# top-level `task()` global in the REPL, so it must never be exposed through
+# the `tools.*` PTC namespace (see `filter_tools_for_ptc`).
+_RESERVED_SUBAGENT_TASK_NAME = "task"
+
+_TASK_IN_PTC_MSG = (
+    "The subagent `task` tool cannot be exposed via `ptc`. It is always "
+    "available as the top-level `task()` global inside the REPL (with "
+    "`subagentType` and `responseSchema` support); exposing it through the "
+    "`tools.*` namespace would create a second, conflicting dispatch path "
+    'that drops `responseSchema`. Remove "task" from `ptc`.'
+)
+
 
 def filter_tools_for_ptc(
     tools: Sequence[BaseTool],
@@ -58,6 +71,11 @@ def filter_tools_for_ptc(
     are included first, then name-matched agent tools are appended.
     Duplicate tool names are deduplicated.
 
+    The subagent ``task`` tool is reserved and may not appear in ``config``
+    (by name or instance) — it is always available as the ``task()`` global,
+    so a ``tools.task`` PTC variant would be a conflicting, degraded duplicate.
+    A ``"task"`` entry raises ``ValueError``.
+
     Warning:
         PTC tool calls execute through the REPL bridge and currently do
         not respect `interrupt_on` / HITL approval hooks for each
@@ -68,10 +86,14 @@ def filter_tools_for_ptc(
         allow_names: set[str] = set()
         for entry in config:
             if isinstance(entry, BaseTool):
+                if entry.name == _RESERVED_SUBAGENT_TASK_NAME:
+                    raise ValueError(_TASK_IN_PTC_MSG)
                 if entry.name != self_tool_name:
                     explicit_tools.append(entry)
                 continue
             if isinstance(entry, str):
+                if entry == _RESERVED_SUBAGENT_TASK_NAME:
+                    raise ValueError(_TASK_IN_PTC_MSG)
                 allow_names.add(entry)
                 continue
             msg = "ptc list entries must be str or BaseTool"

--- a/libs/partners/quickjs/langchain_quickjs/_subagent.py
+++ b/libs/partners/quickjs/langchain_quickjs/_subagent.py
@@ -28,13 +28,18 @@ _SCHEMA_MAX_PROPERTIES = 32
 _SUBAGENT_TASK_TOOL_FIELDS = frozenset({"description", "subagent_type"})
 
 
+def is_subagent_task_tool(tool: BaseTool) -> bool:
+    """Return whether `tool` is the Deep Agents task tool backing `task()`."""
+    return (
+        getattr(tool, "name", None) == "task"
+        and _tool_input_field_names(tool) >= _SUBAGENT_TASK_TOOL_FIELDS
+    )
+
+
 def find_subagent_task_tool(tools: Sequence[BaseTool]) -> BaseTool | None:
     """Return the Deep Agents task tool that backs top-level `task()`."""
     for tool in tools:
-        if (
-            getattr(tool, "name", None) == "task"
-            and _tool_input_field_names(tool) >= _SUBAGENT_TASK_TOOL_FIELDS
-        ):
+        if is_subagent_task_tool(tool):
             return tool
     return None
 

--- a/libs/partners/quickjs/langchain_quickjs/_subagent.py
+++ b/libs/partners/quickjs/langchain_quickjs/_subagent.py
@@ -28,18 +28,13 @@ _SCHEMA_MAX_PROPERTIES = 32
 _SUBAGENT_TASK_TOOL_FIELDS = frozenset({"description", "subagent_type"})
 
 
-def is_subagent_task_tool(tool: BaseTool) -> bool:
-    """Return whether `tool` is the Deep Agents task tool backing `task()`."""
-    return (
-        getattr(tool, "name", None) == "task"
-        and _tool_input_field_names(tool) >= _SUBAGENT_TASK_TOOL_FIELDS
-    )
-
-
 def find_subagent_task_tool(tools: Sequence[BaseTool]) -> BaseTool | None:
     """Return the Deep Agents task tool that backs top-level `task()`."""
     for tool in tools:
-        if is_subagent_task_tool(tool):
+        if (
+            getattr(tool, "name", None) == "task"
+            and _tool_input_field_names(tool) >= _SUBAGENT_TASK_TOOL_FIELDS
+        ):
             return tool
     return None
 

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions.md
@@ -376,27 +376,27 @@ console.log({ city, normalized });
 
 ```typescript
 /** Find users with the given name. */
-async function findUsersByName(input: {
+tools.findUsersByName(input: {
   name: string;
 }): Promise<unknown[]>
 
 /** Get the location id for a user. */
-async function getUserLocation(input: {
+tools.getUserLocation(input: {
   user_id: number;
 }): Promise<number>
 
 /** Get the city for a location. */
-async function getCityForLocation(input: {
+tools.getCityForLocation(input: {
   location_id: number;
 }): Promise<string>
 
 /** Normalize a user name for matching. */
-async function normalizeName(input: {
+tools.normalizeName(input: {
   name: string;
 }): Promise<string>
 
 /** Fetch the current weather for a city. */
-async function fetchWeather(input: {
+tools.fetchWeather(input: {
   city: string;
 }): Promise<string>
 ```

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_call.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_call.md
@@ -376,27 +376,27 @@ console.log({ city, normalized });
 
 ```typescript
 /** Find users with the given name. */
-async function findUsersByName(input: {
+tools.findUsersByName(input: {
   name: string;
 }): Promise<unknown[]>
 
 /** Get the location id for a user. */
-async function getUserLocation(input: {
+tools.getUserLocation(input: {
   user_id: number;
 }): Promise<number>
 
 /** Get the city for a location. */
-async function getCityForLocation(input: {
+tools.getCityForLocation(input: {
   location_id: number;
 }): Promise<string>
 
 /** Normalize a user name for matching. */
-async function normalizeName(input: {
+tools.normalizeName(input: {
   name: string;
 }): Promise<string>
 
 /** Fetch the current weather for a city. */
-async function fetchWeather(input: {
+tools.fetchWeather(input: {
   city: string;
 }): Promise<string>
 ```

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_turn.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_turn.md
@@ -376,27 +376,27 @@ console.log({ city, normalized });
 
 ```typescript
 /** Find users with the given name. */
-async function findUsersByName(input: {
+tools.findUsersByName(input: {
   name: string;
 }): Promise<unknown[]>
 
 /** Get the location id for a user. */
-async function getUserLocation(input: {
+tools.getUserLocation(input: {
   user_id: number;
 }): Promise<number>
 
 /** Get the city for a location. */
-async function getCityForLocation(input: {
+tools.getCityForLocation(input: {
   location_id: number;
 }): Promise<string>
 
 /** Normalize a user name for matching. */
-async function normalizeName(input: {
+tools.normalizeName(input: {
   name: string;
 }): Promise<string>
 
 /** Fetch the current weather for a city. */
-async function fetchWeather(input: {
+tools.fetchWeather(input: {
   city: string;
 }): Promise<string>
 ```

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -252,6 +252,28 @@ def test_filter_list_include() -> None:
     assert [t.name for t in out] == ["a", "c"]
 
 
+def test_filter_rejects_task_by_name() -> None:
+    task = _echo_tool("task")
+    with pytest.raises(ValueError, match="task` tool cannot be exposed"):
+        filter_tools_for_ptc([task], ["task"], self_tool_name="eval")
+
+
+def test_filter_rejects_task_by_instance() -> None:
+    task = _echo_tool("task")
+    with pytest.raises(ValueError, match="task` tool cannot be exposed"):
+        filter_tools_for_ptc([], [task], self_tool_name="eval")
+
+
+def test_filter_allows_non_task_tools() -> None:
+    # Sanity: the reservation is specific to the name "task".
+    out = filter_tools_for_ptc(
+        [_echo_tool("tasks"), _echo_tool("subtask")],
+        ["tasks", "subtask"],
+        self_tool_name="eval",
+    )
+    assert [t.name for t in out] == ["tasks", "subtask"]
+
+
 def test_filter_list_of_tools_uses_them_directly() -> None:
     """`list[BaseTool]` ignores agent tools and uses the supplied list."""
     greet = _greet_tool()

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -327,6 +327,29 @@ def test_render_ptc_prompt_rejects_invalid_js_identifiers() -> None:
         render_ptc_prompt([_echo_tool("123bad")])
 
 
+def test_render_ptc_prompt_camelcases_task_subagent_type() -> None:
+    """The `task` signature must use `subagentType` (what the JS bridge reads).
+
+    The Pydantic schema field is `subagent_type`, but the REPL `task()` bridge
+    only accepts the camelCase key, so the rendered signature must match.
+    """
+
+    class _TaskInput(BaseModel):
+        description: str = Field(description="Task prompt")
+        subagent_type: str = Field(description="Subagent name")
+
+    task_tool = StructuredTool.from_function(
+        func=lambda description, subagent_type: "ok",
+        name="task",
+        description="Launch a subagent",
+        args_schema=_TaskInput,
+    )
+
+    prompt = render_ptc_prompt([task_tool])
+    assert "subagentType: string" in prompt
+    assert "subagent_type" not in prompt
+
+
 # ---------------------------------------------------------------------------
 # In-REPL invocation
 # ---------------------------------------------------------------------------

--- a/libs/partners/quickjs/tests/unit_tests/test_ptc.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_ptc.py
@@ -314,7 +314,7 @@ def test_render_ptc_prompt_uses_signatures() -> None:
     prompt = render_ptc_prompt([_greet_tool()])
     assert "`tools` namespace" in prompt
     assert "globalThis.tools" in prompt
-    assert "async function greet(input:" in prompt
+    assert "tools.greet(input:" in prompt
     # Fields come through
     assert "name: string" in prompt
     assert "times?: number" in prompt
@@ -325,29 +325,6 @@ def test_render_ptc_prompt_uses_signatures() -> None:
 def test_render_ptc_prompt_rejects_invalid_js_identifiers() -> None:
     with pytest.raises(ValueError, match="cannot be exposed as JavaScript identifier"):
         render_ptc_prompt([_echo_tool("123bad")])
-
-
-def test_render_ptc_prompt_camelcases_task_subagent_type() -> None:
-    """The `task` signature must use `subagentType` (what the JS bridge reads).
-
-    The Pydantic schema field is `subagent_type`, but the REPL `task()` bridge
-    only accepts the camelCase key, so the rendered signature must match.
-    """
-
-    class _TaskInput(BaseModel):
-        description: str = Field(description="Task prompt")
-        subagent_type: str = Field(description="Subagent name")
-
-    task_tool = StructuredTool.from_function(
-        func=lambda description, subagent_type: "ok",
-        name="task",
-        description="Launch a subagent",
-        args_schema=_TaskInput,
-    )
-
-    prompt = render_ptc_prompt([task_tool])
-    assert "subagentType: string" in prompt
-    assert "subagent_type" not in prompt
 
 
 # ---------------------------------------------------------------------------
@@ -606,7 +583,7 @@ def test_middleware_ptc_list_includes_prompt_block() -> None:
     req = SimpleNamespace(tools=[_greet_tool(), _echo_tool("eval")])
     prompt = mw._prepare_for_call(req)
     # Greet included
-    assert "async function greet(" in prompt
+    assert "tools.greet(" in prompt
     # The REPL's own tool never appears
     assert "tools.eval(" not in prompt
 
@@ -618,7 +595,7 @@ def test_middleware_ptc_list_of_tools_exposes_without_agent_tools() -> None:
     mw = CodeInterpreterMiddleware(ptc=[_greet_tool()])
     req = SimpleNamespace(tools=[])
     prompt = mw._prepare_for_call(req)
-    assert "async function greet(" in prompt
+    assert "tools.greet(" in prompt
 
 
 async def test_ptc_install_and_eval_resolve_to_same_repl() -> None:

--- a/libs/partners/quickjs/tests/unit_tests/test_thread_affinity.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_thread_affinity.py
@@ -9,8 +9,6 @@ from collections.abc import (
 from typing import TYPE_CHECKING, Any
 
 from deepagents import create_deep_agent
-from deepagents.middleware.subagents import SubAgentMiddleware
-from langchain.agents import create_agent
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.runnables import RunnableLambda
@@ -105,8 +103,12 @@ async def test_quickjs_async_ptc_runs_tools_on_outer_loop() -> None:
     _assert_result_contains(tool_message.content, outer_loop_id)
 
 
-async def test_quickjs_async_ptc_task_subagent_loop_affinity_e2e() -> None:
-    """E2E: PTC `task` runs compiled subagents on the caller loop."""
+async def test_quickjs_async_task_global_subagent_loop_affinity_e2e() -> None:
+    """E2E: the top-level `task()` global runs compiled subagents on the caller loop.
+
+    `task` is reserved and cannot be exposed via `ptc` (it is always the global),
+    so the loop-affinity guarantee is exercised through the global dispatch path.
+    """
     outer_loop_id = id(asyncio.get_running_loop())
     owner_loop = asyncio.get_running_loop()
     subagent_loop_ids: list[int] = []
@@ -126,33 +128,28 @@ async def test_quickjs_async_ptc_task_subagent_loop_affinity_e2e() -> None:
         return {"messages": [AIMessage(content="subagent-ok")]}
 
     subagent_runnable = RunnableLambda(_subagent_sync, afunc=_subagent_async)
-    agent = create_agent(
+    agent = create_deep_agent(
         model=_FakeChatModel(
             messages=_script(
-                "await tools.task({"
-                "description: 'say hi', subagent_type: 'researcher'"
-                "})",
+                "await task({description: 'say hi', subagentType: 'researcher'})",
                 final_message="done",
             )
         ),
+        subagents=[
+            {
+                "name": "researcher",
+                "description": "returns one short answer",
+                "runnable": subagent_runnable,
+            }
+        ],
         middleware=[
-            SubAgentMiddleware(
-                backend=None,
-                subagents=[
-                    {
-                        "name": "researcher",
-                        "description": "returns one short answer",
-                        "runnable": subagent_runnable,
-                    }
-                ],
-            ),
-            CodeInterpreterMiddleware(ptc=["task"]),
+            CodeInterpreterMiddleware(),
         ],
     )
 
     result = await agent.ainvoke(
         {"messages": [HumanMessage(content="Use eval and call task for researcher")]},
-        config={"configurable": {"thread_id": "ptc-task-loop-affinity"}},
+        config={"configurable": {"thread_id": "task-global-loop-affinity"}},
     )
     tool_message = _eval_tool_message(result)
     _assert_result_contains(tool_message.content, "subagent-ok")


### PR DESCRIPTION
### Summary

Our system prompt for the code interpreter has a tools namespace section that shows call signatures for PTC tools. The existing logic rendered those tools without tools. prepended. This caused the agent to confuse the task global with the tools-namespaced (PTC) task variant, which uses `subagent_type` instead of `subagentType`. Additionally, since we already expose task as a global we should disallow it from being provided as a ptc tool.

This PR prepends tools. to rendered PTC tool signatures to differentiate PTC tools from globals and throws a value error if task is passed in ptc.

### Tests

- Unit tests to validate expected behavior
- Ran an e2e test in LangSmith to validate behavior