### PR TITLE
test(code): speed up Textual widget tests

### DIFF
--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -112,6 +112,24 @@ def _clear_update_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _disable_app_startup_update_checks(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep app startup tests from racing PyPI or user update config.
+
+    `test_config_manifest` and `test_main` patch `is_update_check_enabled` themselves.
+    """
+    module_name = request.module.__name__.rsplit(".", 1)[-1]
+    if module_name in {"test_config_manifest", "test_main"}:
+        return
+    monkeypatch.setattr(
+        "deepagents_code.update_check.is_update_check_enabled",
+        lambda: False,
+    )
+
+
+@pytest.fixture(autouse=True)
 def _clear_external_event_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent local alpha event-listener env vars from affecting tests."""
     monkeypatch.delenv("DEEPAGENTS_CODE_EXTERNAL_EVENT_SOCKET", raising=False)
@@ -198,6 +216,20 @@ def _provide_app_context() -> Generator[None]:
         yield
     finally:
         active_app.reset(token)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect app-managed state away from the developer's real data."""
+    state_dir = tmp_path / ".state"
+    monkeypatch.setattr("deepagents_code.model_config.DEFAULT_STATE_DIR", state_dir)
+
+    from deepagents_code import sessions
+
+    monkeypatch.setattr(sessions, "_db_path", None)
+    sessions._message_count_cache.clear()
+    sessions._initial_prompt_cache.clear()
+    sessions._recent_threads_cache.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -67,6 +67,16 @@ async def _wait_for_branch(app: DeepAgentsApp, branch: str) -> None:
     raise AssertionError(msg)
 
 
+def _closing_run_worker_mock(
+    work: object, *args: object, **kwargs: object
+) -> MagicMock:
+    """Close coroutine work swallowed by a `run_worker` mock."""
+    del args, kwargs
+    if inspect.iscoroutine(work):
+        work.close()
+    return MagicMock()
+
+
 class TestWhatsNewMessage:
     """Tests for the post-upgrade banner content."""
 
@@ -8571,6 +8581,7 @@ class TestRestartServerForAgentSwap:
             thread_id="old-thread",
             server_kwargs={"assistant_id": "coder"},
             server_proc=server_proc,
+            defer_server_start=True,
         )
         return app, server_proc
 
@@ -8671,7 +8682,7 @@ class TestRestartServerForAgentSwap:
                     return_value=True,
                 ),
                 patch.object(app, "_mount_message", side_effect=mounted.append),
-                patch.object(app, "run_worker"),
+                patch.object(app, "run_worker", side_effect=_closing_run_worker_mock),
             ):
                 await app._restart_server_for_agent_swap("researcher")
 
@@ -8700,7 +8711,7 @@ class TestRestartServerForAgentSwap:
                     return_value=True,
                 ),
                 patch.object(app, "_mount_message", side_effect=mounted.append),
-                patch.object(app, "run_worker"),
+                patch.object(app, "run_worker", side_effect=_closing_run_worker_mock),
             ):
                 await app._restart_server_for_agent_swap("researcher")
 
@@ -8720,6 +8731,7 @@ class TestRestartServerForAgentSwap:
             thread_id=None,
             server_kwargs={"assistant_id": "coder"},
             server_proc=server_proc,
+            defer_server_start=True,
         )
         mounted: list[object] = []
         async with app.run_test() as pilot:
@@ -8730,7 +8742,7 @@ class TestRestartServerForAgentSwap:
                     return_value=True,
                 ),
                 patch.object(app, "_mount_message", side_effect=mounted.append),
-                patch.object(app, "run_worker"),
+                patch.object(app, "run_worker", side_effect=_closing_run_worker_mock),
             ):
                 await app._restart_server_for_agent_swap("researcher")
 
@@ -8780,7 +8792,7 @@ class TestRestartServerForAgentSwap:
                 patch.object(
                     app, "_mount_message", AsyncMock(side_effect=record_mount)
                 ),
-                patch.object(app, "run_worker"),
+                patch.object(app, "run_worker", side_effect=_closing_run_worker_mock),
                 patch.object(app, "notify", side_effect=record_notify) as notify_mock,
             ):
                 await app._restart_server_for_agent_swap("researcher")

--- a/libs/code/tests/unit_tests/test_mcp_viewer.py
+++ b/libs/code/tests/unit_tests/test_mcp_viewer.py
@@ -1086,14 +1086,13 @@ class TestMCPViewerScreen:
             assert screen._selected_index == 1
             assert scroll.scroll_offset.y > initial_offset
 
-            # Many Downs eventually expose the bottom and the next press jumps.
-            for _ in range(60):
-                if screen._selected_index == 2:
-                    break
-                await pilot.press("down")
-                await pilot.pause()
+            # Put the bottom edge in view, then the next Down should jump.
+            scroll.scroll_relative(y=1000, animate=False)
+            await pilot.pause()
+            await pilot.press("down")
+            await pilot.pause()
             assert screen._selected_index == 2, (
-                "expected to eventually jump to next tool"
+                "expected to jump to next tool once the bottom is visible"
             )
 
     async def test_arrow_up_scrolls_inside_tall_tool_then_jumps(self) -> None:
@@ -1136,13 +1135,11 @@ class TestMCPViewerScreen:
             assert screen._selected_index == 2
             assert scroll.scroll_offset.y < offset_before
 
-            # Many Ups eventually re-expose the top and the next press jumps
-            # to "prev" (row 1). Cap the loop so a regression can't hang.
-            for _ in range(60):
-                if screen._selected_index == 1:
-                    break
-                await pilot.press("up")
-                await pilot.pause()
+            # Put the top edge in view, then the next Up should jump to "prev".
+            scroll.scroll_relative(y=-1000, animate=False)
+            await pilot.pause()
+            await pilot.press("up")
+            await pilot.pause()
             assert screen._selected_index == 1
 
     async def test_up_jump_pins_previous_tool_to_viewport_bottom(self) -> None:
@@ -1175,17 +1172,15 @@ class TestMCPViewerScreen:
             await pilot.press("down")
             await pilot.press("enter")
             await pilot.pause()
-            # Scroll all the way down through "big" until we jump to "next"
-            # (row 2).
-            for _ in range(80):
-                await pilot.press("down")
-                await pilot.pause()
-                if screen._selected_index == 2:
-                    break
-            assert screen._selected_index == 2
-
             scroll = screen.query_one(".mcp-list", VerticalScroll)
             big = screen._tool_widgets[0]
+
+            # Put the bottom edge in view, then press Down to jump to "next" (row 2).
+            scroll.scroll_relative(y=1000, animate=False)
+            await pilot.pause()
+            await pilot.press("down")
+            await pilot.pause()
+            assert screen._selected_index == 2
 
             # Press Up — should jump back to "big" (row 1) and pin its
             # bottom near the viewport bottom (within 1 row, allowing for

--- a/libs/code/tests/unit_tests/test_model_selector.py
+++ b/libs/code/tests/unit_tests/test_model_selector.py
@@ -41,6 +41,32 @@ def _seed_provider_credentials(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
     )
 
 
+_FILTER_TEST_MODELS: list[tuple[str, str]] = [
+    ("anthropic:claude-sonnet-4-5", "anthropic"),
+    ("anthropic:claude-opus-4-7", "anthropic"),
+    ("anthropic:claude-haiku-4-5", "anthropic"),
+    ("openai:gpt-4", "openai"),
+    ("openai:gpt-5.5", "openai"),
+    ("openrouter:anthropic/claude-sonnet-4.7", "openrouter"),
+]
+
+
+def _model_selector_for_filtering() -> ModelSelectorScreen:
+    """Create a selector with deterministic model data for filter unit tests."""
+    screen = ModelSelectorScreen(
+        current_model="claude-sonnet-4-5",
+        current_provider="anthropic",
+    )
+    screen._recommended_only = False
+    screen._unfiltered_models = list(_FILTER_TEST_MODELS)
+    screen._all_models = list(_FILTER_TEST_MODELS)
+    screen._filtered_models = list(_FILTER_TEST_MODELS)
+    screen._recent_specs = []
+    screen._install_extras = {}
+    screen._selected_index = screen._find_current_model_index()
+    return screen
+
+
 class ModelSelectorTestApp(App):
     """Test app for ModelSelectorScreen."""
 
@@ -845,53 +871,50 @@ class TestModelSelectorFiltering:
 
             assert screen._filter_text == "claude"
 
-    async def test_custom_model_spec_entry(self) -> None:
+    def test_custom_model_spec_entry(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """User can enter a custom provider:model spec."""
-        app = ModelSelectorTestApp()
-        async with app.run_test() as pilot:
-            app.show_selector()
-            await pilot.pause()
+        screen = _model_selector_for_filtering()
+        result: tuple[str, str] | None = None
 
-            # Type a custom model spec
-            for char in "custom:my-model":
-                await pilot.press(char)
-            await pilot.pause()
+        class FakeInput:
+            value = "custom:my-model"
 
-            # Press enter to select
-            await pilot.press("enter")
-            await pilot.pause()
+        screen._filtered_models = []
+        monkeypatch.setattr(screen, "query_one", lambda *_args, **_kwargs: FakeInput())
 
-            assert app.dismissed is True
-            assert app.result == ("custom:my-model", "custom")
+        def record(value: tuple[str, str] | None) -> None:
+            nonlocal result
+            result = value
 
-    async def test_enter_selects_highlighted_model_not_filter_text(self) -> None:
+        monkeypatch.setattr(screen, "_dismiss_with_result", record)
+
+        screen.action_select()
+
+        assert result == ("custom:my-model", "custom")
+
+    def test_enter_selects_highlighted_model_not_filter_text(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Enter selects highlighted model, not raw filter text."""
-        app = ModelSelectorTestApp()
-        async with app.run_test() as pilot:
-            app.show_selector()
-            await pilot.pause()
+        screen = _model_selector_for_filtering()
+        selected: tuple[str, str] | None = None
 
-            screen = app.screen
-            assert isinstance(screen, ModelSelectorScreen)
+        def record(model_spec: str, provider: str) -> None:
+            nonlocal selected
+            selected = (model_spec, provider)
 
-            # Type a partial spec with colon that matches existing models
-            for char in "anthropic:claude":
-                await pilot.press(char)
-            await pilot.pause()
+        screen._filter_text = "anthropic:claude"
+        screen._update_filtered_list()
+        monkeypatch.setattr(screen, "_select_with_auth_check", record)
 
-            # Should have filtered results
-            assert len(screen._filtered_models) > 0
+        assert len(screen._filtered_models) > 0
 
-            # Press enter - should select the highlighted model, not raw text
-            await pilot.press("enter")
-            await pilot.pause()
+        screen.action_select()
 
-            assert app.dismissed is True
-            assert app.result is not None
-            # Result should be a full model spec from the list, not "anthropic:claude"
-            model_spec, provider = app.result
-            assert model_spec != "anthropic:claude"
-            assert provider == "anthropic"
+        assert selected is not None
+        model_spec, provider = selected
+        assert model_spec != "anthropic:claude"
+        assert provider == "anthropic"
 
 
 class TestModelSelectorCurrentModelPreselection:
@@ -959,214 +982,127 @@ class TestModelSelectorCurrentModelPreselection:
 class TestModelSelectorFuzzyMatching:
     """Tests for fuzzy search filtering."""
 
-    async def test_fuzzy_exact_substring_still_works(self) -> None:
+    def test_fuzzy_exact_substring_still_works(self) -> None:
         """Exact substring matches should still work with fuzzy matching."""
-        app = ModelSelectorTestApp()
-        async with app.run_test() as pilot:
-            app.show_selector()
-            await pilot.pause()
+        screen = _model_selector_for_filtering()
+        screen._filter_text = "claude"
+        screen._update_filtered_list()
 
-            screen = app.screen
-            assert isinstance(screen, ModelSelectorScreen)
+        specs = [spec for spec, _ in screen._filtered_models]
+        assert any("claude" in s for s in specs), (
+            f"'claude' substring should match. Got: {specs}"
+        )
 
-            for char in "claude":
-                await pilot.press(char)
-            await pilot.pause()
-
-            specs = [spec for spec, _ in screen._filtered_models]
-            assert any("claude" in s for s in specs), (
-                f"'claude' substring should match. Got: {specs}"
-            )
-
-    async def test_fuzzy_subsequence_match(self) -> None:
+    def test_fuzzy_subsequence_match(self) -> None:
         """Subsequence queries like 'cs45' should match 'claude-sonnet-4-5'."""
-        app = ModelSelectorTestApp()
-        async with app.run_test() as pilot:
-            app.show_selector()
-            await pilot.pause()
+        screen = _model_selector_for_filtering()
+        screen._filter_text = "cs45"
+        screen._update_filtered_list()
 
-            screen = app.screen
-            assert isinstance(screen, ModelSelectorScreen)
+        specs = [spec for spec, _ in screen._filtered_models]
+        assert any("claude-sonnet-4-5" in s for s in specs), (
+            f"'cs45' should fuzzy-match claude-sonnet-4-5. Got: {specs}"
+        )
 
-            for char in "cs45":
-                await pilot.press(char)
-            await pilot.pause()
-
-            specs = [spec for spec, _ in screen._filtered_models]
-            assert any("claude-sonnet-4-5" in s for s in specs), (
-                f"'cs45' should fuzzy-match claude-sonnet-4-5. Got: {specs}"
-            )
-
-    async def test_fuzzy_across_hyphen(self) -> None:
+    def test_fuzzy_across_hyphen(self) -> None:
         """Queries should match across hyphens (e.g., 'gpt4' matches 'gpt-5.5')."""
-        app = ModelSelectorTestApp()
-        async with app.run_test() as pilot:
-            app.show_selector()
-            await pilot.pause()
+        screen = _model_selector_for_filtering()
+        screen._filter_text = "gpt4"
+        screen._update_filtered_list()
 
-            screen = app.screen
-            assert isinstance(screen, ModelSelectorScreen)
+        specs = [spec for spec, _ in screen._filtered_models]
+        assert any("gpt-4" in s for s in specs), (
+            f"'gpt4' should fuzzy-match gpt-4 models. Got: {specs}"
+        )
 
-            for char in "gpt4":
-                await pilot.press(char)
-            await pilot.pause()
-
-            specs = [spec for spec, _ in screen._filtered_models]
-            assert any("gpt-4" in s for s in specs), (
-                f"'gpt4' should fuzzy-match gpt-4 models. Got: {specs}"
-            )
-
-    async def test_fuzzy_case_insensitive(self) -> None:
+    def test_fuzzy_case_insensitive(self) -> None:
         """Fuzzy matching should be case-insensitive."""
-        app = ModelSelectorTestApp()
-        async with app.run_test() as pilot:
-            app.show_selector()
-            await pilot.pause()
+        screen = _model_selector_for_filtering()
+        screen._filter_text = "CLAUDE"
+        screen._update_filtered_list()
 
-            screen = app.screen
-            assert isinstance(screen, ModelSelectorScreen)
+        specs = [spec for spec, _ in screen._filtered_models]
+        assert any("claude" in s for s in specs), (
+            f"'CLAUDE' should case-insensitively match claude models. Got: {specs}"
+        )
 
-            # Type uppercase "CLAUDE"
-            for char in "CLAUDE":
-                await pilot.press(char)
-            await pilot.pause()
-
-            specs = [spec for spec, _ in screen._filtered_models]
-            assert any("claude" in s for s in specs), (
-                f"'CLAUDE' should case-insensitively match claude models. Got: {specs}"
-            )
-
-    async def test_fuzzy_no_match(self) -> None:
+    def test_fuzzy_no_match(self) -> None:
         """A query that matches nothing should produce an empty filtered list."""
-        app = ModelSelectorTestApp()
-        async with app.run_test() as pilot:
-            app.show_selector()
-            await pilot.pause()
+        screen = _model_selector_for_filtering()
+        screen._filter_text = "xyz999qqq"
+        screen._update_filtered_list()
 
-            screen = app.screen
-            assert isinstance(screen, ModelSelectorScreen)
+        assert len(screen._filtered_models) == 0
 
-            for char in "xyz999qqq":
-                await pilot.press(char)
-            await pilot.pause()
-
-            assert len(screen._filtered_models) == 0
-
-    async def test_fuzzy_ranking_better_match_first(self) -> None:
+    def test_fuzzy_ranking_better_match_first(self) -> None:
         """Better fuzzy matches should rank higher than weaker matches."""
-        app = ModelSelectorTestApp()
-        async with app.run_test() as pilot:
-            app.show_selector()
-            await pilot.pause()
+        screen = _model_selector_for_filtering()
+        screen._filter_text = "claude"
+        screen._update_filtered_list()
 
-            screen = app.screen
-            assert isinstance(screen, ModelSelectorScreen)
+        specs = [spec for spec, _ in screen._filtered_models]
+        assert len(specs) > 0
+        assert "claude" in specs[0].lower()
 
-            for char in "claude":
-                await pilot.press(char)
-            await pilot.pause()
-
-            specs = [spec for spec, _ in screen._filtered_models]
-            assert len(specs) > 0
-            # First result should be a strong match containing the query
-            assert "claude" in specs[0].lower()
-
-    async def test_empty_filter_shows_all(self) -> None:
+    def test_empty_filter_shows_all(self) -> None:
         """Empty filter should show all models in original order."""
-        app = ModelSelectorTestApp()
-        async with app.run_test() as pilot:
-            app.show_selector()
-            await pilot.pause()
+        screen = _model_selector_for_filtering()
+        screen._filter_text = ""
+        screen._update_filtered_list()
 
-            screen = app.screen
-            assert isinstance(screen, ModelSelectorScreen)
+        assert len(screen._filtered_models) == len(screen._all_models)
 
-            total = len(screen._filtered_models)
-            assert total == len(screen._all_models)
-
-    async def test_whitespace_filter_shows_all(self) -> None:
+    def test_whitespace_filter_shows_all(self) -> None:
         """Whitespace-only filter should be treated as empty."""
-        app = ModelSelectorTestApp()
-        async with app.run_test() as pilot:
-            app.show_selector()
-            await pilot.pause()
+        screen = _model_selector_for_filtering()
+        screen._filter_text = "   "
+        screen._update_filtered_list()
 
-            screen = app.screen
-            assert isinstance(screen, ModelSelectorScreen)
+        assert len(screen._filtered_models) == len(screen._all_models)
 
-            await pilot.press("space", "space", "space")
-            await pilot.pause()
-
-            assert len(screen._filtered_models) == len(screen._all_models)
-
-    async def test_selection_clamped_on_filter(self) -> None:
+    def test_selection_clamped_on_filter(self) -> None:
         """Selected index should stay valid when filter results shrink."""
-        app = ModelSelectorTestApp()
-        async with app.run_test() as pilot:
-            app.show_selector()
-            await pilot.pause()
+        screen = _model_selector_for_filtering()
+        screen._selected_index = 5
+        screen._filter_text = "claude"
+        screen._update_filtered_list()
 
-            screen = app.screen
-            assert isinstance(screen, ModelSelectorScreen)
+        assert screen._filtered_models, "Filter should match claude models"
+        assert screen._selected_index == 0, (
+            "Fuzzy filter should reset selection to best match (index 0)"
+        )
 
-            # Move selection down several times
-            for _ in range(5):
-                await pilot.press("down")
-            await pilot.pause()
-
-            # Now type a filter that produces fewer results
-            for char in "claude":
-                await pilot.press(char)
-            await pilot.pause()
-
-            assert screen._filtered_models, "Filter should match claude models"
-            assert screen._selected_index == 0, (
-                "Fuzzy filter should reset selection to best match (index 0)"
-            )
-
-    async def test_enter_selects_fuzzy_result(self) -> None:
+    def test_enter_selects_fuzzy_result(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Pressing Enter after fuzzy filtering should select the top result."""
-        app = ModelSelectorTestApp()
-        async with app.run_test() as pilot:
-            app.show_selector()
-            await pilot.pause()
+        screen = _model_selector_for_filtering()
+        selected: tuple[str, str] | None = None
 
-            screen = app.screen
-            assert isinstance(screen, ModelSelectorScreen)
+        def record(model_spec: str, provider: str) -> None:
+            nonlocal selected
+            selected = (model_spec, provider)
 
-            for char in "claude":
-                await pilot.press(char)
-            await pilot.pause()
+        screen._filter_text = "claude"
+        screen._update_filtered_list()
+        monkeypatch.setattr(screen, "_select_with_auth_check", record)
 
-            assert len(screen._filtered_models) > 0
+        assert len(screen._filtered_models) > 0
 
-            await pilot.press("enter")
-            await pilot.pause()
+        screen.action_select()
 
-            assert app.dismissed is True
-            assert app.result is not None
-            model_spec, _ = app.result
-            assert "claude" in model_spec.lower()
+        assert selected is not None
+        model_spec, _ = selected
+        assert "claude" in model_spec.lower()
 
-    async def test_fuzzy_space_separated_tokens(self) -> None:
+    def test_fuzzy_space_separated_tokens(self) -> None:
         """Space-separated tokens should each fuzzy-match independently."""
-        app = ModelSelectorTestApp()
-        async with app.run_test() as pilot:
-            app.show_selector()
-            await pilot.pause()
+        screen = _model_selector_for_filtering()
+        screen._filter_text = "claude sonnet"
+        screen._update_filtered_list()
 
-            screen = app.screen
-            assert isinstance(screen, ModelSelectorScreen)
-
-            # "claude sonnet" should match models containing both subsequences
-            for char in "claude sonnet":
-                await pilot.press(char)
-            await pilot.pause()
-
-            specs = [spec for spec, _ in screen._filtered_models]
-            assert any("claude" in s and "sonnet" in s for s in specs), (
-                f"'claude sonnet' should match claude-sonnet models. Got: {specs}"
-            )
+        specs = [spec for spec, _ in screen._filtered_models]
+        assert any("claude" in s and "sonnet" in s for s in specs), (
+            f"'claude sonnet' should match claude-sonnet models. Got: {specs}"
+        )
 
     async def test_tab_noop_when_no_matches(self) -> None:
         """Tab should do nothing when filter matches no models."""

--- a/libs/code/tests/unit_tests/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/test_thread_selector.py
@@ -507,34 +507,34 @@ class TestThreadSelectorTabSort:
                 agent_select = screen.query_one("#thread-agent-select", Select)
                 assert filter_input.has_focus
 
-                await pilot.press("tab")
+                screen.action_focus_next_filter()
                 await pilot.pause()
                 assert scope_select.has_focus
 
-                await pilot.press("tab")
+                screen.action_focus_next_filter()
                 await pilot.pause()
                 assert agent_select.has_focus
 
-                await pilot.press("tab")
+                screen.action_focus_next_filter()
                 await pilot.pause()
                 assert sort_switch.has_focus
 
                 relative_time_switch = screen.query_one(
                     "#thread-relative-time", Checkbox
                 )
-                await pilot.press("tab")
+                screen.action_focus_next_filter()
                 await pilot.pause()
                 assert relative_time_switch.has_focus
 
-                await pilot.press("tab")
+                screen.action_focus_next_filter()
                 await pilot.pause()
                 assert thread_id_switch.has_focus
 
-                await pilot.press("tab")
+                screen.action_focus_next_filter()
                 await pilot.pause()
                 assert agent_name_switch.has_focus
 
-                await pilot.press("tab")
+                screen.action_focus_next_filter()
                 await pilot.pause()
                 assert messages_switch.has_focus
 

--- a/libs/partners/quickjs/CHANGELOG.md
+++ b/libs/partners/quickjs/CHANGELOG.md
@@ -4,15 +4,14 @@
 
 ## [0.3.0](https://github.com/langchain-ai/deepagents/compare/langchain-quickjs==0.2.0...langchain-quickjs==0.3.0) (2026-06-18)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **quickjs:** upgrade to 0.2.0 quickjs-rs ([#4067](https://github.com/langchain-ai/deepagents/issues/4067))
+* Upgrade to 0.2.0 quickjs-rs ([#4067](https://github.com/langchain-ai/deepagents/issues/4067))
 
 ### Features
 
-* **quickjs:** prompt tuning on task global ([#4066](https://github.com/langchain-ai/deepagents/issues/4066)) ([a47696f](https://github.com/langchain-ai/deepagents/commit/a47696f6d3e57eccb5ea19fb344305a7995ecc76))
-* **quickjs:** upgrade to 0.2.0 quickjs-rs ([#4067](https://github.com/langchain-ai/deepagents/issues/4067)) ([4ffea88](https://github.com/langchain-ai/deepagents/commit/4ffea88690418207b5e4fa800ee8c1abfa454bec))
+* Prompt tuning on task global ([#4066](https://github.com/langchain-ai/deepagents/issues/4066)) ([a47696f](https://github.com/langchain-ai/deepagents/commit/a47696f6d3e57eccb5ea19fb344305a7995ecc76))
+* Upgrade to 0.2.0 quickjs-rs ([#4067](https://github.com/langchain-ai/deepagents/issues/4067)) ([4ffea88](https://github.com/langchain-ai/deepagents/commit/4ffea88690418207b5e4fa800ee8c1abfa454bec))
 
 ## [0.2.0](https://github.com/langchain-ai/deepagents/compare/langchain-quickjs==0.1.4...langchain-quickjs==0.2.0) (2026-06-12)
 


### PR DESCRIPTION
Several UI-heavy unit tests now exercise the logic they care about directly instead of routing every assertion through full Textual keypress flows. The test harness also isolates update checks and app state more consistently so local developer config and background startup behavior do not affect unrelated tests.

## Changes
- Added shared test isolation for startup update checks and app-managed state, while leaving `test_config_manifest` and `test_main` free to patch `is_update_check_enabled` themselves.
- Added `_closing_run_worker_mock` for server restart tests so mocked `run_worker` calls close swallowed coroutine work and avoid leaking unawaited coroutine warnings.
- Converted pure `ModelSelectorScreen` filtering and fuzzy matching tests to use deterministic in-memory selector state, while keeping separate Textual smoke coverage for real keyboard/UI behavior.
- Reduced repeated Textual keypress loops in MCP viewer scrolling tests by directly positioning the scroll viewport before asserting jump behavior.
- Changed the thread selector focus-order test to call `ThreadSelectorScreen.action_focus_next_filter()` directly instead of dispatching repeated synthetic Tab events.