### PR TITLE
fix(code): word-delete backspace parity in ask-user text area

### DIFF
--- a/libs/code/deepagents_code/widgets/ask_user.py
+++ b/libs/code/deepagents_code/widgets/ask_user.py
@@ -71,6 +71,12 @@ class AskUserTextArea(TextArea):
             show=False,
             priority=True,
         ),
+        Binding(
+            "ctrl+backspace,alt+backspace",
+            "delete_word_left",
+            "Delete left to start of word",
+            show=False,
+        ),
     ]
 
     class Submitted(Message):

--- a/libs/code/tests/unit_tests/test_ask_user.py
+++ b/libs/code/tests/unit_tests/test_ask_user.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from textual.app import App, ComposeResult
+from textual.binding import Binding
 from textual.widgets import Markdown, Static
 
 from deepagents_code.tool_display import format_tool_display
@@ -124,6 +125,22 @@ class TestTrailingAnnotationRegex:
     def test_leaves_question_without_annotation(self) -> None:
         text = "What is your name?"
         assert _TRAILING_ANNOTATION_RE.sub("", text) == text
+
+
+class TestAskUserTextAreaBindings:
+    """Ensures the ask-user text area matches chat input editing shortcuts."""
+
+    def test_modified_backspace_deletes_word_left(self) -> None:
+        """Modified Backspace aliases should delete the previous word."""
+        word_delete_keys = {
+            key.strip()
+            for binding in AskUserTextArea.BINDINGS
+            if isinstance(binding, Binding) and binding.action == "delete_word_left"
+            for key in binding.key.split(",")
+        }
+
+        assert "ctrl+backspace" in word_delete_keys
+        assert "alt+backspace" in word_delete_keys
 
 
 class TestAskUserMenu:


### PR DESCRIPTION
Fix `ctrl+backspace`/`alt+backspace` word deletion in the ask-user free-text input.

---

The ask-user free-text field didn't support `ctrl+backspace`/`alt+backspace` word deletion, unlike the main chat input. This adds the same `delete_word_left` binding to `AskUserTextArea` for input parity.

Made by [Open SWE](https://openswe.vercel.app/agents/18d30e16-2f6b-0d6b-e96f-fdbefa421845)