### PR TITLE
fix(talon): default workspace to current directory

### DIFF
--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -21,7 +21,7 @@ AGENT_ASSISTANT_ID=local AGENT_MODEL=openai:gpt-5.2 uv run deepagents-talon --on
 
 If `AGENT_MODEL` is unset, Talon starts with the echo runtime. This is useful for checking host lifecycle and channel wiring without provider credentials.
 
-Assistant state lives under `~/.deepagents/<assistant_id>/` by default. The host creates restrictive state directories for the materialized agent manifest, channel sessions, and cron jobs. The default local execution workspace is `/workspace`; set `DEEPAGENTS_TALON_WORKSPACE` to use a different directory.
+Assistant state lives under `~/.deepagents/<assistant_id>/` by default. The host creates restrictive state directories for the materialized agent manifest, channel sessions, and cron jobs. The default local execution workspace is the current working directory; set `DEEPAGENTS_TALON_WORKSPACE` to use a different directory.
 
 ## Fleet Exports
 

--- a/libs/talon/deepagents_talon/channels/whatsapp.py
+++ b/libs/talon/deepagents_talon/channels/whatsapp.py
@@ -123,7 +123,7 @@ class WhatsAppChannelConfig:
         outbound_media_dir = Path(
             env.get("DEEPAGENTS_TALON_OUTBOUND_MEDIA_DIR")
             or env.get("DEEPAGENTS_TALON_WORKSPACE")
-            or "/workspace",
+            or Path.cwd(),
         )
         command = _bridge_command(env)
         return cls(

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -52,7 +52,6 @@ logger = logging.getLogger(__name__)
 _STOP_COMMAND = "/stop"
 _APPROVE_REPLIES = frozenset({"approve", "approved", "yes", "y"})
 _DENY_REPLIES = frozenset({"deny", "denied", "reject", "rejected", "no", "n"})
-_DEFAULT_WORKSPACE = "/workspace"
 _OUTBOUND_MEDIA_DIR_ENV = "DEEPAGENTS_TALON_OUTBOUND_MEDIA_DIR"
 _WORKSPACE_ENV = "DEEPAGENTS_TALON_WORKSPACE"
 
@@ -484,12 +483,10 @@ def _outbound_media_from_refs(
 
 
 def _outbound_media_root(config: TalonConfig) -> Path:
-    raw = (
-        config.env.get(_OUTBOUND_MEDIA_DIR_ENV)
-        or config.env.get(_WORKSPACE_ENV)
-        or _DEFAULT_WORKSPACE
-    )
-    return Path(raw).expanduser()
+    raw = config.env.get(_OUTBOUND_MEDIA_DIR_ENV) or config.env.get(_WORKSPACE_ENV)
+    if raw:
+        return Path(raw).expanduser()
+    return Path.cwd()
 
 
 def _with_failed_attachment_text(text: str, failed: list[str]) -> str:

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -52,8 +52,8 @@ DEFAULT_RECURSION_LIMIT = 150
 DEFAULT_MAX_RETRIES = 3
 DEFAULT_MAX_CONTINUATIONS = 3
 DEFAULT_MAX_APPROVAL_ROUNDS = 50
-DEFAULT_WORKSPACE = "/workspace"
 CONTEXT_SIZE_ENV_KEY = "DEEPAGENTS_TALON_CONTEXT_SIZE"
+_WORKSPACE_ENV = "DEEPAGENTS_TALON_WORKSPACE"
 _SAFE_BACKEND_PATH = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 ModelContent = str | list[dict[str, object]]
 
@@ -779,7 +779,7 @@ def _decision_payload(
 
 def _default_backend(env: Mapping[str, str] | None) -> LocalShellBackend:
     values = os.environ if env is None else env
-    root = values.get("DEEPAGENTS_TALON_WORKSPACE", DEFAULT_WORKSPACE)
+    root = values.get(_WORKSPACE_ENV) or None
     return LocalShellBackend(
         root_dir=root,
         virtual_mode=False,

--- a/libs/talon/tests/channels/test_whatsapp.py
+++ b/libs/talon/tests/channels/test_whatsapp.py
@@ -64,7 +64,11 @@ class JsonResponse:
         return json.dumps({"success": True}).encode()
 
 
-def test_config_from_talon_env_maps_exposure(tmp_path: Path) -> None:
+def test_config_from_talon_env_maps_exposure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
     config = TalonConfig.from_env(
         {
             "AGENT_ASSISTANT_ID": "assistant",
@@ -81,6 +85,7 @@ def test_config_from_talon_env_maps_exposure(tmp_path: Path) -> None:
 
     assert whatsapp.session_dir == tmp_path / "assistant" / "channels" / "whatsapp"
     assert whatsapp.inbound_media_dir == tmp_path / "assistant" / "media" / "inbound" / "whatsapp"
+    assert whatsapp.outbound_media_dir == tmp_path
     assert whatsapp.exposure == ChannelExposure(
         mode=ExposureMode.ALLOWLIST,
         operator_id="operator",

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
@@ -23,6 +22,8 @@ from deepagents_talon.runtime import (
 )
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from langgraph.types import Command
 
 
@@ -144,6 +145,7 @@ async def test_runtime_wires_backend_checkpointer_tools_skills_and_memory(
     monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
     monkeypatch.setattr("deepagents_talon.runtime.fetch_url", fetch_url)
     monkeypatch.setattr("deepagents_talon.runtime.web_search", web_search)
+    monkeypatch.chdir(tmp_path)
 
     runtime = DeepAgentRuntime(
         model="test:model",
@@ -160,7 +162,7 @@ async def test_runtime_wires_backend_checkpointer_tools_skills_and_memory(
     assert captured["skills"] == [str(assistant_dir / "skills")]
     assert captured["memory"] == [str(assistant_dir / "memory" / "AGENTS.md")]
     assert (assistant_dir / "memory" / "AGENTS.md").is_file()
-    assert captured["backend"].cwd == Path("/workspace")
+    assert captured["backend"].cwd == tmp_path.resolve()
 
     tool_names = {_tool_name(tool) for tool in captured["tools"]}
     assert {


### PR DESCRIPTION
Talon currently defaults its local execution backend to `/workspace`, which only exists in the Docker example. Bare-metal runs can fail before the agent command executes because `LocalShellBackend` receives a missing working directory.

This changes the unset workspace behavior to use the process current working directory, while still preserving explicit `DEEPAGENTS_TALON_WORKSPACE` and `DEEPAGENTS_TALON_OUTBOUND_MEDIA_DIR` overrides. The Docker example continues to set `DEEPAGENTS_TALON_WORKSPACE=/workspace`, so container behavior is unchanged.

Tests run:
- `uv run --group test pytest tests/test_runtime.py tests/channels/test_whatsapp.py`
- `make lint`
- `make test`