### PR TITLE
feat(sdk): honor backend-declared file MIME types

### DIFF
--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -173,6 +173,9 @@ class FileData(TypedDict):
     encoding: str
     """Content encoding: `"utf-8"` for text, `"base64"` for binary."""
 
+    mime_type: NotRequired[str]
+    """Backend-declared MIME type for content, when known."""
+
     created_at: NotRequired[str]
     """ISO 8601 timestamp of file creation."""
 

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -6,6 +6,7 @@ enable composition without fragile string parsing.
 """
 
 import functools
+import mimetypes
 import os
 import re
 from collections.abc import Sequence
@@ -62,6 +63,13 @@ Derived from Google's multimodal API supported formats:
 - Video: https://ai.google.dev/gemini-api/docs/video-understanding
 - Audio: https://ai.google.dev/gemini-api/docs/audio
 """
+
+_MIME_PREFIX_TO_FILE_TYPE: dict[str, FileType] = {
+    "image/": "image",
+    "audio/": "audio",
+    "video/": "video",
+}
+"""MIME type prefixes that map directly to multimodal content block types."""
 
 MAX_LINE_LENGTH = 5000
 LINE_NUMBER_WIDTH = 6
@@ -177,18 +185,40 @@ def check_empty_content(content: str) -> str | None:
     return None
 
 
-def _get_file_type(path: str) -> FileType:
-    """Classify a file by its extension.
+def _get_file_type(path: str, mime_type: str | None = None) -> FileType:
+    """Classify a file by backend-declared MIME type or extension.
 
     Args:
         path: File path to classify.
+        mime_type: Optional backend-declared MIME type.
 
     Returns:
         One of `"text"`, `"image"`, `"audio"`, `"video"`, or `"file"`.
 
             Defaults to `"text"` for unrecognized extensions.
     """
+    if mime_type:
+        normalized_mime_type = mime_type.split(";", maxsplit=1)[0].strip().lower()
+        for prefix, file_type in _MIME_PREFIX_TO_FILE_TYPE.items():
+            if normalized_mime_type.startswith(prefix):
+                return file_type
+        if normalized_mime_type.startswith("text/"):
+            return "text"
+        return "file"
     return _EXTENSION_TO_FILE_TYPE.get(PurePosixPath(path).suffix.lower(), "text")
+
+
+def _get_mime_type(path: str, file_data: FileData) -> str:
+    """Return the backend-declared MIME type or a path-based fallback.
+
+    Args:
+        path: File path used for extension-based fallback.
+        file_data: File data that may include a backend-declared MIME type.
+
+    Returns:
+        MIME type string for the file content.
+    """
+    return file_data.get("mime_type") or mimetypes.guess_type("file" + Path(path).suffix)[0] or "application/octet-stream"
 
 
 def _to_legacy_file_data(file_data: FileData) -> dict[str, Any]:

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -5,12 +5,11 @@ import asyncio
 import concurrent.futures
 import contextlib
 import contextvars
-import mimetypes
 import threading
 import uuid
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Annotated, Any, Literal, NotRequired, cast
 
 if TYPE_CHECKING:
@@ -56,6 +55,7 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.utils import (
     _get_file_type,
+    _get_mime_type,
     check_empty_content,
     format_content_with_line_numbers,
     format_grep_matches,
@@ -1105,9 +1105,11 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            file_type = _get_file_type(validated_path)
+            has_declared_encoding = "encoding" in read_result.file_data
             encoding = read_result.file_data.get("encoding", "utf-8")
             content = read_result.file_data["content"]
+            mime_type = _get_mime_type(validated_path, read_result.file_data)
+            file_type = _get_file_type(validated_path, read_result.file_data.get("mime_type"))
 
             # Empty files get a uniform warning regardless of encoding/type, so
             # check before routing to avoid a degenerate empty content block for
@@ -1126,9 +1128,8 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             # when the extension is absent from `_EXTENSION_TO_FILE_TYPE`.
             # The extension map is only consulted to pick the multimodal block
             # type; unknown binary extensions fall back to the generic `"file"`.
-            if encoding == "base64" or file_type != "text":
+            if encoding == "base64" or (not has_declared_encoding and file_type != "text"):
                 block_type = file_type if file_type != "text" else "file"
-                mime_type = mimetypes.guess_type("file" + Path(validated_path).suffix)[0] or "application/octet-stream"
                 return ToolMessage(
                     content_blocks=cast("list[ContentBlock]", [{"type": block_type, "base64": content, "mime_type": mime_type}]),
                     name="read_file",

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -204,6 +204,20 @@ def test_get_file_type_returns_text_for_unknown_extensions() -> None:
     assert _get_file_type("/foo/bar") == "text"
 
 
+@pytest.mark.parametrize(
+    ("mime_type", "expected"),
+    [
+        ("image/png", "image"),
+        ("audio/mpeg", "audio"),
+        ("video/mp4", "video"),
+        ("text/markdown", "text"),
+        ("application/pdf", "file"),
+    ],
+)
+def test_get_file_type_prefers_declared_mime_type(mime_type: str, expected: str) -> None:
+    assert _get_file_type("/foo/blob", mime_type) == expected
+
+
 def test_get_file_type_non_text_values_are_valid_content_block_types() -> None:
     """Every non-text file type must be accepted as a ContentBlock `type`."""
     for file_type in _EXTENSION_TO_FILE_TYPE.values():

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -761,6 +761,57 @@ class TestFilesystemMiddleware:
         )
         assert result.content == "No matches found"
 
+    def test_read_file_uses_backend_declared_mime_type_for_binary_without_extension(self):
+        class ImageBackend(StateBackend):
+            def read(self, file_path: str, offset: int = 0, limit: int = 100) -> ReadResult:
+                return ReadResult(
+                    file_data=FileData(
+                        content="<base64_data>",
+                        encoding="base64",
+                        mime_type="image/png",
+                    )
+                )
+
+        middleware = FilesystemMiddleware(backend=ImageBackend())
+        read_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        result = read_tool.invoke({"file_path": "/media/blob", "runtime": _runtime()})
+
+        assert result.content_blocks == [
+            {
+                "type": "image",
+                "base64": "<base64_data>",
+                "mime_type": "image/png",
+            }
+        ]
+        assert result.additional_kwargs["read_file_media_type"] == "image/png"
+
+    def test_read_file_text_without_extension_stays_text(self):
+        class TextBackend(StateBackend):
+            def read(self, file_path: str, offset: int = 0, limit: int = 100) -> ReadResult:
+                return ReadResult(file_data=FileData(content="hello\nworld", encoding="utf-8"))
+
+        middleware = FilesystemMiddleware(backend=TextBackend())
+        read_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        result = read_tool.invoke({"file_path": "/notes/README", "runtime": _runtime()})
+
+        assert result.content == "     1\thello\n     2\tworld"
+        assert not isinstance(result.content, list)
+
+    def test_read_file_utf8_encoding_overrides_non_text_mime_type(self):
+        class JsonBackend(StateBackend):
+            def read(self, file_path: str, offset: int = 0, limit: int = 100) -> ReadResult:
+                return ReadResult(file_data=FileData(content='{"ok": true}', encoding="utf-8", mime_type="application/json"))
+
+        middleware = FilesystemMiddleware(backend=JsonBackend())
+        read_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        result = read_tool.invoke({"file_path": "/data/blob", "runtime": _runtime()})
+
+        assert result.content == '     1\t{"ok": true}'
+        assert not isinstance(result.content, list)
+
     def test_grep_search_shortterm_invalid_regex(self):
         """Test grep with special characters (literal search, not regex)."""
         files = {


### PR DESCRIPTION
Closes #3660

---

Adds a backend-declared `mime_type` field to `FileData` so read results can carry authoritative media type information instead of forcing the middleware to infer everything from the file extension.

The read pipeline now:

- prefers backend-declared MIME type when choosing multimodal content block type
- preserves the existing extension-based fallback when no MIME type is provided
- routes base64 payloads as binary content blocks, including extensionless files
- keeps declared UTF-8 content as line-numbered text even when its MIME type is not one of the multimodal prefixes

Focused verification passed with the MIME routing regression tests and ruff on the touched files.