### PR TITLE
docs(code): add dev quickstart and reorder

### DIFF
--- a/libs/code/AGENTS.md
+++ b/libs/code/AGENTS.md
@@ -71,40 +71,7 @@ Casts are acceptable when the type violation is the point of the test (for examp
 
 `deepagents-code` pins an exact `deepagents==X.Y.Z` version in `pyproject.toml`. When developing features that depend on new SDK functionality, bump this pin as part of the same PR. A CI check verifies the pin matches the current SDK version at release time (unless bypassed with `dangerous-skip-sdk-pin-check`).
 
-## Local dev installs
-
-Keep the released CLI and editable development CLI separate:
-
-- `dcode` / `deepagents-code` should point at the normal installed tool, typically managed by `uv tool install deepagents-code`.
-- `dcode-dev` should point at a dedicated editable venv under `~/.local/share/dcode-dev`, with a symlink in `~/.local/bin/dcode-dev`.
-
-This uses a manual `uv venv` + `uv pip install -e` rather than `uv sync` or `uv tool install --editable` on purpose: it builds an isolated venv outside the workspace's locked environment, so the dev binary can be re-resolved on demand without disturbing the released tool or the repo's `uv.lock`. `uv pip`/`uv venv` are first-class `uv` subcommands here, not bare `pip`.
-
-`~/.local/bin` must be on your `PATH` for the `dcode-dev` symlink to resolve (`uv tool install` adds its own shim directory automatically, but a hand-rolled symlink does not).
-
-Example setup. The `--python` value is illustrative — any interpreter satisfying the package's `requires-python` (currently `>=3.11`) works; omit the flag to let `uv` pick. Replace `<repo>` with your local checkout path.
-
-```bash
-uv venv ~/.local/share/dcode-dev --python 3.13
-uv pip install --python ~/.local/share/dcode-dev/bin/python -e <repo>/libs/code
-ln -sf ~/.local/share/dcode-dev/bin/dcode ~/.local/bin/dcode-dev
-```
-
-When dependency constraints change in `libs/code/pyproject.toml`, update the dev venv explicitly:
-
-```bash
-uv pip install --python ~/.local/share/dcode-dev/bin/python -e <repo>/libs/code --upgrade
-```
-
-Verify command resolution and editable imports (the `dcode` checks assume the released tool is installed separately, per above):
-
-```bash
-which dcode
-which dcode-dev
-dcode --version
-dcode-dev --version
-~/.local/share/dcode-dev/bin/python -c 'import deepagents_code; print(deepagents_code.__file__)'
-```
+For a persistent editable `dcode-dev` install that stays separate from a released install, see [Local dev installs](./DEVELOPMENT.md#local-dev-installs) in the development guide.
 
 ## Startup performance
 

--- a/libs/code/DEVELOPMENT.md
+++ b/libs/code/DEVELOPMENT.md
@@ -2,6 +2,62 @@
 
 New to the package? Start with [`ARCHITECTURE.md`](./ARCHITECTURE.md) for a high-level map of how the TUI, the `langgraph dev` server subprocess, and the agent graph fit together.
 
+## Contents
+
+- [QuickStart](#quickstart) — get a local checkout running
+- [Running the tests and linters](#running-the-tests-and-linters) — the checks CI runs
+- [Live CSS development with Textual devtools](#live-css-development-with-textual-devtools) — UI/CSS hot-reload
+- [Debugging](#debugging) — diagnose startup crashes and client-side issues
+
+## QuickStart
+
+This package uses [`uv`](https://docs.astral.sh/uv/) for environment and dependency management. Install it first if you haven't:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Clone the monorepo and sync the `code` package with its test dependencies (this creates the virtualenv and installs everything you need to run and test the app):
+
+```bash
+git clone https://github.com/langchain-ai/deepagents.git
+cd deepagents/libs/code
+uv sync --group test
+```
+
+Run the TUI from your local checkout:
+
+```bash
+uv run deepagents-code
+```
+
+`uv run` executes against the editable install, so your local changes take effect on the next launch. If you want a persistent `dcode-dev` command that stays separate from a released install, see "Local dev installs" in [`AGENTS.md`](./AGENTS.md).
+
+## Running the tests and linters
+
+All commands run from `libs/code`. These mirror what CI enforces, so run them before opening a PR.
+
+```bash
+# Unit tests (no network)
+make test
+
+# A single test file
+make test TEST_FILE=tests/unit_tests/test_specific.py
+
+# Integration tests (network permitted)
+make integration_test
+```
+
+```bash
+# Auto-format (ruff format + autofix)
+make format
+
+# Lint + type-check (ruff, ty, commands-catalog check)
+make lint
+```
+
+Run `make help` to see every available target.
+
 ## Live CSS development with Textual devtools
 
 Textual's devtools console enables CSS hot-reload and live `self.log()` output during development.

--- a/libs/code/DEVELOPMENT.md
+++ b/libs/code/DEVELOPMENT.md
@@ -58,6 +58,53 @@ make lint
 
 Run `make help` to see every available target.
 
+## Debugging
+
+The app runs a `langgraph dev` subprocess when it starts. When the subprocess crashes during startup, the TUI shows a one-line failure banner; the actual exception lives in the subprocess's stdout/stderr, which is captured to a temp file.
+
+### Environment variables
+
+| Variable | Effect |
+| --- | --- |
+| `DEEPAGENTS_CODE_DEBUG=1` | Preserves the server subprocess log on shutdown and prints its path to stderr. Without this, the log is deleted when the process stops. Also enables the app-process file handler below. Accepts `1`/`true`/`yes`/`on` (case-insensitive) as enabled; `0`/`false`/`no`/`off`/empty/unset as disabled. |
+| `DEEPAGENTS_CODE_DEBUG_FILE=<path>` | Overrides the default path (`/tmp/deepagents_debug.log`) for the app-process file handler, which attaches at `DEBUG` level to the `deepagents_code` package logger. **Only takes effect when `DEEPAGENTS_CODE_DEBUG` is truthy.** Useful for diagnosing client-side app issues; does **not** capture the server subprocess. |
+
+`DEEPAGENTS_CODE_DEBUG` is what you want for startup crashes (graph init, MCP config, sandbox): the preserved subprocess log contains the real traceback. The optional `DEEPAGENTS_CODE_DEBUG_FILE` override is for post-startup client-side debugging.
+
+To capture client-side logs while reproducing an issue:
+
+```bash
+cd libs/code
+DEEPAGENTS_CODE_DEBUG=1 uv run deepagents-code
+```
+
+Then in another terminal:
+
+```bash
+tail -f /tmp/deepagents_debug.log
+```
+
+### Finding the server subprocess log
+
+On macOS, `tempfile` resolves to `$TMPDIR` (a path under `/var/folders/.../T/`). Each `ServerProcess` writes its combined stdout+stderr to a file matching `deepagents_server_log_*.txt`:
+
+```bash
+# Newest first
+ls -lt ${TMPDIR:-/tmp}/deepagents_server_log_*.txt | head -5
+
+# Tail the latest while reproducing the crash
+tail -F "$(ls -t ${TMPDIR:-/tmp}/deepagents_server_log_*.txt | head -1)"
+```
+
+The interesting line is `Failed to initialize server graph: <exc>` followed by a traceback — everything above that is uvicorn/lifespan unwinding.
+
+### Triage flow for a startup crash
+
+1. **Rerun with `DEEPAGENTS_CODE_DEBUG=1`.** The log is preserved and a "Server log preserved at: ..." line is printed to stderr. Textual's fullscreen mode can hide that line, but the file itself is still on disk.
+2. **Locate the log** via the `ls` command above. Open it in your editor.
+3. **Search for `Failed to initialize server graph`.** The stack trace beneath names the concrete failure point (MCP config validation, sandbox init, model resolution, subagent load, etc.).
+4. **Pre-flight validators run in the app process** for the common failure modes (e.g., `--mcp-config` is validated in `start_server_and_get_agent` before the subprocess spawns). When the banner shows `MCPConfigError: <path>: <reason>`, the subprocess never started — fix the file and retry.
+
 ## Local dev installs
 
 A *local dev install* gives you a persistent `dcode-dev` command that launches your checkout directly. It lives in a dedicated editable venv under `~/.local/share/dcode-dev`, symlinked into `~/.local/bin/dcode-dev`. It can sit alongside a released `dcode` without interfering:
@@ -105,59 +152,6 @@ dcode --version
 dcode-dev --version
 ~/.local/share/dcode-dev/bin/python -c 'import deepagents_code; print(deepagents_code.__file__)'
 ```
-
-## Debugging
-
-The app runs a `langgraph dev` subprocess for every interactive session. When the subprocess crashes during startup, the TUI shows a one-line failure banner; the actual exception lives in the subprocess's stdout/stderr, which is captured to a temp file.
-
-### Environment variables
-
-| Variable | Effect |
-| --- | --- |
-| `DEEPAGENTS_CODE_DEBUG=1` | Preserves the server subprocess log on shutdown and prints its path to stderr. Without this, the log is deleted when the process stops. Also enables the app-process file handler below. Accepts `1`/`true`/`yes`/`on` (case-insensitive) as enabled; `0`/`false`/`no`/`off`/empty/unset as disabled. |
-| `DEEPAGENTS_CODE_DEBUG_FILE=<path>` | Overrides the default path (`/tmp/deepagents_debug.log`) for the app-process file handler, which attaches at `DEBUG` level to the `deepagents_code` package logger. **Only takes effect when `DEEPAGENTS_CODE_DEBUG` is truthy.** Useful for diagnosing client-side app issues; does **not** capture the server subprocess. |
-
-`DEEPAGENTS_CODE_DEBUG` is what you want for startup crashes (graph init, MCP config, sandbox): the preserved subprocess log contains the real traceback. The optional `DEEPAGENTS_CODE_DEBUG_FILE` override is for post-startup client-side debugging.
-
-To capture client-side logs while reproducing an issue:
-
-```bash
-cd libs/code
-DEEPAGENTS_CODE_DEBUG=1 uv run deepagents-code
-```
-
-Then in another terminal:
-
-```bash
-tail -f /tmp/deepagents_debug.log
-```
-
-### Finding the server subprocess log
-
-On macOS, `tempfile` resolves to `$TMPDIR` (a path under `/var/folders/.../T/`). Each `ServerProcess` writes its combined stdout+stderr to a file matching `deepagents_server_log_*.txt`:
-
-```bash
-# Newest first
-ls -lt ${TMPDIR:-/tmp}/deepagents_server_log_*.txt | head -5
-
-# Tail the latest while reproducing the crash
-tail -F "$(ls -t ${TMPDIR:-/tmp}/deepagents_server_log_*.txt | head -1)"
-```
-
-The interesting line is `Failed to initialize server graph: <exc>` followed by a traceback — everything above that is uvicorn/lifespan unwinding.
-
-### Triage flow for a startup crash
-
-1. **Rerun with `DEEPAGENTS_CODE_DEBUG=1`.** The log is preserved and a "Server log preserved at: ..." line is printed to stderr. Textual's fullscreen mode can hide that line, but the file itself is still on disk.
-2. **Locate the log** via the `ls` command above. Open it in your editor.
-3. **Search for `Failed to initialize server graph`.** The stack trace beneath names the concrete failure point (MCP config validation, sandbox init, model resolution, subagent load, etc.).
-4. **Pre-flight validators run in the app process** for the common failure modes (e.g., `--mcp-config` is validated in `start_server_and_get_agent` before the subprocess spawns). When the banner shows `MCPConfigError: <path>: <reason>`, the subprocess never started — fix the file and retry.
-
-### Common startup failure patterns
-
-- **`MCPConfigError: Invalid MCP config at <path>: ...`** — malformed `--mcp-config`. The pre-flight wraps the underlying `ValueError`/`TypeError` with the offending path. See `_preflight_validate_mcp_config` in `server_manager.py`.
-- **`Server 'X' missing required 'command' field`** (from a discovered project `.mcp.json`, not `--mcp-config`) — an stdio server config without `command`. For remote servers, just use `{"url": "..."}`; transport is inferred as `http` when no `type`/`transport` is present.
-- **Uncaught exception inside a bare `sys.exit(1)`** — usually means the surrounding `make_graph()` raised. Look one traceback up in the subprocess log for the real cause.
 
 ## Live CSS development with Textual devtools
 

--- a/libs/code/DEVELOPMENT.md
+++ b/libs/code/DEVELOPMENT.md
@@ -4,12 +4,12 @@ New to the package? Start with [`ARCHITECTURE.md`](./ARCHITECTURE.md) for a high
 
 ## Contents
 
-- [QuickStart](#quickstart) — get a local checkout running
-- [Running the tests and linters](#running-the-tests-and-linters) — the checks CI runs
-- [Live CSS development with Textual devtools](#live-css-development-with-textual-devtools) — UI/CSS hot-reload
+- [Quickstart](#quickstart) — get a local checkout running and run the checks CI enforces
+- [Local dev installs](#local-dev-installs) — keep an editable `dcode-dev` separate from a released install
 - [Debugging](#debugging) — diagnose startup crashes and client-side issues
+- [Live CSS development with Textual devtools](#live-css-development-with-textual-devtools) — UI/CSS hot-reload
 
-## QuickStart
+## Quickstart
 
 This package uses [`uv`](https://docs.astral.sh/uv/) for environment and dependency management. Install it first if you haven't:
 
@@ -25,15 +25,15 @@ cd deepagents/libs/code
 uv sync --group test
 ```
 
-Run the TUI from your local checkout:
+Run the TUI from `libs/code` in your local checkout:
 
 ```bash
 uv run deepagents-code
 ```
 
-`uv run` executes against the editable install, so your local changes take effect on the next launch. If you want a persistent `dcode-dev` command that stays separate from a released install, see "Local dev installs" in [`AGENTS.md`](./AGENTS.md).
+`uv run` uses the project environment with the package installed editable, so source changes take effect on the next launch. If you want a persistent `dcode-dev` command that stays separate from a released install, use the local dev install setup below.
 
-## Running the tests and linters
+### Running the tests and linters
 
 All commands run from `libs/code`. These mirror what CI enforces, so run them before opening a PR.
 
@@ -58,56 +58,40 @@ make lint
 
 Run `make help` to see every available target.
 
-## Live CSS development with Textual devtools
+## Local dev installs
 
-Textual's devtools console enables CSS hot-reload and live `self.log()` output during development.
+Keep the released CLI and editable development CLI separate:
 
-### Prerequisites
+- `dcode` / `deepagents-code` should point at the normal installed tool, typically managed by `uv tool install deepagents-code`.
+- `dcode-dev` should point at a dedicated editable venv under `~/.local/share/dcode-dev`, with a symlink in `~/.local/bin/dcode-dev`.
 
-Sync the `test` dependency group (includes `textual-dev`):
+This uses a manual `uv venv` + `uv pip install -e` rather than `uv sync` or `uv tool install --editable` on purpose: it builds an isolated venv outside the workspace's locked environment, so the dev binary can be re-resolved on demand without disturbing the released tool or the repo's `uv.lock`. `uv pip`/`uv venv` are first-class `uv` subcommands here, not bare `pip`.
 
-```bash
-cd libs/code && uv sync --group test
-```
+`~/.local/bin` must be on your `PATH` for the `dcode-dev` symlink to resolve (`uv tool install` adds its own shim directory automatically, but a hand-rolled symlink does not).
 
-Create the dev wrapper script (one-time):
-
-```bash
-cat > /tmp/dev_deepagents.py << 'PYEOF'
-"""Dev wrapper to run Deep Agents Code with textual devtools."""
-import sys
-sys.argv = ["deepagents"] + sys.argv[1:]
-
-from deepagents_code.main import cli_main
-cli_main()
-PYEOF
-```
-
-### Running
-
-**Terminal 1** — devtools console:
+Example setup. The `--python` value is illustrative — any interpreter satisfying the package's `requires-python` (currently `>=3.11`) works; omit the flag to let `uv` pick. Replace `<repo>` with your local checkout path.
 
 ```bash
-cd libs/code && uv run --group test textual console
+uv venv ~/.local/share/dcode-dev --python 3.13
+uv pip install --python ~/.local/share/dcode-dev/bin/python -e <repo>/libs/code
+ln -sf ~/.local/share/dcode-dev/bin/dcode ~/.local/bin/dcode-dev
 ```
 
-**Terminal 2** — TUI with live reload:
+When dependency constraints change in `libs/code/pyproject.toml`, update the dev venv explicitly:
 
 ```bash
-cd libs/code && uv run --group test textual run --dev /tmp/dev_deepagents.py
+uv pip install --python ~/.local/share/dcode-dev/bin/python -e <repo>/libs/code --upgrade
 ```
 
-Edit any `.tcss` file and save — changes appear immediately. Any `self.log()` calls in widget code show in the console.
+Verify command resolution and editable imports (the `dcode` checks assume the released tool is installed separately, per above):
 
-### Console options
-
-- `textual console -v` — verbose mode, shows all events (key presses, mouse, etc.)
-- `textual console -x EVENT` — exclude noisy event groups
-- `textual console --port 7342` — custom port (pass matching `--port` to `textual run`)
-
-### Why the wrapper script?
-
-`textual run --dev` handles the devtools connection, but it needs to run inside the project's virtualenv to import `deepagents_code`. The wrapper script bridges the gap — `uv run --group test textual run --dev` ensures both `textual-dev` (from the `test` group) and `deepagents_code` are available in the same environment.
+```bash
+which dcode
+which dcode-dev
+dcode --version
+dcode-dev --version
+~/.local/share/dcode-dev/bin/python -c 'import deepagents_code; print(deepagents_code.__file__)'
+```
 
 ## Debugging
 
@@ -161,3 +145,54 @@ The interesting line is `Failed to initialize server graph: <exc>` followed by a
 - **`MCPConfigError: Invalid MCP config at <path>: ...`** — malformed `--mcp-config`. The pre-flight wraps the underlying `ValueError`/`TypeError` with the offending path. See `_preflight_validate_mcp_config` in `server_manager.py`.
 - **`Server 'X' missing required 'command' field`** (from a discovered project `.mcp.json`, not `--mcp-config`) — an stdio server config without `command`. For remote servers, just use `{"url": "..."}`; transport is inferred as `http` when no `type`/`transport` is present.
 - **Uncaught exception inside a bare `sys.exit(1)`** — usually means the surrounding `make_graph()` raised. Look one traceback up in the subprocess log for the real cause.
+
+## Live CSS development with Textual devtools
+
+Textual's devtools console enables CSS hot-reload and live `self.log()` output during development.
+
+### Prerequisites
+
+Sync the `test` dependency group (includes `textual-dev`):
+
+```bash
+cd libs/code && uv sync --group test
+```
+
+Create the dev wrapper script (one-time):
+
+```bash
+cat > /tmp/dev_deepagents.py << 'PYEOF'
+"""Dev wrapper to run Deep Agents Code with textual devtools."""
+import sys
+sys.argv = ["deepagents"] + sys.argv[1:]
+
+from deepagents_code.main import cli_main
+cli_main()
+PYEOF
+```
+
+### Running
+
+**Terminal 1** — devtools console:
+
+```bash
+cd libs/code && uv run --group test textual console
+```
+
+**Terminal 2** — TUI with live reload:
+
+```bash
+cd libs/code && uv run --group test textual run --dev /tmp/dev_deepagents.py
+```
+
+Edit any `.tcss` file and save — changes appear immediately. Any `self.log()` calls in widget code show in the console.
+
+### Console options
+
+- `textual console -v` — verbose mode, shows all events (key presses, mouse, etc.)
+- `textual console -x EVENT` — exclude noisy event groups
+- `textual console --port 7342` — custom port (pass matching `--port` to `textual run`)
+
+### Why the wrapper script?
+
+`textual run --dev` handles the devtools connection, but it needs to run inside the project's virtualenv to import `deepagents_code`. The wrapper script bridges the gap — `uv run --group test textual run --dev` ensures both `textual-dev` (from the `test` group) and `deepagents_code` are available in the same environment.

--- a/libs/code/DEVELOPMENT.md
+++ b/libs/code/DEVELOPMENT.md
@@ -60,32 +60,43 @@ Run `make help` to see every available target.
 
 ## Local dev installs
 
-A local dev install is useful when you want to dogfood changes from your checkout without replacing an installed, stable released version. We recommend keeping two commands available:
+A *local dev install* gives you a persistent `dcode-dev` command that launches your checkout directly. It lives in a dedicated editable venv under `~/.local/share/dcode-dev`, symlinked into `~/.local/bin/dcode-dev`. It can sit alongside a released `dcode` without interfering:
 
-- `dcode` / `deepagents-code` points at the normal installed tool (from the installation script)
-- `dcode-dev` to point at a local checkout through a dedicated editable venv under `~/.local/share/dcode-dev`, with a symlink in `~/.local/bin/dcode-dev`.
+- `dcode` / `deepagents-code` — the released tool, installed via `curl -LsSf https://langch.in/dcode | bash` (the install script).
+- `dcode-dev` — your local checkout.
 
-That split lets you quickly compare released behavior against local behavior, test unpublished fixes in real sessions, and recover to a known-good app install if the development checkout is broken. It also keeps dependency experiments for the dev binary out of both the released tool environment and the repo's locked `uv sync` environment.
+That lets you compare released behavior against local, and fall back to a known-good build if your checkout breaks. Either way, the dedicated venv keeps the dev binary's dependency experiments out of the repo's locked `uv sync` environment.
 
-The setup below uses a manual `uv venv` + `uv pip install -e` rather than `uv sync` or `uv tool install --editable` on purpose: it builds an isolated venv outside the workspace's locked environment, so the dev binary can be re-resolved on demand without disturbing the released tool or the repo's `uv.lock`. `uv pip`/`uv venv` are first-class `uv` subcommands here, not bare `pip`.
+### Setup
 
-`~/.local/bin` must be on your `PATH` for the `dcode-dev` symlink to resolve (`uv tool install` adds its own shim directory automatically, but a hand-rolled symlink does not).
-
-Example setup. The `--python` value is illustrative — any interpreter satisfying the package's `requires-python` (currently `>=3.11`) works; omit the flag to let `uv` pick. Replace `<repo>` with your local checkout path.
+`~/.local/bin` must be on your `PATH` for the symlink to resolve (`uv tool install` adds its own shim directory automatically, but a hand-rolled symlink does not). Replace `<repo>` with your local checkout path:
 
 ```bash
+# 1. Create an isolated venv for the dev binary
 uv venv ~/.local/share/dcode-dev --python 3.13
+
+# 2. Install your checkout into it, editable
 uv pip install --python ~/.local/share/dcode-dev/bin/python -e <repo>/libs/code
+
+# 3. Expose it as `dcode-dev` on your PATH
 ln -sf ~/.local/share/dcode-dev/bin/dcode ~/.local/bin/dcode-dev
 ```
 
-When dependency constraints change in `libs/code/pyproject.toml`, update the dev venv explicitly:
+The `--python 3.13` is illustrative — any interpreter satisfying the package's `requires-python` (currently `>=3.11`) works; omit the flag to let `uv` pick.
+
+> **Why `uv venv` + `uv pip install -e` rather than `uv sync` or `uv tool install --editable`?** This builds an isolated venv *outside* the workspace's locked environment, so the dev binary can be re-resolved on demand without disturbing the released tool or the repo's `uv.lock`. (`uv pip` and `uv venv` are first-class `uv` subcommands here, not bare `pip`.)
+
+### Updating
+
+When dependency constraints change in `libs/code/pyproject.toml`, refresh the dev venv:
 
 ```bash
 uv pip install --python ~/.local/share/dcode-dev/bin/python -e <repo>/libs/code --upgrade
 ```
 
-Verify command resolution and editable imports (the `dcode` checks assume the released tool is installed separately, per above):
+### Verifying
+
+Confirm command resolution and editable imports (the `dcode` checks assume the released tool is installed separately, per above):
 
 ```bash
 which dcode

--- a/libs/code/DEVELOPMENT.md
+++ b/libs/code/DEVELOPMENT.md
@@ -60,12 +60,14 @@ Run `make help` to see every available target.
 
 ## Local dev installs
 
-Keep the released CLI and editable development CLI separate:
+A local dev install is useful when you want to dogfood changes from your checkout without replacing an installed, stable released version. We recommend keeping two commands available:
 
-- `dcode` / `deepagents-code` should point at the normal installed tool, typically managed by `uv tool install deepagents-code`.
-- `dcode-dev` should point at a dedicated editable venv under `~/.local/share/dcode-dev`, with a symlink in `~/.local/bin/dcode-dev`.
+- `dcode` / `deepagents-code` points at the normal installed tool (from the installation script)
+- `dcode-dev` to point at a local checkout through a dedicated editable venv under `~/.local/share/dcode-dev`, with a symlink in `~/.local/bin/dcode-dev`.
 
-This uses a manual `uv venv` + `uv pip install -e` rather than `uv sync` or `uv tool install --editable` on purpose: it builds an isolated venv outside the workspace's locked environment, so the dev binary can be re-resolved on demand without disturbing the released tool or the repo's `uv.lock`. `uv pip`/`uv venv` are first-class `uv` subcommands here, not bare `pip`.
+That split lets you quickly compare released behavior against local behavior, test unpublished fixes in real sessions, and recover to a known-good app install if the development checkout is broken. It also keeps dependency experiments for the dev binary out of both the released tool environment and the repo's locked `uv sync` environment.
+
+The setup below uses a manual `uv venv` + `uv pip install -e` rather than `uv sync` or `uv tool install --editable` on purpose: it builds an isolated venv outside the workspace's locked environment, so the dev binary can be re-resolved on demand without disturbing the released tool or the repo's `uv.lock`. `uv pip`/`uv venv` are first-class `uv` subcommands here, not bare `pip`.
 
 `~/.local/bin` must be on your `PATH` for the `dcode-dev` symlink to resolve (`uv tool install` adds its own shim directory automatically, but a hand-rolled symlink does not).
 
@@ -148,17 +150,9 @@ The interesting line is `Failed to initialize server graph: <exc>` followed by a
 
 ## Live CSS development with Textual devtools
 
-Textual's devtools console enables CSS hot-reload and live `self.log()` output during development.
+After completing the [Quickstart](#quickstart), use Textual's devtools console for CSS hot-reload and live `self.log()` output during development.
 
-### Prerequisites
-
-Sync the `test` dependency group (includes `textual-dev`):
-
-```bash
-cd libs/code && uv sync --group test
-```
-
-Create the dev wrapper script (one-time):
+Create the dev wrapper script once:
 
 ```bash
 cat > /tmp/dev_deepagents.py << 'PYEOF'
@@ -171,18 +165,18 @@ cli_main()
 PYEOF
 ```
 
-### Running
+Run both commands from `libs/code`:
 
 **Terminal 1** — devtools console:
 
 ```bash
-cd libs/code && uv run --group test textual console
+uv run --group test textual console
 ```
 
 **Terminal 2** — TUI with live reload:
 
 ```bash
-cd libs/code && uv run --group test textual run --dev /tmp/dev_deepagents.py
+uv run --group test textual run --dev /tmp/dev_deepagents.py
 ```
 
 Edit any `.tcss` file and save — changes appear immediately. Any `self.log()` calls in widget code show in the console.

--- a/libs/code/DEVELOPMENT.md
+++ b/libs/code/DEVELOPMENT.md
@@ -60,50 +60,52 @@ Run `make help` to see every available target.
 
 ## Debugging
 
-The app runs a `langgraph dev` subprocess when it starts. When the subprocess crashes during startup, the TUI shows a one-line failure banner; the actual exception lives in the subprocess's stdout/stderr, which is captured to a temp file.
-
-### Environment variables
-
-| Variable | Effect |
-| --- | --- |
-| `DEEPAGENTS_CODE_DEBUG=1` | Preserves the server subprocess log on shutdown and prints its path to stderr. Without this, the log is deleted when the process stops. Also enables the app-process file handler below. Accepts `1`/`true`/`yes`/`on` (case-insensitive) as enabled; `0`/`false`/`no`/`off`/empty/unset as disabled. |
-| `DEEPAGENTS_CODE_DEBUG_FILE=<path>` | Overrides the default path (`/tmp/deepagents_debug.log`) for the app-process file handler, which attaches at `DEBUG` level to the `deepagents_code` package logger. **Only takes effect when `DEEPAGENTS_CODE_DEBUG` is truthy.** Useful for diagnosing client-side app issues; does **not** capture the server subprocess. |
-
-`DEEPAGENTS_CODE_DEBUG` is what you want for startup crashes (graph init, MCP config, sandbox): the preserved subprocess log contains the real traceback. The optional `DEEPAGENTS_CODE_DEBUG_FILE` override is for post-startup client-side debugging.
-
-To capture client-side logs while reproducing an issue:
+Deep Agents Code runs as two processes: the **Textual TUI** you interact with, and a **`langgraph dev` subprocess** that hosts the agent graph. Each writes its own log, and a single switch turns both on:
 
 ```bash
 cd libs/code
-DEEPAGENTS_CODE_DEBUG=1 uv run deepagents-code
+export DEEPAGENTS_CODE_DEBUG=1
+uv run deepagents-code
 ```
 
-Then in another terminal:
+| Variable | Effect |
+| --- | --- |
+| `DEEPAGENTS_CODE_DEBUG` | Master switch. Preserves the server subprocess log on exit (printing its path to stderr) and attaches the client `DEBUG` file handler. Truthy: `1`/`true`/`yes`/`on` (case-insensitive). Falsy: `0`/`false`/`no`/`off`/empty/unset. |
+| `DEEPAGENTS_CODE_DEBUG_FILE=<path>` | Overrides the client log path (default `/tmp/deepagents_debug.log`). **Only takes effect when `DEEPAGENTS_CODE_DEBUG` is truthy**; does **not** affect the server subprocess log. |
+
+Then pick the log you need by symptom:
+
+| Symptom | Log you want | Default location |
+| --- | --- | --- |
+| App crashes on launch (one-line failure banner) | **Server subprocess log** — the real traceback | `$TMPDIR/deepagents_server_log_*.txt` |
+| App starts, then misbehaves (UI, model calls, slash commands) | **Client app log** — `deepagents_code` at `DEBUG` | `/tmp/deepagents_debug.log` |
+
+### Startup crash -> server subprocess log
+
+The TUI only surfaces a one-line banner; the actual exception lives in the subprocess's combined stdout/stderr. To get it:
+
+1. **Re-run with debugging on** (see above). On exit, the log is preserved and its path is printed to stderr as `Server log preserved at: ...`. Textual's fullscreen mode can hide that line, but the file is still on disk.
+2. **Open the newest log.** On macOS, `tempfile` resolves to `$TMPDIR` (a path under `/var/folders/.../T/`):
+
+   ```bash
+   # Newest first
+   ls -lt ${TMPDIR:-/tmp}/deepagents_server_log_*.txt | head -5
+
+   # Or tail the latest live while you reproduce the crash
+   tail -F "$(ls -t ${TMPDIR:-/tmp}/deepagents_server_log_*.txt | head -1)"
+   ```
+
+3. **Search for `Failed to initialize server graph`.** The traceback beneath it names the concrete failure — MCP config validation, sandbox init, model resolution, subagent load, and so on. Everything above that line is uvicorn/lifespan unwinding and can be ignored.
+
+### Client-side issue -> app log
+
+For problems that appear after the app is up, tail the client log in another terminal while reproducing:
 
 ```bash
 tail -f /tmp/deepagents_debug.log
 ```
 
-### Finding the server subprocess log
-
-On macOS, `tempfile` resolves to `$TMPDIR` (a path under `/var/folders/.../T/`). Each `ServerProcess` writes its combined stdout+stderr to a file matching `deepagents_server_log_*.txt`:
-
-```bash
-# Newest first
-ls -lt ${TMPDIR:-/tmp}/deepagents_server_log_*.txt | head -5
-
-# Tail the latest while reproducing the crash
-tail -F "$(ls -t ${TMPDIR:-/tmp}/deepagents_server_log_*.txt | head -1)"
-```
-
-The interesting line is `Failed to initialize server graph: <exc>` followed by a traceback — everything above that is uvicorn/lifespan unwinding.
-
-### Triage flow for a startup crash
-
-1. **Rerun with `DEEPAGENTS_CODE_DEBUG=1`.** The log is preserved and a "Server log preserved at: ..." line is printed to stderr. Textual's fullscreen mode can hide that line, but the file itself is still on disk.
-2. **Locate the log** via the `ls` command above. Open it in your editor.
-3. **Search for `Failed to initialize server graph`.** The stack trace beneath names the concrete failure point (MCP config validation, sandbox init, model resolution, subagent load, etc.).
-4. **Pre-flight validators run in the app process** for the common failure modes (e.g., `--mcp-config` is validated in `start_server_and_get_agent` before the subprocess spawns). When the banner shows `MCPConfigError: <path>: <reason>`, the subprocess never started — fix the file and retry.
+To send it elsewhere, also `export DEEPAGENTS_CODE_DEBUG_FILE=<path>`. The handler appends across runs, so a single file accumulates every session.
 
 ## Local dev installs
 


### PR DESCRIPTION
The `libs/code` development guide jumped straight into specialized topics (Textual CSS devtools, debugging) with no on-ramp for a contributor who just wants to get the package running locally.

This adds a quickstart section up top, then keeps the existing CSS devtools and debugging guides below. Ordering now flows from what most contributors need first to the more specialized workflows.

Made by [Open SWE](https://openswe.vercel.app/agents/4da98c6a-a5d3-6209-003b-f4f3fb734389)