### PR TITLE
fix(sdk): show remaining lines after paginated read

### DIFF
--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -17,7 +17,6 @@ from deepagents.backends.protocol import (
     INVALID_PATH,
     BackendProtocol,
     EditResult,
-    FileData,
     FileDownloadResponse,
     FileInfo,
     FileUploadResponse,
@@ -29,9 +28,9 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from deepagents.backends.utils import (
+    build_sliced_read_result,
     create_file_data,
     perform_string_replacement,
-    slice_read_response,
 )
 
 if TYPE_CHECKING:
@@ -150,17 +149,7 @@ class ContextHubBackend(BackendProtocol):
             return ReadResult(error=f"File '{file_path}' not found")
 
         file_data = create_file_data(content)
-        sliced = slice_read_response(file_data, offset, limit)
-        if isinstance(sliced, ReadResult):
-            return sliced
-        return ReadResult(
-            file_data=FileData(
-                content=sliced,
-                encoding=file_data.get("encoding", "utf-8"),
-                created_at=file_data.get("created_at", ""),
-                modified_at=file_data.get("modified_at", ""),
-            )
-        )
+        return build_sliced_read_result(file_data, offset, limit)
 
     def write(self, file_path: str, content: str) -> WriteResult:
         """Commit `content` to `file_path`."""

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -458,6 +458,7 @@ class FilesystemBackend(BackendProtocol):
                         return ReadResult(error=f"Line offset {offset} exceeds file length ({len(lines)} lines)")
 
                     file_data = FileData(content="".join(lines[start_idx:end_idx]), encoding="utf-8")
+                    return ReadResult(file_data=file_data, total_lines=len(lines), start_line=offset + 1, end_line=end_idx)
 
             return ReadResult(file_data=file_data)
         except (OSError, UnicodeDecodeError) as e:

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -187,10 +187,16 @@ class ReadResult:
     Attributes:
         error: Error message on failure, None on success.
         file_data: FileData dict on success, None on failure.
+        total_lines: Total number of source lines in text reads, if known.
+        start_line: 1-indexed first source line returned for text reads, if known.
+        end_line: 1-indexed last source line returned for text reads, if known.
     """
 
     error: str | None = None
     file_data: FileData | None = None
+    total_lines: int | None = None
+    start_line: int | None = None
+    end_line: int | None = None
 
 
 class _Unset:

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -347,8 +347,8 @@ try:
             line_count += 1
             if line_count <= offset:
                 continue
-            if returned_lines >= limit:
-                break
+            if returned_lines >= limit or truncated:
+                continue
 
             line = raw_line.rstrip('\\n').rstrip('\\r')
             piece = line if returned_lines == 0 else '\\n' + line
@@ -361,7 +361,7 @@ try:
                     if prefix:
                         parts.append(prefix)
                         current_bytes += len(prefix.encode('utf-8'))
-                break
+                continue
 
             parts.append(piece)
             current_bytes += piece_bytes
@@ -375,7 +375,14 @@ try:
     if truncated:
         text += TRUNCATION_MSG
 
-    print(json.dumps({{'encoding': 'utf-8', 'content': text}}))
+    response = {{'encoding': 'utf-8', 'content': text}}
+    if not truncated:
+        response.update({{
+            'total_lines': line_count,
+            'start_line': offset + 1,
+            'end_line': offset + returned_lines,
+        }})
+    print(json.dumps(response))
 except FileNotFoundError:
     print(json.dumps({{'error': 'file_not_found'}}))
 except PermissionError:
@@ -466,7 +473,10 @@ def _parse_read_output(output: str, file_path: str) -> ReadResult:
         file_data=FileData(
             content=data["content"],
             encoding=data.get("encoding", "utf-8"),
-        )
+        ),
+        total_lines=data.get("total_lines"),
+        start_line=data.get("start_line"),
+        end_line=data.get("end_line"),
     )
 
 

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -26,11 +26,11 @@ from deepagents.backends.utils import (
     _get_file_type,
     _glob_search_files,
     _to_legacy_file_data,
+    build_sliced_read_result,
     create_file_data,
     file_data_to_string,
     grep_matches_from_files,
     perform_string_replacement,
-    slice_read_response,
     update_file_data,
 )
 
@@ -233,18 +233,7 @@ class StateBackend(BackendProtocol):
         if _get_file_type(file_path) != "text":
             return ReadResult(file_data=file_data)
 
-        sliced = slice_read_response(file_data, offset, limit)
-        if isinstance(sliced, ReadResult):
-            return sliced
-        sliced_fd = FileData(
-            content=sliced,
-            encoding=file_data.get("encoding", "utf-8"),
-        )
-        if "created_at" in file_data:
-            sliced_fd["created_at"] = file_data["created_at"]
-        if "modified_at" in file_data:
-            sliced_fd["modified_at"] = file_data["modified_at"]
-        return ReadResult(file_data=sliced_fd)
+        return build_sliced_read_result(file_data, offset, limit)
 
     def write(
         self,

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -30,11 +30,11 @@ from deepagents.backends.utils import (
     _get_file_type,
     _glob_search_files,
     _to_legacy_file_data,
+    build_sliced_read_result,
     create_file_data,
     file_data_to_string,
     grep_matches_from_files,
     perform_string_replacement,
-    slice_read_response,
     update_file_data,
 )
 
@@ -517,18 +517,7 @@ class StoreBackend(BackendProtocol):
         if _get_file_type(file_path) != "text":
             return ReadResult(file_data=file_data)
 
-        sliced = slice_read_response(file_data, offset, limit)
-        if isinstance(sliced, ReadResult):
-            return sliced
-        sliced_fd = FileData(
-            content=sliced,
-            encoding=file_data.get("encoding", "utf-8"),
-        )
-        if "created_at" in file_data:
-            sliced_fd["created_at"] = file_data["created_at"]
-        if "modified_at" in file_data:
-            sliced_fd["modified_at"] = file_data["modified_at"]
-        return ReadResult(file_data=sliced_fd)
+        return build_sliced_read_result(file_data, offset, limit)
 
     async def aread(
         self,
@@ -555,18 +544,7 @@ class StoreBackend(BackendProtocol):
         if _get_file_type(file_path) != "text":
             return ReadResult(file_data=file_data)
 
-        sliced = slice_read_response(file_data, offset, limit)
-        if isinstance(sliced, ReadResult):
-            return sliced
-        sliced_fd = FileData(
-            content=sliced,
-            encoding=file_data.get("encoding", "utf-8"),
-        )
-        if "created_at" in file_data:
-            sliced_fd["created_at"] = file_data["created_at"]
-        if "modified_at" in file_data:
-            sliced_fd["modified_at"] = file_data["modified_at"]
-        return ReadResult(file_data=sliced_fd)
+        return build_sliced_read_result(file_data, offset, limit)
 
     def write(
         self,

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -172,7 +172,7 @@ def check_empty_content(content: str) -> str | None:
     Returns:
         Warning message if empty, `None` otherwise
     """
-    if not content or content.strip() == "":
+    if not content:
         return EMPTY_CONTENT_WARNING
     return None
 
@@ -297,7 +297,7 @@ def slice_read_response(
     """
     content = file_data_to_string(file_data)
 
-    if not content or content.strip() == "":
+    if not content:
         return content
 
     # `splitlines(keepends=True)` retains each line's terminator, including
@@ -317,6 +317,35 @@ def slice_read_response(
     # State/Store backends may carry CRLF or CR content as written;
     # downstream tooling (edit match, grep, format) assumes LF.
     return "".join(lines[start_idx:end_idx]).replace("\r\n", "\n").replace("\r", "\n")
+
+
+def build_sliced_read_result(file_data: FileData, offset: int, limit: int) -> ReadResult:
+    """Build a `ReadResult` for a paginated text read.
+
+    The returned `file_data` contains only the requested window while the result
+    metadata preserves the total source line count so middleware can tell the
+    model whether more content remains.
+    """
+    sliced = slice_read_response(file_data, offset, limit)
+    if isinstance(sliced, ReadResult):
+        return sliced
+
+    sliced_fd = FileData(
+        content=sliced,
+        encoding=file_data.get("encoding", "utf-8"),
+    )
+    if "created_at" in file_data:
+        sliced_fd["created_at"] = file_data["created_at"]
+    if "modified_at" in file_data:
+        sliced_fd["modified_at"] = file_data["modified_at"]
+
+    content = file_data_to_string(file_data)
+    if not content:
+        return ReadResult(file_data=sliced_fd)
+
+    total_lines = len(content.splitlines(keepends=True))
+    end_line = min(offset + limit, total_lines)
+    return ReadResult(file_data=sliced_fd, total_lines=total_lines, start_line=offset + 1, end_line=end_line)
 
 
 def perform_string_replacement(

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1063,6 +1063,20 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
             return content
 
+        def _remaining_lines_notice(read_result: ReadResult) -> str:
+            if read_result.total_lines is None or read_result.start_line is None or read_result.end_line is None:
+                return ""
+            if read_result.end_line >= read_result.total_lines:
+                return ""
+
+            read_lines = read_result.end_line - read_result.start_line + 1
+            remaining = read_result.total_lines - read_result.end_line
+            line_noun = "line" if remaining == 1 else "lines"
+            return (
+                f"\n\n[Read {read_lines} lines (lines {read_result.start_line}-{read_result.end_line} "
+                f"of {read_result.total_lines} total). {remaining} {line_noun} remaining from offset {read_result.end_line}.]"
+            )
+
         def _handle_read_result(
             read_result: ReadResult | str,
             validated_path: str,
@@ -1115,7 +1129,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             empty_msg = check_empty_content(content)
             if empty_msg:
                 return ToolMessage(
-                    content=empty_msg,
+                    content=empty_msg + _remaining_lines_notice(read_result),
                     name="read_file",
                     tool_call_id=tool_call_id,
                     status="success",
@@ -1138,6 +1152,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 )
 
             content = format_content_with_line_numbers(content, start_line=offset + 1)
+            content += _remaining_lines_notice(read_result)
             # `limit` already bounded raw source lines at the backend; do not
             # re-truncate by row count here, or wrapped continuation rows would
             # push real source lines off the end of the page (#2453).

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -29,6 +29,7 @@ from deepagents.backends.sandbox import (
     _GLOB_COMMAND_TEMPLATE,
     _READ_COMMAND_TEMPLATE,
     _WRITE_CHECK_TEMPLATE,
+    MAX_OUTPUT_BYTES,
     BaseSandbox,
     _check_preflight_result,
     _map_edit_error,
@@ -1147,6 +1148,20 @@ def test_read_script_ascii_larger_than_prefix(tmp_path: Path) -> None:
     result = _run_read_script(target)
 
     assert result["encoding"] == "utf-8"
+
+
+def test_read_script_byte_truncation_omits_line_metadata(tmp_path: Path) -> None:
+    """A byte-truncated line is not a complete line window for pagination notices."""
+    target = tmp_path / "huge-line.txt"
+    target.write_text("a" * (MAX_OUTPUT_BYTES + 100), encoding="utf-8")
+
+    result = _run_read_script(target, offset=0, limit=1)
+
+    assert result["encoding"] == "utf-8"
+    assert "Output was truncated due to size limits" in result["content"]
+    assert "total_lines" not in result
+    assert "start_line" not in result
+    assert "end_line" not in result
 
 
 # -- script-level permission/error tests --------------------------------------

--- a/libs/deepagents/tests/unit_tests/middleware/test_filesystem_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_filesystem_middleware_init.py
@@ -4,11 +4,12 @@ from typing import Any
 
 from langchain.agents import create_agent
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain.tools import ToolRuntime
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.store.memory import InMemoryStore
 
-from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
+from deepagents.backends import CompositeBackend, FilesystemBackend, StateBackend, StoreBackend
 from deepagents.middleware.filesystem import (
     EXECUTION_SYSTEM_PROMPT,
     WRITE_FILE_TOOL_DESCRIPTION,
@@ -19,6 +20,10 @@ from tests.unit_tests.chat_model import GenericFakeChatModel
 
 def build_composite_state_backend(*, routes: dict[str, Any]) -> CompositeBackend:
     return CompositeBackend(default=StateBackend(), routes=routes)
+
+
+def _runtime(tool_call_id: str = "read-file-test") -> ToolRuntime:
+    return ToolRuntime(state={}, context=None, tool_call_id=tool_call_id, store=None, stream_writer=lambda _: None, config={})
 
 
 class TestDynamicSystemPromptCache:
@@ -120,3 +125,91 @@ class TestFilesystemMiddlewareInit:
         assert tools["write_file"].description == WRITE_FILE_TOOL_DESCRIPTION.rstrip()
         assert "edit_file" in tools
         assert tools["edit_file"].description == "Squirtle"
+
+
+class TestReadFilePaginationNotice:
+    def test_partial_read_includes_remaining_line_notice(self) -> None:
+        store = InMemoryStore()
+        store.put(
+            ("filesystem",),
+            "/notes.txt",
+            {
+                "content": "one\ntwo\nthree\nfour\n",
+                "encoding": "utf-8",
+                "created_at": "",
+                "modified_at": "",
+            },
+        )
+        middleware = FilesystemMiddleware(backend=StoreBackend(store=store, namespace=lambda _ctx: ("filesystem",)))
+        read_file = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        result = read_file.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 0, "limit": 2})
+
+        assert result.content.endswith("[Read 2 lines (lines 1-2 of 4 total). 2 lines remaining from offset 2.]")
+
+    def test_read_reaching_end_omits_remaining_line_notice(self) -> None:
+        store = InMemoryStore()
+        store.put(
+            ("filesystem",),
+            "/notes.txt",
+            {
+                "content": "one\ntwo\nthree\nfour\n",
+                "encoding": "utf-8",
+                "created_at": "",
+                "modified_at": "",
+            },
+        )
+        middleware = FilesystemMiddleware(backend=StoreBackend(store=store, namespace=lambda _ctx: ("filesystem",)))
+        read_file = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        result = read_file.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 2, "limit": 2})
+
+        assert "lines remaining" not in result.content
+
+    def test_offset_read_reports_remaining_lines_from_next_offset(self) -> None:
+        store = InMemoryStore()
+        store.put(
+            ("filesystem",),
+            "/notes.txt",
+            {
+                "content": "one\ntwo\nthree\nfour\nfive\n",
+                "encoding": "utf-8",
+                "created_at": "",
+                "modified_at": "",
+            },
+        )
+        middleware = FilesystemMiddleware(backend=StoreBackend(store=store, namespace=lambda _ctx: ("filesystem",)))
+        read_file = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        result = read_file.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 2, "limit": 2})
+
+        assert "lines 3-4 of 5 total" in result.content
+        assert "1 line remaining from offset 4" in result.content
+
+    def test_filesystem_backend_partial_read_includes_remaining_line_notice(self, tmp_path) -> None:
+        (tmp_path / "notes.txt").write_text("one\ntwo\nthree\n", encoding="utf-8")
+        middleware = FilesystemMiddleware(backend=FilesystemBackend(root_dir=tmp_path, virtual_mode=True))
+        read_file = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        result = read_file.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 0, "limit": 2})
+
+        assert result.content.endswith("[Read 2 lines (lines 1-2 of 3 total). 1 line remaining from offset 2.]")
+
+    def test_blank_line_file_partial_read_includes_remaining_line_notice(self) -> None:
+        store = InMemoryStore()
+        store.put(
+            ("filesystem",),
+            "/blank.txt",
+            {
+                "content": "\n\n\n",
+                "encoding": "utf-8",
+                "created_at": "",
+                "modified_at": "",
+            },
+        )
+        middleware = FilesystemMiddleware(backend=StoreBackend(store=store, namespace=lambda _ctx: ("filesystem",)))
+        read_file = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        result = read_file.invoke({"runtime": _runtime(), "file_path": "/blank.txt", "offset": 0, "limit": 2})
+
+        assert result.content.endswith("[Read 2 lines (lines 1-2 of 3 total). 1 line remaining from offset 2.]")


### PR DESCRIPTION
Fixes #2142

---

Adds remaining-line metadata to paginated `read_file` results so `FilesystemMiddleware` can tell agents when more source lines are available and which offset to use next. The metadata is propagated across filesystem, state, store, context hub, and sandbox backends without changing the existing `read_file` arguments.

Verified with focused backend and middleware tests, ruff format/check on touched files, and ty on touched SDK files.

AI assistance used: Hermes Agent.
