### PR TITLE
refactor(quickjs): remove deprecated `snapshot_between_turns` flag

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -19,7 +19,6 @@ from langchain.agents.middleware.types import (
 )
 from langchain.tools import BaseTool, ToolRuntime
 from langchain_core._api import beta
-from langchain_core._api.deprecation import warn_deprecated
 from langchain_core.messages import SystemMessage, ToolMessage
 from langchain_core.tools import StructuredTool
 from langgraph.channels import DeltaChannel
@@ -53,6 +52,8 @@ _DEFAULT_MAX_PTC_CALLS = 256
 _DEFAULT_MAX_RESULT_CHARS = 4_000
 _DEFAULT_TOOL_NAME = "eval"
 
+PersistenceMode = Literal["thread", "turn", "call"]
+
 
 class REPLState(AgentState):
     """State schema for `CodeInterpreterMiddleware`."""
@@ -77,45 +78,21 @@ class EvalSchema(BaseModel):
     )
 
 
-def _resolve_persistence_flags(
+def _resolve_mode(
     *,
-    mode: Literal["thread", "turn", "call"] | None,
-    snapshot_between_turns: bool | None,
-) -> tuple[Literal["thread", "turn", "call"], bool, bool]:
-    """Normalize persistence configuration and enforce invariant constraints."""
-    if snapshot_between_turns is not None:
-        warn_deprecated(
-            since="0.1.2",
-            removal="0.2.0",
-            message=(
-                "Passing `snapshot_between_turns` to "
-                "`CodeInterpreterMiddleware` is deprecated and will be "
-                "removed in langchain-quickjs==0.2.0. Use `mode='thread'` "
-                "or `mode='turn'` instead."
-            ),
-            package="langchain-quickjs",
-        )
-    if mode is None:
-        if snapshot_between_turns is None or snapshot_between_turns:
-            return "thread", True, False
-        return "turn", False, False
-
-    if mode == "thread":
-        if snapshot_between_turns is False:
-            msg = "`snapshot_between_turns=False` is incompatible with `mode='thread'`."
+    mode: str | None,
+) -> PersistenceMode:
+    """Normalize persistence mode and enforce invariant constraints."""
+    match mode:
+        case None | "thread":
+            return "thread"
+        case "turn":
+            return "turn"
+        case "call":
+            return "call"
+        case _:
+            msg = "`mode` must be one of 'thread', 'turn', or 'call'."
             raise ValueError(msg)
-        return "thread", True, False
-
-    if mode == "turn":
-        if snapshot_between_turns is True:
-            msg = "`snapshot_between_turns=True` is incompatible with `mode='turn'`."
-            raise ValueError(msg)
-        return "turn", False, False
-
-    if snapshot_between_turns is True:
-        msg = "`snapshot_between_turns=True` is incompatible with `mode='call'`."
-        raise ValueError(msg)
-    return "call", False, True
 
 
 def _resolve_thread_id(fallback: str) -> str:
@@ -212,15 +189,6 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
             - `"turn"`: state persists across calls within a turn only.
             - `"call"`: each eval call runs in a fresh REPL.
             If omitted, defaults to `"thread"`
-        snapshot_between_turns: Compatibility knob for turn-vs-thread
-            behavior. When `mode` is omitted, `True` resolves to
-            `"thread"` and `False` resolves to `"turn"`. When `mode` is
-            provided, incompatible combinations raise `ValueError`.
-
-            !!! deprecated
-
-                Passing `snapshot_between_turns` is deprecated. Use
-                `mode="thread"` or `mode="turn"` instead.
         max_snapshot_bytes: Maximum serialized snapshot payload size allowed
             in middleware state. If a snapshot exceeds this size, it is
             dropped (`_quickjs_snapshot_payload=None`). Defaults to
@@ -251,8 +219,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         capture_console: bool = True,
         subagents: bool = True,
         ptc: PTCOption | None = None,
-        mode: Literal["thread", "turn", "call"] | None = None,
-        snapshot_between_turns: bool | None = None,
+        mode: PersistenceMode | None = None,
         max_snapshot_bytes: int | None = None,
     ) -> None:
         """Initialize REPL middleware state and build the exposed eval tool."""
@@ -271,14 +238,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         self._capture_console = capture_console
         self._subagents = subagents
         self._ptc = ptc
-        (
-            self._mode,
-            self._snapshot_between_turns,
-            self._reset_between_calls,
-        ) = _resolve_persistence_flags(
-            mode=mode,
-            snapshot_between_turns=snapshot_between_turns,
-        )
+        self._mode = _resolve_mode(mode=mode)
         self._max_snapshot_bytes = (
             memory_limit if max_snapshot_bytes is None else max_snapshot_bytes
         )
@@ -332,7 +292,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
                     outer_runtime=runtime,
                 )
             finally:
-                if middleware._reset_between_calls:
+                if middleware._mode == "call":
                     middleware._registry.reset_repl(thread_id)
             return _make_tool_message(outcome, runtime.tool_call_id)
 
@@ -349,7 +309,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
                     outer_loop=asyncio.get_running_loop(),
                 )
             finally:
-                if middleware._reset_between_calls:
+                if middleware._mode == "call":
                     middleware._registry.reset_repl(thread_id)
             return _make_tool_message(outcome, runtime.tool_call_id)
 
@@ -376,7 +336,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
     def _repl_for_eval(self, thread_id: str) -> Any:
         """Return the REPL slot for one eval invocation."""
         repl = self._registry.get(thread_id)
-        if self._reset_between_calls and self._ptc is not None:
+        if self._mode == "call" and self._ptc is not None:
             repl.install_tools(list(self._ptc_tools_by_thread.get(thread_id, ())))
         return repl
 
@@ -386,7 +346,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         runtime: "Runtime[ContextT]",  # noqa: ARG002
     ) -> dict[str, Any] | None:
         """Restore REPL snapshot bytes into the current thread slot."""
-        if self._reset_between_calls or not self._snapshot_between_turns:
+        if self._mode != "thread":
             return None
         payload = state.get("_quickjs_snapshot_payload")
         if not payload:
@@ -410,7 +370,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         runtime: "Runtime[ContextT]",  # noqa: ARG002
     ) -> dict[str, Any] | None:
         """Async variant of `before_agent` snapshot restore."""
-        if self._reset_between_calls or not self._snapshot_between_turns:
+        if self._mode != "thread":
             return None
         payload = state.get("_quickjs_snapshot_payload")
         if not payload:
@@ -546,7 +506,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         """Snapshot REPL state (optional) and evict this turn's REPL slot."""
         thread_id = _resolve_thread_id(self._fallback_thread_id)
         self._ptc_tools_by_thread.pop(thread_id, None)
-        if self._reset_between_calls or not self._snapshot_between_turns:
+        if self._mode != "thread":
             self._registry.evict(thread_id)
             return None
 
@@ -580,7 +540,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         """Async variant of `after_agent` snapshot+evict behavior."""
         thread_id = _resolve_thread_id(self._fallback_thread_id)
         self._ptc_tools_by_thread.pop(thread_id, None)
-        if self._reset_between_calls or not self._snapshot_between_turns:
+        if self._mode != "thread":
             await self._registry.aevict(thread_id)
             return None
 

--- a/libs/partners/quickjs/tests/benchmarks/_common.py
+++ b/libs/partners/quickjs/tests/benchmarks/_common.py
@@ -15,6 +15,8 @@ from langchain_quickjs import CodeInterpreterMiddleware
 from tests._common import FakeChatModel
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from langchain_quickjs.middleware import REPLState
 
 CONSOLE_LOG_CODE = "for (let i = 0; i < 200; i += 1) {  console.log(`line-${i}`);}'ok';"
@@ -110,12 +112,10 @@ def assert_eval_succeeded(result: dict[str, Any]) -> None:
 def run_counter_turns(
     *,
     turn_count: int,
-    snapshot_between_turns: bool,
+    mode: Literal["thread", "turn"],
 ) -> list[str]:
     """Run `turn_count` REPL turns and return counter values per turn."""
-    middleware = CodeInterpreterMiddleware(
-        snapshot_between_turns=snapshot_between_turns
-    )
+    middleware = CodeInterpreterMiddleware(mode=mode)
     state: REPLState = {}
     runtime: Any = None  # hooks ignore runtime; `None` keeps this path lightweight
     values: list[str] = []
@@ -143,12 +143,12 @@ def run_counter_turns(
 def assert_counter_turn_values(
     *,
     values: list[str],
-    snapshot_between_turns: bool,
+    mode: Literal["thread", "turn"],
 ) -> None:
-    """Assert expected counter values with snapshots enabled/disabled."""
+    """Assert expected counter values for the configured persistence mode."""
     expected = (
         [str(turn_index) for turn_index in range(len(values))]
-        if snapshot_between_turns
+        if mode == "thread"
         else ["0", *(["missing"] * max(0, len(values) - 1))]
     )
     assert values == expected, f"expected {expected}, got {values}"

--- a/libs/partners/quickjs/tests/benchmarks/test_quickjs_memory.py
+++ b/libs/partners/quickjs/tests/benchmarks/test_quickjs_memory.py
@@ -27,6 +27,8 @@ from tests.benchmarks._common import (
 )
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from pytest_benchmark.fixture import BenchmarkFixture
 
 
@@ -61,15 +63,15 @@ class TestQuickJSMemoryBenchmarks:
         self,
         *,
         turn_count: int,
-        snapshot_between_turns: bool,
+        mode: Literal["thread", "turn"],
     ) -> None:
         values = run_counter_turns(
             turn_count=turn_count,
-            snapshot_between_turns=snapshot_between_turns,
+            mode=mode,
         )
         assert_counter_turn_values(
             values=values,
-            snapshot_between_turns=snapshot_between_turns,
+            mode=mode,
         )
 
     @pytest.mark.parametrize(
@@ -106,15 +108,15 @@ class TestQuickJSMemoryBenchmarks:
 
     @pytest.mark.parametrize("turn_count", [10, 50, 200], ids=lambda n: f"{n}_turns")
     @pytest.mark.parametrize(
-        "snapshot_between_turns",
-        [False, True],
-        ids=["snapshot_disabled", "snapshot_enabled"],
+        "mode",
+        ["turn", "thread"],
+        ids=["mode_turn", "mode_thread"],
     )
     def test_multiturn_snapshot_memory_peak(
         self,
         benchmark: BenchmarkFixture,
         turn_count: int,
-        snapshot_between_turns: bool,
+        mode: Literal["thread", "turn"],
     ) -> None:
         """Measure memory cost of multi-turn execution with optional snapshots."""
 
@@ -122,10 +124,10 @@ class TestQuickJSMemoryBenchmarks:
         def _() -> None:
             self._run_multiturn_memory_workload(
                 turn_count=turn_count,
-                snapshot_between_turns=snapshot_between_turns,
+                mode=mode,
             )
 
         benchmark.extra_info["scenario"] = "multi_turn_snapshot_restore"
         benchmark.extra_info["thread_count"] = 1
         benchmark.extra_info["turn_count"] = turn_count
-        benchmark.extra_info["snapshot_between_turns"] = snapshot_between_turns
+        benchmark.extra_info["mode"] = mode

--- a/libs/partners/quickjs/tests/benchmarks/test_quickjs_throughput.py
+++ b/libs/partners/quickjs/tests/benchmarks/test_quickjs_throughput.py
@@ -26,6 +26,8 @@ from tests.benchmarks._common import (
 )
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from pytest_benchmark.fixture import BenchmarkFixture
 
 
@@ -80,26 +82,26 @@ class TestQuickJSThroughputBenchmarks:
     @pytest.mark.throughput_benchmark
     @pytest.mark.parametrize("turn_count", [10, 50, 200], ids=lambda n: f"{n}_turns")
     @pytest.mark.parametrize(
-        "snapshot_between_turns",
-        [False, True],
-        ids=["snapshot_disabled", "snapshot_enabled"],
+        "mode",
+        ["turn", "thread"],
+        ids=["mode_turn", "mode_thread"],
     )
     def test_multi_turn_snapshot_throughput(
         self,
         benchmark: BenchmarkFixture,
         turn_count: int,
-        snapshot_between_turns: bool,
+        mode: Literal["thread", "turn"],
     ) -> None:
         """Measure throughput across explicit multi-turn REPL lifecycle calls."""
 
         def _run_round() -> None:
             values = run_counter_turns(
                 turn_count=turn_count,
-                snapshot_between_turns=snapshot_between_turns,
+                mode=mode,
             )
             assert_counter_turn_values(
                 values=values,
-                snapshot_between_turns=snapshot_between_turns,
+                mode=mode,
             )
 
         @benchmark
@@ -108,6 +110,6 @@ class TestQuickJSThroughputBenchmarks:
 
         benchmark.extra_info["thread_count"] = 1
         benchmark.extra_info["turn_count"] = turn_count
-        benchmark.extra_info["snapshot_between_turns"] = snapshot_between_turns
+        benchmark.extra_info["mode"] = mode
         benchmark.extra_info["workload"] = "multi_turn_snapshot_restore"
         self._record_turn_metrics(benchmark=benchmark, turns_per_round=turn_count)

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -264,9 +264,8 @@ def test_system_prompt_omits_subagent_guidance_when_disabled() -> None:
     assert "await task({" not in sys_text
 
 
-def test_system_prompt_mentions_single_turn_when_snapshots_disabled() -> None:
-    with pytest.warns(DeprecationWarning, match="snapshot_between_turns"):
-        mw = CodeInterpreterMiddleware(snapshot_between_turns=False)
+def test_system_prompt_mentions_single_turn_for_mode_turn() -> None:
+    mw = CodeInterpreterMiddleware(mode="turn")
     assert "DO NOT persist across multiple turns" in mw._base_prompt(ptc_attached=False)
 
 
@@ -277,47 +276,24 @@ def test_system_prompt_mentions_mode_call() -> None:
     assert "does not persist across tool calls" in base_prompt
 
 
-def test_mode_call_defaults_snapshot_between_turns_to_false() -> None:
-    mw = CodeInterpreterMiddleware(mode="call")
-    assert mw._snapshot_between_turns is False
+def test_default_mode_is_thread() -> None:
+    mw = CodeInterpreterMiddleware()
+    assert mw._mode == "thread"
 
 
-def test_mode_turn_defaults_snapshot_between_turns_to_false() -> None:
+def test_mode_turn_is_stored() -> None:
     mw = CodeInterpreterMiddleware(mode="turn")
-    assert mw._snapshot_between_turns is False
-
-
-def test_snapshot_between_turns_false_resolves_to_mode_turn() -> None:
-    with pytest.warns(DeprecationWarning, match="snapshot_between_turns"):
-        mw = CodeInterpreterMiddleware(snapshot_between_turns=False)
     assert mw._mode == "turn"
 
 
-def test_snapshot_between_turns_emits_deprecation_warning() -> None:
-    with pytest.warns(DeprecationWarning, match="snapshot_between_turns"):
-        CodeInterpreterMiddleware(snapshot_between_turns=True)
+def test_mode_call_is_stored() -> None:
+    mw = CodeInterpreterMiddleware(mode="call")
+    assert mw._mode == "call"
 
 
-def test_mode_call_with_snapshot_between_turns_true_raises() -> None:
-    with (
-        pytest.warns(DeprecationWarning, match="snapshot_between_turns"),
-        pytest.raises(ValueError, match="incompatible"),
-    ):
-        CodeInterpreterMiddleware(
-            mode="call",
-            snapshot_between_turns=True,
-        )
-
-
-def test_mode_thread_with_snapshot_between_turns_false_raises() -> None:
-    with (
-        pytest.warns(DeprecationWarning, match="snapshot_between_turns"),
-        pytest.raises(ValueError, match="incompatible"),
-    ):
-        CodeInterpreterMiddleware(
-            mode="thread",
-            snapshot_between_turns=False,
-        )
+def test_rejects_invalid_mode() -> None:
+    with pytest.raises(ValueError, match="must be one of"):
+        CodeInterpreterMiddleware(mode="session")  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------

--- a/libs/partners/quickjs/tests/unit_tests/test_snapshot.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_snapshot.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import bsdiff4
-import pytest
 from langchain.agents import create_agent
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage
@@ -483,9 +482,8 @@ def test_delta_channel_resume_from_history_reconstructs_state() -> None:
     assert any(getattr(m, "content", None) == "done" for m in final["messages"])
 
 
-def test_snapshot_between_turns_disabled_keeps_reset_behavior() -> None:
-    with pytest.warns(DeprecationWarning, match="snapshot_between_turns"):
-        mw = CodeInterpreterMiddleware(snapshot_between_turns=False)
+def test_mode_turn_keeps_reset_behavior() -> None:
+    mw = CodeInterpreterMiddleware(mode="turn")
     try:
         repl = mw._registry.get(mw._fallback_thread_id)
         repl.eval_sync("globalThis.answer = 42")

--- a/libs/partners/quickjs/tests/unit_tests/test_snapshot_persistence.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_snapshot_persistence.py
@@ -133,13 +133,13 @@ async def test_repl_snapshot_persists_state_between_turns(
     ["invoke", "ainvoke"],
     ids=["sync_invoke", "async_ainvoke"],
 )
-async def test_repl_without_snapshots_resets_state_between_turns(
+async def test_repl_mode_turn_resets_state_between_turns(
     invoke_mode: InvokeMode,
 ) -> None:
-    """When snapshots are disabled, turn-2 eval starts with a fresh context."""
+    """In turn mode, turn-2 eval starts with a fresh context."""
     agent = create_deep_agent(
         model=FakeChatModel(messages=iter(_script_two_turns_without_snapshots())),
-        middleware=[CodeInterpreterMiddleware(snapshot_between_turns=False)],
+        middleware=[CodeInterpreterMiddleware(mode="turn")],
         checkpointer=InMemorySaver(),
     )
     config = {"configurable": {"thread_id": "quickjs-no-snapshot-thread"}}


### PR DESCRIPTION
Remove the deprecated `snapshot_between_turns` compatibility option from `CodeInterpreterMiddleware` now that persistence is controlled entirely by `mode`.

This keeps REPL persistence configuration to one public knob and one internal normalized value. `thread` remains the default, `turn` skips cross-turn snapshot restore/save, and `call` resets after each eval.

Changes:
- delete the deprecated constructor parameter and deprecation shim
- collapse persistence state to the normalized `_mode`
- update unit tests and QuickJS benchmarks to use `mode` directly
