### PR TITLE
fix(infra): expand PR labeler scope aliases to all package components

### DIFF
--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -85,12 +85,12 @@ jobs:
             );
             core.setOutput('is-external', isExternal ? 'true' : 'false');
 
-      # Rename `deepagents` scope → `sdk` for non-release PRs.
-      # Release PRs (e.g. `release(deepagents): 1.2.0`) are left
-      # untouched since their titles are canonical version records.
-      # Runs before labeling so title-based labels read the
-      # corrected title.
-      - name: Rename deepagents scope to sdk
+      # Rename package-component scopes to their canonical PR scopes for
+      # non-release PRs. Release PRs (e.g. `release(deepagents): 1.2.0` or
+      # `release(deepagents-code): 1.2.0`) are left untouched since their titles
+      # are canonical version records. Runs before labeling so title-based labels
+      # read the corrected title.
+      - name: Rename package component scopes
         id: rename-scope
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -115,10 +115,17 @@ jobs:
               return;
             }
 
+            const scopeAliases = new Map([
+              ['deepagents', 'sdk'],
+              ['deepagents-acp', 'acp'],
+              ['deepagents-cli', 'cli'],
+              ['deepagents-code', 'code'],
+              ['deepagents-talon', 'talon'],
+            ]);
             const scopeStr = match[2];
             const newScope = scopeStr
               .split(',')
-              .map(s => s.trim() === 'deepagents' ? 'sdk' : s.trim())
+              .map(s => scopeAliases.get(s.trim()) ?? s.trim())
               .join(',');
 
             if (newScope === scopeStr) return;


### PR DESCRIPTION
Extends the scope-rewrite step in `pr_labeler.yml` so non-release PR titles get every package-component scope normalized to its canonical short scope, not just `deepagents`. Previously the renamer only handled `deepagents → sdk`; titles using `deepagents-acp`, `deepagents-cli`, `deepagents-code`, or `deepagents-talon` passed through unrewritten, so the downstream title-based labels (and matching against the lint config's allowed scopes) saw a scope the labeler wasn't mapping.