### PR TITLE
ci(infra): credit releaser in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -722,21 +722,15 @@ jobs:
             RELEASE_BODY=$(printf "%s\n\nInternal maintainers: %s" "$RELEASE_BODY" "$INTERNAL_LIST")
           fi
 
-          # Credit whoever shipped the release, unless they're already listed as a
-          # community contributor or internal maintainer (avoid crediting twice).
+          # Credit whoever shipped the release. This is a distinct role from
+          # contributing release changes, so show it even when the same user also
+          # appears as a community contributor or internal maintainer.
           if [ -n "$RELEASER" ]; then
-            ALREADY_PRESENT=false
-            if printf '%s %s' "$CONTRIBUTOR_LIST" "$INTERNAL_LIST" \
-              | grep -qE "(^|[ ,])@${RELEASER}([ ,(]|\$)"; then
-              ALREADY_PRESENT=true
+            if [ "$SEPARATOR_ADDED" = "false" ]; then
+              RELEASE_BODY=$(printf "%s\n\n---" "$RELEASE_BODY")
+              SEPARATOR_ADDED=true
             fi
-            if [ "$ALREADY_PRESENT" = "false" ]; then
-              if [ "$SEPARATOR_ADDED" = "false" ]; then
-                RELEASE_BODY=$(printf "%s\n\n---" "$RELEASE_BODY")
-                SEPARATOR_ADDED=true
-              fi
-              RELEASE_BODY=$(printf "%s\n\nReleased by: @%s" "$RELEASE_BODY" "$RELEASER")
-            fi
+            RELEASE_BODY=$(printf "%s\n\nReleased by: @%s" "$RELEASE_BODY" "$RELEASER")
           fi
 
           # Output release body using heredoc for proper multiline handling

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -463,7 +463,7 @@ jobs:
       # is that PR's squash-merge); when the release commit has no associated
       # merged PR (initial release, or a direct push / manual recovery), fall back
       # to the actor who triggered the workflow. Bot accounts are dropped — there's
-      # no human to credit (the auto path's dispatcher is github-actions[bot]).
+      # no human to credit (e.g. the auto path's dispatcher is github-actions[bot]).
       - name: Resolve releaser
         id: resolve-releaser
         env:
@@ -476,13 +476,27 @@ jobs:
 
           RELEASER=""
 
-          # Primary: the user who merged the release PR.
+          # Primary: the user who merged the release PR. Distinguish "commit has no
+          # associated merged PR" (initial release, direct push, manual recovery, or
+          # eventual-consistency on a fresh squash-merge) from a real API failure.
+          # The latter must warn rather than silently fall through to the actor —
+          # on a manual release that would credit the dispatcher instead of the
+          # merger, with no breadcrumb. Mirrors the lookup pattern used below for
+          # release-label resolution.
           if [ -n "$RELEASE_COMMIT" ]; then
-            PR_NUM=$(gh api "/repos/$REPOSITORY/commits/$RELEASE_COMMIT/pulls" \
-              --jq '.[0].number // empty' 2>/dev/null || true)
+            if PULLS=$(gh api "/repos/$REPOSITORY/commits/$RELEASE_COMMIT/pulls" 2>&1); then
+              PR_NUM=$(printf '%s' "$PULLS" | jq -r '.[0].number // empty')
+            else
+              echo "::warning::releaser lookup: commit-pulls API failed: $PULLS — falling back to actor"
+              PR_NUM=""
+            fi
             if [ -n "$PR_NUM" ]; then
-              RELEASER=$(gh pr view "$PR_NUM" --repo "$REPOSITORY" \
-                --json mergedBy --jq '.mergedBy.login // empty' 2>/dev/null || true)
+              if MERGED_BY=$(gh pr view "$PR_NUM" --repo "$REPOSITORY" \
+                --json mergedBy --jq '.mergedBy.login // empty' 2>&1); then
+                RELEASER="$MERGED_BY"
+              else
+                echo "::warning::releaser lookup: gh pr view #$PR_NUM failed: $MERGED_BY — falling back to actor"
+              fi
             fi
           fi
 
@@ -491,7 +505,10 @@ jobs:
             RELEASER="$ACTOR"
           fi
 
-          # Drop bot accounts (quoted patterns are literal, so "[bot]" is not a glob class).
+          # Drop bot accounts. Quoted patterns are literal, so "[bot]" matches as a
+          # literal suffix, not a glob char class — "*[bot]" matches any login ending
+          # in "[bot]". The bare "github-actions" arm covers github.actor surfacing
+          # without the "[bot]" suffix, which "*[bot]" would not catch.
           case "$RELEASER" in
             ""|*"[bot]"|github-actions) RELEASER="" ;;
           esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -460,9 +460,10 @@ jobs:
 
       # Resolve the human who shipped this release so release notes can credit
       # them. Primary source is whoever merged the release PR (the release commit
-      # is that PR's squash-merge); manual `gh workflow run` dispatches fall back
-      # to the triggering actor. Bot accounts are dropped — there's no human to
-      # credit (the auto path's dispatcher is github-actions[bot]).
+      # is that PR's squash-merge); when the release commit has no associated
+      # merged PR (initial release, or a direct push / manual recovery), fall back
+      # to the actor who triggered the workflow. Bot accounts are dropped — there's
+      # no human to credit (the auto path's dispatcher is github-actions[bot]).
       - name: Resolve releaser
         id: resolve-releaser
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -458,6 +458,46 @@ jobs:
           echo "Release commit: $RELEASE_COMMIT"
           echo "release-commit=$RELEASE_COMMIT" >> "$GITHUB_OUTPUT"
 
+      # Resolve the human who shipped this release so release notes can credit
+      # them. Primary source is whoever merged the release PR (the release commit
+      # is that PR's squash-merge); manual `gh workflow run` dispatches fall back
+      # to the triggering actor. Bot accounts are dropped — there's no human to
+      # credit (the auto path's dispatcher is github-actions[bot]).
+      - name: Resolve releaser
+        id: resolve-releaser
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_COMMIT: ${{ steps.resolve-refs.outputs.release-commit }}
+          ACTOR: ${{ github.actor }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+
+          RELEASER=""
+
+          # Primary: the user who merged the release PR.
+          if [ -n "$RELEASE_COMMIT" ]; then
+            PR_NUM=$(gh api "/repos/$REPOSITORY/commits/$RELEASE_COMMIT/pulls" \
+              --jq '.[0].number // empty' 2>/dev/null || true)
+            if [ -n "$PR_NUM" ]; then
+              RELEASER=$(gh pr view "$PR_NUM" --repo "$REPOSITORY" \
+                --json mergedBy --jq '.mergedBy.login // empty' 2>/dev/null || true)
+            fi
+          fi
+
+          # Fallback: the actor who dispatched the workflow (manual releases).
+          if [ -z "$RELEASER" ]; then
+            RELEASER="$ACTOR"
+          fi
+
+          # Drop bot accounts (quoted patterns are literal, so "[bot]" is not a glob class).
+          case "$RELEASER" in
+            ""|*"[bot]"|github-actions) RELEASER="" ;;
+          esac
+
+          echo "Resolved releaser: ${RELEASER:-<none>}"
+          echo "releaser=$RELEASER" >> "$GITHUB_OUTPUT"
+
       - name: Generate release body
         id: generate-release-body
         env:
@@ -466,6 +506,7 @@ jobs:
           VERSION: ${{ needs.build.outputs.version }}
           PREV_TAG: ${{ steps.resolve-refs.outputs.prev-tag }}
           RELEASE_COMMIT: ${{ steps.resolve-refs.outputs.release-commit }}
+          RELEASER: ${{ steps.resolve-releaser.outputs.releaser }}
           IS_PRERELEASE: ${{ needs.build.outputs.is-prerelease }}
           BASE_BRANCH: ${{ github.ref_name }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -675,8 +716,26 @@ jobs:
           if [ -n "$INTERNAL_LIST" ]; then
             if [ "$SEPARATOR_ADDED" = "false" ]; then
               RELEASE_BODY=$(printf "%s\n\n---" "$RELEASE_BODY")
+              SEPARATOR_ADDED=true
             fi
             RELEASE_BODY=$(printf "%s\n\nInternal maintainers: %s" "$RELEASE_BODY" "$INTERNAL_LIST")
+          fi
+
+          # Credit whoever shipped the release, unless they're already listed as a
+          # community contributor or internal maintainer (avoid crediting twice).
+          if [ -n "$RELEASER" ]; then
+            ALREADY_PRESENT=false
+            if printf '%s %s' "$CONTRIBUTOR_LIST" "$INTERNAL_LIST" \
+              | grep -qE "(^|[ ,])@${RELEASER}([ ,(]|\$)"; then
+              ALREADY_PRESENT=true
+            fi
+            if [ "$ALREADY_PRESENT" = "false" ]; then
+              if [ "$SEPARATOR_ADDED" = "false" ]; then
+                RELEASE_BODY=$(printf "%s\n\n---" "$RELEASE_BODY")
+                SEPARATOR_ADDED=true
+              fi
+              RELEASE_BODY=$(printf "%s\n\nReleased by: @%s" "$RELEASE_BODY" "$RELEASER")
+            fi
           fi
 
           # Output release body using heredoc for proper multiline handling


### PR DESCRIPTION
Release notes did not say who shipped a release, which makes it harder to see who handled the final release step. This resolves the releaser from the release PR merge, falls back to the actor who triggered the workflow when the release commit has no associated merged PR, and skips bot accounts.

The footer always adds `Released by: @username` when a human releaser is resolved. This is intentionally independent of the community-contributor and internal-maintainer lists — releasing is a distinct role from contributing the changes — so a user who both authored changes and merged the release is credited in both places.

When the release-PR lookup hits a real API failure (as opposed to the commit genuinely having no merged PR), the step emits a `::warning::` and falls back to the actor rather than failing silently, so a mis-credit leaves a breadcrumb in the run log. This mirrors the existing label-resolution lookup elsewhere in the workflow.