### PR TITLE
feat(sdk): add `persists_to_filesystem` metadata for ephemeral state detection

### DIFF
--- a/libs/deepagents/deepagents/backends/__init__.py
+++ b/libs/deepagents/deepagents/backends/__init__.py
@@ -5,6 +5,7 @@ from deepagents.backends.context_hub import ContextHubBackend
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.langsmith import LangSmithSandbox
 from deepagents.backends.local_shell import DEFAULT_EXECUTE_TIMEOUT, LocalShellBackend
+from deepagents.backends.persistence import persists_to_filesystem
 from deepagents.backends.protocol import BackendProtocol
 from deepagents.backends.state import StateBackend
 from deepagents.backends.store import (
@@ -25,4 +26,5 @@ __all__ = [
     "NamespaceFactory",
     "StateBackend",
     "StoreBackend",
+    "persists_to_filesystem",
 ]

--- a/libs/deepagents/deepagents/backends/persistence.py
+++ b/libs/deepagents/deepagents/backends/persistence.py
@@ -1,0 +1,60 @@
+"""Persistence checks for file backends.
+
+Utilities to determine whether a [`BackendProtocol`][deepagents.backends.protocol.BackendProtocol]
+writes files to the real filesystem (visible to external processes like a test
+verifier) or stores them in ephemeral, in-process state that vanishes when the
+graph execution ends.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from deepagents.backends.composite import CompositeBackend
+from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.backends.local_shell import LocalShellBackend
+
+if TYPE_CHECKING:
+    from deepagents.backends.protocol import BACKEND_TYPES
+
+
+def persists_to_filesystem(backend: BACKEND_TYPES) -> bool:
+    """Return ``True`` if *backend* writes files to the real filesystem.
+
+    A backend "persists to the filesystem" when file writes reach the actual
+    disk of the host environment, making them visible to external processes
+    (e.g. a test verifier that runs ``test.sh`` against the working directory
+    after the agent finishes).
+
+    Backends that store files in LangGraph state channels
+    ([`StateBackend`][deepagents.backends.state.StateBackend]), LangGraph's
+    [`BaseStore`][langgraph.store.base.BaseStore]
+    ([`StoreBackend`][deepagents.backends.store.StoreBackend]), or remote
+    services ([`ContextHubBackend`][deepagents.backends.context_hub.ContextHubBackend],
+    sandbox backends) do **not** persist to the local filesystem and return
+    ``False``.
+
+    For [`CompositeBackend`][deepagents.backends.composite.CompositeBackend],
+    returns ``True`` only when **every** route (including the default backend)
+    persists to the filesystem. If any route is ephemeral, files written to
+    that route's paths will not reach disk, so the composite as a whole is
+    considered non-persistent.
+
+    Backend factories (callables that return a backend at runtime) cannot be
+    checked at compile time and return ``False``.
+
+    Args:
+        backend: The backend to check — either a resolved instance or a
+            factory callable. May be a single backend or a
+            [`CompositeBackend`][deepagents.backends.composite.CompositeBackend]
+            with nested routes.
+
+    Returns:
+        ``True`` if all file writes reach the real filesystem, ``False``
+        otherwise.
+    """
+    if isinstance(backend, CompositeBackend):
+        return persists_to_filesystem(backend.default) and all(
+            persists_to_filesystem(route_backend) for _prefix, route_backend in backend.sorted_routes
+        )
+    return isinstance(backend, (FilesystemBackend, LocalShellBackend))

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -35,7 +35,7 @@ from deepagents._messages_reducer import _messages_delta_reducer
 from deepagents._models import resolve_model
 from deepagents._tools import _apply_tool_description_overrides
 from deepagents._version import __version__
-from deepagents.backends import StateBackend
+from deepagents.backends import StateBackend, persists_to_filesystem
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
 from deepagents.middleware._fs_interrupt import _build_interrupt_on_from_permissions
 from deepagents.middleware._state import private_state_field_names
@@ -860,6 +860,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 "ls_integration": "deepagents",
                 "lc_versions": {"deepagents": __version__},
                 "lc_agent_name": name,
+                "persists_to_filesystem": persists_to_filesystem(backend),
             },
         }
     )

--- a/libs/deepagents/tests/unit_tests/backends/test_persistence.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_persistence.py
@@ -1,0 +1,86 @@
+"""Tests for `persists_to_filesystem`."""
+
+from deepagents.backends import (
+    CompositeBackend,
+    FilesystemBackend,
+    LocalShellBackend,
+    StateBackend,
+    StoreBackend,
+    persists_to_filesystem,
+)
+
+
+def test_filesystem_backend_persists():
+    assert persists_to_filesystem(FilesystemBackend()) is True
+
+
+def test_local_shell_backend_persists():
+    assert persists_to_filesystem(LocalShellBackend()) is True
+
+
+def test_state_backend_does_not_persist():
+    assert persists_to_filesystem(StateBackend()) is False
+
+
+def test_store_backend_does_not_persist():
+    assert persists_to_filesystem(StoreBackend()) is False
+
+
+def test_composite_all_persistent():
+    backend = CompositeBackend(
+        default=FilesystemBackend(),
+        routes={"/cache/": LocalShellBackend()},
+    )
+    assert persists_to_filesystem(backend) is True
+
+
+def test_composite_default_ephemeral():
+    backend = CompositeBackend(
+        default=StateBackend(),
+        routes={"/cache/": FilesystemBackend()},
+    )
+    assert persists_to_filesystem(backend) is False
+
+
+def test_composite_route_ephemeral():
+    backend = CompositeBackend(
+        default=FilesystemBackend(),
+        routes={"/memories/": StateBackend()},
+    )
+    assert persists_to_filesystem(backend) is False
+
+
+def test_composite_all_ephemeral():
+    backend = CompositeBackend(
+        default=StateBackend(),
+        routes={"/memories/": StoreBackend()},
+    )
+    assert persists_to_filesystem(backend) is False
+
+
+def test_composite_nested_persistent():
+    inner = CompositeBackend(
+        default=FilesystemBackend(),
+        routes={"/cache/": LocalShellBackend()},
+    )
+    backend = CompositeBackend(
+        default=inner,
+        routes={"/data/": FilesystemBackend()},
+    )
+    assert persists_to_filesystem(backend) is True
+
+
+def test_composite_nested_ephemeral():
+    inner = CompositeBackend(
+        default=FilesystemBackend(),
+        routes={"/memories/": StateBackend()},
+    )
+    backend = CompositeBackend(
+        default=inner,
+        routes={"/data/": FilesystemBackend()},
+    )
+    assert persists_to_filesystem(backend) is False
+
+
+def test_factory_does_not_persist():
+    assert persists_to_filesystem(lambda _rt: FilesystemBackend()) is False

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -16,6 +16,7 @@ from langchain_core.tools import BaseTool, StructuredTool
 from deepagents._api.deprecation import LangChainDeprecationWarning
 from deepagents._tools import _apply_tool_description_overrides, _tool_name
 from deepagents._version import __version__
+from deepagents.backends import FilesystemBackend
 from deepagents.graph import (
     _REQUIRED_MIDDLEWARE_CLASSES,
     _REQUIRED_MIDDLEWARE_NAMES,
@@ -74,6 +75,27 @@ class TestCreateDeepAgentMetadata:
         agent = create_deep_agent(model=model)
         assert agent.config is not None
         assert agent.config["metadata"]["ls_integration"] == "deepagents"
+
+    def test_persists_to_filesystem_defaults_false(self) -> None:
+        """Default backend is StateBackend, which doesn't persist to filesystem."""
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+        agent = create_deep_agent(model=model)
+        assert agent.config is not None
+        assert agent.config["metadata"]["persists_to_filesystem"] is False
+
+    def test_persists_to_filesystem_true_for_filesystem_backend(self, tmp_path):
+        """FilesystemBackend should set persists_to_filesystem to True."""
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+        agent = create_deep_agent(model=model, backend=FilesystemBackend())
+        assert agent.config is not None
+        assert agent.config["metadata"]["persists_to_filesystem"] is True
+
+    def test_persists_to_filesystem_false_for_factory_backend(self) -> None:
+        """Factory backends can't be checked at compile time, so metadata is False."""
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+        agent = create_deep_agent(model=model, backend=lambda _rt: FilesystemBackend())
+        assert agent.config is not None
+        assert agent.config["metadata"]["persists_to_filesystem"] is False
 
 
 class TestProfileForModel:


### PR DESCRIPTION
## Summary

Add a `persists_to_filesystem` boolean to the compiled graph\'s metadata so external harnesses can detect when an agent\'s file backend won\'t write to the real filesystem.

## Problem

When an agent uses a non-filesystem backend (e.g. `StateBackend` — the default), file writes live in LangGraph graph state channels or a `BaseStore` and never reach disk. External processes that run after the graph exits — such as a test verifier running `test.sh` against the working directory — can\'t see those files. The agent appears to have done the task but leaves no trace on disk.

Currently there is no way for an external harness to detect this. The backend instance is buried inside `FilesystemMiddleware` held by middleware nodes in the compiled graph, requiring fragile introspection of `PregelNode.bound → RunnableCallable.func.__self__` to reach it.

## Solution

Add a `persists_to_filesystem` helper that checks whether a backend writes to the real filesystem, and set the result as a boolean in the compiled graph\'s metadata:

```python
graph = create_deep_agent(...)
graph.config["metadata"]["persists_to_filesystem"]  # True or False
```

The check handles `CompositeBackend` by recursively verifying that every route and the default backend are individually persistent. A composite is only persistent if **all** routes are persistent.

### Backend classification

| Backend | `persists_to_filesystem` | Reason |
|---|---|---|
| `FilesystemBackend` | `True` | Writes to disk |
| `LocalShellBackend` | `True` | Subclass of `FilesystemBackend` |
| `StateBackend` (default) | `False` | Graph state channels only |
| `StoreBackend` | `False` | LangGraph `BaseStore` |
| `ContextHubBackend` | `False` | Remote LangSmith Hub repo |
| `BaseSandbox` subclasses | `False` | Remote sandbox API |
| `CompositeBackend` | `True` only if all routes + default are `True` |

## Changes

- `deepagents/backends/persistence.py` — `persists_to_filesystem(backend)` helper with recursive `CompositeBackend` support
- `deepagents/backends/__init__.py` — export the new helper
- `deepagents/graph.py` — set `"persists_to_filesystem"` in the compiled graph\'s metadata
- `tests/unit_tests/backends/test_persistence.py` — 10 tests covering all backend types and composite nesting
- `tests/unit_tests/test_graph.py` — 2 tests verifying metadata is set correctly for default (`StateBackend`) and `FilesystemBackend`

## Usage

External harnesses (e.g. Harbor) can read the metadata after resolving the graph:

```python
metadata = getattr(graph, "config", {}).get("metadata", {}) or {}
if metadata.get("persists_to_filesystem") is False:
    raise ValueError(
        "Agent backend doesn\'t persist files to the environment filesystem. "
        "Use FilesystemBackend or LocalShellBackend so the verifier can see file outputs."
    )
```

The boolean is JSON-serializable, so it also shows up in LangSmith traces.

## Test plan

- [x] `tests/unit_tests/backends/test_persistence.py` — 10/10 passed
- [x] `tests/unit_tests/test_graph.py::TestCreateDeepAgentMetadata` — 4/4 passed