### PR TITLE
feat(sdk): retain the active todo list across context summarization

### DIFF
--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -800,6 +800,30 @@ A condensed summary follows:
             )
         ]
 
+    def _append_active_todos(self, summary: str, state: AgentState[Any]) -> str:
+        """Append the active todo list to the summary so the plan survives compaction.
+
+        The authoritative todo list lives in agent state, but the model only sees it
+        through the `write_todos` tool message in the conversation history. When that
+        message is old enough to be summarized away, the model loses sight of the active
+        plan even though state still holds it. Re-attaching the current todos to the
+        summary keeps the plan visible after compaction without depending on the original
+        tool message surviving, and without coupling to the cutoff selection logic.
+
+        Args:
+            summary: The generated conversation summary.
+            state: The current agent state, which may carry a `todos` list when the
+                agent uses `TodoListMiddleware`.
+
+        Returns:
+            The summary, with the active todo list appended when one is present;
+                otherwise the summary unchanged.
+        """
+        todos = state.get("todos")
+        if not todos:
+            return summary
+        return f"{summary}\n\n## Active todo list\n{todos}"
+
     def _get_effective_messages(self, request: ModelRequest) -> list[AnyMessage]:
         """Generate effective messages for model call based on summarization event.
 
@@ -1481,6 +1505,9 @@ A condensed summary follows:
         # Generate summary
         summary = self._create_summary(offloaded_media_messages)
 
+        # Re-attach the active todo list so the plan survives compaction
+        summary = self._append_active_todos(summary, request.state)
+
         # Build summary message with file path reference
         new_messages = self._build_new_messages_with_path(summary, file_path)
 
@@ -1615,6 +1642,9 @@ A condensed summary follows:
             )
             logger.warning(msg)
             warnings.warn(msg, stacklevel=2)
+
+        # Re-attach the active todo list so the plan survives compaction
+        summary = self._append_active_todos(summary, request.state)
 
         # Build summary message with file path reference
         new_messages = self._build_new_messages_with_path(summary, file_path)

--- a/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
@@ -1345,6 +1345,95 @@ class TestSummaryMessageFormat:
         # Should have lc_source marker
         assert summary_msg.additional_kwargs.get("lc_source") == "summarization"
 
+    def test_summary_includes_active_todos(self) -> None:
+        """Active todos are re-attached to the summary so the plan survives compaction.
+
+        The todo list lives in state but reaches the model only through the
+        `write_todos` tool message, which compaction can summarize away. The summary
+        message must carry the current plan forward so the model does not lose it.
+        """
+        backend = MockBackend()
+        mock_model = make_mock_model(summary_response="Test summary content")
+
+        middleware = SummarizationMiddleware(
+            model=mock_model,
+            backend=backend,
+            trigger=("messages", 5),
+            keep=("messages", 2),
+        )
+
+        messages = make_conversation_messages(num_old=6, num_recent=2)
+        todos = [
+            {"content": "Read the source code", "status": "completed"},
+            {"content": "Write the patch", "status": "in_progress"},
+            {"content": "Add unit tests", "status": "pending"},
+        ]
+        state = cast("AgentState[Any]", {"messages": messages, "todos": todos})
+        runtime = make_mock_runtime()
+
+        result, modified_request = call_wrap_model_call(middleware, state, runtime)
+
+        assert isinstance(result, ExtendedModelResponse)
+        assert modified_request is not None
+        summary_msg = modified_request.messages[0]
+
+        # The active plan header and each todo item should be visible to the model.
+        assert "Active todo list" in summary_msg.content
+        assert "Write the patch" in summary_msg.content
+        assert "Add unit tests" in summary_msg.content
+
+    def test_summary_omits_todos_when_absent(self) -> None:
+        """Summaries are unchanged when state carries no todos."""
+        backend = MockBackend()
+        mock_model = make_mock_model(summary_response="Test summary content")
+
+        middleware = SummarizationMiddleware(
+            model=mock_model,
+            backend=backend,
+            trigger=("messages", 5),
+            keep=("messages", 2),
+        )
+
+        messages = make_conversation_messages(num_old=6, num_recent=2)
+        state = cast("AgentState[Any]", {"messages": messages})
+        runtime = make_mock_runtime()
+
+        result, modified_request = call_wrap_model_call(middleware, state, runtime)
+
+        assert isinstance(result, ExtendedModelResponse)
+        assert modified_request is not None
+        summary_msg = modified_request.messages[0]
+
+        assert "Active todo list" not in summary_msg.content
+        assert "Test summary content" in summary_msg.content
+
+    async def test_summary_includes_active_todos_async(self) -> None:
+        """Active todos are re-attached on the async summarization path as well."""
+        backend = MockBackend()
+        mock_model = make_mock_model(summary_response="Test summary content")
+        mock_model.ainvoke = MagicMock(return_value=MagicMock(text="Async summary"))
+
+        middleware = SummarizationMiddleware(
+            model=mock_model,
+            backend=backend,
+            trigger=("messages", 5),
+            keep=("messages", 2),
+        )
+
+        messages = make_conversation_messages(num_old=6, num_recent=2)
+        todos = [{"content": "Write the patch", "status": "in_progress"}]
+        state = cast("AgentState[Any]", {"messages": messages, "todos": todos})
+        runtime = make_mock_runtime()
+
+        result, modified_request = await call_awrap_model_call(middleware, state, runtime)
+
+        assert isinstance(result, ExtendedModelResponse)
+        assert modified_request is not None
+        summary_msg = modified_request.messages[0]
+
+        assert "Active todo list" in summary_msg.content
+        assert "Write the patch" in summary_msg.content
+
 
 class TestNoSummarizationTriggered:
     """Tests for when summarization threshold is not met."""


### PR DESCRIPTION
When an agent uses `TodoListMiddleware`, the authoritative todo list lives in state, but the model only sees it through the `write_todos` tool message. Once that message ages past the summarization cutoff, `SummarizationMiddleware` compacts it away, so the model can lose track of the active plan even though state still holds it.

This adds `_append_active_todos`, which re-attaches the current `todos` from state to the generated summary on both the sync and async paths. Reading the list from state on every compaction keeps the plan current and visible without depending on the original tool message surviving, and without coupling to the cutoff-selection logic. When no `todos` are present the summary is returned unchanged, so agents that do not use `TodoListMiddleware` are unaffected.

The todo list is rendered with the same representation already used by the `write_todos` tool message, keeping the model's view of the plan consistent before and after summarization.