### PR TITLE
test(code): clean up unit test warnings

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1518,6 +1518,7 @@ def create_cli_agent(
             # and resurrect the popped carrier var, leaking it into `execute`.
             backend = LocalShellBackend(
                 root_dir=root_dir,
+                virtual_mode=False,
                 inherit_env=False,
                 env=shell_env,
             )

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -1,5 +1,8 @@
 """Unit tests for agent formatting functions."""
 
+import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import fields
 from pathlib import Path
 from types import SimpleNamespace
@@ -45,6 +48,18 @@ def _make_fake_chat_model() -> GenericFakeChatModel:
     model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
     model.profile = {"max_input_tokens": 200000}
     return model
+
+
+@contextmanager
+def _ignore_interpreter_beta_warning() -> Iterator[None]:
+    """Suppress the dependency's expected beta middleware warning."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="The class `CodeInterpreterMiddleware` is in beta",
+            category=Warning,
+        )
+        yield
 
 
 def test_add_interrupt_on_gates_async_task_tools() -> None:
@@ -2989,6 +3004,7 @@ class TestCreateCliAgentInterpreterWiring:
                 "deepagents._models.init_chat_model",
                 return_value=fake_model,
             ),
+            _ignore_interpreter_beta_warning(),
         ):
             create_cli_agent(
                 model="fake-model",
@@ -3094,6 +3110,7 @@ class TestCreateCliAgentInterpreterWiring:
                 "deepagents._models.init_chat_model",
                 return_value=fake_model,
             ),
+            _ignore_interpreter_beta_warning(),
         ):
             create_cli_agent(
                 model="fake-model",
@@ -3186,6 +3203,7 @@ class TestCreateCliAgentInterpreterWiring:
                 "deepagents._models.init_chat_model",
                 return_value=fake_model,
             ),
+            _ignore_interpreter_beta_warning(),
         ):
             create_cli_agent(
                 model="fake-model",

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -2,6 +2,7 @@
 
 import logging
 import time
+import warnings
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, ClassVar
@@ -4502,7 +4503,16 @@ class TestCreateModelCodex:
         self._plant_token(path)
         monkeypatch.setattr(openai_codex, "default_store_path", lambda: path)
         clear_caches()
-        result = create_model("openai_codex:gpt-5.2-codex")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="`_ChatOpenAICodex` is experimental",
+                category=UserWarning,
+            )
+            result = create_model(
+                "openai_codex:gpt-5.2-codex",
+                extra_kwargs={"http_socket_options": []},
+            )
         assert isinstance(result.model, _ChatOpenAICodex)
         assert result.provider == "openai_codex"
         assert result.model_name == "gpt-5.2-codex"
@@ -4531,10 +4541,19 @@ class TestCreateModelCodex:
 
         monkeypatch.setattr(codex_mod, "build_chat_model", _capture)
         clear_caches()
-        create_model(
-            "openai_codex:gpt-5.2-codex",
-            extra_kwargs={"api_key": "sk-should-be-stripped"},
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="`_ChatOpenAICodex` is experimental",
+                category=UserWarning,
+            )
+            create_model(
+                "openai_codex:gpt-5.2-codex",
+                extra_kwargs={
+                    "api_key": "sk-should-be-stripped",
+                    "http_socket_options": [],
+                },
+            )
         assert "api_key" not in captured
 
     def test_expired_session_routes_to_auth(

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -593,6 +593,15 @@ class TestMaxTurnsArgument:
         assert exc_info.value.code == 2
 
 
+async def _raise_timeout_and_close(awaitable: object, **_kwargs: object) -> None:
+    """Close the mocked awaitable before simulating a timeout."""
+    close = getattr(awaitable, "close", None)
+    if callable(close):
+        close()
+    await asyncio.sleep(0)
+    raise TimeoutError
+
+
 def _wait_for_timeout(mock_wait_for: MagicMock) -> object:
     """Extract the `timeout` arg from a mocked `asyncio.wait_for` call.
 
@@ -732,7 +741,7 @@ class TestTimeoutArgument:
             ),
             patch(
                 "asyncio.wait_for",
-                side_effect=asyncio.TimeoutError,
+                side_effect=_raise_timeout_and_close,
             ),
             pytest.raises(SystemExit) as exc_info,
         ):

--- a/libs/code/tests/unit_tests/test_managed_tools.py
+++ b/libs/code/tests/unit_tests/test_managed_tools.py
@@ -7,6 +7,7 @@ import io
 import os
 import subprocess
 import tarfile
+import warnings
 import zipfile
 from pathlib import Path
 from unittest import mock
@@ -230,7 +231,13 @@ def _patch_legacy_tar_extractall(monkeypatch: pytest.MonkeyPatch) -> None:
         if "filter" in kwargs:
             msg = "TarFile.extractall() got an unexpected keyword argument 'filter'"
             raise TypeError(msg)
-        original(self, path, members=members, numeric_owner=numeric_owner)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Python 3.14 will, by default, filter extracted tar archives",
+                category=DeprecationWarning,
+            )
+            original(self, path, members=members, numeric_owner=numeric_owner)
 
     monkeypatch.setattr(tarfile.TarFile, "extractall", _legacy_extractall)
 

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -4,7 +4,7 @@ import asyncio
 import io
 import signal
 import sys
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Iterator, Sequence
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
@@ -38,6 +38,17 @@ from deepagents_code.non_interactive import (
 def console() -> Console:
     """Console that captures output."""
     return Console(quiet=True)
+
+
+@pytest.fixture(autouse=True)
+def skip_mcp_metadata_preload() -> Iterator[None]:
+    """Keep non-MCP non-interactive tests from starting connector discovery."""
+    with patch(
+        "deepagents_code.main._preload_session_mcp_server_info",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        yield
 
 
 class TestMakeHitlDecision:

--- a/libs/code/tests/unit_tests/test_openai_codex_integration.py
+++ b/libs/code/tests/unit_tests/test_openai_codex_integration.py
@@ -12,6 +12,7 @@ import json
 import os
 import secrets
 import threading
+import warnings
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
@@ -66,6 +67,18 @@ def _override_default_store(path: Path) -> Iterator[None]:
     finally:
         setattr(openai_codex, "default_store_path", original)  # noqa: B010  # restore original
         clear_caches()
+
+
+@contextmanager
+def _ignore_codex_experimental_warning() -> Iterator[None]:
+    """Suppress the dependency's expected experimental class warning."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="`_ChatOpenAICodex` is experimental",
+            category=UserWarning,
+        )
+        yield
 
 
 class TestGetStatus:
@@ -181,7 +194,12 @@ class TestBuildChatModel:
     def test_returns_chat_model_when_token_present(self, tmp_path: Path) -> None:
         path = tmp_path / "auth.json"
         _write_token(path)
-        model = openai_codex.build_chat_model("gpt-5.2-codex", store_path=path)
+        with _ignore_codex_experimental_warning():
+            model = openai_codex.build_chat_model(
+                "gpt-5.2-codex",
+                store_path=path,
+                http_socket_options=[],
+            )
         from langchain_openai.chat_models.codex import (
             _ChatOpenAICodex,
         )
@@ -198,7 +216,12 @@ class TestBuildChatModel:
         """
         path = tmp_path / "auth.json"
         _write_token(path)
-        model = openai_codex.build_chat_model("dsjhfbshjdf", store_path=path)
+        with _ignore_codex_experimental_warning():
+            model = openai_codex.build_chat_model(
+                "dsjhfbshjdf",
+                store_path=path,
+                http_socket_options=[],
+            )
         from langchain_openai.chat_models.codex import (
             _ChatOpenAICodex,
         )


### PR DESCRIPTION
`make test` in `libs/code` had started reporting warning noise from a few dependency and test-helper paths, which made it harder to notice new warnings in the unit suite.

This keeps the production `LocalShellBackend` construction explicit about `virtual_mode=False`, and localizes expected dependency warnings in the tests that intentionally instantiate beta or experimental classes. It also avoids socket-guard warnings from test-only setup paths by disabling unrelated MCP metadata preload in non-interactive tests and passing explicit empty socket options when constructing the Codex model under the socket guard.