### PR TITLE
feat(ci): block package scope file mismatches

### DIFF
--- a/.github/scripts/check_pr_scope_files.py
+++ b/.github/scripts/check_pr_scope_files.py
@@ -5,8 +5,10 @@ The PR labeler config already defines both sides of this relationship:
 `fileRules` maps package directories to the same labels. This helper reads that
 config directly so the CI gate cannot drift from the labeler.
 
-The script only reports offenders and exits 0 after successful analysis. The
-workflow that calls it decides whether to fail, bypass, or comment.
+On successful analysis the script reports offenders on stdout and exits 0; the
+workflow that calls it decides whether to fail, bypass, or comment. If the
+labeler config cannot be read or validated, the script exits 2 so CI fails
+closed.
 """
 
 import json
@@ -57,11 +59,23 @@ def _package_rules(config: dict[str, Any]) -> list[dict[str, str]]:
     package_rules: list[dict[str, str]] = []
     for rule in rules:
         if not isinstance(rule, dict):
-            continue
+            msg = f"pr-labeler fileRules entry is not an object: {rule!r}"
+            raise ValueError(msg)
         label = rule.get("label")
         prefix = rule.get("prefix")
-        if not isinstance(label, str) or not isinstance(prefix, str):
+        # Rules without a 'prefix' (suffix/exact/pattern rules) are not package
+        # directory rules and are legitimately skipped.
+        if prefix is None:
             continue
+        # A rule that *has* a 'prefix' but with a malformed type is config
+        # corruption, not a non-package rule. Fail closed rather than silently
+        # dropping it: a single dropped package rule would let a real
+        # scope/file mismatch pass unnoticed (the gate's worst outcome).
+        if not isinstance(label, str) or not isinstance(prefix, str):
+            msg = f"pr-labeler fileRules entry has non-string label/prefix: {rule!r}"
+            raise ValueError(msg)
+        # A non-`libs/` prefix (e.g. `.github/workflows/`) is a legitimate
+        # non-package rule.
         if not prefix.startswith("libs/"):
             continue
         package_rules.append({"label": label, "prefix": prefix.rstrip("/") + "/"})

--- a/.github/scripts/check_pr_scope_files.py
+++ b/.github/scripts/check_pr_scope_files.py
@@ -1,0 +1,224 @@
+"""Flag PRs whose package title scopes do not cover touched package dirs.
+
+The PR labeler config already defines both sides of this relationship:
+`scopeToLabel` maps conventional-commit scopes to package labels, and
+`fileRules` maps package directories to the same labels. This helper reads that
+config directly so the CI gate cannot drift from the labeler.
+
+The script only reports offenders and exits 0 after successful analysis. The
+workflow that calls it decides whether to fail, bypass, or comment.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = REPO_ROOT / ".github" / "scripts" / "pr-labeler-config.json"
+
+_TITLE_RE = re.compile(r"^[a-z]+(?:\(([^)]*)\))?!?:\s")
+
+
+def parse_title_scopes(title: str) -> tuple[str, ...]:
+    """Return conventional-commit scopes parsed from `title`.
+
+    Args:
+        title: PR title, e.g. `fix(cli,code): repair command`.
+
+    Returns:
+        Tuple of scope strings. Empty when the title is not conventional-commit
+            shaped or has no scope.
+    """
+    match = _TITLE_RE.match(title)
+    if not match or not match.group(1):
+        return ()
+    return tuple(scope.strip() for scope in match.group(1).split(",") if scope.strip())
+
+
+def _package_rules(config: dict[str, Any]) -> list[dict[str, str]]:
+    """Return package directory rules from the PR labeler config.
+
+    Args:
+        config: Parsed `.github/scripts/pr-labeler-config.json`.
+
+    Returns:
+        List of rules with `label` and normalized `prefix` keys.
+
+    Raises:
+        ValueError: If required config sections are missing or malformed.
+    """
+    rules = config.get("fileRules")
+    if not isinstance(rules, list) or not rules:
+        msg = "pr-labeler config has no non-empty 'fileRules' list"
+        raise ValueError(msg)
+
+    package_rules: list[dict[str, str]] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        label = rule.get("label")
+        prefix = rule.get("prefix")
+        if not isinstance(label, str) or not isinstance(prefix, str):
+            continue
+        if not prefix.startswith("libs/"):
+            continue
+        package_rules.append({"label": label, "prefix": prefix.rstrip("/") + "/"})
+
+    if not package_rules:
+        msg = "pr-labeler config has no package directory fileRules"
+        raise ValueError(msg)
+    return sorted(package_rules, key=lambda r: r["prefix"])
+
+
+def _scope_packages(config: dict[str, Any], package_labels: set[str]) -> set[str]:
+    """Return scope names whose label points at a package label.
+
+    Args:
+        config: Parsed `.github/scripts/pr-labeler-config.json`.
+        package_labels: Labels used by package directory rules.
+
+    Returns:
+        Set of scope names that represent package scopes.
+
+    Raises:
+        ValueError: If `scopeToLabel` is missing or malformed.
+    """
+    scope_to_label = config.get("scopeToLabel")
+    if not isinstance(scope_to_label, dict) or not scope_to_label:
+        msg = "pr-labeler config has no non-empty 'scopeToLabel' map"
+        raise ValueError(msg)
+    return {
+        scope
+        for scope, label in scope_to_label.items()
+        if isinstance(scope, str) and isinstance(label, str) and label in package_labels
+    }
+
+
+def declared_packages(title: str, config: dict[str, Any]) -> set[str]:
+    """Return package labels declared by the PR title scopes.
+
+    Args:
+        title: PR title.
+        config: Parsed `.github/scripts/pr-labeler-config.json`.
+
+    Returns:
+        Set of package labels. Non-package scopes are ignored.
+
+    Raises:
+        ValueError: If required config sections are missing or malformed.
+    """
+    rules = _package_rules(config)
+    package_labels = {rule["label"] for rule in rules}
+    package_scopes = _scope_packages(config, package_labels)
+    scope_to_label = config["scopeToLabel"]
+    return {
+        scope_to_label[scope]
+        for scope in parse_title_scopes(title)
+        if scope in package_scopes
+    }
+
+
+def changed_packages(
+    changed: list[str], config: dict[str, Any]
+) -> dict[str, list[str]]:
+    """Return package labels and dirs touched by changed files.
+
+    Args:
+        changed: Changed file paths, repo-root-relative.
+        config: Parsed `.github/scripts/pr-labeler-config.json`.
+
+    Returns:
+        Map of package label to touched package directories.
+
+    Raises:
+        ValueError: If required config sections are missing or malformed.
+    """
+    packages: dict[str, set[str]] = {}
+    for rule in _package_rules(config):
+        prefix = rule["prefix"]
+        package_dir = prefix.rstrip("/")
+        for file in changed:
+            if file == package_dir or file.startswith(prefix):
+                packages.setdefault(rule["label"], set()).add(prefix)
+                break
+    return {label: sorted(dirs) for label, dirs in sorted(packages.items())}
+
+
+def find_offenders(
+    title: str, changed: list[str], config: dict[str, Any]
+) -> list[dict[str, object]]:
+    """Return touched package dirs not covered by package scopes in `title`.
+
+    Args:
+        title: PR title.
+        changed: Changed file paths, repo-root-relative.
+        config: Parsed `.github/scripts/pr-labeler-config.json`.
+
+    Returns:
+        Sorted list of offender objects with `package` and `dirs` keys. Empty
+            when the title declares no package scopes, when no package dirs are
+            touched, or when every touched package is covered by a declared scope.
+
+    Raises:
+        ValueError: If required config sections are missing or malformed.
+    """
+    declared = declared_packages(title, config)
+    if not declared:
+        return []
+
+    touched = changed_packages(changed, config)
+    return [
+        {"package": package, "dirs": dirs}
+        for package, dirs in touched.items()
+        if package not in declared
+    ]
+
+
+def main(title: str, changed: list[str], config_path: Path = DEFAULT_CONFIG) -> int:
+    """Print offending packages as a JSON array to stdout.
+
+    Args:
+        title: PR title.
+        changed: Changed file paths, repo-root-relative.
+        config_path: Path to the PR labeler config.
+
+    Returns:
+        `0` after successful analysis. Offenders are reported on stdout and the
+            workflow makes the blocking decision.
+        `2` when the config cannot be read or validated, so CI fails closed.
+    """
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        offenders = find_offenders(title, changed, config)
+    except (OSError, json.JSONDecodeError, ValueError) as e:
+        print(
+            f"::error::Could not read PR labeler config {config_path}: {e}",
+            file=sys.stderr,
+        )
+        return 2
+
+    if offenders:
+        summary = ", ".join(
+            f"{offender['package']} ({', '.join(offender['dirs'])})"
+            for offender in offenders
+        )
+        print(
+            f"PR title scope does not cover touched package dirs: {summary}",
+            file=sys.stderr,
+        )
+    print(json.dumps(offenders))
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(
+            "usage: check_pr_scope_files.py <pr-title>  (changed files on stdin)",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    pr_title = sys.argv[1]
+    changed_files = [line.strip() for line in sys.stdin if line.strip()]
+    raise SystemExit(main(pr_title, changed_files))

--- a/.github/scripts/test_check_pr_scope_files.py
+++ b/.github/scripts/test_check_pr_scope_files.py
@@ -1,0 +1,192 @@
+"""Tests for check_pr_scope_files (PR title scope vs changed package dirs)."""
+
+import json
+
+from check_pr_scope_files import (
+    DEFAULT_CONFIG,
+    changed_packages,
+    declared_packages,
+    find_offenders,
+    main,
+    parse_title_scopes,
+)
+
+CONFIG = {
+    "scopeToLabel": {
+        "ci": "infra",
+        "cli": "cli",
+        "code": "dcode",
+        "deepagents-cli": "cli",
+        "deepagents-code": "dcode",
+        "docs": "documentation",
+        "infra": "infra",
+        "sdk": "deepagents",
+    },
+    "fileRules": [
+        {"label": "deepagents", "prefix": "libs/deepagents/"},
+        {"label": "cli", "prefix": "libs/cli/"},
+        {"label": "dcode", "prefix": "libs/code/"},
+        {"label": "github_actions", "prefix": ".github/workflows/"},
+        {"label": "dependencies", "suffix": "pyproject.toml"},
+    ],
+}
+
+
+def test_matching_scope_files_pass() -> None:
+    """A package scope that covers the touched package dir is clean."""
+    changed = ["libs/code/deepagents_code/app.py"]
+    assert find_offenders("fix(code): repair startup", changed, CONFIG) == []
+
+
+def test_cli_scope_with_code_files_blocks() -> None:
+    """`fix(cli):` does not cover files under `libs/code/`."""
+    changed = ["libs/code/deepagents_code/app.py"]
+    assert find_offenders("fix(cli): repair startup", changed, CONFIG) == [
+        {"package": "dcode", "dirs": ["libs/code/"]}
+    ]
+
+
+def test_multi_scope_title_covers_multiple_package_dirs() -> None:
+    """Comma-separated scopes cover every matching package label."""
+    changed = [
+        "libs/cli/deepagents_cli/main.py",
+        "libs/code/deepagents_code/app.py",
+    ]
+    assert find_offenders("feat(cli,code): share option", changed, CONFIG) == []
+
+
+def test_multi_scope_title_blocks_uncovered_package_dir() -> None:
+    """A third package remains an offender when absent from a multi-scope title."""
+    changed = [
+        "libs/cli/deepagents_cli/main.py",
+        "libs/code/deepagents_code/app.py",
+        "libs/deepagents/deepagents/graph.py",
+    ]
+    assert find_offenders("feat(cli,code): share option", changed, CONFIG) == [
+        {"package": "deepagents", "dirs": ["libs/deepagents/"]}
+    ]
+
+
+def test_unscoped_title_type_and_non_package_paths_pass() -> None:
+    """Non-package scopes and non-package paths are ignored as unscoped."""
+    assert (
+        find_offenders(
+            "ci(infra): tune workflow",
+            [".github/workflows/ci.yml", "README.md", "pyproject.toml"],
+            CONFIG,
+        )
+        == []
+    )
+    assert (
+        find_offenders(
+            "ci(infra): tune package job",
+            ["libs/code/deepagents_code/app.py"],
+            CONFIG,
+        )
+        == []
+    )
+
+
+def test_non_package_path_with_package_scope_passes() -> None:
+    """A package scope plus only non-package paths has no touched package offender."""
+    assert find_offenders("fix(cli): repair action", ["action.yml"], CONFIG) == []
+
+
+def test_package_scope_aliases_resolve_to_same_package_label() -> None:
+    """Long package-name scopes are aliases for the same labels as short scopes."""
+    assert declared_packages("fix(deepagents-code): repair startup", CONFIG) == {
+        "dcode"
+    }
+    assert (
+        find_offenders(
+            "fix(deepagents-code): repair startup",
+            ["libs/code/deepagents_code/app.py"],
+            CONFIG,
+        )
+        == []
+    )
+
+
+def test_parse_title_scopes_variants() -> None:
+    """Scopes are parsed from conventional-commit-shaped titles only."""
+    assert parse_title_scopes("feat(cli, code): x") == ("cli", "code")
+    assert parse_title_scopes("fix(deepagents-code)!: x") == ("deepagents-code",)
+    assert parse_title_scopes("fix: x") == ()
+    assert parse_title_scopes("not conventional") == ()
+
+
+def test_changed_packages_returns_touched_package_dirs_only() -> None:
+    """Only `libs/**` prefix rules are treated as package dirs."""
+    assert changed_packages(
+        ["libs/code/deepagents_code/app.py", ".github/workflows/ci.yml"], CONFIG
+    ) == {"dcode": ["libs/code/"]}
+
+
+def test_main_stdout_is_json_array(capsys, tmp_path) -> None:
+    """The workflow can strictly parse stdout as JSON."""
+    config_path = tmp_path / "pr-labeler-config.json"
+    config_path.write_text(json.dumps(CONFIG), encoding="utf-8")
+
+    rc = main(
+        "fix(cli): repair startup",
+        ["libs/code/deepagents_code/app.py"],
+        config_path=config_path,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert json.loads(captured.out) == [{"package": "dcode", "dirs": ["libs/code/"]}]
+    assert "PR title scope does not cover" in captured.err
+
+
+def test_main_missing_config_returns_2(capsys, tmp_path) -> None:
+    """A missing config fails closed instead of silently passing."""
+    rc = main("fix(cli): x", ["libs/code/file.py"], config_path=tmp_path / "nope.json")
+    assert rc == 2
+    assert "::error::" in capsys.readouterr().err
+
+
+def test_main_malformed_config_returns_2(capsys, tmp_path) -> None:
+    """Invalid JSON fails closed."""
+    config_path = tmp_path / "pr-labeler-config.json"
+    config_path.write_text("{not json", encoding="utf-8")
+    rc = main("fix(cli): x", ["libs/code/file.py"], config_path=config_path)
+    assert rc == 2
+    assert "::error::" in capsys.readouterr().err
+
+
+def test_main_empty_file_rules_returns_2(capsys, tmp_path) -> None:
+    """Config drift that removes package file rules fails closed."""
+    config_path = tmp_path / "pr-labeler-config.json"
+    config_path.write_text(
+        json.dumps({"scopeToLabel": CONFIG["scopeToLabel"], "fileRules": []}),
+        encoding="utf-8",
+    )
+    rc = main("fix(cli): x", ["libs/code/file.py"], config_path=config_path)
+    assert rc == 2
+    assert "fileRules" in capsys.readouterr().err
+
+
+def test_main_missing_scope_map_returns_2(capsys, tmp_path) -> None:
+    """Config drift that removes `scopeToLabel` fails closed."""
+    config_path = tmp_path / "pr-labeler-config.json"
+    config_path.write_text(
+        json.dumps({"scopeToLabel": {}, "fileRules": CONFIG["fileRules"]}),
+        encoding="utf-8",
+    )
+    rc = main("fix(cli): x", ["libs/code/file.py"], config_path=config_path)
+    assert rc == 2
+    assert "scopeToLabel" in capsys.readouterr().err
+
+
+def test_real_config_has_package_scope_and_dir_mappings() -> None:
+    """The committed PR labeler config exposes the maps this check reads."""
+    config = json.loads(DEFAULT_CONFIG.read_text(encoding="utf-8"))
+    assert declared_packages("fix(cli): x", config) == {"cli"}
+    assert declared_packages("fix(code): x", config) == {"dcode"}
+    assert changed_packages(["libs/cli/deepagents_cli/main.py"], config) == {
+        "cli": ["libs/cli/"]
+    }
+    assert changed_packages(["libs/code/deepagents_code/app.py"], config) == {
+        "dcode": ["libs/code/"]
+    }

--- a/.github/scripts/test_check_pr_scope_files.py
+++ b/.github/scripts/test_check_pr_scope_files.py
@@ -2,6 +2,7 @@
 
 import json
 
+import pytest
 from check_pr_scope_files import (
     DEFAULT_CONFIG,
     changed_packages,
@@ -120,6 +121,77 @@ def test_changed_packages_returns_touched_package_dirs_only() -> None:
     assert changed_packages(
         ["libs/code/deepagents_code/app.py", ".github/workflows/ci.yml"], CONFIG
     ) == {"dcode": ["libs/code/"]}
+
+
+def test_changed_packages_matches_bare_package_dir() -> None:
+    """A path equal to the package dir (no trailing slash) still matches."""
+    assert changed_packages(["libs/code"], CONFIG) == {"dcode": ["libs/code/"]}
+
+
+def test_changed_packages_ignores_prefix_collision() -> None:
+    """A sibling dir sharing a name prefix is not treated as the package."""
+    assert changed_packages(["libs/codex/app.py"], CONFIG) == {}
+
+
+def test_breaking_change_title_still_detects_offender() -> None:
+    """A breaking-change `!` title parses its scope for offender detection."""
+    assert find_offenders(
+        "feat(cli)!: drop option", ["libs/code/deepagents_code/app.py"], CONFIG
+    ) == [{"package": "dcode", "dirs": ["libs/code/"]}]
+
+
+def test_partner_package_dir_detected_with_real_config() -> None:
+    """Partner packages under `libs/partners/` are package dirs too."""
+    config = json.loads(DEFAULT_CONFIG.read_text(encoding="utf-8"))
+    assert find_offenders(
+        "fix(cli): repair startup",
+        ["libs/partners/daytona/langchain_daytona/sandbox.py"],
+        config,
+    ) == [{"package": "daytona", "dirs": ["libs/partners/daytona/"]}]
+
+
+def test_partner_scope_aliases_resolve_with_real_config() -> None:
+    """`langchain-*` scope aliases map to the same partner package labels."""
+    config = json.loads(DEFAULT_CONFIG.read_text(encoding="utf-8"))
+    assert declared_packages("fix(langchain-quickjs): x", config) == {"quickjs"}
+    assert declared_packages("fix(quickjs): x", config) == {"quickjs"}
+
+
+def test_non_dict_file_rule_raises() -> None:
+    """A non-object `fileRules` entry is config corruption, not a skip."""
+    config = {"scopeToLabel": CONFIG["scopeToLabel"], "fileRules": ["libs/code/"]}
+    with pytest.raises(ValueError, match="not an object"):
+        find_offenders("fix(cli): x", ["libs/code/file.py"], config)
+
+
+def test_non_string_prefix_file_rule_raises() -> None:
+    """A package rule with a malformed `prefix` type fails closed."""
+    config = {
+        "scopeToLabel": CONFIG["scopeToLabel"],
+        "fileRules": [{"label": "dcode", "prefix": 123}],
+    }
+    with pytest.raises(ValueError, match="non-string label/prefix"):
+        find_offenders("fix(cli): x", ["libs/code/file.py"], config)
+
+
+def test_main_partially_malformed_file_rules_returns_2(capsys, tmp_path) -> None:
+    """A single malformed package rule fails closed instead of being dropped."""
+    config_path = tmp_path / "pr-labeler-config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "scopeToLabel": CONFIG["scopeToLabel"],
+                "fileRules": [
+                    {"label": "dcode", "prefix": 123},
+                    {"label": "cli", "prefix": "libs/cli/"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc = main("fix(cli): x", ["libs/code/file.py"], config_path=config_path)
+    assert rc == 2
+    assert "::error::" in capsys.readouterr().err
 
 
 def test_main_stdout_is_json_array(capsys, tmp_path) -> None:

--- a/.github/workflows/pr_scope_file_check.yml
+++ b/.github/workflows/pr_scope_file_check.yml
@@ -20,6 +20,11 @@
 #     .github/scripts/pr-labeler-config.json by the helper script — see
 #     .github/scripts/check_pr_scope_files.py.
 #
+# Trust model:
+#   - The detector and labeler config run from the PR *base* revision, not the
+#     PR head, so a PR cannot edit them to self-bypass the gate. Only the PR
+#     title (event payload) and changed-file list (API) come from the PR.
+#
 # Limitations:
 #   - Runs under `pull_request` (not `pull_request_target`), so PRs from forks get
 #     the read-only token and the comment is surfaced to the job summary instead.
@@ -43,8 +48,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - name: "📋 Checkout Code"
+      - name: "📋 Checkout base revision"
+        # Check out the PR *base* (trusted), never the PR head. The detector and
+        # labeler config are executed from this tree, so the PR under test cannot
+        # edit check_pr_scope_files.py or pr-labeler-config.json to print "[]" and
+        # self-bypass the gate — defeating it for the exact PRs it must block. The
+        # PR title (event payload) and changed-file list (API) are fed in
+        # separately and are authoritative regardless of this checkout.
+        #
+        # `persist-credentials: false` so the job token is not written into the
+        # checkout's git config; the detector needs no git credentials, and the
+        # github-script steps receive their own token directly.
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
 
       - name: "🐍 Setup Python 3.11"
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -69,7 +87,13 @@ jobs:
             // create a false one, so fail closed if the collected count doesn't
             // match the PR's reported total.
             const expected = context.payload.pull_request.changed_files;
-            if (typeof expected === 'number' && files.length !== expected) {
+            // Without a numeric reported total we cannot verify completeness, so
+            // fail closed rather than proceeding on a possibly-truncated list.
+            if (typeof expected !== 'number') {
+              core.setFailed(`PR payload missing numeric changed_files (got ${JSON.stringify(expected)}); cannot verify the changed-file list is complete. Failing closed.`);
+              return;
+            }
+            if (files.length !== expected) {
               core.setFailed(`Changed-file list is incomplete (${files.length} of ${expected}); cannot determine PR scope/file alignment reliably. Failing closed.`);
               return;
             }
@@ -84,10 +108,22 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
-          # A config-read error in the detector exits non-zero; under `set -e`
-          # the command substitution propagates it and this step fails, so the
-          # comment step (default `if: success()`) is skipped — fail closed.
-          offenders=$(python .github/scripts/check_pr_scope_files.py "$PR_TITLE" < changed_files.txt)
+          detector=".github/scripts/check_pr_scope_files.py"
+          if [[ ! -f "$detector" ]]; then
+            # The detector does not exist on the base revision yet: the PR that
+            # first introduces this check, or a branch cut from before it
+            # existed. There is no trusted gate to enforce, so treat as clean.
+            # A PR cannot reach this path deliberately — it can only change its
+            # own head, never what is present on base — so it is not a bypass.
+            # Once merged, base always carries the detector and it runs normally.
+            echo "::notice::Detector absent on base revision; nothing to enforce yet."
+            offenders="[]"
+          else
+            # A config-read error in the detector exits non-zero; under `set -e`
+            # the command substitution propagates it and this step fails, so the
+            # comment step (default `if: success()`) is skipped — fail closed.
+            offenders=$(python "$detector" "$PR_TITLE" < changed_files.txt)
+          fi
           # Heredoc form so a multi-line value can never corrupt $GITHUB_OUTPUT.
           {
             echo "offenders<<__SCOPE_FILE_EOF__"
@@ -139,6 +175,10 @@ jobs:
             // no PR-author-controlled text reaches a code path.
             const bypassed = (labels || []).some(l => l.name === BYPASS_LABEL);
 
+            // Display-only: this re-parses the title solely to render the
+            // scope list in the sticky comment. The pass/fail decision comes
+            // entirely from the detector's JSON offenders, not from here. Keep
+            // this regex in sync with `_TITLE_RE` in check_pr_scope_files.py.
             const titleScopes = (() => {
               const match = title.match(/^[a-z]+(?:\(([^)]*)\))?!?:\s/);
               if (!match || !match[1]) {

--- a/.github/workflows/pr_scope_file_check.yml
+++ b/.github/workflows/pr_scope_file_check.yml
@@ -1,0 +1,250 @@
+# Pre-merge blocking check for PR title package scopes vs touched package dirs.
+#
+# Why this exists:
+#   PR titles use Conventional Commit scopes, and those scopes drive release notes,
+#   package labels, and reviewer expectations. A title like `fix(cli): ...` should
+#   not describe a PR whose only package edits live under `libs/code/`. This check
+#   compares package scopes from the PR title with package directories from the
+#   changed-file list, posts a sticky warning when they disagree, and FAILS the
+#   check so the mismatch is fixed before merge.
+#
+# Escape hatch:
+#   Apply the `allow-scope-mismatch` label when the mismatch is intentional. The
+#   check re-runs on `labeled`/`unlabeled`, leaves an informational sticky note,
+#   and passes while the label is present.
+#
+# To actually gate merges, add this check to the branch's required status checks.
+#
+# How it stays faithful to existing repo configuration:
+#   - Scope -> package and dir -> package mappings are read from
+#     .github/scripts/pr-labeler-config.json by the helper script — see
+#     .github/scripts/check_pr_scope_files.py.
+#
+# Limitations:
+#   - Runs under `pull_request` (not `pull_request_target`), so PRs from forks get
+#     the read-only token and the comment is surfaced to the job summary instead.
+#     No secrets are exposed to PR-author-controlled code.
+
+name: "🔍 PR scope file check"
+
+on:
+  pull_request:
+    # `labeled`/`unlabeled` so applying the bypass label re-runs the check and
+    # clears the red without needing a new commit.
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scope-file-check:
+    name: "validate title scope covers package dirs"
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: "📋 Checkout Code"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: "🐍 Setup Python 3.11"
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+
+      - name: "Collect changed files"
+        # Use the API rather than `git diff` so the changed-file list is
+        # authoritative regardless of checkout depth. Newline-delimited to
+        # changed_files.txt, which the detector reads from stdin.
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              ...context.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            // listFiles is hard-capped by GitHub at 3000 files regardless of
+            // pagination. A truncated list could hide a package dir mismatch or
+            // create a false one, so fail closed if the collected count doesn't
+            // match the PR's reported total.
+            const expected = context.payload.pull_request.changed_files;
+            if (typeof expected === 'number' && files.length !== expected) {
+              core.setFailed(`Changed-file list is incomplete (${files.length} of ${expected}); cannot determine PR scope/file alignment reliably. Failing closed.`);
+              return;
+            }
+            fs.writeFileSync('changed_files.txt', files.map(f => f.filename).join('\n'));
+            core.info(`Collected ${files.length} changed file(s).`);
+
+      - name: "Detect package scope/file mismatch"
+        id: detect
+        # PR title is passed via env (never interpolated into the script body)
+        # to avoid shell injection from PR-author-controlled text.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          # A config-read error in the detector exits non-zero; under `set -e`
+          # the command substitution propagates it and this step fails, so the
+          # comment step (default `if: success()`) is skipped — fail closed.
+          offenders=$(python .github/scripts/check_pr_scope_files.py "$PR_TITLE" < changed_files.txt)
+          # Heredoc form so a multi-line value can never corrupt $GITHUB_OUTPUT.
+          {
+            echo "offenders<<__SCOPE_FILE_EOF__"
+            echo "$offenders"
+            echo "__SCOPE_FILE_EOF__"
+          } >> "$GITHUB_OUTPUT"
+          echo "Detector offenders: $offenders"
+
+      - name: "Comment on package scope/file mismatch"
+        # Offenders passed via env (not interpolated into the script body) for
+        # the same injection-safety reason as the title above.
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          OFFENDERS: ${{ steps.detect.outputs.offenders }}
+        with:
+          script: |
+            const STICKY_MARKER = '<!-- pr-scope-file-check -->';
+            const BYPASS_LABEL = 'allow-scope-mismatch';
+            const { title, number, labels } = context.payload.pull_request;
+
+            // Strict, fail-closed parse. The detector always prints a JSON array
+            // ("[]" when clean), so empty or non-array output means the detector
+            // didn't run as expected — block rather than silently coerce a
+            // missing result into "no offenders → pass."
+            const raw = process.env.OFFENDERS;
+            if (raw === undefined || raw.trim() === '') {
+              core.setFailed('Detector produced no output; cannot determine PR scope/file alignment. Failing closed.');
+              return;
+            }
+            let offenders;
+            try {
+              offenders = JSON.parse(raw);
+            } catch (parseErr) {
+              core.setFailed(`Detector output was not valid JSON: ${JSON.stringify(raw)} (${parseErr.message})`);
+              return;
+            }
+            if (!Array.isArray(offenders)) {
+              core.setFailed(`Detector output was not a JSON array: ${JSON.stringify(raw)}`);
+              return;
+            }
+            for (const offender of offenders) {
+              if (!offender || typeof offender !== 'object' || typeof offender.package !== 'string' || !Array.isArray(offender.dirs) || offender.dirs.some(d => typeof d !== 'string')) {
+                core.setFailed(`Detector output contained an invalid offender object: ${JSON.stringify(offender)}`);
+                return;
+              }
+            }
+
+            // Constant string comparison against the structured label payload —
+            // no PR-author-controlled text reaches a code path.
+            const bypassed = (labels || []).some(l => l.name === BYPASS_LABEL);
+
+            const titleScopes = (() => {
+              const match = title.match(/^[a-z]+(?:\(([^)]*)\))?!?:\s/);
+              if (!match || !match[1]) {
+                return [];
+              }
+              return match[1].split(',').map(s => s.trim()).filter(Boolean);
+            })();
+            const scopeList = titleScopes.length > 0
+              ? titleScopes.map(s => `\`${s}\``).join(', ')
+              : '_none parsed_';
+
+            const offenderLines = offenders.map(o => {
+              const dirs = o.dirs.map(d => `\`${d}\``).join(', ');
+              return `- package label \`${o.package}\` from ${dirs}`;
+            }).join('\n');
+            const offenderSummary = offenders.map(o => `${o.package} (${o.dirs.join(', ')})`).join(', ');
+
+            async function findStickyComment() {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                ...context.repo,
+                issue_number: number,
+                per_page: 100,
+              });
+              return comments.find(c => c.body && c.body.startsWith(STICKY_MARKER));
+            }
+
+            async function deleteSticky() {
+              const existing = await findStickyComment();
+              if (existing) {
+                await github.rest.issues.deleteComment({ ...context.repo, comment_id: existing.id });
+              }
+            }
+
+            async function upsertSticky(body) {
+              try {
+                const existing = await findStickyComment();
+                if (existing) {
+                  await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
+                } else {
+                  await github.rest.issues.createComment({ ...context.repo, issue_number: number, body });
+                }
+              } catch (commentErr) {
+                // Fork PRs run with a restricted token; surface to the job
+                // summary so the mismatch is still visible alongside the red check.
+                core.warning(`Could not post sticky comment (fork PR token, rate limit, or transient API error): ${commentErr.message}`);
+                // Guard the summary write too: if it throws (unwritable summary,
+                // size limit) it must not escape upsertSticky and preempt the
+                // caller's core.setFailed — the red check is the load-bearing signal.
+                try {
+                  await core.summary
+                    .addHeading('PR scope/file mismatch')
+                    .addRaw(body)
+                    .write();
+                } catch (summaryErr) {
+                  core.warning(`Could not write job summary fallback: ${summaryErr.message}`);
+                }
+              }
+            }
+
+            if (offenders.length === 0) {
+              // Resolved: clear any stale comment and pass. Wrapped so a cleanup
+              // hiccup can't turn a clean result red.
+              try {
+                await deleteSticky();
+              } catch (cleanupErr) {
+                core.warning(`Could not clean up prior scope/file-check comment: ${cleanupErr.message}`);
+              }
+              core.info('No PR scope/file mismatch detected.');
+              return;
+            }
+
+            if (bypassed) {
+              // Acknowledged as intentional via the bypass label: leave an
+              // informational note (not a failure) and pass.
+              await upsertSticky([
+                STICKY_MARKER,
+                `ℹ️ **PR scope/file mismatch acknowledged** via the \`${BYPASS_LABEL}\` label.`,
+                '',
+                `Title scope(s): ${scopeList}`,
+                '',
+                'Touched package dir(s) not covered by those scopes:',
+                offenderLines,
+                '',
+                'Remove the label to re-enable the block.',
+              ].join('\n'));
+              core.info(`Bypassed via ${BYPASS_LABEL} label.`);
+              return;
+            }
+
+            await upsertSticky([
+              STICKY_MARKER,
+              '⛔ **This PR title scope does not match the package directory it changes.**',
+              '',
+              `Title scope(s): ${scopeList}`,
+              '',
+              'Touched package dir(s) not covered by those scopes:',
+              offenderLines,
+              '',
+              'This check is **blocking** because the PR title declares one package scope while the changed files live in a different package directory.',
+              '',
+              '### To resolve',
+              '',
+              'Edit the PR title scope so it covers the changed package directory (for example, use `fix(code): ...` for `libs/code/**`), or move the files so they match the declared scope.',
+              '',
+              '### If intentional',
+              '',
+              `Apply the \`${BYPASS_LABEL}\` label. The check re-runs and passes with an informational note.`,
+            ].join('\n'));
+            core.setFailed(`PR title scope(s) ${titleScopes.join(', ') || '(none)'} do not cover touched package dir(s): ${offenderSummary}. Fix the title scope/files, or apply the '${BYPASS_LABEL}' label if intentional.`);


### PR DESCRIPTION
Adds a pre-merge CI check that compares the package scopes declared by a PR title with the package directories touched by the PR. The check uses the existing PR labeler config as its source of truth, so scope aliases like `code`/`deepagents-code` and directory mappings like `libs/code/` stay aligned with the rest of the repo automation.

When a PR declares one package scope but touches a different package directory, the workflow posts a sticky warning comment and fails. If the mismatch is intentional, maintainers can apply `allow-scope-mismatch` to downgrade the block to an informational note while keeping the mismatch visible.

The detector is covered by unit tests for matching scope/file pairs, the `fix(cli)` + `libs/code/**` mismatch, multi-scope titles, unscoped scopes/paths, and config-read fail-closed behavior.