### PR TITLE
fix(ci): run release-please scope check from trusted base revision

### DIFF
--- a/.github/workflows/release_please_scope_check.yml
+++ b/.github/workflows/release_please_scope_check.yml
@@ -29,6 +29,12 @@
 #     from release-please-config.json by the helper script — see
 #     .github/scripts/check_lockfile_release_scope.py for the rationale.
 #
+# Trust model:
+#   - The detector and release-please-config.json run from the PR *base*
+#     revision, not the PR head, so a PR cannot edit them to self-bypass the
+#     gate. Only the PR title (event payload) and changed-file list (API) come
+#     from the PR.
+#
 # Limitations:
 #   - Runs under `pull_request` (not `pull_request_target`), so PRs from forks
 #     get the read-only token and the comment is surfaced to the job summary
@@ -53,8 +59,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - name: "📋 Checkout Code"
+      - name: "📋 Checkout base revision"
+        # Check out the PR *base* (trusted), never the PR head. The detector and
+        # release-please-config.json are executed from this tree, so the PR under
+        # test cannot edit check_lockfile_release_scope.py or the config to print
+        # "[]" and self-bypass the gate. The PR title (event payload) and
+        # changed-file list (API) are fed in separately and are authoritative
+        # regardless of this checkout.
+        #
+        # `persist-credentials: false` so the job token is not written into the
+        # checkout's git config; the detector needs no git credentials, and the
+        # github-script steps receive their own token directly.
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
 
       - name: "🐍 Setup Python 3.11"
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -80,7 +99,13 @@ jobs:
             // or hide a lockfile past the cap (false pass). Fail closed if the
             // collected count doesn't match the PR's reported total.
             const expected = context.payload.pull_request.changed_files;
-            if (typeof expected === 'number' && files.length !== expected) {
+            // Without a numeric reported total we cannot verify completeness, so
+            // fail closed rather than proceeding on a possibly-truncated list.
+            if (typeof expected !== 'number') {
+              core.setFailed(`PR payload missing numeric changed_files (got ${JSON.stringify(expected)}); cannot verify the changed-file list is complete. Failing closed.`);
+              return;
+            }
+            if (files.length !== expected) {
               core.setFailed(`Changed-file list is incomplete (${files.length} of ${expected}); cannot determine release scope reliably. Failing closed.`);
               return;
             }
@@ -95,10 +120,22 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
-          # A config-read error in the detector exits non-zero; under `set -e`
-          # the command substitution propagates it and this step fails, so the
-          # comment step (default `if: success()`) is skipped — fail closed.
-          offenders=$(python .github/scripts/check_lockfile_release_scope.py "$PR_TITLE" < changed_files.txt)
+          detector=".github/scripts/check_lockfile_release_scope.py"
+          if [[ ! -f "$detector" ]]; then
+            # The detector does not exist on the base revision yet: the PR that
+            # first introduces this check, or a branch cut from before it
+            # existed. There is no trusted gate to enforce, so treat as clean.
+            # A PR cannot reach this path deliberately — it can only change its
+            # own head, never what is present on base — so it is not a bypass.
+            # Once merged, base always carries the detector and it runs normally.
+            echo "::notice::Detector absent on base revision; nothing to enforce yet."
+            offenders="[]"
+          else
+            # A config-read error in the detector exits non-zero; under `set -e`
+            # the command substitution propagates it and this step fails, so the
+            # comment step (default `if: success()`) is skipped — fail closed.
+            offenders=$(python "$detector" "$PR_TITLE" < changed_files.txt)
+          fi
           # Heredoc form so a multi-line value can never corrupt $GITHUB_OUTPUT.
           {
             echo "offenders<<__SCOPE_EOF__"


### PR DESCRIPTION
The `release-please` scope check (`release_please_scope_check.yml`) is a pre-merge gate that blocks lockfile-only release fan-out. It ran its detector (`check_lockfile_release_scope.py`) and `release-please-config.json` from the **PR head** checkout while the job held `pull-requests: write`. That created two problems:

- **Self-bypass:** a PR could edit the detector or the config to print `[]`, passing the very gate meant to block it — defeating the check for exactly the PRs it should catch.
- **Token exposure:** the default `persist-credentials: true` writes the job token into the checkout's git config, where PR-author-controlled code could read it.

This checks out the PR **base** revision instead of the head, so the detector and config are trusted; sets `persist-credentials: false`; and adds a bootstrap guard so a base revision that predates the detector is treated as clean rather than erroring (a PR cannot make `base` lack the file, so this is not a bypass). It also fails closed when `changed_files` is non-numeric instead of silently skipping the truncation guard.

The approach mirrors the trusted-base pattern already used by `release_please_initial_baseline_check.yml`, and matches the same hardening applied to `pr_scope_file_check.yml` in #4171, where this class of issue was first flagged in review.