### PR TITLE
fix(ci): surface absent-detector desync and document scope-check trust model

### DIFF
--- a/.github/scripts/test_check_pr_scope_files.py
+++ b/.github/scripts/test_check_pr_scope_files.py
@@ -211,6 +211,29 @@ def test_main_stdout_is_json_array(capsys, tmp_path) -> None:
     assert "PR title scope does not cover" in captured.err
 
 
+def test_main_clean_stdout_is_empty_json_array(capsys, tmp_path) -> None:
+    """A clean PR prints exactly `[]` and nothing on stderr.
+
+    The calling workflow consumes raw stdout: its fail-closed JSON parse blocks
+    on empty or non-array output, and its detector-absent branch hard-codes the
+    same `[]` sentinel. Pin the exact wire contract here so a future change to
+    the clean-path output can't silently desync the gate from the script.
+    """
+    config_path = tmp_path / "pr-labeler-config.json"
+    config_path.write_text(json.dumps(CONFIG), encoding="utf-8")
+
+    rc = main(
+        "fix(cli): repair startup",
+        ["libs/cli/deepagents_cli/main.py"],
+        config_path=config_path,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert captured.out.strip() == "[]"
+    assert captured.err == ""
+
+
 def test_main_missing_config_returns_2(capsys, tmp_path) -> None:
     """A missing config fails closed instead of silently passing."""
     rc = main("fix(cli): x", ["libs/code/file.py"], config_path=tmp_path / "nope.json")

--- a/.github/workflows/pr_scope_file_check.yml
+++ b/.github/workflows/pr_scope_file_check.yml
@@ -22,13 +22,26 @@
 #
 # Trust model:
 #   - The detector and labeler config run from the PR *base* revision, not the
-#     PR head, so a PR cannot edit them to self-bypass the gate. Only the PR
+#     PR head, so a PR cannot edit *those* to self-bypass the gate. Only the PR
 #     title (event payload) and changed-file list (API) come from the PR.
+#   - This base checkout closes the detector/config edit vector but does not by
+#     itself make the gate un-bypassable: under `pull_request` the workflow file
+#     itself is taken from the PR head, so a PR that edits this workflow can
+#     still neuter the check. Gate integrity therefore also relies on branch
+#     protection (this job as a required status check) and review of
+#     `.github/workflows/` edits.
 #
 # Limitations:
 #   - Runs under `pull_request` (not `pull_request_target`), so PRs from forks get
 #     the read-only token and the comment is surfaced to the job summary instead.
 #     No secrets are exposed to PR-author-controlled code.
+#   - The detector and config run from base, so a PR that itself *adds* a new
+#     package directory (and its labeler `fileRules`/`scopeToLabel` entries) is
+#     checked against the base config that does not yet know that package: a
+#     scope/file mismatch for the just-added package dir is not flagged until the
+#     rule exists on base. Reading head config instead would reopen the
+#     self-bypass the base checkout closes, so this is the deliberate tradeoff;
+#     the next PR touching the package is gated normally.
 
 name: "🔍 PR scope file check"
 
@@ -110,13 +123,20 @@ jobs:
           set -euo pipefail
           detector=".github/scripts/check_pr_scope_files.py"
           if [[ ! -f "$detector" ]]; then
-            # The detector does not exist on the base revision yet: the PR that
-            # first introduces this check, or a branch cut from before it
-            # existed. There is no trusted gate to enforce, so treat as clean.
-            # A PR cannot reach this path deliberately — it can only change its
-            # own head, never what is present on base — so it is not a bypass.
-            # Once merged, base always carries the detector and it runs normally.
-            echo "::notice::Detector absent on base revision; nothing to enforce yet."
+            # The detector does not exist on the base revision: the bootstrapping
+            # PR that first introduces this check, or a branch cut from before it
+            # existed. There is no trusted gate on base to enforce, so treat as
+            # clean. This is not a self-bypass vector: presence is read from
+            # trusted base, and an author cannot strip the detector from a base
+            # that has it (head edits never change base). An author *can* target
+            # an old base that never had it, but gains nothing — that base never
+            # gated anything, so there is nothing to evade.
+            #
+            # The residual risk is operator error, not attack: if the detector is
+            # renamed/moved on base without updating the path above, this branch
+            # silently disables the gate. Emit a *warning* (not a notice) so the
+            # desync surfaces in the Checks UI rather than only the fold-out log.
+            echo "::warning::Detector '$detector' absent on base revision; scope/file check is NOT enforcing. Expected only on the bootstrapping PR or a pre-gate branch — otherwise the detector path here may be out of sync with the repo."
             offenders="[]"
           else
             # A config-read error in the detector exits non-zero; under `set -e`
@@ -223,7 +243,7 @@ jobs:
               } catch (commentErr) {
                 // Fork PRs run with a restricted token; surface to the job
                 // summary so the mismatch is still visible alongside the red check.
-                core.warning(`Could not post sticky comment (fork PR token, rate limit, or transient API error): ${commentErr.message}`);
+                core.warning(`Could not post sticky comment (fork PR token, rate limit, or transient API error) [status=${commentErr.status ?? 'n/a'}]: ${commentErr.message}`);
                 // Guard the summary write too: if it throws (unwritable summary,
                 // size limit) it must not escape upsertSticky and preempt the
                 // caller's core.setFailed — the red check is the load-bearing signal.
@@ -233,7 +253,7 @@ jobs:
                     .addRaw(body)
                     .write();
                 } catch (summaryErr) {
-                  core.warning(`Could not write job summary fallback: ${summaryErr.message}`);
+                  core.warning(`Could not write job summary fallback [status=${summaryErr.status ?? 'n/a'}]: ${summaryErr.message}`);
                 }
               }
             }
@@ -244,7 +264,7 @@ jobs:
               try {
                 await deleteSticky();
               } catch (cleanupErr) {
-                core.warning(`Could not clean up prior scope/file-check comment: ${cleanupErr.message}`);
+                core.warning(`Could not clean up prior scope/file-check comment (stale comment may persist on a now-passing PR) [status=${cleanupErr.status ?? 'n/a'}]: ${cleanupErr.message}`);
               }
               core.info('No PR scope/file mismatch detected.');
               return;

--- a/.github/workflows/release_please_scope_check.yml
+++ b/.github/workflows/release_please_scope_check.yml
@@ -31,15 +31,27 @@
 #
 # Trust model:
 #   - The detector and release-please-config.json run from the PR *base*
-#     revision, not the PR head, so a PR cannot edit them to self-bypass the
+#     revision, not the PR head, so a PR cannot edit *those* to self-bypass the
 #     gate. Only the PR title (event payload) and changed-file list (API) come
 #     from the PR.
+#   - This base checkout closes the detector/config edit vector but does not by
+#     itself make the gate un-bypassable: under `pull_request` the workflow file
+#     itself is taken from the PR head, so a PR that edits this workflow can
+#     still neuter the check. Gate integrity therefore also relies on branch
+#     protection (this job as a required status check) and review of
+#     `.github/workflows/` edits.
 #
 # Limitations:
 #   - Runs under `pull_request` (not `pull_request_target`), so PRs from forks
 #     get the read-only token and the comment is surfaced to the job summary
 #     instead (same fallback as release_please_parse_check.yml). No secrets are
 #     exposed to PR-author-controlled code.
+#   - The detector and config run from base, so a PR that itself *adds* a new
+#     release-please package is checked against the base config that does not
+#     yet know that package: a lockfile-only fan-out into the just-added package
+#     path is not flagged until the package exists on base. Reading head config
+#     instead would reopen the self-bypass the base checkout closes, so this is
+#     the deliberate tradeoff; the next PR touching the package is gated normally.
 
 name: "🔍 Release-please scope check"
 
@@ -122,13 +134,20 @@ jobs:
           set -euo pipefail
           detector=".github/scripts/check_lockfile_release_scope.py"
           if [[ ! -f "$detector" ]]; then
-            # The detector does not exist on the base revision yet: the PR that
-            # first introduces this check, or a branch cut from before it
-            # existed. There is no trusted gate to enforce, so treat as clean.
-            # A PR cannot reach this path deliberately — it can only change its
-            # own head, never what is present on base — so it is not a bypass.
-            # Once merged, base always carries the detector and it runs normally.
-            echo "::notice::Detector absent on base revision; nothing to enforce yet."
+            # The detector does not exist on the base revision: the bootstrapping
+            # PR that first introduces this check, or a branch cut from before it
+            # existed. There is no trusted gate on base to enforce, so treat as
+            # clean. This is not a self-bypass vector: presence is read from
+            # trusted base, and an author cannot strip the detector from a base
+            # that has it (head edits never change base). An author *can* target
+            # an old base that never had it, but gains nothing — that base never
+            # gated anything, so there is nothing to evade.
+            #
+            # The residual risk is operator error, not attack: if the detector is
+            # renamed/moved on base without updating the path above, this branch
+            # silently disables the gate. Emit a *warning* (not a notice) so the
+            # desync surfaces in the Checks UI rather than only the fold-out log.
+            echo "::warning::Detector '$detector' absent on base revision; scope check is NOT enforcing. Expected only on the bootstrapping PR or a pre-gate branch — otherwise the detector path here may be out of sync with the repo."
             offenders="[]"
           else
             # A config-read error in the detector exits non-zero; under `set -e`
@@ -208,7 +227,7 @@ jobs:
               } catch (commentErr) {
                 // Fork PRs run with a restricted token; surface to the job
                 // summary so the fan-out is still visible alongside the red check.
-                core.warning(`Could not post sticky comment (fork PR token, rate limit, or transient API error): ${commentErr.message}`);
+                core.warning(`Could not post sticky comment (fork PR token, rate limit, or transient API error) [status=${commentErr.status ?? 'n/a'}]: ${commentErr.message}`);
                 // Guard the summary write too: if it throws (unwritable summary,
                 // size limit) it must not escape upsertSticky and preempt the
                 // caller's core.setFailed — the red check is the load-bearing signal.
@@ -218,7 +237,7 @@ jobs:
                     .addRaw(`Affected components: ${offenders.join(', ')}`)
                     .write();
                 } catch (summaryErr) {
-                  core.warning(`Could not write job summary fallback: ${summaryErr.message}`);
+                  core.warning(`Could not write job summary fallback [status=${summaryErr.status ?? 'n/a'}]: ${summaryErr.message}`);
                 }
               }
             }
@@ -229,7 +248,7 @@ jobs:
               try {
                 await deleteSticky();
               } catch (cleanupErr) {
-                core.warning(`Could not clean up prior scope-check comment: ${cleanupErr.message}`);
+                core.warning(`Could not clean up prior scope-check comment (stale comment may persist on a now-passing PR) [status=${cleanupErr.status ?? 'n/a'}]: ${cleanupErr.message}`);
               }
               core.info('No lockfile-only release fan-out detected.');
               return;


### PR DESCRIPTION
Follow-up hardening for the two scope-check merge gates (`release_please_scope_check.yml`, `pr_scope_file_check.yml`), applying review findings from the trusted-base work in #4175 / #4171.

- **Make a silently-disabled gate visible.** The detector-absent branch (bootstrapping PR or a branch cut before the gate existed) is a deliberate fail-open. If the detector is ever renamed or moved on `base` without updating the hard-coded path, that same branch would silently stop enforcing. Escalating its `::notice::` to `::warning::` surfaces the desync in the Checks UI instead of only the fold-out log. The gate's pass/fail logic is unchanged.
- **Scope the trust-model comment.** The base checkout closes only the detector/config edit vector; under `pull_request` the workflow file itself comes from the PR head, so integrity also depends on branch protection plus review of `.github/workflows/` edits. The comment now says so rather than implying the gate is un-bypassable.
- **Document the base-config staleness tradeoff.** Running the detector and config from `base` means a PR that itself adds a new package (or labeler rule) is not checked against it until it lands on base. Reading head config would reopen the bypass the base checkout closes, so this is intentional, not a regression.
- **Better diagnostics on swallowed errors.** The three `core.warning` fallbacks now include `[status=…]`, matching the already-merged `release_please_initial_baseline_check.yml`.
- **Lock the wire contract.** Added a test asserting the detector prints exactly `[]` on a clean PR — the contract the workflow's fail-closed JSON parse and the detector-absent sentinel both rely on.