### PR TITLE
style(code): simplify onboarding name prompt copy

### DIFF
--- a/libs/code/deepagents_code/widgets/launch_init.py
+++ b/libs/code/deepagents_code/widgets/launch_init.py
@@ -113,10 +113,7 @@ class LaunchNameScreen(ModalScreen[str | None]):
         with Vertical():
             yield Static("Welcome to Deep Agents", classes="launch-init-title")
             yield Static(
-                Content.assemble(
-                    "What should Deep Agents call you? This is optional and "
-                    "will be remembered for future sessions."
-                ),
+                Content.assemble("What should Deep Agents call you?"),
                 classes="launch-init-copy",
             )
             yield Input(

--- a/libs/code/tests/unit_tests/test_launch_init.py
+++ b/libs/code/tests/unit_tests/test_launch_init.py
@@ -83,8 +83,8 @@ class TestLaunchNameScreen:
 
         assert name_input.placeholder == "Your name (optional)"
 
-    async def test_copy_explains_name_memory_and_skip(self) -> None:
-        """The name screen should describe memory and skip semantics."""
+    async def test_copy_prompts_for_name_and_explains_skip(self) -> None:
+        """The name screen should prompt for a name and describe skip semantics."""
         app = LaunchNameTestApp()
         async with app.run_test() as pilot:
             app.show_name_screen()
@@ -93,7 +93,7 @@ class TestLaunchNameScreen:
             copy = app.screen.query_one(".launch-init-copy", Static)
             help_text = app.screen.query_one(".launch-init-help", Static)
 
-        assert "remembered for future sessions" in str(copy.content)
+        assert "What should Deep Agents call you?" in str(copy.content)
         assert "Esc skip setup" in str(help_text.content)
 
     async def test_submit_returns_normalized_name(self) -> None:


### PR DESCRIPTION
Removes the "This is optional and will be remembered for future sessions." sentence from the launch onboarding name prompt, leaving just "What should Deep Agents call you?". 

Made by [Open SWE](https://openswe.vercel.app/agents/009d4ddd-1c00-0c84-6aa3-13c0311cf608)