### PR TITLE
fix(code): quiet uv installer output and require Xcode CLT on macOS

### DIFF
--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -56,7 +56,8 @@
 #     prompt.
 #   DEEPAGENTS_CODE_SKIP_OPTIONAL — set to 1 to skip optional tool checks
 #   DEEPAGENTS_CODE_VERBOSE — set to 1 to show uv's raw stderr (timing lines,
-#     unfiltered package diff) and the quiet-by-default status lines
+#     unfiltered package diff), the uv installer's own output (shown only when
+#     uv isn't already installed), and the quiet-by-default status lines
 #     (optional-tool checks, post-install footer); useful when debugging. A
 #     fresh install otherwise hides the full list of installed dependencies.
 #   UV_BIN — path to uv binary (auto-detected if unset)
@@ -131,6 +132,22 @@ detect_os() {
   esac
 }
 detect_os
+
+# ---------------------------------------------------------------------------
+# macOS: require Xcode Command Line Tools
+# ---------------------------------------------------------------------------
+# On a fresh Mac the /usr/bin shims for git, python3, etc. are stubs that pop a
+# blocking GUI dialog ("…requires the command line developer tools") the first
+# time they run. uv's interpreter discovery and dcode's own git usage hit those
+# stubs, so fail fast here with a clear instruction instead of leaving the user
+# staring at a confusing popup mid-install. `xcode-select -p` only reports the
+# active developer dir — it never triggers the install dialog itself.
+if [ "$OS" = "macos" ] && ! xcode-select -p >/dev/null 2>&1; then
+  log_error "Xcode Command Line Tools are required but not installed."
+  log_error "  Install them with:  xcode-select --install"
+  log_error "  Then re-run this installer."
+  exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # Root / MDM support (macOS — Kandji, Jamf, etc.)
@@ -375,20 +392,26 @@ fi
 # uv installation
 # ---------------------------------------------------------------------------
 install_uv() {
+  # The upstream uv installer is chatty (download progress, install paths,
+  # PATH-setup hints). Capture it and surface the output only when debugging
+  # or when the install fails — by default it's noise the user doesn't need.
+  local uv_install_out uv_install_rc=0
+  uv_install_out=$(mktemp 2>/dev/null) || uv_install_out="/tmp/deepagents-uv-install.$$.out"
   if command -v curl >/dev/null 2>&1; then
-    log_info "Downloading uv installer..."
-    if ! curl -fsSL https://astral.sh/uv/install.sh | sh; then
-      log_error "uv installation failed. See errors above."
-      exit 1
-    fi
+    curl -fsSL https://astral.sh/uv/install.sh | sh >"$uv_install_out" 2>&1 || uv_install_rc=$?
   elif command -v wget >/dev/null 2>&1; then
-    log_info "Downloading uv installer..."
-    if ! wget -qO- https://astral.sh/uv/install.sh | sh; then
-      log_error "uv installation failed. See errors above."
-      exit 1
-    fi
+    wget -qO- https://astral.sh/uv/install.sh | sh >"$uv_install_out" 2>&1 || uv_install_rc=$?
   else
+    rm -f "$uv_install_out"
     log_error "curl or wget is required to install uv."
+    exit 1
+  fi
+  if [ "$VERBOSE" = "1" ] || [ "$uv_install_rc" -ne 0 ]; then
+    cat "$uv_install_out" >&2
+  fi
+  rm -f "$uv_install_out"
+  if [ "$uv_install_rc" -ne 0 ]; then
+    log_error "uv installation failed. See errors above."
     exit 1
   fi
 }

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -836,7 +836,11 @@ fi
 # "Run: dcode" footer below isn't a dead end.
 if [ "$VERIFY_OK" = true ] && [ "$DCODE_ON_PATH" = false ]; then
   log_warn "${DCODE_NAME} isn't on your PATH yet${DCODE_BIN_DISPLAY:+ (installed at ${DCODE_BIN_DISPLAY})}. Restart your shell, or run:"
-  log_warn "  source ~/.local/bin/env"
+  if [ -f "${HOME}/.local/bin/env" ]; then
+    log_warn "  source ~/.local/bin/env"
+  else
+    log_warn "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+  fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -142,7 +142,7 @@ detect_os
 # macOS: require Xcode Command Line Tools
 # ---------------------------------------------------------------------------
 # On a fresh Mac the /usr/bin shims for git, python3, etc. are stubs that pop a
-# blocking GUI dialog ("…requires the command line developer tools") the first
+# blocking GUI dialog ("...requires the command line developer tools") the first
 # time they run. uv's interpreter discovery and dcode's own git usage hit those
 # stubs, so fail fast here with a clear instruction instead of leaving the user
 # staring at a confusing popup mid-install. `xcode-select -p` only reports the
@@ -577,7 +577,7 @@ else
 fi
 
 # Capture uv stderr so we can:
-#   1. Rewrite the cryptic "Ignoring existing environment …" warning into
+#   1. Rewrite the cryptic "Ignoring existing environment ..." warning into
 #      plain English. uv emits that line when it rebuilds the tool venv
 #      instead of upgrading in place (e.g., Python interpreter mismatch, or
 #      editable↔regular install swap).

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -404,7 +404,10 @@ install_uv() {
   # PATH-setup hints). Capture it and surface the output only when debugging
   # or when the install fails — by default it's noise the user doesn't need.
   local uv_install_out uv_install_rc=0
-  uv_install_out=$(mktemp 2>/dev/null) || uv_install_out="/tmp/deepagents-uv-install.$$.out"
+  uv_install_out=$(mktemp 2>/dev/null) || {
+    log_error "mktemp is required to create a secure temp file."
+    exit 1
+  }
   # Only the piped `sh` (the installer body) is captured by `>"$uv_install_out"
   # 2>&1`; curl/wget keep their own stderr on the terminal. That's intentional —
   # `-fsSL` includes `-S`, so a failed download still prints curl's error

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -55,6 +55,8 @@
 #     terminal (CI, wrapper scripts) update instead of stalling at the y/n
 #     prompt.
 #   DEEPAGENTS_CODE_SKIP_OPTIONAL — set to 1 to skip optional tool checks
+#   DEEPAGENTS_CODE_SKIP_XCODE_CHECK — set to 1 to bypass the macOS Xcode
+#     Command Line Tools preflight check
 #   DEEPAGENTS_CODE_VERBOSE — set to 1 to show uv's raw stderr (timing lines,
 #     unfiltered package diff), the uv installer's own output (shown only when
 #     uv isn't already installed), and the quiet-by-default status lines
@@ -147,9 +149,10 @@ detect_os
 # stubs, so fail fast here with a clear instruction instead of leaving the user
 # staring at a confusing popup mid-install. `xcode-select -p` only reports the
 # active developer dir — it never triggers the install dialog itself.
-if [ "$OS" = "macos" ] && ! xcode-select -p >/dev/null 2>&1; then
+if [ "$OS" = "macos" ] && [ "${DEEPAGENTS_CODE_SKIP_XCODE_CHECK:-}" != "1" ] && ! xcode-select -p >/dev/null 2>&1; then
   log_error "Xcode Command Line Tools are required but not installed."
   log_error "  Install them with:  xcode-select --install"
+  log_error "  To bypass this check, set:  DEEPAGENTS_CODE_SKIP_XCODE_CHECK=1"
   log_error "  Then re-run this installer."
   exit 1
 fi

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -725,10 +725,17 @@ fix_install_log_owner
 # ---------------------------------------------------------------------------
 DCODE_BIN=""
 DCODE_NAME=""
+# Tracks whether the binary resolved via PATH (`command -v`) or only via the
+# ~/.local/bin fallback. A fresh `uv tool install` drops the binary in
+# ~/.local/bin, but the current shell won't have it on PATH until it's
+# restarted or the env file is sourced — so we can verify it directly yet still
+# need to tell the user it isn't callable as `dcode` yet.
+DCODE_ON_PATH=false
 for candidate in dcode deepagents-code; do
   if resolved=$(command -v "$candidate" 2>/dev/null) && [ -n "$resolved" ]; then
     DCODE_BIN="$resolved"
     DCODE_NAME="$candidate"
+    DCODE_ON_PATH=true
     break
   elif [ -x "${HOME}/.local/bin/${candidate}" ]; then
     DCODE_BIN="${HOME}/.local/bin/${candidate}"
@@ -803,6 +810,15 @@ elif [ -n "$DCODE_BIN" ]; then
 else
   log_warn "dcode (or deepagents-code) command not found in PATH. Restart your shell or run:"
   log_warn "  source ~/.zshrc   # (or ~/.bashrc)"
+fi
+
+# The binary verified via its absolute path but isn't on the current shell's
+# PATH (typical right after a fresh `uv tool install`): typing `dcode` won't
+# work until the shell picks up ~/.local/bin. Point the user at the fix so the
+# "Run: dcode" footer below isn't a dead end.
+if [ "$VERIFY_OK" = true ] && [ "$DCODE_ON_PATH" = false ]; then
+  log_warn "${DCODE_NAME} isn't on your PATH yet${DCODE_BIN_DISPLAY:+ (installed at ${DCODE_BIN_DISPLAY})}. Restart your shell, or run:"
+  log_warn "  source ~/.local/bin/env"
 fi
 
 # ---------------------------------------------------------------------------

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -402,6 +402,11 @@ install_uv() {
   # or when the install fails — by default it's noise the user doesn't need.
   local uv_install_out uv_install_rc=0
   uv_install_out=$(mktemp 2>/dev/null) || uv_install_out="/tmp/deepagents-uv-install.$$.out"
+  # Only the piped `sh` (the installer body) is captured by `>"$uv_install_out"
+  # 2>&1`; curl/wget keep their own stderr on the terminal. That's intentional —
+  # `-fsSL` includes `-S`, so a failed download still prints curl's error
+  # directly (above the "uv installation failed" line) even though the captured
+  # file is then empty. Don't assume curl's stderr is in the capture.
   if command -v curl >/dev/null 2>&1; then
     curl -fsSL https://astral.sh/uv/install.sh | sh >"$uv_install_out" 2>&1 || uv_install_rc=$?
   elif command -v wget >/dev/null 2>&1; then

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -68,6 +68,11 @@
 
 set -euo pipefail
 
+# Keep the shell PATH the user started with. The installer may source
+# ~/.local/bin/env later so it can find a freshly installed uv, but that does
+# not update the parent shell that will receive the final "Run: dcode" advice.
+ORIGINAL_PATH="${PATH:-}"
+
 # ---------------------------------------------------------------------------
 # Colors & logging
 # ---------------------------------------------------------------------------
@@ -725,17 +730,19 @@ fix_install_log_owner
 # ---------------------------------------------------------------------------
 DCODE_BIN=""
 DCODE_NAME=""
-# Tracks whether the binary resolved via PATH (`command -v`) or only via the
-# ~/.local/bin fallback. A fresh `uv tool install` drops the binary in
-# ~/.local/bin, but the current shell won't have it on PATH until it's
-# restarted or the env file is sourced — so we can verify it directly yet still
-# need to tell the user it isn't callable as `dcode` yet.
+# Tracks whether the binary would have resolved via the user's original PATH,
+# not the installer-mutated PATH. A fresh `uv tool install` drops the binary in
+# ~/.local/bin, and this script may have sourced ~/.local/bin/env earlier to
+# find uv; the parent shell still won't have dcode on PATH until it is
+# restarted or the env file is sourced.
 DCODE_ON_PATH=false
 for candidate in dcode deepagents-code; do
   if resolved=$(command -v "$candidate" 2>/dev/null) && [ -n "$resolved" ]; then
     DCODE_BIN="$resolved"
     DCODE_NAME="$candidate"
-    DCODE_ON_PATH=true
+    if PATH="$ORIGINAL_PATH" command -v "$candidate" >/dev/null 2>&1; then
+      DCODE_ON_PATH=true
+    fi
     break
   elif [ -x "${HOME}/.local/bin/${candidate}" ]; then
     DCODE_BIN="${HOME}/.local/bin/${candidate}"

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -937,20 +937,89 @@ def test_install_script_interactive_empty_answer_keeps_current(tmp_path: Path) -
     assert "Keeping deepagents-code 0.1.0" in output
 
 
+def _path_without_dcode() -> str:
+    """Return the host `PATH` with any directory that already provides dcode dropped.
+
+    The test venv installs a real `dcode`/`deepagents-code` on `PATH`. Tests that
+    need to exercise the `~/.local/bin` fallback must ensure neither resolves via
+    `PATH`, while keeping the system directories the script's coreutils need.
+    Filtering the real `PATH` is portable across hosts, unlike hardcoding
+    `/usr/bin:/bin`.
+    """
+    kept = [
+        entry
+        for entry in os.environ.get("PATH", "").split(os.pathsep)
+        if entry
+        and not any(
+            (Path(entry) / name).exists() for name in ("dcode", "deepagents-code")
+        )
+    ]
+    return os.pathsep.join(kept)
+
+
+def _invoke_with_os(
+    tmp_path: Path,
+    *,
+    uname_os: str,
+    xcode_select_rc: int,
+    installed_version: str | None = None,
+    latest_version: str | None = None,
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    """Run `install.sh` with faked `uname`/`xcode-select` os probes.
+
+    Pins the detected OS and the Xcode Command Line Tools check deterministically,
+    independent of the host running the suite, on top of the usual fake tool rig.
+    Returns the completed process and the path where the fake `uv` records its
+    `tool install` argv — absent if the script exited before invoking uv.
+    """
+    bin_dir, home, uv = _write_fake_tools(
+        tmp_path,
+        installed_version=installed_version,
+        latest_version=latest_version,
+    )
+    uname = bin_dir / "uname"
+    uname.write_text(f"#!/usr/bin/env bash\necho {uname_os}\n")
+    _make_executable(uname)
+    xcode_select = bin_dir / "xcode-select"
+    xcode_select.write_text(f"#!/usr/bin/env bash\nexit {xcode_select_rc}\n")
+    _make_executable(xcode_select)
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "XDG_CACHE_HOME": str(home / ".cache"),
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "UV_BIN": str(uv),
+        "DEEPAGENTS_CODE_SKIP_OPTIONAL": "1",
+    }
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    return proc, tmp_path / "uv-args.txt"
+
+
 def _run_install_uv(
-    tmp_path: Path, *, verbose: bool
+    tmp_path: Path, *, verbose: bool, fails: bool = False
 ) -> subprocess.CompletedProcess[str]:
     """Run the real `install_uv` from `install.sh` against a fake uv installer.
 
-    A fake `curl` emits a trivial "installer" that just prints a noise line; the
-    function pipes it to `sh`, so the noise lands in its captured output. Returns
-    the completed process so callers can assert on whether that noise reached the
-    terminal (it should only do so under verbose mode).
+    A fake `curl` emits a trivial "installer" that prints a noise line; the
+    function pipes it to `sh`, so the noise lands in its captured output. When
+    `fails` is set, that installer also exits non-zero, exercising the
+    surface-output-on-failure branch. Returns the completed process so callers
+    can assert on whether the noise reached the terminal and on the exit code.
     """
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     curl = bin_dir / "curl"
-    curl.write_text("#!/usr/bin/env bash\nprintf '%s\\n' 'echo UV_INSTALLER_NOISE'\n")
+    installer = "'echo UV_INSTALLER_NOISE'" + (" 'exit 3'" if fails else "")
+    curl.write_text(f"#!/usr/bin/env bash\nprintf '%s\\n' {installer}\n")
     _make_executable(curl)
 
     script = tmp_path / "install_uv_harness.sh"
@@ -991,40 +1060,76 @@ def test_install_uv_verbose_shows_installer_output(tmp_path: Path) -> None:
     assert "UV_INSTALLER_NOISE" in proc.stderr
 
 
+def test_install_uv_surfaces_output_on_failure(tmp_path: Path) -> None:
+    """A failed uv install replays the captured output even when not verbose.
+
+    The surface-on-failure half of the gate (`uv_install_rc -ne 0`) is the only
+    diagnostic the user gets when the upstream installer dies, so it must fire
+    regardless of `DEEPAGENTS_CODE_VERBOSE` and the script must exit non-zero.
+    """
+    proc = _run_install_uv(tmp_path, verbose=False, fails=True)
+
+    assert proc.returncode != 0
+    assert "UV_INSTALLER_NOISE" in proc.stderr
+    assert "uv installation failed" in proc.stderr
+
+
 def test_install_script_macos_without_clt_exits_early(tmp_path: Path) -> None:
     """On macOS, missing Xcode Command Line Tools fails fast before uv runs.
 
-    Fakes `uname` so the script detects macOS and a failing `xcode-select -p`
-    so the pre-flight check trips. The script must exit non-zero with an
-    actionable message instead of letting a downstream tool trigger the macOS
-    "install developer tools" GUI popup.
+    Pins `uname`→Darwin and a failing `xcode-select -p` so the pre-flight check
+    trips. The script must exit non-zero with an actionable message and must do
+    so before invoking uv (the fake `uv` records no argv), rather than letting a
+    downstream tool trigger the macOS "install developer tools" GUI popup.
     """
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    uname = bin_dir / "uname"
-    uname.write_text("#!/usr/bin/env bash\necho Darwin\n")
-    _make_executable(uname)
-    xcode_select = bin_dir / "xcode-select"
-    xcode_select.write_text("#!/usr/bin/env bash\nexit 2\n")
-    _make_executable(xcode_select)
-
-    env = {
-        **os.environ,
-        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-        "HOME": str(tmp_path),
-    }
-    proc = subprocess.run(
-        ["bash", str(SCRIPT)],
-        env=env,
-        capture_output=True,
-        text=True,
-        stdin=subprocess.DEVNULL,
-        check=False,
+    proc, uv_args = _invoke_with_os(
+        tmp_path, uname_os="Darwin", xcode_select_rc=2, installed_version="0.0.1"
     )
 
     assert proc.returncode != 0
     assert "Xcode Command Line Tools" in proc.stderr
     assert "xcode-select --install" in proc.stderr
+    assert not uv_args.exists()
+
+
+def test_install_script_macos_with_clt_proceeds_to_install(tmp_path: Path) -> None:
+    """On macOS with Xcode CLT present, the pre-flight check passes through to uv.
+
+    Pins `uname`→Darwin and a succeeding `xcode-select -p` so the gate's no-fire
+    branch is asserted deterministically rather than relying on the host's own
+    CLT state. The run must reach `uv tool install` without emitting the CLT
+    error.
+    """
+    proc, uv_args = _invoke_with_os(
+        tmp_path,
+        uname_os="Darwin",
+        xcode_select_rc=0,
+        installed_version="0.0.1",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "Xcode Command Line Tools" not in proc.stderr
+    assert uv_args.exists()
+
+
+def test_install_script_linux_skips_clt_check(tmp_path: Path) -> None:
+    """The CLT gate is macOS-only: a failing `xcode-select` is ignored on Linux.
+
+    Pins `uname`→Linux with a failing `xcode-select -p`; the `$OS = macos` guard
+    must short-circuit so the check never trips and the install proceeds.
+    """
+    proc, uv_args = _invoke_with_os(
+        tmp_path,
+        uname_os="Linux",
+        xcode_select_rc=2,
+        installed_version="0.0.1",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "Xcode Command Line Tools" not in proc.stderr
+    assert uv_args.exists()
 
 
 def test_install_script_warns_when_dcode_installed_but_not_on_path(
@@ -1051,13 +1156,14 @@ def test_install_script_warns_when_dcode_installed_but_not_on_path(
     )
     _make_executable(dcode)
 
-    # Curated PATH excluding any real dcode (e.g. the test venv's bin), so the
-    # only resolvable binary is the ~/.local/bin fallback — the case under test.
+    # Real PATH minus any dir already providing dcode (e.g. the test venv's bin),
+    # so the only resolvable binary is the ~/.local/bin fallback — the case under
+    # test — while keeping the system coreutils dirs the script needs.
     env = {
         **os.environ,
         "HOME": str(home),
         "XDG_CACHE_HOME": str(home / ".cache"),
-        "PATH": f"{bin_dir}{os.pathsep}/usr/bin{os.pathsep}/bin",
+        "PATH": f"{bin_dir}{os.pathsep}{_path_without_dcode()}",
         "UV_BIN": str(uv),
         "DEEPAGENTS_CODE_SKIP_OPTIONAL": "1",
     }

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -964,6 +964,7 @@ def _invoke_with_os(
     xcode_select_rc: int,
     installed_version: str | None = None,
     latest_version: str | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
     """Run `install.sh` with faked `uname`/`xcode-select` os probes.
 
@@ -991,6 +992,7 @@ def _invoke_with_os(
         "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
         "UV_BIN": str(uv),
         "DEEPAGENTS_CODE_SKIP_OPTIONAL": "1",
+        **(extra_env or {}),
     }
     proc = subprocess.run(
         ["bash", str(SCRIPT)],
@@ -1090,6 +1092,24 @@ def test_install_script_macos_without_clt_exits_early(tmp_path: Path) -> None:
     assert "Xcode Command Line Tools" in proc.stderr
     assert "xcode-select --install" in proc.stderr
     assert not uv_args.exists()
+
+
+def test_install_script_macos_skip_xcode_check_proceeds_without_clt(
+    tmp_path: Path,
+) -> None:
+    """The macOS CLT check can be bypassed for managed install environments."""
+    proc, uv_args = _invoke_with_os(
+        tmp_path,
+        uname_os="Darwin",
+        xcode_select_rc=2,
+        installed_version="0.0.1",
+        latest_version="0.2.0",
+        extra_env={"DEEPAGENTS_CODE_SKIP_XCODE_CHECK": "1"},
+    )
+
+    assert proc.returncode == 0
+    assert "Xcode Command Line Tools" not in proc.stderr
+    assert uv_args.exists()
 
 
 def test_install_script_macos_with_clt_proceeds_to_install(tmp_path: Path) -> None:

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1007,7 +1007,11 @@ def _invoke_with_os(
 
 
 def _run_install_uv(
-    tmp_path: Path, *, verbose: bool, fails: bool = False
+    tmp_path: Path,
+    *,
+    verbose: bool,
+    fails: bool = False,
+    mktemp_fails: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     """Run the real `install_uv` from `install.sh` against a fake uv installer.
 
@@ -1023,6 +1027,10 @@ def _run_install_uv(
     installer = "'echo UV_INSTALLER_NOISE'" + (" 'exit 3'" if fails else "")
     curl.write_text(f"#!/usr/bin/env bash\nprintf '%s\\n' {installer}\n")
     _make_executable(curl)
+    if mktemp_fails:
+        mktemp = bin_dir / "mktemp"
+        mktemp.write_text("#!/usr/bin/env bash\nexit 1\n")
+        _make_executable(mktemp)
 
     script = tmp_path / "install_uv_harness.sh"
     script.write_text(
@@ -1074,6 +1082,15 @@ def test_install_uv_surfaces_output_on_failure(tmp_path: Path) -> None:
     assert proc.returncode != 0
     assert "UV_INSTALLER_NOISE" in proc.stderr
     assert "uv installation failed" in proc.stderr
+
+
+def test_install_uv_requires_secure_temp_file(tmp_path: Path) -> None:
+    """`install_uv` fails closed if secure temporary file creation is unavailable."""
+    proc = _run_install_uv(tmp_path, verbose=False, mktemp_fails=True)
+
+    assert proc.returncode != 0
+    assert "mktemp is required to create a secure temp file" in proc.stderr
+    assert "UV_INSTALLER_NOISE" not in proc.stderr
 
 
 def test_install_script_macos_without_clt_exits_early(tmp_path: Path) -> None:

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1169,6 +1169,43 @@ def test_install_script_linux_skips_clt_check(tmp_path: Path) -> None:
     assert uv_args.exists()
 
 
+def _invoke_with_local_dcode_not_on_path(
+    tmp_path: Path, *, create_env_file: bool = False
+) -> subprocess.CompletedProcess[str]:
+    """Run with a working `dcode` in ~/.local/bin but outside the original PATH."""
+    bin_dir, home, uv = _write_fake_tools(tmp_path, installed_version=None)
+
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    dcode = local_bin / "dcode"
+    dcode.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "${1:-}" = "-v" ]; then printf "deepagents-code 0.1.0\\n"; exit 0; fi\n'
+        "exit 0\n"
+    )
+    _make_executable(dcode)
+    if create_env_file:
+        (local_bin / "env").write_text('export PATH="$HOME/.local/bin:$PATH"\n')
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "XDG_CACHE_HOME": str(home / ".cache"),
+        "PATH": f"{bin_dir}{os.pathsep}{_path_without_dcode()}",
+        "UV_BIN": str(uv),
+        "DEEPAGENTS_CODE_SKIP_OPTIONAL": "1",
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
 def test_install_script_warns_when_dcode_installed_but_not_on_path(
     tmp_path: Path,
 ) -> None:
@@ -1180,39 +1217,20 @@ def test_install_script_warns_when_dcode_installed_but_not_on_path(
     tell the user the binary isn't callable as `dcode` yet and how to fix it,
     rather than printing a "Run: dcode" footer that dead-ends.
     """
-    bin_dir, home, uv = _write_fake_tools(tmp_path, installed_version=None)
+    proc = _invoke_with_local_dcode_not_on_path(tmp_path)
 
-    # Place a working dcode in ~/.local/bin only — not on PATH (bin_dir).
-    local_bin = home / ".local" / "bin"
-    local_bin.mkdir(parents=True)
-    dcode = local_bin / "dcode"
-    dcode.write_text(
-        "#!/usr/bin/env bash\n"
-        'if [ "${1:-}" = "-v" ]; then printf "deepagents-code 0.1.0\\n"; exit 0; fi\n'
-        "exit 0\n"
-    )
-    _make_executable(dcode)
+    assert proc.returncode == 0
+    combined = proc.stdout + proc.stderr
+    assert "isn't on your PATH yet" in combined
+    assert 'export PATH="$HOME/.local/bin:$PATH"' in combined
+    assert "source ~/.local/bin/env" not in combined
 
-    # Real PATH minus any dir already providing dcode (e.g. the test venv's bin),
-    # so the only resolvable binary is the ~/.local/bin fallback — the case under
-    # test — while keeping the system coreutils dirs the script needs.
-    env = {
-        **os.environ,
-        "HOME": str(home),
-        "XDG_CACHE_HOME": str(home / ".cache"),
-        "PATH": f"{bin_dir}{os.pathsep}{_path_without_dcode()}",
-        "UV_BIN": str(uv),
-        "DEEPAGENTS_CODE_SKIP_OPTIONAL": "1",
-    }
-    proc = subprocess.run(
-        ["bash", str(SCRIPT)],
-        env=env,
-        check=False,
-        capture_output=True,
-        text=True,
-        stdin=subprocess.DEVNULL,
-        start_new_session=True,
-    )
+
+def test_install_script_uses_uv_env_file_path_hint_when_available(
+    tmp_path: Path,
+) -> None:
+    """When uv wrote ~/.local/bin/env, the not-on-PATH hint points to it."""
+    proc = _invoke_with_local_dcode_not_on_path(tmp_path, create_env_file=True)
 
     assert proc.returncode == 0
     combined = proc.stdout + proc.stderr

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -935,3 +935,93 @@ def test_install_script_interactive_empty_answer_keeps_current(tmp_path: Path) -
     assert code == 0
     assert not args_path.exists()
     assert "Keeping deepagents-code 0.1.0" in output
+
+
+def _run_install_uv(
+    tmp_path: Path, *, verbose: bool
+) -> subprocess.CompletedProcess[str]:
+    """Run the real `install_uv` from `install.sh` against a fake uv installer.
+
+    A fake `curl` emits a trivial "installer" that just prints a noise line; the
+    function pipes it to `sh`, so the noise lands in its captured output. Returns
+    the completed process so callers can assert on whether that noise reached the
+    terminal (it should only do so under verbose mode).
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    curl = bin_dir / "curl"
+    curl.write_text("#!/usr/bin/env bash\nprintf '%s\\n' 'echo UV_INSTALLER_NOISE'\n")
+    _make_executable(curl)
+
+    script = tmp_path / "install_uv_harness.sh"
+    script.write_text(
+        "set -euo pipefail\n"
+        "log_info() { :; }\n"
+        'log_error() { printf "%s\\n" "$*" >&2; }\n'
+        f"VERBOSE={'1' if verbose else '0'}\n"
+        f"{_extract_shell_function('install_uv')}\n"
+        "install_uv\n",
+        encoding="utf-8",
+    )
+    env = {**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
+    return subprocess.run(
+        ["bash", str(script)],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        check=False,
+    )
+
+
+def test_install_uv_hides_installer_output_by_default(tmp_path: Path) -> None:
+    """The chatty upstream uv installer output is suppressed on a normal run."""
+    proc = _run_install_uv(tmp_path, verbose=False)
+
+    assert proc.returncode == 0
+    assert "UV_INSTALLER_NOISE" not in proc.stdout
+    assert "UV_INSTALLER_NOISE" not in proc.stderr
+
+
+def test_install_uv_verbose_shows_installer_output(tmp_path: Path) -> None:
+    """`DEEPAGENTS_CODE_VERBOSE=1` opts back in to the uv installer's output."""
+    proc = _run_install_uv(tmp_path, verbose=True)
+
+    assert proc.returncode == 0
+    assert "UV_INSTALLER_NOISE" in proc.stderr
+
+
+def test_install_script_macos_without_clt_exits_early(tmp_path: Path) -> None:
+    """On macOS, missing Xcode Command Line Tools fails fast before uv runs.
+
+    Fakes `uname` so the script detects macOS and a failing `xcode-select -p`
+    so the pre-flight check trips. The script must exit non-zero with an
+    actionable message instead of letting a downstream tool trigger the macOS
+    "install developer tools" GUI popup.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    uname = bin_dir / "uname"
+    uname.write_text("#!/usr/bin/env bash\necho Darwin\n")
+    _make_executable(uname)
+    xcode_select = bin_dir / "xcode-select"
+    xcode_select.write_text("#!/usr/bin/env bash\nexit 2\n")
+    _make_executable(xcode_select)
+
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+    }
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        check=False,
+    )
+
+    assert proc.returncode != 0
+    assert "Xcode Command Line Tools" in proc.stderr
+    assert "xcode-select --install" in proc.stderr

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1025,3 +1025,62 @@ def test_install_script_macos_without_clt_exits_early(tmp_path: Path) -> None:
     assert proc.returncode != 0
     assert "Xcode Command Line Tools" in proc.stderr
     assert "xcode-select --install" in proc.stderr
+
+
+def test_install_script_warns_when_dcode_installed_but_not_on_path(
+    tmp_path: Path,
+) -> None:
+    """A fresh install resolved only via ~/.local/bin warns it isn't on PATH.
+
+    Simulates `uv tool install` dropping the binary in ~/.local/bin without the
+    current shell having picked it up: `command -v dcode` misses, the fallback
+    path hits, and the script verifies it directly. The success path must still
+    tell the user the binary isn't callable as `dcode` yet and how to fix it,
+    rather than printing a "Run: dcode" footer that dead-ends.
+    """
+    bin_dir, home, uv = _write_fake_tools(tmp_path, installed_version=None)
+
+    # Place a working dcode in ~/.local/bin only — not on PATH (bin_dir).
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    dcode = local_bin / "dcode"
+    dcode.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "${1:-}" = "-v" ]; then printf "deepagents-code 0.1.0\\n"; exit 0; fi\n'
+        "exit 0\n"
+    )
+    _make_executable(dcode)
+
+    # Curated PATH excluding any real dcode (e.g. the test venv's bin), so the
+    # only resolvable binary is the ~/.local/bin fallback — the case under test.
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "XDG_CACHE_HOME": str(home / ".cache"),
+        "PATH": f"{bin_dir}{os.pathsep}/usr/bin{os.pathsep}/bin",
+        "UV_BIN": str(uv),
+        "DEEPAGENTS_CODE_SKIP_OPTIONAL": "1",
+    }
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+    assert proc.returncode == 0
+    combined = proc.stdout + proc.stderr
+    assert "isn't on your PATH yet" in combined
+    assert "source ~/.local/bin/env" in combined
+
+
+def test_install_script_no_path_warning_when_dcode_on_path(tmp_path: Path) -> None:
+    """When `dcode` resolves via PATH, the not-on-PATH hint is suppressed."""
+    proc, _ = _invoke(tmp_path, {}, installed_version="0.1.0", latest_version="0.2.0")
+
+    assert proc.returncode == 0
+    combined = proc.stdout + proc.stderr
+    assert "isn't on your PATH yet" not in combined


### PR DESCRIPTION
The install script now hides the uv installer's output by default and exits early on macOS when Xcode Command Line Tools are not installed.

---

The uv installer's verbose download/PATH output cluttered a fresh `dcode` install; it's now hidden by default and shown only with `DEEPAGENTS_CODE_VERBOSE=1` or on failure. On macOS, the installer now fails fast with an actionable message when the Xcode Command Line Tools are missing, instead of letting a downstream tool (uv interpreter discovery / git) trigger the blocking macOS "install developer tools" GUI popup mid-install.

Made by [Open SWE](https://openswe.vercel.app/agents/c4c6c178-52dd-957a-68b7-dcba7f3223e0)