### PR TITLE
docs(code): clarify onboarding integrations copy

### DIFF
--- a/libs/code/deepagents_code/widgets/launch_init.py
+++ b/libs/code/deepagents_code/widgets/launch_init.py
@@ -241,9 +241,9 @@ class LaunchDependenciesScreen(ModalScreen[bool | None]):
         with Vertical():
             yield Static("Installed Integrations", classes="launch-init-title")
             yield Static(
-                "Model providers and sandboxes work through optional add-on "
-                "packages. The ones you've already installed are ready to use "
-                "now; the rest can be added anytime with `/install`.",
+                "Model providers and sandboxes are enabled by optional add-on "
+                "packages. The ones already present in your environment are "
+                "ready to use now; you can add others anytime with `/install`.",
                 classes="launch-init-copy",
             )
             if self._statuses:

--- a/libs/code/deepagents_code/widgets/launch_init.py
+++ b/libs/code/deepagents_code/widgets/launch_init.py
@@ -241,8 +241,9 @@ class LaunchDependenciesScreen(ModalScreen[bool | None]):
         with Vertical():
             yield Static("Installed Integrations", classes="launch-init-title")
             yield Static(
-                "Deep Agents uses installed optional packages to decide which "
-                "providers and runtime integrations are ready now.",
+                "Model providers and sandboxes work through optional add-on "
+                "packages. The ones you've already installed are ready to use "
+                "now; the rest can be added anytime with `/install`.",
                 classes="launch-init-copy",
             )
             if self._statuses:


### PR DESCRIPTION
The onboarding "Installed Integrations" screen described optional packages in a way that was confusing to new or non-technical users. This rewords the copy to plainly explain that model providers and sandboxes come from optional add-on packages, the installed ones are ready to use now, and the rest can be added with `/install`.

Made by [Open SWE](https://openswe.vercel.app/agents/903002d2-207e-17b7-f276-79c35f68641e)