### PR TITLE
fix(code): generic "missing credentials" in model switcher

### DIFF
--- a/libs/code/deepagents_code/auth_display.py
+++ b/libs/code/deepagents_code/auth_display.py
@@ -75,8 +75,6 @@ def format_auth_indicator(status: ProviderAuthStatus, glyphs: Glyphs) -> str:
         case ProviderAuthState.CONFIGURED:
             return ""
         case ProviderAuthState.MISSING:
-            if status.env_var:
-                return f"{glyphs.warning} missing {status.env_var}"
             return f"{glyphs.warning} missing credentials"
         case ProviderAuthState.NOT_REQUIRED:
             return status.detail or "no API key required"

--- a/libs/code/tests/unit_tests/test_auth_display.py
+++ b/libs/code/tests/unit_tests/test_auth_display.py
@@ -56,7 +56,7 @@ _AUTH_STATUS_CASES = [
             env_var="ANTHROPIC_API_KEY",
         ),
         "[missing]",
-        f"{get_glyphs().warning} missing ANTHROPIC_API_KEY",
+        f"{get_glyphs().warning} missing credentials",
     ),
     (
         ProviderAuthStatus(

--- a/libs/code/tests/unit_tests/test_model_selector.py
+++ b/libs/code/tests/unit_tests/test_model_selector.py
@@ -1478,8 +1478,8 @@ class TestFormatAuthIndicator:
 
         assert indicator == "local provider"
 
-    def test_missing_auth_names_env_var(self) -> None:
-        """Missing credentials should show the missing env var name."""
+    def test_missing_auth_uses_generic_message(self) -> None:
+        """Missing credentials show a generic label, not the env var name."""
         indicator = ModelSelectorScreen._format_auth_indicator(
             ProviderAuthStatus(
                 state=ProviderAuthState.MISSING,
@@ -1489,7 +1489,8 @@ class TestFormatAuthIndicator:
             get_glyphs(),
         )
 
-        assert "missing ANTHROPIC_API_KEY" in indicator
+        assert "missing credentials" in indicator
+        assert "ANTHROPIC_API_KEY" not in indicator
 
     def test_missing_auth_without_env_var_uses_generic_message(self) -> None:
         """MISSING without env_var falls back to a generic missing-creds label."""


### PR DESCRIPTION
The model switcher now shows a generic "missing credentials" indicator instead of the specific environment variable name.

---

The `/model` switcher provider header — in both the regular selector and the onboarding flow — rendered the literal env var name as helper text (e.g. `missing ANTHROPIC_API_KEY`). This switches the `MISSING` auth indicator to the generic `missing credentials` label already used for providers without a named env var (e.g. `openai_codex`), keeping the indicator consistent and avoiding surfacing internal env var names.

Made by [Open SWE](https://openswe.vercel.app/agents/b2361e5f-76b9-ddc3-a948-49b8495c5b3a)