### PR TITLE
style(code): dim modal backdrop for notification center

### DIFF
--- a/libs/code/deepagents_code/widgets/notification_center.py
+++ b/libs/code/deepagents_code/widgets/notification_center.py
@@ -163,7 +163,6 @@ class NotificationCenterScreen(ModalScreen[NotificationActionResult | None]):
     CSS = """
     NotificationCenterScreen {
         align: center middle;
-        background: transparent;
     }
 
     NotificationCenterScreen > Vertical {

--- a/libs/code/tests/unit_tests/test_notification_center.py
+++ b/libs/code/tests/unit_tests/test_notification_center.py
@@ -58,6 +58,10 @@ def _update_entry() -> PendingNotification:
 class TestNotificationCenterScreen:
     """Drill-in behavior tests for the list-of-notifications modal."""
 
+    def test_uses_modal_backdrop(self) -> None:
+        """The center should keep Textual's dimmed modal backdrop."""
+        assert "background: transparent" not in NotificationCenterScreen.CSS
+
     async def test_renders_one_row_per_notification(self) -> None:
         """Each pending entry shows up as a single `_NotificationRow`."""
         app = App()


### PR DESCRIPTION
Fixed the `ctrl+n` notification center so it dims the background like other modals.

Made by [Open SWE](https://openswe.vercel.app/agents/d5972953-2e01-983d-9eb9-c83c64922ca8)