### PR TITLE
feat(evals): OOLONG long-context aggregation benchmark (plain vs code-interpreter)

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -840,6 +840,45 @@ contract.
 _ARTIFACT_KEY_RE = re.compile(r"[^a-zA-Z0-9._-]+")
 """Characters disallowed in GHA artifact names (model specs use `:` and `/`)."""
 
+OOLONG_ARMS = ("plain", "code_interpreter")
+"""Allowlisted OOLONG eval arms.
+
+Crossing the model matrix with these arms lets the OOLONG long-context
+aggregation eval run both configurations (subagents vs. code interpreter) as
+concurrent jobs, each its own LangSmith experiment. Values are validated
+against this allowlist before they reach `OOLONG_ARM` env / `--sub-model`
+plumbing in `_eval.yml`, so an arbitrary dispatch input can never flow
+unchecked into a shell step.
+"""
+
+
+def _resolve_oolong_arms(value: str) -> list[str] | None:
+    """Parse a comma-separated OOLONG arm selection into a validated list.
+
+    Args:
+        value: Raw `OOLONG_ARMS` env value (e.g. `"plain,code_interpreter"`).
+            Empty/whitespace means "no arm crossing".
+
+    Returns:
+        An order-preserving, deduped list of allowlisted arms, or ``None`` when
+        no arms are requested (the matrix is then built exactly as before —
+        no `arm` field, unchanged `artifact_key`).
+
+    Raises:
+        ValueError: If any requested arm is not in `OOLONG_ARMS`.
+    """
+    arms = [a.strip() for a in value.split(",") if a.strip()]
+    if not arms:
+        return None
+    invalid = [a for a in arms if a not in OOLONG_ARMS]
+    if invalid:
+        msg = (
+            f"Invalid OOLONG arm(s): {', '.join(repr(a) for a in invalid)}. "
+            f"Allowed: {', '.join(OOLONG_ARMS)}"
+        )
+        raise ValueError(msg)
+    return list(dict.fromkeys(arms))
+
 
 def _filter_by_tag(prefix: str, tag: str | None) -> list[str]:
     """Return model specs matching a tag filter, in REGISTRY order."""
@@ -895,16 +934,30 @@ def _artifact_key(model_spec: str) -> str:
     return _ARTIFACT_KEY_RE.sub("-", model_spec).strip("-")
 
 
-def _matrix_entry(model_spec: str) -> dict[str, str]:
-    """Build one GitHub Actions matrix entry for a model."""
-    return {
+def _matrix_entry(model_spec: str, arm: str | None = None) -> dict[str, str]:
+    """Build one GitHub Actions matrix entry for a model.
+
+    Args:
+        model_spec: The `provider:model` spec.
+        arm: Optional OOLONG arm. When given, it is appended to `artifact_key`
+            (keeping per-arm cache/artifact scopes distinct) and surfaced as an
+            `arm` field the per-provider job forwards to `_eval.yml`. When
+            ``None`` the entry is identical to the pre-OOLONG shape.
+    """
+    entry = {
         "model": model_spec,
         "provider": _provider(model_spec),
         "artifact_key": _artifact_key(model_spec),
     }
+    if arm is not None:
+        entry["artifact_key"] = f"{entry['artifact_key']}-{arm}"
+        entry["arm"] = arm
+    return entry
 
 
-def _matrix_outputs(workflow: str, models: list[str]) -> dict[str, object]:
+def _matrix_outputs(
+    workflow: str, models: list[str], arms: list[str] | None = None
+) -> dict[str, object]:
     """Build matrix outputs consumed by GitHub Actions workflows.
 
     The evals workflow needs one matrix per provider so each provider can use
@@ -917,11 +970,19 @@ def _matrix_outputs(workflow: str, models: list[str]) -> dict[str, object]:
     Args:
         workflow: "eval" or "harbor".
         models: Ordered model specs selected for the workflow.
+        arms: Optional OOLONG arms to cross with every model (e.g.
+            ``["plain", "code_interpreter"]``). ``None`` (the default) builds
+            the matrix exactly as before — one entry per model, no `arm`
+            field. When given, every model is crossed with every arm so the
+            arms run as concurrent jobs.
 
     Returns:
         Mapping of GitHub output names to JSON-serializable values.
     """
-    entries = [_matrix_entry(model) for model in models]
+    if arms:
+        entries = [_matrix_entry(model, arm) for model in models for arm in arms]
+    else:
+        entries = [_matrix_entry(model) for model in models]
     # Tripwire: `_resolve_models` dedupes raw specs, and our `provider:model`
     # convention plus the registry's canonical specs make it effectively
     # impossible for two distinct specs to collapse to the same slug. If this
@@ -1005,7 +1066,10 @@ def main() -> None:
     env_var, _ = _WORKFLOW_CONFIG[workflow]
     selection = os.environ.get(env_var, "all")
     models = _resolve_models(workflow, selection)
-    outputs = _matrix_outputs(workflow, models)
+    # OOLONG arm crossing is eval-only and opt-in: with `OOLONG_ARMS` unset the
+    # matrix is byte-identical to the pre-OOLONG shape.
+    arms = _resolve_oolong_arms(os.environ.get("OOLONG_ARMS", "")) if workflow == "eval" else None
+    outputs = _matrix_outputs(workflow, models, arms)
 
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:

--- a/.github/scripts/test_models.py
+++ b/.github/scripts/test_models.py
@@ -277,6 +277,152 @@ def test_matrix_outputs_rejects_three_way_collision(
     assert "foo:a:b" in msg
 
 
+# ---------------------------------------------------------------------------
+# OOLONG arm crossing
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_oolong_arms_empty_means_no_crossing(models: ModuleType) -> None:
+    """Empty / whitespace-only `OOLONG_ARMS` resolves to `None` (no crossing)."""
+    assert models._resolve_oolong_arms("") is None
+    assert models._resolve_oolong_arms("   ") is None
+    assert models._resolve_oolong_arms(" , ,") is None
+
+
+def test_resolve_oolong_arms_valid_and_deduped(models: ModuleType) -> None:
+    """Valid arms parse in order, trimmed and deduped."""
+    assert models._resolve_oolong_arms("plain") == ["plain"]
+    assert models._resolve_oolong_arms(" plain , code_interpreter ") == [
+        "plain",
+        "code_interpreter",
+    ]
+    assert models._resolve_oolong_arms("plain,plain,code_interpreter") == [
+        "plain",
+        "code_interpreter",
+    ]
+
+
+def test_resolve_oolong_arms_rejects_unknown(models: ModuleType) -> None:
+    """An arm outside the allowlist raises, naming the offender and the allowed set.
+
+    This is the injection guard: a dispatch input can never reach the
+    `OOLONG_ARM` env / `--sub-model` plumbing in `_eval.yml` unless it is one
+    of the literal allowlisted values.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        models._resolve_oolong_arms("plain,rm -rf /")
+    msg = str(excinfo.value)
+    assert "rm -rf /" in msg
+    assert "plain" in msg
+    assert "code_interpreter" in msg
+
+
+def test_matrix_entry_default_has_no_arm_field(models: ModuleType) -> None:
+    """Without an arm the entry shape is unchanged (no `arm`, unsuffixed key)."""
+    entry = models._matrix_entry("anthropic:claude-sonnet-4-6")
+    assert entry == {
+        "model": "anthropic:claude-sonnet-4-6",
+        "provider": "anthropic",
+        "artifact_key": "anthropic-claude-sonnet-4-6",
+    }
+    assert "arm" not in entry
+
+
+def test_matrix_entry_with_arm_suffixes_key(models: ModuleType) -> None:
+    """An arm is appended to `artifact_key` and surfaced as an `arm` field."""
+    entry = models._matrix_entry("openai:gpt-5", "code_interpreter")
+    assert entry == {
+        "model": "openai:gpt-5",
+        "provider": "openai",
+        "artifact_key": "openai-gpt-5-code_interpreter",
+        "arm": "code_interpreter",
+    }
+
+
+def test_matrix_outputs_crosses_models_with_arms(models: ModuleType) -> None:
+    """Passing arms crosses every model with every arm, partitioned by provider."""
+    outputs = models._matrix_outputs(
+        "eval",
+        ["anthropic:claude-sonnet-4-6", "openai:gpt-5"],
+        ["plain", "code_interpreter"],
+    )
+
+    assert outputs["anthropic_matrix"] == {
+        "include": [
+            {
+                "model": "anthropic:claude-sonnet-4-6",
+                "provider": "anthropic",
+                "artifact_key": "anthropic-claude-sonnet-4-6-plain",
+                "arm": "plain",
+            },
+            {
+                "model": "anthropic:claude-sonnet-4-6",
+                "provider": "anthropic",
+                "artifact_key": "anthropic-claude-sonnet-4-6-code_interpreter",
+                "arm": "code_interpreter",
+            },
+        ]
+    }
+    openai = outputs["openai_matrix"]["include"]
+    assert [e["arm"] for e in openai] == ["plain", "code_interpreter"]
+    # Per-arm artifact keys stay unique so caches / uploads don't collide.
+    keys = [e["artifact_key"] for e in outputs["matrix"]["include"]]
+    assert len(keys) == len(set(keys))
+
+
+def test_matrix_outputs_without_arms_is_unchanged(models: ModuleType) -> None:
+    """`arms=None` (and `[]`) leaves the matrix byte-identical to the legacy shape."""
+    baseline = models._matrix_outputs("eval", ["openai:gpt-5"])
+    assert models._matrix_outputs("eval", ["openai:gpt-5"], None) == baseline
+    assert models._matrix_outputs("eval", ["openai:gpt-5"], []) == baseline
+    assert "arm" not in baseline["openai_matrix"]["include"][0]
+
+
+def test_main_crosses_arms_from_env(
+    models: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`main()` reads `OOLONG_ARMS` and crosses the eval matrix with the arms."""
+    output_file = tmp_path / "github_output"
+    output_file.touch()
+
+    monkeypatch.setenv("EVAL_MODELS", "anthropic:claude-sonnet-4-6")
+    monkeypatch.setenv("OOLONG_ARMS", "plain,code_interpreter")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    monkeypatch.setattr("sys.argv", ["models.py", "eval"])
+
+    models.main()
+
+    keyed = dict(line.split("=", 1) for line in output_file.read_text().splitlines())
+    anthropic = json.loads(keyed["anthropic_matrix"])["include"]
+    assert [e["arm"] for e in anthropic] == ["plain", "code_interpreter"]
+    assert anthropic[0]["artifact_key"].endswith("-plain")
+
+
+def test_main_ignores_oolong_arms_for_harbor(
+    models: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Arm crossing is eval-only; harbor ignores `OOLONG_ARMS` entirely."""
+    output_file = tmp_path / "github_output"
+    output_file.touch()
+
+    monkeypatch.setenv("HARBOR_MODELS", "openai:gpt-5.4")
+    monkeypatch.setenv("OOLONG_ARMS", "plain,code_interpreter")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    monkeypatch.setattr("sys.argv", ["models.py", "harbor"])
+
+    models.main()
+
+    keyed = dict(line.split("=", 1) for line in output_file.read_text().splitlines())
+    matrix = json.loads(keyed["matrix"])["include"]
+    assert matrix == [
+        {"model": "openai:gpt-5.4", "provider": "openai", "artifact_key": "openai-gpt-5.4"}
+    ]
+
+
 def test_provider_returns_whole_string_when_no_colon(models: ModuleType) -> None:
     """`_provider` falls through cleanly when the spec lacks a `:` separator.
 

--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -86,6 +86,11 @@ on:
         required: false
         default: ""
         type: string
+      oolong_n_repeats:
+        description: "OOLONG repetitions per example (`OOLONG_N_REPEATS`). Empty = 1. Only used when `oolong_arm` is set."
+        required: false
+        default: ""
+        type: string
       oolong_dataset:
         description: "OOLONG input subset (`OOLONG_DATASET`), e.g. `agnews` or `trec_coarse`. Only used when `oolong_arm` is set."
         required: false
@@ -278,6 +283,7 @@ jobs:
           SUB_MODEL_IN: ${{ inputs.sub_model }}
           OOLONG_N_EXAMPLES_IN: ${{ inputs.oolong_n_examples }}
           OOLONG_CONTEXT_LEN_IN: ${{ inputs.oolong_context_len }}
+          OOLONG_N_REPEATS_IN: ${{ inputs.oolong_n_repeats }}
           OOLONG_DATASET_IN: ${{ inputs.oolong_dataset }}
           MODEL_IN: ${{ inputs.model }}
         run: |
@@ -305,7 +311,7 @@ jobs:
           fi
 
           # Numeric knobs: integers only (empty = use the test's default).
-          for pair in "OOLONG_N_EXAMPLES:${OOLONG_N_EXAMPLES_IN}" "OOLONG_CONTEXT_LEN:${OOLONG_CONTEXT_LEN_IN}"; do
+          for pair in "OOLONG_N_EXAMPLES:${OOLONG_N_EXAMPLES_IN}" "OOLONG_CONTEXT_LEN:${OOLONG_CONTEXT_LEN_IN}" "OOLONG_N_REPEATS:${OOLONG_N_REPEATS_IN}"; do
             val="${pair#*:}"
             name="${pair%%:*}"
             if [ -n "$val" ] && ! printf '%s' "$val" | grep -Eq '^[0-9]+$'; then
@@ -338,6 +344,7 @@ jobs:
             printf 'OOLONG_ARM=%s\n' "$OOLONG_ARM_IN"
             [ -n "$OOLONG_N_EXAMPLES_IN" ] && printf 'OOLONG_N_EXAMPLES=%s\n' "$OOLONG_N_EXAMPLES_IN"
             [ -n "$OOLONG_CONTEXT_LEN_IN" ] && printf 'OOLONG_CONTEXT_LEN=%s\n' "$OOLONG_CONTEXT_LEN_IN"
+            [ -n "$OOLONG_N_REPEATS_IN" ] && printf 'OOLONG_N_REPEATS=%s\n' "$OOLONG_N_REPEATS_IN"
             [ -n "$OOLONG_DATASET_IN" ] && printf 'OOLONG_DATASET=%s\n' "$OOLONG_DATASET_IN"
             # Log OOLONG experiments to the OSS LangSmith workspace.
             printf 'LANGSMITH_WORKSPACE_ID=495db4ef-0b85-4f00-8deb-326a2ec006ec\n'
@@ -347,7 +354,11 @@ jobs:
             printf 'LANGSMITH_EXPERIMENT=%s-oolong-%s-%s\n' "$MODEL_IN" "$OOLONG_ARM_IN" "$CTX_LABEL"
           } >> "$GITHUB_ENV"
 
-          printf 'PYTEST_ADDOPTS=%s --sub-model %s\n' "${PYTEST_ADDOPTS}" "$SUB_MODEL_IN" >> "$GITHUB_ENV"
+          # Per-test hang guard (pytest-timeout). The timeout covers the whole
+          # test item — i.e. ALL repetitions of one example — so it is generous
+          # (50 min): it kills a truly stuck run without nuking a legitimate
+          # slow rep-loop. The 6h job cap remains the overall backstop.
+          printf 'PYTEST_ADDOPTS=%s --sub-model %s --timeout=3000\n' "${PYTEST_ADDOPTS}" "$SUB_MODEL_IN" >> "$GITHUB_ENV"
 
       - name: "📊 Run Evals"
         env:

--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -354,11 +354,11 @@ jobs:
             printf 'LANGSMITH_EXPERIMENT=%s-oolong-%s-%s\n' "$MODEL_IN" "$OOLONG_ARM_IN" "$CTX_LABEL"
           } >> "$GITHUB_ENV"
 
-          # Per-test hang guard (pytest-timeout). The timeout covers the whole
-          # test item — i.e. ALL repetitions of one example — so it is generous
-          # (50 min): it kills a truly stuck run without nuking a legitimate
-          # slow rep-loop. The 6h job cap remains the overall backstop.
-          printf 'PYTEST_ADDOPTS=%s --sub-model %s --timeout=3000\n' "${PYTEST_ADDOPTS}" "$SUB_MODEL_IN" >> "$GITHUB_ENV"
+          # NOTE: no per-test pytest-timeout — that plugin isn't in the evals
+          # `test` dependency group, so `--timeout` is an unrecognized pytest
+          # arg and crashes the run. The 6h job cap + LangGraph recursion limits
+          # are the runaway backstops.
+          printf 'PYTEST_ADDOPTS=%s --sub-model %s\n' "${PYTEST_ADDOPTS}" "$SUB_MODEL_IN" >> "$GITHUB_ENV"
 
       - name: "📊 Run Evals"
         env:

--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -320,6 +320,17 @@ jobs:
             exit 1
           fi
 
+          # Human-readable context-length label for the experiment name
+          # (131072 -> 128k, 65536 -> 64k, 8192 -> 8k, else <n>tok). Empty input
+          # means the test default (8192).
+          CTX_RAW="${OOLONG_CONTEXT_LEN_IN:-8192}"
+          case "$CTX_RAW" in
+            131072) CTX_LABEL=128k ;;
+            65536)  CTX_LABEL=64k ;;
+            8192)   CTX_LABEL=8k ;;
+            *)      CTX_LABEL="${CTX_RAW}tok" ;;
+          esac
+
           # Select the arm + sub-model. `OOLONG_ARM` is read by the eval module
           # and by the reporter (which records arm + sub_model as experiment
           # metadata so both arms share one dataset example).
@@ -328,9 +339,12 @@ jobs:
             [ -n "$OOLONG_N_EXAMPLES_IN" ] && printf 'OOLONG_N_EXAMPLES=%s\n' "$OOLONG_N_EXAMPLES_IN"
             [ -n "$OOLONG_CONTEXT_LEN_IN" ] && printf 'OOLONG_CONTEXT_LEN=%s\n' "$OOLONG_CONTEXT_LEN_IN"
             [ -n "$OOLONG_DATASET_IN" ] && printf 'OOLONG_DATASET=%s\n' "$OOLONG_DATASET_IN"
-            # Distinct experiment per arm so the two arms don't share a session
-            # (they share the dataset example, not the experiment).
-            printf 'LANGSMITH_EXPERIMENT=%s-oolong-%s\n' "$MODEL_IN" "$OOLONG_ARM_IN"
+            # Log OOLONG experiments to the OSS LangSmith workspace.
+            printf 'LANGSMITH_WORKSPACE_ID=495db4ef-0b85-4f00-8deb-326a2ec006ec\n'
+            # Distinct experiment per (arm, context length) so runs don't collide
+            # and the size is visible in the name. The two arms still share the
+            # dataset example (same inputs), not the experiment.
+            printf 'LANGSMITH_EXPERIMENT=%s-oolong-%s-%s\n' "$MODEL_IN" "$OOLONG_ARM_IN" "$CTX_LABEL"
           } >> "$GITHUB_ENV"
 
           printf 'PYTEST_ADDOPTS=%s --sub-model %s\n' "${PYTEST_ADDOPTS}" "$SUB_MODEL_IN" >> "$GITHUB_ENV"

--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -66,6 +66,31 @@ on:
         required: false
         default: ""
         type: string
+      oolong_arm:
+        description: "OOLONG eval arm for this run (`plain` or `code_interpreter`). Empty = not an OOLONG run; the OOLONG-specific config below is ignored."
+        required: false
+        default: ""
+        type: string
+      sub_model:
+        description: "Sub-model id for OOLONG (`--sub-model`), e.g. `openai:gpt-5-mini`. Only used when `oolong_arm` is set."
+        required: false
+        default: ""
+        type: string
+      oolong_n_examples:
+        description: "OOLONG example count (`OOLONG_N_EXAMPLES`). `0` = full 50-task bucket. Only used when `oolong_arm` is set."
+        required: false
+        default: ""
+        type: string
+      oolong_context_len:
+        description: "OOLONG context-length bucket (`OOLONG_CONTEXT_LEN`). Only used when `oolong_arm` is set."
+        required: false
+        default: ""
+        type: string
+      oolong_dataset:
+        description: "OOLONG input subset (`OOLONG_DATASET`), e.g. `agnews` or `trec_coarse`. Only used when `oolong_arm` is set."
+        required: false
+        default: ""
+        type: string
     secrets:
       ANTHROPIC_API_KEY:
         required: false
@@ -237,6 +262,78 @@ jobs:
               ;;
           esac
           printf 'PYTEST_ADDOPTS=%s --repl %s\n' "${PYTEST_ADDOPTS}" "${repl}" >> "$GITHUB_ENV"
+
+      - name: "🐢 Apply OOLONG config"
+        # OOLONG long-context aggregation runs one arm per job (matching the
+        # one-experiment-per-arm requirement). The arm + sub-model + dataset
+        # knobs arrive as workflow_call inputs. All of them are user-influenced
+        # (they originate from a `workflow_dispatch` form), so each is read via
+        # an `env:` indirection — never inline `${{ }}` in the `run:` body — and
+        # structurally validated (allowlist / integer / safe-charset) before it
+        # is written to `$GITHUB_ENV` or appended to `PYTEST_ADDOPTS`. This
+        # prevents a crafted input from injecting shell or extra pytest flags.
+        if: inputs.oolong_arm != ''
+        env:
+          OOLONG_ARM_IN: ${{ inputs.oolong_arm }}
+          SUB_MODEL_IN: ${{ inputs.sub_model }}
+          OOLONG_N_EXAMPLES_IN: ${{ inputs.oolong_n_examples }}
+          OOLONG_CONTEXT_LEN_IN: ${{ inputs.oolong_context_len }}
+          OOLONG_DATASET_IN: ${{ inputs.oolong_dataset }}
+          MODEL_IN: ${{ inputs.model }}
+        run: |
+          set -euo pipefail
+
+          # Arm: allowlist. Keep in sync with `OOLONG_ARMS` in
+          # `.github/scripts/models.py` and the `Arm` literal in the eval module.
+          case "$OOLONG_ARM_IN" in
+            plain|code_interpreter) ;;
+            *)
+              echo "::error::Unsupported oolong_arm: '${OOLONG_ARM_IN}'. Allowed: plain, code_interpreter."
+              exit 1
+              ;;
+          esac
+
+          # Sub-model: must look like a `provider:model` spec. Same safe charset
+          # the matrix builder enforces for model specs.
+          if [ -z "$SUB_MODEL_IN" ]; then
+            echo "::error::oolong_arm is set but sub_model is empty; pass a --sub-model spec (e.g. openai:gpt-5-mini)."
+            exit 1
+          fi
+          if ! printf '%s' "$SUB_MODEL_IN" | grep -Eq '^[A-Za-z0-9._/:-]+$'; then
+            echo "::error::sub_model contains disallowed characters: '${SUB_MODEL_IN}'."
+            exit 1
+          fi
+
+          # Numeric knobs: integers only (empty = use the test's default).
+          for pair in "OOLONG_N_EXAMPLES:${OOLONG_N_EXAMPLES_IN}" "OOLONG_CONTEXT_LEN:${OOLONG_CONTEXT_LEN_IN}"; do
+            val="${pair#*:}"
+            name="${pair%%:*}"
+            if [ -n "$val" ] && ! printf '%s' "$val" | grep -Eq '^[0-9]+$'; then
+              echo "::error::${name} must be a non-negative integer, got '${val}'."
+              exit 1
+            fi
+          done
+
+          # Dataset subset: conservative identifier charset (empty = default).
+          if [ -n "$OOLONG_DATASET_IN" ] && ! printf '%s' "$OOLONG_DATASET_IN" | grep -Eq '^[A-Za-z0-9_-]+$'; then
+            echo "::error::oolong_dataset contains disallowed characters: '${OOLONG_DATASET_IN}'."
+            exit 1
+          fi
+
+          # Select the arm + sub-model. `OOLONG_ARM` is read by the eval module
+          # and by the reporter (which records arm + sub_model as experiment
+          # metadata so both arms share one dataset example).
+          {
+            printf 'OOLONG_ARM=%s\n' "$OOLONG_ARM_IN"
+            [ -n "$OOLONG_N_EXAMPLES_IN" ] && printf 'OOLONG_N_EXAMPLES=%s\n' "$OOLONG_N_EXAMPLES_IN"
+            [ -n "$OOLONG_CONTEXT_LEN_IN" ] && printf 'OOLONG_CONTEXT_LEN=%s\n' "$OOLONG_CONTEXT_LEN_IN"
+            [ -n "$OOLONG_DATASET_IN" ] && printf 'OOLONG_DATASET=%s\n' "$OOLONG_DATASET_IN"
+            # Distinct experiment per arm so the two arms don't share a session
+            # (they share the dataset example, not the experiment).
+            printf 'LANGSMITH_EXPERIMENT=%s-oolong-%s\n' "$MODEL_IN" "$OOLONG_ARM_IN"
+          } >> "$GITHUB_ENV"
+
+          printf 'PYTEST_ADDOPTS=%s --sub-model %s\n' "${PYTEST_ADDOPTS}" "$SUB_MODEL_IN" >> "$GITHUB_ENV"
 
       - name: "📊 Run Evals"
         env:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -274,6 +274,12 @@ on:
         required: false
         default: ""
         type: string
+      oolong_n_repeats:
+        description: "OOLONG repetitions per example (`OOLONG_N_REPEATS`, native
+          langsmith repetitions). Empty = 1. Only used when oolong_arms is set."
+        required: false
+        default: ""
+        type: string
       notes:
         description: "Free-text notes for this dispatch (e.g. hypothesis being tested,
           retry reason). Shown on the run summary; does not affect eval
@@ -654,6 +660,7 @@ jobs:
       oolong_n_examples: ${{ inputs.oolong_n_examples }}
       oolong_context_len: ${{ inputs.oolong_context_len }}
       oolong_dataset: ${{ inputs.oolong_dataset }}
+      oolong_n_repeats: ${{ inputs.oolong_n_repeats }}
     secrets: inherit
 
   eval-baseten:
@@ -685,6 +692,7 @@ jobs:
       oolong_n_examples: ${{ inputs.oolong_n_examples }}
       oolong_context_len: ${{ inputs.oolong_context_len }}
       oolong_dataset: ${{ inputs.oolong_dataset }}
+      oolong_n_repeats: ${{ inputs.oolong_n_repeats }}
     secrets: inherit
 
   eval-fireworks:
@@ -716,6 +724,7 @@ jobs:
       oolong_n_examples: ${{ inputs.oolong_n_examples }}
       oolong_context_len: ${{ inputs.oolong_context_len }}
       oolong_dataset: ${{ inputs.oolong_dataset }}
+      oolong_n_repeats: ${{ inputs.oolong_n_repeats }}
     secrets: inherit
 
   eval-google-genai:
@@ -747,6 +756,7 @@ jobs:
       oolong_n_examples: ${{ inputs.oolong_n_examples }}
       oolong_context_len: ${{ inputs.oolong_context_len }}
       oolong_dataset: ${{ inputs.oolong_dataset }}
+      oolong_n_repeats: ${{ inputs.oolong_n_repeats }}
     secrets: inherit
 
   eval-groq:
@@ -778,6 +788,7 @@ jobs:
       oolong_n_examples: ${{ inputs.oolong_n_examples }}
       oolong_context_len: ${{ inputs.oolong_context_len }}
       oolong_dataset: ${{ inputs.oolong_dataset }}
+      oolong_n_repeats: ${{ inputs.oolong_n_repeats }}
     secrets: inherit
 
   eval-nvidia:
@@ -809,6 +820,7 @@ jobs:
       oolong_n_examples: ${{ inputs.oolong_n_examples }}
       oolong_context_len: ${{ inputs.oolong_context_len }}
       oolong_dataset: ${{ inputs.oolong_dataset }}
+      oolong_n_repeats: ${{ inputs.oolong_n_repeats }}
     secrets: inherit
 
   eval-ollama:
@@ -840,6 +852,7 @@ jobs:
       oolong_n_examples: ${{ inputs.oolong_n_examples }}
       oolong_context_len: ${{ inputs.oolong_context_len }}
       oolong_dataset: ${{ inputs.oolong_dataset }}
+      oolong_n_repeats: ${{ inputs.oolong_n_repeats }}
     secrets: inherit
 
   eval-openai:
@@ -871,6 +884,7 @@ jobs:
       oolong_n_examples: ${{ inputs.oolong_n_examples }}
       oolong_context_len: ${{ inputs.oolong_context_len }}
       oolong_dataset: ${{ inputs.oolong_dataset }}
+      oolong_n_repeats: ${{ inputs.oolong_n_repeats }}
     secrets: inherit
 
   eval-openrouter:
@@ -902,6 +916,7 @@ jobs:
       oolong_n_examples: ${{ inputs.oolong_n_examples }}
       oolong_context_len: ${{ inputs.oolong_context_len }}
       oolong_dataset: ${{ inputs.oolong_dataset }}
+      oolong_n_repeats: ${{ inputs.oolong_n_repeats }}
     secrets: inherit
 
   eval-xai:
@@ -933,6 +948,7 @@ jobs:
       oolong_n_examples: ${{ inputs.oolong_n_examples }}
       oolong_context_len: ${{ inputs.oolong_context_len }}
       oolong_dataset: ${{ inputs.oolong_dataset }}
+      oolong_n_repeats: ${{ inputs.oolong_n_repeats }}
     secrets: inherit
 
   eval-other:
@@ -964,6 +980,7 @@ jobs:
       oolong_n_examples: ${{ inputs.oolong_n_examples }}
       oolong_context_len: ${{ inputs.oolong_context_len }}
       oolong_dataset: ${{ inputs.oolong_dataset }}
+      oolong_n_repeats: ${{ inputs.oolong_n_repeats }}
     secrets: inherit
 
   aggregate:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -71,6 +71,7 @@ on:
           - "anthropic:claude-opus-4-6"
           - "anthropic:claude-opus-4-7"
           - "baseten:zai-org/GLM-5"
+          - "baseten:zai-org/GLM-5.2"
           - "baseten:MiniMaxAI/MiniMax-M2.5"
           - "baseten:moonshotai/Kimi-K2.5"
           - "baseten:moonshotai/Kimi-K2.6"

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -234,6 +234,46 @@ on:
         options:
           - ""
           - quickjs
+      oolong_arms:
+        description: "OOLONG long-context aggregation: which arms to run. Each
+          arm is crossed with every selected model and runs as its own job /
+          experiment. Empty = not an OOLONG run. Forces
+          eval_categories=long_context_aggregation when set."
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - plain
+          - code_interpreter
+          - plain,code_interpreter
+      sub_model:
+        description: "OOLONG sub-model (`--sub-model`), the general-purpose
+          subagent that reads/classifies context chunks. Only used when
+          oolong_arms is set."
+        required: false
+        default: "openai:gpt-5-mini"
+        type: string
+      oolong_n_examples:
+        description: "OOLONG example count (`OOLONG_N_EXAMPLES`). `0` = full
+          50-task bucket. Empty = the test default (5). Only used when
+          oolong_arms is set."
+        required: false
+        default: ""
+        type: string
+      oolong_context_len:
+        description: "OOLONG context-length bucket (`OOLONG_CONTEXT_LEN`). Empty
+          = the test default (8192). Only used when oolong_arms is set."
+        required: false
+        default: ""
+        type: string
+      oolong_dataset:
+        description: "OOLONG input subset (`OOLONG_DATASET`), e.g. `agnews` or
+          `trec_coarse`. Empty = the test default (agnews). Only used when
+          oolong_arms is set."
+        required: false
+        default: ""
+        type: string
       notes:
         description: "Free-text notes for this dispatch (e.g. hypothesis being tested,
           retry reason). Shown on the run summary; does not affect eval
@@ -535,6 +575,11 @@ jobs:
         run: python .github/scripts/models.py eval
         env:
           EVAL_MODELS: ${{ inputs.models_override || inputs.models || 'all' }}
+          # When set, the builder crosses every model with each arm so the
+          # OOLONG arms run as concurrent jobs (each its own experiment).
+          # Empty leaves the matrix identical to a normal eval run. Validated
+          # against an allowlist inside `models.py`.
+          OOLONG_ARMS: ${{ inputs.oolong_arms }}
 
       - name: "🔖 Record resolved versions"
         # Versions are identical for every per-model job (same lockfile, same
@@ -593,7 +638,7 @@ jobs:
       model: ${{ matrix.model }}
       provider: ${{ matrix.provider }}
       artifact_key: ${{ matrix.artifact_key }}
-      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_categories: ${{ inputs.oolong_arms != '' && 'long_context_aggregation' || inputs.eval_categories_override || inputs.eval_categories }}
       eval_categories_exclude: ${{ inputs.eval_categories_exclude }}
       eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
       analyze_failures: ${{ inputs.analyze_failures }}
@@ -602,6 +647,13 @@ jobs:
       openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
+      # OOLONG: `matrix.arm` is only present when `oolong_arms` crossed the
+      # matrix (otherwise it renders empty and `_eval.yml` ignores the rest).
+      oolong_arm: ${{ matrix.arm }}
+      sub_model: ${{ inputs.sub_model }}
+      oolong_n_examples: ${{ inputs.oolong_n_examples }}
+      oolong_context_len: ${{ inputs.oolong_context_len }}
+      oolong_dataset: ${{ inputs.oolong_dataset }}
     secrets: inherit
 
   eval-baseten:
@@ -617,7 +669,7 @@ jobs:
       model: ${{ matrix.model }}
       provider: ${{ matrix.provider }}
       artifact_key: ${{ matrix.artifact_key }}
-      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_categories: ${{ inputs.oolong_arms != '' && 'long_context_aggregation' || inputs.eval_categories_override || inputs.eval_categories }}
       eval_categories_exclude: ${{ inputs.eval_categories_exclude }}
       eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
       analyze_failures: ${{ inputs.analyze_failures }}
@@ -626,6 +678,13 @@ jobs:
       openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
+      # OOLONG: `matrix.arm` is only present when `oolong_arms` crossed the
+      # matrix (otherwise it renders empty and `_eval.yml` ignores the rest).
+      oolong_arm: ${{ matrix.arm }}
+      sub_model: ${{ inputs.sub_model }}
+      oolong_n_examples: ${{ inputs.oolong_n_examples }}
+      oolong_context_len: ${{ inputs.oolong_context_len }}
+      oolong_dataset: ${{ inputs.oolong_dataset }}
     secrets: inherit
 
   eval-fireworks:
@@ -641,7 +700,7 @@ jobs:
       model: ${{ matrix.model }}
       provider: ${{ matrix.provider }}
       artifact_key: ${{ matrix.artifact_key }}
-      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_categories: ${{ inputs.oolong_arms != '' && 'long_context_aggregation' || inputs.eval_categories_override || inputs.eval_categories }}
       eval_categories_exclude: ${{ inputs.eval_categories_exclude }}
       eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
       analyze_failures: ${{ inputs.analyze_failures }}
@@ -650,6 +709,13 @@ jobs:
       openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
+      # OOLONG: `matrix.arm` is only present when `oolong_arms` crossed the
+      # matrix (otherwise it renders empty and `_eval.yml` ignores the rest).
+      oolong_arm: ${{ matrix.arm }}
+      sub_model: ${{ inputs.sub_model }}
+      oolong_n_examples: ${{ inputs.oolong_n_examples }}
+      oolong_context_len: ${{ inputs.oolong_context_len }}
+      oolong_dataset: ${{ inputs.oolong_dataset }}
     secrets: inherit
 
   eval-google-genai:
@@ -665,7 +731,7 @@ jobs:
       model: ${{ matrix.model }}
       provider: ${{ matrix.provider }}
       artifact_key: ${{ matrix.artifact_key }}
-      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_categories: ${{ inputs.oolong_arms != '' && 'long_context_aggregation' || inputs.eval_categories_override || inputs.eval_categories }}
       eval_categories_exclude: ${{ inputs.eval_categories_exclude }}
       eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
       analyze_failures: ${{ inputs.analyze_failures }}
@@ -674,6 +740,13 @@ jobs:
       openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
+      # OOLONG: `matrix.arm` is only present when `oolong_arms` crossed the
+      # matrix (otherwise it renders empty and `_eval.yml` ignores the rest).
+      oolong_arm: ${{ matrix.arm }}
+      sub_model: ${{ inputs.sub_model }}
+      oolong_n_examples: ${{ inputs.oolong_n_examples }}
+      oolong_context_len: ${{ inputs.oolong_context_len }}
+      oolong_dataset: ${{ inputs.oolong_dataset }}
     secrets: inherit
 
   eval-groq:
@@ -689,7 +762,7 @@ jobs:
       model: ${{ matrix.model }}
       provider: ${{ matrix.provider }}
       artifact_key: ${{ matrix.artifact_key }}
-      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_categories: ${{ inputs.oolong_arms != '' && 'long_context_aggregation' || inputs.eval_categories_override || inputs.eval_categories }}
       eval_categories_exclude: ${{ inputs.eval_categories_exclude }}
       eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
       analyze_failures: ${{ inputs.analyze_failures }}
@@ -698,6 +771,13 @@ jobs:
       openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
+      # OOLONG: `matrix.arm` is only present when `oolong_arms` crossed the
+      # matrix (otherwise it renders empty and `_eval.yml` ignores the rest).
+      oolong_arm: ${{ matrix.arm }}
+      sub_model: ${{ inputs.sub_model }}
+      oolong_n_examples: ${{ inputs.oolong_n_examples }}
+      oolong_context_len: ${{ inputs.oolong_context_len }}
+      oolong_dataset: ${{ inputs.oolong_dataset }}
     secrets: inherit
 
   eval-nvidia:
@@ -713,7 +793,7 @@ jobs:
       model: ${{ matrix.model }}
       provider: ${{ matrix.provider }}
       artifact_key: ${{ matrix.artifact_key }}
-      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_categories: ${{ inputs.oolong_arms != '' && 'long_context_aggregation' || inputs.eval_categories_override || inputs.eval_categories }}
       eval_categories_exclude: ${{ inputs.eval_categories_exclude }}
       eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
       analyze_failures: ${{ inputs.analyze_failures }}
@@ -722,6 +802,13 @@ jobs:
       openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
+      # OOLONG: `matrix.arm` is only present when `oolong_arms` crossed the
+      # matrix (otherwise it renders empty and `_eval.yml` ignores the rest).
+      oolong_arm: ${{ matrix.arm }}
+      sub_model: ${{ inputs.sub_model }}
+      oolong_n_examples: ${{ inputs.oolong_n_examples }}
+      oolong_context_len: ${{ inputs.oolong_context_len }}
+      oolong_dataset: ${{ inputs.oolong_dataset }}
     secrets: inherit
 
   eval-ollama:
@@ -737,7 +824,7 @@ jobs:
       model: ${{ matrix.model }}
       provider: ${{ matrix.provider }}
       artifact_key: ${{ matrix.artifact_key }}
-      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_categories: ${{ inputs.oolong_arms != '' && 'long_context_aggregation' || inputs.eval_categories_override || inputs.eval_categories }}
       eval_categories_exclude: ${{ inputs.eval_categories_exclude }}
       eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
       analyze_failures: ${{ inputs.analyze_failures }}
@@ -746,6 +833,13 @@ jobs:
       openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
+      # OOLONG: `matrix.arm` is only present when `oolong_arms` crossed the
+      # matrix (otherwise it renders empty and `_eval.yml` ignores the rest).
+      oolong_arm: ${{ matrix.arm }}
+      sub_model: ${{ inputs.sub_model }}
+      oolong_n_examples: ${{ inputs.oolong_n_examples }}
+      oolong_context_len: ${{ inputs.oolong_context_len }}
+      oolong_dataset: ${{ inputs.oolong_dataset }}
     secrets: inherit
 
   eval-openai:
@@ -761,7 +855,7 @@ jobs:
       model: ${{ matrix.model }}
       provider: ${{ matrix.provider }}
       artifact_key: ${{ matrix.artifact_key }}
-      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_categories: ${{ inputs.oolong_arms != '' && 'long_context_aggregation' || inputs.eval_categories_override || inputs.eval_categories }}
       eval_categories_exclude: ${{ inputs.eval_categories_exclude }}
       eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
       analyze_failures: ${{ inputs.analyze_failures }}
@@ -770,6 +864,13 @@ jobs:
       openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
+      # OOLONG: `matrix.arm` is only present when `oolong_arms` crossed the
+      # matrix (otherwise it renders empty and `_eval.yml` ignores the rest).
+      oolong_arm: ${{ matrix.arm }}
+      sub_model: ${{ inputs.sub_model }}
+      oolong_n_examples: ${{ inputs.oolong_n_examples }}
+      oolong_context_len: ${{ inputs.oolong_context_len }}
+      oolong_dataset: ${{ inputs.oolong_dataset }}
     secrets: inherit
 
   eval-openrouter:
@@ -785,7 +886,7 @@ jobs:
       model: ${{ matrix.model }}
       provider: ${{ matrix.provider }}
       artifact_key: ${{ matrix.artifact_key }}
-      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_categories: ${{ inputs.oolong_arms != '' && 'long_context_aggregation' || inputs.eval_categories_override || inputs.eval_categories }}
       eval_categories_exclude: ${{ inputs.eval_categories_exclude }}
       eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
       analyze_failures: ${{ inputs.analyze_failures }}
@@ -794,6 +895,13 @@ jobs:
       openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
+      # OOLONG: `matrix.arm` is only present when `oolong_arms` crossed the
+      # matrix (otherwise it renders empty and `_eval.yml` ignores the rest).
+      oolong_arm: ${{ matrix.arm }}
+      sub_model: ${{ inputs.sub_model }}
+      oolong_n_examples: ${{ inputs.oolong_n_examples }}
+      oolong_context_len: ${{ inputs.oolong_context_len }}
+      oolong_dataset: ${{ inputs.oolong_dataset }}
     secrets: inherit
 
   eval-xai:
@@ -809,7 +917,7 @@ jobs:
       model: ${{ matrix.model }}
       provider: ${{ matrix.provider }}
       artifact_key: ${{ matrix.artifact_key }}
-      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_categories: ${{ inputs.oolong_arms != '' && 'long_context_aggregation' || inputs.eval_categories_override || inputs.eval_categories }}
       eval_categories_exclude: ${{ inputs.eval_categories_exclude }}
       eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
       analyze_failures: ${{ inputs.analyze_failures }}
@@ -818,6 +926,13 @@ jobs:
       openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
+      # OOLONG: `matrix.arm` is only present when `oolong_arms` crossed the
+      # matrix (otherwise it renders empty and `_eval.yml` ignores the rest).
+      oolong_arm: ${{ matrix.arm }}
+      sub_model: ${{ inputs.sub_model }}
+      oolong_n_examples: ${{ inputs.oolong_n_examples }}
+      oolong_context_len: ${{ inputs.oolong_context_len }}
+      oolong_dataset: ${{ inputs.oolong_dataset }}
     secrets: inherit
 
   eval-other:
@@ -833,7 +948,7 @@ jobs:
       model: ${{ matrix.model }}
       provider: ${{ matrix.provider }}
       artifact_key: ${{ matrix.artifact_key }}
-      eval_categories: ${{ inputs.eval_categories_override || inputs.eval_categories }}
+      eval_categories: ${{ inputs.oolong_arms != '' && 'long_context_aggregation' || inputs.eval_categories_override || inputs.eval_categories }}
       eval_categories_exclude: ${{ inputs.eval_categories_exclude }}
       eval_tiers: ${{ inputs.eval_tiers_override || inputs.eval_tiers }}
       analyze_failures: ${{ inputs.analyze_failures }}
@@ -842,6 +957,13 @@ jobs:
       openrouter_allow_fallbacks: ${{ inputs.openrouter_allow_fallbacks }}
       openai_reasoning_effort: ${{ inputs.openai_reasoning_effort }}
       repl: ${{ inputs.repl }}
+      # OOLONG: `matrix.arm` is only present when `oolong_arms` crossed the
+      # matrix (otherwise it renders empty and `_eval.yml` ignores the rest).
+      oolong_arm: ${{ matrix.arm }}
+      sub_model: ${{ inputs.sub_model }}
+      oolong_n_examples: ${{ inputs.oolong_n_examples }}
+      oolong_context_len: ${{ inputs.oolong_context_len }}
+      oolong_dataset: ${{ inputs.oolong_dataset }}
     secrets: inherit
 
   aggregate:

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -7,10 +7,10 @@ Source of truth: [`tests/evals/`](tests/evals/).
 Categories (for `--eval-category` filtering):
 
 ```txt
-file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,langchain/middleware
+file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,langchain/middleware,long_context_aggregation
 ```
 
-**118 evals** across **8 categories**
+**119 evals** across **9 categories**
 
 ## File Ops (`file_operations`) (13 evals)
 
@@ -153,3 +153,7 @@ file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,l
 - [`test_design_api_lands_in_final_message`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L283) — `tests/evals/test_langchain_middleware_todo.py:283`
 - [`test_density_cairo_lands_in_final_message`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L321) — `tests/evals/test_langchain_middleware_todo.py:321`
 - [`test_trivial_plan_skips_write_todos`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L355) — `tests/evals/test_langchain_middleware_todo.py:355`
+
+## Long-Context Aggregation (`long_context_aggregation`) (1 eval)
+
+- [`test_oolong_synth`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py#L70) — `tests/evals/test_oolong_rlm_vs_subagents.py:70`

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -156,4 +156,4 @@ file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,l
 
 ## Long-Context Aggregation (`long_context_aggregation`) (1 eval)
 
-- [`test_oolong_synth`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py#L70) — `tests/evals/test_oolong_rlm_vs_subagents.py:70`
+- [`test_oolong_synth`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py#L82) — `tests/evals/test_oolong_rlm_vs_subagents.py:82`

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -156,4 +156,4 @@ file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,l
 
 ## Long-Context Aggregation (`long_context_aggregation`) (1 eval)
 
-- [`test_oolong_synth`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py#L82) — `tests/evals/test_oolong_rlm_vs_subagents.py:82`
+- [`test_oolong_synth`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py#L92) — `tests/evals/test_oolong_rlm_vs_subagents.py:92`

--- a/libs/evals/deepagents_evals/categories.json
+++ b/libs/evals/deepagents_evals/categories.json
@@ -7,7 +7,8 @@
     "conversation",
     "summarization",
     "unit_test",
-    "langchain/middleware"
+    "langchain/middleware",
+    "long_context_aggregation"
   ],
   "radar_categories": [
     "file_operations",
@@ -25,6 +26,7 @@
     "conversation": "Conversation",
     "summarization": "Summarization",
     "unit_test": "Unit Test",
-    "langchain/middleware": "Upstream Middleware"
+    "langchain/middleware": "Upstream Middleware",
+    "long_context_aggregation": "Long-Context Aggregation"
   }
 }

--- a/libs/evals/tests/evals/conftest.py
+++ b/libs/evals/tests/evals/conftest.py
@@ -131,6 +131,18 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=None,
         help="Optional REPL middleware for tests marked with @pytest.mark.repl. If omitted, those tests bind their tools directly instead of routing through a REPL.",
     )
+    parser.addoption(
+        "--sub-model",
+        action="store",
+        default="openai:gpt-5-mini",
+        help=(
+            "Sub-model id for tests that use recursive / sub-LLM calls "
+            "(e.g. the OOLONG RLM-vs-subagents eval). Used as the model "
+            "behind the `llm()` REPL callable in the RLM arm and the "
+            "general-purpose subagent in the subagents arm. Defaults to "
+            "`openai:gpt-5-mini`, matching the RLM paper."
+        ),
+    )
 
 
 def _filter_by_marker(
@@ -277,3 +289,24 @@ def model(model_name: str, request: pytest.FixtureRequest) -> BaseChatModel:
             raise ValueError(msg)
         kwargs["reasoning_effort"] = reasoning_effort
     return init_chat_model(model_name, **kwargs)
+
+
+@pytest.fixture
+def sub_model_name(request: pytest.FixtureRequest) -> str:
+    """The `provider:model` id used for recursive / sub-LLM calls."""
+    return str(request.config.getoption("--sub-model"))
+
+
+@pytest.fixture
+def sub_model(sub_model_name: str) -> BaseChatModel:
+    """Pre-built chat model for sub-LLM calls.
+
+    Mirrors the minimal subset of provider-specific kwargs the `model`
+    fixture applies — currently just the OpenAI Responses-API toggle.
+    Sub-model usage doesn't go through the OpenRouter allowlist or
+    reasoning-effort options, so we don't replicate those here.
+    """
+    kwargs: dict[str, Any] = {}
+    if sub_model_name.startswith("openai:"):
+        kwargs["use_responses_api"] = True
+    return init_chat_model(sub_model_name, **kwargs)

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -291,11 +291,78 @@ def _oolong_score(text: str, gold_answers: tuple[str, ...], answer_type: str) ->
 # Agent factories
 # ---------------------------------------------------------------------------
 
-_PLAIN_SYSTEM_PROMPT = (
+_PLAIN_BASE_PROMPT = (
     "You are a helpful assistant. "
     "The document you need to analyze is at `/context.txt` in your workspace. "
     "Use the task tool to delegate parts of the analysis to subagents."
 )
+
+#: Orchestration-style plain prompt mirroring the code-interpreter guidance, but
+#: without a REPL — the final aggregation is done by the model. Select with
+#: OOLONG_PLAIN_PROMPT={base,orchestrate}.
+_PLAIN_ORCHESTRATE_PROMPT = (
+    "You are a precise data analyst. The document to analyze is at `/context.txt`.\n"
+    "\n"
+    "1. UNDERSTAND: read the header plus a few lines of `/context.txt` to learn its format and "
+    "how many data lines it has. Do not read or analyze the whole document yourself — it is "
+    "too large to do accurately in one pass.\n"
+    "2. DELEGATE: split the data lines into contiguous chunks (~40-60 lines each) and dispatch "
+    "the chunks to `general-purpose` subagents *in parallel* — emit several `task` tool calls "
+    "in the same turn. Each `task` tells its subagent the exact line range to read and to "
+    "return the structured per-chunk result the question needs (e.g. the count of each label "
+    "within that range, or the relevant per-line fields). Each subagent must process every "
+    "line in its range exactly — no skipping or estimating.\n"
+    "3. AGGREGATE: combine the per-chunk results yourself — sum the per-chunk counts across all "
+    "chunks, then compute the final answer. Add the chunk numbers carefully and double-check "
+    "the arithmetic. Finish by stating the final answer in the exact format the question "
+    "requests."
+)
+
+#: Minimal plain prompt: point at the file, nothing else — let the model decide
+#: how to use its tools (subagents). For faithful, low-scaffolding comparison.
+_PLAIN_MINIMAL_PROMPT = (
+    "You are a helpful assistant. The document to analyze is at `/context.txt` in your "
+    "workspace. Answer the question."
+)
+
+#: Optimized plain prompt — the architecture-appropriate counterpart to the
+#: optimized RLM prompt: anti-refusal + decompose, field-complete extraction,
+#: restate-as-spec. (Plain has no REPL, so the model aggregates instead of code.)
+_PLAIN_OPTIMIZED_PROMPT = (
+    "You are a precise data analyst. The document is at `/context.txt`; each data line is "
+    "`Date: <date> || User: <id> || Instance: <article text>`.\n"
+    "\n"
+    "You CAN answer this exactly — never refuse or say it is impossible. Decompose it:\n"
+    "1. Read the header plus a few lines to learn the format and the exact number of data lines.\n"
+    "2. Restate the question as a spec: target field (label / user / date), filters (a specific "
+    "user? a date range? only instances of a given label?), and operation (count / most / least "
+    "/ second / compare / numeric). Apply EVERY constraint.\n"
+    "3. Delegate contiguous line ranges to `general-purpose` subagents IN PARALLEL (emit several "
+    "`task` calls in one turn); each returns, for every line in its range, the verbatim date, "
+    "verbatim user, and inferred label.\n"
+    "4. Combine the per-line results yourself and compute the answer applying the full spec; sum "
+    "carefully, double-check the arithmetic, and confirm your answer satisfies the operation. "
+    "State the final answer in the exact format the question requests."
+)
+
+_PLAIN_PROMPTS: dict[str, str] = {
+    "base": _PLAIN_BASE_PROMPT,
+    "orchestrate": _PLAIN_ORCHESTRATE_PROMPT,
+    "minimal": _PLAIN_MINIMAL_PROMPT,
+    "optimized": _PLAIN_OPTIMIZED_PROMPT,
+}
+
+
+def _plain_prompt() -> str:
+    """Select the plain-arm system prompt via OOLONG_PLAIN_PROMPT.
+
+    Options: {minimal,base,orchestrate,optimized}. Defaults to ``minimal`` — the
+    symmetric, low-scaffolding prompt used for the fair plain-vs-RLM comparison.
+    """
+    return _PLAIN_PROMPTS.get(
+        os.environ.get("OOLONG_PLAIN_PROMPT", "minimal"), _PLAIN_MINIMAL_PROMPT
+    )
+
 
 _CODE_INTERPRETER_SYSTEM_PROMPT = (
     "You are a precise data analyst. The document to analyze is at `/context.txt`.\n"
@@ -323,6 +390,64 @@ _CODE_INTERPRETER_SYSTEM_PROMPT = (
     "re-dispatch subagents for missing/duplicate lines — if a few lines are missing, just "
     "aggregate what you have. One round keeps latency bounded."
 )
+
+#: Minimal code-interpreter prompt: point at the file + tools, and keep ONLY the
+#: single-round fan-out instruction (that controls latency, not accuracy). No
+#: prescribed chunk size / schema / aggregation recipe.
+_CODE_INTERPRETER_MINIMAL_PROMPT = (
+    "You are a helpful assistant. The document to analyze is at `/context.txt` in your "
+    "workspace. Use the `eval` REPL and `task` subagents to analyze it and answer the "
+    "question.\n"
+    "To keep latency bounded, do the work in a single fan-out round: one `Promise.all` of "
+    "`task(...)` calls over contiguous chunks of the document, then combine the results in "
+    "the REPL. Avoid validation/repair re-dispatch rounds."
+)
+
+#: Optimized code-interpreter prompt (prompt-only fixes from the 128k trace
+#: analysis): field-complete per-line extraction, restate-question-as-spec so no
+#: constraint is dropped, and aggregate+self-verify in JS.
+_CODE_INTERPRETER_OPTIMIZED_PROMPT = (
+    "You are a precise data analyst. The document is at `/context.txt`; each data line is "
+    "`Date: <date> || User: <id> || Instance: <article text>`.\n"
+    "\n"
+    "1. UNDERSTAND: read the header plus a few lines to learn the format and the EXACT number "
+    "of data lines.\n"
+    "2. RESTATE THE QUESTION AS A SPEC before coding — the target field (label / user / date), "
+    "the filters (a specific user? a date range? only instances of a given label?), and the "
+    "operation (count / most / least / second / compare / numeric). You MUST apply every "
+    "constraint in the question; do not drop a qualifier.\n"
+    "3. EXTRACT in a SINGLE fan-out round: split the data lines into contiguous chunks sized so "
+    "all chunks run in one `Promise.all` wave (about total_lines / 30 lines per chunk; never "
+    "read past the real line count). Each `task` has its subagent read its exact range and "
+    "return, FOR EVERY line, a record with: line number, the verbatim `date`, the verbatim "
+    "`user`, and the inferred topic `label`. Always capture all four fields, even if the "
+    "question seems to need only one — that lets you apply any filter in code.\n"
+    "4. AGGREGATE IN JAVASCRIPT and VERIFY: concatenate all per-line records and compute the "
+    "answer with code that applies the full spec from step 2. Assert that every line is covered "
+    "exactly once, that the label counts sum to the line count, and that the value you return "
+    "actually satisfies the operation (e.g. it is the argmin/argmax you intended, not second "
+    "place). Never let a subagent compute the final aggregate; do not run repair re-dispatch "
+    "rounds.\n"
+    "Finish by stating the final answer in the exact format the question requests."
+)
+
+_CODE_INTERPRETER_PROMPTS: dict[str, str] = {
+    "minimal": _CODE_INTERPRETER_MINIMAL_PROMPT,
+    "orchestrate": _CODE_INTERPRETER_SYSTEM_PROMPT,
+    "optimized": _CODE_INTERPRETER_OPTIMIZED_PROMPT,
+}
+
+
+def _code_interpreter_prompt() -> str:
+    """Select the orchestrator prompt via OOLONG_CI_ORCH={minimal,orchestrate,optimized}.
+
+    Defaults to ``minimal`` — the symmetric, low-scaffolding prompt used for the
+    fair plain-vs-RLM comparison.
+    """
+    return _CODE_INTERPRETER_PROMPTS.get(
+        os.environ.get("OOLONG_CI_ORCH", "minimal"), _CODE_INTERPRETER_MINIMAL_PROMPT
+    )
+
 
 _SUBAGENT_SYSTEM_PROMPT = (
     "You analyze one assigned range of /context.txt. "
@@ -357,7 +482,7 @@ def build_agent(
     if arm == "plain":
         agent = create_deep_agent(
             model=root_model,
-            system_prompt=_PLAIN_SYSTEM_PROMPT,
+            system_prompt=_plain_prompt(),
             subagents=subagent_cfg,
         )
         return agent, {"/context.txt": context}
@@ -365,7 +490,7 @@ def build_agent(
     if arm == "code_interpreter":
         agent = create_deep_agent(
             model=root_model,
-            system_prompt=_CODE_INTERPRETER_SYSTEM_PROMPT,
+            system_prompt=_code_interpreter_prompt(),
             # Long timeout: a single `eval` awaits a Promise.all of `task()`
             # subagent dispatches, which take much longer than the 5s default.
             middleware=[CodeInterpreterMiddleware(timeout=600.0)],

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -263,9 +263,12 @@ def _oolong_score(text: str, gold_answers: tuple[str, ...], answer_type: str) ->
         if upper.endswith("DATE"):
             try:
                 parsed_dt = dateutil.parser.parse(candidate)
-                if parsed_dt == gold:
+                # Compare calendar dates: gold is tz-aware (UTC) while a parsed
+                # candidate is naive, so a direct datetime `==` is always False.
+                gold_date = gold.date() if hasattr(gold, "date") else gold
+                if parsed_dt.date() == gold_date:
                     return 1.0
-            except (ValueError, OverflowError):
+            except (ValueError, OverflowError, TypeError):
                 pass
             continue
 
@@ -295,9 +298,40 @@ _PLAIN_SYSTEM_PROMPT = (
 )
 
 _CODE_INTERPRETER_SYSTEM_PROMPT = (
-    "You are a helpful assistant. "
-    "The document you need to analyze is at `/context.txt` in your workspace. "
-    "Use the eval and task tools to analyze the document."
+    "You are a precise data analyst. The document to analyze is at `/context.txt`.\n"
+    "\n"
+    "Work in two phases:\n"
+    "1. UNDERSTAND: read enough of `/context.txt` (the header plus a few lines) to "
+    "learn its exact format and how many data lines it has. Do not try to read or "
+    "classify the whole document yourself — it is too large to do accurately in one pass.\n"
+    "2. ORCHESTRATE IN THE REPL: do ALL of the heavy work inside a single `eval` program. "
+    "Split the data lines into contiguous chunks (~40-60 lines each) and fan the chunks out "
+    "to `general-purpose` subagents *in parallel* with `Promise.all([...])` of `task(...)` "
+    "calls. Each `task` tells its subagent the exact line range to read from `/context.txt` "
+    "and uses a `responseSchema` so it returns structured per-line results (e.g. the label "
+    "for each line in its range). Subagents read their own range with `read_file`.\n"
+    "\n"
+    "Then AGGREGATE deterministically in JavaScript: concatenate the per-line results from "
+    "all chunks and compute the answer with code (count labels, take the min/max, etc.). "
+    "Never ask one subagent to process the whole document, and never let a subagent return "
+    "the final aggregate — the counting and the final computation must happen in your "
+    "JavaScript so they are exact. Finish by stating the final answer in the exact format "
+    "the question requests.\n"
+    "\n"
+    "Keep the orchestration to a SINGLE fan-out round: one `Promise.all` of `task` calls over "
+    "fixed contiguous chunks, then aggregate. Do NOT run validation-and-repair passes or "
+    "re-dispatch subagents for missing/duplicate lines — if a few lines are missing, just "
+    "aggregate what you have. One round keeps latency bounded."
+)
+
+_SUBAGENT_SYSTEM_PROMPT = (
+    "You analyze one assigned range of /context.txt. "
+    "Read the ENTIRE assigned line range with read_file (paginate with "
+    "offset/limit if needed), then process every line in the range — do not "
+    "skip, sample, or approximate. Return exactly the structured per-line "
+    "result the task asks for (one entry per data line in your range). "
+    "Do not compute aggregates or totals; return the raw per-line data so the "
+    "caller can aggregate. Do not delegate further."
 )
 
 
@@ -314,13 +348,8 @@ def build_agent(
     subagent_cfg: list[SubAgent] = [
         {
             "name": "general-purpose",
-            "description": "Reads a range of /context.txt and extracts facts as directed.",
-            "system_prompt": (
-                "You are a helpful assistant. "
-                "Read the assigned range of /context.txt using read_file, "
-                "extract the requested facts, and return concise results. "
-                "Do not delegate further."
-            ),
+            "description": "Reads a range of /context.txt and extracts per-line facts as directed.",
+            "system_prompt": _SUBAGENT_SYSTEM_PROMPT,
             "model": sub_model_id,
         }
     ]
@@ -337,7 +366,9 @@ def build_agent(
         agent = create_deep_agent(
             model=root_model,
             system_prompt=_CODE_INTERPRETER_SYSTEM_PROMPT,
-            middleware=[CodeInterpreterMiddleware()],
+            # Long timeout: a single `eval` awaits a Promise.all of `task()`
+            # subagent dispatches, which take much longer than the 5s default.
+            middleware=[CodeInterpreterMiddleware(timeout=600.0)],
             subagents=subagent_cfg,
         )
         return agent, {"/context.txt": context}

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -28,8 +28,8 @@ parameterizes over (arm, example) pairs.
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
+from datetime import UTC
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -44,6 +44,7 @@ from tests.evals.utils import (
 )
 
 if TYPE_CHECKING:
+    from deepagents.middleware.subagents import SubAgent
     from langchain_core.language_models import BaseChatModel
     from langgraph.graph.state import CompiledStateGraph
 
@@ -186,97 +187,118 @@ def _coerce_gold(raw: Any) -> tuple[str, ...]:  # noqa: ANN401
 
 
 # ---------------------------------------------------------------------------
-# Scoring
+# Scoring — adapted from abertsch72/oolong src/eval/eval_helpers.py
 # ---------------------------------------------------------------------------
 
-# Labels in OOLONG can contain `/` (e.g. agnews "Sci/Tech") and digits
-# (rare). Capture everything up to a comma, period, newline, or end of
-# string to avoid truncating multi-token labels.
-_LABEL_RE = re.compile(r"Label\s*:\s*([^\n.,;]+?)\s*(?:[.,;\n]|$)", re.IGNORECASE)
-_USER_RE = re.compile(r"User\s*:\s*\[?(\d+)\]?", re.IGNORECASE)
-_NUMBER_RE = re.compile(r"Answer\s*:\s*\[?(-?\d+(?:\.\d+)?)\]?", re.IGNORECASE)
-_MONTH_YEAR_RE = re.compile(
-    r"Answer\s*:\s*([A-Za-z]+\s+\d{4})",
-    re.IGNORECASE,
-)
-# COMPARISON: extract the direction phrase regardless of how many words the
-# subject has (e.g. "numeric value is less common than entity").
-_COMPARISON_RE = re.compile(
-    r"\b((?:more|less)\s+common\s+than|equally\s+common)\b",
-    re.IGNORECASE,
-)
-# DATE: match MM/DD/YYYY or YYYY-MM-DD in the model's answer
-_DATE_MDY_RE = re.compile(r"\b(\d{1,2})/(\d{1,2})/(\d{4})\b")
-_DATE_ISO_RE = re.compile(r"\b(\d{4})-(\d{2})-(\d{2})\b")
-# Gold DATE is stored as e.g. "datetime.date(2023, 2, 6)"
-_GOLD_DATE_RE = re.compile(r"datetime\.date\((\d+),\s*(\d+),\s*(\d+)\)")
+
+def _parse_answer(text: str) -> str:
+    """Extract the candidate answer from a model response.
+
+    Mirrors ``synth_attempt_answer_parse`` from the official OOLONG harness:
+    split on ``:``, take the last segment, strip markdown decorators.
+    """
+    if ":" not in text:
+        return (text if len(text) < 20 else text.rsplit(maxsplit=1)[-1]).strip()
+    candidate = text.rsplit(":", maxsplit=1)[-1].strip()
+    candidate = candidate.replace("*", "").replace("[", "").replace("]", "")
+    return candidate.strip()
 
 
-def _extract_answer(text: str, answer_type: str) -> str | None:
-    """Pull the formatted answer out of the model's free-form response."""
+def _parse_gold(gold: str, answer_type: str) -> object:
+    """Parse the dataset's gold answer into a comparable Python value."""
+    import ast  # noqa: PLC0415
+
     upper = answer_type.upper()
-    if upper.endswith("LABEL"):
-        m = _LABEL_RE.search(text)
-        return m.group(1).lower() if m else None
-    if upper.endswith("USER"):
-        m = _USER_RE.search(text)
-        return m.group(1) if m else None
-    if upper.endswith("NUMERIC"):
-        m = _NUMBER_RE.search(text)
-        return m.group(1) if m else None
-    if upper.endswith("MONTH_YEAR"):
-        m = _MONTH_YEAR_RE.search(text)
-        return m.group(1).strip().lower() if m else None
-    if upper.endswith("COMPARISON"):
-        m = _COMPARISON_RE.search(text)
-        return m.group(1).strip().lower() if m else None
     if upper.endswith("DATE"):
-        m = _DATE_MDY_RE.search(text)
-        if m:
-            return f"{int(m.group(1)):02d}/{int(m.group(2)):02d}/{m.group(3)}"
-        m = _DATE_ISO_RE.search(text)
-        if m:
-            return f"{int(m.group(2)):02d}/{int(m.group(3)):02d}/{m.group(1)}"
-        return None
-    return None
+        from datetime import datetime  # noqa: PLC0415
+
+        try:
+            return datetime.strptime(gold, "[datetime.date(%Y, %m, %d)]").replace(tzinfo=UTC)
+        except ValueError:
+            return gold
+    try:
+        parsed = ast.literal_eval(gold)
+        return parsed[0] if isinstance(parsed, list) else parsed
+    except (ValueError, SyntaxError):
+        return gold
 
 
-def _normalize_gold(gold: str, answer_type: str) -> str:
-    """Mirror the normalization applied to the extracted answer."""
+def _oolong_score(text: str, gold_answers: tuple[str, ...], answer_type: str) -> float:
+    """Score a model response against gold, returning 0.0-1.0.
+
+    Follows the official OOLONG scoring from ``synth_process_response``:
+    - Exact string match for most types.
+    - COMPARISON: substring check for "more common"/"less common"/"same frequency".
+    - NUMERIC: partial credit ``0.75 ** abs(gold - pred)``.
+    - DATE: flexible parse via ``dateutil`` then exact equality.
+    """
+    import dateutil.parser  # noqa: PLC0415
+
+    candidate = _parse_answer(text)
     upper = answer_type.upper()
-    g = gold.strip()
-    if upper.endswith("DATE"):
-        # Gold is stored as "datetime.date(YYYY, M, D)" or "[datetime.date(...)]"
-        m = _GOLD_DATE_RE.search(g)
-        if m:
-            return f"{int(m.group(2)):02d}/{int(m.group(3)):02d}/{m.group(1)}"
-        return g.lower()
-    if upper.endswith(("LABEL", "MONTH_YEAR", "COMPARISON")):
-        return g.lower()
-    return g
+
+    for raw_gold in gold_answers:
+        gold = _parse_gold(raw_gold, upper)
+
+        if upper.endswith("COMPARISON"):
+            for phrase in ("more common", "less common", "same frequency"):
+                if phrase in candidate.lower():
+                    normalized = phrase
+                    break
+            else:
+                normalized = candidate.lower()
+            if normalized in str(gold).lower() or str(gold).lower() in normalized:
+                return 1.0
+            continue
+
+        if upper.endswith("DATE"):
+            try:
+                parsed_dt = dateutil.parser.parse(candidate)
+                if parsed_dt == gold:
+                    return 1.0
+            except (ValueError, OverflowError):
+                pass
+            continue
+
+        if upper.endswith("NUMERIC"):
+            if str(candidate) == str(gold):
+                return 1.0
+            try:
+                return 0.75 ** abs(int(str(gold)) - int(candidate))
+            except (ValueError, TypeError):
+                pass
+            continue
+
+        if str(candidate).lower() == str(gold).lower():
+            return 1.0
+
+    return 0.0
 
 
 @dataclass(frozen=True)
 class _OolongAnswerMatches(SuccessAssertion):
-    """Fail unless the trajectory's final answer matches any gold answer."""
+    """Fail unless the trajectory's final answer exactly matches any gold answer.
+
+    Also computes a partial score (0.0-1.0) stored on ``self`` so callers can
+    log it as metadata without re-running the scorer.
+    """
 
     gold_answers: tuple[str, ...]
     answer_type: str
 
+    def score(self, trajectory: AgentTrajectory) -> float:
+        return _oolong_score(trajectory.answer, self.gold_answers, self.answer_type)
+
     def check(self, trajectory: AgentTrajectory) -> bool:
-        extracted = _extract_answer(trajectory.answer, self.answer_type)
-        if extracted is None:
-            return False
-        normalized = extracted.strip().lower()
-        return any(
-            normalized == _normalize_gold(gold, self.answer_type) for gold in self.gold_answers
-        )
+        return self.score(trajectory) >= 1.0
 
     def describe_failure(self, trajectory: AgentTrajectory) -> str:
-        extracted = _extract_answer(trajectory.answer, self.answer_type)
+        s = self.score(trajectory)
+        candidate = _parse_answer(trajectory.answer)
         return (
-            f"OOLONG answer mismatch (answer_type={self.answer_type!r}). "
-            f"Extracted={extracted!r}, "
+            f"OOLONG answer mismatch (answer_type={self.answer_type!r}, "
+            f"partial_score={s:.3f}). "
+            f"Parsed={candidate!r}, "
             f"gold={list(self.gold_answers)!r}, "
             f"final_text={trajectory.answer[:300]!r}"
         )
@@ -309,7 +331,7 @@ def build_agent(
     """Build a deep agent configured for the given arm."""
     # Both arms spawn task subagents — configure them to use the sub-model
     # (GPT-5-mini in paper setup) so sub-calls are cheaper and match paper specs.
-    subagent_cfg = [
+    subagent_cfg: list[SubAgent] = [
         {
             "name": "general-purpose",
             "description": "Reads a range of /context.txt and extracts facts as directed.",

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -28,18 +28,17 @@ parameterizes over (arm, example) pairs.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from datetime import UTC
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from deepagents import create_deep_agent
 from langchain_quickjs import CodeInterpreterMiddleware
+from langsmith import testing as t
 
 from tests.evals.utils import (
-    AgentTrajectory,
-    SuccessAssertion,
-    TrajectoryScorer,
     run_agent,
 )
 
@@ -166,6 +165,16 @@ def load_oolong_examples(
     return tuple(out[:n_examples])
 
 
+def resolve_arm() -> Arm:
+    """Resolve the experiment arm from the ``OOLONG_ARM`` env var (default ``plain``)."""
+    arm = os.environ.get("OOLONG_ARM", "plain")
+    valid = get_args(Arm)
+    if arm not in valid:
+        msg = f"OOLONG_ARM must be one of {valid}, got {arm!r}"
+        raise ValueError(msg)
+    return arm  # type: ignore[return-value]
+
+
 def _coerce_gold(raw: Any) -> tuple[str, ...]:  # noqa: ANN401
     """Coerce the dataset's `answer` field into a tuple of strings."""
     if isinstance(raw, list):
@@ -275,35 +284,6 @@ def _oolong_score(text: str, gold_answers: tuple[str, ...], answer_type: str) ->
     return 0.0
 
 
-@dataclass(frozen=True)
-class _OolongAnswerMatches(SuccessAssertion):
-    """Fail unless the trajectory's final answer exactly matches any gold answer.
-
-    Also computes a partial score (0.0-1.0) stored on ``self`` so callers can
-    log it as metadata without re-running the scorer.
-    """
-
-    gold_answers: tuple[str, ...]
-    answer_type: str
-
-    def score(self, trajectory: AgentTrajectory) -> float:
-        return _oolong_score(trajectory.answer, self.gold_answers, self.answer_type)
-
-    def check(self, trajectory: AgentTrajectory) -> bool:
-        return self.score(trajectory) >= 1.0
-
-    def describe_failure(self, trajectory: AgentTrajectory) -> str:
-        s = self.score(trajectory)
-        candidate = _parse_answer(trajectory.answer)
-        return (
-            f"OOLONG answer mismatch (answer_type={self.answer_type!r}, "
-            f"partial_score={s:.3f}). "
-            f"Parsed={candidate!r}, "
-            f"gold={list(self.gold_answers)!r}, "
-            f"final_text={trajectory.answer[:300]!r}"
-        )
-
-
 # ---------------------------------------------------------------------------
 # Agent factories
 # ---------------------------------------------------------------------------
@@ -378,7 +358,26 @@ def run_oolong_case(
     root_model: BaseChatModel,
     sub_model_id: str,
 ) -> None:
-    """Run a single OOLONG example through the given arm and score it."""
+    """Run a single OOLONG example through the given arm and score it.
+
+    Uses the standard `run_agent` LangSmith wiring (so examples, latency and
+    inputs are recorded the normal way), but scores *softly*: the answer is
+    graded into ``correctness`` / ``partial_score`` feedback rather than
+    hard-failing the test. This matters for a pairwise benchmark — a
+    ``pytest.fail`` leaves the LangSmith root run ``pending`` and never syncs the
+    dataset example, which would drop the wrong-answer arm out of the
+    side-by-side comparison entirely. Logged shape:
+
+    - **inputs** (`eval_inputs`): the question + task metadata, identical across
+      arms so both experiments share one dataset example;
+    - **reference output**: the gold answer;
+    - **feedback**: ``correctness`` / ``partial_score`` / ``agent_steps`` /
+      ``tool_call_requests`` (numeric scores).
+
+    The arm, root model and sub-model travel as metadata, not inputs.
+    """
+    t.log_reference_outputs({"gold_answer": list(example.gold_answers)})
+
     agent, initial_files = build_agent(
         arm,
         root_model=root_model,
@@ -386,28 +385,33 @@ def run_oolong_case(
         context=example.context_window_text,
     )
 
-    query = f"The document is at `/context.txt` in your workspace.\n\n{example.question}"
-
-    run_agent(
+    # The context is uploaded to the agent's filesystem at `/context.txt` (via
+    # `initial_files`); the question alone is the human message (the system
+    # prompt already points the agent at `/context.txt`).
+    trajectory = run_agent(
         agent,
         model=root_model,
-        query=query,
+        query=example.question,
         initial_files=initial_files,
-        scorer=TrajectoryScorer().success(
-            _OolongAnswerMatches(
-                gold_answers=example.gold_answers,
-                answer_type=example.answer_type,
-            )
-        ),
-        eval_metadata={
-            "arm": arm,
+        eval_inputs={
+            "question": example.question,
             "oolong_id": example.id,
             "task_group": example.task_group,
-            "task": example.task,
-            "context_len": example.context_len,
+            "task_type": example.task,
             "answer_type": example.answer_type,
-            "origin_benchmark": "oolong-synth",
+            "context_len": example.context_len,
             "input_subset": example.input_subset,
-            "sub_model": sub_model_id,
         },
+        eval_metadata={"arm": arm, "sub_model": sub_model_id, "origin_benchmark": "oolong-synth"},
+    )
+
+    # Soft scoring: log the grade as feedback; never `pytest.fail` (see above).
+    # `score=` (not `value=`) so the metrics surface as columns in the compare view.
+    score = _oolong_score(trajectory.answer, example.gold_answers, example.answer_type)
+    t.log_feedback(key="correctness", score=1.0 if score >= 1.0 else 0.0)
+    t.log_feedback(key="partial_score", score=score)
+    t.log_feedback(key="agent_steps", score=len(trajectory.steps))
+    t.log_feedback(
+        key="tool_call_requests",
+        score=sum(len(step.action.tool_calls) for step in trajectory.steps),
     )

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -1,0 +1,405 @@
+"""OOLONG long-context aggregation benchmark — plain subagents vs. code interpreter.
+
+Loads a small subset of `oolongbench/oolong-synth` from HuggingFace and
+runs the same examples through two agent configurations:
+
+- ``plain``: a deep agent that delegates chunk-level analysis to
+  general-purpose subagents via the ``task`` tool. The long context is
+  seeded as `/context.txt` in the agent workspace.
+- ``code_interpreter``: a deep agent with the QuickJS
+  ``CodeInterpreterMiddleware``, which exposes a JS ``eval`` tool the agent
+  uses for aggregation. Subagents launched via ``task`` handle file reads
+  from the shared workspace (no PTC required).
+
+Dataset choice: the paper evaluates on the OOLONG ``trec_coarse`` split
+(50 tasks at 131K-token context). The current ``oolongbench/oolong-synth``
+HuggingFace release does not include ``trec_coarse``; the closest analog
+is ``agnews`` — 4-way topic classification aggregation with the same
+counting/user/timeline task groups. There are 50 ``agnews`` examples at
+each context-length bucket (matching the paper's task count).
+
+Scoring follows OOLONG paper conventions: extract ``Label: X``,
+``Answer: N``, ``User: X``, or ``Answer: Month YYYY`` from the
+trajectory's final answer and exact-match against the gold.
+
+The module is self-contained: the pytest test module just
+parameterizes over (arm, example) pairs.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any, Literal
+
+from deepagents import create_deep_agent
+from langchain_quickjs import CodeInterpreterMiddleware
+
+from tests.evals.utils import (
+    AgentTrajectory,
+    SuccessAssertion,
+    TrajectoryScorer,
+    run_agent,
+)
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+    from langgraph.graph.state import CompiledStateGraph
+
+
+# ---------------------------------------------------------------------------
+# Dataset loading
+# ---------------------------------------------------------------------------
+
+#: HuggingFace dataset id for OOLONG-synth.
+_HF_DATASET = "oolongbench/oolong-synth"
+
+#: Input subset to filter on. The RLM paper uses ``trec_coarse``; the
+#: current HF release of OOLONG-synth does not include it, so we use
+#: ``agnews`` — the closest analog (4-way topic classification
+#: aggregation, same task-group structure, 50 examples per
+#: context-length bucket).
+_INPUT_SUBSET = "agnews"
+
+#: HF dataset split for each input subset.
+#: ``trec_coarse`` is in ``validation``; ``agnews`` and others are in ``test``.
+_SPLIT_FOR_SUBSET: dict[str, str] = {
+    "trec_coarse": "validation",
+}
+
+#: Task groups across all supported subsets.
+TASK_GROUPS = ("counting", "user", "timeline")
+
+#: Arm names — keep in sync with `build_agent` and pytest marks.
+#:
+#: ``plain`` — `create_deep_agent` that delegates chunk-level analysis to
+#: general-purpose subagents via the ``task`` tool; context is in the
+#: workspace at `/context.txt`.
+#: ``code_interpreter`` — `create_deep_agent` with the QuickJS
+#: `CodeInterpreterMiddleware`; uses ``eval`` for JS aggregation and
+#: ``task`` subagents for chunk classification.
+Arm = Literal["plain", "code_interpreter"]
+
+
+@dataclass(frozen=True)
+class OolongExample:
+    """One OOLONG-synth example, materialized into the shape the harness uses."""
+
+    id: int
+    input_subset: str
+    task_group: str
+    task: str
+    context_len: int
+    context_window_text: str
+    question: str
+    gold_answers: tuple[str, ...]
+    answer_type: str
+
+
+@lru_cache(maxsize=8)
+def load_oolong_examples(
+    *,
+    input_subset: str = "agnews",
+    context_len: int = 8192,
+    n_examples: int | None = 5,
+    split: str | None = None,
+) -> tuple[OolongExample, ...]:
+    """Load a deterministic OOLONG-synth subset at one context length.
+
+    The paper uses ``trec_coarse`` (validation split) at 131K tokens, 50
+    examples. ``agnews`` (test split) is the closest HF-available analog.
+
+    Args:
+        input_subset: Dataset name to filter on. Use ``"trec_coarse"`` for
+            the paper's exact dataset, ``"agnews"`` for the default.
+        context_len: Token-length bucket. OOLONG-synth has buckets at
+            1024-4194304; 65536 and 131072 are the most useful.
+        n_examples: How many examples to return. ``None`` means all 50.
+            Otherwise distributed evenly across task groups by ``id``.
+        split: HuggingFace split. Defaults to ``"validation"`` for
+            ``trec_coarse``, ``"test"`` for everything else.
+
+    Returns:
+        A tuple of `OolongExample` instances, deterministic across calls.
+    """
+    from datasets import load_dataset  # noqa: PLC0415
+
+    resolved_split = split or _SPLIT_FOR_SUBSET.get(input_subset, "test")
+    dataset = load_dataset(_HF_DATASET, split=resolved_split)
+    filtered = dataset.filter(
+        lambda row: row["dataset"] == input_subset and row["context_len"] == context_len
+    )
+    filtered = filtered.sort("id")
+
+    def _row_to_example(row: dict[str, Any]) -> OolongExample:
+        return OolongExample(
+            id=int(row["id"]),
+            input_subset=str(row["dataset"]),
+            task_group=str(row["task_group"]),
+            task=str(row["task"]),
+            context_len=int(row["context_len"]),
+            context_window_text=str(row["context_window_text"]),
+            question=str(row["question"]),
+            gold_answers=_coerce_gold(row["answer"]),
+            answer_type=str(row["answer_type"]),
+        )
+
+    if n_examples is None:
+        return tuple(_row_to_example(row) for row in filtered)
+
+    # Determine which task groups actually exist in this subset/bucket.
+    actual_groups = sorted({str(row["task_group"]) for row in filtered})
+    per_group = -(-n_examples // len(actual_groups))  # ceil div
+    by_group: dict[str, list[OolongExample]] = {tg: [] for tg in actual_groups}
+    for row in filtered:
+        tg = row["task_group"]
+        if tg in by_group and len(by_group[tg]) < per_group:
+            by_group[tg].append(_row_to_example(row))
+        if all(len(by_group[g]) >= per_group for g in actual_groups):
+            break
+
+    out: list[OolongExample] = []
+    for tg in actual_groups:
+        out.extend(by_group[tg])
+    return tuple(out[:n_examples])
+
+
+def _coerce_gold(raw: Any) -> tuple[str, ...]:  # noqa: ANN401
+    """Coerce the dataset's `answer` field into a tuple of strings."""
+    if isinstance(raw, list):
+        return tuple(str(x) for x in raw)
+    if isinstance(raw, str):
+        # Some HF preprocessors store python-list literals as strings.
+        stripped = raw.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            import ast  # noqa: PLC0415
+
+            try:
+                parsed = ast.literal_eval(stripped)
+                if isinstance(parsed, list):
+                    return tuple(str(x) for x in parsed)
+            except (ValueError, SyntaxError):
+                pass
+        return (stripped,)
+    return (str(raw),)
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+# Labels in OOLONG can contain `/` (e.g. agnews "Sci/Tech") and digits
+# (rare). Capture everything up to a comma, period, newline, or end of
+# string to avoid truncating multi-token labels.
+_LABEL_RE = re.compile(r"Label\s*:\s*([^\n.,;]+?)\s*(?:[.,;\n]|$)", re.IGNORECASE)
+_USER_RE = re.compile(r"User\s*:\s*\[?(\d+)\]?", re.IGNORECASE)
+_NUMBER_RE = re.compile(r"Answer\s*:\s*\[?(-?\d+(?:\.\d+)?)\]?", re.IGNORECASE)
+_MONTH_YEAR_RE = re.compile(
+    r"Answer\s*:\s*([A-Za-z]+\s+\d{4})",
+    re.IGNORECASE,
+)
+_COMPARISON_RE = re.compile(
+    r"Answer\s*:\s*[A-Za-z_]+\s+is\s+([a-z ]+?)\s+[A-Za-z_0-9-]+",
+    re.IGNORECASE,
+)
+# DATE: match MM/DD/YYYY or YYYY-MM-DD in the model's answer
+_DATE_MDY_RE = re.compile(r"\b(\d{1,2})/(\d{1,2})/(\d{4})\b")
+_DATE_ISO_RE = re.compile(r"\b(\d{4})-(\d{2})-(\d{2})\b")
+# Gold DATE is stored as e.g. "datetime.date(2023, 2, 6)"
+_GOLD_DATE_RE = re.compile(r"datetime\.date\((\d+),\s*(\d+),\s*(\d+)\)")
+
+
+def _extract_answer(text: str, answer_type: str) -> str | None:
+    """Pull the formatted answer out of the model's free-form response."""
+    upper = answer_type.upper()
+    if upper.endswith("LABEL"):
+        m = _LABEL_RE.search(text)
+        return m.group(1).lower() if m else None
+    if upper.endswith("USER"):
+        m = _USER_RE.search(text)
+        return m.group(1) if m else None
+    if upper.endswith("NUMERIC"):
+        m = _NUMBER_RE.search(text)
+        return m.group(1) if m else None
+    if upper.endswith("MONTH_YEAR"):
+        m = _MONTH_YEAR_RE.search(text)
+        return m.group(1).strip().lower() if m else None
+    if upper.endswith("COMPARISON"):
+        m = _COMPARISON_RE.search(text)
+        return m.group(1).strip().lower() if m else None
+    if upper.endswith("DATE"):
+        m = _DATE_MDY_RE.search(text)
+        if m:
+            return f"{int(m.group(1)):02d}/{int(m.group(2)):02d}/{m.group(3)}"
+        m = _DATE_ISO_RE.search(text)
+        if m:
+            return f"{int(m.group(2)):02d}/{int(m.group(3)):02d}/{m.group(1)}"
+        return None
+    return None
+
+
+def _normalize_gold(gold: str, answer_type: str) -> str:
+    """Mirror the normalization applied to the extracted answer."""
+    upper = answer_type.upper()
+    g = gold.strip()
+    if upper.endswith("DATE"):
+        # Gold is stored as "datetime.date(YYYY, M, D)" or "[datetime.date(...)]"
+        m = _GOLD_DATE_RE.search(g)
+        if m:
+            return f"{int(m.group(2)):02d}/{int(m.group(3)):02d}/{m.group(1)}"
+        return g.lower()
+    if upper.endswith(("LABEL", "MONTH_YEAR", "COMPARISON")):
+        return g.lower()
+    return g
+
+
+@dataclass(frozen=True)
+class _OolongAnswerMatches(SuccessAssertion):
+    """Fail unless the trajectory's final answer matches any gold answer."""
+
+    gold_answers: tuple[str, ...]
+    answer_type: str
+
+    def check(self, trajectory: AgentTrajectory) -> bool:
+        extracted = _extract_answer(trajectory.answer, self.answer_type)
+        if extracted is None:
+            return False
+        normalized = extracted.strip().lower()
+        return any(
+            normalized == _normalize_gold(gold, self.answer_type) for gold in self.gold_answers
+        )
+
+    def describe_failure(self, trajectory: AgentTrajectory) -> str:
+        extracted = _extract_answer(trajectory.answer, self.answer_type)
+        return (
+            f"OOLONG answer mismatch (answer_type={self.answer_type!r}). "
+            f"Extracted={extracted!r}, "
+            f"gold={list(self.gold_answers)!r}, "
+            f"final_text={trajectory.answer[:300]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Agent factories
+# ---------------------------------------------------------------------------
+
+_PLAIN_SYSTEM_PROMPT = (
+    "You are answering an aggregation question over a long document.\n"
+    "The full document is in your workspace at `/context.txt`.\n"
+    "\n"
+    "Use the `task` tool to delegate chunk-level analysis to subagents. "
+    "Tell each subagent which lines of `/context.txt` to read and what to extract. "
+    "Aggregate the results and reply with ONLY the final answer in the exact format "
+    "requested (e.g. `Label: Business`, `Answer: 4`, `User: 76063`)."
+)
+
+_CODE_INTERPRETER_SYSTEM_PROMPT = (
+    "You are answering an aggregation question over a long document.\n"
+    "The full document is in the workspace at `/context.txt`.\n"
+    "\n"
+    "Solve this as a workflow:\n"
+    "1. Use `task` to launch subagents in parallel — each subagent reads a "
+    "specific range of `/context.txt` (e.g. lines 0-100) and returns the "
+    "atomic facts needed (e.g. per-article label, user ID, or date).\n"
+    "2. Use `eval` to aggregate the structured results from all subagents "
+    "in JavaScript (e.g. count, sort, find the majority).\n"
+    "3. Reply with ONLY the final answer in the exact format the "
+    "question requests (e.g. `Label: Business`, `Answer: 4`, "
+    "`User: 76063`)."
+)
+
+
+def build_agent(
+    arm: Arm,
+    *,
+    root_model: BaseChatModel,
+    sub_model_id: str,
+    context: str,
+) -> tuple[CompiledStateGraph, dict[str, str]]:
+    """Build a deep agent configured for the given arm."""
+    # Both arms spawn task subagents — configure them to use the sub-model
+    # (GPT-5-mini in paper setup) so sub-calls are cheaper and match paper specs.
+    subagent_cfg = [
+        {
+            "name": "general-purpose",
+            "description": (
+                "Reads a specified range of /context.txt and extracts atomic "
+                "facts (labels, dates, user IDs, counts). Used for chunk-level "
+                "analysis delegated by the orchestrator."
+            ),
+            "system_prompt": (
+                "You are a document analysis subagent. Read the assigned range of "
+                "/context.txt using read_file, extract the requested facts, and "
+                "return concise structured results. Do not delegate further."
+            ),
+            "model": sub_model_id,
+        }
+    ]
+
+    if arm == "plain":
+        agent = create_deep_agent(
+            model=root_model,
+            system_prompt=_PLAIN_SYSTEM_PROMPT,
+            subagents=subagent_cfg,
+        )
+        return agent, {"/context.txt": context}
+
+    if arm == "code_interpreter":
+        agent = create_deep_agent(
+            model=root_model,
+            system_prompt=_CODE_INTERPRETER_SYSTEM_PROMPT,
+            middleware=[CodeInterpreterMiddleware()],
+            subagents=subagent_cfg,
+        )
+        return agent, {"/context.txt": context}
+
+    msg = f"unknown arm: {arm!r}"
+    raise ValueError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point used by the pytest module
+# ---------------------------------------------------------------------------
+
+
+def run_oolong_case(
+    example: OolongExample,
+    arm: Arm,
+    *,
+    root_model: BaseChatModel,
+    sub_model_id: str,
+) -> None:
+    """Run a single OOLONG example through the given arm and score it."""
+    agent, initial_files = build_agent(
+        arm,
+        root_model=root_model,
+        sub_model_id=sub_model_id,
+        context=example.context_window_text,
+    )
+
+    query = f"The document is at `/context.txt` in your workspace.\n\n{example.question}"
+
+    run_agent(
+        agent,
+        model=root_model,
+        query=query,
+        initial_files=initial_files,
+        scorer=TrajectoryScorer().success(
+            _OolongAnswerMatches(
+                gold_answers=example.gold_answers,
+                answer_type=example.answer_type,
+            )
+        ),
+        eval_metadata={
+            "arm": arm,
+            "oolong_id": example.id,
+            "task_group": example.task_group,
+            "task": example.task,
+            "context_len": example.context_len,
+            "answer_type": example.answer_type,
+            "origin_benchmark": "oolong-synth",
+            "input_subset": example.input_subset,
+            "sub_model": sub_model_id,
+        },
+    )

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -199,8 +199,10 @@ _MONTH_YEAR_RE = re.compile(
     r"Answer\s*:\s*([A-Za-z]+\s+\d{4})",
     re.IGNORECASE,
 )
+# COMPARISON: extract the direction phrase regardless of how many words the
+# subject has (e.g. "numeric value is less common than entity").
 _COMPARISON_RE = re.compile(
-    r"Answer\s*:\s*[A-Za-z_]+\s+is\s+([a-z ]+?)\s+[A-Za-z_0-9-]+",
+    r"\b((?:more|less)\s+common\s+than|equally\s+common)\b",
     re.IGNORECASE,
 )
 # DATE: match MM/DD/YYYY or YYYY-MM-DD in the model's answer
@@ -285,28 +287,15 @@ class _OolongAnswerMatches(SuccessAssertion):
 # ---------------------------------------------------------------------------
 
 _PLAIN_SYSTEM_PROMPT = (
-    "You are answering an aggregation question over a long document.\n"
-    "The full document is in your workspace at `/context.txt`.\n"
-    "\n"
-    "Use the `task` tool to delegate chunk-level analysis to subagents. "
-    "Tell each subagent which lines of `/context.txt` to read and what to extract. "
-    "Aggregate the results and reply with ONLY the final answer in the exact format "
-    "requested (e.g. `Label: Business`, `Answer: 4`, `User: 76063`)."
+    "You are a helpful assistant. "
+    "The document you need to analyze is at `/context.txt` in your workspace. "
+    "Use the task tool to delegate parts of the analysis to subagents."
 )
 
 _CODE_INTERPRETER_SYSTEM_PROMPT = (
-    "You are answering an aggregation question over a long document.\n"
-    "The full document is in the workspace at `/context.txt`.\n"
-    "\n"
-    "Solve this as a workflow:\n"
-    "1. Use `task` to launch subagents in parallel — each subagent reads a "
-    "specific range of `/context.txt` (e.g. lines 0-100) and returns the "
-    "atomic facts needed (e.g. per-article label, user ID, or date).\n"
-    "2. Use `eval` to aggregate the structured results from all subagents "
-    "in JavaScript (e.g. count, sort, find the majority).\n"
-    "3. Reply with ONLY the final answer in the exact format the "
-    "question requests (e.g. `Label: Business`, `Answer: 4`, "
-    "`User: 76063`)."
+    "You are a helpful assistant. "
+    "The document you need to analyze is at `/context.txt` in your workspace. "
+    "Use the eval and task tools to analyze the document."
 )
 
 
@@ -323,15 +312,12 @@ def build_agent(
     subagent_cfg = [
         {
             "name": "general-purpose",
-            "description": (
-                "Reads a specified range of /context.txt and extracts atomic "
-                "facts (labels, dates, user IDs, counts). Used for chunk-level "
-                "analysis delegated by the orchestrator."
-            ),
+            "description": "Reads a range of /context.txt and extracts facts as directed.",
             "system_prompt": (
-                "You are a document analysis subagent. Read the assigned range of "
-                "/context.txt using read_file, extract the requested facts, and "
-                "return concise structured results. Do not delegate further."
+                "You are a helpful assistant. "
+                "Read the assigned range of /context.txt using read_file, "
+                "extract the requested facts, and return concise results. "
+                "Do not delegate further."
             ),
             "model": sub_model_id,
         }

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -402,7 +402,6 @@ def run_oolong_case(
             "context_len": example.context_len,
             "input_subset": example.input_subset,
         },
-        eval_metadata={"arm": arm, "sub_model": sub_model_id, "origin_benchmark": "oolong-synth"},
     )
 
     # Soft scoring: log the grade as feedback; never `pytest.fail` (see above).

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -562,14 +562,14 @@ def run_oolong_case(
 
     # Score: the official OOLONG per-example score (binary for most answer
     # types; NUMERIC gets partial credit `0.75 ** |gold - pred|`). The paper's
-    # reported metric is the mean of this score — there is no separate binary
-    # "correctness", so we log exactly one `score` to match. `agent_steps` /
-    # `tool_call_requests` are harness telemetry, not part of the OOLONG metric.
+    # reported metric is the mean of this score, so we log exactly one `score`.
+    #
+    # We deliberately do NOT log root-level `agent_steps` / `tool_call_requests`:
+    # the root trajectory only sees the orchestrator's own steps, so for the
+    # code_interpreter arm all the subagent work happens inside `eval` (via the
+    # QuickJS `task()` bridge) and is invisible here — making those counts
+    # asymmetric across arms. Efficiency (subagent dispatches, LLM calls, tokens,
+    # latency) is measured post-hoc from the LangSmith run tree instead.
     # Soft-scored: logged as feedback, never `pytest.fail` (see above).
     score = _oolong_score(trajectory.answer, example.gold_answers, example.answer_type)
     t.log_feedback(key="score", score=score)
-    t.log_feedback(key="agent_steps", score=len(trajectory.steps))
-    t.log_feedback(
-        key="tool_call_requests",
-        score=sum(len(step.action.tool_calls) for step in trajectory.steps),
-    )

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -560,11 +560,14 @@ def run_oolong_case(
         },
     )
 
-    # Soft scoring: log the grade as feedback; never `pytest.fail` (see above).
-    # `score=` (not `value=`) so the metrics surface as columns in the compare view.
+    # Score: the official OOLONG per-example score (binary for most answer
+    # types; NUMERIC gets partial credit `0.75 ** |gold - pred|`). The paper's
+    # reported metric is the mean of this score — there is no separate binary
+    # "correctness", so we log exactly one `score` to match. `agent_steps` /
+    # `tool_call_requests` are harness telemetry, not part of the OOLONG metric.
+    # Soft-scored: logged as feedback, never `pytest.fail` (see above).
     score = _oolong_score(trajectory.answer, example.gold_answers, example.answer_type)
-    t.log_feedback(key="correctness", score=1.0 if score >= 1.0 else 0.0)
-    t.log_feedback(key="partial_score", score=score)
+    t.log_feedback(key="score", score=score)
     t.log_feedback(key="agent_steps", score=len(trajectory.steps))
     t.log_feedback(
         key="tool_call_requests",

--- a/libs/evals/tests/evals/pytest_reporter.py
+++ b/libs/evals/tests/evals/pytest_reporter.py
@@ -156,6 +156,13 @@ def pytest_sessionstart(session: pytest.Session) -> None:
             "date": date_str,
             "deepagents_version": __version__,
         }
+        # OOLONG rlm-vs-subagents selects the arm + sub-model per run; record
+        # them as experiment metadata (the experiment dimension) so the dataset
+        # example stays shared across arms.
+        oolong_arm = os.environ.get("OOLONG_ARM")
+        if oolong_arm:
+            experiment_metadata["arm"] = oolong_arm
+            experiment_metadata["sub_model"] = session.config.getoption("--sub-model")
 
         # Auto-generate a descriptive LANGSMITH_EXPERIMENT prefix if the caller
         # didn't set one explicitly. The prefix drives _get_experiment_name, which

--- a/libs/evals/tests/evals/pytest_reporter.py
+++ b/libs/evals/tests/evals/pytest_reporter.py
@@ -148,11 +148,30 @@ def pytest_sessionstart(session: pytest.Session) -> None:
         client = ls_client.Client()
         dataset = _get_test_suite(client, test_suite_name)
 
+        model_opt = session.config.getoption("--model") or ""
+        date_str = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+
         experiment_metadata = {
-            "model": session.config.getoption("--model"),
-            "date": datetime.now(tz=UTC).strftime("%Y-%m-%d"),
+            "model": model_opt,
+            "date": date_str,
             "deepagents_version": __version__,
         }
+
+        # Auto-generate a descriptive LANGSMITH_EXPERIMENT prefix if the caller
+        # didn't set one explicitly. The prefix drives _get_experiment_name, which
+        # appends a short random suffix, so the full name stays unique.
+        if not os.environ.get("LANGSMITH_EXPERIMENT"):
+            # Sanitize: keep only alphanumerics, hyphens, and dots; collapse runs
+            # of other chars to a single hyphen. Prevents shell metacharacters from
+            # reaching subprocess environments.
+            import re as _re  # noqa: PLC0415
+
+            def _slug(s: str) -> str:
+                return _re.sub(r"[^A-Za-z0-9.\-]+", "-", s).strip("-")
+
+            suite_slug = _slug(test_suite_name)
+            model_slug = _slug(model_opt) if model_opt else "unknown-model"
+            os.environ["LANGSMITH_EXPERIMENT"] = f"{suite_slug}-{model_slug}-{date_str}"
 
         experiment = _start_experiment(client, dataset, experiment_metadata)
     except Exception as exc:  # noqa: BLE001

--- a/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py
+++ b/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py
@@ -1,21 +1,31 @@
-"""OOLONG-synth: plain `create_deep_agent` vs. code-interpreter.
+"""OOLONG-synth: plain subagents vs. code-interpreter (RLM).
 
 Same examples, asymmetric model setup (matching Zhang et al. 2025):
 
 - **Root model** (``--model``, e.g. ``openai:gpt-5``): drives the
   orchestrator in both arms.
-- **Sub-model** (``--sub-model``, default ``openai:gpt-5-mini``):
-  unused by both arms (kept for conftest fixture compatibility).
+- **Sub-model** (``--sub-model``, default ``openai:gpt-5-mini``): the
+  general-purpose subagent that reads/classifies context chunks.
 
-Both arms run as parameterized pytest cases so a single eval
-invocation captures both into one LangSmith project. Each case is
-tagged with ``arm`` and ``task_group`` metadata so you can slice the
-LangSmith dashboard by either axis.
+LangSmith structure
+-------------------
+`run_oolong_case` logs the example explicitly: the **inputs** are the question
++ task metadata, the **reference output** is the gold answer, the run
+**outputs** are the parsed prediction + score, and numeric **feedback** is
+correctness / partial_score / agent_steps / tool_call_requests. The model and
+arm go in **metadata**, not inputs. Inputs are identical across arms, so both
+experiments share one dataset example and line up for side-by-side comparison.
 
-Default smoke subset (``context_len=8192``, 5 examples from the
-``agnews`` input subset) is intentionally tiny — pass
-``n_examples=None`` to `load_oolong_examples` for the full 50-task
-bucket that matches the paper's task count.
+The arm is the experiment dimension, not an input: select it with
+``OOLONG_ARM=plain`` or ``OOLONG_ARM=code_interpreter`` and give each run its
+own ``LANGSMITH_EXPERIMENT`` name. Run each arm in its own session, e.g.::
+
+    OOLONG_ARM=plain            LANGSMITH_EXPERIMENT=oolong-plain-... pytest ...
+    OOLONG_ARM=code_interpreter LANGSMITH_EXPERIMENT=oolong-rlm-...   pytest ...
+
+Default smoke subset (``context_len=8192``, ``OOLONG_N_EXAMPLES=5`` from the
+``agnews`` input subset) is intentionally tiny — set ``OOLONG_N_EXAMPLES=0``
+for the full 50-task bucket that matches the paper's task count.
 """
 
 from __future__ import annotations
@@ -28,13 +38,14 @@ import pytest
 from tests.evals.oolong_benchmarks import (
     TASK_GROUPS,
     load_oolong_examples,
+    resolve_arm,
     run_oolong_case,
 )
 
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
 
-    from tests.evals.oolong_benchmarks import Arm, OolongExample
+    from tests.evals.oolong_benchmarks import OolongExample
 
 
 pytestmark = [
@@ -46,38 +57,38 @@ pytestmark = [
 
 
 def _example_params() -> list[pytest.param]:
-    """Build the (arm, example) parameter matrix.
+    """Build the per-example parameter matrix (one row per example, not per arm).
 
     Set ``OOLONG_N_EXAMPLES=0`` (or empty) for the full 50-task bucket.
     Set ``OOLONG_CONTEXT_LEN`` to override the context bucket (default 8192).
-    Set ``OOLONG_DATASET`` to change the input subset (default ``agnews``).
-      Use ``trec_coarse`` for the paper's exact dataset (validation split).
+    Set ``OOLONG_DATASET`` to change the input subset (default ``agnews``);
+      use ``trec_coarse`` for the paper's exact dataset (validation split).
+
+    The arm is *not* a parameter — it is read from ``OOLONG_ARM`` at runtime so
+    both arms produce the same example identity and line up for comparison.
     """
     raw = os.environ.get("OOLONG_N_EXAMPLES", "5")
     n_examples: int | None = int(raw) if raw and raw != "0" else None
     context_len = int(os.environ.get("OOLONG_CONTEXT_LEN", "8192"))
     input_subset = os.environ.get("OOLONG_DATASET", "agnews")
+
     examples = load_oolong_examples(
         input_subset=input_subset, context_len=context_len, n_examples=n_examples
     )
-    params: list[pytest.param] = []
-    for arm in ("plain", "code_interpreter"):
-        params.extend(pytest.param(arm, ex, id=f"{arm}-{ex.task_group}-{ex.id}") for ex in examples)
-    return params
+    return [pytest.param(ex, id=f"{ex.task_group}-{ex.id}") for ex in examples]
 
 
-@pytest.mark.parametrize(("arm", "example"), _example_params())
+@pytest.mark.parametrize("example", _example_params())
 def test_oolong_synth(
-    arm: Arm,
     example: OolongExample,
     model: BaseChatModel,
     sub_model_name: str,
 ) -> None:
-    """Run a single OOLONG-synth example against the given arm."""
+    """Run a single OOLONG-synth example against the arm given by ``OOLONG_ARM``."""
     assert example.task_group in TASK_GROUPS
     run_oolong_case(
         example,
-        arm,
+        resolve_arm(),
         root_model=model,
         sub_model_id=sub_model_name,
     )

--- a/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py
+++ b/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py
@@ -1,0 +1,83 @@
+"""OOLONG-synth: plain `create_deep_agent` vs. code-interpreter.
+
+Same examples, asymmetric model setup (matching Zhang et al. 2025):
+
+- **Root model** (``--model``, e.g. ``openai:gpt-5``): drives the
+  orchestrator in both arms.
+- **Sub-model** (``--sub-model``, default ``openai:gpt-5-mini``):
+  unused by both arms (kept for conftest fixture compatibility).
+
+Both arms run as parameterized pytest cases so a single eval
+invocation captures both into one LangSmith project. Each case is
+tagged with ``arm`` and ``task_group`` metadata so you can slice the
+LangSmith dashboard by either axis.
+
+Default smoke subset (``context_len=8192``, 5 examples from the
+``agnews`` input subset) is intentionally tiny — pass
+``n_examples=None`` to `load_oolong_examples` for the full 50-task
+bucket that matches the paper's task count.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.evals.oolong_benchmarks import (
+    TASK_GROUPS,
+    load_oolong_examples,
+    run_oolong_case,
+)
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+
+    from tests.evals.oolong_benchmarks import Arm, OolongExample
+
+
+pytestmark = [
+    pytest.mark.eval_category("long_context_aggregation"),
+    pytest.mark.eval_tier("hillclimb"),
+    pytest.mark.langsmith,
+]
+"""All cases in this module are long-context aggregation, hillclimb-tier."""
+
+
+def _example_params() -> list[pytest.param]:
+    """Build the (arm, example) parameter matrix.
+
+    Set ``OOLONG_N_EXAMPLES=0`` (or empty) for the full 50-task bucket.
+    Set ``OOLONG_CONTEXT_LEN`` to override the context bucket (default 8192).
+    Set ``OOLONG_DATASET`` to change the input subset (default ``agnews``).
+      Use ``trec_coarse`` for the paper's exact dataset (validation split).
+    """
+    raw = os.environ.get("OOLONG_N_EXAMPLES", "5")
+    n_examples: int | None = int(raw) if raw and raw != "0" else None
+    context_len = int(os.environ.get("OOLONG_CONTEXT_LEN", "8192"))
+    input_subset = os.environ.get("OOLONG_DATASET", "agnews")
+    examples = load_oolong_examples(
+        input_subset=input_subset, context_len=context_len, n_examples=n_examples
+    )
+    params: list[pytest.param] = []
+    for arm in ("plain", "code_interpreter"):
+        params.extend(pytest.param(arm, ex, id=f"{arm}-{ex.task_group}-{ex.id}") for ex in examples)
+    return params
+
+
+@pytest.mark.parametrize(("arm", "example"), _example_params())
+def test_oolong_synth(
+    arm: Arm,
+    example: OolongExample,
+    model: BaseChatModel,
+    sub_model_name: str,
+) -> None:
+    """Run a single OOLONG-synth example against the given arm."""
+    assert example.task_group in TASK_GROUPS
+    run_oolong_case(
+        example,
+        arm,
+        root_model=model,
+        sub_model_id=sub_model_name,
+    )

--- a/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py
+++ b/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py
@@ -48,10 +48,20 @@ if TYPE_CHECKING:
     from tests.evals.oolong_benchmarks import OolongExample
 
 
+def _oolong_repeats() -> int:
+    """Repetitions per example (``OOLONG_N_REPEATS``, default 1).
+
+    Uses the langsmith pytest plugin's native `repetitions`, so each example
+    runs N times within a single experiment (proper per-example variance view).
+    """
+    raw = os.environ.get("OOLONG_N_REPEATS", "1")
+    return int(raw) if raw and raw.isdigit() and int(raw) >= 1 else 1
+
+
 pytestmark = [
     pytest.mark.eval_category("long_context_aggregation"),
     pytest.mark.eval_tier("hillclimb"),
-    pytest.mark.langsmith,
+    pytest.mark.langsmith(repetitions=_oolong_repeats()),
 ]
 """All cases in this module are long-context aggregation, hillclimb-tier."""
 

--- a/libs/evals/tests/evals/utils.py
+++ b/libs/evals/tests/evals/utils.py
@@ -1102,14 +1102,30 @@ def _build_invoke_inputs(
 def _build_logged_inputs(
     model: BaseChatModel,
     eval_metadata: dict[str, object] | None,
+    eval_inputs: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Build the LangSmith input payload for the current test run."""
+    """Build the LangSmith input payload for the current test run.
+
+    By default the logged input is ``{test_name, model, eval_metadata}``. When
+    ``eval_inputs`` is provided, those task-specific fields (e.g. the question)
+    become the logged input and ``model``/``test_name`` fold into
+    ``eval_metadata`` — so the example input stays task-centric (no model
+    object) and is identical across experiment arms for side-by-side
+    comparison, while the model still travels with the run as metadata.
+    """
     run_tree = get_current_run_tree()
     model_str = str(getattr(model, "model", None) or getattr(model, "model_name", ""))
-    logged_inputs: dict[str, Any] = {
-        "test_name": run_tree.name if run_tree else "unknown",
-        "model": model_str,
-    }
+    test_name = run_tree.name if run_tree else "unknown"
+
+    if eval_inputs is not None:
+        logged_inputs: dict[str, Any] = dict(eval_inputs)
+        metadata = dict(eval_metadata or {})
+        metadata.setdefault("model", model_str)
+        metadata.setdefault("test_name", test_name)
+        logged_inputs["eval_metadata"] = metadata
+        return logged_inputs
+
+    logged_inputs = {"test_name": test_name, "model": model_str}
     if eval_metadata is not None:
         logged_inputs["eval_metadata"] = eval_metadata
     return logged_inputs
@@ -1137,6 +1153,7 @@ def run_agent(
     scorer: TrajectoryScorer | None = None,
     thread_id: str | None = None,
     eval_metadata: dict[str, object] | None = None,
+    eval_inputs: dict[str, Any] | None = None,
     extra_state: dict[str, Any] | None = None,
 ) -> AgentTrajectory:
     """Run agent eval against the given query.
@@ -1149,6 +1166,9 @@ def run_agent(
         scorer: Optional trajectory expectations to validate.
         thread_id: Optional thread ID for the invocation.
         eval_metadata: Optional metadata to attach to the logged inputs.
+        eval_inputs: Optional task-specific fields (e.g. the question) to log as
+            the LangSmith example input instead of the default
+            `{test_name, model}` payload. The model folds into `eval_metadata`.
         extra_state: Optional extra fields merged into the invoke input
             (e.g. `{"rubric": "..."}` for `RubricMiddleware`).
 
@@ -1164,8 +1184,7 @@ def run_agent(
         thread_id = str(uuid.uuid4())
     config = {"configurable": {"thread_id": thread_id}}
 
-    logged_inputs = _build_logged_inputs(model, eval_metadata)
-    _log_run_inputs(logged_inputs)
+    _log_run_inputs(_build_logged_inputs(model, eval_metadata, eval_inputs))
     result = agent.invoke(invoke_inputs, config)
     t.log_outputs(result)
 
@@ -1188,6 +1207,7 @@ async def run_agent_async(
     scorer: TrajectoryScorer | None = None,
     thread_id: str | None = None,
     eval_metadata: dict[str, object] | None = None,
+    eval_inputs: dict[str, Any] | None = None,
     extra_state: dict[str, Any] | None = None,
 ) -> AgentTrajectory:
     """Run agent eval asynchronously against the given query.
@@ -1200,6 +1220,9 @@ async def run_agent_async(
         scorer: Optional trajectory expectations to validate.
         thread_id: Optional thread ID for the invocation.
         eval_metadata: Optional metadata to attach to the logged inputs.
+        eval_inputs: Optional task-specific fields (e.g. the question) to log as
+            the LangSmith example input instead of the default
+            `{test_name, model}` payload. The model folds into `eval_metadata`.
         extra_state: Optional extra fields merged into the invoke input
             (e.g. `{"rubric": "..."}` for `RubricMiddleware`).
 
@@ -1215,8 +1238,7 @@ async def run_agent_async(
         thread_id = str(uuid.uuid4())
     config = {"configurable": {"thread_id": thread_id}}
 
-    logged_inputs = _build_logged_inputs(model, eval_metadata)
-    _log_run_inputs(logged_inputs)
+    _log_run_inputs(_build_logged_inputs(model, eval_metadata, eval_inputs))
     result = await agent.ainvoke(invoke_inputs, config)
     t.log_outputs(result)
 

--- a/libs/evals/tests/evals/utils.py
+++ b/libs/evals/tests/evals/utils.py
@@ -1108,24 +1108,21 @@ def _build_logged_inputs(
 
     By default the logged input is ``{test_name, model, eval_metadata}``. When
     ``eval_inputs`` is provided, those task-specific fields (e.g. the question)
-    become the logged input and ``model``/``test_name`` fold into
-    ``eval_metadata`` — so the example input stays task-centric (no model
-    object) and is identical across experiment arms for side-by-side
-    comparison, while the model still travels with the run as metadata.
+    become the logged input *verbatim* — no model, no metadata — so the example
+    input stays task-centric and is byte-identical across experiment arms. The
+    example id is derived from the inputs, so identical inputs mean both arms
+    map to the *same* dataset example for side-by-side comparison. Run-level
+    context (model, arm, ...) belongs in the experiment metadata, not here.
     """
+    if eval_inputs is not None:
+        return dict(eval_inputs)
+
     run_tree = get_current_run_tree()
     model_str = str(getattr(model, "model", None) or getattr(model, "model_name", ""))
-    test_name = run_tree.name if run_tree else "unknown"
-
-    if eval_inputs is not None:
-        logged_inputs: dict[str, Any] = dict(eval_inputs)
-        metadata = dict(eval_metadata or {})
-        metadata.setdefault("model", model_str)
-        metadata.setdefault("test_name", test_name)
-        logged_inputs["eval_metadata"] = metadata
-        return logged_inputs
-
-    logged_inputs = {"test_name": test_name, "model": model_str}
+    logged_inputs: dict[str, Any] = {
+        "test_name": run_tree.name if run_tree else "unknown",
+        "model": model_str,
+    }
     if eval_metadata is not None:
         logged_inputs["eval_metadata"] = eval_metadata
     return logged_inputs


### PR DESCRIPTION
## Summary

- Adds `oolong_benchmarks.py` with dataset loading (agnews / trec_coarse), a full OOLONG scorer (LABEL/NUMERIC/USER/MONTH_YEAR/COMPARISON/DATE), and agent factories for two arms: **plain** (task-based subagent delegation) and **code_interpreter** (JS `eval` + task subagents via `CodeInterpreterMiddleware`)
- Adds `test_oolong_rlm_vs_subagents.py` as a parameterized pytest suite driven by `OOLONG_N_EXAMPLES`, `OOLONG_CONTEXT_LEN`, `OOLONG_DATASET` env vars
- Adds `--sub-model` CLI option (default `openai:gpt-5-mini`) to conftest for configuring subagent model, matching Zhang et al. 2025 paper specs
- Auto-generates descriptive `LANGSMITH_EXPERIMENT` names (`{suite}-{model}-{date}`) in `pytest_reporter.py` when the env var is unset
- Adds `long_context_aggregation` eval category

## Motivation

Replicates the RLM paper (Zhang et al. 2025) comparison: at 131k-token context, the code-interpreter arm (structured JS aggregation of subagent results) is expected to outperform plain subagent delegation due to deterministic counting. Initial smoke tests at 65k show both arms at 0.33 — consistent with the paper's observation that the gap only emerges at longer contexts.

## Test plan

- [ ] Smoke: `OOLONG_N_EXAMPLES=3 OOLONG_CONTEXT_LEN=65536 pytest tests/evals/test_oolong_rlm_vs_subagents.py -k plain`
- [ ] Smoke: `OOLONG_N_EXAMPLES=3 OOLONG_CONTEXT_LEN=65536 pytest tests/evals/test_oolong_rlm_vs_subagents.py -k code_interpreter`
- [ ] Smoke: `OOLONG_N_EXAMPLES=3 OOLONG_CONTEXT_LEN=131072 OOLONG_DATASET=trec_coarse pytest ... -k plain`
- [ ] Smoke: `OOLONG_N_EXAMPLES=3 OOLONG_CONTEXT_LEN=131072 OOLONG_DATASET=trec_coarse pytest ... -k code_interpreter`