### PR TITLE
fix(code): unpin uv self-updates and warn when a stale dcode shadows PATH

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3907,10 +3907,12 @@ class DeepAgentsApp(App):
             from deepagents_code.update_check import (
                 _PRERELEASE_UNSUPPORTED_MESSAGE,
                 dependency_refresh_supported,
+                detect_shadowed_dcode_safe,
                 format_age_suffix,
                 format_dependency_changes,
                 format_installed_age_suffix,
                 format_release_age_parenthetical,
+                format_shadowed_dcode_warning,
                 is_update_available,
                 parse_dependency_changes,
                 perform_dependency_refresh_dry_run,
@@ -4047,13 +4049,27 @@ class DeepAgentsApp(App):
             )
             if success:
                 self._update_available = (False, None)
-                await self._mount_message(
-                    AppMessage(
-                        f"Updated to v{latest}. Quit and relaunch dcode to use "
-                        "the new version (`/restart` only restarts the server, "
-                        "not the CLI)."
-                    ),
-                )
+                # uv may have installed the upgraded shim into a directory that
+                # isn't first on the user's PATH (e.g. a leftover pre-uv
+                # `dcode` from a former `pipx` install). Detect that before
+                # mounting the success line so we don't follow a green
+                # "relaunch to use the new version" with a warning that
+                # relaunching will keep the old version. Use the
+                # never-raises wrapper so a detector defect can't turn a
+                # successful upgrade into a "/update failed" message.
+                shadow = await asyncio.to_thread(detect_shadowed_dcode_safe)
+                if shadow is None:
+                    await self._mount_message(
+                        AppMessage(
+                            f"Updated to v{latest}. Quit and relaunch dcode "
+                            "to use the new version (`/restart` only restarts "
+                            "the server, not the CLI)."
+                        ),
+                    )
+                else:
+                    await self._mount_message(
+                        ErrorMessage(format_shadowed_dcode_warning(shadow)),
+                    )
                 # The upgrade re-resolves the whole environment, so surface any
                 # dependency bumps that rode along with the dcode release.
                 dep_changes = [
@@ -10564,6 +10580,9 @@ class DeepAgentsApp(App):
         from deepagents_code.update_check import (
             clear_update_notified,
             create_update_log_path,
+            detect_shadowed_dcode_safe,
+            format_shadowed_dcode_fix_command,
+            format_shadowed_dcode_warning,
             mark_update_notified,
             perform_upgrade,
             upgrade_command,
@@ -10617,16 +10636,38 @@ class DeepAgentsApp(App):
                 )
                 if success:
                     self._notice_registry.remove(entry.key)
-                    screen.mark_success()
-                    if not progress_modal_visible:
+                    # Same shadowing risk as `/update`: if a stale `dcode` is
+                    # earlier on PATH, the user's next launch will silently
+                    # run the old version. Surface that loudly even when only
+                    # a toast is visible. Keep the modal itself out of the
+                    # success state when relaunching would keep using the old
+                    # binary.
+                    shadow = await asyncio.to_thread(detect_shadowed_dcode_safe)
+                    if shadow is not None:
+                        warning = format_shadowed_dcode_warning(shadow)
+                        if progress_modal_visible:
+                            screen.mark_warning(
+                                warning,
+                                copy_text=format_shadowed_dcode_fix_command(shadow),
+                            )
                         self.notify(
-                            f"Updated to v{payload.latest}. "
-                            "Quit and relaunch dcode to use the new version "
-                            "(/restart only restarts the server, not the CLI).",
-                            severity="information",
-                            timeout=10,
+                            warning,
+                            severity="warning",
+                            timeout=20,
                             markup=False,
                         )
+                        return
+                    screen.mark_success()
+                    if progress_modal_visible:
+                        return
+                    self.notify(
+                        f"Updated to v{payload.latest}. "
+                        "Quit and relaunch dcode to use the new version "
+                        "(/restart only restarts the server, not the CLI).",
+                        severity="information",
+                        timeout=10,
+                        markup=False,
+                    )
                     return
                 logger.warning(
                     "Auto-upgrade failed for v%s. Output:\n%s",

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -195,7 +195,9 @@ def _run_startup_auto_update(console: "Console") -> None:
     from deepagents_code.config import _is_editable_install
     from deepagents_code.update_check import (
         create_update_log_path,
+        detect_shadowed_dcode_safe,
         format_release_age_parenthetical,
+        format_shadowed_dcode_warning,
         get_cached_update_available,
         is_auto_update_enabled,
         is_installed_version_at_least,
@@ -295,6 +297,31 @@ def _run_startup_auto_update(console: "Console") -> None:
         )
         success, output = asyncio.run(perform_upgrade(log_path=log_path))
         if success:
+            # If a stale `dcode` is earlier on PATH, the auto-restart would
+            # re-exec into the old binary and the user would silently keep
+            # running the pre-upgrade version. Detect that *before* the
+            # re-exec so the warning isn't immediately wiped by the new
+            # process's startup, and skip the restart — re-exec'ing into
+            # an unchanged version would also trip the `restarted_for`
+            # no-op loop guard on the next launch. Use the never-raises
+            # wrapper so a detector defect can't crash startup after an
+            # otherwise-successful upgrade.
+            shadow = detect_shadowed_dcode_safe()
+            if shadow is not None:
+                # The warning embeds filesystem paths from `shutil.which`,
+                # which can legally contain `[` (macOS/Linux). With
+                # `markup=True` those would be parsed as Rich style tags,
+                # so escape the warning before interpolation; the sibling
+                # auto-update failure branch at the bottom of this function
+                # escapes its uv output the same way.
+                warning = format_shadowed_dcode_warning(shadow)
+                console.print(
+                    f"[bold yellow]Warning:[/bold yellow] {escape(warning)}\n"
+                    f"Continuing with v{cli_version}.",
+                    highlight=False,
+                    markup=True,
+                )
+                return
             console.print(
                 f"[green]Updated to v{latest}. Launching...[/green]",
                 highlight=False,

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -71,10 +71,7 @@ _SDK_RELEASE_TIMES_KEY = "sdk_release_times"
 
 InstallMethod = Literal["uv", "brew", "other", "unknown"]
 
-_UV_TOOL_INSTALL_UPGRADE_BASE = "uv tool install -U deepagents-code"
-"""Base uv reinstall command that clears uv tool receipt pins."""
-
-FALLBACK_UPGRADE_COMMAND = _UV_TOOL_INSTALL_UPGRADE_BASE
+FALLBACK_UPGRADE_COMMAND = "uv tool install -U deepagents-code"
 """Generic upgrade hint used when install-method detection fails.
 
 Callers that surface an upgrade command in user-facing text should prefer
@@ -100,7 +97,7 @@ _UPGRADE_COMMANDS: dict[InstallMethod, str] = {
     # release, which is what users running `/update` actually want.
     # `dependency_refresh_command` builds the inverse command for the
     # explicit "stay on this version, refresh deps" flow.
-    "uv": _UV_TOOL_INSTALL_UPGRADE_BASE,
+    "uv": FALLBACK_UPGRADE_COMMAND,
     "brew": "brew upgrade deepagents-code",
 }
 """Upgrade commands keyed by install method.
@@ -111,7 +108,7 @@ upgraded with a different package manager, because that can update a separate
 environment from the one currently providing `dcode`.
 """
 
-_UV_PRERELEASE_UPGRADE_COMMAND = f"{_UV_TOOL_INSTALL_UPGRADE_BASE} --prerelease allow"
+_UV_PRERELEASE_UPGRADE_COMMAND = f"{FALLBACK_UPGRADE_COMMAND} --prerelease allow"
 """uv upgrade command that opts into alpha/beta/rc release resolution.
 
 Uses `uv tool install -U` (not `uv tool upgrade`) for the same receipt-pin
@@ -1177,13 +1174,13 @@ def format_shadowed_dcode_fix_command(shadow: ShadowedDcode) -> str:
     """
     bin_dir = str(shadow.upgraded_bin_dir)
     if os.name == "nt":
-        # PowerShell, the default Windows shell. Wrap the directory in double
-        # quotes (escaping any literal `"`) so a path with spaces survives, and
-        # prepend it to the session PATH. No cache flush is needed — PowerShell
-        # resolves executables per invocation rather than caching like POSIX
-        # shells' `hash`.
-        quoted = bin_dir.replace('"', '""')
-        return f'$env:PATH = "{quoted};$env:PATH"'
+        # PowerShell, the default Windows shell. Single-quote the literal path so
+        # `$`, `$()`, and backticks in directory names are not expanded, then
+        # concatenate the live session PATH outside the literal. No cache flush is
+        # needed — PowerShell resolves executables per invocation rather than
+        # caching like POSIX shells' `hash`.
+        quoted = bin_dir.replace("'", "''")
+        return f"$env:PATH = '{quoted};' + $env:PATH"
     quoted = shlex.quote(bin_dir)
     return f"export PATH={quoted}:$PATH\nhash -r 2>/dev/null || true"
 

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -24,6 +24,7 @@ import time
 import tomllib
 from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal, NamedTuple, TextIO
@@ -70,15 +71,18 @@ _SDK_RELEASE_TIMES_KEY = "sdk_release_times"
 
 InstallMethod = Literal["uv", "brew", "other", "unknown"]
 
-FALLBACK_UPGRADE_COMMAND = "uv tool upgrade deepagents-code"
+FALLBACK_UPGRADE_COMMAND = "uv tool install -U deepagents-code"
 """Generic upgrade hint used when install-method detection fails.
 
 Callers that surface an upgrade command in user-facing text should prefer
 `upgrade_command()`; this constant exists so those callers have something
 to render when detection raises unexpectedly. The documented install path
 is `uv tool install` (see `scripts/install.sh`), so the uv command is the
-right display fallback. Execution paths still refuse unrecognized installs
-instead of updating a separate environment.
+right display fallback. Uses `uv tool install -U` rather than `uv tool
+upgrade` for the same receipt-pin reason documented on `_UPGRADE_COMMANDS`:
+showing a user the `upgrade` form would hand them a command that silently
+stays on the old version for a pinned install. Execution paths still refuse
+unrecognized installs instead of updating a separate environment.
 """
 
 _UPGRADE_COMMANDS: dict[InstallMethod, str] = {
@@ -897,13 +901,20 @@ def dependency_refresh_supported(
     return False, _DEPENDENCY_REFRESH_UNSUPPORTED[method]
 
 
-class ShadowedDcode(NamedTuple):
+@dataclass(frozen=True)
+class ShadowedDcode:
     """A different dcode entry point is winning on PATH than the one we upgraded.
 
     Returned by `detect_shadowed_dcode` after a successful upgrade so the TUI can
     warn the user that re-launching will pick up the wrong binary. The most
     common cause is a pre-uv install (e.g. a leftover from a previous
     `pipx`/`pip`-based install) earlier on `PATH` than the uv tool shims.
+
+    A frozen dataclass rather than a `NamedTuple` (unlike the sibling
+    `DependencyChange`) so `__post_init__` can enforce the conflict invariant
+    the type's name promises: an instance only exists when there genuinely is
+    a shadow. The producer already guarantees this, so the check is defensive
+    against future direct construction, not a runtime gate on the hot path.
     """
 
     shadowing_bin: Path
@@ -921,6 +932,24 @@ class ShadowedDcode(NamedTuple):
     Resolved via uv's documented executable-directory precedence (see
     `_uv_tool_bin_dir`).
     """
+
+    def __post_init__(self) -> None:
+        """Reject a non-conflict instance — the type's namesake invariant.
+
+        If the shadowing binary already lives in the upgraded bin dir there is
+        no shadow, and a warning built from it would tell the user a binary
+        shadows itself. `detect_shadowed_dcode` returns `None` in that case, so
+        this only fires on a misconstructed instance.
+
+        Raises:
+            ValueError: If `shadowing_bin` already resides in `upgraded_bin_dir`.
+        """
+        if self.shadowing_bin.parent == self.upgraded_bin_dir:
+            msg = (
+                f"ShadowedDcode requires a real shadow, but {self.shadowing_bin} "
+                f"already resides in the upgraded bin dir {self.upgraded_bin_dir}"
+            )
+            raise ValueError(msg)
 
     @property
     def upgraded_bin(self) -> Path:
@@ -940,10 +969,12 @@ def _uv_tool_bin_dir() -> Path | None:
     directory uv would install into. Following uv's reference at
     https://docs.astral.sh/uv/reference/storage/#executable-directory:
 
-    - Unix: `UV_TOOL_BIN_DIR` → `XDG_BIN_HOME` → `$XDG_DATA_HOME/../bin` →
-        `$HOME/.local/bin`.
-    - Windows: same env-var chain, with `%USERPROFILE%/.local/bin` as the
-        final fallback (uv normalizes path separators).
+    The precedence (single, unbranched code path): `UV_TOOL_BIN_DIR` →
+    `XDG_BIN_HOME` → `$XDG_DATA_HOME/../bin` → the final `.local/bin` under
+    the home directory. The last candidate is `Path.home() / ".local" / "bin"`,
+    which `pathlib` resolves per-platform — `$HOME/.local/bin` on Unix and
+    `%USERPROFILE%/.local/bin` on Windows — so one expression satisfies uv's
+    documented fallback on both without an `os.name` branch here.
 
     The first candidate that exists as a directory wins; an existing but
     unusable candidate (read failures, race) is skipped so a transient
@@ -1120,7 +1151,7 @@ def format_shadowed_dcode_warning(shadow: ShadowedDcode) -> str:
         "After closing dcode, run this to make the upgraded shim win in this "
         "terminal:\n"
         f"  {indented_command}\n"
-        "Then relaunch dcode. To make the fix permanent, add that export line "
+        "Then relaunch dcode. To make the fix permanent, add the PATH change "
         "to your shell profile, or uninstall the older dcode if you no longer "
         "need it."
     )
@@ -1129,16 +1160,29 @@ def format_shadowed_dcode_warning(shadow: ShadowedDcode) -> str:
 def format_shadowed_dcode_fix_command(shadow: ShadowedDcode) -> str:
     """Return a session-scoped shell command to prefer the upgraded shim.
 
+    The command targets the shell that matches the current platform: PowerShell
+    on Windows (where `_uv_tool_bin_dir` can resolve `%USERPROFILE%/.local/bin`
+    and `export`/`hash` are not valid), and POSIX `sh`/`bash`/`zsh` elsewhere.
+
     Args:
         shadow: The shadowing-binary description returned by
             `detect_shadowed_dcode`.
 
     Returns:
         A copy-pasteable shell command that updates only the current terminal
-            session and clears common shell command caches.
+            session and, on POSIX, clears the shell's command-path cache.
     """
-    bin_dir = shlex.quote(str(shadow.upgraded_bin_dir))
-    return f"export PATH={bin_dir}:$PATH\nhash -r 2>/dev/null || true"
+    bin_dir = str(shadow.upgraded_bin_dir)
+    if os.name == "nt":
+        # PowerShell, the default Windows shell. Wrap the directory in double
+        # quotes (escaping any literal `"`) so a path with spaces survives, and
+        # prepend it to the session PATH. No cache flush is needed — PowerShell
+        # resolves executables per invocation rather than caching like POSIX
+        # shells' `hash`.
+        quoted = bin_dir.replace('"', '""')
+        return f'$env:PATH = "{quoted};$env:PATH"'
+    quoted = shlex.quote(bin_dir)
+    return f"export PATH={quoted}:$PATH\nhash -r 2>/dev/null || true"
 
 
 def cleanup_update_logs(
@@ -1351,6 +1395,7 @@ async def perform_upgrade(
         if not supported:
             return False, reason or _PRERELEASE_UNSUPPORTED_MESSAGE
 
+    fell_back_to_bare_command = False
     if method == "uv":
         # Prefer the receipt-aware `uv tool install -U` builder so installed
         # extras / `--with` packages survive the upgrade and any stale
@@ -1365,11 +1410,7 @@ async def perform_upgrade(
             cmd = upgrade_install_command(
                 include_prereleases=resolved_include_prereleases,
             )
-        except (
-            ExtrasIntrospectionError,
-            ToolRequirementIntrospectionError,
-            ValueError,
-        ) as exc:
+        except (ExtrasIntrospectionError, ToolRequirementIntrospectionError) as exc:
             logger.warning(
                 "Could not build receipt-aware uv upgrade command (%s: %s); "
                 "falling back to the bare command. Installed extras may be "
@@ -1377,16 +1418,7 @@ async def perform_upgrade(
                 type(exc).__name__,
                 exc,
             )
-            # The bare fallback only knows the distribution name, so the log
-            # line above is invisible to the user — surface the same caveat in
-            # the progress stream so they know to re-add extras / `--with`
-            # packages if a feature stops working after the upgrade.
-            await _emit_progress(
-                progress,
-                "Note: couldn't read your full install configuration; "
-                "installed extras or extra packages may not carry over. "
-                "Re-add them if a feature stops working after relaunch.",
-            )
+            fell_back_to_bare_command = True
             cmd = upgrade_command(
                 method,
                 include_prereleases=resolved_include_prereleases,
@@ -1401,7 +1433,23 @@ async def perform_upgrade(
     if method == "brew" and not shutil.which("brew"):
         return False, "brew not found on PATH."
 
-    return await _run_install_subprocess(cmd, progress=progress, log_path=log_path)
+    success, output = await _run_install_subprocess(
+        cmd, progress=progress, log_path=log_path
+    )
+    if success and fell_back_to_bare_command:
+        # Surface the dropped-extras caveat only now that the bare upgrade has
+        # actually succeeded. Emitting it before `_run_install_subprocess` ran
+        # would misfire on a failed upgrade — telling the user to re-add extras
+        # for an install that was left untouched. The log line above is
+        # invisible in the TUI, so the progress stream is the user's only window
+        # into this.
+        await _emit_progress(
+            progress,
+            "Note: couldn't read your full install configuration; "
+            "installed extras or extra packages may not carry over. "
+            "Re-add them if a feature stops working after relaunch.",
+        )
+    return success, output
 
 
 async def perform_dependency_refresh(
@@ -1846,17 +1894,34 @@ def upgrade_install_command(
     Returns:
         Shell command string suitable for execution via the shell.
 
-    Propagates `ExtrasIntrospectionError` if installed extras cannot be
-    determined safely from distribution metadata, and
-    `ToolRequirementIntrospectionError` if the uv tool `--with` packages or
-    interpreter cannot be determined safely from the tool receipt. Callers choose
-    whether to treat those errors as failures or fall back to a simpler unpinned
-    upgrade command with a user-facing warning.
+    Raises:
+        ExtrasIntrospectionError: If installed extras cannot be determined
+            safely from distribution metadata, or a metadata-sourced extra name
+            fails PEP 508 validation (re-raised from the underlying `ValueError`
+            so callers need not catch a broad built-in).
+
+    Also propagates `ToolRequirementIntrospectionError` if the uv tool `--with`
+    packages or interpreter cannot be determined safely from the tool receipt.
+    Callers choose whether to treat those errors as failures or fall back to a
+    simpler unpinned upgrade command with a user-facing warning.
     """
-    from deepagents_code.extras_info import installed_extra_names
+    from deepagents_code.extras_info import (
+        ExtrasIntrospectionError,
+        installed_extra_names,
+    )
 
     extras = installed_extra_names(distribution_name, strict=True)
-    requirement = _dcode_extras_requirement(extras, version=None)
+    try:
+        requirement = _dcode_extras_requirement(extras, version=None)
+    except ValueError as exc:
+        # `extras` come from the distribution's own optional-dependency
+        # metadata, so a PEP 508 validation failure here means that metadata is
+        # malformed. Translate to the typed introspection error so callers
+        # (`perform_upgrade`) handle it like any other unreadable-config case
+        # instead of relying on a broad `ValueError` catch that could also
+        # swallow an unrelated future bug in this builder.
+        msg = f"Distribution metadata yielded an invalid extra name: {exc}"
+        raise ExtrasIntrospectionError(msg) from exc
     cmd = "uv tool install -U"
     python = _uv_tool_python()
     if python is not None:

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -898,12 +898,12 @@ def dependency_refresh_supported(
 
 
 class ShadowedDcode(NamedTuple):
-    """A different `dcode` is winning on the user's PATH than the one we upgraded.
+    """A different dcode entry point is winning on PATH than the one we upgraded.
 
     Returned by `detect_shadowed_dcode` after a successful upgrade so the TUI can
     warn the user that re-launching will pick up the wrong binary. The most
-    common cause is a pre-uv install of `dcode` (e.g. a leftover from a previous
-    `pipx`/`pip`-based install) earlier on `PATH` than the uv tool shim.
+    common cause is a pre-uv install (e.g. a leftover from a previous
+    `pipx`/`pip`-based install) earlier on `PATH` than the uv tool shims.
     """
 
     shadowing_bin: Path
@@ -998,7 +998,7 @@ def _uv_tool_bin_dir() -> Path | None:
 
 
 def detect_shadowed_dcode() -> ShadowedDcode | None:
-    """Return the shadowing `dcode` on the user's PATH, if any.
+    """Return the shadowing dcode entry point on the user's PATH, if any.
 
     After a successful `uv tool upgrade`, the upgraded binary only takes effect
     on the next launch if the user's `PATH` resolves to uv's tool bin dir for
@@ -1006,8 +1006,8 @@ def detect_shadowed_dcode() -> ShadowedDcode | None:
     silently win and report the old version, which looks like "the upgrade
     didn't work" to the user.
 
-    This compares `shutil.which("dcode")` against uv's tool bin dir. A mismatch
-    means a different binary will run next launch.
+    This compares each supported console script against uv's tool bin dir. A
+    mismatch means a different binary will run next launch for that entry point.
 
     Caveat: a `dcode` symlink that lives in some unrelated bin dir but
     points *into* the upgraded tool venv (e.g. a manually-created
@@ -1020,17 +1020,16 @@ def detect_shadowed_dcode() -> ShadowedDcode | None:
     Returns:
         A `ShadowedDcode` describing the conflict, or `None` when there is no
             shadowing binary (the common case) or when detection is not
-            applicable (non-uv install, uv bin dir unknown, no `dcode` on
-            `PATH` at all).
+            applicable (non-uv install, uv bin dir unknown, no supported entry
+            point on `PATH` at all).
     """
     if detect_install_method() != "uv":
         return None
     upgraded_bin_dir = _uv_tool_bin_dir()
     if upgraded_bin_dir is None:
         return None
-    # Prefer `dcode` (the documented entry point) and fall back to the legacy
-    # `deepagents-code` name, mirroring how the install script verifies the
-    # post-install binary.
+    # Check every supported entry point. One healthy command name does not
+    # prove another command name cannot still be shadowed earlier on PATH.
     for name in ("dcode", "deepagents-code"):
         resolved = shutil.which(name)
         if resolved is None:
@@ -1065,8 +1064,10 @@ def detect_shadowed_dcode() -> ShadowedDcode | None:
             )
             continue
         if canonical_path_dir == upgraded_bin_dir:
-            # PATH resolves to the directory uv just wrote into — no shadow.
-            return None
+            # This entry point resolves to the directory uv just wrote into.
+            # Keep checking the other supported entry point before declaring
+            # there is no shadow.
+            continue
         return ShadowedDcode(
             shadowing_bin=Path(resolved),
             upgraded_bin_dir=upgraded_bin_dir,

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -82,7 +82,18 @@ instead of updating a separate environment.
 """
 
 _UPGRADE_COMMANDS: dict[InstallMethod, str] = {
-    "uv": "uv tool upgrade deepagents-code",
+    # Use `uv tool install -U` instead of `uv tool upgrade`: the latter
+    # *respects* the requirement string baked into the uv tool receipt by the
+    # original install (or by any prior `dependency_refresh_command` that
+    # wrote `deepagents-code==<old_version>` into the receipt). When that
+    # requirement is pinned, `uv tool upgrade` "succeeds" but re-installs the
+    # same pinned version, silently leaving the user behind latest. A bare
+    # `uv tool install -U deepagents-code` rewrites the receipt's requirement
+    # to an unpinned `deepagents-code` and re-resolves to the latest stable
+    # release, which is what users running `/update` actually want.
+    # `dependency_refresh_command` builds the inverse command for the
+    # explicit "stay on this version, refresh deps" flow.
+    "uv": "uv tool install -U deepagents-code",
     "brew": "brew upgrade deepagents-code",
 }
 """Upgrade commands keyed by install method.
@@ -93,8 +104,12 @@ upgraded with a different package manager, because that can update a separate
 environment from the one currently providing `dcode`.
 """
 
-_UV_PRERELEASE_UPGRADE_COMMAND = "uv tool upgrade deepagents-code --prerelease allow"
-"""uv upgrade command that opts into alpha/beta/rc release resolution."""
+_UV_PRERELEASE_UPGRADE_COMMAND = "uv tool install -U deepagents-code --prerelease allow"
+"""uv upgrade command that opts into alpha/beta/rc release resolution.
+
+Uses `uv tool install -U` (not `uv tool upgrade`) for the same receipt-pin
+reason documented on `_UPGRADE_COMMANDS`.
+"""
 
 _PRERELEASE_UNSUPPORTED_MESSAGE = (
     "Pre-release updates aren't supported for this install. Reinstall with "
@@ -882,6 +897,249 @@ def dependency_refresh_supported(
     return False, _DEPENDENCY_REFRESH_UNSUPPORTED[method]
 
 
+class ShadowedDcode(NamedTuple):
+    """A different `dcode` is winning on the user's PATH than the one we upgraded.
+
+    Returned by `detect_shadowed_dcode` after a successful upgrade so the TUI can
+    warn the user that re-launching will pick up the wrong binary. The most
+    common cause is a pre-uv install of `dcode` (e.g. a leftover from a previous
+    `pipx`/`pip`-based install) earlier on `PATH` than the uv tool shim.
+    """
+
+    shadowing_bin: Path
+    """Absolute path to the `dcode` (or `deepagents-code`) binary the user's
+    `PATH` currently resolves first — the file their next `dcode` will run.
+
+    Reported as the un-followed `shutil.which` result rather than its symlink
+    target, since that's the file the user needs to either delete or demote
+    on `PATH`.
+    """
+
+    upgraded_bin_dir: Path
+    """Absolute path to the bin directory uv installed the upgraded shim into.
+
+    Resolved via uv's documented executable-directory precedence (see
+    `_uv_tool_bin_dir`).
+    """
+
+    @property
+    def upgraded_bin(self) -> Path:
+        """Absolute path to the upgraded `dcode` shim uv installed.
+
+        Keeps the `dcode` entry-point name owned by the type rather than
+        re-derived at each call site (mirrors `DependencyChange.kind`).
+        """
+        return self.upgraded_bin_dir / "dcode"
+
+
+def _uv_tool_bin_dir() -> Path | None:
+    """Return the bin directory uv installed the running `dcode` shim into.
+
+    Mirrors uv's documented executable-directory precedence so a custom
+    layout (e.g. `XDG_BIN_HOME` set on Linux) is compared against the same
+    directory uv would install into. Following uv's reference at
+    https://docs.astral.sh/uv/reference/storage/#executable-directory:
+
+    - Unix: `UV_TOOL_BIN_DIR` → `XDG_BIN_HOME` → `$XDG_DATA_HOME/../bin` →
+        `$HOME/.local/bin`.
+    - Windows: same env-var chain, with `%USERPROFILE%/.local/bin` as the
+        final fallback (uv normalizes path separators).
+
+    The first candidate that exists as a directory wins; an existing but
+    unusable candidate (read failures, race) is skipped so a transient
+    glitch doesn't downgrade the answer to a less-preferred path.
+
+    Returns:
+        The absolute, resolved bin directory, or `None` when no candidate
+            exists (e.g. a CI install that never created `~/.local/bin`).
+    """
+
+    def _from_env(name: str) -> Path | None:
+        raw = os.environ.get(name)
+        return Path(raw).expanduser() if raw else None
+
+    home = Path.home()
+    xdg_data_home_str = os.environ.get("XDG_DATA_HOME")
+    xdg_data_home = (
+        Path(xdg_data_home_str).expanduser()
+        if xdg_data_home_str
+        else home / ".local" / "share"
+    )
+
+    # Build candidates in uv's documented precedence order. None entries
+    # (env var unset) are filtered out before iteration so each remaining
+    # candidate is a real path.
+    candidates: list[Path | None] = [
+        _from_env("UV_TOOL_BIN_DIR"),
+        _from_env("XDG_BIN_HOME"),
+        # `$XDG_DATA_HOME/../bin` — uv's documented intermediate fallback.
+        # Falls back to the spec default (`~/.local/share`) when the env
+        # var is unset; the resulting `~/.local/share/../bin` = `~/.local/bin`
+        # matches the final fallback below, which is fine — only the first
+        # match wins.
+        xdg_data_home.parent / "bin",
+        home / ".local" / "bin",
+    ]
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            logger.debug(
+                "Could not resolve uv tool bin dir candidate %s",
+                candidate,
+                exc_info=True,
+            )
+            continue
+        if resolved.is_dir():
+            return resolved
+    return None
+
+
+def detect_shadowed_dcode() -> ShadowedDcode | None:
+    """Return the shadowing `dcode` on the user's PATH, if any.
+
+    After a successful `uv tool upgrade`, the upgraded binary only takes effect
+    on the next launch if the user's `PATH` resolves to uv's tool bin dir for
+    `dcode` (and `deepagents-code`). A pre-uv install earlier on `PATH` will
+    silently win and report the old version, which looks like "the upgrade
+    didn't work" to the user.
+
+    This compares `shutil.which("dcode")` against uv's tool bin dir. A mismatch
+    means a different binary will run next launch.
+
+    Caveat: a `dcode` symlink that lives in some unrelated bin dir but
+    points *into* the upgraded tool venv (e.g. a manually-created
+    convenience symlink) is reported as shadowing even though the next
+    launch would actually run the upgraded entry point. Comparing
+    directories rather than resolved targets is intentional — see the
+    inline note below for why — and this edge is rare enough that we
+    accept a benign false positive over a class of false negatives.
+
+    Returns:
+        A `ShadowedDcode` describing the conflict, or `None` when there is no
+            shadowing binary (the common case) or when detection is not
+            applicable (non-uv install, uv bin dir unknown, no `dcode` on
+            `PATH` at all).
+    """
+    if detect_install_method() != "uv":
+        return None
+    upgraded_bin_dir = _uv_tool_bin_dir()
+    if upgraded_bin_dir is None:
+        return None
+    # Prefer `dcode` (the documented entry point) and fall back to the legacy
+    # `deepagents-code` name, mirroring how the install script verifies the
+    # post-install binary.
+    for name in ("dcode", "deepagents-code"):
+        resolved = shutil.which(name)
+        if resolved is None:
+            continue
+        # Compare the *PATH-entry directory* against uv's bin dir, NOT the
+        # symlink target. uv exposes its tool entry points as symlinks under
+        # the user's bin dir (e.g. `~/.local/bin/dcode` -> the tool venv at
+        # `~/.local/share/uv/tools/deepagents-code/bin/dcode`). Following the
+        # link would make every healthy uv install look shadowed, because the
+        # resolved parent is the tool venv's bin dir rather than the
+        # PATH-visible one. Take the parent of the un-followed `which`
+        # result so we answer the question we actually care about: "is uv's
+        # bin dir what PATH resolves to?" `Path(...).parent` does not follow
+        # the file's symlink. Only the directory is canonicalized, so
+        # benign filesystem aliases (case folding, /private/var vs /var on
+        # macOS, mount-point synonyms) still compare equal.
+        path_dir = Path(resolved).parent
+        try:
+            canonical_path_dir = path_dir.resolve()
+        except OSError:
+            # Couldn't canonicalize the PATH-entry directory (e.g. a stale
+            # symlink, a vanished mount). Returning `None` here would
+            # silently hide a real shadow, so continue to the next candidate
+            # name if any; if this was the last (`deepagents-code`), the loop
+            # falls through to `None` — an indeterminate result we'd rather
+            # surface to a developer than mask, hence `warning`, not `debug`.
+            logger.warning(
+                "Could not resolve PATH directory for %s at %s",
+                name,
+                path_dir,
+                exc_info=True,
+            )
+            continue
+        if canonical_path_dir == upgraded_bin_dir:
+            # PATH resolves to the directory uv just wrote into — no shadow.
+            return None
+        return ShadowedDcode(
+            shadowing_bin=Path(resolved),
+            upgraded_bin_dir=upgraded_bin_dir,
+        )
+    return None
+
+
+def detect_shadowed_dcode_safe() -> ShadowedDcode | None:
+    """Best-effort `detect_shadowed_dcode` that never raises.
+
+    The shadow check only ever runs to decorate an already-successful upgrade,
+    so a defect in detection — or an unexpected error escaping the narrow
+    `OSError` guards inside `detect_shadowed_dcode` — must not turn a working
+    upgrade into a user-facing failure. Any unexpected exception is logged and
+    treated as "no shadow detected", matching the fail-open bias the detector
+    already applies internally.
+
+    Returns:
+        Whatever `detect_shadowed_dcode` returns, or `None` if it raised.
+    """
+    try:
+        return detect_shadowed_dcode()
+    except Exception:
+        logger.warning("Shadow detection failed after upgrade", exc_info=True)
+        return None
+
+
+def format_shadowed_dcode_warning(shadow: ShadowedDcode) -> str:
+    """Render a user-facing warning for a shadowed-dcode situation.
+
+    Shared by the `/update` slash command, the update-notification "Install
+    now" action, and the pre-launch auto-update path so the wording stays
+    consistent.
+
+    Args:
+        shadow: The shadowing-binary description returned by
+            `detect_shadowed_dcode`.
+
+    Returns:
+        A plain-text, multi-line warning suitable for either the TUI message
+            stream or a Rich `console.print`.
+    """
+    fix_command = format_shadowed_dcode_fix_command(shadow)
+    indented_command = fix_command.replace("\n", "\n  ")
+    return (
+        "Update installed, but another `dcode` is earlier on your PATH and "
+        "will keep running the old version on relaunch:\n"
+        f"  Shadowing binary: {shadow.shadowing_bin}\n"
+        f"  Upgraded shim:    {shadow.upgraded_bin}\n"
+        "After closing dcode, run this to make the upgraded shim win in this "
+        "terminal:\n"
+        f"  {indented_command}\n"
+        "Then relaunch dcode. To make the fix permanent, add that export line "
+        "to your shell profile, or uninstall the older dcode if you no longer "
+        "need it."
+    )
+
+
+def format_shadowed_dcode_fix_command(shadow: ShadowedDcode) -> str:
+    """Return a session-scoped shell command to prefer the upgraded shim.
+
+    Args:
+        shadow: The shadowing-binary description returned by
+            `detect_shadowed_dcode`.
+
+    Returns:
+        A copy-pasteable shell command that updates only the current terminal
+            session and clears common shell command caches.
+    """
+    bin_dir = shlex.quote(str(shadow.upgraded_bin_dir))
+    return f"export PATH={bin_dir}:$PATH\nhash -r 2>/dev/null || true"
+
+
 def cleanup_update_logs(
     *,
     retention_days: int = UPDATE_LOG_RETENTION_DAYS,
@@ -1092,7 +1350,51 @@ async def perform_upgrade(
         if not supported:
             return False, reason or _PRERELEASE_UNSUPPORTED_MESSAGE
 
-    cmd = upgrade_command(method, include_prereleases=resolved_include_prereleases)
+    if method == "uv":
+        # Prefer the receipt-aware `uv tool install -U` builder so installed
+        # extras / `--with` packages survive the upgrade and any stale
+        # `==<version>` pin in the receipt is cleared. Fall back to the bare
+        # display command when extras or receipt introspection fails — the
+        # fallback might drop extras, but a successful unpinned upgrade is
+        # still strictly better than a pinned "upgrade" that quietly stays
+        # on the old version.
+        from deepagents_code.extras_info import ExtrasIntrospectionError
+
+        try:
+            cmd = upgrade_install_command(
+                include_prereleases=resolved_include_prereleases,
+            )
+        except (
+            ExtrasIntrospectionError,
+            ToolRequirementIntrospectionError,
+            ValueError,
+        ) as exc:
+            logger.warning(
+                "Could not build receipt-aware uv upgrade command (%s: %s); "
+                "falling back to the bare command. Installed extras may be "
+                "dropped.",
+                type(exc).__name__,
+                exc,
+            )
+            # The bare fallback only knows the distribution name, so the log
+            # line above is invisible to the user — surface the same caveat in
+            # the progress stream so they know to re-add extras / `--with`
+            # packages if a feature stops working after the upgrade.
+            await _emit_progress(
+                progress,
+                "Note: couldn't read your full install configuration; "
+                "installed extras or extra packages may not carry over. "
+                "Re-add them if a feature stops working after relaunch.",
+            )
+            cmd = upgrade_command(
+                method,
+                include_prereleases=resolved_include_prereleases,
+            )
+    else:
+        cmd = upgrade_command(
+            method,
+            include_prereleases=resolved_include_prereleases,
+        )
 
     # Skip brew if binary not on PATH
     if method == "brew" and not shutil.which("brew"):
@@ -1514,6 +1816,56 @@ def _dcode_extras_requirement(
     if not names and version is None:
         return requirement
     return shlex.quote(requirement)
+
+
+def upgrade_install_command(
+    *,
+    include_prereleases: bool | None = None,
+    distribution_name: str = "deepagents-code",
+) -> str:
+    """Return the uv command that upgrades dcode while clearing any version pin.
+
+    Built specifically to avoid the `uv tool upgrade` receipt-pin trap: when
+    the tool was originally installed via `uv tool install deepagents-code==X.Y.Z`
+    — or when a prior `dependency_refresh_command` rewrote the receipt with a
+    version-pinned requirement — `uv tool upgrade deepagents-code` will only
+    re-resolve *within* that pin and silently keep the user on the same
+    version. Re-running `uv tool install -U deepagents-code[<extras>]` (no
+    version pin) rewrites the receipt's requirement to unpinned so the next
+    upgrade can actually move forward. Installed extras and `--with`
+    packages are preserved to mirror `dependency_refresh_command`; only the
+    version pin is intentionally stripped.
+
+    Args:
+        include_prereleases: Whether to include alpha/beta/rc releases. When
+            `None`, follows the installed version's channel.
+        distribution_name: Name of the installed distribution to inspect for
+            already-installed extras.
+
+    Returns:
+        Shell command string suitable for execution via the shell.
+
+    Propagates `ExtrasIntrospectionError` if installed extras cannot be
+    determined safely from distribution metadata, and
+    `ToolRequirementIntrospectionError` if the uv tool `--with` packages or
+    interpreter cannot be determined safely from the tool receipt.
+    `perform_upgrade` converts both into a user-facing failure.
+    """
+    from deepagents_code.extras_info import installed_extra_names
+
+    extras = installed_extra_names(distribution_name, strict=True)
+    requirement = _dcode_extras_requirement(extras, version=None)
+    cmd = "uv tool install -U"
+    python = _uv_tool_python()
+    if python is not None:
+        cmd += f" --python {shlex.quote(python)}"
+    cmd += f" {requirement}"
+    with_packages = _uv_tool_with_packages(distribution_name=distribution_name)
+    for package in with_packages:
+        cmd += f" --with {shlex.quote(package)}"
+    if _resolve_include_prereleases(include_prereleases):
+        cmd += " --prerelease allow"
+    return cmd
 
 
 def dependency_refresh_command(

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -71,7 +71,10 @@ _SDK_RELEASE_TIMES_KEY = "sdk_release_times"
 
 InstallMethod = Literal["uv", "brew", "other", "unknown"]
 
-FALLBACK_UPGRADE_COMMAND = "uv tool install -U deepagents-code"
+_UV_TOOL_INSTALL_UPGRADE_BASE = "uv tool install -U deepagents-code"
+"""Base uv reinstall command that clears uv tool receipt pins."""
+
+FALLBACK_UPGRADE_COMMAND = _UV_TOOL_INSTALL_UPGRADE_BASE
 """Generic upgrade hint used when install-method detection fails.
 
 Callers that surface an upgrade command in user-facing text should prefer
@@ -97,7 +100,7 @@ _UPGRADE_COMMANDS: dict[InstallMethod, str] = {
     # release, which is what users running `/update` actually want.
     # `dependency_refresh_command` builds the inverse command for the
     # explicit "stay on this version, refresh deps" flow.
-    "uv": "uv tool install -U deepagents-code",
+    "uv": _UV_TOOL_INSTALL_UPGRADE_BASE,
     "brew": "brew upgrade deepagents-code",
 }
 """Upgrade commands keyed by install method.
@@ -108,7 +111,7 @@ upgraded with a different package manager, because that can update a separate
 environment from the one currently providing `dcode`.
 """
 
-_UV_PRERELEASE_UPGRADE_COMMAND = "uv tool install -U deepagents-code --prerelease allow"
+_UV_PRERELEASE_UPGRADE_COMMAND = f"{_UV_TOOL_INSTALL_UPGRADE_BASE} --prerelease allow"
 """uv upgrade command that opts into alpha/beta/rc release resolution.
 
 Uses `uv tool install -U` (not `uv tool upgrade`) for the same receipt-pin
@@ -1867,6 +1870,42 @@ def _dcode_extras_requirement(
     return shlex.quote(requirement)
 
 
+def _uv_tool_install_command(
+    *,
+    version: str | None,
+    include_prereleases: bool | None,
+    distribution_name: str,
+) -> str:
+    """Return the receipt-preserving `uv tool install -U` command.
+
+    Raises:
+        ExtrasIntrospectionError: If a metadata-sourced extra name fails PEP 508
+            validation.
+    """
+    from deepagents_code.extras_info import (
+        ExtrasIntrospectionError,
+        installed_extra_names,
+    )
+
+    extras = installed_extra_names(distribution_name, strict=True)
+    try:
+        requirement = _dcode_extras_requirement(extras, version=version)
+    except ValueError as exc:
+        msg = f"Distribution metadata yielded an invalid extra name: {exc}"
+        raise ExtrasIntrospectionError(msg) from exc
+    cmd = "uv tool install -U"
+    python = _uv_tool_python()
+    if python is not None:
+        cmd += f" --python {shlex.quote(python)}"
+    cmd += f" {requirement}"
+    with_packages = _uv_tool_with_packages(distribution_name=distribution_name)
+    for package in with_packages:
+        cmd += f" --with {shlex.quote(package)}"
+    if _resolve_include_prereleases(include_prereleases):
+        cmd += " --prerelease allow"
+    return cmd
+
+
 def upgrade_install_command(
     *,
     include_prereleases: bool | None = None,
@@ -1894,45 +1933,19 @@ def upgrade_install_command(
     Returns:
         Shell command string suitable for execution via the shell.
 
-    Raises:
-        ExtrasIntrospectionError: If installed extras cannot be determined
-            safely from distribution metadata, or a metadata-sourced extra name
-            fails PEP 508 validation (re-raised from the underlying `ValueError`
-            so callers need not catch a broad built-in).
-
-    Also propagates `ToolRequirementIntrospectionError` if the uv tool `--with`
-    packages or interpreter cannot be determined safely from the tool receipt.
-    Callers choose whether to treat those errors as failures or fall back to a
-    simpler unpinned upgrade command with a user-facing warning.
+    Propagates `ExtrasIntrospectionError` if installed extras cannot be
+    determined safely from distribution metadata, or a metadata-sourced extra name
+    fails PEP 508 validation. Also propagates `ToolRequirementIntrospectionError`
+    if the uv tool `--with` packages or interpreter cannot be determined safely
+    from the tool receipt. Callers choose whether to treat those errors as
+    failures or fall back to a simpler unpinned upgrade command with a
+    user-facing warning.
     """
-    from deepagents_code.extras_info import (
-        ExtrasIntrospectionError,
-        installed_extra_names,
+    return _uv_tool_install_command(
+        version=None,
+        include_prereleases=include_prereleases,
+        distribution_name=distribution_name,
     )
-
-    extras = installed_extra_names(distribution_name, strict=True)
-    try:
-        requirement = _dcode_extras_requirement(extras, version=None)
-    except ValueError as exc:
-        # `extras` come from the distribution's own optional-dependency
-        # metadata, so a PEP 508 validation failure here means that metadata is
-        # malformed. Translate to the typed introspection error so callers
-        # (`perform_upgrade`) handle it like any other unreadable-config case
-        # instead of relying on a broad `ValueError` catch that could also
-        # swallow an unrelated future bug in this builder.
-        msg = f"Distribution metadata yielded an invalid extra name: {exc}"
-        raise ExtrasIntrospectionError(msg) from exc
-    cmd = "uv tool install -U"
-    python = _uv_tool_python()
-    if python is not None:
-        cmd += f" --python {shlex.quote(python)}"
-    cmd += f" {requirement}"
-    with_packages = _uv_tool_with_packages(distribution_name=distribution_name)
-    for package in with_packages:
-        cmd += f" --with {shlex.quote(package)}"
-    if _resolve_include_prereleases(include_prereleases):
-        cmd += " --prerelease allow"
-    return cmd
 
 
 def dependency_refresh_command(
@@ -1954,30 +1967,17 @@ def dependency_refresh_command(
         Shell command string suitable for execution via the shell.
 
     Propagates `ExtrasIntrospectionError` if installed extras cannot be
-    determined safely from distribution metadata, and
-    `ToolRequirementIntrospectionError` if the uv tool `--with` packages or
-    interpreter cannot be determined safely from the tool receipt.
-    `perform_dependency_refresh` converts both into a user-facing failure.
+    determined safely from distribution metadata, or a metadata-sourced extra name
+    fails PEP 508 validation, and `ToolRequirementIntrospectionError` if the uv
+    tool `--with` packages or interpreter cannot be determined safely from the
+    tool receipt. `perform_dependency_refresh` converts both into a user-facing
+    failure.
     """
-    from deepagents_code.extras_info import installed_extra_names
-
-    # `installed_extra_names` raises `ExtrasIntrospectionError`; `_uv_tool_python`
-    # and `_uv_tool_with_packages` raise `ToolRequirementIntrospectionError`.
-    # Both propagate to `perform_dependency_refresh`, which converts them into a
-    # user-facing failure, so there's nothing to add by catching here.
-    extras = installed_extra_names(distribution_name, strict=True)
-    requirement = _dcode_extras_requirement(extras, version=version)
-    cmd = "uv tool install -U"
-    python = _uv_tool_python()
-    if python is not None:
-        cmd += f" --python {shlex.quote(python)}"
-    cmd += f" {requirement}"
-    with_packages = _uv_tool_with_packages(distribution_name=distribution_name)
-    for package in with_packages:
-        cmd += f" --with {shlex.quote(package)}"
-    if _resolve_include_prereleases(include_prereleases):
-        cmd += " --prerelease allow"
-    return cmd
+    return _uv_tool_install_command(
+        version=version,
+        include_prereleases=include_prereleases,
+        distribution_name=distribution_name,
+    )
 
 
 def dependency_refresh_dry_run_command(

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -1848,8 +1848,9 @@ def upgrade_install_command(
     Propagates `ExtrasIntrospectionError` if installed extras cannot be
     determined safely from distribution metadata, and
     `ToolRequirementIntrospectionError` if the uv tool `--with` packages or
-    interpreter cannot be determined safely from the tool receipt.
-    `perform_upgrade` converts both into a user-facing failure.
+    interpreter cannot be determined safely from the tool receipt. Callers choose
+    whether to treat those errors as failures or fall back to a simpler unpinned
+    upgrade command with a user-facing warning.
     """
     from deepagents_code.extras_info import installed_extra_names
 

--- a/libs/code/deepagents_code/widgets/update_progress.py
+++ b/libs/code/deepagents_code/widgets/update_progress.py
@@ -126,6 +126,7 @@ class UpdateProgressScreen(ModalScreen[None]):
         self._details_visible = False
         self._done = False
         self._status = f"Installing v{latest}..."
+        self._done_glyph: str | None = None
         self._status_widget: Static | None = None
         self._spinner = Spinner()
         self._spinner_widget: Static | None = None
@@ -134,6 +135,8 @@ class UpdateProgressScreen(ModalScreen[None]):
         self._log_path_widget: Static | None = None
         self._tail_widget: Log | None = None
         self._help_widget: Static | None = None
+        self._copy_text: str | None = None
+        self._copy_label = "log path"
 
     def compose(self) -> ComposeResult:
         """Compose the modal.
@@ -196,6 +199,7 @@ class UpdateProgressScreen(ModalScreen[None]):
     def mark_success(self) -> None:
         """Render the completed-success state."""
         self._done = True
+        self._done_glyph = get_glyphs().checkmark
         self._status = (
             f"Update complete. Quit and relaunch Deep Agents Code to use "
             f"v{self._latest}."
@@ -210,7 +214,32 @@ class UpdateProgressScreen(ModalScreen[None]):
             command: Manual command users can run to retry.
         """
         self._done = True
+        self._done_glyph = get_glyphs().checkmark
         self._status = f"Update failed. Try manually: {command}"
+        self._details_visible = True
+        self._stop_spinner_timer()
+        self._refresh_status()
+        self._apply_details_visibility()
+
+    def mark_warning(
+        self,
+        warning: str,
+        *,
+        copy_text: str | None = None,
+        copy_label: str = "fix command",
+    ) -> None:
+        """Render a completed state that needs user action.
+
+        Args:
+            warning: Durable warning text to show in the modal status.
+            copy_text: Optional text copied by the `c` key in warning state.
+            copy_label: User-facing name for the copied text.
+        """
+        self._done = True
+        self._done_glyph = get_glyphs().warning
+        self._status = warning
+        self._copy_text = copy_text
+        self._copy_label = copy_label
         self._details_visible = True
         self._stop_spinner_timer()
         self._refresh_status()
@@ -227,12 +256,19 @@ class UpdateProgressScreen(ModalScreen[None]):
             self.dismiss(None)
 
     def action_copy_log_path(self) -> None:
-        """Copy the persisted log path when details are visible."""
-        if not self._details_visible:
+        """Copy warning action text or the persisted log path."""
+        copy_text = self._copy_text
+        copy_label = self._copy_label
+        if copy_text is None:
+            if not self._details_visible:
+                return
+            copy_text = str(self._log_path)
+            copy_label = "log path"
+        if not copy_text:
             return
-        self.app.copy_to_clipboard(str(self._log_path))
+        self.app.copy_to_clipboard(copy_text)
         self.app.notify(
-            "Copied log path.",
+            f"Copied {copy_label}.",
             severity="information",
             timeout=3,
             markup=False,
@@ -243,7 +279,7 @@ class UpdateProgressScreen(ModalScreen[None]):
             self._status_widget.update(self._status)
         if self._spinner_widget is not None:
             if self._done:
-                self._spinner_widget.update(get_glyphs().checkmark)
+                self._spinner_widget.update(self._done_glyph or get_glyphs().checkmark)
                 self._spinner_widget.display = True
             else:
                 self._spinner_widget.display = True
@@ -271,7 +307,9 @@ class UpdateProgressScreen(ModalScreen[None]):
         details = "Hide details" if self._details_visible else "Show details"
         close = "Esc close" if self._done else "Esc close when complete"
         parts = [f"d {details}", close]
-        if self._details_visible:
+        if self._copy_text is not None:
+            parts.insert(1, f"c copy {self._copy_label}")
+        elif self._details_visible:
             parts.insert(1, "c copy log path")
         return f" {glyphs.bullet} ".join(parts)
 

--- a/libs/code/deepagents_code/widgets/update_progress.py
+++ b/libs/code/deepagents_code/widgets/update_progress.py
@@ -214,7 +214,7 @@ class UpdateProgressScreen(ModalScreen[None]):
             command: Manual command users can run to retry.
         """
         self._done = True
-        self._done_glyph = get_glyphs().checkmark
+        self._done_glyph = get_glyphs().error
         self._status = f"Update failed. Try manually: {command}"
         self._details_visible = True
         self._stop_spinner_timer()

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -10384,6 +10384,78 @@ class TestNotificationCenterIntegration:
             for m in notified
         )
 
+    async def test_install_success_with_shadow_toast_only_when_modal_hidden(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A shadow with no progress modal still reaches the user as a toast.
+
+        When a modal is already on screen the install runs without pushing the
+        `UpdateProgressScreen`, so `progress_modal_visible` is `False` and
+        `mark_warning` is skipped. The shadow warning must still fire as a
+        `notify(severity="warning")` toast — this is the less-common leg of the
+        shadow branch, and the exact "user silently keeps the old version"
+        failure mode this PR exists to prevent. A regression that nested the
+        `self.notify(warning, ...)` inside `if progress_modal_visible:` would
+        drop the warning entirely here and pass the modal-visible test.
+        """
+        from textual.screen import ModalScreen
+
+        from deepagents_code.notifications import ActionId
+        from deepagents_code.update_check import ShadowedDcode
+        from deepagents_code.widgets.update_progress import UpdateProgressScreen
+
+        shadow = ShadowedDcode(
+            shadowing_bin=Path("/opt/stale/bin/dcode"),
+            upgraded_bin_dir=Path("/home/user/.local/bin"),
+        )
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        entry = _update_entry()
+        app._notice_registry.add(entry)
+
+        notified: list[str] = []
+        original_notify = app.notify
+
+        def capture_notify(message: str, **kwargs: Any) -> None:
+            notified.append(message)
+            original_notify(message, **kwargs)
+
+        monkeypatch.setattr(app, "notify", capture_notify)
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # A modal already owns the screen, so the install path takes the
+            # toast-only branch (`progress_modal_visible` is False).
+            await app.push_screen(ModalScreen())
+            await pilot.pause()
+            with (
+                patch(
+                    "deepagents_code.update_check.perform_upgrade",
+                    new=AsyncMock(return_value=(True, "Updated deepagents-code")),
+                ),
+                patch(
+                    "deepagents_code.update_check.detect_shadowed_dcode",
+                    return_value=shadow,
+                ),
+            ):
+                await app._dispatch_notification_action(entry.key, ActionId.INSTALL)
+                await pilot.pause()
+
+            # The progress modal was never pushed, so the warning could only
+            # have reached the user as a toast.
+            assert not isinstance(app.screen, UpdateProgressScreen)
+
+        assert app._notice_registry.get("update:available") is None
+        # The success line must not appear — relaunch would keep the old binary.
+        assert not any(
+            "Updated to v" in m and "Quit and relaunch" in m for m in notified
+        )
+        # The warning toast names both paths so the user can act on it.
+        assert any(
+            "/opt/stale/bin/dcode" in m and "/home/user/.local/bin" in m
+            for m in notified
+        )
+
     async def test_debug_update_install_does_not_run_upgrade(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -10489,7 +10489,7 @@ class TestNotificationCenterIntegration:
             spinner = app.screen.query(Static).filter(".up-spinner").first()
             assert "Update failed. Try manually:" in str(status.render())
             assert details.display is True
-            assert str(spinner.render()) == get_glyphs().checkmark
+            assert str(spinner.render()) == get_glyphs().error
 
     async def test_update_skip_once_clears_notified_marker(self) -> None:
         """'Remind me next launch' calls clear_update_notified and removes the entry."""

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -9660,6 +9660,23 @@ class TestNotificationCenterIntegration:
         ):
             yield
 
+    @pytest.fixture(autouse=True)
+    def _no_shadowed_dcode(self) -> Iterator[None]:
+        """Default to no PATH shadow for the notification-action tests.
+
+        Without this, every successful "Install now" test runs the real
+        `detect_shadowed_dcode` against the host filesystem. The runner's
+        editable install currently short-circuits at `detect_install_method()`,
+        but a uv-tool-managed runner would silently re-route every success
+        case through the new warning branch. Pin to `None` here; the
+        dedicated shadow-present test below overrides it.
+        """
+        with patch(
+            "deepagents_code.update_check.detect_shadowed_dcode",
+            return_value=None,
+        ):
+            yield
+
     async def test_ctrl_n_with_empty_registry_emits_toast(self) -> None:
         """ctrl+n with nothing pending notifies and doesn't push a modal."""
         from deepagents_code.notifications import NotificationRegistry
@@ -10170,6 +10187,82 @@ class TestNotificationCenterIntegration:
                 await pilot.pause()
 
         assert app._notice_registry.get("update:available") is None
+
+    async def test_install_success_with_shadow_surfaces_warning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When PATH is shadowed, modal success is replaced by the warning.
+
+        Regression guard for the inverted `if/elif` in the install-action
+        branch: a `if shadow / elif not progress_modal_visible` that got
+        flipped would ship a reassuring "Updated to vX.Y.Z" state over a
+        broken upgrade. This pins the contract that the success modal status
+        and toast are suppressed while the warning stays visible.
+        """
+        from deepagents_code.notifications import ActionId
+        from deepagents_code.update_check import (
+            ShadowedDcode,
+            format_shadowed_dcode_fix_command,
+        )
+        from deepagents_code.widgets.update_progress import UpdateProgressScreen
+
+        shadow = ShadowedDcode(
+            shadowing_bin=Path("/opt/stale/bin/dcode"),
+            upgraded_bin_dir=Path("/home/user/.local/bin"),
+        )
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        entry = _update_entry()
+        app._notice_registry.add(entry)
+
+        copied: list[str] = []
+        notified: list[str] = []
+        original_notify = app.notify
+        monkeypatch.setattr(app, "copy_to_clipboard", copied.append)
+
+        def capture_notify(message: str, **kwargs: Any) -> None:
+            notified.append(message)
+            original_notify(message, **kwargs)
+
+        app.notify = capture_notify  # ty: ignore
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with (
+                patch(
+                    "deepagents_code.update_check.perform_upgrade",
+                    new=AsyncMock(return_value=(True, "Updated deepagents-code")),
+                ),
+                # Override the autouse `None` patch.
+                patch(
+                    "deepagents_code.update_check.detect_shadowed_dcode",
+                    return_value=shadow,
+                ),
+            ):
+                await app._dispatch_notification_action(entry.key, ActionId.INSTALL)
+                await pilot.pause()
+
+            assert isinstance(app.screen, UpdateProgressScreen)
+            status = app.screen.query(Static).filter(".up-status").first()
+            assert "Update complete" not in str(status.render())
+            assert "/opt/stale/bin/dcode" in str(status.render())
+            assert "/home/user/.local/bin/dcode" in str(status.render())
+            await pilot.press("c")
+            await pilot.pause()
+
+        # The entry is still cleared — the upgrade did succeed; only the
+        # post-restart guidance is different.
+        assert app._notice_registry.get("update:available") is None
+        assert copied == [format_shadowed_dcode_fix_command(shadow)]
+        # The toast must NOT congratulate the user on a working upgrade.
+        assert not any(
+            "Updated to v" in m and "Quit and relaunch" in m for m in notified
+        )
+        # The warning toast names both paths so the user can act on it.
+        assert any(
+            "/opt/stale/bin/dcode" in m and "/home/user/.local/bin" in m
+            for m in notified
+        )
 
     async def test_debug_update_install_does_not_run_upgrade(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -47,6 +47,31 @@ class TestStartupAutoUpdate:
         ):
             yield
 
+    @pytest.fixture(autouse=True)
+    def _no_shadowed_dcode(self) -> Iterator[None]:
+        """Default to "no PATH shadow detected" for the success-path tests.
+
+        Without this, every successful-upgrade test would run the real
+        `detect_shadowed_dcode` against the host filesystem. That's
+        hermetic only by accident — the test runner's editable install
+        currently short-circuits at `detect_install_method() != "uv"` — but
+        a uv-tool-managed Python or CI image that does match would silently
+        re-route every "successful update" test through the new
+        `if shadow is not None: return` branch and skip the restart
+        assertion. Pin to `None` here so the contract being tested is
+        "shadow path is opt-in"; the dedicated shadow-present test below
+        patches it explicitly.
+
+        Patches at the source module rather than `deepagents_code.main`
+        because `_run_startup_auto_update` lazy-imports it inside the
+        function.
+        """
+        with patch(
+            "deepagents_code.update_check.detect_shadowed_dcode",
+            return_value=None,
+        ):
+            yield
+
     def test_successful_update_restarts_before_launch(self) -> None:
         """A successful startup auto-update should exec a fresh process."""
         console = MagicMock()
@@ -85,6 +110,77 @@ class TestStartupAutoUpdate:
 
         upgrade.assert_awaited_once()
         restart.assert_called_once_with()
+
+    def test_successful_update_skips_restart_when_shadowed(self) -> None:
+        """Successful upgrade + shadowed dcode must NOT restart into the old binary.
+
+        Regression guard for the critical bug: when a stale `dcode` is
+        earlier on PATH than uv's bin dir, re-exec'ing would silently
+        re-launch the old version. The pre-launch path must surface a
+        warning and return *before* `_restart_current_process` so the user
+        sees the message and isn't stranded on the old in-memory version
+        with no explanation. Also pins the markup-escape behavior: a path
+        containing a Rich-special character must not raise.
+        """
+        from deepagents_code.update_check import ShadowedDcode
+
+        console = MagicMock()
+        upgrade = AsyncMock(return_value=(True, "updated"))
+        # Embed `[` in the shadowing path — legal on POSIX filesystems —
+        # so a regression that dropped `escape()` would raise a Rich
+        # `MarkupError` here instead of silently emitting broken styling.
+        shadow = ShadowedDcode(
+            shadowing_bin=Path("/opt/old [legacy]/bin/dcode"),
+            upgraded_bin_dir=Path("/home/user/.local/bin"),
+        )
+
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.is_update_check_enabled",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.update_check.get_cached_update_available",
+                return_value=(True, "9.9.9"),
+            ),
+            patch(
+                "deepagents_code.update_check.format_release_age_parenthetical",
+                return_value="",
+            ),
+            patch(
+                "deepagents_code.update_check.create_update_log_path",
+                return_value=Path("/tmp/dcode-update.log"),
+            ),
+            patch("deepagents_code.update_check.perform_upgrade", upgrade),
+            # Override the autouse `_no_shadowed_dcode` fixture for this
+            # single test by re-patching the same name with the positive
+            # case. The innermost patch wins, so the autouse fixture's
+            # `None` doesn't leak through.
+            patch(
+                "deepagents_code.update_check.detect_shadowed_dcode",
+                return_value=shadow,
+            ),
+            patch("deepagents_code.main._restart_current_process") as restart,
+        ):
+            _run_startup_auto_update(console)
+
+        upgrade.assert_awaited_once()
+        restart.assert_not_called()
+        printed = " ".join(str(c.args[0]) for c in console.print.call_args_list)
+        assert "Warning:" in printed
+        # The path's `[legacy]` segment must be Rich-escaped (`\[legacy]`)
+        # before interpolation under `markup=True`; a regression that
+        # dropped `escape()` would either raise `MarkupError` (test fails)
+        # or render `[legacy]` as a (broken) style tag. Asserting the
+        # escaped form pins the fix.
+        assert "/opt/old \\[legacy]/bin/dcode" in printed
+        assert "/home/user/.local/bin" in printed
+        assert "Continuing with v" in printed
 
     def test_disabled_update_does_not_check_pypi(self) -> None:
         """Disabled auto-update should not perform network or install work."""
@@ -667,6 +763,15 @@ class TestStartupAutoUpdate:
 
 class TestAutoUpdateDefaultMigration:
     """First-run consent/migration notice for the auto-update opt-out default."""
+
+    @pytest.fixture(autouse=True)
+    def _no_shadowed_dcode(self) -> Iterator[None]:
+        """Default to no PATH shadow — same reasoning as `TestStartupAutoUpdate`."""
+        with patch(
+            "deepagents_code.update_check.detect_shadowed_dcode",
+            return_value=None,
+        ):
+            yield
 
     def test_first_run_announces_and_skips_install(self) -> None:
         """An implicit (default) opt-in announces once and skips the install."""

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -1383,6 +1383,19 @@ class TestDetectShadowedDcode:
         )
         assert command.replace("\n", "\n  ") in rendered
 
+    def test_windows_fix_command_uses_powershell_literal_path(self, tmp_path) -> None:
+        """PowerShell paths must not expand `$` or evaluate subexpressions."""
+        shadow = ShadowedDcode(
+            shadowing_bin=tmp_path / "old-bin" / "dcode",
+            upgraded_bin_dir=tmp_path / "uv $dcode's $(bin)",
+        )
+
+        with patch("deepagents_code.update_check.os.name", "nt"):
+            command = format_shadowed_dcode_fix_command(shadow)
+
+        quoted_bin_dir = str(shadow.upgraded_bin_dir).replace("'", "''")
+        assert command == f"$env:PATH = '{quoted_bin_dir};' + $env:PATH"
+
     def test_canonicalize_failure_continues_to_deepagents_code_name(
         self, tmp_path
     ) -> None:

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -1162,6 +1162,39 @@ class TestDetectShadowedDcode:
         ):
             assert detect_shadowed_dcode() is None
 
+    def test_checks_deepagents_code_when_dcode_is_healthy(self, tmp_path) -> None:
+        """A healthy `dcode` must not hide a shadowed `deepagents-code`."""
+        uv_bin = tmp_path / "uv-bin"
+        uv_bin.mkdir()
+        (uv_bin / "dcode").write_text("")
+        (uv_bin / "deepagents-code").write_text("")
+        stale_bin = tmp_path / "stale-bin"
+        stale_bin.mkdir()
+        stale = stale_bin / "deepagents-code"
+        stale.write_text("")
+
+        def _which(name: str) -> str | None:
+            if name == "dcode":
+                return str(uv_bin / "dcode")
+            if name == "deepagents-code":
+                return str(stale)
+            return None
+
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch.dict(os.environ, {"UV_TOOL_BIN_DIR": str(uv_bin)}),
+            patch("shutil.which", side_effect=_which),
+        ):
+            shadow = detect_shadowed_dcode()
+
+        assert shadow == ShadowedDcode(
+            shadowing_bin=stale,
+            upgraded_bin_dir=uv_bin.resolve(),
+        )
+
     def test_returns_none_for_uv_symlink_shim(self, tmp_path) -> None:
         """A uv-style symlink shim under the user bin dir is NOT a shadow.
 
@@ -1277,7 +1310,7 @@ class TestDetectShadowedDcode:
             assert detect_shadowed_dcode() is None
 
     def test_falls_back_to_deepagents_code_binary_name(self, tmp_path) -> None:
-        """The legacy `deepagents-code` binary is checked when `dcode` is missing.
+        """The `deepagents-code` binary is checked when `dcode` is missing.
 
         Mirrors the install-script verification loop so an install that only
         exposes `deepagents-code` (e.g. an older `uv tool install` that
@@ -1350,8 +1383,10 @@ class TestDetectShadowedDcode:
         )
         assert command.replace("\n", "\n  ") in rendered
 
-    def test_canonicalize_failure_continues_to_legacy_name(self, tmp_path) -> None:
-        """A `resolve()` failure on `dcode` must not hide a legacy-name shadow.
+    def test_canonicalize_failure_continues_to_deepagents_code_name(
+        self, tmp_path
+    ) -> None:
+        """A `resolve()` failure on `dcode` must not hide another shadow.
 
         The detector deliberately `continue`s to the `deepagents-code` name
         when canonicalizing `dcode`'s PATH directory raises, rather than
@@ -1368,20 +1403,20 @@ class TestDetectShadowedDcode:
         (bad_dir / "dcode").write_text("")
         stale_bin = tmp_path / "stale-bin"
         stale_bin.mkdir()
-        legacy = stale_bin / "deepagents-code"
-        legacy.write_text("")
+        stale_deepagents_code = stale_bin / "deepagents-code"
+        stale_deepagents_code.write_text("")
 
         def _which(name: str) -> str | None:
             if name == "dcode":
                 return str(bad_dir / "dcode")
             if name == "deepagents-code":
-                return str(legacy)
+                return str(stale_deepagents_code)
             return None
 
         real_resolve = Path.resolve
 
         def _resolve(self: Path, strict: bool = False) -> Path:
-            # Only `dcode`'s PATH-entry directory raises; the legacy binary's
+            # Only `dcode`'s PATH-entry directory raises; the other binary's
             # directory resolves cleanly so the loop can reach a real answer.
             if self == bad_dir:
                 msg = "simulated resolve failure"
@@ -1403,7 +1438,7 @@ class TestDetectShadowedDcode:
             shadow = detect_shadowed_dcode()
 
         assert shadow is not None
-        assert shadow.shadowing_bin == legacy
+        assert shadow.shadowing_bin == stale_deepagents_code
         assert shadow.upgraded_bin_dir == uv_bin
 
 

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -2286,6 +2286,29 @@ class TestUpgradeInstallCommand:
         ):
             upgrade_install_command()
 
+    def test_invalid_metadata_extra_reraised_as_introspection_error(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A malformed extra name from metadata surfaces as the typed error.
+
+        `_dcode_extras_requirement` raises a bare `ValueError` on a PEP
+        508-invalid extra name. Since the extras here come from the
+        distribution's own metadata, such a name signals malformed metadata —
+        the builder re-raises it as `ExtrasIntrospectionError` so `perform_upgrade`
+        handles it through its typed fallback rather than relying on a broad
+        `ValueError` catch that could also mask an unrelated builder bug.
+        """
+        _write_uv_receipt(tmp_path, '{ name = "deepagents-code" }')
+        monkeypatch.setattr("sys.prefix", str(tmp_path))
+        with (
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=frozenset({"not a valid extra"}),
+            ),
+            pytest.raises(ExtrasIntrospectionError),
+        ):
+            upgrade_install_command()
+
 
 class TestParseDependencyChanges:
     """`parse_dependency_changes` collapses uv's env diff into changes."""

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -10,14 +10,11 @@ import sys
 import time
 import tomllib
 from collections.abc import Mapping, Sequence  # noqa: TC003
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
 from packaging.version import InvalidVersion, Version
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 from deepagents_code._version import __version__
 from deepagents_code.extras_info import ExtrasIntrospectionError, installed_extra_names
@@ -25,10 +22,12 @@ from deepagents_code.update_check import (
     CACHE_TTL,
     DependencyChange,
     InstallMethod,
+    ShadowedDcode,
     ToolRequirementIntrospectionError,
     _extract_release_times,
     _latest_from_releases,
     _parse_version,
+    _uv_tool_bin_dir,
     cleanup_update_logs,
     clear_update_notified,
     create_update_log_path,
@@ -36,6 +35,8 @@ from deepagents_code.update_check import (
     dependency_refresh_dry_run_command,
     dependency_refresh_supported,
     detect_install_method,
+    detect_shadowed_dcode,
+    detect_shadowed_dcode_safe,
     editable_extra_hint,
     editable_package_hint,
     format_age_suffix,
@@ -45,6 +46,8 @@ from deepagents_code.update_check import (
     format_release_age_parenthetical,
     format_sdk_age_suffix,
     format_sdk_release_age,
+    format_shadowed_dcode_fix_command,
+    format_shadowed_dcode_warning,
     get_cached_update_available,
     get_latest_version,
     get_release_time,
@@ -73,6 +76,7 @@ from deepagents_code.update_check import (
     should_announce_auto_update_default,
     should_notify_update,
     upgrade_command,
+    upgrade_install_command,
 )
 
 
@@ -950,6 +954,508 @@ class TestDetectInstallMethod:
             assert detect_install_method() == "other"
 
 
+class TestUvToolBinDir:
+    """Coverage for uv's documented executable-directory precedence chain.
+
+    `detect_shadowed_dcode` compares the user's PATH against whatever
+    `_uv_tool_bin_dir` returns, so any drift between this helper and uv's
+    actual install location causes false-positive shadow warnings *and*
+    skipped auto-update restarts. Each candidate in uv's precedence list
+    gets explicit coverage.
+    """
+
+    def test_uv_tool_bin_dir_env_wins(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`UV_TOOL_BIN_DIR` overrides every other candidate."""
+        override = tmp_path / "uv-tool-bin"
+        override.mkdir()
+        xdg_bin = tmp_path / "xdg-bin"
+        xdg_bin.mkdir()
+        monkeypatch.setenv("UV_TOOL_BIN_DIR", str(override))
+        monkeypatch.setenv("XDG_BIN_HOME", str(xdg_bin))
+
+        assert _uv_tool_bin_dir() == override.resolve()
+
+    def test_xdg_bin_home_wins_when_uv_var_unset(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`XDG_BIN_HOME` is the second-precedence candidate per uv's docs.
+
+        Hits the branch users hit on Linux when they've adopted the XDG
+        Base Directory convention but haven't set uv-specific overrides.
+        Without this branch the detector would skip past XDG_BIN_HOME to
+        ~/.local/bin and silently warn on every successful upgrade.
+        """
+        xdg_bin = tmp_path / "xdg-bin"
+        xdg_bin.mkdir()
+        # Also create a `~/.local/bin` candidate to prove XDG_BIN_HOME
+        # wins even when later candidates exist.
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        monkeypatch.delenv("UV_TOOL_BIN_DIR", raising=False)
+        monkeypatch.setenv("XDG_BIN_HOME", str(xdg_bin))
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+
+        assert _uv_tool_bin_dir() == xdg_bin.resolve()
+
+    def test_xdg_data_home_parent_bin_wins_when_only_xdg_data_set(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`$XDG_DATA_HOME/../bin` is uv's third-precedence candidate.
+
+        Pins the intermediate fallback rather than collapsing it into the
+        `~/.local/bin` default — a setup where the user has redirected
+        XDG_DATA_HOME (e.g. to a non-standard prefix) must land on the
+        sibling bin dir uv itself would target.
+        """
+        data_root = tmp_path / "alt-data-root"
+        data_root.mkdir()
+        sibling_bin = tmp_path / "bin"
+        sibling_bin.mkdir()
+        home = tmp_path / "home"
+        (home / ".local" / "bin").mkdir(parents=True)
+        monkeypatch.delenv("UV_TOOL_BIN_DIR", raising=False)
+        monkeypatch.delenv("XDG_BIN_HOME", raising=False)
+        monkeypatch.setenv("XDG_DATA_HOME", str(data_root))
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+
+        # `$XDG_DATA_HOME/../bin` resolves to `tmp_path/bin` (sibling).
+        assert _uv_tool_bin_dir() == sibling_bin.resolve()
+
+    def test_local_bin_fallback_when_no_env_vars(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`~/.local/bin` is the documented final fallback on Unix and Windows.
+
+        The path most real users hit: no env vars set, default home,
+        `~/.local/bin` exists. Without coverage here a regression that
+        broke the fallback would only show up in production.
+        """
+        home = tmp_path / "home"
+        local_bin = home / ".local" / "bin"
+        local_bin.mkdir(parents=True)
+        monkeypatch.delenv("UV_TOOL_BIN_DIR", raising=False)
+        monkeypatch.delenv("XDG_BIN_HOME", raising=False)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+
+        assert _uv_tool_bin_dir() == local_bin.resolve()
+
+    def test_returns_none_when_no_candidate_exists(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No env vars and no `~/.local/bin` → `None`, not a bogus path.
+
+        Returning a non-existent path would make `detect_shadowed_dcode`
+        report every install as shadowed against a directory the user
+        couldn't possibly have on PATH. `None` is the right signal so the
+        detector short-circuits silently.
+        """
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.delenv("UV_TOOL_BIN_DIR", raising=False)
+        monkeypatch.delenv("XDG_BIN_HOME", raising=False)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+
+        assert _uv_tool_bin_dir() is None
+
+    def test_skips_missing_candidate_and_falls_through(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A higher-precedence candidate that doesn't exist falls through.
+
+        An env var set to a non-existent path must not bind the answer to
+        that bad value — the helper should keep walking the precedence
+        list. This is what makes the env override safe to set
+        unconditionally in dotfiles even when the directory hasn't been
+        created yet.
+        """
+        missing = tmp_path / "does-not-exist"
+        # Deliberately do not mkdir.
+        home = tmp_path / "home"
+        local_bin = home / ".local" / "bin"
+        local_bin.mkdir(parents=True)
+        monkeypatch.setenv("UV_TOOL_BIN_DIR", str(missing))
+        monkeypatch.delenv("XDG_BIN_HOME", raising=False)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+
+        assert _uv_tool_bin_dir() == local_bin.resolve()
+
+    def test_resolve_failure_falls_through_to_next_candidate(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A candidate that raises on `resolve()` must not bind the answer.
+
+        Distinct from the "missing candidate" case: here the higher-precedence
+        candidate exists but `resolve()` raises `OSError` (a vanished mount,
+        a permission glitch). The helper's `except OSError: continue` exists so
+        a transient failure doesn't downgrade the answer to a less-preferred
+        path *or* poison it with the bad candidate — it must keep walking to
+        the next entry, exactly like the missing-candidate path.
+        """
+        override = tmp_path / "uv-tool-bin"
+        override.mkdir()
+        home = tmp_path / "home"
+        local_bin = home / ".local" / "bin"
+        local_bin.mkdir(parents=True)
+        monkeypatch.setenv("UV_TOOL_BIN_DIR", str(override))
+        monkeypatch.delenv("XDG_BIN_HOME", raising=False)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+
+        real_resolve = Path.resolve
+
+        def _resolve(self: Path, strict: bool = False) -> Path:
+            # Only the first (UV_TOOL_BIN_DIR) candidate raises; everything
+            # else — including the eventual `~/.local/bin` winner — resolves
+            # normally so the test pins fallthrough, not a blanket failure.
+            if self == override:
+                msg = "simulated resolve failure"
+                raise OSError(msg)
+            return real_resolve(self, strict)
+
+        monkeypatch.setattr(Path, "resolve", _resolve)
+
+        assert _uv_tool_bin_dir() == real_resolve(local_bin)
+
+
+class TestDetectShadowedDcode:
+    """Regression coverage for the post-upgrade shadowing detector.
+
+    The detector is the only thing standing between a successful `uv tool
+    upgrade` and the user silently relaunching into a pre-uv `dcode` earlier on
+    PATH, so each branch of the comparison is covered explicitly.
+    """
+
+    def test_returns_none_for_non_uv_install(self, tmp_path) -> None:
+        """Non-uv installs cannot describe an 'upgraded shim' location."""
+        uv_bin = tmp_path / "bin"
+        uv_bin.mkdir()
+        (uv_bin / "dcode").write_text("")
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="brew",
+            ),
+            patch.dict(os.environ, {"UV_TOOL_BIN_DIR": str(uv_bin)}),
+            patch("shutil.which", return_value=str(uv_bin / "dcode")),
+        ):
+            assert detect_shadowed_dcode() is None
+
+    def test_returns_none_when_path_resolves_into_uv_bin_dir(self, tmp_path) -> None:
+        """The happy path: PATH points at the directory uv installs into."""
+        uv_bin = tmp_path / "bin"
+        uv_bin.mkdir()
+        shim = uv_bin / "dcode"
+        shim.write_text("")
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch.dict(os.environ, {"UV_TOOL_BIN_DIR": str(uv_bin)}),
+            patch("shutil.which", return_value=str(shim)),
+        ):
+            assert detect_shadowed_dcode() is None
+
+    def test_returns_none_for_uv_symlink_shim(self, tmp_path) -> None:
+        """A uv-style symlink shim under the user bin dir is NOT a shadow.
+
+        On a healthy uv tool install, `~/.local/bin/dcode` is a symlink to
+        `~/.local/share/uv/tools/deepagents-code/bin/dcode`. If we followed
+        that symlink the parent would be the tool venv's internal bin dir,
+        which differs from uv's user-facing bin dir and would make every
+        healthy install look shadowed. The detector must compare the
+        PATH-entry directory, not the symlink target.
+        """
+        uv_bin = tmp_path / "uv-bin"
+        uv_bin.mkdir()
+        tool_internal_bin = tmp_path / "tools" / "deepagents-code" / "bin"
+        tool_internal_bin.mkdir(parents=True)
+        real_entry_point = tool_internal_bin / "dcode"
+        real_entry_point.write_text("")
+        shim = uv_bin / "dcode"
+        shim.symlink_to(real_entry_point)
+
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch.dict(os.environ, {"UV_TOOL_BIN_DIR": str(uv_bin)}),
+            patch("shutil.which", return_value=str(shim)),
+        ):
+            assert detect_shadowed_dcode() is None
+
+    def test_returns_shadow_when_path_resolves_outside_uv_bin_dir(
+        self, tmp_path
+    ) -> None:
+        """A different `dcode` earlier on PATH is the bug we're protecting against.
+
+        Also pins the reported `shadowing_bin` to the PATH-visible path
+        (not the resolved symlink target), since that's the file the user
+        needs to act on.
+        """
+        uv_bin = tmp_path / "uv-bin"
+        uv_bin.mkdir()
+        (uv_bin / "dcode").write_text("")  # the upgraded shim uv would install
+        stale_bin = tmp_path / "stale-bin"
+        stale_bin.mkdir()
+        stale = stale_bin / "dcode"
+        stale.write_text("")
+
+        def _which(name: str) -> str | None:
+            return str(stale) if name == "dcode" else None
+
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch.dict(os.environ, {"UV_TOOL_BIN_DIR": str(uv_bin)}),
+            patch("shutil.which", side_effect=_which),
+        ):
+            shadow = detect_shadowed_dcode()
+
+        assert shadow == ShadowedDcode(
+            shadowing_bin=stale,
+            upgraded_bin_dir=uv_bin.resolve(),
+        )
+
+    def test_returns_shadow_for_symlink_shim_in_wrong_directory(self, tmp_path) -> None:
+        """A symlinked `dcode` outside uv's bin dir is still a real shadow.
+
+        Distinguishes the genuine shadow case (symlink in some other PATH
+        directory) from the false-positive case the previous test covers
+        (uv's own symlinks under its bin dir). Without separating these,
+        a fix for either could regress the other.
+        """
+        uv_bin = tmp_path / "uv-bin"
+        uv_bin.mkdir()
+        (uv_bin / "dcode").write_text("")
+        other_bin = tmp_path / "homebrew-bin"
+        other_bin.mkdir()
+        target = tmp_path / "Cellar" / "dcode" / "bin"
+        target.mkdir(parents=True)
+        real_dcode = target / "dcode"
+        real_dcode.write_text("")
+        stale_shim = other_bin / "dcode"
+        stale_shim.symlink_to(real_dcode)
+
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch.dict(os.environ, {"UV_TOOL_BIN_DIR": str(uv_bin)}),
+            patch("shutil.which", return_value=str(stale_shim)),
+        ):
+            shadow = detect_shadowed_dcode()
+
+        assert shadow is not None
+        # The reported path is the PATH-entry symlink, not the resolved
+        # target — that's what the user needs to delete or demote.
+        assert shadow.shadowing_bin == stale_shim
+        assert shadow.upgraded_bin_dir == uv_bin.resolve()
+
+    def test_returns_none_when_no_dcode_on_path(self, tmp_path) -> None:
+        """Without any `dcode` on PATH there's nothing to be shadowed by."""
+        uv_bin = tmp_path / "uv-bin"
+        uv_bin.mkdir()
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch.dict(os.environ, {"UV_TOOL_BIN_DIR": str(uv_bin)}),
+            patch("shutil.which", return_value=None),
+        ):
+            assert detect_shadowed_dcode() is None
+
+    def test_falls_back_to_deepagents_code_binary_name(self, tmp_path) -> None:
+        """The legacy `deepagents-code` binary is checked when `dcode` is missing.
+
+        Mirrors the install-script verification loop so an install that only
+        exposes `deepagents-code` (e.g. an older `uv tool install` that
+        predates the `dcode` entry point) still gets shadow-checked.
+        """
+        uv_bin = tmp_path / "uv-bin"
+        uv_bin.mkdir()
+        (uv_bin / "deepagents-code").write_text("")
+        stale_bin = tmp_path / "stale-bin"
+        stale_bin.mkdir()
+        stale = stale_bin / "deepagents-code"
+        stale.write_text("")
+
+        def _which(name: str) -> str | None:
+            if name == "dcode":
+                return None
+            if name == "deepagents-code":
+                return str(stale)
+            return None
+
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch.dict(os.environ, {"UV_TOOL_BIN_DIR": str(uv_bin)}),
+            patch("shutil.which", side_effect=_which),
+        ):
+            shadow = detect_shadowed_dcode()
+
+        assert shadow is not None
+        assert shadow.shadowing_bin == stale
+        assert shadow.upgraded_bin_dir == uv_bin.resolve()
+
+    def test_warning_text_includes_both_paths(self, tmp_path) -> None:
+        """The user-facing warning must name the shadowing binary AND the shim.
+
+        Without both paths the user can't tell which one is wrong or how to
+        fix their PATH, so this guards the message contract callers rely on.
+        The suggested command is intentionally session-scoped and
+        non-destructive because the shadowing binary may be package-managed.
+        """
+        shadow = ShadowedDcode(
+            shadowing_bin=tmp_path / "old-bin" / "dcode",
+            upgraded_bin_dir=tmp_path / "uv-bin",
+        )
+        rendered = format_shadowed_dcode_warning(shadow)
+        assert str(shadow.shadowing_bin) in rendered
+        assert str(shadow.upgraded_bin_dir / "dcode") in rendered
+        assert "earlier on your PATH" in rendered
+        command = format_shadowed_dcode_fix_command(shadow)
+        assert command.replace("\n", "\n  ") in rendered
+        assert "hash -r" in rendered
+        assert "rm " not in rendered
+
+    def test_warning_text_quotes_fix_command_path(self, tmp_path) -> None:
+        """The suggested PATH command must be safe to copy with odd paths."""
+        shadow = ShadowedDcode(
+            shadowing_bin=tmp_path / "old bin" / "dcode",
+            upgraded_bin_dir=tmp_path / "uv bin's dir",
+        )
+
+        rendered = format_shadowed_dcode_warning(shadow)
+        command = format_shadowed_dcode_fix_command(shadow)
+        quoted_bin_dir = shlex.quote(str(shadow.upgraded_bin_dir))
+
+        assert (
+            command
+            == f"export PATH={quoted_bin_dir}:$PATH\nhash -r 2>/dev/null || true"
+        )
+        assert command.replace("\n", "\n  ") in rendered
+
+    def test_canonicalize_failure_continues_to_legacy_name(self, tmp_path) -> None:
+        """A `resolve()` failure on `dcode` must not hide a legacy-name shadow.
+
+        The detector deliberately `continue`s to the `deepagents-code` name
+        when canonicalizing `dcode`'s PATH directory raises, rather than
+        returning `None` (which would silently report "no shadow"). This pins
+        that fall-through: `dcode`'s directory raises, but `deepagents-code`
+        resolves to a stale directory and is still reported as the shadow. A
+        regression that turned the `continue` into `return None` would
+        re-introduce the exact silent-hide bug the inline comment warns about.
+        """
+        uv_bin = (tmp_path / "uv-bin").resolve()
+        uv_bin.mkdir()
+        bad_dir = tmp_path / "bad-dir"
+        bad_dir.mkdir()
+        (bad_dir / "dcode").write_text("")
+        stale_bin = tmp_path / "stale-bin"
+        stale_bin.mkdir()
+        legacy = stale_bin / "deepagents-code"
+        legacy.write_text("")
+
+        def _which(name: str) -> str | None:
+            if name == "dcode":
+                return str(bad_dir / "dcode")
+            if name == "deepagents-code":
+                return str(legacy)
+            return None
+
+        real_resolve = Path.resolve
+
+        def _resolve(self: Path, strict: bool = False) -> Path:
+            # Only `dcode`'s PATH-entry directory raises; the legacy binary's
+            # directory resolves cleanly so the loop can reach a real answer.
+            if self == bad_dir:
+                msg = "simulated resolve failure"
+                raise OSError(msg)
+            return real_resolve(self, strict)
+
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_bin_dir",
+                return_value=uv_bin,
+            ),
+            patch("shutil.which", side_effect=_which),
+            patch.object(Path, "resolve", _resolve),
+        ):
+            shadow = detect_shadowed_dcode()
+
+        assert shadow is not None
+        assert shadow.shadowing_bin == legacy
+        assert shadow.upgraded_bin_dir == uv_bin
+
+
+class TestDetectShadowedDcodeSafe:
+    """The never-raises wrapper used at every post-upgrade call site.
+
+    Shadow detection only decorates an already-successful upgrade, so a
+    detector defect must degrade to "no shadow" rather than turning a working
+    upgrade into a user-facing failure.
+    """
+
+    def test_passes_through_shadow(self, tmp_path) -> None:
+        """A detected shadow flows through unchanged."""
+        shadow = ShadowedDcode(
+            shadowing_bin=tmp_path / "stale" / "dcode",
+            upgraded_bin_dir=tmp_path / "uv-bin",
+        )
+        with patch(
+            "deepagents_code.update_check.detect_shadowed_dcode",
+            return_value=shadow,
+        ):
+            assert detect_shadowed_dcode_safe() == shadow
+
+    def test_passes_through_none(self) -> None:
+        """The common "no shadow" answer flows through unchanged."""
+        with patch(
+            "deepagents_code.update_check.detect_shadowed_dcode",
+            return_value=None,
+        ):
+            assert detect_shadowed_dcode_safe() is None
+
+    def test_swallows_unexpected_exception(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An unexpected raise becomes `None`, not a propagated crash.
+
+        This is the whole reason the wrapper exists: the success path that
+        calls it has already committed the upgrade, so a detector bug must not
+        surface as "update failed". The failure is logged at warning level so
+        it stays diagnosable.
+        """
+        with (
+            patch(
+                "deepagents_code.update_check.detect_shadowed_dcode",
+                side_effect=RuntimeError("boom"),
+            ),
+            caplog.at_level(logging.WARNING, logger="deepagents_code.update_check"),
+        ):
+            assert detect_shadowed_dcode_safe() is None
+        assert any("Shadow detection failed" in r.message for r in caplog.records)
+
+
 class TestUpdateLogs:
     def test_create_update_log_path_uses_log_dir(self, update_log_dir) -> None:
         path = create_update_log_path()
@@ -987,9 +1493,12 @@ class TestUpdateLogs:
                 "deepagents_code.update_check.detect_install_method",
                 return_value="uv",
             ),
-            patch.dict(
-                "deepagents_code.update_check._UPGRADE_COMMANDS",
-                {"uv": "printf 'ok\\n'"},
+            # Stub the receipt-aware command builder so the test doesn't
+            # depend on a real `uv-receipt.toml`; the assertion is about
+            # log-creation failure surfacing through.
+            patch(
+                "deepagents_code.update_check.upgrade_install_command",
+                return_value="printf 'ok\\n'",
             ),
         ):
             success, output = await perform_upgrade(log_path=log_path)
@@ -1008,9 +1517,13 @@ class TestUpdateLogs:
                 "deepagents_code.update_check.detect_install_method",
                 return_value="uv",
             ),
-            patch.dict(
-                "deepagents_code.update_check._UPGRADE_COMMANDS",
-                {"uv": "printf 'ok\\n'"},
+            # `perform_upgrade` now calls `upgrade_install_command`, which
+            # reads the uv receipt and distribution metadata. Stub those
+            # out so the test can focus on the log-close-failure assertion
+            # rather than fight with the broad `pathlib.Path.open` mock.
+            patch(
+                "deepagents_code.update_check.upgrade_install_command",
+                return_value="printf 'ok\\n'",
             ),
             patch("pathlib.Path.open", opener),
         ):
@@ -1031,11 +1544,29 @@ class TestUpdateLogs:
         assert "Unsupported install method" in output
 
     async def test_perform_upgrade_uses_uv_prerelease_command(self) -> None:
-        """Pre-release upgrades pass uv's explicit pre-release strategy."""
+        """Pre-release upgrades pass uv's explicit pre-release strategy.
+
+        Uses `uv tool install -U` (not `uv tool upgrade`) so any stale
+        `==<version>` pin in the receipt — left over from a prior install
+        or dependency refresh — is cleared, letting uv resolve to the
+        latest available release.
+        """
         with (
             patch(
                 "deepagents_code.update_check.detect_install_method",
                 return_value="uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=frozenset(),
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_python",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_with_packages",
+                return_value=(),
             ),
             patch(
                 "deepagents_code.update_check._run_install_subprocess",
@@ -1050,7 +1581,7 @@ class TestUpdateLogs:
         await_args = run_mock.await_args
         assert await_args is not None
         assert await_args.args[0] == (
-            "uv tool upgrade deepagents-code --prerelease allow"
+            "uv tool install -U deepagents-code --prerelease allow"
         )
 
     async def test_perform_upgrade_follows_installed_prerelease_channel(self) -> None:
@@ -1060,6 +1591,18 @@ class TestUpdateLogs:
             patch(
                 "deepagents_code.update_check.detect_install_method",
                 return_value="uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=frozenset(),
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_python",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_with_packages",
+                return_value=(),
             ),
             patch(
                 "deepagents_code.update_check._run_install_subprocess",
@@ -1074,21 +1617,36 @@ class TestUpdateLogs:
         await_args = run_mock.await_args
         assert await_args is not None
         assert await_args.args[0] == (
-            "uv tool upgrade deepagents-code --prerelease allow"
+            "uv tool install -U deepagents-code --prerelease allow"
         )
 
-    async def test_perform_upgrade_uses_plain_uv_command_by_default(self) -> None:
-        """Stable upgrades shell out to uv without the pre-release strategy.
+    async def test_perform_upgrade_uses_unpinned_uv_install_by_default(self) -> None:
+        """Stable upgrades shell out to `uv tool install -U`, not `uv tool upgrade`.
 
-        `perform_upgrade` routes through `upgrade_command(method, ...)`, so a
-        regression that always opted into the pre-release channel would slip
-        past the default-path tests that override `_UPGRADE_COMMANDS`.
+        `uv tool upgrade` respects the receipt's requirement string, so a
+        previously-pinned install (e.g. via `DEEPAGENTS_CODE_VERSION` or a
+        prior dependency refresh that wrote `==<version>` into the receipt)
+        would silently keep the user on the old version. Using `uv tool
+        install -U deepagents-code` (no version) rewrites the receipt to an
+        unpinned requirement and re-resolves to the latest release.
         """
         with (
             patch("deepagents_code.update_check.__version__", "1.0.0"),
             patch(
                 "deepagents_code.update_check.detect_install_method",
                 return_value="uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=frozenset(),
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_python",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_with_packages",
+                return_value=(),
             ),
             patch(
                 "deepagents_code.update_check._run_install_subprocess",
@@ -1102,7 +1660,116 @@ class TestUpdateLogs:
         run_mock.assert_awaited_once()
         await_args = run_mock.await_args
         assert await_args is not None
-        assert await_args.args[0] == "uv tool upgrade deepagents-code"
+        assert await_args.args[0] == "uv tool install -U deepagents-code"
+
+    async def test_perform_upgrade_preserves_installed_extras(self) -> None:
+        """An upgrade must not silently drop the user's installed extras.
+
+        The unpinned-install fix to the receipt-pin bug could otherwise
+        reinstall a bare `deepagents-code` and remove every extra the user
+        had set up. Receipt-aware command building keeps them in the
+        requirement so they survive the reinstall.
+        """
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=frozenset({"quickjs", "nvidia"}),
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_python",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_with_packages",
+                return_value=(),
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as run_mock,
+        ):
+            success, _output = await perform_upgrade()
+
+        assert success is True
+        run_mock.assert_awaited_once()
+        await_args = run_mock.await_args
+        assert await_args is not None
+        assert await_args.args[0] == (
+            "uv tool install -U 'deepagents-code[nvidia,quickjs]'"
+        )
+
+    async def test_perform_upgrade_falls_back_when_receipt_introspection_fails(
+        self,
+    ) -> None:
+        """Receipt failures must not block the upgrade — fall back to bare.
+
+        Dropping extras is bad, but silently keeping the user pinned to an
+        old version is worse. The fallback path runs the bare upgrade
+        command rather than refusing the upgrade outright.
+        """
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                side_effect=ExtrasIntrospectionError("metadata unreadable"),
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as run_mock,
+        ):
+            success, _output = await perform_upgrade()
+
+        assert success is True
+        run_mock.assert_awaited_once()
+        await_args = run_mock.await_args
+        assert await_args is not None
+        assert await_args.args[0] == "uv tool install -U deepagents-code"
+
+    async def test_perform_upgrade_fallback_warns_user_about_dropped_extras(
+        self,
+    ) -> None:
+        """The bare fallback surfaces the extras caveat to the user, not just logs.
+
+        When receipt introspection fails, `perform_upgrade` still upgrades via
+        the bare command but may drop extras / `--with` packages. The user's
+        only window into the upgrade is the progress stream, so the caveat must
+        be emitted there; a log-only warning is invisible in the TUI and the
+        user would discover the missing extra later as an unrelated-looking
+        import error.
+        """
+        progress_lines: list[str] = []
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                side_effect=ExtrasIntrospectionError("metadata unreadable"),
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+        ):
+            success, _output = await perform_upgrade(progress=progress_lines.append)
+
+        assert success is True
+        assert any("may not carry over" in line for line in progress_lines)
 
     async def test_perform_upgrade_refuses_prerelease_for_brew(self) -> None:
         """Pre-release channel switching is only safe for uv tool installs."""
@@ -1124,10 +1791,15 @@ class TestUpdateLogs:
         run_mock.assert_not_awaited()
 
     def test_upgrade_command_prerelease(self) -> None:
-        """Manual fallback command includes uv's pre-release strategy."""
+        """Manual fallback command includes uv's pre-release strategy.
+
+        Uses `uv tool install -U` (not `uv tool upgrade`): see the docstring
+        on `_UPGRADE_COMMANDS` for why we avoid the receipt-respecting
+        `upgrade` form.
+        """
         assert (
             upgrade_command(include_prereleases=True)
-            == "uv tool upgrade deepagents-code --prerelease allow"
+            == "uv tool install -U deepagents-code --prerelease allow"
         )
 
     def test_dependency_refresh_command_pins_current_version(
@@ -1477,6 +2149,107 @@ class TestUpdateLogs:
         assert supported is False
         assert reason is not None
         assert "aren't supported for this install" in reason
+
+
+class TestUpgradeInstallCommand:
+    """Direct coverage for the receipt-aware unpinned-upgrade command builder.
+
+    `perform_upgrade`'s uv path delegates to `upgrade_install_command`, but its
+    tests stub `_uv_tool_python`/`_uv_tool_with_packages` to empty, so the
+    `--python` and `--with` assembly branches are never exercised through this
+    function there. The structurally-similar `dependency_refresh_command` has
+    its own coverage, but it is a different function — a `shlex.quote` slip in
+    this builder would pass every `perform_upgrade` test. These pin the command
+    string end-to-end against a real receipt.
+    """
+
+    def test_unpinned_bare_command(self, tmp_path, monkeypatch) -> None:
+        """No extras, no `--with`, no recorded python → the bare unpinned form.
+
+        The version pin is *always* stripped (unlike `dependency_refresh_command`),
+        because clearing a stale receipt pin is the entire point of routing
+        `/update` through this builder.
+        """
+        _write_uv_receipt(tmp_path, '{ name = "deepagents-code" }')
+        monkeypatch.setattr("sys.prefix", str(tmp_path))
+        with patch(
+            "deepagents_code.extras_info.installed_extra_names",
+            return_value=frozenset(),
+        ):
+            assert upgrade_install_command() == "uv tool install -U deepagents-code"
+
+    def test_preserves_extras_and_prerelease(self, tmp_path, monkeypatch) -> None:
+        """Installed extras survive the unpinned reinstall; prerelease opt-in too."""
+        _write_uv_receipt(tmp_path, '{ name = "deepagents-code" }')
+        monkeypatch.setattr("sys.prefix", str(tmp_path))
+        with patch(
+            "deepagents_code.extras_info.installed_extra_names",
+            return_value=frozenset({"quickjs", "nvidia"}),
+        ):
+            assert upgrade_install_command(include_prereleases=True) == (
+                "uv tool install -U 'deepagents-code[nvidia,quickjs]' "
+                "--prerelease allow"
+            )
+
+    def test_preserves_with_packages(self, tmp_path, monkeypatch) -> None:
+        """Packages installed via `--with` must survive the unpinned reinstall."""
+        _write_uv_receipt(
+            tmp_path,
+            (
+                '{ name = "deepagents-code" }, '
+                '{ name = "langchain-custom" }, '
+                '{ name = "langchain.another_provider" }'
+            ),
+        )
+        monkeypatch.setattr("sys.prefix", str(tmp_path))
+        with patch(
+            "deepagents_code.extras_info.installed_extra_names",
+            return_value=frozenset(),
+        ):
+            assert upgrade_install_command() == (
+                "uv tool install -U deepagents-code "
+                "--with langchain-custom --with langchain.another_provider"
+            )
+
+    def test_quotes_uv_python(self, tmp_path, monkeypatch) -> None:
+        """A recorded interpreter path with spaces is shell-quoted, not split.
+
+        This is the branch `perform_upgrade`'s tests never reach (they stub
+        `_uv_tool_python` to `None`). A dropped `shlex.quote` here would shell
+        out to a broken, word-split `--python` argument.
+        """
+        _write_uv_receipt(
+            tmp_path,
+            '{ name = "deepagents-code" }, { name = "langchain-custom" }',
+            python="/opt/Python 3.13/bin/python",
+        )
+        monkeypatch.setattr("sys.prefix", str(tmp_path))
+        with patch(
+            "deepagents_code.extras_info.installed_extra_names",
+            return_value=frozenset(),
+        ):
+            assert upgrade_install_command() == (
+                "uv tool install -U --python '/opt/Python 3.13/bin/python' "
+                "deepagents-code --with langchain-custom"
+            )
+
+    def test_propagates_extras_introspection_error(self, tmp_path, monkeypatch) -> None:
+        """Unreadable extras metadata propagates rather than silently dropping.
+
+        `perform_upgrade` catches this and falls back to the bare command, but
+        the builder itself must surface the failure so that decision stays at
+        the caller, matching the docstring's documented contract.
+        """
+        _write_uv_receipt(tmp_path, '{ name = "deepagents-code" }')
+        monkeypatch.setattr("sys.prefix", str(tmp_path))
+        with (
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                side_effect=ExtrasIntrospectionError("metadata unreadable"),
+            ),
+            pytest.raises(ExtrasIntrospectionError),
+        ):
+            upgrade_install_command()
 
 
 class TestParseDependencyChanges:

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -1977,6 +1977,21 @@ class TestUpdateLogs:
         ):
             dependency_refresh_command(version="1.2.3")
 
+    def test_dependency_refresh_command_invalid_metadata_extra_reraised(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Malformed metadata extras surface through the typed error contract."""
+        _write_uv_receipt(tmp_path, '{ name = "deepagents-code" }')
+        monkeypatch.setattr("sys.prefix", str(tmp_path))
+        with (
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=frozenset({"not a valid extra"}),
+            ),
+            pytest.raises(ExtrasIntrospectionError),
+        ):
+            dependency_refresh_command(version="1.2.3")
+
     def test_dependency_refresh_dry_run_command_targets_current_python(
         self, tmp_path, monkeypatch
     ) -> None:

--- a/libs/code/tests/unit_tests/test_update_progress.py
+++ b/libs/code/tests/unit_tests/test_update_progress.py
@@ -182,3 +182,42 @@ async def test_update_progress_screen_warning_stays_visible(
         await pilot.pause()
 
         assert copied == [fix_command]
+
+
+async def test_update_progress_screen_warning_without_copy_text_copies_log_path(
+    tmp_path, monkeypatch
+) -> None:
+    """`mark_warning` without `copy_text` falls back to copying the log path.
+
+    The production call site always supplies `copy_text`, but the parameter is
+    optional, so this pins the documented fallback: with no fix command the
+    help line reverts to "c copy log path" and `c` copies the log path rather
+    than silently doing nothing.
+    """
+    log_path = tmp_path / "update.log"
+    screen = UpdateProgressScreen(
+        latest="2.0.0",
+        command="uv tool install -U deepagents-code",
+        log_path=log_path,
+    )
+
+    copied: list[str] = []
+    app = App()
+    monkeypatch.setattr(app, "copy_to_clipboard", copied.append)
+    async with app.run_test() as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+
+        screen.mark_warning("Another `dcode` is earlier on your PATH.")
+        await pilot.pause()
+
+        spinner = screen.query(Static).filter(".up-spinner").first()
+        help_text = screen.query(Static).filter(".up-help").first()
+        assert str(spinner.render()) == get_glyphs().warning
+        assert "c copy log path" in str(help_text.render())
+        assert "c copy fix command" not in str(help_text.render())
+
+        await pilot.press("c")
+        await pilot.pause()
+
+        assert copied == [str(log_path)]

--- a/libs/code/tests/unit_tests/test_update_progress.py
+++ b/libs/code/tests/unit_tests/test_update_progress.py
@@ -117,3 +117,46 @@ async def test_update_progress_screen_close_waits_until_done(tmp_path) -> None:
         await pilot.press("escape")
         await pilot.pause()
         assert app.screen is app.screen_stack[0]
+
+
+async def test_update_progress_screen_warning_stays_visible(
+    tmp_path, monkeypatch
+) -> None:
+    """Warning completion keeps the user action visible in the modal."""
+    screen = UpdateProgressScreen(
+        latest="2.0.0",
+        command="uv tool upgrade deepagents-code",
+        log_path=tmp_path / "update.log",
+    )
+
+    copied: list[str] = []
+    app = App()
+    monkeypatch.setattr(app, "copy_to_clipboard", copied.append)
+    async with app.run_test() as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+
+        fix_command = "export PATH=/home/user/.local/bin:$PATH\nhash -r"
+        screen.mark_warning(
+            "Update installed, but another `dcode` is earlier on your PATH.\n"
+            "Remove the shadowing binary, or put /home/user/.local/bin earlier "
+            "on your PATH, then relaunch.",
+            copy_text=fix_command,
+        )
+        await pilot.pause()
+
+        status = screen.query(Static).filter(".up-status").first()
+        details = screen.query(Static).filter(".up-details").first()
+        spinner = screen.query(Static).filter(".up-spinner").first()
+        help_text = screen.query(Static).filter(".up-help").first()
+        assert "Update complete" not in str(status.render())
+        assert "another `dcode` is earlier on your PATH" in str(status.render())
+        assert "Remove the shadowing binary" in str(status.render())
+        assert details.display is True
+        assert str(spinner.render()) == get_glyphs().warning
+        assert "c copy fix command" in str(help_text.render())
+
+        await pilot.press("c")
+        await pilot.pause()
+
+        assert copied == [fix_command]

--- a/libs/code/tests/unit_tests/test_update_progress.py
+++ b/libs/code/tests/unit_tests/test_update_progress.py
@@ -119,6 +119,28 @@ async def test_update_progress_screen_close_waits_until_done(tmp_path) -> None:
         assert app.screen is app.screen_stack[0]
 
 
+async def test_update_progress_screen_failure_uses_error_glyph(tmp_path) -> None:
+    """Failure completion should not look visually successful."""
+    screen = UpdateProgressScreen(
+        latest="2.0.0",
+        command="uv tool install -U deepagents-code",
+        log_path=tmp_path / "update.log",
+    )
+
+    app = App()
+    async with app.run_test() as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+
+        screen.mark_failure("uv tool install -U deepagents-code")
+        await pilot.pause()
+
+        status = screen.query(Static).filter(".up-status").first()
+        spinner = screen.query(Static).filter(".up-spinner").first()
+        assert "Update failed" in str(status.render())
+        assert str(spinner.render()) == get_glyphs().error
+
+
 async def test_update_progress_screen_warning_stays_visible(
     tmp_path, monkeypatch
 ) -> None:

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -41,6 +41,17 @@ def _block_sdk_pypi_fetch(tmp_path: Path) -> Iterator[None]:
             "deepagents_code.update_check.is_update_available",
             return_value=(False, None),
         ),
+        # Pin the post-upgrade shadow check to a clean "no shadow" for the
+        # whole module. Several `/update` tests pin `detect_install_method`
+        # to `"uv"` to exercise pre-release handling, which would otherwise
+        # make the real `detect_shadowed_dcode` run against the test
+        # runner's filesystem and replace the expected success message
+        # with the shadow warning. The dedicated shadow-present tests in
+        # this file override this patch with their own.
+        patch(
+            "deepagents_code.update_check.detect_shadowed_dcode",
+            return_value=None,
+        ),
     ):
         yield
 
@@ -540,6 +551,67 @@ async def test_update_slash_command_prerelease_updates_channel() -> None:
         assert str(user_msgs[-1]._content) == "/update --prerelease"
         app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
         assert "Updated to v99.0.0rc1" in str(app_msgs[-1]._content)
+
+
+async def test_update_slash_command_replaces_success_with_shadow_warning() -> None:
+    """A shadowed `dcode` after a successful upgrade swaps success line for warning.
+
+    Regression guard for the inverted-conditional bug class: showing the
+    user a green "relaunch to use the new version" line and then *also*
+    warning that relaunching will keep the old version is the exact UX
+    this branch exists to prevent. The shadow path must mount an
+    `ErrorMessage` with the warning and skip the success `AppMessage`
+    entirely; a regression that flipped the `if/else` (or kept the
+    success line unconditionally) would ship a reassuring success line
+    over a broken upgrade.
+    """
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.update_check import ShadowedDcode
+    from deepagents_code.widgets.messages import AppMessage, ErrorMessage
+
+    shadow = ShadowedDcode(
+        shadowing_bin=Path("/opt/stale/bin/dcode"),
+        upgraded_bin_dir=Path("/home/user/.local/bin"),
+    )
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch(
+                "deepagents_code.config._is_editable_install",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_code.update_check.is_update_available",
+                return_value=(True, "99.0.0"),
+            ),
+            patch(
+                "deepagents_code.update_check.perform_upgrade",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ),
+            # Override the module-level autouse `None` patch with the
+            # positive case. Innermost patch wins.
+            patch(
+                "deepagents_code.update_check.detect_shadowed_dcode",
+                return_value=shadow,
+            ),
+        ):
+            await app._handle_command("/update")
+            await pilot.pause()
+
+        plain_msgs = [
+            str(m._content) for m in app.query(AppMessage) if not m._is_markdown
+        ]
+        # The shadow path must NOT mount the success line, because relaunching
+        # would not actually use the new version. A regression that kept the
+        # success line would show both messages, contradicting itself.
+        assert not any("Updated to v99.0.0" in m for m in plain_msgs)
+        # The warning is mounted as an `ErrorMessage` (red), not a generic
+        # `AppMessage`, so it visually stands apart from neutral status text.
+        error_msgs = [str(m._content) for m in app.query(ErrorMessage)]
+        assert any("/opt/stale/bin/dcode" in m for m in error_msgs)
+        assert any("/home/user/.local/bin" in m for m in error_msgs)
 
 
 async def test_update_slash_command_prerelease_unsupported_install_refuses() -> None:


### PR DESCRIPTION
`uv tool upgrade` honors the requirement string baked into the uv tool receipt, so a self-update could report success while silently re-resolving the same pinned version — and even a genuine upgrade has no effect if an older `dcode` sits earlier on the user's PATH. The update path now forces an unpinned `uv tool install -U` and checks for a shadowing binary after every upgrade, surfacing a copy-pasteable PATH fix instead of a misleading "relaunch to use the new version."

## Changes

- **Unpinned uv upgrades.** `/update` and auto-update run `uv tool install -U deepagents-code` instead of `uv tool upgrade`, clearing any `==<version>` pin left in the receipt (from an original pinned install or a prior dependency refresh) that would otherwise keep re-resolving the same version. `upgrade_install_command` rebuilds the requirement receipt-aware so installed extras, `--with` packages, and the recorded `--python` survive; on receipt-introspection failure it falls back to the bare command and emits a progress note that extras may not carry over.
- **Shadowed-`dcode` detection.** `detect_shadowed_dcode` compares `shutil.which("dcode")` against uv's documented executable directory (`_uv_tool_bin_dir`, following the `UV_TOOL_BIN_DIR → XDG_BIN_HOME → $XDG_DATA_HOME/../bin → ~/.local/bin` precedence). When a different binary wins on PATH, `/update`, the "Install now" notification action, and startup auto-update surface a warning naming both paths plus a session-scoped `export PATH=…` fix from `format_shadowed_dcode_fix_command`. The comparison is deliberately against the un-followed PATH entry so healthy uv symlink shims aren't flagged.
- **Startup auto-update skips the re-exec when shadowed.** Re-exec'ing would relaunch the old binary and trip the no-op restart guard, so the pre-launch path prints the warning and continues on the current version.
- **Detection can't sink a good upgrade.** All three call sites route through `detect_shadowed_dcode_safe`, which logs and returns `None` on any unexpected error, so a detector defect never turns a successful upgrade into a user-facing failure.
- **Warning completion state for the progress modal.** `UpdateProgressScreen.mark_warning` adds a third terminal state — warning glyph, durable status, `c` to copy the fix command — distinct from success/failure, and the "Install now" modal enters it instead of the success state when the upgraded shim is shadowed.

## Testing

- Shadow detection is covered branch-by-branch: the paired symlink cases (uv's own shim must not flag; a symlink in another PATH dir must), the legacy `deepagents-code` name fallback, and `OSError` fault injection on path resolution. `detect_shadowed_dcode_safe` is pinned to swallow an unexpected raise.
- `upgrade_install_command` gets direct coverage of the `--python` quoting and `--with` assembly that the `perform_upgrade` tests stub out, and the modal's warning state asserts the durable status, glyph, and copy-fix-command behavior.