### PR TITLE
feat(sdk): allow users to override default middleware by name

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -543,7 +543,7 @@ class CompositeBackend(BackendProtocol):
         """Delete a file, routing to the appropriate backend.
 
         `CompositeBackend` always advertises delete support (it overrides this
-        method), so the `delete_file` tool is never filtered out for it. A
+        method), so the `delete` tool is never filtered out for it. A
         route may still point at a backend that does not implement `delete`;
         rather than letting `NotImplementedError` escape to the caller, that
         case is converted into a `DeleteResult` error.

--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -22,6 +22,7 @@ from typing import cast
 
 from deepagents.backends.protocol import (
     BackendProtocol,
+    DeleteResult,
     EditResult,
     ExecuteResponse,
     FileDownloadResponse,
@@ -37,6 +38,8 @@ from deepagents.backends.protocol import (
     execute_accepts_timeout,
 )
 from deepagents.backends.state import StateBackend
+
+_DELETE_UNSUPPORTED_ERROR = "Error: deletion is not supported for '{file_path}'."
 
 
 def _remap_grep_path(m: GrepMatch, route_prefix: str) -> GrepMatch:
@@ -532,6 +535,42 @@ class CompositeBackend(BackendProtocol):
         """Async version of edit."""
         backend, stripped_key = self._get_backend_and_key(file_path)
         res = await backend.aedit(stripped_key, old_string, new_string, replace_all=replace_all)
+        if res.path is not None:
+            res.path = file_path
+        return res
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file, routing to the appropriate backend.
+
+        `CompositeBackend` always advertises delete support (it overrides this
+        method), so the `delete_file` tool is never filtered out for it. A
+        route may still point at a backend that does not implement `delete`;
+        rather than letting `NotImplementedError` escape to the caller, that
+        case is converted into a `DeleteResult` error.
+
+        Args:
+            file_path: Absolute file path.
+
+        Returns:
+            `DeleteResult` with the original path on success, or an error
+            (including when the routed backend does not support deletion).
+        """
+        backend, stripped_key = self._get_backend_and_key(file_path)
+        try:
+            res = backend.delete(stripped_key)
+        except NotImplementedError:
+            return DeleteResult(error=_DELETE_UNSUPPORTED_ERROR.format(file_path=file_path))
+        if res.path is not None:
+            res.path = file_path
+        return res
+
+    async def adelete(self, file_path: str) -> DeleteResult:
+        """Async version of delete."""
+        backend, stripped_key = self._get_backend_and_key(file_path)
+        try:
+            res = await backend.adelete(stripped_key)
+        except NotImplementedError:
+            return DeleteResult(error=_DELETE_UNSUPPORTED_ERROR.format(file_path=file_path))
         if res.path is not None:
             res.path = file_path
         return res

--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -30,6 +30,7 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.utils import (
     create_file_data,
+    expand_delete_keys,
     perform_string_replacement,
     slice_read_response,
 )
@@ -210,13 +211,25 @@ class ContextHubBackend(BackendProtocol):
         return EditResult(path=file_path, occurrences=occurrences)
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file by committing its removal from the hub repo."""
+        """Delete a file or directory by committing its removal from the hub repo.
+
+        Deleting a path removes the exact file plus every nested entry under it
+        (the prefix `file_path` + "/"), so a directory is removed recursively.
+
+        Args:
+            file_path: Path of the file or directory to delete.
+
+        Returns:
+            `DeleteResult` with `file_path` on success, or an error if nothing is
+                stored at or under it (or the hub is unavailable).
+        """
         hub_path = self._strip_prefix(file_path)
         try:
             cache = self._ensure_cache()
-            if hub_path not in cache:
+            to_delete = expand_delete_keys(cache, hub_path)
+            if not to_delete:
                 return DeleteResult(error=f"Error: File '{file_path}' not found")
-            self._commit({hub_path: None})
+            self._commit(dict.fromkeys(to_delete, None))
         except LangSmithError as exc:
             logger.exception("Hub delete failed for %r", self._identifier)
             self._cache = None

--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -210,13 +210,27 @@ class ContextHubBackend(BackendProtocol):
         return EditResult(path=file_path, occurrences=occurrences)
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file by committing its removal from the hub repo."""
+        """Delete a file or directory by committing its removal from the hub repo.
+
+        Deleting a path removes the exact file plus every nested entry under it
+        (the prefix `file_path` + "/"), so a directory is removed recursively.
+
+        Args:
+            file_path: Path of the file or directory to delete.
+
+        Returns:
+            `DeleteResult` with `file_path` on success, or an error if nothing is
+                stored at or under it (or the hub is unavailable).
+        """
         hub_path = self._strip_prefix(file_path)
         try:
             cache = self._ensure_cache()
-            if hub_path not in cache:
+            base = hub_path.rstrip("/")
+            prefix = base + "/"
+            to_delete = [key for key in cache if key == base or key.startswith(prefix)]
+            if not to_delete:
                 return DeleteResult(error=f"Error: File '{file_path}' not found")
-            self._commit({hub_path: None})
+            self._commit(dict.fromkeys(to_delete, None))
         except LangSmithError as exc:
             logger.exception("Hub delete failed for %r", self._identifier)
             self._cache = None

--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -30,7 +30,6 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.utils import (
     create_file_data,
-    expand_delete_keys,
     perform_string_replacement,
     slice_read_response,
 )
@@ -226,7 +225,9 @@ class ContextHubBackend(BackendProtocol):
         hub_path = self._strip_prefix(file_path)
         try:
             cache = self._ensure_cache()
-            to_delete = expand_delete_keys(cache, hub_path)
+            base = hub_path.rstrip("/")
+            prefix = base + "/"
+            to_delete = [key for key in cache if key == base or key.startswith(prefix)]
             if not to_delete:
                 return DeleteResult(error=f"Error: File '{file_path}' not found")
             self._commit(dict.fromkeys(to_delete, None))

--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -15,6 +15,7 @@ from deepagents.backends.protocol import (
     FILE_NOT_FOUND,
     INVALID_PATH,
     BackendProtocol,
+    DeleteResult,
     EditResult,
     FileData,
     FileDownloadResponse,
@@ -102,13 +103,18 @@ class ContextHubBackend(BackendProtocol):
         self._ensure_cache()
         return self._commit_hash is not None
 
-    def _commit(self, files: dict[str, str]) -> None:
-        """Push `files` as one commit; update the cache on success."""
-        if not files:
+    def _commit(self, changes: dict[str, str | None]) -> None:
+        """Push `changes` as one commit; update the cache on success.
+
+        Each value is either new file content or `None`. A `None` value is the
+        deletion marker: relative to `parent_commit`, the server drops that path
+        from the tree.
+        """
+        if not changes:
             return
 
         payload: dict[str, FileEntry | AgentEntry | SkillEntry | None] = {
-            path: FileEntry(type="file", content=content) for path, content in files.items()
+            path: FileEntry(type="file", content=content) if content is not None else None for path, content in changes.items()
         }
         url = self._client.push_agent(
             self._identifier,
@@ -120,8 +126,11 @@ class ContextHubBackend(BackendProtocol):
             self._commit_hash = match.group(1)
 
         if self._cache is not None:
-            for path, content in files.items():
-                self._cache[path] = content
+            # Rebuild the cache rather than mutating in place: drop paths whose
+            # new content is None (deletions) and overlay the rest as updates.
+            deletions = {path for path, content in changes.items() if content is None}
+            updates = {path: content for path, content in changes.items() if content is not None}
+            self._cache = {path: content for path, content in self._cache.items() if path not in deletions} | updates
 
     @staticmethod
     def _strip_prefix(path: str) -> str:
@@ -199,6 +208,20 @@ class ContextHubBackend(BackendProtocol):
             self._cache = None
             return EditResult(error=f"Hub unavailable: {exc}")
         return EditResult(path=file_path, occurrences=occurrences)
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file by committing its removal from the hub repo."""
+        hub_path = self._strip_prefix(file_path)
+        try:
+            cache = self._ensure_cache()
+            if hub_path not in cache:
+                return DeleteResult(error=f"Error: File '{file_path}' not found")
+            self._commit({hub_path: None})
+        except LangSmithError as exc:
+            logger.exception("Hub delete failed for %r", self._identifier)
+            self._cache = None
+            return DeleteResult(error=f"Hub unavailable: {exc}")
+        return DeleteResult(path=file_path)
 
     def ls(self, path: str = "/") -> LsResult:
         """List immediate files and subdirectories under `path` (non-recursive)."""
@@ -282,7 +305,7 @@ class ContextHubBackend(BackendProtocol):
         """Upload text files in one commit; non-UTF-8 inputs rejected per file."""
         # Decode each input; `None` text means we'll reject this entry as invalid.
         decoded: list[tuple[str, str | None]] = []
-        valid_files: dict[str, str] = {}
+        valid_files: dict[str, str | None] = {}
         for path, content in files:
             try:
                 text = content.decode("utf-8")

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -569,9 +569,6 @@ class FilesystemBackend(BackendProtocol):
         try:
             if not resolved_path.exists() and not resolved_path.is_symlink():
                 return DeleteResult(error=f"Error: '{file_path}' not found")
-            # Check is_symlink() before is_dir(): is_dir() follows symlinks, so a
-            # symlink pointing at a directory would otherwise be recursed into and
-            # delete the target's contents. Removing the link itself is correct.
             if resolved_path.is_symlink():
                 resolved_path.unlink()
             elif resolved_path.is_dir():

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -546,29 +546,41 @@ class FilesystemBackend(BackendProtocol):
             return EditResult(error=f"Error editing file '{file_path}': {e}")
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file from the filesystem.
+        """Delete a file or directory from the filesystem.
+
+        Files are unlinked. Directories are removed recursively along with all
+        of their contents. Symlinks are removed as links and never followed into
+        their target (so deleting a symlink to a directory removes only the link).
 
         Args:
-            file_path: Path to the file to delete.
+            file_path: Path to the file or directory to delete.
 
         Returns:
             `DeleteResult` with the deleted path on success, or an error if the
-                file does not exist, is a directory, or removal fails.
+                path does not exist or removal fails. A recursive directory
+                removal may delete some entries before failing partway (for
+                example when a nested entry is not writable).
         """
         try:
             resolved_path = self._resolve_path(file_path)
         except (OSError, RuntimeError) as e:
-            return DeleteResult(error=f"Error deleting file '{file_path}': {e}")
+            return DeleteResult(error=f"Error deleting '{file_path}': {e}")
 
         try:
-            if resolved_path.is_dir():
-                return DeleteResult(error=f"Error: '{file_path}' is a directory, not a file")
             if not resolved_path.exists() and not resolved_path.is_symlink():
-                return DeleteResult(error=f"Error: File '{file_path}' not found")
-            resolved_path.unlink()
+                return DeleteResult(error=f"Error: '{file_path}' not found")
+            # Check is_symlink() before is_dir(): is_dir() follows symlinks, so a
+            # symlink pointing at a directory would otherwise be recursed into and
+            # delete the target's contents. Removing the link itself is correct.
+            if resolved_path.is_symlink():
+                resolved_path.unlink()
+            elif resolved_path.is_dir():
+                shutil.rmtree(resolved_path)
+            else:
+                resolved_path.unlink()
             return DeleteResult(path=file_path)
         except (OSError, RuntimeError) as e:
-            return DeleteResult(error=f"Error deleting file '{file_path}': {e}")
+            return DeleteResult(error=f"Error deleting '{file_path}': {e}")
 
     def grep(
         self,

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -546,29 +546,38 @@ class FilesystemBackend(BackendProtocol):
             return EditResult(error=f"Error editing file '{file_path}': {e}")
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file from the filesystem.
+        """Delete a file or directory from the filesystem.
+
+        Files are unlinked. Directories are removed recursively along with all
+        of their contents. Symlinks are removed as links and never followed into
+        their target (so deleting a symlink to a directory removes only the link).
 
         Args:
-            file_path: Path to the file to delete.
+            file_path: Path to the file or directory to delete.
 
         Returns:
             `DeleteResult` with the deleted path on success, or an error if the
-                file does not exist, is a directory, or removal fails.
+                path does not exist or removal fails. A recursive directory
+                removal may delete some entries before failing partway (for
+                example when a nested entry is not writable).
         """
         try:
             resolved_path = self._resolve_path(file_path)
         except (OSError, RuntimeError) as e:
-            return DeleteResult(error=f"Error deleting file '{file_path}': {e}")
+            return DeleteResult(error=f"Error deleting '{file_path}': {e}")
 
         try:
-            if resolved_path.is_dir():
-                return DeleteResult(error=f"Error: '{file_path}' is a directory, not a file")
             if not resolved_path.exists() and not resolved_path.is_symlink():
-                return DeleteResult(error=f"Error: File '{file_path}' not found")
-            resolved_path.unlink()
+                return DeleteResult(error=f"Error: '{file_path}' not found")
+            if resolved_path.is_symlink():
+                resolved_path.unlink()
+            elif resolved_path.is_dir():
+                shutil.rmtree(resolved_path)
+            else:
+                resolved_path.unlink()
             return DeleteResult(path=file_path)
         except (OSError, RuntimeError) as e:
-            return DeleteResult(error=f"Error deleting file '{file_path}': {e}")
+            return DeleteResult(error=f"Error deleting '{file_path}': {e}")
 
     def grep(
         self,

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -23,6 +23,7 @@ from deepagents.backends.protocol import (
     IS_DIRECTORY,
     PERMISSION_DENIED,
     BackendProtocol,
+    DeleteResult,
     EditResult,
     FileData,
     FileDownloadResponse,
@@ -543,6 +544,31 @@ class FilesystemBackend(BackendProtocol):
             return EditResult(path=file_path, occurrences=int(occurrences))
         except (OSError, UnicodeDecodeError, UnicodeEncodeError) as e:
             return EditResult(error=f"Error editing file '{file_path}': {e}")
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file from the filesystem.
+
+        Args:
+            file_path: Path to the file to delete.
+
+        Returns:
+            `DeleteResult` with the deleted path on success, or an error if the
+                file does not exist, is a directory, or removal fails.
+        """
+        try:
+            resolved_path = self._resolve_path(file_path)
+        except (OSError, RuntimeError) as e:
+            return DeleteResult(error=f"Error deleting file '{file_path}': {e}")
+
+        try:
+            if resolved_path.is_dir():
+                return DeleteResult(error=f"Error: '{file_path}' is a directory, not a file")
+            if not resolved_path.exists() and not resolved_path.is_symlink():
+                return DeleteResult(error=f"Error: File '{file_path}' not found")
+            resolved_path.unlink()
+            return DeleteResult(path=file_path)
+        except (OSError, RuntimeError) as e:
+            return DeleteResult(error=f"Error deleting file '{file_path}': {e}")
 
     def grep(
         self,

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -446,15 +446,14 @@ class FilesystemBackend(BackendProtocol):
         file_path: str,
         content: str,
     ) -> WriteResult:
-        """Create a new file with content.
+        """Write content to a file, creating it or overwriting it if it already exists.
 
         Args:
-            file_path: Path where the new file will be created.
+            file_path: Path where the file will be written.
             content: Text content to write to the file.
 
         Returns:
-            `WriteResult` with path on success, or error message if the file
-                already exists or write fails.
+            `WriteResult` with path on success, or error message on write failure.
         """
         try:
             resolved_path = self._resolve_path(file_path)
@@ -462,10 +461,6 @@ class FilesystemBackend(BackendProtocol):
             return WriteResult(error=f"Error writing file '{file_path}': {e}")
 
         try:
-            if resolved_path.exists():
-                msg = f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path."
-                return WriteResult(error=msg)
-
             # Create parent directories if needed
             resolved_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -617,7 +617,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         return await asyncio.to_thread(self.edit, file_path, old_string, new_string, replace_all)
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a single file from the filesystem.
+        """Delete a path, recursively removing anything nested under it.
 
         This method is optional. Backends that do not implement it inherit this
         default, which raises `NotImplementedError`. Callers that need to support
@@ -625,16 +625,19 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         [`supports_delete`][deepagents.backends.protocol.supports_delete] before
         calling, or catch `NotImplementedError`.
 
-        Directories are not supported. Directory-based backends return an error for
-        directory paths; key-value backends treat `file_path` as an exact key.
+        Deletion is recursive: it removes `file_path` plus everything nested
+        under it. On hierarchical backends (e.g.
+        [`FilesystemBackend`][deepagents.backends.filesystem.FilesystemBackend])
+        that means a directory and its contents; on key-value backends it means
+        the exact key plus every key sharing the `file_path` + "/" prefix.
 
         Args:
-            file_path: Absolute path to the file to delete. Must start with '/'
-                and refer to a file, not a directory.
+            file_path: Absolute path to delete (a file, or a directory/prefix to
+                remove recursively). Must start with '/'.
 
         Returns:
-            `DeleteResult` with the deleted path on success, or an error if the
-                file does not exist or `file_path` refers to a directory.
+            `DeleteResult` with the deleted path on success, or an error if
+                nothing exists at or under the path or removal fails.
 
         Raises:
             NotImplementedError: If the backend does not implement `delete`.

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -617,7 +617,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         return await asyncio.to_thread(self.edit, file_path, old_string, new_string, replace_all)
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a single file from the filesystem.
+        """Delete a file (or directory) from the filesystem.
 
         This method is optional. Backends that do not implement it inherit this
         default, which raises `NotImplementedError`. Callers that need to support
@@ -625,16 +625,19 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         [`supports_delete`][deepagents.backends.protocol.supports_delete] before
         calling, or catch `NotImplementedError`.
 
-        Directories are not supported. Directory-based backends return an error for
-        directory paths; key-value backends treat `file_path` as an exact key.
+        Directory handling is backend-dependent. Directory-based backends such as
+        [`FilesystemBackend`][deepagents.backends.filesystem.FilesystemBackend]
+        remove a directory recursively along with all of its contents; other
+        backends may return an error for directory paths. Key-value backends
+        treat `file_path` as an exact key.
 
         Args:
-            file_path: Absolute path to the file to delete. Must start with '/'
-                and refer to a file, not a directory.
+            file_path: Absolute path to the file or directory to delete. Must
+                start with '/'.
 
         Returns:
             `DeleteResult` with the deleted path on success, or an error if the
-                file does not exist or `file_path` refers to a directory.
+                path does not exist or removal fails.
 
         Raises:
             NotImplementedError: If the backend does not implement `delete`.

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -617,7 +617,7 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         return await asyncio.to_thread(self.edit, file_path, old_string, new_string, replace_all)
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file (or directory) from the filesystem.
+        """Delete a path, recursively removing anything nested under it.
 
         This method is optional. Backends that do not implement it inherit this
         default, which raises `NotImplementedError`. Callers that need to support
@@ -625,19 +625,19 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         [`supports_delete`][deepagents.backends.protocol.supports_delete] before
         calling, or catch `NotImplementedError`.
 
-        Directory handling is backend-dependent. Directory-based backends such as
-        [`FilesystemBackend`][deepagents.backends.filesystem.FilesystemBackend]
-        remove a directory recursively along with all of its contents; other
-        backends may return an error for directory paths. Key-value backends
-        treat `file_path` as an exact key.
+        Deletion is recursive: it removes `file_path` plus everything nested
+        under it. On hierarchical backends (e.g.
+        [`FilesystemBackend`][deepagents.backends.filesystem.FilesystemBackend])
+        that means a directory and its contents; on key-value backends it means
+        the exact key plus every key sharing the `file_path` + "/" prefix.
 
         Args:
-            file_path: Absolute path to the file or directory to delete. Must
-                start with '/'.
+            file_path: Absolute path to delete (a file, or a directory/prefix to
+                remove recursively). Must start with '/'.
 
         Returns:
-            `DeleteResult` with the deleted path on success, or an error if the
-                path does not exist or removal fails.
+            `DeleteResult` with the deleted path on success, or an error if
+                nothing exists at or under the path or removal fails.
 
         Raises:
             NotImplementedError: If the backend does not implement `delete`.

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -287,6 +287,23 @@ class EditResult:
 
 
 @dataclass
+class DeleteResult:
+    """Result from backend delete operations.
+
+    Attributes:
+        error: Error message on failure, None on success.
+        path: Absolute path of the deleted file, None on failure.
+
+    Examples:
+        >>> DeleteResult(path="/f.txt")
+        >>> DeleteResult(error="File not found")
+    """
+
+    error: str | None = None
+    path: str | None = None
+
+
+@dataclass
 class LsResult:
     """Result from backend ls operations.
 
@@ -599,6 +616,35 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         """Async version of edit."""
         return await asyncio.to_thread(self.edit, file_path, old_string, new_string, replace_all)
 
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a single file from the filesystem.
+
+        This method is optional. Backends that do not implement it inherit this
+        default, which raises `NotImplementedError`. Callers that need to support
+        a mix of backends should guard with
+        [`supports_delete`][deepagents.backends.protocol.supports_delete] before
+        calling, or catch `NotImplementedError`.
+
+        Directories are not supported. Directory-based backends return an error for
+        directory paths; key-value backends treat `file_path` as an exact key.
+
+        Args:
+            file_path: Absolute path to the file to delete. Must start with '/'
+                and refer to a file, not a directory.
+
+        Returns:
+            `DeleteResult` with the deleted path on success, or an error if the
+                file does not exist or `file_path` refers to a directory.
+
+        Raises:
+            NotImplementedError: If the backend does not implement `delete`.
+        """
+        raise NotImplementedError
+
+    async def adelete(self, file_path: str) -> DeleteResult:
+        """Async version of `delete`."""
+        return await asyncio.to_thread(self.delete, file_path)
+
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
         """Upload multiple files to the sandbox.
 
@@ -876,6 +922,25 @@ def execute_accepts_timeout(cls: type[SandboxBackendProtocol]) -> bool:
         return False
     else:
         return "timeout" in sig.parameters
+
+
+def _supports_delete(backend: BackendProtocol) -> bool:
+    """Check whether a backend implements `delete`.
+
+    `delete` is optional: backends that don't override it inherit the
+    `NotImplementedError` default from
+    [`BackendProtocol`][deepagents.backends.protocol.BackendProtocol]. This
+    helper lets callers detect support without invoking the method (and
+    triggering the error), mirroring the override check used for the legacy
+    `ls_info`/`grep_raw`/`glob_info` methods.
+
+    Args:
+        backend: The backend instance to check.
+
+    Returns:
+        True if the backend overrides `delete`, False otherwise.
+    """
+    return type(backend).delete is not BackendProtocol.delete
 
 
 BackendFactory: TypeAlias = Callable[[ToolRuntime[Any, Any]], BackendProtocol]

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -558,10 +558,10 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         file_path: str,
         content: str,
     ) -> WriteResult:
-        """Write content to a new file in the filesystem, error if file exists.
+        """Write content to a file, creating it or overwriting it if it already exists.
 
         Args:
-            file_path: Absolute path where the file should be created.
+            file_path: Absolute path where the file should be written.
 
                 Must start with '/'.
             content: String content to write to the file.

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -23,6 +23,7 @@ from abc import ABC, abstractmethod
 from typing import Final
 
 from deepagents.backends.protocol import (
+    DeleteResult,
     EditResult,
     ExecuteResponse,
     FileData,
@@ -755,6 +756,32 @@ except PermissionError:
             "multiple_occurrences": (f"Error: String '{old_string}' appears multiple times. Use replace_all=True to replace all occurrences."),
         }
         return EditResult(error=messages.get(error, f"Error editing file '{file_path}': {error}"))
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file from the sandbox via a server-side ``rm``.
+
+        Uses ``rm -f``, so deleting a path that does not exist succeeds
+        silently; a non-zero exit (e.g. the path is a directory, or a
+        permission error) is reported as a failure.
+
+        Args:
+            file_path: Absolute path to the file to delete.
+
+        Returns:
+            `DeleteResult` with the deleted path on success, or an error if the
+                deletion command fails.
+        """
+        # `shlex.quote` only neutralizes shell metacharacters so the path is
+        # passed to `rm` as a single literal argument. It is NOT a security
+        # boundary: it does not confine the deletion to any sandbox root or
+        # block traversal. Whatever the sandbox shell can reach, this can delete.
+        quoted = shlex.quote(file_path)
+        result = self.execute(f"rm -f {quoted}")
+
+        if result.exit_code == 0:
+            return DeleteResult(path=file_path)
+
+        return DeleteResult(error=f"Error deleting file '{file_path}': {result.output.strip() or 'unknown error'}")
 
     def grep(
         self,

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -79,16 +79,12 @@ Uses base64-encoded parameters to avoid shell escaping issues.
 """
 
 _WRITE_CHECK_TEMPLATE = """python3 -c "
-import os, sys, base64
+import os, base64
 
 path = base64.b64decode('{path_b64}').decode('utf-8')
-if os.path.exists(path):
-    print('Error: File already exists: ' + repr(path))
-    sys.exit(1)
 os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
 " 2>&1"""
-"""Preflight check for write operations: verify the target file does not already
-exist and create parent directories.
+"""Preflight for write operations: create parent directories for the target path if it doesn't exist.
 
 Only the (small) base64-encoded path is interpolated — file content is
 transferred separately via `upload_files()`.
@@ -544,21 +540,20 @@ except PermissionError:
         )
 
     def _write_preflight(self, file_path: str) -> WriteResult | None:
-        """Run the existence check + parent-directory creation for `write()`.
+        """Create parent directories for `write()`.
 
         Subclasses overriding `write()` (e.g., to use a native SDK transport)
-        should call this first so they preserve the same "fail if file exists"
-        and parent-mkdir semantics as `BaseSandbox.write()`. There is a TOCTOU
-        window between this check and the actual write — an inherent limitation
-        of splitting the operation across two backend calls.
+        should call this first so they preserve the parent-mkdir semantics of
+        `BaseSandbox.write()`. There is a TOCTOU window between this and the
+        actual write — an inherent limitation of splitting the operation across
+        two backend calls.
 
         Args:
             file_path: Absolute path for the file about to be written.
 
         Returns:
-            `None` if the preflight passes (target does not exist, parents
-                created); a populated `WriteResult` with `error` set if the
-                check fails.
+            `None` if the preflight passes (parents created); a populated
+                `WriteResult` with `error` set if the preflight fails.
         """
         path_b64 = base64.b64encode(file_path.encode("utf-8")).decode("ascii")
         check_cmd = _WRITE_CHECK_TEMPLATE.format(path_b64=path_b64)
@@ -573,10 +568,10 @@ except PermissionError:
         file_path: str,
         content: str,
     ) -> WriteResult:
-        """Create a new file, failing if it already exists.
+        """Write content to a file, creating or overwriting it if it already exists.
 
         Args:
-            file_path: Absolute path for the new file.
+            file_path: Absolute path for the file.
             content: UTF-8 text content to write.
 
         Returns:

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -758,14 +758,14 @@ except PermissionError:
         return EditResult(error=messages.get(error, f"Error editing file '{file_path}': {error}"))
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file from the sandbox via a server-side ``rm``.
+        """Delete a file or directory from the sandbox via a server-side ``rm``.
 
-        Uses ``rm -f``, so deleting a path that does not exist succeeds
-        silently; a non-zero exit (e.g. the path is a directory, or a
-        permission error) is reported as a failure.
+        Uses ``rm -rf``, so directories are removed recursively along with their
+        contents, and deleting a path that does not exist succeeds silently. A
+        non-zero exit (e.g. a permission error) is reported as a failure.
 
         Args:
-            file_path: Absolute path to the file to delete.
+            file_path: Absolute path to the file or directory to delete.
 
         Returns:
             `DeleteResult` with the deleted path on success, or an error if the
@@ -776,7 +776,7 @@ except PermissionError:
         # boundary: it does not confine the deletion to any sandbox root or
         # block traversal. Whatever the sandbox shell can reach, this can delete.
         quoted = shlex.quote(file_path)
-        result = self.execute(f"rm -f {quoted}")
+        result = self.execute(f"rm -rf {quoted}")
 
         if result.exit_code == 0:
             return DeleteResult(path=file_path)

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -28,6 +28,7 @@ from deepagents.backends.utils import (
     _glob_search_files,
     _to_legacy_file_data,
     create_file_data,
+    expand_delete_keys,
     file_data_to_string,
     grep_matches_from_files,
     perform_string_replacement,
@@ -292,17 +293,27 @@ class StateBackend(BackendProtocol):
         return EditResult(path=file_path, occurrences=int(occurrences))
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file from state.
+        """Delete a file or directory from state.
 
-        The deletion is queued via `CONFIG_KEY_SEND` as a ``None`` value, which
-        the `files` channel reducer interprets as a deletion marker.
+        Deleting a path removes the exact file at `file_path` plus every nested
+        key under it (the prefix `file_path` + "/"), so a directory is removed
+        recursively. Each removal is queued via `CONFIG_KEY_SEND` as a ``None``
+        value, which the `files` channel reducer interprets as a deletion marker.
+
+        Args:
+            file_path: Path of the file or directory to delete.
+
+        Returns:
+            `DeleteResult` with `file_path` on success, or an error if nothing is
+                stored at or under it.
         """
         files = self._read_files()
 
-        if file_path not in files:
+        to_delete = expand_delete_keys(files, file_path)
+        if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
-        self._send_files_update({file_path: None})
+        self._send_files_update(dict.fromkeys(to_delete, None))
         return DeleteResult(path=file_path)
 
     def grep(

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -257,10 +257,7 @@ class StateBackend(BackendProtocol):
         files = self._read_files()
 
         existing = files.get(file_path)
-        if existing is not None:
-            new_file_data = update_file_data(existing, content)
-        else:
-            new_file_data = create_file_data(content)
+        new_file_data = update_file_data(existing, content) if existing is not None else create_file_data(content)
         self._send_files_update({file_path: self._prepare_for_storage(new_file_data)})
         return WriteResult(path=file_path)
 

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -10,6 +10,7 @@ from langgraph.config import get_config
 from deepagents._api.deprecation import warn_deprecated
 from deepagents.backends.protocol import (
     BackendProtocol,
+    DeleteResult,
     EditResult,
     FileData,
     FileDownloadResponse,
@@ -289,6 +290,20 @@ class StateBackend(BackendProtocol):
         new_file_data = update_file_data(file_data, new_content)
         self._send_files_update({file_path: self._prepare_for_storage(new_file_data)})
         return EditResult(path=file_path, occurrences=int(occurrences))
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file from state.
+
+        The deletion is queued via `CONFIG_KEY_SEND` as a ``None`` value, which
+        the `files` channel reducer interprets as a deletion marker.
+        """
+        files = self._read_files()
+
+        if file_path not in files:
+            return DeleteResult(error=f"Error: File '{file_path}' not found")
+
+        self._send_files_update({file_path: None})
+        return DeleteResult(path=file_path)
 
     def grep(
         self,

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -292,17 +292,29 @@ class StateBackend(BackendProtocol):
         return EditResult(path=file_path, occurrences=int(occurrences))
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file from state.
+        """Delete a file or directory from state.
 
-        The deletion is queued via `CONFIG_KEY_SEND` as a ``None`` value, which
-        the `files` channel reducer interprets as a deletion marker.
+        Deleting a path removes the exact file at `file_path` plus every nested
+        key under it (the prefix `file_path` + "/"), so a directory is removed
+        recursively. Each removal is queued via `CONFIG_KEY_SEND` as a ``None``
+        value, which the `files` channel reducer interprets as a deletion marker.
+
+        Args:
+            file_path: Path of the file or directory to delete.
+
+        Returns:
+            `DeleteResult` with `file_path` on success, or an error if nothing is
+                stored at or under it.
         """
         files = self._read_files()
 
-        if file_path not in files:
+        base = file_path.rstrip("/")
+        prefix = base + "/"
+        to_delete = [key for key in files if key == base or key.startswith(prefix)]
+        if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
-        self._send_files_update({file_path: None})
+        self._send_files_update(dict.fromkeys(to_delete, None))
         return DeleteResult(path=file_path)
 
     def grep(

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -28,7 +28,6 @@ from deepagents.backends.utils import (
     _glob_search_files,
     _to_legacy_file_data,
     create_file_data,
-    expand_delete_keys,
     file_data_to_string,
     grep_matches_from_files,
     perform_string_replacement,
@@ -309,7 +308,9 @@ class StateBackend(BackendProtocol):
         """
         files = self._read_files()
 
-        to_delete = expand_delete_keys(files, file_path)
+        base = file_path.rstrip("/")
+        prefix = base + "/"
+        to_delete = [key for key in files if key == base or key.startswith(prefix)]
         if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -250,16 +250,17 @@ class StateBackend(BackendProtocol):
         file_path: str,
         content: str,
     ) -> WriteResult:
-        """Create a new file with content.
+        """Write content to a file, creating it or overwriting it if it already exists.
 
         The update is queued directly via `CONFIG_KEY_SEND`.
         """
         files = self._read_files()
 
-        if file_path in files:
-            return WriteResult(error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path.")
-
-        new_file_data = create_file_data(content)
+        existing = files.get(file_path)
+        if existing is not None:
+            new_file_data = update_file_data(existing, content)
+        else:
+            new_file_data = create_file_data(content)
         self._send_files_update({file_path: self._prepare_for_storage(new_file_data)})
         return WriteResult(path=file_path)
 

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Generic, cast
 
 from langgraph.config import get_config, get_store
 from langgraph.runtime import get_runtime
-from langgraph.store.base import BaseStore, Item
+from langgraph.store.base import BaseStore, Item, PutOp
 from langgraph.typing import ContextT, StateT
 
 from deepagents._api.deprecation import deprecated, warn_deprecated
@@ -736,8 +736,7 @@ class StoreBackend(BackendProtocol):
         if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
-        for key in to_delete:
-            store.delete(namespace, key)
+        store.batch([PutOp(namespace, key, None) for key in to_delete])
         return DeleteResult(path=file_path)
 
     async def adelete(self, file_path: str) -> DeleteResult:
@@ -750,8 +749,7 @@ class StoreBackend(BackendProtocol):
         if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
-        for key in to_delete:
-            await store.adelete(namespace, key)
+        await store.abatch([PutOp(namespace, key, None) for key in to_delete])
         return DeleteResult(path=file_path)
 
     # Removed legacy grep() convenience to keep lean surface

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -14,6 +14,7 @@ from langgraph.typing import ContextT, StateT
 from deepagents._api.deprecation import deprecated, warn_deprecated
 from deepagents.backends.protocol import (
     BackendProtocol,
+    DeleteResult,
     EditResult,
     FileData,
     FileDownloadResponse,
@@ -682,6 +683,39 @@ class StoreBackend(BackendProtocol):
         store_value = self._convert_file_data_to_store_value(new_file_data)
         await store.aput(namespace, file_path, store_value)
         return EditResult(path=file_path, occurrences=int(occurrences))
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file from the store.
+
+        `file_path` is used as an exact store key. Wildcards (e.g. `*`) are treated
+        literally and do not expand to multiple entries.
+
+
+        Returns `DeleteResult` with the deleted path on success, or an error if
+        the file does not exist.
+        """
+        store = self._get_store()
+        namespace = self._get_namespace()
+
+        if store.get(namespace, file_path) is None:
+            return DeleteResult(error=f"Error: File '{file_path}' not found")
+
+        store.delete(namespace, file_path)
+        return DeleteResult(path=file_path)
+
+    async def adelete(self, file_path: str) -> DeleteResult:
+        """Async version of delete using native store async methods.
+
+        This avoids sync calls in async context by using store.aget/adelete directly.
+        """
+        store = self._get_store()
+        namespace = self._get_namespace()
+
+        if await store.aget(namespace, file_path) is None:
+            return DeleteResult(error=f"Error: File '{file_path}' not found")
+
+        await store.adelete(namespace, file_path)
+        return DeleteResult(path=file_path)
 
     # Removed legacy grep() convenience to keep lean surface
 

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -596,20 +596,19 @@ class StoreBackend(BackendProtocol):
         file_path: str,
         content: str,
     ) -> WriteResult:
-        """Create a new file with content.
+        """Write content to a file, creating it or overwriting it if it already exists.
 
         Returns WriteResult on success or error.
         """
         store = self._get_store()
         namespace = self._get_namespace()
 
-        # Check if file exists
         existing = store.get(namespace, file_path)
         if existing is not None:
-            return WriteResult(error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path.")
-
-        # Create new file
-        file_data = create_file_data(content)
+            existing_file_data = self._convert_store_item_to_file_data(existing)
+            file_data = update_file_data(existing_file_data, content)
+        else:
+            file_data = create_file_data(content)
         store_value = self._convert_file_data_to_store_value(file_data)
         store.put(namespace, file_path, store_value)
         return WriteResult(path=file_path)
@@ -626,13 +625,12 @@ class StoreBackend(BackendProtocol):
         store = self._get_store()
         namespace = self._get_namespace()
 
-        # Check if file exists using async method
         existing = await store.aget(namespace, file_path)
         if existing is not None:
-            return WriteResult(error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path.")
-
-        # Create new file using async method
-        file_data = create_file_data(content)
+            existing_file_data = self._convert_store_item_to_file_data(existing)
+            file_data = update_file_data(existing_file_data, content)
+        else:
+            file_data = create_file_data(content)
         store_value = self._convert_file_data_to_store_value(file_data)
         await store.aput(namespace, file_path, store_value)
         return WriteResult(path=file_path)

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Generic, cast
 
 from langgraph.config import get_config, get_store
 from langgraph.runtime import get_runtime
-from langgraph.store.base import BaseStore, Item
+from langgraph.store.base import BaseStore, Item, PutOp
 from langgraph.typing import ContextT, StateT
 
 from deepagents._api.deprecation import deprecated, warn_deprecated
@@ -419,6 +419,35 @@ class StoreBackend(BackendProtocol):
 
         return all_items
 
+    async def _asearch_store_paginated(
+        self,
+        store: BaseStore,
+        namespace: tuple[str, ...],
+        *,
+        query: str | None = None,
+        filter: dict[str, Any] | None = None,  # noqa: A002  # Matches LangGraph BaseStore.asearch() API
+        page_size: int = 100,
+    ) -> list[Item]:
+        """Async version of `_search_store_paginated`."""
+        all_items: list[Item] = []
+        offset = 0
+        while True:
+            page_items = await store.asearch(
+                namespace,
+                query=query,
+                filter=filter,
+                limit=page_size,
+                offset=offset,
+            )
+            if not page_items:
+                break
+            all_items.extend(page_items)
+            if len(page_items) < page_size:
+                break
+            offset += page_size
+
+        return all_items
+
     def ls(self, path: str) -> LsResult:
         """List files and directories in the specified directory (non-recursive).
 
@@ -685,36 +714,46 @@ class StoreBackend(BackendProtocol):
         return EditResult(path=file_path, occurrences=int(occurrences))
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file from the store.
+        """Delete a file or directory from the store.
 
-        `file_path` is used as an exact store key. Wildcards (e.g. `*`) are treated
-        literally and do not expand to multiple entries.
+        Deleting a path removes the exact key `file_path` plus every key nested
+        under it (the prefix `file_path` + "/"), so a directory is removed
+        recursively. Wildcards (e.g. `*`) in `file_path` are treated literally.
 
+        Args:
+            file_path: Path of the file or directory to delete.
 
-        Returns `DeleteResult` with the deleted path on success, or an error if
-        the file does not exist.
+        Returns:
+            `DeleteResult` with `file_path` on success, or an error if no key is
+                stored at or under it.
         """
         store = self._get_store()
         namespace = self._get_namespace()
 
-        if store.get(namespace, file_path) is None:
+        items = self._search_store_paginated(store, namespace)
+        # A recursive delete removes the exact key plus everything nested under it.
+        base = file_path.rstrip("/")
+        prefix = base + "/"
+        to_delete = [key for item in items if (key := str(item.key)) == base or key.startswith(prefix)]
+        if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
-        store.delete(namespace, file_path)
+        store.batch([PutOp(namespace, key, None) for key in to_delete])
         return DeleteResult(path=file_path)
 
     async def adelete(self, file_path: str) -> DeleteResult:
-        """Async version of delete using native store async methods.
-
-        This avoids sync calls in async context by using store.aget/adelete directly.
-        """
+        """Async version of `delete` using native store async methods."""
         store = self._get_store()
         namespace = self._get_namespace()
 
-        if await store.aget(namespace, file_path) is None:
+        items = await self._asearch_store_paginated(store, namespace)
+        base = file_path.rstrip("/")
+        prefix = base + "/"
+        to_delete = [key for item in items if (key := str(item.key)) == base or key.startswith(prefix)]
+        if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
-        await store.adelete(namespace, file_path)
+        await store.abatch([PutOp(namespace, key, None) for key in to_delete])
         return DeleteResult(path=file_path)
 
     # Removed legacy grep() convenience to keep lean surface

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -32,7 +32,6 @@ from deepagents.backends.utils import (
     _glob_search_files,
     _to_legacy_file_data,
     create_file_data,
-    expand_delete_keys,
     file_data_to_string,
     grep_matches_from_files,
     perform_string_replacement,
@@ -732,7 +731,10 @@ class StoreBackend(BackendProtocol):
         namespace = self._get_namespace()
 
         items = self._search_store_paginated(store, namespace)
-        to_delete = expand_delete_keys((str(item.key) for item in items), file_path)
+        # A recursive delete removes the exact key plus everything nested under it.
+        base = file_path.rstrip("/")
+        prefix = base + "/"
+        to_delete = [key for item in items if (key := str(item.key)) == base or key.startswith(prefix)]
         if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
@@ -745,7 +747,9 @@ class StoreBackend(BackendProtocol):
         namespace = self._get_namespace()
 
         items = await self._asearch_store_paginated(store, namespace)
-        to_delete = expand_delete_keys((str(item.key) for item in items), file_path)
+        base = file_path.rstrip("/")
+        prefix = base + "/"
+        to_delete = [key for item in items if (key := str(item.key)) == base or key.startswith(prefix)]
         if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -32,6 +32,7 @@ from deepagents.backends.utils import (
     _glob_search_files,
     _to_legacy_file_data,
     create_file_data,
+    expand_delete_keys,
     file_data_to_string,
     grep_matches_from_files,
     perform_string_replacement,
@@ -419,6 +420,35 @@ class StoreBackend(BackendProtocol):
 
         return all_items
 
+    async def _asearch_store_paginated(
+        self,
+        store: BaseStore,
+        namespace: tuple[str, ...],
+        *,
+        query: str | None = None,
+        filter: dict[str, Any] | None = None,  # noqa: A002  # Matches LangGraph BaseStore.asearch() API
+        page_size: int = 100,
+    ) -> list[Item]:
+        """Async version of `_search_store_paginated`."""
+        all_items: list[Item] = []
+        offset = 0
+        while True:
+            page_items = await store.asearch(
+                namespace,
+                query=query,
+                filter=filter,
+                limit=page_size,
+                offset=offset,
+            )
+            if not page_items:
+                break
+            all_items.extend(page_items)
+            if len(page_items) < page_size:
+                break
+            offset += page_size
+
+        return all_items
+
     def ls(self, path: str) -> LsResult:
         """List files and directories in the specified directory (non-recursive).
 
@@ -685,36 +715,43 @@ class StoreBackend(BackendProtocol):
         return EditResult(path=file_path, occurrences=int(occurrences))
 
     def delete(self, file_path: str) -> DeleteResult:
-        """Delete a file from the store.
+        """Delete a file or directory from the store.
 
-        `file_path` is used as an exact store key. Wildcards (e.g. `*`) are treated
-        literally and do not expand to multiple entries.
+        Deleting a path removes the exact key `file_path` plus every key nested
+        under it (the prefix `file_path` + "/"), so a directory is removed
+        recursively. Wildcards (e.g. `*`) in `file_path` are treated literally.
 
+        Args:
+            file_path: Path of the file or directory to delete.
 
-        Returns `DeleteResult` with the deleted path on success, or an error if
-        the file does not exist.
+        Returns:
+            `DeleteResult` with `file_path` on success, or an error if no key is
+                stored at or under it.
         """
         store = self._get_store()
         namespace = self._get_namespace()
 
-        if store.get(namespace, file_path) is None:
+        items = self._search_store_paginated(store, namespace)
+        to_delete = expand_delete_keys((str(item.key) for item in items), file_path)
+        if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
-        store.delete(namespace, file_path)
+        for key in to_delete:
+            store.delete(namespace, key)
         return DeleteResult(path=file_path)
 
     async def adelete(self, file_path: str) -> DeleteResult:
-        """Async version of delete using native store async methods.
-
-        This avoids sync calls in async context by using store.aget/adelete directly.
-        """
+        """Async version of `delete` using native store async methods."""
         store = self._get_store()
         namespace = self._get_namespace()
 
-        if await store.aget(namespace, file_path) is None:
+        items = await self._asearch_store_paginated(store, namespace)
+        to_delete = expand_delete_keys((str(item.key) for item in items), file_path)
+        if not to_delete:
             return DeleteResult(error=f"Error: File '{file_path}' not found")
 
-        await store.adelete(namespace, file_path)
+        for key in to_delete:
+            await store.adelete(namespace, key)
         return DeleteResult(path=file_path)
 
     # Removed legacy grep() convenience to keep lean surface

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -73,14 +73,11 @@ GrepMatch = _GrepMatch
 
 
 def expand_delete_keys(keys: Iterable[str], path: str) -> list[str]:
-    """Keys that a recursive delete of `path` should remove.
+    """Return all keys removed by a recursive delete of `path`.
 
-    For key-value backends a "directory" is a key prefix: deleting `path` removes
-    the exact key `path` (a file) plus every key nested under it (anything
-    starting with `path` followed by "/"). Used by the key-value backends
-    (`StateBackend`, `StoreBackend`, `ContextHubBackend`) to give `delete`
-    the same recursive semantics directory-based backends get from removing a
-    subtree.
+    Deleting `path` removes the exact key and any nested keys (those with the
+    prefix `path + "/"`). Used by key-value backends to provide the same
+    recursive delete semantics as directory-based backends.
 
     Args:
         keys: All stored keys in the namespace.

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -7,7 +7,7 @@ enable composition without fragile string parsing.
 
 import os
 import re
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal, overload
@@ -70,6 +70,28 @@ TRUNCATION_GUIDANCE = "... [results truncated, try being more specific with your
 # Re-export protocol types for backwards compatibility
 FileInfo = _FileInfo
 GrepMatch = _GrepMatch
+
+
+def expand_delete_keys(keys: Iterable[str], path: str) -> list[str]:
+    """Keys that a recursive delete of `path` should remove.
+
+    For key-value backends a "directory" is a key prefix: deleting `path` removes
+    the exact key `path` (a file) plus every key nested under it (anything
+    starting with `path` followed by "/"). Used by the key-value backends
+    (`StateBackend`, `StoreBackend`, `ContextHubBackend`) to give `delete`
+    the same recursive semantics directory-based backends get from removing a
+    subtree.
+
+    Args:
+        keys: All stored keys in the namespace.
+        path: The delete target path.
+
+    Returns:
+        The matching keys, empty if nothing is stored at or under `path`.
+    """
+    base = path.rstrip("/")
+    prefix = base + "/"
+    return [key for key in keys if key == base or key.startswith(prefix)]
 
 
 def _normalize_content(file_data: FileData) -> str:

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -7,7 +7,7 @@ enable composition without fragile string parsing.
 
 import os
 import re
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal, overload
@@ -70,25 +70,6 @@ TRUNCATION_GUIDANCE = "... [results truncated, try being more specific with your
 # Re-export protocol types for backwards compatibility
 FileInfo = _FileInfo
 GrepMatch = _GrepMatch
-
-
-def expand_delete_keys(keys: Iterable[str], path: str) -> list[str]:
-    """Return all keys removed by a recursive delete of `path`.
-
-    Deleting `path` removes the exact key and any nested keys (those with the
-    prefix `path + "/"`). Used by key-value backends to provide the same
-    recursive delete semantics as directory-based backends.
-
-    Args:
-        keys: All stored keys in the namespace.
-        path: The delete target path.
-
-    Returns:
-        The matching keys, empty if nothing is stored at or under `path`.
-    """
-    base = path.rstrip("/")
-    prefix = base + "/"
-    return [key for key in keys if key == base or key.startswith(prefix)]
 
 
 def _normalize_content(file_data: FileData) -> str:

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -203,32 +203,51 @@ def _merge_fs_interrupt_on(
     return merged
 
 
-def _apply_user_middleware(
+def _apply_custom_middleware(
     base: list[AgentMiddleware[Any, Any, Any]],
     custom: Sequence[AgentMiddleware[Any, Any, Any]],
+    original_name_to_index: dict[str, int] | None = None,
 ) -> list[AgentMiddleware[Any, Any, Any]]:
     """Merge custom middleware into the base stack by name.
 
-    For each custom entry whose ``.name`` matches a base entry, the base entry
-    is replaced in-place (preserving stack order). Custom entries that don't
-    match any base name are appended at the end in their original order,
-    without deduplication; same-named non-default entries are all preserved.
+    For each custom entry:
+
+    - If its ``.name`` matches a name still present in ``base``: replace in-place,
+      preserving stack order.
+    - If it matches a middleware that was excluded, insert it where that middleware
+    originally appeared.
+    - Otherwise: append at the end in the order supplied.
+
+    Custom middleware that doesn't match a default entry is always preserved.
     """
     if not custom:
-        return base
-    base_names = {m.name for m in base}
+        return list(base)
+    current_names = {m.name for m in base}
     replacements: dict[str, AgentMiddleware[Any, Any, Any]] = {}
-    appended: list[AgentMiddleware[Any, Any, Any]] = []
+    to_insert: list[tuple[int, AgentMiddleware[Any, Any, Any]]] = []
+    to_append: list[AgentMiddleware[Any, Any, Any]] = []
     for m in custom:
-        if m.name in base_names:
+        if m.name in current_names:
             replacements[m.name] = m
+        elif original_name_to_index is not None and m.name in original_name_to_index:
+            to_insert.append((original_name_to_index[m.name], m))
         else:
-            appended.append(m)
+            to_append.append(m)
     result = list(base)
     for i, m in enumerate(result):
         if m.name in replacements:
             result[i] = replacements[m.name]
-    result.extend(appended)
+    # Insert excluded-slot entries at their original positions in ascending order so
+    # relative ordering is preserved when multiple slots are filled at once.
+    to_insert.sort(key=lambda x: x[0])
+    for orig_idx, mw in to_insert:
+        insert_pos = 0
+        for i, existing in enumerate(result):
+            existing_orig = original_name_to_index.get(existing.name) if original_name_to_index is not None else None
+            if existing_orig is not None and existing_orig < orig_idx:
+                insert_pos = i + 1
+        result.insert(insert_pos, mw)
+    result.extend(to_append)
     return result
 
 
@@ -658,8 +677,6 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             subagent_skills = spec.get("skills")
             if subagent_skills:
                 subagent_middleware.append(SkillsMiddleware(backend=backend, sources=subagent_skills))
-            subagent_middleware = _apply_user_middleware(subagent_middleware, spec.get("middleware", []))
-
             # Harness-profile middleware for this subagent's model
             subagent_middleware.extend(_subagent_profile.materialize_extra_middleware())
             if _subagent_profile.excluded_tools:
@@ -668,6 +685,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             # Prompt caching
             subagent_middleware.append(AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore"))
 
+            _subagent_original_name_to_index = {m.name: i for i, m in enumerate(subagent_middleware)}
             _subagent_matched_classes: set[type[AgentMiddleware[Any, Any, Any]]] = set()
             _subagent_matched_names: set[str] = set()
             _validate_excluded_middleware_config(
@@ -675,6 +693,13 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
                 required_classes=_REQUIRED_MIDDLEWARE_CLASSES,
                 required_names=_REQUIRED_MIDDLEWARE_NAMES,
             )
+            subagent_middleware = _apply_excluded_middleware(
+                subagent_middleware,
+                _subagent_profile,
+                matched_classes=_subagent_matched_classes,
+                matched_names=_subagent_matched_names,
+            )
+            subagent_middleware = _apply_custom_middleware(subagent_middleware, spec.get("middleware", []), _subagent_original_name_to_index)
             subagent_middleware = _apply_excluded_middleware(
                 subagent_middleware,
                 _subagent_profile,
@@ -815,8 +840,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         # Currently this supports agents deployed via LangSmith deployments.
         deepagent_middleware.append(AsyncSubAgentMiddleware(async_subagents=async_subagents))
 
-    deepagent_middleware = _apply_user_middleware(deepagent_middleware, middleware or [])
-    # Harness-profile middleware goes between user middleware and memory so
+    # Harness-profile middleware goes between core middleware and memory so
     # that memory updates (which change the system prompt) don't invalidate the
     # Anthropic prompt cache prefix.
     deepagent_middleware.extend(_profile.materialize_extra_middleware())
@@ -840,6 +864,14 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     )
     if main_interrupt_on is not None:
         deepagent_middleware.append(HumanInTheLoopMiddleware(interrupt_on=main_interrupt_on))
+    _main_original_name_to_index = {m.name: i for i, m in enumerate(deepagent_middleware)}
+    deepagent_middleware = _apply_excluded_middleware(
+        deepagent_middleware,
+        _profile,
+        matched_classes=_main_matched_classes,
+        matched_names=_main_matched_names,
+    )
+    deepagent_middleware = _apply_custom_middleware(deepagent_middleware, middleware or [], _main_original_name_to_index)
     deepagent_middleware = _apply_excluded_middleware(
         deepagent_middleware,
         _profile,

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -211,16 +211,24 @@ def _apply_user_middleware(
 
     For each custom entry whose ``.name`` matches a base entry, the base entry
     is replaced in-place (preserving stack order). Custom entries that don't
-    match any base entry are appended at the end in their original order.
+    match any base name are appended at the end in their original order,
+    without deduplication; same-named non-default entries are all preserved.
     """
     if not custom:
         return base
-    custom_by_name: dict[str, AgentMiddleware[Any, Any, Any]] = {m.name: m for m in custom}
+    base_names = {m.name for m in base}
+    replacements: dict[str, AgentMiddleware[Any, Any, Any]] = {}
+    appended: list[AgentMiddleware[Any, Any, Any]] = []
+    for m in custom:
+        if m.name in base_names:
+            replacements[m.name] = m
+        else:
+            appended.append(m)
     result = list(base)
     for i, m in enumerate(result):
-        if m.name in custom_by_name:
-            result[i] = custom_by_name.pop(m.name)
-    result.extend(custom_by_name.values())
+        if m.name in replacements:
+            result[i] = replacements[m.name]
+    result.extend(appended)
     return result
 
 

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -203,6 +203,27 @@ def _merge_fs_interrupt_on(
     return merged
 
 
+def _apply_user_middleware(
+    base: list[AgentMiddleware[Any, Any, Any]],
+    custom: Sequence[AgentMiddleware[Any, Any, Any]],
+) -> list[AgentMiddleware[Any, Any, Any]]:
+    """Merge custom middleware into the base stack by name.
+
+    For each custom entry whose ``.name`` matches a base entry, the base entry
+    is replaced in-place (preserving stack order). Custom entries that don't
+    match any base entry are appended at the end in their original order.
+    """
+    if not custom:
+        return base
+    custom_by_name: dict[str, AgentMiddleware[Any, Any, Any]] = {m.name: m for m in custom}
+    result = list(base)
+    for i, m in enumerate(result):
+        if m.name in custom_by_name:
+            result[i] = custom_by_name.pop(m.name)
+    result.extend(custom_by_name.values())
+    return result
+
+
 _REQUIRED_MIDDLEWARE: tuple[tuple[type[AgentMiddleware[Any, Any, Any]], tuple[str, ...]], ...] = (
     (FilesystemMiddleware, ()),
     (SubAgentMiddleware, ()),
@@ -629,7 +650,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             subagent_skills = spec.get("skills")
             if subagent_skills:
                 subagent_middleware.append(SkillsMiddleware(backend=backend, sources=subagent_skills))
-            subagent_middleware.extend(spec.get("middleware", []))
+            subagent_middleware = _apply_user_middleware(subagent_middleware, spec.get("middleware", []))
 
             # Harness-profile middleware for this subagent's model
             subagent_middleware.extend(_subagent_profile.materialize_extra_middleware())
@@ -786,8 +807,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         # Currently this supports agents deployed via LangSmith deployments.
         deepagent_middleware.append(AsyncSubAgentMiddleware(async_subagents=async_subagents))
 
-    if middleware:
-        deepagent_middleware.extend(middleware)
+    deepagent_middleware = _apply_user_middleware(deepagent_middleware, middleware or [])
     # Harness-profile middleware goes between user middleware and memory so
     # that memory updates (which change the system prompt) don't invalidate the
     # Anthropic prompt cache prefix.

--- a/libs/deepagents/deepagents/middleware/_fs_interrupt.py
+++ b/libs/deepagents/deepagents/middleware/_fs_interrupt.py
@@ -40,6 +40,7 @@ _FS_TOOL_PATH_ARGS: dict[str, tuple[FilesystemOperation, str, ToolScope, str | N
     "read_file": ("read", "file_path", "exact", None),
     "write_file": ("write", "file_path", "exact", None),
     "edit_file": ("write", "file_path", "exact", None),
+    "delete": ("write", "file_path", "bulk", None),
     "glob": ("read", "path", "bulk", "pattern"),
     "grep": ("read", "path", "bulk", None),
 }

--- a/libs/deepagents/deepagents/middleware/_fs_interrupt.py
+++ b/libs/deepagents/deepagents/middleware/_fs_interrupt.py
@@ -40,7 +40,7 @@ _FS_TOOL_PATH_ARGS: dict[str, tuple[FilesystemOperation, str, ToolScope, str | N
     "read_file": ("read", "file_path", "exact", None),
     "write_file": ("write", "file_path", "exact", None),
     "edit_file": ("write", "file_path", "exact", None),
-    "delete_file": ("write", "file_path", "bulk", None),
+    "delete": ("write", "file_path", "bulk", None),
     "glob": ("read", "path", "bulk", "pattern"),
     "grep": ("read", "path", "bulk", None),
 }

--- a/libs/deepagents/deepagents/middleware/_fs_interrupt.py
+++ b/libs/deepagents/deepagents/middleware/_fs_interrupt.py
@@ -40,6 +40,7 @@ _FS_TOOL_PATH_ARGS: dict[str, tuple[FilesystemOperation, str, ToolScope, str | N
     "read_file": ("read", "file_path", "exact", None),
     "write_file": ("write", "file_path", "exact", None),
     "edit_file": ("write", "file_path", "exact", None),
+    "delete_file": ("write", "file_path", "bulk", None),
     "glob": ("read", "path", "bulk", "pattern"),
     "grep": ("read", "path", "bulk", None),
 }

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -229,6 +229,13 @@ def _apply_permissions_to_glob_results(
     return [fi.get("path", "") for fi in filtered_infos]
 
 
+def _format_file_paths(paths: list[str]) -> str:
+    """Format filesystem path lists for tool output."""
+    if not paths:
+        return "No files found"
+    return str(truncate_if_too_long(paths))
+
+
 EMPTY_CONTENT_WARNING = "System reminder: File exists but has empty contents"
 GLOB_TIMEOUT = 20.0  # seconds
 LINE_NUMBER_WIDTH = 6
@@ -832,7 +839,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             infos = ls_result.entries or []
             paths = _apply_permissions_to_ls_results(self._permissions, infos)
             return ToolMessage(
-                content=str(truncate_if_too_long(paths)),
+                content=_format_file_paths(paths),
                 tool_call_id=runtime.tool_call_id,
                 name="ls",
                 status="success",
@@ -871,7 +878,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             infos = ls_result.entries or []
             paths = _apply_permissions_to_ls_results(self._permissions, infos)
             return ToolMessage(
-                content=str(truncate_if_too_long(paths)),
+                content=_format_file_paths(paths),
                 tool_call_id=runtime.tool_call_id,
                 name="ls",
                 status="success",
@@ -1290,7 +1297,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             infos = glob_result.matches or []
             paths = _apply_permissions_to_glob_results(self._permissions, infos)
             return ToolMessage(
-                content=str(truncate_if_too_long(paths)),
+                content=_format_file_paths(paths),
                 tool_call_id=runtime.tool_call_id,
                 name="glob",
                 status="success",
@@ -1342,7 +1349,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             infos = glob_result.matches or []
             paths = _apply_permissions_to_glob_results(self._permissions, infos)
             return ToolMessage(
-                content=str(truncate_if_too_long(paths)),
+                content=_format_file_paths(paths),
                 tool_call_id=runtime.tool_call_id,
                 name="glob",
                 status="success",

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -39,6 +39,7 @@ from deepagents.backends import CompositeBackend, StateBackend
 from deepagents.backends.protocol import (
     BACKEND_TYPES as BACKEND_TYPES,  # Re-export type here for backwards compatibility
     BackendProtocol,
+    DeleteResult,
     EditResult,
     FileData as FileData,  # Re-export for backwards compatibility
     FileInfo,
@@ -48,6 +49,7 @@ from deepagents.backends.protocol import (
     SandboxBackendProtocol,
     WriteResult,
     _resolve_backend,
+    _supports_delete,
     execute_accepts_timeout,
 )
 from deepagents.backends.utils import (
@@ -79,6 +81,7 @@ _DEFAULT_FS_TOOL_OPS: dict[str, FilesystemOperation] = {
     "grep": "read",
     "write_file": "write",
     "edit_file": "write",
+    "delete_file": "write",
 }
 
 
@@ -358,6 +361,12 @@ class EditFileSchema(BaseModel):
     )
 
 
+class DeleteFileSchema(BaseModel):
+    """Input schema for the `delete_file` tool."""
+
+    file_path: str = Field(description="Absolute path to the file to delete. Must be absolute, not relative.")
+
+
 class GlobSchema(BaseModel):
     """Input schema for the `glob` tool."""
 
@@ -432,6 +441,13 @@ Usage:
 - Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.
 """
 
+DELETE_FILE_TOOL_DESCRIPTION = """Deletes a file from the filesystem.
+
+Usage:
+- Permanently removes the file at the given absolute path.
+- This cannot be undone, so only delete files you are sure are no longer needed.
+"""
+
 GLOB_TOOL_DESCRIPTION = """Find files matching a glob pattern.
 
 Supports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).
@@ -503,7 +519,7 @@ _FILESYSTEM_SYSTEM_PROMPT_TEMPLATE = """## Following Conventions
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -512,6 +528,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete_file: delete a file from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 
@@ -581,6 +598,7 @@ TOOLS_EXCLUDED_FROM_EVICTION = (
     "read_file",
     "edit_file",
     "write_file",
+    "delete_file",
 )
 
 
@@ -773,6 +791,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             self._create_read_file_tool(),
             self._create_write_file_tool(),
             self._create_edit_file_tool(),
+            self._create_delete_file_tool(),
             self._create_glob_tool(),
             self._create_grep_tool(),
             self._create_execute_tool(),
@@ -1247,6 +1266,95 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=EditFileSchema,
         )
 
+    def _create_delete_file_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
+        """Create the delete_file tool."""
+        tool_description = self._custom_tool_descriptions.get("delete_file") or DELETE_FILE_TOOL_DESCRIPTION
+
+        def sync_delete_file(
+            file_path: Annotated[str, "Absolute path to the file to delete. Must be absolute, not relative."],
+            runtime: ToolRuntime[None, FilesystemState],
+        ) -> ToolMessage:
+            """Synchronous wrapper for delete_file tool."""
+            resolved_backend = self._get_backend(runtime)
+            try:
+                validated_path = validate_path(file_path)
+            except ValueError as e:
+                return ToolMessage(
+                    content=f"Error: {e}",
+                    name="delete_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+
+            if _check_fs_permission(self._permissions, "write", validated_path) == "deny":
+                return ToolMessage(
+                    content=f"Error: permission denied for write on {validated_path}",
+                    name="delete_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            res: DeleteResult = resolved_backend.delete(validated_path)
+            if res.error:
+                return ToolMessage(
+                    content=res.error,
+                    name="delete_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            return ToolMessage(
+                content=f"Deleted file {res.path}",
+                name="delete_file",
+                tool_call_id=runtime.tool_call_id,
+                status="success",
+            )
+
+        async def async_delete_file(
+            file_path: Annotated[str, "Absolute path to the file to delete. Must be absolute, not relative."],
+            runtime: ToolRuntime[None, FilesystemState],
+        ) -> ToolMessage:
+            """Asynchronous wrapper for delete_file tool."""
+            resolved_backend = self._get_backend(runtime)
+            try:
+                validated_path = validate_path(file_path)
+            except ValueError as e:
+                return ToolMessage(
+                    content=f"Error: {e}",
+                    name="delete_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+
+            if _check_fs_permission(self._permissions, "write", validated_path) == "deny":
+                return ToolMessage(
+                    content=f"Error: permission denied for write on {validated_path}",
+                    name="delete_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            res: DeleteResult = await resolved_backend.adelete(validated_path)
+            if res.error:
+                return ToolMessage(
+                    content=res.error,
+                    name="delete_file",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            return ToolMessage(
+                content=f"Deleted file {res.path}",
+                name="delete_file",
+                tool_call_id=runtime.tool_call_id,
+                status="success",
+            )
+
+        return StructuredTool.from_function(
+            name="delete_file",
+            description=tool_description,
+            func=sync_delete_file,
+            coroutine=async_delete_file,
+            infer_schema=False,
+            args_schema=DeleteFileSchema,
+        )
+
     def _create_glob_tool(self) -> BaseTool:  # noqa: C901  # Tool wiring + permission/result shaping
         """Create the glob tool."""
         tool_description = self._custom_tool_descriptions.get("glob") or GLOB_TOOL_DESCRIPTION
@@ -1653,6 +1761,61 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=ExecuteSchema,
         )
 
+    def _filter_unsupported_tools_and_apply_prompt(self, request: ModelRequest[ContextT]) -> ModelRequest[ContextT]:
+        """Drop capability-gated tools the backend can't serve, then apply the system prompt.
+
+        Shared by the sync and async `wrap_model_call` paths (the only part that
+        differs between them is sync vs. async message eviction). The `execute`
+        and `delete_file` tools are optional per backend, so when the resolved
+        backend doesn't support a capability the corresponding tool is filtered
+        out of the request rather than advertised to the model and left to fail
+        at call time. Resolving the backend and probing support is synchronous,
+        so both paths route through here.
+
+        Returns the request with unsupported tools removed and the filesystem
+        system prompt appended.
+        """
+        tool_names = {(tool.name if hasattr(tool, "name") else tool.get("name")) for tool in request.tools}
+        has_execute_tool = "execute" in tool_names
+        has_delete_tool = "delete_file" in tool_names
+
+        # `execute` and `delete_file` are optional per backend; resolve the
+        # backend once and filter out any tool the backend can't serve.
+        if has_execute_tool or has_delete_tool:
+            backend = self._get_backend(request.runtime)  # ty: ignore[invalid-argument-type]
+            unsupported: set[str | None] = set()
+            if has_execute_tool and not supports_execution(backend):
+                unsupported.add("execute")
+                has_execute_tool = False
+            if has_delete_tool and not _supports_delete(backend):
+                unsupported.add("delete_file")
+            if unsupported:
+                filtered_tools = [tool for tool in request.tools if (tool.name if hasattr(tool, "name") else tool.get("name")) not in unsupported]
+                request = request.override(tools=filtered_tools)
+
+        # Use custom system prompt if provided, otherwise generate dynamically
+        if self._custom_system_prompt is not None:
+            system_prompt = self._custom_system_prompt
+        else:
+            # Build dynamic system prompt based on available tools
+            prompt_parts = [
+                _FILESYSTEM_SYSTEM_PROMPT_TEMPLATE.format(
+                    large_tool_results_prefix=self._large_tool_results_prefix,
+                )
+            ]
+
+            # Add execution instructions only if the execute tool survived filtering
+            if has_execute_tool:
+                prompt_parts.append(EXECUTION_SYSTEM_PROMPT)
+
+            system_prompt = "\n\n".join(prompt_parts).strip()
+
+        if system_prompt:
+            new_system_message = append_to_system_message(request.system_message, system_prompt)
+            request = request.override(system_message=new_system_message)
+
+        return request
+
     def wrap_model_call(
         self,
         request: ModelRequest[ContextT],
@@ -1678,41 +1841,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             The model response, or an `ExtendedModelResponse` with a state
             update tagging a newly evicted message.
         """
-        # Check if execute tool is present and if backend supports it
-        has_execute_tool = any((tool.name if hasattr(tool, "name") else tool.get("name")) == "execute" for tool in request.tools)
-
-        backend_supports_execution = False
-        if has_execute_tool:
-            # Resolve backend to check execution support
-            backend = self._get_backend(request.runtime)  # ty: ignore[invalid-argument-type]
-            backend_supports_execution = supports_execution(backend)
-
-            # If execute tool exists but backend doesn't support it, filter it out
-            if not backend_supports_execution:
-                filtered_tools = [tool for tool in request.tools if (tool.name if hasattr(tool, "name") else tool.get("name")) != "execute"]
-                request = request.override(tools=filtered_tools)
-                has_execute_tool = False
-
-        # Use custom system prompt if provided, otherwise generate dynamically
-        if self._custom_system_prompt is not None:
-            system_prompt = self._custom_system_prompt
-        else:
-            # Build dynamic system prompt based on available tools
-            prompt_parts = [
-                _FILESYSTEM_SYSTEM_PROMPT_TEMPLATE.format(
-                    large_tool_results_prefix=self._large_tool_results_prefix,
-                )
-            ]
-
-            # Add execution instructions if execute tool is available
-            if has_execute_tool and backend_supports_execution:
-                prompt_parts.append(EXECUTION_SYSTEM_PROMPT)
-
-            system_prompt = "\n\n".join(prompt_parts).strip()
-
-        if system_prompt:
-            new_system_message = append_to_system_message(request.system_message, system_prompt)
-            request = request.override(system_message=new_system_message)
+        request = self._filter_unsupported_tools_and_apply_prompt(request)
 
         eviction_result = self._evict_and_truncate_messages(request)
         if eviction_result is not None:
@@ -1743,41 +1872,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             The model response from the handler, or an `ExtendedModelResponse`
             with a state update tagging newly evicted messages.
         """
-        # Check if execute tool is present and if backend supports it
-        has_execute_tool = any((tool.name if hasattr(tool, "name") else tool.get("name")) == "execute" for tool in request.tools)
-
-        backend_supports_execution = False
-        if has_execute_tool:
-            # Resolve backend to check execution support
-            backend = self._get_backend(request.runtime)  # ty: ignore[invalid-argument-type]
-            backend_supports_execution = supports_execution(backend)
-
-            # If execute tool exists but backend doesn't support it, filter it out
-            if not backend_supports_execution:
-                filtered_tools = [tool for tool in request.tools if (tool.name if hasattr(tool, "name") else tool.get("name")) != "execute"]
-                request = request.override(tools=filtered_tools)
-                has_execute_tool = False
-
-        # Use custom system prompt if provided, otherwise generate dynamically
-        if self._custom_system_prompt is not None:
-            system_prompt = self._custom_system_prompt
-        else:
-            # Build dynamic system prompt based on available tools
-            prompt_parts = [
-                _FILESYSTEM_SYSTEM_PROMPT_TEMPLATE.format(
-                    large_tool_results_prefix=self._large_tool_results_prefix,
-                )
-            ]
-
-            # Add execution instructions if execute tool is available
-            if has_execute_tool and backend_supports_execution:
-                prompt_parts.append(EXECUTION_SYSTEM_PROMPT)
-
-            system_prompt = "\n\n".join(prompt_parts).strip()
-
-        if system_prompt:
-            new_system_message = append_to_system_message(request.system_message, system_prompt)
-            request = request.override(system_message=new_system_message)
+        request = self._filter_unsupported_tools_and_apply_prompt(request)
 
         eviction_result = await self._aevict_and_truncate_messages(request)
         if eviction_result is not None:

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1307,7 +1307,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         """Sync subtree deny scan: returns the first denied path, or None."""
         if not self._permissions:
             return None
-        descendants = [m["path"] for m in backend.glob("**/*", path=target).matches]
+        descendants = [m["path"] for m in (backend.glob("**/*", path=target).matches or [])]
         return self._scan_delete_for_denied_path(target, descendants)
 
     async def _adelete_denied_path(self, backend: BackendProtocol, target: str) -> str | None:
@@ -1315,7 +1315,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         if not self._permissions:
             return None
         result = await backend.aglob("**/*", path=target)
-        descendants = [m["path"] for m in result.matches]
+        descendants = [m["path"] for m in (result.matches or [])]
         return self._scan_delete_for_denied_path(target, descendants)
 
     def _create_delete_tool(self) -> BaseTool:  # Tool wiring + permission/support handling

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -54,6 +54,8 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.utils import (
     _get_file_type,
+    _glob_anchor,
+    _paths_overlap,
     check_empty_content,
     format_content_with_line_numbers,
     format_grep_matches,
@@ -81,7 +83,7 @@ _DEFAULT_FS_TOOL_OPS: dict[str, FilesystemOperation] = {
     "grep": "read",
     "write_file": "write",
     "edit_file": "write",
-    "delete_file": "write",
+    "delete": "write",
 }
 
 
@@ -133,6 +135,32 @@ def _check_fs_permission(
         if any(wcglob.globmatch(path, pattern, flags=_FS_WCMATCH_FLAGS) for pattern in rule.paths):
             return rule.mode
     return "allow"
+
+
+def _find_delete_deny_patterns(rules: list[FilesystemPermission], target: str) -> list[str]:
+    """Return deny-write patterns that block deleting `target`.
+
+    A recursive delete removes `target` and all descendants, so any overlapping
+    deny-write pattern prevents the operation. The check is based only on
+    permission rules and returns all matching patterns.
+
+    Args:
+        rules: Filesystem permission rules.
+        target: Absolute, validated path being deleted.
+
+    Returns:
+        Matching deny-write patterns, or an empty list if the delete is allowed.
+    """
+    denying: list[str] = []
+    seen: set[str] = set()
+    for rule in rules:
+        if rule.mode != "deny" or "write" not in rule.operations:
+            continue
+        for pattern in rule.paths:
+            if pattern not in seen and _paths_overlap(target, _glob_anchor(pattern)):
+                seen.add(pattern)
+                denying.append(pattern)
+    return denying
 
 
 def _filter_paths_by_permission(
@@ -361,8 +389,8 @@ class EditFileSchema(BaseModel):
     )
 
 
-class DeleteFileSchema(BaseModel):
-    """Input schema for the `delete_file` tool."""
+class DeleteSchema(BaseModel):
+    """Input schema for the `delete` tool."""
 
     file_path: str = Field(description="Absolute path to the file to delete. Must be absolute, not relative.")
 
@@ -441,11 +469,13 @@ Usage:
 - Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.
 """
 
-DELETE_FILE_TOOL_DESCRIPTION = """Deletes a file from the filesystem.
+DELETE_TOOL_DESCRIPTION = """Deletes a file or directory from the filesystem.
 
 Usage:
-- Permanently removes the file at the given absolute path.
-- This cannot be undone, so only delete files you are sure are no longer needed.
+- Permanently removes the file or directory at the given absolute path.
+- Deleting a directory removes it and everything inside it, recursively. Prefer
+  deleting a directory in one call over deleting each file individually.
+- This cannot be undone, so only delete paths you are sure are no longer needed.
 """
 
 GLOB_TOOL_DESCRIPTION = """Find files matching a glob pattern.
@@ -519,7 +549,7 @@ _FILESYSTEM_SYSTEM_PROMPT_TEMPLATE = """## Following Conventions
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -528,7 +558,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
-- delete_file: delete a file from the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 
@@ -598,7 +628,7 @@ TOOLS_EXCLUDED_FROM_EVICTION = (
     "read_file",
     "edit_file",
     "write_file",
-    "delete_file",
+    "delete",
 )
 
 
@@ -791,7 +821,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             self._create_read_file_tool(),
             self._create_write_file_tool(),
             self._create_edit_file_tool(),
-            self._create_delete_file_tool(),
+            self._create_delete_tool(),
             self._create_glob_tool(),
             self._create_grep_tool(),
             self._create_execute_tool(),
@@ -1266,30 +1296,31 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=EditFileSchema,
         )
 
-    def _create_delete_file_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
-        """Create the delete_file tool."""
-        tool_description = self._custom_tool_descriptions.get("delete_file") or DELETE_FILE_TOOL_DESCRIPTION
+    def _create_delete_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
+        """Create the delete tool."""
+        tool_description = self._custom_tool_descriptions.get("delete") or DELETE_TOOL_DESCRIPTION
 
-        def sync_delete_file(
+        def sync_delete(
             file_path: Annotated[str, "Absolute path to the file to delete. Must be absolute, not relative."],
             runtime: ToolRuntime[None, FilesystemState],
         ) -> ToolMessage:
-            """Synchronous wrapper for delete_file tool."""
+            """Synchronous wrapper for delete tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(file_path)
             except ValueError as e:
                 return ToolMessage(
                     content=f"Error: {e}",
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
 
-            if _check_fs_permission(self._permissions, "write", validated_path) == "deny":
+            denying_patterns = _find_delete_deny_patterns(self._permissions, validated_path)
+            if denying_patterns:
                 return ToolMessage(
-                    content=f"Error: permission denied for write on {validated_path}",
-                    name="delete_file",
+                    content=f"Error: permission denied for write on {validated_path} (matches deny rule(s): {', '.join(denying_patterns)})",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
@@ -1297,37 +1328,38 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if res.error:
                 return ToolMessage(
                     content=res.error,
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
             return ToolMessage(
-                content=f"Deleted file {res.path}",
-                name="delete_file",
+                content=f"Deleted {res.path}",
+                name="delete",
                 tool_call_id=runtime.tool_call_id,
                 status="success",
             )
 
-        async def async_delete_file(
+        async def async_delete(
             file_path: Annotated[str, "Absolute path to the file to delete. Must be absolute, not relative."],
             runtime: ToolRuntime[None, FilesystemState],
         ) -> ToolMessage:
-            """Asynchronous wrapper for delete_file tool."""
+            """Asynchronous wrapper for delete tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(file_path)
             except ValueError as e:
                 return ToolMessage(
                     content=f"Error: {e}",
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
 
-            if _check_fs_permission(self._permissions, "write", validated_path) == "deny":
+            denying_patterns = _find_delete_deny_patterns(self._permissions, validated_path)
+            if denying_patterns:
                 return ToolMessage(
-                    content=f"Error: permission denied for write on {validated_path}",
-                    name="delete_file",
+                    content=f"Error: permission denied for write on {validated_path} (matches deny rule(s): {', '.join(denying_patterns)})",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
@@ -1335,24 +1367,24 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if res.error:
                 return ToolMessage(
                     content=res.error,
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
             return ToolMessage(
-                content=f"Deleted file {res.path}",
-                name="delete_file",
+                content=f"Deleted {res.path}",
+                name="delete",
                 tool_call_id=runtime.tool_call_id,
                 status="success",
             )
 
         return StructuredTool.from_function(
-            name="delete_file",
+            name="delete",
             description=tool_description,
-            func=sync_delete_file,
-            coroutine=async_delete_file,
+            func=sync_delete,
+            coroutine=async_delete,
             infer_schema=False,
-            args_schema=DeleteFileSchema,
+            args_schema=DeleteSchema,
         )
 
     def _create_glob_tool(self) -> BaseTool:  # noqa: C901  # Tool wiring + permission/result shaping
@@ -1766,7 +1798,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         Shared by the sync and async `wrap_model_call` paths (the only part that
         differs between them is sync vs. async message eviction). The `execute`
-        and `delete_file` tools are optional per backend, so when the resolved
+        and `delete` tools are optional per backend, so when the resolved
         backend doesn't support a capability the corresponding tool is filtered
         out of the request rather than advertised to the model and left to fail
         at call time. Resolving the backend and probing support is synchronous,
@@ -1777,9 +1809,9 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         """
         tool_names = {(tool.name if hasattr(tool, "name") else tool.get("name")) for tool in request.tools}
         has_execute_tool = "execute" in tool_names
-        has_delete_tool = "delete_file" in tool_names
+        has_delete_tool = "delete" in tool_names
 
-        # `execute` and `delete_file` are optional per backend; resolve the
+        # `execute` and `delete` are optional per backend; resolve the
         # backend once and filter out any tool the backend can't serve.
         if has_execute_tool or has_delete_tool:
             backend = self._get_backend(request.runtime)  # ty: ignore[invalid-argument-type]
@@ -1788,7 +1820,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 unsupported.add("execute")
                 has_execute_tool = False
             if has_delete_tool and not _supports_delete(backend):
-                unsupported.add("delete_file")
+                unsupported.add("delete")
             if unsupported:
                 filtered_tools = [tool for tool in request.tools if (tool.name if hasattr(tool, "name") else tool.get("name")) not in unsupported]
                 request = request.override(tools=filtered_tools)

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -81,7 +81,7 @@ _DEFAULT_FS_TOOL_OPS: dict[str, FilesystemOperation] = {
     "grep": "read",
     "write_file": "write",
     "edit_file": "write",
-    "delete_file": "write",
+    "delete": "write",
 }
 
 
@@ -361,8 +361,8 @@ class EditFileSchema(BaseModel):
     )
 
 
-class DeleteFileSchema(BaseModel):
-    """Input schema for the `delete_file` tool."""
+class DeleteSchema(BaseModel):
+    """Input schema for the `delete` tool."""
 
     file_path: str = Field(description="Absolute path to the file to delete. Must be absolute, not relative.")
 
@@ -441,7 +441,7 @@ Usage:
 - Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.
 """
 
-DELETE_FILE_TOOL_DESCRIPTION = """Deletes a file or directory from the filesystem.
+DELETE_TOOL_DESCRIPTION = """Deletes a file or directory from the filesystem.
 
 Usage:
 - Permanently removes the file or directory at the given absolute path.
@@ -521,7 +521,7 @@ _FILESYSTEM_SYSTEM_PROMPT_TEMPLATE = """## Following Conventions
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -530,7 +530,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
-- delete_file: delete a file from the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 
@@ -600,7 +600,7 @@ TOOLS_EXCLUDED_FROM_EVICTION = (
     "read_file",
     "edit_file",
     "write_file",
-    "delete_file",
+    "delete",
 )
 
 
@@ -793,7 +793,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             self._create_read_file_tool(),
             self._create_write_file_tool(),
             self._create_edit_file_tool(),
-            self._create_delete_file_tool(),
+            self._create_delete_tool(),
             self._create_glob_tool(),
             self._create_grep_tool(),
             self._create_execute_tool(),
@@ -1318,22 +1318,22 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         descendants = [m["path"] for m in result.matches]
         return self._scan_delete_for_denied_path(target, descendants)
 
-    def _create_delete_file_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
-        """Create the delete_file tool."""
-        tool_description = self._custom_tool_descriptions.get("delete_file") or DELETE_FILE_TOOL_DESCRIPTION
+    def _create_delete_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
+        """Create the delete tool."""
+        tool_description = self._custom_tool_descriptions.get("delete") or DELETE_TOOL_DESCRIPTION
 
-        def sync_delete_file(
+        def sync_delete(
             file_path: Annotated[str, "Absolute path to the file to delete. Must be absolute, not relative."],
             runtime: ToolRuntime[None, FilesystemState],
         ) -> ToolMessage:
-            """Synchronous wrapper for delete_file tool."""
+            """Synchronous wrapper for delete tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(file_path)
             except ValueError as e:
                 return ToolMessage(
                     content=f"Error: {e}",
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
@@ -1342,7 +1342,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if denied_path is not None:
                 return ToolMessage(
                     content=f"Error: permission denied for write on {denied_path}",
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
@@ -1350,29 +1350,29 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if res.error:
                 return ToolMessage(
                     content=res.error,
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
             return ToolMessage(
                 content=f"Deleted file {res.path}",
-                name="delete_file",
+                name="delete",
                 tool_call_id=runtime.tool_call_id,
                 status="success",
             )
 
-        async def async_delete_file(
+        async def async_delete(
             file_path: Annotated[str, "Absolute path to the file to delete. Must be absolute, not relative."],
             runtime: ToolRuntime[None, FilesystemState],
         ) -> ToolMessage:
-            """Asynchronous wrapper for delete_file tool."""
+            """Asynchronous wrapper for delete tool."""
             resolved_backend = self._get_backend(runtime)
             try:
                 validated_path = validate_path(file_path)
             except ValueError as e:
                 return ToolMessage(
                     content=f"Error: {e}",
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
@@ -1381,7 +1381,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if denied_path is not None:
                 return ToolMessage(
                     content=f"Error: permission denied for write on {denied_path}",
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
@@ -1389,24 +1389,24 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             if res.error:
                 return ToolMessage(
                     content=res.error,
-                    name="delete_file",
+                    name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
                 )
             return ToolMessage(
                 content=f"Deleted file {res.path}",
-                name="delete_file",
+                name="delete",
                 tool_call_id=runtime.tool_call_id,
                 status="success",
             )
 
         return StructuredTool.from_function(
-            name="delete_file",
+            name="delete",
             description=tool_description,
-            func=sync_delete_file,
-            coroutine=async_delete_file,
+            func=sync_delete,
+            coroutine=async_delete,
             infer_schema=False,
-            args_schema=DeleteFileSchema,
+            args_schema=DeleteSchema,
         )
 
     def _create_glob_tool(self) -> BaseTool:  # noqa: C901  # Tool wiring + permission/result shaping
@@ -1820,7 +1820,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
 
         Shared by the sync and async `wrap_model_call` paths (the only part that
         differs between them is sync vs. async message eviction). The `execute`
-        and `delete_file` tools are optional per backend, so when the resolved
+        and `delete` tools are optional per backend, so when the resolved
         backend doesn't support a capability the corresponding tool is filtered
         out of the request rather than advertised to the model and left to fail
         at call time. Resolving the backend and probing support is synchronous,
@@ -1831,9 +1831,9 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         """
         tool_names = {(tool.name if hasattr(tool, "name") else tool.get("name")) for tool in request.tools}
         has_execute_tool = "execute" in tool_names
-        has_delete_tool = "delete_file" in tool_names
+        has_delete_tool = "delete" in tool_names
 
-        # `execute` and `delete_file` are optional per backend; resolve the
+        # `execute` and `delete` are optional per backend; resolve the
         # backend once and filter out any tool the backend can't serve.
         if has_execute_tool or has_delete_tool:
             backend = self._get_backend(request.runtime)  # ty: ignore[invalid-argument-type]
@@ -1842,7 +1842,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 unsupported.add("execute")
                 has_execute_tool = False
             if has_delete_tool and not _supports_delete(backend):
-                unsupported.add("delete_file")
+                unsupported.add("delete")
             if unsupported:
                 filtered_tools = [tool for tool in request.tools if (tool.name if hasattr(tool, "name") else tool.get("name")) not in unsupported]
                 request = request.override(tools=filtered_tools)

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -54,6 +54,8 @@ from deepagents.backends.protocol import (
 )
 from deepagents.backends.utils import (
     _get_file_type,
+    _glob_anchor,
+    _paths_overlap,
     check_empty_content,
     format_content_with_line_numbers,
     format_grep_matches,
@@ -1268,55 +1270,29 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=EditFileSchema,
         )
 
-    def _scan_delete_for_denied_path(self, target: str, descendant_files: list[str]) -> str | None:
-        """All-or-nothing write-deny scan for a (possibly recursive) delete.
+    def _delete_denied_pattern(self, target: str) -> str | None:
+        """All-or-nothing write-deny check for a (possibly recursive) delete.
 
-        A recursive delete removes ``target`` plus every descendant, so each of
-        those paths must pass the ``write`` permission check. Returns the first
-        write-denied path found (so the whole delete can be refused), or ``None``
-        if the entire subtree is allowed.
+        A recursive delete of ``target`` removes ``target`` plus every descendant,
+        so the operation is refused if any ``deny`` write rule's pattern overlaps
+        that subtree. Overlap is checked against the rule pattern's literal anchor
+        (`_glob_anchor`) in either direction, so a rule scoped inside the target
+        (``/work/secrets/**``) and a rule that the target falls under
+        (``/work/**``) both block it. The check is purely rule-based — no backend
+        enumeration — and never under-refuses relative to the on-disk contents:
+        any real path a recursive delete would touch makes the target and the
+        rule anchor comparable, so the overlap fires.
 
-        ``descendant_files`` are the files ``glob('**/*')`` found under ``target``;
-        intermediate directories are derived from them so a rule that denies a
-        directory path (rather than its ``/**`` contents) is also honored. Empty
-        directories produce no glob hit and are therefore not enumerated.
+        Returns the first overlapping deny pattern (so the delete can be refused
+        with a useful message), or ``None`` if no deny rule overlaps.
         """
-        if not self._permissions:
-            return None
-        if _check_fs_permission(self._permissions, "write", target) == "deny":
-            return target
-
-        anchor = target.rstrip("/")
-        paths_to_check: set[str] = set()
-        for file_path in descendant_files:
-            paths_to_check.add(file_path)
-            parent = PurePosixPath(file_path).parent
-            while True:
-                parent_str = str(parent)
-                if parent_str == anchor or not parent_str.startswith(anchor + "/"):
-                    break
-                paths_to_check.add(parent_str)
-                parent = parent.parent
-
-        for path in sorted(paths_to_check):
-            if _check_fs_permission(self._permissions, "write", path) == "deny":
-                return path
+        for rule in self._permissions:
+            if rule.mode != "deny" or "write" not in rule.operations:
+                continue
+            for pattern in rule.paths:
+                if _paths_overlap(target, _glob_anchor(pattern)):
+                    return pattern
         return None
-
-    def _delete_denied_path(self, backend: BackendProtocol, target: str) -> str | None:
-        """Sync subtree deny scan: returns the first denied path, or None."""
-        if not self._permissions:
-            return None
-        descendants = [m["path"] for m in (backend.glob("**/*", path=target).matches or [])]
-        return self._scan_delete_for_denied_path(target, descendants)
-
-    async def _adelete_denied_path(self, backend: BackendProtocol, target: str) -> str | None:
-        """Async subtree deny scan: returns the first denied path, or None."""
-        if not self._permissions:
-            return None
-        result = await backend.aglob("**/*", path=target)
-        descendants = [m["path"] for m in (result.matches or [])]
-        return self._scan_delete_for_denied_path(target, descendants)
 
     def _create_delete_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
         """Create the delete tool."""
@@ -1338,10 +1314,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            denied_path = self._delete_denied_path(resolved_backend, validated_path)
-            if denied_path is not None:
+            denied_pattern = self._delete_denied_pattern(validated_path)
+            if denied_pattern is not None:
                 return ToolMessage(
-                    content=f"Error: permission denied for write on {denied_path}",
+                    content=f"Error: permission denied for write on {validated_path} (matches deny rule {denied_pattern})",
                     name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
@@ -1377,10 +1353,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            denied_path = await self._adelete_denied_path(resolved_backend, validated_path)
-            if denied_path is not None:
+            denied_pattern = self._delete_denied_pattern(validated_path)
+            if denied_pattern is not None:
                 return ToolMessage(
-                    content=f"Error: permission denied for write on {denied_path}",
+                    content=f"Error: permission denied for write on {validated_path} (matches deny rule {denied_pattern})",
                     name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -441,11 +441,13 @@ Usage:
 - Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.
 """
 
-DELETE_FILE_TOOL_DESCRIPTION = """Deletes a file from the filesystem.
+DELETE_FILE_TOOL_DESCRIPTION = """Deletes a file or directory from the filesystem.
 
 Usage:
-- Permanently removes the file at the given absolute path.
-- This cannot be undone, so only delete files you are sure are no longer needed.
+- Permanently removes the file or directory at the given absolute path.
+- Deleting a directory removes it and everything inside it, recursively. Prefer
+  deleting a directory in one call over deleting each file individually.
+- This cannot be undone, so only delete paths you are sure are no longer needed.
 """
 
 GLOB_TOOL_DESCRIPTION = """Find files matching a glob pattern.
@@ -1266,6 +1268,56 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=EditFileSchema,
         )
 
+    def _scan_delete_for_denied_path(self, target: str, descendant_files: list[str]) -> str | None:
+        """All-or-nothing write-deny scan for a (possibly recursive) delete.
+
+        A recursive delete removes ``target`` plus every descendant, so each of
+        those paths must pass the ``write`` permission check. Returns the first
+        write-denied path found (so the whole delete can be refused), or ``None``
+        if the entire subtree is allowed.
+
+        ``descendant_files`` are the files ``glob('**/*')`` found under ``target``;
+        intermediate directories are derived from them so a rule that denies a
+        directory path (rather than its ``/**`` contents) is also honored. Empty
+        directories produce no glob hit and are therefore not enumerated.
+        """
+        if not self._permissions:
+            return None
+        if _check_fs_permission(self._permissions, "write", target) == "deny":
+            return target
+
+        anchor = target.rstrip("/")
+        paths_to_check: set[str] = set()
+        for file_path in descendant_files:
+            paths_to_check.add(file_path)
+            parent = PurePosixPath(file_path).parent
+            while True:
+                parent_str = str(parent)
+                if parent_str == anchor or not parent_str.startswith(anchor + "/"):
+                    break
+                paths_to_check.add(parent_str)
+                parent = parent.parent
+
+        for path in sorted(paths_to_check):
+            if _check_fs_permission(self._permissions, "write", path) == "deny":
+                return path
+        return None
+
+    def _delete_denied_path(self, backend: BackendProtocol, target: str) -> str | None:
+        """Sync subtree deny scan: returns the first denied path, or None."""
+        if not self._permissions:
+            return None
+        descendants = [m["path"] for m in backend.glob("**/*", path=target).matches]
+        return self._scan_delete_for_denied_path(target, descendants)
+
+    async def _adelete_denied_path(self, backend: BackendProtocol, target: str) -> str | None:
+        """Async subtree deny scan: returns the first denied path, or None."""
+        if not self._permissions:
+            return None
+        result = await backend.aglob("**/*", path=target)
+        descendants = [m["path"] for m in result.matches]
+        return self._scan_delete_for_denied_path(target, descendants)
+
     def _create_delete_file_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
         """Create the delete_file tool."""
         tool_description = self._custom_tool_descriptions.get("delete_file") or DELETE_FILE_TOOL_DESCRIPTION
@@ -1286,9 +1338,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            if _check_fs_permission(self._permissions, "write", validated_path) == "deny":
+            denied_path = self._delete_denied_path(resolved_backend, validated_path)
+            if denied_path is not None:
                 return ToolMessage(
-                    content=f"Error: permission denied for write on {validated_path}",
+                    content=f"Error: permission denied for write on {denied_path}",
                     name="delete_file",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
@@ -1324,9 +1377,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            if _check_fs_permission(self._permissions, "write", validated_path) == "deny":
+            denied_path = await self._adelete_denied_path(resolved_backend, validated_path)
+            if denied_path is not None:
                 return ToolMessage(
-                    content=f"Error: permission denied for write on {validated_path}",
+                    content=f"Error: permission denied for write on {denied_path}",
                     name="delete_file",
                     tool_call_id=runtime.tool_call_id,
                     status="error",

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -137,6 +137,32 @@ def _check_fs_permission(
     return "allow"
 
 
+def _find_delete_deny_patterns(rules: list[FilesystemPermission], target: str) -> list[str]:
+    """Return deny-write patterns that block deleting `target`.
+
+    A recursive delete removes `target` and all descendants, so any overlapping
+    deny-write pattern prevents the operation. The check is based only on
+    permission rules and returns all matching patterns.
+
+    Args:
+        rules: Filesystem permission rules.
+        target: Absolute, validated path being deleted.
+
+    Returns:
+        Matching deny-write patterns, or an empty list if the delete is allowed.
+    """
+    denying: list[str] = []
+    seen: set[str] = set()
+    for rule in rules:
+        if rule.mode != "deny" or "write" not in rule.operations:
+            continue
+        for pattern in rule.paths:
+            if pattern not in seen and _paths_overlap(target, _glob_anchor(pattern)):
+                seen.add(pattern)
+                denying.append(pattern)
+    return denying
+
+
 def _filter_paths_by_permission(
     rules: list[FilesystemPermission],
     operation: FilesystemOperation,
@@ -1270,41 +1296,6 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=EditFileSchema,
         )
 
-    def _find_delete_deny_patterns(self, target: str, limit: int = 5) -> list[str]:
-        """All-or-nothing write-deny check for a (possibly recursive) delete.
-
-        A recursive delete of `target` removes `target` plus every descendant, so
-        the operation is refused if any `deny` write rule's pattern overlaps that
-        subtree. Overlap is checked against the rule pattern's literal anchor
-        (`_glob_anchor`) in either direction, so a rule scoped inside the target
-        (`/work/secrets/**`) and a rule that the target falls under (`/work/**`)
-        both block it. The check is purely rule-based — no backend enumeration —
-        and never under-refuses relative to the on-disk contents: any real path a
-        recursive delete would touch makes the target and the rule anchor
-        comparable, so the overlap fires.
-
-        Args:
-            target: Absolute, validated target path of the delete.
-            limit: Maximum number of overlapping patterns to collect before
-                returning, so the caller can report several conflicting rules
-                without scanning every permission once enough are found.
-
-        Returns:
-            Up to `limit` overlapping `deny` write patterns, empty if the delete
-            is permitted.
-        """
-        denying: list[str] = []
-        for rule in self._permissions:
-            if rule.mode != "deny" or "write" not in rule.operations:
-                continue
-            for pattern in rule.paths:
-                if _paths_overlap(target, _glob_anchor(pattern)):
-                    denying.append(pattern)
-                    if len(denying) >= limit:
-                        return denying
-        return denying
-        return None
-
     def _create_delete_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
         """Create the delete tool."""
         tool_description = self._custom_tool_descriptions.get("delete") or DELETE_TOOL_DESCRIPTION
@@ -1325,7 +1316,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            denying_patterns = self._find_delete_deny_patterns(validated_path)
+            denying_patterns = _find_delete_deny_patterns(self._permissions, validated_path)
             if denying_patterns:
                 return ToolMessage(
                     content=f"Error: permission denied for write on {validated_path} (matches deny rule(s): {', '.join(denying_patterns)})",
@@ -1342,7 +1333,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
             return ToolMessage(
-                content=f"Deleted file {res.path}",
+                content=f"Deleted {res.path}",
                 name="delete",
                 tool_call_id=runtime.tool_call_id,
                 status="success",
@@ -1364,7 +1355,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            denying_patterns = self._find_delete_deny_patterns(validated_path)
+            denying_patterns = _find_delete_deny_patterns(self._permissions, validated_path)
             if denying_patterns:
                 return ToolMessage(
                     content=f"Error: permission denied for write on {validated_path} (matches deny rule(s): {', '.join(denying_patterns)})",
@@ -1381,7 +1372,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
             return ToolMessage(
-                content=f"Deleted file {res.path}",
+                content=f"Deleted {res.path}",
                 name="delete",
                 tool_call_id=runtime.tool_call_id,
                 status="success",

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -373,7 +373,8 @@ class ReadFileSchema(BaseModel):
 class WriteFileSchema(BaseModel):
     """Input schema for the `write_file` tool."""
 
-    file_path: str = Field(description="Absolute path where the file should be created. Must be absolute, not relative.")
+    file_path: str = Field(description="Absolute path where the file should be written. Must be absolute, not relative.")
+
     content: str = Field(description="The text content to write to the file. This parameter is required.")
 
 
@@ -462,11 +463,11 @@ Usage:
 - Only use emojis if the user explicitly requests it."""
 
 
-WRITE_FILE_TOOL_DESCRIPTION = """Writes to a new file in the filesystem.
+WRITE_FILE_TOOL_DESCRIPTION = """Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.
 
 Usage:
-- The write_file tool will create the a new file.
-- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.
+- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.
+- Prefer edit_file when making targeted changes to an existing file while leaving the rest intact.
 """
 
 DELETE_TOOL_DESCRIPTION = """Deletes a file or directory from the filesystem.
@@ -1113,7 +1114,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         tool_description = self._custom_tool_descriptions.get("write_file") or WRITE_FILE_TOOL_DESCRIPTION
 
         def sync_write_file(
-            file_path: Annotated[str, "Absolute path where the file should be created. Must be absolute, not relative."],
+            file_path: Annotated[str, "Absolute path where the file should be written. Must be absolute, not relative."],
             content: Annotated[str, "The text content to write to the file. This parameter is required."],
             runtime: ToolRuntime[None, FilesystemState],
         ) -> ToolMessage:
@@ -1152,7 +1153,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             )
 
         async def async_write_file(
-            file_path: Annotated[str, "Absolute path where the file should be created. Must be absolute, not relative."],
+            file_path: Annotated[str, "Absolute path where the file should be written. Must be absolute, not relative."],
             content: Annotated[str, "The text content to write to the file. This parameter is required."],
             runtime: ToolRuntime[None, FilesystemState],
         ) -> ToolMessage:

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -1270,28 +1270,39 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=EditFileSchema,
         )
 
-    def _delete_denied_pattern(self, target: str) -> str | None:
+    def _find_delete_deny_patterns(self, target: str, limit: int = 5) -> list[str]:
         """All-or-nothing write-deny check for a (possibly recursive) delete.
 
-        A recursive delete of ``target`` removes ``target`` plus every descendant,
-        so the operation is refused if any ``deny`` write rule's pattern overlaps
-        that subtree. Overlap is checked against the rule pattern's literal anchor
+        A recursive delete of `target` removes `target` plus every descendant, so
+        the operation is refused if any `deny` write rule's pattern overlaps that
+        subtree. Overlap is checked against the rule pattern's literal anchor
         (`_glob_anchor`) in either direction, so a rule scoped inside the target
-        (``/work/secrets/**``) and a rule that the target falls under
-        (``/work/**``) both block it. The check is purely rule-based — no backend
-        enumeration — and never under-refuses relative to the on-disk contents:
-        any real path a recursive delete would touch makes the target and the
-        rule anchor comparable, so the overlap fires.
+        (`/work/secrets/**`) and a rule that the target falls under (`/work/**`)
+        both block it. The check is purely rule-based — no backend enumeration —
+        and never under-refuses relative to the on-disk contents: any real path a
+        recursive delete would touch makes the target and the rule anchor
+        comparable, so the overlap fires.
 
-        Returns the first overlapping deny pattern (so the delete can be refused
-        with a useful message), or ``None`` if no deny rule overlaps.
+        Args:
+            target: Absolute, validated target path of the delete.
+            limit: Maximum number of overlapping patterns to collect before
+                returning, so the caller can report several conflicting rules
+                without scanning every permission once enough are found.
+
+        Returns:
+            Up to `limit` overlapping `deny` write patterns, empty if the delete
+            is permitted.
         """
+        denying: list[str] = []
         for rule in self._permissions:
             if rule.mode != "deny" or "write" not in rule.operations:
                 continue
             for pattern in rule.paths:
                 if _paths_overlap(target, _glob_anchor(pattern)):
-                    return pattern
+                    denying.append(pattern)
+                    if len(denying) >= limit:
+                        return denying
+        return denying
         return None
 
     def _create_delete_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
@@ -1314,10 +1325,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            denied_pattern = self._delete_denied_pattern(validated_path)
-            if denied_pattern is not None:
+            denying_patterns = self._find_delete_deny_patterns(validated_path)
+            if denying_patterns:
                 return ToolMessage(
-                    content=f"Error: permission denied for write on {validated_path} (matches deny rule {denied_pattern})",
+                    content=f"Error: permission denied for write on {validated_path} (matches deny rule(s): {', '.join(denying_patterns)})",
                     name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",
@@ -1353,10 +1364,10 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="error",
                 )
 
-            denied_pattern = self._delete_denied_pattern(validated_path)
-            if denied_pattern is not None:
+            denying_patterns = self._find_delete_deny_patterns(validated_path)
+            if denying_patterns:
                 return ToolMessage(
-                    content=f"Error: permission denied for write on {validated_path} (matches deny rule {denied_pattern})",
+                    content=f"Error: permission denied for write on {validated_path} (matches deny rule(s): {', '.join(denying_patterns)})",
                     name="delete",
                     tool_call_id=runtime.tool_call_id,
                     status="error",

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -467,7 +467,7 @@ WRITE_FILE_TOOL_DESCRIPTION = """Writes content to a file. Creates the file if i
 
 Usage:
 - Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.
-- Prefer edit_file when making targeted changes to an existing file while leaving the rest intact.
+- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.
 """
 
 DELETE_TOOL_DESCRIPTION = """Deletes a file or directory from the filesystem.

--- a/libs/deepagents/tests/integration_tests/test_filesystem_middleware.py
+++ b/libs/deepagents/tests/integration_tests/test_filesystem_middleware.py
@@ -346,7 +346,7 @@ class TestFilesystem:
         assert isinstance(content, str), f"Expected str content, got {type(content)}"
         assert "fiery" in content or "Fiery" in content
 
-    def test_write_file_fail_already_exists_in_local(self):
+    def test_write_file_overwrites_existing_in_local(self):
         checkpointer = MemorySaver()
         store = InMemoryStore()
         agent = create_agent(
@@ -376,7 +376,8 @@ class TestFilesystem:
         messages = response["messages"]
         write_file_message = next(message for message in messages if message.type == "tool" and message.name == "write_file")
         assert write_file_message is not None
-        assert "Cannot write" in write_file_message.content
+        assert write_file_message.status == "success"
+        assert "fiery" in response["files"]["/charmander.txt"]["content"].lower() or "Fiery" in response["files"]["/charmander.txt"]["content"]
 
     def test_edit_file_longterm(self):
         checkpointer = MemorySaver()

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -8,6 +8,7 @@ from langgraph.store.memory import InMemoryStore
 from deepagents.backends.composite import CompositeBackend, _route_for_path
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import (
+    BackendProtocol,
     ExecuteResponse,
     SandboxBackendProtocol,
     WriteResult,
@@ -1403,3 +1404,94 @@ def test_edit_result_path_restored_to_full_routed_path():
 
     assert res.error is None
     assert res.path == "/memories/notes.md"  # not "/notes.md"
+
+
+def test_composite_delete_routes_to_correct_backend() -> None:
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/memories/": StoreBackend(store=mem_store, namespace=lambda _rt: ("memories",))},
+    )
+
+    be.write("/file.txt", "alpha")
+    be.write("/memories/note.txt", "beta")
+
+    # delete default-routed file; path is remapped back to the original
+    res_default = be.delete("/file.txt")
+    assert res_default.error is None
+    assert res_default.path == "/file.txt"
+    assert be.read("/file.txt").error is not None
+
+    # delete route-routed file
+    res_route = be.delete("/memories/note.txt")
+    assert res_route.error is None
+    assert res_route.path == "/memories/note.txt"
+    assert be.read("/memories/note.txt").error is not None
+
+
+def test_composite_delete_missing_returns_error() -> None:
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/memories/": StoreBackend(store=mem_store, namespace=lambda _rt: ("memories",))},
+    )
+    result = be.delete("/memories/ghost.txt")
+    assert result.path is None
+    assert result.error is not None and "not found" in result.error
+
+
+async def test_composite_adelete_routes_to_correct_backend() -> None:
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/memories/": StoreBackend(store=mem_store, namespace=lambda _rt: ("memories",))},
+    )
+    await be.awrite("/memories/note.txt", "beta")
+    res = await be.adelete("/memories/note.txt")
+    assert res.error is None
+    assert res.path == "/memories/note.txt"
+    assert (await be.aread("/memories/note.txt")).error is not None
+
+
+async def test_composite_adelete_missing_returns_error() -> None:
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/memories/": StoreBackend(store=mem_store, namespace=lambda _rt: ("memories",))},
+    )
+    result = await be.adelete("/memories/ghost.txt")
+    assert result.path is None
+    assert result.error is not None and "not found" in result.error
+
+
+class _NoDeleteStore(StoreBackend):
+    """StoreBackend variant that opts out of delete (inherits protocol default)."""
+
+    delete = BackendProtocol.delete
+    adelete = BackendProtocol.adelete
+
+
+def test_composite_delete_unsupported_route_returns_error() -> None:
+    """A route to a backend without delete yields an error, not a raise."""
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/nodelete/": _NoDeleteStore(store=mem_store, namespace=lambda _rt: ("nodelete",))},
+    )
+    result = be.delete("/nodelete/x.txt")
+    assert result.path is None
+    assert result.error is not None
+    assert "not supported" in result.error
+
+
+async def test_composite_adelete_unsupported_route_returns_error() -> None:
+    """The async route to a backend without delete yields an error, not a raise."""
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/nodelete/": _NoDeleteStore(store=mem_store, namespace=lambda _rt: ("nodelete",))},
+    )
+    result = await be.adelete("/nodelete/x.txt")
+    assert result.path is None
+    assert result.error is not None
+    assert "not supported" in result.error

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -1429,6 +1429,27 @@ def test_composite_delete_routes_to_correct_backend() -> None:
     assert be.read("/memories/note.txt").error is not None
 
 
+def test_composite_delete_directory_recurses_within_route() -> None:
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/memories/": StoreBackend(store=mem_store, namespace=lambda _rt: ("memories",))},
+    )
+
+    be.write("/memories/proj/a.txt", "a")
+    be.write("/memories/proj/sub/b.txt", "b")
+    be.write("/memories/keep.txt", "k")
+
+    # Deleting a directory inside a route removes the whole subtree there,
+    # remapped back to the original path, while siblings survive.
+    res = be.delete("/memories/proj")
+    assert res.error is None
+    assert res.path == "/memories/proj"
+    assert be.read("/memories/proj/a.txt").error is not None
+    assert be.read("/memories/proj/sub/b.txt").error is not None
+    assert be.read("/memories/keep.txt").error is None
+
+
 def test_composite_delete_missing_returns_error() -> None:
     mem_store = InMemoryStore()
     be = CompositeBackend(

--- a/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
@@ -523,3 +523,75 @@ def test_composite_backend_routes_prefix_correctly(tmp_path: Path) -> None:
     glob_mem = composite.glob("*.md", path="/memories")
     assert glob_mem.matches is not None
     assert any(m["path"] == "/memories/notes.md" for m in glob_mem.matches)
+
+
+def test_delete_commits_none_entry() -> None:
+    backend, mock_client = _make_backend(**{"a.md": FileEntry(type="file", content="bye")})
+    result = backend.delete("/a.md")
+
+    assert result.error is None
+    assert result.path == "/a.md"
+    mock_client.push_agent.assert_called_once()
+    call = mock_client.push_agent.call_args
+    files_arg = call.kwargs["files"]
+    # A None entry is the deletion marker.
+    assert "a.md" in files_arg
+    assert files_arg["a.md"] is None
+    assert call.kwargs["parent_commit"] == _COMMIT_HASH
+
+
+def test_delete_missing_returns_not_found() -> None:
+    backend, mock_client = _make_backend()
+    result = backend.delete("/ghost.md")
+
+    assert result.path is None
+    assert result.error is not None
+    assert "not found" in result.error
+    mock_client.push_agent.assert_not_called()
+
+
+def test_delete_updates_cache_after_commit() -> None:
+    backend, _ = _make_backend(**{"a.md": FileEntry(type="file", content="bye")})
+    assert backend.read("/a.md").error is None
+
+    backend.delete("/a.md")
+
+    # File is gone from the cache; no re-pull needed.
+    assert backend.read("/a.md").error is not None
+
+
+def test_delete_failure_invalidates_cache() -> None:
+    backend, mock_client = _make_backend(**{"a.md": FileEntry(type="file", content="a")})
+    mock_client.push_agent.side_effect = LangSmithAPIError("500")
+
+    result = backend.delete("/a.md")
+    assert result.error is not None
+    assert "Hub unavailable" in result.error
+
+    backend.read("/a.md")
+    assert mock_client.pull_agent.call_count == 2
+
+
+async def test_adelete_commits_none_entry() -> None:
+    """Async delete (protocol default `asyncio.to_thread`) behaves like sync."""
+    backend, mock_client = _make_backend(**{"a.md": FileEntry(type="file", content="bye")})
+    result = await backend.adelete("/a.md")
+
+    assert result.error is None
+    assert result.path == "/a.md"
+    mock_client.push_agent.assert_called_once()
+    files_arg = mock_client.push_agent.call_args.kwargs["files"]
+    # A None entry is the deletion marker, same as the sync path.
+    assert files_arg["a.md"] is None
+    # Cache was updated, so a follow-up read finds the file gone without re-pulling.
+    assert backend.read("/a.md").error is not None
+
+
+async def test_adelete_missing_returns_not_found() -> None:
+    backend, mock_client = _make_backend()
+    result = await backend.adelete("/ghost.md")
+
+    assert result.path is None
+    assert result.error is not None
+    assert "not found" in result.error
+    mock_client.push_agent.assert_not_called()

--- a/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
@@ -540,6 +540,26 @@ def test_delete_commits_none_entry() -> None:
     assert call.kwargs["parent_commit"] == _COMMIT_HASH
 
 
+def test_delete_directory_commits_all_nested_entries() -> None:
+    backend, mock_client = _make_backend(
+        **{
+            "work/a.md": FileEntry(type="file", content="a"),
+            "work/sub/b.md": FileEntry(type="file", content="b"),
+            "keep.md": FileEntry(type="file", content="k"),
+        }
+    )
+    result = backend.delete("/work")
+
+    assert result.error is None
+    assert result.path == "/work"
+    files_arg = mock_client.push_agent.call_args.kwargs["files"]
+    # Every nested entry under /work is marked for deletion...
+    assert files_arg["work/a.md"] is None
+    assert files_arg["work/sub/b.md"] is None
+    # ...and the sibling outside the subtree is left alone.
+    assert "keep.md" not in files_arg
+
+
 def test_delete_missing_returns_not_found() -> None:
     backend, mock_client = _make_backend()
     result = backend.delete("/ghost.md")

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -1285,13 +1285,51 @@ class TestFilesystemDelete:
         assert result.error is not None
         assert "not found" in result.error
 
-    def test_delete_directory_returns_error(self, tmp_path: Path) -> None:
+    def test_delete_empty_directory(self, tmp_path: Path) -> None:
         (tmp_path / "sub").mkdir()
         be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
         result = be.delete("/sub")
-        assert result.path is None
-        assert result.error is not None
-        assert "directory" in result.error
+        assert result.error is None
+        assert result.path == "/sub"
+        assert not (tmp_path / "sub").exists()
+
+    def test_delete_directory_recursively(self, tmp_path: Path) -> None:
+        # A directory is removed along with all of its nested contents.
+        sub = tmp_path / "sub"
+        (sub / "deep").mkdir(parents=True)
+        write_file(sub / "b.txt", "b")
+        write_file(sub / "deep" / "d.txt", "d")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        result = be.delete("/sub")
+        assert result.error is None
+        assert result.path == "/sub"
+        assert not sub.exists()
+
+    def test_delete_directory_leaves_siblings(self, tmp_path: Path) -> None:
+        (tmp_path / "sub").mkdir()
+        write_file(tmp_path / "sub" / "b.txt", "b")
+        write_file(tmp_path / "keep.txt", "keep")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        assert be.delete("/sub").error is None
+        assert not (tmp_path / "sub").exists()
+        assert (tmp_path / "keep.txt").exists()
+
+    def test_delete_symlink_to_dir_does_not_follow(self, tmp_path: Path) -> None:
+        # Deleting a symlink that points at a directory removes only the link;
+        target = tmp_path / "target"
+        target.mkdir()
+        write_file(target / "keep.txt", "keep")
+        link = tmp_path / "link"
+        link.symlink_to(target, target_is_directory=True)
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+        result = be.delete(str(link))
+        assert result.error is None
+        assert not link.exists()
+        assert target.exists()
+        assert (target / "keep.txt").exists()
 
     def test_delete_only_removes_target(self, tmp_path: Path) -> None:
         write_file(tmp_path / "keep.txt", "keep")
@@ -1323,7 +1361,7 @@ class TestFilesystemDelete:
         result = be.delete("/a.txt")
         assert result.path is None
         assert result.error is not None
-        assert "Error deleting file" in result.error
+        assert "Error deleting" in result.error
 
     def test_delete_unlink_failure_returns_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         # An OSError from unlink (e.g. permission denied) is reported, file kept.
@@ -1338,5 +1376,5 @@ class TestFilesystemDelete:
         result = be.delete("/a.txt")
         assert result.path is None
         assert result.error is not None
-        assert "Error deleting file" in result.error
+        assert "Error deleting" in result.error
         assert f.exists()

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -12,7 +12,7 @@ from langchain_core.messages import ToolMessage
 from deepagents._api.deprecation import LangChainDeprecationWarning
 from deepagents.backends import filesystem as fs_module
 from deepagents.backends.filesystem import FilesystemBackend
-from deepagents.backends.protocol import EditResult, ReadResult, WriteResult
+from deepagents.backends.protocol import DeleteResult, EditResult, ReadResult, WriteResult
 from deepagents.middleware.filesystem import FilesystemMiddleware
 
 
@@ -1262,3 +1262,81 @@ class TestReadTrailingNewlineRoundtrip:
         assert result.error is not None
         assert "old_string ends with a newline" in result.error
         assert target.read_text() == "# Agent Role:\nyou are an assistant"
+
+
+class TestFilesystemDelete:
+    """Tests for FilesystemBackend.delete."""
+
+    def test_delete_existing_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "a.txt"
+        write_file(f, "hello")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        result = be.delete("/a.txt")
+        assert isinstance(result, DeleteResult)
+        assert result.error is None
+        assert result.path == "/a.txt"
+        assert not f.exists()
+
+    def test_delete_missing_file_returns_error(self, tmp_path: Path) -> None:
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        result = be.delete("/missing.txt")
+        assert result.path is None
+        assert result.error is not None
+        assert "not found" in result.error
+
+    def test_delete_directory_returns_error(self, tmp_path: Path) -> None:
+        (tmp_path / "sub").mkdir()
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        result = be.delete("/sub")
+        assert result.path is None
+        assert result.error is not None
+        assert "directory" in result.error
+
+    def test_delete_only_removes_target(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "keep.txt", "keep")
+        write_file(tmp_path / "drop.txt", "drop")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        assert be.delete("/drop.txt").error is None
+        assert not (tmp_path / "drop.txt").exists()
+        assert (tmp_path / "keep.txt").exists()
+
+    async def test_adelete_existing_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "a.txt"
+        write_file(f, "hello")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        result = await be.adelete("/a.txt")
+        assert result.error is None
+        assert result.path == "/a.txt"
+        assert not f.exists()
+
+    def test_delete_resolve_failure_returns_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A failure resolving the path surfaces as a deletion error, not a raise.
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        def _boom(_path: str) -> Path:
+            raise OSError
+
+        monkeypatch.setattr(be, "_resolve_path", _boom)
+        result = be.delete("/a.txt")
+        assert result.path is None
+        assert result.error is not None
+        assert "Error deleting file" in result.error
+
+    def test_delete_unlink_failure_returns_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An OSError from unlink (e.g. permission denied) is reported, file kept.
+        f = tmp_path / "a.txt"
+        write_file(f, "hello")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        def _boom(_self: Path, *_args: object, **_kwargs: object) -> None:
+            raise OSError
+
+        monkeypatch.setattr(Path, "unlink", _boom)
+        result = be.delete("/a.txt")
+        assert result.path is None
+        assert result.error is not None
+        assert "Error deleting file" in result.error
+        assert f.exists()

--- a/libs/deepagents/tests/unit_tests/backends/test_protocol.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_protocol.py
@@ -16,10 +16,12 @@ from deepagents.backends.protocol import (
     ASYNC_GREP_TIMEOUT,
     DEFAULT_GREP_TIMEOUT,
     BackendProtocol,
+    DeleteResult,
     GlobResult,
     GrepResult,
     LsResult,
     SandboxBackendProtocol,
+    _supports_delete,
 )
 
 
@@ -68,6 +70,10 @@ class TestBackendProtocolRaisesNotImplemented:
         with pytest.raises(NotImplementedError):
             backend.edit("/file.txt", "old", "new")
 
+    def test_delete(self, backend: BareBackend) -> None:
+        with pytest.raises(NotImplementedError):
+            backend.delete("/file.txt")
+
     def test_upload_files(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):
             backend.upload_files([("/file.txt", b"data")])
@@ -111,6 +117,24 @@ class TestAsyncMethodsPropagateNotImplemented:
     async def test_aedit(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):
             await backend.aedit("/file.txt", "old", "new")
+
+    async def test_adelete(self, backend: BareBackend) -> None:
+        with pytest.raises(NotImplementedError):
+            await backend.adelete("/file.txt")
+
+
+class TestSupportsDelete:
+    """`_supports_delete` detects whether a backend overrides `delete`."""
+
+    def test_false_when_not_overridden(self, backend: BareBackend) -> None:
+        assert _supports_delete(backend) is False
+
+    def test_true_when_overridden(self) -> None:
+        class MyBackend(BackendProtocol):
+            def delete(self, file_path: str) -> DeleteResult:
+                return DeleteResult(path=file_path)
+
+        assert _supports_delete(MyBackend()) is True
 
 
 class TestDeprecatedMethodsRouteToNewNames:

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -537,17 +537,17 @@ def test_sandbox_write_with_special_content() -> None:
     assert sandbox._uploaded[0][1] == content.encode("utf-8")
 
 
-def test_sandbox_write_returns_error_on_existing_file() -> None:
-    """Test that write() returns an error when the check command fails."""
+def test_sandbox_write_returns_error_on_preflight_failure() -> None:
+    """Test that write() returns an error and skips upload when the preflight fails."""
     sandbox = MockSandbox()
 
     def fail_execute(command: str, *, timeout: int | None = None) -> ExecuteResponse:  # noqa: ARG001
         sandbox.last_command = command
-        return ExecuteResponse(output="Error: File already exists", exit_code=1)
+        return ExecuteResponse(output="Error: Permission denied", exit_code=1)
 
     sandbox.execute = fail_execute
 
-    result = sandbox.write("/test/existing.txt", "content")
+    result = sandbox.write("/test/protected.txt", "content")
     assert result.error is not None
     assert "Error:" in result.error
     assert len(sandbox._uploaded) == 0  # upload should not have been called

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -1338,10 +1338,21 @@ class TestSandboxDelete:
         result = sandbox.delete("/file.txt")
         assert result.error is None
         assert result.path == "/file.txt"
-        # The shell command quotes the path and uses rm -f
+        # The shell command quotes the path and uses rm -rf (recursive)
         assert sandbox.last_command is not None
-        assert "rm -f" in sandbox.last_command
+        assert "rm -rf" in sandbox.last_command
         assert "/file.txt" in sandbox.last_command
+
+    def test_delete_directory_uses_recursive_rm(self) -> None:
+        sandbox = MockSandbox()
+        sandbox._next_output = ""
+        sandbox._next_exit_code = 0
+        result = sandbox.delete("/some/dir")
+        assert result.error is None
+        assert result.path == "/some/dir"
+        assert sandbox.last_command is not None
+        assert "rm -rf" in sandbox.last_command
+        assert "/some/dir" in sandbox.last_command
 
     def test_delete_missing_is_noop_success(self) -> None:
         # `rm -f` ignores a missing path: exit 0, so delete reports success.
@@ -1353,7 +1364,7 @@ class TestSandboxDelete:
         assert result.path == "/missing.txt"
 
     def test_delete_failure_reports_output(self) -> None:
-        # A non-zero exit (e.g. the path is a directory) surfaces rm's stderr.
+        # A non-zero exit (e.g. a permission error) surfaces rm's stderr.
         sandbox = MockSandbox()
         sandbox._next_output = "rm: cannot remove '/some/dir': Is a directory"
         sandbox._next_exit_code = 1

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -1326,3 +1326,57 @@ def test_sandbox_edit_inline_permission_denied() -> None:
     assert result.error is not None
     assert "permission" in result.error.lower()
     assert "/test/locked.txt" in result.error
+
+
+class TestSandboxDelete:
+    """BaseSandbox.delete maps the `rm -f` exit code onto DeleteResult."""
+
+    def test_delete_success(self) -> None:
+        sandbox = MockSandbox()
+        sandbox._next_output = ""
+        sandbox._next_exit_code = 0
+        result = sandbox.delete("/file.txt")
+        assert result.error is None
+        assert result.path == "/file.txt"
+        # The shell command quotes the path and uses rm -f
+        assert sandbox.last_command is not None
+        assert "rm -f" in sandbox.last_command
+        assert "/file.txt" in sandbox.last_command
+
+    def test_delete_missing_is_noop_success(self) -> None:
+        # `rm -f` ignores a missing path: exit 0, so delete reports success.
+        sandbox = MockSandbox()
+        sandbox._next_output = ""
+        sandbox._next_exit_code = 0
+        result = sandbox.delete("/missing.txt")
+        assert result.error is None
+        assert result.path == "/missing.txt"
+
+    def test_delete_failure_reports_output(self) -> None:
+        # A non-zero exit (e.g. the path is a directory) surfaces rm's stderr.
+        sandbox = MockSandbox()
+        sandbox._next_output = "rm: cannot remove '/some/dir': Is a directory"
+        sandbox._next_exit_code = 1
+        result = sandbox.delete("/some/dir")
+        assert result.path is None
+        assert result.error is not None
+        assert "Error deleting file" in result.error
+        assert "Is a directory" in result.error
+
+    def test_delete_failure_unknown_error(self) -> None:
+        # Non-zero exit with no output falls back to a generic message.
+        sandbox = MockSandbox()
+        sandbox._next_output = ""
+        sandbox._next_exit_code = 1
+        result = sandbox.delete("/file.txt")
+        assert result.path is None
+        assert result.error is not None
+        assert "unknown error" in result.error
+
+    async def test_adelete_success(self) -> None:
+        sandbox = MockSandbox()
+        sandbox._next_output = ""
+        sandbox._next_exit_code = 0
+        result = await sandbox.adelete("/file.txt")
+        assert result.error is None
+        assert result.path == "/file.txt"

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -537,6 +537,20 @@ def test_sandbox_write_with_special_content() -> None:
     assert sandbox._uploaded[0][1] == content.encode("utf-8")
 
 
+def test_sandbox_write_overwrites_existing_file() -> None:
+    """Test that write() replaces an existing file without error."""
+    sandbox = MockSandbox()
+
+    result = sandbox.write("/test/file.txt", "original content")
+    assert result.error is None
+
+    result = sandbox.write("/test/file.txt", "new content")
+    assert result.error is None
+
+    assert len(sandbox._uploaded) == 2
+    assert sandbox._uploaded[-1] == ("/test/file.txt", b"new content")
+
+
 def test_sandbox_write_returns_error_on_preflight_failure() -> None:
     """Test that write() returns an error and skips upload when the preflight fails."""
     sandbox = MockSandbox()

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -8,6 +8,7 @@ import pytest
 from langchain.tools import ToolRuntime
 from langchain_core.messages import ToolMessage
 from langgraph.runtime import Runtime
+from langgraph.store.base import PutOp
 from langgraph.store.memory import InMemoryStore
 
 from deepagents._api.deprecation import LangChainDeprecationWarning
@@ -560,6 +561,64 @@ async def test_store_backend_adelete_directory_recursive() -> None:
     assert (await be.aread("/work/a.txt")).error is not None
     assert (await be.aread("/work/sub/b.txt")).error is not None
     assert (await be.aread("/keep.txt")).error is None
+
+
+def test_store_backend_delete_uses_single_batch_call() -> None:
+    """A recursive delete issues one batched store write, not one call per key."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    be.write("/work/a.txt", "a")
+    be.write("/work/sub/b.txt", "b")
+    be.write("/keep.txt", "k")
+
+    # Spy on the store's batch primitive (search and delete both route through it).
+    batches: list[list] = []
+    original_batch = mem_store.batch
+
+    def spy_batch(ops):
+        ops = list(ops)
+        batches.append(ops)
+        return original_batch(ops)
+
+    mem_store.batch = spy_batch  # type: ignore[method-assign]
+
+    result = be.delete("/work")
+    assert result.error is None
+
+    # Exactly one batch carried PutOps — all the deletes in a single round-trip.
+    delete_batches = [ops for ops in batches if any(isinstance(op, PutOp) for op in ops)]
+    assert len(delete_batches) == 1
+    ops = delete_batches[0]
+    assert all(isinstance(op, PutOp) and op.value is None for op in ops)
+    assert {op.key for op in ops} == {"/work/a.txt", "/work/sub/b.txt"}
+
+
+async def test_store_backend_adelete_uses_single_batch_call() -> None:
+    """Async recursive delete issues one batched store write, not one per key."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    await be.awrite("/work/a.txt", "a")
+    await be.awrite("/work/sub/b.txt", "b")
+    await be.awrite("/keep.txt", "k")
+
+    batches: list[list] = []
+    original_abatch = mem_store.abatch
+
+    async def spy_abatch(ops):
+        ops = list(ops)
+        batches.append(ops)
+        return await original_abatch(ops)
+
+    mem_store.abatch = spy_abatch  # type: ignore[method-assign]
+
+    result = await be.adelete("/work")
+    assert result.error is None
+
+    delete_batches = [ops for ops in batches if any(isinstance(op, PutOp) for op in ops)]
+    assert len(delete_batches) == 1
+    ops = delete_batches[0]
+    assert all(isinstance(op, PutOp) and op.value is None for op in ops)
+    assert {op.key for op in ops} == {"/work/a.txt", "/work/sub/b.txt"}
 
 
 def test_store_backend_delete_missing_returns_error() -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -8,6 +8,7 @@ import pytest
 from langchain.tools import ToolRuntime
 from langchain_core.messages import ToolMessage
 from langgraph.runtime import Runtime
+from langgraph.store.base import PutOp
 from langgraph.store.memory import InMemoryStore
 
 from deepagents._api.deprecation import LangChainDeprecationWarning
@@ -529,6 +530,103 @@ def test_store_backend_delete() -> None:
     assert result.path == "/docs/readme.md"
     # File is gone
     assert be.read("/docs/readme.md").error is not None
+
+
+def test_store_backend_delete_directory_recursive() -> None:
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    be.write("/work/a.txt", "a")
+    be.write("/work/sub/b.txt", "b")
+    be.write("/keep.txt", "k")
+
+    result = be.delete("/work")
+    assert result.error is None
+    assert result.path == "/work"
+    # Every key at or under /work is gone.
+    assert be.read("/work/a.txt").error is not None
+    assert be.read("/work/sub/b.txt").error is not None
+    # A sibling outside the subtree is untouched.
+    assert be.read("/keep.txt").error is None
+
+
+async def test_store_backend_adelete_directory_recursive() -> None:
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    await be.awrite("/work/a.txt", "a")
+    await be.awrite("/work/sub/b.txt", "b")
+    await be.awrite("/keep.txt", "k")
+
+    result = await be.adelete("/work")
+    assert result.error is None
+    assert (await be.aread("/work/a.txt")).error is not None
+    assert (await be.aread("/work/sub/b.txt")).error is not None
+    assert (await be.aread("/keep.txt")).error is None
+
+
+class _RecordingStore(InMemoryStore):
+    """InMemoryStore that records the ops passed to each batch/abatch call.
+
+    `batch`/`abatch` are the single primitive every store op routes through, so
+    recording them lets a test assert how many round-trips a delete performs.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.batch_calls: list[list] = []
+
+    def batch(self, ops):
+        ops = list(ops)
+        self.batch_calls.append(ops)
+        return super().batch(ops)
+
+    async def abatch(self, ops):
+        ops = list(ops)
+        self.batch_calls.append(ops)
+        return await super().abatch(ops)
+
+
+def _delete_op_batches(batch_calls: list[list]) -> list[list]:
+    """Batches that carried at least one delete (PutOp with value=None)."""
+    return [ops for ops in batch_calls if any(isinstance(op, PutOp) and op.value is None for op in ops)]
+
+
+def test_store_backend_delete_uses_single_batch_call() -> None:
+    """A recursive delete issues one batched store write, not one call per key."""
+    store = _RecordingStore()
+    be = StoreBackend(store=store, namespace=lambda _rt: ("filesystem",))
+    be.write("/work/a.txt", "a")
+    be.write("/work/sub/b.txt", "b")
+    be.write("/keep.txt", "k")
+    store.batch_calls.clear()  # ignore the setup writes
+
+    result = be.delete("/work")
+    assert result.error is None
+
+    # All the deletes happened in exactly one batch (not one call per key).
+    delete_batches = _delete_op_batches(store.batch_calls)
+    assert len(delete_batches) == 1
+    ops = delete_batches[0]
+    assert all(isinstance(op, PutOp) and op.value is None for op in ops)
+    assert {op.key for op in ops} == {"/work/a.txt", "/work/sub/b.txt"}
+
+
+async def test_store_backend_adelete_uses_single_batch_call() -> None:
+    """Async recursive delete issues one batched store write, not one per key."""
+    store = _RecordingStore()
+    be = StoreBackend(store=store, namespace=lambda _rt: ("filesystem",))
+    await be.awrite("/work/a.txt", "a")
+    await be.awrite("/work/sub/b.txt", "b")
+    await be.awrite("/keep.txt", "k")
+    store.batch_calls.clear()
+
+    result = await be.adelete("/work")
+    assert result.error is None
+
+    delete_batches = _delete_op_batches(store.batch_calls)
+    assert len(delete_batches) == 1
+    ops = delete_batches[0]
+    assert all(isinstance(op, PutOp) and op.value is None for op in ops)
+    assert {op.key for op in ops} == {"/work/a.txt", "/work/sub/b.txt"}
 
 
 def test_store_backend_delete_missing_returns_error() -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -531,6 +531,37 @@ def test_store_backend_delete() -> None:
     assert be.read("/docs/readme.md").error is not None
 
 
+def test_store_backend_delete_directory_recursive() -> None:
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    be.write("/work/a.txt", "a")
+    be.write("/work/sub/b.txt", "b")
+    be.write("/keep.txt", "k")
+
+    result = be.delete("/work")
+    assert result.error is None
+    assert result.path == "/work"
+    # Every key at or under /work is gone.
+    assert be.read("/work/a.txt").error is not None
+    assert be.read("/work/sub/b.txt").error is not None
+    # A sibling outside the subtree is untouched.
+    assert be.read("/keep.txt").error is None
+
+
+async def test_store_backend_adelete_directory_recursive() -> None:
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    await be.awrite("/work/a.txt", "a")
+    await be.awrite("/work/sub/b.txt", "b")
+    await be.awrite("/keep.txt", "k")
+
+    result = await be.adelete("/work")
+    assert result.error is None
+    assert (await be.aread("/work/a.txt")).error is not None
+    assert (await be.aread("/work/sub/b.txt")).error is not None
+    assert (await be.aread("/keep.txt")).error is None
+
+
 def test_store_backend_delete_missing_returns_error() -> None:
     be = StoreBackend(store=InMemoryStore(), namespace=lambda _rt: ("filesystem",))
     result = be.delete("/nope.md")

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -515,3 +515,99 @@ def test_store_backend_legacy_path_rejects_malicious_assistant_id() -> None:
             warnings.simplefilter("always")
             with pytest.raises(ValueError, match="disallowed characters"):
                 be.write("/test.txt", "content")
+
+
+def test_store_backend_delete() -> None:
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+
+    be.write("/docs/readme.md", "hello store")
+    assert be.read("/docs/readme.md").error is None
+
+    result = be.delete("/docs/readme.md")
+    assert result.error is None
+    assert result.path == "/docs/readme.md"
+    # File is gone
+    assert be.read("/docs/readme.md").error is not None
+
+
+def test_store_backend_delete_missing_returns_error() -> None:
+    be = StoreBackend(store=InMemoryStore(), namespace=lambda _rt: ("filesystem",))
+    result = be.delete("/nope.md")
+    assert result.path is None
+    assert result.error is not None
+    assert "not found" in result.error
+
+
+async def test_store_backend_adelete() -> None:
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+
+    await be.awrite("/a.md", "x")
+    result = await be.adelete("/a.md")
+    assert result.error is None
+    assert result.path == "/a.md"
+    assert (await be.aread("/a.md")).error is not None
+
+    missing = await be.adelete("/a.md")
+    assert missing.error is not None and "not found" in missing.error
+
+
+def test_store_backend_delete_treats_wildcard_as_literal_key() -> None:
+    """`*` is used as an exact store key, not a wildcard.
+
+    Deleting "*" must only remove an entry whose key is literally "*" and must
+    never expand to match/remove other files in the namespace.
+    """
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+
+    be.write("/a.md", "a")
+    be.write("/b.md", "b")
+    be.write("*", "literal star")
+
+    # Deleting "*" removes only the literally-named entry.
+    result = be.delete("*")
+    assert result.error is None
+    assert result.path == "*"
+
+    # The other files are untouched — "*" did not expand to a wildcard.
+    assert be.read("/a.md").error is None
+    assert be.read("/b.md").error is None
+    assert be.read("*").error is not None
+
+
+def test_store_backend_delete_wildcard_missing_does_not_match_files() -> None:
+    """Deleting "*" when no literal "*" key exists is a not-found, not a purge."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+
+    be.write("/a.md", "a")
+    be.write("/b.md", "b")
+
+    result = be.delete("*")
+    assert result.path is None
+    assert result.error is not None and "not found" in result.error
+
+    # Nothing was deleted by the wildcard-looking key.
+    assert be.read("/a.md").error is None
+    assert be.read("/b.md").error is None
+
+
+async def test_store_backend_adelete_treats_wildcard_as_literal_key() -> None:
+    """Async delete also treats `*` as an exact key, not a wildcard."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+
+    await be.awrite("/a.md", "a")
+    await be.awrite("*", "literal star")
+
+    result = await be.adelete("*")
+    assert result.error is None
+    assert result.path == "*"
+
+    assert (await be.aread("/a.md")).error is None
+    assert (await be.aread("*")).error is not None
+
+    missing = await be.adelete("*")
+    assert missing.error is not None and "not found" in missing.error

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -563,30 +563,47 @@ async def test_store_backend_adelete_directory_recursive() -> None:
     assert (await be.aread("/keep.txt")).error is None
 
 
+class _RecordingStore(InMemoryStore):
+    """InMemoryStore that records the ops passed to each batch/abatch call.
+
+    `batch`/`abatch` are the single primitive every store op routes through, so
+    recording them lets a test assert how many round-trips a delete performs.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.batch_calls: list[list] = []
+
+    def batch(self, ops):
+        ops = list(ops)
+        self.batch_calls.append(ops)
+        return super().batch(ops)
+
+    async def abatch(self, ops):
+        ops = list(ops)
+        self.batch_calls.append(ops)
+        return await super().abatch(ops)
+
+
+def _delete_op_batches(batch_calls: list[list]) -> list[list]:
+    """Batches that carried at least one delete (PutOp with value=None)."""
+    return [ops for ops in batch_calls if any(isinstance(op, PutOp) and op.value is None for op in ops)]
+
+
 def test_store_backend_delete_uses_single_batch_call() -> None:
     """A recursive delete issues one batched store write, not one call per key."""
-    mem_store = InMemoryStore()
-    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    store = _RecordingStore()
+    be = StoreBackend(store=store, namespace=lambda _rt: ("filesystem",))
     be.write("/work/a.txt", "a")
     be.write("/work/sub/b.txt", "b")
     be.write("/keep.txt", "k")
-
-    # Spy on the store's batch primitive (search and delete both route through it).
-    batches: list[list] = []
-    original_batch = mem_store.batch
-
-    def spy_batch(ops):
-        ops = list(ops)
-        batches.append(ops)
-        return original_batch(ops)
-
-    mem_store.batch = spy_batch  # type: ignore[method-assign]
+    store.batch_calls.clear()  # ignore the setup writes
 
     result = be.delete("/work")
     assert result.error is None
 
-    # Exactly one batch carried PutOps — all the deletes in a single round-trip.
-    delete_batches = [ops for ops in batches if any(isinstance(op, PutOp) for op in ops)]
+    # All the deletes happened in exactly one batch (not one call per key).
+    delete_batches = _delete_op_batches(store.batch_calls)
     assert len(delete_batches) == 1
     ops = delete_batches[0]
     assert all(isinstance(op, PutOp) and op.value is None for op in ops)
@@ -595,26 +612,17 @@ def test_store_backend_delete_uses_single_batch_call() -> None:
 
 async def test_store_backend_adelete_uses_single_batch_call() -> None:
     """Async recursive delete issues one batched store write, not one per key."""
-    mem_store = InMemoryStore()
-    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    store = _RecordingStore()
+    be = StoreBackend(store=store, namespace=lambda _rt: ("filesystem",))
     await be.awrite("/work/a.txt", "a")
     await be.awrite("/work/sub/b.txt", "b")
     await be.awrite("/keep.txt", "k")
-
-    batches: list[list] = []
-    original_abatch = mem_store.abatch
-
-    async def spy_abatch(ops):
-        ops = list(ops)
-        batches.append(ops)
-        return await original_abatch(ops)
-
-    mem_store.abatch = spy_abatch  # type: ignore[method-assign]
+    store.batch_calls.clear()
 
     result = await be.adelete("/work")
     assert result.error is None
 
-    delete_batches = [ops for ops in batches if any(isinstance(op, PutOp) for op in ops)]
+    delete_batches = _delete_op_batches(store.batch_calls)
     assert len(delete_batches) == 1
     ops = delete_batches[0]
     assert all(isinstance(op, PutOp) and op.value is None for op in ops)

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -51,7 +51,7 @@ def test_store_backend_crud_and_search():
     assert any(i["path"] == "/docs/readme.md" for i in g2)
 
 
-def test_store_backend_write_rejects_existing_file():
+def test_store_backend_write_overwrites_existing_file():
     mem_store = InMemoryStore()
     be = StoreBackend(store=mem_store, namespace=lambda _ctx: ("filesystem",))
 
@@ -59,16 +59,14 @@ def test_store_backend_write_rejects_existing_file():
     result = be.write("/charmander.txt", "Hello world")
     assert result.error is None
 
-    # Attempt to overwrite — should fail
+    # Overwrite should succeed
     result = be.write("/charmander.txt", "New content")
-    assert result.error is not None
-    assert "Cannot write" in result.error
-    assert "already exists" in result.error
+    assert result.error is None
 
-    # Original content preserved
+    # New content visible
     read_result = be.read("/charmander.txt")
     assert read_result.file_data is not None
-    assert "Hello world" in read_result.file_data["content"]
+    assert "New content" in read_result.file_data["content"]
 
 
 def test_store_backend_ls_nested_directories():

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -1,6 +1,6 @@
 """Tests for backends/utils.py utility functions."""
 
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 from langchain_core.messages.content import ContentBlock
@@ -11,6 +11,7 @@ from deepagents.backends.utils import (
     _EXTENSION_TO_FILE_TYPE,
     _get_file_type,
     _glob_search_files,
+    expand_delete_keys,
     perform_string_replacement,
     slice_read_response,
     to_posix_path,
@@ -353,3 +354,29 @@ class TestSliceReadResponse:
         assert isinstance(result, ReadResult)
         assert result.error is not None
         assert "exceeds file length" in result.error
+
+
+class TestExpandDeleteKeys:
+    """Prefix expansion shared by the key-value backends' recursive delete."""
+
+    KEYS: ClassVar[list[str]] = ["/work", "/work/a.txt", "/work/sub/b.txt", "/workshop/x", "/keep.txt"]
+
+    def test_exact_file_key(self):
+        assert expand_delete_keys(self.KEYS, "/keep.txt") == ["/keep.txt"]
+
+    def test_directory_prefix_includes_self_and_descendants(self):
+        assert expand_delete_keys(self.KEYS, "/work") == ["/work", "/work/a.txt", "/work/sub/b.txt"]
+
+    def test_trailing_slash_normalized(self):
+        assert expand_delete_keys(self.KEYS, "/work/") == ["/work", "/work/a.txt", "/work/sub/b.txt"]
+
+    def test_does_not_match_sibling_prefix(self):
+        # "/work" must not swallow "/workshop/x" (the prefix is "/work/", not "/work").
+        assert "/workshop/x" not in expand_delete_keys(self.KEYS, "/work")
+
+    def test_no_match_returns_empty(self):
+        assert expand_delete_keys(self.KEYS, "/missing") == []
+
+    def test_wildcard_key_treated_literally(self):
+        # A literal "*" key matches only itself, never other paths.
+        assert expand_delete_keys(["*", "/a.txt", "/b.txt"], "*") == ["*"]

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -1,6 +1,6 @@
 """Tests for backends/utils.py utility functions."""
 
-from typing import Any, ClassVar
+from typing import Any
 
 import pytest
 from langchain_core.messages.content import ContentBlock
@@ -11,7 +11,6 @@ from deepagents.backends.utils import (
     _EXTENSION_TO_FILE_TYPE,
     _get_file_type,
     _glob_search_files,
-    expand_delete_keys,
     perform_string_replacement,
     slice_read_response,
     to_posix_path,
@@ -354,29 +353,3 @@ class TestSliceReadResponse:
         assert isinstance(result, ReadResult)
         assert result.error is not None
         assert "exceeds file length" in result.error
-
-
-class TestExpandDeleteKeys:
-    """Prefix expansion shared by the key-value backends' recursive delete."""
-
-    KEYS: ClassVar[list[str]] = ["/work", "/work/a.txt", "/work/sub/b.txt", "/workshop/x", "/keep.txt"]
-
-    def test_exact_file_key(self):
-        assert expand_delete_keys(self.KEYS, "/keep.txt") == ["/keep.txt"]
-
-    def test_directory_prefix_includes_self_and_descendants(self):
-        assert expand_delete_keys(self.KEYS, "/work") == ["/work", "/work/a.txt", "/work/sub/b.txt"]
-
-    def test_trailing_slash_normalized(self):
-        assert expand_delete_keys(self.KEYS, "/work/") == ["/work", "/work/a.txt", "/work/sub/b.txt"]
-
-    def test_does_not_match_sibling_prefix(self):
-        # "/work" must not swallow "/workshop/x" (the prefix is "/work/", not "/work").
-        assert "/workshop/x" not in expand_delete_keys(self.KEYS, "/work")
-
-    def test_no_match_returns_empty(self):
-        assert expand_delete_keys(self.KEYS, "/missing") == []
-
-    def test_wildcard_key_treated_literally(self):
-        # A literal "*" key matches only itself, never other paths.
-        assert expand_delete_keys(["*", "/a.txt", "/b.txt"], "*") == ["*"]

--- a/libs/deepagents/tests/unit_tests/middleware/test_tool_schemas.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_tool_schemas.py
@@ -25,6 +25,7 @@ class TestFilesystemToolSchemas:
             "read_file": ["file_path", "offset", "limit"],
             "write_file": ["file_path", "content"],
             "edit_file": ["file_path", "old_string", "new_string", "replace_all"],
+            "delete_file": ["file_path"],
             "glob": ["pattern", "path"],
             "grep": ["pattern", "path", "glob", "output_mode"],
             "execute": ["command"],

--- a/libs/deepagents/tests/unit_tests/middleware/test_tool_schemas.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_tool_schemas.py
@@ -25,7 +25,7 @@ class TestFilesystemToolSchemas:
             "read_file": ["file_path", "offset", "limit"],
             "write_file": ["file_path", "content"],
             "edit_file": ["file_path", "old_string", "new_string", "replace_all"],
-            "delete_file": ["file_path"],
+            "delete": ["file_path"],
             "glob": ["pattern", "path"],
             "grep": ["pattern", "path", "glob", "output_mode"],
             "execute": ["command"],

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message.md
@@ -68,7 +68,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -77,6 +77,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete_file: delete a file from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message.md
@@ -68,7 +68,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -77,7 +77,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
-- delete_file: delete a file from the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -146,8 +146,8 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
-      "name": "delete_file",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer edit_file when making targeted changes to an existing file while leaving the rest intact.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -97,7 +97,7 @@
             "type": "string"
           },
           "file_path": {
-            "description": "Absolute path where the file should be created. Must be absolute, not relative.",
+            "description": "Absolute path where the file should be written. Must be absolute, not relative.",
             "type": "string"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer edit_file when making targeted changes to an existing file while leaving the rest intact.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -146,7 +146,7 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
       "name": "delete_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -147,7 +147,7 @@
   {
     "function": {
       "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
-      "name": "delete_file",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "name": "delete_file",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in the backend's default root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,7 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
-- delete_file: delete a file from the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,6 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete_file: delete a file from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -146,8 +146,8 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
-      "name": "delete_file",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer edit_file when making targeted changes to an existing file while leaving the rest intact.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -97,7 +97,7 @@
             "type": "string"
           },
           "file_path": {
-            "description": "Absolute path where the file should be created. Must be absolute, not relative.",
+            "description": "Absolute path where the file should be written. Must be absolute, not relative.",
             "type": "string"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer edit_file when making targeted changes to an existing file while leaving the rest intact.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -146,7 +146,7 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
       "name": "delete_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -147,7 +147,7 @@
   {
     "function": {
       "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
-      "name": "delete_file",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "name": "delete_file",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in the backend's default root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
@@ -112,7 +112,7 @@ Remember: Skills make you more capable and consistent. When in doubt, check if a
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -121,6 +121,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete_file: delete a file from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
@@ -112,7 +112,7 @@ Remember: Skills make you more capable and consistent. When in doubt, check if a
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -121,7 +121,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
-- delete_file: delete a file from the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -146,8 +146,8 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
-      "name": "delete_file",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer edit_file when making targeted changes to an existing file while leaving the rest intact.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -97,7 +97,7 @@
             "type": "string"
           },
           "file_path": {
-            "description": "Absolute path where the file should be created. Must be absolute, not relative.",
+            "description": "Absolute path where the file should be written. Must be absolute, not relative.",
             "type": "string"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer edit_file when making targeted changes to an existing file while leaving the rest intact.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -146,7 +146,7 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
       "name": "delete_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -147,7 +147,7 @@
   {
     "function": {
       "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
-      "name": "delete_file",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "name": "delete_file",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in the backend's default root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,7 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
-- delete_file: delete a file from the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,6 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete_file: delete a file from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -146,8 +146,8 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
-      "name": "delete_file",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer edit_file when making targeted changes to an existing file while leaving the rest intact.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -97,7 +97,7 @@
             "type": "string"
           },
           "file_path": {
-            "description": "Absolute path where the file should be created. Must be absolute, not relative.",
+            "description": "Absolute path where the file should be written. Must be absolute, not relative.",
             "type": "string"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer edit_file when making targeted changes to an existing file while leaving the rest intact.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -146,7 +146,7 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
       "name": "delete_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -147,7 +147,7 @@
   {
     "function": {
       "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
-      "name": "delete_file",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "name": "delete_file",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in the backend's default root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,7 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
-- delete_file: delete a file from the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete_file`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,6 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete_file: delete a file from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -146,8 +146,8 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
-      "name": "delete_file",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer edit_file when making targeted changes to an existing file while leaving the rest intact.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -97,7 +97,7 @@
             "type": "string"
           },
           "file_path": {
-            "description": "Absolute path where the file should be created. Must be absolute, not relative.",
+            "description": "Absolute path where the file should be written. Must be absolute, not relative.",
             "type": "string"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer edit_file when making targeted changes to an existing file while leaving the rest intact.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -146,7 +146,7 @@
   },
   {
     "function": {
-      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
       "name": "delete_file",
       "parameters": {
         "properties": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -147,7 +147,7 @@
   {
     "function": {
       "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
-      "name": "delete_file",
+      "name": "delete",
       "parameters": {
         "properties": {
           "file_path": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file from the filesystem.\n\nUsage:\n- Permanently removes the file at the given absolute path.\n- This cannot be undone, so only delete files you are sure are no longer needed.",
+      "name": "delete_file",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in the backend's default root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -1394,7 +1394,7 @@ class TestDeleteFileTool:
         tool_messages = [m for m in result["messages"] if m.type == "tool"]
         assert len(tool_messages) == 1
         assert tool_messages[0].status == "success"
-        assert tool_messages[0].content == "Deleted file /keep.txt"
+        assert tool_messages[0].content == "Deleted /keep.txt"
         assert set(result["files"].keys()) == {"/other.txt"}
 
     def test_delete_directory_removes_nested_files(self) -> None:

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -1397,6 +1397,44 @@ class TestDeleteFileTool:
         assert tool_messages[0].content == "Deleted file /keep.txt"
         assert set(result["files"].keys()) == {"/other.txt"}
 
+    def test_delete_directory_removes_nested_files(self) -> None:
+        """Delete on a directory removes every nested file from state (StateBackend)."""
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "delete",
+                                "args": {"file_path": "/work"},
+                                "id": "call_1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model)
+        result = agent.invoke(
+            {
+                "messages": [HumanMessage(content="delete the work dir")],
+                "files": {
+                    "/work/a.txt": create_file_data("a"),
+                    "/work/sub/b.txt": create_file_data("b"),
+                    "/keep.txt": create_file_data("stay"),
+                },
+            }
+        )
+
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert tool_messages[0].status == "success"
+        # Whole /work subtree gone; sibling preserved.
+        assert set(result["files"].keys()) == {"/keep.txt"}
+
     def test_delete_missing_returns_error(self) -> None:
         """Delete on a missing path returns an error tool message."""
         model = FixedGenericFakeChatModel(

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -1357,10 +1357,10 @@ class TestDeepAgentEndToEnd:
 
 
 class TestDeleteFileTool:
-    """End-to-end tests for the `delete_file` filesystem tool."""
+    """End-to-end tests for the `delete` filesystem tool."""
 
-    def test_delete_file_removes_existing_file(self) -> None:
-        """delete_file removes a file from state and reports success."""
+    def test_delete_removes_existing_file(self) -> None:
+        """delete removes a file from state and reports success."""
         model = FixedGenericFakeChatModel(
             messages=iter(
                 [
@@ -1368,7 +1368,7 @@ class TestDeleteFileTool:
                         content="",
                         tool_calls=[
                             {
-                                "name": "delete_file",
+                                "name": "delete",
                                 "args": {"file_path": "/keep.txt"},
                                 "id": "call_1",
                                 "type": "tool_call",
@@ -1397,8 +1397,8 @@ class TestDeleteFileTool:
         assert tool_messages[0].content == "Deleted file /keep.txt"
         assert set(result["files"].keys()) == {"/other.txt"}
 
-    def test_delete_file_missing_returns_error(self) -> None:
-        """delete_file on a missing path returns an error tool message."""
+    def test_delete_missing_returns_error(self) -> None:
+        """delete on a missing path returns an error tool message."""
         model = FixedGenericFakeChatModel(
             messages=iter(
                 [
@@ -1406,7 +1406,7 @@ class TestDeleteFileTool:
                         content="",
                         tool_calls=[
                             {
-                                "name": "delete_file",
+                                "name": "delete",
                                 "args": {"file_path": "/nope.txt"},
                                 "id": "call_1",
                                 "type": "tool_call",
@@ -1426,8 +1426,8 @@ class TestDeleteFileTool:
         assert tool_messages[0].status == "error"
         assert "not found" in tool_messages[0].content
 
-    def test_delete_file_permission_deny_blocks_delete(self) -> None:
-        """FilesystemPermission deny write blocks delete_file (delete is a write op)."""
+    def test_delete_permission_deny_blocks_delete(self) -> None:
+        """FilesystemPermission deny write blocks delete (delete is a write op)."""
         model = FixedGenericFakeChatModel(
             messages=iter(
                 [
@@ -1435,7 +1435,7 @@ class TestDeleteFileTool:
                         content="",
                         tool_calls=[
                             {
-                                "name": "delete_file",
+                                "name": "delete",
                                 "args": {"file_path": "/secrets/key.txt"},
                                 "id": "call_1",
                                 "type": "tool_call",

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -2846,6 +2846,52 @@ class TestStateBackendConfigKeys:
         assert "buffered" in tool_msg.content
         assert "ERROR" not in tool_msg.content
 
+    def test_write_overwrites_existing_file(self) -> None:
+        """write_file on an existing path replaces its content."""
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "write_file",
+                                "args": {"file_path": "/doc.txt", "content": "new content"},
+                                "id": "call_w2",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "read_file",
+                                "args": {"file_path": "/doc.txt"},
+                                "id": "call_r2",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model)
+        result = agent.invoke(
+            {
+                "messages": [HumanMessage(content="go")],
+                "files": {"/doc.txt": {"content": "old content", "encoding": "utf-8"}},
+            }
+        )
+
+        tool_msgs = [m for m in result["messages"] if m.type == "tool"]
+        # write should succeed and overwrite the old content
+        assert any("Updated file" in m.content for m in tool_msgs)
+        assert any("new content" in m.content for m in tool_msgs)
+        assert not any("old content" in m.content for m in tool_msgs)
+
     def test_state_backend_delete_in_graph_context(self) -> None:
         """delete() removes a file from state; missing paths report an error."""
         backend = StateBackend()

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -1356,6 +1356,119 @@ class TestDeepAgentEndToEnd:
         assert "base64" in tm.content[0]
 
 
+class TestDeleteFileTool:
+    """End-to-end tests for the `delete_file` filesystem tool."""
+
+    def test_delete_file_removes_existing_file(self) -> None:
+        """delete_file removes a file from state and reports success."""
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "delete_file",
+                                "args": {"file_path": "/keep.txt"},
+                                "id": "call_1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model)
+        result = agent.invoke(
+            {
+                "messages": [HumanMessage(content="delete it")],
+                "files": {
+                    "/keep.txt": create_file_data("bye"),
+                    "/other.txt": create_file_data("stay"),
+                },
+            }
+        )
+
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert len(tool_messages) == 1
+        assert tool_messages[0].status == "success"
+        assert tool_messages[0].content == "Deleted file /keep.txt"
+        assert set(result["files"].keys()) == {"/other.txt"}
+
+    def test_delete_file_missing_returns_error(self) -> None:
+        """delete_file on a missing path returns an error tool message."""
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "delete_file",
+                                "args": {"file_path": "/nope.txt"},
+                                "id": "call_1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model)
+        result = agent.invoke({"messages": [HumanMessage(content="delete it")]})
+
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert len(tool_messages) == 1
+        assert tool_messages[0].status == "error"
+        assert "not found" in tool_messages[0].content
+
+    def test_delete_file_permission_deny_blocks_delete(self) -> None:
+        """FilesystemPermission deny write blocks delete_file (delete is a write op)."""
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "delete_file",
+                                "args": {"file_path": "/secrets/key.txt"},
+                                "id": "call_1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(
+            model=model,
+            permissions=[
+                FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="deny"),
+            ],
+        )
+        result = agent.invoke(
+            {
+                "messages": [HumanMessage(content="delete secret")],
+                "files": {"/secrets/key.txt": create_file_data("data")},
+            }
+        )
+
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert len(tool_messages) == 1
+        assert tool_messages[0].status == "error"
+        assert "permission denied" in tool_messages[0].content
+        assert "write" in tool_messages[0].content
+        # The file must still be present after a denied delete.
+        assert "/secrets/key.txt" in result["files"]
+
+
 class TestDeepAgentPermissionsEndToEnd:
     """End-to-end tests for create_deep_agent with FilesystemPermission."""
 
@@ -2694,6 +2807,100 @@ class TestStateBackendConfigKeys:
         tool_msg = next(m for m in result["messages"] if m.type == "tool" and m.tool_call_id == "call_wr")
         assert "buffered" in tool_msg.content
         assert "ERROR" not in tool_msg.content
+
+    def test_state_backend_delete_in_graph_context(self) -> None:
+        """delete() removes a file from state; missing paths report an error."""
+        backend = StateBackend()
+
+        @tool
+        def delete_path(path: str) -> str:
+            """Delete a file via StateBackend."""
+            result = backend.delete(path)
+            return result.error or f"deleted {result.path}"
+
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {"name": "delete_path", "args": {"path": "/keep.txt"}, "id": "c1", "type": "tool_call"},
+                        ],
+                    ),
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {"name": "delete_path", "args": {"path": "/missing.txt"}, "id": "c2", "type": "tool_call"},
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model, backend=backend, tools=[delete_path])
+        result = agent.invoke(
+            {
+                "messages": [HumanMessage(content="go")],
+                "files": {
+                    "/keep.txt": create_file_data("bye"),
+                    "/other.txt": create_file_data("stay"),
+                },
+            }
+        )
+
+        tool_msgs = {m.tool_call_id: m.content for m in result["messages"] if m.type == "tool"}
+        assert tool_msgs["c1"] == "deleted /keep.txt"
+        assert "not found" in tool_msgs["c2"]
+        # The deleted file is gone; the untouched file remains.
+        assert set(result["files"].keys()) == {"/other.txt"}
+
+    async def test_state_backend_delete_in_graph_context_async(self) -> None:
+        """adelete() removes a file from state on the async path; missing paths report an error."""
+        backend = StateBackend()
+
+        @tool
+        async def adelete_path(path: str) -> str:
+            """Delete a file via StateBackend's async path."""
+            result = await backend.adelete(path)
+            return result.error or f"deleted {result.path}"
+
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {"name": "adelete_path", "args": {"path": "/keep.txt"}, "id": "c1", "type": "tool_call"},
+                        ],
+                    ),
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {"name": "adelete_path", "args": {"path": "/missing.txt"}, "id": "c2", "type": "tool_call"},
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model, backend=backend, tools=[adelete_path])
+        result = await agent.ainvoke(
+            {
+                "messages": [HumanMessage(content="go")],
+                "files": {
+                    "/keep.txt": create_file_data("bye"),
+                    "/other.txt": create_file_data("stay"),
+                },
+            }
+        )
+
+        tool_msgs = {m.tool_call_id: m.content for m in result["messages"] if m.type == "tool"}
+        assert tool_msgs["c1"] == "deleted /keep.txt"
+        assert "not found" in tool_msgs["c2"]
+        # The deleted file is gone; the untouched file remains.
+        assert set(result["files"].keys()) == {"/other.txt"}
 
 
 class TestArtifactsRoot:

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -1360,7 +1360,7 @@ class TestDeleteFileTool:
     """End-to-end tests for the `delete` filesystem tool."""
 
     def test_delete_removes_existing_file(self) -> None:
-        """delete removes a file from state and reports success."""
+        """Delete removes a file from state and reports success."""
         model = FixedGenericFakeChatModel(
             messages=iter(
                 [
@@ -1398,7 +1398,7 @@ class TestDeleteFileTool:
         assert set(result["files"].keys()) == {"/other.txt"}
 
     def test_delete_missing_returns_error(self) -> None:
-        """delete on a missing path returns an error tool message."""
+        """Delete on a missing path returns an error tool message."""
         model = FixedGenericFakeChatModel(
             messages=iter(
                 [

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -1357,10 +1357,10 @@ class TestDeepAgentEndToEnd:
 
 
 class TestDeleteFileTool:
-    """End-to-end tests for the `delete_file` filesystem tool."""
+    """End-to-end tests for the `delete` filesystem tool."""
 
-    def test_delete_file_removes_existing_file(self) -> None:
-        """delete_file removes a file from state and reports success."""
+    def test_delete_removes_existing_file(self) -> None:
+        """Delete removes a file from state and reports success."""
         model = FixedGenericFakeChatModel(
             messages=iter(
                 [
@@ -1368,7 +1368,7 @@ class TestDeleteFileTool:
                         content="",
                         tool_calls=[
                             {
-                                "name": "delete_file",
+                                "name": "delete",
                                 "args": {"file_path": "/keep.txt"},
                                 "id": "call_1",
                                 "type": "tool_call",
@@ -1394,11 +1394,11 @@ class TestDeleteFileTool:
         tool_messages = [m for m in result["messages"] if m.type == "tool"]
         assert len(tool_messages) == 1
         assert tool_messages[0].status == "success"
-        assert tool_messages[0].content == "Deleted file /keep.txt"
+        assert tool_messages[0].content == "Deleted /keep.txt"
         assert set(result["files"].keys()) == {"/other.txt"}
 
-    def test_delete_file_missing_returns_error(self) -> None:
-        """delete_file on a missing path returns an error tool message."""
+    def test_delete_directory_removes_nested_files(self) -> None:
+        """Delete on a directory removes every nested file from state (StateBackend)."""
         model = FixedGenericFakeChatModel(
             messages=iter(
                 [
@@ -1406,7 +1406,45 @@ class TestDeleteFileTool:
                         content="",
                         tool_calls=[
                             {
-                                "name": "delete_file",
+                                "name": "delete",
+                                "args": {"file_path": "/work"},
+                                "id": "call_1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model)
+        result = agent.invoke(
+            {
+                "messages": [HumanMessage(content="delete the work dir")],
+                "files": {
+                    "/work/a.txt": create_file_data("a"),
+                    "/work/sub/b.txt": create_file_data("b"),
+                    "/keep.txt": create_file_data("stay"),
+                },
+            }
+        )
+
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert tool_messages[0].status == "success"
+        # Whole /work subtree gone; sibling preserved.
+        assert set(result["files"].keys()) == {"/keep.txt"}
+
+    def test_delete_missing_returns_error(self) -> None:
+        """Delete on a missing path returns an error tool message."""
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "delete",
                                 "args": {"file_path": "/nope.txt"},
                                 "id": "call_1",
                                 "type": "tool_call",
@@ -1426,8 +1464,8 @@ class TestDeleteFileTool:
         assert tool_messages[0].status == "error"
         assert "not found" in tool_messages[0].content
 
-    def test_delete_file_permission_deny_blocks_delete(self) -> None:
-        """FilesystemPermission deny write blocks delete_file (delete is a write op)."""
+    def test_delete_permission_deny_blocks_delete(self) -> None:
+        """FilesystemPermission deny write blocks delete (delete is a write op)."""
         model = FixedGenericFakeChatModel(
             messages=iter(
                 [
@@ -1435,7 +1473,7 @@ class TestDeleteFileTool:
                         content="",
                         tool_calls=[
                             {
-                                "name": "delete_file",
+                                "name": "delete",
                                 "args": {"file_path": "/secrets/key.txt"},
                                 "id": "call_1",
                                 "type": "tool_call",

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -22,14 +22,15 @@ from deepagents.graph import (
     _REQUIRED_MIDDLEWARE_NAMES,
     BASE_AGENT_PROMPT,
     DeepAgentState,
+    _apply_user_middleware,
     create_deep_agent,
     get_default_model,
 )
 from deepagents.middleware._tool_exclusion import _ToolExclusionMiddleware
 from deepagents.middleware.async_subagents import AsyncSubAgentMiddleware
 from deepagents.middleware.filesystem import FilesystemMiddleware
-from deepagents.middleware.subagents import SubAgentMiddleware
-from deepagents.middleware.summarization import _DeepAgentsSummarizationMiddleware
+from deepagents.middleware.subagents import SubAgent, SubAgentMiddleware
+from deepagents.middleware.summarization import SummarizationMiddleware, _DeepAgentsSummarizationMiddleware
 from deepagents.profiles import GeneralPurposeSubagentProfile, HarnessProfile, register_harness_profile
 from deepagents.profiles.harness.harness_profiles import (
     _HARNESS_PROFILES,
@@ -2086,3 +2087,177 @@ class TestBuildDefaultModelContract:
         msg = str(deprecations[0].message)
         assert "deprecated" in msg
         assert "https://docs.langchain.com/oss/python/deepagents/models" in msg
+
+
+def _named_mw(name: str) -> AgentMiddleware[Any, Any, Any]:
+    """Return a minimal AgentMiddleware whose .name returns `name`."""
+
+    class _MW(AgentMiddleware[Any, Any, Any]):
+        @property
+        def name(self) -> str:
+            return name
+
+    return _MW()
+
+
+class TestApplyUserMiddleware:
+    """Unit tests for the _apply_user_middleware helper."""
+
+    def test_matching_name_replaces_at_same_position(self) -> None:
+        a, b, c = _named_mw("A"), _named_mw("B"), _named_mw("C")
+        replacement = _named_mw("B")
+        result = _apply_user_middleware([a, b, c], [replacement])
+        assert result[1] is replacement
+        assert result[0] is a
+        assert result[2] is c
+        assert len(result) == 3
+
+    def test_non_matching_name_is_appended(self) -> None:
+        a, b = _named_mw("A"), _named_mw("B")
+        new = _named_mw("Z")
+        result = _apply_user_middleware([a, b], [new])
+        assert result[-1] is new
+        assert len(result) == 3
+
+    def test_empty_user_list_returns_base_unchanged(self) -> None:
+        a, b = _named_mw("A"), _named_mw("B")
+        result = _apply_user_middleware([a, b], [])
+        assert result == [a, b]
+
+    def test_multiple_replacements_in_one_call(self) -> None:
+        a, b, c = _named_mw("A"), _named_mw("B"), _named_mw("C")
+        r_a, r_c = _named_mw("A"), _named_mw("C")
+        result = _apply_user_middleware([a, b, c], [r_a, r_c])
+        assert result[0] is r_a
+        assert result[1] is b
+        assert result[2] is r_c
+        assert len(result) == 3
+
+    def test_non_matching_appended_in_original_order(self) -> None:
+        base = _named_mw("Base")
+        x, y = _named_mw("X"), _named_mw("Y")
+        result = _apply_user_middleware([base], [x, y])
+        assert result[1] is x
+        assert result[2] is y
+
+    def test_mix_of_replacements_and_new_entries(self) -> None:
+        a, b = _named_mw("A"), _named_mw("B")
+        r_a, new = _named_mw("A"), _named_mw("New")
+        result = _apply_user_middleware([a, b], [r_a, new])
+        assert result[0] is r_a
+        assert result[1] is b
+        assert result[2] is new
+
+
+class TestUserMiddlewareOverride:
+    """Integration tests: user-supplied middleware replaces same-named defaults in create_deep_agent."""
+
+    def _run(self, user_mw: list[Any]) -> list[Any]:
+        fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+        fake_agent = MagicMock()
+        fake_agent.with_config.return_value = "compiled-agent"
+        with (
+            patch("deepagents.graph.resolve_model", return_value=fake_model),
+            patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
+        ):
+            create_deep_agent(model="anthropic:claude-sonnet-4-6", middleware=user_mw)
+        return mock_create.call_args.kwargs["middleware"]
+
+    def test_summarization_middleware_replaces_default(self) -> None:
+        """Passing SummarizationMiddleware in middleware= replaces the built-in instance."""
+        custom = SummarizationMiddleware(
+            model=GenericFakeChatModel(messages=iter([])),
+            backend=StateBackend(),
+            trigger=("tokens", 50_000),
+        )
+        stack = self._run([custom])
+
+        summ_entries = [m for m in stack if isinstance(m, _DeepAgentsSummarizationMiddleware)]
+        assert len(summ_entries) == 1, "expected exactly one SummarizationMiddleware in stack"
+        assert summ_entries[0] is custom
+
+    def test_same_name_subclass_replaces_default(self) -> None:
+        """A subclass whose .name == 'SummarizationMiddleware' replaces the default."""
+
+        class MySummarizationMiddleware(SummarizationMiddleware):
+            @property
+            def name(self) -> str:
+                return "SummarizationMiddleware"
+
+        custom = MySummarizationMiddleware(
+            model=GenericFakeChatModel(messages=iter([])),
+            backend=StateBackend(),
+        )
+        stack = self._run([custom])
+
+        summ_entries = [m for m in stack if isinstance(m, _DeepAgentsSummarizationMiddleware)]
+        assert len(summ_entries) == 1
+        assert summ_entries[0] is custom
+
+    def test_diff_name_subclass_is_appended(self) -> None:
+        """A subclass with a different .name doesn't replace the default. Both are present."""
+
+        class CompactSummarizationMiddleware(SummarizationMiddleware):
+            pass
+
+        custom = CompactSummarizationMiddleware(
+            model=GenericFakeChatModel(messages=iter([])),
+            backend=StateBackend(),
+        )
+        stack = self._run([custom])
+
+        summ_entries = [m for m in stack if isinstance(m, _DeepAgentsSummarizationMiddleware)]
+        assert len(summ_entries) == 2
+        assert any(m is custom for m in summ_entries)
+
+    def test_replacement_preserves_stack_position(self) -> None:
+        """The replaced entry sits at the same index as the original default."""
+        custom = SummarizationMiddleware(
+            model=GenericFakeChatModel(messages=iter([])),
+            backend=StateBackend(),
+        )
+        stack = self._run([custom])
+
+        default_index = next(i for i, m in enumerate(stack) if isinstance(m, _DeepAgentsSummarizationMiddleware))
+        assert stack[default_index] is custom
+
+    def test_subagent_middleware_replaces_default(self) -> None:
+        """SubAgent middleware= field also replaces same-named defaults in that subagent's stack."""
+        custom = SummarizationMiddleware(
+            model=GenericFakeChatModel(messages=iter([])),
+            backend=StateBackend(),
+            trigger=("tokens", 30_000),
+        )
+        subagent: SubAgent = {
+            "name": "researcher",
+            "description": "Research subagent",
+            "system_prompt": "You are a researcher.",
+            "middleware": [custom],
+        }
+        original = dict(_HARNESS_PROFILES)
+        try:
+            register_harness_profile(
+                "samwprov",
+                HarnessProfile(general_purpose_subagent=GeneralPurposeSubagentProfile(enabled=False)),
+            )
+            fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+            fake_agent = MagicMock()
+            fake_agent.with_config.return_value = "compiled-agent"
+            with (
+                patch("deepagents.graph.resolve_model", return_value=fake_model),
+                patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
+            ):
+                create_deep_agent(model="samwprov:some-model", subagents=[subagent])
+        finally:
+            _HARNESS_PROFILES.clear()
+            _HARNESS_PROFILES.update(original)
+
+        sub_specs = mock_create.call_args.kwargs["middleware"]
+        # SubAgentMiddleware is in the main stack; the processed subagent specs
+        # are accessible via the subagents kwarg passed to its constructor.
+        sub_mw = next(m for m in sub_specs if isinstance(m, SubAgentMiddleware))
+        researcher_spec = next(s for s in sub_mw._subagents if s.get("name") == "researcher")
+        subagent_stack = researcher_spec["middleware"]
+        summ_entries = [m for m in subagent_stack if isinstance(m, _DeepAgentsSummarizationMiddleware)]
+        assert len(summ_entries) == 1
+        assert summ_entries[0] is custom

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -22,7 +22,7 @@ from deepagents.graph import (
     _REQUIRED_MIDDLEWARE_NAMES,
     BASE_AGENT_PROMPT,
     DeepAgentState,
-    _apply_user_middleware,
+    _apply_custom_middleware,
     create_deep_agent,
     get_default_model,
 )
@@ -2106,7 +2106,7 @@ class TestApplyUserMiddleware:
     def test_matching_name_replaces_at_same_position(self) -> None:
         a, b, c = _named_mw("A"), _named_mw("B"), _named_mw("C")
         replacement = _named_mw("B")
-        result = _apply_user_middleware([a, b, c], [replacement])
+        result = _apply_custom_middleware([a, b, c], [replacement])
         assert result[1] is replacement
         assert result[0] is a
         assert result[2] is c
@@ -2115,19 +2115,19 @@ class TestApplyUserMiddleware:
     def test_non_matching_name_is_appended(self) -> None:
         a, b = _named_mw("A"), _named_mw("B")
         new = _named_mw("Z")
-        result = _apply_user_middleware([a, b], [new])
+        result = _apply_custom_middleware([a, b], [new])
         assert result[-1] is new
         assert len(result) == 3
 
     def test_empty_user_list_returns_base_unchanged(self) -> None:
         a, b = _named_mw("A"), _named_mw("B")
-        result = _apply_user_middleware([a, b], [])
+        result = _apply_custom_middleware([a, b], [])
         assert result == [a, b]
 
     def test_multiple_replacements_in_one_call(self) -> None:
         a, b, c = _named_mw("A"), _named_mw("B"), _named_mw("C")
         r_a, r_c = _named_mw("A"), _named_mw("C")
-        result = _apply_user_middleware([a, b, c], [r_a, r_c])
+        result = _apply_custom_middleware([a, b, c], [r_a, r_c])
         assert result[0] is r_a
         assert result[1] is b
         assert result[2] is r_c
@@ -2136,17 +2136,38 @@ class TestApplyUserMiddleware:
     def test_non_matching_appended_in_original_order(self) -> None:
         base = _named_mw("Base")
         x, y = _named_mw("X"), _named_mw("Y")
-        result = _apply_user_middleware([base], [x, y])
+        result = _apply_custom_middleware([base], [x, y])
         assert result[1] is x
         assert result[2] is y
 
     def test_mix_of_replacements_and_new_entries(self) -> None:
         a, b = _named_mw("A"), _named_mw("B")
         r_a, new = _named_mw("A"), _named_mw("New")
-        result = _apply_user_middleware([a, b], [r_a, new])
+        result = _apply_custom_middleware([a, b], [r_a, new])
         assert result[0] is r_a
         assert result[1] is b
         assert result[2] is new
+
+    def test_excluded_slot_inserted_at_original_position(self) -> None:
+        """Excluded-slot replacement is inserted at its original position, not appended."""
+        a, b, c = _named_mw("A"), _named_mw("B"), _named_mw("C")
+        original = {m.name: i for i, m in enumerate([a, b, c])}
+        filtered = [a, c]  # b was excluded
+        r_b = _named_mw("B")
+        result = _apply_custom_middleware(filtered, [r_b], original)
+        assert len(result) == 3
+        assert result[0] is a
+        assert result[1] is r_b
+        assert result[2] is c
+
+    def test_multiple_excluded_slots_preserve_relative_order(self) -> None:
+        """Multiple excluded-slot insertions are placed in their original relative order."""
+        a, b, c, d = _named_mw("A"), _named_mw("B"), _named_mw("C"), _named_mw("D")
+        original = {m.name: i for i, m in enumerate([a, b, c, d])}
+        filtered = [a, d]  # b and c were excluded
+        r_b, r_c = _named_mw("B"), _named_mw("C")
+        result = _apply_custom_middleware(filtered, [r_b, r_c], original)
+        assert result == [a, r_b, r_c, d]
 
 
 class TestUserMiddlewareOverride:
@@ -2261,3 +2282,37 @@ class TestUserMiddlewareOverride:
         summ_entries = [m for m in subagent_stack if isinstance(m, _DeepAgentsSummarizationMiddleware)]
         assert len(summ_entries) == 1
         assert summ_entries[0] is custom
+
+    def test_same_name_subclass_with_exclusion_does_not_raise(self) -> None:
+        """Profile-excluded default replaced by same-name subclass does not raise ValueError."""
+
+        class MySummarizationMiddleware(SummarizationMiddleware):
+            @property
+            def name(self) -> str:
+                return "SummarizationMiddleware"
+
+        custom = MySummarizationMiddleware(
+            model=GenericFakeChatModel(messages=iter([])),
+            backend=StateBackend(),
+        )
+        original = dict(_HARNESS_PROFILES)
+        try:
+            register_harness_profile(
+                "excsamwprov",
+                HarnessProfile(excluded_middleware=frozenset({_DeepAgentsSummarizationMiddleware})),
+            )
+            fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="ok")]))
+            fake_agent = MagicMock()
+            fake_agent.with_config.return_value = "compiled-agent"
+            with (
+                patch("deepagents.graph.resolve_model", return_value=fake_model),
+                patch("deepagents.graph.create_agent", return_value=fake_agent) as mock_create,
+            ):
+                # Should not raise ValueError from coverage verification
+                create_deep_agent(model="excsamwprov:some-model", middleware=[custom])
+        finally:
+            _HARNESS_PROFILES.clear()
+            _HARNESS_PROFILES.update(original)
+
+        stack = mock_create.call_args.kwargs["middleware"]
+        assert any(m is custom for m in stack)

--- a/libs/deepagents/tests/unit_tests/test_local_sandbox_operations.py
+++ b/libs/deepagents/tests/unit_tests/test_local_sandbox_operations.py
@@ -281,20 +281,19 @@ class TestLocalSandboxOperations:
         exec_result = sandbox.execute(f"cat {test_path}")
         assert exec_result.output.strip() == content
 
-    def test_write_existing_file_fails(self, sandbox: LocalSubprocessSandbox) -> None:
-        """Test that writing to an existing file returns an error."""
+    def test_write_existing_file_overwrites(self, sandbox: LocalSubprocessSandbox) -> None:
+        """Test that writing to an existing file overwrites it."""
         test_path = "/tmp/test_sandbox_ops/existing.txt"
         # Create file first
         sandbox.write(test_path, "First content")
 
-        # Try to write again
+        # Write again should overwrite
         result = sandbox.write(test_path, "Second content")
 
-        assert result.error is not None
-        assert "already exists" in result.error.lower()
-        # Verify original content unchanged
+        assert result.error is None
+        # Verify new content
         exec_result = sandbox.execute(f"cat {test_path}")
-        assert exec_result.output.strip() == "First content"
+        assert exec_result.output.strip() == "Second content"
 
     def test_write_special_characters(self, sandbox: LocalSubprocessSandbox) -> None:
         """Test writing content with special characters and escape sequences."""

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -122,27 +122,27 @@ class TestFilesystemMiddleware:
         middleware = FilesystemMiddleware()
         assert isinstance(middleware.backend, StateBackend)
         assert middleware._custom_system_prompt is None
-        assert len(middleware.tools) == 8  # All tools including execute and delete_file
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_with_composite_backend(self):
         backend = CompositeBackend(default=StateBackend(), routes={"/memories/": StoreBackend()})
         middleware = FilesystemMiddleware(backend=backend)
         assert isinstance(middleware.backend, CompositeBackend)
         assert middleware._custom_system_prompt is None
-        assert len(middleware.tools) == 8  # All tools including execute and delete_file
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_custom_system_prompt_default(self):
         middleware = FilesystemMiddleware(system_prompt="Custom system prompt")
         assert isinstance(middleware.backend, StateBackend)
         assert middleware._custom_system_prompt == "Custom system prompt"
-        assert len(middleware.tools) == 8  # All tools including execute and delete_file
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_custom_system_prompt_with_composite(self):
         backend = CompositeBackend(default=StateBackend(), routes={"/memories/": StoreBackend()})
         middleware = FilesystemMiddleware(backend=backend, system_prompt="Custom system prompt")
         assert isinstance(middleware.backend, CompositeBackend)
         assert middleware._custom_system_prompt == "Custom system prompt"
-        assert len(middleware.tools) == 8  # All tools including execute and delete_file
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_custom_tool_descriptions_default(self):
         middleware = FilesystemMiddleware(custom_tool_descriptions={"ls": "Custom ls tool description"})
@@ -1507,8 +1507,8 @@ class TestFilesystemMiddleware:
         assert "Error: Execution not available" in result.content
         assert "does not support command execution" in result.content
 
-    def test_delete_file_filtered_when_backend_lacks_delete(self):
-        """delete_file is removed from the request when the backend can't delete.
+    def test_delete_filtered_when_backend_lacks_delete(self):
+        """delete is removed from the request when the backend can't delete.
 
         Mirrors how the execute tool is filtered out when the backend doesn't
         support execution, rather than advertising a tool that fails at call time.
@@ -1523,7 +1523,7 @@ class TestFilesystemMiddleware:
         ls_tool = MagicMock()
         ls_tool.name = "ls"
         delete_tool = MagicMock()
-        delete_tool.name = "delete_file"
+        delete_tool.name = "delete"
         request = MagicMock()
         request.tools = [ls_tool, delete_tool]
         request.override.return_value = request
@@ -1532,17 +1532,17 @@ class TestFilesystemMiddleware:
 
         request.override.assert_called_once()
         filtered_names = {tool.name for tool in request.override.call_args.kwargs["tools"]}
-        assert "delete_file" not in filtered_names
+        assert "delete" not in filtered_names
         assert "ls" in filtered_names
 
-    def test_delete_file_kept_when_backend_supports_delete(self):
-        """delete_file stays in the request when the backend supports deletion."""
+    def test_delete_kept_when_backend_supports_delete(self):
+        """delete stays in the request when the backend supports deletion."""
         middleware = FilesystemMiddleware(backend=StateBackend(), system_prompt="")
 
         ls_tool = MagicMock()
         ls_tool.name = "ls"
         delete_tool = MagicMock()
-        delete_tool.name = "delete_file"
+        delete_tool.name = "delete"
         request = MagicMock()
         request.tools = [ls_tool, delete_tool]
         request.override.return_value = request
@@ -1553,10 +1553,10 @@ class TestFilesystemMiddleware:
         # tool filtering — and with an empty system prompt, no override at all.
         request.override.assert_not_called()
 
-    def test_delete_file_invalid_path_returns_error(self):
-        """The sync delete_file tool rejects a traversal path before deleting."""
+    def test_delete_invalid_path_returns_error(self):
+        """The sync delete tool rejects a traversal path before deleting."""
         middleware = FilesystemMiddleware(backend=StateBackend(), system_prompt="")
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = delete_tool.invoke({"file_path": "../etc/passwd", "runtime": _runtime("d1")})
         assert isinstance(result, ToolMessage)
         assert result.status == "error"

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1508,7 +1508,7 @@ class TestFilesystemMiddleware:
         assert "does not support command execution" in result.content
 
     def test_delete_filtered_when_backend_lacks_delete(self):
-        """delete is removed from the request when the backend can't delete.
+        """Delete is removed from the request when the backend can't delete.
 
         Mirrors how the execute tool is filtered out when the backend doesn't
         support execution, rather than advertising a tool that fails at call time.
@@ -1536,7 +1536,7 @@ class TestFilesystemMiddleware:
         assert "ls" in filtered_names
 
     def test_delete_kept_when_backend_supports_delete(self):
-        """delete stays in the request when the backend supports deletion."""
+        """Delete stays in the request when the backend supports deletion."""
         middleware = FilesystemMiddleware(backend=StateBackend(), system_prompt="")
 
         ls_tool = MagicMock()

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -177,6 +177,13 @@ class TestFilesystemMiddleware:
         result = ls_tool.invoke({"runtime": _runtime(), "path": "/"})
         assert result.content == str(["/test.txt", "/test2.txt"])
 
+    def test_ls_shortterm_no_files(self):
+        backend, _ = _make_backend({})
+        middleware = FilesystemMiddleware(backend=backend)
+        ls_tool = next(tool for tool in middleware.tools if tool.name == "ls")
+        result = ls_tool.invoke({"runtime": _runtime(), "path": "/"})
+        assert result.content == "No files found"
+
     def test_ls_shortterm_with_path(self):
         files = {
             "/test.txt": FileData(
@@ -409,7 +416,7 @@ class TestFilesystemMiddleware:
                 "runtime": _runtime(),
             }
         )
-        assert result.content == str([])
+        assert result.content == "No files found"
 
     def test_glob_timeout_returns_error_message(self):
         backend, _ = _make_backend()

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -122,27 +122,27 @@ class TestFilesystemMiddleware:
         middleware = FilesystemMiddleware()
         assert isinstance(middleware.backend, StateBackend)
         assert middleware._custom_system_prompt is None
-        assert len(middleware.tools) == 8  # All tools including execute and delete_file
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_with_composite_backend(self):
         backend = CompositeBackend(default=StateBackend(), routes={"/memories/": StoreBackend()})
         middleware = FilesystemMiddleware(backend=backend)
         assert isinstance(middleware.backend, CompositeBackend)
         assert middleware._custom_system_prompt is None
-        assert len(middleware.tools) == 8  # All tools including execute and delete_file
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_custom_system_prompt_default(self):
         middleware = FilesystemMiddleware(system_prompt="Custom system prompt")
         assert isinstance(middleware.backend, StateBackend)
         assert middleware._custom_system_prompt == "Custom system prompt"
-        assert len(middleware.tools) == 8  # All tools including execute and delete_file
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_custom_system_prompt_with_composite(self):
         backend = CompositeBackend(default=StateBackend(), routes={"/memories/": StoreBackend()})
         middleware = FilesystemMiddleware(backend=backend, system_prompt="Custom system prompt")
         assert isinstance(middleware.backend, CompositeBackend)
         assert middleware._custom_system_prompt == "Custom system prompt"
-        assert len(middleware.tools) == 8  # All tools including execute and delete_file
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_custom_tool_descriptions_default(self):
         middleware = FilesystemMiddleware(custom_tool_descriptions={"ls": "Custom ls tool description"})
@@ -1507,8 +1507,8 @@ class TestFilesystemMiddleware:
         assert "Error: Execution not available" in result.content
         assert "does not support command execution" in result.content
 
-    def test_delete_file_filtered_when_backend_lacks_delete(self):
-        """delete_file is removed from the request when the backend can't delete.
+    def test_delete_filtered_when_backend_lacks_delete(self):
+        """Delete is removed from the request when the backend can't delete.
 
         Mirrors how the execute tool is filtered out when the backend doesn't
         support execution, rather than advertising a tool that fails at call time.
@@ -1523,7 +1523,7 @@ class TestFilesystemMiddleware:
         ls_tool = MagicMock()
         ls_tool.name = "ls"
         delete_tool = MagicMock()
-        delete_tool.name = "delete_file"
+        delete_tool.name = "delete"
         request = MagicMock()
         request.tools = [ls_tool, delete_tool]
         request.override.return_value = request
@@ -1532,17 +1532,17 @@ class TestFilesystemMiddleware:
 
         request.override.assert_called_once()
         filtered_names = {tool.name for tool in request.override.call_args.kwargs["tools"]}
-        assert "delete_file" not in filtered_names
+        assert "delete" not in filtered_names
         assert "ls" in filtered_names
 
-    def test_delete_file_kept_when_backend_supports_delete(self):
-        """delete_file stays in the request when the backend supports deletion."""
+    def test_delete_kept_when_backend_supports_delete(self):
+        """Delete stays in the request when the backend supports deletion."""
         middleware = FilesystemMiddleware(backend=StateBackend(), system_prompt="")
 
         ls_tool = MagicMock()
         ls_tool.name = "ls"
         delete_tool = MagicMock()
-        delete_tool.name = "delete_file"
+        delete_tool.name = "delete"
         request = MagicMock()
         request.tools = [ls_tool, delete_tool]
         request.override.return_value = request
@@ -1553,10 +1553,10 @@ class TestFilesystemMiddleware:
         # tool filtering — and with an empty system prompt, no override at all.
         request.override.assert_not_called()
 
-    def test_delete_file_invalid_path_returns_error(self):
-        """The sync delete_file tool rejects a traversal path before deleting."""
+    def test_delete_invalid_path_returns_error(self):
+        """The sync delete tool rejects a traversal path before deleting."""
         middleware = FilesystemMiddleware(backend=StateBackend(), system_prompt="")
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = delete_tool.invoke({"file_path": "../etc/passwd", "runtime": _runtime("d1")})
         assert isinstance(result, ToolMessage)
         assert result.status == "error"

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1,6 +1,6 @@
 import mimetypes
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain.agents import create_agent
@@ -19,6 +19,7 @@ from langgraph.types import Command, Overwrite
 import deepagents.middleware.filesystem as filesystem_middleware
 from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
 from deepagents.backends.protocol import (
+    BackendProtocol,
     ExecuteResponse,
     GrepResult,
     ReadResult,
@@ -121,27 +122,27 @@ class TestFilesystemMiddleware:
         middleware = FilesystemMiddleware()
         assert isinstance(middleware.backend, StateBackend)
         assert middleware._custom_system_prompt is None
-        assert len(middleware.tools) == 7  # All tools including execute
+        assert len(middleware.tools) == 8  # All tools including execute and delete_file
 
     def test_init_with_composite_backend(self):
         backend = CompositeBackend(default=StateBackend(), routes={"/memories/": StoreBackend()})
         middleware = FilesystemMiddleware(backend=backend)
         assert isinstance(middleware.backend, CompositeBackend)
         assert middleware._custom_system_prompt is None
-        assert len(middleware.tools) == 7  # All tools including execute
+        assert len(middleware.tools) == 8  # All tools including execute and delete_file
 
     def test_init_custom_system_prompt_default(self):
         middleware = FilesystemMiddleware(system_prompt="Custom system prompt")
         assert isinstance(middleware.backend, StateBackend)
         assert middleware._custom_system_prompt == "Custom system prompt"
-        assert len(middleware.tools) == 7  # All tools including execute
+        assert len(middleware.tools) == 8  # All tools including execute and delete_file
 
     def test_init_custom_system_prompt_with_composite(self):
         backend = CompositeBackend(default=StateBackend(), routes={"/memories/": StoreBackend()})
         middleware = FilesystemMiddleware(backend=backend, system_prompt="Custom system prompt")
         assert isinstance(middleware.backend, CompositeBackend)
         assert middleware._custom_system_prompt == "Custom system prompt"
-        assert len(middleware.tools) == 7  # All tools including execute
+        assert len(middleware.tools) == 8  # All tools including execute and delete_file
 
     def test_init_custom_tool_descriptions_default(self):
         middleware = FilesystemMiddleware(custom_tool_descriptions={"ls": "Custom ls tool description"})
@@ -1505,6 +1506,61 @@ class TestFilesystemMiddleware:
         assert isinstance(result, ToolMessage)
         assert "Error: Execution not available" in result.content
         assert "does not support command execution" in result.content
+
+    def test_delete_file_filtered_when_backend_lacks_delete(self):
+        """delete_file is removed from the request when the backend can't delete.
+
+        Mirrors how the execute tool is filtered out when the backend doesn't
+        support execution, rather than advertising a tool that fails at call time.
+        """
+
+        class _NoDeleteBackend(StateBackend):
+            # Opt out of delete support by inheriting the protocol's default.
+            delete = BackendProtocol.delete
+
+        middleware = FilesystemMiddleware(backend=_NoDeleteBackend(), system_prompt="")
+
+        ls_tool = MagicMock()
+        ls_tool.name = "ls"
+        delete_tool = MagicMock()
+        delete_tool.name = "delete_file"
+        request = MagicMock()
+        request.tools = [ls_tool, delete_tool]
+        request.override.return_value = request
+
+        middleware._filter_unsupported_tools_and_apply_prompt(request)
+
+        request.override.assert_called_once()
+        filtered_names = {tool.name for tool in request.override.call_args.kwargs["tools"]}
+        assert "delete_file" not in filtered_names
+        assert "ls" in filtered_names
+
+    def test_delete_file_kept_when_backend_supports_delete(self):
+        """delete_file stays in the request when the backend supports deletion."""
+        middleware = FilesystemMiddleware(backend=StateBackend(), system_prompt="")
+
+        ls_tool = MagicMock()
+        ls_tool.name = "ls"
+        delete_tool = MagicMock()
+        delete_tool.name = "delete_file"
+        request = MagicMock()
+        request.tools = [ls_tool, delete_tool]
+        request.override.return_value = request
+
+        middleware._filter_unsupported_tools_and_apply_prompt(request)
+
+        # StateBackend supports delete (and no execute tool is present), so no
+        # tool filtering — and with an empty system prompt, no override at all.
+        request.override.assert_not_called()
+
+    def test_delete_file_invalid_path_returns_error(self):
+        """The sync delete_file tool rejects a traversal path before deleting."""
+        middleware = FilesystemMiddleware(backend=StateBackend(), system_prompt="")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        result = delete_tool.invoke({"file_path": "../etc/passwd", "runtime": _runtime("d1")})
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert "traversal" in result.content
 
     def test_execute_tool_output_formatting(self):
         """Test execute tool formats output correctly."""

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -676,7 +676,7 @@ class TestFilesystemMiddlewareAsync:
         )
         assert isinstance(result, ToolMessage)
         assert result.status == "success"
-        assert "Deleted file" in result.content
+        assert "Deleted" in result.content
         assert mem_store.get(("filesystem",), "/test.txt") is None
 
     async def test_adelete_invalid_path(self):

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -10,7 +10,7 @@ from langgraph.store.memory import InMemoryStore
 import deepagents.middleware.filesystem as filesystem_middleware
 from deepagents.backends import StateBackend, StoreBackend
 from deepagents.backends.protocol import ExecuteResponse, GrepResult, SandboxBackendProtocol
-from deepagents.middleware.filesystem import FileData, FilesystemMiddleware, FilesystemState
+from deepagents.middleware.filesystem import FileData, FilesystemMiddleware, FilesystemPermission, FilesystemState
 
 
 def _make_backend(files=None):
@@ -660,6 +660,71 @@ class TestFilesystemMiddlewareAsync:
             }
         )
         assert isinstance(result, ToolMessage)
+        assert mem_store.get(("filesystem",), "/test.txt") is not None
+
+    async def test_adelete_file(self):
+        """Async delete_file removes the file and reports success."""
+        files = {"/test.txt": FileData(content=["bye"], modified_at="2021-01-01", created_at="2021-01-01")}
+        backend, mem_store = _make_backend(files)
+        middleware = FilesystemMiddleware(backend=backend)
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        result = await delete_tool.ainvoke(
+            {
+                "file_path": "/test.txt",
+                "runtime": ToolRuntime(state={}, context=None, tool_call_id="d1", store=None, stream_writer=lambda _: None, config={}),
+            }
+        )
+        assert isinstance(result, ToolMessage)
+        assert result.status == "success"
+        assert "Deleted file" in result.content
+        assert mem_store.get(("filesystem",), "/test.txt") is None
+
+    async def test_adelete_file_invalid_path(self):
+        """Async delete_file rejects a traversal path with an error."""
+        backend, _ = _make_backend()
+        middleware = FilesystemMiddleware(backend=backend)
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        result = await delete_tool.ainvoke(
+            {
+                "file_path": "../etc/passwd",
+                "runtime": ToolRuntime(state={}, context=None, tool_call_id="d2", store=None, stream_writer=lambda _: None, config={}),
+            }
+        )
+        assert result.status == "error"
+        assert "traversal" in result.content
+
+    async def test_adelete_file_missing_returns_error(self):
+        """Async delete_file surfaces the backend's not-found error."""
+        backend, _ = _make_backend()
+        middleware = FilesystemMiddleware(backend=backend)
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        result = await delete_tool.ainvoke(
+            {
+                "file_path": "/ghost.txt",
+                "runtime": ToolRuntime(state={}, context=None, tool_call_id="d3", store=None, stream_writer=lambda _: None, config={}),
+            }
+        )
+        assert result.status == "error"
+        assert "not found" in result.content
+
+    async def test_adelete_file_permission_denied(self):
+        """Async delete_file is blocked by a deny write permission."""
+        files = {"/test.txt": FileData(content=["bye"], modified_at="2021-01-01", created_at="2021-01-01")}
+        backend, mem_store = _make_backend(files)
+        middleware = FilesystemMiddleware(
+            backend=backend,
+            _permissions=[FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")],
+        )
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        result = await delete_tool.ainvoke(
+            {
+                "file_path": "/test.txt",
+                "runtime": ToolRuntime(state={}, context=None, tool_call_id="d5", store=None, stream_writer=lambda _: None, config={}),
+            }
+        )
+        assert result.status == "error"
+        assert "permission denied for write" in result.content
+        # The file is left untouched since deletion was blocked.
         assert mem_store.get(("filesystem",), "/test.txt") is not None
 
     async def test_aexecute_tool_returns_error_when_backend_doesnt_support(self):

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -139,6 +139,13 @@ class TestFilesystemMiddlewareAsync:
         assert "/pokemon/charmander.txt" not in result.content
         assert "/pokemon/water/squirtle.txt" not in result.content
 
+    async def test_als_shortterm_no_files(self):
+        backend, _ = _make_backend({})
+        middleware = FilesystemMiddleware(backend=backend)
+        ls_tool = next(tool for tool in middleware.tools if tool.name == "ls")
+        result = await ls_tool.ainvoke({"runtime": _runtime(), "path": "/"})
+        assert result.content == "No files found"
+
     async def test_aglob_search_shortterm_simple_pattern(self):
         """Test async glob with simple pattern."""
         files = {
@@ -290,7 +297,7 @@ class TestFilesystemMiddlewareAsync:
                 "runtime": _runtime(),
             }
         )
-        assert result.content == str([])
+        assert result.content == "No files found"
 
     async def test_glob_timeout_returns_error_message_async(self):
         backend, _ = _make_backend()

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -662,12 +662,12 @@ class TestFilesystemMiddlewareAsync:
         assert isinstance(result, ToolMessage)
         assert mem_store.get(("filesystem",), "/test.txt") is not None
 
-    async def test_adelete_file(self):
-        """Async delete_file removes the file and reports success."""
+    async def test_adelete(self):
+        """Async delete removes the file and reports success."""
         files = {"/test.txt": FileData(content=["bye"], modified_at="2021-01-01", created_at="2021-01-01")}
         backend, mem_store = _make_backend(files)
         middleware = FilesystemMiddleware(backend=backend)
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = await delete_tool.ainvoke(
             {
                 "file_path": "/test.txt",
@@ -679,11 +679,11 @@ class TestFilesystemMiddlewareAsync:
         assert "Deleted file" in result.content
         assert mem_store.get(("filesystem",), "/test.txt") is None
 
-    async def test_adelete_file_invalid_path(self):
-        """Async delete_file rejects a traversal path with an error."""
+    async def test_adelete_invalid_path(self):
+        """Async delete rejects a traversal path with an error."""
         backend, _ = _make_backend()
         middleware = FilesystemMiddleware(backend=backend)
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = await delete_tool.ainvoke(
             {
                 "file_path": "../etc/passwd",
@@ -693,11 +693,11 @@ class TestFilesystemMiddlewareAsync:
         assert result.status == "error"
         assert "traversal" in result.content
 
-    async def test_adelete_file_missing_returns_error(self):
-        """Async delete_file surfaces the backend's not-found error."""
+    async def test_adelete_missing_returns_error(self):
+        """Async delete surfaces the backend's not-found error."""
         backend, _ = _make_backend()
         middleware = FilesystemMiddleware(backend=backend)
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = await delete_tool.ainvoke(
             {
                 "file_path": "/ghost.txt",
@@ -707,15 +707,15 @@ class TestFilesystemMiddlewareAsync:
         assert result.status == "error"
         assert "not found" in result.content
 
-    async def test_adelete_file_permission_denied(self):
-        """Async delete_file is blocked by a deny write permission."""
+    async def test_adelete_permission_denied(self):
+        """Async delete is blocked by a deny write permission."""
         files = {"/test.txt": FileData(content=["bye"], modified_at="2021-01-01", created_at="2021-01-01")}
         backend, mem_store = _make_backend(files)
         middleware = FilesystemMiddleware(
             backend=backend,
             _permissions=[FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")],
         )
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = await delete_tool.ainvoke(
             {
                 "file_path": "/test.txt",

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -662,12 +662,12 @@ class TestFilesystemMiddlewareAsync:
         assert isinstance(result, ToolMessage)
         assert mem_store.get(("filesystem",), "/test.txt") is not None
 
-    async def test_adelete_file(self):
-        """Async delete_file removes the file and reports success."""
+    async def test_adelete(self):
+        """Async delete removes the file and reports success."""
         files = {"/test.txt": FileData(content=["bye"], modified_at="2021-01-01", created_at="2021-01-01")}
         backend, mem_store = _make_backend(files)
         middleware = FilesystemMiddleware(backend=backend)
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = await delete_tool.ainvoke(
             {
                 "file_path": "/test.txt",
@@ -676,14 +676,14 @@ class TestFilesystemMiddlewareAsync:
         )
         assert isinstance(result, ToolMessage)
         assert result.status == "success"
-        assert "Deleted file" in result.content
+        assert "Deleted" in result.content
         assert mem_store.get(("filesystem",), "/test.txt") is None
 
-    async def test_adelete_file_invalid_path(self):
-        """Async delete_file rejects a traversal path with an error."""
+    async def test_adelete_invalid_path(self):
+        """Async delete rejects a traversal path with an error."""
         backend, _ = _make_backend()
         middleware = FilesystemMiddleware(backend=backend)
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = await delete_tool.ainvoke(
             {
                 "file_path": "../etc/passwd",
@@ -693,11 +693,11 @@ class TestFilesystemMiddlewareAsync:
         assert result.status == "error"
         assert "traversal" in result.content
 
-    async def test_adelete_file_missing_returns_error(self):
-        """Async delete_file surfaces the backend's not-found error."""
+    async def test_adelete_missing_returns_error(self):
+        """Async delete surfaces the backend's not-found error."""
         backend, _ = _make_backend()
         middleware = FilesystemMiddleware(backend=backend)
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = await delete_tool.ainvoke(
             {
                 "file_path": "/ghost.txt",
@@ -707,15 +707,15 @@ class TestFilesystemMiddlewareAsync:
         assert result.status == "error"
         assert "not found" in result.content
 
-    async def test_adelete_file_permission_denied(self):
-        """Async delete_file is blocked by a deny write permission."""
+    async def test_adelete_permission_denied(self):
+        """Async delete is blocked by a deny write permission."""
         files = {"/test.txt": FileData(content=["bye"], modified_at="2021-01-01", created_at="2021-01-01")}
         backend, mem_store = _make_backend(files)
         middleware = FilesystemMiddleware(
             backend=backend,
             _permissions=[FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")],
         )
-        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete_file")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
         result = await delete_tool.ainvoke(
             {
                 "file_path": "/test.txt",

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -9,6 +9,7 @@ from langgraph.store.memory import InMemoryStore
 
 from deepagents.backends import StateBackend, StoreBackend
 from deepagents.backends.composite import CompositeBackend
+from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import EditResult, ExecuteResponse, ReadResult, SandboxBackendProtocol, WriteResult
 from deepagents.backends.utils import _glob_anchor, _paths_overlap
 from deepagents.graph import create_deep_agent
@@ -19,6 +20,7 @@ from deepagents.middleware.filesystem import (
     _all_paths_scoped_to_routes,
     _check_fs_permission,
     _filter_paths_by_permission,
+    _find_delete_deny_patterns,
 )
 from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT
 
@@ -109,6 +111,213 @@ async def _ainvoke_with_permissions(tool, args, rules, tool_call_id="test", back
     if isinstance(result, ToolMessage):
         return result.content
     return str(result)
+
+
+class TestRecursiveDeletePermissions:
+    """All-or-nothing write-permission enforcement for recursive delete.
+
+    A recursive delete is refused if any ``deny`` write rule's pattern overlaps
+    the target subtree, in either direction: a rule scoped inside the target
+    (``/work/secrets/**``) and a rule the target falls under (``/work``) both
+    block it. The check is rule-based (no filesystem enumeration).
+    """
+
+    def _fs_backend(self, tmp_path):
+        # /work/a.txt, /work/logs/run.log, /work/secrets/{key,token}.txt
+        (tmp_path / "work" / "logs").mkdir(parents=True)
+        (tmp_path / "work" / "secrets").mkdir(parents=True)
+        (tmp_path / "work" / "a.txt").write_text("a")
+        (tmp_path / "work" / "logs" / "run.log").write_text("log")
+        (tmp_path / "work" / "secrets" / "key.txt").write_text("k")
+        (tmp_path / "work" / "secrets" / "token.txt").write_text("t")
+        return FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+    def test_recursive_delete_refused_when_descendant_denied(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert "/work/secrets" in result
+        # All-or-nothing: nothing was removed.
+        assert (tmp_path / "work" / "a.txt").exists()
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_recursive_delete_allowed_when_whole_subtree_allowed(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/other/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "Deleted" in result
+        assert not (tmp_path / "work").exists()
+
+    def test_delete_denied_directory_path_itself(self, tmp_path):
+        # A rule on the bare directory path (no /**) still blocks deleting it.
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_delete_refused_when_ancestor_denied(self, tmp_path):
+        # Any overlap denies: a rule on an ancestor of the target also blocks,
+        # since the target subtree falls under it.
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work/logs"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert (tmp_path / "work" / "logs" / "run.log").exists()
+
+    def test_delete_unaffected_sibling_subtree(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets", "/work/secrets/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work/logs"}, rules, backend=backend)
+
+        assert "Deleted" in result
+        assert not (tmp_path / "work" / "logs").exists()
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_delete_reports_multiple_overlapping_patterns(self, tmp_path):
+        # The agent gets context: several overlapping deny patterns are reported.
+        backend = self._fs_backend(tmp_path)
+        rules = [
+            FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny"),
+            FilesystemPermission(operations=["write"], paths=["/work/logs/**"], mode="deny"),
+        ]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "/work/secrets/**" in result
+        assert "/work/logs/**" in result
+        assert (tmp_path / "work" / "a.txt").exists()
+
+    def test_single_file_delete_still_works(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work/a.txt"}, [], backend=backend)
+
+        assert "Deleted" in result
+        assert not (tmp_path / "work" / "a.txt").exists()
+
+    async def test_recursive_delete_refused_async(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = await _ainvoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_delete_registered_as_bulk_interrupt(self):
+        # An interrupt rule on a descendant must fire for a recursive delete,
+        # so delete is registered (bulk scope) in the interrupt builder.
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="interrupt")]
+        out = _build_interrupt_on_from_permissions(rules)
+        assert "delete" in out
+
+
+def _deny(*paths: str) -> FilesystemPermission:
+    return FilesystemPermission(operations=["write"], paths=list(paths), mode="deny")
+
+
+class TestFindDeleteDenyPatterns:
+    """Exhaustive unit tests for the pure `_find_delete_deny_patterns` helper.
+
+    Returns every `deny` write pattern whose glob overlaps the delete subtree
+    (target + descendants). An empty result means the delete is permitted.
+    """
+
+    @pytest.mark.parametrize(
+        ("pattern", "target", "expected"),
+        [
+            # --- no overlap -> permitted (empty result) ----------------------
+            pytest.param("/other/**", "/work", [], id="unrelated-subtree"),
+            pytest.param("/workshop/**", "/work", [], id="sibling-prefix-glob"),
+            pytest.param("/work2", "/work", [], id="sibling-prefix-literal"),
+            pytest.param("/work/secrets", "/work/logs", [], id="sibling-leaf"),
+            # --- overlap in either direction -> blocked ----------------------
+            pytest.param("/work/a.txt", "/work/a.txt", ["/work/a.txt"], id="exact-file"),
+            pytest.param("/work", "/work", ["/work"], id="exact-dir-literal"),
+            pytest.param("/work/secrets/**", "/work", ["/work/secrets/**"], id="descendant-pattern-blocks-ancestor-target"),
+            pytest.param("/work/**", "/work/logs", ["/work/**"], id="ancestor-glob-blocks-descendant-target"),
+            pytest.param("/work", "/work/sub/deep", ["/work"], id="ancestor-literal-blocks-descendant-target"),
+            pytest.param("/work/secrets", "/work", ["/work/secrets"], id="bare-directory-pattern"),
+            # --- wildcard / root anchors -------------------------------------
+            pytest.param("/anything/**", "/", ["/anything/**"], id="root-target-blocked-by-any-rule"),
+            pytest.param("/**/secrets", "/work", ["/**/secrets"], id="leading-wildcard-anchor-is-root"),
+            # --- trailing-slash normalization (both sides) -------------------
+            pytest.param("/work/**", "/work/", ["/work/**"], id="target-trailing-slash"),
+            pytest.param("/work/", "/work/sub", ["/work/"], id="pattern-trailing-slash"),
+            pytest.param("/work/", "/work/", ["/work/"], id="both-trailing-slash"),
+        ],
+    )
+    def test_overlap_geometry(self, pattern: str, target: str, expected: list[str]):
+        assert _find_delete_deny_patterns([_deny(pattern)], target) == expected
+
+    @pytest.mark.parametrize(
+        ("operations", "mode", "expected"),
+        [
+            pytest.param(["write"], "deny", ["/work/**"], id="write-deny-blocks"),
+            pytest.param(["read", "write"], "deny", ["/work/**"], id="readwrite-deny-blocks"),
+            pytest.param(["write"], "allow", [], id="allow-ignored"),
+            pytest.param(["write"], "interrupt", [], id="interrupt-ignored"),
+            pytest.param(["read"], "deny", [], id="read-only-deny-ignored"),
+        ],
+    )
+    def test_mode_and_operation_filtering(self, operations, mode, expected):
+        # Only deny + write rules count; the target always overlaps the pattern.
+        rule = FilesystemPermission(operations=operations, paths=["/work/**"], mode=mode)
+        assert _find_delete_deny_patterns([rule], "/work") == expected
+
+    @pytest.mark.parametrize(
+        ("rule_paths", "target", "expected"),
+        [
+            pytest.param([], "/work", [], id="no-permissions"),
+            pytest.param([["/work/a/**"], ["/work/b/**"]], "/work", ["/work/a/**", "/work/b/**"], id="multiple-rules"),
+            pytest.param(
+                [["/work/a/**", "/work/b/**", "/other/**"]],
+                "/work",
+                ["/work/a/**", "/work/b/**"],
+                id="multiple-paths-one-rule-filters-non-overlapping",
+            ),
+            pytest.param(
+                [[f"/work/d{i}/**"] for i in range(8)],
+                "/work",
+                [f"/work/d{i}/**" for i in range(8)],
+                id="all-overlapping-no-cap",
+            ),
+            pytest.param(
+                [["/work/x/**"], ["/work/x/**", "/work/y/**"]],
+                "/work",
+                ["/work/x/**", "/work/y/**"],
+                id="deduplicated-first-seen-order",
+            ),
+            pytest.param(
+                [["/other/**"], ["/work/x/**"], ["/elsewhere/**"]],
+                "/work",
+                ["/work/x/**"],
+                id="only-overlapping-returned",
+            ),
+        ],
+    )
+    def test_multiple_rule_aggregation(self, rule_paths, target, expected):
+        rules = [_deny(*paths) for paths in rule_paths]
+        assert _find_delete_deny_patterns(rules, target) == expected
 
 
 class TestFilesystemPermission:
@@ -225,7 +434,7 @@ class TestBuildInterruptOnFromPermissions:
         """A write-only interrupt rule registers only the write-op tools."""
         rule = FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="interrupt")
         out = _build_interrupt_on_from_permissions([rule])
-        assert set(out) == {"write_file", "edit_file"}
+        assert set(out) == {"write_file", "edit_file", "delete"}
 
     def test_registers_read_tools_for_read_interrupt(self):
         rule = FilesystemPermission(operations=["read"], paths=["/secrets/**"], mode="interrupt")

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -20,6 +20,7 @@ from deepagents.middleware.filesystem import (
     _all_paths_scoped_to_routes,
     _check_fs_permission,
     _filter_paths_by_permission,
+    _find_delete_deny_patterns,
 )
 from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT
 
@@ -203,15 +204,6 @@ class TestRecursiveDeletePermissions:
         assert "/work/logs/**" in result
         assert (tmp_path / "work" / "a.txt").exists()
 
-    def test_find_delete_deny_patterns_caps_at_five(self, tmp_path):
-        backend = self._fs_backend(tmp_path)
-        middleware = FilesystemMiddleware(
-            backend=backend,
-            _permissions=[FilesystemPermission(operations=["write"], paths=[f"/work/d{i}/**"], mode="deny") for i in range(8)],
-        )
-        # All 8 overlap /work, but at most 5 are collected.
-        assert len(middleware._find_delete_deny_patterns("/work")) == 5
-
     def test_single_file_delete_still_works(self, tmp_path):
         backend = self._fs_backend(tmp_path)
         tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
@@ -237,6 +229,93 @@ class TestRecursiveDeletePermissions:
         rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="interrupt")]
         out = _build_interrupt_on_from_permissions(rules)
         assert "delete" in out
+
+
+class TestFindDeleteDenyPatterns:
+    """Exhaustive unit tests for the pure `_find_delete_deny_patterns` helper.
+
+    Returns the `deny` write patterns whose glob overlaps the delete subtree
+    (target + descendants), capped at `limit`. Empty result == delete permitted.
+    """
+
+    @staticmethod
+    def _deny(*paths: str) -> FilesystemPermission:
+        return FilesystemPermission(operations=["write"], paths=list(paths), mode="deny")
+
+    def test_no_permissions_returns_empty(self):
+        assert _find_delete_deny_patterns([], "/work") == []
+
+    def test_unrelated_rule_returns_empty(self):
+        assert _find_delete_deny_patterns([self._deny("/other/**")], "/work") == []
+
+    def test_sibling_prefix_does_not_match(self):
+        # "/work" must not be blocked by a rule on the sibling "/workshop".
+        assert _find_delete_deny_patterns([self._deny("/workshop/**")], "/work") == []
+
+    def test_exact_path_match(self):
+        assert _find_delete_deny_patterns([self._deny("/work/a.txt")], "/work/a.txt") == ["/work/a.txt"]
+
+    def test_descendant_pattern_blocks_ancestor_target(self):
+        # Deleting /work is blocked by a rule scoped inside it.
+        assert _find_delete_deny_patterns([self._deny("/work/secrets/**")], "/work") == ["/work/secrets/**"]
+
+    def test_ancestor_pattern_blocks_descendant_target(self):
+        # Deleting /work/logs is blocked by a rule the target falls under.
+        assert _find_delete_deny_patterns([self._deny("/work/**")], "/work/logs") == ["/work/**"]
+
+    def test_bare_directory_pattern_blocks(self):
+        assert _find_delete_deny_patterns([self._deny("/work/secrets")], "/work") == ["/work/secrets"]
+
+    def test_root_target_blocked_by_any_rule(self):
+        # "/" overlaps everything, so any deny rule blocks delete("/").
+        assert _find_delete_deny_patterns([self._deny("/anything/**")], "/") == ["/anything/**"]
+
+    def test_leading_wildcard_anchor_overlaps_everything(self):
+        # `_glob_anchor("/**/secrets")` collapses to "/", overlapping any target.
+        assert _find_delete_deny_patterns([self._deny("/**/secrets")], "/work") == ["/**/secrets"]
+
+    def test_allow_rules_ignored(self):
+        rule = FilesystemPermission(operations=["write"], paths=["/work/**"], mode="allow")
+        assert _find_delete_deny_patterns([rule], "/work") == []
+
+    def test_interrupt_rules_ignored(self):
+        rule = FilesystemPermission(operations=["write"], paths=["/work/**"], mode="interrupt")
+        assert _find_delete_deny_patterns([rule], "/work") == []
+
+    def test_read_only_deny_ignored(self):
+        # `delete` maps to `write`; a read-scoped deny must not block it.
+        rule = FilesystemPermission(operations=["read"], paths=["/work/**"], mode="deny")
+        assert _find_delete_deny_patterns([rule], "/work") == []
+
+    def test_mixed_operation_deny_matches(self):
+        rule = FilesystemPermission(operations=["read", "write"], paths=["/work/**"], mode="deny")
+        assert _find_delete_deny_patterns([rule], "/work") == ["/work/**"]
+
+    def test_collects_multiple_overlapping_patterns(self):
+        rules = [self._deny("/work/a/**"), self._deny("/work/b/**")]
+        assert _find_delete_deny_patterns(rules, "/work") == ["/work/a/**", "/work/b/**"]
+
+    def test_multiple_paths_in_one_rule(self):
+        rules = [self._deny("/work/a/**", "/work/b/**", "/other/**")]
+        assert _find_delete_deny_patterns(rules, "/work") == ["/work/a/**", "/work/b/**"]
+
+    def test_returns_all_overlapping_patterns(self):
+        # No cap: every conflicting pattern is surfaced for full agent context.
+        rules = [self._deny(f"/work/d{i}/**") for i in range(8)]
+        assert _find_delete_deny_patterns(rules, "/work") == [f"/work/d{i}/**" for i in range(8)]
+
+    def test_deduplicates_repeated_pattern(self):
+        # The same pattern in two rules is reported once, in first-seen order.
+        rules = [self._deny("/work/x/**"), self._deny("/work/x/**", "/work/y/**")]
+        assert _find_delete_deny_patterns(rules, "/work") == ["/work/x/**", "/work/y/**"]
+
+    def test_only_overlapping_patterns_returned(self):
+        # Non-overlapping rules are skipped entirely.
+        rules = [self._deny("/other/**"), self._deny("/work/x/**"), self._deny("/elsewhere/**")]
+        assert _find_delete_deny_patterns(rules, "/work") == ["/work/x/**"]
+
+    def test_target_trailing_slash_normalized(self):
+        assert _find_delete_deny_patterns([self._deny("/work/**")], "/work/") == ["/work/**"]
 
 
 class TestFilesystemPermission:

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -188,6 +188,30 @@ class TestRecursiveDeletePermissions:
         assert not (tmp_path / "work" / "logs").exists()
         assert (tmp_path / "work" / "secrets" / "key.txt").exists()
 
+    def test_delete_reports_multiple_overlapping_patterns(self, tmp_path):
+        # The agent gets context: several overlapping deny patterns are reported.
+        backend = self._fs_backend(tmp_path)
+        rules = [
+            FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny"),
+            FilesystemPermission(operations=["write"], paths=["/work/logs/**"], mode="deny"),
+        ]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "/work/secrets/**" in result
+        assert "/work/logs/**" in result
+        assert (tmp_path / "work" / "a.txt").exists()
+
+    def test_find_delete_deny_patterns_caps_at_five(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        middleware = FilesystemMiddleware(
+            backend=backend,
+            _permissions=[FilesystemPermission(operations=["write"], paths=[f"/work/d{i}/**"], mode="deny") for i in range(8)],
+        )
+        # All 8 overlap /work, but at most 5 are collected.
+        assert len(middleware._find_delete_deny_patterns("/work")) == 5
+
     def test_single_file_delete_still_works(self, tmp_path):
         backend = self._fs_backend(tmp_path)
         tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -9,6 +9,7 @@ from langgraph.store.memory import InMemoryStore
 
 from deepagents.backends import StateBackend, StoreBackend
 from deepagents.backends.composite import CompositeBackend
+from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import EditResult, ExecuteResponse, ReadResult, SandboxBackendProtocol, WriteResult
 from deepagents.backends.utils import _glob_anchor, _paths_overlap
 from deepagents.graph import create_deep_agent
@@ -119,8 +120,6 @@ class TestRecursiveDeletePermissions:
     """
 
     def _fs_backend(self, tmp_path):
-        from deepagents.backends.filesystem import FilesystemBackend
-
         # /work/a.txt, /work/logs/run.log, /work/secrets/{key,token}.txt
         (tmp_path / "work" / "logs").mkdir(parents=True)
         (tmp_path / "work" / "secrets").mkdir(parents=True)

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -111,6 +111,97 @@ async def _ainvoke_with_permissions(tool, args, rules, tool_call_id="test", back
     return str(result)
 
 
+class TestRecursiveDeletePermissions:
+    """All-or-nothing write-permission enforcement for recursive delete.
+
+    A recursive delete removes the target plus every descendant, so the whole
+    operation is refused if ANY path in the subtree is write-denied.
+    """
+
+    def _fs_backend(self, tmp_path):
+        from deepagents.backends.filesystem import FilesystemBackend
+
+        # /work/a.txt, /work/logs/run.log, /work/secrets/{key,token}.txt
+        (tmp_path / "work" / "logs").mkdir(parents=True)
+        (tmp_path / "work" / "secrets").mkdir(parents=True)
+        (tmp_path / "work" / "a.txt").write_text("a")
+        (tmp_path / "work" / "logs" / "run.log").write_text("log")
+        (tmp_path / "work" / "secrets" / "key.txt").write_text("k")
+        (tmp_path / "work" / "secrets" / "token.txt").write_text("t")
+        return FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+    def test_recursive_delete_refused_when_descendant_denied(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert "/work/secrets" in result
+        # All-or-nothing: nothing was removed.
+        assert (tmp_path / "work" / "a.txt").exists()
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_recursive_delete_allowed_when_whole_subtree_allowed(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/other/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "Deleted" in result
+        assert not (tmp_path / "work").exists()
+
+    def test_delete_denied_directory_path_itself(self, tmp_path):
+        # A rule on the bare directory path (no /**) still blocks deleting it.
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_delete_unaffected_sibling_subtree(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets", "/work/secrets/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work/logs"}, rules, backend=backend)
+
+        assert "Deleted" in result
+        assert not (tmp_path / "work" / "logs").exists()
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_single_file_delete_still_works(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work/a.txt"}, [], backend=backend)
+
+        assert "Deleted" in result
+        assert not (tmp_path / "work" / "a.txt").exists()
+
+    async def test_recursive_delete_refused_async(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+
+        result = await _ainvoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_delete_registered_as_bulk_interrupt(self):
+        # An interrupt rule on a descendant must fire for a recursive delete,
+        # so delete_file is registered (bulk scope) in the interrupt builder.
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="interrupt")]
+        out = _build_interrupt_on_from_permissions(rules)
+        assert "delete_file" in out
+
+
 class TestFilesystemPermission:
     def test_default_effect_is_allow(self):
         rule = FilesystemPermission(operations=["read"], paths=["/workspace/**"])
@@ -225,7 +316,7 @@ class TestBuildInterruptOnFromPermissions:
         """A write-only interrupt rule registers only the write-op tools."""
         rule = FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="interrupt")
         out = _build_interrupt_on_from_permissions([rule])
-        assert set(out) == {"write_file", "edit_file"}
+        assert set(out) == {"write_file", "edit_file", "delete_file"}
 
     def test_registers_read_tools_for_read_interrupt(self):
         rule = FilesystemPermission(operations=["read"], paths=["/secrets/**"], mode="interrupt")

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -115,8 +115,10 @@ async def _ainvoke_with_permissions(tool, args, rules, tool_call_id="test", back
 class TestRecursiveDeletePermissions:
     """All-or-nothing write-permission enforcement for recursive delete.
 
-    A recursive delete removes the target plus every descendant, so the whole
-    operation is refused if ANY path in the subtree is write-denied.
+    A recursive delete is refused if any ``deny`` write rule's pattern overlaps
+    the target subtree, in either direction: a rule scoped inside the target
+    (``/work/secrets/**``) and a rule the target falls under (``/work``) both
+    block it. The check is rule-based (no filesystem enumeration).
     """
 
     def _fs_backend(self, tmp_path):
@@ -162,6 +164,18 @@ class TestRecursiveDeletePermissions:
 
         assert "permission denied for write" in result
         assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_delete_refused_when_ancestor_denied(self, tmp_path):
+        # Any overlap denies: a rule on an ancestor of the target also blocks,
+        # since the target subtree falls under it.
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work/logs"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert (tmp_path / "work" / "logs" / "run.log").exists()
 
     def test_delete_unaffected_sibling_subtree(self, tmp_path):
         backend = self._fs_backend(tmp_path)

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -133,7 +133,7 @@ class TestRecursiveDeletePermissions:
     def test_recursive_delete_refused_when_descendant_denied(self, tmp_path):
         backend = self._fs_backend(tmp_path)
         rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny")]
-        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
 
         result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
 
@@ -146,7 +146,7 @@ class TestRecursiveDeletePermissions:
     def test_recursive_delete_allowed_when_whole_subtree_allowed(self, tmp_path):
         backend = self._fs_backend(tmp_path)
         rules = [FilesystemPermission(operations=["write"], paths=["/other/**"], mode="deny")]
-        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
 
         result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
 
@@ -157,7 +157,7 @@ class TestRecursiveDeletePermissions:
         # A rule on the bare directory path (no /**) still blocks deleting it.
         backend = self._fs_backend(tmp_path)
         rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets"], mode="deny")]
-        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
 
         result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
 
@@ -167,7 +167,7 @@ class TestRecursiveDeletePermissions:
     def test_delete_unaffected_sibling_subtree(self, tmp_path):
         backend = self._fs_backend(tmp_path)
         rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets", "/work/secrets/**"], mode="deny")]
-        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
 
         result = _invoke_with_permissions(tool, {"file_path": "/work/logs"}, rules, backend=backend)
 
@@ -177,7 +177,7 @@ class TestRecursiveDeletePermissions:
 
     def test_single_file_delete_still_works(self, tmp_path):
         backend = self._fs_backend(tmp_path)
-        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
 
         result = _invoke_with_permissions(tool, {"file_path": "/work/a.txt"}, [], backend=backend)
 
@@ -187,7 +187,7 @@ class TestRecursiveDeletePermissions:
     async def test_recursive_delete_refused_async(self, tmp_path):
         backend = self._fs_backend(tmp_path)
         rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny")]
-        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete_file")
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
 
         result = await _ainvoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
 
@@ -196,10 +196,10 @@ class TestRecursiveDeletePermissions:
 
     def test_delete_registered_as_bulk_interrupt(self):
         # An interrupt rule on a descendant must fire for a recursive delete,
-        # so delete_file is registered (bulk scope) in the interrupt builder.
+        # so delete is registered (bulk scope) in the interrupt builder.
         rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="interrupt")]
         out = _build_interrupt_on_from_permissions(rules)
-        assert "delete_file" in out
+        assert "delete" in out
 
 
 class TestFilesystemPermission:
@@ -316,7 +316,7 @@ class TestBuildInterruptOnFromPermissions:
         """A write-only interrupt rule registers only the write-op tools."""
         rule = FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="interrupt")
         out = _build_interrupt_on_from_permissions([rule])
-        assert set(out) == {"write_file", "edit_file", "delete_file"}
+        assert set(out) == {"write_file", "edit_file", "delete"}
 
     def test_registers_read_tools_for_read_interrupt(self):
         rule = FilesystemPermission(operations=["read"], paths=["/secrets/**"], mode="interrupt")

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -231,91 +231,93 @@ class TestRecursiveDeletePermissions:
         assert "delete" in out
 
 
+def _deny(*paths: str) -> FilesystemPermission:
+    return FilesystemPermission(operations=["write"], paths=list(paths), mode="deny")
+
+
 class TestFindDeleteDenyPatterns:
     """Exhaustive unit tests for the pure `_find_delete_deny_patterns` helper.
 
-    Returns the `deny` write patterns whose glob overlaps the delete subtree
-    (target + descendants), capped at `limit`. Empty result == delete permitted.
+    Returns every `deny` write pattern whose glob overlaps the delete subtree
+    (target + descendants). An empty result means the delete is permitted.
     """
 
-    @staticmethod
-    def _deny(*paths: str) -> FilesystemPermission:
-        return FilesystemPermission(operations=["write"], paths=list(paths), mode="deny")
+    @pytest.mark.parametrize(
+        ("pattern", "target", "expected"),
+        [
+            # --- no overlap -> permitted (empty result) ----------------------
+            pytest.param("/other/**", "/work", [], id="unrelated-subtree"),
+            pytest.param("/workshop/**", "/work", [], id="sibling-prefix-glob"),
+            pytest.param("/work2", "/work", [], id="sibling-prefix-literal"),
+            pytest.param("/work/secrets", "/work/logs", [], id="sibling-leaf"),
+            # --- overlap in either direction -> blocked ----------------------
+            pytest.param("/work/a.txt", "/work/a.txt", ["/work/a.txt"], id="exact-file"),
+            pytest.param("/work", "/work", ["/work"], id="exact-dir-literal"),
+            pytest.param("/work/secrets/**", "/work", ["/work/secrets/**"], id="descendant-pattern-blocks-ancestor-target"),
+            pytest.param("/work/**", "/work/logs", ["/work/**"], id="ancestor-glob-blocks-descendant-target"),
+            pytest.param("/work", "/work/sub/deep", ["/work"], id="ancestor-literal-blocks-descendant-target"),
+            pytest.param("/work/secrets", "/work", ["/work/secrets"], id="bare-directory-pattern"),
+            # --- wildcard / root anchors -------------------------------------
+            pytest.param("/anything/**", "/", ["/anything/**"], id="root-target-blocked-by-any-rule"),
+            pytest.param("/**/secrets", "/work", ["/**/secrets"], id="leading-wildcard-anchor-is-root"),
+            # --- trailing-slash normalization (both sides) -------------------
+            pytest.param("/work/**", "/work/", ["/work/**"], id="target-trailing-slash"),
+            pytest.param("/work/", "/work/sub", ["/work/"], id="pattern-trailing-slash"),
+            pytest.param("/work/", "/work/", ["/work/"], id="both-trailing-slash"),
+        ],
+    )
+    def test_overlap_geometry(self, pattern: str, target: str, expected: list[str]):
+        assert _find_delete_deny_patterns([_deny(pattern)], target) == expected
 
-    def test_no_permissions_returns_empty(self):
-        assert _find_delete_deny_patterns([], "/work") == []
+    @pytest.mark.parametrize(
+        ("operations", "mode", "expected"),
+        [
+            pytest.param(["write"], "deny", ["/work/**"], id="write-deny-blocks"),
+            pytest.param(["read", "write"], "deny", ["/work/**"], id="readwrite-deny-blocks"),
+            pytest.param(["write"], "allow", [], id="allow-ignored"),
+            pytest.param(["write"], "interrupt", [], id="interrupt-ignored"),
+            pytest.param(["read"], "deny", [], id="read-only-deny-ignored"),
+        ],
+    )
+    def test_mode_and_operation_filtering(self, operations, mode, expected):
+        # Only deny + write rules count; the target always overlaps the pattern.
+        rule = FilesystemPermission(operations=operations, paths=["/work/**"], mode=mode)
+        assert _find_delete_deny_patterns([rule], "/work") == expected
 
-    def test_unrelated_rule_returns_empty(self):
-        assert _find_delete_deny_patterns([self._deny("/other/**")], "/work") == []
-
-    def test_sibling_prefix_does_not_match(self):
-        # "/work" must not be blocked by a rule on the sibling "/workshop".
-        assert _find_delete_deny_patterns([self._deny("/workshop/**")], "/work") == []
-
-    def test_exact_path_match(self):
-        assert _find_delete_deny_patterns([self._deny("/work/a.txt")], "/work/a.txt") == ["/work/a.txt"]
-
-    def test_descendant_pattern_blocks_ancestor_target(self):
-        # Deleting /work is blocked by a rule scoped inside it.
-        assert _find_delete_deny_patterns([self._deny("/work/secrets/**")], "/work") == ["/work/secrets/**"]
-
-    def test_ancestor_pattern_blocks_descendant_target(self):
-        # Deleting /work/logs is blocked by a rule the target falls under.
-        assert _find_delete_deny_patterns([self._deny("/work/**")], "/work/logs") == ["/work/**"]
-
-    def test_bare_directory_pattern_blocks(self):
-        assert _find_delete_deny_patterns([self._deny("/work/secrets")], "/work") == ["/work/secrets"]
-
-    def test_root_target_blocked_by_any_rule(self):
-        # "/" overlaps everything, so any deny rule blocks delete("/").
-        assert _find_delete_deny_patterns([self._deny("/anything/**")], "/") == ["/anything/**"]
-
-    def test_leading_wildcard_anchor_overlaps_everything(self):
-        # `_glob_anchor("/**/secrets")` collapses to "/", overlapping any target.
-        assert _find_delete_deny_patterns([self._deny("/**/secrets")], "/work") == ["/**/secrets"]
-
-    def test_allow_rules_ignored(self):
-        rule = FilesystemPermission(operations=["write"], paths=["/work/**"], mode="allow")
-        assert _find_delete_deny_patterns([rule], "/work") == []
-
-    def test_interrupt_rules_ignored(self):
-        rule = FilesystemPermission(operations=["write"], paths=["/work/**"], mode="interrupt")
-        assert _find_delete_deny_patterns([rule], "/work") == []
-
-    def test_read_only_deny_ignored(self):
-        # `delete` maps to `write`; a read-scoped deny must not block it.
-        rule = FilesystemPermission(operations=["read"], paths=["/work/**"], mode="deny")
-        assert _find_delete_deny_patterns([rule], "/work") == []
-
-    def test_mixed_operation_deny_matches(self):
-        rule = FilesystemPermission(operations=["read", "write"], paths=["/work/**"], mode="deny")
-        assert _find_delete_deny_patterns([rule], "/work") == ["/work/**"]
-
-    def test_collects_multiple_overlapping_patterns(self):
-        rules = [self._deny("/work/a/**"), self._deny("/work/b/**")]
-        assert _find_delete_deny_patterns(rules, "/work") == ["/work/a/**", "/work/b/**"]
-
-    def test_multiple_paths_in_one_rule(self):
-        rules = [self._deny("/work/a/**", "/work/b/**", "/other/**")]
-        assert _find_delete_deny_patterns(rules, "/work") == ["/work/a/**", "/work/b/**"]
-
-    def test_returns_all_overlapping_patterns(self):
-        # No cap: every conflicting pattern is surfaced for full agent context.
-        rules = [self._deny(f"/work/d{i}/**") for i in range(8)]
-        assert _find_delete_deny_patterns(rules, "/work") == [f"/work/d{i}/**" for i in range(8)]
-
-    def test_deduplicates_repeated_pattern(self):
-        # The same pattern in two rules is reported once, in first-seen order.
-        rules = [self._deny("/work/x/**"), self._deny("/work/x/**", "/work/y/**")]
-        assert _find_delete_deny_patterns(rules, "/work") == ["/work/x/**", "/work/y/**"]
-
-    def test_only_overlapping_patterns_returned(self):
-        # Non-overlapping rules are skipped entirely.
-        rules = [self._deny("/other/**"), self._deny("/work/x/**"), self._deny("/elsewhere/**")]
-        assert _find_delete_deny_patterns(rules, "/work") == ["/work/x/**"]
-
-    def test_target_trailing_slash_normalized(self):
-        assert _find_delete_deny_patterns([self._deny("/work/**")], "/work/") == ["/work/**"]
+    @pytest.mark.parametrize(
+        ("rule_paths", "target", "expected"),
+        [
+            pytest.param([], "/work", [], id="no-permissions"),
+            pytest.param([["/work/a/**"], ["/work/b/**"]], "/work", ["/work/a/**", "/work/b/**"], id="multiple-rules"),
+            pytest.param(
+                [["/work/a/**", "/work/b/**", "/other/**"]],
+                "/work",
+                ["/work/a/**", "/work/b/**"],
+                id="multiple-paths-one-rule-filters-non-overlapping",
+            ),
+            pytest.param(
+                [[f"/work/d{i}/**"] for i in range(8)],
+                "/work",
+                [f"/work/d{i}/**" for i in range(8)],
+                id="all-overlapping-no-cap",
+            ),
+            pytest.param(
+                [["/work/x/**"], ["/work/x/**", "/work/y/**"]],
+                "/work",
+                ["/work/x/**", "/work/y/**"],
+                id="deduplicated-first-seen-order",
+            ),
+            pytest.param(
+                [["/other/**"], ["/work/x/**"], ["/elsewhere/**"]],
+                "/work",
+                ["/work/x/**"],
+                id="only-overlapping-returned",
+            ),
+        ],
+    )
+    def test_multiple_rule_aggregation(self, rule_paths, target, expected):
+        rules = [_deny(*paths) for paths in rule_paths]
+        assert _find_delete_deny_patterns(rules, target) == expected
 
 
 class TestFilesystemPermission:

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -10,32 +10,37 @@ Categories (for `--eval-category` filtering):
 file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,langchain/middleware
 ```
 
-**118 evals** across **8 categories**
+**123 evals** across **8 categories**
 
-## File Ops (`file_operations`) (13 evals)
+## File Ops (`file_operations`) (18 evals)
 
-- [`test_read_file_seeded_state_backend_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L34) — `tests/evals/test_file_operations.py:34`
-- [`test_write_file_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L54) — `tests/evals/test_file_operations.py:54`
-- [`test_write_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L76) — `tests/evals/test_file_operations.py:76`
-- [`test_write_files_in_parallel_confirm_with_verification`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L108) — `tests/evals/test_file_operations.py:108`
-- [`test_write_files_in_parallel_ambiguous_confirmation`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L143) — `tests/evals/test_file_operations.py:143`
-- [`test_ls_directory_contains_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L178) — `tests/evals/test_file_operations.py:178`
-- [`test_ls_directory_missing_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L202) — `tests/evals/test_file_operations.py:202`
-- [`test_edit_file_replace_text`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L225) — `tests/evals/test_file_operations.py:225`
-- [`test_read_then_write_derived_output`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L248) — `tests/evals/test_file_operations.py:248`
-- [`test_avoid_unnecessary_tool_calls`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L273) — `tests/evals/test_file_operations.py:273`
-- [`test_read_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L291) — `tests/evals/test_file_operations.py:291`
-- [`test_read_file_truncation_recovery_with_pagination`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L561) — `tests/evals/test_file_operations.py:561`
-- [`test_read_file_empty_file_reports_empty`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L599) — `tests/evals/test_file_operations.py:599`
+- [`test_read_file_seeded_state_backend_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L35) — `tests/evals/test_file_operations.py:35`
+- [`test_write_file_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L55) — `tests/evals/test_file_operations.py:55`
+- [`test_write_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L77) — `tests/evals/test_file_operations.py:77`
+- [`test_write_files_in_parallel_confirm_with_verification`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L109) — `tests/evals/test_file_operations.py:109`
+- [`test_write_files_in_parallel_ambiguous_confirmation`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L144) — `tests/evals/test_file_operations.py:144`
+- [`test_ls_directory_contains_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L179) — `tests/evals/test_file_operations.py:179`
+- [`test_ls_directory_missing_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L203) — `tests/evals/test_file_operations.py:203`
+- [`test_edit_file_replace_text`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L226) — `tests/evals/test_file_operations.py:226`
+- [`test_read_then_write_derived_output`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L249) — `tests/evals/test_file_operations.py:249`
+- [`test_avoid_unnecessary_tool_calls`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L274) — `tests/evals/test_file_operations.py:274`
+- [`test_read_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L292) — `tests/evals/test_file_operations.py:292`
+- [`test_read_file_truncation_recovery_with_pagination`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L562) — `tests/evals/test_file_operations.py:562`
+- [`test_read_file_empty_file_reports_empty`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L600) — `tests/evals/test_file_operations.py:600`
+- [`test_delete_file_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L617) — `tests/evals/test_file_operations.py:617`
+- [`test_delete_one_of_several_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L646) — `tests/evals/test_file_operations.py:646`
+- [`test_delete_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L681) — `tests/evals/test_file_operations.py:681`
+- [`test_write_then_delete_same_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L714) — `tests/evals/test_file_operations.py:714`
+- [`test_delete_missing_file_reports_absence`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L744) — `tests/evals/test_file_operations.py:744`
 
 ## Retrieval (`retrieval`) (6 evals)
 
 - [`test_frames`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_external_benchmarks.py#L67) — `tests/evals/test_external_benchmarks.py:67`
-- [`test_grep_finds_matching_paths`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L321) — `tests/evals/test_file_operations.py:321`
-- [`test_glob_lists_markdown_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L349) — `tests/evals/test_file_operations.py:349`
-- [`test_find_magic_phrase_deep_nesting`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L377) — `tests/evals/test_file_operations.py:377`
-- [`test_identify_quote_author_from_directory_parallel_reads`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L413) — `tests/evals/test_file_operations.py:413`
-- [`test_identify_quote_author_from_directory_unprompted_efficiency`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L488) — `tests/evals/test_file_operations.py:488`
+- [`test_grep_finds_matching_paths`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L322) — `tests/evals/test_file_operations.py:322`
+- [`test_glob_lists_markdown_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L350) — `tests/evals/test_file_operations.py:350`
+- [`test_find_magic_phrase_deep_nesting`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L378) — `tests/evals/test_file_operations.py:378`
+- [`test_identify_quote_author_from_directory_parallel_reads`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L414) — `tests/evals/test_file_operations.py:414`
+- [`test_identify_quote_author_from_directory_unprompted_efficiency`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L489) — `tests/evals/test_file_operations.py:489`
 
 ## Tool Use (`tool_use`) (53 evals)
 

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -10,37 +10,40 @@ Categories (for `--eval-category` filtering):
 file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,langchain/middleware
 ```
 
-**123 evals** across **8 categories**
+**126 evals** across **8 categories**
 
-## File Ops (`file_operations`) (18 evals)
+## File Ops (`file_operations`) (21 evals)
 
-- [`test_read_file_seeded_state_backend_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L35) — `tests/evals/test_file_operations.py:35`
-- [`test_write_file_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L55) — `tests/evals/test_file_operations.py:55`
-- [`test_write_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L77) — `tests/evals/test_file_operations.py:77`
-- [`test_write_files_in_parallel_confirm_with_verification`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L109) — `tests/evals/test_file_operations.py:109`
-- [`test_write_files_in_parallel_ambiguous_confirmation`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L144) — `tests/evals/test_file_operations.py:144`
-- [`test_ls_directory_contains_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L179) — `tests/evals/test_file_operations.py:179`
-- [`test_ls_directory_missing_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L203) — `tests/evals/test_file_operations.py:203`
-- [`test_edit_file_replace_text`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L226) — `tests/evals/test_file_operations.py:226`
-- [`test_read_then_write_derived_output`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L249) — `tests/evals/test_file_operations.py:249`
-- [`test_avoid_unnecessary_tool_calls`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L274) — `tests/evals/test_file_operations.py:274`
-- [`test_read_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L292) — `tests/evals/test_file_operations.py:292`
-- [`test_read_file_truncation_recovery_with_pagination`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L562) — `tests/evals/test_file_operations.py:562`
-- [`test_read_file_empty_file_reports_empty`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L600) — `tests/evals/test_file_operations.py:600`
-- [`test_delete_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L617) — `tests/evals/test_file_operations.py:617`
-- [`test_delete_one_of_several_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L646) — `tests/evals/test_file_operations.py:646`
-- [`test_deletes_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L681) — `tests/evals/test_file_operations.py:681`
-- [`test_write_then_delete_same_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L714) — `tests/evals/test_file_operations.py:714`
-- [`test_delete_missing_file_reports_absence`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L744) — `tests/evals/test_file_operations.py:744`
+- [`test_read_file_seeded_state_backend_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L36) — `tests/evals/test_file_operations.py:36`
+- [`test_write_file_overwrites_existing`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L56) — `tests/evals/test_file_operations.py:56`
+- [`test_write_file_overwrite_drops_old_content`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L85) — `tests/evals/test_file_operations.py:85`
+- [`test_write_file_prefers_edit_for_targeted_change`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L109) — `tests/evals/test_file_operations.py:109`
+- [`test_write_file_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L139) — `tests/evals/test_file_operations.py:139`
+- [`test_write_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L161) — `tests/evals/test_file_operations.py:161`
+- [`test_write_files_in_parallel_confirm_with_verification`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L193) — `tests/evals/test_file_operations.py:193`
+- [`test_write_files_in_parallel_ambiguous_confirmation`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L228) — `tests/evals/test_file_operations.py:228`
+- [`test_ls_directory_contains_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L263) — `tests/evals/test_file_operations.py:263`
+- [`test_ls_directory_missing_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L287) — `tests/evals/test_file_operations.py:287`
+- [`test_edit_file_replace_text`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L310) — `tests/evals/test_file_operations.py:310`
+- [`test_read_then_write_derived_output`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L333) — `tests/evals/test_file_operations.py:333`
+- [`test_avoid_unnecessary_tool_calls`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L358) — `tests/evals/test_file_operations.py:358`
+- [`test_read_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L376) — `tests/evals/test_file_operations.py:376`
+- [`test_read_file_truncation_recovery_with_pagination`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L646) — `tests/evals/test_file_operations.py:646`
+- [`test_read_file_empty_file_reports_empty`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L684) — `tests/evals/test_file_operations.py:684`
+- [`test_delete_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L701) — `tests/evals/test_file_operations.py:701`
+- [`test_delete_one_of_several_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L730) — `tests/evals/test_file_operations.py:730`
+- [`test_deletes_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L765) — `tests/evals/test_file_operations.py:765`
+- [`test_write_then_delete_same_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L798) — `tests/evals/test_file_operations.py:798`
+- [`test_delete_missing_file_reports_absence`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L828) — `tests/evals/test_file_operations.py:828`
 
 ## Retrieval (`retrieval`) (6 evals)
 
 - [`test_frames`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_external_benchmarks.py#L67) — `tests/evals/test_external_benchmarks.py:67`
-- [`test_grep_finds_matching_paths`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L322) — `tests/evals/test_file_operations.py:322`
-- [`test_glob_lists_markdown_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L350) — `tests/evals/test_file_operations.py:350`
-- [`test_find_magic_phrase_deep_nesting`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L378) — `tests/evals/test_file_operations.py:378`
-- [`test_identify_quote_author_from_directory_parallel_reads`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L414) — `tests/evals/test_file_operations.py:414`
-- [`test_identify_quote_author_from_directory_unprompted_efficiency`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L489) — `tests/evals/test_file_operations.py:489`
+- [`test_grep_finds_matching_paths`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L406) — `tests/evals/test_file_operations.py:406`
+- [`test_glob_lists_markdown_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L434) — `tests/evals/test_file_operations.py:434`
+- [`test_find_magic_phrase_deep_nesting`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L462) — `tests/evals/test_file_operations.py:462`
+- [`test_identify_quote_author_from_directory_parallel_reads`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L498) — `tests/evals/test_file_operations.py:498`
+- [`test_identify_quote_author_from_directory_unprompted_efficiency`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L573) — `tests/evals/test_file_operations.py:573`
 
 ## Tool Use (`tool_use`) (53 evals)
 

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -27,9 +27,9 @@ file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,l
 - [`test_read_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L292) — `tests/evals/test_file_operations.py:292`
 - [`test_read_file_truncation_recovery_with_pagination`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L562) — `tests/evals/test_file_operations.py:562`
 - [`test_read_file_empty_file_reports_empty`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L600) — `tests/evals/test_file_operations.py:600`
-- [`test_delete_file_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L617) — `tests/evals/test_file_operations.py:617`
+- [`test_delete_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L617) — `tests/evals/test_file_operations.py:617`
 - [`test_delete_one_of_several_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L646) — `tests/evals/test_file_operations.py:646`
-- [`test_delete_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L681) — `tests/evals/test_file_operations.py:681`
+- [`test_deletes_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L681) — `tests/evals/test_file_operations.py:681`
 - [`test_write_then_delete_same_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L714) — `tests/evals/test_file_operations.py:714`
 - [`test_delete_missing_file_reports_absence`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L744) — `tests/evals/test_file_operations.py:744`
 

--- a/libs/evals/tests/evals/test_file_operations.py
+++ b/libs/evals/tests/evals/test_file_operations.py
@@ -22,6 +22,7 @@ from tests.evals.utils import (
     file_absent,
     file_contains,
     file_equals,
+    file_excludes,
     final_text_contains,
     final_text_excludes,
     run_agent,
@@ -46,6 +47,90 @@ def test_read_file_seeded_state_backend_file(model: BaseChatModel) -> None:
         scorer=TrajectoryScorer()
         .expect(agent_steps=2, tool_call_requests=1)
         .success(final_text_contains("three", case_insensitive=True)),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_write_file_overwrites_existing(model: BaseChatModel) -> None:
+    """Overwrites an existing file without reading it first."""
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        initial_files={"/note.md": "old content\n"},
+        query='Rewrite /note.md so it contains only "new content". Reply with DONE only.',
+        # 1st step: write_file to /note.md (no read needed).
+        # 2nd step: reply DONE.
+        # 1 tool call request: write_file.
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=2,
+            tool_call_requests=1,
+            tool_calls=[
+                tool_call(name="write_file", step=1, args_contains={"file_path": "/note.md"}),
+            ],
+        )
+        .success(
+            final_text_contains("DONE"),
+            file_equals("/note.md", "new content"),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_write_file_overwrite_drops_old_content(model: BaseChatModel) -> None:
+    """Overwriting a file replaces it entirely, no trace of old content should remain."""
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        initial_files={"/log.txt": "stale line\n"},
+        query='Write "fresh line" to /log.txt. Reply with DONE only.',
+        # 1st step: write_file to /log.txt.
+        # 2nd step: reply DONE.
+        # 1 tool call request: write_file.
+        scorer=TrajectoryScorer()
+        .expect(agent_steps=2, tool_call_requests=1)
+        .success(
+            final_text_contains("DONE"),
+            file_contains("/log.txt", "fresh line"),
+            file_excludes("/log.txt", "stale"),
+        ),
+    )
+
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_write_file_prefers_edit_for_targeted_change(model: BaseChatModel) -> None:
+    """Uses edit_file (not write_file) when only a targeted in-place change is needed."""
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        initial_files={"/note.md": "cat dog bird\n"},
+        query="In /note.md, replace 'cat' with 'lion'. Reply with DONE only.",
+        # 1st step: edit_file on /note.md (targeted change, rest of file preserved).
+        # 2nd step: reply DONE.
+        # 1 tool call request: edit_file.
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=2,
+            tool_call_requests=1,
+            tool_calls=[
+                tool_call(name="edit_file", step=1, args_contains={"file_path": "/note.md"}),
+            ],
+        )
+        .success(
+            final_text_contains("DONE"),
+            file_contains("/note.md", "lion"),
+            file_excludes("/note.md", "cat"),
+        ),
     )
 
 

--- a/libs/evals/tests/evals/test_file_operations.py
+++ b/libs/evals/tests/evals/test_file_operations.py
@@ -103,7 +103,6 @@ def test_write_file_overwrite_drops_old_content(model: BaseChatModel) -> None:
     )
 
 
-
 @pytest.mark.eval_tier("baseline")
 @pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith

--- a/libs/evals/tests/evals/test_file_operations.py
+++ b/libs/evals/tests/evals/test_file_operations.py
@@ -614,7 +614,7 @@ def test_read_file_empty_file_reports_empty(model: BaseChatModel) -> None:
 @pytest.mark.eval_tier("baseline")
 @pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
-def test_delete_file_simple(model: BaseChatModel) -> None:
+def test_delete_simple(model: BaseChatModel) -> None:
     """Deletes a seeded file and confirms it is gone."""
     agent = create_deep_agent(model=model)
     run_agent(
@@ -622,15 +622,15 @@ def test_delete_file_simple(model: BaseChatModel) -> None:
         model=model,
         initial_files={"/foo.md": "delete me\n"},
         query="Delete the file /foo.md, then reply with DONE only.",
-        # 1st step: request a delete_file tool call for /foo.md.
+        # 1st step: request a delete tool call for /foo.md.
         # 2nd step: reply DONE.
-        # 1 tool call request: delete_file.
+        # 1 tool call request: delete.
         scorer=TrajectoryScorer()
         .expect(
             agent_steps=2,
             tool_call_requests=1,
             tool_calls=[
-                tool_call(name="delete_file", step=1, args_contains={"file_path": "/foo.md"}),
+                tool_call(name="delete", step=1, args_contains={"file_path": "/foo.md"}),
             ],
         )
         .success(
@@ -655,15 +655,15 @@ def test_delete_one_of_several_files(model: BaseChatModel) -> None:
             "/c.md": "c",
         },
         query="Delete /b.md only. Leave the other files untouched. Reply with DONE only.",
-        # 1st step: request a delete_file tool call for /b.md.
+        # 1st step: request a delete tool call for /b.md.
         # 2nd step: reply DONE.
-        # 1 tool call request: delete_file.
+        # 1 tool call request: delete.
         scorer=TrajectoryScorer()
         .expect(
             agent_steps=2,
             tool_call_requests=1,
             tool_calls=[
-                tool_call(name="delete_file", step=1, args_contains={"file_path": "/b.md"}),
+                tool_call(name="delete", step=1, args_contains={"file_path": "/b.md"}),
             ],
         )
         .success(
@@ -678,7 +678,7 @@ def test_delete_one_of_several_files(model: BaseChatModel) -> None:
 @pytest.mark.eval_tier("baseline")
 @pytest.mark.eval_category("file_operations")
 @pytest.mark.langsmith
-def test_delete_files_in_parallel(model: BaseChatModel) -> None:
+def test_deletes_in_parallel(model: BaseChatModel) -> None:
     """Deletes two files in parallel without extra tool calls."""
     agent = create_deep_agent(model=model)
     run_agent(
@@ -688,16 +688,16 @@ def test_delete_files_in_parallel(model: BaseChatModel) -> None:
         query=(
             "Delete /a.md and /b.md. Do the deletes in parallel. Do NOT read any files afterward. Reply with DONE only."
         ),
-        # 1st step: request 2 delete_file tool calls in parallel.
+        # 1st step: request 2 delete tool calls in parallel.
         # 2nd step: reply DONE.
-        # 2 tool call requests: delete_file /a.md and delete_file /b.md.
+        # 2 tool call requests: delete /a.md and delete /b.md.
         scorer=TrajectoryScorer()
         .expect(
             agent_steps=2,
             tool_call_requests=2,
             tool_calls=[
-                tool_call(name="delete_file", step=1, args_contains={"file_path": "/a.md"}),
-                tool_call(name="delete_file", step=1, args_contains={"file_path": "/b.md"}),
+                tool_call(name="delete", step=1, args_contains={"file_path": "/a.md"}),
+                tool_call(name="delete", step=1, args_contains={"file_path": "/b.md"}),
             ],
         )
         .success(
@@ -719,16 +719,16 @@ def test_write_then_delete_same_file(model: BaseChatModel) -> None:
         model=model,
         query=('Write "scratch" to /tmp.md, then delete /tmp.md. Reply with DONE only.'),
         # 1st step: request a write_file tool call for /tmp.md.
-        # 2nd step: request a delete_file tool call for /tmp.md.
+        # 2nd step: request a delete tool call for /tmp.md.
         # 3rd step: reply DONE.
-        # 2 tool call requests: write_file then delete_file.
+        # 2 tool call requests: write_file then delete.
         scorer=TrajectoryScorer()
         .expect(
             agent_steps=3,
             tool_call_requests=2,
             tool_calls=[
                 tool_call(name="write_file", step=1, args_contains={"file_path": "/tmp.md"}),
-                tool_call(name="delete_file", step=2, args_contains={"file_path": "/tmp.md"}),
+                tool_call(name="delete", step=2, args_contains={"file_path": "/tmp.md"}),
             ],
         )
         .success(
@@ -744,7 +744,7 @@ def test_write_then_delete_same_file(model: BaseChatModel) -> None:
 def test_delete_missing_file_reports_absence(model: BaseChatModel) -> None:
     """A delete of a nonexistent file is reported, not faked.
 
-    The `delete_file` tool returns a "File ... not found" error for a path
+    The `delete` tool returns a "File ... not found" error for a path
     that does not exist. The agent should surface that the file is missing
     rather than claim a successful deletion, and must leave the real file
     untouched. Tool-call shape is intentionally not enforced: a model may

--- a/libs/evals/tests/evals/test_file_operations.py
+++ b/libs/evals/tests/evals/test_file_operations.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 from tests.evals.utils import (
     TrajectoryScorer,
+    file_absent,
     file_contains,
     file_equals,
     final_text_contains,
@@ -607,4 +608,159 @@ def test_read_file_empty_file_reports_empty(model: BaseChatModel) -> None:
         scorer=TrajectoryScorer()
         .expect(agent_steps=2, tool_call_requests=1)
         .success(final_text_contains("EMPTY")),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_delete_file_simple(model: BaseChatModel) -> None:
+    """Deletes a seeded file and confirms it is gone."""
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        initial_files={"/foo.md": "delete me\n"},
+        query="Delete the file /foo.md, then reply with DONE only.",
+        # 1st step: request a delete_file tool call for /foo.md.
+        # 2nd step: reply DONE.
+        # 1 tool call request: delete_file.
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=2,
+            tool_call_requests=1,
+            tool_calls=[
+                tool_call(name="delete_file", step=1, args_contains={"file_path": "/foo.md"}),
+            ],
+        )
+        .success(
+            final_text_contains("DONE"),
+            file_absent("/foo.md"),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_delete_one_of_several_files(model: BaseChatModel) -> None:
+    """Deletes a single target file, leaving the others untouched."""
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        initial_files={
+            "/a.md": "a",
+            "/b.md": "b",
+            "/c.md": "c",
+        },
+        query="Delete /b.md only. Leave the other files untouched. Reply with DONE only.",
+        # 1st step: request a delete_file tool call for /b.md.
+        # 2nd step: reply DONE.
+        # 1 tool call request: delete_file.
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=2,
+            tool_call_requests=1,
+            tool_calls=[
+                tool_call(name="delete_file", step=1, args_contains={"file_path": "/b.md"}),
+            ],
+        )
+        .success(
+            final_text_contains("DONE"),
+            file_absent("/b.md"),
+            file_equals("/a.md", "a"),
+            file_equals("/c.md", "c"),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_delete_files_in_parallel(model: BaseChatModel) -> None:
+    """Deletes two files in parallel without extra tool calls."""
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        initial_files={"/a.md": "a", "/b.md": "b"},
+        query=(
+            "Delete /a.md and /b.md. Do the deletes in parallel. Do NOT read any files afterward. Reply with DONE only."
+        ),
+        # 1st step: request 2 delete_file tool calls in parallel.
+        # 2nd step: reply DONE.
+        # 2 tool call requests: delete_file /a.md and delete_file /b.md.
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=2,
+            tool_call_requests=2,
+            tool_calls=[
+                tool_call(name="delete_file", step=1, args_contains={"file_path": "/a.md"}),
+                tool_call(name="delete_file", step=1, args_contains={"file_path": "/b.md"}),
+            ],
+        )
+        .success(
+            final_text_contains("DONE"),
+            file_absent("/a.md"),
+            file_absent("/b.md"),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_write_then_delete_same_file(model: BaseChatModel) -> None:
+    """Writes a file and then deletes it, leaving no trace."""
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        query=('Write "scratch" to /tmp.md, then delete /tmp.md. Reply with DONE only.'),
+        # 1st step: request a write_file tool call for /tmp.md.
+        # 2nd step: request a delete_file tool call for /tmp.md.
+        # 3rd step: reply DONE.
+        # 2 tool call requests: write_file then delete_file.
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=3,
+            tool_call_requests=2,
+            tool_calls=[
+                tool_call(name="write_file", step=1, args_contains={"file_path": "/tmp.md"}),
+                tool_call(name="delete_file", step=2, args_contains={"file_path": "/tmp.md"}),
+            ],
+        )
+        .success(
+            final_text_contains("DONE"),
+            file_absent("/tmp.md"),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_delete_missing_file_reports_absence(model: BaseChatModel) -> None:
+    """A delete of a nonexistent file is reported, not faked.
+
+    The `delete_file` tool returns a "File ... not found" error for a path
+    that does not exist. The agent should surface that the file is missing
+    rather than claim a successful deletion, and must leave the real file
+    untouched. Tool-call shape is intentionally not enforced: a model may
+    list/read first, or attempt the delete and recover from the error.
+    """
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        initial_files={"/exists.md": "still here\n"},
+        query=(
+            "Delete the file /missing.md. If it does not exist, reply with exactly: NOT_FOUND. "
+            "Otherwise reply with exactly: DONE."
+        ),
+        scorer=TrajectoryScorer().success(
+            final_text_contains("NOT_FOUND"),
+            file_equals("/exists.md", "still here\n"),
+        ),
     )

--- a/libs/evals/tests/evals/utils.py
+++ b/libs/evals/tests/evals/utils.py
@@ -511,6 +511,49 @@ class FileExcludes(SuccessAssertion):
         return f"File {self.path!r} unexpectedly contains {self.substring!r}.\nActual content:\n{actual!r}"
 
 
+@dataclass(frozen=True)
+class FileAbsent(SuccessAssertion):
+    """Assert that a file path does not exist in the trajectory.
+
+    A successful deletion removes the path from state entirely (the ``files``
+    channel reducer drops keys whose update value is ``None``), so a deleted
+    path should not appear in ``trajectory.files`` at all. This is stricter
+    than ``FileExcludes``, which only checks for an absent substring and
+    therefore passes even when the file is still present.
+
+    Attributes:
+        path: The file path that must not exist.
+    """
+
+    path: str
+
+    def check(self, trajectory: AgentTrajectory) -> bool:
+        """Check that ``self.path`` is absent from the trajectory files.
+
+        Args:
+            trajectory: The agent trajectory to check.
+
+        Returns:
+            Whether the file path is absent.
+        """
+        return self.path not in trajectory.files
+
+    def describe_failure(self, trajectory: AgentTrajectory) -> str:
+        """Describe why the file-absent check failed.
+
+        Args:
+            trajectory: The agent trajectory that failed the check.
+
+        Returns:
+            A human-readable failure description.
+        """
+        actual = trajectory.files.get(self.path)
+        return (
+            f"Expected file {self.path!r} to be absent, but it still exists "
+            f"with content:\n{actual!r}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Concrete efficiency assertions
 # ---------------------------------------------------------------------------
@@ -811,6 +854,18 @@ def file_excludes(path: str, substring: str) -> FileExcludes:
         A ``FileExcludes`` assertion instance.
     """
     return FileExcludes(path=path, substring=substring)
+
+
+def file_absent(path: str) -> FileAbsent:
+    """Create a ``FileAbsent`` success assertion.
+
+    Args:
+        path: The file path that must not exist in the trajectory files.
+
+    Returns:
+        A ``FileAbsent`` assertion instance.
+    """
+    return FileAbsent(path=path)
 
 
 def agent_steps(n: int) -> AgentSteps:


### PR DESCRIPTION
#### Summary

- Adds _apply_user_middleware helper in graph.py that merges user-supplied middleware into the assembled stack by `.name` rather than blindly appending
- When a user-supplied entry's `.name` matches a default (e.g. "`SummarizationMiddleware`"), it replaces the default in-place, preserving stack order
- Entries with no matching default are appended at the end, unchanged (same behavior as before)
- Applied to both the main agent stack and inline subagent stacks

#### Motivation

Previously, passing a custom `SummarizationMiddleware` (e.g. with a different model or summary_prompt) in middleware  would land a duplicate alongside the built-in one, causing `create_agent` to raise `AssertionError: Please remove duplicate middleware instances`. There was no way to override a default without also excluding in `HarnessProfile.excluded_middleware`.

#### Now users can do:

```
custom_summarization = SummarizationMiddleware(
    model="openai:gpt-5.5",
    backend=backend,
    summary_prompt="Your custom summary prompt here.",
)

agent = create_deep_agent(
    model="openai:gpt-5.5",
    middleware=[custom_summarization],  # replaces the default SummarizationMiddleware
)

```
