### PR TITLE
style(code): hide Esc skip-setup hint in onboarding modals

### DIFF
--- a/libs/code/deepagents_code/widgets/launch_init.py
+++ b/libs/code/deepagents_code/widgets/launch_init.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from deepagents_code.extras_info import ExtraDependencyStatus
 
 from deepagents_code import theme
-from deepagents_code.config import get_glyphs, is_ascii_mode
+from deepagents_code.config import is_ascii_mode
 from deepagents_code.extras_info import MODEL_PROVIDER_EXTRAS, SANDBOX_EXTRAS
 
 logger = logging.getLogger(__name__)
@@ -109,7 +109,6 @@ class LaunchNameScreen(ModalScreen[str | None]):
         Yields:
             Widgets for the modal content.
         """
-        glyphs = get_glyphs()
         with Vertical():
             yield Static("Welcome to Deep Agents", classes="launch-init-title")
             yield Static(
@@ -121,7 +120,7 @@ class LaunchNameScreen(ModalScreen[str | None]):
                 id="launch-name-input",
             )
             yield Static(
-                f"Enter to continue {glyphs.bullet} Esc skip setup",
+                "Enter to continue",
                 classes="launch-init-help",
             )
 
@@ -234,7 +233,6 @@ class LaunchDependenciesScreen(ModalScreen[bool | None]):
         Yields:
             Widgets for the modal content.
         """
-        glyphs = get_glyphs()
         with Vertical():
             yield Static("Installed Integrations", classes="launch-init-title")
             yield Static(
@@ -263,7 +261,7 @@ class LaunchDependenciesScreen(ModalScreen[bool | None]):
                     classes="launch-dependencies-section",
                 )
             yield Static(
-                f"Enter to continue {glyphs.bullet} Esc skip setup",
+                "Enter to continue",
                 classes="launch-init-help",
             )
 

--- a/libs/code/deepagents_code/widgets/model_selector.py
+++ b/libs/code/deepagents_code/widgets/model_selector.py
@@ -441,22 +441,21 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
     def _help_text(self) -> str:
         """Build the footer help text.
 
-        Curated/onboarding mode omits the Ctrl+R toggle and uses
-        "Esc skip setup" wording.
+        Curated/onboarding mode omits the Ctrl+R toggle and the Esc hint;
+        Escape stays bound but is not advertised. Standard mode shows
+        "Esc cancel".
 
         Returns:
             The bullet-separated help line.
         """
         glyphs = get_glyphs()
-        esc_label = "Esc skip setup" if self._curated else "Esc cancel"
         parts = [
             f"{glyphs.arrow_up}/{glyphs.arrow_down} navigate",
             "Enter select",
             "Ctrl+S set default",
         ]
         if not self._curated:
-            parts.append("Ctrl+R recommended")
-        parts.append(esc_label)
+            parts.extend(("Ctrl+R recommended", "Esc cancel"))
         sep = f" {glyphs.bullet} "
         return sep.join(parts)
 

--- a/libs/code/tests/unit_tests/test_launch_init.py
+++ b/libs/code/tests/unit_tests/test_launch_init.py
@@ -83,8 +83,8 @@ class TestLaunchNameScreen:
 
         assert name_input.placeholder == "Your name (optional)"
 
-    async def test_copy_prompts_for_name_and_explains_skip(self) -> None:
-        """The name screen should prompt for a name and describe skip semantics."""
+    async def test_copy_prompts_for_name_and_hides_skip_hint(self) -> None:
+        """The name screen prompts for a name without advertising the skip hint."""
         app = LaunchNameTestApp()
         async with app.run_test() as pilot:
             app.show_name_screen()
@@ -94,7 +94,8 @@ class TestLaunchNameScreen:
             help_text = app.screen.query_one(".launch-init-help", Static)
 
         assert "What should Deep Agents call you?" in str(copy.content)
-        assert "Esc skip setup" in str(help_text.content)
+        assert "Enter to continue" in str(help_text.content)
+        assert "Esc skip setup" not in str(help_text.content)
 
     async def test_submit_returns_normalized_name(self) -> None:
         """Submitting a name should dismiss with the trimmed, title-cased value."""
@@ -195,7 +196,8 @@ class TestLaunchDependenciesScreen:
         assert "Available to add" in content
         assert "Model providers: bedrock" in content
         assert "Sandboxes: runloop" in content
-        assert "Esc skip setup" in content
+        assert "Enter to continue" in content
+        assert "Esc skip setup" not in content
 
     async def test_enter_continues(self) -> None:
         """Enter should continue to the next onboarding step."""

--- a/libs/code/tests/unit_tests/test_model_selector.py
+++ b/libs/code/tests/unit_tests/test_model_selector.py
@@ -239,8 +239,8 @@ class TestModelSelectorChrome:
             assert "Choose a Recommended Model" in str(title.content)
             assert "Curated models backed by evals." in str(description.content)
 
-    async def test_curated_selector_help_uses_skip_setup(self) -> None:
-        """Onboarding model selection should label Escape as setup skip."""
+    async def test_curated_selector_help_hides_esc_hint(self) -> None:
+        """Onboarding model selection keeps Escape bound but hides its hint."""
         app = ModelSelectorTestApp()
         async with app.run_test() as pilot:
             screen = ModelSelectorScreen(curated=True)
@@ -249,7 +249,7 @@ class TestModelSelectorChrome:
 
             help_text = screen.query_one(".model-selector-help", Static)
 
-            assert "Esc skip setup" in str(help_text.content)
+            assert "Esc skip setup" not in str(help_text.content)
             assert "Esc cancel" not in str(help_text.content)
 
     async def test_standard_selector_help_uses_cancel(self) -> None:


### PR DESCRIPTION
Keeps Escape bound on the onboarding modals (name, dependency summary, and curated model selection) but stops advertising the `Esc skip setup` hint in their footers. The escape hatch still works for anyone who presses Escape — it's just no longer surfaced as a prompt, per discussion. Standard `/model` keeps its `Esc cancel` label.

The `escape` `Binding`s and the dismiss/skip logic are untouched, so existing `test_escape_skips` coverage continues to assert the binding stays functional.

Made by [Open SWE](https://openswe.vercel.app/agents/68bbbc5d-5b24-1de8-eb78-67627981a639)