### PR TITLE
style(code): sort credentialed providers to top of `/auth` modal

### DIFF
--- a/libs/code/deepagents_code/widgets/auth.py
+++ b/libs/code/deepagents_code/widgets/auth.py
@@ -152,6 +152,25 @@ def _provider_display_name(provider: str, config: ModelConfig | None = None) -> 
     ) or PROVIDER_DISPLAY_NAMES.get(provider, provider.replace("_", " ").title())
 
 
+def _auth_status_for(provider: str) -> ProviderAuthStatus:
+    """Resolve the credential readiness of a provider or non-model service.
+
+    Routes services (e.g. Tavily) and model providers to their respective
+    status helpers. Each call reads the credential file, so callers that need
+    the status more than once should resolve it here a single time and reuse
+    the result.
+
+    Args:
+        provider: Provider or service config key.
+
+    Returns:
+        The auth status used for both ordering and badge rendering.
+    """
+    if is_service(provider):
+        return get_service_auth_status(provider)
+    return get_provider_auth_status(provider)
+
+
 class AuthResult(StrEnum):
     """Outcome of an `AuthPromptScreen` interaction.
 
@@ -486,11 +505,7 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
         # cached instance instead of reloading outside this crash-safety guard.
         try:
             self._config = ModelConfig.load()
-            self._auth_status = (
-                get_service_auth_status(provider)
-                if is_service(provider)
-                else get_provider_auth_status(provider)
-            )
+            self._auth_status = _auth_status_for(provider)
             self._has_existing = auth_store.get_stored_key(provider) is not None
             self._existing_base_url = auth_store.get_stored_base_url(provider) or ""
             self._advanced_visible = bool(self._existing_base_url)
@@ -1294,42 +1309,34 @@ class AuthManagerScreen(ModalScreen[None]):
         # ones already shown above are skipped.
         self._install_extras = self._uninstalled_known_providers(config, shown)
 
+        # Resolve each manageable entry's auth status once and reuse it for
+        # both ordering and badge rendering. `_auth_status_for` reads the
+        # credential file, so resolving it separately in the sort key and in
+        # `_format_label` would read `auth.json` twice per row (and, on a
+        # corrupt store, log the same warning twice). A single pass halves both.
+        services = set(SERVICE_API_KEY_ENV) - shown - set(self._install_extras)
+        status_by_key = {key: _auth_status_for(key) for key in shown | services}
+
         # Float entries that already have a credential configured to the top so
         # the keys a user is actively using are easiest to find; everything else
-        # keeps alphabetical order. Uninstalled install-on-select entries are
-        # listed afterwards (alphabetically) since selecting them installs a
-        # package rather than managing a key.
-        services = set(SERVICE_API_KEY_ENV) - shown - set(self._install_extras)
-        manageable = sorted(shown | services, key=self._configured_sort_key)
+        # keeps alphabetical order (the `key` tiebreaker). Uninstalled
+        # install-on-select entries are listed afterwards (alphabetically) since
+        # selecting them installs a package rather than managing a key.
+        def sort_key(key: str) -> tuple[int, str]:
+            configured = status_by_key[key].state is ProviderAuthState.CONFIGURED
+            return (0 if configured else 1, key)
+
+        manageable = sorted(status_by_key, key=sort_key)
         extra_providers = sorted(self._install_extras)
         options = [
-            Option(self._format_label(provider), id=provider) for provider in manageable
+            Option(self._format_label(key, status=status_by_key[key]), id=key)
+            for key in manageable
         ]
         options.extend(
             Option(self._format_label(provider, installed=False), id=provider)
             for provider in extra_providers
         )
         return options, warning
-
-    @staticmethod
-    def _configured_sort_key(provider: str) -> tuple[int, str]:
-        """Sort key placing providers with a configured credential first.
-
-        Args:
-            provider: Provider or service config key.
-
-        Returns:
-            `(0, provider)` when the credential resolves to `CONFIGURED`,
-                otherwise `(1, provider)`, so configured entries sort ahead of
-                the rest while each group stays alphabetical.
-        """
-        status = (
-            get_service_auth_status(provider)
-            if is_service(provider)
-            else get_provider_auth_status(provider)
-        )
-        configured = status.state is ProviderAuthState.CONFIGURED
-        return (0 if configured else 1, provider)
 
     @staticmethod
     def _uninstalled_known_providers(
@@ -1361,7 +1368,12 @@ class AuthManagerScreen(ModalScreen[None]):
         return uninstalled
 
     @staticmethod
-    def _format_label(provider: str, *, installed: bool = True) -> Content:
+    def _format_label(
+        provider: str,
+        *,
+        installed: bool = True,
+        status: ProviderAuthStatus | None = None,
+    ) -> Content:
         """Build a `Content` label for `provider` showing its credential source.
 
         Args:
@@ -1369,6 +1381,10 @@ class AuthManagerScreen(ModalScreen[None]):
             installed: Whether the provider's integration package is installed.
                 Uninstalled providers render dimmed with a `[not installed]`
                 marker since selecting them prompts an install, not a key.
+            status: Precomputed auth status to render. Pass this when the
+                caller already resolved it to avoid a duplicate credential-file
+                read; resolved on demand when omitted. Ignored for uninstalled
+                providers, which render no badge.
 
         Returns:
             A composed `Content` with the provider label and a status badge.
@@ -1380,11 +1396,8 @@ class AuthManagerScreen(ModalScreen[None]):
                 "  ",
                 Content.styled("[not installed]", "dim"),
             )
-        status = (
-            get_service_auth_status(provider)
-            if is_service(provider)
-            else get_provider_auth_status(provider)
-        )
+        if status is None:
+            status = _auth_status_for(provider)
         badge = format_auth_badge(status)
         return Content.assemble(
             Content.from_markup("$provider", provider=name),

--- a/libs/code/deepagents_code/widgets/auth.py
+++ b/libs/code/deepagents_code/widgets/auth.py
@@ -1294,30 +1294,20 @@ class AuthManagerScreen(ModalScreen[None]):
         # ones already shown above are skipped.
         self._install_extras = self._uninstalled_known_providers(config, shown)
 
-        # Float installed providers that already have a credential configured
-        # to the top so the keys a user is actively using are easiest to find;
-        # everything else keeps alphabetical order. Uninstalled
-        # install-on-select entries are listed afterwards (alphabetically)
-        # since selecting them installs a package rather than managing a key.
-        installed_providers = sorted(shown, key=self._configured_sort_key)
+        # Float entries that already have a credential configured to the top so
+        # the keys a user is actively using are easiest to find; everything else
+        # keeps alphabetical order. Uninstalled install-on-select entries are
+        # listed afterwards (alphabetically) since selecting them installs a
+        # package rather than managing a key.
+        services = set(SERVICE_API_KEY_ENV) - shown - set(self._install_extras)
+        manageable = sorted(shown | services, key=self._configured_sort_key)
         extra_providers = sorted(self._install_extras)
         options = [
-            Option(self._format_label(provider), id=provider)
-            for provider in installed_providers
+            Option(self._format_label(provider), id=provider) for provider in manageable
         ]
         options.extend(
             Option(self._format_label(provider, installed=False), id=provider)
             for provider in extra_providers
-        )
-        # Append non-model services (e.g. Tavily web search) after the model
-        # providers. These are always shown — their key is configurable here
-        # regardless of whether the backing package is installed — so users can
-        # enter it the same way they enter a model-provider key. Configured
-        # services float to the top of their group for the same reason.
-        services = set(SERVICE_API_KEY_ENV) - shown - set(self._install_extras)
-        options.extend(
-            Option(self._format_label(service), id=service)
-            for service in sorted(services, key=self._configured_sort_key)
         )
         return options, warning
 

--- a/libs/code/deepagents_code/widgets/auth.py
+++ b/libs/code/deepagents_code/widgets/auth.py
@@ -1294,25 +1294,52 @@ class AuthManagerScreen(ModalScreen[None]):
         # ones already shown above are skipped.
         self._install_extras = self._uninstalled_known_providers(config, shown)
 
-        providers = sorted(shown | set(self._install_extras))
+        # Float installed providers that already have a credential configured
+        # to the top so the keys a user is actively using are easiest to find;
+        # everything else keeps alphabetical order. Uninstalled
+        # install-on-select entries are listed afterwards (alphabetically)
+        # since selecting them installs a package rather than managing a key.
+        installed_providers = sorted(shown, key=self._configured_sort_key)
+        extra_providers = sorted(self._install_extras)
         options = [
-            Option(
-                self._format_label(
-                    provider, installed=provider not in self._install_extras
-                ),
-                id=provider,
-            )
-            for provider in providers
+            Option(self._format_label(provider), id=provider)
+            for provider in installed_providers
         ]
+        options.extend(
+            Option(self._format_label(provider, installed=False), id=provider)
+            for provider in extra_providers
+        )
         # Append non-model services (e.g. Tavily web search) after the model
         # providers. These are always shown — their key is configurable here
         # regardless of whether the backing package is installed — so users can
-        # enter it the same way they enter a model-provider key.
+        # enter it the same way they enter a model-provider key. Configured
+        # services float to the top of their group for the same reason.
+        services = set(SERVICE_API_KEY_ENV) - shown - set(self._install_extras)
         options.extend(
             Option(self._format_label(service), id=service)
-            for service in sorted(set(SERVICE_API_KEY_ENV) - set(providers))
+            for service in sorted(services, key=self._configured_sort_key)
         )
         return options, warning
+
+    @staticmethod
+    def _configured_sort_key(provider: str) -> tuple[int, str]:
+        """Sort key placing providers with a configured credential first.
+
+        Args:
+            provider: Provider or service config key.
+
+        Returns:
+            `(0, provider)` when the credential resolves to `CONFIGURED`,
+                otherwise `(1, provider)`, so configured entries sort ahead of
+                the rest while each group stays alphabetical.
+        """
+        status = (
+            get_service_auth_status(provider)
+            if is_service(provider)
+            else get_provider_auth_status(provider)
+        )
+        configured = status.state is ProviderAuthState.CONFIGURED
+        return (0 if configured else 1, provider)
 
     @staticmethod
     def _uninstalled_known_providers(

--- a/libs/code/tests/unit_tests/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/test_auth_widgets.py
@@ -912,6 +912,77 @@ api_key_env = "MY_GATEWAY_API_KEY"
         assert label is not None
         assert "stored" in str(label)
 
+    async def test_configured_providers_sort_to_top(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Providers with a credential float above unconfigured ones.
+
+        `openai` sorts after `anthropic` alphabetically, but storing a key for
+        it should lift it to the top of the installed-provider group while the
+        rest stay in alphabetical order.
+        """
+        for var in (
+            "OPENAI_API_KEY",
+            "DEEPAGENTS_CODE_OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "DEEPAGENTS_CODE_ANTHROPIC_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(
+            "deepagents_code.widgets.auth.get_available_models",
+            lambda: {"openai": ["gpt-5.4"], "anthropic": ["claude-opus-4-7"]},
+        )
+        monkeypatch.setattr(
+            "deepagents_code.config_manifest.is_provider_package_installed",
+            lambda _provider: True,
+        )
+        auth_store.set_stored_key("openai", "k")
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_manager()
+            await pilot.pause()
+            options = app.screen.query_one("#auth-manager-options", OptionList)
+            ids = [
+                options.get_option_at_index(i).id for i in range(options.option_count)
+            ]
+        assert ids.index("openai") < ids.index("anthropic")
+
+    async def test_uninstalled_providers_stay_below_configured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Greyed-out install-on-select entries sort after configured rows.
+
+        An uninstalled provider routes to an install prompt rather than a key
+        entry, so it must stay at the bottom even if a credential float would
+        otherwise reorder the list.
+        """
+        for var in (
+            "OPENAI_API_KEY",
+            "DEEPAGENTS_CODE_OPENAI_API_KEY",
+            "GROQ_API_KEY",
+            "DEEPAGENTS_CODE_GROQ_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(
+            "deepagents_code.widgets.auth.get_available_models",
+            lambda: {"openai": ["gpt-5.4"]},
+        )
+        monkeypatch.setattr(
+            "deepagents_code.config_manifest.is_provider_package_installed",
+            lambda provider: provider != "groq",
+        )
+        auth_store.set_stored_key("openai", "k")
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_manager()
+            await pilot.pause()
+            options = app.screen.query_one("#auth-manager-options", OptionList)
+            ids = [
+                options.get_option_at_index(i).id for i in range(options.option_count)
+            ]
+        assert "groq" in ids
+        assert ids.index("openai") < ids.index("groq")
+
     async def test_stored_service_is_not_duplicated(self) -> None:
         """Stored non-model services appear once in the manager list."""
         auth_store.set_stored_key("tavily", "k")

--- a/libs/code/tests/unit_tests/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/test_auth_widgets.py
@@ -980,22 +980,28 @@ api_key_env = "MY_GATEWAY_API_KEY"
     async def test_uninstalled_providers_stay_below_configured(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Greyed-out install-on-select entries sort after configured rows.
+        """Greyed-out install-on-select entries sort after every installed row.
 
         An uninstalled provider routes to an install prompt rather than a key
-        entry, so it must stay at the bottom even if a credential float would
-        otherwise reorder the list.
+        entry, so it stays at the bottom even when an installed-but-unconfigured
+        provider (`anthropic`) sorts below a configured one (`openai`). The
+        unconfigured installed row makes the float load-bearing: a list that
+        ignored the credential float would order `anthropic` before `openai`.
+        `groq` stays last because uninstalled extras are appended after the
+        whole manageable block, regardless of the float.
         """
         for var in (
             "OPENAI_API_KEY",
             "DEEPAGENTS_CODE_OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "DEEPAGENTS_CODE_ANTHROPIC_API_KEY",
             "GROQ_API_KEY",
             "DEEPAGENTS_CODE_GROQ_API_KEY",
         ):
             monkeypatch.delenv(var, raising=False)
         monkeypatch.setattr(
             "deepagents_code.widgets.auth.get_available_models",
-            lambda: {"openai": ["gpt-5.4"]},
+            lambda: {"openai": ["gpt-5.4"], "anthropic": ["claude-opus-4-7"]},
         )
         monkeypatch.setattr(
             "deepagents_code.config_manifest.is_provider_package_installed",
@@ -1011,7 +1017,149 @@ api_key_env = "MY_GATEWAY_API_KEY"
                 options.get_option_at_index(i).id for i in range(options.option_count)
             ]
         assert "groq" in ids
-        assert ids.index("openai") < ids.index("groq")
+        # Configured openai floats above unconfigured anthropic, and the
+        # uninstalled groq extra stays below both.
+        assert ids.index("openai") < ids.index("anthropic") < ids.index("groq")
+
+    async def test_refresh_options_resorts_after_saving_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Saving a key re-floats its provider on the next options refresh.
+
+        The float is only useful if the live save/clear path re-sorts; this
+        exercises `_refresh_options` rather than the initial render. `openai`
+        starts below `anthropic` alphabetically and must overtake it once a key
+        is stored.
+        """
+        for var in (
+            "OPENAI_API_KEY",
+            "DEEPAGENTS_CODE_OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "DEEPAGENTS_CODE_ANTHROPIC_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(
+            "deepagents_code.widgets.auth.get_available_models",
+            lambda: {"openai": ["gpt-5.4"], "anthropic": ["claude-opus-4-7"]},
+        )
+        monkeypatch.setattr(
+            "deepagents_code.config_manifest.is_provider_package_installed",
+            lambda _provider: True,
+        )
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_manager()
+            await pilot.pause()
+            options = app.screen.query_one("#auth-manager-options", OptionList)
+
+            def current_ids() -> list[str | None]:
+                return [
+                    options.get_option_at_index(i).id
+                    for i in range(options.option_count)
+                ]
+
+            before = current_ids()
+            assert before.index("anthropic") < before.index("openai")
+
+            auth_store.set_stored_key("openai", "k")
+            screen = cast("AuthManagerScreen", app.screen)
+            screen._refresh_options()  # exercise the live re-sort path
+            await pilot.pause()
+            after = current_ids()
+        assert after.index("openai") < after.index("anthropic")
+
+    async def test_configured_group_preserves_alphabetical_order(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Within each group, entries keep alphabetical order.
+
+        The sort key is `(0|1, name)`, so the name tiebreaker must keep both the
+        configured block and the unconfigured block alphabetical. A regression
+        that dropped the name element (e.g. returned a bare flag) would scramble
+        order within a group while still floating configured entries.
+        """
+        for var in (
+            "ANTHROPIC_API_KEY",
+            "DEEPAGENTS_CODE_ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "DEEPAGENTS_CODE_OPENAI_API_KEY",
+            "COHERE_API_KEY",
+            "DEEPAGENTS_CODE_COHERE_API_KEY",
+            "MISTRAL_API_KEY",
+            "DEEPAGENTS_CODE_MISTRAL_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(
+            "deepagents_code.widgets.auth.get_available_models",
+            lambda: {
+                "openai": ["gpt-5.4"],
+                "anthropic": ["claude-opus-4-7"],
+                "cohere": ["command"],
+                "mistralai": ["mistral-large"],
+            },
+        )
+        monkeypatch.setattr(
+            "deepagents_code.config_manifest.is_provider_package_installed",
+            lambda _provider: True,
+        )
+        auth_store.set_stored_key("anthropic", "k")
+        auth_store.set_stored_key("openai", "k")
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_manager()
+            await pilot.pause()
+            options = app.screen.query_one("#auth-manager-options", OptionList)
+            ids = [
+                options.get_option_at_index(i).id for i in range(options.option_count)
+            ]
+        # Configured group stays alphabetical, unconfigured group stays
+        # alphabetical, and the whole configured block sits above the rest.
+        assert ids.index("anthropic") < ids.index("openai")
+        assert ids.index("openai") < ids.index("cohere")
+        assert ids.index("cohere") < ids.index("mistralai")
+
+    async def test_env_configured_provider_floats(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A provider configured only via an env var floats like a stored key.
+
+        The sort keys off resolved auth status, not the stored-key set, so an
+        env-only credential must float too. `openai` is configured via
+        `OPENAI_API_KEY` alone and overtakes unconfigured `anthropic`.
+        """
+        for var in (
+            "OPENAI_API_KEY",
+            "DEEPAGENTS_CODE_OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "DEEPAGENTS_CODE_ANTHROPIC_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(
+            "deepagents_code.widgets.auth.get_available_models",
+            lambda: {"openai": ["gpt-5.4"], "anthropic": ["claude-opus-4-7"]},
+        )
+        monkeypatch.setattr(
+            "deepagents_code.config_manifest.is_provider_package_installed",
+            lambda _provider: True,
+        )
+        monkeypatch.setenv("OPENAI_API_KEY", "from-env")
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_manager()
+            await pilot.pause()
+            options = app.screen.query_one("#auth-manager-options", OptionList)
+            ids = [
+                options.get_option_at_index(i).id for i in range(options.option_count)
+            ]
+            openai_label = next(
+                str(options.get_option_at_index(i).prompt)
+                for i in range(options.option_count)
+                if options.get_option_at_index(i).id == "openai"
+            )
+        assert ids.index("openai") < ids.index("anthropic")
+        # The env-resolved status object must be threaded through to the badge,
+        # not just the sort key: an env-only credential renders `[env set: …]`.
+        assert "env set" in openai_label
 
     async def test_stored_service_is_not_duplicated(self) -> None:
         """Stored non-model services appear once in the manager list."""

--- a/libs/code/tests/unit_tests/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/test_auth_widgets.py
@@ -947,6 +947,36 @@ api_key_env = "MY_GATEWAY_API_KEY"
             ]
         assert ids.index("openai") < ids.index("anthropic")
 
+    async def test_configured_services_sort_with_configured_providers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Configured services float above missing provider rows."""
+        for var in (
+            "ANTHROPIC_API_KEY",
+            "DEEPAGENTS_CODE_ANTHROPIC_API_KEY",
+            "TAVILY_API_KEY",
+            "DEEPAGENTS_CODE_TAVILY_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(
+            "deepagents_code.widgets.auth.get_available_models",
+            lambda: {"anthropic": ["claude-opus-4-7"]},
+        )
+        monkeypatch.setattr(
+            "deepagents_code.config_manifest.is_provider_package_installed",
+            lambda _provider: True,
+        )
+        monkeypatch.setenv("TAVILY_API_KEY", "from-env")
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_manager()
+            await pilot.pause()
+            options = app.screen.query_one("#auth-manager-options", OptionList)
+            ids = [
+                options.get_option_at_index(i).id for i in range(options.option_count)
+            ]
+        assert ids.index("tavily") < ids.index("anthropic")
+
     async def test_uninstalled_providers_stay_below_configured(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
The `/auth` modal now floats providers and services that already have credentials configured to the top of the list.

---

The `/auth` manager listed every entry strictly alphabetically, which buried the credentials a user is actively using beneath providers they've never configured. This sorts entries whose credential resolves to `CONFIGURED` (a stored key or a resolvable env var) ahead of the rest, so the keys in active use are easiest to find.

Model providers and non-model services (e.g. Tavily web search) are ordered together in a single pass rather than as separate blocks, so a configured service can float above an unconfigured model provider. Alphabetical order is preserved within the configured block and within the unconfigured block.

Uninstalled install-on-select rows intentionally stay at the bottom, since selecting one installs a package rather than managing a key.

Made by [Open SWE](https://openswe.vercel.app/agents/50a27fa0-1aa1-208a-647b-aa9003321d93)
