### PR TITLE
fix(code): hide "Recent" section during onboarding model selection

### DIFF
--- a/libs/code/deepagents_code/widgets/model_selector.py
+++ b/libs/code/deepagents_code/widgets/model_selector.py
@@ -526,6 +526,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         cli_override: dict[str, Any] | None,
         *,
         include_uninstalled: bool = True,
+        include_recent: bool = True,
     ) -> _ModelData:
         """Gather model discovery data synchronously.
 
@@ -541,6 +542,12 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 upstream profiles omit the model, added as normal selectable
                 rows. Onboarding sets this `False` because it has a dedicated
                 dependency-install step.
+            include_recent: When `True`, load the recent-models MRU so the
+                pinned "Recent" section can render. Onboarding sets this
+                `False`: first-run users have never picked a model, and the
+                startup default-fallback resolution writes its auto-detected
+                pick into the MRU, which would otherwise surface as a bogus
+                "Recent" entry the user never chose.
 
         Returns:
             A `_ModelData` bundle of the discovered models, default spec,
@@ -602,7 +609,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 all_models.append((spec, provider))
 
         profiles = get_model_profiles(cli_override=cli_override)
-        recent_specs = load_recent_models()
+        recent_specs = load_recent_models() if include_recent else []
         return _ModelData(
             all_models,
             config.default_model,
@@ -690,6 +697,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 self._load_model_data,
                 self._cli_profile_override,
                 include_uninstalled=not self._curated,
+                include_recent=not self._curated,
             )
         except Exception:
             logger.exception("Failed to load model data for /model selector")

--- a/libs/code/deepagents_code/widgets/model_selector.py
+++ b/libs/code/deepagents_code/widgets/model_selector.py
@@ -481,6 +481,12 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 return i
         return 0
 
+    def _initial_selected_index(self) -> int:
+        """Return the default highlighted row for the current selector mode."""
+        if self._curated:
+            return 0
+        return self._find_current_model_index()
+
     def compose(self) -> ComposeResult:
         """Compose the screen layout.
 
@@ -736,7 +742,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         self._install_extras = data.install_extras
         self._all_models = self._apply_subset(self._unfiltered_models)
         self._filtered_models = list(self._all_models)
-        self._selected_index = self._find_current_model_index()
+        self._selected_index = self._initial_selected_index()
         self._loaded = True
 
         # Re-apply any filter text the user typed while data was loading
@@ -824,7 +830,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         query = self._filter_text.strip()
         if not query:
             self._filtered_models = list(self._all_models)
-            self._selected_index = self._find_current_model_index()
+            self._selected_index = self._initial_selected_index()
             return
 
         tokens = query.split()
@@ -845,7 +851,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
                 exc_info=True,
             )
             self._filtered_models = list(search_models)
-            self._selected_index = self._find_current_model_index()
+            self._selected_index = self._initial_selected_index()
             return
 
         self._filtered_models = [

--- a/libs/code/tests/unit_tests/test_model_selector.py
+++ b/libs/code/tests/unit_tests/test_model_selector.py
@@ -585,6 +585,44 @@ class TestRecentModelsSection:
             specs = [spec for spec, _ in screen._filtered_models]
             assert "anthropic:claude-sonnet-4-5" in specs
 
+    async def test_recent_section_hidden_during_onboarding(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Curated onboarding never shows Recent, even if the MRU is populated.
+
+        On a fresh install the startup default-fallback resolution writes its
+        auto-detected pick into the recent-models MRU. Onboarding must not
+        surface that as a "Recent" entry the user never chose.
+        """
+        from deepagents_code.widgets import model_selector
+
+        recent_called = False
+
+        def _tracked_load_recent_models() -> list[str]:
+            nonlocal recent_called
+            recent_called = True
+            return ["anthropic:claude-opus-4-7"]
+
+        monkeypatch.setattr(
+            model_selector,
+            "load_recent_models",
+            _tracked_load_recent_models,
+        )
+
+        app = ModelSelectorTestApp()
+        async with app.run_test() as pilot:
+            screen = ModelSelectorScreen(curated=True)
+            app.push_screen(screen)
+            await pilot.pause()
+
+            assert recent_called is False
+            assert screen._recent_specs == []
+            headers = [
+                str(h.content)
+                for h in screen.query(".model-provider-header").results(Static)
+            ]
+            assert not any("Recent" in h for h in headers)
+
     async def test_recent_section_hidden_during_filter(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/test_model_selector.py
+++ b/libs/code/tests/unit_tests/test_model_selector.py
@@ -631,9 +631,9 @@ class TestRecentModelsSection:
     ) -> None:
         """Curated onboarding never shows Recent, even if the MRU is populated.
 
-        On a fresh install the startup default-fallback resolution writes its
-        auto-detected pick into the recent-models MRU. Onboarding must not
-        surface that as a "Recent" entry the user never chose.
+        Guards the `include_recent` gating in `_load_model_data` (see its
+        docstring for why the startup auto-detected fallback must not surface
+        as a "Recent" entry the user never chose).
         """
         from deepagents_code.widgets import model_selector
 
@@ -642,6 +642,9 @@ class TestRecentModelsSection:
         def _tracked_load_recent_models() -> list[str]:
             nonlocal recent_called
             recent_called = True
+            # Deliberately a recommended model so it survives curated filtering:
+            # on a revert it would reach the rendered "Recent" header, keeping
+            # the header assertion below an effective regression guard.
             return ["anthropic:claude-opus-4-7"]
 
         monkeypatch.setattr(
@@ -1943,6 +1946,10 @@ class TestModelSelectorInstallRouting:
             await pilot.pause()
 
         assert captured["include_uninstalled"] is True
+        # Curated onboarding must skip the recent-models MRU at the call site,
+        # independent of the rendering-level guard in
+        # test_recent_section_hidden_during_onboarding.
+        assert captured["include_recent"] is False
 
     async def test_load_model_data_surfaces_uninstalled_recommended(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_model_selector.py
+++ b/libs/code/tests/unit_tests/test_model_selector.py
@@ -1383,6 +1383,21 @@ class TestCuratedModelSelection:
             ("openai:gpt-5.3-codex", "openai"),
         ]
 
+    def test_curated_initial_selection_starts_at_top(self) -> None:
+        """Onboarding should highlight the first model, not the current one."""
+        screen = ModelSelectorScreen(
+            current_model="claude-opus-4-7",
+            current_provider="anthropic",
+            curated=True,
+        )
+        screen._filtered_models = [
+            ("openai:gpt-5.5", "openai"),
+            ("anthropic:claude-opus-4-7", "anthropic"),
+        ]
+
+        assert screen._find_current_model_index() == 1
+        assert screen._initial_selected_index() == 0
+
 
 class TestFormatOptionLabel:
     """Tests for _format_option_label."""


### PR DESCRIPTION
Onboarding model selection no longer shows a spurious "Recent" model on a fresh install.

---

On a fresh install, the onboarding "Choose a Recommended Model" screen showed a "Recent" entry for a model the user never picked. The startup default-fallback resolution auto-detects a provider and persists it to the recent-models MRU (`save_recent_model` / `touch_recent_model`), which the curated onboarding picker then surfaced as "Recent". The fix skips loading recents in curated (onboarding) mode, so the section only appears once a user has genuinely switched models.

Made by [Open SWE](https://openswe.vercel.app/agents/1188b11f-a113-c648-0ba7-b0a91b2f5c0c)