### PR TITLE
feat(code): surface `/auth` in `/trace not-configured` hint

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6956,7 +6956,8 @@ class DeepAgentsApp(App):
             await self._mount_message(
                 AppMessage(
                     "LangSmith tracing is not configured. "
-                    "Set LANGSMITH_API_KEY and LANGSMITH_TRACING=true to enable.",
+                    "Run `/auth` and select LangSmith to enable tracing, or set "
+                    "LANGSMITH_API_KEY and LANGSMITH_TRACING=true.",
                 ),
             )
             return

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -3622,7 +3622,9 @@ class TestTraceCommand:
                 await pilot.pause()
 
             app_msgs = app.query(AppMessage)
-            assert any("LANGSMITH_API_KEY" in str(w._content) for w in app_msgs)
+            rendered = "\n".join(str(w._content) for w in app_msgs)
+            assert "LANGSMITH_API_KEY" in rendered
+            assert "/auth" in rendered
 
     async def test_trace_shows_network_error_when_url_fetch_times_out(self) -> None:
         """Should distinguish a network/timeout failure from a config gap.


### PR DESCRIPTION
`/trace` now points to `/auth` when LangSmith tracing is not yet configured.

---

Following #4193, LangSmith tracing can be configured directly from `/auth`. The `/trace` command's "not configured" helper text still only mentioned the `LANGSMITH_API_KEY` / `LANGSMITH_TRACING` env vars, so it now points users to `/auth` first while keeping the env-var fallback.

Made by [Open SWE](https://openswe.vercel.app/agents/dc58d0c4-6dfe-42ae-4af1-28ff95148006)