### PR TITLE
fix(code): note subscription plans unusable for Anthropic in `/auth`

### DIFF
--- a/libs/code/deepagents_code/widgets/auth.py
+++ b/libs/code/deepagents_code/widgets/auth.py
@@ -800,6 +800,21 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
                 "Request access to Chat completions (/v1/chat/completions). ",
                 (label, self._link_style(url)),
             )
+        elif self._provider == "anthropic":
+            instructions = Content.assemble(
+                f"Sign in to {provider}, create or copy an API key, "
+                "then paste it below. ",
+                (label, self._link_style(url)),
+                "\n",
+                (
+                    (
+                        "Subscription plans (Claude Pro/Max, Claude Code) cannot "
+                        "be used for Anthropic calls in Deep Agents Code. Only a "
+                        "standard API key with pay-as-you-go billing works here."
+                    ),
+                    "italic $text-muted",
+                ),
+            )
         else:
             instructions = Content.assemble(
                 f"Sign in to {provider}, create or copy an API key, "

--- a/libs/code/deepagents_code/widgets/auth.py
+++ b/libs/code/deepagents_code/widgets/auth.py
@@ -763,9 +763,10 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
         """Build provider-specific API-key acquisition guidance.
 
         Returns:
-            Content shown before the API-key input. Appends a muted notice when
-                a user-configured `api_key_url` was rejected for using an
-                unsupported URL scheme.
+            Content shown before the API-key input. May append muted notices: a
+                provider-specific caveat (e.g. Anthropic subscription plans are
+                unsupported) and/or a warning that a user-configured `api_key_url`
+                was rejected for using an unsupported URL scheme.
         """
         config = self._config
         configured_url = config.get_provider_api_key_url(self._provider)

--- a/libs/code/tests/unit_tests/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/test_auth_widgets.py
@@ -443,6 +443,26 @@ api_key_env = "MY_GATEWAY_API_KEY"
             assert "configured api_key_url was ignored" in text
             assert "unsupported URL scheme" in text
 
+    async def test_anthropic_notice_and_rejected_url_notice_coexist(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Provider-specific and rejected-URL notices both render when both fire."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("""
+[models.providers.anthropic]
+api_key_url = "javascript:alert(1)"
+""")
+        monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config_path)
+        model_config.clear_caches()
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_prompt("anthropic", "ANTHROPIC_API_KEY")
+            await pilot.pause()
+            instructions = app.screen.query_one("#auth-prompt-key-instructions", Static)
+            text = str(instructions.content)
+            assert "Subscription plans (Claude Pro/Max, Claude Code) cannot be" in text
+            assert "configured api_key_url was ignored" in text
+
     async def test_f2_toggles_advanced_details(self) -> None:
         """Advanced endpoint and env-var details are hidden behind F2."""
         app = _AuthHostApp()

--- a/libs/code/tests/unit_tests/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/test_auth_widgets.py
@@ -334,6 +334,21 @@ class TestAuthPromptScreen:
             assert "For older models" in text
             assert "Request access to Chat completions (/v1/chat/completions)" in text
 
+    async def test_anthropic_instructions_warn_against_subscription_plans(
+        self,
+    ) -> None:
+        """Anthropic keys note subscription plans don't work for API calls."""
+        app = _AuthHostApp()
+        async with app.run_test() as pilot:
+            app.show_prompt("anthropic", "ANTHROPIC_API_KEY")
+            await pilot.pause()
+            instructions = app.screen.query_one("#auth-prompt-key-instructions", Static)
+            text = str(instructions.content)
+            assert "Sign in to Anthropic" in text
+            assert "create or copy an API key" in text
+            assert "Subscription plans (Claude Pro/Max, Claude Code) cannot be" in text
+            assert "pay-as-you-go billing" in text
+
     async def test_provider_instructions_use_config_metadata(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
The `/auth` Anthropic key prompt now notes that subscription plans (Claude Pro/Max, Claude Code) can't be used — only standard API keys.

Made by [Open SWE](https://openswe.vercel.app/agents/e11dbb2d-1a7a-1984-12b0-f0c3921e7a93)