### PR TITLE
feat(evals): OOLONG benchmark — official scorer, targeted fetch, spec-aligned feedback, docs

### DIFF
--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -7,10 +7,10 @@ Source of truth: [`tests/evals/`](tests/evals/).
 Categories (for `--eval-category` filtering):
 
 ```txt
-file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,langchain/middleware
+file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,langchain/middleware,long_context_aggregation
 ```
 
-**118 evals** across **8 categories**
+**119 evals** across **9 categories**
 
 ## File Ops (`file_operations`) (13 evals)
 
@@ -153,3 +153,7 @@ file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,l
 - [`test_design_api_lands_in_final_message`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L283) — `tests/evals/test_langchain_middleware_todo.py:283`
 - [`test_density_cairo_lands_in_final_message`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L321) — `tests/evals/test_langchain_middleware_todo.py:321`
 - [`test_trivial_plan_skips_write_todos`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_langchain_middleware_todo.py#L355) — `tests/evals/test_langchain_middleware_todo.py:355`
+
+## Long-Context Aggregation (`long_context_aggregation`) (1 eval)
+
+- [`test_oolong_synth`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py#L70) — `tests/evals/test_oolong_rlm_vs_subagents.py:70`

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -156,4 +156,4 @@ file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,l
 
 ## Long-Context Aggregation (`long_context_aggregation`) (1 eval)
 
-- [`test_oolong_synth`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py#L70) — `tests/evals/test_oolong_rlm_vs_subagents.py:70`
+- [`test_oolong_synth`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py#L82) — `tests/evals/test_oolong_rlm_vs_subagents.py:82`

--- a/libs/evals/deepagents_evals/categories.json
+++ b/libs/evals/deepagents_evals/categories.json
@@ -7,7 +7,8 @@
     "conversation",
     "summarization",
     "unit_test",
-    "langchain/middleware"
+    "langchain/middleware",
+    "long_context_aggregation"
   ],
   "radar_categories": [
     "file_operations",
@@ -25,6 +26,7 @@
     "conversation": "Conversation",
     "summarization": "Summarization",
     "unit_test": "Unit Test",
-    "langchain/middleware": "Upstream Middleware"
+    "langchain/middleware": "Upstream Middleware",
+    "long_context_aggregation": "Long-Context Aggregation"
   }
 }

--- a/libs/evals/tests/evals/OOLONG.md
+++ b/libs/evals/tests/evals/OOLONG.md
@@ -1,0 +1,239 @@
+# OOLONG long-context aggregation benchmark
+
+Runs [OOLONG](https://arxiv.org/abs/2511.02817) (Bertsch et al., 2025) long-context
+aggregation tasks through a Deep Agent, comparing two configurations on the **same**
+examples:
+
+- **`plain`** — a deep agent that delegates chunk-level analysis to general-purpose
+  subagents via the `task` tool. The long context is seeded as `/context.txt` in the
+  agent workspace.
+- **`code_interpreter`** — a deep agent with the QuickJS `CodeInterpreterMiddleware`
+  (an `eval` tool for JS aggregation), plus `task` subagents for chunk reads. This is
+  the "RLM"-style arm from Zhang et al. 2025.
+
+Files:
+
+- `oolong_benchmarks.py` — dataset loader, official scorer, agent factories, runner.
+- `test_oolong_rlm_vs_subagents.py` — the pytest module (parameterizes over examples).
+
+---
+
+## Quickstart (smoke test)
+
+One example, the paper's `trec_coarse` dataset, smallest context bucket:
+
+```bash
+cd libs/evals
+
+OOLONG_DATASET=trec_coarse OOLONG_CONTEXT_LEN=1024 OOLONG_N_EXAMPLES=1 OOLONG_ARM=plain \
+LANGSMITH_TRACING=true LANGSMITH_TEST_SUITE=oolong-smoke \
+LANGSMITH_EXPERIMENT=oolong-trec_coarse-gpt5mini-$(date +%Y-%m-%d) \
+uv run --group test pytest tests/evals/test_oolong_rlm_vs_subagents.py \
+  --model openai:gpt-5-mini --sub-model openai:gpt-5-mini -v --tb=short
+```
+
+This downloads only the 50 rows of that one bucket (~0.3 MB), not the whole split.
+
+---
+
+## Prerequisites
+
+- **LangSmith tracing** must be on or the suite aborts: set `LANGSMITH_TRACING=true`
+  (any of `LANGSMITH_TRACING` / `LANGSMITH_TRACING_V2` / `LANGCHAIN_TRACING_V2`) and a
+  valid `LANGSMITH_API_KEY`.
+- **`--model` is required** (the root/orchestrator model).
+- **Model credentials** for the providers you use (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+  …). When routing through the LangSmith model gateway, set the provider key to your
+  LangSmith service key value.
+- `LANGSMITH_TEST_SUITE` names the LangSmith project/dataset; `LANGSMITH_EXPERIMENT`
+  names the run. Use a descriptive experiment name, e.g. `{suite}-{model}-{date}`.
+- Set `LANGSMITH_WORKSPACE_ID` to the deepagents OSS workspace so runs land there.
+
+---
+
+## Knobs
+
+### Environment variables
+
+| Variable             | Default   | Description                                                              |
+| -------------------- | --------- | ------------------------------------------------------------------------ |
+| `OOLONG_ARM`         | `plain`   | Which arm to run: `plain` or `code_interpreter`.                          |
+| `OOLONG_DATASET`     | `agnews`  | Input subset. Use `trec_coarse` for the paper's exact dataset.           |
+| `OOLONG_CONTEXT_LEN` | `8192`    | Token-length bucket (e.g. `1024`, `8192`, `32768`, `65536`, `131072`).   |
+| `OOLONG_N_EXAMPLES`  | `5`       | Examples to run, balanced across task groups. `0` (or empty) = full bucket (50). |
+
+### CLI options (pytest)
+
+| Option                | Default              | Description                                       |
+| --------------------- | -------------------- | ------------------------------------------------- |
+| `--model`             | (required)           | Root/orchestrator model id, e.g. `openai:gpt-5`.  |
+| `--sub-model`         | `openai:gpt-5-mini`  | Sub-model for `task` subagents (paper uses mini). |
+
+> The **arm is not a CLI/parametrize dimension** — it's read from `OOLONG_ARM` at
+> runtime so both arms produce the *same* example identity and line up for a
+> side-by-side compare in LangSmith. Run each arm in its own invocation.
+
+---
+
+## Recipes
+
+### Compare the two arms side-by-side
+
+Run each arm in its own session with its own experiment name. Inputs are identical
+across arms, so both experiments map to the same dataset examples and compare cleanly.
+
+```bash
+cd libs/evals
+COMMON="OOLONG_DATASET=trec_coarse OOLONG_CONTEXT_LEN=131072 OOLONG_N_EXAMPLES=0 \
+  LANGSMITH_TRACING=true LANGSMITH_TEST_SUITE=oolong-rlm-vs-subagents"
+
+# Arm 1: plain subagents
+env $COMMON OOLONG_ARM=plain \
+  LANGSMITH_EXPERIMENT=oolong-plain-gpt5-$(date +%Y-%m-%d) \
+  uv run --group test pytest tests/evals/test_oolong_rlm_vs_subagents.py \
+    --model openai:gpt-5 --sub-model openai:gpt-5-mini -q
+
+# Arm 2: code interpreter (RLM)
+env $COMMON OOLONG_ARM=code_interpreter \
+  LANGSMITH_EXPERIMENT=oolong-rlm-gpt5-$(date +%Y-%m-%d) \
+  uv run --group test pytest tests/evals/test_oolong_rlm_vs_subagents.py \
+    --model openai:gpt-5 --sub-model openai:gpt-5-mini -q
+```
+
+### Paper-matching run (`trec_coarse`, 131K, 50 tasks)
+
+Set `OOLONG_CONTEXT_LEN=131072` and `OOLONG_N_EXAMPLES=0` (full 50-task bucket):
+
+```bash
+OOLONG_DATASET=trec_coarse OOLONG_CONTEXT_LEN=131072 OOLONG_N_EXAMPLES=0 OOLONG_ARM=plain \
+LANGSMITH_TRACING=true LANGSMITH_TEST_SUITE=oolong-paper \
+LANGSMITH_EXPERIMENT=oolong-trec_coarse-131k-gpt5-$(date +%Y-%m-%d) \
+uv run --group test pytest tests/evals/test_oolong_rlm_vs_subagents.py \
+  --model openai:gpt-5 -q
+```
+
+### Default analog dataset (`agnews`)
+
+`agnews` (test split) is a same-shape 4-way classification analog kept as the cheap
+default. Just omit `OOLONG_DATASET`:
+
+```bash
+OOLONG_CONTEXT_LEN=8192 OOLONG_N_EXAMPLES=10 OOLONG_ARM=plain \
+LANGSMITH_TRACING=true LANGSMITH_TEST_SUITE=oolong-agnews \
+LANGSMITH_EXPERIMENT=oolong-agnews-8k-gpt5mini-$(date +%Y-%m-%d) \
+uv run --group test pytest tests/evals/test_oolong_rlm_vs_subagents.py \
+  --model openai:gpt-5-mini -q
+```
+
+### Sweep context lengths
+
+```bash
+for ctx in 1024 8192 32768 131072; do
+  OOLONG_DATASET=trec_coarse OOLONG_CONTEXT_LEN=$ctx OOLONG_N_EXAMPLES=0 OOLONG_ARM=plain \
+  LANGSMITH_TRACING=true LANGSMITH_TEST_SUITE=oolong-ctx-sweep \
+  LANGSMITH_EXPERIMENT=oolong-trec-${ctx}-gpt5-$(date +%Y-%m-%d) \
+  uv run --group test pytest tests/evals/test_oolong_rlm_vs_subagents.py --model openai:gpt-5 -q
+done
+```
+
+---
+
+## Datasets, splits & context buckets
+
+OOLONG-synth ([`oolongbench/oolong-synth`](https://huggingface.co/datasets/oolongbench/oolong-synth))
+is partitioned across two HuggingFace splits by source dataset:
+
+| Subset        | Split        | Notes                                                       |
+| ------------- | ------------ | ---------------------------------------------------------- |
+| `trec_coarse` | `validation` | The paper's dataset. 50 tasks per context bucket.         |
+| `agnews`      | `test`       | Default analog (same task-group structure, 50/bucket).    |
+| others (`spam`, `imdb`, `yahoo`, …) | `test` | Additional source datasets.            |
+
+The split is resolved automatically per subset (`trec_coarse` → `validation`, else
+`test`), so you only set `OOLONG_DATASET`. Context buckets exist at `1024`, `4096`,
+`8192`, `16384`, `32768`, `65536`, `131072` (and larger). The paper reports `131072`.
+
+Task groups: `counting`, `user`, `timeline` (which groups are present varies by
+subset/bucket; `OOLONG_N_EXAMPLES` balances across whatever groups exist).
+
+---
+
+## Data loading & caching
+
+Rows are fetched **targeted** via the HuggingFace datasets-server `/filter` endpoint —
+only the rows matching `dataset` + `context_len`, server-side — and cached to JSONL.
+This avoids `datasets.load_dataset`, which downloads the entire split parquet:
+
+| Split        | Whole-split download | Targeted (50 rows)        |
+| ------------ | -------------------- | ------------------------- |
+| `validation` | ~2.0 GB / 4.3 GB mem | ~0.3 MB @ 1024, ~35 MB @ 131K |
+| `test`       | ~10 GB / 19 GB mem   | proportional to bucket    |
+
+Cache location: `tests/evals/.cache/oolong/{split}__{subset}__ctx{N}.jsonl`
+(git-ignored). Delete a file to force a re-fetch.
+
+---
+
+## Scoring & metrics
+
+The scorer is a faithful port of the official OOLONG harness
+([`abertsch72/oolong` `src/eval/eval_helpers.py`](https://github.com/abertsch72/oolong/blob/main/src/eval/eval_helpers.py):
+`synth_attempt_answer_parse` + `synth_process_response`), so results are directly
+comparable to the paper:
+
+1. **Parse** — split the model answer on `:`, take the last segment, strip
+   `*`/`[`/`]` artifacts; normalize long comparison answers to the phrase.
+2. **Exact match** → `1.0`.
+3. **`ANSWER_TYPE.COMPARISON`** → substring match for
+   "more common" / "less common" / "same frequency".
+4. **`ANSWER_TYPE.NUMERIC`** → partial credit `0.75 ** |gold − pred|`.
+5. **`ANSWER_TYPE.DATE`** → flexible `dateutil` parse, then equality.
+
+### LangSmith feedback & outputs
+
+Scoring is **soft** (logged as feedback, never `pytest.fail`) so a wrong answer still
+syncs its example and stays in the side-by-side compare view.
+
+OOLONG defines exactly **one** metric per example — `score` — and the paper reports its
+mean. We log that and nothing that competes with it:
+
+| Feedback key         | Meaning                                                              |
+| -------------------- | ------------------------------------------------------------------- |
+| `score`              | **The OOLONG metric** (0–1, numeric partial credit folded in). The paper reports the mean of this. |
+| `agent_steps`        | Number of agent steps — harness efficiency telemetry, *not* part of OOLONG. |
+| `tool_call_requests` | Total tool calls — harness efficiency telemetry, *not* part of OOLONG. |
+
+We deliberately **do not** log a binary "correctness": it is not in the OOLONG spec, is
+redundant for LABEL/COMPARISON/DATE (already 0/1), and would discard partial credit on
+NUMERIC tasks.
+
+Per-example **outputs** mirror the official record for debuggability:
+`attempted_parse` (parsed prediction), `parse_confidence` (`low`/`med`/`high`/`vhigh`),
+`score`, and `gold_answer`.
+
+> To reproduce a paper number, aggregate the **mean `score`** over the bucket.
+
+> Note: the pytest terminal summary prints a `correctness: N.NN` line — that is the
+> harness-wide **pytest pass-rate**, unrelated to the OOLONG score. Because this suite
+> scores softly (never fails), it is always `1.00` here; ignore it and read `score`.
+
+---
+
+## Notes
+
+- The official parser strips markdown/brackets and normalizes comparison phrases only
+  when the answer contains a `:` (e.g. `Label: X`, `Answer: N`). The arm system prompts
+  and the OOLONG questions themselves steer the model toward that format.
+- `marks`: this module is tagged `eval_category("long_context_aggregation")` and
+  `eval_tier("hillclimb")`, so it runs under `--eval-category long_context_aggregation`.
+
+## Citation
+
+```bibtex
+@article{bertsch2025oolong,
+  title={Oolong: Evaluating Long Context Reasoning and Aggregation Capabilities},
+  author={Bertsch, Amanda and Pratapa, Adithya and Mitamura, Teruko and Neubig, Graham and Gormley, Matthew R.},
+  journal={arXiv preprint arXiv:2511.02817},
+  year={2025}
+}
+```

--- a/libs/evals/tests/evals/conftest.py
+++ b/libs/evals/tests/evals/conftest.py
@@ -131,6 +131,18 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=None,
         help="Optional REPL middleware for tests marked with @pytest.mark.repl. If omitted, those tests bind their tools directly instead of routing through a REPL.",
     )
+    parser.addoption(
+        "--sub-model",
+        action="store",
+        default="openai:gpt-5-mini",
+        help=(
+            "Sub-model id for tests that use recursive / sub-LLM calls "
+            "(e.g. the OOLONG RLM-vs-subagents eval). Used as the model "
+            "behind the `llm()` REPL callable in the RLM arm and the "
+            "general-purpose subagent in the subagents arm. Defaults to "
+            "`openai:gpt-5-mini`, matching the RLM paper."
+        ),
+    )
 
 
 def _filter_by_marker(
@@ -277,3 +289,24 @@ def model(model_name: str, request: pytest.FixtureRequest) -> BaseChatModel:
             raise ValueError(msg)
         kwargs["reasoning_effort"] = reasoning_effort
     return init_chat_model(model_name, **kwargs)
+
+
+@pytest.fixture
+def sub_model_name(request: pytest.FixtureRequest) -> str:
+    """The `provider:model` id used for recursive / sub-LLM calls."""
+    return str(request.config.getoption("--sub-model"))
+
+
+@pytest.fixture
+def sub_model(sub_model_name: str) -> BaseChatModel:
+    """Pre-built chat model for sub-LLM calls.
+
+    Mirrors the minimal subset of provider-specific kwargs the `model`
+    fixture applies — currently just the OpenAI Responses-API toggle.
+    Sub-model usage doesn't go through the OpenRouter allowlist or
+    reasoning-effort options, so we don't replicate those here.
+    """
+    kwargs: dict[str, Any] = {}
+    if sub_model_name.startswith("openai:"):
+        kwargs["use_responses_api"] = True
+    return init_chat_model(sub_model_name, **kwargs)

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -28,8 +28,8 @@ parameterizes over (arm, example) pairs.
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
+from datetime import UTC
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -44,6 +44,7 @@ from tests.evals.utils import (
 )
 
 if TYPE_CHECKING:
+    from deepagents.middleware.subagents import SubAgent
     from langchain_core.language_models import BaseChatModel
     from langgraph.graph.state import CompiledStateGraph
 
@@ -186,97 +187,118 @@ def _coerce_gold(raw: Any) -> tuple[str, ...]:  # noqa: ANN401
 
 
 # ---------------------------------------------------------------------------
-# Scoring
+# Scoring — adapted from abertsch72/oolong src/eval/eval_helpers.py
 # ---------------------------------------------------------------------------
 
-# Labels in OOLONG can contain `/` (e.g. agnews "Sci/Tech") and digits
-# (rare). Capture everything up to a comma, period, newline, or end of
-# string to avoid truncating multi-token labels.
-_LABEL_RE = re.compile(r"Label\s*:\s*([^\n.,;]+?)\s*(?:[.,;\n]|$)", re.IGNORECASE)
-_USER_RE = re.compile(r"User\s*:\s*\[?(\d+)\]?", re.IGNORECASE)
-_NUMBER_RE = re.compile(r"Answer\s*:\s*\[?(-?\d+(?:\.\d+)?)\]?", re.IGNORECASE)
-_MONTH_YEAR_RE = re.compile(
-    r"Answer\s*:\s*([A-Za-z]+\s+\d{4})",
-    re.IGNORECASE,
-)
-# COMPARISON: extract the direction phrase regardless of how many words the
-# subject has (e.g. "numeric value is less common than entity").
-_COMPARISON_RE = re.compile(
-    r"\b((?:more|less)\s+common\s+than|equally\s+common)\b",
-    re.IGNORECASE,
-)
-# DATE: match MM/DD/YYYY or YYYY-MM-DD in the model's answer
-_DATE_MDY_RE = re.compile(r"\b(\d{1,2})/(\d{1,2})/(\d{4})\b")
-_DATE_ISO_RE = re.compile(r"\b(\d{4})-(\d{2})-(\d{2})\b")
-# Gold DATE is stored as e.g. "datetime.date(2023, 2, 6)"
-_GOLD_DATE_RE = re.compile(r"datetime\.date\((\d+),\s*(\d+),\s*(\d+)\)")
+
+def _parse_answer(text: str) -> str:
+    """Extract the candidate answer from a model response.
+
+    Mirrors ``synth_attempt_answer_parse`` from the official OOLONG harness:
+    split on ``:``, take the last segment, strip markdown decorators.
+    """
+    if ":" not in text:
+        return (text if len(text) < 20 else text.rsplit(maxsplit=1)[-1]).strip()
+    candidate = text.rsplit(":", maxsplit=1)[-1].strip()
+    candidate = candidate.replace("*", "").replace("[", "").replace("]", "")
+    return candidate.strip()
 
 
-def _extract_answer(text: str, answer_type: str) -> str | None:
-    """Pull the formatted answer out of the model's free-form response."""
+def _parse_gold(gold: str, answer_type: str) -> object:
+    """Parse the dataset's gold answer into a comparable Python value."""
+    import ast  # noqa: PLC0415
+
     upper = answer_type.upper()
-    if upper.endswith("LABEL"):
-        m = _LABEL_RE.search(text)
-        return m.group(1).lower() if m else None
-    if upper.endswith("USER"):
-        m = _USER_RE.search(text)
-        return m.group(1) if m else None
-    if upper.endswith("NUMERIC"):
-        m = _NUMBER_RE.search(text)
-        return m.group(1) if m else None
-    if upper.endswith("MONTH_YEAR"):
-        m = _MONTH_YEAR_RE.search(text)
-        return m.group(1).strip().lower() if m else None
-    if upper.endswith("COMPARISON"):
-        m = _COMPARISON_RE.search(text)
-        return m.group(1).strip().lower() if m else None
     if upper.endswith("DATE"):
-        m = _DATE_MDY_RE.search(text)
-        if m:
-            return f"{int(m.group(1)):02d}/{int(m.group(2)):02d}/{m.group(3)}"
-        m = _DATE_ISO_RE.search(text)
-        if m:
-            return f"{int(m.group(2)):02d}/{int(m.group(3)):02d}/{m.group(1)}"
-        return None
-    return None
+        from datetime import datetime  # noqa: PLC0415
+
+        try:
+            return datetime.strptime(gold, "[datetime.date(%Y, %m, %d)]").replace(tzinfo=UTC)
+        except ValueError:
+            return gold
+    try:
+        parsed = ast.literal_eval(gold)
+        return parsed[0] if isinstance(parsed, list) else parsed
+    except (ValueError, SyntaxError):
+        return gold
 
 
-def _normalize_gold(gold: str, answer_type: str) -> str:
-    """Mirror the normalization applied to the extracted answer."""
+def _oolong_score(text: str, gold_answers: tuple[str, ...], answer_type: str) -> float:
+    """Score a model response against gold, returning 0.0-1.0.
+
+    Follows the official OOLONG scoring from ``synth_process_response``:
+    - Exact string match for most types.
+    - COMPARISON: substring check for "more common"/"less common"/"same frequency".
+    - NUMERIC: partial credit ``0.75 ** abs(gold - pred)``.
+    - DATE: flexible parse via ``dateutil`` then exact equality.
+    """
+    import dateutil.parser  # noqa: PLC0415
+
+    candidate = _parse_answer(text)
     upper = answer_type.upper()
-    g = gold.strip()
-    if upper.endswith("DATE"):
-        # Gold is stored as "datetime.date(YYYY, M, D)" or "[datetime.date(...)]"
-        m = _GOLD_DATE_RE.search(g)
-        if m:
-            return f"{int(m.group(2)):02d}/{int(m.group(3)):02d}/{m.group(1)}"
-        return g.lower()
-    if upper.endswith(("LABEL", "MONTH_YEAR", "COMPARISON")):
-        return g.lower()
-    return g
+
+    for raw_gold in gold_answers:
+        gold = _parse_gold(raw_gold, upper)
+
+        if upper.endswith("COMPARISON"):
+            for phrase in ("more common", "less common", "same frequency"):
+                if phrase in candidate.lower():
+                    normalized = phrase
+                    break
+            else:
+                normalized = candidate.lower()
+            if normalized in str(gold).lower() or str(gold).lower() in normalized:
+                return 1.0
+            continue
+
+        if upper.endswith("DATE"):
+            try:
+                parsed_dt = dateutil.parser.parse(candidate)
+                if parsed_dt == gold:
+                    return 1.0
+            except (ValueError, OverflowError):
+                pass
+            continue
+
+        if upper.endswith("NUMERIC"):
+            if str(candidate) == str(gold):
+                return 1.0
+            try:
+                return 0.75 ** abs(int(str(gold)) - int(candidate))
+            except (ValueError, TypeError):
+                pass
+            continue
+
+        if str(candidate).lower() == str(gold).lower():
+            return 1.0
+
+    return 0.0
 
 
 @dataclass(frozen=True)
 class _OolongAnswerMatches(SuccessAssertion):
-    """Fail unless the trajectory's final answer matches any gold answer."""
+    """Fail unless the trajectory's final answer exactly matches any gold answer.
+
+    Also computes a partial score (0.0-1.0) stored on ``self`` so callers can
+    log it as metadata without re-running the scorer.
+    """
 
     gold_answers: tuple[str, ...]
     answer_type: str
 
+    def score(self, trajectory: AgentTrajectory) -> float:
+        return _oolong_score(trajectory.answer, self.gold_answers, self.answer_type)
+
     def check(self, trajectory: AgentTrajectory) -> bool:
-        extracted = _extract_answer(trajectory.answer, self.answer_type)
-        if extracted is None:
-            return False
-        normalized = extracted.strip().lower()
-        return any(
-            normalized == _normalize_gold(gold, self.answer_type) for gold in self.gold_answers
-        )
+        return self.score(trajectory) >= 1.0
 
     def describe_failure(self, trajectory: AgentTrajectory) -> str:
-        extracted = _extract_answer(trajectory.answer, self.answer_type)
+        s = self.score(trajectory)
+        candidate = _parse_answer(trajectory.answer)
         return (
-            f"OOLONG answer mismatch (answer_type={self.answer_type!r}). "
-            f"Extracted={extracted!r}, "
+            f"OOLONG answer mismatch (answer_type={self.answer_type!r}, "
+            f"partial_score={s:.3f}). "
+            f"Parsed={candidate!r}, "
             f"gold={list(self.gold_answers)!r}, "
             f"final_text={trajectory.answer[:300]!r}"
         )
@@ -309,7 +331,7 @@ def build_agent(
     """Build a deep agent configured for the given arm."""
     # Both arms spawn task subagents — configure them to use the sub-model
     # (GPT-5-mini in paper setup) so sub-calls are cheaper and match paper specs.
-    subagent_cfg = [
+    subagent_cfg: list[SubAgent] = [
         {
             "name": "general-purpose",
             "description": "Reads a range of /context.txt and extracts facts as directed.",

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -12,15 +12,20 @@ runs the same examples through two agent configurations:
   from the shared workspace (no PTC required).
 
 Dataset choice: the paper evaluates on the OOLONG ``trec_coarse`` split
-(50 tasks at 131K-token context). The current ``oolongbench/oolong-synth``
-HuggingFace release does not include ``trec_coarse``; the closest analog
-is ``agnews`` — 4-way topic classification aggregation with the same
-counting/user/timeline task groups. There are 50 ``agnews`` examples at
-each context-length bucket (matching the paper's task count).
+(50 tasks at 131K-token context). ``trec_coarse`` *is* available in the
+``oolongbench/oolong-synth`` HuggingFace release — it lives in the
+``validation`` split (50 tasks per context-length bucket). Select it with
+``OOLONG_DATASET=trec_coarse`` to match the paper exactly. The default is
+``agnews`` (``test`` split) — a 4-way topic classification analog with the
+same counting/user/timeline task groups — kept as the cheap default.
 
-Scoring follows OOLONG paper conventions: extract ``Label: X``,
-``Answer: N``, ``User: X``, or ``Answer: Month YYYY`` from the
-trajectory's final answer and exact-match against the gold.
+Scoring is a faithful port of the official OOLONG harness
+(`abertsch72/oolong` ``src/eval/eval_helpers.py``: ``synth_attempt_answer_parse``
++ ``synth_process_response``) so results are directly comparable to the
+paper: parse the model's answer (split on ``:``, strip markdown/bracket
+artifacts), then exact-match — with substring matching for COMPARISON,
+``0.75 ** |gold - pred|`` partial credit for NUMERIC, and flexible
+``dateutil`` parsing for DATE.
 
 The module is self-contained: the pytest test module just
 parameterizes over (arm, example) pairs.
@@ -28,10 +33,15 @@ parameterizes over (arm, example) pairs.
 
 from __future__ import annotations
 
+import json
 import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
 from dataclasses import dataclass
-from datetime import UTC
 from functools import lru_cache
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from deepagents import create_deep_agent
@@ -55,11 +65,11 @@ if TYPE_CHECKING:
 #: HuggingFace dataset id for OOLONG-synth.
 _HF_DATASET = "oolongbench/oolong-synth"
 
-#: Input subset to filter on. The RLM paper uses ``trec_coarse``; the
-#: current HF release of OOLONG-synth does not include it, so we use
-#: ``agnews`` — the closest analog (4-way topic classification
-#: aggregation, same task-group structure, 50 examples per
-#: context-length bucket).
+#: Default input subset to filter on. The RLM paper uses ``trec_coarse``
+#: (available in the ``validation`` split — set ``OOLONG_DATASET=trec_coarse``
+#: to match the paper). ``agnews`` is the cheap default: a 4-way topic
+#: classification analog with the same task-group structure and 50 examples
+#: per context-length bucket.
 _INPUT_SUBSET = "agnews"
 
 #: HF dataset split for each input subset.
@@ -67,6 +77,87 @@ _INPUT_SUBSET = "agnews"
 _SPLIT_FOR_SUBSET: dict[str, str] = {
     "trec_coarse": "validation",
 }
+
+#: HuggingFace datasets-server ``/filter`` endpoint. We fetch *only* the rows
+#: matching ``dataset`` + ``context_len`` (server-side filter) instead of
+#: ``datasets.load_dataset``, which would download the entire split parquet
+#: (~2 GB for ``validation``, ~10 GB for ``test``) just to keep 50 rows.
+_FILTER_URL = "https://datasets-server.huggingface.co/filter"
+
+#: Max rows per ``/filter`` request (the endpoint caps ``length`` at 100).
+_PAGE_SIZE = 100
+
+#: On-disk cache for fetched rows, one JSONL per (split, subset, context_len).
+_CACHE_DIR = Path(__file__).parent / ".cache" / "oolong"
+
+
+def _get_json_with_retry(url: str, *, attempts: int = 4) -> dict[str, Any]:
+    """GET a JSON payload, retrying the datasets-server's intermittent 5xx."""
+    last_err: Exception | None = None
+    for i in range(attempts):
+        try:
+            with urllib.request.urlopen(url, timeout=60) as resp:
+                return json.loads(resp.read())
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as err:
+            last_err = err
+            time.sleep(1.5 * (i + 1))
+    msg = f"datasets-server request failed after {attempts} attempts: {url}\n{last_err}"
+    raise RuntimeError(msg)
+
+
+def _fetch_oolong_rows(subset: str, context_len: int | None, split: str) -> list[dict[str, Any]]:
+    """Fetch all rows for one (subset, context_len) bucket via the filter API.
+
+    Paginates server-side until the full matching set is retrieved. A bucket is
+    typically 50 rows, so this transfers a few hundred KB (or ~35 MB at the
+    131K-token bucket) rather than the multi-GB whole-split download.
+    """
+    where = f"\"dataset\"='{subset}'"
+    if context_len is not None:
+        where += f' AND "context_len"={context_len}'
+
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        params = urllib.parse.urlencode(
+            {
+                "dataset": _HF_DATASET,
+                "config": "default",
+                "split": split,
+                "where": where,
+                "offset": offset,
+                "length": _PAGE_SIZE,
+            }
+        )
+        data = _get_json_with_retry(f"{_FILTER_URL}?{params}")
+        batch = [r["row"] for r in data.get("rows", [])]
+        if not batch:
+            break
+        rows.extend(batch)
+        offset += len(batch)
+        if offset >= (data.get("num_rows_total") or 0):
+            break
+    return rows
+
+
+def _load_rows_cached(subset: str, context_len: int | None, split: str) -> list[dict[str, Any]]:
+    """Return the bucket's rows, fetching + caching to JSONL on first access."""
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    ctx_key = context_len if context_len is not None else "all"
+    cache_path = _CACHE_DIR / f"{split}__{subset}__ctx{ctx_key}.jsonl"
+
+    if cache_path.exists():
+        with cache_path.open(encoding="utf-8") as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+    rows = _fetch_oolong_rows(subset, context_len, split)
+    tmp_path = cache_path.with_suffix(".jsonl.tmp")
+    with tmp_path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+    tmp_path.replace(cache_path)  # atomic publish so partial fetches never cache
+    return rows
+
 
 #: Task groups across all supported subsets.
 TASK_GROUPS = ("counting", "user", "timeline")
@@ -94,6 +185,10 @@ class OolongExample:
     context_window_text: str
     question: str
     gold_answers: tuple[str, ...]
+    #: Raw HF ``answer`` field, verbatim (e.g. ``"['spam']"`` or
+    #: ``"[datetime.date(2024, 1, 15)]"``). The official scorer parses this
+    #: directly via ``ast.literal_eval`` / ``strptime``.
+    answer_raw: str
     answer_type: str
 
 
@@ -108,29 +203,29 @@ def load_oolong_examples(
     """Load a deterministic OOLONG-synth subset at one context length.
 
     The paper uses ``trec_coarse`` (validation split) at 131K tokens, 50
-    examples. ``agnews`` (test split) is the closest HF-available analog.
+    examples. ``agnews`` (test split) is a same-shape analog used as the
+    cheap default.
+
+    Rows are fetched targeted via the HuggingFace datasets-server ``/filter``
+    endpoint (only the matching bucket, cached to JSONL) — *not* the whole
+    split, which would be a 2-10 GB download for 50 rows.
 
     Args:
         input_subset: Dataset name to filter on. Use ``"trec_coarse"`` for
             the paper's exact dataset, ``"agnews"`` for the default.
         context_len: Token-length bucket. OOLONG-synth has buckets at
             1024-4194304; 65536 and 131072 are the most useful.
-        n_examples: How many examples to return. ``None`` means all 50.
-            Otherwise distributed evenly across task groups by ``id``.
+        n_examples: How many examples to return. ``None`` means the whole
+            bucket (50). Otherwise distributed evenly across task groups by ``id``.
         split: HuggingFace split. Defaults to ``"validation"`` for
             ``trec_coarse``, ``"test"`` for everything else.
 
     Returns:
         A tuple of `OolongExample` instances, deterministic across calls.
     """
-    from datasets import load_dataset  # noqa: PLC0415
-
     resolved_split = split or _SPLIT_FOR_SUBSET.get(input_subset, "test")
-    dataset = load_dataset(_HF_DATASET, split=resolved_split)
-    filtered = dataset.filter(
-        lambda row: row["dataset"] == input_subset and row["context_len"] == context_len
-    )
-    filtered = filtered.sort("id")
+    rows = _load_rows_cached(input_subset, context_len, resolved_split)
+    filtered = sorted(rows, key=lambda row: int(row["id"]))
 
     def _row_to_example(row: dict[str, Any]) -> OolongExample:
         return OolongExample(
@@ -142,6 +237,7 @@ def load_oolong_examples(
             context_window_text=str(row["context_window_text"]),
             question=str(row["question"]),
             gold_answers=_coerce_gold(row["answer"]),
+            answer_raw=str(row["answer"]),
             answer_type=str(row["answer_type"]),
         )
 
@@ -196,92 +292,118 @@ def _coerce_gold(raw: Any) -> tuple[str, ...]:  # noqa: ANN401
 
 
 # ---------------------------------------------------------------------------
-# Scoring — adapted from abertsch72/oolong src/eval/eval_helpers.py
+# Scoring — faithful port of abertsch72/oolong src/eval/eval_helpers.py
+# (``synth_attempt_answer_parse`` + ``synth_process_response``). Kept verbatim
+# in logic — including the ``parse_confidence`` tiers — so the record we log
+# matches the official harness and results are directly comparable to the paper.
 # ---------------------------------------------------------------------------
 
 
-def _parse_answer(text: str) -> str:
-    """Extract the candidate answer from a model response.
+@dataclass(frozen=True)
+class OolongScore:
+    """The OOLONG per-example scoring record (mirrors ``synth_process_response``)."""
 
-    Mirrors ``synth_attempt_answer_parse`` from the official OOLONG harness:
-    split on ``:``, take the last segment, strip markdown decorators.
+    #: 0.0-1.0; the paper's headline metric, with numeric partial credit folded in.
+    score: float
+    #: The parsed candidate answer (official ``attempted_parse``).
+    prediction: str
+    #: Parse heuristic confidence: ``low`` / ``med`` / ``high`` / ``vhigh``.
+    parse_confidence: str
+    #: The gold answer, stringified (official ``answer``).
+    gold: str
+
+
+def _synth_attempt_answer_parse(answer: str) -> tuple[str, str]:
+    """Parse a model response into ``(candidate, parse_confidence)``.
+
+    Mirrors the official ``synth_attempt_answer_parse``: if there is no ``:``,
+    return the whole answer when short else its last word; otherwise take the
+    segment after the last ``:`` and strip ``*``/``[``/``]`` formatting
+    artifacts (models like to bold answers or wrap them in brackets). A long
+    candidate containing a comparison phrase is normalized to that phrase. The
+    confidence tier is reported but never affects the score.
     """
-    if ":" not in text:
-        return (text if len(text) < 20 else text.rsplit(maxsplit=1)[-1]).strip()
-    candidate = text.rsplit(":", maxsplit=1)[-1].strip()
+    parse_confidence = "low"
+    if ":" not in answer:
+        if len(answer) < 20:
+            return answer, parse_confidence
+        return answer.rsplit(maxsplit=1)[-1], parse_confidence
+
+    candidate = answer.rsplit(":", maxsplit=1)[-1].strip()
     candidate = candidate.replace("*", "").replace("[", "").replace("]", "")
-    return candidate.strip()
+
+    parse_confidence = "med"
+    if "User:" in answer or "Answer:" in answer or "Date:" in answer or "Label" in answer:
+        parse_confidence = "high"
+    if len(candidate) < 20:
+        parse_confidence = "vhigh"
+    elif "more common" in candidate:
+        candidate = "more common"
+    elif "less common" in candidate:
+        candidate = "less common"
+    elif "same frequency" in candidate:
+        candidate = "same frequency"
+    return candidate, parse_confidence
 
 
-def _parse_gold(gold: str, answer_type: str) -> object:
-    """Parse the dataset's gold answer into a comparable Python value."""
-    import ast  # noqa: PLC0415
+def _synth_process_response(output: str, answer_raw: str, answer_type: str) -> OolongScore:
+    """Score a model response against the raw gold answer.
 
-    upper = answer_type.upper()
-    if upper.endswith("DATE"):
-        from datetime import datetime  # noqa: PLC0415
+    Faithful port of the official ``synth_process_response``:
 
-        try:
-            return datetime.strptime(gold, "[datetime.date(%Y, %m, %d)]").replace(tzinfo=UTC)
-        except ValueError:
-            return gold
-    try:
-        parsed = ast.literal_eval(gold)
-        return parsed[0] if isinstance(parsed, list) else parsed
-    except (ValueError, SyntaxError):
-        return gold
+    - gold is ``ast.literal_eval(answer)[0]`` unless the raw answer is a
+      ``datetime.date(...)`` literal, in which case it is parsed via ``strptime``;
+    - exact string match scores 1.0;
+    - a parsed answer of "more common"/"less common"/"same frequency" scores 1.0
+      when contained in the gold (COMPARISON wording differences);
+    - ``ANSWER_TYPE.NUMERIC`` gets ``0.75 ** |gold - pred|`` partial credit;
+    - ``ANSWER_TYPE.DATE`` is parsed with ``dateutil`` and compared for equality.
 
+    Args:
+        output: The model's final answer text.
+        answer_raw: The dataset's raw ``answer`` field, verbatim.
+        answer_type: The dataset's ``answer_type`` (e.g. ``ANSWER_TYPE.NUMERIC``).
 
-def _oolong_score(text: str, gold_answers: tuple[str, ...], answer_type: str) -> float:
-    """Score a model response against gold, returning 0.0-1.0.
-
-    Follows the official OOLONG scoring from ``synth_process_response``:
-    - Exact string match for most types.
-    - COMPARISON: substring check for "more common"/"less common"/"same frequency".
-    - NUMERIC: partial credit ``0.75 ** abs(gold - pred)``.
-    - DATE: flexible parse via ``dateutil`` then exact equality.
+    Returns:
+        An `OolongScore` with the score plus the parsed prediction, confidence,
+        and gold — the same fields the official harness records per example.
     """
+    import ast  # noqa: PLC0415
+    from datetime import datetime  # noqa: PLC0415
+
     import dateutil.parser  # noqa: PLC0415
 
-    candidate = _parse_answer(text)
-    upper = answer_type.upper()
+    # ``answer_raw`` is a trusted dataset field, not model output; literal_eval
+    # only ever sees the HF gold string (a list literal or a date literal).
+    if "datetime" not in answer_raw:
+        gold: object = ast.literal_eval(answer_raw)[0]
+    else:
+        gold = datetime.strptime(answer_raw, "[datetime.date(%Y, %m, %d)]")  # noqa: DTZ007
 
-    for raw_gold in gold_answers:
-        gold = _parse_gold(raw_gold, upper)
+    trimmed, parse_confidence = _synth_attempt_answer_parse(output)
 
-        if upper.endswith("COMPARISON"):
-            for phrase in ("more common", "less common", "same frequency"):
-                if phrase in candidate.lower():
-                    normalized = phrase
-                    break
-            else:
-                normalized = candidate.lower()
-            if normalized in str(gold).lower() or str(gold).lower() in normalized:
-                return 1.0
-            continue
+    score = 0.0
+    if str(trimmed) == str(gold):
+        score = 1.0
+    elif str(trimmed) in ("more common", "less common", "same frequency"):
+        score = 1.0 if str(trimmed) in str(gold) else 0.0
+    elif answer_type == "ANSWER_TYPE.NUMERIC":
+        try:
+            score = 0.75 ** abs(int(gold) - int(trimmed))  # type: ignore[arg-type]
+        except (ValueError, TypeError):
+            score = 0.0
+    elif answer_type == "ANSWER_TYPE.DATE":
+        try:
+            score = 1.0 if dateutil.parser.parse(trimmed) == gold else 0.0
+        except (ValueError, OverflowError, TypeError):
+            score = 0.0
 
-        if upper.endswith("DATE"):
-            try:
-                parsed_dt = dateutil.parser.parse(candidate)
-                if parsed_dt == gold:
-                    return 1.0
-            except (ValueError, OverflowError):
-                pass
-            continue
-
-        if upper.endswith("NUMERIC"):
-            if str(candidate) == str(gold):
-                return 1.0
-            try:
-                return 0.75 ** abs(int(str(gold)) - int(candidate))
-            except (ValueError, TypeError):
-                pass
-            continue
-
-        if str(candidate).lower() == str(gold).lower():
-            return 1.0
-
-    return 0.0
+    return OolongScore(
+        score=score,
+        prediction=str(trimmed),
+        parse_confidence=parse_confidence,
+        gold=str(gold),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -362,17 +484,19 @@ def run_oolong_case(
 
     Uses the standard `run_agent` LangSmith wiring (so examples, latency and
     inputs are recorded the normal way), but scores *softly*: the answer is
-    graded into ``correctness`` / ``partial_score`` feedback rather than
-    hard-failing the test. This matters for a pairwise benchmark — a
-    ``pytest.fail`` leaves the LangSmith root run ``pending`` and never syncs the
-    dataset example, which would drop the wrong-answer arm out of the
-    side-by-side comparison entirely. Logged shape:
+    graded into feedback rather than hard-failing the test. This matters for a
+    pairwise benchmark — a ``pytest.fail`` leaves the LangSmith root run
+    ``pending`` and never syncs the dataset example, which would drop the
+    wrong-answer arm out of the side-by-side comparison entirely. Logged shape:
 
     - **inputs** (`eval_inputs`): the question + task metadata, identical across
       arms so both experiments share one dataset example;
     - **reference output**: the gold answer;
-    - **feedback**: ``correctness`` / ``partial_score`` / ``agent_steps`` /
-      ``tool_call_requests`` (numeric scores).
+    - **feedback**: ``score`` (the *only* OOLONG metric — 0-1 with numeric partial
+      credit; the paper reports its mean) plus ``agent_steps`` /
+      ``tool_call_requests`` (harness efficiency telemetry, not part of OOLONG);
+    - **outputs**: the OOLONG per-example record — ``attempted_parse`` (parsed
+      prediction), ``parse_confidence``, ``score`` and ``gold_answer``.
 
     The arm, root model and sub-model travel as metadata, not inputs.
     """
@@ -406,11 +530,24 @@ def run_oolong_case(
 
     # Soft scoring: log the grade as feedback; never `pytest.fail` (see above).
     # `score=` (not `value=`) so the metrics surface as columns in the compare view.
-    score = _oolong_score(trajectory.answer, example.gold_answers, example.answer_type)
-    t.log_feedback(key="correctness", score=1.0 if score >= 1.0 else 0.0)
-    t.log_feedback(key="partial_score", score=score)
+    result = _synth_process_response(trajectory.answer, example.answer_raw, example.answer_type)
+    # `score` is the *only* OOLONG metric: 0-1 with numeric partial credit folded
+    # in. The paper reports its mean. We deliberately do not log a separate binary
+    # "correctness" — it is not in the OOLONG spec and would discard partial credit
+    # on NUMERIC tasks. `agent_steps` / `tool_call_requests` are harness efficiency
+    # telemetry, orthogonal to the OOLONG score.
+    t.log_feedback(key="score", score=result.score)
     t.log_feedback(key="agent_steps", score=len(trajectory.steps))
     t.log_feedback(
         key="tool_call_requests",
         score=sum(len(step.action.tool_calls) for step in trajectory.steps),
+    )
+    # Mirror the official harness's per-example record for debuggability.
+    t.log_outputs(
+        {
+            "attempted_parse": result.prediction,
+            "parse_confidence": result.parse_confidence,
+            "score": result.score,
+            "gold_answer": result.gold,
+        }
     )

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -28,18 +28,17 @@ parameterizes over (arm, example) pairs.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from datetime import UTC
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from deepagents import create_deep_agent
 from langchain_quickjs import CodeInterpreterMiddleware
+from langsmith import testing as t
 
 from tests.evals.utils import (
-    AgentTrajectory,
-    SuccessAssertion,
-    TrajectoryScorer,
     run_agent,
 )
 
@@ -166,6 +165,16 @@ def load_oolong_examples(
     return tuple(out[:n_examples])
 
 
+def resolve_arm() -> Arm:
+    """Resolve the experiment arm from the ``OOLONG_ARM`` env var (default ``plain``)."""
+    arm = os.environ.get("OOLONG_ARM", "plain")
+    valid = get_args(Arm)
+    if arm not in valid:
+        msg = f"OOLONG_ARM must be one of {valid}, got {arm!r}"
+        raise ValueError(msg)
+    return arm  # type: ignore[return-value]
+
+
 def _coerce_gold(raw: Any) -> tuple[str, ...]:  # noqa: ANN401
     """Coerce the dataset's `answer` field into a tuple of strings."""
     if isinstance(raw, list):
@@ -275,35 +284,6 @@ def _oolong_score(text: str, gold_answers: tuple[str, ...], answer_type: str) ->
     return 0.0
 
 
-@dataclass(frozen=True)
-class _OolongAnswerMatches(SuccessAssertion):
-    """Fail unless the trajectory's final answer exactly matches any gold answer.
-
-    Also computes a partial score (0.0-1.0) stored on ``self`` so callers can
-    log it as metadata without re-running the scorer.
-    """
-
-    gold_answers: tuple[str, ...]
-    answer_type: str
-
-    def score(self, trajectory: AgentTrajectory) -> float:
-        return _oolong_score(trajectory.answer, self.gold_answers, self.answer_type)
-
-    def check(self, trajectory: AgentTrajectory) -> bool:
-        return self.score(trajectory) >= 1.0
-
-    def describe_failure(self, trajectory: AgentTrajectory) -> str:
-        s = self.score(trajectory)
-        candidate = _parse_answer(trajectory.answer)
-        return (
-            f"OOLONG answer mismatch (answer_type={self.answer_type!r}, "
-            f"partial_score={s:.3f}). "
-            f"Parsed={candidate!r}, "
-            f"gold={list(self.gold_answers)!r}, "
-            f"final_text={trajectory.answer[:300]!r}"
-        )
-
-
 # ---------------------------------------------------------------------------
 # Agent factories
 # ---------------------------------------------------------------------------
@@ -378,7 +358,26 @@ def run_oolong_case(
     root_model: BaseChatModel,
     sub_model_id: str,
 ) -> None:
-    """Run a single OOLONG example through the given arm and score it."""
+    """Run a single OOLONG example through the given arm and score it.
+
+    Uses the standard `run_agent` LangSmith wiring (so examples, latency and
+    inputs are recorded the normal way), but scores *softly*: the answer is
+    graded into ``correctness`` / ``partial_score`` feedback rather than
+    hard-failing the test. This matters for a pairwise benchmark — a
+    ``pytest.fail`` leaves the LangSmith root run ``pending`` and never syncs the
+    dataset example, which would drop the wrong-answer arm out of the
+    side-by-side comparison entirely. Logged shape:
+
+    - **inputs** (`eval_inputs`): the question + task metadata, identical across
+      arms so both experiments share one dataset example;
+    - **reference output**: the gold answer;
+    - **feedback**: ``correctness`` / ``partial_score`` / ``agent_steps`` /
+      ``tool_call_requests`` (numeric scores).
+
+    The arm, root model and sub-model travel as metadata, not inputs.
+    """
+    t.log_reference_outputs({"gold_answer": list(example.gold_answers)})
+
     agent, initial_files = build_agent(
         arm,
         root_model=root_model,
@@ -386,28 +385,33 @@ def run_oolong_case(
         context=example.context_window_text,
     )
 
-    query = f"The document is at `/context.txt` in your workspace.\n\n{example.question}"
-
-    run_agent(
+    # The context is uploaded to the agent's filesystem at `/context.txt` (via
+    # `initial_files`); the question alone is the human message (the system
+    # prompt already points the agent at `/context.txt`).
+    trajectory = run_agent(
         agent,
         model=root_model,
-        query=query,
+        query=example.question,
         initial_files=initial_files,
-        scorer=TrajectoryScorer().success(
-            _OolongAnswerMatches(
-                gold_answers=example.gold_answers,
-                answer_type=example.answer_type,
-            )
-        ),
-        eval_metadata={
-            "arm": arm,
+        eval_inputs={
+            "question": example.question,
             "oolong_id": example.id,
             "task_group": example.task_group,
-            "task": example.task,
-            "context_len": example.context_len,
+            "task_type": example.task,
             "answer_type": example.answer_type,
-            "origin_benchmark": "oolong-synth",
+            "context_len": example.context_len,
             "input_subset": example.input_subset,
-            "sub_model": sub_model_id,
         },
+        eval_metadata={"arm": arm, "sub_model": sub_model_id, "origin_benchmark": "oolong-synth"},
+    )
+
+    # Soft scoring: log the grade as feedback; never `pytest.fail` (see above).
+    # `score=` (not `value=`) so the metrics surface as columns in the compare view.
+    score = _oolong_score(trajectory.answer, example.gold_answers, example.answer_type)
+    t.log_feedback(key="correctness", score=1.0 if score >= 1.0 else 0.0)
+    t.log_feedback(key="partial_score", score=score)
+    t.log_feedback(key="agent_steps", score=len(trajectory.steps))
+    t.log_feedback(
+        key="tool_call_requests",
+        score=sum(len(step.action.tool_calls) for step in trajectory.steps),
     )

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -1,0 +1,405 @@
+"""OOLONG long-context aggregation benchmark — plain subagents vs. code interpreter.
+
+Loads a small subset of `oolongbench/oolong-synth` from HuggingFace and
+runs the same examples through two agent configurations:
+
+- ``plain``: a deep agent that delegates chunk-level analysis to
+  general-purpose subagents via the ``task`` tool. The long context is
+  seeded as `/context.txt` in the agent workspace.
+- ``code_interpreter``: a deep agent with the QuickJS
+  ``CodeInterpreterMiddleware``, which exposes a JS ``eval`` tool the agent
+  uses for aggregation. Subagents launched via ``task`` handle file reads
+  from the shared workspace (no PTC required).
+
+Dataset choice: the paper evaluates on the OOLONG ``trec_coarse`` split
+(50 tasks at 131K-token context). The current ``oolongbench/oolong-synth``
+HuggingFace release does not include ``trec_coarse``; the closest analog
+is ``agnews`` — 4-way topic classification aggregation with the same
+counting/user/timeline task groups. There are 50 ``agnews`` examples at
+each context-length bucket (matching the paper's task count).
+
+Scoring follows OOLONG paper conventions: extract ``Label: X``,
+``Answer: N``, ``User: X``, or ``Answer: Month YYYY`` from the
+trajectory's final answer and exact-match against the gold.
+
+The module is self-contained: the pytest test module just
+parameterizes over (arm, example) pairs.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any, Literal
+
+from deepagents import create_deep_agent
+from langchain_quickjs import CodeInterpreterMiddleware
+
+from tests.evals.utils import (
+    AgentTrajectory,
+    SuccessAssertion,
+    TrajectoryScorer,
+    run_agent,
+)
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+    from langgraph.graph.state import CompiledStateGraph
+
+
+# ---------------------------------------------------------------------------
+# Dataset loading
+# ---------------------------------------------------------------------------
+
+#: HuggingFace dataset id for OOLONG-synth.
+_HF_DATASET = "oolongbench/oolong-synth"
+
+#: Input subset to filter on. The RLM paper uses ``trec_coarse``; the
+#: current HF release of OOLONG-synth does not include it, so we use
+#: ``agnews`` — the closest analog (4-way topic classification
+#: aggregation, same task-group structure, 50 examples per
+#: context-length bucket).
+_INPUT_SUBSET = "agnews"
+
+#: HF dataset split for each input subset.
+#: ``trec_coarse`` is in ``validation``; ``agnews`` and others are in ``test``.
+_SPLIT_FOR_SUBSET: dict[str, str] = {
+    "trec_coarse": "validation",
+}
+
+#: Task groups across all supported subsets.
+TASK_GROUPS = ("counting", "user", "timeline")
+
+#: Arm names — keep in sync with `build_agent` and pytest marks.
+#:
+#: ``plain`` — `create_deep_agent` that delegates chunk-level analysis to
+#: general-purpose subagents via the ``task`` tool; context is in the
+#: workspace at `/context.txt`.
+#: ``code_interpreter`` — `create_deep_agent` with the QuickJS
+#: `CodeInterpreterMiddleware`; uses ``eval`` for JS aggregation and
+#: ``task`` subagents for chunk classification.
+Arm = Literal["plain", "code_interpreter"]
+
+
+@dataclass(frozen=True)
+class OolongExample:
+    """One OOLONG-synth example, materialized into the shape the harness uses."""
+
+    id: int
+    input_subset: str
+    task_group: str
+    task: str
+    context_len: int
+    context_window_text: str
+    question: str
+    gold_answers: tuple[str, ...]
+    answer_type: str
+
+
+@lru_cache(maxsize=8)
+def load_oolong_examples(
+    *,
+    input_subset: str = "agnews",
+    context_len: int = 8192,
+    n_examples: int | None = 5,
+    split: str | None = None,
+) -> tuple[OolongExample, ...]:
+    """Load a deterministic OOLONG-synth subset at one context length.
+
+    The paper uses ``trec_coarse`` (validation split) at 131K tokens, 50
+    examples. ``agnews`` (test split) is the closest HF-available analog.
+
+    Args:
+        input_subset: Dataset name to filter on. Use ``"trec_coarse"`` for
+            the paper's exact dataset, ``"agnews"`` for the default.
+        context_len: Token-length bucket. OOLONG-synth has buckets at
+            1024-4194304; 65536 and 131072 are the most useful.
+        n_examples: How many examples to return. ``None`` means all 50.
+            Otherwise distributed evenly across task groups by ``id``.
+        split: HuggingFace split. Defaults to ``"validation"`` for
+            ``trec_coarse``, ``"test"`` for everything else.
+
+    Returns:
+        A tuple of `OolongExample` instances, deterministic across calls.
+    """
+    from datasets import load_dataset  # noqa: PLC0415
+
+    resolved_split = split or _SPLIT_FOR_SUBSET.get(input_subset, "test")
+    dataset = load_dataset(_HF_DATASET, split=resolved_split)
+    filtered = dataset.filter(
+        lambda row: row["dataset"] == input_subset and row["context_len"] == context_len
+    )
+    filtered = filtered.sort("id")
+
+    def _row_to_example(row: dict[str, Any]) -> OolongExample:
+        return OolongExample(
+            id=int(row["id"]),
+            input_subset=str(row["dataset"]),
+            task_group=str(row["task_group"]),
+            task=str(row["task"]),
+            context_len=int(row["context_len"]),
+            context_window_text=str(row["context_window_text"]),
+            question=str(row["question"]),
+            gold_answers=_coerce_gold(row["answer"]),
+            answer_type=str(row["answer_type"]),
+        )
+
+    if n_examples is None:
+        return tuple(_row_to_example(row) for row in filtered)
+
+    # Determine which task groups actually exist in this subset/bucket.
+    actual_groups = sorted({str(row["task_group"]) for row in filtered})
+    per_group = -(-n_examples // len(actual_groups))  # ceil div
+    by_group: dict[str, list[OolongExample]] = {tg: [] for tg in actual_groups}
+    for row in filtered:
+        tg = row["task_group"]
+        if tg in by_group and len(by_group[tg]) < per_group:
+            by_group[tg].append(_row_to_example(row))
+        if all(len(by_group[g]) >= per_group for g in actual_groups):
+            break
+
+    out: list[OolongExample] = []
+    for tg in actual_groups:
+        out.extend(by_group[tg])
+    return tuple(out[:n_examples])
+
+
+def _coerce_gold(raw: Any) -> tuple[str, ...]:  # noqa: ANN401
+    """Coerce the dataset's `answer` field into a tuple of strings."""
+    if isinstance(raw, list):
+        return tuple(str(x) for x in raw)
+    if isinstance(raw, str):
+        # Some HF preprocessors store python-list literals as strings.
+        stripped = raw.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            import ast  # noqa: PLC0415
+
+            try:
+                parsed = ast.literal_eval(stripped)
+                if isinstance(parsed, list):
+                    return tuple(str(x) for x in parsed)
+            except (ValueError, SyntaxError):
+                pass
+        return (stripped,)
+    return (str(raw),)
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+# Labels in OOLONG can contain `/` (e.g. agnews "Sci/Tech") and digits
+# (rare). Capture everything up to a comma, period, newline, or end of
+# string to avoid truncating multi-token labels.
+_LABEL_RE = re.compile(r"Label\s*:\s*([^\n.,;]+?)\s*(?:[.,;\n]|$)", re.IGNORECASE)
+_USER_RE = re.compile(r"User\s*:\s*\[?(\d+)\]?", re.IGNORECASE)
+_NUMBER_RE = re.compile(r"Answer\s*:\s*\[?(-?\d+(?:\.\d+)?)\]?", re.IGNORECASE)
+_MONTH_YEAR_RE = re.compile(
+    r"Answer\s*:\s*([A-Za-z]+\s+\d{4})",
+    re.IGNORECASE,
+)
+_COMPARISON_RE = re.compile(
+    r"Answer\s*:\s*[A-Za-z_]+\s+is\s+([a-z ]+?)\s+[A-Za-z_0-9-]+",
+    re.IGNORECASE,
+)
+# DATE: match MM/DD/YYYY or YYYY-MM-DD in the model's answer
+_DATE_MDY_RE = re.compile(r"\b(\d{1,2})/(\d{1,2})/(\d{4})\b")
+_DATE_ISO_RE = re.compile(r"\b(\d{4})-(\d{2})-(\d{2})\b")
+# Gold DATE is stored as e.g. "datetime.date(2023, 2, 6)"
+_GOLD_DATE_RE = re.compile(r"datetime\.date\((\d+),\s*(\d+),\s*(\d+)\)")
+
+
+def _extract_answer(text: str, answer_type: str) -> str | None:
+    """Pull the formatted answer out of the model's free-form response."""
+    upper = answer_type.upper()
+    if upper.endswith("LABEL"):
+        m = _LABEL_RE.search(text)
+        return m.group(1).lower() if m else None
+    if upper.endswith("USER"):
+        m = _USER_RE.search(text)
+        return m.group(1) if m else None
+    if upper.endswith("NUMERIC"):
+        m = _NUMBER_RE.search(text)
+        return m.group(1) if m else None
+    if upper.endswith("MONTH_YEAR"):
+        m = _MONTH_YEAR_RE.search(text)
+        return m.group(1).strip().lower() if m else None
+    if upper.endswith("COMPARISON"):
+        m = _COMPARISON_RE.search(text)
+        return m.group(1).strip().lower() if m else None
+    if upper.endswith("DATE"):
+        m = _DATE_MDY_RE.search(text)
+        if m:
+            return f"{int(m.group(1)):02d}/{int(m.group(2)):02d}/{m.group(3)}"
+        m = _DATE_ISO_RE.search(text)
+        if m:
+            return f"{int(m.group(2)):02d}/{int(m.group(3)):02d}/{m.group(1)}"
+        return None
+    return None
+
+
+def _normalize_gold(gold: str, answer_type: str) -> str:
+    """Mirror the normalization applied to the extracted answer."""
+    upper = answer_type.upper()
+    g = gold.strip()
+    if upper.endswith("DATE"):
+        # Gold is stored as "datetime.date(YYYY, M, D)" or "[datetime.date(...)]"
+        m = _GOLD_DATE_RE.search(g)
+        if m:
+            return f"{int(m.group(2)):02d}/{int(m.group(3)):02d}/{m.group(1)}"
+        return g.lower()
+    if upper.endswith(("LABEL", "MONTH_YEAR", "COMPARISON")):
+        return g.lower()
+    return g
+
+
+@dataclass(frozen=True)
+class _OolongAnswerMatches(SuccessAssertion):
+    """Fail unless the trajectory's final answer matches any gold answer."""
+
+    gold_answers: tuple[str, ...]
+    answer_type: str
+
+    def check(self, trajectory: AgentTrajectory) -> bool:
+        extracted = _extract_answer(trajectory.answer, self.answer_type)
+        if extracted is None:
+            return False
+        normalized = extracted.strip().lower()
+        return any(
+            normalized == _normalize_gold(gold, self.answer_type) for gold in self.gold_answers
+        )
+
+    def describe_failure(self, trajectory: AgentTrajectory) -> str:
+        extracted = _extract_answer(trajectory.answer, self.answer_type)
+        return (
+            f"OOLONG answer mismatch (answer_type={self.answer_type!r}). "
+            f"Extracted={extracted!r}, "
+            f"gold={list(self.gold_answers)!r}, "
+            f"final_text={trajectory.answer[:300]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Agent factories
+# ---------------------------------------------------------------------------
+
+_PLAIN_SYSTEM_PROMPT = (
+    "You are answering an aggregation question over a long document.\n"
+    "The full document is in your workspace at `/context.txt`.\n"
+    "\n"
+    "Use the `task` tool to delegate chunk-level analysis to subagents. "
+    "Tell each subagent which lines of `/context.txt` to read and what to extract. "
+    "Aggregate the results and reply with ONLY the final answer in the exact format "
+    "requested (e.g. `Label: Business`, `Answer: 4`, `User: 76063`)."
+)
+
+_CODE_INTERPRETER_SYSTEM_PROMPT = (
+    "You are answering an aggregation question over a long document.\n"
+    "The full document is in the workspace at `/context.txt`.\n"
+    "\n"
+    "Solve this as a workflow:\n"
+    "1. Use `task` to launch subagents in parallel — each subagent reads a "
+    "specific range of `/context.txt` (e.g. lines 0-100) and returns the "
+    "atomic facts needed (e.g. per-article label, user ID, or date).\n"
+    "2. Use `eval` to aggregate the structured results from all subagents "
+    "in JavaScript (e.g. count, sort, find the majority).\n"
+    "3. Reply with ONLY the final answer in the exact format the "
+    "question requests (e.g. `Label: Business`, `Answer: 4`, "
+    "`User: 76063`)."
+)
+
+
+def build_agent(
+    arm: Arm,
+    *,
+    root_model: BaseChatModel,
+    sub_model_id: str,
+    context: str,
+) -> tuple[CompiledStateGraph, dict[str, str]]:
+    """Build a deep agent configured for the given arm."""
+    # Both arms spawn task subagents — configure them to use the sub-model
+    # (GPT-5-mini in paper setup) so sub-calls are cheaper and match paper specs.
+    subagent_cfg = [
+        {
+            "name": "general-purpose",
+            "description": (
+                "Reads a specified range of /context.txt and extracts atomic "
+                "facts (labels, dates, user IDs, counts). Used for chunk-level "
+                "analysis delegated by the orchestrator."
+            ),
+            "system_prompt": (
+                "You are a document analysis subagent. Read the assigned range of "
+                "/context.txt using read_file, extract the requested facts, and "
+                "return concise structured results. Do not delegate further."
+            ),
+            "model": sub_model_id,
+        }
+    ]
+
+    if arm == "plain":
+        agent = create_deep_agent(
+            model=root_model,
+            system_prompt=_PLAIN_SYSTEM_PROMPT,
+            subagents=subagent_cfg,
+        )
+        return agent, {"/context.txt": context}
+
+    if arm == "code_interpreter":
+        agent = create_deep_agent(
+            model=root_model,
+            system_prompt=_CODE_INTERPRETER_SYSTEM_PROMPT,
+            middleware=[CodeInterpreterMiddleware()],
+            subagents=subagent_cfg,
+        )
+        return agent, {"/context.txt": context}
+
+    msg = f"unknown arm: {arm!r}"
+    raise ValueError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point used by the pytest module
+# ---------------------------------------------------------------------------
+
+
+def run_oolong_case(
+    example: OolongExample,
+    arm: Arm,
+    *,
+    root_model: BaseChatModel,
+    sub_model_id: str,
+) -> None:
+    """Run a single OOLONG example through the given arm and score it."""
+    agent, initial_files = build_agent(
+        arm,
+        root_model=root_model,
+        sub_model_id=sub_model_id,
+        context=example.context_window_text,
+    )
+
+    query = f"The document is at `/context.txt` in your workspace.\n\n{example.question}"
+
+    run_agent(
+        agent,
+        model=root_model,
+        query=query,
+        initial_files=initial_files,
+        scorer=TrajectoryScorer().success(
+            _OolongAnswerMatches(
+                gold_answers=example.gold_answers,
+                answer_type=example.answer_type,
+            )
+        ),
+        eval_metadata={
+            "arm": arm,
+            "oolong_id": example.id,
+            "task_group": example.task_group,
+            "task": example.task,
+            "context_len": example.context_len,
+            "answer_type": example.answer_type,
+            "origin_benchmark": "oolong-synth",
+            "input_subset": example.input_subset,
+            "sub_model": sub_model_id,
+        },
+    )

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -199,8 +199,10 @@ _MONTH_YEAR_RE = re.compile(
     r"Answer\s*:\s*([A-Za-z]+\s+\d{4})",
     re.IGNORECASE,
 )
+# COMPARISON: extract the direction phrase regardless of how many words the
+# subject has (e.g. "numeric value is less common than entity").
 _COMPARISON_RE = re.compile(
-    r"Answer\s*:\s*[A-Za-z_]+\s+is\s+([a-z ]+?)\s+[A-Za-z_0-9-]+",
+    r"\b((?:more|less)\s+common\s+than|equally\s+common)\b",
     re.IGNORECASE,
 )
 # DATE: match MM/DD/YYYY or YYYY-MM-DD in the model's answer
@@ -285,28 +287,15 @@ class _OolongAnswerMatches(SuccessAssertion):
 # ---------------------------------------------------------------------------
 
 _PLAIN_SYSTEM_PROMPT = (
-    "You are answering an aggregation question over a long document.\n"
-    "The full document is in your workspace at `/context.txt`.\n"
-    "\n"
-    "Use the `task` tool to delegate chunk-level analysis to subagents. "
-    "Tell each subagent which lines of `/context.txt` to read and what to extract. "
-    "Aggregate the results and reply with ONLY the final answer in the exact format "
-    "requested (e.g. `Label: Business`, `Answer: 4`, `User: 76063`)."
+    "You are a helpful assistant. "
+    "The document you need to analyze is at `/context.txt` in your workspace. "
+    "Use the task tool to delegate parts of the analysis to subagents."
 )
 
 _CODE_INTERPRETER_SYSTEM_PROMPT = (
-    "You are answering an aggregation question over a long document.\n"
-    "The full document is in the workspace at `/context.txt`.\n"
-    "\n"
-    "Solve this as a workflow:\n"
-    "1. Use `task` to launch subagents in parallel — each subagent reads a "
-    "specific range of `/context.txt` (e.g. lines 0-100) and returns the "
-    "atomic facts needed (e.g. per-article label, user ID, or date).\n"
-    "2. Use `eval` to aggregate the structured results from all subagents "
-    "in JavaScript (e.g. count, sort, find the majority).\n"
-    "3. Reply with ONLY the final answer in the exact format the "
-    "question requests (e.g. `Label: Business`, `Answer: 4`, "
-    "`User: 76063`)."
+    "You are a helpful assistant. "
+    "The document you need to analyze is at `/context.txt` in your workspace. "
+    "Use the eval and task tools to analyze the document."
 )
 
 
@@ -323,15 +312,12 @@ def build_agent(
     subagent_cfg = [
         {
             "name": "general-purpose",
-            "description": (
-                "Reads a specified range of /context.txt and extracts atomic "
-                "facts (labels, dates, user IDs, counts). Used for chunk-level "
-                "analysis delegated by the orchestrator."
-            ),
+            "description": "Reads a range of /context.txt and extracts facts as directed.",
             "system_prompt": (
-                "You are a document analysis subagent. Read the assigned range of "
-                "/context.txt using read_file, extract the requested facts, and "
-                "return concise structured results. Do not delegate further."
+                "You are a helpful assistant. "
+                "Read the assigned range of /context.txt using read_file, "
+                "extract the requested facts, and return concise results. "
+                "Do not delegate further."
             ),
             "model": sub_model_id,
         }

--- a/libs/evals/tests/evals/oolong_benchmarks.py
+++ b/libs/evals/tests/evals/oolong_benchmarks.py
@@ -402,7 +402,6 @@ def run_oolong_case(
             "context_len": example.context_len,
             "input_subset": example.input_subset,
         },
-        eval_metadata={"arm": arm, "sub_model": sub_model_id, "origin_benchmark": "oolong-synth"},
     )
 
     # Soft scoring: log the grade as feedback; never `pytest.fail` (see above).

--- a/libs/evals/tests/evals/pytest_reporter.py
+++ b/libs/evals/tests/evals/pytest_reporter.py
@@ -156,6 +156,13 @@ def pytest_sessionstart(session: pytest.Session) -> None:
             "date": date_str,
             "deepagents_version": __version__,
         }
+        # OOLONG rlm-vs-subagents selects the arm + sub-model per run; record
+        # them as experiment metadata (the experiment dimension) so the dataset
+        # example stays shared across arms.
+        oolong_arm = os.environ.get("OOLONG_ARM")
+        if oolong_arm:
+            experiment_metadata["arm"] = oolong_arm
+            experiment_metadata["sub_model"] = session.config.getoption("--sub-model")
 
         # Auto-generate a descriptive LANGSMITH_EXPERIMENT prefix if the caller
         # didn't set one explicitly. The prefix drives _get_experiment_name, which

--- a/libs/evals/tests/evals/pytest_reporter.py
+++ b/libs/evals/tests/evals/pytest_reporter.py
@@ -148,11 +148,30 @@ def pytest_sessionstart(session: pytest.Session) -> None:
         client = ls_client.Client()
         dataset = _get_test_suite(client, test_suite_name)
 
+        model_opt = session.config.getoption("--model") or ""
+        date_str = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+
         experiment_metadata = {
-            "model": session.config.getoption("--model"),
-            "date": datetime.now(tz=UTC).strftime("%Y-%m-%d"),
+            "model": model_opt,
+            "date": date_str,
             "deepagents_version": __version__,
         }
+
+        # Auto-generate a descriptive LANGSMITH_EXPERIMENT prefix if the caller
+        # didn't set one explicitly. The prefix drives _get_experiment_name, which
+        # appends a short random suffix, so the full name stays unique.
+        if not os.environ.get("LANGSMITH_EXPERIMENT"):
+            # Sanitize: keep only alphanumerics, hyphens, and dots; collapse runs
+            # of other chars to a single hyphen. Prevents shell metacharacters from
+            # reaching subprocess environments.
+            import re as _re  # noqa: PLC0415
+
+            def _slug(s: str) -> str:
+                return _re.sub(r"[^A-Za-z0-9.\-]+", "-", s).strip("-")
+
+            suite_slug = _slug(test_suite_name)
+            model_slug = _slug(model_opt) if model_opt else "unknown-model"
+            os.environ["LANGSMITH_EXPERIMENT"] = f"{suite_slug}-{model_slug}-{date_str}"
 
         experiment = _start_experiment(client, dataset, experiment_metadata)
     except Exception as exc:  # noqa: BLE001

--- a/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py
+++ b/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py
@@ -1,21 +1,31 @@
-"""OOLONG-synth: plain `create_deep_agent` vs. code-interpreter.
+"""OOLONG-synth: plain subagents vs. code-interpreter (RLM).
 
 Same examples, asymmetric model setup (matching Zhang et al. 2025):
 
 - **Root model** (``--model``, e.g. ``openai:gpt-5``): drives the
   orchestrator in both arms.
-- **Sub-model** (``--sub-model``, default ``openai:gpt-5-mini``):
-  unused by both arms (kept for conftest fixture compatibility).
+- **Sub-model** (``--sub-model``, default ``openai:gpt-5-mini``): the
+  general-purpose subagent that reads/classifies context chunks.
 
-Both arms run as parameterized pytest cases so a single eval
-invocation captures both into one LangSmith project. Each case is
-tagged with ``arm`` and ``task_group`` metadata so you can slice the
-LangSmith dashboard by either axis.
+LangSmith structure
+-------------------
+`run_oolong_case` logs the example explicitly: the **inputs** are the question
++ task metadata, the **reference output** is the gold answer, the run
+**outputs** are the parsed prediction + score, and numeric **feedback** is
+correctness / partial_score / agent_steps / tool_call_requests. The model and
+arm go in **metadata**, not inputs. Inputs are identical across arms, so both
+experiments share one dataset example and line up for side-by-side comparison.
 
-Default smoke subset (``context_len=8192``, 5 examples from the
-``agnews`` input subset) is intentionally tiny — pass
-``n_examples=None`` to `load_oolong_examples` for the full 50-task
-bucket that matches the paper's task count.
+The arm is the experiment dimension, not an input: select it with
+``OOLONG_ARM=plain`` or ``OOLONG_ARM=code_interpreter`` and give each run its
+own ``LANGSMITH_EXPERIMENT`` name. Run each arm in its own session, e.g.::
+
+    OOLONG_ARM=plain            LANGSMITH_EXPERIMENT=oolong-plain-... pytest ...
+    OOLONG_ARM=code_interpreter LANGSMITH_EXPERIMENT=oolong-rlm-...   pytest ...
+
+Default smoke subset (``context_len=8192``, ``OOLONG_N_EXAMPLES=5`` from the
+``agnews`` input subset) is intentionally tiny — set ``OOLONG_N_EXAMPLES=0``
+for the full 50-task bucket that matches the paper's task count.
 """
 
 from __future__ import annotations
@@ -28,13 +38,14 @@ import pytest
 from tests.evals.oolong_benchmarks import (
     TASK_GROUPS,
     load_oolong_examples,
+    resolve_arm,
     run_oolong_case,
 )
 
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
 
-    from tests.evals.oolong_benchmarks import Arm, OolongExample
+    from tests.evals.oolong_benchmarks import OolongExample
 
 
 pytestmark = [
@@ -46,38 +57,38 @@ pytestmark = [
 
 
 def _example_params() -> list[pytest.param]:
-    """Build the (arm, example) parameter matrix.
+    """Build the per-example parameter matrix (one row per example, not per arm).
 
     Set ``OOLONG_N_EXAMPLES=0`` (or empty) for the full 50-task bucket.
     Set ``OOLONG_CONTEXT_LEN`` to override the context bucket (default 8192).
-    Set ``OOLONG_DATASET`` to change the input subset (default ``agnews``).
-      Use ``trec_coarse`` for the paper's exact dataset (validation split).
+    Set ``OOLONG_DATASET`` to change the input subset (default ``agnews``);
+      use ``trec_coarse`` for the paper's exact dataset (validation split).
+
+    The arm is *not* a parameter — it is read from ``OOLONG_ARM`` at runtime so
+    both arms produce the same example identity and line up for comparison.
     """
     raw = os.environ.get("OOLONG_N_EXAMPLES", "5")
     n_examples: int | None = int(raw) if raw and raw != "0" else None
     context_len = int(os.environ.get("OOLONG_CONTEXT_LEN", "8192"))
     input_subset = os.environ.get("OOLONG_DATASET", "agnews")
+
     examples = load_oolong_examples(
         input_subset=input_subset, context_len=context_len, n_examples=n_examples
     )
-    params: list[pytest.param] = []
-    for arm in ("plain", "code_interpreter"):
-        params.extend(pytest.param(arm, ex, id=f"{arm}-{ex.task_group}-{ex.id}") for ex in examples)
-    return params
+    return [pytest.param(ex, id=f"{ex.task_group}-{ex.id}") for ex in examples]
 
 
-@pytest.mark.parametrize(("arm", "example"), _example_params())
+@pytest.mark.parametrize("example", _example_params())
 def test_oolong_synth(
-    arm: Arm,
     example: OolongExample,
     model: BaseChatModel,
     sub_model_name: str,
 ) -> None:
-    """Run a single OOLONG-synth example against the given arm."""
+    """Run a single OOLONG-synth example against the arm given by ``OOLONG_ARM``."""
     assert example.task_group in TASK_GROUPS
     run_oolong_case(
         example,
-        arm,
+        resolve_arm(),
         root_model=model,
         sub_model_id=sub_model_name,
     )

--- a/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py
+++ b/libs/evals/tests/evals/test_oolong_rlm_vs_subagents.py
@@ -1,0 +1,83 @@
+"""OOLONG-synth: plain `create_deep_agent` vs. code-interpreter.
+
+Same examples, asymmetric model setup (matching Zhang et al. 2025):
+
+- **Root model** (``--model``, e.g. ``openai:gpt-5``): drives the
+  orchestrator in both arms.
+- **Sub-model** (``--sub-model``, default ``openai:gpt-5-mini``):
+  unused by both arms (kept for conftest fixture compatibility).
+
+Both arms run as parameterized pytest cases so a single eval
+invocation captures both into one LangSmith project. Each case is
+tagged with ``arm`` and ``task_group`` metadata so you can slice the
+LangSmith dashboard by either axis.
+
+Default smoke subset (``context_len=8192``, 5 examples from the
+``agnews`` input subset) is intentionally tiny — pass
+``n_examples=None`` to `load_oolong_examples` for the full 50-task
+bucket that matches the paper's task count.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.evals.oolong_benchmarks import (
+    TASK_GROUPS,
+    load_oolong_examples,
+    run_oolong_case,
+)
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+
+    from tests.evals.oolong_benchmarks import Arm, OolongExample
+
+
+pytestmark = [
+    pytest.mark.eval_category("long_context_aggregation"),
+    pytest.mark.eval_tier("hillclimb"),
+    pytest.mark.langsmith,
+]
+"""All cases in this module are long-context aggregation, hillclimb-tier."""
+
+
+def _example_params() -> list[pytest.param]:
+    """Build the (arm, example) parameter matrix.
+
+    Set ``OOLONG_N_EXAMPLES=0`` (or empty) for the full 50-task bucket.
+    Set ``OOLONG_CONTEXT_LEN`` to override the context bucket (default 8192).
+    Set ``OOLONG_DATASET`` to change the input subset (default ``agnews``).
+      Use ``trec_coarse`` for the paper's exact dataset (validation split).
+    """
+    raw = os.environ.get("OOLONG_N_EXAMPLES", "5")
+    n_examples: int | None = int(raw) if raw and raw != "0" else None
+    context_len = int(os.environ.get("OOLONG_CONTEXT_LEN", "8192"))
+    input_subset = os.environ.get("OOLONG_DATASET", "agnews")
+    examples = load_oolong_examples(
+        input_subset=input_subset, context_len=context_len, n_examples=n_examples
+    )
+    params: list[pytest.param] = []
+    for arm in ("plain", "code_interpreter"):
+        params.extend(pytest.param(arm, ex, id=f"{arm}-{ex.task_group}-{ex.id}") for ex in examples)
+    return params
+
+
+@pytest.mark.parametrize(("arm", "example"), _example_params())
+def test_oolong_synth(
+    arm: Arm,
+    example: OolongExample,
+    model: BaseChatModel,
+    sub_model_name: str,
+) -> None:
+    """Run a single OOLONG-synth example against the given arm."""
+    assert example.task_group in TASK_GROUPS
+    run_oolong_case(
+        example,
+        arm,
+        root_model=model,
+        sub_model_id=sub_model_name,
+    )

--- a/libs/evals/tests/evals/utils.py
+++ b/libs/evals/tests/evals/utils.py
@@ -1102,14 +1102,30 @@ def _build_invoke_inputs(
 def _build_logged_inputs(
     model: BaseChatModel,
     eval_metadata: dict[str, object] | None,
+    eval_inputs: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Build the LangSmith input payload for the current test run."""
+    """Build the LangSmith input payload for the current test run.
+
+    By default the logged input is ``{test_name, model, eval_metadata}``. When
+    ``eval_inputs`` is provided, those task-specific fields (e.g. the question)
+    become the logged input and ``model``/``test_name`` fold into
+    ``eval_metadata`` — so the example input stays task-centric (no model
+    object) and is identical across experiment arms for side-by-side
+    comparison, while the model still travels with the run as metadata.
+    """
     run_tree = get_current_run_tree()
     model_str = str(getattr(model, "model", None) or getattr(model, "model_name", ""))
-    logged_inputs: dict[str, Any] = {
-        "test_name": run_tree.name if run_tree else "unknown",
-        "model": model_str,
-    }
+    test_name = run_tree.name if run_tree else "unknown"
+
+    if eval_inputs is not None:
+        logged_inputs: dict[str, Any] = dict(eval_inputs)
+        metadata = dict(eval_metadata or {})
+        metadata.setdefault("model", model_str)
+        metadata.setdefault("test_name", test_name)
+        logged_inputs["eval_metadata"] = metadata
+        return logged_inputs
+
+    logged_inputs = {"test_name": test_name, "model": model_str}
     if eval_metadata is not None:
         logged_inputs["eval_metadata"] = eval_metadata
     return logged_inputs
@@ -1137,6 +1153,7 @@ def run_agent(
     scorer: TrajectoryScorer | None = None,
     thread_id: str | None = None,
     eval_metadata: dict[str, object] | None = None,
+    eval_inputs: dict[str, Any] | None = None,
     extra_state: dict[str, Any] | None = None,
 ) -> AgentTrajectory:
     """Run agent eval against the given query.
@@ -1149,6 +1166,9 @@ def run_agent(
         scorer: Optional trajectory expectations to validate.
         thread_id: Optional thread ID for the invocation.
         eval_metadata: Optional metadata to attach to the logged inputs.
+        eval_inputs: Optional task-specific fields (e.g. the question) to log as
+            the LangSmith example input instead of the default
+            `{test_name, model}` payload. The model folds into `eval_metadata`.
         extra_state: Optional extra fields merged into the invoke input
             (e.g. `{"rubric": "..."}` for `RubricMiddleware`).
 
@@ -1164,8 +1184,7 @@ def run_agent(
         thread_id = str(uuid.uuid4())
     config = {"configurable": {"thread_id": thread_id}}
 
-    logged_inputs = _build_logged_inputs(model, eval_metadata)
-    _log_run_inputs(logged_inputs)
+    _log_run_inputs(_build_logged_inputs(model, eval_metadata, eval_inputs))
     result = agent.invoke(invoke_inputs, config)
     t.log_outputs(result)
 
@@ -1188,6 +1207,7 @@ async def run_agent_async(
     scorer: TrajectoryScorer | None = None,
     thread_id: str | None = None,
     eval_metadata: dict[str, object] | None = None,
+    eval_inputs: dict[str, Any] | None = None,
     extra_state: dict[str, Any] | None = None,
 ) -> AgentTrajectory:
     """Run agent eval asynchronously against the given query.
@@ -1200,6 +1220,9 @@ async def run_agent_async(
         scorer: Optional trajectory expectations to validate.
         thread_id: Optional thread ID for the invocation.
         eval_metadata: Optional metadata to attach to the logged inputs.
+        eval_inputs: Optional task-specific fields (e.g. the question) to log as
+            the LangSmith example input instead of the default
+            `{test_name, model}` payload. The model folds into `eval_metadata`.
         extra_state: Optional extra fields merged into the invoke input
             (e.g. `{"rubric": "..."}` for `RubricMiddleware`).
 
@@ -1215,8 +1238,7 @@ async def run_agent_async(
         thread_id = str(uuid.uuid4())
     config = {"configurable": {"thread_id": thread_id}}
 
-    logged_inputs = _build_logged_inputs(model, eval_metadata)
-    _log_run_inputs(logged_inputs)
+    _log_run_inputs(_build_logged_inputs(model, eval_metadata, eval_inputs))
     result = await agent.ainvoke(invoke_inputs, config)
     t.log_outputs(result)
 

--- a/libs/evals/tests/evals/utils.py
+++ b/libs/evals/tests/evals/utils.py
@@ -1108,24 +1108,21 @@ def _build_logged_inputs(
 
     By default the logged input is ``{test_name, model, eval_metadata}``. When
     ``eval_inputs`` is provided, those task-specific fields (e.g. the question)
-    become the logged input and ``model``/``test_name`` fold into
-    ``eval_metadata`` — so the example input stays task-centric (no model
-    object) and is identical across experiment arms for side-by-side
-    comparison, while the model still travels with the run as metadata.
+    become the logged input *verbatim* — no model, no metadata — so the example
+    input stays task-centric and is byte-identical across experiment arms. The
+    example id is derived from the inputs, so identical inputs mean both arms
+    map to the *same* dataset example for side-by-side comparison. Run-level
+    context (model, arm, ...) belongs in the experiment metadata, not here.
     """
+    if eval_inputs is not None:
+        return dict(eval_inputs)
+
     run_tree = get_current_run_tree()
     model_str = str(getattr(model, "model", None) or getattr(model, "model_name", ""))
-    test_name = run_tree.name if run_tree else "unknown"
-
-    if eval_inputs is not None:
-        logged_inputs: dict[str, Any] = dict(eval_inputs)
-        metadata = dict(eval_metadata or {})
-        metadata.setdefault("model", model_str)
-        metadata.setdefault("test_name", test_name)
-        logged_inputs["eval_metadata"] = metadata
-        return logged_inputs
-
-    logged_inputs = {"test_name": test_name, "model": model_str}
+    logged_inputs: dict[str, Any] = {
+        "test_name": run_tree.name if run_tree else "unknown",
+        "model": model_str,
+    }
     if eval_metadata is not None:
         logged_inputs["eval_metadata"] = eval_metadata
     return logged_inputs


### PR DESCRIPTION
## Summary

Adds the **OOLONG** long-context aggregation benchmark ([Bertsch et al. 2025](https://arxiv.org/abs/2511.02817)) to the evals suite, comparing two Deep Agent configurations on the **same** examples: `plain` (subagents via the `task` tool) vs. `code_interpreter` (QuickJS `CodeInterpreterMiddleware` `eval` tool).

> Supersedes #4213 (now closed). This PR keeps the official scorer from that effort and adds the two things it lacked: a **targeted dataset fetch** (no multi-GB download) and **spec-aligned feedback**.

### What's here

- **Official scorer.** Faithful port of the official OOLONG harness (`abertsch72/oolong` `src/eval/eval_helpers.py`: `synth_attempt_answer_parse` + `synth_process_response`) so `score` is directly comparable to the paper.
- **Targeted dataset fetch.** Fetches only the needed `(dataset, context_len)` rows via the HF datasets-server `/filter` endpoint with JSONL caching, instead of `datasets.load_dataset` downloading the whole split (~2 GB validation / ~10 GB test) just to keep 50 rows. A 50-row bucket is ~0.3 MB at 1024 tokens, ~35 MB at the 131K paper bucket.
- **Spec-aligned feedback.** Logs `score` — the *only* OOLONG metric, with numeric partial credit (`0.75 ** |gold − pred|`); the paper reports its mean. No non-spec binary `correctness`. Records `attempted_parse` / `parse_confidence` / `gold_answer` as run outputs, mirroring the official per-example record. Plus `agent_steps` / `tool_call_requests` as harness telemetry.
- **`trec_coarse` fix.** Corrects the prior (wrong) claim that `trec_coarse` is absent from the HF release — it's in the `validation` split (50 tasks/bucket). Select it with `OOLONG_DATASET=trec_coarse`.
- **Docs.** New `libs/evals/tests/evals/OOLONG.md` covering prerequisites, env knobs, recipes (smoke / paper-matching 131K / side-by-side arms / sweeps), data-loading/caching, and scoring.

## Test plan

- Scorer unit-checked against exact / numeric-partial-credit / date / comparison cases.
- End-to-end smoke runs of **both arms** on `trec_coarse`, `openai:gpt-5-mini`:
  - `@1024` (3 examples/arm) — 3/3 each.
  - `@8192` (3 examples/arm, **uncached**) — 3/3 each; the `/filter` fetch fired fresh and cached, confirming fetch + scoring end-to-end.
- Each arm logs to its own LangSmith experiment over a shared dataset for side-by-side comparison.

> Note: this branch is behind `main`; the three-dot PR diff is OOLONG-only, but it may need updating before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)