### PR TITLE
feat(evals): allow overriding the Harbor package in the Harbor workflow

### DIFF
--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -155,6 +155,11 @@ on:
         required: true
         default: "1"
         type: string
+      harbor_package_override:
+        description: "Optional: install Harbor from an arbitrary package spec (e.g. 'harbor[langsmith] @ git+https://github.com/owner/harbor.git@branch') instead of the locked version, to test an unreleased Harbor build. Leave empty to use the pinned Harbor."
+        required: false
+        default: ""
+        type: string
 permissions:
   contents: read
 
@@ -314,6 +319,13 @@ jobs:
 
       - name: "📦 Install Dependencies"
         run: uv sync --group test --locked
+
+      - name: "⚓ Install Harbor override"
+        if: ${{ inputs.harbor_package_override != '' }}
+        env:
+          # Passed via env (not interpolated into the shell) to avoid injection.
+          HARBOR_PACKAGE_OVERRIDE: ${{ inputs.harbor_package_override }}
+        run: uv pip install "$HARBOR_PACKAGE_OVERRIDE"
 
       - name: "🔇 Suppress Harbor first-run tips"
         run: |


### PR DESCRIPTION
## What

Adds a `harbor_package_override` `workflow_dispatch` input to the **Evals - Harbor** workflow. When set, the Harbor run job installs Harbor from the given package spec **after** `uv sync`, replacing the locked version:

```yaml
- name: "⚓ Install Harbor override"
  if: ${{ inputs.harbor_package_override != '' }}
  env:
    HARBOR_PACKAGE_OVERRIDE: ${{ inputs.harbor_package_override }}
  run: uv pip install "$HARBOR_PACKAGE_OVERRIDE"
```

Empty (the default) leaves the pinned Harbor untouched — normal runs are unaffected.

## Why

Lets us run the eval suite against an **unreleased Harbor build** (e.g. a fix on a branch) without bumping the lockfile, e.g.:

```
harbor[langsmith] @ git+https://github.com/owner/harbor.git@my-fix-branch
```

## Notes

- The spec is passed via an env var and referenced quoted (`"$HARBOR_PACKAGE_OVERRIDE"`), not interpolated directly into the shell, to avoid command injection.
- Manual dispatch only, runs in the `evals` environment; defaults to off.