### PR TITLE
fix(ci): bypass release PR scope check for release artifacts

### DIFF
--- a/.github/scripts/check_pr_scope_files.py
+++ b/.github/scripts/check_pr_scope_files.py
@@ -21,6 +21,85 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONFIG = REPO_ROOT / ".github" / "scripts" / "pr-labeler-config.json"
 
 _TITLE_RE = re.compile(r"^[a-z]+(?:\(([^)]*)\))?!?:\s")
+_RELEASE_TITLE_RE = re.compile(r"^release\([^)]*\):\s")
+
+
+def is_release_file(file: str) -> bool:
+    """Return whether `file` is a file release-please may update in a release PR.
+
+    Covers the version-of-record manifest, per-package `CHANGELOG.md` /
+    `pyproject.toml` / `_version.py`, and `uv.lock` files anywhere the uv
+    workspace resolves.
+
+    Keep in sync with `extra-files`/`changelog-path` in
+    `release-please-config.json`. Drift fails closed — an unrecognized artifact
+    means the bypass does not fire and the normal scope gate runs — so this is a
+    maintenance note, not a safety hole.
+
+    Args:
+        file: Changed file path, repo-root-relative.
+
+    Returns:
+        `True` when the path is one release-please may update in a release PR.
+    """
+    path = Path(file)
+    # The version-of-record manifest release-please rewrites on every release.
+    if file == ".release-please-manifest.json":
+        return True
+    # release-please regenerates lockfiles wherever the uv workspace resolves —
+    # not just package dirs but also `examples/*/uv.lock` (observed in real
+    # partner release PRs). `uv.lock` is generated-only, so accept it at any
+    # path rather than enumerating workspace-member dirs that drift over time.
+    if path.name == "uv.lock":
+        return True
+    parts = path.parts
+    if len(parts) < 3 or parts[0] != "libs":
+        return False
+    # Package-root files: depth 3 for top-level packages (`libs/<pkg>/...`) and
+    # depth 4 for partners, which nest one level deeper under `libs/partners/`.
+    if path.name in {"CHANGELOG.md", "pyproject.toml"}:
+        return len(parts) == 3 or (len(parts) == 4 and parts[1] == "partners")
+    # `_version.py` sits inside the import package, one level below the
+    # package-root files above: depth 4 top-level, depth 5 for partners.
+    if path.name == "_version.py":
+        return len(parts) == 4 or (len(parts) == 5 and parts[1] == "partners")
+    return False
+
+
+def is_release_title(title: str) -> bool:
+    """Return whether `title` is a release PR title.
+
+    Args:
+        title: PR title, e.g. `release(deepagents-code): 1.2.0`.
+
+    Returns:
+        `True` when the title uses the release PR conventional-commit shape.
+    """
+    return bool(_RELEASE_TITLE_RE.match(title))
+
+
+def is_release_pr_change(title: str, changed: list[str]) -> bool:
+    """Return whether the PR looks like a release-please artifact update.
+
+    The title is author-controlled (PR event payload) and the release component
+    is not validated against real package names, so a non-release PR can adopt a
+    `release(...)` title. Safety therefore rests entirely on the file allowlist:
+    the bypass only applies when *every* changed file matches `is_release_file`,
+    so a single source file re-arms the scope gate.
+
+    Args:
+        title: PR title.
+        changed: Changed file paths, repo-root-relative.
+
+    Returns:
+        `True` only when the title is release-shaped and every changed file is a
+        release-please generated/version artifact.
+    """
+    return (
+        bool(changed)
+        and is_release_title(title)
+        and all(is_release_file(file) for file in changed)
+    )
 
 
 def parse_title_scopes(title: str) -> tuple[str, ...]:
@@ -178,6 +257,9 @@ def find_offenders(
     Raises:
         ValueError: If required config sections are missing or malformed.
     """
+    if is_release_pr_change(title, changed):
+        return []
+
     declared = declared_packages(title, config)
     if not declared:
         return []
@@ -212,6 +294,18 @@ def main(title: str, changed: list[str], config_path: Path = DEFAULT_CONFIG) -> 
             file=sys.stderr,
         )
         return 2
+
+    # Surface the release bypass so "gate stood down" is distinguishable from
+    # "genuinely clean" in the Checks UI, mirroring the workflow's
+    # detector-absent ::warning::. To stderr so it never corrupts the JSON
+    # offenders the workflow captures from stdout. ::notice:: (not ::warning::)
+    # because this is a designed, expected bypass.
+    if is_release_pr_change(title, changed):
+        print(
+            "::notice::Release-shaped title; scope/file gate bypassed because "
+            "every changed file matched the release-please artifact allowlist.",
+            file=sys.stderr,
+        )
 
     if offenders:
         summary = ", ".join(

--- a/.github/scripts/check_pr_scope_files.py
+++ b/.github/scripts/check_pr_scope_files.py
@@ -284,10 +284,10 @@ def find_offenders(
     Raises:
         ValueError: If required config sections are missing or malformed.
     """
+    declared = declared_packages(title, config)
     if is_release_pr_change(title, changed):
         return []
 
-    declared = declared_packages(title, config)
     if not declared:
         return []
 

--- a/.github/scripts/check_pr_scope_files.py
+++ b/.github/scripts/check_pr_scope_files.py
@@ -19,51 +19,78 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONFIG = REPO_ROOT / ".github" / "scripts" / "pr-labeler-config.json"
+DEFAULT_RELEASE_CONFIG = REPO_ROOT / "release-please-config.json"
 
 _TITLE_RE = re.compile(r"^[a-z]+(?:\(([^)]*)\))?!?:\s")
 _RELEASE_TITLE_RE = re.compile(r"^release\([^)]*\):\s")
 
 
+def _release_files(config_path: Path = DEFAULT_RELEASE_CONFIG) -> set[str]:
+    """Return release-please managed artifact paths.
+
+    Args:
+        config_path: Path to `release-please-config.json`.
+
+    Returns:
+        Set of repo-root-relative files release-please manages directly.
+
+    Raises:
+        ValueError: If the release-please config is missing required structure.
+    """
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        msg = f"could not read release-please config {config_path}: {e}"
+        raise ValueError(msg) from e
+
+    packages = config.get("packages")
+    if not isinstance(packages, dict) or not packages:
+        msg = "release-please config has no non-empty 'packages' map"
+        raise ValueError(msg)
+
+    files = {".release-please-manifest.json"}
+    for root, package in packages.items():
+        if not isinstance(root, str) or not isinstance(package, dict):
+            msg = f"release-please package entry is malformed: {root!r}: {package!r}"
+            raise ValueError(msg)
+        changelog = package.get("changelog-path")
+        if isinstance(changelog, str):
+            files.add(str(Path(root) / changelog))
+        extra_files = package.get("extra-files", [])
+        if not isinstance(extra_files, list):
+            msg = f"release-please package {root!r} has malformed 'extra-files'"
+            raise ValueError(msg)
+        for extra in extra_files:
+            if not isinstance(extra, str):
+                msg = f"release-please package {root!r} has non-string extra file"
+                raise ValueError(msg)
+            files.add(str(Path(root) / extra))
+    return files
+
+
 def is_release_file(file: str) -> bool:
     """Return whether `file` is a file release-please may update in a release PR.
 
-    Covers the version-of-record manifest, per-package `CHANGELOG.md` /
-    `pyproject.toml` / `_version.py`, and `uv.lock` files anywhere the uv
-    workspace resolves.
-
-    Keep in sync with `extra-files`/`changelog-path` in
-    `release-please-config.json`. Drift fails closed — an unrecognized artifact
-    means the bypass does not fire and the normal scope gate runs — so this is a
-    maintenance note, not a safety hole.
+    Covers the version-of-record manifest, configured per-package changelog and
+    extra files, and `uv.lock` files anywhere the uv workspace resolves.
 
     Args:
         file: Changed file path, repo-root-relative.
 
     Returns:
         `True` when the path is one release-please may update in a release PR.
+
+    Raises:
+        ValueError: If the release-please config cannot be read or validated.
     """
     path = Path(file)
-    # The version-of-record manifest release-please rewrites on every release.
-    if file == ".release-please-manifest.json":
-        return True
     # release-please regenerates lockfiles wherever the uv workspace resolves —
     # not just package dirs but also `examples/*/uv.lock` (observed in real
     # partner release PRs). `uv.lock` is generated-only, so accept it at any
     # path rather than enumerating workspace-member dirs that drift over time.
     if path.name == "uv.lock":
         return True
-    parts = path.parts
-    if len(parts) < 3 or parts[0] != "libs":
-        return False
-    # Package-root files: depth 3 for top-level packages (`libs/<pkg>/...`) and
-    # depth 4 for partners, which nest one level deeper under `libs/partners/`.
-    if path.name in {"CHANGELOG.md", "pyproject.toml"}:
-        return len(parts) == 3 or (len(parts) == 4 and parts[1] == "partners")
-    # `_version.py` sits inside the import package, one level below the
-    # package-root files above: depth 4 top-level, depth 5 for partners.
-    if path.name == "_version.py":
-        return len(parts) == 4 or (len(parts) == 5 and parts[1] == "partners")
-    return False
+    return file in _release_files()
 
 
 def is_release_title(title: str) -> bool:

--- a/.github/scripts/check_pr_scope_files.py
+++ b/.github/scripts/check_pr_scope_files.py
@@ -14,6 +14,7 @@ closed.
 import json
 import re
 import sys
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -25,8 +26,14 @@ _TITLE_RE = re.compile(r"^[a-z]+(?:\(([^)]*)\))?!?:\s")
 _RELEASE_TITLE_RE = re.compile(r"^release\([^)]*\):\s")
 
 
+@lru_cache(maxsize=None)
 def _release_files(config_path: Path = DEFAULT_RELEASE_CONFIG) -> set[str]:
     """Return release-please managed artifact paths.
+
+    Cached per `config_path` so a single run does not re-read and re-parse the
+    config once per changed file. The config is immutable within a process, and
+    raised `ValueError`s are not cached, so a malformed config keeps failing
+    closed on every call.
 
     Args:
         config_path: Path to `release-please-config.json`.
@@ -68,7 +75,9 @@ def _release_files(config_path: Path = DEFAULT_RELEASE_CONFIG) -> set[str]:
     return files
 
 
-def is_release_file(file: str) -> bool:
+def is_release_file(
+    file: str, *, release_config_path: Path = DEFAULT_RELEASE_CONFIG
+) -> bool:
     """Return whether `file` is a file release-please may update in a release PR.
 
     Covers the version-of-record manifest, configured per-package changelog and
@@ -76,12 +85,14 @@ def is_release_file(file: str) -> bool:
 
     Args:
         file: Changed file path, repo-root-relative.
+        release_config_path: Path to `release-please-config.json`.
 
     Returns:
         `True` when the path is one release-please may update in a release PR.
 
     Raises:
         ValueError: If the release-please config cannot be read or validated.
+            Not reachable for `uv.lock` inputs, which return before any read.
     """
     path = Path(file)
     # release-please regenerates lockfiles wherever the uv workspace resolves —
@@ -90,7 +101,7 @@ def is_release_file(file: str) -> bool:
     # path rather than enumerating workspace-member dirs that drift over time.
     if path.name == "uv.lock":
         return True
-    return file in _release_files()
+    return file in _release_files(release_config_path)
 
 
 def is_release_title(title: str) -> bool:
@@ -105,7 +116,12 @@ def is_release_title(title: str) -> bool:
     return bool(_RELEASE_TITLE_RE.match(title))
 
 
-def is_release_pr_change(title: str, changed: list[str]) -> bool:
+def is_release_pr_change(
+    title: str,
+    changed: list[str],
+    *,
+    release_config_path: Path = DEFAULT_RELEASE_CONFIG,
+) -> bool:
     """Return whether the PR looks like a release-please artifact update.
 
     The title is author-controlled (PR event payload) and the release component
@@ -117,15 +133,26 @@ def is_release_pr_change(title: str, changed: list[str]) -> bool:
     Args:
         title: PR title.
         changed: Changed file paths, repo-root-relative.
+        release_config_path: Path to `release-please-config.json`.
 
     Returns:
         `True` only when the title is release-shaped and every changed file is a
         release-please generated/version artifact.
+
+    Raises:
+        ValueError: If the release-please config cannot be read or validated.
     """
-    return (
-        bool(changed)
-        and is_release_title(title)
-        and all(is_release_file(file) for file in changed)
+    if not (changed and is_release_title(title)):
+        return False
+    # Read (and thereby validate) the release config up front so a malformed
+    # `release-please-config.json` fails closed even when every changed file is
+    # a `uv.lock` — those short-circuit inside `is_release_file` before any read,
+    # which would otherwise let the gate stand down without validating the config.
+    # `_release_files` is cached, so the per-file checks below reuse this result.
+    _release_files(release_config_path)
+    return all(
+        is_release_file(file, release_config_path=release_config_path)
+        for file in changed
     )
 
 
@@ -267,7 +294,11 @@ def changed_packages(
 
 
 def find_offenders(
-    title: str, changed: list[str], config: dict[str, Any]
+    title: str,
+    changed: list[str],
+    config: dict[str, Any],
+    *,
+    release_config_path: Path = DEFAULT_RELEASE_CONFIG,
 ) -> list[dict[str, object]]:
     """Return touched package dirs not covered by package scopes in `title`.
 
@@ -275,17 +306,21 @@ def find_offenders(
         title: PR title.
         changed: Changed file paths, repo-root-relative.
         config: Parsed `.github/scripts/pr-labeler-config.json`.
+        release_config_path: Path to `release-please-config.json`.
 
     Returns:
         Sorted list of offender objects with `package` and `dirs` keys. Empty
+            when the PR is a release-please artifact update (`is_release_pr_change`),
             when the title declares no package scopes, when no package dirs are
             touched, or when every touched package is covered by a declared scope.
 
     Raises:
         ValueError: If required config sections are missing or malformed.
     """
+    # Computed before the release short-circuit so a malformed labeler config
+    # still fails closed (raises) on release PRs rather than passing unchecked.
     declared = declared_packages(title, config)
-    if is_release_pr_change(title, changed):
+    if is_release_pr_change(title, changed, release_config_path=release_config_path):
         return []
 
     if not declared:
@@ -299,13 +334,20 @@ def find_offenders(
     ]
 
 
-def main(title: str, changed: list[str], config_path: Path = DEFAULT_CONFIG) -> int:
+def main(
+    title: str,
+    changed: list[str],
+    config_path: Path = DEFAULT_CONFIG,
+    *,
+    release_config_path: Path = DEFAULT_RELEASE_CONFIG,
+) -> int:
     """Print offending packages as a JSON array to stdout.
 
     Args:
         title: PR title.
         changed: Changed file paths, repo-root-relative.
         config_path: Path to the PR labeler config.
+        release_config_path: Path to `release-please-config.json`.
 
     Returns:
         `0` after successful analysis. Offenders are reported on stdout and the
@@ -313,11 +355,25 @@ def main(title: str, changed: list[str], config_path: Path = DEFAULT_CONFIG) -> 
         `2` when the config cannot be read or validated, so CI fails closed.
     """
     try:
-        config = json.loads(config_path.read_text(encoding="utf-8"))
-        offenders = find_offenders(title, changed, config)
+        # Wrap the labeler-config read so its errors name the labeler file. The
+        # outer handler also catches ValueErrors raised while reading the
+        # release config (via find_offenders -> is_release_pr_change), whose
+        # messages name release-please-config.json themselves — so the generic
+        # prefix below does not mis-attribute one config's failure to the other.
+        try:
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            msg = f"could not read PR labeler config {config_path}: {e}"
+            raise ValueError(msg) from e
+        offenders = find_offenders(
+            title, changed, config, release_config_path=release_config_path
+        )
+        bypassed = is_release_pr_change(
+            title, changed, release_config_path=release_config_path
+        )
     except (OSError, json.JSONDecodeError, ValueError) as e:
         print(
-            f"::error::Could not read PR labeler config {config_path}: {e}",
+            f"::error::PR scope/file check failed to read or validate config: {e}",
             file=sys.stderr,
         )
         return 2
@@ -327,7 +383,7 @@ def main(title: str, changed: list[str], config_path: Path = DEFAULT_CONFIG) -> 
     # detector-absent ::warning::. To stderr so it never corrupts the JSON
     # offenders the workflow captures from stdout. ::notice:: (not ::warning::)
     # because this is a designed, expected bypass.
-    if is_release_pr_change(title, changed):
+    if bypassed:
         print(
             "::notice::Release-shaped title; scope/file gate bypassed because "
             "every changed file matched the release-please artifact allowlist.",

--- a/.github/scripts/test_check_pr_scope_files.py
+++ b/.github/scripts/test_check_pr_scope_files.py
@@ -200,6 +200,19 @@ def test_release_file_covers_partner_generated_files() -> None:
     assert not is_release_file("libs/code/deepagents_code/CHANGELOG.md")
 
 
+def test_unmanaged_package_artifacts_do_not_trigger_release_bypass() -> None:
+    """Only package roots declared in release-please config are release artifacts."""
+    config = json.loads(DEFAULT_CONFIG.read_text(encoding="utf-8"))
+    changed = ["libs/evals/pyproject.toml"]
+
+    assert not is_release_file("libs/evals/pyproject.toml")
+    assert not is_release_file("libs/evals/deepagents_evals/_version.py")
+    assert not is_release_pr_change("release(deepagents-code): 0.1.22", changed)
+    assert find_offenders("release(deepagents-code): 0.1.22", changed, config) == [
+        {"package": "evals", "dirs": ["libs/evals/"]}
+    ]
+
+
 def test_release_pr_change_covers_repo_wide_lockfiles() -> None:
     """Real partner release PRs regenerate `uv.lock` under `examples/` too.
 

--- a/.github/scripts/test_check_pr_scope_files.py
+++ b/.github/scripts/test_check_pr_scope_files.py
@@ -8,6 +8,9 @@ from check_pr_scope_files import (
     changed_packages,
     declared_packages,
     find_offenders,
+    is_release_file,
+    is_release_pr_change,
+    is_release_title,
     main,
     parse_title_scopes,
 )
@@ -140,6 +143,122 @@ def test_breaking_change_title_still_detects_offender() -> None:
     ) == [{"package": "dcode", "dirs": ["libs/code/"]}]
 
 
+def test_release_title_with_release_files_bypasses_scope_file_check() -> None:
+    """Release PRs can touch generated/version files across package dirs."""
+    assert is_release_title("release(deepagents-code): 0.1.22")
+    assert (
+        find_offenders(
+            "release(deepagents-code): 0.1.22",
+            [
+                "libs/code/deepagents_code/_version.py",
+                "libs/evals/deepagents_evals/_version.py",
+                "libs/talon/deepagents_talon/_version.py",
+            ],
+            CONFIG,
+        )
+        == []
+    )
+
+
+def test_release_title_with_source_change_still_blocks_mismatch() -> None:
+    """An author-controlled release title cannot hide ordinary package edits."""
+    assert find_offenders(
+        "release(cli): anything",
+        ["libs/code/deepagents_code/app.py"],
+        CONFIG,
+    ) == [{"package": "dcode", "dirs": ["libs/code/"]}]
+
+
+def test_release_pr_change_requires_release_files_only() -> None:
+    """The release bypass is limited to generated/version file patterns."""
+    assert is_release_file(".release-please-manifest.json")
+    assert is_release_file("libs/code/CHANGELOG.md")
+    assert is_release_file("libs/code/pyproject.toml")
+    assert is_release_file("libs/code/uv.lock")
+    assert is_release_file("libs/code/deepagents_code/_version.py")
+    assert is_release_file("libs/partners/daytona/langchain_daytona/_version.py")
+    assert not is_release_file("libs/code/deepagents_code/app.py")
+    assert not is_release_file("libs/code/docs/CHANGELOG.md")
+    assert not is_release_file("libs/code/deepagents_code/nested/_version.py")
+    # The manifest match is anchored to the repo root, not matched by name.
+    assert not is_release_file("libs/code/.release-please-manifest.json")
+    assert not is_release_pr_change(
+        "release(cli): anything",
+        ["libs/code/deepagents_code/app.py"],
+    )
+    assert not is_release_pr_change("release(cli): anything", [])
+
+
+def test_release_file_covers_partner_generated_files() -> None:
+    """Partner packages nest one level deeper; their generated files match too."""
+    assert is_release_file("libs/partners/daytona/pyproject.toml")
+    assert is_release_file("libs/partners/daytona/CHANGELOG.md")
+    assert is_release_file("libs/partners/daytona/uv.lock")
+    # A non-partner package's CHANGELOG/pyproject live at the package root
+    # (depth 3), so the same names at depth 4 are not generated-file locations.
+    assert not is_release_file("libs/code/deepagents_code/pyproject.toml")
+    assert not is_release_file("libs/code/deepagents_code/CHANGELOG.md")
+
+
+def test_release_pr_change_covers_repo_wide_lockfiles() -> None:
+    """Real partner release PRs regenerate `uv.lock` under `examples/` too.
+
+    Regression for a partner release PR (e.g. `release(langchain-quickjs)`)
+    whose changeset includes `examples/*/uv.lock`: the bypass must still fire so
+    the release PR is not blocked by cross-dir lockfile churn its title scope
+    cannot cover.
+    """
+    assert is_release_file("examples/async-subagent-server/uv.lock")
+    assert is_release_file("examples/llm-wiki/uv.lock")
+    assert is_release_pr_change(
+        "release(langchain-quickjs): 0.3.1",
+        [
+            ".release-please-manifest.json",
+            "examples/async-subagent-server/uv.lock",
+            "examples/llm-wiki/uv.lock",
+            "libs/code/uv.lock",
+            "libs/evals/uv.lock",
+            "libs/partners/quickjs/CHANGELOG.md",
+            "libs/partners/quickjs/pyproject.toml",
+            "libs/partners/quickjs/uv.lock",
+        ],
+    )
+
+
+def test_release_title_with_mixed_files_does_not_bypass() -> None:
+    """A release artifact cannot launder an accompanying source edit."""
+    changed = ["libs/code/CHANGELOG.md", "libs/code/deepagents_code/app.py"]
+    assert not is_release_pr_change("release(cli): 0.1.22", changed)
+    assert find_offenders("release(cli): 0.1.22", changed, CONFIG) == [
+        {"package": "dcode", "dirs": ["libs/code/"]}
+    ]
+
+
+def test_release_bypass_does_not_validate_component() -> None:
+    """The bypass keys off title shape + files, not a real component name.
+
+    Pins that an unrecognized component still bypasses when every file is a
+    release artifact, so a future tightening (validating the component against
+    real package names) is a conscious change rather than a silent one.
+    """
+    assert (
+        find_offenders(
+            "release(not-a-real-scope): 9.9.9", ["libs/code/uv.lock"], CONFIG
+        )
+        == []
+    )
+
+
+def test_is_release_title_boundaries() -> None:
+    """Only `release(<scope>):` shapes trigger the bypass title gate."""
+    assert is_release_title("release(cli): 1.0.0")
+    assert is_release_title("release(): 1.0.0")  # empty scope still matches
+    assert not is_release_title("release: 1.0.0")  # scope required
+    assert not is_release_title("release(scope)!: 1.0.0")  # breaking marker excluded
+    assert not is_release_title("  release(cli): 1.0.0")  # anchored; no leading ws
+    assert not is_release_title("Release(cli): 1.0.0")  # case-sensitive
+
+
 def test_partner_package_dir_detected_with_real_config() -> None:
     """Partner packages under `libs/partners/` are package dirs too."""
     config = json.loads(DEFAULT_CONFIG.read_text(encoding="utf-8"))
@@ -232,6 +351,28 @@ def test_main_clean_stdout_is_empty_json_array(capsys, tmp_path) -> None:
     assert rc == 0
     assert captured.out.strip() == "[]"
     assert captured.err == ""
+
+
+def test_main_release_bypass_emits_notice(capsys, tmp_path) -> None:
+    """A fired release bypass surfaces a `::notice::` so it is not silent.
+
+    The gate standing down must be distinguishable from a genuinely clean PR in
+    the Checks UI. The notice goes to stderr so it never corrupts the JSON
+    offenders the workflow captures from stdout.
+    """
+    config_path = tmp_path / "pr-labeler-config.json"
+    config_path.write_text(json.dumps(CONFIG), encoding="utf-8")
+
+    rc = main(
+        "release(deepagents-code): 0.1.22",
+        ["libs/code/uv.lock", "libs/evals/uv.lock"],
+        config_path=config_path,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert captured.out.strip() == "[]"
+    assert "::notice::" in captured.err
 
 
 def test_main_missing_config_returns_2(capsys, tmp_path) -> None:

--- a/.github/scripts/test_check_pr_scope_files.py
+++ b/.github/scripts/test_check_pr_scope_files.py
@@ -5,6 +5,7 @@ import json
 import pytest
 from check_pr_scope_files import (
     DEFAULT_CONFIG,
+    _release_files,
     changed_packages,
     declared_packages,
     find_offenders,
@@ -144,15 +145,20 @@ def test_breaking_change_title_still_detects_offender() -> None:
 
 
 def test_release_title_with_release_files_bypasses_scope_file_check() -> None:
-    """Release PRs can touch generated/version files across package dirs."""
+    """Release PRs can touch generated/version files across package dirs.
+
+    `libs/cli/` is touched and the `deepagents-code` title scope does not cover
+    it, so absent the bypass `cli` is a genuine offender. The assertion can
+    therefore only pass via the release bypass, not ordinary scope coverage —
+    deleting the early-return in `find_offenders` makes this test fail.
+    """
     assert is_release_title("release(deepagents-code): 0.1.22")
     assert (
         find_offenders(
             "release(deepagents-code): 0.1.22",
             [
                 "libs/code/deepagents_code/_version.py",
-                "libs/evals/deepagents_evals/_version.py",
-                "libs/talon/deepagents_talon/_version.py",
+                "libs/cli/deepagents_cli/_version.py",
             ],
             CONFIG,
         )
@@ -211,6 +217,97 @@ def test_unmanaged_package_artifacts_do_not_trigger_release_bypass() -> None:
     assert find_offenders("release(deepagents-code): 0.1.22", changed, config) == [
         {"package": "evals", "dirs": ["libs/evals/"]}
     ]
+
+
+def test_release_files_validates_structure(tmp_path) -> None:
+    """`_release_files` fails closed on every malformed release-config shape."""
+    cases = [
+        ({"packages": {}}, "no non-empty 'packages' map"),
+        ({"packages": {"libs/code": "notadict"}}, "malformed"),
+        ({"packages": {"libs/code": {"extra-files": "x"}}}, "malformed 'extra-files'"),
+        ({"packages": {"libs/code": {"extra-files": [1]}}}, "non-string extra file"),
+    ]
+    for i, (obj, pattern) in enumerate(cases):
+        path = tmp_path / f"release-{i}.json"
+        path.write_text(json.dumps(obj), encoding="utf-8")
+        with pytest.raises(ValueError, match=pattern):
+            _release_files(path)
+
+    missing = tmp_path / "nope.json"
+    with pytest.raises(ValueError, match="could not read release-please config"):
+        _release_files(missing)
+
+
+def test_release_pr_change_fails_closed_on_malformed_release_config(tmp_path) -> None:
+    """The bypass predicate raises (fails closed) on a broken release config."""
+    bad = tmp_path / "release-please-config.json"
+    bad.write_text(json.dumps({"packages": {}}), encoding="utf-8")
+    with pytest.raises(ValueError, match="no non-empty 'packages' map"):
+        is_release_pr_change(
+            "release(deepagents-code): 0.1.22",
+            ["libs/code/deepagents_code/_version.py"],
+            release_config_path=bad,
+        )
+
+
+def test_release_uv_lock_only_still_validates_release_config(tmp_path) -> None:
+    """An all-`uv.lock` release PR still reads/validates the release config.
+
+    `uv.lock` short-circuits in `is_release_file`, but the gate must not stand
+    down without first validating the release config — otherwise a broken config
+    would silently let the bypass fire for a lockfile-only release PR.
+    """
+    bad = tmp_path / "release-please-config.json"
+    bad.write_text("{not json", encoding="utf-8")
+    with pytest.raises(ValueError, match="could not read release-please config"):
+        is_release_pr_change(
+            "release(deepagents-code): 0.1.22",
+            ["libs/code/uv.lock", "libs/cli/uv.lock"],
+            release_config_path=bad,
+        )
+
+
+def test_main_malformed_release_config_fails_closed_and_attributes_correctly(
+    capsys, tmp_path
+) -> None:
+    """A broken release config returns 2 and is not mis-reported as labeler config."""
+    labeler = tmp_path / "pr-labeler-config.json"
+    labeler.write_text(json.dumps(CONFIG), encoding="utf-8")
+    release = tmp_path / "release-please-config.json"
+    release.write_text(json.dumps({"packages": {}}), encoding="utf-8")
+
+    rc = main(
+        "release(deepagents-code): 0.1.22",
+        ["libs/code/deepagents_code/_version.py"],
+        config_path=labeler,
+        release_config_path=release,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 2
+    assert captured.out == ""
+    assert "release-please config" in captured.err
+    assert "PR labeler config" not in captured.err
+
+
+def test_main_uv_lock_only_fails_closed_on_bad_release_config(capsys, tmp_path) -> None:
+    """All-`uv.lock` release PR returns 2 when the release config cannot be read."""
+    labeler = tmp_path / "pr-labeler-config.json"
+    labeler.write_text(json.dumps(CONFIG), encoding="utf-8")
+    release = tmp_path / "release-please-config.json"
+    release.write_text("{not json", encoding="utf-8")
+
+    rc = main(
+        "release(deepagents-code): 0.1.22",
+        ["libs/code/uv.lock", "libs/cli/uv.lock"],
+        config_path=labeler,
+        release_config_path=release,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 2
+    assert captured.out == ""
+    assert "release-please config" in captured.err
 
 
 def test_release_pr_change_covers_repo_wide_lockfiles() -> None:

--- a/.github/scripts/test_check_pr_scope_files.py
+++ b/.github/scripts/test_check_pr_scope_files.py
@@ -326,6 +326,30 @@ def test_main_partially_malformed_file_rules_returns_2(capsys, tmp_path) -> None
     assert "::error::" in capsys.readouterr().err
 
 
+def test_main_release_bypass_validates_labeler_config(capsys, tmp_path) -> None:
+    """Release artifact bypasses still fail closed on malformed labeler config."""
+    config_path = tmp_path / "pr-labeler-config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "scopeToLabel": CONFIG["scopeToLabel"],
+                "fileRules": [{"label": "dcode", "prefix": 123}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc = main(
+        "release(deepagents-code): 0.1.22",
+        ["libs/code/uv.lock"],
+        config_path=config_path,
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 2
+    assert captured.out == ""
+    assert "fileRules" in captured.err
+
+
 def test_main_stdout_is_json_array(capsys, tmp_path) -> None:
     """The workflow can strictly parse stdout as JSON."""
     config_path = tmp_path / "pr-labeler-config.json"

--- a/.github/workflows/pr_scope_file_check.yml
+++ b/.github/workflows/pr_scope_file_check.yml
@@ -8,10 +8,13 @@
 #   changed-file list, posts a sticky warning when they disagree, and FAILS the
 #   check so the mismatch is fixed before merge.
 #
-# Escape hatch:
-#   Apply the `allow-scope-mismatch` label when the mismatch is intentional. The
-#   check re-runs on `labeled`/`unlabeled`, leaves an informational sticky note,
-#   and passes while the label is present.
+# Bypasses:
+#   - `release(...)` PR titles pass only when every changed file matches a
+#     release-please generated/version-file pattern. Release-please PRs can touch
+#     those files across package dirs.
+#   - Apply the `allow-scope-mismatch` label when another mismatch is intentional.
+#     The check re-runs on `labeled`/`unlabeled`, leaves an informational sticky
+#     note, and passes while the label is present.
 #
 # To actually gate merges, add this check to the branch's required status checks.
 #
@@ -30,6 +33,12 @@
 #     still neuter the check. Gate integrity therefore also relies on branch
 #     protection (this job as a required status check) and review of
 #     `.github/workflows/` edits.
+#   - The `release(...)` bypass is title-driven, so it rests on the same
+#     author-controlled title input — but it cannot be abused because it
+#     requires *every* changed file to match a release-please artifact pattern
+#     (see `is_release_file`); a single source file re-arms the gate. The
+#     detector emits a `::notice::` when the bypass fires so the stood-down gate
+#     is visible in the Checks UI rather than silent.
 #
 # Limitations:
 #   - Runs under `pull_request` (not `pull_request_target`), so PRs from forks get


### PR DESCRIPTION
Release-please PRs can touch generated/version artifacts across multiple package directories, which does not fit the normal “title scope covers touched package dirs” rule. The scope/file gate now stands down only for release-shaped PRs whose entire changeset is limited to known release-please artifacts, so ordinary source edits still trigger the mismatch check.
