### PR TITLE
fix(code): drop redundant version from "already up to date" message

### DIFF
--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -553,12 +553,12 @@ elif [ -n "$PRE_VERSION" ] && [ -z "$VERSION" ] && [ -z "$PRERELEASE" ]; then
     log_warn "Could not determine the latest version from PyPI — continuing with an upgrade attempt."
   elif [ -n "$EXTRAS" ] || [ "$PYTHON_REQUESTED" = true ]; then
     if [ "$LATEST_VERSION" = "$PRE_VERSION" ]; then
-      log_info "deepagents-code ${PRE_VERSION} is already up to date — rebuilding with requested options."
+      log_info "deepagents-code is already up to date — rebuilding with requested options."
     else
       log_info "Updating deepagents-code ${PRE_VERSION} → ${LATEST_VERSION} with requested options..."
     fi
   elif [ "$LATEST_VERSION" = "$PRE_VERSION" ]; then
-    log_success "deepagents-code ${PRE_VERSION} is already up to date."
+    log_success "deepagents-code is already up to date."
     exit 0
   elif [ "$ASSUME_YES" = "1" ]; then
     log_info "Updating deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}..."


### PR DESCRIPTION
The `libs/code` install script already prints the version on the preceding `deepagents-code <ver> found — checking for updates...` line, so repeating it on the `is already up to date` status line is redundant. Simplified both the `log_info` (rebuild-with-extras) and `log_success` (no-op exit) lines to `deepagents-code is already up to date`.

Made by [Open SWE](https://openswe.vercel.app/agents/deff72b5-ac91-9dff-439e-934b65a8e99f)