### PR TITLE
feat(quickjs): load imports from attached backend

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -7,10 +7,12 @@ without constructing an agent or wiring up LangGraph state.
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import hashlib
 import json
 import logging
+import posixpath
 import threading
 import uuid
 from dataclasses import dataclass, field, replace
@@ -46,8 +48,9 @@ from langchain_quickjs._subagent import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
+    from deepagents.backends.protocol import BackendProtocol
     from langchain_core.tools import BaseTool
     from langgraph.prebuilt import ToolRuntime
 
@@ -376,6 +379,35 @@ def _render_tools_namespace_assignment(bridges: dict[str, str]) -> str:
     return " ".join(statements)
 
 
+_MODULE_EXTENSIONS = (".js", ".mjs", ".ts")
+_MODULE_INDEX_FILES = tuple(f"index{ext}" for ext in _MODULE_EXTENSIONS)
+
+
+def _module_candidates(path: str) -> tuple[str, ...]:
+    """Return backend paths to try for an import specifier."""
+    candidates = [path]
+    basename = posixpath.basename(path)
+    if "." not in basename:
+        candidates.extend(f"{path}{ext}" for ext in _MODULE_EXTENSIONS)
+        candidates.extend(posixpath.join(path, index) for index in _MODULE_INDEX_FILES)
+    return tuple(dict.fromkeys(candidates))
+
+
+def _decode_file_data(file_data: Mapping[str, Any]) -> str | None:
+    """Decode a backend FileData-like dict into UTF-8 module source."""
+    raw_content = file_data.get("content", "")
+    if isinstance(raw_content, list):
+        content = "\n".join(raw_content)
+    else:
+        content = str(raw_content)
+    if file_data.get("encoding", "utf-8") == "base64":
+        try:
+            return base64.standard_b64decode(content).decode("utf-8")
+        except (UnicodeDecodeError, ValueError):
+            return None
+    return content
+
+
 class _ThreadREPL:
     """One QuickJS context + console buffer, per LangGraph thread.
 
@@ -394,6 +426,7 @@ class _ThreadREPL:
         max_stdout_chars: int,
         max_ptc_calls: int | None = 256,
         subagents_enabled: bool = True,
+        module_backend: BackendProtocol | None = None,
     ) -> None:
         self._worker = worker
         self._runtime = runtime
@@ -406,6 +439,7 @@ class _ThreadREPL:
         # Static budget config; mutable counters live in `_ptc_state`.
         self._max_ptc_calls = max_ptc_calls
         self._subagents_enabled = subagents_enabled
+        self._module_backend = module_backend
         self._console = _ConsoleBuffer(max_stdout_chars)
         self._ctx: Context | None = None
         # PTC state. `_registered_tools` tracks which camel-case names
@@ -435,6 +469,11 @@ class _ThreadREPL:
         worker.run_sync(self._ainit())
 
     async def _ainit(self) -> None:
+        if self._module_backend is not None:
+            self._runtime.set_module_loader(
+                normalize=self._normalize_module_specifier,
+                load=self._read_module_source,
+            )
         self._ctx = self._runtime.new_context(timeout=self._per_call_timeout)
         if self._capture_console:
             self._install_console()
@@ -448,6 +487,40 @@ class _ThreadREPL:
             msg = "QuickJS context is closed"
             raise RuntimeError(msg)
         return self._ctx
+
+    def _normalize_module_specifier(self, base: str, specifier: str) -> str | None:
+        """Resolve QuickJS ESM specifiers to absolute backend paths."""
+        if specifier.startswith("/"):
+            candidate = specifier
+        elif specifier.startswith(("./", "../")):
+            base_dir = posixpath.dirname(base) if base.startswith("/") else "/"
+            candidate = posixpath.join(base_dir, specifier)
+        else:
+            # Treat bare specifiers as virtual absolute paths so a backend can
+            # expose `/lodash.js` and the model can `import("lodash")`.
+            candidate = f"/{specifier}"
+        normalized = posixpath.normpath(candidate)
+        if not normalized.startswith("/"):
+            normalized = f"/{normalized}"
+        for path in _module_candidates(normalized):
+            if self._read_module_source(path) is not None:
+                return path
+        return normalized
+
+    def _read_module_source(self, path: str) -> str | None:
+        """Read one UTF-8 import source file from the configured backend."""
+        backend = self._module_backend
+        if backend is None:
+            return None
+
+        try:
+            read_result = backend.read(path, 0, 1_000_000)
+        except Exception:  # noqa: BLE001 - backends raise implementation-specific errors
+            logger.debug("QuickJS import read failed for %s", path, exc_info=True)
+            return None
+        if read_result.error is not None or read_result.file_data is None:
+            return None
+        return _decode_file_data(read_result.file_data)
 
     def _install_console(self) -> None:
         ctx = self._require_ctx()
@@ -927,6 +1000,7 @@ class _Registry:
     max_stdout_chars: int
     max_ptc_calls: int | None = 256
     subagents_enabled: bool = True
+    module_backend: BackendProtocol | None = None
     _slots: dict[str, _Slot] = field(default_factory=dict)
     _lock: threading.Lock = field(default_factory=threading.Lock)
 
@@ -975,6 +1049,7 @@ class _Registry:
             max_stdout_chars=self.max_stdout_chars,
             max_ptc_calls=self.max_ptc_calls,
             subagents_enabled=self.subagents_enabled,
+            module_backend=self.module_backend,
         )
 
         with self._lock:
@@ -998,6 +1073,7 @@ class _Registry:
             max_stdout_chars=self.max_stdout_chars,
             max_ptc_calls=self.max_ptc_calls,
             subagents_enabled=self.subagents_enabled,
+            module_backend=self.module_backend,
         )
         return _Slot(worker=worker, runtime=runtime, repl=repl)
 

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -382,6 +382,14 @@ def _render_tools_namespace_assignment(bridges: dict[str, str]) -> str:
 
 _MODULE_EXTENSIONS = (".js", ".mjs", ".ts")
 _MODULE_INDEX_FILES = tuple(f"index{ext}" for ext in _MODULE_EXTENSIONS)
+_STATIC_IMPORT_TO_DYNAMIC_IMPORT = getattr(
+    SourceTransform,
+    "STATIC_IMPORT_TO_DYNAMIC_IMPORT",
+    SourceTransform.NONE,
+)
+_TOP_LEVEL_EVAL_TRANSFORM_FLAGS = (
+    SourceTransform.TOP_LEVEL_CONST_TO_VAR | _STATIC_IMPORT_TO_DYNAMIC_IMPORT
+)
 
 
 def _module_candidates(path: str) -> tuple[str, ...]:
@@ -1105,7 +1113,7 @@ class _Registry:
     async def _acreate_runtime(self) -> Runtime:
         return Runtime(
             memory_limit=self.memory_limit,
-            transform_flags=SourceTransform.TOP_LEVEL_CONST_TO_VAR,
+            transform_flags=_TOP_LEVEL_EVAL_TRANSFORM_FLAGS,
         )
 
     def close(self) -> None:

--- a/libs/partners/quickjs/langchain_quickjs/_repl.py
+++ b/libs/partners/quickjs/langchain_quickjs/_repl.py
@@ -31,6 +31,7 @@ from quickjs_rs import (
     Snapshot,
     SourceTransform,
     ThreadWorker,
+    default_module_transform_flags,
 )
 from quickjs_rs import (
     TimeoutError as QJSTimeoutError,
@@ -393,6 +394,11 @@ def _module_candidates(path: str) -> tuple[str, ...]:
     return tuple(dict.fromkeys(candidates))
 
 
+def _module_transform_flags(name: str) -> SourceTransform:
+    """Return transform flags for a backend-loaded import."""
+    return default_module_transform_flags(name) | SourceTransform.TOP_LEVEL_CONST_TO_VAR
+
+
 def _decode_file_data(file_data: Mapping[str, Any]) -> str | None:
     """Decode a backend FileData-like dict into UTF-8 module source."""
     raw_content = file_data.get("content", "")
@@ -473,6 +479,7 @@ class _ThreadREPL:
             self._runtime.set_module_loader(
                 normalize=self._normalize_module_specifier,
                 load=self._read_module_source,
+                transform_flags=_module_transform_flags,
             )
         self._ctx = self._runtime.new_context(timeout=self._per_call_timeout)
         if self._capture_console:

--- a/libs/partners/quickjs/langchain_quickjs/middleware.py
+++ b/libs/partners/quickjs/langchain_quickjs/middleware.py
@@ -7,6 +7,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Annotated, Any, Literal, NotRequired
 
+from deepagents.backends.protocol import BackendProtocol
 from deepagents.middleware._utils import append_to_system_message
 from langchain.agents.middleware.types import (
     AgentMiddleware,
@@ -193,6 +194,11 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
             in middleware state. If a snapshot exceeds this size, it is
             dropped (`_quickjs_snapshot_payload=None`). Defaults to
             `memory_limit`.
+        backend: Optional Deep Agents backend used for JavaScript imports.
+            When provided, imports read source from the backend. Absolute paths
+            are loaded as-is, relative imports are resolved from the importing
+            file, and extensionless imports try `.js`, `.mjs`, `.ts`, and
+            `index.*` candidates.
 
     Example:
         ```python
@@ -221,6 +227,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
         ptc: PTCOption | None = None,
         mode: PersistenceMode | None = None,
         max_snapshot_bytes: int | None = None,
+        backend: BackendProtocol | None = None,
     ) -> None:
         """Initialize REPL middleware state and build the exposed eval tool."""
         super().__init__()
@@ -249,6 +256,7 @@ class CodeInterpreterMiddleware(AgentMiddleware[REPLState, ContextT, ResponseT])
             max_stdout_chars=max_result_chars,
             max_ptc_calls=max_ptc_calls,
             subagents_enabled=subagents,
+            module_backend=backend,
         )
         self._memory_limit_mb = memory_limit // (1024 * 1024)
         self._base_prompt_cache: dict[bool, str] = {}

--- a/libs/partners/quickjs/pyproject.toml
+++ b/libs/partners/quickjs/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["deepagents", "langchain", "langgraph", "repl", "javascript", "quick
 
 dependencies = [
     "deepagents>=0.6.8,<0.7.0",
-    "quickjs-rs>=0.2.3,<0.3.0",
+    "quickjs-rs>=0.2.4,<0.3.0",
     "langchain>=1.3.9,<2.0.0",
     "langchain-core>=1.4.7,<2.0.0",
     "langgraph>=1.2.5,<2.0.0",

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -395,6 +395,28 @@ def test_backend_import_loader_supports_import(
     assert outcome.result == "42"
 
 
+def test_backend_import_loader_strips_typescript_imports(
+    worker: ThreadWorker,
+    runtime: Runtime,
+) -> None:
+    backend = _DictModuleBackend(
+        {"/math.ts": "export const answer: number = 42;"}
+    )
+    module_repl = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+        module_backend=backend,
+    )
+
+    outcome = module_repl.eval_sync("import('/math').then((m) => m.answer)")
+
+    assert outcome.error_type is None
+    assert outcome.result == "42"
+
+
 def test_backend_import_loader_resolves_relative_extensionless_imports(
     worker: ThreadWorker,
     runtime: Runtime,

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -24,7 +24,7 @@ from langchain_core.messages import AIMessage, SystemMessage
 from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import BaseTool, StructuredTool
 from pydantic import BaseModel, Field
-from quickjs_rs import Runtime, ThreadWorker
+from quickjs_rs import Runtime, SourceTransform, ThreadWorker
 
 from langchain_quickjs import CodeInterpreterMiddleware
 from langchain_quickjs._format import format_outcome
@@ -390,6 +390,29 @@ def test_backend_import_loader_supports_import(
     )
 
     outcome = module_repl.eval_sync("import('/math.js').then((m) => m.answer)")
+
+    assert outcome.error_type is None
+    assert outcome.result == "42"
+
+
+@pytest.mark.skipif(
+    not hasattr(SourceTransform, "STATIC_IMPORT_TO_DYNAMIC_IMPORT"),
+    reason="quickjs-rs does not expose static-import rewrite transform",
+)
+def test_top_level_static_imports_are_rewritten_for_backend_loader() -> None:
+    backend = _DictModuleBackend({"/math.js": "export const answer = 42;"})
+    reg = _Registry(
+        memory_limit=32 * 1024 * 1024,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+        module_backend=backend,
+    )
+    try:
+        repl = reg.get("thread-a")
+        outcome = repl.eval_sync('import { answer } from "/math.js"; answer')
+    finally:
+        reg.close()
 
     assert outcome.error_type is None
     assert outcome.result == "42"

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from deepagents.backends.protocol import BackendProtocol, ReadResult
 from deepagents.backends.state import StateBackend
 from deepagents.middleware.subagents import (
     SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY,
@@ -79,6 +80,23 @@ def repl(worker: ThreadWorker, runtime: Runtime) -> _ThreadREPL:
         capture_console=True,
         max_stdout_chars=4000,
     )
+
+
+class _DictModuleBackend(BackendProtocol):
+    def __init__(self, files: dict[str, str]) -> None:
+        self.files = files
+
+    def read(
+        self,
+        file_path: str,
+        offset: int = 0,
+        limit: int = 2000,
+    ) -> ReadResult:
+        del offset, limit
+        content = self.files.get(file_path)
+        if content is None:
+            return ReadResult(error="file_not_found")
+        return ReadResult(file_data={"content": content, "encoding": "utf-8"})
 
 
 # ---------------------------------------------------------------------------
@@ -353,6 +371,55 @@ def test_registry_reset_repl_clears_state_without_recreating_runtime() -> None:
     finally:
         reg.close()
     assert outcome.result == "undefined"
+
+
+def test_backend_import_loader_supports_import(
+    worker: ThreadWorker,
+    runtime: Runtime,
+) -> None:
+    backend = _DictModuleBackend(
+        {"/math.js": "export const answer = 42; export default answer + 1;"}
+    )
+    module_repl = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+        module_backend=backend,
+    )
+
+    outcome = module_repl.eval_sync("import('/math.js').then((m) => m.answer)")
+
+    assert outcome.error_type is None
+    assert outcome.result == "42"
+
+
+def test_backend_import_loader_resolves_relative_extensionless_imports(
+    worker: ThreadWorker,
+    runtime: Runtime,
+) -> None:
+    backend = _DictModuleBackend(
+        {
+            "/lib/main.js": (
+                "import { twice } from './math'; export const value = twice(21);"
+            ),
+            "/lib/math.js": "export function twice(x) { return x * 2; }",
+        }
+    )
+    module_repl = _ThreadREPL(
+        worker,
+        runtime,
+        timeout=5.0,
+        capture_console=True,
+        max_stdout_chars=4000,
+        module_backend=backend,
+    )
+
+    outcome = module_repl.eval_sync("import('/lib/main').then((m) => m.value)")
+
+    assert outcome.error_type is None
+    assert outcome.result == "42"
 
 
 # ---------------------------------------------------------------------------

--- a/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_repl_middleware.py
@@ -422,9 +422,7 @@ def test_backend_import_loader_strips_typescript_imports(
     worker: ThreadWorker,
     runtime: Runtime,
 ) -> None:
-    backend = _DictModuleBackend(
-        {"/math.ts": "export const answer: number = 42;"}
-    )
+    backend = _DictModuleBackend({"/math.ts": "export const answer: number = 42;"})
     module_repl = _ThreadREPL(
         worker,
         runtime,

--- a/libs/partners/quickjs/uv.lock
+++ b/libs/partners/quickjs/uv.lock
@@ -975,7 +975,7 @@ requires-dist = [
     { name = "langchain", specifier = ">=1.3.9,<2.0.0" },
     { name = "langchain-core", specifier = ">=1.4.7,<2.0.0" },
     { name = "langgraph", specifier = ">=1.2.5,<2.0.0" },
-    { name = "quickjs-rs", specifier = ">=0.2.3,<0.3.0" },
+    { name = "quickjs-rs", specifier = ">=0.2.4,<0.3.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1779,14 +1779,14 @@ wheels = [
 
 [[package]]
 name = "quickjs-rs"
-version = "0.2.3"
+version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wasmtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/d5/3657636d9cdff1b2e76e17c210a52704158f13149e7f8175cb533bb64ca2/quickjs_rs-0.2.3.tar.gz", hash = "sha256:5715bb3b6c7583999a4f053a4547fb149c70a9ef0962aa93884cbfb89fb5a471", size = 829047, upload-time = "2026-06-22T20:40:56.372Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/34/1b63bc3db8d950139618d1d38eff5648e5aaa53b2982da5ec121fcf72c63/quickjs_rs-0.2.4.tar.gz", hash = "sha256:7226d18bfa05d97fd629348b7d71512dab4da12bfbe29bdd50486bfc10858cc9", size = 829056, upload-time = "2026-06-24T19:42:21.6Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/fe/637b4128ee76febedc18350329099a764024736eafa79b72635b928a7b80/quickjs_rs-0.2.3-py3-none-any.whl", hash = "sha256:52879678d62dea10f7f30c5821f217a75a2c6d51a3f4c3059d0eacf319b9a889", size = 799751, upload-time = "2026-06-22T20:40:54.697Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/5f/38a30bdfc4fd0a369f1cfe394ea51fbb43a7e492ffe4006f212d24ab05c5/quickjs_rs-0.2.4-py3-none-any.whl", hash = "sha256:3b497b712c4e94401d5617a4c5808b290e2d6bac8e147b315e880306145ae734", size = 799749, upload-time = "2026-06-24T19:42:19.707Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds support for QuickJS imports backed by an explicitly attached Deep Agents backend. When `CodeInterpreterMiddleware` is constructed with `backend=...`, the QuickJS runtime installs a loader that resolves imports against backend paths and reads source through `backend.read(...)`.

Usage example: I have a script saved that either myself or an agent can write which stashes instructions.

```typescript
// .scripts/classify.ts

const CLASSIFY_JSON_SCHEMA = {
  ...
} as const;

function classifyPrompt(input: string) {
  return `You are a classifier agent... input: ${input}`
}

export function classify(input: string) {
  return task({
    subagentType: 'general-purpose'
    description: classifyPrompt(input),
    responseSchema: CLASSIFY_JSON_SCHEMA,
  });
}
```

Agent then writes code like this:

```typescript
import { classify } from "./scripts/classify.ts";

await Promise.all(
  records.map(item => classify(item))
);
```

This lets us store more advanced routines/instructions ahead of time while still giving the agent an easy way to access them.

## Changes

### langchain-quickjs

- Adds a `backend` option to `CodeInterpreterMiddleware` and threads it through the QuickJS REPL registry.
- Installs a QuickJS import loader only when a backend instance is explicitly attached.
- Resolves absolute, relative, bare, and extensionless import specifiers against the attached backend, trying `.js`, `.mjs`, `.ts`, and `index.*` candidates.
- Reads import source exclusively through `backend.read(...)` and decodes backend file data, including UTF-8 and base64-encoded content.

### Tests

- Adds coverage for backend-backed imports and relative extensionless import resolution in the QuickJS REPL tests.
