### PR TITLE
chore(code): pin `deepagents` to `0.7.0a2`

### DIFF
--- a/.github/scripts/check_sdk_pin.py
+++ b/.github/scripts/check_sdk_pin.py
@@ -21,7 +21,12 @@ import re
 import tomllib
 from pathlib import Path
 
-_VERSION_RE = re.compile(r"==\s*([0-9]+\.[0-9]+\.[0-9]+)")
+# Capture the full version token after `==`, stopping at any PEP 508 delimiter
+# (quote, comma, whitespace, marker `;`, or a range operator). Mirrors the
+# `deepagents==([^", <>=;]+)` sed extractor in `check_sdk_pin.yml` and
+# `release.yml` so all three stay in lock-step — notably all three accept PEP
+# 440 prerelease pins like `0.7.0a2`, which a strict `X.Y.Z` pattern truncates.
+_VERSION_RE = re.compile(r"==\s*([^\",\s;<>=]+)")
 _NAME_RE = re.compile(r"[A-Za-z0-9._-]+")
 
 
@@ -48,7 +53,7 @@ def _code_pin(repo_root: Path) -> str:
             version_match = _VERSION_RE.search(dep)
             if version_match:
                 return version_match.group(1)
-    msg = f"No `deepagents==X.Y.Z` pin found in {path}"
+    msg = f"No `deepagents==<version>` pin found in {path}"
     raise ValueError(msg)
 
 

--- a/.github/scripts/test_check_sdk_pin.py
+++ b/.github/scripts/test_check_sdk_pin.py
@@ -59,7 +59,7 @@ def test_missing_pin_raises(tmp_path) -> None:
         sdk_section='[project]\nname = "deepagents"\nversion = "0.6.10"\n',
         code_deps='"deepagents>=0.6.0", "rich>=15"',
     )
-    with pytest.raises(ValueError, match="No `deepagents==X.Y.Z` pin"):
+    with pytest.raises(ValueError, match="No `deepagents==<version>` pin"):
         main(repo)
 
 
@@ -74,12 +74,32 @@ def test_missing_sdk_version_raises(tmp_path) -> None:
         main(repo)
 
 
-def test_non_semver_pin_not_recognized(tmp_path) -> None:
-    """A pin without three numeric segments is not treated as a valid pin."""
+def test_prerelease_pin_in_sync(tmp_path) -> None:
+    """A PEP 440 prerelease pin matching the SDK returns 0.
+
+    The extractor must capture the full `0.7.0a2` token; a strict `X.Y.Z`
+    pattern would truncate it to `0.7.0` and report false drift against an
+    in-sync prerelease SDK. Guards parity with the release workflow's gate.
+    """
+    assert main(_write_repo(tmp_path, "0.7.0a2", "0.7.0a2")) == 0
+
+
+def test_prerelease_pin_drift(tmp_path) -> None:
+    """Two distinct prereleases must be compared verbatim, not truncated."""
+    assert main(_write_repo(tmp_path, "0.7.0a3", "0.7.0a2")) == 1
+
+
+def test_two_segment_pin_recognized(tmp_path) -> None:
+    """Any `==` token is accepted and compared verbatim (parity with sed).
+
+    The extractor no longer requires three numeric segments — it mirrors the
+    `deepagents==([^", <>=;]+)` sed pattern in the workflows, which captures
+    whatever follows `==`. A two-segment `0.6` pin is therefore recognized and
+    reported as drift against the SDK's `0.6.10` (not silently rejected).
+    """
     repo = _write_repo_raw(
         tmp_path,
         sdk_section='[project]\nname = "deepagents"\nversion = "0.6.10"\n',
         code_deps='"deepagents==0.6"',
     )
-    with pytest.raises(ValueError, match="No `deepagents==X.Y.Z` pin"):
-        main(repo)
+    assert main(repo) == 1

--- a/.github/workflows/check_sdk_pin.yml
+++ b/.github/workflows/check_sdk_pin.yml
@@ -52,15 +52,15 @@ jobs:
         env:
           PKG_PYPROJECT: ${{ steps.pkg.outputs.pyproject }}
         run: |
-          SDK_VERSION=$(sed -nE 's/^version = "([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' libs/deepagents/pyproject.toml | head -1)
+          SDK_VERSION=$(sed -nE 's/^version = "([^"]*)".*/\1/p' libs/deepagents/pyproject.toml | head -1)
           if [[ -z "$SDK_VERSION" ]]; then
-            echo "::error file=libs/deepagents/pyproject.toml::Failed to extract SDK version. Expected a line matching: version = \"X.Y.Z\""
+            echo "::error file=libs/deepagents/pyproject.toml::Failed to extract SDK version. Expected a line matching: version = \"<version>\""
             exit 1
           fi
 
-          PKG_SDK_PIN=$(sed -nE 's/.*deepagents==([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' "$PKG_PYPROJECT" | head -1)
+          PKG_SDK_PIN=$(sed -nE 's/.*deepagents==([^", <>=;]+).*/\1/p' "$PKG_PYPROJECT" | head -1)
           if [[ -z "$PKG_SDK_PIN" ]]; then
-            echo "::error file=${PKG_PYPROJECT}::Failed to extract SDK pin. Expected a dependency matching: deepagents==X.Y.Z"
+            echo "::error file=${PKG_PYPROJECT}::Failed to extract SDK pin. Expected a dependency matching: deepagents==<version>"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -869,9 +869,9 @@ jobs:
             exit 1
           fi
 
-          PKG_SDK_PIN=$(sed -nE 's/.*deepagents==([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' "$PKG_PYPROJECT" | head -1)
+          PKG_SDK_PIN=$(sed -nE 's/.*deepagents==([^", <>=;]+).*/\1/p' "$PKG_PYPROJECT" | head -1)
           if [ -z "$PKG_SDK_PIN" ]; then
-            echo "::error file=${PKG_PYPROJECT}::Failed to extract SDK pin. Expected a dependency matching: deepagents==X.Y.Z"
+            echo "::error file=${PKG_PYPROJECT}::Failed to extract SDK pin. Expected a dependency matching: deepagents==<version>"
             exit 1
           fi
 

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     # Framework
-    "deepagents==0.6.11",
+    "deepagents==0.7.0a2",
     "langchain>=1.3.11,<2.0.0",
     "langgraph-checkpoint-sqlite>=3.1.0,<4.0.0",
 


### PR DESCRIPTION
Pins deepagents-code to deepagents 0.7.0a2 so the package installs the intended alpha SDK release.