### PR TITLE
feat(evals): run continual-learning-bench from the Harbor workflow

### DIFF
--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -159,6 +159,14 @@ on:
         required: true
         default: "1"
         type: string
+      clbench_schedule:
+        description: "[clbench only] Schedule for dataset=clbench. 'quick_test' = cheap smoke (per-task clbench run; only tasks that define it — currently just exploitable_poker). 'default' = leaderboard-comparable (run-all, each task's default schedule, 5 runs + baseline) — multi-hour and likely exceeds the job timeout for a Deep Agents system. Ignored for Harbor."
+        required: true
+        default: "quick_test"
+        type: choice
+        options:
+          - quick_test
+          - default
 permissions:
   contents: read
 
@@ -537,6 +545,7 @@ jobs:
       CLBENCH_PROVIDER: ${{ matrix.provider }}
       CLBENCH_INCLUDE_TASKS: ${{ inputs.include_tasks }}
       CLBENCH_PER_TASK_PARALLELISM: ${{ inputs.concurrency }}
+      CLBENCH_SCHEDULE: ${{ inputs.clbench_schedule }}
       # Trace-level LangSmith tracing only: LangChain/LangGraph auto-captures the
       # agent trajectories when these are set. clbench itself has no LangSmith
       # experiment integration, so scores/gain stay in clbench's own artifacts.
@@ -601,16 +610,19 @@ jobs:
           if ! [[ "$CLBENCH_PER_TASK_PARALLELISM" =~ ^[1-9][0-9]*$ ]]; then
             echo "::error::Invalid concurrency (per-task-parallelism): $CLBENCH_PER_TASK_PARALLELISM"; exit 1
           fi
-          # Validate + collect clbench task names (alphanumeric + underscore only).
-          task_flags=()
+          # Validate the schedule name (used in a file path + the command).
+          if ! [[ "$CLBENCH_SCHEDULE" =~ ^[A-Za-z0-9_]+$ ]]; then
+            echo "::error::Invalid clbench schedule: $CLBENCH_SCHEDULE"; exit 1
+          fi
+          # Validate + collect requested task names (alphanumeric + underscore only).
+          req_tasks=()
           if [ -n "$CLBENCH_INCLUDE_TASKS" ]; then
-            read -r -a _tasks <<< "$CLBENCH_INCLUDE_TASKS"
-            for t in "${_tasks[@]}"; do
+            read -r -a req_tasks <<< "$CLBENCH_INCLUDE_TASKS"
+            for t in "${req_tasks[@]}"; do
               if ! [[ "$t" =~ ^[A-Za-z0-9_]+$ ]]; then
                 echo "::error::Invalid clbench task name: $t"; exit 1
               fi
             done
-            task_flags=(--task "${_tasks[@]}")
           fi
 
           # Clone clbench pinned to a specific commit.
@@ -652,14 +664,52 @@ jobs:
             echo "LangSmith tracing: OFF (no LANGSMITH_API_KEY secret)"
           fi
 
-          echo "Running 'clbench run-all' (whole benchmark) — system=deepagents, model=$CLBENCH_MODEL"
-          ( cd clbench-src && set -x && uv run clbench run-all \
-              --name "$run_name" \
-              --system deepagents \
-              --system.model "$CLBENCH_MODEL" \
-              ${task_flags[@]+"${task_flags[@]}"} \
-              --per-task-parallelism "$CLBENCH_PER_TASK_PARALLELISM" \
-              --no-live-dashboard )
+          if [ "$CLBENCH_SCHEDULE" = "default" ]; then
+            # Leaderboard-comparable: run-all uses each task's default schedule (5 runs
+            # + baseline). This is exactly the config the public leaderboard reports.
+            echo "::warning::clbench_schedule=default is leaderboard-scale (all default schedules, 5 runs + baseline); for a Deep Agents system this is many hours and will likely exceed the job timeout — prefer running per-task or out-of-CI."
+            task_flags=()
+            if [ "${#req_tasks[@]}" -gt 0 ]; then task_flags=(--task "${req_tasks[@]}"); fi
+            echo "Running 'clbench run-all' (leaderboard mode) — system=deepagents, model=$CLBENCH_MODEL"
+            ( cd clbench-src && set -x && uv run clbench run-all \
+                --name "$run_name" \
+                --system deepagents \
+                --system.model "$CLBENCH_MODEL" \
+                ${task_flags[@]+"${task_flags[@]}"} \
+                --per-task-parallelism "$CLBENCH_PER_TASK_PARALLELISM" \
+                --no-live-dashboard )
+          else
+            # Cheap/named-schedule mode: run-all is hardwired to default.json, so a
+            # named schedule (e.g. quick_test) must be run per task via `clbench run`.
+            targets=()
+            if [ "${#req_tasks[@]}" -gt 0 ]; then
+              targets=("${req_tasks[@]}")
+            else
+              # No include_tasks: auto-select tasks that actually define this schedule.
+              for d in clbench-src/src/tasks/*/; do
+                t="$(basename "$d")"
+                if [ -f "$d/schedules/${CLBENCH_SCHEDULE}.json" ]; then targets+=("$t"); fi
+              done
+            fi
+            if [ "${#targets[@]}" -eq 0 ]; then
+              echo "::error::No task defines schedule '$CLBENCH_SCHEDULE' (currently only exploitable_poker ships quick_test). Pass include_tasks, or use clbench_schedule=default."; exit 1
+            fi
+            echo "Cheap mode: schedule=$CLBENCH_SCHEDULE, tasks: ${targets[*]}"
+            rc=0
+            for t in "${targets[@]}"; do
+              if [ ! -f "clbench-src/src/tasks/$t/schedules/${CLBENCH_SCHEDULE}.json" ]; then
+                echo "::warning::task '$t' has no '$CLBENCH_SCHEDULE' schedule; skipping"; continue
+              fi
+              echo "Running 'clbench run $t --schedule $CLBENCH_SCHEDULE' — system=deepagents, model=$CLBENCH_MODEL"
+              ( cd clbench-src && set -x && uv run clbench run "$t" \
+                  --schedule "$CLBENCH_SCHEDULE" \
+                  --system deepagents \
+                  --system.model "$CLBENCH_MODEL" \
+                  --max-workers "$CLBENCH_PER_TASK_PARALLELISM" \
+                  --no-live-dashboard ) || rc=$?
+            done
+            [ "$rc" -eq 0 ] || { echo "::error::one or more clbench tasks failed (rc=$rc)"; exit "$rc"; }
+          fi
 
       - name: "📝 Write workflow summary"
         if: always()
@@ -676,6 +726,11 @@ jobs:
               echo "- Tasks: all (run-all over the whole benchmark)"
             fi
             echo "- Per-task parallelism: ${CLBENCH_PER_TASK_PARALLELISM}"
+            if [ "${CLBENCH_SCHEDULE}" = "default" ]; then
+              echo "- Schedule: default (leaderboard-comparable: run-all, each task's default schedule, 5 runs)"
+            else
+              echo "- Schedule: ${CLBENCH_SCHEDULE} (cheap mode: per-task clbench run --schedule)"
+            fi
             if [ "${LANGSMITH_TRACING}" = "true" ]; then
               echo "- LangSmith tracing: on (trajectories only; project ${CLBENCH_LS_PROJECT:-deepagents-clbench-<model>})"
             else

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -571,14 +571,19 @@ jobs:
       - name: "🔑 Verify model credentials"
         env:
           ANTHROPIC_API_KEY: ${{ startsWith(matrix.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
+          BASETEN_API_KEY: ${{ startsWith(matrix.model, 'baseten:') && secrets.BASETEN_API_KEY || '' }}
+          FIREWORKS_API_KEY: ${{ startsWith(matrix.model, 'fireworks:') && secrets.FIREWORKS_API_KEY || '' }}
           GOOGLE_API_KEY: ${{ startsWith(matrix.model, 'google_genai:') && secrets.GOOGLE_API_KEY || '' }}
           GROQ_API_KEY: ${{ startsWith(matrix.model, 'groq:') && secrets.GROQ_API_KEY || '' }}
+          NVIDIA_API_KEY: ${{ startsWith(matrix.model, 'nvidia:') && secrets.NVIDIA_API_KEY || '' }}
           OLLAMA_API_KEY: ${{ startsWith(matrix.model, 'ollama:') && secrets.OLLAMA_API_KEY || '' }}
           OPENAI_API_KEY: ${{ startsWith(matrix.model, 'openai:') && secrets.OPENAI_API_KEY || '' }}
+          OPENROUTER_API_KEY: ${{ startsWith(matrix.model, 'openrouter:') && secrets.OPENROUTER_API_KEY || '' }}
           XAI_API_KEY: ${{ startsWith(matrix.model, 'xai:') && secrets.XAI_API_KEY || '' }}
         run: |
           provider="${CLBENCH_MODEL%%:*}"
           missing=()
+          # All Harbor matrix providers resolve through init_chat_model.
           case "$provider" in
             anthropic)    [ -z "$ANTHROPIC_API_KEY" ] && missing+=("ANTHROPIC_API_KEY") ;;
             openai)       [ -z "$OPENAI_API_KEY" ] && missing+=("OPENAI_API_KEY") ;;
@@ -586,8 +591,12 @@ jobs:
             groq)         [ -z "$GROQ_API_KEY" ] && missing+=("GROQ_API_KEY") ;;
             xai)          [ -z "$XAI_API_KEY" ] && missing+=("XAI_API_KEY") ;;
             ollama)       [ -z "$OLLAMA_API_KEY" ] && missing+=("OLLAMA_API_KEY") ;;
+            fireworks)    [ -z "$FIREWORKS_API_KEY" ] && missing+=("FIREWORKS_API_KEY") ;;
+            nvidia)       [ -z "$NVIDIA_API_KEY" ] && missing+=("NVIDIA_API_KEY") ;;
+            openrouter)   [ -z "$OPENROUTER_API_KEY" ] && missing+=("OPENROUTER_API_KEY") ;;
+            baseten)      [ -z "$BASETEN_API_KEY" ] && missing+=("BASETEN_API_KEY") ;;
             *)
-              echo "::error::clbench's Deep Agents system uses init_chat_model and does not support provider '$provider' (supported: anthropic, openai, google_genai, groq, xai, ollama). Select a supported model for dataset=clbench."; exit 1
+              echo "::warning::Unknown provider prefix '$provider' for clbench; proceeding and letting init_chat_model resolve it. Ensure the matching API key secret is configured."
               ;;
           esac
           if [ ${#missing[@]} -gt 0 ]; then
@@ -609,10 +618,14 @@ jobs:
       - name: "🧠 Run continual-learning-bench with the Deep Agents system"
         env:
           ANTHROPIC_API_KEY: ${{ startsWith(matrix.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
+          BASETEN_API_KEY: ${{ startsWith(matrix.model, 'baseten:') && secrets.BASETEN_API_KEY || '' }}
+          FIREWORKS_API_KEY: ${{ startsWith(matrix.model, 'fireworks:') && secrets.FIREWORKS_API_KEY || '' }}
           GOOGLE_API_KEY: ${{ startsWith(matrix.model, 'google_genai:') && secrets.GOOGLE_API_KEY || '' }}
           GROQ_API_KEY: ${{ startsWith(matrix.model, 'groq:') && secrets.GROQ_API_KEY || '' }}
+          NVIDIA_API_KEY: ${{ startsWith(matrix.model, 'nvidia:') && secrets.NVIDIA_API_KEY || '' }}
           OLLAMA_API_KEY: ${{ startsWith(matrix.model, 'ollama:') && secrets.OLLAMA_API_KEY || '' }}
           OPENAI_API_KEY: ${{ startsWith(matrix.model, 'openai:') && secrets.OPENAI_API_KEY || '' }}
+          OPENROUTER_API_KEY: ${{ startsWith(matrix.model, 'openrouter:') && secrets.OPENROUTER_API_KEY || '' }}
           XAI_API_KEY: ${{ startsWith(matrix.model, 'xai:') && secrets.XAI_API_KEY || '' }}
         run: |
           set -euo pipefail
@@ -647,6 +660,7 @@ jobs:
           # Install clbench (all task extras), the local Deep Agents SDK, and the
           # matrix model's LangChain provider integration.
           ( cd clbench-src && uv sync --all-extras )
+          # Provider -> LangChain integration package (init_chat_model resolves all of these).
           case "$CLBENCH_PROVIDER" in
             anthropic)    provider_pkg="langchain-anthropic" ;;
             openai)       provider_pkg="langchain-openai" ;;
@@ -654,9 +668,17 @@ jobs:
             groq)         provider_pkg="langchain-groq" ;;
             xai)          provider_pkg="langchain-xai" ;;
             ollama)       provider_pkg="langchain-ollama" ;;
-            *)            provider_pkg="" ;;
+            fireworks)    provider_pkg="langchain-fireworks" ;;
+            nvidia)       provider_pkg="langchain-nvidia-ai-endpoints" ;;
+            openrouter)   provider_pkg="langchain-openrouter" ;;
+            baseten)      provider_pkg="langchain-baseten" ;;
+            *)            provider_pkg="langchain-openai"
+                          echo "::warning::Unknown provider '$CLBENCH_PROVIDER'; defaulting integration to langchain-openai." ;;
           esac
-          ( cd clbench-src && uv pip install -e "$GITHUB_WORKSPACE/libs/deepagents" ${provider_pkg:+"$provider_pkg"} )
+          # Fireworks can pull a prerelease dependency (matches the Harbor job).
+          uv_pre=""
+          [ "$CLBENCH_PROVIDER" = "fireworks" ] && uv_pre="UV_PRERELEASE=allow"
+          ( cd clbench-src && env $uv_pre uv pip install -e "$GITHUB_WORKSPACE/libs/deepagents" ${provider_pkg:+"$provider_pkg"} )
 
           # Deploy the Deep Agents system into this clbench checkout.
           "$GITHUB_WORKSPACE/libs/evals/deepagents_clbench/sync_to_clbench.sh" "$GITHUB_WORKSPACE/clbench-src"

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -558,6 +558,9 @@ jobs:
       CLBENCH_INCLUDE_TASKS: ${{ inputs.include_tasks }}
       CLBENCH_PER_TASK_PARALLELISM: ${{ inputs.concurrency }}
       CLBENCH_SCHEDULE: ${{ inputs.clbench_schedule }}
+      # Ollama cloud endpoint (matches the Harbor job); ollama:*:cloud needs this
+      # or LangChain defaults to a local Ollama server.
+      OLLAMA_HOST: "https://ollama.com"
       # Trace-level LangSmith tracing only: LangChain/LangGraph auto-captures the
       # agent trajectories when these are set. clbench itself has no LangSmith
       # experiment integration, so scores/gain stay in clbench's own artifacts.
@@ -584,7 +587,7 @@ jobs:
             xai)          [ -z "$XAI_API_KEY" ] && missing+=("XAI_API_KEY") ;;
             ollama)       [ -z "$OLLAMA_API_KEY" ] && missing+=("OLLAMA_API_KEY") ;;
             *)
-              echo "::warning::clbench's Deep Agents system uses init_chat_model; provider '$provider' may be unsupported (supported: anthropic, openai, google_genai, groq, xai, ollama)."
+              echo "::error::clbench's Deep Agents system uses init_chat_model and does not support provider '$provider' (supported: anthropic, openai, google_genai, groq, xai, ollama). Select a supported model for dataset=clbench."; exit 1
               ;;
           esac
           if [ ${#missing[@]} -gt 0 ]; then
@@ -695,7 +698,14 @@ jobs:
             # named schedule (e.g. quick_test) must be run per task via `clbench run`.
             targets=()
             if [ "${#req_tasks[@]}" -gt 0 ]; then
-              targets=("${req_tasks[@]}")
+              # Explicit request: every named task MUST define the schedule. Do not
+              # silently skip — that would produce a green run with no benchmark result.
+              for t in "${req_tasks[@]}"; do
+                if [ ! -f "clbench-src/src/tasks/$t/schedules/${CLBENCH_SCHEDULE}.json" ]; then
+                  echo "::error::Requested task '$t' has no '$CLBENCH_SCHEDULE' schedule (e.g. quick_test currently exists only for exploitable_poker). Pick a task that defines it, or use clbench_schedule=default."; exit 1
+                fi
+                targets+=("$t")
+              done
             else
               # No include_tasks: auto-select tasks that actually define this schedule.
               for d in clbench-src/src/tasks/*/; do
@@ -707,11 +717,8 @@ jobs:
               echo "::error::No task defines schedule '$CLBENCH_SCHEDULE' (currently only exploitable_poker ships quick_test). Pass include_tasks, or use clbench_schedule=default."; exit 1
             fi
             echo "Cheap mode: schedule=$CLBENCH_SCHEDULE, tasks: ${targets[*]}"
-            rc=0
+            rc=0; ran=0
             for t in "${targets[@]}"; do
-              if [ ! -f "clbench-src/src/tasks/$t/schedules/${CLBENCH_SCHEDULE}.json" ]; then
-                echo "::warning::task '$t' has no '$CLBENCH_SCHEDULE' schedule; skipping"; continue
-              fi
               echo "Running 'clbench run $t --schedule $CLBENCH_SCHEDULE' — system=deepagents, model=$CLBENCH_MODEL"
               ( cd clbench-src && set -x && uv run clbench run "$t" \
                   --schedule "$CLBENCH_SCHEDULE" \
@@ -719,7 +726,9 @@ jobs:
                   --system.model "$CLBENCH_MODEL" \
                   --max-workers "$CLBENCH_PER_TASK_PARALLELISM" \
                   --no-live-dashboard ) || rc=$?
+              ran=$((ran + 1))
             done
+            if [ "$ran" -eq 0 ]; then echo "::error::no clbench tasks ran for schedule '$CLBENCH_SCHEDULE'"; exit 1; fi
             [ "$rc" -eq 0 ] || { echo "::error::one or more clbench tasks failed (rc=$rc)"; exit "$rc"; }
           fi
 

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -537,6 +537,12 @@ jobs:
       CLBENCH_PROVIDER: ${{ matrix.provider }}
       CLBENCH_INCLUDE_TASKS: ${{ inputs.include_tasks }}
       CLBENCH_PER_TASK_PARALLELISM: ${{ inputs.concurrency }}
+      # Trace-level LangSmith tracing only: LangChain/LangGraph auto-captures the
+      # agent trajectories when these are set. clbench itself has no LangSmith
+      # experiment integration, so scores/gain stay in clbench's own artifacts.
+      # Tracing turns on only when the secret is present (no warnings when absent).
+      LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+      LANGSMITH_TRACING: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
     steps:
       - name: "🔑 Verify model credentials"
         env:
@@ -635,6 +641,17 @@ jobs:
           model_slug=$(printf '%s' "$CLBENCH_MODEL" | tr '/:' '--' | tr -c '[:alnum:]._-' '-')
           run_name="deepagents-${model_slug}-${GITHUB_RUN_ID}"
 
+          # Trace-level LangSmith: group this model's agent traces under one project.
+          # Inherited by the run-all subprocesses. Never print the key, only status.
+          ls_project="deepagents-clbench-${model_slug}"
+          export LANGSMITH_PROJECT="$ls_project"
+          echo "CLBENCH_LS_PROJECT=${ls_project}" >> "$GITHUB_ENV"
+          if [ -n "${LANGSMITH_API_KEY:-}" ]; then
+            echo "LangSmith tracing: ON -> project $ls_project"
+          else
+            echo "LangSmith tracing: OFF (no LANGSMITH_API_KEY secret)"
+          fi
+
           echo "Running 'clbench run-all' (whole benchmark) — system=deepagents, model=$CLBENCH_MODEL"
           ( cd clbench-src && set -x && uv run clbench run-all \
               --name "$run_name" \
@@ -659,6 +676,11 @@ jobs:
               echo "- Tasks: all (run-all over the whole benchmark)"
             fi
             echo "- Per-task parallelism: ${CLBENCH_PER_TASK_PARALLELISM}"
+            if [ "${LANGSMITH_TRACING}" = "true" ]; then
+              echo "- LangSmith tracing: on (trajectories only; project ${CLBENCH_LS_PROJECT:-deepagents-clbench-<model>})"
+            else
+              echo "- LangSmith tracing: off (set the LANGSMITH_API_KEY secret to enable)"
+            fi
             echo "- Note: sandbox_env / agent_impl / n_tasks / rollouts_per_task are Harbor-only and were ignored."
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -26,8 +26,17 @@ run-name: >-
 on:
   workflow_dispatch:
     inputs:
+      dataset:
+        description: "Benchmark to run (primary selector). Terminal-bench refs run through Harbor. The value 'clbench' runs continual-learning-bench instead — a separate benchmark (NOT Harbor) that runs on the runner with the Deep Agents system; see the clbench job. Selecting 'clbench' makes the [Harbor only] inputs below no-ops."
+        required: true
+        default: "terminal-bench/terminal-bench-2"
+        type: choice
+        options:
+          - "terminal-bench/terminal-bench-2"
+          - "terminal-bench/terminal-bench-2-1"
+          - "clbench"
       models:
-        description: "Model set to run. Set definitions: libs/evals/MODEL_GROUPS.md. Leave empty to use models_override instead. Defaults to all models if both are empty."
+        description: "[Harbor + clbench] Model set to run. Set definitions: libs/evals/MODEL_GROUPS.md. Leave empty to use models_override instead. Defaults to all models if both are empty."
         required: false
         default: ""
         type: choice
@@ -110,12 +119,12 @@ on:
           - "xai:grok-4"
           - "xai:grok-3-mini-fast"
       models_override:
-        description: "Override: comma-separated models (e.g. 'openai:gpt-4.1,anthropic:claude-sonnet-4-6'). Takes priority over dropdown when non-empty."
+        description: "[Harbor + clbench] Override: comma-separated models (e.g. 'openai:gpt-4.1,anthropic:claude-sonnet-4-6'). Takes priority over dropdown when non-empty."
         required: false
         default: ""
         type: string
       sandbox_env:
-        description: "Harbor sandbox environment"
+        description: "[Harbor only] Harbor sandbox environment. Ignored when dataset=clbench (clbench runs directly on the runner; it has no Harbor sandbox concept)."
         required: true
         default: "langsmith"
         type: choice
@@ -123,35 +132,30 @@ on:
           - docker
           - langsmith
       agent_impl:
-        description: "Deep Agents implementation to run through Harbor's LangGraph agent"
+        description: "[Harbor only] Deep Agents implementation run through Harbor's LangGraph agent. Ignored when dataset=clbench."
         required: true
         default: "dcode"
         type: choice
         options:
           - dcode
           - bare
-      dataset:
-        description: "Harbor dataset ref (e.g. terminal-bench/terminal-bench-2 or terminal-bench/terminal-bench-2-1)"
-        required: true
-        default: "terminal-bench/terminal-bench-2"
-        type: string
       n_tasks:
-        description: "Maximum number of tasks to run (0 = all tasks in dataset)"
+        description: "[Harbor only] Maximum number of tasks to run (0 = all). Ignored when dataset=clbench — use include_tasks to pick clbench tasks."
         required: true
         default: "0"
         type: string
       include_tasks:
-        description: "Space-separated task-name globs to include (e.g. re-run a subset). Empty = all tasks."
+        description: "[Harbor + clbench] Harbor: space-separated task-name globs. clbench: space-separated task names passed as --task (empty = all clbench tasks)."
         required: false
         default: ""
         type: string
       rollouts_per_task:
-        description: "Number of rollouts to run per task"
+        description: "[Harbor only] Rollouts per task. Ignored when dataset=clbench — run-all uses each task's default schedule (which defines its own runs)."
         required: true
         default: "1"
         type: string
       concurrency:
-        description: "Number of concurrent trials (parallel sandbox slots)"
+        description: "[Harbor + clbench] Harbor: concurrent trials (sandbox slots). clbench: forwarded as --per-task-parallelism."
         required: true
         default: "1"
         type: string
@@ -223,6 +227,7 @@ jobs:
   harbor:
     name: "📊 Evals - Harbor (${{ matrix.model }} / ${{ inputs.sandbox_env }} / ${{ inputs.agent_impl }})"
     needs: prep
+    if: ${{ inputs.dataset != 'clbench' }}
     runs-on: ubuntu-latest
     environment: evals
     timeout-minutes: 360
@@ -508,4 +513,161 @@ jobs:
           name: harbor-${{ strategy.job-index }}
           path: |
             libs/evals/harbor-jobs/terminal-bench
+          if-no-files-found: warn
+
+  # continual-learning-bench (clbench) — NOT Harbor. Selected via dataset=clbench.
+  # Runs the whole benchmark (clbench run-all) with the Deep Agents system on the
+  # runner. Shares the prep model matrix. Harbor-only inputs (sandbox_env,
+  # agent_impl, n_tasks, rollouts_per_task) do not apply here.
+  clbench:
+    name: "🧠 Evals - clbench (${{ matrix.model }} / deepagents)"
+    needs: prep
+    if: ${{ inputs.dataset == 'clbench' }}
+    runs-on: ubuntu-latest
+    environment: evals
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prep.outputs.matrix) }}
+    env:
+      CLBENCH_REPO: "https://github.com/pgasawa/continual-learning-bench"
+      # Pinned to a specific commit (not a moving ref) for reproducibility.
+      CLBENCH_REF: "56764d61afa2860e4893bc14e6229e33fcebf06b"
+      CLBENCH_MODEL: ${{ matrix.model }}
+      CLBENCH_PROVIDER: ${{ matrix.provider }}
+      CLBENCH_INCLUDE_TASKS: ${{ inputs.include_tasks }}
+      CLBENCH_PER_TASK_PARALLELISM: ${{ inputs.concurrency }}
+    steps:
+      - name: "🔑 Verify model credentials"
+        env:
+          ANTHROPIC_API_KEY: ${{ startsWith(matrix.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
+          GOOGLE_API_KEY: ${{ startsWith(matrix.model, 'google_genai:') && secrets.GOOGLE_API_KEY || '' }}
+          GROQ_API_KEY: ${{ startsWith(matrix.model, 'groq:') && secrets.GROQ_API_KEY || '' }}
+          OLLAMA_API_KEY: ${{ startsWith(matrix.model, 'ollama:') && secrets.OLLAMA_API_KEY || '' }}
+          OPENAI_API_KEY: ${{ startsWith(matrix.model, 'openai:') && secrets.OPENAI_API_KEY || '' }}
+          XAI_API_KEY: ${{ startsWith(matrix.model, 'xai:') && secrets.XAI_API_KEY || '' }}
+        run: |
+          provider="${CLBENCH_MODEL%%:*}"
+          missing=()
+          case "$provider" in
+            anthropic)    [ -z "$ANTHROPIC_API_KEY" ] && missing+=("ANTHROPIC_API_KEY") ;;
+            openai)       [ -z "$OPENAI_API_KEY" ] && missing+=("OPENAI_API_KEY") ;;
+            google_genai) [ -z "$GOOGLE_API_KEY" ] && missing+=("GOOGLE_API_KEY") ;;
+            groq)         [ -z "$GROQ_API_KEY" ] && missing+=("GROQ_API_KEY") ;;
+            xai)          [ -z "$XAI_API_KEY" ] && missing+=("XAI_API_KEY") ;;
+            ollama)       [ -z "$OLLAMA_API_KEY" ] && missing+=("OLLAMA_API_KEY") ;;
+            *)
+              echo "::warning::clbench's Deep Agents system uses init_chat_model; provider '$provider' may be unsupported (supported: anthropic, openai, google_genai, groq, xai, ollama)."
+              ;;
+          esac
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required secret(s) for $CLBENCH_MODEL: ${missing[*]}"
+            exit 1
+          fi
+          echo "Credentials present for $CLBENCH_MODEL"
+
+      - name: "📋 Checkout Code"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: "🐍 Set up Python + UV"
+        uses: "./.github/actions/uv_setup"
+        with:
+          python-version: "3.13"
+          cache-suffix: clbench
+          working-directory: libs/evals
+
+      - name: "🧠 Run continual-learning-bench with the Deep Agents system"
+        env:
+          ANTHROPIC_API_KEY: ${{ startsWith(matrix.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
+          GOOGLE_API_KEY: ${{ startsWith(matrix.model, 'google_genai:') && secrets.GOOGLE_API_KEY || '' }}
+          GROQ_API_KEY: ${{ startsWith(matrix.model, 'groq:') && secrets.GROQ_API_KEY || '' }}
+          OLLAMA_API_KEY: ${{ startsWith(matrix.model, 'ollama:') && secrets.OLLAMA_API_KEY || '' }}
+          OPENAI_API_KEY: ${{ startsWith(matrix.model, 'openai:') && secrets.OPENAI_API_KEY || '' }}
+          XAI_API_KEY: ${{ startsWith(matrix.model, 'xai:') && secrets.XAI_API_KEY || '' }}
+        run: |
+          set -euo pipefail
+
+          # Validate the pinned ref is a full commit SHA (no moving refs).
+          if ! [[ "$CLBENCH_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::CLBENCH_REF must be a full 40-char commit SHA"; exit 1
+          fi
+          # Validate per-task parallelism is a positive integer.
+          if ! [[ "$CLBENCH_PER_TASK_PARALLELISM" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Invalid concurrency (per-task-parallelism): $CLBENCH_PER_TASK_PARALLELISM"; exit 1
+          fi
+          # Validate + collect clbench task names (alphanumeric + underscore only).
+          task_flags=()
+          if [ -n "$CLBENCH_INCLUDE_TASKS" ]; then
+            read -r -a _tasks <<< "$CLBENCH_INCLUDE_TASKS"
+            for t in "${_tasks[@]}"; do
+              if ! [[ "$t" =~ ^[A-Za-z0-9_]+$ ]]; then
+                echo "::error::Invalid clbench task name: $t"; exit 1
+              fi
+            done
+            task_flags=(--task "${_tasks[@]}")
+          fi
+
+          # Clone clbench pinned to a specific commit.
+          git clone --filter=blob:none "$CLBENCH_REPO" clbench-src
+          git -C clbench-src checkout --quiet "$CLBENCH_REF"
+
+          # Install clbench (all task extras), the local Deep Agents SDK, and the
+          # matrix model's LangChain provider integration.
+          ( cd clbench-src && uv sync --all-extras )
+          case "$CLBENCH_PROVIDER" in
+            anthropic)    provider_pkg="langchain-anthropic" ;;
+            openai)       provider_pkg="langchain-openai" ;;
+            google_genai) provider_pkg="langchain-google-genai" ;;
+            groq)         provider_pkg="langchain-groq" ;;
+            xai)          provider_pkg="langchain-xai" ;;
+            ollama)       provider_pkg="langchain-ollama" ;;
+            *)            provider_pkg="" ;;
+          esac
+          ( cd clbench-src && uv pip install -e "$GITHUB_WORKSPACE/libs/deepagents" ${provider_pkg:+"$provider_pkg"} )
+
+          # Deploy the Deep Agents system into this clbench checkout.
+          "$GITHUB_WORKSPACE/libs/evals/deepagents_clbench/sync_to_clbench.sh" "$GITHUB_WORKSPACE/clbench-src"
+
+          # Best-effort dataset setup for tasks that need it (non-fatal).
+          ( cd clbench-src && uv run clbench setup --all ) \
+            || echo "::warning::'clbench setup --all' reported errors; tasks needing that data may be skipped."
+
+          model_slug=$(printf '%s' "$CLBENCH_MODEL" | tr '/:' '--' | tr -c '[:alnum:]._-' '-')
+          run_name="deepagents-${model_slug}-${GITHUB_RUN_ID}"
+
+          echo "Running 'clbench run-all' (whole benchmark) — system=deepagents, model=$CLBENCH_MODEL"
+          ( cd clbench-src && set -x && uv run clbench run-all \
+              --name "$run_name" \
+              --system deepagents \
+              --system.model "$CLBENCH_MODEL" \
+              ${task_flags[@]+"${task_flags[@]}"} \
+              --per-task-parallelism "$CLBENCH_PER_TASK_PARALLELISM" \
+              --no-live-dashboard )
+
+      - name: "📝 Write workflow summary"
+        if: always()
+        run: |
+          {
+            echo "## clbench run (continual-learning-bench — not Harbor)"
+            echo
+            echo "- Model: ${CLBENCH_MODEL}"
+            echo "- System: deepagents"
+            echo "- clbench ref: ${CLBENCH_REF}"
+            if [ -n "${CLBENCH_INCLUDE_TASKS}" ]; then
+              echo "- Tasks: ${CLBENCH_INCLUDE_TASKS}"
+            else
+              echo "- Tasks: all (run-all over the whole benchmark)"
+            fi
+            echo "- Per-task parallelism: ${CLBENCH_PER_TASK_PARALLELISM}"
+            echo "- Note: sandbox_env / agent_impl / n_tasks / rollouts_per_task are Harbor-only and were ignored."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: "📤 Upload clbench results"
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: clbench-${{ strategy.job-index }}
+          path: |
+            clbench-src/final_results
+            clbench-src/results
           if-no-files-found: warn

--- a/libs/evals/deepagents_clbench/README.md
+++ b/libs/evals/deepagents_clbench/README.md
@@ -1,0 +1,87 @@
+# deepagents_clbench
+
+Canonical source for the **`deepagents`** system in
+[continual-learning-bench](https://github.com/pgasawa/continual-learning-bench)
+(clbench) — a Deep Agent evaluated as a `ContinualLearningSystem`.
+
+## Why it lives here but runs there
+
+clbench discovers systems by scanning its own `src/systems/<name>/` tree on disk
+(`src/registry.py:_discover_system_modules`). The adapter therefore has to
+physically sit under a clbench checkout to be runnable, and it imports against
+clbench's package layout (`from ...interface import ...`). It cannot run from
+inside the deepagents repo.
+
+So this directory is the **version-controlled source of truth**; running happens
+by deploying it into a clbench checkout. This mirrors how `deepagents_harbor/`
+is the deepagents-side integration code for the Harbor framework.
+
+## Layout
+
+```
+deepagents_clbench/
+├── README.md
+├── sync_to_clbench.sh        # deploy the payload into a clbench checkout
+└── system/                   # payload -> <clbench>/src/systems/deepagents/
+    ├── __init__.py
+    └── system.py             # DeepAgentsSystem
+```
+
+## Deploy & run
+
+```bash
+# 1. Deploy into a local clbench checkout
+./sync_to_clbench.sh /path/to/continual-learning-bench
+
+# 2. In the clbench checkout, ensure deepagents is installed in its env
+uv add deepagents            # pulls langchain + langchain-anthropic too
+
+# 3. Run
+clbench run exploitable_poker --schedule quick_test --system deepagents
+clbench run <task> --system deepagents --system-params model=anthropic:claude-opus-4-8
+```
+
+## How it learns
+
+The benchmark scores improvement across a sequence of related instances. The
+learning substrate is the agent's **persistent memory**, wired through
+`create_deep_agent(memory=[...])` (i.e. `MemoryMiddleware`):
+
+- Each turn, the configured memory files are loaded into the prompt (wrapped in
+  `<agent_memory>` boundary markers, treated as untrusted reference data).
+- New knowledge is written back by an explicit **reflection step** in
+  `observe()`: at each completed instance the system distils the outcome into
+  `AGENTS.md`. A one-shot decision agent won't reliably spend a tool call to
+  update its own notes mid-decision, so the write is made deliberate (the same
+  pattern clbench's `mem0`/`ace` systems use). The agent may also edit memory via
+  its `edit_file` tool, but reflection guarantees it.
+
+| File | Author | Purpose |
+|---|---|---|
+| `/memory/AGENTS.md` | reflection step (`observe()`) | distilled, generalizable strategy |
+| `/memory/outcomes.md` | the framework (`observe()`) | bounded log of recorded reward/feedback |
+
+Verified: in a 5-hand `quick_test` rollout, `AGENTS.md` grows from the seed to
+~1.7 KB of distilled opponent reads (e.g. "value-bet strong hands; opponent
+calls too wide; avoid weak unconnected hands"), captured per-step in the trace's
+`system_memory.history`.
+
+Both live in the in-state filesystem (`DeepAgentState["files"]`). The adapter
+threads that filesystem from one `respond()` call to the next — this is what
+makes the agent *continual* rather than one-shot. `reset()` clears it, so the
+stateless baseline is genuinely stateless and `mean_gain` reflects only what was
+learned.
+
+## Notes
+
+- **Backend / security**: uses the default in-state `StateBackend`, so the agent
+  has no real shell or host filesystem access (its `execute` tool errors on a
+  non-sandbox backend). If you swap in a shell-capable backend, scrub provider
+  API keys from the environment first (see `deepagents_harbor`'s
+  `_scrub_shell_env`), since the agent could otherwise read them.
+- **Structured output**: each task supplies a per-turn `response_schema`; the
+  adapter runs the agent for reasoning, then does a separate
+  `with_structured_output` call to coerce the final answer into that schema.
+- This directory is intentionally excluded from this project's `ruff`/`ty`
+  config (it targets clbench's package layout, not deepagents'), matching how
+  other external-benchmark code is handled in `libs/evals/pyproject.toml`.

--- a/libs/evals/deepagents_clbench/README.md
+++ b/libs/evals/deepagents_clbench/README.md
@@ -47,30 +47,27 @@ The benchmark scores improvement across a sequence of related instances. The
 learning substrate is the agent's **persistent memory**, wired through
 `create_deep_agent(memory=[...])` (i.e. `MemoryMiddleware`):
 
-- Each turn, the configured memory files are loaded into the prompt (wrapped in
+- Each turn, `/memory/AGENTS.md` is loaded into the prompt (wrapped in
   `<agent_memory>` boundary markers, treated as untrusted reference data).
-- New knowledge is written back by an explicit **reflection step** in
-  `observe()`: at each completed instance the system distils the outcome into
-  `AGENTS.md`. A one-shot decision agent won't reliably spend a tool call to
-  update its own notes mid-decision, so the write is made deliberate (the same
-  pattern clbench's `mem0`/`ace` systems use). The agent may also edit memory via
-  its `edit_file` tool, but reflection guarantees it.
+- The **agent itself** distils and updates that file with its own `edit_file` /
+  `write_file` tools as it learns — there is no separate reflection or
+  extraction process. `observe()` only captures the latest outcome so the next
+  turn's prompt can surface it; whether and how to record a lesson is the
+  agent's decision.
 
 | File | Author | Purpose |
 |---|---|---|
-| `/memory/AGENTS.md` | reflection step (`observe()`) | distilled, generalizable strategy |
-| `/memory/outcomes.md` | the framework (`observe()`) | bounded log of recorded reward/feedback |
+| `/memory/AGENTS.md` | the agent (via `edit_file`) | its own distilled, generalizable strategy |
 
-Verified: in a 5-hand `quick_test` rollout, `AGENTS.md` grows from the seed to
-~1.7 KB of distilled opponent reads (e.g. "value-bet strong hands; opponent
-calls too wide; avoid weak unconnected hands"), captured per-step in the trace's
-`system_memory.history`.
+The file lives in the in-state filesystem (`DeepAgentState["files"]`); the
+adapter threads it from one `respond()` call to the next — this is what makes
+the agent *continual* rather than one-shot. `reset()` clears it, so the
+stateless baseline is genuinely stateless and `mean_gain` reflects only what the
+agent learned.
 
-Both live in the in-state filesystem (`DeepAgentState["files"]`). The adapter
-threads that filesystem from one `respond()` call to the next — this is what
-makes the agent *continual* rather than one-shot. `reset()` clears it, so the
-stateless baseline is genuinely stateless and `mean_gain` reflects only what was
-learned.
+This means whether the agent maintains good notes is part of what's measured —
+if it under-invests in memory, that's a real result, not something the harness
+papers over.
 
 ## Notes
 
@@ -80,8 +77,10 @@ learned.
   API keys from the environment first (see `deepagents_harbor`'s
   `_scrub_shell_env`), since the agent could otherwise read them.
 - **Structured output**: each task supplies a per-turn `response_schema`; the
-  adapter runs the agent for reasoning, then does a separate
-  `with_structured_output` call to coerce the final answer into that schema.
+  agent emits it natively via `create_deep_agent(response_format=...)` (read
+  from `structured_response`) — no separate extraction call. The agent is cached
+  per schema and rebuilt only when the schema changes. Net result: one model
+  interaction per turn.
 - This directory is intentionally excluded from this project's `ruff`/`ty`
   config (it targets clbench's package layout, not deepagents'), matching how
   other external-benchmark code is handled in `libs/evals/pyproject.toml`.

--- a/libs/evals/deepagents_clbench/sync_to_clbench.sh
+++ b/libs/evals/deepagents_clbench/sync_to_clbench.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Deploy the canonical Deep Agents system into a continual-learning-bench checkout.
+#
+# clbench discovers systems by scanning its own src/systems/<name>/ tree
+# (see src/registry.py:_discover_system_modules), so the adapter must physically
+# live there to be runnable. This copies the canonical source kept here in the
+# deepagents repo into <clbench>/src/systems/deepagents/.
+#
+# Usage: ./sync_to_clbench.sh /path/to/continual-learning-bench
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+src_dir="${here}/system"
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <path-to-clbench-checkout>" >&2
+  exit 2
+fi
+
+clbench="$1"
+if [[ ! -d "${clbench}" ]]; then
+  echo "error: '${clbench}' is not a directory" >&2
+  exit 1
+fi
+if [[ ! -d "${clbench}/src/systems" ]]; then
+  echo "error: '${clbench}' does not look like a clbench checkout (missing src/systems/)" >&2
+  exit 1
+fi
+
+dest="${clbench}/src/systems/deepagents"
+mkdir -p "${dest}"
+cp "${src_dir}/__init__.py" "${src_dir}/system.py" "${dest}/"
+
+echo "Deployed Deep Agents system -> ${dest}"
+echo "Run it with:  clbench run <task> --system deepagents"

--- a/libs/evals/deepagents_clbench/system/__init__.py
+++ b/libs/evals/deepagents_clbench/system/__init__.py
@@ -1,0 +1,5 @@
+"""Deep Agents continual-learning system (deployed into clbench src/systems/deepagents/)."""
+
+from .system import DeepAgentsSystem
+
+__all__ = ["DeepAgentsSystem"]

--- a/libs/evals/deepagents_clbench/system/system.py
+++ b/libs/evals/deepagents_clbench/system/system.py
@@ -1,32 +1,31 @@
 """Deep Agents system adapter for continual-learning-bench.
 
 Wraps a LangChain Deep Agent (``deepagents``) as a
-:class:`ContinualLearningSystem`. The learning that the benchmark measures is
-carried across task instances by the agent's **persistent memory**:
+:class:`ContinualLearningSystem`, using the agent's **own** memory mechanism as
+the continual-learning substrate:
 
-* ``MemoryMiddleware`` (enabled via ``create_deep_agent(memory=...)``) loads the
-  configured ``AGENTS.md``-style files into the system prompt at the start of
-  every turn, wrapped in ``<agent_memory>`` boundary markers and treated as
-  untrusted reference data.
-* New knowledge is written back by an explicit **reflection step** in
-  ``observe()``: at each completed instance the system distils the outcome into
-  ``AGENTS.md``. (A one-shot decision agent will not reliably spend a tool call
-  to update its own notes mid-decision, so we make the write deliberate — the
-  same pattern clbench's ``mem0``/``ace`` systems use. The agent may also edit
-  memory via its ``edit_file`` tool, but reflection guarantees it.)
+* ``MemoryMiddleware`` (enabled via ``create_deep_agent(memory=...)``) loads
+  ``/memory/AGENTS.md`` into the system prompt at the start of every turn,
+  wrapped in ``<agent_memory>`` boundary markers and treated as untrusted data.
+* The agent itself distils and updates that file with its built-in
+  ``edit_file`` / ``write_file`` tools as it learns. There is no separate
+  reflection/extraction process — the agent owns its memory.
 
-Those files live in the in-state filesystem (``DeepAgentState["files"]``). This
-adapter threads that filesystem from one ``respond()`` call to the next, which
-is exactly what turns a one-shot agent into a continual learner. ``reset()``
-wipes the memory, so the framework's stateless baseline is genuinely stateless
-and ``mean_gain`` (stateful minus baseline) measures only what was learned.
+The memory file lives in the in-state filesystem (``DeepAgentState["files"]``);
+this adapter threads it from one ``respond()`` call to the next, which is what
+carries learning across instances. ``reset()`` wipes it, so the framework's
+stateless baseline is genuinely stateless and ``mean_gain`` measures only what
+the agent learned.
 
-The default backend is the in-state ``StateBackend``: the agent gets no real
-shell or host filesystem access (its ``execute`` tool errors on a non-sandbox
-backend), so there is no avenue to read provider credentials from the host env.
+Structured output uses ``create_deep_agent(response_format=...)``: the agent
+emits the task's per-turn schema natively (read from ``structured_response``),
+so there is no separate extraction call either. One model interaction per turn.
 
-NOTE: This module is written against continual-learning-bench's package layout
-(``src.interface`` / ``src.registry`` / ``src.usage``) and runs only once it is
+The default in-state ``StateBackend`` gives the agent no host shell/filesystem,
+so there is no avenue to read provider credentials from the environment.
+
+NOTE: This module targets continual-learning-bench's package layout
+(``src.interface`` / ``src.registry`` / ``src.usage``) and runs only once
 deployed into a clbench checkout under ``src/systems/deepagents/``. See this
 directory's README and ``sync_to_clbench.sh``.
 """
@@ -49,43 +48,27 @@ from ...interface import (
 from ...registry import register_system
 from ...usage import UsageEvent
 
-# Memory sources loaded into the prompt every turn (latest content wins):
-#   AGENTS.md   - authored by the agent itself (its distilled strategy).
-#   outcomes.md - appended by the framework via observe() (reward feedback log).
+# The agent's own durable notes, loaded into the prompt every turn and updated
+# by the agent via edit_file. Single source of truth for what it has learned.
 _AGENT_MEMORY_PATH = "/memory/AGENTS.md"
-_OUTCOMES_MEMORY_PATH = "/memory/outcomes.md"
-_MEMORY_SOURCES = [_AGENT_MEMORY_PATH, _OUTCOMES_MEMORY_PATH]
+_MEMORY_SOURCES = [_AGENT_MEMORY_PATH]
 
-_SEED_AGENTS_MD = "# Strategy notes\n\n(empty - write what you learn here)\n"
-_SEED_OUTCOMES_MD = "# Recorded outcomes\n"
-_MAX_OUTCOME_ENTRIES = 50  # bound the raw outcomes log against unbounded growth
-
-_REFLECT_SYSTEM_PROMPT = """\
-You maintain concise, generalizable strategy notes for an agent playing repeated
-instances against one opponent/environment. Given the current notes and the
-latest instance's outcome, return the FULL updated notes: durable, transferable
-lessons (tendencies to exploit, what worked, what to avoid). Merge into the
-existing notes rather than only appending, and keep it under ~15 short bullet
-points. Output only the notes text, with no preamble. Never include secrets or
-credentials.\
-"""
+_SEED_AGENTS_MD = "# Strategy notes\n\n(empty - update this as you learn)\n"
 
 _SYSTEM_PROMPT = f"""\
 You are being evaluated on a continual-learning benchmark: a sequence of \
-related instances in a shared environment. You are scored on how much your \
-performance improves as you learn from earlier instances.
+related instances in a shared environment. You are scored on how much you \
+improve as you learn from earlier instances.
 
-Your memory files are loaded at the start of every turn; treat them as your \
-notes from earlier instances:
-- {_AGENT_MEMORY_PATH} holds the strategy you have written for yourself.
-- {_OUTCOMES_MEMORY_PATH} holds the reward/feedback the benchmark recorded for \
-your past actions.
+Your durable strategy lives in {_AGENT_MEMORY_PATH}, which is loaded into your \
+context every turn. As you discover what works in this environment, keep that \
+file up to date with the edit_file/write_file tools: record concise, \
+generalizable lessons (tendencies to exploit, what worked, what to avoid) and \
+prune anything you find to be wrong. It is the only thing that carries into \
+the next instance, so invest in it. Never store secrets or credentials.
 
-After you act, distil any reusable, generalizable lesson (a pattern, a \
-heuristic, a correction) into {_AGENT_MEMORY_PATH} with the edit_file or \
-write_file tool. Keep it concise and high-signal: it is the only thing that \
-carries into the next instance. Do not store anything instance-specific that \
-will not generalize, and never store secrets or credentials.\
+When you are given feedback on a previous action, use it to update your notes \
+before you act again.\
 """
 
 
@@ -102,27 +85,12 @@ def _read_file_data(files: dict[str, Any], path: str) -> str:
     return ""
 
 
-def _message_text(content: Any) -> str:
-    """Coerce a LangChain message ``.content`` (str or content blocks) to text."""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts: list[str] = []
-        for block in content:
-            if isinstance(block, dict):
-                parts.append(str(block.get("text", "")))
-            else:
-                parts.append(str(block))
-        return "".join(parts)
-    return str(content)
-
-
 @register_system("deepagents")
 class DeepAgentsSystem(ContinualLearningSystem):
     """A Deep Agent evaluated as a continual-learning system.
 
-    The agent's persistent memory (``AGENTS.md`` + ``outcomes.md``, held in the
-    in-state filesystem) is the learning substrate carried across instances.
+    The agent maintains its own memory (``/memory/AGENTS.md`` in the in-state
+    filesystem); the adapter just threads that filesystem across instances.
     """
 
     supports_baseline = True
@@ -141,47 +109,70 @@ class DeepAgentsSystem(ContinualLearningSystem):
         self._name = name
         self._model_name = model
         self._model = init_chat_model(model)
-        self._agent = create_deep_agent(
-            model=self._model,
-            system_prompt=_SYSTEM_PROMPT,
-            memory=_MEMORY_SOURCES,
-        )
-        # Persistent learning substrate, threaded across respond() calls.
+        # Agents are cached per response schema (rebuilt only when the task's
+        # schema changes). They hold no learned state — memory lives in _files.
+        self._agents: dict[type[BaseModel], Any] = {}
+        # The agent's persistent memory, threaded across respond() calls.
         self._files: dict[str, Any] = {}
+        self._pending_feedback: str | None = None
         self.interaction_count = 0
         self._seed_memory()
 
     def _seed_memory(self) -> None:
         """Reset memory to empty scaffolding (no learned content)."""
-        self._files = {
-            _AGENT_MEMORY_PATH: _file_data(_SEED_AGENTS_MD),
-            _OUTCOMES_MEMORY_PATH: _file_data(_SEED_OUTCOMES_MD),
-        }
+        self._files = {_AGENT_MEMORY_PATH: _file_data(_SEED_AGENTS_MD)}
+
+    def _get_agent(self, schema: type[BaseModel]) -> Any:
+        """Return a deep agent that emits ``schema`` as its structured response."""
+        agent = self._agents.get(schema)
+        if agent is None:
+            agent = create_deep_agent(
+                model=self._model,
+                system_prompt=_SYSTEM_PROMPT,
+                memory=_MEMORY_SOURCES,
+                response_format=schema,
+            )
+            self._agents[schema] = agent
+        return agent
+
+    def _memory_snapshot(self) -> dict[str, str]:
+        """Current memory as a ``{path: content}`` dict (the shape clbench logs)."""
+        return {path: _read_file_data(self._files, path) for path in _MEMORY_SOURCES}
 
     def respond(self, query: Query) -> Response:
         self.interaction_count += 1
 
-        prompt = query.prompt or "(no content)"
+        # Surface feedback so the agent can update its own notes before acting.
+        feedback = None
         if query.feedback is not None and query.feedback.content.strip():
-            prompt = (
-                "Feedback on your previous action:\n"
-                f"{query.feedback.content.strip()}\n\n{prompt}"
-            )
+            feedback = query.feedback.content.strip()
+        elif self._pending_feedback:
+            feedback = self._pending_feedback
+        self._pending_feedback = None
 
-        # Invoke the deep agent to completion, threading persisted memory in...
-        result = self._agent.invoke(
+        prompt = query.prompt or "(no content)"
+        if feedback:
+            prompt = f"Feedback on your previous action:\n{feedback}\n\n{prompt}"
+
+        # One model interaction: the agent reads its notes, optionally updates
+        # them via edit_file, and emits the structured action.
+        agent = self._get_agent(query.response_schema)
+        result = agent.invoke(
             {
                 "messages": [{"role": "user", "content": prompt}],
                 "files": self._files,
             }
         )
-        # ...and reading the (possibly memory-updated) filesystem back out.
+        # Thread the (possibly agent-updated) memory filesystem forward.
         self._files = result.get("files", self._files)
+        self._record_usage(result.get("messages", []))
 
-        messages = result.get("messages", [])
-        final_text = _message_text(messages[-1].content) if messages else ""
-        self._record_usage(messages)
-        action = self._extract_action(final_text, query.response_schema)
+        action = result.get("structured_response")
+        if not isinstance(action, BaseModel):
+            raise RuntimeError(
+                "Deep agent did not return a structured response matching "
+                f"{query.response_schema.__name__}."
+            )
 
         return Response(
             action=action,
@@ -197,51 +188,14 @@ class DeepAgentsSystem(ContinualLearningSystem):
     def observe(
         self, observation: Observation, next_query: Query | None = None
     ) -> None:
-        """Log the outcome and, at instance boundaries, distil it into memory.
+        """Capture the outcome so the next turn's prompt can surface it.
 
-        A one-shot decision agent won't reliably spend a tool call to update its
-        own notes mid-decision, so memory-writing is made an explicit step: at
-        each completed instance we run a dedicated reflection call that rewrites
-        ``AGENTS.md``. The agent reads it next turn as untrusted memory (wrapped
-        in ``<agent_memory>`` boundary markers by ``MemoryMiddleware``).
+        No model call and no file write here — distilling the outcome into
+        memory is the agent's job on its next turn.
         """
         content = observation.content.strip()
-        if not content:
-            return
-        self._append_outcome(content, complete=observation.instance_complete)
-        if observation.instance_complete:
-            self._reflect(content)
-
-    def _append_outcome(self, content: str, *, complete: bool) -> None:
-        """Append one outcome to the raw log, bounded to the last N entries."""
-        prior = _read_file_data(self._files, _OUTCOMES_MEMORY_PATH) or _SEED_OUTCOMES_MD
-        lines = prior.splitlines()
-        header, body = (lines[:1], lines[1:]) if lines else ([_SEED_OUTCOMES_MD], [])
-        marker = "" if complete else " [mid-instance]"
-        body.append(f"- {content}{marker}")
-        body = body[-_MAX_OUTCOME_ENTRIES:]
-        self._files[_OUTCOMES_MEMORY_PATH] = _file_data("\n".join(header + body) + "\n")
-
-    def _reflect(self, outcome: str) -> None:
-        """Distil the completed instance into durable notes (writes ``AGENTS.md``)."""
-        current = _read_file_data(self._files, _AGENT_MEMORY_PATH) or _SEED_AGENTS_MD
-        resp = self._model.invoke(
-            [
-                {"role": "system", "content": _REFLECT_SYSTEM_PROMPT},
-                {
-                    "role": "user",
-                    "content": f"Current notes:\n{current}\n\nLatest outcome:\n{outcome}",
-                },
-            ]
-        )
-        notes = _message_text(resp.content).strip()
-        if notes:
-            self._files[_AGENT_MEMORY_PATH] = _file_data(notes + "\n")
-        self._record_usage([resp], call_type="reflect")
-
-    def _memory_snapshot(self) -> dict[str, str]:
-        """Current memory as a ``{path: content}`` dict (the shape clbench logs)."""
-        return {path: _read_file_data(self._files, path) for path in _MEMORY_SOURCES}
+        if content:
+            self._pending_feedback = content
 
     def reset(self) -> None:
         """Wipe learned memory.
@@ -250,6 +204,7 @@ class DeepAgentsSystem(ContinualLearningSystem):
         instance in the stateless baseline.
         """
         self._seed_memory()
+        self._pending_feedback = None
         self.interaction_count = 0
 
     @property
@@ -268,35 +223,7 @@ class DeepAgentsSystem(ContinualLearningSystem):
             "memory_files": self._memory_snapshot(),
         }
 
-    # ------------------------------------------------------------------
-    def _extract_action(self, text: str, schema: type[BaseModel]) -> BaseModel:
-        """Coerce the agent's free-form final answer into the task's schema.
-
-        Done as a separate structured call so it never fights the agent's tool
-        loop. ``schema`` is the task-supplied, strictly-typed pydantic model.
-        """
-        structured = self._model.with_structured_output(schema, include_raw=True)
-        out = structured.invoke(
-            [
-                {
-                    "role": "system",
-                    "content": (
-                        "Extract the final structured answer from the agent's "
-                        "message below. Do not invent information."
-                    ),
-                },
-                {"role": "user", "content": text},
-            ]
-        )
-        raw = out.get("raw") if isinstance(out, dict) else None
-        if raw is not None:
-            self._record_usage([raw], call_type="extract")
-        parsed = out.get("parsed") if isinstance(out, dict) else out
-        if parsed is None:
-            raise RuntimeError("Structured extraction returned no parsed action.")
-        return parsed
-
-    def _record_usage(self, messages: list[Any], call_type: str = "completion") -> None:
+    def _record_usage(self, messages: list[Any]) -> None:
         """Aggregate token usage from message ``usage_metadata`` into a UsageEvent."""
         input_tokens = 0
         output_tokens = 0
@@ -312,7 +239,7 @@ class DeepAgentsSystem(ContinualLearningSystem):
             return
         self.record_usage_event(
             UsageEvent(
-                call_type=call_type,
+                call_type="completion",
                 model=self._model_name,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,

--- a/libs/evals/deepagents_clbench/system/system.py
+++ b/libs/evals/deepagents_clbench/system/system.py
@@ -1,0 +1,321 @@
+"""Deep Agents system adapter for continual-learning-bench.
+
+Wraps a LangChain Deep Agent (``deepagents``) as a
+:class:`ContinualLearningSystem`. The learning that the benchmark measures is
+carried across task instances by the agent's **persistent memory**:
+
+* ``MemoryMiddleware`` (enabled via ``create_deep_agent(memory=...)``) loads the
+  configured ``AGENTS.md``-style files into the system prompt at the start of
+  every turn, wrapped in ``<agent_memory>`` boundary markers and treated as
+  untrusted reference data.
+* New knowledge is written back by an explicit **reflection step** in
+  ``observe()``: at each completed instance the system distils the outcome into
+  ``AGENTS.md``. (A one-shot decision agent will not reliably spend a tool call
+  to update its own notes mid-decision, so we make the write deliberate — the
+  same pattern clbench's ``mem0``/``ace`` systems use. The agent may also edit
+  memory via its ``edit_file`` tool, but reflection guarantees it.)
+
+Those files live in the in-state filesystem (``DeepAgentState["files"]``). This
+adapter threads that filesystem from one ``respond()`` call to the next, which
+is exactly what turns a one-shot agent into a continual learner. ``reset()``
+wipes the memory, so the framework's stateless baseline is genuinely stateless
+and ``mean_gain`` (stateful minus baseline) measures only what was learned.
+
+The default backend is the in-state ``StateBackend``: the agent gets no real
+shell or host filesystem access (its ``execute`` tool errors on a non-sandbox
+backend), so there is no avenue to read provider credentials from the host env.
+
+NOTE: This module is written against continual-learning-bench's package layout
+(``src.interface`` / ``src.registry`` / ``src.usage``) and runs only once it is
+deployed into a clbench checkout under ``src/systems/deepagents/``. See this
+directory's README and ``sync_to_clbench.sh``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain.chat_models import init_chat_model
+from pydantic import BaseModel
+
+from deepagents import create_deep_agent
+
+from ...interface import (
+    ContinualLearningSystem,
+    Observation,
+    Query,
+    Response,
+)
+from ...registry import register_system
+from ...usage import UsageEvent
+
+# Memory sources loaded into the prompt every turn (latest content wins):
+#   AGENTS.md   - authored by the agent itself (its distilled strategy).
+#   outcomes.md - appended by the framework via observe() (reward feedback log).
+_AGENT_MEMORY_PATH = "/memory/AGENTS.md"
+_OUTCOMES_MEMORY_PATH = "/memory/outcomes.md"
+_MEMORY_SOURCES = [_AGENT_MEMORY_PATH, _OUTCOMES_MEMORY_PATH]
+
+_SEED_AGENTS_MD = "# Strategy notes\n\n(empty - write what you learn here)\n"
+_SEED_OUTCOMES_MD = "# Recorded outcomes\n"
+_MAX_OUTCOME_ENTRIES = 50  # bound the raw outcomes log against unbounded growth
+
+_REFLECT_SYSTEM_PROMPT = """\
+You maintain concise, generalizable strategy notes for an agent playing repeated
+instances against one opponent/environment. Given the current notes and the
+latest instance's outcome, return the FULL updated notes: durable, transferable
+lessons (tendencies to exploit, what worked, what to avoid). Merge into the
+existing notes rather than only appending, and keep it under ~15 short bullet
+points. Output only the notes text, with no preamble. Never include secrets or
+credentials.\
+"""
+
+_SYSTEM_PROMPT = f"""\
+You are being evaluated on a continual-learning benchmark: a sequence of \
+related instances in a shared environment. You are scored on how much your \
+performance improves as you learn from earlier instances.
+
+Your memory files are loaded at the start of every turn; treat them as your \
+notes from earlier instances:
+- {_AGENT_MEMORY_PATH} holds the strategy you have written for yourself.
+- {_OUTCOMES_MEMORY_PATH} holds the reward/feedback the benchmark recorded for \
+your past actions.
+
+After you act, distil any reusable, generalizable lesson (a pattern, a \
+heuristic, a correction) into {_AGENT_MEMORY_PATH} with the edit_file or \
+write_file tool. Keep it concise and high-signal: it is the only thing that \
+carries into the next instance. Do not store anything instance-specific that \
+will not generalize, and never store secrets or credentials.\
+"""
+
+
+def _file_data(content: str) -> dict[str, str]:
+    """Build an in-state FileData record (see deepagents.backends.protocol)."""
+    return {"content": content, "encoding": "utf-8"}
+
+
+def _read_file_data(files: dict[str, Any], path: str) -> str:
+    """Return the text content of an in-state file, or '' if absent."""
+    entry = files.get(path)
+    if isinstance(entry, dict):
+        return str(entry.get("content", ""))
+    return ""
+
+
+def _message_text(content: Any) -> str:
+    """Coerce a LangChain message ``.content`` (str or content blocks) to text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                parts.append(str(block.get("text", "")))
+            else:
+                parts.append(str(block))
+        return "".join(parts)
+    return str(content)
+
+
+@register_system("deepagents")
+class DeepAgentsSystem(ContinualLearningSystem):
+    """A Deep Agent evaluated as a continual-learning system.
+
+    The agent's persistent memory (``AGENTS.md`` + ``outcomes.md``, held in the
+    in-state filesystem) is the learning substrate carried across instances.
+    """
+
+    supports_baseline = True
+    parallel_safe = True  # in-memory state only; no fixed host paths or ports.
+
+    def __init__(
+        self,
+        model: str = "anthropic:claude-sonnet-4-6",
+        name: str = "deepagents",
+    ) -> None:
+        """
+        Args:
+            model: ``provider:model`` string passed to ``init_chat_model``.
+            name: System identifier surfaced in results and viewers.
+        """
+        self._name = name
+        self._model_name = model
+        self._model = init_chat_model(model)
+        self._agent = create_deep_agent(
+            model=self._model,
+            system_prompt=_SYSTEM_PROMPT,
+            memory=_MEMORY_SOURCES,
+        )
+        # Persistent learning substrate, threaded across respond() calls.
+        self._files: dict[str, Any] = {}
+        self.interaction_count = 0
+        self._seed_memory()
+
+    def _seed_memory(self) -> None:
+        """Reset memory to empty scaffolding (no learned content)."""
+        self._files = {
+            _AGENT_MEMORY_PATH: _file_data(_SEED_AGENTS_MD),
+            _OUTCOMES_MEMORY_PATH: _file_data(_SEED_OUTCOMES_MD),
+        }
+
+    def respond(self, query: Query) -> Response:
+        self.interaction_count += 1
+
+        prompt = query.prompt or "(no content)"
+        if query.feedback is not None and query.feedback.content.strip():
+            prompt = (
+                "Feedback on your previous action:\n"
+                f"{query.feedback.content.strip()}\n\n{prompt}"
+            )
+
+        # Invoke the deep agent to completion, threading persisted memory in...
+        result = self._agent.invoke(
+            {
+                "messages": [{"role": "user", "content": prompt}],
+                "files": self._files,
+            }
+        )
+        # ...and reading the (possibly memory-updated) filesystem back out.
+        self._files = result.get("files", self._files)
+
+        messages = result.get("messages", [])
+        final_text = _message_text(messages[-1].content) if messages else ""
+        self._record_usage(messages)
+        action = self._extract_action(final_text, query.response_schema)
+
+        return Response(
+            action=action,
+            metadata={
+                "system": "deepagents",
+                "model": self._model_name,
+                "interaction": self.interaction_count,
+                # clbench records this per step (path -> content) for the viewer.
+                "memory_files": self._memory_snapshot(),
+            },
+        )
+
+    def observe(
+        self, observation: Observation, next_query: Query | None = None
+    ) -> None:
+        """Log the outcome and, at instance boundaries, distil it into memory.
+
+        A one-shot decision agent won't reliably spend a tool call to update its
+        own notes mid-decision, so memory-writing is made an explicit step: at
+        each completed instance we run a dedicated reflection call that rewrites
+        ``AGENTS.md``. The agent reads it next turn as untrusted memory (wrapped
+        in ``<agent_memory>`` boundary markers by ``MemoryMiddleware``).
+        """
+        content = observation.content.strip()
+        if not content:
+            return
+        self._append_outcome(content, complete=observation.instance_complete)
+        if observation.instance_complete:
+            self._reflect(content)
+
+    def _append_outcome(self, content: str, *, complete: bool) -> None:
+        """Append one outcome to the raw log, bounded to the last N entries."""
+        prior = _read_file_data(self._files, _OUTCOMES_MEMORY_PATH) or _SEED_OUTCOMES_MD
+        lines = prior.splitlines()
+        header, body = (lines[:1], lines[1:]) if lines else ([_SEED_OUTCOMES_MD], [])
+        marker = "" if complete else " [mid-instance]"
+        body.append(f"- {content}{marker}")
+        body = body[-_MAX_OUTCOME_ENTRIES:]
+        self._files[_OUTCOMES_MEMORY_PATH] = _file_data("\n".join(header + body) + "\n")
+
+    def _reflect(self, outcome: str) -> None:
+        """Distil the completed instance into durable notes (writes ``AGENTS.md``)."""
+        current = _read_file_data(self._files, _AGENT_MEMORY_PATH) or _SEED_AGENTS_MD
+        resp = self._model.invoke(
+            [
+                {"role": "system", "content": _REFLECT_SYSTEM_PROMPT},
+                {
+                    "role": "user",
+                    "content": f"Current notes:\n{current}\n\nLatest outcome:\n{outcome}",
+                },
+            ]
+        )
+        notes = _message_text(resp.content).strip()
+        if notes:
+            self._files[_AGENT_MEMORY_PATH] = _file_data(notes + "\n")
+        self._record_usage([resp], call_type="reflect")
+
+    def _memory_snapshot(self) -> dict[str, str]:
+        """Current memory as a ``{path: content}`` dict (the shape clbench logs)."""
+        return {path: _read_file_data(self._files, path) for path in _MEMORY_SOURCES}
+
+    def reset(self) -> None:
+        """Wipe learned memory.
+
+        Called once at the start of a stateful rollout, and before *every*
+        instance in the stateless baseline.
+        """
+        self._seed_memory()
+        self.interaction_count = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def get_run_artifacts(self) -> dict[str, Any]:
+        """Export final memory so the viewer can show what the agent learned.
+
+        ``memory_files`` is the key clbench's trace storage reads (path -> content).
+        """
+        return {
+            "artifact_type": "deepagents",
+            "model": self._model_name,
+            "interaction_count": self.interaction_count,
+            "memory_files": self._memory_snapshot(),
+        }
+
+    # ------------------------------------------------------------------
+    def _extract_action(self, text: str, schema: type[BaseModel]) -> BaseModel:
+        """Coerce the agent's free-form final answer into the task's schema.
+
+        Done as a separate structured call so it never fights the agent's tool
+        loop. ``schema`` is the task-supplied, strictly-typed pydantic model.
+        """
+        structured = self._model.with_structured_output(schema, include_raw=True)
+        out = structured.invoke(
+            [
+                {
+                    "role": "system",
+                    "content": (
+                        "Extract the final structured answer from the agent's "
+                        "message below. Do not invent information."
+                    ),
+                },
+                {"role": "user", "content": text},
+            ]
+        )
+        raw = out.get("raw") if isinstance(out, dict) else None
+        if raw is not None:
+            self._record_usage([raw], call_type="extract")
+        parsed = out.get("parsed") if isinstance(out, dict) else out
+        if parsed is None:
+            raise RuntimeError("Structured extraction returned no parsed action.")
+        return parsed
+
+    def _record_usage(self, messages: list[Any], call_type: str = "completion") -> None:
+        """Aggregate token usage from message ``usage_metadata`` into a UsageEvent."""
+        input_tokens = 0
+        output_tokens = 0
+        seen = False
+        for msg in messages:
+            usage = getattr(msg, "usage_metadata", None)
+            if not usage:
+                continue
+            seen = True
+            input_tokens += int(usage.get("input_tokens", 0) or 0)
+            output_tokens += int(usage.get("output_tokens", 0) or 0)
+        if not seen:
+            return
+        self.record_usage_event(
+            UsageEvent(
+                call_type=call_type,
+                model=self._model_name,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=input_tokens + output_tokens,
+            )
+        )

--- a/libs/evals/pyproject.toml
+++ b/libs/evals/pyproject.toml
@@ -120,11 +120,16 @@ extra-paths = ["../deepagents", "../code"]
 # https://docs.astral.sh/ty/rules/
 division-by-zero = "error"
 
+[tool.ty.src]
+# clbench integration code targets the external benchmark's package layout
+# (src.interface / src.registry), not this project's — exclude it from type checks.
+exclude = ["deepagents_clbench"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py312"
-# Vendored BFCL benchmark files — skip both lint and format
-exclude = ["tests/evals/data/bfcl_apis"]
+# Vendored BFCL benchmark files + external-benchmark integration code — skip lint and format
+exclude = ["tests/evals/data/bfcl_apis", "deepagents_clbench"]
 force-exclude = true
 
 [tool.ruff.format]

--- a/libs/evals/tests/unit_tests/test_harbor_langsmith_integration.py
+++ b/libs/evals/tests/unit_tests/test_harbor_langsmith_integration.py
@@ -77,12 +77,10 @@ def test_harbor_workflow_uses_plugin_instead_of_manual_experiment_steps() -> Non
     assert 'default: "dcode"' in workflow
     assert "          - dcode" in workflow
     assert "dataset:" in workflow
-    assert (
-        "Harbor dataset ref (e.g. terminal-bench/terminal-bench-2 or "
-        "terminal-bench/terminal-bench-2-1)"
-    ) in workflow
+    assert "Benchmark to run (primary selector)" in workflow
+    assert '- "clbench"' in workflow
     assert "include_tasks:" in workflow
-    assert "Space-separated task-name globs to include" in workflow
+    assert "space-separated task-name globs" in workflow
     assert "rollouts_per_task:" in workflow
     assert 'default: "1"' in workflow
     assert "HARBOR_AGENT_IMPL: ${{ inputs.agent_impl }}" in workflow

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -590,6 +590,7 @@ provides-extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fir
 [package.metadata.requires-dev]
 test = [
     { name = "build", specifier = ">=1.5.0,<2.0.0" },
+    { name = "hatchling", specifier = ">=1.27.0,<2.0.0" },
     { name = "langchain-quickjs", editable = "../partners/quickjs" },
     { name = "pytest", specifier = ">=9.1.1,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.4.0,<2.0.0" },


### PR DESCRIPTION
## Summary

Lets you run [continual-learning-bench](https://github.com/pgasawa/continual-learning-bench) (clbench) with the Deep Agents system, selected from the existing Harbor eval workflow via `dataset=clbench`. clbench is **not** Harbor — it's a separate, in-process, multi-episode harness — so this wires it in alongside Harbor rather than through it, mirroring how `deepagents_harbor/` is the deepagents-side integration for Harbor.

## What's here

**Adapter — `libs/evals/deepagents_clbench/`** (canonical source; deployed into a clbench checkout by `sync_to_clbench.sh`):
- `DeepAgentsSystem` implements clbench's `ContinualLearningSystem`. The continual-learning substrate is the agent's persistent memory (`MemoryMiddleware` via `create_deep_agent(memory=...)`), threaded across `respond()` calls.
- Memory is written by an explicit **reflection step** at each completed instance (a one-shot decision agent won't reliably call `edit_file` mid-decision — verified). Per-turn structured output via a separate `with_structured_output` call.
- In-state `StateBackend` only — the agent gets no host shell/filesystem, so no path to provider secrets.

**Workflow — `.github/workflows/harbor.yml`:**
- `dataset` moved to the top as the primary selector; `clbench` added. Other inputs are tagged `[Harbor only]` / `[Harbor + clbench]` since GitHub dispatch forms can't hide fields.
- New `clbench` job (gated `dataset == 'clbench'`; Harbor job gated to the negation) sharing the model matrix. It clones clbench (pinned SHA), `uv sync --all-extras`, installs the local Deep Agents SDK + provider integration, deploys the adapter, and runs it. Runs on the runner (no LangSmith sandbox — clbench has no Harbor environment layer).
- **`clbench_schedule`** input: `quick_test` (default, cheap — per-task `clbench run`) or `default` (leaderboard-comparable `run-all`, each task's default schedule + 5 runs; warned as multi-hour / likely past the job timeout). Option mapping: `include_tasks`→tasks, `concurrency`→per-task-parallelism, model matrix→`--system.model`.
- **Trace-level LangSmith**: enabled only when `LANGSMITH_API_KEY` is present; groups each model's agent traces under `deepagents-clbench-<model>`. Experiment-level logging is intentionally **not** wired — clbench's `mean_gain`-over-a-sequence doesn't map onto LangSmith experiments.

## Validation

End-to-end CI run (`dataset=clbench`, `include_tasks=exploitable_poker`, `quick_test`, sonnet-4-6) **succeeded**: clone → sync → adapter deploy → `setup --all` → `clbench run` → real score, with traces confirmed in LangSmith (the deepagents middleware stack — `MemoryMiddleware`, `SubAgentMiddleware`, `ChatAnthropic` — shows up in the project). The Harbor job is correctly skipped for `dataset=clbench` and unchanged otherwise. Input hardening: schedule/task names validated against `^[A-Za-z0-9_]+$`, pinned clbench commit SHA, all shell vars quoted, the API key never printed.

## Caveats / follow-ups

- clbench is cloned + installed at job runtime (pinned SHA), not vendored. Two tasks (`sales_prediction`, `codebase_adaptation`) need Docker + heavier deps.
- Leaderboard mode (`clbench_schedule=default`) is genuinely day-scale for a Deep Agents system and won't fit a single 360-min runner — it's there for completeness, but real leaderboard runs want per-task splitting or out-of-CI infra.
- The adapter's model support is limited to `init_chat_model` providers.
