### PR TITLE
feat(evals): add tau3-bench dataset and conversational tau3 agent to Harbor

### DIFF
--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -413,6 +413,11 @@ jobs:
               HARBOR_AGENT_LABEL="bare create_deep_agent"
               ;;
             tau3)
+              # Requires a Harbor build that forwards the task environment's MCP
+              # servers into the LangGraph graph configurable. The pinned Harbor
+              # does not yet, so set `harbor_package_override` to such a build
+              # until that support ships in a release; otherwise tau3_deepagent
+              # exits early with no MCP servers.
               HARBOR_AGENT_GRAPH=tau3_deepagent
               HARBOR_AGENT_LABEL="tau3 conversational deepagent"
               ;;

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -130,10 +130,20 @@ on:
         options:
           - dcode
           - bare
+          - tau3
       dataset:
-        description: "Harbor dataset ref (e.g. terminal-bench/terminal-bench-2 or terminal-bench/terminal-bench-2-1)"
+        description: "Harbor dataset to run. Leave dataset_override empty to use this dropdown."
         required: true
         default: "terminal-bench/terminal-bench-2"
+        type: choice
+        options:
+          - terminal-bench/terminal-bench-2
+          - terminal-bench/terminal-bench-2-1
+          - sierra-research/tau3-bench
+      dataset_override:
+        description: "Override: arbitrary Harbor dataset ref (e.g. 'owner/dataset'). Takes priority over the dropdown when non-empty."
+        required: false
+        default: ""
         type: string
       n_tasks:
         description: "Maximum number of tasks to run (0 = all tasks in dataset)"
@@ -165,7 +175,7 @@ permissions:
 
 env:
   UV_NO_SYNC: "true"
-  HARBOR_DATASET: ${{ inputs.dataset || 'terminal-bench/terminal-bench-2' }}
+  HARBOR_DATASET: ${{ inputs.dataset_override || inputs.dataset || 'terminal-bench/terminal-bench-2' }}
 
 jobs:
   prep:
@@ -184,7 +194,7 @@ jobs:
           MODELS_OVERRIDE: ${{ inputs.models_override || '(empty)' }}
           SANDBOX_ENV: ${{ inputs.sandbox_env }}
           AGENT_IMPL: ${{ inputs.agent_impl }}
-          DATASET: ${{ inputs.dataset || 'terminal-bench/terminal-bench-2' }}
+          DATASET: ${{ inputs.dataset_override || inputs.dataset || 'terminal-bench/terminal-bench-2' }}
           N_TASKS: ${{ inputs.n_tasks }}
           INCLUDE_TASKS: ${{ inputs.include_tasks }}
           ROLLOUTS_PER_TASK: ${{ inputs.rollouts_per_task }}
@@ -401,6 +411,10 @@ jobs:
             bare)
               HARBOR_AGENT_GRAPH=bare_deepagent
               HARBOR_AGENT_LABEL="bare create_deep_agent"
+              ;;
+            tau3)
+              HARBOR_AGENT_GRAPH=tau3_deepagent
+              HARBOR_AGENT_LABEL="tau3 conversational deepagent"
               ;;
             *)
               echo "::error::Unknown agent implementation: $HARBOR_AGENT_IMPL"

--- a/libs/evals/deepagents_harbor/langgraph_project/langgraph.json
+++ b/libs/evals/deepagents_harbor/langgraph_project/langgraph.json
@@ -13,11 +13,13 @@
     "langchain-openai>=1.3.0,<1.4.0",
     "langchain-openrouter>=0.2.3,<0.3.0",
     "langchain-xai>=1.2.2,<1.3.0",
+    "langchain-mcp-adapters>=0.3.0,<0.4.0",
     "aiohttp>=3.14.0,<4.0.0",
     "toml>=0.10.2,<1.0.0"
   ],
   "graphs": {
     "deepagent": "./langgraph_agent.py:make_graph",
-    "bare_deepagent": "./langgraph_agent.py:make_bare_graph"
+    "bare_deepagent": "./langgraph_agent.py:make_bare_graph",
+    "tau3_deepagent": "./langgraph_agent.py:make_tau3_graph"
   }
 }

--- a/libs/evals/deepagents_harbor/langgraph_project/langgraph_agent.py
+++ b/libs/evals/deepagents_harbor/langgraph_project/langgraph_agent.py
@@ -6,7 +6,7 @@ import os
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from deepagents import create_deep_agent
 from deepagents.backends import LocalShellBackend
@@ -200,14 +200,21 @@ silently. Keep working with the user until the case is resolved.
 """
 
 
-def _mcp_connections(configurable: dict[str, object]) -> dict[str, dict[str, Any]]:
+def _mcp_connections(configurable: dict[str, object]) -> dict[str, Any]:
     """Build langchain-mcp-adapters connections from Harbor-forwarded servers.
 
     Harbor's LangGraph agent forwards the task environment's declared MCP servers
     via ``configurable["mcp_servers"]`` (a list of dicts shaped like Harbor's
     ``MCPServerConfig``: ``name``/``transport``/``url``/``command``/``args``). We
-    connect only to those trusted, environment-declared servers — never to a URL
-    supplied by the model at runtime.
+    connect only to those environment-declared servers, and only over remote
+    transports.
+
+    ``stdio`` servers are rejected on purpose: they carry a local ``command``/
+    ``args`` that ``MultiServerMCPClient`` would execute inside the agent sandbox.
+    Since the dataset (selectable via the workflow's ``dataset_override``) controls
+    this config, honoring ``stdio`` would let an untrusted dataset run arbitrary
+    commands in CI. tau3-runtime is a remote ``streamable-http`` server, so only
+    ``streamable-http``/``sse`` (URL-based) transports are allowed.
 
     Args:
         configurable: The graph's ``configurable`` mapping.
@@ -216,37 +223,48 @@ def _mcp_connections(configurable: dict[str, object]) -> dict[str, dict[str, Any
         A mapping of server name to a langchain-mcp-adapters connection dict.
 
     Raises:
-        ValueError: If no MCP servers were forwarded.
-        TypeError: If ``mcp_servers`` is not a list.
+        ValueError: If no MCP servers were forwarded, a server uses an
+            unsupported (e.g. ``stdio``) transport, or a server lacks a URL.
+        TypeError: If ``mcp_servers`` is not a list of mappings.
     """
     servers = configurable.get("mcp_servers")
     if not servers:
         msg = (
             "tau3 graph requires MCP servers forwarded via "
-            "`configurable['mcp_servers']`. This needs Harbor's LangGraph agent to "
-            "forward task-environment MCP servers into the graph configurable."
+            "`configurable['mcp_servers']`. Harbor's LangGraph agent must forward "
+            "the task environment's MCP servers into the graph configurable; the "
+            "pinned Harbor release does not yet do this, so run tau3 with a "
+            "`harbor_package_override` that includes MCP-server forwarding until it "
+            "ships in a release."
         )
         raise ValueError(msg)
     if not isinstance(servers, list):
         msg = "`configurable.mcp_servers` must be a list"
         raise TypeError(msg)
 
-    connections: dict[str, dict[str, Any]] = {}
-    for server in servers:
-        name = server["name"]
+    connections: dict[str, Any] = {}
+    for raw in servers:
+        if not isinstance(raw, dict):
+            msg = "Each entry in `configurable.mcp_servers` must be a mapping"
+            raise TypeError(msg)
+        server = cast("dict[str, Any]", raw)
+        name = str(server["name"])
         transport = server.get("transport", "sse")
         if transport in ("streamable-http", "http"):
             transport = "streamable_http"
-        connection: dict[str, Any] = {"transport": transport}
-        if transport in ("streamable_http", "sse"):
-            connection["url"] = server["url"]
-        elif transport == "stdio":
-            connection["command"] = server["command"]
-            connection["args"] = server.get("args", [])
-        else:
-            msg = f"Unsupported MCP transport for tau3 graph: {transport!r}"
+        if transport not in ("streamable_http", "sse"):
+            msg = (
+                f"MCP server {name!r} uses unsupported transport {transport!r}; the "
+                "tau3 graph only allows remote transports (streamable-http, sse). "
+                "stdio servers are rejected to avoid executing dataset-provided "
+                "commands in the agent sandbox."
+            )
             raise ValueError(msg)
-        connections[name] = connection
+        url = server.get("url")
+        if not url:
+            msg = f"MCP server {name!r} must declare a 'url' for transport {transport!r}"
+            raise ValueError(msg)
+        connections[name] = {"transport": transport, "url": url}
     return connections
 
 

--- a/libs/evals/deepagents_harbor/langgraph_project/langgraph_agent.py
+++ b/libs/evals/deepagents_harbor/langgraph_project/langgraph_agent.py
@@ -12,6 +12,7 @@ from deepagents import create_deep_agent
 from deepagents.backends import LocalShellBackend
 from deepagents_code.agent import create_cli_agent
 from langchain.chat_models import init_chat_model
+from langchain_mcp_adapters.client import MultiServerMCPClient
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -174,4 +175,108 @@ def make_bare_graph(config: dict[str, object] | None = None) -> object:
         model=model,
         backend=backend,
         system_prompt=_SYSTEM_PROMPT,
+    )
+
+
+_TAU3_SYSTEM_PROMPT = """You are a customer-service agent in a Harbor benchmark, \
+talking with a simulated user through the `tau3-runtime` MCP tools. Follow the \
+task's policy exactly.
+
+Protocol:
+- Call `start_conversation` exactly once at the very start to begin (or resume) the
+  conversation and read the user's first message.
+- Call `send_message_to_user` to say anything to the user; it returns their next
+  message.
+- Use the domain tools (also on the `tau3-runtime` server) to inspect or modify the
+  environment.
+- In each step, either talk to the user OR call one domain tool — never both, and
+  only one tool call at a time.
+- When you are confident the case is resolved, end the conversation by calling
+  `end_conversation` (or, if your agent emits stop tokens directly, reply
+  `###STOP###`).
+
+Unlike terminal tasks, there IS a user to talk to here: do not try to finish
+silently. Keep working with the user until the case is resolved.
+"""
+
+
+def _mcp_connections(configurable: dict[str, object]) -> dict[str, dict[str, Any]]:
+    """Build langchain-mcp-adapters connections from Harbor-forwarded servers.
+
+    Harbor's LangGraph agent forwards the task environment's declared MCP servers
+    via ``configurable["mcp_servers"]`` (a list of dicts shaped like Harbor's
+    ``MCPServerConfig``: ``name``/``transport``/``url``/``command``/``args``). We
+    connect only to those trusted, environment-declared servers — never to a URL
+    supplied by the model at runtime.
+
+    Args:
+        configurable: The graph's ``configurable`` mapping.
+
+    Returns:
+        A mapping of server name to a langchain-mcp-adapters connection dict.
+
+    Raises:
+        ValueError: If no MCP servers were forwarded.
+        TypeError: If ``mcp_servers`` is not a list.
+    """
+    servers = configurable.get("mcp_servers")
+    if not servers:
+        msg = (
+            "tau3 graph requires MCP servers forwarded via "
+            "`configurable['mcp_servers']`. This needs Harbor's LangGraph agent to "
+            "forward task-environment MCP servers into the graph configurable."
+        )
+        raise ValueError(msg)
+    if not isinstance(servers, list):
+        msg = "`configurable.mcp_servers` must be a list"
+        raise TypeError(msg)
+
+    connections: dict[str, dict[str, Any]] = {}
+    for server in servers:
+        name = server["name"]
+        transport = server.get("transport", "sse")
+        if transport in ("streamable-http", "http"):
+            transport = "streamable_http"
+        connection: dict[str, Any] = {"transport": transport}
+        if transport in ("streamable_http", "sse"):
+            connection["url"] = server["url"]
+        elif transport == "stdio":
+            connection["command"] = server["command"]
+            connection["args"] = server.get("args", [])
+        else:
+            msg = f"Unsupported MCP transport for tau3 graph: {transport!r}"
+            raise ValueError(msg)
+        connections[name] = connection
+    return connections
+
+
+async def make_tau3_graph(config: dict[str, object] | None = None) -> object:
+    """Create a conversational Deep Agents graph for tau3-bench (and tau2) tasks.
+
+    Unlike the terminal-bench graphs, this attaches the task environment's
+    ``tau3-runtime`` MCP tools (``start_conversation``, ``send_message_to_user``,
+    domain tools, ...) so the agent can converse with the simulated user. The MCP
+    server connection comes from Harbor's forwarded ``configurable["mcp_servers"]``;
+    no URL is hardcoded.
+
+    Args:
+        config: LangGraph runtime config. Harbor passes the selected model in
+            ``configurable.model`` and the task's MCP servers in
+            ``configurable.mcp_servers``.
+
+    Returns:
+        A compiled LangGraph graph invokable by Harbor's LangGraph runner.
+
+    Raises:
+        TypeError: If configurable values have unexpected types.
+        ValueError: If no model name or MCP servers are provided.
+    """
+    configurable = _configurable(config)
+    model = init_chat_model(_model_name(configurable), **_model_kwargs(configurable))
+    client = MultiServerMCPClient(_mcp_connections(configurable))
+    tools = await client.get_tools()
+    return create_deep_agent(
+        model=model,
+        tools=tools,
+        system_prompt=_TAU3_SYSTEM_PROMPT,
     )

--- a/libs/evals/tests/unit_tests/test_harbor_langgraph_agent.py
+++ b/libs/evals/tests/unit_tests/test_harbor_langgraph_agent.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+
+import pytest
 
 from deepagents_harbor.langgraph_project import langgraph_agent
-
-if TYPE_CHECKING:
-    import pytest
 
 
 def test_langgraph_config_points_to_deepagent_factory() -> None:
@@ -21,6 +19,7 @@ def test_langgraph_config_points_to_deepagent_factory() -> None:
     assert config["graphs"] == {
         "deepagent": "./langgraph_agent.py:make_graph",
         "bare_deepagent": "./langgraph_agent.py:make_bare_graph",
+        "tau3_deepagent": "./langgraph_agent.py:make_tau3_graph",
     }
     assert not (project_path / "langsmith.py").exists()
 
@@ -186,3 +185,49 @@ def test_make_bare_graph_builds_sdk_deepagent_with_local_shell(
     assert captured_create[0]["backend"] is backend
     assert isinstance(captured_create[0]["system_prompt"], str)
     assert "Harbor benchmark sandbox" in captured_create[0]["system_prompt"]
+
+
+def test_mcp_connections_maps_streamable_http_server() -> None:
+    connections = langgraph_agent._mcp_connections(
+        {
+            "mcp_servers": [
+                {
+                    "name": "tau3-runtime",
+                    "transport": "streamable-http",
+                    "url": "http://tau3-runtime:8000/mcp",
+                    "command": None,
+                    "args": [],
+                }
+            ]
+        }
+    )
+
+    assert connections == {
+        "tau3-runtime": {
+            "transport": "streamable_http",
+            "url": "http://tau3-runtime:8000/mcp",
+        }
+    }
+
+
+def test_mcp_connections_rejects_stdio_servers() -> None:
+    # A dataset-provided stdio server would run an arbitrary local command in the
+    # agent sandbox; the tau3 graph must reject it rather than execute it.
+    with pytest.raises(ValueError, match="stdio"):
+        langgraph_agent._mcp_connections(
+            {
+                "mcp_servers": [
+                    {
+                        "name": "evil",
+                        "transport": "stdio",
+                        "command": "/bin/sh",
+                        "args": ["-c", "exfiltrate-secrets"],
+                    }
+                ]
+            }
+        )
+
+
+def test_mcp_connections_requires_forwarded_servers() -> None:
+    with pytest.raises(ValueError, match="mcp_servers"):
+        langgraph_agent._mcp_connections({})

--- a/libs/evals/tests/unit_tests/test_harbor_langsmith_integration.py
+++ b/libs/evals/tests/unit_tests/test_harbor_langsmith_integration.py
@@ -77,16 +77,19 @@ def test_harbor_workflow_uses_plugin_instead_of_manual_experiment_steps() -> Non
     assert 'default: "dcode"' in workflow
     assert "          - dcode" in workflow
     assert "dataset:" in workflow
-    assert (
-        "Harbor dataset ref (e.g. terminal-bench/terminal-bench-2 or "
-        "terminal-bench/terminal-bench-2-1)"
-    ) in workflow
+    assert "Harbor dataset to run. Leave dataset_override empty" in workflow
+    assert "dataset_override:" in workflow
+    assert "          - sierra-research/tau3-bench" in workflow
+    assert "          - tau3" in workflow
     assert "include_tasks:" in workflow
     assert "Space-separated task-name globs to include" in workflow
     assert "rollouts_per_task:" in workflow
     assert 'default: "1"' in workflow
     assert "HARBOR_AGENT_IMPL: ${{ inputs.agent_impl }}" in workflow
-    assert "HARBOR_DATASET: ${{ inputs.dataset || 'terminal-bench/terminal-bench-2' }}" in workflow
+    assert (
+        "HARBOR_DATASET: ${{ inputs.dataset_override || inputs.dataset || "
+        "'terminal-bench/terminal-bench-2' }}"
+    ) in workflow
     assert "HARBOR_INCLUDE_TASKS: ${{ inputs.include_tasks }}" in workflow
     assert "HARBOR_ROLLOUTS_PER_TASK: ${{ inputs.rollouts_per_task }}" in workflow
     assert 'echo "| \\`dataset\\` | \\`${DATASET}\\` |"' in workflow

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -590,6 +590,7 @@ provides-extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fir
 [package.metadata.requires-dev]
 test = [
     { name = "build", specifier = ">=1.5.0,<2.0.0" },
+    { name = "hatchling", specifier = ">=1.27.0,<2.0.0" },
     { name = "langchain-quickjs", editable = "../partners/quickjs" },
     { name = "pytest", specifier = ">=9.1.1,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.4.0,<2.0.0" },


### PR DESCRIPTION
## What

Makes [tau3-bench](https://github.com/sierra-research/tau3-bench) runnable from the Harbor workflow, with a dedicated conversational agent.

- **`harbor.yml`** — `dataset` becomes a dropdown (`terminal-bench/terminal-bench-2`, `terminal-bench/terminal-bench-2-1`, `sierra-research/tau3-bench`) plus a free-text `dataset_override` (mirrors the `models` / `models_override` pattern). Adds a `tau3` `agent_impl` that maps to the new `tau3_deepagent` graph.
- **`langgraph_agent.py`** — `make_tau3_graph`, an async factory that attaches the task environment's MCP tools (`tau3-runtime`: `start_conversation`, `send_message_to_user`, domain tools) and uses a conversational system prompt, so the agent talks to the simulated user instead of running autonomously like the terminal-bench graphs.
- **`langgraph.json`** — registers `tau3_deepagent`; adds `langchain-mcp-adapters`.

## Why a new graph

tau3 is a conversation with a simulated user via MCP tools — structurally unlike terminal-bench. The existing graphs (a) use a "complete autonomously, no human operator" prompt and (b) attach no MCP tools, so they cannot do tau3.

## Dependency: Harbor must forward env-declared MCP servers

`make_tau3_graph` reads `configurable["mcp_servers"]`. Harbor's installed LangGraph agent currently stores `self.mcp_servers` but never forwards them to the runner (every other installed agent does). That fix lives in a Harbor branch (`nh/langgraph-forward-mcp-servers`). Without it, the graph raises a clear error rather than guessing a URL.

## Verification

1-task tau3-telecom rollout (bare `anthropic:claude-haiku-4-5`, docker, `tau3_deepagent`): **reward 1.0, 0 exceptions**, 35-step conversation, `termination_reason=user_stop`. The agent received the full tau3 toolset and resolved the case.

## Running tau3 in CI (follow-ups, not in this PR)

- The LangGraph agent dependency install needs `UV_PRERELEASE=allow` (the workflow sets it only for Fireworks today).
- `tau3-runtime` user-simulator + verifier need working `OPENAI_API_KEY` + `OPENAI_BASE_URL` + `TAU2_USER_MODEL` / `TAU2_NL_ASSERTIONS_MODEL` wired into the Harbor job env.
