### PR TITLE
style(code): pointer cursor when hovering markdown links

### DIFF
--- a/libs/code/deepagents_code/widgets/_links.py
+++ b/libs/code/deepagents_code/widgets/_links.py
@@ -11,9 +11,29 @@ from deepagents_code.unicode_security import check_url_safety, strip_dangerous_u
 
 if TYPE_CHECKING:
     from textual.app import App
-    from textual.events import Click
+    from textual.events import Click, MouseMove
 
 logger = logging.getLogger(__name__)
+
+
+def event_targets_link(event: MouseMove) -> bool:
+    """Return whether the style under the mouse points to a clickable link.
+
+    Detects both Rich `Style(link=...)` (OSC 8) hyperlinks and the
+    `@click=link(...)` meta actions that Textual's `Markdown` widget attaches
+    to rendered links and images.
+
+    Args:
+        event: The Textual mouse-move event to inspect.
+
+    Returns:
+        `True` when the hovered character belongs to a link span.
+    """
+    style = event.style
+    if style.link:
+        return True
+    click = style.meta.get("@click")
+    return isinstance(click, str) and click.startswith("link(")
 
 
 async def open_url_async(url: str, *, app: App) -> bool:

--- a/libs/code/deepagents_code/widgets/messages.py
+++ b/libs/code/deepagents_code/widgets/messages.py
@@ -43,7 +43,7 @@ from deepagents_code.widgets._js_eval_display import (
     JsEvalStdout,
     parse_js_eval_blocks,
 )
-from deepagents_code.widgets._links import open_style_link
+from deepagents_code.widgets._links import event_targets_link, open_style_link
 from deepagents_code.widgets.diff import compose_diff_lines
 
 if TYPE_CHECKING:
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
         RenderResult,
     )
     from textual.app import ComposeResult
+    from textual.events import MouseMove
     from textual.timer import Timer
     from textual.widgets import Markdown
     from textual.widgets._markdown import MarkdownStream
@@ -723,6 +724,23 @@ class AssistantMessage(Vertical):
         from textual.widgets import Markdown
 
         self._markdown = self.query_one("#assistant-content", Markdown)
+
+    def on_mouse_move(self, event: MouseMove) -> None:
+        """Show a grab pointer over markdown links, text cursor elsewhere.
+
+        The pointer is set on the inner `Markdown` widget because it carries a
+        non-default (`text`) pointer in CSS, so the screen resolves its shape
+        before reaching this container.
+        """
+        if self._markdown is not None:
+            self._markdown.styles.pointer = (
+                "grab" if event_targets_link(event) else "text"
+            )
+
+    def on_leave(self) -> None:
+        """Reset the markdown pointer shape when the mouse leaves the message."""
+        if self._markdown is not None:
+            self._markdown.styles.pointer = "text"
 
     def _get_markdown(self) -> Markdown:
         """Get the markdown widget, querying if not cached.

--- a/libs/code/deepagents_code/widgets/messages.py
+++ b/libs/code/deepagents_code/widgets/messages.py
@@ -726,7 +726,7 @@ class AssistantMessage(Vertical):
         self._markdown = self.query_one("#assistant-content", Markdown)
 
     def on_mouse_move(self, event: MouseMove) -> None:
-        """Show a grab pointer over markdown links, text cursor elsewhere.
+        """Show a pointer cursor over markdown links, text cursor elsewhere.
 
         The pointer is set on the inner `Markdown` widget because it carries a
         non-default (`text`) pointer in CSS, so the screen resolves its shape
@@ -734,7 +734,7 @@ class AssistantMessage(Vertical):
         """
         if self._markdown is not None:
             self._markdown.styles.pointer = (
-                "grab" if event_targets_link(event) else "text"
+                "pointer" if event_targets_link(event) else "text"
             )
 
     def on_leave(self) -> None:

--- a/libs/code/tests/unit_tests/test_links.py
+++ b/libs/code/tests/unit_tests/test_links.py
@@ -3,7 +3,35 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from deepagents_code.widgets._links import open_style_link
+from deepagents_code.widgets._links import event_targets_link, open_style_link
+
+
+def _move_event(
+    *, link: str | None = None, meta: dict | None = None
+) -> SimpleNamespace:
+    """Build a minimal mouse-move-like event for hover tests."""
+    return SimpleNamespace(style=SimpleNamespace(link=link, meta=meta or {}))
+
+
+def test_event_targets_link_detects_osc8_link() -> None:
+    """A Rich `Style(link=...)` span counts as a link."""
+    assert event_targets_link(_move_event(link="https://example.com")) is True  # ty: ignore
+
+
+def test_event_targets_link_detects_markdown_click_action() -> None:
+    """Markdown `@click=link(...)` meta actions count as links."""
+    event = _move_event(meta={"@click": "link('https://example.com')"})
+    assert event_targets_link(event) is True  # ty: ignore
+
+
+def test_event_targets_link_ignores_plain_text() -> None:
+    """Plain hovered text is not a link."""
+    assert event_targets_link(_move_event()) is False  # ty: ignore
+
+
+def test_event_targets_link_ignores_other_click_actions() -> None:
+    """Non-link `@click` actions are not treated as links."""
+    assert event_targets_link(_move_event(meta={"@click": "toggle()"})) is False  # ty: ignore
 
 
 def _event_with_link(url: str) -> SimpleNamespace:

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -290,6 +290,44 @@ class TestAssistantMessageMarkdownRendering:
         assert msg._content == "```python\nnew content\n```"
 
 
+class TestAssistantMessageLinkPointer:
+    """Tests for the grab pointer shown when hovering markdown links."""
+
+    @staticmethod
+    def _move_event(*, meta: dict | None = None) -> MagicMock:
+        event = MagicMock()
+        event.style.link = None
+        event.style.meta = meta or {}
+        return event
+
+    def test_hovering_link_sets_grab_pointer(self) -> None:
+        """A markdown link span switches the pointer to grab."""
+        msg = AssistantMessage()
+        msg._markdown = MagicMock()
+
+        msg.on_mouse_move(self._move_event(meta={"@click": "link('https://x')"}))
+
+        assert msg._markdown.styles.pointer == "grab"
+
+    def test_hovering_text_sets_text_pointer(self) -> None:
+        """Plain markdown text keeps the text pointer."""
+        msg = AssistantMessage()
+        msg._markdown = MagicMock()
+
+        msg.on_mouse_move(self._move_event())
+
+        assert msg._markdown.styles.pointer == "text"
+
+    def test_leave_resets_pointer(self) -> None:
+        """Leaving the message resets the pointer to text."""
+        msg = AssistantMessage()
+        msg._markdown = MagicMock()
+
+        msg.on_leave()
+
+        assert msg._markdown.styles.pointer == "text"
+
+
 class _AssistantMessageApp(App[None]):
     """Minimal app that mounts an AssistantMessage for timer-based tests."""
 

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -1,6 +1,7 @@
 """Unit tests for message widgets markup safety."""
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -290,51 +291,84 @@ class TestAssistantMessageMarkdownRendering:
         assert msg._content == "```python\nnew content\n```"
 
 
-class TestAssistantMessageLinkPointer:
-    """Tests for the pointer cursor shown when hovering markdown links."""
-
-    @staticmethod
-    def _move_event(*, meta: dict | None = None) -> MagicMock:
-        event = MagicMock()
-        event.style.link = None
-        event.style.meta = meta or {}
-        return event
-
-    def test_hovering_link_sets_pointer_cursor(self) -> None:
-        """A markdown link span switches the pointer to pointer."""
-        msg = AssistantMessage()
-        msg._markdown = MagicMock()
-
-        msg.on_mouse_move(self._move_event(meta={"@click": "link('https://x')"}))
-
-        assert msg._markdown.styles.pointer == "pointer"
-
-    def test_hovering_text_sets_text_pointer(self) -> None:
-        """Plain markdown text keeps the text pointer."""
-        msg = AssistantMessage()
-        msg._markdown = MagicMock()
-
-        msg.on_mouse_move(self._move_event())
-
-        assert msg._markdown.styles.pointer == "text"
-
-    def test_leave_resets_pointer(self) -> None:
-        """Leaving the message resets the pointer to text."""
-        msg = AssistantMessage()
-        msg._markdown = MagicMock()
-
-        msg.on_leave()
-
-        assert msg._markdown.styles.pointer == "text"
-
-
 class _AssistantMessageApp(App[None]):
-    """Minimal app that mounts an AssistantMessage for timer-based tests."""
+    """Minimal app that mounts an AssistantMessage for runtime tests."""
 
     def compose(self) -> ComposeResult:
         widget = AssistantMessage()
         widget.id = "assistant"
         yield widget
+
+
+class TestAssistantMessageLinkPointer:
+    """Tests for the pointer cursor shown when hovering markdown links."""
+
+    @staticmethod
+    def _move_event(
+        *, link: str | None = None, meta: dict | None = None
+    ) -> SimpleNamespace:
+        """Build a minimal mouse-move-like event exposing the hovered style.
+
+        The handlers only read `event.style.link` and `event.style.meta`, so a
+        namespace is enough; the assertions run against the real `Markdown`
+        widget mounted by `_AssistantMessageApp`.
+        """
+        return SimpleNamespace(style=SimpleNamespace(link=link, meta=meta or {}))
+
+    async def test_hovering_markdown_link_sets_pointer_cursor(self) -> None:
+        """A markdown `@click=link(...)` span switches the real pointer to pointer."""
+        async with _AssistantMessageApp().run_test() as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+
+            msg.on_mouse_move(self._move_event(meta={"@click": "link('https://x')"}))  # ty: ignore
+
+            assert msg._markdown is not None
+            assert msg._markdown.styles.pointer == "pointer"
+
+    async def test_hovering_osc8_link_sets_pointer_cursor(self) -> None:
+        """An OSC 8 `Style(link=...)` span also switches the pointer to pointer."""
+        async with _AssistantMessageApp().run_test() as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+
+            msg.on_mouse_move(self._move_event(link="https://example.com"))  # ty: ignore
+
+            assert msg._markdown is not None
+            assert msg._markdown.styles.pointer == "pointer"
+
+    async def test_hovering_text_sets_text_pointer(self) -> None:
+        """Plain markdown text keeps the text pointer."""
+        async with _AssistantMessageApp().run_test() as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+
+            msg.on_mouse_move(self._move_event())  # ty: ignore
+
+            assert msg._markdown is not None
+            assert msg._markdown.styles.pointer == "text"
+
+    async def test_leave_resets_pointer(self) -> None:
+        """Leaving the message resets the pointer to text after a link hover."""
+        async with _AssistantMessageApp().run_test() as pilot:
+            msg = pilot.app.query_one("#assistant", AssistantMessage)
+            msg.on_mouse_move(self._move_event(link="https://example.com"))  # ty: ignore
+
+            msg.on_leave()
+
+            assert msg._markdown is not None
+            assert msg._markdown.styles.pointer == "text"
+
+    def test_mouse_move_before_mount_is_noop(self) -> None:
+        """Hovering before mount (no markdown widget yet) must not raise."""
+        msg = AssistantMessage()
+        assert msg._markdown is None
+
+        msg.on_mouse_move(self._move_event(link="https://example.com"))  # ty: ignore
+
+    def test_leave_before_mount_is_noop(self) -> None:
+        """Leaving before mount (no markdown widget yet) must not raise."""
+        msg = AssistantMessage()
+        assert msg._markdown is None
+
+        msg.on_leave()
 
 
 class TestAssistantMessageStreamCoalescing:

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -291,7 +291,7 @@ class TestAssistantMessageMarkdownRendering:
 
 
 class TestAssistantMessageLinkPointer:
-    """Tests for the grab pointer shown when hovering markdown links."""
+    """Tests for the pointer cursor shown when hovering markdown links."""
 
     @staticmethod
     def _move_event(*, meta: dict | None = None) -> MagicMock:
@@ -300,14 +300,14 @@ class TestAssistantMessageLinkPointer:
         event.style.meta = meta or {}
         return event
 
-    def test_hovering_link_sets_grab_pointer(self) -> None:
-        """A markdown link span switches the pointer to grab."""
+    def test_hovering_link_sets_pointer_cursor(self) -> None:
+        """A markdown link span switches the pointer to pointer."""
         msg = AssistantMessage()
         msg._markdown = MagicMock()
 
         msg.on_mouse_move(self._move_event(meta={"@click": "link('https://x')"}))
 
-        assert msg._markdown.styles.pointer == "grab"
+        assert msg._markdown.styles.pointer == "pointer"
 
     def test_hovering_text_sets_text_pointer(self) -> None:
         """Plain markdown text keeps the text pointer."""


### PR DESCRIPTION
Hovering over links in assistant markdown now shows the pointer cursor.

---

Hovering over URLs in rendered assistant markdown showed the plain text cursor. This detects link spans under the mouse (both OSC 8 `Style(link=...)` and the `@click=link(...)` meta actions Textual's `Markdown` attaches to links/images) and switches the inner `Markdown` widget's pointer to `pointer`, resetting it to `text` otherwise.

Made by [Open SWE](https://openswe.vercel.app/agents/957519a2-ca36-ca25-0858-04f366a8eb46)
