### PR TITLE
chore(code): remove `/restart` hint from upgrade messages

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -4131,8 +4131,7 @@ class DeepAgentsApp(App):
                     await self._mount_message(
                         AppMessage(
                             f"Updated to v{latest}. Quit and relaunch dcode "
-                            "to use the new version (`/restart` only restarts "
-                            "the server, not the CLI)."
+                            "to use the new version."
                         ),
                     )
                 else:
@@ -11166,8 +11165,7 @@ class DeepAgentsApp(App):
                         return
                     self.notify(
                         f"Updated to v{payload.latest}. "
-                        "Quit and relaunch dcode to use the new version "
-                        "(/restart only restarts the server, not the CLI).",
+                        "Quit and relaunch dcode to use the new version.",
                         severity="information",
                         timeout=10,
                         markup=False,


### PR DESCRIPTION
Removes the redundant parenthetical hint "`/restart` only restarts the server, not the CLI" from the two post-upgrade relaunch messages in `app.py`.

Made by [Open SWE](https://openswe.vercel.app/agents/bd8a6fc4-f59a-20d2-733f-987e1a018a8a)