### PR TITLE
hotfix(code): allow prereleases for pinned alpha updates

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3867,7 +3867,10 @@ class DeepAgentsApp(App):
                 release_requires_prereleases,
                 latest,
             )
-            cmd = upgrade_command(include_prereleases=update_needs_prereleases)
+            cmd = upgrade_command(
+                include_prereleases=True if update_needs_prereleases else None,
+                version=latest if update_needs_prereleases else None,
+            )
             release_age = await asyncio.to_thread(
                 format_release_age_parenthetical,
                 latest,
@@ -4072,21 +4075,13 @@ class DeepAgentsApp(App):
                 )
                 return
             upgrade_include_prereleases = include_prereleases
+            pin_upgrade_version: str | None = None
             if include_prereleases is None and await asyncio.to_thread(
                 release_requires_prereleases,
                 latest,
             ):
                 upgrade_include_prereleases = True
-            if upgrade_include_prereleases is True:
-                supported, reason = await asyncio.to_thread(
-                    prerelease_upgrade_supported,
-                )
-                if not supported:
-                    await self._mount_message(
-                        AppMessage(reason or _PRERELEASE_UNSUPPORTED_MESSAGE),
-                    )
-                    return
-
+                pin_upgrade_version = latest
             if not available:
                 if deps_only:
                     await self._refresh_dependencies(
@@ -4154,6 +4149,16 @@ class DeepAgentsApp(App):
                     )
                     return
 
+            if upgrade_include_prereleases is True:
+                supported, reason = await asyncio.to_thread(
+                    prerelease_upgrade_supported,
+                )
+                if not supported:
+                    await self._mount_message(
+                        AppMessage(reason or _PRERELEASE_UNSUPPORTED_MESSAGE),
+                    )
+                    return
+
             release_age = await asyncio.to_thread(
                 format_release_age_parenthetical,
                 latest,
@@ -4215,7 +4220,10 @@ class DeepAgentsApp(App):
                         ),
                     )
             else:
-                cmd = upgrade_command(include_prereleases=upgrade_include_prereleases)
+                cmd = upgrade_command(
+                    include_prereleases=upgrade_include_prereleases,
+                    version=pin_upgrade_version,
+                )
                 detail = f": {output[:200]}" if output else ""
                 await self._mount_message(
                     AppMessage(f"Auto-update failed{detail}\nRun manually: {cmd}"),

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -4180,7 +4180,7 @@ class DeepAgentsApp(App):
                 )
                 return
             success, output = await perform_upgrade(
-                include_prereleases=upgrade_include_prereleases,
+                include_prereleases=include_prereleases,
                 target_version=latest,
             )
             if success:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3833,6 +3833,7 @@ class DeepAgentsApp(App):
                 format_installed_age_suffix,
                 format_release_age_parenthetical,
                 mark_update_notified,
+                release_requires_prereleases,
                 should_notify_update,
             )
 
@@ -3862,7 +3863,11 @@ class DeepAgentsApp(App):
             if not await asyncio.to_thread(should_notify_update, latest):
                 return
 
-            cmd = upgrade_command()
+            update_needs_prereleases = await asyncio.to_thread(
+                release_requires_prereleases,
+                latest,
+            )
+            cmd = upgrade_command(include_prereleases=update_needs_prereleases)
             release_age = await asyncio.to_thread(
                 format_release_age_parenthetical,
                 latest,
@@ -4026,6 +4031,7 @@ class DeepAgentsApp(App):
                 perform_dependency_refresh_dry_run,
                 perform_upgrade,
                 prerelease_upgrade_supported,
+                release_requires_prereleases,
                 upgrade_command,
             )
 
@@ -4065,6 +4071,22 @@ class DeepAgentsApp(App):
                     ),
                 )
                 return
+            upgrade_include_prereleases = include_prereleases
+            if include_prereleases is None and await asyncio.to_thread(
+                release_requires_prereleases,
+                latest,
+            ):
+                upgrade_include_prereleases = True
+            if upgrade_include_prereleases is True:
+                supported, reason = await asyncio.to_thread(
+                    prerelease_upgrade_supported,
+                )
+                if not supported:
+                    await self._mount_message(
+                        AppMessage(reason or _PRERELEASE_UNSUPPORTED_MESSAGE),
+                    )
+                    return
+
             if not available:
                 if deps_only:
                     await self._refresh_dependencies(
@@ -4153,7 +4175,8 @@ class DeepAgentsApp(App):
                 )
                 return
             success, output = await perform_upgrade(
-                include_prereleases=include_prereleases,
+                include_prereleases=upgrade_include_prereleases,
+                target_version=latest,
             )
             if success:
                 self._update_available = (False, None)
@@ -4192,7 +4215,7 @@ class DeepAgentsApp(App):
                         ),
                     )
             else:
-                cmd = upgrade_command(include_prereleases=include_prereleases)
+                cmd = upgrade_command(include_prereleases=upgrade_include_prereleases)
                 detail = f": {output[:200]}" if output else ""
                 await self._mount_message(
                     AppMessage(f"Auto-update failed{detail}\nRun manually: {cmd}"),
@@ -11115,7 +11138,6 @@ class DeepAgentsApp(App):
             format_shadowed_dcode_warning,
             mark_update_notified,
             perform_upgrade,
-            upgrade_command,
         )
 
         if action_id == ActionId.INSTALL:
@@ -11132,7 +11154,7 @@ class DeepAgentsApp(App):
 
             from deepagents_code.widgets.update_progress import UpdateProgressScreen
 
-            cmd = upgrade_command()
+            cmd = payload.upgrade_cmd
             log_path = create_update_log_path()
             screen = UpdateProgressScreen(
                 latest=payload.latest,
@@ -11163,6 +11185,7 @@ class DeepAgentsApp(App):
                 success, output = await perform_upgrade(
                     progress=screen.append_line,
                     log_path=log_path,
+                    target_version=payload.latest,
                 )
                 if success:
                     self._notice_registry.remove(entry.key)

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -204,6 +204,7 @@ def _run_startup_auto_update(console: "Console") -> None:
         is_update_check_enabled,
         mark_auto_update_default_acknowledged,
         perform_upgrade,
+        release_requires_prereleases,
         should_announce_auto_update_default,
         upgrade_command,
     )
@@ -243,7 +244,9 @@ def _run_startup_auto_update(console: "Console") -> None:
             # reports as available: the install did not change the running
             # version. Bail out instead of upgrading and restarting forever
             # (this runs before the TUI, so there is no in-app way to stop it).
-            cmd = upgrade_command()
+            cmd = upgrade_command(
+                include_prereleases=release_requires_prereleases(latest)
+            )
             console.print(
                 f"[bold yellow]Warning:[/bold yellow] v{latest} still reports as "
                 "available after an automatic update; skipping auto-update to "
@@ -295,7 +298,9 @@ def _run_startup_auto_update(console: "Console") -> None:
             highlight=False,
             markup=False,
         )
-        success, output = asyncio.run(perform_upgrade(log_path=log_path))
+        success, output = asyncio.run(
+            perform_upgrade(log_path=log_path, target_version=latest)
+        )
         if success:
             # If a stale `dcode` is earlier on PATH, the auto-restart would
             # re-exec into the old binary and the user would silently keep
@@ -2584,6 +2589,7 @@ def cli_main() -> None:
                     is_update_available,
                     perform_upgrade,
                     prerelease_upgrade_supported,
+                    release_requires_prereleases,
                     upgrade_command,
                 )
 
@@ -2628,6 +2634,17 @@ def cli_main() -> None:
                     )
                     sys.exit(0)
 
+                if include_prereleases is None and release_requires_prereleases(latest):
+                    include_prereleases = True
+                if include_prereleases is True:
+                    supported, reason = prerelease_upgrade_supported()
+                    if not supported:
+                        console.print(
+                            "[bold red]Error:[/bold red] "
+                            f"{reason or _PRERELEASE_UNSUPPORTED_MESSAGE}"
+                        )
+                        sys.exit(1)
+
                 release_age = format_release_age_parenthetical(latest)
                 installed_age = format_installed_age_suffix(cli_version)
                 console.print(
@@ -2649,6 +2666,7 @@ def cli_main() -> None:
                     perform_upgrade(
                         log_path=log_path,
                         include_prereleases=include_prereleases,
+                        target_version=latest,
                     )
                 )
                 if success:

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2640,11 +2640,12 @@ def cli_main() -> None:
                     )
                     sys.exit(0)
 
+                upgrade_include_prereleases = include_prereleases
                 pin_upgrade_version: str | None = None
                 if include_prereleases is None and release_requires_prereleases(latest):
-                    include_prereleases = True
+                    upgrade_include_prereleases = True
                     pin_upgrade_version = latest
-                if include_prereleases is True:
+                if upgrade_include_prereleases is True:
                     supported, reason = prerelease_upgrade_supported()
                     if not supported:
                         console.print(
@@ -2681,7 +2682,7 @@ def cli_main() -> None:
                     console.print(f"[green]Updated to v{latest}.[/green]")
                 else:
                     cmd = upgrade_command(
-                        include_prereleases=include_prereleases,
+                        include_prereleases=upgrade_include_prereleases,
                         version=pin_upgrade_version,
                     )
                     detail = f": {escape(output[:200])}" if output else ""

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -244,8 +244,10 @@ def _run_startup_auto_update(console: "Console") -> None:
             # reports as available: the install did not change the running
             # version. Bail out instead of upgrading and restarting forever
             # (this runs before the TUI, so there is no in-app way to stop it).
+            update_needs_prereleases = release_requires_prereleases(latest)
             cmd = upgrade_command(
-                include_prereleases=release_requires_prereleases(latest)
+                include_prereleases=True if update_needs_prereleases else None,
+                version=latest if update_needs_prereleases else None,
             )
             console.print(
                 f"[bold yellow]Warning:[/bold yellow] v{latest} still reports as "
@@ -350,7 +352,11 @@ def _run_startup_auto_update(console: "Console") -> None:
                     highlight=False,
                 )
             return
-        cmd = upgrade_command()
+        update_needs_prereleases = release_requires_prereleases(latest)
+        cmd = upgrade_command(
+            include_prereleases=True if update_needs_prereleases else None,
+            version=latest if update_needs_prereleases else None,
+        )
         detail = f": {escape(output[:200])}" if output else ""
         console.print(
             f"[bold red]Auto-update failed{detail}[/bold red]\n"
@@ -2634,8 +2640,10 @@ def cli_main() -> None:
                     )
                     sys.exit(0)
 
+                pin_upgrade_version: str | None = None
                 if include_prereleases is None and release_requires_prereleases(latest):
                     include_prereleases = True
+                    pin_upgrade_version = latest
                 if include_prereleases is True:
                     supported, reason = prerelease_upgrade_supported()
                     if not supported:
@@ -2672,7 +2680,10 @@ def cli_main() -> None:
                 if success:
                     console.print(f"[green]Updated to v{latest}.[/green]")
                 else:
-                    cmd = upgrade_command(include_prereleases=include_prereleases)
+                    cmd = upgrade_command(
+                        include_prereleases=include_prereleases,
+                        version=pin_upgrade_version,
+                    )
                     detail = f": {escape(output[:200])}" if output else ""
                     console.print(
                         f"[bold red]Auto-update failed{detail}[/bold red]\n"

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -941,6 +941,7 @@ def upgrade_command(
     method: InstallMethod | None = None,
     *,
     include_prereleases: bool | None = None,
+    version: str | None = None,
 ) -> str:
     """Return the shell command to upgrade `deepagents-code`.
 
@@ -954,8 +955,15 @@ def upgrade_command(
             `None`, follows the installed version's channel. When `True`,
             returns the uv pre-release command regardless of `method`, since
             only uv can be steered onto the pre-release channel.
+        version: Optional exact `deepagents-code` version pin for uv guidance.
     """
     include_prereleases = _resolve_include_prereleases(include_prereleases)
+    if version is not None:
+        requirement = _dcode_extras_requirement((), version=version)
+        cmd = f"uv tool install -U {requirement}"
+        if include_prereleases:
+            cmd += " --prerelease allow"
+        return cmd
     if include_prereleases:
         return _UV_PRERELEASE_UPGRADE_COMMAND
     if method is None:
@@ -1522,12 +1530,14 @@ async def perform_upgrade(
             "manager originally used for this install."
         )
     resolved_include_prereleases = _resolve_include_prereleases(include_prereleases)
+    pin_target_version: str | None = None
     if (
         not resolved_include_prereleases
         and include_prereleases is None
         and release_requires_prereleases(target_version)
     ):
         resolved_include_prereleases = True
+        pin_target_version = target_version
     if resolved_include_prereleases:
         supported, reason = prerelease_upgrade_supported(method)
         if not supported:
@@ -1547,6 +1557,7 @@ async def perform_upgrade(
         try:
             cmd = upgrade_install_command(
                 include_prereleases=resolved_include_prereleases,
+                version=pin_target_version,
             )
         except (ExtrasIntrospectionError, ToolRequirementIntrospectionError) as exc:
             logger.warning(
@@ -1560,6 +1571,7 @@ async def perform_upgrade(
             cmd = upgrade_command(
                 method,
                 include_prereleases=resolved_include_prereleases,
+                version=pin_target_version,
             )
     else:
         cmd = upgrade_command(
@@ -2078,8 +2090,9 @@ def upgrade_install_command(
     *,
     include_prereleases: bool | None = None,
     distribution_name: str = "deepagents-code",
+    version: str | None = None,
 ) -> str:
-    """Return the uv command that upgrades dcode while clearing any version pin.
+    """Return the uv command that upgrades dcode while clearing stale pins.
 
     Built specifically to avoid the `uv tool upgrade` receipt-pin trap: when
     the tool was originally installed via `uv tool install deepagents-code==X.Y.Z`
@@ -2088,15 +2101,19 @@ def upgrade_install_command(
     re-resolve *within* that pin and silently keep the user on the same
     version. Re-running `uv tool install -U deepagents-code[<extras>]` (no
     version pin) rewrites the receipt's requirement to unpinned so the next
-    upgrade can actually move forward. Installed extras and `--with`
-    packages are preserved to mirror `dependency_refresh_command`; only the
-    version pin is intentionally stripped.
+    upgrade can actually move forward. Callers can still pass `version` when
+    the resolver must allow pre-release dependencies for a stable app target;
+    that prevents the root `deepagents-code` package from floating to a newer
+    app pre-release. Installed extras and `--with` packages are preserved to
+    mirror `dependency_refresh_command`.
 
     Args:
         include_prereleases: Whether to include alpha/beta/rc releases. When
             `None`, follows the installed version's channel.
         distribution_name: Name of the installed distribution to inspect for
             already-installed extras.
+        version: Optional exact target version. Use only when pre-release
+            dependency resolution must not also select a root app pre-release.
 
     Returns:
         Shell command string suitable for execution via the shell.
@@ -2110,7 +2127,7 @@ def upgrade_install_command(
     user-facing warning.
     """
     return _uv_tool_install_command(
-        version=None,
+        version=version,
         include_prereleases=include_prereleases,
         distribution_name=distribution_name,
     )

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -20,6 +20,7 @@ import re
 import shlex
 import shutil
 import sys
+import tempfile
 import time
 import tomllib
 from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
@@ -253,7 +254,21 @@ def get_cached_update_available() -> tuple[bool, str | None]:
 
 
 def _requires_prerelease_dependency(requirements: Sequence[object] | None) -> bool:
-    """Return whether any requirement specifier names a pre-release version."""
+    """Return whether any requirement specifier names a pre-release version.
+
+    Accepts the raw `Requires-Dist` list from PyPI metadata, which may contain
+    non-string or non-PEP-508 junk; such entries are skipped rather than raising
+    so one malformed line cannot poison the whole check.
+
+    The check is intentionally operator- and marker-agnostic: it returns `True`
+    if *any* specifier across *any* requirement pins a pre-release version,
+    regardless of the operator (`==`, `>=`, even `!=`) or environment markers
+    (extras, `python_version`). This errs toward `True`, which is the safe
+    direction — opting `uv` into `--prerelease allow` still resolves stable
+    releases correctly, so a false positive only widens the candidate set and
+    never strands a user. Do not "tighten" this to the dangerous direction
+    without revisiting the fallback asymmetry in `release_requires_prereleases`.
+    """
     if not requirements:
         return False
     for raw in requirements:
@@ -278,6 +293,33 @@ def _requires_prerelease_dependency(requirements: Sequence[object] | None) -> bo
     return False
 
 
+def _atomic_write_cache(data: dict[str, Any]) -> None:
+    """Write `data` to `CACHE_FILE` as JSON atomically.
+
+    A plain `write_text` truncates the file before writing, so a crash or a
+    concurrent reader/writer can observe a half-written cache. Serializing to a
+    sibling temp file and `os.replace`-ing it into place makes the swap atomic,
+    so readers always see either the old or new contents — never a partial one.
+
+    Raises:
+        OSError: If the cache directory or temp file cannot be written, or the
+            atomic replace fails. Callers handle reporting.
+    """
+    CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=CACHE_FILE.parent, prefix=".latest_version-", suffix=".tmp"
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle)
+        tmp_path.replace(CACHE_FILE)
+    except OSError:
+        with suppress(OSError):
+            tmp_path.unlink()
+        raise
+
+
 def _write_release_requires_prereleases(version: str, requires: bool) -> None:
     """Cache whether a release needs uv's pre-release resolver opt-in."""
     try:
@@ -293,8 +335,7 @@ def _write_release_requires_prereleases(version: str, requires: bool) -> None:
         values[version] = requires
         data[_RELEASE_PRERELEASE_DEPS_KEY] = values
         data.setdefault("checked_at", time.time())
-        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-        CACHE_FILE.write_text(json.dumps(data), encoding="utf-8")
+        _atomic_write_cache(data)
     except (OSError, json.JSONDecodeError, TypeError):
         logger.debug(
             "Failed to write release pre-release dependency cache",
@@ -382,19 +423,32 @@ def get_latest_version(
         payload, stable=stable, prerelease=prerelease, installed=__version__
     )
 
+    # Preserve per-version pre-release-dependency entries written by
+    # `_write_release_requires_prereleases` for *other* versions; this refresh
+    # only knows the answer for `stable`, so merge rather than overwrite the map
+    # (otherwise a routine check would evict a cached answer and force a re-fetch
+    # that, on a PyPI hiccup, falls back to the unsafe stable-only default).
+    prerelease_deps: dict[str, Any] = {}
     try:
-        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-        CACHE_FILE.write_text(
-            json.dumps(
-                {
-                    "version": stable,
-                    "version_prerelease": prerelease,
-                    "release_times": release_times,
-                    _RELEASE_PRERELEASE_DEPS_KEY: {stable: stable_requires_prereleases},
-                    "checked_at": time.time(),
-                }
-            ),
-            encoding="utf-8",
+        if CACHE_FILE.exists():
+            existing = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+            if isinstance(existing, dict):
+                cached_deps = existing.get(_RELEASE_PRERELEASE_DEPS_KEY)
+                if isinstance(cached_deps, dict):
+                    prerelease_deps = cached_deps
+    except (OSError, json.JSONDecodeError, TypeError):
+        logger.debug("Failed to read cached pre-release deps before refresh")
+    prerelease_deps[stable] = stable_requires_prereleases
+
+    try:
+        _atomic_write_cache(
+            {
+                "version": stable,
+                "version_prerelease": prerelease,
+                "release_times": release_times,
+                _RELEASE_PRERELEASE_DEPS_KEY: prerelease_deps,
+                "checked_at": time.time(),
+            }
         )
     except OSError:
         logger.debug("Failed to write update-check cache", exc_info=True)
@@ -415,6 +469,18 @@ def release_requires_prereleases(
 
     Returns:
         `True` when the release metadata pins or bounds a pre-release dependency.
+
+    Note:
+        On any lookup failure (no `requests`, network/parse error) this returns
+        `False` — i.e. "stable-only resolution". That is deliberately
+        conservative rather than fail-safe: the truly safe default would be to
+        allow pre-releases, but a spurious `True` would make
+        `prerelease_upgrade_supported` *refuse* the upgrade outright on non-uv
+        installs (Homebrew/other), regressing the common case. `False` keeps
+        those installs upgradable; the cost is that, during a PyPI outage, a
+        stable release that genuinely pins a pre-release dependency may be
+        installed stable-only. Failures are logged at `warning` so the blind
+        decision is at least visible.
     """
     if not version:
         return False
@@ -434,7 +500,11 @@ def release_requires_prereleases(
     try:
         import requests
     except ImportError:
-        logger.debug("requests unavailable — release dependency lookup disabled")
+        logger.warning(
+            "requests package not installed — cannot check whether v%s pins a "
+            "pre-release dependency; assuming stable-only resolution",
+            version,
+        )
         return False
 
     try:
@@ -449,9 +519,11 @@ def release_requires_prereleases(
         info = payload.get("info")
         requires = info.get("requires_dist") if isinstance(info, dict) else None
         result = _requires_prerelease_dependency(requires)
-    except (requests.RequestException, OSError, json.JSONDecodeError):
-        logger.debug(
-            "Failed to fetch release dependency metadata from PyPI",
+    except (requests.RequestException, OSError, KeyError, json.JSONDecodeError):
+        logger.warning(
+            "Failed to fetch dependency metadata for v%s from PyPI; assuming "
+            "stable-only resolution",
+            version,
             exc_info=True,
         )
         return False

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -29,6 +29,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal, NamedTuple, TextIO
 
+from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 
@@ -68,6 +69,9 @@ INSTALLED_AGE_NOTICE_DAYS = 7
 
 _SDK_RELEASE_TIMES_KEY = "sdk_release_times"
 """`CACHE_FILE` key for cached SDK upload timestamps, keyed by version string."""
+
+_RELEASE_PRERELEASE_DEPS_KEY = "release_requires_prereleases"
+"""`CACHE_FILE` key for release versions that require pre-release dependencies."""
 
 InstallMethod = Literal["uv", "brew", "other", "unknown"]
 
@@ -248,6 +252,56 @@ def get_cached_update_available() -> tuple[bool, str | None]:
         return False, None
 
 
+def _requires_prerelease_dependency(requirements: Sequence[object] | None) -> bool:
+    """Return whether any requirement specifier names a pre-release version."""
+    if not requirements:
+        return False
+    for raw in requirements:
+        if not isinstance(raw, str):
+            continue
+        try:
+            requirement = Requirement(raw)
+        except InvalidRequirement:
+            logger.debug("Skipping unparseable Requires-Dist entry: %r", raw)
+            continue
+        for specifier in requirement.specifier:
+            try:
+                version = Version(specifier.version)
+            except InvalidVersion:
+                logger.debug(
+                    "Skipping unparseable requirement version: %r",
+                    specifier.version,
+                )
+                continue
+            if version.is_prerelease:
+                return True
+    return False
+
+
+def _write_release_requires_prereleases(version: str, requires: bool) -> None:
+    """Cache whether a release needs uv's pre-release resolver opt-in."""
+    try:
+        data: dict[str, Any]
+        if CACHE_FILE.exists():
+            loaded = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+            data = loaded if isinstance(loaded, dict) else {}
+        else:
+            data = {}
+        values = data.get(_RELEASE_PRERELEASE_DEPS_KEY)
+        if not isinstance(values, dict):
+            values = {}
+        values[version] = requires
+        data[_RELEASE_PRERELEASE_DEPS_KEY] = values
+        data.setdefault("checked_at", time.time())
+        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        CACHE_FILE.write_text(json.dumps(data), encoding="utf-8")
+    except (OSError, json.JSONDecodeError, TypeError):
+        logger.debug(
+            "Failed to write release pre-release dependency cache",
+            exc_info=True,
+        )
+
+
 def get_latest_version(
     *,
     bypass_cache: bool = False,
@@ -304,11 +358,22 @@ def get_latest_version(
         )
         resp.raise_for_status()
         payload = resp.json()
-        stable: str = payload["info"]["version"]
+        info = payload.get("info")
+        if not isinstance(info, dict):
+            logger.debug("PyPI response missing object 'info' key")
+            return cached_version
+        value = info.get("version")
+        if not isinstance(value, str):
+            logger.debug("PyPI response missing string 'info.version' key")
+            return cached_version
+        stable = value
         releases: dict[str, list[object]] = payload.get("releases", {})
         if not releases:
             logger.debug("PyPI response missing or empty 'releases' key")
         prerelease = _latest_from_releases(releases, include_prereleases=True)
+        stable_requires_prereleases = _requires_prerelease_dependency(
+            info.get("requires_dist")
+        )
     except (requests.RequestException, OSError, KeyError, json.JSONDecodeError):
         logger.debug("Failed to fetch latest version from PyPI", exc_info=True)
         return cached_version
@@ -325,6 +390,7 @@ def get_latest_version(
                     "version": stable,
                     "version_prerelease": prerelease,
                     "release_times": release_times,
+                    _RELEASE_PRERELEASE_DEPS_KEY: {stable: stable_requires_prereleases},
                     "checked_at": time.time(),
                 }
             ),
@@ -334,6 +400,64 @@ def get_latest_version(
         logger.debug("Failed to write update-check cache", exc_info=True)
 
     return prerelease if include_prereleases else stable
+
+
+def release_requires_prereleases(
+    version: str | None,
+    *,
+    bypass_cache: bool = False,
+) -> bool:
+    """Return whether installing `version` needs uv pre-release resolution.
+
+    Args:
+        version: `deepagents-code` version to inspect.
+        bypass_cache: Skip cached release metadata and fetch PyPI directly.
+
+    Returns:
+        `True` when the release metadata pins or bounds a pre-release dependency.
+    """
+    if not version:
+        return False
+    try:
+        if not bypass_cache and CACHE_FILE.exists():
+            data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                values = data.get(_RELEASE_PRERELEASE_DEPS_KEY)
+                if isinstance(values, dict) and isinstance(values.get(version), bool):
+                    return values[version]
+    except (OSError, json.JSONDecodeError, TypeError):
+        logger.debug(
+            "Failed to read release pre-release dependency cache",
+            exc_info=True,
+        )
+
+    try:
+        import requests
+    except ImportError:
+        logger.debug("requests unavailable — release dependency lookup disabled")
+        return False
+
+    try:
+        url = f"{PYPI_URL.removesuffix('/json')}/{version}/json"
+        resp = requests.get(
+            url,
+            headers={"User-Agent": USER_AGENT},
+            timeout=3,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        info = payload.get("info")
+        requires = info.get("requires_dist") if isinstance(info, dict) else None
+        result = _requires_prerelease_dependency(requires)
+    except (requests.RequestException, OSError, json.JSONDecodeError):
+        logger.debug(
+            "Failed to fetch release dependency metadata from PyPI",
+            exc_info=True,
+        )
+        return False
+
+    _write_release_requires_prereleases(version, result)
+    return result
 
 
 def _extract_release_times(
@@ -1367,6 +1491,7 @@ async def perform_upgrade(
     progress: UpgradeProgressCallback | None = None,
     log_path: Path | None = None,
     include_prereleases: bool | None = None,
+    target_version: str | None = None,
 ) -> tuple[bool, str]:
     """Attempt to upgrade `deepagents-code` using the detected install method.
 
@@ -1377,8 +1502,11 @@ async def perform_upgrade(
         progress: Optional callback invoked for each output line.
         log_path: Optional path to persist command output.
         include_prereleases: Whether to include alpha/beta/rc releases. When
-            `None`, follows the installed version's channel. Pre-release
-            upgrades require the uv install method; returns failure otherwise.
+            `None`, follows the installed version's channel and the target
+            release's dependency metadata. Pre-release upgrades require the uv
+            install method; returns failure otherwise.
+        target_version: Release version being installed, used to detect stable
+            dcode releases that intentionally depend on pre-release packages.
 
     Returns:
         `(success, output)` — *output* is the combined stdout/stderr.
@@ -1394,6 +1522,12 @@ async def perform_upgrade(
             "manager originally used for this install."
         )
     resolved_include_prereleases = _resolve_include_prereleases(include_prereleases)
+    if (
+        not resolved_include_prereleases
+        and include_prereleases is None
+        and release_requires_prereleases(target_version)
+    ):
+        resolved_include_prereleases = True
     if resolved_include_prereleases:
         supported, reason = prerelease_upgrade_supported(method)
         if not supported:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -11931,6 +11931,10 @@ class TestNotificationCenterIntegration:
                 return_value="",
             ),
             patch(
+                "deepagents_code.update_check.release_requires_prereleases",
+                return_value=False,
+            ),
+            patch(
                 "deepagents_code.update_check.upgrade_command",
                 return_value="uv tool upgrade deepagents-code",
             ),
@@ -11982,6 +11986,10 @@ class TestNotificationCenterIntegration:
             patch(
                 "deepagents_code.update_check.format_installed_age_suffix",
                 return_value="",
+            ),
+            patch(
+                "deepagents_code.update_check.release_requires_prereleases",
+                return_value=False,
             ),
             patch(
                 "deepagents_code.update_check.upgrade_command",

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -11945,6 +11945,55 @@ class TestNotificationCenterIntegration:
                 await pilot.pause()
                 assert isinstance(app.screen, UpdateAvailableScreen)
 
+    async def test_update_check_preserves_prerelease_channel_in_command(self) -> None:
+        """Prerelease users get a prerelease-capable update command in notices."""
+        from deepagents_code.notifications import UpdateAvailablePayload
+        from deepagents_code.widgets.update_available import UpdateAvailableScreen
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+
+        with (
+            patch(
+                "deepagents_code.config._is_editable_install",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_code.update_check.is_update_available",
+                return_value=(True, "9.9.9rc2"),
+            ),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_code.update_check.should_notify_update",
+                return_value=True,
+            ),
+            patch("deepagents_code.update_check.mark_update_notified"),
+            patch(
+                "deepagents_code.update_check.release_requires_prereleases",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_code.update_check.upgrade_command",
+                return_value="uv tool install -U deepagents-code --prerelease allow",
+            ) as upgrade_command_mock,
+        ):
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                await app._check_for_updates()
+                await pilot.pause()
+                assert isinstance(app.screen, UpdateAvailableScreen)
+
+        upgrade_command_mock.assert_called_once_with(
+            include_prereleases=None,
+            version=None,
+        )
+        entry = app._notice_registry.get("update:available")
+        assert entry is not None
+        assert isinstance(entry.payload, UpdateAvailablePayload)
+        assert "--prerelease allow" in entry.payload.upgrade_cmd
+
     async def test_periodic_update_check_toasts_without_opening_modal(self) -> None:
         """Hourly rechecks surface updates without interrupting the session."""
         app = DeepAgentsApp(agent=MagicMock(), thread_id="t")

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -35,6 +35,22 @@ class TestStartupAutoUpdate:
     """Tests for startup auto-update behavior."""
 
     @pytest.fixture(autouse=True)
+    def _no_prerelease_lookup(self) -> Iterator[None]:
+        """Stub the pre-release dependency lookup for startup tests.
+
+        The startup auto-update path calls `release_requires_prereleases`
+        (e.g. in the restart-loop guard) with `latest`. Unstubbed, that reads
+        the real host cache and falls through to a live PyPI request, which is
+        non-hermetic and would hit the network under a bare `pytest` run. Pin it
+        to `False`; the function's own behavior is covered in `test_update_check`.
+        """
+        with patch(
+            "deepagents_code.update_check.release_requires_prereleases",
+            return_value=False,
+        ):
+            yield
+
+    @pytest.fixture(autouse=True)
     def _ack_auto_update_default(self) -> Iterator[None]:
         """Treat the auto-update default as already acknowledged.
 

--- a/libs/code/tests/unit_tests/test_main_args.py
+++ b/libs/code/tests/unit_tests/test_main_args.py
@@ -1442,6 +1442,7 @@ class TestUpdateSubcommand:
         flag_style: bool = False,
         prerelease_before_command: bool = False,
         install_method: str = "uv",
+        release_requires_prereleases: bool = False,
     ) -> tuple[int, MagicMock, MagicMock]:
         """Invoke `cli_main()` with `update`; return exit code + mocks."""
         from deepagents_code._env_vars import DEBUG_UPDATE
@@ -1474,6 +1475,10 @@ class TestUpdateSubcommand:
                 "deepagents_code.update_check.is_update_available",
                 return_value=is_update_available_return,
             ) as is_update_mock,
+            patch(
+                "deepagents_code.update_check.release_requires_prereleases",
+                return_value=release_requires_prereleases,
+            ),
             patch(
                 "deepagents_code.update_check.create_update_log_path",
                 return_value=log_path,
@@ -1554,6 +1559,28 @@ class TestUpdateSubcommand:
         perform_upgrade_mock.assert_awaited_once_with(
             log_path="/tmp/deepagents-update.log",
             include_prereleases=None,
+            target_version="99.0.0",
+        )
+
+    def test_stable_update_with_prerelease_deps_keeps_upgrade_intent_none(
+        self,
+    ) -> None:
+        """Stable releases with pre-release deps let `perform_upgrade` pin the app."""
+        code, is_update_mock, perform_upgrade_mock = self._run_update(
+            editable=False,
+            is_update_available_return=(True, "99.0.0"),
+            release_requires_prereleases=True,
+        )
+
+        assert code == 0
+        is_update_mock.assert_called_once_with(
+            bypass_cache=True,
+            include_prereleases=None,
+        )
+        perform_upgrade_mock.assert_awaited_once_with(
+            log_path="/tmp/deepagents-update.log",
+            include_prereleases=None,
+            target_version="99.0.0",
         )
 
     def test_prerelease_update_includes_prereleases(self) -> None:
@@ -1572,6 +1599,7 @@ class TestUpdateSubcommand:
         perform_upgrade_mock.assert_awaited_once_with(
             log_path="/tmp/deepagents-update.log",
             include_prereleases=True,
+            target_version="99.0.0rc1",
         )
 
     def test_prerelease_update_flag_includes_prereleases(self) -> None:
@@ -1591,6 +1619,7 @@ class TestUpdateSubcommand:
         perform_upgrade_mock.assert_awaited_once_with(
             log_path="/tmp/deepagents-update.log",
             include_prereleases=True,
+            target_version="99.0.0rc1",
         )
 
     def test_prerelease_before_update_includes_prereleases(self) -> None:
@@ -1609,6 +1638,7 @@ class TestUpdateSubcommand:
         perform_upgrade_mock.assert_awaited_once_with(
             log_path="/tmp/deepagents-update.log",
             include_prereleases=True,
+            target_version="99.0.0rc1",
         )
 
     def test_prerelease_unsupported_install_refuses_before_pypi(

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -29,6 +29,7 @@ from deepagents_code.update_check import (
     _latest_from_releases,
     _note_install_baseline,
     _parse_version,
+    _requires_prerelease_dependency,
     _uv_tool_bin_dir,
     cleanup_update_logs,
     clear_update_notified,
@@ -486,6 +487,160 @@ class TestGetLatestVersion:
             result = get_latest_version()
 
         assert result == "3.0.0"
+
+    def test_fresh_fetch_preserves_other_release_prerelease_entries(
+        self, cache_file
+    ) -> None:
+        """A refresh keeps cached pre-release answers for unrelated versions."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "release_requires_prereleases": {"1.0.0": True},
+                    "checked_at": time.time(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        with patch("requests.get", return_value=_mock_pypi_response("2.0.0")):
+            result = get_latest_version()
+
+        assert result == "2.0.0"
+        data = json.loads(cache_file.read_text())
+        assert data["release_requires_prereleases"] == {"1.0.0": True, "2.0.0": False}
+
+    def test_fresh_fetch_non_dict_info_returns_cached(self, cache_file) -> None:
+        """A PyPI payload whose `info` is not an object falls back to cache."""
+        resp = MagicMock()
+        resp.json.return_value = {"info": "not-a-dict", "releases": {}}
+        resp.raise_for_status = MagicMock()
+        with patch("requests.get", return_value=resp):
+            result = get_latest_version()
+
+        assert result is None
+        assert not cache_file.exists()
+
+    def test_fresh_fetch_non_str_version_returns_cached(self, cache_file) -> None:
+        """A PyPI payload whose `info.version` is not a string falls back."""
+        resp = MagicMock()
+        resp.json.return_value = {"info": {"version": 123}, "releases": {}}
+        resp.raise_for_status = MagicMock()
+        with patch("requests.get", return_value=resp):
+            result = get_latest_version()
+
+        assert result is None
+        assert not cache_file.exists()
+
+
+class TestRequiresPrereleaseDependency:
+    """Unit tests for the `Requires-Dist` pre-release detection helper."""
+
+    @pytest.mark.parametrize(
+        ("requirements", "expected"),
+        [
+            (None, False),
+            ((), False),
+            (("deepagents==0.7.0",), False),
+            (("deepagents==0.7.0a2",), True),
+            (("deepagents>=0.7.0a2",), True),
+            (("deepagents~=0.7.0a2",), True),
+            # Operator-agnostic by design: even an exclusion of a pre-release
+            # flags the release. Errs toward enabling --prerelease (safe).
+            (("deepagents!=0.7.0a1",), True),
+            # Marker-gated pre-release pins still flag the release (conservative).
+            (('deepagents==0.7.0a2; extra=="x"',), True),
+            (("deepagents>=0.7.0,<0.8",), False),
+            (("deepagents",), False),  # no version specifier
+            (("requests>=2", "deepagents==0.7.0a2"), True),  # one of many
+            (("not a valid requirement !!!",), False),  # unparseable -> skipped
+            (("deepagents===not.a.version",), False),  # unparseable version
+            ((123, "deepagents==0.7.0a2"), True),  # non-str entry skipped
+            ((123, 456), False),  # all non-str entries
+        ],
+    )
+    def test_detects_prerelease_specifiers(self, requirements, expected) -> None:
+        assert _requires_prerelease_dependency(requirements) is expected
+
+
+class TestReleaseRequiresPrereleases:
+    """Unit tests for `release_requires_prereleases`."""
+
+    def test_none_version_is_false(self) -> None:
+        """A missing version never needs the pre-release resolver."""
+        assert release_requires_prereleases(None) is False
+
+    def test_cache_hit_true(self, cache_file) -> None:
+        """A cached `True` short-circuits without a network call."""
+        cache_file.write_text(
+            json.dumps({"release_requires_prereleases": {"1.1.0": True}}),
+            encoding="utf-8",
+        )
+        with patch("requests.get") as get_mock:
+            assert release_requires_prereleases("1.1.0") is True
+        get_mock.assert_not_called()
+
+    def test_cache_hit_false(self, cache_file) -> None:
+        """A cached `False` short-circuits without a network call."""
+        cache_file.write_text(
+            json.dumps({"release_requires_prereleases": {"1.1.0": False}}),
+            encoding="utf-8",
+        )
+        with patch("requests.get") as get_mock:
+            assert release_requires_prereleases("1.1.0") is False
+        get_mock.assert_not_called()
+
+    def test_cache_miss_fetches_and_writes(self, cache_file) -> None:
+        """A cache miss fetches per-version metadata and caches the result."""
+        with patch(
+            "requests.get",
+            return_value=_mock_pypi_response(
+                "1.1.0", requires_dist=("deepagents==0.7.0a2",)
+            ),
+        ) as get_mock:
+            assert release_requires_prereleases("1.1.0") is True
+        assert get_mock.call_args.args[0].endswith("/deepagents-code/1.1.0/json")
+        data = json.loads(cache_file.read_text())
+        assert data["release_requires_prereleases"]["1.1.0"] is True
+
+    def test_bypass_cache_forces_fetch(self, cache_file) -> None:
+        """`bypass_cache` re-fetches even when a cached value exists."""
+        cache_file.write_text(
+            json.dumps({"release_requires_prereleases": {"1.1.0": False}}),
+            encoding="utf-8",
+        )
+        with patch(
+            "requests.get",
+            return_value=_mock_pypi_response(
+                "1.1.0", requires_dist=("deepagents==0.7.0a2",)
+            ),
+        ) as get_mock:
+            result = release_requires_prereleases("1.1.0", bypass_cache=True)
+        assert result is True
+        get_mock.assert_called_once()
+
+    def test_network_failure_returns_false(self, cache_file) -> None:
+        """A PyPI failure conservatively reports stable-only resolution."""
+        import requests
+
+        with patch("requests.get", side_effect=requests.RequestException("boom")):
+            assert release_requires_prereleases("1.1.0") is False
+        # Nothing cached, so a later successful lookup can still self-correct.
+        assert not cache_file.exists()
+
+    def test_missing_requests_returns_false(self, cache_file) -> None:
+        """Without `requests`, the lookup degrades to stable-only resolution."""
+        with patch.dict(sys.modules, {"requests": None}):
+            assert release_requires_prereleases("1.1.0") is False
+        assert not cache_file.exists()
+
+    def test_malformed_info_returns_false(self, cache_file) -> None:
+        """A payload with a non-object `info` is treated as no requirement."""
+        resp = MagicMock()
+        resp.json.return_value = {"info": "not-a-dict"}
+        resp.raise_for_status = MagicMock()
+        with patch("requests.get", return_value=resp):
+            assert release_requires_prereleases("1.1.0") is False
+        data = json.loads(cache_file.read_text())
+        assert data["release_requires_prereleases"]["1.1.0"] is False
 
 
 class TestIsUpdateAvailable:

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -75,6 +75,7 @@ from deepagents_code.update_check import (
     perform_install_package,
     perform_upgrade,
     prerelease_upgrade_supported,
+    release_requires_prereleases,
     set_auto_update,
     should_announce_auto_update_default,
     should_notify_update,
@@ -103,6 +104,7 @@ def _mock_pypi_response(
     version: str = "99.0.0",
     releases: Mapping[str, Sequence[Mapping[str, object]]] | None = None,
     release_times: dict[str, str] | None = None,
+    requires_dist: Sequence[str] | None = None,
 ) -> MagicMock:
     if releases is None:
         releases = {version: [{"filename": "fake.tar.gz"}]}
@@ -116,9 +118,12 @@ def _mock_pypi_response(
         files = releases_data.get(ver)
         if files:
             files[0]["upload_time_iso_8601"] = iso
+    info: dict[str, object] = {"version": version}
+    if requires_dist is not None:
+        info["requires_dist"] = list(requires_dist)
     resp = MagicMock()
     resp.json.return_value = {
-        "info": {"version": version},
+        "info": info,
         "releases": releases_data,
     }
     resp.raise_for_status = MagicMock()
@@ -296,6 +301,24 @@ class TestGetLatestVersion:
         data = json.loads(cache_file.read_text())
         assert data["version"] == "2.0.0"
         assert "checked_at" in data
+
+    def test_fresh_fetch_caches_prerelease_dependency_requirement(
+        self, cache_file
+    ) -> None:
+        """Stable dcode releases can intentionally pin pre-release dependencies."""
+        with patch(
+            "requests.get",
+            return_value=_mock_pypi_response(
+                "2.0.0",
+                requires_dist=("deepagents==0.7.0a2",),
+            ),
+        ):
+            result = get_latest_version()
+
+        assert result == "2.0.0"
+        assert release_requires_prereleases("2.0.0") is True
+        data = json.loads(cache_file.read_text())
+        assert data["release_requires_prereleases"] == {"2.0.0": True}
 
     def test_fresh_fetch_prerelease(self, cache_file) -> None:
         """PyPI fetch with include_prereleases returns pre-release version."""
@@ -1626,6 +1649,53 @@ class TestUpdateLogs:
             ) as run_mock,
         ):
             success, _output = await perform_upgrade(include_prereleases=True)
+
+        assert success is True
+        run_mock.assert_awaited_once()
+        await_args = run_mock.await_args
+        assert await_args is not None
+        assert await_args.args[0] == (
+            "uv tool install -U deepagents-code --prerelease allow"
+        )
+
+    async def test_perform_upgrade_allows_prereleases_for_target_dependency(
+        self, cache_file
+    ) -> None:
+        """A stable target that pins an alpha dependency opts uv into prereleases."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "release_requires_prereleases": {"1.1.0": True},
+                    "checked_at": time.time(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=frozenset(),
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_python",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_with_packages",
+                return_value=(),
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as run_mock,
+        ):
+            success, _output = await perform_upgrade(target_version="1.1.0")
 
         assert success is True
         run_mock.assert_awaited_once()

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -1702,7 +1702,46 @@ class TestUpdateLogs:
         await_args = run_mock.await_args
         assert await_args is not None
         assert await_args.args[0] == (
-            "uv tool install -U deepagents-code --prerelease allow"
+            "uv tool install -U deepagents-code==1.1.0 --prerelease allow"
+        )
+
+    async def test_perform_upgrade_fallback_pins_target_with_prerelease_deps(
+        self, cache_file
+    ) -> None:
+        """The bare fallback also avoids floating stable targets to app prereleases."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "release_requires_prereleases": {"1.1.0": True},
+                    "checked_at": time.time(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                side_effect=ExtrasIntrospectionError("metadata unreadable"),
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as run_mock,
+        ):
+            success, _output = await perform_upgrade(target_version="1.1.0")
+
+        assert success is True
+        run_mock.assert_awaited_once()
+        await_args = run_mock.await_args
+        assert await_args is not None
+        assert await_args.args[0] == (
+            "uv tool install -U deepagents-code==1.1.0 --prerelease allow"
         )
 
     async def test_perform_upgrade_follows_installed_prerelease_channel(self) -> None:
@@ -1921,6 +1960,16 @@ class TestUpdateLogs:
         assert (
             upgrade_command(include_prereleases=True)
             == "uv tool install -U deepagents-code --prerelease allow"
+        )
+
+    def test_upgrade_command_pins_target_with_prerelease_deps(self) -> None:
+        """Manual fallback pins root dcode when prerelease deps are allowed."""
+        assert (
+            upgrade_command(
+                include_prereleases=True,
+                version="1.1.0",
+            )
+            == "uv tool install -U deepagents-code==1.1.0 --prerelease allow"
         )
 
     def test_dependency_refresh_command_pins_current_version(
@@ -2313,6 +2362,21 @@ class TestUpgradeInstallCommand:
             return_value=frozenset(),
         ):
             assert upgrade_install_command() == "uv tool install -U deepagents-code"
+
+    def test_pins_target_version_when_requested(self, tmp_path, monkeypatch) -> None:
+        """Target pins prevent prerelease dependency mode from floating the app."""
+        _write_uv_receipt(tmp_path, '{ name = "deepagents-code" }')
+        monkeypatch.setattr("sys.prefix", str(tmp_path))
+        with patch(
+            "deepagents_code.extras_info.installed_extra_names",
+            return_value=frozenset({"openai"}),
+        ):
+            assert upgrade_install_command(
+                version="1.1.0",
+                include_prereleases=True,
+            ) == (
+                "uv tool install -U 'deepagents-code[openai]==1.1.0' --prerelease allow"
+            )
 
     def test_preserves_extras_and_prerelease(self, tmp_path, monkeypatch) -> None:
         """Installed extras survive the unpinned reinstall; prerelease opt-in too."""

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -1155,7 +1155,7 @@ async def test_update_already_current_reports_dependency_check_failure() -> None
 
 
 async def test_update_already_current_skips_prompt_when_refresh_unsupported() -> None:
-    """brew/other installs aren't prompted for a refresh that can't run."""
+    """brew/other installs aren't prompted for a refresh or prerelease support."""
     from deepagents_code.app import DeepAgentsApp
     from deepagents_code.widgets.messages import AppMessage
 
@@ -1171,6 +1171,14 @@ async def test_update_already_current_skips_prompt_when_refresh_unsupported() ->
                 "deepagents_code.update_check.is_update_available",
                 return_value=(False, "1.0.0"),
             ),
+            patch(
+                "deepagents_code.update_check.release_requires_prereleases",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.update_check.prerelease_upgrade_supported",
+                return_value=(False, "Pre-release updates aren't supported"),
+            ) as prerelease_supported_mock,
             patch(
                 "deepagents_code.update_check.dependency_refresh_supported",
                 return_value=(False, "Homebrew install detected — ..."),
@@ -1190,6 +1198,7 @@ async def test_update_already_current_skips_prompt_when_refresh_unsupported() ->
 
         confirm_mock.assert_not_awaited()
         refresh_mock.assert_not_awaited()
+        prerelease_supported_mock.assert_not_called()
         app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
         assert "Already on the latest version" in str(app_msgs[-1]._content)
 

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -516,6 +516,45 @@ async def test_update_slash_command_omitted_prerelease_preserves_channel() -> No
         assert "Updated to v99.0.0" in str(app_msgs[-1]._content)
 
 
+async def test_update_slash_command_stable_prerelease_deps_keep_intent_none() -> None:
+    """Stable releases with pre-release deps let `perform_upgrade` pin the app."""
+    from deepagents_code.app import DeepAgentsApp
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch(
+                "deepagents_code.config._is_editable_install",
+                return_value=False,
+            ),
+            patch(
+                "deepagents_code.update_check.is_update_available",
+                return_value=(True, "99.0.0"),
+            ),
+            patch(
+                "deepagents_code.update_check.release_requires_prereleases",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.update_check.perform_upgrade",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as perform_upgrade_mock,
+        ):
+            await app._handle_command("/update")
+            await pilot.pause()
+
+    perform_upgrade_mock.assert_awaited_once_with(
+        include_prereleases=None,
+        target_version="99.0.0",
+    )
+
+
 async def test_update_slash_command_prerelease_updates_channel() -> None:
     """`/update --prerelease` opts into alpha/beta/rc releases."""
     from deepagents_code.app import DeepAgentsApp

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -41,6 +41,10 @@ def _block_sdk_pypi_fetch(tmp_path: Path) -> Iterator[None]:
             "deepagents_code.update_check.is_update_available",
             return_value=(False, None),
         ),
+        patch(
+            "deepagents_code.update_check.release_requires_prereleases",
+            return_value=False,
+        ),
         # Pin the post-upgrade shadow check to a clean "no shadow" for the
         # whole module. Several `/update` tests pin `detect_install_method`
         # to `"uv"` to exercise pre-release handling, which would otherwise
@@ -504,7 +508,10 @@ async def test_update_slash_command_omitted_prerelease_preserves_channel() -> No
             bypass_cache=True,
             include_prereleases=None,
         )
-        perform_upgrade_mock.assert_awaited_once_with(include_prereleases=None)
+        perform_upgrade_mock.assert_awaited_once_with(
+            include_prereleases=None,
+            target_version="99.0.0",
+        )
         app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
         assert "Updated to v99.0.0" in str(app_msgs[-1]._content)
 
@@ -546,7 +553,10 @@ async def test_update_slash_command_prerelease_updates_channel() -> None:
             bypass_cache=True,
             include_prereleases=True,
         )
-        perform_upgrade_mock.assert_awaited_once_with(include_prereleases=True)
+        perform_upgrade_mock.assert_awaited_once_with(
+            include_prereleases=True,
+            target_version="99.0.0rc1",
+        )
         user_msgs = list(app.query(UserMessage))
         assert str(user_msgs[-1]._content) == "/update --prerelease"
         app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
@@ -831,7 +841,10 @@ async def test_update_deps_skips_refresh_prompt_when_refresh_unsupported() -> No
 
         confirm_mock.assert_not_awaited()
         refresh_mock.assert_not_awaited()
-        perform_upgrade_mock.assert_awaited_once_with(include_prereleases=None)
+        perform_upgrade_mock.assert_awaited_once_with(
+            include_prereleases=None,
+            target_version="1.1.0",
+        )
         app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
         content = str(app_msgs[-1]._content)
         assert "Updated to v1.1.0" in content


### PR DESCRIPTION
Stable `deepagents-code` releases can intentionally depend on prerelease package versions, such as an alpha SDK pin during coordinated release work. Previously, the updater discovered the stable app release but invoked `uv` in stable-only mode, so `uv` resolved back to the old app version while `dcode update` still reported success.

This teaches the update flow to inspect the target release metadata for prerelease dependency specifiers and opt `uv` into prerelease resolution only when the target needs it. The behavior is wired through CLI updates, startup auto-update, in-app `/update`, and notification-driven installs, so manual and automatic paths use the same resolver mode.

Users on older versions can recover manually with:

```bash
uv tool install --reinstall -U 'deepagents-code[anthropic,baseten,google-genai,openai]' --prerelease allow
```