### PR TITLE
ci(evals): split clbench into its own workflow

### DIFF
--- a/.github/scripts/models.py
+++ b/.github/scripts/models.py
@@ -809,9 +809,19 @@ _EVAL_PRESETS: dict[str, str | None] = _build_presets("eval")
 _HARBOR_PRESETS: dict[str, str | None] = _build_presets("harbor")
 """Flat preset name → `harbor:{tag}` mapping for the Harbor workflow."""
 
-_WORKFLOW_CONFIG: dict[str, tuple[str, dict[str, str | None]]] = {
-    "eval": ("EVAL_MODELS", _EVAL_PRESETS),
-    "harbor": ("HARBOR_MODELS", _HARBOR_PRESETS),
+# workflow -> (dispatch env var, preset map, registry tag prefix). The tag
+# prefix is how a `None`-suffixed preset such as `all` resolves: it selects
+# every REGISTRY model carrying a group under that prefix (see `_resolve_models`
+# / `_filter_by_tag`). It is usually the workflow name, but clbench borrows
+# Harbor's so the two benchmarks stay in lockstep on model groups.
+_WORKFLOW_CONFIG: dict[str, tuple[str, dict[str, str | None], str]] = {
+    "eval": ("EVAL_MODELS", _EVAL_PRESETS, "eval"),
+    "harbor": ("HARBOR_MODELS", _HARBOR_PRESETS, "harbor"),
+    # clbench (continual-learning-bench) runs the same model set as Harbor and,
+    # like Harbor, consumes a single flat `{model, provider}` matrix (see the
+    # non-"eval" early return in `_matrix_outputs`). It reuses `_HARBOR_PRESETS`
+    # and the `harbor` tag prefix so group selections resolve identically.
+    "clbench": ("CLBENCH_MODELS", _HARBOR_PRESETS, "harbor"),
 }
 
 _EVAL_PROVIDER_OUTPUTS: tuple[str, ...] = (
@@ -971,11 +981,11 @@ def _resolve_models(workflow: str, selection: str) -> list[str]:
     Raises:
         ValueError: If the selection is empty or contains invalid specs.
     """
-    env_var, presets = _WORKFLOW_CONFIG[workflow]
+    env_var, presets, tag_prefix = _WORKFLOW_CONFIG[workflow]
     normalized = selection.strip()
 
     if normalized in presets:
-        specs = _filter_by_tag(f"{workflow}:", presets[normalized])
+        specs = _filter_by_tag(f"{tag_prefix}:", presets[normalized])
     else:
         specs = [s.strip() for s in normalized.split(",") if s.strip()]
         if not specs:
@@ -1002,7 +1012,7 @@ def main() -> None:
         raise SystemExit(msg)
 
     workflow = sys.argv[1]
-    env_var, _ = _WORKFLOW_CONFIG[workflow]
+    env_var, _, _ = _WORKFLOW_CONFIG[workflow]
     selection = os.environ.get(env_var, "all")
     models = _resolve_models(workflow, selection)
     outputs = _matrix_outputs(workflow, models)

--- a/.github/scripts/test_models.py
+++ b/.github/scripts/test_models.py
@@ -99,6 +99,35 @@ def test_harbor_matrix_output_stays_flat(models: ModuleType) -> None:
     }
 
 
+def test_clbench_matrix_output_stays_flat(models: ModuleType) -> None:
+    """clbench shares Harbor's single-matrix output contract (flat, no per-provider)."""
+    outputs = models._matrix_outputs("clbench", ["openai:gpt-5.4"])
+
+    assert outputs == {
+        "matrix": {
+            "include": [
+                {
+                    "model": "openai:gpt-5.4",
+                    "provider": "openai",
+                    "artifact_key": "openai-gpt-5.4",
+                }
+            ]
+        }
+    }
+
+
+def test_clbench_resolves_models_like_harbor(models: ModuleType) -> None:
+    """clbench reuses Harbor's presets, so selections must resolve identically.
+
+    Encodes the design intent of the shared `_HARBOR_PRESETS`: the two
+    benchmarks stay in lockstep on which models belong to each group.
+    """
+    for selection in ("all", "openai:gpt-5.4"):
+        assert models._resolve_models("clbench", selection) == models._resolve_models(
+            "harbor", selection
+        )
+
+
 def test_eval_matrix_outputs_with_no_models(models: ModuleType) -> None:
     """Empty model list emits empty includes for every declared provider.
 

--- a/.github/workflows/clbench.yml
+++ b/.github/workflows/clbench.yml
@@ -1,0 +1,352 @@
+# continual-learning-bench (clbench) evaluation workflow for Deep Agents.
+#
+# Runs continual-learning-bench (https://github.com/pgasawa/continual-learning-bench)
+# with the Deep Agents system, directly on the runner. This is NOT Harbor — clbench
+# has no sandbox concept. Split out of the Harbor workflow so this dispatch form is
+# scoped to clbench alone (every input below applies).
+#
+# Models are selected via a free-text field (group name or comma-separated specs),
+# resolved by `.github/scripts/models.py` against Harbor's model groups.
+#
+# Required secrets:
+#   LANGSMITH_API_KEY  — optional; enables trajectory tracing when present
+#   ANTHROPIC_API_KEY  — needed for Anthropic models
+#   OPENAI_API_KEY     — needed for OpenAI models
+#   GOOGLE_API_KEY     — needed for Google models
+#   XAI_API_KEY        — needed for xAI/Grok models
+#   GROQ_API_KEY       — needed for Groq-hosted models
+#   OLLAMA_API_KEY     — needed for Ollama Cloud models
+#   NVIDIA_API_KEY     — needed for NVIDIA NIM models
+#   BASETEN_API_KEY    — needed for Baseten-hosted models
+#   FIREWORKS_API_KEY  — needed for Fireworks-hosted models
+#   OPENROUTER_API_KEY — needed for OpenRouter-hosted models
+
+name: "🧠 Evals - clbench"
+run-name: >-
+  🧠 Evals - clbench — ${{ contains(inputs.models, ',') && 'custom models' || (inputs.models || 'all') }} / ${{ inputs.clbench_schedule }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      models:
+        description: "Model set to run. A group name (set definitions: libs/evals/MODEL_GROUPS.md) or comma-separated 'provider:model' specs (e.g. 'openai:gpt-4.1,anthropic:claude-sonnet-4-6'). Defaults to all models when empty."
+        required: false
+        default: "all"
+        type: string
+      include_tasks:
+        description: "Space-separated clbench task names passed as --task (empty = all clbench tasks)."
+        required: false
+        default: ""
+        type: string
+      concurrency:
+        description: "Forwarded to clbench as --per-task-parallelism."
+        required: true
+        default: "1"
+        type: string
+      clbench_schedule:
+        description: "'quick_test' = cheap smoke (per-task clbench run; only tasks that define it — currently just exploitable_poker). 'default' = leaderboard-comparable (run-all, each task's default schedule, 5 runs + baseline) — multi-hour and likely exceeds the job timeout for a Deep Agents system."
+        required: true
+        default: "quick_test"
+        type: choice
+        options:
+          - quick_test
+          - default
+
+permissions:
+  contents: read
+
+env:
+  UV_NO_SYNC: "true"
+
+jobs:
+  prep:
+    name: "🔧 Prepare matrix"
+    runs-on: ubuntu-latest
+    environment: evals
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: "📝 Log dispatch inputs"
+        continue-on-error: true
+        env:
+          MODELS: ${{ inputs.models || 'all' }}
+          INCLUDE_TASKS: ${{ inputs.include_tasks }}
+          CONCURRENCY: ${{ inputs.concurrency }}
+          CLBENCH_SCHEDULE: ${{ inputs.clbench_schedule }}
+        run: |
+          echo "### 🧠 Evals - clbench dispatch inputs" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Input | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`models\` | \`${MODELS}\` |" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${INCLUDE_TASKS}" ]; then
+            echo "| \`include_tasks\` | \`${INCLUDE_TASKS}\` |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| \`include_tasks\` | all |" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "| \`concurrency\` | \`${CONCURRENCY}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| \`clbench_schedule\` | \`${CLBENCH_SCHEDULE}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: "📋 Checkout Code"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: "🐍 Compute clbench matrix"
+        id: set-matrix
+        run: python .github/scripts/models.py clbench
+        env:
+          CLBENCH_MODELS: ${{ inputs.models || 'all' }}
+
+  # continual-learning-bench (clbench) — NOT Harbor. Runs the whole benchmark
+  # (clbench run-all) with the Deep Agents system on the runner. Shares the prep
+  # model matrix with the evals/Harbor model groups.
+  clbench:
+    name: "🧠 Evals - clbench (${{ matrix.model }} / deepagents)"
+    needs: prep
+    runs-on: ubuntu-latest
+    environment: evals
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prep.outputs.matrix) }}
+    env:
+      CLBENCH_REPO: "https://github.com/pgasawa/continual-learning-bench"
+      # Pinned to a specific commit (not a moving ref) for reproducibility.
+      CLBENCH_REF: "56764d61afa2860e4893bc14e6229e33fcebf06b"
+      CLBENCH_MODEL: ${{ matrix.model }}
+      CLBENCH_PROVIDER: ${{ matrix.provider }}
+      CLBENCH_INCLUDE_TASKS: ${{ inputs.include_tasks }}
+      CLBENCH_PER_TASK_PARALLELISM: ${{ inputs.concurrency }}
+      CLBENCH_SCHEDULE: ${{ inputs.clbench_schedule }}
+      # Ollama cloud endpoint (matches the Harbor job); ollama:*:cloud needs this
+      # or LangChain defaults to a local Ollama server.
+      OLLAMA_HOST: "https://ollama.com"
+      # Trace-level LangSmith tracing only: LangChain/LangGraph auto-captures the
+      # agent trajectories when these are set. clbench itself has no LangSmith
+      # experiment integration, so scores/gain stay in clbench's own artifacts.
+      # Tracing turns on only when the secret is present (no warnings when absent).
+      LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+      LANGSMITH_TRACING: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
+    steps:
+      - name: "🔑 Verify model credentials"
+        env:
+          ANTHROPIC_API_KEY: ${{ startsWith(matrix.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
+          BASETEN_API_KEY: ${{ startsWith(matrix.model, 'baseten:') && secrets.BASETEN_API_KEY || '' }}
+          FIREWORKS_API_KEY: ${{ startsWith(matrix.model, 'fireworks:') && secrets.FIREWORKS_API_KEY || '' }}
+          GOOGLE_API_KEY: ${{ startsWith(matrix.model, 'google_genai:') && secrets.GOOGLE_API_KEY || '' }}
+          GROQ_API_KEY: ${{ startsWith(matrix.model, 'groq:') && secrets.GROQ_API_KEY || '' }}
+          NVIDIA_API_KEY: ${{ startsWith(matrix.model, 'nvidia:') && secrets.NVIDIA_API_KEY || '' }}
+          OLLAMA_API_KEY: ${{ startsWith(matrix.model, 'ollama:') && secrets.OLLAMA_API_KEY || '' }}
+          OPENAI_API_KEY: ${{ startsWith(matrix.model, 'openai:') && secrets.OPENAI_API_KEY || '' }}
+          OPENROUTER_API_KEY: ${{ startsWith(matrix.model, 'openrouter:') && secrets.OPENROUTER_API_KEY || '' }}
+          XAI_API_KEY: ${{ startsWith(matrix.model, 'xai:') && secrets.XAI_API_KEY || '' }}
+        run: |
+          provider="${CLBENCH_MODEL%%:*}"
+          missing=()
+          # All Harbor matrix providers resolve through init_chat_model.
+          case "$provider" in
+            anthropic)    [ -z "$ANTHROPIC_API_KEY" ] && missing+=("ANTHROPIC_API_KEY") ;;
+            openai)       [ -z "$OPENAI_API_KEY" ] && missing+=("OPENAI_API_KEY") ;;
+            google_genai) [ -z "$GOOGLE_API_KEY" ] && missing+=("GOOGLE_API_KEY") ;;
+            groq)         [ -z "$GROQ_API_KEY" ] && missing+=("GROQ_API_KEY") ;;
+            xai)          [ -z "$XAI_API_KEY" ] && missing+=("XAI_API_KEY") ;;
+            ollama)       [ -z "$OLLAMA_API_KEY" ] && missing+=("OLLAMA_API_KEY") ;;
+            fireworks)    [ -z "$FIREWORKS_API_KEY" ] && missing+=("FIREWORKS_API_KEY") ;;
+            nvidia)       [ -z "$NVIDIA_API_KEY" ] && missing+=("NVIDIA_API_KEY") ;;
+            openrouter)   [ -z "$OPENROUTER_API_KEY" ] && missing+=("OPENROUTER_API_KEY") ;;
+            baseten)      [ -z "$BASETEN_API_KEY" ] && missing+=("BASETEN_API_KEY") ;;
+            *)
+              echo "::warning::Unknown provider prefix '$provider' for clbench; proceeding and letting init_chat_model resolve it. Ensure the matching API key secret is configured."
+              ;;
+          esac
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required secret(s) for $CLBENCH_MODEL: ${missing[*]}"
+            exit 1
+          fi
+          echo "Credentials present for $CLBENCH_MODEL"
+
+      - name: "📋 Checkout Code"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: "🐍 Set up Python + UV"
+        uses: "./.github/actions/uv_setup"
+        with:
+          python-version: "3.13"
+          cache-suffix: clbench
+          working-directory: libs/evals
+
+      - name: "🧠 Run continual-learning-bench with the Deep Agents system"
+        env:
+          ANTHROPIC_API_KEY: ${{ startsWith(matrix.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
+          BASETEN_API_KEY: ${{ startsWith(matrix.model, 'baseten:') && secrets.BASETEN_API_KEY || '' }}
+          FIREWORKS_API_KEY: ${{ startsWith(matrix.model, 'fireworks:') && secrets.FIREWORKS_API_KEY || '' }}
+          GOOGLE_API_KEY: ${{ startsWith(matrix.model, 'google_genai:') && secrets.GOOGLE_API_KEY || '' }}
+          GROQ_API_KEY: ${{ startsWith(matrix.model, 'groq:') && secrets.GROQ_API_KEY || '' }}
+          NVIDIA_API_KEY: ${{ startsWith(matrix.model, 'nvidia:') && secrets.NVIDIA_API_KEY || '' }}
+          OLLAMA_API_KEY: ${{ startsWith(matrix.model, 'ollama:') && secrets.OLLAMA_API_KEY || '' }}
+          OPENAI_API_KEY: ${{ startsWith(matrix.model, 'openai:') && secrets.OPENAI_API_KEY || '' }}
+          OPENROUTER_API_KEY: ${{ startsWith(matrix.model, 'openrouter:') && secrets.OPENROUTER_API_KEY || '' }}
+          XAI_API_KEY: ${{ startsWith(matrix.model, 'xai:') && secrets.XAI_API_KEY || '' }}
+        run: |
+          set -euo pipefail
+
+          # Validate the pinned ref is a full commit SHA (no moving refs).
+          if ! [[ "$CLBENCH_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::CLBENCH_REF must be a full 40-char commit SHA"; exit 1
+          fi
+          # Validate per-task parallelism is a positive integer.
+          if ! [[ "$CLBENCH_PER_TASK_PARALLELISM" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Invalid concurrency (per-task-parallelism): $CLBENCH_PER_TASK_PARALLELISM"; exit 1
+          fi
+          # Validate the schedule name (used in a file path + the command).
+          if ! [[ "$CLBENCH_SCHEDULE" =~ ^[A-Za-z0-9_]+$ ]]; then
+            echo "::error::Invalid clbench schedule: $CLBENCH_SCHEDULE"; exit 1
+          fi
+          # Validate + collect requested task names (alphanumeric + underscore only).
+          req_tasks=()
+          if [ -n "$CLBENCH_INCLUDE_TASKS" ]; then
+            read -r -a req_tasks <<< "$CLBENCH_INCLUDE_TASKS"
+            for t in "${req_tasks[@]}"; do
+              if ! [[ "$t" =~ ^[A-Za-z0-9_]+$ ]]; then
+                echo "::error::Invalid clbench task name: $t"; exit 1
+              fi
+            done
+          fi
+
+          # Clone clbench pinned to a specific commit.
+          git clone --filter=blob:none "$CLBENCH_REPO" clbench-src
+          git -C clbench-src checkout --quiet "$CLBENCH_REF"
+
+          # Install clbench (all task extras), the local Deep Agents SDK, and the
+          # matrix model's LangChain provider integration.
+          ( cd clbench-src && uv sync --all-extras )
+          # Provider -> LangChain integration package (init_chat_model resolves all of these).
+          case "$CLBENCH_PROVIDER" in
+            anthropic)    provider_pkg="langchain-anthropic" ;;
+            openai)       provider_pkg="langchain-openai" ;;
+            google_genai) provider_pkg="langchain-google-genai" ;;
+            groq)         provider_pkg="langchain-groq" ;;
+            xai)          provider_pkg="langchain-xai" ;;
+            ollama)       provider_pkg="langchain-ollama" ;;
+            fireworks)    provider_pkg="langchain-fireworks" ;;
+            nvidia)       provider_pkg="langchain-nvidia-ai-endpoints" ;;
+            openrouter)   provider_pkg="langchain-openrouter" ;;
+            baseten)      provider_pkg="langchain-baseten" ;;
+            *)            provider_pkg="langchain-openai"
+                          echo "::warning::Unknown provider '$CLBENCH_PROVIDER'; defaulting integration to langchain-openai." ;;
+          esac
+          # Fireworks can pull a prerelease dependency (matches the Harbor job).
+          uv_pre=""
+          [ "$CLBENCH_PROVIDER" = "fireworks" ] && uv_pre="UV_PRERELEASE=allow"
+          ( cd clbench-src && env $uv_pre uv pip install -e "$GITHUB_WORKSPACE/libs/deepagents" ${provider_pkg:+"$provider_pkg"} )
+
+          # Deploy the Deep Agents system into this clbench checkout.
+          "$GITHUB_WORKSPACE/libs/evals/deepagents_clbench/sync_to_clbench.sh" "$GITHUB_WORKSPACE/clbench-src"
+
+          # Best-effort dataset setup for tasks that need it (non-fatal).
+          ( cd clbench-src && uv run clbench setup --all ) \
+            || echo "::warning::'clbench setup --all' reported errors; tasks needing that data may be skipped."
+
+          model_slug=$(printf '%s' "$CLBENCH_MODEL" | tr '/:' '--' | tr -c '[:alnum:]._-' '-')
+          run_name="deepagents-${model_slug}-${GITHUB_RUN_ID}"
+
+          # Trace-level LangSmith: group this model's agent traces under one project.
+          # Inherited by the run-all subprocesses. Never print the key, only status.
+          ls_project="deepagents-clbench-${model_slug}"
+          export LANGSMITH_PROJECT="$ls_project"
+          echo "CLBENCH_LS_PROJECT=${ls_project}" >> "$GITHUB_ENV"
+          if [ -n "${LANGSMITH_API_KEY:-}" ]; then
+            echo "LangSmith tracing: ON -> project $ls_project"
+          else
+            echo "LangSmith tracing: OFF (no LANGSMITH_API_KEY secret)"
+          fi
+
+          if [ "$CLBENCH_SCHEDULE" = "default" ]; then
+            # Leaderboard-comparable: run-all uses each task's default schedule (5 runs
+            # + baseline). This is exactly the config the public leaderboard reports.
+            echo "::warning::clbench_schedule=default is leaderboard-scale (all default schedules, 5 runs + baseline); for a Deep Agents system this is many hours and will likely exceed the job timeout — prefer running per-task or out-of-CI."
+            task_flags=()
+            if [ "${#req_tasks[@]}" -gt 0 ]; then task_flags=(--task "${req_tasks[@]}"); fi
+            echo "Running 'clbench run-all' (leaderboard mode) — system=deepagents, model=$CLBENCH_MODEL"
+            ( cd clbench-src && set -x && uv run clbench run-all \
+                --name "$run_name" \
+                --system deepagents \
+                --system.model "$CLBENCH_MODEL" \
+                ${task_flags[@]+"${task_flags[@]}"} \
+                --per-task-parallelism "$CLBENCH_PER_TASK_PARALLELISM" \
+                --no-live-dashboard )
+          else
+            # Cheap/named-schedule mode: run-all is hardwired to default.json, so a
+            # named schedule (e.g. quick_test) must be run per task via `clbench run`.
+            targets=()
+            if [ "${#req_tasks[@]}" -gt 0 ]; then
+              # Explicit request: every named task MUST define the schedule. Do not
+              # silently skip — that would produce a green run with no benchmark result.
+              for t in "${req_tasks[@]}"; do
+                if [ ! -f "clbench-src/src/tasks/$t/schedules/${CLBENCH_SCHEDULE}.json" ]; then
+                  echo "::error::Requested task '$t' has no '$CLBENCH_SCHEDULE' schedule (e.g. quick_test currently exists only for exploitable_poker). Pick a task that defines it, or use clbench_schedule=default."; exit 1
+                fi
+                targets+=("$t")
+              done
+            else
+              # No include_tasks: auto-select tasks that actually define this schedule.
+              for d in clbench-src/src/tasks/*/; do
+                t="$(basename "$d")"
+                if [ -f "$d/schedules/${CLBENCH_SCHEDULE}.json" ]; then targets+=("$t"); fi
+              done
+            fi
+            if [ "${#targets[@]}" -eq 0 ]; then
+              echo "::error::No task defines schedule '$CLBENCH_SCHEDULE' (currently only exploitable_poker ships quick_test). Pass include_tasks, or use clbench_schedule=default."; exit 1
+            fi
+            echo "Cheap mode: schedule=$CLBENCH_SCHEDULE, tasks: ${targets[*]}"
+            rc=0; ran=0
+            for t in "${targets[@]}"; do
+              echo "Running 'clbench run $t --schedule $CLBENCH_SCHEDULE' — system=deepagents, model=$CLBENCH_MODEL"
+              ( cd clbench-src && set -x && uv run clbench run "$t" \
+                  --schedule "$CLBENCH_SCHEDULE" \
+                  --system deepagents \
+                  --system.model "$CLBENCH_MODEL" \
+                  --max-workers "$CLBENCH_PER_TASK_PARALLELISM" \
+                  --no-live-dashboard ) || rc=$?
+              ran=$((ran + 1))
+            done
+            if [ "$ran" -eq 0 ]; then echo "::error::no clbench tasks ran for schedule '$CLBENCH_SCHEDULE'"; exit 1; fi
+            [ "$rc" -eq 0 ] || { echo "::error::one or more clbench tasks failed (rc=$rc)"; exit "$rc"; }
+          fi
+
+      - name: "📝 Write workflow summary"
+        if: always()
+        run: |
+          {
+            echo "## clbench run (continual-learning-bench — not Harbor)"
+            echo
+            echo "- Model: ${CLBENCH_MODEL}"
+            echo "- System: deepagents"
+            echo "- clbench ref: ${CLBENCH_REF}"
+            if [ -n "${CLBENCH_INCLUDE_TASKS}" ]; then
+              echo "- Tasks: ${CLBENCH_INCLUDE_TASKS}"
+            else
+              echo "- Tasks: all (run-all over the whole benchmark)"
+            fi
+            echo "- Per-task parallelism: ${CLBENCH_PER_TASK_PARALLELISM}"
+            if [ "${CLBENCH_SCHEDULE}" = "default" ]; then
+              echo "- Schedule: default (leaderboard-comparable: run-all, each task's default schedule, 5 runs)"
+            else
+              echo "- Schedule: ${CLBENCH_SCHEDULE} (cheap mode: per-task clbench run --schedule)"
+            fi
+            if [ "${LANGSMITH_TRACING}" = "true" ]; then
+              echo "- LangSmith tracing: on (trajectories only; project ${CLBENCH_LS_PROJECT:-deepagents-clbench-<model>})"
+            else
+              echo "- LangSmith tracing: off (set the LANGSMITH_API_KEY secret to enable)"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: "📤 Upload clbench results"
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: clbench-${{ strategy.job-index }}
+          path: |
+            clbench-src/final_results
+            clbench-src/results
+          if-no-files-found: warn

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -27,7 +27,7 @@ on:
   workflow_dispatch:
     inputs:
       dataset:
-        description: "Benchmark to run (primary selector). Terminal-bench refs run through Harbor. The value 'clbench' runs continual-learning-bench instead — a separate benchmark (NOT Harbor) that runs on the runner with the Deep Agents system; see the clbench job. Selecting 'clbench' makes the [Harbor only] inputs below no-ops."
+        description: "Terminal-bench dataset to run through Harbor."
         required: true
         default: "terminal-bench/terminal-bench-2"
         type: choice
@@ -35,14 +35,13 @@ on:
           - "terminal-bench/terminal-bench-2"
           - "terminal-bench/terminal-bench-2-1"
           - "sierra-research/tau3-bench"
-          - "clbench"
       dataset_override:
-        description: "[Harbor only] Override: arbitrary Harbor dataset ref (e.g. 'owner/dataset'). Takes priority over the dataset dropdown when non-empty. Ignored when dataset=clbench."
+        description: "Override: arbitrary Harbor dataset ref (e.g. 'owner/dataset'). Takes priority over the dataset dropdown when non-empty."
         required: false
         default: ""
         type: string
       models:
-        description: "[Harbor + clbench] Model set to run. Set definitions: libs/evals/MODEL_GROUPS.md. Leave empty to use models_override instead. Defaults to all models if both are empty."
+        description: "Model set to run. Set definitions: libs/evals/MODEL_GROUPS.md. Leave empty to use models_override instead. Defaults to all models if both are empty."
         required: false
         default: ""
         type: choice
@@ -125,12 +124,12 @@ on:
           - "xai:grok-4"
           - "xai:grok-3-mini-fast"
       models_override:
-        description: "[Harbor + clbench] Override: comma-separated models (e.g. 'openai:gpt-4.1,anthropic:claude-sonnet-4-6'). Takes priority over dropdown when non-empty."
+        description: "Override: comma-separated models (e.g. 'openai:gpt-4.1,anthropic:claude-sonnet-4-6'). Takes priority over dropdown when non-empty."
         required: false
         default: ""
         type: string
       sandbox_env:
-        description: "[Harbor only] Harbor sandbox environment. Ignored when dataset=clbench (clbench runs directly on the runner; it has no Harbor sandbox concept)."
+        description: "Harbor sandbox environment."
         required: true
         default: "langsmith"
         type: choice
@@ -138,7 +137,7 @@ on:
           - docker
           - langsmith
       agent_impl:
-        description: "[Harbor only] Deep Agents implementation run through Harbor's LangGraph agent. Ignored when dataset=clbench."
+        description: "Deep Agents implementation run through Harbor's LangGraph agent."
         required: true
         default: "dcode"
         type: choice
@@ -147,38 +146,30 @@ on:
           - bare
           - tau3
       n_tasks:
-        description: "[Harbor only] Maximum number of tasks to run (0 = all). Ignored when dataset=clbench — use include_tasks to pick clbench tasks."
+        description: "Maximum number of tasks to run (0 = all)."
         required: true
         default: "0"
         type: string
       include_tasks:
-        description: "[Harbor + clbench] Harbor: space-separated task-name globs. clbench: space-separated task names passed as --task (empty = all clbench tasks)."
+        description: "Space-separated task-name globs (empty = all tasks)."
         required: false
         default: ""
         type: string
       rollouts_per_task:
-        description: "[Harbor only] Rollouts per task. Ignored when dataset=clbench — run-all uses each task's default schedule (which defines its own runs)."
+        description: "Rollouts per task."
         required: true
         default: "1"
         type: string
       concurrency:
-        description: "[Harbor + clbench] Harbor: concurrent trials (sandbox slots). clbench: forwarded as --per-task-parallelism."
+        description: "Concurrent trials (sandbox slots)."
         required: true
         default: "1"
         type: string
       harbor_package_override:
-        description: "[Harbor only] Optional: install Harbor from an arbitrary package spec (e.g. 'harbor[langsmith] @ git+https://github.com/owner/harbor.git@branch') instead of the locked version, to test an unreleased Harbor build. Leave empty to use the pinned Harbor. Ignored when dataset=clbench."
+        description: "Optional: install Harbor from an arbitrary package spec (e.g. 'harbor[langsmith] @ git+https://github.com/owner/harbor.git@branch') instead of the locked version, to test an unreleased Harbor build. Leave empty to use the pinned Harbor."
         required: false
         default: ""
         type: string
-      clbench_schedule:
-        description: "[clbench only] Schedule for dataset=clbench. 'quick_test' = cheap smoke (per-task clbench run; only tasks that define it — currently just exploitable_poker). 'default' = leaderboard-comparable (run-all, each task's default schedule, 5 runs + baseline) — multi-hour and likely exceeds the job timeout for a Deep Agents system. Ignored for Harbor."
-        required: true
-        default: "quick_test"
-        type: choice
-        options:
-          - quick_test
-          - default
 permissions:
   contents: read
 
@@ -247,7 +238,6 @@ jobs:
   harbor:
     name: "📊 Evals - Harbor (${{ matrix.model }} / ${{ inputs.sandbox_env }} / ${{ inputs.agent_impl }})"
     needs: prep
-    if: ${{ inputs.dataset != 'clbench' }}
     runs-on: ubuntu-latest
     environment: evals
     timeout-minutes: 360
@@ -549,261 +539,4 @@ jobs:
           name: harbor-${{ strategy.job-index }}
           path: |
             libs/evals/harbor-jobs/terminal-bench
-          if-no-files-found: warn
-
-  # continual-learning-bench (clbench) — NOT Harbor. Selected via dataset=clbench.
-  # Runs the whole benchmark (clbench run-all) with the Deep Agents system on the
-  # runner. Shares the prep model matrix. Harbor-only inputs (sandbox_env,
-  # agent_impl, n_tasks, rollouts_per_task) do not apply here.
-  clbench:
-    name: "🧠 Evals - clbench (${{ matrix.model }} / deepagents)"
-    needs: prep
-    if: ${{ inputs.dataset == 'clbench' }}
-    runs-on: ubuntu-latest
-    environment: evals
-    timeout-minutes: 360
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prep.outputs.matrix) }}
-    env:
-      CLBENCH_REPO: "https://github.com/pgasawa/continual-learning-bench"
-      # Pinned to a specific commit (not a moving ref) for reproducibility.
-      CLBENCH_REF: "56764d61afa2860e4893bc14e6229e33fcebf06b"
-      CLBENCH_MODEL: ${{ matrix.model }}
-      CLBENCH_PROVIDER: ${{ matrix.provider }}
-      CLBENCH_INCLUDE_TASKS: ${{ inputs.include_tasks }}
-      CLBENCH_PER_TASK_PARALLELISM: ${{ inputs.concurrency }}
-      CLBENCH_SCHEDULE: ${{ inputs.clbench_schedule }}
-      # Ollama cloud endpoint (matches the Harbor job); ollama:*:cloud needs this
-      # or LangChain defaults to a local Ollama server.
-      OLLAMA_HOST: "https://ollama.com"
-      # Trace-level LangSmith tracing only: LangChain/LangGraph auto-captures the
-      # agent trajectories when these are set. clbench itself has no LangSmith
-      # experiment integration, so scores/gain stay in clbench's own artifacts.
-      # Tracing turns on only when the secret is present (no warnings when absent).
-      LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-      LANGSMITH_TRACING: ${{ secrets.LANGSMITH_API_KEY != '' && 'true' || 'false' }}
-    steps:
-      - name: "🔑 Verify model credentials"
-        env:
-          ANTHROPIC_API_KEY: ${{ startsWith(matrix.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
-          BASETEN_API_KEY: ${{ startsWith(matrix.model, 'baseten:') && secrets.BASETEN_API_KEY || '' }}
-          FIREWORKS_API_KEY: ${{ startsWith(matrix.model, 'fireworks:') && secrets.FIREWORKS_API_KEY || '' }}
-          GOOGLE_API_KEY: ${{ startsWith(matrix.model, 'google_genai:') && secrets.GOOGLE_API_KEY || '' }}
-          GROQ_API_KEY: ${{ startsWith(matrix.model, 'groq:') && secrets.GROQ_API_KEY || '' }}
-          NVIDIA_API_KEY: ${{ startsWith(matrix.model, 'nvidia:') && secrets.NVIDIA_API_KEY || '' }}
-          OLLAMA_API_KEY: ${{ startsWith(matrix.model, 'ollama:') && secrets.OLLAMA_API_KEY || '' }}
-          OPENAI_API_KEY: ${{ startsWith(matrix.model, 'openai:') && secrets.OPENAI_API_KEY || '' }}
-          OPENROUTER_API_KEY: ${{ startsWith(matrix.model, 'openrouter:') && secrets.OPENROUTER_API_KEY || '' }}
-          XAI_API_KEY: ${{ startsWith(matrix.model, 'xai:') && secrets.XAI_API_KEY || '' }}
-        run: |
-          provider="${CLBENCH_MODEL%%:*}"
-          missing=()
-          # All Harbor matrix providers resolve through init_chat_model.
-          case "$provider" in
-            anthropic)    [ -z "$ANTHROPIC_API_KEY" ] && missing+=("ANTHROPIC_API_KEY") ;;
-            openai)       [ -z "$OPENAI_API_KEY" ] && missing+=("OPENAI_API_KEY") ;;
-            google_genai) [ -z "$GOOGLE_API_KEY" ] && missing+=("GOOGLE_API_KEY") ;;
-            groq)         [ -z "$GROQ_API_KEY" ] && missing+=("GROQ_API_KEY") ;;
-            xai)          [ -z "$XAI_API_KEY" ] && missing+=("XAI_API_KEY") ;;
-            ollama)       [ -z "$OLLAMA_API_KEY" ] && missing+=("OLLAMA_API_KEY") ;;
-            fireworks)    [ -z "$FIREWORKS_API_KEY" ] && missing+=("FIREWORKS_API_KEY") ;;
-            nvidia)       [ -z "$NVIDIA_API_KEY" ] && missing+=("NVIDIA_API_KEY") ;;
-            openrouter)   [ -z "$OPENROUTER_API_KEY" ] && missing+=("OPENROUTER_API_KEY") ;;
-            baseten)      [ -z "$BASETEN_API_KEY" ] && missing+=("BASETEN_API_KEY") ;;
-            *)
-              echo "::warning::Unknown provider prefix '$provider' for clbench; proceeding and letting init_chat_model resolve it. Ensure the matching API key secret is configured."
-              ;;
-          esac
-          if [ ${#missing[@]} -gt 0 ]; then
-            echo "::error::Missing required secret(s) for $CLBENCH_MODEL: ${missing[*]}"
-            exit 1
-          fi
-          echo "Credentials present for $CLBENCH_MODEL"
-
-      - name: "📋 Checkout Code"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-
-      - name: "🐍 Set up Python + UV"
-        uses: "./.github/actions/uv_setup"
-        with:
-          python-version: "3.13"
-          cache-suffix: clbench
-          working-directory: libs/evals
-
-      - name: "🧠 Run continual-learning-bench with the Deep Agents system"
-        env:
-          ANTHROPIC_API_KEY: ${{ startsWith(matrix.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}
-          BASETEN_API_KEY: ${{ startsWith(matrix.model, 'baseten:') && secrets.BASETEN_API_KEY || '' }}
-          FIREWORKS_API_KEY: ${{ startsWith(matrix.model, 'fireworks:') && secrets.FIREWORKS_API_KEY || '' }}
-          GOOGLE_API_KEY: ${{ startsWith(matrix.model, 'google_genai:') && secrets.GOOGLE_API_KEY || '' }}
-          GROQ_API_KEY: ${{ startsWith(matrix.model, 'groq:') && secrets.GROQ_API_KEY || '' }}
-          NVIDIA_API_KEY: ${{ startsWith(matrix.model, 'nvidia:') && secrets.NVIDIA_API_KEY || '' }}
-          OLLAMA_API_KEY: ${{ startsWith(matrix.model, 'ollama:') && secrets.OLLAMA_API_KEY || '' }}
-          OPENAI_API_KEY: ${{ startsWith(matrix.model, 'openai:') && secrets.OPENAI_API_KEY || '' }}
-          OPENROUTER_API_KEY: ${{ startsWith(matrix.model, 'openrouter:') && secrets.OPENROUTER_API_KEY || '' }}
-          XAI_API_KEY: ${{ startsWith(matrix.model, 'xai:') && secrets.XAI_API_KEY || '' }}
-        run: |
-          set -euo pipefail
-
-          # Validate the pinned ref is a full commit SHA (no moving refs).
-          if ! [[ "$CLBENCH_REF" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::CLBENCH_REF must be a full 40-char commit SHA"; exit 1
-          fi
-          # Validate per-task parallelism is a positive integer.
-          if ! [[ "$CLBENCH_PER_TASK_PARALLELISM" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::Invalid concurrency (per-task-parallelism): $CLBENCH_PER_TASK_PARALLELISM"; exit 1
-          fi
-          # Validate the schedule name (used in a file path + the command).
-          if ! [[ "$CLBENCH_SCHEDULE" =~ ^[A-Za-z0-9_]+$ ]]; then
-            echo "::error::Invalid clbench schedule: $CLBENCH_SCHEDULE"; exit 1
-          fi
-          # Validate + collect requested task names (alphanumeric + underscore only).
-          req_tasks=()
-          if [ -n "$CLBENCH_INCLUDE_TASKS" ]; then
-            read -r -a req_tasks <<< "$CLBENCH_INCLUDE_TASKS"
-            for t in "${req_tasks[@]}"; do
-              if ! [[ "$t" =~ ^[A-Za-z0-9_]+$ ]]; then
-                echo "::error::Invalid clbench task name: $t"; exit 1
-              fi
-            done
-          fi
-
-          # Clone clbench pinned to a specific commit.
-          git clone --filter=blob:none "$CLBENCH_REPO" clbench-src
-          git -C clbench-src checkout --quiet "$CLBENCH_REF"
-
-          # Install clbench (all task extras), the local Deep Agents SDK, and the
-          # matrix model's LangChain provider integration.
-          ( cd clbench-src && uv sync --all-extras )
-          # Provider -> LangChain integration package (init_chat_model resolves all of these).
-          case "$CLBENCH_PROVIDER" in
-            anthropic)    provider_pkg="langchain-anthropic" ;;
-            openai)       provider_pkg="langchain-openai" ;;
-            google_genai) provider_pkg="langchain-google-genai" ;;
-            groq)         provider_pkg="langchain-groq" ;;
-            xai)          provider_pkg="langchain-xai" ;;
-            ollama)       provider_pkg="langchain-ollama" ;;
-            fireworks)    provider_pkg="langchain-fireworks" ;;
-            nvidia)       provider_pkg="langchain-nvidia-ai-endpoints" ;;
-            openrouter)   provider_pkg="langchain-openrouter" ;;
-            baseten)      provider_pkg="langchain-baseten" ;;
-            *)            provider_pkg="langchain-openai"
-                          echo "::warning::Unknown provider '$CLBENCH_PROVIDER'; defaulting integration to langchain-openai." ;;
-          esac
-          # Fireworks can pull a prerelease dependency (matches the Harbor job).
-          uv_pre=""
-          [ "$CLBENCH_PROVIDER" = "fireworks" ] && uv_pre="UV_PRERELEASE=allow"
-          ( cd clbench-src && env $uv_pre uv pip install -e "$GITHUB_WORKSPACE/libs/deepagents" ${provider_pkg:+"$provider_pkg"} )
-
-          # Deploy the Deep Agents system into this clbench checkout.
-          "$GITHUB_WORKSPACE/libs/evals/deepagents_clbench/sync_to_clbench.sh" "$GITHUB_WORKSPACE/clbench-src"
-
-          # Best-effort dataset setup for tasks that need it (non-fatal).
-          ( cd clbench-src && uv run clbench setup --all ) \
-            || echo "::warning::'clbench setup --all' reported errors; tasks needing that data may be skipped."
-
-          model_slug=$(printf '%s' "$CLBENCH_MODEL" | tr '/:' '--' | tr -c '[:alnum:]._-' '-')
-          run_name="deepagents-${model_slug}-${GITHUB_RUN_ID}"
-
-          # Trace-level LangSmith: group this model's agent traces under one project.
-          # Inherited by the run-all subprocesses. Never print the key, only status.
-          ls_project="deepagents-clbench-${model_slug}"
-          export LANGSMITH_PROJECT="$ls_project"
-          echo "CLBENCH_LS_PROJECT=${ls_project}" >> "$GITHUB_ENV"
-          if [ -n "${LANGSMITH_API_KEY:-}" ]; then
-            echo "LangSmith tracing: ON -> project $ls_project"
-          else
-            echo "LangSmith tracing: OFF (no LANGSMITH_API_KEY secret)"
-          fi
-
-          if [ "$CLBENCH_SCHEDULE" = "default" ]; then
-            # Leaderboard-comparable: run-all uses each task's default schedule (5 runs
-            # + baseline). This is exactly the config the public leaderboard reports.
-            echo "::warning::clbench_schedule=default is leaderboard-scale (all default schedules, 5 runs + baseline); for a Deep Agents system this is many hours and will likely exceed the job timeout — prefer running per-task or out-of-CI."
-            task_flags=()
-            if [ "${#req_tasks[@]}" -gt 0 ]; then task_flags=(--task "${req_tasks[@]}"); fi
-            echo "Running 'clbench run-all' (leaderboard mode) — system=deepagents, model=$CLBENCH_MODEL"
-            ( cd clbench-src && set -x && uv run clbench run-all \
-                --name "$run_name" \
-                --system deepagents \
-                --system.model "$CLBENCH_MODEL" \
-                ${task_flags[@]+"${task_flags[@]}"} \
-                --per-task-parallelism "$CLBENCH_PER_TASK_PARALLELISM" \
-                --no-live-dashboard )
-          else
-            # Cheap/named-schedule mode: run-all is hardwired to default.json, so a
-            # named schedule (e.g. quick_test) must be run per task via `clbench run`.
-            targets=()
-            if [ "${#req_tasks[@]}" -gt 0 ]; then
-              # Explicit request: every named task MUST define the schedule. Do not
-              # silently skip — that would produce a green run with no benchmark result.
-              for t in "${req_tasks[@]}"; do
-                if [ ! -f "clbench-src/src/tasks/$t/schedules/${CLBENCH_SCHEDULE}.json" ]; then
-                  echo "::error::Requested task '$t' has no '$CLBENCH_SCHEDULE' schedule (e.g. quick_test currently exists only for exploitable_poker). Pick a task that defines it, or use clbench_schedule=default."; exit 1
-                fi
-                targets+=("$t")
-              done
-            else
-              # No include_tasks: auto-select tasks that actually define this schedule.
-              for d in clbench-src/src/tasks/*/; do
-                t="$(basename "$d")"
-                if [ -f "$d/schedules/${CLBENCH_SCHEDULE}.json" ]; then targets+=("$t"); fi
-              done
-            fi
-            if [ "${#targets[@]}" -eq 0 ]; then
-              echo "::error::No task defines schedule '$CLBENCH_SCHEDULE' (currently only exploitable_poker ships quick_test). Pass include_tasks, or use clbench_schedule=default."; exit 1
-            fi
-            echo "Cheap mode: schedule=$CLBENCH_SCHEDULE, tasks: ${targets[*]}"
-            rc=0; ran=0
-            for t in "${targets[@]}"; do
-              echo "Running 'clbench run $t --schedule $CLBENCH_SCHEDULE' — system=deepagents, model=$CLBENCH_MODEL"
-              ( cd clbench-src && set -x && uv run clbench run "$t" \
-                  --schedule "$CLBENCH_SCHEDULE" \
-                  --system deepagents \
-                  --system.model "$CLBENCH_MODEL" \
-                  --max-workers "$CLBENCH_PER_TASK_PARALLELISM" \
-                  --no-live-dashboard ) || rc=$?
-              ran=$((ran + 1))
-            done
-            if [ "$ran" -eq 0 ]; then echo "::error::no clbench tasks ran for schedule '$CLBENCH_SCHEDULE'"; exit 1; fi
-            [ "$rc" -eq 0 ] || { echo "::error::one or more clbench tasks failed (rc=$rc)"; exit "$rc"; }
-          fi
-
-      - name: "📝 Write workflow summary"
-        if: always()
-        run: |
-          {
-            echo "## clbench run (continual-learning-bench — not Harbor)"
-            echo
-            echo "- Model: ${CLBENCH_MODEL}"
-            echo "- System: deepagents"
-            echo "- clbench ref: ${CLBENCH_REF}"
-            if [ -n "${CLBENCH_INCLUDE_TASKS}" ]; then
-              echo "- Tasks: ${CLBENCH_INCLUDE_TASKS}"
-            else
-              echo "- Tasks: all (run-all over the whole benchmark)"
-            fi
-            echo "- Per-task parallelism: ${CLBENCH_PER_TASK_PARALLELISM}"
-            if [ "${CLBENCH_SCHEDULE}" = "default" ]; then
-              echo "- Schedule: default (leaderboard-comparable: run-all, each task's default schedule, 5 runs)"
-            else
-              echo "- Schedule: ${CLBENCH_SCHEDULE} (cheap mode: per-task clbench run --schedule)"
-            fi
-            if [ "${LANGSMITH_TRACING}" = "true" ]; then
-              echo "- LangSmith tracing: on (trajectories only; project ${CLBENCH_LS_PROJECT:-deepagents-clbench-<model>})"
-            else
-              echo "- LangSmith tracing: off (set the LANGSMITH_API_KEY secret to enable)"
-            fi
-            echo "- Note: sandbox_env / agent_impl / n_tasks / rollouts_per_task are Harbor-only and were ignored."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: "📤 Upload clbench results"
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: clbench-${{ strategy.job-index }}
-          path: |
-            clbench-src/final_results
-            clbench-src/results
           if-no-files-found: warn


### PR DESCRIPTION
## What

Split continual-learning-bench (clbench) out of the Harbor workflow into its own `🧠 Evals - clbench` workflow.

## Why

clbench was bolted onto `harbor.yml` behind `dataset=clbench`. Because the two benchmarks share nothing but the dispatch form and the model-matrix `prep` job (they're already mutually-exclusive `if:`-gated jobs), every Harbor input had to grow `[Harbor only]` / `[Harbor + clbench]` / `[clbench only]` tags, and ~half of them became no-ops depending on the selector. That pushes a "which fields apply to me?" decision onto the launcher on every run, and hides clbench behind a Harbor dropdown value where it's hard to discover.

Splitting scopes each dispatch form to one benchmark — **every field applies** — and gives clbench its own clearly-named sidebar entry.

## Changes

- **New `.github/workflows/clbench.yml`** — standalone workflow with 4 focused inputs: `models` (free-text), `include_tasks`, `concurrency`, `clbench_schedule`. The clbench job is moved **verbatim**: SHA-pinned external clone, allowlist-regex validation of ref/tasks/schedule/parallelism, and per-provider secret gating are all preserved unchanged.
- **`.github/scripts/models.py`** — adds a first-class `clbench` workflow key (`CLBENCH_MODELS`) that reuses Harbor's model groups and flat `{model, provider}` matrix. `_WORKFLOW_CONFIG` now carries an explicit registry tag prefix (clbench borrows Harbor's), so group selections like `all` resolve identically.
- **`.github/workflows/harbor.yml`** — removes the `clbench` dataset option, the `clbench_schedule` input, the `dataset != 'clbench'` job guard, and the clbench job; de-tags all input descriptions back to plain Harbor. **tau3 / `dataset_override` work on `main` is preserved.**
- **`.github/scripts/test_models.py`** — locks the clbench flat-matrix contract and its model-resolution parity with Harbor.

## Model-input note

clbench uses a **free-text** `models` field (resolved by `models.py`, like `models_override`) rather than copying Harbor's ~60-entry dropdown — avoiding a third hand-maintained copy. The dropdown-sync test stays scoped to `evals.yml` + `harbor.yml`.

## Verification

- `python -m pytest .github/scripts/test_*.py` — **180 passed** (incl. new clbench tests + the harbor/evals dropdown-sync guard).
- `models.py clbench all` resolves to the same 56 models as `harbor all`.
- All three eval workflows parse; `harbor.yml` has no clbench residue and retains tau3/`dataset_override`.
- No external docs referenced the old `dataset=clbench` entry point, so this is not a breaking change to a documented path.

## Not in scope

Follow-up cognitive-load items (separate PRs): naming-hierarchy cleanup + marking `_eval.yml` internal, and reordering `evals.yml` inputs.
