### PR TITLE
ci(evals): unify eval workflow names, mark _eval internal

### DIFF
--- a/.github/workflows/_eval.yml
+++ b/.github/workflows/_eval.yml
@@ -4,7 +4,7 @@
 # upstream by `prep` (`_SAFE_SPEC_RE` in `.github/scripts/models.py`); this
 # workflow trusts that contract.
 
-name: "📊 Eval"
+name: "🔧 Eval run (internal)"
 
 on:
   workflow_call:

--- a/.github/workflows/clbench.yml
+++ b/.github/workflows/clbench.yml
@@ -21,9 +21,9 @@
 #   FIREWORKS_API_KEY  — needed for Fireworks-hosted models
 #   OPENROUTER_API_KEY — needed for OpenRouter-hosted models
 
-name: "🧠 Evals - clbench"
+name: "📊 Evals - Clbench"
 run-name: >-
-  🧠 Evals - clbench — ${{ contains(inputs.models, ',') && 'custom models' || (inputs.models || 'all') }} / ${{ inputs.clbench_schedule }}
+  📊 Evals - Clbench — ${{ contains(inputs.models, ',') && 'custom models' || (inputs.models || 'all') }} / ${{ inputs.clbench_schedule }}
 
 on:
   workflow_dispatch:
@@ -74,7 +74,7 @@ jobs:
           CONCURRENCY: ${{ inputs.concurrency }}
           CLBENCH_SCHEDULE: ${{ inputs.clbench_schedule }}
         run: |
-          echo "### 🧠 Evals - clbench dispatch inputs" >> "$GITHUB_STEP_SUMMARY"
+          echo "### 📊 Evals - Clbench dispatch inputs" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Input | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
@@ -101,7 +101,7 @@ jobs:
   # (clbench run-all) with the Deep Agents system on the runner. Shares the prep
   # model matrix with the evals/Harbor model groups.
   clbench:
-    name: "🧠 Evals - clbench (${{ matrix.model }} / deepagents)"
+    name: "📊 Evals - Clbench (${{ matrix.model }} / deepagents)"
     needs: prep
     runs-on: ubuntu-latest
     environment: evals


### PR DESCRIPTION
## What

Tighten eval workflow names so the Actions sidebar self-groups, place the two external-benchmark evals (Harbor, Clbench) next to each other, and stop the reusable runner from looking launchable.

- `clbench.yml`: `🧠` → `📊` to join the `📊 Evals - …` cluster; display label is **`Clbench`** (capitalized) so it sorts immediately next to `Harbor`. Tool/CLI/env references stay lowercase.
- `_eval.yml`: `📊 Eval` → `🔧 Eval run (internal)` so the reusable workflow sorts out of the eval cluster.

## Why

The Actions sidebar sorts by `name` in **case-sensitive ASCII order** (uppercase before lowercase; [ref](https://7tonshark.com/posts/organize-github-workflows/)). With a lowercase `clbench`, `N Trials` sorts between it and `Harbor`. Capitalizing to `Clbench` (C=67 < H=72) places it right before `Harbor`:

```
📊 Evals
📊 Evals - Clbench
📊 Evals - Harbor
📊 Evals - N Trials
🔧 Eval run (internal)
```

## Scope / safety

- **Names only.** No inputs, jobs, or logic change. Reusable workflows are referenced by path (`uses: ./.github/workflows/_eval.yml`), so renaming `name:` changes nothing functional.
- The decorative per-step icon `🧠 Run continual-learning-bench …` is left as-is (parallel to Harbor's `⚓ Run Harbor`).
- No docs reference the clbench workflow name; `CONTRIBUTING.md`'s `📊 Evals - N Trials` reference is unchanged.
- `python -m pytest .github/scripts/test_*.py` → **180 passed**; all eval workflows parse.

## Not in scope

Tier 1.3 (reordering `evals.yml` inputs + "run with defaults" copy) — separate PR.
