### PR TITLE
test(code): disable unit-test update checks by default

### DIFF
--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -303,6 +303,9 @@ omit = ["tests/*"]
 timeout = 30  # Default timeout for all tests (can be overridden per-test)
 
 addopts = "--strict-markers --strict-config --durations=5"
-markers = ["benchmark: marks tests as benchmarks (select with '-m benchmark')"]
+markers = [
+    "benchmark: marks tests as benchmarks (select with '-m benchmark')",
+    "self_managed_update_check: tests that manage app-startup update-check setup themselves",
+]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -13,18 +13,12 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-# Modules that manage the app-startup update-check gate themselves: `test_main`
-# patches `is_update_check_enabled` directly and `test_config_manifest` sets
-# `DEEPAGENTS_CODE_NO_UPDATE_CHECK` explicitly to assert env/config precedence.
-# The autouse update-env fixtures opt these out of their defaults so they don't
-# clobber that per-test setup. Keep both fixtures reading this one set so a new
-# self-managing module only has to be added in a single place.
-_UPDATE_CHECK_SELF_MANAGED_MODULES = frozenset({"test_config_manifest", "test_main"})
+_UPDATE_CHECK_SELF_MANAGED_MARK = "self_managed_update_check"
 
 
-def _bare_module_name(request: pytest.FixtureRequest) -> str:
-    """Return the unqualified module name for the test under `request`."""
-    return request.module.__name__.rsplit(".", 1)[-1]
+def _self_manages_update_check(request: pytest.FixtureRequest) -> bool:
+    """Return whether the test owns app-startup update-check setup."""
+    return request.node.get_closest_marker(_UPDATE_CHECK_SELF_MANAGED_MARK) is not None
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -170,15 +164,14 @@ def _clear_update_env(
     performs DNS in a background worker, which pytest-socket reports under
     `--disable-socket` even when the app swallows the failure. Set the production
     opt-out env var by default so subprocess tests inherit the same no-network
-    behavior. Modules that cover the update-check gate manage it themselves (by
-    patching `is_update_check_enabled` or setting the env var explicitly) and opt
-    out of this default below.
+    behavior. Tests marked `self_managed_update_check` cover the update-check
+    gate directly, so they opt out of this default below.
     """
     monkeypatch.delenv("DEEPAGENTS_CODE_DEBUG_UPDATE", raising=False)
     monkeypatch.delenv("DEEPAGENTS_CODE_RESTARTED_AFTER_UPDATE", raising=False)
     monkeypatch.delenv("DEEPAGENTS_CODE_AUTO_UPDATE", raising=False)
 
-    if _bare_module_name(request) in _UPDATE_CHECK_SELF_MANAGED_MODULES:
+    if _self_manages_update_check(request):
         monkeypatch.delenv("DEEPAGENTS_CODE_NO_UPDATE_CHECK", raising=False)
     else:
         monkeypatch.setenv("DEEPAGENTS_CODE_NO_UPDATE_CHECK", "1")
@@ -191,10 +184,10 @@ def _disable_app_startup_update_checks(
 ) -> None:
     """Keep app startup tests from racing PyPI or user update config.
 
-    The modules in `_UPDATE_CHECK_SELF_MANAGED_MODULES` manage the gate
-    themselves, so leave `is_update_check_enabled` untouched for them.
+    Tests marked `self_managed_update_check` manage the gate themselves, so leave
+    `is_update_check_enabled` untouched for them.
     """
-    if _bare_module_name(request) in _UPDATE_CHECK_SELF_MANAGED_MODULES:
+    if _self_manages_update_check(request):
         return
     monkeypatch.setattr(
         "deepagents_code.update_check.is_update_check_enabled",

--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -138,24 +138,34 @@ def _clear_onboarding_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _clear_update_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def _clear_update_env(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Prevent update debug/loop-guard and toggle env vars from affecting tests.
 
     `DEEPAGENTS_CODE_DEBUG_UPDATE` short-circuits the install path, and the
     internal `DEEPAGENTS_CODE_RESTARTED_AFTER_UPDATE` sentinel suppresses
-    auto-update to break a restart loop. `DEEPAGENTS_CODE_NO_UPDATE_CHECK` and
-    `DEEPAGENTS_CODE_AUTO_UPDATE` are read directly from the environment by the
-    startup gate (`is_update_check_enabled` / `is_auto_update_enabled`), so a
-    developer who exports either to opt out would otherwise make the auto-update
-    tests fail or pass spuriously. Any of these leaking in (from a developer
-    shell, or a prior test exercising the production code that sets the
-    sentinel) would make the startup auto-update tests non-deterministic. Tests
-    that need a specific value set them explicitly via `monkeypatch`/`patch`.
+    auto-update to break a restart loop. `DEEPAGENTS_CODE_AUTO_UPDATE` is read
+    directly from the environment by `is_auto_update_enabled`, so a developer who
+    exports it would otherwise make auto-update tests fail or pass spuriously.
+
+    Most unit tests should not run the app startup PyPI update check at all: it
+    performs DNS in a background worker, which pytest-socket reports under
+    `--disable-socket` even when the app swallows the failure. Set the production
+    opt-out env var by default so subprocess tests inherit the same no-network
+    behavior. Tests that cover the update-check gate patch it directly and opt
+    out of this default below.
     """
     monkeypatch.delenv("DEEPAGENTS_CODE_DEBUG_UPDATE", raising=False)
     monkeypatch.delenv("DEEPAGENTS_CODE_RESTARTED_AFTER_UPDATE", raising=False)
-    monkeypatch.delenv("DEEPAGENTS_CODE_NO_UPDATE_CHECK", raising=False)
     monkeypatch.delenv("DEEPAGENTS_CODE_AUTO_UPDATE", raising=False)
+
+    module_name = request.module.__name__.rsplit(".", 1)[-1]
+    if module_name in {"test_config_manifest", "test_main"}:
+        monkeypatch.delenv("DEEPAGENTS_CODE_NO_UPDATE_CHECK", raising=False)
+    else:
+        monkeypatch.setenv("DEEPAGENTS_CODE_NO_UPDATE_CHECK", "1")
 
 
 @pytest.fixture(autouse=True)

--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -13,6 +13,20 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+# Modules that manage the app-startup update-check gate themselves: `test_main`
+# patches `is_update_check_enabled` directly and `test_config_manifest` sets
+# `DEEPAGENTS_CODE_NO_UPDATE_CHECK` explicitly to assert env/config precedence.
+# The autouse update-env fixtures opt these out of their defaults so they don't
+# clobber that per-test setup. Keep both fixtures reading this one set so a new
+# self-managing module only has to be added in a single place.
+_UPDATE_CHECK_SELF_MANAGED_MODULES = frozenset({"test_config_manifest", "test_main"})
+
+
+def _bare_module_name(request: pytest.FixtureRequest) -> str:
+    """Return the unqualified module name for the test under `request`."""
+    return request.module.__name__.rsplit(".", 1)[-1]
+
+
 @pytest.fixture(autouse=True, scope="session")
 def _warm_model_caches() -> None:
     """Pre-populate model-config caches once per xdist worker.
@@ -146,7 +160,9 @@ def _clear_update_env(
 
     `DEEPAGENTS_CODE_DEBUG_UPDATE` short-circuits the install path, and the
     internal `DEEPAGENTS_CODE_RESTARTED_AFTER_UPDATE` sentinel suppresses
-    auto-update to break a restart loop. `DEEPAGENTS_CODE_AUTO_UPDATE` is read
+    auto-update to break a restart loop. The sentinel can leak in not just from a
+    developer shell but from a prior test exercising the production code that sets
+    it, so it is cleared unconditionally. `DEEPAGENTS_CODE_AUTO_UPDATE` is read
     directly from the environment by `is_auto_update_enabled`, so a developer who
     exports it would otherwise make auto-update tests fail or pass spuriously.
 
@@ -154,15 +170,15 @@ def _clear_update_env(
     performs DNS in a background worker, which pytest-socket reports under
     `--disable-socket` even when the app swallows the failure. Set the production
     opt-out env var by default so subprocess tests inherit the same no-network
-    behavior. Tests that cover the update-check gate patch it directly and opt
+    behavior. Modules that cover the update-check gate manage it themselves (by
+    patching `is_update_check_enabled` or setting the env var explicitly) and opt
     out of this default below.
     """
     monkeypatch.delenv("DEEPAGENTS_CODE_DEBUG_UPDATE", raising=False)
     monkeypatch.delenv("DEEPAGENTS_CODE_RESTARTED_AFTER_UPDATE", raising=False)
     monkeypatch.delenv("DEEPAGENTS_CODE_AUTO_UPDATE", raising=False)
 
-    module_name = request.module.__name__.rsplit(".", 1)[-1]
-    if module_name in {"test_config_manifest", "test_main"}:
+    if _bare_module_name(request) in _UPDATE_CHECK_SELF_MANAGED_MODULES:
         monkeypatch.delenv("DEEPAGENTS_CODE_NO_UPDATE_CHECK", raising=False)
     else:
         monkeypatch.setenv("DEEPAGENTS_CODE_NO_UPDATE_CHECK", "1")
@@ -175,10 +191,10 @@ def _disable_app_startup_update_checks(
 ) -> None:
     """Keep app startup tests from racing PyPI or user update config.
 
-    `test_config_manifest` and `test_main` patch `is_update_check_enabled` themselves.
+    The modules in `_UPDATE_CHECK_SELF_MANAGED_MODULES` manage the gate
+    themselves, so leave `is_update_check_enabled` untouched for them.
     """
-    module_name = request.module.__name__.rsplit(".", 1)[-1]
-    if module_name in {"test_config_manifest", "test_main"}:
+    if _bare_module_name(request) in _UPDATE_CHECK_SELF_MANAGED_MODULES:
         return
     monkeypatch.setattr(
         "deepagents_code.update_check.is_update_check_enabled",

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -34,6 +34,12 @@ from deepagents_code.config_manifest import (
 )
 from deepagents_code.model_config import PROVIDER_API_KEY_ENV
 
+# Most unit tests set `DEEPAGENTS_CODE_NO_UPDATE_CHECK=1` to avoid accidental
+# PyPI/DNS work. This module checks whether update settings came from the env,
+# config file, or built-in defaults; adding the env var here would hide the
+# config/default cases these tests are trying to verify.
+pytestmark = pytest.mark.self_managed_update_check
+
 
 def _declared_deepagents_env_vars() -> set[str]:
     """Every `DEEPAGENTS_CODE_*` constant declared in `_env_vars`."""

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -30,6 +30,11 @@ from deepagents_code.main import (
     run_textual_cli_async,
 )
 
+# Most unit tests set `DEEPAGENTS_CODE_NO_UPDATE_CHECK=1` and patch
+# `is_update_check_enabled()` to avoid accidental PyPI/DNS work. This module
+# tests startup update behavior itself, so each test must control those values.
+pytestmark = pytest.mark.self_managed_update_check
+
 
 class TestStartupAutoUpdate:
     """Tests for startup auto-update behavior."""


### PR DESCRIPTION
Most unit tests now opt out of the startup PyPI update check through the same environment variable production code already respects. That keeps subprocess-based tests from triggering background DNS under `--disable-socket`, while leaving the update-check gate tests free to exercise the real env behavior.