### PR TITLE
ci(quickjs): run prompt smoke tests on SDK changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,8 @@ jobs:
       needs.changes.outputs.quickjs != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     # Match the canonical test path (_test.yml) and the quickjs Makefile:
     # freeze against uv.lock so `uv sync` cannot rewrite the lockfile (which
     # would dirty the tree and trip the clean-working-directory check below).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,8 @@ jobs:
   # editable local SDK (resolved via [tool.uv.sources] in quickjs).
   #
   # Skipped when:
+  #   - deepagents != 'true': the SDK is unchanged, so there is no new prompt
+  #     wording for the snapshots to drift against.
   #   - quickjs == 'true': the full test-quickjs suite already runs these
   #     snapshots via `make test`, so this would be redundant.
   #   - push: test-quickjs runs on every push regardless of the filter, so
@@ -403,6 +405,20 @@ jobs:
       - name: "📦 Install Test Dependencies"
         shell: bash
         run: uv sync --group test
+
+      # Fail loudly if the smoke test file is moved or renamed. Because any
+      # change under libs/partners/quickjs/** flips the quickjs filter to
+      # 'true' (skipping this job), such a rename lands on a PR that never
+      # runs this job — so without this guard a stale path would silently
+      # collect zero tests on some later SDK-only PR instead of failing here.
+      - name: "🔍 Verify Smoke Test Path"
+        shell: bash
+        run: |
+          set -eu
+          test -f tests/unit_tests/smoke_tests/test_system_prompt.py || {
+            echo "::error::quickjs smoke test file moved or renamed; update its path in ci.yml"
+            exit 1
+          }
 
       - name: "🧪 Run quickjs prompt smoke tests"
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,67 @@ jobs:
       python-versions: '["3.11", "3.12", "3.13", "3.14"]'
       coverage-python-version: "3.11"
 
+  # Catch SDK -> quickjs prompt-snapshot drift: when the deepagents SDK
+  # changes but the quickjs partner is untouched, the full test-quickjs suite
+  # does NOT run (it gates on the quickjs filter), so nothing would validate
+  # quickjs's vendored system-prompt snapshots against the new SDK. This job
+  # fills that gap by re-running just the prompt smoke tests against the
+  # editable local SDK (resolved via [tool.uv.sources] in quickjs).
+  #
+  # Skipped when:
+  #   - quickjs == 'true': the full test-quickjs suite already runs these
+  #     snapshots via `make test`, so this would be redundant.
+  #   - push: test-quickjs runs on every push regardless of the filter, so
+  #     the full suite covers the snapshots there too.
+  test-quickjs-sdk-smoke:
+    name: "🧪 Test quickjs SDK smoke"
+    needs: changes
+    if: >-
+      github.event_name != 'push' &&
+      needs.changes.outputs.deepagents == 'true' &&
+      needs.changes.outputs.quickjs != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Match the canonical test path (_test.yml) and the quickjs Makefile:
+    # freeze against uv.lock so `uv sync` cannot rewrite the lockfile (which
+    # would dirty the tree and trip the clean-working-directory check below).
+    # The editable SDK path dep still reflects the checkout regardless.
+    env:
+      UV_FROZEN: "true"
+    defaults:
+      run:
+        working-directory: "libs/partners/quickjs"
+    steps:
+      - name: "📋 Checkout Code"
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: "🐍 Set up Python 3.11 + UV"
+        uses: "./.github/actions/uv_setup"
+        with:
+          python-version: "3.11"
+          cache-suffix: test-quickjs-sdk-smoke
+          working-directory: "libs/partners/quickjs"
+
+      - name: "📦 Install Test Dependencies"
+        shell: bash
+        run: uv sync --group test
+
+      - name: "🧪 Run quickjs prompt smoke tests"
+        shell: bash
+        run: >-
+          uv run --group test pytest
+          --disable-socket
+          --allow-unix-socket
+          tests/unit_tests/smoke_tests/test_system_prompt.py
+
+      - name: "🧹 Verify Clean Working Directory"
+        shell: bash
+        run: |
+          set -eu
+          STATUS="$(git status)"
+          echo "$STATUS"
+          echo "$STATUS" | grep 'nothing to commit, working tree clean'
+
   # Run CodSpeed benchmarks on SDK changes
   benchmark-deepagents:
     name: "⏱️ Benchmark deepagents"
@@ -435,6 +496,7 @@ jobs:
       - test-runloop
       - test-vercel
       - test-quickjs
+      - test-quickjs-sdk-smoke
       - check-release-options
     if: always()
     runs-on: ubuntu-latest

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/test_system_prompt.py
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/test_system_prompt.py
@@ -18,7 +18,6 @@ intentional prompt change.
 
 from __future__ import annotations
 
-import re
 from collections.abc import (
     Iterator,  # noqa: TC003 — pydantic resolves field annotations at runtime
 )
@@ -132,18 +131,6 @@ def _system_message_as_text(message: SystemMessage) -> str:
     )
 
 
-# Insert a blank line after a `##` heading when the next line is non-blank.
-# The released `langchain==1.3.0` `WRITE_TODOS_SYSTEM_PROMPT` is missing this
-# blank line; the fix is on `langchain` `main` and will land in the next
-# release. Drop this normalization once we pin a `langchain` version that
-# includes it.
-_HEADING_NO_BLANK = re.compile(r"(?m)^(#+ [^\n]*)\n(?=[^\n])")
-
-
-def _normalize_heading_blanks(text: str) -> str:
-    return _HEADING_NO_BLANK.sub(r"\1\n\n", text)
-
-
 def _assert_snapshot(
     snapshot_path: Path, actual: str, *, update_snapshots: bool
 ) -> None:
@@ -155,7 +142,7 @@ def _assert_snapshot(
         raise AssertionError(msg)
 
     expected = snapshot_path.read_text(encoding="utf-8")
-    assert _normalize_heading_blanks(actual) == _normalize_heading_blanks(expected)
+    assert actual == expected
 
 
 def _invoke_for_snapshot(agent: object, payload: dict[str, Any]) -> None:

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/test_system_prompt.py
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/test_system_prompt.py
@@ -1,3 +1,21 @@
+"""Snapshot smoke tests for the quickjs system prompt.
+
+These tests render the system prompt that `CodeInterpreterMiddleware` injects
+into a `create_deep_agent` agent and compare it against committed snapshots in
+`snapshots/`. Their purpose is to catch *drift in the deepagents SDK* that
+silently changes the prompt the quickjs middleware composes — wording the
+middleware does not own but depends on (e.g. the built-in `write_todos`
+prompt, tool-listing format, or harness scaffolding).
+
+Because the quickjs partner can be untouched while the SDK changes, CI runs
+this file as a dedicated `test-quickjs-sdk-smoke` job (see `ci.yml`) whenever
+the SDK changes but quickjs does not — the full quickjs suite would otherwise
+not run and the drift would land unnoticed.
+
+Run `pytest ... --update-snapshots` to regenerate the snapshots after an
+intentional prompt change.
+"""
+
 from __future__ import annotations
 
 import re


### PR DESCRIPTION
QuickJS prompt snapshots can drift when the SDK changes without touching the quickjs partner, because the partner test suite is path-gated. A dedicated pull-request CI job now runs the prompt smoke test against the editable local SDK in that gap, while avoiding redundant runs when the full quickjs suite already covers it.
