### PR TITLE
fix(code): show months instead of "0y ago" for 360-364 day old timestamps

### DIFF
--- a/libs/code/deepagents_code/sessions.py
+++ b/libs/code/deepagents_code/sessions.py
@@ -230,8 +230,8 @@ def format_relative_timestamp(iso_timestamp: str | None) -> str:
     days = hours // 24
     if days < 30:  # noqa: PLR2004
         return f"{days}d ago"
-    months = days // 30
-    if months < 12:  # noqa: PLR2004
+    if days < 365:  # noqa: PLR2004
+        months = days // 30
         return f"{months}mo ago"
     years = days // 365
     return f"{years}y ago"

--- a/libs/code/tests/unit_tests/test_sessions.py
+++ b/libs/code/tests/unit_tests/test_sessions.py
@@ -449,6 +449,13 @@ class TestFormatRelativeTimestamp:
         result = sessions.format_relative_timestamp(ts)
         assert result.endswith("s ago")
 
+    def test_boundary_360_to_364_days_shows_months(self) -> None:
+        """360-364 days old should show months, never the bogus '0y ago'."""
+        for days in (360, 362, 364):
+            ts = (datetime.now(tz=UTC) - timedelta(days=days, hours=1)).isoformat()
+            result = sessions.format_relative_timestamp(ts)
+            assert result == "12mo ago"
+
 
 class TestFormatPath:
     """Tests for format_path helper."""

--- a/libs/code/tests/unit_tests/test_sessions.py
+++ b/libs/code/tests/unit_tests/test_sessions.py
@@ -456,6 +456,12 @@ class TestFormatRelativeTimestamp:
             result = sessions.format_relative_timestamp(ts)
             assert result == "12mo ago"
 
+    def test_boundary_365_days_shows_years(self) -> None:
+        """At exactly 365 days, the year bucket takes over with '1y ago'."""
+        ts = (datetime.now(tz=UTC) - timedelta(days=365, hours=1)).isoformat()
+        result = sessions.format_relative_timestamp(ts)
+        assert result == "1y ago"
+
 
 class TestFormatPath:
     """Tests for format_path helper."""


### PR DESCRIPTION
Fixes #4265

---

<!-- Keep the `Fixes #xx` keyword at the very top and update the issue number — this auto-closes the issue on merge. Replace this comment with a 1-2 sentence description of your change. No `# Summary` header; the description is the summary. -->
## Summary
`format_relative_timestamp` showed `"0y ago"` for timestamps 360–364 days old, since the months branch stopped at `days < 360` but the years branch only kicks in at `days >= 365`. This closes that gap so those dates show `"12mo ago"`.

User story: with relative timestamps enabled, opening the `/threads` switcher to resume an old session shows each thread's age. A thread last touched ~360–364 days ago reads `"0y ago"`, which looks broken and is hard to tell apart from a brand-new thread. The same helper formats the `released … ago` line on the update notice, so that hits the gap too. After this fix both read `"12mo ago"`.

I came across it while reading the timestamp bucketing, the month bucket divides by 30 and the year bucket by 365, so I checked the boundary between them and confirmed 360–364 days falls through to `"0y ago"`.

No breaking changes; only the 360–364 day range is affected.

**How I verified**: added a boundary test that fails on `main` and passes here, and ran `make format`, `make lint`, and `make test` for the `code` package.

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
Twitter: @PrvshHasNoLife
LinkedIn: https://www.linkedin.com/in/saini-parvesh/
