### PR TITLE
chore(repo): cut over v0.7 to main

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -10,6 +10,7 @@ from typing import cast
 
 from deepagents.backends.protocol import (
     BackendProtocol,
+    DeleteResult,
     EditResult,
     ExecuteResponse,
     FileDownloadResponse,
@@ -25,6 +26,8 @@ from deepagents.backends.protocol import (
     execute_accepts_timeout,
 )
 from deepagents.backends.state import StateBackend
+
+_DELETE_UNSUPPORTED_ERROR = "Error: deletion is not supported for '{file_path}'."
 
 
 def _remap_grep_path(m: GrepMatch, route_prefix: str) -> GrepMatch:
@@ -528,6 +531,42 @@ class CompositeBackend(BackendProtocol):
         """Async version of edit."""
         backend, stripped_key = self._get_backend_and_key(file_path)
         res = await backend.aedit(stripped_key, old_string, new_string, replace_all=replace_all)
+        if res.path is not None:
+            res.path = file_path
+        return res
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file, routing to the appropriate backend.
+
+        `CompositeBackend` always advertises delete support (it overrides this
+        method), so the `delete` tool is never filtered out for it. A
+        route may still point at a backend that does not implement `delete`;
+        rather than letting `NotImplementedError` escape to the caller, that
+        case is converted into a `DeleteResult` error.
+
+        Args:
+            file_path: Absolute file path.
+
+        Returns:
+            `DeleteResult` with the original path on success, or an error
+            (including when the routed backend does not support deletion).
+        """
+        backend, stripped_key = self._get_backend_and_key(file_path)
+        try:
+            res = backend.delete(stripped_key)
+        except NotImplementedError:
+            return DeleteResult(error=_DELETE_UNSUPPORTED_ERROR.format(file_path=file_path))
+        if res.path is not None:
+            res.path = file_path
+        return res
+
+    async def adelete(self, file_path: str) -> DeleteResult:
+        """Async version of delete."""
+        backend, stripped_key = self._get_backend_and_key(file_path)
+        try:
+            res = await backend.adelete(stripped_key)
+        except NotImplementedError:
+            return DeleteResult(error=_DELETE_UNSUPPORTED_ERROR.format(file_path=file_path))
         if res.path is not None:
             res.path = file_path
         return res

--- a/libs/deepagents/deepagents/backends/context_hub.py
+++ b/libs/deepagents/deepagents/backends/context_hub.py
@@ -16,6 +16,7 @@ from deepagents.backends.protocol import (
     FILE_NOT_FOUND,
     INVALID_PATH,
     BackendProtocol,
+    DeleteResult,
     EditResult,
     FileData,
     FileDownloadResponse,
@@ -103,13 +104,18 @@ class ContextHubBackend(BackendProtocol):
         self._ensure_cache()
         return self._commit_hash is not None
 
-    def _commit(self, files: dict[str, str]) -> None:
-        """Push `files` as one commit; update the cache on success."""
-        if not files:
+    def _commit(self, changes: dict[str, str | None]) -> None:
+        """Push `changes` as one commit; update the cache on success.
+
+        Each value is either new file content or `None`. A `None` value is the
+        deletion marker: relative to `parent_commit`, the server drops that path
+        from the tree.
+        """
+        if not changes:
             return
 
         payload: dict[str, FileEntry | AgentEntry | SkillEntry | None] = {
-            path: FileEntry(type="file", content=content) for path, content in files.items()
+            path: FileEntry(type="file", content=content) if content is not None else None for path, content in changes.items()
         }
         url = self._client.push_agent(
             self._identifier,
@@ -121,8 +127,11 @@ class ContextHubBackend(BackendProtocol):
             self._commit_hash = match.group(1)
 
         if self._cache is not None:
-            for path, content in files.items():
-                self._cache[path] = content
+            # Rebuild the cache rather than mutating in place: drop paths whose
+            # new content is None (deletions) and overlay the rest as updates.
+            deletions = {path for path, content in changes.items() if content is None}
+            updates = {path: content for path, content in changes.items() if content is not None}
+            self._cache = {path: content for path, content in self._cache.items() if path not in deletions} | updates
 
     @staticmethod
     def _strip_prefix(path: str) -> str:
@@ -200,6 +209,34 @@ class ContextHubBackend(BackendProtocol):
             self._cache = None
             return EditResult(error=f"Hub unavailable: {exc}")
         return EditResult(path=file_path, occurrences=occurrences)
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file or directory by committing its removal from the hub repo.
+
+        Deleting a path removes the exact file plus every nested entry under it
+        (the prefix `file_path` + "/"), so a directory is removed recursively.
+
+        Args:
+            file_path: Path of the file or directory to delete.
+
+        Returns:
+            `DeleteResult` with `file_path` on success, or an error if nothing is
+                stored at or under it (or the hub is unavailable).
+        """
+        hub_path = self._strip_prefix(file_path)
+        try:
+            cache = self._ensure_cache()
+            base = hub_path.rstrip("/")
+            prefix = base + "/"
+            to_delete = [key for key in cache if key == base or key.startswith(prefix)]
+            if not to_delete:
+                return DeleteResult(error=f"Error: File '{file_path}' not found")
+            self._commit(dict.fromkeys(to_delete, None))
+        except LangSmithError as exc:
+            logger.exception("Hub delete failed for %r", self._identifier)
+            self._cache = None
+            return DeleteResult(error=f"Hub unavailable: {exc}")
+        return DeleteResult(path=file_path)
 
     def ls(self, path: str = "/") -> LsResult:
         """List immediate files and subdirectories under `path` (non-recursive)."""
@@ -285,7 +322,7 @@ class ContextHubBackend(BackendProtocol):
         """Upload text files in one commit; non-UTF-8 inputs rejected per file."""
         # Decode each input; `None` text means we'll reject this entry as invalid.
         decoded: list[tuple[str, str | None]] = []
-        valid_files: dict[str, str] = {}
+        valid_files: dict[str, str | None] = {}
         for path, content in files:
             try:
                 text = content.decode("utf-8")

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -469,15 +469,14 @@ class FilesystemBackend(BackendProtocol):
         file_path: str,
         content: str,
     ) -> WriteResult:
-        """Create a new file with content.
+        """Write content to a file, creating it or overwriting it if it already exists.
 
         Args:
-            file_path: Path where the new file will be created.
+            file_path: Path where the file will be written.
             content: Text content to write to the file.
 
         Returns:
-            `WriteResult` with path on success, or error message if the file
-                already exists or write fails.
+            `WriteResult` with path on success, or error message on write failure.
         """
         try:
             resolved_path = self._resolve_path(file_path)
@@ -485,10 +484,6 @@ class FilesystemBackend(BackendProtocol):
             return WriteResult(error=f"Error writing file '{file_path}': {e}")
 
         try:
-            if resolved_path.exists():
-                msg = f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path."
-                return WriteResult(error=msg)
-
             # Create parent directories if needed
             resolved_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -22,6 +22,7 @@ from deepagents.backends.protocol import (
     IS_DIRECTORY,
     PERMISSION_DENIED,
     BackendProtocol,
+    DeleteResult,
     EditResult,
     FileData,
     FileDownloadResponse,
@@ -566,6 +567,40 @@ class FilesystemBackend(BackendProtocol):
             return EditResult(path=file_path, occurrences=int(occurrences))
         except (OSError, UnicodeDecodeError, UnicodeEncodeError) as e:
             return EditResult(error=f"Error editing file '{file_path}': {e}")
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file or directory from the filesystem.
+
+        Files are unlinked. Directories are removed recursively along with all
+        of their contents. Symlinks are removed as links and never followed into
+        their target (so deleting a symlink to a directory removes only the link).
+
+        Args:
+            file_path: Path to the file or directory to delete.
+
+        Returns:
+            `DeleteResult` with the deleted path on success, or an error if the
+                path does not exist or removal fails. A recursive directory
+                removal may delete some entries before failing partway (for
+                example when a nested entry is not writable).
+        """
+        try:
+            resolved_path = self._resolve_path(file_path)
+        except (OSError, RuntimeError) as e:
+            return DeleteResult(error=f"Error deleting '{file_path}': {e}")
+
+        try:
+            if not resolved_path.exists() and not resolved_path.is_symlink():
+                return DeleteResult(error=f"Error: '{file_path}' not found")
+            if resolved_path.is_symlink():
+                resolved_path.unlink()
+            elif resolved_path.is_dir():
+                shutil.rmtree(resolved_path)
+            else:
+                resolved_path.unlink()
+            return DeleteResult(path=file_path)
+        except (OSError, RuntimeError) as e:
+            return DeleteResult(error=f"Error deleting '{file_path}': {e}")
 
     def grep(
         self,

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -287,6 +287,23 @@ class EditResult:
 
 
 @dataclass
+class DeleteResult:
+    """Result from backend delete operations.
+
+    Attributes:
+        error: Error message on failure, None on success.
+        path: Absolute path of the deleted file, None on failure.
+
+    Examples:
+        >>> DeleteResult(path="/f.txt")
+        >>> DeleteResult(error="File not found")
+    """
+
+    error: str | None = None
+    path: str | None = None
+
+
+@dataclass
 class LsResult:
     """Result from backend `ls` operations.
 
@@ -602,6 +619,38 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         """Async version of edit."""
         return await asyncio.to_thread(self.edit, file_path, old_string, new_string, replace_all)
 
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a path, recursively removing anything nested under it.
+
+        This method is optional. Backends that do not implement it inherit this
+        default, which raises `NotImplementedError`. Callers that need to support
+        a mix of backends should guard with
+        [`supports_delete`][deepagents.backends.protocol.supports_delete] before
+        calling, or catch `NotImplementedError`.
+
+        Deletion is recursive: it removes `file_path` plus everything nested
+        under it. On hierarchical backends (e.g.
+        [`FilesystemBackend`][deepagents.backends.filesystem.FilesystemBackend])
+        that means a directory and its contents; on key-value backends it means
+        the exact key plus every key sharing the `file_path` + "/" prefix.
+
+        Args:
+            file_path: Absolute path to delete (a file, or a directory/prefix to
+                remove recursively). Must start with '/'.
+
+        Returns:
+            `DeleteResult` with the deleted path on success, or an error if
+                nothing exists at or under the path or removal fails.
+
+        Raises:
+            NotImplementedError: If the backend does not implement `delete`.
+        """
+        raise NotImplementedError
+
+    async def adelete(self, file_path: str) -> DeleteResult:
+        """Async version of `delete`."""
+        return await asyncio.to_thread(self.delete, file_path)
+
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
         """Upload multiple files to the sandbox.
 
@@ -879,6 +928,25 @@ def execute_accepts_timeout(cls: type[SandboxBackendProtocol]) -> bool:
         return False
     else:
         return "timeout" in sig.parameters
+
+
+def _supports_delete(backend: BackendProtocol) -> bool:
+    """Check whether a backend implements `delete`.
+
+    `delete` is optional: backends that don't override it inherit the
+    `NotImplementedError` default from
+    [`BackendProtocol`][deepagents.backends.protocol.BackendProtocol]. This
+    helper lets callers detect support without invoking the method (and
+    triggering the error), mirroring the override check used for the legacy
+    `ls_info`/`grep_raw`/`glob_info` methods.
+
+    Args:
+        backend: The backend instance to check.
+
+    Returns:
+        True if the backend overrides `delete`, False otherwise.
+    """
+    return type(backend).delete is not BackendProtocol.delete
 
 
 BackendFactory: TypeAlias = Callable[[ToolRuntime[Any, Any]], BackendProtocol]

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -561,10 +561,10 @@ class BackendProtocol(abc.ABC):  # noqa: B024
         file_path: str,
         content: str,
     ) -> WriteResult:
-        """Write content to a new file in the filesystem, error if file exists.
+        """Write content to a file, creating it or overwriting it if it already exists.
 
         Args:
-            file_path: Absolute path where the file should be created.
+            file_path: Absolute path where the file should be written.
 
                 Must start with '/'.
             content: String content to write to the file.

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -25,6 +25,7 @@ from typing import Final
 
 from deepagents.backends.protocol import (
     ASYNC_GREP_TIMEOUT,
+    DeleteResult,
     EditResult,
     ExecuteResponse,
     FileData,
@@ -933,6 +934,32 @@ class BaseSandbox(SandboxBackendProtocol, ABC):
             return _map_edit_error(data["error"], file_path, old_string)
 
         return EditResult(path=file_path, occurrences=data.get("count", 1))
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file or directory from the sandbox via a server-side ``rm``.
+
+        Uses ``rm -rf``, so directories are removed recursively along with their
+        contents, and deleting a path that does not exist succeeds silently. A
+        non-zero exit (e.g. a permission error) is reported as a failure.
+
+        Args:
+            file_path: Absolute path to the file or directory to delete.
+
+        Returns:
+            `DeleteResult` with the deleted path on success, or an error if the
+                deletion command fails.
+        """
+        # `shlex.quote` only neutralizes shell metacharacters so the path is
+        # passed to `rm` as a single literal argument. It is NOT a security
+        # boundary: it does not confine the deletion to any sandbox root or
+        # block traversal. Whatever the sandbox shell can reach, this can delete.
+        quoted = shlex.quote(file_path)
+        result = self.execute(f"rm -rf {quoted}")
+
+        if result.exit_code == 0:
+            return DeleteResult(path=file_path)
+
+        return DeleteResult(error=f"Error deleting file '{file_path}': {result.output.strip() or 'unknown error'}")
 
     def grep(
         self,

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -81,16 +81,12 @@ Uses base64-encoded parameters to avoid shell escaping issues.
 """
 
 _WRITE_CHECK_TEMPLATE = """python3 -c "
-import os, sys, base64
+import os, base64
 
 path = base64.b64decode('{path_b64}').decode('utf-8')
-if os.path.exists(path):
-    print('Error: File already exists: ' + repr(path))
-    sys.exit(1)
 os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
 " 2>&1"""
-"""Preflight check for write operations: verify the target file does not already
-exist and create parent directories.
+"""Preflight for write operations: create parent directories for the target path if it doesn't exist.
 
 Only the (small) base64-encoded path is interpolated — file content is
 transferred separately via `upload_files()`.
@@ -680,21 +676,20 @@ class BaseSandbox(SandboxBackendProtocol, ABC):
         return _parse_read_output(result.output, file_path)
 
     def _write_preflight(self, file_path: str) -> WriteResult | None:
-        """Run the existence check + parent-directory creation for `write()`.
+        """Create parent directories for `write()`.
 
         Subclasses overriding `write()` (e.g., to use a native SDK transport)
-        should call this first so they preserve the same "fail if file exists"
-        and parent-mkdir semantics as `BaseSandbox.write()`. There is a TOCTOU
-        window between this check and the actual write — an inherent limitation
-        of splitting the operation across two backend calls.
+        should call this first so they preserve the parent-mkdir semantics of
+        `BaseSandbox.write()`. There is a TOCTOU window between this and the
+        actual write — an inherent limitation of splitting the operation across
+        two backend calls.
 
         Args:
             file_path: Absolute path for the file about to be written.
 
         Returns:
-            `None` if the preflight passes (target does not exist, parents
-                created); a populated `WriteResult` with `error` set if the
-                check fails.
+            `None` if the preflight passes (parents created); a populated
+                `WriteResult` with `error` set if the preflight fails.
         """
         result = self.execute(_build_write_preflight_cmd(file_path))
         return _check_preflight_result(result, file_path)
@@ -709,10 +704,10 @@ class BaseSandbox(SandboxBackendProtocol, ABC):
         file_path: str,
         content: str,
     ) -> WriteResult:
-        """Create a new file, failing if it already exists.
+        """Write content to a file, creating or overwriting it if it already exists.
 
         Args:
-            file_path: Absolute path for the new file.
+            file_path: Absolute path for the file.
             content: UTF-8 text content to write.
 
         Returns:

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -252,16 +252,14 @@ class StateBackend(BackendProtocol):
         file_path: str,
         content: str,
     ) -> WriteResult:
-        """Create a new file with content.
+        """Write content to a file, creating it or overwriting it if it already exists.
 
         The update is queued directly via `CONFIG_KEY_SEND`.
         """
         files = self._read_files()
 
-        if file_path in files:
-            return WriteResult(error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path.")
-
-        new_file_data = create_file_data(content)
+        existing = files.get(file_path)
+        new_file_data = update_file_data(existing, content) if existing is not None else create_file_data(content)
         self._send_files_update({file_path: self._prepare_for_storage(new_file_data)})
         return WriteResult(path=file_path)
 

--- a/libs/deepagents/deepagents/backends/state.py
+++ b/libs/deepagents/deepagents/backends/state.py
@@ -10,6 +10,7 @@ from langgraph.config import get_config
 from deepagents._api.deprecation import warn_deprecated
 from deepagents.backends.protocol import (
     BackendProtocol,
+    DeleteResult,
     EditResult,
     FileData,
     FileDownloadResponse,
@@ -291,6 +292,32 @@ class StateBackend(BackendProtocol):
         new_file_data = update_file_data(file_data, new_content)
         self._send_files_update({file_path: self._prepare_for_storage(new_file_data)})
         return EditResult(path=file_path, occurrences=int(occurrences))
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file or directory from state.
+
+        Deleting a path removes the exact file at `file_path` plus every nested
+        key under it (the prefix `file_path` + "/"), so a directory is removed
+        recursively. Each removal is queued via `CONFIG_KEY_SEND` as a ``None``
+        value, which the `files` channel reducer interprets as a deletion marker.
+
+        Args:
+            file_path: Path of the file or directory to delete.
+
+        Returns:
+            `DeleteResult` with `file_path` on success, or an error if nothing is
+                stored at or under it.
+        """
+        files = self._read_files()
+
+        base = file_path.rstrip("/")
+        prefix = base + "/"
+        to_delete = [key for key in files if key == base or key.startswith(prefix)]
+        if not to_delete:
+            return DeleteResult(error=f"Error: File '{file_path}' not found")
+
+        self._send_files_update(dict.fromkeys(to_delete, None))
+        return DeleteResult(path=file_path)
 
     def grep(
         self,

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -8,12 +8,13 @@ from typing import TYPE_CHECKING, Any, Generic, cast
 
 from langgraph.config import get_config, get_store
 from langgraph.runtime import get_runtime
-from langgraph.store.base import BaseStore, Item
+from langgraph.store.base import BaseStore, Item, PutOp
 from langgraph.typing import ContextT, StateT
 
 from deepagents._api.deprecation import deprecated, warn_deprecated
 from deepagents.backends.protocol import (
     BackendProtocol,
+    DeleteResult,
     EditResult,
     FileData,
     FileDownloadResponse,
@@ -422,6 +423,35 @@ class StoreBackend(BackendProtocol):
 
         return all_items
 
+    async def _asearch_store_paginated(
+        self,
+        store: BaseStore,
+        namespace: tuple[str, ...],
+        *,
+        query: str | None = None,
+        filter: dict[str, Any] | None = None,  # noqa: A002  # Matches LangGraph BaseStore.asearch() API
+        page_size: int = 100,
+    ) -> list[Item]:
+        """Async version of `_search_store_paginated`."""
+        all_items: list[Item] = []
+        offset = 0
+        while True:
+            page_items = await store.asearch(
+                namespace,
+                query=query,
+                filter=filter,
+                limit=page_size,
+                offset=offset,
+            )
+            if not page_items:
+                break
+            all_items.extend(page_items)
+            if len(page_items) < page_size:
+                break
+            offset += page_size
+
+        return all_items
+
     def ls(self, path: str) -> LsResult:
         """List files and directories in the specified directory (non-recursive).
 
@@ -689,6 +719,49 @@ class StoreBackend(BackendProtocol):
         store_value = self._convert_file_data_to_store_value(new_file_data)
         await store.aput(namespace, file_path, store_value)
         return EditResult(path=file_path, occurrences=int(occurrences))
+
+    def delete(self, file_path: str) -> DeleteResult:
+        """Delete a file or directory from the store.
+
+        Deleting a path removes the exact key `file_path` plus every key nested
+        under it (the prefix `file_path` + "/"), so a directory is removed
+        recursively. Wildcards (e.g. `*`) in `file_path` are treated literally.
+
+        Args:
+            file_path: Path of the file or directory to delete.
+
+        Returns:
+            `DeleteResult` with `file_path` on success, or an error if no key is
+                stored at or under it.
+        """
+        store = self._get_store()
+        namespace = self._get_namespace()
+
+        items = self._search_store_paginated(store, namespace)
+        # A recursive delete removes the exact key plus everything nested under it.
+        base = file_path.rstrip("/")
+        prefix = base + "/"
+        to_delete = [key for item in items if (key := str(item.key)) == base or key.startswith(prefix)]
+        if not to_delete:
+            return DeleteResult(error=f"Error: File '{file_path}' not found")
+
+        store.batch([PutOp(namespace, key, None) for key in to_delete])
+        return DeleteResult(path=file_path)
+
+    async def adelete(self, file_path: str) -> DeleteResult:
+        """Async version of `delete` using native store async methods."""
+        store = self._get_store()
+        namespace = self._get_namespace()
+
+        items = await self._asearch_store_paginated(store, namespace)
+        base = file_path.rstrip("/")
+        prefix = base + "/"
+        to_delete = [key for item in items if (key := str(item.key)) == base or key.startswith(prefix)]
+        if not to_delete:
+            return DeleteResult(error=f"Error: File '{file_path}' not found")
+
+        await store.abatch([PutOp(namespace, key, None) for key in to_delete])
+        return DeleteResult(path=file_path)
 
     # Removed legacy grep() convenience to keep lean surface
 

--- a/libs/deepagents/deepagents/backends/store.py
+++ b/libs/deepagents/deepagents/backends/store.py
@@ -603,20 +603,19 @@ class StoreBackend(BackendProtocol):
         file_path: str,
         content: str,
     ) -> WriteResult:
-        """Create a new file with content.
+        """Write content to a file, creating it or overwriting it if it already exists.
 
         Returns `WriteResult` on success or error.
         """
         store = self._get_store()
         namespace = self._get_namespace()
 
-        # Check if file exists
         existing = store.get(namespace, file_path)
         if existing is not None:
-            return WriteResult(error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path.")
-
-        # Create new file
-        file_data = create_file_data(content)
+            existing_file_data = self._convert_store_item_to_file_data(existing)
+            file_data = update_file_data(existing_file_data, content)
+        else:
+            file_data = create_file_data(content)
         store_value = self._convert_file_data_to_store_value(file_data)
         store.put(namespace, file_path, store_value)
         return WriteResult(path=file_path)
@@ -633,13 +632,12 @@ class StoreBackend(BackendProtocol):
         store = self._get_store()
         namespace = self._get_namespace()
 
-        # Check if file exists using async method
         existing = await store.aget(namespace, file_path)
         if existing is not None:
-            return WriteResult(error=f"Cannot write to {file_path} because it already exists. Read and then make an edit, or write to a new path.")
-
-        # Create new file using async method
-        file_data = create_file_data(content)
+            existing_file_data = self._convert_store_item_to_file_data(existing)
+            file_data = update_file_data(existing_file_data, content)
+        else:
+            file_data = create_file_data(content)
         store_value = self._convert_file_data_to_store_value(file_data)
         await store.aput(namespace, file_path, store_value)
         return WriteResult(path=file_path)

--- a/libs/deepagents/deepagents/middleware/_fs_interrupt.py
+++ b/libs/deepagents/deepagents/middleware/_fs_interrupt.py
@@ -40,6 +40,7 @@ _FS_TOOL_PATH_ARGS: dict[str, tuple[FilesystemOperation, str, ToolScope, str | N
     "read_file": ("read", "file_path", "exact", None),
     "write_file": ("write", "file_path", "exact", None),
     "edit_file": ("write", "file_path", "exact", None),
+    "delete": ("write", "file_path", "bulk", None),
     "glob": ("read", "path", "bulk", "pattern"),
     "grep": ("read", "path", "bulk", None),
 }

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -42,6 +42,7 @@ from deepagents.backends import CompositeBackend, FilesystemBackend, LocalShellB
 from deepagents.backends.protocol import (
     BACKEND_TYPES as BACKEND_TYPES,  # Re-export type here for backwards compatibility
     BackendProtocol,
+    DeleteResult,
     EditResult,
     FileData as FileData,  # Re-export for backwards compatibility
     FileInfo,
@@ -52,10 +53,13 @@ from deepagents.backends.protocol import (
     SandboxBackendProtocol,
     WriteResult,
     _resolve_backend,
+    _supports_delete,
     execute_accepts_timeout,
 )
 from deepagents.backends.utils import (
     _get_file_type,
+    _glob_anchor,
+    _paths_overlap,
     check_empty_content,
     format_content_with_line_numbers,
     format_grep_matches,
@@ -84,6 +88,7 @@ _DEFAULT_FS_TOOL_OPS: dict[str, FilesystemOperation] = {
     "grep": "read",
     "write_file": "write",
     "edit_file": "write",
+    "delete": "write",
 }
 
 
@@ -135,6 +140,32 @@ def _check_fs_permission(
         if any(wcglob.globmatch(path, pattern, flags=_FS_WCMATCH_FLAGS) for pattern in rule.paths):
             return rule.mode
     return "allow"
+
+
+def _find_delete_deny_patterns(rules: list[FilesystemPermission], target: str) -> list[str]:
+    """Return deny-write patterns that block deleting `target`.
+
+    A recursive delete removes `target` and all descendants, so any overlapping
+    deny-write pattern prevents the operation. The check is based only on
+    permission rules and returns all matching patterns.
+
+    Args:
+        rules: Filesystem permission rules.
+        target: Absolute, validated path being deleted.
+
+    Returns:
+        Matching deny-write patterns, or an empty list if the delete is allowed.
+    """
+    denying: list[str] = []
+    seen: set[str] = set()
+    for rule in rules:
+        if rule.mode != "deny" or "write" not in rule.operations:
+            continue
+        for pattern in rule.paths:
+            if pattern not in seen and _paths_overlap(target, _glob_anchor(pattern)):
+                seen.add(pattern)
+                denying.append(pattern)
+    return denying
 
 
 def _filter_paths_by_permission(
@@ -388,6 +419,12 @@ class EditFileSchema(BaseModel):
     )
 
 
+class DeleteSchema(BaseModel):
+    """Input schema for the `delete` tool."""
+
+    file_path: str = Field(description="Absolute path to the file to delete. Must be absolute, not relative.")
+
+
 class GlobSchema(BaseModel):
     """Input schema for the `glob` tool."""
 
@@ -467,6 +504,15 @@ Usage:
 - Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.
 """
 
+DELETE_TOOL_DESCRIPTION = """Deletes a file or directory from the filesystem.
+
+Usage:
+- Permanently removes the file or directory at the given absolute path.
+- Deleting a directory removes it and everything inside it, recursively. Prefer
+  deleting a directory in one call over deleting each file individually.
+- This cannot be undone, so only delete paths you are sure are no longer needed.
+"""
+
 GLOB_TOOL_DESCRIPTION = """Find files matching a glob pattern.
 
 Supports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).
@@ -538,7 +584,7 @@ _FILESYSTEM_SYSTEM_PROMPT_TEMPLATE = """## Following Conventions
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -547,6 +593,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 
@@ -707,6 +754,7 @@ TOOLS_EXCLUDED_FROM_EVICTION = (
     "read_file",
     "edit_file",
     "write_file",
+    "delete",
 )
 
 
@@ -913,6 +961,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             self._create_read_file_tool(),
             self._create_write_file_tool(),
             self._create_edit_file_tool(),
+            self._create_delete_tool(),
             self._create_glob_tool(),
             self._create_grep_tool(),
             self._create_execute_tool(),
@@ -1406,6 +1455,97 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=EditFileSchema,
         )
 
+    def _create_delete_tool(self) -> BaseTool:  # Tool wiring + permission/support handling
+        """Create the delete tool."""
+        tool_description = self._custom_tool_descriptions.get("delete") or DELETE_TOOL_DESCRIPTION
+
+        def sync_delete(
+            file_path: Annotated[str, "Absolute path to the file to delete. Must be absolute, not relative."],
+            runtime: ToolRuntime[None, FilesystemState],
+        ) -> ToolMessage:
+            """Synchronous wrapper for delete tool."""
+            resolved_backend = self._get_backend(runtime)
+            try:
+                validated_path = validate_path(file_path)
+            except ValueError as e:
+                return ToolMessage(
+                    content=f"Error: {e}",
+                    name="delete",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+
+            denying_patterns = _find_delete_deny_patterns(self._permissions, validated_path)
+            if denying_patterns:
+                return ToolMessage(
+                    content=f"Error: permission denied for write on {validated_path} (matches deny rule(s): {', '.join(denying_patterns)})",
+                    name="delete",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            res: DeleteResult = resolved_backend.delete(validated_path)
+            if res.error:
+                return ToolMessage(
+                    content=res.error,
+                    name="delete",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            return ToolMessage(
+                content=f"Deleted {res.path}",
+                name="delete",
+                tool_call_id=runtime.tool_call_id,
+                status="success",
+            )
+
+        async def async_delete(
+            file_path: Annotated[str, "Absolute path to the file to delete. Must be absolute, not relative."],
+            runtime: ToolRuntime[None, FilesystemState],
+        ) -> ToolMessage:
+            """Asynchronous wrapper for delete tool."""
+            resolved_backend = self._get_backend(runtime)
+            try:
+                validated_path = validate_path(file_path)
+            except ValueError as e:
+                return ToolMessage(
+                    content=f"Error: {e}",
+                    name="delete",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+
+            denying_patterns = _find_delete_deny_patterns(self._permissions, validated_path)
+            if denying_patterns:
+                return ToolMessage(
+                    content=f"Error: permission denied for write on {validated_path} (matches deny rule(s): {', '.join(denying_patterns)})",
+                    name="delete",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            res: DeleteResult = await resolved_backend.adelete(validated_path)
+            if res.error:
+                return ToolMessage(
+                    content=res.error,
+                    name="delete",
+                    tool_call_id=runtime.tool_call_id,
+                    status="error",
+                )
+            return ToolMessage(
+                content=f"Deleted {res.path}",
+                name="delete",
+                tool_call_id=runtime.tool_call_id,
+                status="success",
+            )
+
+        return StructuredTool.from_function(
+            name="delete",
+            description=tool_description,
+            func=sync_delete,
+            coroutine=async_delete,
+            infer_schema=False,
+            args_schema=DeleteSchema,
+        )
+
     def _create_glob_tool(self) -> BaseTool:  # noqa: C901, PLR0915  # Tool wiring + permission/result shaping + timeout handling
         """Create the glob tool."""
         tool_description = self._custom_tool_descriptions.get("glob") or GLOB_TOOL_DESCRIPTION
@@ -1868,6 +2008,64 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             args_schema=ExecuteSchema,
         )
 
+    def _filter_unsupported_tools_and_apply_prompt(self, request: ModelRequest[ContextT]) -> ModelRequest[ContextT]:
+        """Drop capability-gated tools the backend can't serve, then apply the system prompt.
+
+        Shared by the sync and async `wrap_model_call` paths (the only part that
+        differs between them is sync vs. async message eviction). The `execute`
+        and `delete` tools are optional per backend, so when the resolved
+        backend doesn't support a capability the corresponding tool is filtered
+        out of the request rather than advertised to the model and left to fail
+        at call time. Resolving the backend and probing support is synchronous,
+        so both paths route through here.
+
+        Returns the request with unsupported tools removed and the filesystem
+        system prompt appended.
+        """
+        tool_names = {(tool.name if hasattr(tool, "name") else tool.get("name")) for tool in request.tools}
+        has_execute_tool = "execute" in tool_names
+        has_delete_tool = "delete" in tool_names
+
+        # `execute` and `delete` are optional per backend; resolve the
+        # backend once and filter out any tool the backend can't serve.
+        if has_execute_tool or has_delete_tool:
+            backend = self._get_backend(request.runtime)  # ty: ignore[invalid-argument-type]
+            unsupported: set[str | None] = set()
+            if has_execute_tool and not supports_execution(backend):
+                unsupported.add("execute")
+                has_execute_tool = False
+            if has_delete_tool and not _supports_delete(backend):
+                unsupported.add("delete")
+            if unsupported:
+                filtered_tools = [tool for tool in request.tools if (tool.name if hasattr(tool, "name") else tool.get("name")) not in unsupported]
+                request = request.override(tools=filtered_tools)
+
+        # Use custom system prompt if provided, otherwise generate dynamically
+        if self._custom_system_prompt is not None:
+            system_prompt = self._custom_system_prompt
+        else:
+            # Build dynamic system prompt based on available tools
+            prompt_parts = [
+                _FILESYSTEM_SYSTEM_PROMPT_TEMPLATE.format(
+                    large_tool_results_prefix=self._large_tool_results_prefix,
+                )
+            ]
+
+            # Add execution instructions only if the execute tool survived filtering
+            if has_execute_tool:
+                prompt_parts.append(EXECUTION_SYSTEM_PROMPT)
+                route_prompt = _route_host_path_prompt(backend)
+                if route_prompt:
+                    prompt_parts.append(route_prompt)
+
+            system_prompt = "\n\n".join(prompt_parts).strip()
+
+        if system_prompt:
+            new_system_message = append_to_system_message(request.system_message, system_prompt)
+            request = request.override(system_message=new_system_message)
+
+        return request
+
     def wrap_model_call(
         self,
         request: ModelRequest[ContextT],
@@ -1893,44 +2091,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             The model response, or an `ExtendedModelResponse` with a state
                 update tagging a newly evicted message.
         """
-        # Check if execute tool is present and if backend supports it
-        has_execute_tool = any((tool.name if hasattr(tool, "name") else tool.get("name")) == "execute" for tool in request.tools)
-
-        backend_supports_execution = False
-        if has_execute_tool:
-            # Resolve backend to check execution support
-            backend = self._get_backend(request.runtime)  # ty: ignore[invalid-argument-type]
-            backend_supports_execution = supports_execution(backend)
-
-            # If execute tool exists but backend doesn't support it, filter it out
-            if not backend_supports_execution:
-                filtered_tools = [tool for tool in request.tools if (tool.name if hasattr(tool, "name") else tool.get("name")) != "execute"]
-                request = request.override(tools=filtered_tools)
-                has_execute_tool = False
-
-        # Use custom system prompt if provided, otherwise generate dynamically
-        if self._custom_system_prompt is not None:
-            system_prompt = self._custom_system_prompt
-        else:
-            # Build dynamic system prompt based on available tools
-            prompt_parts = [
-                _FILESYSTEM_SYSTEM_PROMPT_TEMPLATE.format(
-                    large_tool_results_prefix=self._large_tool_results_prefix,
-                )
-            ]
-
-            # Add execution instructions if execute tool is available
-            if has_execute_tool and backend_supports_execution:
-                prompt_parts.append(EXECUTION_SYSTEM_PROMPT)
-                route_prompt = _route_host_path_prompt(backend)
-                if route_prompt:
-                    prompt_parts.append(route_prompt)
-
-            system_prompt = "\n\n".join(prompt_parts).strip()
-
-        if system_prompt:
-            new_system_message = append_to_system_message(request.system_message, system_prompt)
-            request = request.override(system_message=new_system_message)
+        request = self._filter_unsupported_tools_and_apply_prompt(request)
 
         eviction_result = self._evict_and_truncate_messages(request)
         if eviction_result is not None:
@@ -1961,44 +2122,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             The model response from the handler, or an `ExtendedModelResponse`
                 with a state update tagging newly evicted messages.
         """
-        # Check if execute tool is present and if backend supports it
-        has_execute_tool = any((tool.name if hasattr(tool, "name") else tool.get("name")) == "execute" for tool in request.tools)
-
-        backend_supports_execution = False
-        if has_execute_tool:
-            # Resolve backend to check execution support
-            backend = self._get_backend(request.runtime)  # ty: ignore[invalid-argument-type]
-            backend_supports_execution = supports_execution(backend)
-
-            # If execute tool exists but backend doesn't support it, filter it out
-            if not backend_supports_execution:
-                filtered_tools = [tool for tool in request.tools if (tool.name if hasattr(tool, "name") else tool.get("name")) != "execute"]
-                request = request.override(tools=filtered_tools)
-                has_execute_tool = False
-
-        # Use custom system prompt if provided, otherwise generate dynamically
-        if self._custom_system_prompt is not None:
-            system_prompt = self._custom_system_prompt
-        else:
-            # Build dynamic system prompt based on available tools
-            prompt_parts = [
-                _FILESYSTEM_SYSTEM_PROMPT_TEMPLATE.format(
-                    large_tool_results_prefix=self._large_tool_results_prefix,
-                )
-            ]
-
-            # Add execution instructions if execute tool is available
-            if has_execute_tool and backend_supports_execution:
-                prompt_parts.append(EXECUTION_SYSTEM_PROMPT)
-                route_prompt = _route_host_path_prompt(backend)
-                if route_prompt:
-                    prompt_parts.append(route_prompt)
-
-            system_prompt = "\n\n".join(prompt_parts).strip()
-
-        if system_prompt:
-            new_system_message = append_to_system_message(request.system_message, system_prompt)
-            request = request.override(system_message=new_system_message)
+        request = self._filter_unsupported_tools_and_apply_prompt(request)
 
         eviction_result = await self._aevict_and_truncate_messages(request)
         if eviction_result is not None:

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -234,6 +234,13 @@ def _apply_permissions_to_glob_results(
     return [fi.get("path", "") for fi in filtered_infos]
 
 
+def _format_file_paths(paths: list[str]) -> str:
+    """Format filesystem path lists for tool output."""
+    if not paths:
+        return "No files found"
+    return str(truncate_if_too_long(paths))
+
+
 EMPTY_CONTENT_WARNING = "System reminder: File exists but has empty contents"
 GLOB_TIMEOUT = 20.0  # seconds
 LINE_NUMBER_WIDTH = 6
@@ -991,7 +998,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             infos = ls_result.entries or []
             paths = _apply_permissions_to_ls_results(self._permissions, infos)
             return ToolMessage(
-                content=str(truncate_if_too_long(paths)),
+                content=_format_file_paths(paths),
                 tool_call_id=runtime.tool_call_id,
                 name="ls",
                 status="success",
@@ -1030,7 +1037,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             infos = ls_result.entries or []
             paths = _apply_permissions_to_ls_results(self._permissions, infos)
             return ToolMessage(
-                content=str(truncate_if_too_long(paths)),
+                content=_format_file_paths(paths),
                 tool_call_id=runtime.tool_call_id,
                 name="ls",
                 status="success",
@@ -1493,7 +1500,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             infos = glob_result.matches or []
             paths = _apply_permissions_to_glob_results(self._permissions, infos)
             return ToolMessage(
-                content=str(truncate_if_too_long(paths)),
+                content=_format_file_paths(paths),
                 tool_call_id=runtime.tool_call_id,
                 name="glob",
                 status="success",
@@ -1557,7 +1564,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             infos = glob_result.matches or []
             paths = _apply_permissions_to_glob_results(self._permissions, infos)
             return ToolMessage(
-                content=str(truncate_if_too_long(paths)),
+                content=_format_file_paths(paths),
                 tool_call_id=runtime.tool_call_id,
                 name="glob",
                 status="success",

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -399,7 +399,7 @@ class ReadFileSchema(BaseModel):
 class WriteFileSchema(BaseModel):
     """Input schema for the `write_file` tool."""
 
-    file_path: str = Field(description="Absolute path where the file should be created. Must be absolute, not relative.")
+    file_path: str = Field(description="Absolute path where the file should be written. Must be absolute, not relative.")
 
     content: str = Field(description="The text content to write to the file. This parameter is required.")
 
@@ -497,10 +497,10 @@ Usage:
 - Only use emojis if the user explicitly requests it."""
 
 
-WRITE_FILE_TOOL_DESCRIPTION = """Writes to a new file in the filesystem.
+WRITE_FILE_TOOL_DESCRIPTION = """Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.
 
 Usage:
-- The write_file tool will create the a new file.
+- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.
 - Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.
 """
 
@@ -1272,7 +1272,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
         tool_description = self._custom_tool_descriptions.get("write_file") or WRITE_FILE_TOOL_DESCRIPTION
 
         def sync_write_file(
-            file_path: Annotated[str, "Absolute path where the file should be created. Must be absolute, not relative."],
+            file_path: Annotated[str, "Absolute path where the file should be written. Must be absolute, not relative."],
             content: Annotated[str, "The text content to write to the file. This parameter is required."],
             runtime: ToolRuntime[None, FilesystemState],
         ) -> ToolMessage:
@@ -1311,7 +1311,7 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             )
 
         async def async_write_file(
-            file_path: Annotated[str, "Absolute path where the file should be created. Must be absolute, not relative."],
+            file_path: Annotated[str, "Absolute path where the file should be written. Must be absolute, not relative."],
             content: Annotated[str, "The text content to write to the file. This parameter is required."],
             runtime: ToolRuntime[None, FilesystemState],
         ) -> ToolMessage:

--- a/libs/deepagents/tests/integration_tests/test_filesystem_middleware.py
+++ b/libs/deepagents/tests/integration_tests/test_filesystem_middleware.py
@@ -346,7 +346,7 @@ class TestFilesystem:
         assert isinstance(content, str), f"Expected str content, got {type(content)}"
         assert "fiery" in content or "Fiery" in content
 
-    def test_write_file_fail_already_exists_in_local(self):
+    def test_write_file_overwrites_existing_in_local(self):
         checkpointer = MemorySaver()
         store = InMemoryStore()
         agent = create_agent(
@@ -376,7 +376,8 @@ class TestFilesystem:
         messages = response["messages"]
         write_file_message = next(message for message in messages if message.type == "tool" and message.name == "write_file")
         assert write_file_message is not None
-        assert "Cannot write" in write_file_message.content
+        assert write_file_message.status == "success"
+        assert "fiery" in response["files"]["/charmander.txt"]["content"].lower() or "Fiery" in response["files"]["/charmander.txt"]["content"]
 
     def test_edit_file_longterm(self):
         checkpointer = MemorySaver()

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -8,6 +8,7 @@ from langgraph.store.memory import InMemoryStore
 from deepagents.backends.composite import CompositeBackend, _route_for_path
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import (
+    BackendProtocol,
     ExecuteResponse,
     SandboxBackendProtocol,
     WriteResult,
@@ -1403,3 +1404,115 @@ def test_edit_result_path_restored_to_full_routed_path():
 
     assert res.error is None
     assert res.path == "/memories/notes.md"  # not "/notes.md"
+
+
+def test_composite_delete_routes_to_correct_backend() -> None:
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/memories/": StoreBackend(store=mem_store, namespace=lambda _rt: ("memories",))},
+    )
+
+    be.write("/file.txt", "alpha")
+    be.write("/memories/note.txt", "beta")
+
+    # delete default-routed file; path is remapped back to the original
+    res_default = be.delete("/file.txt")
+    assert res_default.error is None
+    assert res_default.path == "/file.txt"
+    assert be.read("/file.txt").error is not None
+
+    # delete route-routed file
+    res_route = be.delete("/memories/note.txt")
+    assert res_route.error is None
+    assert res_route.path == "/memories/note.txt"
+    assert be.read("/memories/note.txt").error is not None
+
+
+def test_composite_delete_directory_recurses_within_route() -> None:
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/memories/": StoreBackend(store=mem_store, namespace=lambda _rt: ("memories",))},
+    )
+
+    be.write("/memories/proj/a.txt", "a")
+    be.write("/memories/proj/sub/b.txt", "b")
+    be.write("/memories/keep.txt", "k")
+
+    # Deleting a directory inside a route removes the whole subtree there,
+    # remapped back to the original path, while siblings survive.
+    res = be.delete("/memories/proj")
+    assert res.error is None
+    assert res.path == "/memories/proj"
+    assert be.read("/memories/proj/a.txt").error is not None
+    assert be.read("/memories/proj/sub/b.txt").error is not None
+    assert be.read("/memories/keep.txt").error is None
+
+
+def test_composite_delete_missing_returns_error() -> None:
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/memories/": StoreBackend(store=mem_store, namespace=lambda _rt: ("memories",))},
+    )
+    result = be.delete("/memories/ghost.txt")
+    assert result.path is None
+    assert result.error is not None and "not found" in result.error
+
+
+async def test_composite_adelete_routes_to_correct_backend() -> None:
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/memories/": StoreBackend(store=mem_store, namespace=lambda _rt: ("memories",))},
+    )
+    await be.awrite("/memories/note.txt", "beta")
+    res = await be.adelete("/memories/note.txt")
+    assert res.error is None
+    assert res.path == "/memories/note.txt"
+    assert (await be.aread("/memories/note.txt")).error is not None
+
+
+async def test_composite_adelete_missing_returns_error() -> None:
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/memories/": StoreBackend(store=mem_store, namespace=lambda _rt: ("memories",))},
+    )
+    result = await be.adelete("/memories/ghost.txt")
+    assert result.path is None
+    assert result.error is not None and "not found" in result.error
+
+
+class _NoDeleteStore(StoreBackend):
+    """StoreBackend variant that opts out of delete (inherits protocol default)."""
+
+    delete = BackendProtocol.delete
+    adelete = BackendProtocol.adelete
+
+
+def test_composite_delete_unsupported_route_returns_error() -> None:
+    """A route to a backend without delete yields an error, not a raise."""
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/nodelete/": _NoDeleteStore(store=mem_store, namespace=lambda _rt: ("nodelete",))},
+    )
+    result = be.delete("/nodelete/x.txt")
+    assert result.path is None
+    assert result.error is not None
+    assert "not supported" in result.error
+
+
+async def test_composite_adelete_unsupported_route_returns_error() -> None:
+    """The async route to a backend without delete yields an error, not a raise."""
+    mem_store = InMemoryStore()
+    be = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/nodelete/": _NoDeleteStore(store=mem_store, namespace=lambda _rt: ("nodelete",))},
+    )
+    result = await be.adelete("/nodelete/x.txt")
+    assert result.path is None
+    assert result.error is not None
+    assert "not supported" in result.error

--- a/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_context_hub_backend.py
@@ -578,3 +578,95 @@ def test_composite_backend_routes_prefix_correctly(tmp_path: Path) -> None:
     glob_mem = composite.glob("*.md", path="/memories")
     assert glob_mem.matches is not None
     assert any(m["path"] == "/memories/notes.md" for m in glob_mem.matches)
+
+
+def test_delete_commits_none_entry() -> None:
+    backend, mock_client = _make_backend(**{"a.md": FileEntry(type="file", content="bye")})
+    result = backend.delete("/a.md")
+
+    assert result.error is None
+    assert result.path == "/a.md"
+    mock_client.push_agent.assert_called_once()
+    call = mock_client.push_agent.call_args
+    files_arg = call.kwargs["files"]
+    # A None entry is the deletion marker.
+    assert "a.md" in files_arg
+    assert files_arg["a.md"] is None
+    assert call.kwargs["parent_commit"] == _COMMIT_HASH
+
+
+def test_delete_directory_commits_all_nested_entries() -> None:
+    backend, mock_client = _make_backend(
+        **{
+            "work/a.md": FileEntry(type="file", content="a"),
+            "work/sub/b.md": FileEntry(type="file", content="b"),
+            "keep.md": FileEntry(type="file", content="k"),
+        }
+    )
+    result = backend.delete("/work")
+
+    assert result.error is None
+    assert result.path == "/work"
+    files_arg = mock_client.push_agent.call_args.kwargs["files"]
+    # Every nested entry under /work is marked for deletion...
+    assert files_arg["work/a.md"] is None
+    assert files_arg["work/sub/b.md"] is None
+    # ...and the sibling outside the subtree is left alone.
+    assert "keep.md" not in files_arg
+
+
+def test_delete_missing_returns_not_found() -> None:
+    backend, mock_client = _make_backend()
+    result = backend.delete("/ghost.md")
+
+    assert result.path is None
+    assert result.error is not None
+    assert "not found" in result.error
+    mock_client.push_agent.assert_not_called()
+
+
+def test_delete_updates_cache_after_commit() -> None:
+    backend, _ = _make_backend(**{"a.md": FileEntry(type="file", content="bye")})
+    assert backend.read("/a.md").error is None
+
+    backend.delete("/a.md")
+
+    # File is gone from the cache; no re-pull needed.
+    assert backend.read("/a.md").error is not None
+
+
+def test_delete_failure_invalidates_cache() -> None:
+    backend, mock_client = _make_backend(**{"a.md": FileEntry(type="file", content="a")})
+    mock_client.push_agent.side_effect = LangSmithAPIError("500")
+
+    result = backend.delete("/a.md")
+    assert result.error is not None
+    assert "Hub unavailable" in result.error
+
+    backend.read("/a.md")
+    assert mock_client.pull_agent.call_count == 2
+
+
+async def test_adelete_commits_none_entry() -> None:
+    """Async delete (protocol default `asyncio.to_thread`) behaves like sync."""
+    backend, mock_client = _make_backend(**{"a.md": FileEntry(type="file", content="bye")})
+    result = await backend.adelete("/a.md")
+
+    assert result.error is None
+    assert result.path == "/a.md"
+    mock_client.push_agent.assert_called_once()
+    files_arg = mock_client.push_agent.call_args.kwargs["files"]
+    # A None entry is the deletion marker, same as the sync path.
+    assert files_arg["a.md"] is None
+    # Cache was updated, so a follow-up read finds the file gone without re-pulling.
+    assert backend.read("/a.md").error is not None
+
+
+async def test_adelete_missing_returns_not_found() -> None:
+    backend, mock_client = _make_backend()
+    result = await backend.adelete("/ghost.md")
+
+    assert result.path is None
+    assert result.error is not None
+    assert "not found" in result.error
+    mock_client.push_agent.assert_not_called()

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -13,7 +13,7 @@ from langchain_core.messages import ToolMessage
 from deepagents._api.deprecation import LangChainDeprecationWarning
 from deepagents.backends import filesystem as fs_module
 from deepagents.backends.filesystem import FilesystemBackend
-from deepagents.backends.protocol import EditResult, ReadResult, WriteResult
+from deepagents.backends.protocol import DeleteResult, EditResult, ReadResult, WriteResult
 from deepagents.middleware.filesystem import FilesystemMiddleware
 
 
@@ -1622,3 +1622,119 @@ class TestReadTrailingNewlineRoundtrip:
         assert result.error is not None
         assert "old_string ends with a newline" in result.error
         assert target.read_text() == "# Agent Role:\nyou are an assistant"
+
+
+class TestFilesystemDelete:
+    """Tests for FilesystemBackend.delete."""
+
+    def test_delete_existing_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "a.txt"
+        write_file(f, "hello")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        result = be.delete("/a.txt")
+        assert isinstance(result, DeleteResult)
+        assert result.error is None
+        assert result.path == "/a.txt"
+        assert not f.exists()
+
+    def test_delete_missing_file_returns_error(self, tmp_path: Path) -> None:
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        result = be.delete("/missing.txt")
+        assert result.path is None
+        assert result.error is not None
+        assert "not found" in result.error
+
+    def test_delete_empty_directory(self, tmp_path: Path) -> None:
+        (tmp_path / "sub").mkdir()
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        result = be.delete("/sub")
+        assert result.error is None
+        assert result.path == "/sub"
+        assert not (tmp_path / "sub").exists()
+
+    def test_delete_directory_recursively(self, tmp_path: Path) -> None:
+        # A directory is removed along with all of its nested contents.
+        sub = tmp_path / "sub"
+        (sub / "deep").mkdir(parents=True)
+        write_file(sub / "b.txt", "b")
+        write_file(sub / "deep" / "d.txt", "d")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        result = be.delete("/sub")
+        assert result.error is None
+        assert result.path == "/sub"
+        assert not sub.exists()
+
+    def test_delete_directory_leaves_siblings(self, tmp_path: Path) -> None:
+        (tmp_path / "sub").mkdir()
+        write_file(tmp_path / "sub" / "b.txt", "b")
+        write_file(tmp_path / "keep.txt", "keep")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        assert be.delete("/sub").error is None
+        assert not (tmp_path / "sub").exists()
+        assert (tmp_path / "keep.txt").exists()
+
+    def test_delete_symlink_to_dir_does_not_follow(self, tmp_path: Path) -> None:
+        # Deleting a symlink that points at a directory removes only the link;
+        target = tmp_path / "target"
+        target.mkdir()
+        write_file(target / "keep.txt", "keep")
+        link = tmp_path / "link"
+        link.symlink_to(target, target_is_directory=True)
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+        result = be.delete(str(link))
+        assert result.error is None
+        assert not link.exists()
+        assert target.exists()
+        assert (target / "keep.txt").exists()
+
+    def test_delete_only_removes_target(self, tmp_path: Path) -> None:
+        write_file(tmp_path / "keep.txt", "keep")
+        write_file(tmp_path / "drop.txt", "drop")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        assert be.delete("/drop.txt").error is None
+        assert not (tmp_path / "drop.txt").exists()
+        assert (tmp_path / "keep.txt").exists()
+
+    async def test_adelete_existing_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "a.txt"
+        write_file(f, "hello")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        result = await be.adelete("/a.txt")
+        assert result.error is None
+        assert result.path == "/a.txt"
+        assert not f.exists()
+
+    def test_delete_resolve_failure_returns_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A failure resolving the path surfaces as a deletion error, not a raise.
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        def _boom(_path: str) -> Path:
+            raise OSError
+
+        monkeypatch.setattr(be, "_resolve_path", _boom)
+        result = be.delete("/a.txt")
+        assert result.path is None
+        assert result.error is not None
+        assert "Error deleting" in result.error
+
+    def test_delete_unlink_failure_returns_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An OSError from unlink (e.g. permission denied) is reported, file kept.
+        f = tmp_path / "a.txt"
+        write_file(f, "hello")
+        be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+        def _boom(_self: Path, *_args: object, **_kwargs: object) -> None:
+            raise OSError
+
+        monkeypatch.setattr(Path, "unlink", _boom)
+        result = be.delete("/a.txt")
+        assert result.path is None
+        assert result.error is not None
+        assert "Error deleting" in result.error
+        assert f.exists()

--- a/libs/deepagents/tests/unit_tests/backends/test_protocol.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_protocol.py
@@ -16,10 +16,12 @@ from deepagents.backends.protocol import (
     ASYNC_GREP_TIMEOUT,
     DEFAULT_GREP_TIMEOUT,
     BackendProtocol,
+    DeleteResult,
     GlobResult,
     GrepResult,
     LsResult,
     SandboxBackendProtocol,
+    _supports_delete,
 )
 
 
@@ -68,6 +70,10 @@ class TestBackendProtocolRaisesNotImplemented:
         with pytest.raises(NotImplementedError):
             backend.edit("/file.txt", "old", "new")
 
+    def test_delete(self, backend: BareBackend) -> None:
+        with pytest.raises(NotImplementedError):
+            backend.delete("/file.txt")
+
     def test_upload_files(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):
             backend.upload_files([("/file.txt", b"data")])
@@ -111,6 +117,24 @@ class TestAsyncMethodsPropagateNotImplemented:
     async def test_aedit(self, backend: BareBackend) -> None:
         with pytest.raises(NotImplementedError):
             await backend.aedit("/file.txt", "old", "new")
+
+    async def test_adelete(self, backend: BareBackend) -> None:
+        with pytest.raises(NotImplementedError):
+            await backend.adelete("/file.txt")
+
+
+class TestSupportsDelete:
+    """`_supports_delete` detects whether a backend overrides `delete`."""
+
+    def test_false_when_not_overridden(self, backend: BareBackend) -> None:
+        assert _supports_delete(backend) is False
+
+    def test_true_when_overridden(self) -> None:
+        class MyBackend(BackendProtocol):
+            def delete(self, file_path: str) -> DeleteResult:
+                return DeleteResult(path=file_path)
+
+        assert _supports_delete(MyBackend()) is True
 
 
 class TestDeprecatedMethodsRouteToNewNames:

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -1530,3 +1530,68 @@ def test_parse_grep_output_non_integer_line_number_is_skipped() -> None:
     # The only line has a bad line number; no valid matches → error is set.
     assert result.matches is None or result.matches == []
     assert result.error is not None
+
+
+class TestSandboxDelete:
+    """BaseSandbox.delete maps the `rm -f` exit code onto DeleteResult."""
+
+    def test_delete_success(self) -> None:
+        sandbox = MockSandbox()
+        sandbox._next_output = ""
+        sandbox._next_exit_code = 0
+        result = sandbox.delete("/file.txt")
+        assert result.error is None
+        assert result.path == "/file.txt"
+        # The shell command quotes the path and uses rm -rf (recursive)
+        assert sandbox.last_command is not None
+        assert "rm -rf" in sandbox.last_command
+        assert "/file.txt" in sandbox.last_command
+
+    def test_delete_directory_uses_recursive_rm(self) -> None:
+        sandbox = MockSandbox()
+        sandbox._next_output = ""
+        sandbox._next_exit_code = 0
+        result = sandbox.delete("/some/dir")
+        assert result.error is None
+        assert result.path == "/some/dir"
+        assert sandbox.last_command is not None
+        assert "rm -rf" in sandbox.last_command
+        assert "/some/dir" in sandbox.last_command
+
+    def test_delete_missing_is_noop_success(self) -> None:
+        # `rm -f` ignores a missing path: exit 0, so delete reports success.
+        sandbox = MockSandbox()
+        sandbox._next_output = ""
+        sandbox._next_exit_code = 0
+        result = sandbox.delete("/missing.txt")
+        assert result.error is None
+        assert result.path == "/missing.txt"
+
+    def test_delete_failure_reports_output(self) -> None:
+        # A non-zero exit (e.g. a permission error) surfaces rm's stderr.
+        sandbox = MockSandbox()
+        sandbox._next_output = "rm: cannot remove '/some/dir': Is a directory"
+        sandbox._next_exit_code = 1
+        result = sandbox.delete("/some/dir")
+        assert result.path is None
+        assert result.error is not None
+        assert "Error deleting file" in result.error
+        assert "Is a directory" in result.error
+
+    def test_delete_failure_unknown_error(self) -> None:
+        # Non-zero exit with no output falls back to a generic message.
+        sandbox = MockSandbox()
+        sandbox._next_output = ""
+        sandbox._next_exit_code = 1
+        result = sandbox.delete("/file.txt")
+        assert result.path is None
+        assert result.error is not None
+        assert "unknown error" in result.error
+
+    async def test_adelete_success(self) -> None:
+        sandbox = MockSandbox()
+        sandbox._next_output = ""
+        sandbox._next_exit_code = 0
+        result = await sandbox.adelete("/file.txt")
+        assert result.error is None
+        assert result.path == "/file.txt"

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -540,17 +540,31 @@ def test_sandbox_write_with_special_content() -> None:
     assert sandbox._uploaded[0][1] == content.encode("utf-8")
 
 
-def test_sandbox_write_returns_error_on_existing_file() -> None:
-    """Test that write() returns an error when the check command fails."""
+def test_sandbox_write_overwrites_existing_file() -> None:
+    """Test that write() replaces an existing file without error."""
+    sandbox = MockSandbox()
+
+    result = sandbox.write("/test/file.txt", "original content")
+    assert result.error is None
+
+    result = sandbox.write("/test/file.txt", "new content")
+    assert result.error is None
+
+    assert len(sandbox._uploaded) == 2
+    assert sandbox._uploaded[-1] == ("/test/file.txt", b"new content")
+
+
+def test_sandbox_write_returns_error_on_preflight_failure() -> None:
+    """Test that write() returns an error and skips upload when the preflight fails."""
     sandbox = MockSandbox()
 
     def fail_execute(command: str, *, timeout: int | None = None) -> ExecuteResponse:  # noqa: ARG001
         sandbox.last_command = command
-        return ExecuteResponse(output="Error: File already exists", exit_code=1)
+        return ExecuteResponse(output="Error: Permission denied", exit_code=1)
 
     sandbox.execute = fail_execute
 
-    result = sandbox.write("/test/existing.txt", "content")
+    result = sandbox.write("/test/protected.txt", "content")
     assert result.error is not None
     assert "Error:" in result.error
     assert len(sandbox._uploaded) == 0  # upload should not have been called

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -8,6 +8,7 @@ import pytest
 from langchain.tools import ToolRuntime
 from langchain_core.messages import ToolMessage
 from langgraph.runtime import Runtime
+from langgraph.store.base import PutOp
 from langgraph.store.memory import InMemoryStore
 
 from deepagents._api.deprecation import LangChainDeprecationWarning
@@ -515,3 +516,196 @@ def test_store_backend_legacy_path_rejects_malicious_assistant_id() -> None:
             warnings.simplefilter("always")
             with pytest.raises(ValueError, match="disallowed characters"):
                 be.write("/test.txt", "content")
+
+
+def test_store_backend_delete() -> None:
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+
+    be.write("/docs/readme.md", "hello store")
+    assert be.read("/docs/readme.md").error is None
+
+    result = be.delete("/docs/readme.md")
+    assert result.error is None
+    assert result.path == "/docs/readme.md"
+    # File is gone
+    assert be.read("/docs/readme.md").error is not None
+
+
+def test_store_backend_delete_directory_recursive() -> None:
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    be.write("/work/a.txt", "a")
+    be.write("/work/sub/b.txt", "b")
+    be.write("/keep.txt", "k")
+
+    result = be.delete("/work")
+    assert result.error is None
+    assert result.path == "/work"
+    # Every key at or under /work is gone.
+    assert be.read("/work/a.txt").error is not None
+    assert be.read("/work/sub/b.txt").error is not None
+    # A sibling outside the subtree is untouched.
+    assert be.read("/keep.txt").error is None
+
+
+async def test_store_backend_adelete_directory_recursive() -> None:
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    await be.awrite("/work/a.txt", "a")
+    await be.awrite("/work/sub/b.txt", "b")
+    await be.awrite("/keep.txt", "k")
+
+    result = await be.adelete("/work")
+    assert result.error is None
+    assert (await be.aread("/work/a.txt")).error is not None
+    assert (await be.aread("/work/sub/b.txt")).error is not None
+    assert (await be.aread("/keep.txt")).error is None
+
+
+class _RecordingStore(InMemoryStore):
+    """InMemoryStore that records the ops passed to each batch/abatch call.
+
+    `batch`/`abatch` are the single primitive every store op routes through, so
+    recording them lets a test assert how many round-trips a delete performs.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.batch_calls: list[list] = []
+
+    def batch(self, ops):
+        ops = list(ops)
+        self.batch_calls.append(ops)
+        return super().batch(ops)
+
+    async def abatch(self, ops):
+        ops = list(ops)
+        self.batch_calls.append(ops)
+        return await super().abatch(ops)
+
+
+def _delete_op_batches(batch_calls: list[list]) -> list[list]:
+    """Batches that carried at least one delete (PutOp with value=None)."""
+    return [ops for ops in batch_calls if any(isinstance(op, PutOp) and op.value is None for op in ops)]
+
+
+def test_store_backend_delete_uses_single_batch_call() -> None:
+    """A recursive delete issues one batched store write, not one call per key."""
+    store = _RecordingStore()
+    be = StoreBackend(store=store, namespace=lambda _rt: ("filesystem",))
+    be.write("/work/a.txt", "a")
+    be.write("/work/sub/b.txt", "b")
+    be.write("/keep.txt", "k")
+    store.batch_calls.clear()  # ignore the setup writes
+
+    result = be.delete("/work")
+    assert result.error is None
+
+    # All the deletes happened in exactly one batch (not one call per key).
+    delete_batches = _delete_op_batches(store.batch_calls)
+    assert len(delete_batches) == 1
+    ops = delete_batches[0]
+    assert all(isinstance(op, PutOp) and op.value is None for op in ops)
+    assert {op.key for op in ops} == {"/work/a.txt", "/work/sub/b.txt"}
+
+
+async def test_store_backend_adelete_uses_single_batch_call() -> None:
+    """Async recursive delete issues one batched store write, not one per key."""
+    store = _RecordingStore()
+    be = StoreBackend(store=store, namespace=lambda _rt: ("filesystem",))
+    await be.awrite("/work/a.txt", "a")
+    await be.awrite("/work/sub/b.txt", "b")
+    await be.awrite("/keep.txt", "k")
+    store.batch_calls.clear()
+
+    result = await be.adelete("/work")
+    assert result.error is None
+
+    delete_batches = _delete_op_batches(store.batch_calls)
+    assert len(delete_batches) == 1
+    ops = delete_batches[0]
+    assert all(isinstance(op, PutOp) and op.value is None for op in ops)
+    assert {op.key for op in ops} == {"/work/a.txt", "/work/sub/b.txt"}
+
+
+def test_store_backend_delete_missing_returns_error() -> None:
+    be = StoreBackend(store=InMemoryStore(), namespace=lambda _rt: ("filesystem",))
+    result = be.delete("/nope.md")
+    assert result.path is None
+    assert result.error is not None
+    assert "not found" in result.error
+
+
+async def test_store_backend_adelete() -> None:
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+
+    await be.awrite("/a.md", "x")
+    result = await be.adelete("/a.md")
+    assert result.error is None
+    assert result.path == "/a.md"
+    assert (await be.aread("/a.md")).error is not None
+
+    missing = await be.adelete("/a.md")
+    assert missing.error is not None and "not found" in missing.error
+
+
+def test_store_backend_delete_treats_wildcard_as_literal_key() -> None:
+    """`*` is used as an exact store key, not a wildcard.
+
+    Deleting "*" must only remove an entry whose key is literally "*" and must
+    never expand to match/remove other files in the namespace.
+    """
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+
+    be.write("/a.md", "a")
+    be.write("/b.md", "b")
+    be.write("*", "literal star")
+
+    # Deleting "*" removes only the literally-named entry.
+    result = be.delete("*")
+    assert result.error is None
+    assert result.path == "*"
+
+    # The other files are untouched — "*" did not expand to a wildcard.
+    assert be.read("/a.md").error is None
+    assert be.read("/b.md").error is None
+    assert be.read("*").error is not None
+
+
+def test_store_backend_delete_wildcard_missing_does_not_match_files() -> None:
+    """Deleting "*" when no literal "*" key exists is a not-found, not a purge."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+
+    be.write("/a.md", "a")
+    be.write("/b.md", "b")
+
+    result = be.delete("*")
+    assert result.path is None
+    assert result.error is not None and "not found" in result.error
+
+    # Nothing was deleted by the wildcard-looking key.
+    assert be.read("/a.md").error is None
+    assert be.read("/b.md").error is None
+
+
+async def test_store_backend_adelete_treats_wildcard_as_literal_key() -> None:
+    """Async delete also treats `*` as an exact key, not a wildcard."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+
+    await be.awrite("/a.md", "a")
+    await be.awrite("*", "literal star")
+
+    result = await be.adelete("*")
+    assert result.error is None
+    assert result.path == "*"
+
+    assert (await be.aread("/a.md")).error is None
+    assert (await be.aread("*")).error is not None
+
+    missing = await be.adelete("*")
+    assert missing.error is not None and "not found" in missing.error

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -51,7 +51,7 @@ def test_store_backend_crud_and_search():
     assert any(i["path"] == "/docs/readme.md" for i in g2)
 
 
-def test_store_backend_write_rejects_existing_file():
+def test_store_backend_write_overwrites_existing_file():
     mem_store = InMemoryStore()
     be = StoreBackend(store=mem_store, namespace=lambda _ctx: ("filesystem",))
 
@@ -59,16 +59,14 @@ def test_store_backend_write_rejects_existing_file():
     result = be.write("/charmander.txt", "Hello world")
     assert result.error is None
 
-    # Attempt to overwrite — should fail
+    # Overwrite should succeed
     result = be.write("/charmander.txt", "New content")
-    assert result.error is not None
-    assert "Cannot write" in result.error
-    assert "already exists" in result.error
+    assert result.error is None
 
-    # Original content preserved
+    # New content visible
     read_result = be.read("/charmander.txt")
     assert read_result.file_data is not None
-    assert "Hello world" in read_result.file_data["content"]
+    assert "New content" in read_result.file_data["content"]
 
 
 def test_store_backend_ls_nested_directories():

--- a/libs/deepagents/tests/unit_tests/middleware/test_tool_schemas.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_tool_schemas.py
@@ -25,6 +25,7 @@ class TestFilesystemToolSchemas:
             "read_file": ["file_path", "offset", "limit"],
             "write_file": ["file_path", "content"],
             "edit_file": ["file_path", "old_string", "new_string", "replace_all"],
+            "delete": ["file_path"],
             "glob": ["pattern", "path"],
             "grep": ["pattern", "path", "glob", "output_mode"],
             "execute": ["command"],

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message.md
@@ -68,7 +68,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -77,6 +77,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -97,7 +97,7 @@
             "type": "string"
           },
           "file_path": {
-            "description": "Absolute path where the file should be created. Must be absolute, not relative.",
+            "description": "Absolute path where the file should be written. Must be absolute, not relative.",
             "type": "string"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/custom_system_message_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
+      "name": "delete",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in the backend's default root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,6 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -97,7 +97,7 @@
             "type": "string"
           },
           "file_path": {
-            "description": "Absolute path where the file should be created. Must be absolute, not relative.",
+            "description": "Absolute path where the file should be written. Must be absolute, not relative.",
             "type": "string"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_execute_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
+      "name": "delete",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in the backend's default root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills.md
@@ -112,7 +112,7 @@ Remember: Skills make you more capable and consistent. When in doubt, check if a
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -121,6 +121,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -97,7 +97,7 @@
             "type": "string"
           },
           "file_path": {
-            "description": "Absolute path where the file should be created. Must be absolute, not relative.",
+            "description": "Absolute path where the file should be written. Must be absolute, not relative.",
             "type": "string"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_memory_and_skills_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
+      "name": "delete",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in the backend's default root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_routed_backend.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_routed_backend.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,6 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_routed_backend_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_routed_backend_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -97,7 +97,7 @@
             "type": "string"
           },
           "file_path": {
-            "description": "Absolute path where the file should be created. Must be absolute, not relative.",
+            "description": "Absolute path where the file should be written. Must be absolute, not relative.",
             "type": "string"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_routed_backend_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_routed_backend_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
+      "name": "delete",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in the backend's default root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sandbox_default.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sandbox_default.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,6 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,6 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -97,7 +97,7 @@
             "type": "string"
           },
           "file_path": {
-            "description": "Absolute path where the file should be created. Must be absolute, not relative.",
+            "description": "Absolute path where the file should be written. Must be absolute, not relative.",
             "type": "string"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_with_sync_and_async_subagents_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
+      "name": "delete",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in the backend's default root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute.md
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,6 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -88,7 +88,7 @@
   },
   {
     "function": {
-      "description": "Writes to a new file in the filesystem.\n\nUsage:\n- The write_file tool will create the a new file.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
+      "description": "Writes content to a file. Creates the file if it does not exist; replaces it entirely if it does.\n\nUsage:\n- Use this tool when you intend to create a new file or replace the whole file. You do not need to read the file first.\n- Prefer to edit existing files (with the edit_file tool) over creating new ones when possible.",
       "name": "write_file",
       "parameters": {
         "properties": {
@@ -97,7 +97,7 @@
             "type": "string"
           },
           "file_path": {
-            "description": "Absolute path where the file should be created. Must be absolute, not relative.",
+            "description": "Absolute path where the file should be written. Must be absolute, not relative.",
             "type": "string"
           }
         },

--- a/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
+++ b/libs/deepagents/tests/unit_tests/smoke_tests/snapshots/system_prompt_without_execute_tools.json
@@ -146,6 +146,25 @@
   },
   {
     "function": {
+      "description": "Deletes a file or directory from the filesystem.\n\nUsage:\n- Permanently removes the file or directory at the given absolute path.\n- Deleting a directory removes it and everything inside it, recursively. Prefer\n  deleting a directory in one call over deleting each file individually.\n- This cannot be undone, so only delete paths you are sure are no longer needed.",
+      "name": "delete",
+      "parameters": {
+        "properties": {
+          "file_path": {
+            "description": "Absolute path to the file to delete. Must be absolute, not relative.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      }
+    },
+    "type": "function"
+  },
+  {
+    "function": {
       "description": "Find files matching a glob pattern.\n\nSupports standard glob patterns: `*` (any characters), `**` (any directories), `?` (single character).\nReturns a list of absolute file paths that match the pattern.\n\nExamples:\n- `**/*.py` - Find all Python files\n- `*.txt` - Find all text files in the backend's default root\n- `/subdir/**/*.md` - Find all markdown files under /subdir",
       "name": "glob",
       "parameters": {

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -2846,6 +2846,52 @@ class TestStateBackendConfigKeys:
         assert "buffered" in tool_msg.content
         assert "ERROR" not in tool_msg.content
 
+    def test_write_overwrites_existing_file(self) -> None:
+        """write_file on an existing path replaces its content."""
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "write_file",
+                                "args": {"file_path": "/doc.txt", "content": "new content"},
+                                "id": "call_w2",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "read_file",
+                                "args": {"file_path": "/doc.txt"},
+                                "id": "call_r2",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model)
+        result = agent.invoke(
+            {
+                "messages": [HumanMessage(content="go")],
+                "files": {"/doc.txt": {"content": "old content", "encoding": "utf-8"}},
+            }
+        )
+
+        tool_msgs = [m for m in result["messages"] if m.type == "tool"]
+        # write should succeed and overwrite the old content
+        assert any("Updated file" in m.content for m in tool_msgs)
+        assert any("new content" in m.content for m in tool_msgs)
+        assert not any("old content" in m.content for m in tool_msgs)
+
     def test_state_backend_delete_in_graph_context(self) -> None:
         """delete() removes a file from state; missing paths report an error."""
         backend = StateBackend()

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -1356,6 +1356,157 @@ class TestDeepAgentEndToEnd:
         assert "base64" in tm.content[0]
 
 
+class TestDeleteFileTool:
+    """End-to-end tests for the `delete` filesystem tool."""
+
+    def test_delete_removes_existing_file(self) -> None:
+        """Delete removes a file from state and reports success."""
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "delete",
+                                "args": {"file_path": "/keep.txt"},
+                                "id": "call_1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model)
+        result = agent.invoke(
+            {
+                "messages": [HumanMessage(content="delete it")],
+                "files": {
+                    "/keep.txt": create_file_data("bye"),
+                    "/other.txt": create_file_data("stay"),
+                },
+            }
+        )
+
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert len(tool_messages) == 1
+        assert tool_messages[0].status == "success"
+        assert tool_messages[0].content == "Deleted /keep.txt"
+        assert set(result["files"].keys()) == {"/other.txt"}
+
+    def test_delete_directory_removes_nested_files(self) -> None:
+        """Delete on a directory removes every nested file from state (StateBackend)."""
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "delete",
+                                "args": {"file_path": "/work"},
+                                "id": "call_1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model)
+        result = agent.invoke(
+            {
+                "messages": [HumanMessage(content="delete the work dir")],
+                "files": {
+                    "/work/a.txt": create_file_data("a"),
+                    "/work/sub/b.txt": create_file_data("b"),
+                    "/keep.txt": create_file_data("stay"),
+                },
+            }
+        )
+
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert tool_messages[0].status == "success"
+        # Whole /work subtree gone; sibling preserved.
+        assert set(result["files"].keys()) == {"/keep.txt"}
+
+    def test_delete_missing_returns_error(self) -> None:
+        """Delete on a missing path returns an error tool message."""
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "delete",
+                                "args": {"file_path": "/nope.txt"},
+                                "id": "call_1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model)
+        result = agent.invoke({"messages": [HumanMessage(content="delete it")]})
+
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert len(tool_messages) == 1
+        assert tool_messages[0].status == "error"
+        assert "not found" in tool_messages[0].content
+
+    def test_delete_permission_deny_blocks_delete(self) -> None:
+        """FilesystemPermission deny write blocks delete (delete is a write op)."""
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "delete",
+                                "args": {"file_path": "/secrets/key.txt"},
+                                "id": "call_1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(
+            model=model,
+            permissions=[
+                FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="deny"),
+            ],
+        )
+        result = agent.invoke(
+            {
+                "messages": [HumanMessage(content="delete secret")],
+                "files": {"/secrets/key.txt": create_file_data("data")},
+            }
+        )
+
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert len(tool_messages) == 1
+        assert tool_messages[0].status == "error"
+        assert "permission denied" in tool_messages[0].content
+        assert "write" in tool_messages[0].content
+        # The file must still be present after a denied delete.
+        assert "/secrets/key.txt" in result["files"]
+
+
 class TestDeepAgentPermissionsEndToEnd:
     """End-to-end tests for create_deep_agent with FilesystemPermission."""
 
@@ -2694,6 +2845,100 @@ class TestStateBackendConfigKeys:
         tool_msg = next(m for m in result["messages"] if m.type == "tool" and m.tool_call_id == "call_wr")
         assert "buffered" in tool_msg.content
         assert "ERROR" not in tool_msg.content
+
+    def test_state_backend_delete_in_graph_context(self) -> None:
+        """delete() removes a file from state; missing paths report an error."""
+        backend = StateBackend()
+
+        @tool
+        def delete_path(path: str) -> str:
+            """Delete a file via StateBackend."""
+            result = backend.delete(path)
+            return result.error or f"deleted {result.path}"
+
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {"name": "delete_path", "args": {"path": "/keep.txt"}, "id": "c1", "type": "tool_call"},
+                        ],
+                    ),
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {"name": "delete_path", "args": {"path": "/missing.txt"}, "id": "c2", "type": "tool_call"},
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model, backend=backend, tools=[delete_path])
+        result = agent.invoke(
+            {
+                "messages": [HumanMessage(content="go")],
+                "files": {
+                    "/keep.txt": create_file_data("bye"),
+                    "/other.txt": create_file_data("stay"),
+                },
+            }
+        )
+
+        tool_msgs = {m.tool_call_id: m.content for m in result["messages"] if m.type == "tool"}
+        assert tool_msgs["c1"] == "deleted /keep.txt"
+        assert "not found" in tool_msgs["c2"]
+        # The deleted file is gone; the untouched file remains.
+        assert set(result["files"].keys()) == {"/other.txt"}
+
+    async def test_state_backend_delete_in_graph_context_async(self) -> None:
+        """adelete() removes a file from state on the async path; missing paths report an error."""
+        backend = StateBackend()
+
+        @tool
+        async def adelete_path(path: str) -> str:
+            """Delete a file via StateBackend's async path."""
+            result = await backend.adelete(path)
+            return result.error or f"deleted {result.path}"
+
+        model = FixedGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {"name": "adelete_path", "args": {"path": "/keep.txt"}, "id": "c1", "type": "tool_call"},
+                        ],
+                    ),
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {"name": "adelete_path", "args": {"path": "/missing.txt"}, "id": "c2", "type": "tool_call"},
+                        ],
+                    ),
+                    AIMessage(content="Done."),
+                ]
+            )
+        )
+
+        agent = create_deep_agent(model=model, backend=backend, tools=[adelete_path])
+        result = await agent.ainvoke(
+            {
+                "messages": [HumanMessage(content="go")],
+                "files": {
+                    "/keep.txt": create_file_data("bye"),
+                    "/other.txt": create_file_data("stay"),
+                },
+            }
+        )
+
+        tool_msgs = {m.tool_call_id: m.content for m in result["messages"] if m.type == "tool"}
+        assert tool_msgs["c1"] == "deleted /keep.txt"
+        assert "not found" in tool_msgs["c2"]
+        # The deleted file is gone; the untouched file remains.
+        assert set(result["files"].keys()) == {"/other.txt"}
 
 
 class TestArtifactsRoot:

--- a/libs/deepagents/tests/unit_tests/test_local_sandbox_operations.py
+++ b/libs/deepagents/tests/unit_tests/test_local_sandbox_operations.py
@@ -281,20 +281,19 @@ class TestLocalSandboxOperations:
         exec_result = sandbox.execute(f"cat {test_path}")
         assert exec_result.output.strip() == content
 
-    def test_write_existing_file_fails(self, sandbox: LocalSubprocessSandbox) -> None:
-        """Test that writing to an existing file returns an error."""
+    def test_write_existing_file_overwrites(self, sandbox: LocalSubprocessSandbox) -> None:
+        """Test that writing to an existing file overwrites it."""
         test_path = "/tmp/test_sandbox_ops/existing.txt"
         # Create file first
         sandbox.write(test_path, "First content")
 
-        # Try to write again
+        # Write again should overwrite
         result = sandbox.write(test_path, "Second content")
 
-        assert result.error is not None
-        assert "already exists" in result.error.lower()
-        # Verify original content unchanged
+        assert result.error is None
+        # Verify new content
         exec_result = sandbox.execute(f"cat {test_path}")
-        assert exec_result.output.strip() == "First content"
+        assert exec_result.output.strip() == "Second content"
 
     def test_write_special_characters(self, sandbox: LocalSubprocessSandbox) -> None:
         """Test writing content with special characters and escape sequences."""

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -179,6 +179,13 @@ class TestFilesystemMiddleware:
         result = ls_tool.invoke({"runtime": _runtime(), "path": "/"})
         assert result.content == str(["/test.txt", "/test2.txt"])
 
+    def test_ls_shortterm_no_files(self):
+        backend, _ = _make_backend({})
+        middleware = FilesystemMiddleware(backend=backend)
+        ls_tool = next(tool for tool in middleware.tools if tool.name == "ls")
+        result = ls_tool.invoke({"runtime": _runtime(), "path": "/"})
+        assert result.content == "No files found"
+
     def test_ls_shortterm_with_path(self):
         files = {
             "/test.txt": FileData(
@@ -411,7 +418,7 @@ class TestFilesystemMiddleware:
                 "runtime": _runtime(),
             }
         )
-        assert result.content == str([])
+        assert result.content == "No files found"
 
     def test_glob_timeout_returns_error_message(self):
         backend, _ = _make_backend()

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1,6 +1,6 @@
 import mimetypes
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain.agents import create_agent
@@ -21,6 +21,7 @@ from langgraph.types import Command
 import deepagents.middleware.filesystem as filesystem_middleware
 from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
 from deepagents.backends.protocol import (
+    BackendProtocol,
     ExecuteResponse,
     GrepResult,
     ReadResult,
@@ -123,27 +124,27 @@ class TestFilesystemMiddleware:
         middleware = FilesystemMiddleware()
         assert isinstance(middleware.backend, StateBackend)
         assert middleware._custom_system_prompt is None
-        assert len(middleware.tools) == 7  # All tools including execute
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_with_composite_backend(self):
         backend = CompositeBackend(default=StateBackend(), routes={"/memories/": StoreBackend()})
         middleware = FilesystemMiddleware(backend=backend)
         assert isinstance(middleware.backend, CompositeBackend)
         assert middleware._custom_system_prompt is None
-        assert len(middleware.tools) == 7  # All tools including execute
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_custom_system_prompt_default(self):
         middleware = FilesystemMiddleware(system_prompt="Custom system prompt")
         assert isinstance(middleware.backend, StateBackend)
         assert middleware._custom_system_prompt == "Custom system prompt"
-        assert len(middleware.tools) == 7  # All tools including execute
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_custom_system_prompt_with_composite(self):
         backend = CompositeBackend(default=StateBackend(), routes={"/memories/": StoreBackend()})
         middleware = FilesystemMiddleware(backend=backend, system_prompt="Custom system prompt")
         assert isinstance(middleware.backend, CompositeBackend)
         assert middleware._custom_system_prompt == "Custom system prompt"
-        assert len(middleware.tools) == 7  # All tools including execute
+        assert len(middleware.tools) == 8  # All tools including execute and delete
 
     def test_init_custom_tool_descriptions_default(self):
         middleware = FilesystemMiddleware(custom_tool_descriptions={"ls": "Custom ls tool description"})
@@ -1752,6 +1753,61 @@ class TestFilesystemMiddleware:
         assert isinstance(result, ToolMessage)
         assert "Error: Execution not available" in result.content
         assert "does not support command execution" in result.content
+
+    def test_delete_filtered_when_backend_lacks_delete(self):
+        """Delete is removed from the request when the backend can't delete.
+
+        Mirrors how the execute tool is filtered out when the backend doesn't
+        support execution, rather than advertising a tool that fails at call time.
+        """
+
+        class _NoDeleteBackend(StateBackend):
+            # Opt out of delete support by inheriting the protocol's default.
+            delete = BackendProtocol.delete
+
+        middleware = FilesystemMiddleware(backend=_NoDeleteBackend(), system_prompt="")
+
+        ls_tool = MagicMock()
+        ls_tool.name = "ls"
+        delete_tool = MagicMock()
+        delete_tool.name = "delete"
+        request = MagicMock()
+        request.tools = [ls_tool, delete_tool]
+        request.override.return_value = request
+
+        middleware._filter_unsupported_tools_and_apply_prompt(request)
+
+        request.override.assert_called_once()
+        filtered_names = {tool.name for tool in request.override.call_args.kwargs["tools"]}
+        assert "delete" not in filtered_names
+        assert "ls" in filtered_names
+
+    def test_delete_kept_when_backend_supports_delete(self):
+        """Delete stays in the request when the backend supports deletion."""
+        middleware = FilesystemMiddleware(backend=StateBackend(), system_prompt="")
+
+        ls_tool = MagicMock()
+        ls_tool.name = "ls"
+        delete_tool = MagicMock()
+        delete_tool.name = "delete"
+        request = MagicMock()
+        request.tools = [ls_tool, delete_tool]
+        request.override.return_value = request
+
+        middleware._filter_unsupported_tools_and_apply_prompt(request)
+
+        # StateBackend supports delete (and no execute tool is present), so no
+        # tool filtering — and with an empty system prompt, no override at all.
+        request.override.assert_not_called()
+
+    def test_delete_invalid_path_returns_error(self):
+        """The sync delete tool rejects a traversal path before deleting."""
+        middleware = FilesystemMiddleware(backend=StateBackend(), system_prompt="")
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
+        result = delete_tool.invoke({"file_path": "../etc/passwd", "runtime": _runtime("d1")})
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert "traversal" in result.content
 
     def test_execute_tool_output_formatting(self):
         """Test execute tool formats output correctly."""

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -10,7 +10,7 @@ from langgraph.store.memory import InMemoryStore
 import deepagents.middleware.filesystem as filesystem_middleware
 from deepagents.backends import StateBackend, StoreBackend
 from deepagents.backends.protocol import ExecuteResponse, GrepResult, SandboxBackendProtocol
-from deepagents.middleware.filesystem import FileData, FilesystemMiddleware, FilesystemState
+from deepagents.middleware.filesystem import FileData, FilesystemMiddleware, FilesystemPermission, FilesystemState
 
 
 def _make_backend(files=None):
@@ -701,6 +701,71 @@ class TestFilesystemMiddlewareAsync:
             }
         )
         assert isinstance(result, ToolMessage)
+        assert mem_store.get(("filesystem",), "/test.txt") is not None
+
+    async def test_adelete(self):
+        """Async delete removes the file and reports success."""
+        files = {"/test.txt": FileData(content=["bye"], modified_at="2021-01-01", created_at="2021-01-01")}
+        backend, mem_store = _make_backend(files)
+        middleware = FilesystemMiddleware(backend=backend)
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
+        result = await delete_tool.ainvoke(
+            {
+                "file_path": "/test.txt",
+                "runtime": ToolRuntime(state={}, context=None, tool_call_id="d1", store=None, stream_writer=lambda _: None, config={}),
+            }
+        )
+        assert isinstance(result, ToolMessage)
+        assert result.status == "success"
+        assert "Deleted" in result.content
+        assert mem_store.get(("filesystem",), "/test.txt") is None
+
+    async def test_adelete_invalid_path(self):
+        """Async delete rejects a traversal path with an error."""
+        backend, _ = _make_backend()
+        middleware = FilesystemMiddleware(backend=backend)
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
+        result = await delete_tool.ainvoke(
+            {
+                "file_path": "../etc/passwd",
+                "runtime": ToolRuntime(state={}, context=None, tool_call_id="d2", store=None, stream_writer=lambda _: None, config={}),
+            }
+        )
+        assert result.status == "error"
+        assert "traversal" in result.content
+
+    async def test_adelete_missing_returns_error(self):
+        """Async delete surfaces the backend's not-found error."""
+        backend, _ = _make_backend()
+        middleware = FilesystemMiddleware(backend=backend)
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
+        result = await delete_tool.ainvoke(
+            {
+                "file_path": "/ghost.txt",
+                "runtime": ToolRuntime(state={}, context=None, tool_call_id="d3", store=None, stream_writer=lambda _: None, config={}),
+            }
+        )
+        assert result.status == "error"
+        assert "not found" in result.content
+
+    async def test_adelete_permission_denied(self):
+        """Async delete is blocked by a deny write permission."""
+        files = {"/test.txt": FileData(content=["bye"], modified_at="2021-01-01", created_at="2021-01-01")}
+        backend, mem_store = _make_backend(files)
+        middleware = FilesystemMiddleware(
+            backend=backend,
+            _permissions=[FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")],
+        )
+        delete_tool = next(tool for tool in middleware.tools if tool.name == "delete")
+        result = await delete_tool.ainvoke(
+            {
+                "file_path": "/test.txt",
+                "runtime": ToolRuntime(state={}, context=None, tool_call_id="d5", store=None, stream_writer=lambda _: None, config={}),
+            }
+        )
+        assert result.status == "error"
+        assert "permission denied for write" in result.content
+        # The file is left untouched since deletion was blocked.
         assert mem_store.get(("filesystem",), "/test.txt") is not None
 
     async def test_aexecute_tool_returns_error_when_backend_doesnt_support(self):

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -139,6 +139,13 @@ class TestFilesystemMiddlewareAsync:
         assert "/pokemon/charmander.txt" not in result.content
         assert "/pokemon/water/squirtle.txt" not in result.content
 
+    async def test_als_shortterm_no_files(self):
+        backend, _ = _make_backend({})
+        middleware = FilesystemMiddleware(backend=backend)
+        ls_tool = next(tool for tool in middleware.tools if tool.name == "ls")
+        result = await ls_tool.ainvoke({"runtime": _runtime(), "path": "/"})
+        assert result.content == "No files found"
+
     async def test_aglob_search_shortterm_simple_pattern(self):
         """Test async glob with simple pattern."""
         files = {
@@ -290,7 +297,7 @@ class TestFilesystemMiddlewareAsync:
                 "runtime": _runtime(),
             }
         )
-        assert result.content == str([])
+        assert result.content == "No files found"
 
     async def test_glob_timeout_returns_error_message_async(self):
         backend, _ = _make_backend()

--- a/libs/deepagents/tests/unit_tests/test_permissions.py
+++ b/libs/deepagents/tests/unit_tests/test_permissions.py
@@ -11,6 +11,7 @@ from langgraph.store.memory import InMemoryStore
 
 from deepagents.backends import StateBackend, StoreBackend
 from deepagents.backends.composite import CompositeBackend
+from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import EditResult, ExecuteResponse, GlobResult, ReadResult, SandboxBackendProtocol, WriteResult
 from deepagents.backends.utils import _glob_anchor, _paths_overlap
 from deepagents.graph import create_deep_agent
@@ -22,6 +23,7 @@ from deepagents.middleware.filesystem import (
     _all_paths_scoped_to_routes,
     _check_fs_permission,
     _filter_paths_by_permission,
+    _find_delete_deny_patterns,
 )
 from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT
 
@@ -112,6 +114,213 @@ async def _ainvoke_with_permissions(tool, args, rules, tool_call_id="test", back
     if isinstance(result, ToolMessage):
         return result.content
     return str(result)
+
+
+class TestRecursiveDeletePermissions:
+    """All-or-nothing write-permission enforcement for recursive delete.
+
+    A recursive delete is refused if any ``deny`` write rule's pattern overlaps
+    the target subtree, in either direction: a rule scoped inside the target
+    (``/work/secrets/**``) and a rule the target falls under (``/work``) both
+    block it. The check is rule-based (no filesystem enumeration).
+    """
+
+    def _fs_backend(self, tmp_path):
+        # /work/a.txt, /work/logs/run.log, /work/secrets/{key,token}.txt
+        (tmp_path / "work" / "logs").mkdir(parents=True)
+        (tmp_path / "work" / "secrets").mkdir(parents=True)
+        (tmp_path / "work" / "a.txt").write_text("a")
+        (tmp_path / "work" / "logs" / "run.log").write_text("log")
+        (tmp_path / "work" / "secrets" / "key.txt").write_text("k")
+        (tmp_path / "work" / "secrets" / "token.txt").write_text("t")
+        return FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+
+    def test_recursive_delete_refused_when_descendant_denied(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert "/work/secrets" in result
+        # All-or-nothing: nothing was removed.
+        assert (tmp_path / "work" / "a.txt").exists()
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_recursive_delete_allowed_when_whole_subtree_allowed(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/other/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "Deleted" in result
+        assert not (tmp_path / "work").exists()
+
+    def test_delete_denied_directory_path_itself(self, tmp_path):
+        # A rule on the bare directory path (no /**) still blocks deleting it.
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_delete_refused_when_ancestor_denied(self, tmp_path):
+        # Any overlap denies: a rule on an ancestor of the target also blocks,
+        # since the target subtree falls under it.
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work/logs"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert (tmp_path / "work" / "logs" / "run.log").exists()
+
+    def test_delete_unaffected_sibling_subtree(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets", "/work/secrets/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work/logs"}, rules, backend=backend)
+
+        assert "Deleted" in result
+        assert not (tmp_path / "work" / "logs").exists()
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_delete_reports_multiple_overlapping_patterns(self, tmp_path):
+        # The agent gets context: several overlapping deny patterns are reported.
+        backend = self._fs_backend(tmp_path)
+        rules = [
+            FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny"),
+            FilesystemPermission(operations=["write"], paths=["/work/logs/**"], mode="deny"),
+        ]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "/work/secrets/**" in result
+        assert "/work/logs/**" in result
+        assert (tmp_path / "work" / "a.txt").exists()
+
+    def test_single_file_delete_still_works(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = _invoke_with_permissions(tool, {"file_path": "/work/a.txt"}, [], backend=backend)
+
+        assert "Deleted" in result
+        assert not (tmp_path / "work" / "a.txt").exists()
+
+    async def test_recursive_delete_refused_async(self, tmp_path):
+        backend = self._fs_backend(tmp_path)
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="deny")]
+        tool = next(t for t in FilesystemMiddleware(backend=backend).tools if t.name == "delete")
+
+        result = await _ainvoke_with_permissions(tool, {"file_path": "/work"}, rules, backend=backend)
+
+        assert "permission denied for write" in result
+        assert (tmp_path / "work" / "secrets" / "key.txt").exists()
+
+    def test_delete_registered_as_bulk_interrupt(self):
+        # An interrupt rule on a descendant must fire for a recursive delete,
+        # so delete is registered (bulk scope) in the interrupt builder.
+        rules = [FilesystemPermission(operations=["write"], paths=["/work/secrets/**"], mode="interrupt")]
+        out = _build_interrupt_on_from_permissions(rules)
+        assert "delete" in out
+
+
+def _deny(*paths: str) -> FilesystemPermission:
+    return FilesystemPermission(operations=["write"], paths=list(paths), mode="deny")
+
+
+class TestFindDeleteDenyPatterns:
+    """Exhaustive unit tests for the pure `_find_delete_deny_patterns` helper.
+
+    Returns every `deny` write pattern whose glob overlaps the delete subtree
+    (target + descendants). An empty result means the delete is permitted.
+    """
+
+    @pytest.mark.parametrize(
+        ("pattern", "target", "expected"),
+        [
+            # --- no overlap -> permitted (empty result) ----------------------
+            pytest.param("/other/**", "/work", [], id="unrelated-subtree"),
+            pytest.param("/workshop/**", "/work", [], id="sibling-prefix-glob"),
+            pytest.param("/work2", "/work", [], id="sibling-prefix-literal"),
+            pytest.param("/work/secrets", "/work/logs", [], id="sibling-leaf"),
+            # --- overlap in either direction -> blocked ----------------------
+            pytest.param("/work/a.txt", "/work/a.txt", ["/work/a.txt"], id="exact-file"),
+            pytest.param("/work", "/work", ["/work"], id="exact-dir-literal"),
+            pytest.param("/work/secrets/**", "/work", ["/work/secrets/**"], id="descendant-pattern-blocks-ancestor-target"),
+            pytest.param("/work/**", "/work/logs", ["/work/**"], id="ancestor-glob-blocks-descendant-target"),
+            pytest.param("/work", "/work/sub/deep", ["/work"], id="ancestor-literal-blocks-descendant-target"),
+            pytest.param("/work/secrets", "/work", ["/work/secrets"], id="bare-directory-pattern"),
+            # --- wildcard / root anchors -------------------------------------
+            pytest.param("/anything/**", "/", ["/anything/**"], id="root-target-blocked-by-any-rule"),
+            pytest.param("/**/secrets", "/work", ["/**/secrets"], id="leading-wildcard-anchor-is-root"),
+            # --- trailing-slash normalization (both sides) -------------------
+            pytest.param("/work/**", "/work/", ["/work/**"], id="target-trailing-slash"),
+            pytest.param("/work/", "/work/sub", ["/work/"], id="pattern-trailing-slash"),
+            pytest.param("/work/", "/work/", ["/work/"], id="both-trailing-slash"),
+        ],
+    )
+    def test_overlap_geometry(self, pattern: str, target: str, expected: list[str]):
+        assert _find_delete_deny_patterns([_deny(pattern)], target) == expected
+
+    @pytest.mark.parametrize(
+        ("operations", "mode", "expected"),
+        [
+            pytest.param(["write"], "deny", ["/work/**"], id="write-deny-blocks"),
+            pytest.param(["read", "write"], "deny", ["/work/**"], id="readwrite-deny-blocks"),
+            pytest.param(["write"], "allow", [], id="allow-ignored"),
+            pytest.param(["write"], "interrupt", [], id="interrupt-ignored"),
+            pytest.param(["read"], "deny", [], id="read-only-deny-ignored"),
+        ],
+    )
+    def test_mode_and_operation_filtering(self, operations, mode, expected):
+        # Only deny + write rules count; the target always overlaps the pattern.
+        rule = FilesystemPermission(operations=operations, paths=["/work/**"], mode=mode)
+        assert _find_delete_deny_patterns([rule], "/work") == expected
+
+    @pytest.mark.parametrize(
+        ("rule_paths", "target", "expected"),
+        [
+            pytest.param([], "/work", [], id="no-permissions"),
+            pytest.param([["/work/a/**"], ["/work/b/**"]], "/work", ["/work/a/**", "/work/b/**"], id="multiple-rules"),
+            pytest.param(
+                [["/work/a/**", "/work/b/**", "/other/**"]],
+                "/work",
+                ["/work/a/**", "/work/b/**"],
+                id="multiple-paths-one-rule-filters-non-overlapping",
+            ),
+            pytest.param(
+                [[f"/work/d{i}/**"] for i in range(8)],
+                "/work",
+                [f"/work/d{i}/**" for i in range(8)],
+                id="all-overlapping-no-cap",
+            ),
+            pytest.param(
+                [["/work/x/**"], ["/work/x/**", "/work/y/**"]],
+                "/work",
+                ["/work/x/**", "/work/y/**"],
+                id="deduplicated-first-seen-order",
+            ),
+            pytest.param(
+                [["/other/**"], ["/work/x/**"], ["/elsewhere/**"]],
+                "/work",
+                ["/work/x/**"],
+                id="only-overlapping-returned",
+            ),
+        ],
+    )
+    def test_multiple_rule_aggregation(self, rule_paths, target, expected):
+        rules = [_deny(*paths) for paths in rule_paths]
+        assert _find_delete_deny_patterns(rules, target) == expected
 
 
 class TestFilesystemPermission:
@@ -228,7 +437,7 @@ class TestBuildInterruptOnFromPermissions:
         """A write-only interrupt rule registers only the write-op tools."""
         rule = FilesystemPermission(operations=["write"], paths=["/secrets/**"], mode="interrupt")
         out = _build_interrupt_on_from_permissions([rule])
-        assert set(out) == {"write_file", "edit_file"}
+        assert set(out) == {"write_file", "edit_file", "delete"}
 
     def test_registers_read_tools_for_read_interrupt(self):
         rule = FilesystemPermission(operations=["read"], paths=["/secrets/**"], mode="interrupt")

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -10,37 +10,40 @@ Categories (for `--eval-category` filtering):
 file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,langchain/middleware
 ```
 
-**123 evals** across **8 categories**
+**126 evals** across **8 categories**
 
-## File Ops (`file_operations`) (18 evals)
+## File Ops (`file_operations`) (21 evals)
 
-- [`test_read_file_seeded_state_backend_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L35) — `tests/evals/test_file_operations.py:35`
-- [`test_write_file_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L55) — `tests/evals/test_file_operations.py:55`
-- [`test_write_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L77) — `tests/evals/test_file_operations.py:77`
-- [`test_write_files_in_parallel_confirm_with_verification`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L109) — `tests/evals/test_file_operations.py:109`
-- [`test_write_files_in_parallel_ambiguous_confirmation`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L144) — `tests/evals/test_file_operations.py:144`
-- [`test_ls_directory_contains_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L179) — `tests/evals/test_file_operations.py:179`
-- [`test_ls_directory_missing_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L203) — `tests/evals/test_file_operations.py:203`
-- [`test_edit_file_replace_text`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L226) — `tests/evals/test_file_operations.py:226`
-- [`test_read_then_write_derived_output`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L249) — `tests/evals/test_file_operations.py:249`
-- [`test_avoid_unnecessary_tool_calls`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L274) — `tests/evals/test_file_operations.py:274`
-- [`test_read_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L292) — `tests/evals/test_file_operations.py:292`
-- [`test_read_file_truncation_recovery_with_pagination`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L562) — `tests/evals/test_file_operations.py:562`
-- [`test_read_file_empty_file_reports_empty`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L600) — `tests/evals/test_file_operations.py:600`
-- [`test_delete_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L617) — `tests/evals/test_file_operations.py:617`
-- [`test_delete_one_of_several_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L646) — `tests/evals/test_file_operations.py:646`
-- [`test_deletes_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L681) — `tests/evals/test_file_operations.py:681`
-- [`test_write_then_delete_same_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L714) — `tests/evals/test_file_operations.py:714`
-- [`test_delete_missing_file_reports_absence`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L744) — `tests/evals/test_file_operations.py:744`
+- [`test_read_file_seeded_state_backend_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L36) — `tests/evals/test_file_operations.py:36`
+- [`test_write_file_overwrites_existing`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L56) — `tests/evals/test_file_operations.py:56`
+- [`test_write_file_overwrite_drops_old_content`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L85) — `tests/evals/test_file_operations.py:85`
+- [`test_write_file_prefers_edit_for_targeted_change`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L109) — `tests/evals/test_file_operations.py:109`
+- [`test_write_file_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L139) — `tests/evals/test_file_operations.py:139`
+- [`test_write_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L161) — `tests/evals/test_file_operations.py:161`
+- [`test_write_files_in_parallel_confirm_with_verification`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L193) — `tests/evals/test_file_operations.py:193`
+- [`test_write_files_in_parallel_ambiguous_confirmation`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L228) — `tests/evals/test_file_operations.py:228`
+- [`test_ls_directory_contains_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L263) — `tests/evals/test_file_operations.py:263`
+- [`test_ls_directory_missing_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L287) — `tests/evals/test_file_operations.py:287`
+- [`test_edit_file_replace_text`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L310) — `tests/evals/test_file_operations.py:310`
+- [`test_read_then_write_derived_output`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L333) — `tests/evals/test_file_operations.py:333`
+- [`test_avoid_unnecessary_tool_calls`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L358) — `tests/evals/test_file_operations.py:358`
+- [`test_read_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L376) — `tests/evals/test_file_operations.py:376`
+- [`test_read_file_truncation_recovery_with_pagination`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L646) — `tests/evals/test_file_operations.py:646`
+- [`test_read_file_empty_file_reports_empty`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L684) — `tests/evals/test_file_operations.py:684`
+- [`test_delete_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L701) — `tests/evals/test_file_operations.py:701`
+- [`test_delete_one_of_several_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L730) — `tests/evals/test_file_operations.py:730`
+- [`test_deletes_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L765) — `tests/evals/test_file_operations.py:765`
+- [`test_write_then_delete_same_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L798) — `tests/evals/test_file_operations.py:798`
+- [`test_delete_missing_file_reports_absence`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L828) — `tests/evals/test_file_operations.py:828`
 
 ## Retrieval (`retrieval`) (6 evals)
 
 - [`test_frames`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_external_benchmarks.py#L67) — `tests/evals/test_external_benchmarks.py:67`
-- [`test_grep_finds_matching_paths`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L322) — `tests/evals/test_file_operations.py:322`
-- [`test_glob_lists_markdown_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L350) — `tests/evals/test_file_operations.py:350`
-- [`test_find_magic_phrase_deep_nesting`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L378) — `tests/evals/test_file_operations.py:378`
-- [`test_identify_quote_author_from_directory_parallel_reads`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L414) — `tests/evals/test_file_operations.py:414`
-- [`test_identify_quote_author_from_directory_unprompted_efficiency`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L489) — `tests/evals/test_file_operations.py:489`
+- [`test_grep_finds_matching_paths`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L406) — `tests/evals/test_file_operations.py:406`
+- [`test_glob_lists_markdown_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L434) — `tests/evals/test_file_operations.py:434`
+- [`test_find_magic_phrase_deep_nesting`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L462) — `tests/evals/test_file_operations.py:462`
+- [`test_identify_quote_author_from_directory_parallel_reads`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L498) — `tests/evals/test_file_operations.py:498`
+- [`test_identify_quote_author_from_directory_unprompted_efficiency`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L573) — `tests/evals/test_file_operations.py:573`
 
 ## Tool Use (`tool_use`) (53 evals)
 

--- a/libs/evals/EVAL_CATALOG.md
+++ b/libs/evals/EVAL_CATALOG.md
@@ -10,32 +10,37 @@ Categories (for `--eval-category` filtering):
 file_operations,retrieval,tool_use,memory,conversation,summarization,unit_test,langchain/middleware
 ```
 
-**118 evals** across **8 categories**
+**123 evals** across **8 categories**
 
-## File Ops (`file_operations`) (13 evals)
+## File Ops (`file_operations`) (18 evals)
 
-- [`test_read_file_seeded_state_backend_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L34) — `tests/evals/test_file_operations.py:34`
-- [`test_write_file_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L54) — `tests/evals/test_file_operations.py:54`
-- [`test_write_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L76) — `tests/evals/test_file_operations.py:76`
-- [`test_write_files_in_parallel_confirm_with_verification`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L108) — `tests/evals/test_file_operations.py:108`
-- [`test_write_files_in_parallel_ambiguous_confirmation`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L143) — `tests/evals/test_file_operations.py:143`
-- [`test_ls_directory_contains_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L178) — `tests/evals/test_file_operations.py:178`
-- [`test_ls_directory_missing_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L202) — `tests/evals/test_file_operations.py:202`
-- [`test_edit_file_replace_text`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L225) — `tests/evals/test_file_operations.py:225`
-- [`test_read_then_write_derived_output`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L248) — `tests/evals/test_file_operations.py:248`
-- [`test_avoid_unnecessary_tool_calls`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L273) — `tests/evals/test_file_operations.py:273`
-- [`test_read_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L291) — `tests/evals/test_file_operations.py:291`
-- [`test_read_file_truncation_recovery_with_pagination`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L561) — `tests/evals/test_file_operations.py:561`
-- [`test_read_file_empty_file_reports_empty`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L599) — `tests/evals/test_file_operations.py:599`
+- [`test_read_file_seeded_state_backend_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L35) — `tests/evals/test_file_operations.py:35`
+- [`test_write_file_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L55) — `tests/evals/test_file_operations.py:55`
+- [`test_write_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L77) — `tests/evals/test_file_operations.py:77`
+- [`test_write_files_in_parallel_confirm_with_verification`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L109) — `tests/evals/test_file_operations.py:109`
+- [`test_write_files_in_parallel_ambiguous_confirmation`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L144) — `tests/evals/test_file_operations.py:144`
+- [`test_ls_directory_contains_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L179) — `tests/evals/test_file_operations.py:179`
+- [`test_ls_directory_missing_file_yes_no`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L203) — `tests/evals/test_file_operations.py:203`
+- [`test_edit_file_replace_text`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L226) — `tests/evals/test_file_operations.py:226`
+- [`test_read_then_write_derived_output`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L249) — `tests/evals/test_file_operations.py:249`
+- [`test_avoid_unnecessary_tool_calls`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L274) — `tests/evals/test_file_operations.py:274`
+- [`test_read_files_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L292) — `tests/evals/test_file_operations.py:292`
+- [`test_read_file_truncation_recovery_with_pagination`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L562) — `tests/evals/test_file_operations.py:562`
+- [`test_read_file_empty_file_reports_empty`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L600) — `tests/evals/test_file_operations.py:600`
+- [`test_delete_simple`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L617) — `tests/evals/test_file_operations.py:617`
+- [`test_delete_one_of_several_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L646) — `tests/evals/test_file_operations.py:646`
+- [`test_deletes_in_parallel`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L681) — `tests/evals/test_file_operations.py:681`
+- [`test_write_then_delete_same_file`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L714) — `tests/evals/test_file_operations.py:714`
+- [`test_delete_missing_file_reports_absence`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L744) — `tests/evals/test_file_operations.py:744`
 
 ## Retrieval (`retrieval`) (6 evals)
 
 - [`test_frames`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_external_benchmarks.py#L67) — `tests/evals/test_external_benchmarks.py:67`
-- [`test_grep_finds_matching_paths`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L321) — `tests/evals/test_file_operations.py:321`
-- [`test_glob_lists_markdown_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L349) — `tests/evals/test_file_operations.py:349`
-- [`test_find_magic_phrase_deep_nesting`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L377) — `tests/evals/test_file_operations.py:377`
-- [`test_identify_quote_author_from_directory_parallel_reads`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L413) — `tests/evals/test_file_operations.py:413`
-- [`test_identify_quote_author_from_directory_unprompted_efficiency`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L488) — `tests/evals/test_file_operations.py:488`
+- [`test_grep_finds_matching_paths`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L322) — `tests/evals/test_file_operations.py:322`
+- [`test_glob_lists_markdown_files`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L350) — `tests/evals/test_file_operations.py:350`
+- [`test_find_magic_phrase_deep_nesting`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L378) — `tests/evals/test_file_operations.py:378`
+- [`test_identify_quote_author_from_directory_parallel_reads`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L414) — `tests/evals/test_file_operations.py:414`
+- [`test_identify_quote_author_from_directory_unprompted_efficiency`](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/tests/evals/test_file_operations.py#L489) — `tests/evals/test_file_operations.py:489`
 
 ## Tool Use (`tool_use`) (53 evals)
 

--- a/libs/evals/tests/evals/test_file_operations.py
+++ b/libs/evals/tests/evals/test_file_operations.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 from tests.evals.utils import (
     TrajectoryScorer,
+    file_absent,
     file_contains,
     file_equals,
     final_text_contains,
@@ -607,4 +608,159 @@ def test_read_file_empty_file_reports_empty(model: BaseChatModel) -> None:
         scorer=TrajectoryScorer()
         .expect(agent_steps=2, tool_call_requests=1)
         .success(final_text_contains("EMPTY")),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_delete_simple(model: BaseChatModel) -> None:
+    """Deletes a seeded file and confirms it is gone."""
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        initial_files={"/foo.md": "delete me\n"},
+        query="Delete the file /foo.md, then reply with DONE only.",
+        # 1st step: request a delete tool call for /foo.md.
+        # 2nd step: reply DONE.
+        # 1 tool call request: delete.
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=2,
+            tool_call_requests=1,
+            tool_calls=[
+                tool_call(name="delete", step=1, args_contains={"file_path": "/foo.md"}),
+            ],
+        )
+        .success(
+            final_text_contains("DONE"),
+            file_absent("/foo.md"),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_delete_one_of_several_files(model: BaseChatModel) -> None:
+    """Deletes a single target file, leaving the others untouched."""
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        initial_files={
+            "/a.md": "a",
+            "/b.md": "b",
+            "/c.md": "c",
+        },
+        query="Delete /b.md only. Leave the other files untouched. Reply with DONE only.",
+        # 1st step: request a delete tool call for /b.md.
+        # 2nd step: reply DONE.
+        # 1 tool call request: delete.
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=2,
+            tool_call_requests=1,
+            tool_calls=[
+                tool_call(name="delete", step=1, args_contains={"file_path": "/b.md"}),
+            ],
+        )
+        .success(
+            final_text_contains("DONE"),
+            file_absent("/b.md"),
+            file_equals("/a.md", "a"),
+            file_equals("/c.md", "c"),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_deletes_in_parallel(model: BaseChatModel) -> None:
+    """Deletes two files in parallel without extra tool calls."""
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        initial_files={"/a.md": "a", "/b.md": "b"},
+        query=(
+            "Delete /a.md and /b.md. Do the deletes in parallel. Do NOT read any files afterward. Reply with DONE only."
+        ),
+        # 1st step: request 2 delete tool calls in parallel.
+        # 2nd step: reply DONE.
+        # 2 tool call requests: delete /a.md and delete /b.md.
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=2,
+            tool_call_requests=2,
+            tool_calls=[
+                tool_call(name="delete", step=1, args_contains={"file_path": "/a.md"}),
+                tool_call(name="delete", step=1, args_contains={"file_path": "/b.md"}),
+            ],
+        )
+        .success(
+            final_text_contains("DONE"),
+            file_absent("/a.md"),
+            file_absent("/b.md"),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_write_then_delete_same_file(model: BaseChatModel) -> None:
+    """Writes a file and then deletes it, leaving no trace."""
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        query=('Write "scratch" to /tmp.md, then delete /tmp.md. Reply with DONE only.'),
+        # 1st step: request a write_file tool call for /tmp.md.
+        # 2nd step: request a delete tool call for /tmp.md.
+        # 3rd step: reply DONE.
+        # 2 tool call requests: write_file then delete.
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=3,
+            tool_call_requests=2,
+            tool_calls=[
+                tool_call(name="write_file", step=1, args_contains={"file_path": "/tmp.md"}),
+                tool_call(name="delete", step=2, args_contains={"file_path": "/tmp.md"}),
+            ],
+        )
+        .success(
+            final_text_contains("DONE"),
+            file_absent("/tmp.md"),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_delete_missing_file_reports_absence(model: BaseChatModel) -> None:
+    """A delete of a nonexistent file is reported, not faked.
+
+    The `delete` tool returns a "File ... not found" error for a path
+    that does not exist. The agent should surface that the file is missing
+    rather than claim a successful deletion, and must leave the real file
+    untouched. Tool-call shape is intentionally not enforced: a model may
+    list/read first, or attempt the delete and recover from the error.
+    """
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        initial_files={"/exists.md": "still here\n"},
+        query=(
+            "Delete the file /missing.md. If it does not exist, reply with exactly: NOT_FOUND. "
+            "Otherwise reply with exactly: DONE."
+        ),
+        scorer=TrajectoryScorer().success(
+            final_text_contains("NOT_FOUND"),
+            file_equals("/exists.md", "still here\n"),
+        ),
     )

--- a/libs/evals/tests/evals/test_file_operations.py
+++ b/libs/evals/tests/evals/test_file_operations.py
@@ -22,6 +22,7 @@ from tests.evals.utils import (
     file_absent,
     file_contains,
     file_equals,
+    file_excludes,
     final_text_contains,
     final_text_excludes,
     run_agent,
@@ -46,6 +47,89 @@ def test_read_file_seeded_state_backend_file(model: BaseChatModel) -> None:
         scorer=TrajectoryScorer()
         .expect(agent_steps=2, tool_call_requests=1)
         .success(final_text_contains("three", case_insensitive=True)),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_write_file_overwrites_existing(model: BaseChatModel) -> None:
+    """Overwrites an existing file without reading it first."""
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        initial_files={"/note.md": "old content\n"},
+        query='Rewrite /note.md so it contains only "new content". Reply with DONE only.',
+        # 1st step: write_file to /note.md (no read needed).
+        # 2nd step: reply DONE.
+        # 1 tool call request: write_file.
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=2,
+            tool_call_requests=1,
+            tool_calls=[
+                tool_call(name="write_file", step=1, args_contains={"file_path": "/note.md"}),
+            ],
+        )
+        .success(
+            final_text_contains("DONE"),
+            file_equals("/note.md", "new content"),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_write_file_overwrite_drops_old_content(model: BaseChatModel) -> None:
+    """Overwriting a file replaces it entirely, no trace of old content should remain."""
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        initial_files={"/log.txt": "stale line\n"},
+        query='Write "fresh line" to /log.txt. Reply with DONE only.',
+        # 1st step: write_file to /log.txt.
+        # 2nd step: reply DONE.
+        # 1 tool call request: write_file.
+        scorer=TrajectoryScorer()
+        .expect(agent_steps=2, tool_call_requests=1)
+        .success(
+            final_text_contains("DONE"),
+            file_contains("/log.txt", "fresh line"),
+            file_excludes("/log.txt", "stale"),
+        ),
+    )
+
+
+@pytest.mark.eval_tier("baseline")
+@pytest.mark.eval_category("file_operations")
+@pytest.mark.langsmith
+def test_write_file_prefers_edit_for_targeted_change(model: BaseChatModel) -> None:
+    """Uses edit_file (not write_file) when only a targeted in-place change is needed."""
+    agent = create_deep_agent(model=model)
+    run_agent(
+        agent,
+        model=model,
+        initial_files={"/note.md": "cat dog bird\n"},
+        query="In /note.md, replace 'cat' with 'lion'. Reply with DONE only.",
+        # 1st step: edit_file on /note.md (targeted change, rest of file preserved).
+        # 2nd step: reply DONE.
+        # 1 tool call request: edit_file.
+        scorer=TrajectoryScorer()
+        .expect(
+            agent_steps=2,
+            tool_call_requests=1,
+            tool_calls=[
+                tool_call(name="edit_file", step=1, args_contains={"file_path": "/note.md"}),
+            ],
+        )
+        .success(
+            final_text_contains("DONE"),
+            file_contains("/note.md", "lion"),
+            file_excludes("/note.md", "cat"),
+        ),
     )
 
 

--- a/libs/evals/tests/evals/utils.py
+++ b/libs/evals/tests/evals/utils.py
@@ -511,6 +511,49 @@ class FileExcludes(SuccessAssertion):
         return f"File {self.path!r} unexpectedly contains {self.substring!r}.\nActual content:\n{actual!r}"
 
 
+@dataclass(frozen=True)
+class FileAbsent(SuccessAssertion):
+    """Assert that a file path does not exist in the trajectory.
+
+    A successful deletion removes the path from state entirely (the ``files``
+    channel reducer drops keys whose update value is ``None``), so a deleted
+    path should not appear in ``trajectory.files`` at all. This is stricter
+    than ``FileExcludes``, which only checks for an absent substring and
+    therefore passes even when the file is still present.
+
+    Attributes:
+        path: The file path that must not exist.
+    """
+
+    path: str
+
+    def check(self, trajectory: AgentTrajectory) -> bool:
+        """Check that ``self.path`` is absent from the trajectory files.
+
+        Args:
+            trajectory: The agent trajectory to check.
+
+        Returns:
+            Whether the file path is absent.
+        """
+        return self.path not in trajectory.files
+
+    def describe_failure(self, trajectory: AgentTrajectory) -> str:
+        """Describe why the file-absent check failed.
+
+        Args:
+            trajectory: The agent trajectory that failed the check.
+
+        Returns:
+            A human-readable failure description.
+        """
+        actual = trajectory.files.get(self.path)
+        return (
+            f"Expected file {self.path!r} to be absent, but it still exists "
+            f"with content:\n{actual!r}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Concrete efficiency assertions
 # ---------------------------------------------------------------------------
@@ -811,6 +854,18 @@ def file_excludes(path: str, substring: str) -> FileExcludes:
         A `FileExcludes` assertion instance.
     """
     return FileExcludes(path=path, substring=substring)
+
+
+def file_absent(path: str) -> FileAbsent:
+    """Create a ``FileAbsent`` success assertion.
+
+    Args:
+        path: The file path that must not exist in the trajectory files.
+
+    Returns:
+        A ``FileAbsent`` assertion instance.
+    """
+    return FileAbsent(path=path)
 
 
 def agent_steps(n: int) -> AgentSteps:

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,6 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_call.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_call.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,6 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_turn.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_mixed_foreign_functions_turn.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,6 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,6 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools_call.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools_call.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,6 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 

--- a/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools_turn.md
+++ b/libs/partners/quickjs/tests/unit_tests/smoke_tests/snapshots/quickjs_system_prompt_no_tools_turn.md
@@ -66,7 +66,7 @@ When you finish all work, write your final answer in the message AFTER your last
 - Read files before editing — understand existing content before making changes
 - Mimic existing style, naming conventions, and patterns
 
-## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+## Filesystem Tools `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, `grep`
 
 You have access to a filesystem which you can interact with using these tools.
 All file paths must start with a /. Follow the tool docs for the available tools, and use pagination (offset/limit) when reading large files.
@@ -75,6 +75,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 - read_file: read a file from the filesystem
 - write_file: write to a file in the filesystem
 - edit_file: edit a file in the filesystem
+- delete: delete a file or directory (recursively) from the filesystem
 - glob: find files matching a pattern (e.g., "**/*.py")
 - grep: search for text within files
 


### PR DESCRIPTION
This PR represents the `v0.7` cutover onto `main`.

`v0.7` has been rewritten so its history is clean and contains only the intended version-line commits on top of `main`:

- `fix(sdk): return sentinel for empty file lists (#3709)`
- `feat(sdk): add recursive filesystem delete support`
- `feat(sdk): allow write_file to overwrite existing files`

Important: do **not** squash-merge this PR. The cutover must preserve the individual commits so release-please can generate the correct changelog. Use an admin `git merge --no-ff origin/v0.7` into `main` after CI is green, per `.github/RELEASING.md`.
