### PR TITLE
chore(infra): update `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,11 +3,10 @@
 # Owners will be automatically requested for review when someone opens a pull request.
 # For more information: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-/.github/ @mdrxy @eyurtsev
-/libs/sdk/ @hwchase17 @sydney-runkle @ccurme @eyurtsev @vtrivedy
+/.github/ @mdrxy
+/libs/sdk/ @hwchase17 @sydney-runkle @ccurme
 /libs/cli/ @mdrxy
-/libs/evals/ @mdrxy @vtrivedy
+/libs/evals/ @mdrxy
 /libs/talon/ @jkennedyvz
 /libs/partners/ @eyurtsev
 /libs/partners/quickjs/ @hntrl
-/libs/acp/ @jacoblee93


### PR DESCRIPTION
Updates CODEOWNERS to reflect the current ownership assignments requested for repository infrastructure, SDK, evals, and ACP areas.

The ACP entry is removed because it no longer has owners after removing `@jacoblee93`.
