### PR TITLE
fix(ci): skip lockfile fixer for non-uv Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot_lockfile_fix.yml
+++ b/.github/workflows/dependabot_lockfile_fix.yml
@@ -23,6 +23,13 @@ jobs:
     # On that run github.actor is the App's bot identity -- not
     # dependabot[bot] -- so the actor guard skips it. Do not loosen the actor
     # check without adding an explicit loop breaker.
+    #
+    # The head.ref prefix is deliberately scoped to 'dependabot/uv/': this job
+    # only regenerates uv lockfiles, so other ecosystems (e.g. github-actions,
+    # whose branches are 'dependabot/github_actions/...') have nothing to fix
+    # and would only hit the changed-file guard and fail. Do not re-widen this
+    # to 'dependabot/' -- the narrow scope keeps the contents:write token path
+    # reachable only by uv Dependabot PRs.
     if: >
       github.actor == 'dependabot[bot]' &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&

--- a/.github/workflows/dependabot_lockfile_fix.yml
+++ b/.github/workflows/dependabot_lockfile_fix.yml
@@ -29,7 +29,7 @@ jobs:
       github.event.pull_request.user.type == 'Bot' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.base.repo.full_name == github.repository &&
-      startsWith(github.event.pull_request.head.ref, 'dependabot/')
+      startsWith(github.event.pull_request.head.ref, 'dependabot/uv/')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
The Dependabot lockfile fixer is meant to repair uv lockfile PRs, but it currently runs on every same-repo Dependabot PR. GitHub Actions update PRs then fail the security preflight because workflow files are intentionally outside the uv `pyproject.toml`/`uv.lock` allowlist.

This narrows the trusted job guard to `dependabot/uv/` branches, so non-uv Dependabot PRs do not surface a failing lockfile-fix check. The fail-closed changed-file guard still applies to actual uv Dependabot PRs before any write credentials are minted.