### PR TITLE
docs(talon): clarify experimental security support

### DIFF
--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -2,7 +2,9 @@
 
 Deep Agents Talon is the local runtime host for long-running Deep Agents. It owns the process lifecycle for channel adapters, cron schedulers, and the agent runtime in a single event loop.
 
-> **Experimental:** Talon is an experimental runtime and is subject to change or removal at any time.
+> **Experimental:** Talon is an experimental, alpha-status runtime and is subject to change or removal at any time. It is not intended for production or enterprise use.
+>
+> **Security support:** Talon does not yet implement production-grade security controls such as complete human-in-the-loop (HITL) approval policy, channel administrator controls, sandbox-backed execution isolation, or multi-tenant boundaries. Channel access should be treated as direct access to the operator's agent, model credentials, MCP tools, and local host resources. We do not accept security vulnerability reports for the absence of these known, unimplemented Talon hardening features while Talon remains experimental.
 
 Talon currently includes:
 
@@ -127,7 +129,9 @@ These logs complement the persisted `last_status` and `last_error` fields.
 
 ## Security and Data Lifecycle
 
-Talon is single-operator by design. It does not provide multi-tenant isolation, and channel exposure should be treated as direct access to the operator's agent.
+Talon is single-operator by design. It does not provide multi-tenant isolation, sandbox-backed execution isolation, production-grade HITL policy enforcement, or channel administrator boundaries. Any tool approval prompt surfaced through a channel is an experimental convenience feature, not a complete security boundary. Channel exposure should be treated as direct access to the operator's agent, model credentials, MCP tools, and local host resources.
+
+Do not file security vulnerability reports for the absence of these known, unimplemented hardening features in Talon while it remains experimental. Reports about missing enterprise controls, channel admin gates, sandbox integrations, or production HITL policy are considered feature requests for a future production-ready runtime.
 
 Attacker-influenceable inputs include channel message text, voice transcripts, channel media metadata, downloaded media files when a channel adapter persists them for processing, web or search result content, MCP tool results, and imported manifest instructions. Treat all of those inputs as untrusted content entering the agent context.
 


### PR DESCRIPTION
Clarifies Talon’s alpha status and security-support boundaries so readers know production HITL policy, sandbox isolation, channel admin controls, and multi-tenant boundaries are not implemented yet. Also documents that reports about those known missing hardening features are treated as feature requests while Talon remains experimental.

Docs-only change; verified with `git diff --check`.

Made by [Open SWE](https://openswe.vercel.app/agents/25c781c1-fad7-a196-6adb-5e606877a1f2)