### PR TITLE
fix(evals): make Harbor LangGraph example runnable from scratch

### DIFF
--- a/libs/evals/CONTRIBUTING.md
+++ b/libs/evals/CONTRIBUTING.md
@@ -417,6 +417,7 @@ uv run harbor run \
   --agent-kwarg config=langgraph.json \
   --agent-kwarg graph=deepagent \
   --agent-env 'ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}' \
+  --agent-env UV_PRERELEASE=allow \
   --dataset terminal-bench/terminal-bench-2 \
   --model "$MODEL" \
   -n 1 \
@@ -432,6 +433,7 @@ uv run harbor run \
   --agent-env 'ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}' \
   --agent-env 'LANGSMITH_API_KEY=${LANGSMITH_API_KEY}' \
   --agent-env 'LANGSMITH_TRACING=true' \
+  --agent-env UV_PRERELEASE=allow \
   --dataset terminal-bench/terminal-bench-2 \
   --model "$MODEL" \
   -n 1 \
@@ -441,6 +443,11 @@ uv run harbor run \
   --plugin-kwarg dataset_name=terminal-bench/terminal-bench-2 \
   --plugin-kwarg experiment_name=deepagents-baseline-v1
 ```
+
+`UV_PRERELEASE=allow` is required so the in-sandbox dependency install can resolve
+provider packages that pin pre-release dependencies (e.g. `langchain-fireworks`,
+which requires a pre-release of `fireworks-ai`). The `make run-terminal-bench-*`
+shortcuts pass this automatically.
 
 ### Available environments
 
@@ -484,6 +491,7 @@ uv run harbor run \
   --agent-env 'ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}' \
   --agent-env 'LANGSMITH_API_KEY=${LANGSMITH_API_KEY}' \
   --agent-env 'LANGSMITH_TRACING=true' \
+  --agent-env UV_PRERELEASE=allow \
   --dataset terminal-bench/terminal-bench-2 \
   --model "$MODEL" \
   -n 10 \

--- a/libs/evals/Makefile
+++ b/libs/evals/Makefile
@@ -46,7 +46,7 @@ HARBOR_AGENT_GRAPH = $(if $(filter bare,$(HARBOR_AGENT_IMPL)),bare_deepagent,dee
 HARBOR_LANGGRAPH_PROJECT = deepagents_harbor/langgraph_project
 HARBOR_LOCAL_DEPS_DIR = $(HARBOR_LANGGRAPH_PROJECT)/.local_deps
 HARBOR_AGENT_ARGS = --agent langgraph --agent-kwarg project_path=$(HARBOR_LANGGRAPH_PROJECT) --agent-kwarg config=langgraph.json --agent-kwarg graph=$(HARBOR_AGENT_GRAPH)
-HARBOR_AGENT_ENV_ARGS ?= --agent-env 'LANGSMITH_API_KEY=$${LANGSMITH_API_KEY}' --agent-env 'LANGSMITH_TRACING=true' --agent-env 'ANTHROPIC_API_KEY=$${ANTHROPIC_API_KEY}'
+HARBOR_AGENT_ENV_ARGS ?= --agent-env 'LANGSMITH_API_KEY=$${LANGSMITH_API_KEY}' --agent-env 'LANGSMITH_TRACING=true' --agent-env 'ANTHROPIC_API_KEY=$${ANTHROPIC_API_KEY}' --agent-env UV_PRERELEASE=allow
 HARBOR_HELLO_WORLD_JOBS_DIR ?= harbor-jobs/hello-world
 HARBOR_TERMINAL_BENCH_JOBS_DIR ?= harbor-jobs/terminal-bench
 HARBOR_TERMINAL_BENCH_DATASET ?= terminal-bench/terminal-bench-2
@@ -56,10 +56,11 @@ stage-harbor-local-deps: ## Stage checked-out packages for Harbor LangGraph sand
 	@mkdir -p $(HARBOR_LOCAL_DEPS_DIR)
 	rsync -a --delete --exclude '.venv' --exclude '__pycache__' --exclude '.pytest_cache' --exclude 'build' --exclude 'dist' --exclude '*.egg-info' ../deepagents/ $(HARBOR_LOCAL_DEPS_DIR)/deepagents/
 	rsync -a --delete --exclude '.venv' --exclude '__pycache__' --exclude '.pytest_cache' --exclude 'build' --exclude 'dist' --exclude '*.egg-info' ../code/ $(HARBOR_LOCAL_DEPS_DIR)/deepagents-code/
+	rsync -a --delete --exclude '.venv' --exclude '__pycache__' --exclude '.pytest_cache' --exclude 'build' --exclude 'dist' --exclude '*.egg-info' ../partners/ $(HARBOR_LOCAL_DEPS_DIR)/partners/
 
 run-hello-world: stage-harbor-local-deps ## Run hello-world job
 	@mkdir -p $(HARBOR_HELLO_WORLD_JOBS_DIR)
-	uv run harbor run $(HARBOR_AGENT_ARGS) $(HARBOR_AGENT_ENV_ARGS) --dataset hello-world --task-name hello-world -n 1 --jobs-dir $(HARBOR_HELLO_WORLD_JOBS_DIR) --env docker
+	uv run harbor run $(HARBOR_AGENT_ARGS) $(HARBOR_AGENT_ENV_ARGS) --dataset hello-world -i hello-world --model $(or $(MODEL),anthropic:claude-opus-4-8) -n 1 --jobs-dir $(HARBOR_HELLO_WORLD_JOBS_DIR) --env docker
 
 run-terminal-bench-modal: stage-harbor-local-deps ## Run terminal-bench on Modal (4 concurrent)
 	@mkdir -p $(HARBOR_TERMINAL_BENCH_JOBS_DIR)


### PR DESCRIPTION
## Summary

The documented Harbor Deep Agents (LangGraph) flow did not run end-to-end on a clean checkout. Running it from scratch surfaced three independent blockers; this PR fixes all three so `make run-*` and the `CONTRIBUTING.md` commands work as written.

## Root causes

1. **Missing `partners/` staging.** `stage-harbor-local-deps` staged `deepagents` and `deepagents-code` into `.local_deps/`, but `deepagents-code` pins `langchain-quickjs` (and the other partner SDKs) to `../partners/*` via `[tool.uv.sources]`. The in-sandbox editable install of `deepagents-code` therefore failed with `Distribution not found at .local_deps/partners/quickjs`.
2. **Pre-release resolution.** The per-dependency install in Harbor's LangGraph agent runs `uv pip install <dep>`, which rejects pre-releases by default. `langchain-fireworks==1.4.2` requires `fireworks-ai>=1.2.0a71` (a pre-release), so resolution failed with `No solution found`.
3. **`run-hello-world` broken.** It used the removed `--task-name` flag (renamed to `-i`/`--task` in current Harbor) and passed no `--model`, so graph construction raised `configurable.model or HARBOR_MODEL must provide a model name`.

## Changes (`libs/evals/`)

- **Makefile**
  - `stage-harbor-local-deps`: also rsync `../partners/` into `.local_deps/partners/`.
  - `HARBOR_AGENT_ENV_ARGS`: add `--agent-env UV_PRERELEASE=allow` (Harbor merges agent env into the install step, so this reaches the dependency resolver).
  - `run-hello-world`: `--task-name hello-world` → `-i hello-world`, and add `--model $(or $(MODEL),anthropic:claude-opus-4-8)`.
- **CONTRIBUTING.md**: add `UV_PRERELEASE=allow` to the three raw `harbor run` examples and a one-line explanation.

## Verification

`make run-hello-world` on the docker backend:

```
hello-world • langgraph • anthropic:claude-opus-4-8
Trials: 1 · Exceptions: 0 · Mean: 1.000   Reward 1.0 ×1
```

Also confirmed all 16 `langgraph.json` dependencies install cleanly inside a fresh `python:3.12-slim` (linux/arm64) container with `partners/` staged and `UV_PRERELEASE=allow`.

## Note / alternative

`UV_PRERELEASE=allow` is the minimal fix that matches the current pins. An alternative for blocker (2) is to relax the upstream `langchain-fireworks` / `fireworks-ai` pin so a stable release resolves; happy to switch if preferred.
