### PR TITLE
chore(infra): SHA-pin actions/checkout in example workflow

### DIFF
--- a/.github/workflows/deepagents-example.yml.example
+++ b/.github/workflows/deepagents-example.yml.example
@@ -90,7 +90,7 @@ jobs:
           echo "sha=$PR_SHA" >> "$GITHUB_OUTPUT"
           echo "branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           # Use the PR branch name so the agent can commit and push to the PR directly.
           ref: ${{ github.event_name != 'workflow_dispatch' && steps.pr-sha.outputs.branch || '' }}


### PR DESCRIPTION
## Summary

Pin `actions/checkout@v6` → `actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1` in `deepagents-example.yml.example`.

All other workflows and composite actions in the repo were already SHA-pinned. This completes coverage for every third-party action reference in `.github/`.

## Why

SHA-pinning third-party GitHub Actions is a supply-chain security best practice recommended by GitHub and security scanners. Tag-based references (`@v6`) are mutable — a compromised maintainer account or stolen token can push malicious code under the same tag. SHA-pinned references are immutable.

## Notes

The `langchain-ai/deepagents@main` self-reference in the example template is intentionally left unpinned — it is a template file (`.example` suffix) for downstream consumers, not a live workflow.