### PR TITLE
fix(infra): allow repo hotfix history-repair merges

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -477,7 +477,7 @@ This most commonly bites when someone tries to "fix up" a merged PR's changelog 
 
 The `guard-empty-commit` job in [`release-please.yml`](https://github.com/langchain-ai/deepagents/blob/main/.github/workflows/release-please.yml) blocks this at CI time: any push to `main` whose `HEAD` commit changes zero files fails fast with a clear error before the release-please action runs.
 
-There is one narrow exception for history repair: an empty merge commit titled `hotfix(repo): ...` may pass if every commit on the merged branch touches files. This covers cases where the final file tree is intentionally unchanged, but preserving the individual commits matters. For example, release-please reads commit history to decide package scope, version bumps, and changelog entries, so restoring a lost `feat(sdk)!` commit with a `BREAKING CHANGE:` footer can be necessary even when the files already match `main`.
+There is one narrow exception for history repair: an empty merge commit titled `hotfix(repo): ...` may pass if each commit introduced by the merged branch touches files. This covers cases where the final file tree is intentionally unchanged, but preserving the individual commits matters. For example, release-please reads commit history to decide package scope, version bumps, and changelog entries, so restoring a lost `feat(sdk)!` commit with a `BREAKING CHANGE:` footer can be necessary even when the files already match `main`.
 
 **If you need to amend a release note for a commit that already merged**, see [Overriding a Merged Commit's Changelog Entry](#overriding-a-merged-commits-changelog-entry) below. Do not push empty commits to `main`.
 

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -477,7 +477,7 @@ This most commonly bites when someone tries to "fix up" a merged PR's changelog 
 
 The `guard-empty-commit` job in [`release-please.yml`](https://github.com/langchain-ai/deepagents/blob/main/.github/workflows/release-please.yml) blocks this at CI time: any push to `main` whose `HEAD` commit changes zero files fails fast with a clear error before the release-please action runs.
 
-There is one narrow exception for history repair: an empty merge commit titled `hotfix(repo): ...` may pass if the branch being merged contains real, file-changing commits. This covers cases where the final file tree is intentionally unchanged, but preserving the individual commits matters. For example, release-please reads commit history to decide package scope, version bumps, and changelog entries, so restoring a lost `feat(sdk)!` commit with a `BREAKING CHANGE:` footer can be necessary even when the files already match `main`.
+There is one narrow exception for history repair: an empty merge commit titled `hotfix(repo): ...` may pass if every commit on the merged branch touches files. This covers cases where the final file tree is intentionally unchanged, but preserving the individual commits matters. For example, release-please reads commit history to decide package scope, version bumps, and changelog entries, so restoring a lost `feat(sdk)!` commit with a `BREAKING CHANGE:` footer can be necessary even when the files already match `main`.
 
 **If you need to amend a release note for a commit that already merged**, see [Overriding a Merged Commit's Changelog Entry](#overriding-a-merged-commits-changelog-entry) below. Do not push empty commits to `main`.
 

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -477,6 +477,8 @@ This most commonly bites when someone tries to "fix up" a merged PR's changelog 
 
 The `guard-empty-commit` job in [`release-please.yml`](https://github.com/langchain-ai/deepagents/blob/main/.github/workflows/release-please.yml) blocks this at CI time: any push to `main` whose `HEAD` commit changes zero files fails fast with a clear error before the release-please action runs.
 
+There is one narrow exception for history repair: an empty merge commit titled `hotfix(repo): ...` may pass if the branch being merged contains real, file-changing commits. Use this only when the file tree intentionally stays the same but the individual commits must be restored for release metadata, such as repairing an accidental squash merge of a version-line cutover. Merge that repair PR with a merge commit so the second-parent commits remain visible; do not squash or rebase it.
+
 **If you need to amend a release note for a commit that already merged**, see [Overriding a Merged Commit's Changelog Entry](#overriding-a-merged-commits-changelog-entry) below. Do not push empty commits to `main`.
 
 **If a fan-out has already happened** (release PRs opened for packages you didn't change), revert the offending commit on `main`. release-please will reconcile the open release PRs on the next push that actually touches package files; PRs for unaffected packages can be closed manually.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -477,7 +477,7 @@ This most commonly bites when someone tries to "fix up" a merged PR's changelog 
 
 The `guard-empty-commit` job in [`release-please.yml`](https://github.com/langchain-ai/deepagents/blob/main/.github/workflows/release-please.yml) blocks this at CI time: any push to `main` whose `HEAD` commit changes zero files fails fast with a clear error before the release-please action runs.
 
-There is one narrow exception for history repair: an empty merge commit titled `hotfix(repo): ...` may pass if the branch being merged contains real, file-changing commits. This covers cases where the final file tree is intentionally unchanged, but preserving the individual commits matters for release metadata or audit history.
+There is one narrow exception for history repair: an empty merge commit titled `hotfix(repo): ...` may pass if the branch being merged contains real, file-changing commits. This covers cases where the final file tree is intentionally unchanged, but preserving the individual commits matters. For example, release-please reads commit history to decide package scope, version bumps, and changelog entries, so restoring a lost `feat(sdk)!` commit with a `BREAKING CHANGE:` footer can be necessary even when the files already match `main`.
 
 **If you need to amend a release note for a commit that already merged**, see [Overriding a Merged Commit's Changelog Entry](#overriding-a-merged-commits-changelog-entry) below. Do not push empty commits to `main`.
 

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -477,7 +477,7 @@ This most commonly bites when someone tries to "fix up" a merged PR's changelog 
 
 The `guard-empty-commit` job in [`release-please.yml`](https://github.com/langchain-ai/deepagents/blob/main/.github/workflows/release-please.yml) blocks this at CI time: any push to `main` whose `HEAD` commit changes zero files fails fast with a clear error before the release-please action runs.
 
-There is one narrow exception for history repair: an empty merge commit titled `hotfix(repo): ...` may pass if the branch being merged contains real, file-changing commits. Use this only when the file tree intentionally stays the same but the individual commits must be restored for release metadata, such as repairing an accidental squash merge of a version-line cutover. Merge that repair PR with a merge commit so the second-parent commits remain visible; do not squash or rebase it.
+There is one narrow exception for history repair: an empty merge commit titled `hotfix(repo): ...` may pass if the branch being merged contains real, file-changing commits. This covers cases where the final file tree is intentionally unchanged, but preserving the individual commits matters for release metadata or audit history.
 
 **If you need to amend a release note for a commit that already merged**, see [Overriding a Merged Commit's Changelog Entry](#overriding-a-merged-commits-changelog-entry) below. Do not push empty commits to `main`.
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,22 +40,35 @@ jobs:
             echo "Single-commit history; skipping empty-commit guard."
             exit 0
           fi
-          CHANGED=$(git diff-tree --no-commit-id --name-only -r HEAD)
+          COMMIT_MSG=$(git log -1 --format=%s HEAD)
+          SHA=$(git rev-parse HEAD)
+          PARENT_COUNT=$(git show --no-patch --format=%P HEAD | wc -w | tr -d ' ')
+          if [ "$PARENT_COUNT" -gt 2 ]; then
+            echo "::error::Octopus merge detected on main: $SHA \"$COMMIT_MSG\""
+            echo "::error::The empty-commit guard only supports one- or two-parent commits. Recreate this as a normal two-parent merge."
+            exit 1
+          fi
+
+          # `git diff-tree` reports no paths for merge commits unless given -m.
+          # Compare merges to their first parent so non-empty merges pass before
+          # the repo-hotfix history-repair exception below.
+          if [ "$PARENT_COUNT" -eq 2 ]; then
+            CHANGED=$(git diff --name-only HEAD^1 HEAD)
+          else
+            CHANGED=$(git diff-tree --no-commit-id --name-only -r HEAD)
+          fi
           if [ -n "$CHANGED" ]; then
             echo "HEAD touches files; proceeding."
             exit 0
           fi
 
-          COMMIT_MSG=$(git log -1 --format=%s HEAD)
-          SHA=$(git rev-parse HEAD)
-          PARENT_COUNT=$(git show --no-patch --format=%P HEAD | wc -w | tr -d ' ')
-          if [ "$PARENT_COUNT" -ge 2 ]; then
+          if [ "$PARENT_COUNT" -eq 2 ]; then
             case "$COMMIT_MSG" in
               "hotfix(repo):"*) ;;
               *)
                 echo "::error::Empty merge commit detected on main: $SHA \"$COMMIT_MSG\""
                 echo "::error::Only repo-scoped hotfix merge commits may use the history-repair exception."
-                echo "::error::release-please scopes commits to packages by changed file paths. Empty commits have none, so every package gets bumped."
+                echo "::error::See .github/RELEASING.md -> \"Empty commit fan-out\"."
                 exit 1
                 ;;
             esac
@@ -64,13 +77,19 @@ jobs:
             if [ -z "$MERGED_COMMITS" ]; then
               echo "::error::Empty merge commit detected on main: $SHA \"$COMMIT_MSG\""
               echo "::error::The merge commit does not introduce any second-parent commits."
+              echo "::error::See .github/RELEASING.md -> \"Empty commit fan-out\"."
               exit 1
             fi
 
             EMPTY_MERGED_COMMITS=""
             for COMMIT in $MERGED_COMMITS; do
               COMMIT_PARENT_COUNT=$(git show --no-patch --format=%P "$COMMIT" | wc -w | tr -d ' ')
-              if [ "$COMMIT_PARENT_COUNT" -ge 2 ]; then
+              if [ "$COMMIT_PARENT_COUNT" -gt 2 ]; then
+                echo "::error::Octopus merge detected in merged branch: $COMMIT"
+                echo "::error::The empty-commit guard only supports one- or two-parent commits. Recreate this as normal two-parent merges."
+                exit 1
+              fi
+              if [ "$COMMIT_PARENT_COUNT" -eq 2 ]; then
                 COMMIT_CHANGED=$(git diff --name-only "$COMMIT^1" "$COMMIT")
               else
                 COMMIT_CHANGED=$(git diff-tree --no-commit-id --name-only -r "$COMMIT")
@@ -86,7 +105,8 @@ jobs:
             fi
             echo "::error::Empty merge commit detected on main: $SHA \"$COMMIT_MSG\""
             echo "::error::The merged branch contains empty commits:$EMPTY_MERGED_COMMITS"
-            echo "::error::release-please scopes commits to packages by changed file paths. Empty commits have none, so every package gets bumped."
+            echo "::error::Every commit in a history-repair branch must touch files so release-please can scope it."
+            echo "::error::See .github/RELEASING.md -> \"Empty commit fan-out\"."
             exit 1
           fi
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -69,7 +69,13 @@ jobs:
 
             EMPTY_MERGED_COMMITS=""
             for COMMIT in $MERGED_COMMITS; do
-              if [ -z "$(git diff-tree --no-commit-id --name-only -r "$COMMIT")" ]; then
+              COMMIT_PARENT_COUNT=$(git show --no-patch --format=%P "$COMMIT" | wc -w | tr -d ' ')
+              if [ "$COMMIT_PARENT_COUNT" -ge 2 ]; then
+                COMMIT_CHANGED=$(git diff --name-only "$COMMIT^1" "$COMMIT")
+              else
+                COMMIT_CHANGED=$(git diff-tree --no-commit-id --name-only -r "$COMMIT")
+              fi
+              if [ -z "$COMMIT_CHANGED" ]; then
                 EMPTY_MERGED_COMMITS="$EMPTY_MERGED_COMMITS $COMMIT"
               fi
             done

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Reject empty commits
         run: |
           if [ "$(git rev-list --count HEAD)" -lt 2 ]; then
@@ -45,8 +45,45 @@ jobs:
             echo "HEAD touches files; proceeding."
             exit 0
           fi
+
           COMMIT_MSG=$(git log -1 --format=%s HEAD)
           SHA=$(git rev-parse HEAD)
+          PARENT_COUNT=$(git show --no-patch --format=%P HEAD | wc -w | tr -d ' ')
+          if [ "$PARENT_COUNT" -ge 2 ]; then
+            case "$COMMIT_MSG" in
+              "hotfix(repo):"*) ;;
+              *)
+                echo "::error::Empty merge commit detected on main: $SHA \"$COMMIT_MSG\""
+                echo "::error::Only repo-scoped hotfix merge commits may use the history-repair exception."
+                echo "::error::release-please scopes commits to packages by changed file paths. Empty commits have none, so every package gets bumped."
+                exit 1
+                ;;
+            esac
+
+            MERGED_COMMITS=$(git rev-list HEAD^1..HEAD^2)
+            if [ -z "$MERGED_COMMITS" ]; then
+              echo "::error::Empty merge commit detected on main: $SHA \"$COMMIT_MSG\""
+              echo "::error::The merge commit does not introduce any second-parent commits."
+              exit 1
+            fi
+
+            EMPTY_MERGED_COMMITS=""
+            for COMMIT in $MERGED_COMMITS; do
+              if [ -z "$(git diff-tree --no-commit-id --name-only -r "$COMMIT")" ]; then
+                EMPTY_MERGED_COMMITS="$EMPTY_MERGED_COMMITS $COMMIT"
+              fi
+            done
+            if [ -z "$EMPTY_MERGED_COMMITS" ]; then
+              echo "Empty repo hotfix merge commit detected, but every commit merged from the second parent touches files; proceeding."
+              git log --oneline HEAD^1..HEAD^2
+              exit 0
+            fi
+            echo "::error::Empty merge commit detected on main: $SHA \"$COMMIT_MSG\""
+            echo "::error::The merged branch contains empty commits:$EMPTY_MERGED_COMMITS"
+            echo "::error::release-please scopes commits to packages by changed file paths. Empty commits have none, so every package gets bumped."
+            exit 1
+          fi
+
           echo "::error::Empty commit detected on main: $SHA \"$COMMIT_MSG\""
           echo "::error::release-please scopes commits to packages by changed file paths. An empty commit has none, so every package gets bumped."
           echo "::error::Recovery: revert this commit on main, then push a non-empty commit scoped to a single package directory. See .github/RELEASING.md -> \"Empty commit fan-out\"."


### PR DESCRIPTION
The empty-commit guard in the release-please workflow correctly blocks pathless commits because release-please cannot scope them to a package. PR #4294 exposed a narrow false positive: a history-repair PR can produce an empty merge commit while the second-parent side contains real, file-changing commits that release-please should process.

This keeps the guard strict while allowing that repair shape:

- normal file-changing commits still pass immediately
- direct empty commits still fail
- empty merge commits still fail unless their subject is repo-scoped `hotfix(repo): ...`
- repo hotfix empty merge commits only pass when the second-parent side introduces commits and every merged commit touches files

Verified locally against the failed #4294 merge commit, an empty direct commit, and an empty merge commit with a release-relevant subject.
