### PR TITLE
hotfix(code): use `if-necessary` for installer prerelease resolution

### DIFF
--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -7,11 +7,14 @@
 # Install an exact pre-release version:
 #   curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_VERSION="0.1.0rc1" bash
 #
-# Allow uv to consider alpha/beta/rc releases when resolving the latest version:
+# Override uv's pre-release strategy when resolving the latest version:
 #   curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_PRERELEASE="allow" bash
 #
-# DEEPAGENTS_CODE_VERSION and DEEPAGENTS_CODE_PRERELEASE are mutually exclusive:
-# an exact pin already selects a single version, so setting both is an error.
+# By default, the installer uses uv's `if-necessary` pre-release strategy so
+# stable deepagents-code releases that pin a pre-release dependency can resolve.
+# DEEPAGENTS_CODE_VERSION and an explicit DEEPAGENTS_CODE_PRERELEASE are mutually
+# exclusive: an exact pin already selects a single version, so setting both is an
+# error.
 #
 # Already installed?
 #   Safe to re-run. If a newer version exists, it asks before upgrading — or
@@ -47,8 +50,8 @@
 #     (mutually exclusive with DEEPAGENTS_CODE_PRERELEASE)
 #   DEEPAGENTS_CODE_PRERELEASE — uv pre-release strategy applied when
 #     resolving the latest version: disallow, allow, if-necessary, explicit,
-#     or if-necessary-or-explicit (mutually exclusive with
-#     DEEPAGENTS_CODE_VERSION)
+#     or if-necessary-or-explicit (default: if-necessary; explicitly setting it
+#     is mutually exclusive with DEEPAGENTS_CODE_VERSION)
 #   DEEPAGENTS_CODE_PYTHON — Python version to use (default: 3.13)
 #   DEEPAGENTS_CODE_YES — set to 1 to accept an available update without
 #     prompting (assume "yes"). Exists so automated runs that still attach a
@@ -341,7 +344,8 @@ copy_install_log() {
 # ---------------------------------------------------------------------------
 EXTRAS="${DEEPAGENTS_CODE_EXTRAS:-}"
 VERSION="${DEEPAGENTS_CODE_VERSION:-}"
-PRERELEASE="${DEEPAGENTS_CODE_PRERELEASE:-}"
+PRERELEASE_REQUESTED="${DEEPAGENTS_CODE_PRERELEASE:-}"
+PRERELEASE="${PRERELEASE_REQUESTED:-if-necessary}"
 PYTHON_REQUESTED=false
 if [[ -n "${DEEPAGENTS_CODE_PYTHON:-}" ]]; then
   PYTHON_REQUESTED=true
@@ -383,11 +387,12 @@ if [[ -n "$EXTRAS" ]]; then
   EXTRAS="[${EXTRAS}]"
 fi
 
-# An exact pin already selects a single version, so a pre-release strategy
-# (which only affects how a range resolves) is redundant at best and
-# contradictory at worst (e.g. an rc pin with "disallow"). Reject the combo
-# up front rather than forwarding an ambiguous request to uv.
-if [[ -n "$VERSION" && -n "$PRERELEASE" ]]; then
+# An exact pin already selects a single version, so an explicitly requested
+# pre-release strategy (which only affects how a range resolves) is redundant at
+# best and contradictory at worst (e.g. an rc pin with "disallow"). Reject only
+# user-provided combinations; the installer's default `if-necessary` strategy is
+# not forwarded when a version is pinned.
+if [[ -n "$VERSION" && -n "$PRERELEASE_REQUESTED" ]]; then
   log_error "DEEPAGENTS_CODE_VERSION and DEEPAGENTS_CODE_PRERELEASE are mutually exclusive."
   log_error "Pin an exact version, or set a pre-release strategy — not both."
   exit 1
@@ -555,7 +560,7 @@ if [ "$IS_EDITABLE" = true ]; then
     log_info "deepagents-code ${pre_label} found (editable install from local source)."
   fi
   log_info "  Replacing with a standard install from PyPI — the existing environment will be rebuilt."
-elif [ -n "$PRE_VERSION" ] && [ -z "$VERSION" ] && [ -z "$PRERELEASE" ]; then
+elif [ -n "$PRE_VERSION" ] && [ -z "$VERSION" ] && [ -z "$PRERELEASE_REQUESTED" ]; then
   # Default path with an existing install: probe PyPI and prompt before
   # upgrading, rather than silently pulling the latest version every run.
   # A pinned version or pre-release strategy (handled by the branches above and
@@ -609,8 +614,8 @@ fi
 #      instead of upgrading in place (e.g., Python interpreter mismatch, or
 #      editable↔regular install swap).
 #   2. Drop uv's per-step timing lines ("Resolved N packages in...", etc.)
-#      and the trailing "Installed N executables:" line — we already show
-#      a Verified line with the binary name and version.
+#      download/build progress, and the trailing "Installed N executables:" line
+#      — we already show a concise install/update summary.
 #   3. Reformat the `- pkg==X` / `+ pkg==Y` diff into an aligned
 #      "pkg  X → Y" table under a single header.
 #   4. Detect whether uv actually moved any packages (those same
@@ -652,7 +657,7 @@ if [ -n "$cache_root" ]; then
     fi
   fi
 fi
-if [[ -n "$PRERELEASE" ]]; then
+if [[ -z "$VERSION" ]]; then
   "$UV_BIN" tool install -U --python "$PYTHON_VERSION" \
     --prerelease "$PRERELEASE" "$PACKAGE" 2>"$uv_stderr" || uv_rc=$?
 else
@@ -665,12 +670,16 @@ if [ "$VERBOSE" != "1" ] && command -v awk >/dev/null 2>&1; then
       print "⚠ Existing environment uses a different Python — rebuilding from scratch (this is normal)."
       next
     }
-    /^Resolved [0-9]+ packages? in /    { next }
-    /^Prepared [0-9]+ packages? in /    { next }
-    /^Uninstalled [0-9]+ packages? in / { next }
-    /^Installed [0-9]+ packages? in /   { next }
-    /^Audited [0-9]+ packages? in /     { next }
-    /^Checked [0-9]+ packages? in /     { next }
+    /^Resolved( [0-9]+ packages?)? in /     { next }
+    /^Prepared [0-9]+ packages?( |$)/       { next }
+    /^Uninstalled [0-9]+ packages? in /     { next }
+    /^Installed [0-9]+ packages? in /       { next }
+    /^Audited( [0-9]+ packages?)? in /      { next }
+    /^Checked( [0-9]+ packages?)? in /      { next }
+    /^[[:space:]]*Downloading /         { next }
+    /^[[:space:]]*Downloaded /          { next }
+    /^[[:space:]]*Building /            { next }
+    /^[[:space:]]*Built /                { next }
     /^Installed [0-9]+ executables?:/   { next }
     /^ - / {
       s = $0; sub(/^ - /, "", s); n = index(s, "==")
@@ -968,7 +977,7 @@ if [ "$SKIP_OPTIONAL" != "1" ]; then
     # PATH and honors DEEPAGENTS_CODE_OFFLINE and
     # DEEPAGENTS_CODE_RIPGREP_INSTALLER=system, reporting what it did.
     echo ""
-    log_info "Setting up ripgrep (managed; opt out with DEEPAGENTS_CODE_RIPGREP_INSTALLER=system)..."
+    log_info "Setting up ripgrep..."
     if "$DCODE_BIN" tools install; then
       fix_owner "${HOME}/.deepagents/bin"
     else

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -292,13 +292,13 @@ def test_install_script_default_invocation_installs_plain_package(
     """A fresh machine installs the bare package with no prompt.
 
     Guards the most common `curl ... | bash` path against accidentally
-    appending a version pin, extras, or a `--prerelease` flag.
+    appending a version pin or extras, while allowing stable releases that pin
+    pre-release dependencies to resolve.
     """
     args = _run_install_script(tmp_path, {}, installed_version=None)
 
     assert args[:3] == ["tool", "install", "-U"]
-    assert args[-1] == "deepagents-code"
-    assert "--prerelease" not in args
+    assert args[-3:] == ["--prerelease", "if-necessary", "deepagents-code"]
 
 
 def test_install_script_supports_exact_version_with_extras(tmp_path: Path) -> None:
@@ -583,7 +583,21 @@ _DEPENDENCY_UPDATE_DIFF = " - boto3==1.43.33\n + boto3==1.43.34"
 _DEPENDENCY_ADDITION_DIFF = " + brand-new-dep==1.0.0"
 
 # uv ran but moved nothing — only timing/summary noise, no `± pkg==ver` lines.
-_NO_PACKAGE_CHANGE_STDERR = "Resolved 5 packages in 12ms\nAudited 5 packages in 1ms"
+_NO_PACKAGE_CHANGE_STDERR = (
+    "Resolved 5 packages in 12ms\n"
+    "Resolved in 12ms\n"
+    "Prepared 1 package for build in 20ms\n"
+    "Checked in 1ms\n"
+    "Audited 5 packages in 1ms"
+)
+
+_UV_PROGRESS_STDERR = (
+    "Downloading uvloop (1.3MiB)\n"
+    " Downloading pygments (1.2MiB)\n"
+    "Downloaded uvloop\n"
+    "Building forbiddenfruit==0.1.4\n"
+    "Built forbiddenfruit==0.1.4"
+)
 
 
 def test_install_script_fresh_install_hides_packages(tmp_path: Path) -> None:
@@ -612,6 +626,41 @@ def test_install_script_verbose_lists_every_package(tmp_path: Path) -> None:
     assert "agent-client-protocol==0.10.1" in proc.stderr
     assert "zstandard==0.25.0" in proc.stderr
     assert "Installed 3 packages" not in proc.stderr
+
+
+def test_install_script_hides_uv_download_and_build_progress(tmp_path: Path) -> None:
+    """Non-verbose installs hide uv's download and build progress lines."""
+    proc, _ = _invoke(
+        tmp_path,
+        {"FAKE_UV_INSTALL_STDERR": _UV_PROGRESS_STDERR},
+        installed_version=None,
+    )
+
+    assert proc.returncode == 0
+    assert "Downloading uvloop" not in proc.stderr
+    assert "Downloaded uvloop" not in proc.stderr
+    assert "Building forbiddenfruit" not in proc.stderr
+    assert "Built forbiddenfruit" not in proc.stderr
+
+
+def test_install_script_verbose_shows_uv_download_and_build_progress(
+    tmp_path: Path,
+) -> None:
+    """Verbose installs preserve uv's raw download and build progress lines."""
+    proc, _ = _invoke(
+        tmp_path,
+        {
+            "FAKE_UV_INSTALL_STDERR": _UV_PROGRESS_STDERR,
+            "DEEPAGENTS_CODE_VERBOSE": "1",
+        },
+        installed_version=None,
+    )
+
+    assert proc.returncode == 0
+    assert "Downloading uvloop" in proc.stderr
+    assert "Downloaded uvloop" in proc.stderr
+    assert "Building forbiddenfruit" in proc.stderr
+    assert "Built forbiddenfruit" in proc.stderr
 
 
 def test_install_script_upgrade_still_shows_diff(tmp_path: Path) -> None:
@@ -1273,6 +1322,9 @@ def test_install_script_managed_ripgrep_calls_tools_install(tmp_path: Path) -> N
     tools_log = tmp_path / "dcode-tools.txt"
     assert tools_log.exists(), proc.stdout + proc.stderr
     assert "tools install" in tools_log.read_text()
+    combined = proc.stdout + proc.stderr
+    assert "Setting up ripgrep..." in combined
+    assert "opt out with DEEPAGENTS_CODE_RIPGREP_INSTALLER=system" not in combined
 
 
 def test_install_script_system_ripgrep_skips_tools_install(tmp_path: Path) -> None:


### PR DESCRIPTION
Stable `deepagents-code` releases can temporarily depend on pre-release packages, which made the default installer path fail when uv refused pre-release resolution. The installer now applies uv's `if-necessary` strategy for unpinned installs while keeping exact version pins mutually exclusive with explicitly requested pre-release settings.

## Changes

- Default unpinned installs to `--prerelease if-necessary`, but avoid forwarding that default when `DEEPAGENTS_CODE_VERSION` selects an exact package version.
- Keep the mutual-exclusion error for explicit `DEEPAGENTS_CODE_PRERELEASE` plus `DEEPAGENTS_CODE_VERSION`, preserving pinned install behavior.
- Filter uv download/build progress and newer timing summary variants from non-verbose output while preserving them under `DEEPAGENTS_CODE_VERBOSE=1`.
- Shorten the managed ripgrep setup message so the installer no longer advertises the opt-out path during the normal setup flow.