### PR TITLE
style(code): simplify install-then-skip-switch message

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -9995,9 +9995,8 @@ class DeepAgentsApp(App):
         if not await self._prompt_model_auth_if_needed(model_spec):
             await self._mount_message(
                 AppMessage(
-                    f"Installed '{extra}'. Skipped switching to {model_spec} for "
-                    f"now — add credentials with `/auth`, then switch with "
-                    f"`/model` anytime.",
+                    f"Installed '{extra}'. Switch to {model_spec} anytime with "
+                    f"`/model` — you'll be prompted for credentials.",
                 ),
             )
             return

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -8012,8 +8012,8 @@ class TestInstallExtraModelSwitch:
             for c in app._mount_message.await_args_list  # ty: ignore
         )
         assert "Installed" in mounted
-        assert "/auth" in mounted
         assert "/model" in mounted
+        assert "prompted for credentials" in mounted
 
     async def test_install_extra_auto_restart_skips_restart_for_deferred_startup(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
When a provider extra installs but the user dismisses the credential prompt, the confirmation message pointed users to `/auth`. That step is unnecessary — selecting the model via `/model` prompts for credentials directly. Simplified the message to a single `/model` instruction.

Made by [Open SWE](https://openswe.vercel.app/agents/4bda915c-4fb5-aa2c-2ee8-2a3b80bd9a50)