### PR TITLE
hotfix(code): avoid reinstalling existing `uv`

### DIFF
--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -458,29 +458,54 @@ install_uv() {
   fi
 }
 
-if ! command -v uv >/dev/null 2>&1; then
+# Resolve uv binary: honor UV_BIN override, then PATH, the env file written by
+# uv's installer, then the default install location (~/.local/bin). MDM and cron
+# jobs often run with a minimal PATH, so an existing uv in ~/.local/bin must
+# count as installed before we invoke the upstream installer.
+resolve_uv_bin() {
+  if [ -n "${UV_BIN:-}" ]; then
+    case "$UV_BIN" in
+      */*) [ -f "$UV_BIN" ] && [ -x "$UV_BIN" ] ;;
+      *)   command -v "$UV_BIN" >/dev/null 2>&1 ;;
+    esac
+    return $?
+  fi
+
+  if command -v uv >/dev/null 2>&1; then
+    UV_BIN="uv"
+    return 0
+  fi
+
+  if [ -f "${HOME}/.local/bin/env" ]; then
+    set +e +u
+    # shellcheck source=/dev/null
+    . "${HOME}/.local/bin/env"
+    set -e -u
+    if command -v uv >/dev/null 2>&1; then
+      UV_BIN="uv"
+      return 0
+    fi
+  fi
+
+  if [ -x "${HOME}/.local/bin/uv" ]; then
+    UV_BIN="${HOME}/.local/bin/uv"
+    return 0
+  fi
+
+  return 1
+}
+
+if ! resolve_uv_bin; then
+  if [ -n "${UV_BIN:-}" ]; then
+    log_error "UV_BIN is set but does not point to an executable uv: ${UV_BIN}"
+    exit 1
+  fi
   log_info "uv not found — installing..."
   install_uv
   fix_owner "${HOME}/.local/bin"  # root installs: restore user ownership
-fi
-
-# Resolve uv binary: honor UV_BIN override, then PATH, then the default
-# install location (~/.local/bin). A fresh install may not have updated PATH
-# in the current session, so we source the env file the installer creates.
-if [ -z "${UV_BIN:-}" ]; then
-  UV_BIN="uv"
-  if ! command -v "$UV_BIN" >/dev/null 2>&1; then
-    if [ -f "${HOME}/.local/bin/env" ]; then
-      # shellcheck source=/dev/null
-      . "${HOME}/.local/bin/env"
-    fi
-  fi
-  if ! command -v uv >/dev/null 2>&1; then
-    UV_BIN="${HOME}/.local/bin/uv"
-    if [ ! -x "$UV_BIN" ]; then
-      log_error "uv not found after installation. Restart your shell or add ~/.local/bin to PATH."
-      exit 1
-    fi
+  if ! resolve_uv_bin; then
+    log_error "uv not found after installation. Restart your shell or add ~/.local/bin to PATH."
+    exit 1
   fi
 fi
 

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1231,6 +1231,92 @@ def test_install_script_linux_skips_clt_check(tmp_path: Path) -> None:
     assert uv_args.exists()
 
 
+def _invoke_with_local_uv_not_on_path(
+    tmp_path: Path, *, env_file_content: str | None = None
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    """Run with uv present only in ~/.local/bin, absent from PATH."""
+    bin_dir, home, uv = _write_fake_tools(
+        tmp_path, installed_version=None, latest_version="0.2.0"
+    )
+
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    local_uv = local_bin / "uv"
+    local_uv.write_text(uv.read_text())
+    _make_executable(local_uv)
+    uv.unlink()
+    if env_file_content is not None:
+        (local_bin / "env").write_text(env_file_content)
+
+    path_without_uv = os.pathsep.join(
+        entry
+        for entry in _path_without_dcode().split(os.pathsep)
+        if entry and not (Path(entry) / "uv").exists()
+    )
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "XDG_CACHE_HOME": str(home / ".cache"),
+        "PATH": f"{bin_dir}{os.pathsep}{path_without_uv}",
+        "DEEPAGENTS_CODE_SKIP_OPTIONAL": "1",
+    }
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    return proc, tmp_path / "uv-args.txt"
+
+
+def test_install_script_uses_local_uv_when_not_on_path(tmp_path: Path) -> None:
+    """A minimal MDM PATH must not reinstall uv when ~/.local/bin/uv exists."""
+    proc, uv_args = _invoke_with_local_uv_not_on_path(tmp_path)
+
+    assert proc.returncode == 0
+    assert uv_args.exists()
+    assert "uv not found — installing" not in proc.stdout + proc.stderr
+    assert uv_args.read_text().splitlines()[:3] == ["tool", "install", "-U"]
+
+
+def test_install_script_sources_uv_env_file_defensively(tmp_path: Path) -> None:
+    """A non-zero command in uv's env file must not abort the installer."""
+    proc, uv_args = _invoke_with_local_uv_not_on_path(
+        tmp_path,
+        env_file_content='export PATH="$HOME/.local/bin:$PATH"\nfalse\n',
+    )
+
+    assert proc.returncode == 0
+    assert uv_args.exists()
+    assert "uv not found — installing" not in proc.stdout + proc.stderr
+    assert uv_args.read_text().splitlines()[:3] == ["tool", "install", "-U"]
+
+
+def test_install_script_rejects_invalid_uv_bin_without_installing(
+    tmp_path: Path,
+) -> None:
+    """A bad `UV_BIN` should fail clearly instead of reinstalling uv."""
+    cases = [
+        (tmp_path / "missing", tmp_path / "missing" / "uv"),
+        (tmp_path / "directory", tmp_path / "directory" / "uv"),
+    ]
+    cases[1][1].mkdir(parents=True)
+
+    for root, uv_bin in cases:
+        root.mkdir(exist_ok=True)
+        proc, uv_args = _invoke(root, {"UV_BIN": str(uv_bin)})
+
+        assert proc.returncode != 0
+        assert not uv_args.exists()
+        assert (
+            f"UV_BIN is set but does not point to an executable uv: {uv_bin}"
+            in proc.stderr
+        )
+
+
 def _invoke_with_local_dcode_not_on_path(
     tmp_path: Path, *, create_env_file: bool = False
 ) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
The install script now resolves an existing `uv` before invoking the upstream installer, including installs that are present in `~/.local/bin` but hidden by a minimal MDM or cron PATH. Bad `UV_BIN` values fail fast with a clear error instead of falling through to a network install attempt.

## Changes
- Added `resolve_uv_bin` to check `UV_BIN`, PATH, uv’s generated env file, and `~/.local/bin/uv` before installing uv.
- Hardened env-file sourcing so stale or hand-written `~/.local/bin/env` files with non-zero commands do not abort the installer.
- Tightened `UV_BIN` path validation so directories are rejected before `uv tool install` runs.
- Added installer regression coverage for minimal-PATH uv detection, defensive env-file sourcing, and invalid `UV_BIN` values.