### PR TITLE
style(code): mark default tracing project in `dcode doctor`

### DIFF
--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -2771,7 +2771,7 @@ def _tracing_endpoint_from(env: dict[str, str]) -> str | None:
     return None
 
 
-def _resolve_tracing_project_from(env: dict[str, str]) -> str:
+def _resolve_tracing_project_from(env: dict[str, str]) -> tuple[str, bool]:
     """Resolve the project agent traces would route to, without bootstrap.
 
     The reported project matches the `tracing.langsmith_project` manifest
@@ -2784,7 +2784,8 @@ def _resolve_tracing_project_from(env: dict[str, str]) -> str:
         env: Environment mapping to read.
 
     Returns:
-        The resolved project name, or the default when none is configured.
+        The resolved project name and whether it fell back to the default
+        because no project was explicitly configured.
     """
     from deepagents_code._env_vars import LANGSMITH_PROJECT
     from deepagents_code.config_manifest import LANGSMITH_PROJECT_DEFAULT
@@ -2792,8 +2793,8 @@ def _resolve_tracing_project_from(env: dict[str, str]) -> str:
     for name in (LANGSMITH_PROJECT, "LANGSMITH_PROJECT"):
         value = env.get(name)
         if value:
-            return value
-    return LANGSMITH_PROJECT_DEFAULT
+            return value, False
+    return LANGSMITH_PROJECT_DEFAULT, True
 
 
 def _tracing_diagnostic_env() -> dict[str, str]:
@@ -2829,6 +2830,9 @@ class TracingStatus:
     project: str | None
     """Resolved configured project name, independent of active trace ingestion."""
 
+    project_is_default: bool
+    """Whether `project` is the built-in default rather than an explicit setting."""
+
     replica_project: str | None
     """Extra project agent runs are mirrored to, if configured."""
 
@@ -2848,11 +2852,13 @@ def get_tracing_status() -> TracingStatus:
     enabled = _tracing_enabled_from(env)
     has_credentials = _tracing_has_credentials_from(env)
     endpoint = _tracing_endpoint_from(env)
+    project, project_is_default = _resolve_tracing_project_from(env)
     return TracingStatus(
         enabled=enabled,
         has_credentials=has_credentials,
         endpoint=endpoint,
-        project=_resolve_tracing_project_from(env),
+        project=project,
+        project_is_default=project_is_default,
         replica_project=_get_first_langsmith_replica_project(
             _get_langsmith_replica_projects_from(env)
         ),

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -2785,7 +2785,7 @@ def _resolve_tracing_project_from(env: dict[str, str]) -> tuple[str, bool]:
 
     Returns:
         The resolved project name and whether it fell back to the default
-        because no project was explicitly configured.
+            because no project was explicitly configured.
     """
     from deepagents_code._env_vars import LANGSMITH_PROJECT
     from deepagents_code.config_manifest import LANGSMITH_PROJECT_DEFAULT

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -2810,7 +2810,7 @@ def _tracing_diagnostic_env() -> dict[str, str]:
     return _preview_dotenv_environ(start_path=ctx.user_cwd if ctx else None)
 
 
-@dataclass
+@dataclass(frozen=True)
 class TracingStatus:
     """Offline snapshot of LangSmith tracing configuration for diagnostics.
 

--- a/libs/code/deepagents_code/doctor.py
+++ b/libs/code/deepagents_code/doctor.py
@@ -23,6 +23,8 @@ from deepagents_code.output import write_json
 if TYPE_CHECKING:
     import argparse
 
+    from deepagents_code.config import TracingStatus
+
 logger = logging.getLogger(__name__)
 
 
@@ -248,6 +250,20 @@ def _sanitize_endpoint(endpoint: str) -> str:
     return f"{parsed.scheme}://{netloc}"
 
 
+def _format_tracing_project(status: TracingStatus) -> str:
+    """Render the tracing project, marking the unconfigured default.
+
+    Returns:
+        The project name with a `(default)` suffix when it is the built-in
+        fallback rather than an explicit setting, or `(unset)` when absent.
+    """
+    if not status.project:
+        return "(unset)"
+    if status.project_is_default:
+        return f"{status.project} (default)"
+    return status.project
+
+
 def _collect_tracing() -> DiagnosticSection:
     """Collect LangSmith tracing status from env and profile (offline).
 
@@ -271,7 +287,7 @@ def _collect_tracing() -> DiagnosticSection:
             "configured" if status.has_credentials else "not configured",
             ok=status.has_credentials or not creds_required,
         ),
-        DiagnosticItem("Project", status.project or "(unset)"),
+        DiagnosticItem("Project", _format_tracing_project(status)),
     ]
     if status.endpoint:
         items.append(DiagnosticItem("Endpoint", _sanitize_endpoint(status.endpoint)))

--- a/libs/code/deepagents_code/doctor.py
+++ b/libs/code/deepagents_code/doctor.py
@@ -255,7 +255,7 @@ def _format_tracing_project(status: TracingStatus) -> str:
 
     Returns:
         The project name with a `(default)` suffix when it is the built-in
-        fallback rather than an explicit setting, or `(unset)` when absent.
+            fallback rather than an explicit setting, or `(unset)` when absent.
     """
     if not status.project:
         return "(unset)"

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -2336,6 +2336,7 @@ class TestGetTracingStatus:
         assert status.has_credentials is False
         assert status.endpoint is None
         assert status.project == LANGSMITH_PROJECT_DEFAULT
+        assert status.project_is_default is True
         assert status.replica_project is None
 
     def test_prefixed_flag_and_key_are_detected(self) -> None:
@@ -2356,6 +2357,7 @@ class TestGetTracingStatus:
         assert status.enabled is True
         assert status.has_credentials is True
         assert status.project == "prefixed-proj"
+        assert status.project_is_default is False
 
     def test_dotenv_values_are_detected(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -2359,6 +2359,23 @@ class TestGetTracingStatus:
         assert status.project == "prefixed-proj"
         assert status.project_is_default is False
 
+    def test_explicit_default_name_is_not_marked_default(self) -> None:
+        """Explicitly setting the default name still counts as configured.
+
+        `project_is_default` tracks provenance (was anything set), not a string
+        match against the default. A user who sets the project to the same name
+        as the built-in default must not get the `(default)` marker.
+        """
+        from deepagents_code.config import get_tracing_status
+        from deepagents_code.config_manifest import LANGSMITH_PROJECT_DEFAULT
+
+        env = dict(self._CLEAN)
+        env["DEEPAGENTS_CODE_LANGSMITH_PROJECT"] = LANGSMITH_PROJECT_DEFAULT
+        with patch.dict("os.environ", env, clear=False):
+            status = get_tracing_status()
+        assert status.project == LANGSMITH_PROJECT_DEFAULT
+        assert status.project_is_default is False
+
     def test_dotenv_values_are_detected(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -2519,6 +2536,7 @@ class TestGetTracingStatus:
         with patch.dict("os.environ", env, clear=False):
             status = get_tracing_status()
         assert status.project == "prod"
+        assert status.project_is_default is False
 
     def test_reports_first_replica_project(self) -> None:
         """Only the first replica project is reported (server mirrors one)."""

--- a/libs/code/tests/unit_tests/test_doctor.py
+++ b/libs/code/tests/unit_tests/test_doctor.py
@@ -127,6 +127,12 @@ class TestCollectTracing:
         labels = {item.label: item.value for item in section.items}
         assert labels["Project"] == "deepagents-code"
 
+    def test_unset_project_renders_unset(self) -> None:
+        """A missing project renders the `(unset)` placeholder."""
+        section = self._section(project=None)
+        labels = {item.label: item.value for item in section.items}
+        assert labels["Project"] == "(unset)"
+
     def test_enabled_without_credentials_is_unhealthy(self) -> None:
         """Tracing on with no key and no endpoint is a genuine problem."""
         section = self._section(enabled=True, has_credentials=False)

--- a/libs/code/tests/unit_tests/test_doctor.py
+++ b/libs/code/tests/unit_tests/test_doctor.py
@@ -97,6 +97,7 @@ class TestCollectTracing:
             "has_credentials": False,
             "endpoint": None,
             "project": None,
+            "project_is_default": False,
             "replica_project": None,
         }
         defaults.update(kwargs)
@@ -112,6 +113,18 @@ class TestCollectTracing:
         labels = {item.label: item.value for item in section.items}
         assert labels["Tracing"] == "disabled"
         assert labels["Credentials"] == "not configured"
+        assert labels["Project"] == "deepagents-code"
+
+    def test_default_project_is_marked(self) -> None:
+        """An unconfigured project shows the default marker."""
+        section = self._section(project="deepagents-code", project_is_default=True)
+        labels = {item.label: item.value for item in section.items}
+        assert labels["Project"] == "deepagents-code (default)"
+
+    def test_explicit_project_has_no_default_marker(self) -> None:
+        """An explicitly set project name is reported verbatim."""
+        section = self._section(project="deepagents-code", project_is_default=False)
+        labels = {item.label: item.value for item in section.items}
         assert labels["Project"] == "deepagents-code"
 
     def test_enabled_without_credentials_is_unhealthy(self) -> None:


### PR DESCRIPTION
`dcode doctor` now marks the tracing project as `(default)` when it is the built-in fallback rather than an explicit setting.

---

`dcode doctor` reports `project: deepagents-code` whether or not the user set it. This adds a `(default)` marker next to the tracing project when it falls back to the built-in `deepagents-code` default because no project was explicitly configured. An explicitly set project (even one named `deepagents-code`) shows no marker.

Made by [Open SWE](https://openswe.vercel.app/agents/bfb609d9-b37d-aaca-4151-d01e60c1f80b)