### PR TITLE
feat(sdk): add workflow mode for declarative multi-agent orchestration

### DIFF
--- a/libs/deepagents/README.md
+++ b/libs/deepagents/README.md
@@ -30,6 +30,7 @@ Deep Agents is an open source agent harness — an opinionated agent that runs o
 **Features include:**
 
 - **Sub-agents** — delegate tasks to agents with isolated context windows
+- **Workflow mode** — opt-in `workflow` tool that runs a declarative multi-agent plan (parallel fan-out, then fan-in) in a single call
 - **Filesystem** — read, write, edit, or search over pluggable local, sandboxed, or remote backends
 - **Context management** — summarize long threads and offload tool outputs to disk
 - **Shell access** — run commands in your sandbox of choice
@@ -50,6 +51,47 @@ result = agent.invoke({"messages": "Research LangGraph and write a summary"})
 ```
 
 The agent can plan, read/write files, and manage its own context. Add your own tools, swap models, customize prompts, configure sub-agents, and more. For a full overview and quickstart of Deep Agents, the best resource is our [docs](https://docs.langchain.com/oss/python/deepagents/overview).
+
+### Workflow mode
+
+Set `workflow_mode=True` to give the agent a `workflow` tool. Instead of delegating to sub-agents one `task` call at a time, the agent can author a whole multi-stage plan in a single call: a list of **phases** that run sequentially, where the **steps** inside each phase run concurrently (fan-out). A later step consumes an earlier step's output by embedding `{{step_id}}` in its prompt (fan-in / pipeline). The engine runs the plan autonomously and returns only the final result, keeping the orchestrator's context small.
+
+```python
+agent = create_deep_agent(model="openai:gpt-5.5", workflow_mode=True)
+```
+
+The agent might then emit a workflow like:
+
+```json
+{
+  "phases": [
+    {"title": "Research", "steps": [
+      {"id": "a", "subagent_type": "general-purpose", "description": "Research topic A", "prompt": "Research topic A."},
+      {"id": "b", "subagent_type": "general-purpose", "description": "Research topic B", "prompt": "Research topic B."}
+    ]},
+    {"title": "Synthesize", "steps": [
+      {"id": "s", "subagent_type": "general-purpose", "description": "Synthesize A and B", "depends_on": ["a", "b"],
+       "prompt": "Compare and synthesize:\n\nA: {{a}}\n\nB: {{b}}"}
+    ]}
+  ]
+}
+```
+
+Each step takes an optional `description` (shown in a plan preview before the workflow runs). Workflow steps delegate to the same sub-agents the `task` tool uses, so any sub-agent you configure is also available as a workflow step.
+
+Pass `workflow_model=...` to run the workflow's worker sub-agents on a different (e.g. cheaper or faster) model than the orchestrator; it defaults to the deep agent's model:
+
+```python
+agent = create_deep_agent(
+    model="openai:gpt-5.5",          # orchestrator
+    workflow_mode=True,
+    workflow_model="openai:gpt-5.4-mini",  # workflow step runners
+)
+```
+
+Why it helps: without workflow mode a single agent runs every step in one conversation, so each tool call's output piles into a growing context that the model re-sends on every turn — more tokens, and more room for it to drift or hallucinate as stale prior-step detail accumulates. Workflow mode runs each step in a fresh, isolated sub-agent that only sees its own task (plus any results passed in via `{{step_id}}`), so no single context carries everything.
+
+See `examples/workflow_mode_demo.py` for a runnable demo that builds a small Python library (writing files and running tests in a real shell) two ways — a plain DeepAgent and a DeepAgent in workflow mode — and compares them on tokens, context behavior, and the final answer.
 
 **Acknowledgements: This project was primarily inspired by Claude Code, and initially was largely an attempt to see what made Claude Code general purpose, and make it even more so.**
 

--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -11,6 +11,12 @@ from deepagents.middleware.subagents import (
     SubAgent,
     SubAgentMiddleware,
 )
+from deepagents.middleware.workflow import (
+    WorkflowMiddleware,
+    WorkflowPhase,
+    WorkflowSpec,
+    WorkflowStep,
+)
 from deepagents.profiles.harness.harness_profiles import (
     GeneralPurposeSubagentProfile,
     HarnessProfile,
@@ -37,6 +43,10 @@ __all__ = [
     "RubricMiddleware",
     "SubAgent",
     "SubAgentMiddleware",
+    "WorkflowMiddleware",
+    "WorkflowPhase",
+    "WorkflowSpec",
+    "WorkflowStep",
     "__version__",
     "create_deep_agent",
     "register_harness_profile",

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -53,6 +53,7 @@ from deepagents.middleware.subagents import (
     SubAgentMiddleware,
 )
 from deepagents.middleware.summarization import create_summarization_middleware
+from deepagents.middleware.workflow import WorkflowMiddleware
 from deepagents.profiles.harness.harness_profiles import (
     GeneralPurposeSubagentProfile,
     _apply_profile_prompt,
@@ -264,6 +265,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     system_prompt: str | SystemMessage | None = None,
     middleware: Sequence[AgentMiddleware] = (),
     subagents: Sequence[SubAgent | CompiledSubAgent | AsyncSubAgent] | None = None,
+    workflow_mode: bool = False,
+    workflow_model: str | BaseChatModel | None = None,
     skills: list[str] | None = None,
     memory: list[str] | None = None,
     permissions: list[FilesystemPermission] | None = None,
@@ -424,6 +427,37 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             subagents in play — none passed and the default disabled via
             `general_purpose_subagent=GeneralPurposeSubagentProfile(enabled=False)`
             — the `task` tool is not exposed. Async subagents are independent.
+
+        workflow_mode: Enable the declarative multi-agent `workflow` tool.
+
+            When `True`, the agent gains a `workflow` tool
+            ([`WorkflowMiddleware`][deepagents.middleware.workflow.WorkflowMiddleware])
+            that lets it author a phase/step DAG of subagent invocations in a
+            single call. Phases run sequentially; steps within a phase run
+            concurrently (fan-out); a later step consumes earlier outputs via
+            `{{step_id}}` templating (fan-in / pipeline). The engine runs the
+            plan autonomously and returns only the final result, keeping the
+            orchestrator's context small for large multi-stage tasks.
+
+            The workflow tool delegates to the same subagents reachable through
+            `task`, so it requires at least one synchronous subagent to be in
+            play (the auto-added `general-purpose` subagent satisfies this by
+            default). When no synchronous subagent is available, enabling
+            `workflow_mode` has no effect and a warning is logged. Defaults to
+            `False` (the tool is not exposed), preserving existing behavior.
+
+        workflow_model: Optional model for the workflow's step runners (the
+            sub-agents that execute workflow steps), used only when
+            `workflow_mode=True`.
+
+            Accepts a `provider:model` string or a pre-initialized
+            [`BaseChatModel`][langchain.chat_models.BaseChatModel]. When set, the
+            declarative (raw `SubAgent`) steps run on this model instead of the
+            main agent's model — handy for running the workers on a cheaper or
+            faster model while the orchestrator stays on a stronger one.
+            `CompiledSubAgent` steps keep the model they were compiled with.
+            When `None` (default), workflow steps use the deep agent's model,
+            preserving existing behavior.
 
         skills: List of skill source paths (e.g., `["/skills/user/", "/skills/project/"]`).
 
@@ -796,6 +830,28 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             state_schema=state_schema,
         )
         deepagent_middleware.append(sub_agent_middleware)
+
+    # Workflow mode adds a declarative multi-agent `workflow` tool backed by the
+    # same synchronous subagents the `task` tool uses. Without any synchronous
+    # subagents there is nothing to orchestrate, so the tool is not exposed.
+    workflow_middleware: WorkflowMiddleware | None = None
+    if workflow_mode:
+        if inline_subagents:
+            resolved_workflow_model = resolve_model(workflow_model) if workflow_model is not None else None
+            workflow_middleware = WorkflowMiddleware(
+                subagents=inline_subagents,
+                description=_profile.tool_description_overrides.get("workflow"),
+                state_schema=state_schema,
+                model=resolved_workflow_model,
+            )
+            deepagent_middleware.append(workflow_middleware)
+        else:
+            logger.warning(
+                "workflow_mode=True but no synchronous subagents are available "
+                "(the default general-purpose subagent is disabled and none were "
+                "passed via subagents=). The `workflow` tool will not be exposed.",
+            )
+
     deepagent_middleware.extend(
         [
             create_summarization_middleware(model, backend),
@@ -842,6 +898,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     private_state_keys = private_state_field_names(*(mw.state_schema for mw in deepagent_middleware if getattr(mw, "state_schema", None) is not None))
     if sub_agent_middleware is not None:
         sub_agent_middleware.private_state_keys = private_state_keys
+    if workflow_middleware is not None:
+        workflow_middleware.private_state_keys = private_state_keys
     # Verify every main-profile exclusion matched at least one middleware in
     # either the main agent stack or the GP subagent stack. An entry that
     # matched nothing across both is almost certainly a typo or a stale

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -75,6 +75,12 @@ from deepagents.middleware.summarization import (
     SummarizationToolMiddleware,
     create_summarization_tool_middleware,
 )
+from deepagents.middleware.workflow import (
+    WorkflowMiddleware,
+    WorkflowPhase,
+    WorkflowSpec,
+    WorkflowStep,
+)
 
 __all__ = [
     "DEEPAGENTS_DEFAULT_SUMMARY_PROMPT",
@@ -100,5 +106,9 @@ __all__ = [
     "SubAgentMiddleware",
     "SummarizationMiddleware",
     "SummarizationToolMiddleware",
+    "WorkflowMiddleware",
+    "WorkflowPhase",
+    "WorkflowSpec",
+    "WorkflowStep",
     "create_summarization_tool_middleware",
 ]

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -3,7 +3,7 @@
 import contextlib
 import dataclasses
 import json
-from collections.abc import Awaitable, Callable, Generator, Sequence
+from collections.abc import Awaitable, Callable, Generator, Mapping, Sequence
 from typing import Any, NotRequired, TypedDict, cast
 
 from langchain.agents import create_agent
@@ -511,6 +511,129 @@ def create_sub_agent(
     return create_agent(model, **create_agent_kwargs)
 
 
+def compile_subagent_spec(
+    spec: SubAgent | CompiledSubAgent,
+    *,
+    state_schema: type | None = None,
+    response_format: ResponseFormat[Any] | type | dict[str, Any] | None = None,
+) -> CompiledSubAgent:
+    """Compile one raw `SubAgent` spec or configure one provided runnable.
+
+    Shared by the `task` tool ([`SubAgentMiddleware`][deepagents.middleware.subagents.SubAgentMiddleware])
+    and the `workflow` tool ([`WorkflowMiddleware`][deepagents.middleware.workflow.WorkflowMiddleware])
+    so both expose the same subagent runnables and result semantics.
+
+    Args:
+        spec: A declarative `SubAgent` spec or a pre-built `CompiledSubAgent`.
+        state_schema: Base graph state schema forwarded to raw `SubAgent` specs.
+        response_format: Optional response-format override (raw specs only).
+
+    Returns:
+        A `CompiledSubAgent` with a ready-to-invoke `runnable`.
+
+    Raises:
+        ValueError: If `response_format` is supplied for a `CompiledSubAgent`.
+    """
+    if "runnable" in spec:
+        if response_format is not None:
+            msg = f'response_schema cannot be used with compiled subagent "{spec["name"]}"; dynamic schemas require a raw SubAgent spec.'
+            raise ValueError(msg)
+
+        # Use with_config (not attribute mutation) so the original runnable is
+        # untouched and a shared instance can be registered under multiple names.
+        compiled = cast("CompiledSubAgent", spec)
+        runnable = compiled["runnable"].with_config(
+            {
+                "metadata": {"lc_agent_name": spec["name"]},
+                "run_name": spec["name"],
+            }
+        )
+        return {
+            "name": spec["name"],
+            "description": spec["description"],
+            "runnable": runnable,
+        }
+    return {
+        "name": spec["name"],
+        "description": spec["description"],
+        "runnable": create_sub_agent(
+            spec,
+            state_schema=state_schema,
+            response_format=response_format,
+        ),
+    }
+
+
+def extract_subagent_text(result: dict) -> str:
+    """Return the textual result from a subagent's final state.
+
+    Prefers a JSON-serialized `structured_response` when present; otherwise
+    walks back to the last non-empty `AIMessage` text. Anthropic occasionally
+    emits a trailing empty `end_turn` `AIMessage` after a successful final tool
+    call, which is why we skip empty messages.
+    """
+    structured = result.get("structured_response")
+    if structured is not None:
+        if hasattr(structured, "model_dump_json"):
+            return structured.model_dump_json()
+        if dataclasses.is_dataclass(structured) and not isinstance(structured, type):
+            return json.dumps(dataclasses.asdict(structured))
+        return json.dumps(structured)
+    for msg in reversed(result.get("messages", [])):
+        if isinstance(msg, AIMessage):
+            text = msg.text.rstrip() if msg.text else ""
+            if text:
+                return text
+    return ""
+
+
+def subagent_state_delta(result: dict) -> dict:
+    """Return subagent state updates safe to merge into the parent state.
+
+    Excludes `messages` (handled explicitly by the caller), `todos`, and
+    `structured_response` (no defined cross-agent reducer / meaning).
+    """
+    return {k: v for k, v in result.items() if k not in _EXCLUDED_STATE_KEYS}
+
+
+def prepare_subagent_state(
+    state: Mapping[str, Any],
+    description: str,
+    *,
+    private_state_keys: frozenset[str] = frozenset(),
+) -> dict:
+    """Build a fresh subagent input state from filtered parent state.
+
+    Strips excluded and agent-private keys, then seeds a single `HumanMessage`
+    carrying the task `description`.
+    """
+    subagent_state = {k: v for k, v in state.items() if k not in _EXCLUDED_STATE_KEYS}
+    subagent_state = {k: v for k, v in subagent_state.items() if k not in private_state_keys}
+    subagent_state["messages"] = [HumanMessage(content=description)]
+    return subagent_state
+
+
+def _return_command_with_state_update(result: dict, tool_call_id: str) -> Command:
+    """Build the `Command` returned to the parent from a subagent's final state."""
+    # Validate that the result contains a 'messages' key
+    if "messages" not in result:
+        error_msg = (
+            "CompiledSubAgent must return a state containing a 'messages' key. "
+            "Custom StateGraphs used with CompiledSubAgent should include 'messages' "
+            "in their state schema to communicate results back to the main agent."
+        )
+        raise ValueError(error_msg)
+
+    state_update = subagent_state_delta(result)
+    content = extract_subagent_text(result)
+    return Command(
+        update={
+            **state_update,
+            "messages": [ToolMessage(content, tool_call_id=tool_call_id)],
+        }
+    )
+
+
 def _get_subagent_response_format(
     runtime: ToolRuntime,
 ) -> ResponseFormat[Any] | type | dict[str, Any] | None:
@@ -525,7 +648,7 @@ def _get_subagent_response_format(
     return value
 
 
-def _build_task_tool(  # noqa: C901, PLR0915
+def _build_task_tool(  # noqa: C901
     subagents: Sequence[SubAgent | CompiledSubAgent],
     task_description: str | None = None,
     *,
@@ -545,43 +668,7 @@ def _build_task_tool(  # noqa: C901, PLR0915
     Returns:
         A StructuredTool that can invoke subagents by type.
     """
-
-    def _compile_spec(
-        spec: SubAgent | CompiledSubAgent,
-        *,
-        response_format: ResponseFormat[Any] | type | dict[str, Any] | None = None,
-    ) -> CompiledSubAgent:
-        """Compile one raw spec or configure one provided runnable."""
-        if "runnable" in spec:
-            if response_format is not None:
-                msg = f'response_schema cannot be used with compiled subagent "{spec["name"]}"; dynamic schemas require a raw SubAgent spec.'
-                raise ValueError(msg)
-
-            # Use with_config (not attribute mutation) so the original runnable is
-            # untouched and a shared instance can be registered under multiple names.
-            compiled = cast("CompiledSubAgent", spec)
-            runnable = compiled["runnable"].with_config(
-                {
-                    "metadata": {"lc_agent_name": spec["name"]},
-                    "run_name": spec["name"],
-                }
-            )
-            return {
-                "name": spec["name"],
-                "description": spec["description"],
-                "runnable": runnable,
-            }
-        return {
-            "name": spec["name"],
-            "description": spec["description"],
-            "runnable": create_sub_agent(
-                spec,
-                state_schema=state_schema,
-                response_format=response_format,
-            ),
-        }
-
-    compiled_subagents = [_compile_spec(spec) for spec in subagents]
+    compiled_subagents = [compile_subagent_spec(spec, state_schema=state_schema) for spec in subagents]
     subagents_by_name = {spec["name"]: spec for spec in subagents}
 
     # Build the graphs dict and descriptions from the unified spec list
@@ -597,46 +684,6 @@ def _build_task_tool(  # noqa: C901, PLR0915
     else:
         description = task_description
 
-    def _return_command_with_state_update(result: dict, tool_call_id: str) -> Command:
-        # Validate that the result contains a 'messages' key
-        if "messages" not in result:
-            error_msg = (
-                "CompiledSubAgent must return a state containing a 'messages' key. "
-                "Custom StateGraphs used with CompiledSubAgent should include 'messages' "
-                "in their state schema to communicate results back to the main agent."
-            )
-            raise ValueError(error_msg)
-
-        state_update = {k: v for k, v in result.items() if k not in _EXCLUDED_STATE_KEYS}
-
-        structured = result.get("structured_response")
-        if structured is not None:
-            if hasattr(structured, "model_dump_json"):
-                content: str = structured.model_dump_json()
-            elif dataclasses.is_dataclass(structured) and not isinstance(structured, type):
-                content = json.dumps(dataclasses.asdict(structured))
-            else:
-                content = json.dumps(structured)
-        else:
-            # Walk back to the last AIMessage with non-empty text. Anthropic
-            # occasionally emits a trailing empty `end_turn` AIMessage after a
-            # successful final tool call, which would otherwise be forwarded
-            # as an empty ToolMessage.
-            content = ""
-            for msg in reversed(result["messages"]):
-                if isinstance(msg, AIMessage):
-                    text = msg.text.rstrip() if msg.text else ""
-                    if text:
-                        content = text
-                        break
-
-        return Command(
-            update={
-                **state_update,
-                "messages": [ToolMessage(content, tool_call_id=tool_call_id)],
-            }
-        )
-
     def _select_subagent(
         subagent_type: str,
         runtime: ToolRuntime,
@@ -644,8 +691,9 @@ def _build_task_tool(  # noqa: C901, PLR0915
         """Return the runnable to use for this task invocation."""
         response_format = _get_subagent_response_format(runtime)
         if response_format is not None:
-            new_spec = _compile_spec(
+            new_spec = compile_subagent_spec(
                 subagents_by_name[subagent_type],
+                state_schema=state_schema,
                 response_format=response_format,
             )
             return new_spec["runnable"]
@@ -660,9 +708,11 @@ def _build_task_tool(  # noqa: C901, PLR0915
         """Prepare state for invocation."""
         subagent = _select_subagent(subagent_type, runtime)
         # Create a new state dict to avoid mutating the original
-        subagent_state = {k: v for k, v in runtime.state.items() if k not in _EXCLUDED_STATE_KEYS}
-        subagent_state = {k: v for k, v in subagent_state.items() if k not in private_state_keys}
-        subagent_state["messages"] = [HumanMessage(content=description)]
+        subagent_state = prepare_subagent_state(
+            runtime.state,
+            description,
+            private_state_keys=private_state_keys,
+        )
         return subagent, subagent_state
 
     def task(

--- a/libs/deepagents/deepagents/middleware/workflow.py
+++ b/libs/deepagents/deepagents/middleware/workflow.py
@@ -1,0 +1,626 @@
+"""Middleware for declarative, multi-agent workflows via a `workflow` tool.
+
+`workflow_mode` lets the main agent author a *declarative orchestration plan*
+in a single tool call instead of round-tripping through the `task` tool stage
+by stage. The plan is a small DAG of subagent invocations grouped into phases:
+
+- Phases run **sequentially** — phase ``N + 1`` starts only after phase ``N``
+    finishes.
+- Steps **within a phase** run **concurrently** — this is the fan-out.
+- A step in a later phase may consume the output of any earlier step via
+    ``{{step_id}}`` templating in its prompt — this is the fan-in / pipeline.
+
+The engine executes the plan autonomously and returns only the final phase's
+output(s) to the orchestrator, keeping the orchestrator's context small. It
+reuses the same compiled subagent runnables and result semantics as the
+[`task` tool][deepagents.middleware.subagents.SubAgentMiddleware], so a
+workflow can delegate to any subagent the agent already has.
+
+This is the *declarative* engine. It deliberately does not execute
+model-authored code; control flow is limited to the phase/step DAG plus
+templated data passing, which covers fan-out, fan-in, and pipelines safely.
+"""
+
+import asyncio
+import contextvars
+import logging
+import os
+import re
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    ContextT,
+    ModelRequest,
+    ModelResponse,
+    ResponseT,
+)
+from langchain.tools import BaseTool, ToolRuntime
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import StructuredTool
+from langgraph.types import Command
+from pydantic import BaseModel, Field, field_validator
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+    from langchain_core.runnables import Runnable, RunnableConfig
+
+from deepagents.middleware._utils import append_to_system_message
+from deepagents.middleware.subagents import (
+    CompiledSubAgent,
+    SubAgent,
+    _subagent_tracing_context,
+    compile_subagent_spec,
+    extract_subagent_text,
+    prepare_subagent_state,
+    subagent_state_delta,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_STEPS = 25
+"""Maximum number of steps allowed in a single workflow (runaway guard)."""
+
+_TEMPLATE_RE = re.compile(r"\{\{\s*([A-Za-z0-9_-]+)(?:\.output)?\s*\}\}")
+"""Matches ``{{step_id}}`` and ``{{step_id.output}}`` placeholders."""
+
+
+def _default_max_concurrency() -> int:
+    """Default cap on subagents running at once within a phase."""
+    return min(8, max(1, os.cpu_count() or 4))
+
+
+class WorkflowStep(BaseModel):
+    """A single subagent invocation within a workflow phase."""
+
+    id: str = Field(
+        description="Unique identifier for this step. Referenced by later steps via `{{id}}` in their prompt.",
+    )
+    subagent_type: str = Field(
+        description="The subagent to run for this step. Must be one of the available agent types listed in the tool description.",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Short human-readable summary of what this step does (a few words). Shown in the plan preview before the workflow runs.",
+    )
+    prompt: str = Field(
+        description=(
+            "The complete, self-contained task for the subagent. Include all context the subagent needs. "
+            "To consume the output of an earlier step, embed `{{step_id}}` where that step's result should appear."
+        ),
+    )
+    depends_on: list[str] = Field(
+        default_factory=list,
+        description="IDs of earlier-phase steps whose output this step consumes. Every `{{id}}` used in `prompt` must be listed here.",
+    )
+
+    @field_validator("id", "subagent_type")
+    @classmethod
+    def _non_empty(cls, value: str) -> str:
+        if not value or not value.strip():
+            msg = "must be a non-empty string"
+            raise ValueError(msg)
+        return value
+
+
+class WorkflowPhase(BaseModel):
+    """A group of steps that run concurrently. Phases run in declaration order."""
+
+    title: str = Field(description="Short human-readable label for this phase (shown in progress output).")
+    steps: list[WorkflowStep] = Field(description="Steps to run concurrently in this phase. Must contain at least one step.")
+
+    @field_validator("steps")
+    @classmethod
+    def _non_empty_steps(cls, value: list[WorkflowStep]) -> list[WorkflowStep]:
+        if not value:
+            msg = "each phase must contain at least one step"
+            raise ValueError(msg)
+        return value
+
+
+class WorkflowSpec(BaseModel):
+    """A declarative workflow: an ordered list of phases.
+
+    Used internally to validate a workflow before execution. The `workflow`
+    tool itself advertises a deliberately looser argument schema
+    ([`WorkflowToolArgs`][deepagents.middleware.workflow.WorkflowToolArgs]) so
+    that a slightly-malformed plan reaches the engine and is answered with an
+    actionable error message instead of an opaque tool-call rejection.
+    """
+
+    phases: list[WorkflowPhase] = Field(description="Ordered list of phases. Phases run sequentially; steps within a phase run in parallel.")
+
+    @field_validator("phases")
+    @classmethod
+    def _non_empty_phases(cls, value: list[WorkflowPhase]) -> list[WorkflowPhase]:
+        if not value:
+            msg = "a workflow must contain at least one phase"
+            raise ValueError(msg)
+        return value
+
+
+class WorkflowToolArgs(BaseModel):
+    """Permissive argument schema advertised by the `workflow` tool.
+
+    Kept loose on purpose: full structural and semantic validation runs inside
+    the tool via [`WorkflowSpec`][deepagents.middleware.workflow.WorkflowSpec]
+    and [`validate_workflow`][deepagents.middleware.workflow.validate_workflow],
+    so the model receives an actionable error message it can correct from,
+    rather than an opaque tool-call rejection, when a plan is slightly off. The
+    exact expected shape is spelled out in the tool description.
+    """
+
+    # `list[Any]` (not `list[dict]`) on purpose: a stricter element type makes
+    # LangChain reject a slightly-off plan at the tool boundary with an opaque
+    # error before the engine's friendly validation can run. Accepting any list
+    # lets `WorkflowSpec` coerce + report precise, correctable errors.
+    phases: list[Any] = Field(
+        description=(
+            "Ordered list of phase objects, each shaped like "
+            "{title, steps: [{id, subagent_type, prompt, depends_on}]}. Phases run "
+            "sequentially; steps within a phase run in parallel. See the tool "
+            "description for the full schema and an example."
+        )
+    )
+
+
+def _template_refs(prompt: str) -> set[str]:
+    """Return the set of step ids referenced via `{{...}}` in `prompt`."""
+    return set(_TEMPLATE_RE.findall(prompt))
+
+
+def validate_workflow(  # noqa: C901, PLR0911
+    spec: WorkflowSpec,
+    *,
+    available_subagents: frozenset[str],
+    max_steps: int = DEFAULT_MAX_STEPS,
+) -> str | None:
+    """Validate a workflow spec against the structural rules.
+
+    Returns an error message describing the first problem found, or ``None``
+    when the spec is valid. Returning a message (rather than raising) lets the
+    `workflow` tool hand the model an actionable correction instead of
+    crashing the run.
+
+    Rules enforced:
+
+    - Step ids are unique across the whole workflow.
+    - Every `subagent_type` names an available subagent.
+    - Every `depends_on` id refers to a step in a strictly earlier phase
+        (no same-phase or forward dependencies — same-phase steps run in
+        parallel and cannot see each other).
+    - Every `{{id}}` referenced in a prompt is declared in that step's
+        `depends_on`.
+    - The total step count does not exceed `max_steps`.
+    """
+    total_steps = sum(len(phase.steps) for phase in spec.phases)
+    if total_steps > max_steps:
+        return f"Workflow has {total_steps} steps, which exceeds the limit of {max_steps}. Split the work or use fewer, broader steps."
+
+    seen_ids: set[str] = set()
+    # Maps each step id to the phase index it was declared in.
+    id_phase: dict[str, int] = {}
+    for phase_idx, phase in enumerate(spec.phases):
+        for step in phase.steps:
+            if step.id in seen_ids:
+                return f"Duplicate step id '{step.id}'. Every step id must be unique across the whole workflow."
+            seen_ids.add(step.id)
+            id_phase[step.id] = phase_idx
+
+    for phase_idx, phase in enumerate(spec.phases):
+        for step in phase.steps:
+            if step.subagent_type not in available_subagents:
+                allowed = ", ".join(f"`{name}`" for name in sorted(available_subagents))
+                return f"Step '{step.id}' references unknown subagent '{step.subagent_type}'. Available subagents: {allowed}."
+            for dep in step.depends_on:
+                if dep not in id_phase:
+                    return f"Step '{step.id}' depends on unknown step '{dep}'."
+                if id_phase[dep] >= phase_idx:
+                    return (
+                        f"Step '{step.id}' depends on '{dep}', which is in the same or a later phase. "
+                        "Dependencies must point to steps in an earlier phase."
+                    )
+            missing = _template_refs(step.prompt) - set(step.depends_on)
+            if missing:
+                missing_str = ", ".join(sorted(missing))
+                return f"Step '{step.id}' references {{{{{missing_str}}}}} in its prompt but does not list them in `depends_on`."
+    return None
+
+
+def _render_prompt(prompt: str, results: Mapping[str, str]) -> str:
+    """Substitute `{{step_id}}` / `{{step_id.output}}` with prior step outputs."""
+
+    def _replace(match: re.Match[str]) -> str:
+        return results.get(match.group(1), match.group(0))
+
+    return _TEMPLATE_RE.sub(_replace, prompt)
+
+
+def _merge_state_delta(acc: dict[str, Any], new: Mapping[str, Any]) -> None:
+    """Merge a subagent's state delta into the accumulator in place.
+
+    Dict-valued keys (e.g. the filesystem map) are shallow-merged so writes to
+    distinct files from parallel steps all survive; for the same key, the later
+    write wins. Non-dict values are replaced wholesale (last write wins).
+    """
+    for key, value in new.items():
+        existing = acc.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            merged = {**existing, **value}
+            acc[key] = merged
+        else:
+            acc[key] = value
+
+
+def _aggregate_final_output(spec: WorkflowSpec, results: Mapping[str, str]) -> str:
+    """Build the orchestrator-facing result from the final phase's outputs."""
+    final_steps = spec.phases[-1].steps
+    if len(final_steps) == 1:
+        return results.get(final_steps[0].id, "")
+    return "\n\n".join(f"## {step.id}\n{results.get(step.id, '')}" for step in final_steps)
+
+
+def workflow_plan_payload(spec: WorkflowSpec) -> dict[str, Any]:
+    """Build the `plan` progress event emitted before a workflow runs.
+
+    Consumers (e.g. a CLI renderer) can use this to show the full plan — phases,
+    steps, each step's subagent, description, and dependencies — before any work
+    starts. Emitted once, ahead of the first `phase_start` event.
+    """
+    return {
+        "event": "plan",
+        "phase_count": len(spec.phases),
+        "step_count": sum(len(phase.steps) for phase in spec.phases),
+        "phases": [
+            {
+                "index": phase_idx,
+                "title": phase.title,
+                "steps": [
+                    {
+                        "id": step.id,
+                        "subagent_type": step.subagent_type,
+                        "description": step.description,
+                        "depends_on": list(step.depends_on),
+                    }
+                    for step in phase.steps
+                ],
+            }
+            for phase_idx, phase in enumerate(spec.phases)
+        ],
+    }
+
+
+WORKFLOW_TOOL_DESCRIPTION = """Run a declarative, multi-agent workflow in a single call.
+
+A workflow is an ordered list of **phases**; each phase contains **steps** that each delegate to a subagent.
+
+- Phases run **sequentially** (phase N+1 starts only after phase N finishes).
+- Steps **within a phase** run **concurrently** — this is how you fan out work.
+- A step in a later phase can consume the output of any earlier step by embedding `{{step_id}}` in its `prompt`. List every referenced id in that step's `depends_on`.
+- Give every step a short `description` (a few words). It is shown in a plan preview before the workflow runs, so the user can see what will happen.
+
+The engine runs the whole plan autonomously and returns only the **final phase's output** to you — intermediate step outputs and tool calls are not surfaced. This keeps your context small for large multi-stage tasks.
+
+Available subagent types:
+{available_agents}
+
+## When to use `workflow` instead of `task`
+- Multi-stage work where later stages depend on earlier stages (research → verify → synthesize).
+- Fan-out then fan-in: run many independent subtasks in parallel, then combine their results.
+- Any time you would otherwise call `task`, read the results, then call `task` again — author it as one workflow so you don't burn context round-tripping each stage.
+
+## When NOT to use it
+- A single delegated task — use `task`.
+- Trivial work doable with a few direct tool calls.
+- Steps that need to loop or branch on intermediate results in ways a fixed DAG can't express — drive those with `task` yourself.
+
+## Example
+Research two topics in parallel, then synthesize:
+```json
+{
+  "phases": [
+    {
+      "title": "Research",
+      "steps": [
+        {"id": "a", "subagent_type": "general-purpose", "description": "Research topic A", "prompt": "Research topic A and report key findings."},
+        {"id": "b", "subagent_type": "general-purpose", "description": "Research topic B", "prompt": "Research topic B and report key findings."}
+      ]
+    },
+    {
+      "title": "Synthesize",
+      "steps": [
+        {"id": "synth", "subagent_type": "general-purpose", "description": "Synthesize A and B", "depends_on": ["a", "b"],
+         "prompt": "Compare these two research findings and write a synthesis.\\n\\nTopic A:\\n{{a}}\\n\\nTopic B:\\n{{b}}"}
+      ]
+    }
+  ]
+}
+```
+"""  # noqa: E501
+
+WORKFLOW_SYSTEM_PROMPT = """## `workflow` (multi-agent orchestration)
+
+You have access to a `workflow` tool that runs a declarative, multi-stage plan of subagents in a single call. Use it for complex objectives that decompose into stages where later stages build on earlier ones, or where many independent subtasks should run in parallel and then be combined.
+
+Author a workflow as an ordered list of phases:
+
+- Phases run **sequentially**; steps within a phase run **in parallel**.
+- Put independent subtasks as parallel steps in the same phase (fan-out).
+- Put a combine/synthesize/verify step in a later phase and reference upstream outputs with `{{step_id}}` (fan-in). List referenced ids in that step's `depends_on`.
+
+Prefer `workflow` over repeated `task` calls whenever the orchestration is fixed in advance — it runs autonomously and returns only the final result, saving your context. Keep using `task` for one-off delegation and for orchestration that must branch on intermediate results."""  # noqa: E501
+
+
+def _build_workflow_tool(  # noqa: C901, PLR0915
+    subagents: Sequence[SubAgent | CompiledSubAgent],
+    *,
+    description: str | None = None,
+    private_state_keys: frozenset[str] = frozenset(),
+    state_schema: type | None = None,
+    model: "BaseChatModel | None" = None,
+    max_concurrency: int | None = None,
+    max_steps: int = DEFAULT_MAX_STEPS,
+) -> BaseTool:
+    """Create the `workflow` tool backed by the given subagent specs.
+
+    When `model` is provided, raw `SubAgent` step runners are compiled to run on
+    it instead of their default (the main agent's) model; `CompiledSubAgent`
+    entries keep the model they were built with.
+    """
+
+    def _with_model(spec: SubAgent | CompiledSubAgent) -> SubAgent | CompiledSubAgent:
+        if model is None or "runnable" in spec:
+            return spec
+        return {**spec, "model": model}
+
+    compiled = [compile_subagent_spec(_with_model(spec), state_schema=state_schema) for spec in subagents]
+    runnables: dict[str, Runnable] = {spec["name"]: spec["runnable"] for spec in compiled}
+    available = frozenset(runnables)
+    concurrency = max_concurrency if max_concurrency is not None else _default_max_concurrency()
+
+    subagent_description_str = "\n".join(f"- {spec['name']}: {spec['description']}" for spec in compiled)
+    # Use str.replace (not str.format) because the description embeds a literal
+    # JSON example with `{`/`}` braces and `{{step_id}}` template placeholders.
+    source = WORKFLOW_TOOL_DESCRIPTION if description is None else description
+    tool_description = source.replace("{available_agents}", subagent_description_str)
+
+    def _emit(runtime: ToolRuntime, payload: dict[str, Any]) -> None:
+        """Best-effort progress emission via the stream writer."""
+        writer = getattr(runtime, "stream_writer", None)
+        if writer is None:
+            return
+        try:
+            writer({"workflow": payload})
+        except Exception:  # noqa: BLE001 - progress emission must never break execution
+            logger.debug("WorkflowMiddleware stream_writer raised; ignoring", exc_info=True)
+
+    def _run_step_sync(step: WorkflowStep, base_state: Mapping[str, Any], results: dict[str, str]) -> tuple[str, dict]:
+        rendered = _render_prompt(step.prompt, results)
+        state = prepare_subagent_state(base_state, rendered, private_state_keys=private_state_keys)
+        config: RunnableConfig = {"configurable": {"ls_agent_type": "subagent"}}
+        with _subagent_tracing_context():
+            result = runnables[step.subagent_type].invoke(state, config)
+        return extract_subagent_text(result), subagent_state_delta(result)
+
+    async def _run_step_async(step: WorkflowStep, base_state: Mapping[str, Any], results: dict[str, str]) -> tuple[str, dict]:
+        rendered = _render_prompt(step.prompt, results)
+        state = prepare_subagent_state(base_state, rendered, private_state_keys=private_state_keys)
+        config: RunnableConfig = {"configurable": {"ls_agent_type": "subagent"}}
+        with _subagent_tracing_context():
+            result = await runnables[step.subagent_type].ainvoke(state, config)
+        return extract_subagent_text(result), subagent_state_delta(result)
+
+    def _prepare(phases: list[WorkflowPhase], runtime: ToolRuntime) -> tuple[WorkflowSpec | None, str | None]:
+        """Validate inputs; return (spec, error_message)."""
+        if not runtime.tool_call_id:
+            msg = "Tool call ID is required for workflow invocation"
+            raise ValueError(msg)
+        try:
+            spec = WorkflowSpec(phases=phases)
+        except Exception as exc:  # noqa: BLE001 - surface validation errors to the model
+            return None, f"Invalid workflow spec: {exc}"
+        error = validate_workflow(spec, available_subagents=available, max_steps=max_steps)
+        if error is not None:
+            return None, error
+        return spec, None
+
+    def _execute_sync(spec: WorkflowSpec, runtime: ToolRuntime) -> Command:
+        results: dict[str, str] = {}
+        working_state: dict[str, Any] = dict(runtime.state)
+        state_delta: dict[str, Any] = {}
+        _emit(runtime, workflow_plan_payload(spec))
+
+        def _run_in_context(step: WorkflowStep) -> tuple[str, dict]:
+            # Run each step in a copy of the current context so worker threads
+            # inherit the parent's callbacks and tracing (LangSmith, token usage).
+            # A fresh copy per step avoids re-entering a single Context.
+            return contextvars.copy_context().run(_run_step_sync, step, working_state, results)
+
+        for phase_idx, phase in enumerate(spec.phases):
+            _emit(runtime, {"event": "phase_start", "index": phase_idx, "title": phase.title})
+            with ThreadPoolExecutor(max_workers=concurrency) as pool:
+                futures = {step.id: pool.submit(_run_in_context, step) for step in phase.steps}
+                for step_id, future in futures.items():
+                    try:
+                        text, delta = future.result()
+                    except Exception as exc:  # isolate step failure; logged below
+                        logger.exception("Workflow step '%s' failed", step_id)
+                        results[step_id] = f"[step '{step_id}' failed: {exc}]"
+                        _emit(runtime, {"event": "step_error", "id": step_id, "error": str(exc)})
+                        continue
+                    results[step_id] = text
+                    _merge_state_delta(state_delta, delta)
+                    _emit(runtime, {"event": "step_done", "id": step_id})
+            _merge_state_delta(working_state, state_delta)
+        final = _aggregate_final_output(spec, results)
+        return Command(update={**state_delta, "messages": [ToolMessage(final, tool_call_id=runtime.tool_call_id)]})
+
+    async def _execute_async(spec: WorkflowSpec, runtime: ToolRuntime) -> Command:
+        results: dict[str, str] = {}
+        working_state: dict[str, Any] = dict(runtime.state)
+        state_delta: dict[str, Any] = {}
+        _emit(runtime, workflow_plan_payload(spec))
+        semaphore = asyncio.Semaphore(concurrency)
+
+        async def _guarded(step: WorkflowStep) -> tuple[str, dict]:
+            async with semaphore:
+                return await _run_step_async(step, working_state, results)
+
+        for phase_idx, phase in enumerate(spec.phases):
+            _emit(runtime, {"event": "phase_start", "index": phase_idx, "title": phase.title})
+            outcomes = await asyncio.gather(
+                *(_guarded(step) for step in phase.steps),
+                return_exceptions=True,
+            )
+            for step, outcome in zip(phase.steps, outcomes, strict=True):
+                if isinstance(outcome, BaseException):
+                    logger.exception("Workflow step '%s' failed", step.id, exc_info=outcome)
+                    results[step.id] = f"[step '{step.id}' failed: {outcome}]"
+                    _emit(runtime, {"event": "step_error", "id": step.id, "error": str(outcome)})
+                    continue
+                text, delta = outcome
+                results[step.id] = text
+                _merge_state_delta(state_delta, delta)
+                _emit(runtime, {"event": "step_done", "id": step.id})
+            _merge_state_delta(working_state, state_delta)
+        final = _aggregate_final_output(spec, results)
+        return Command(update={**state_delta, "messages": [ToolMessage(final, tool_call_id=runtime.tool_call_id)]})
+
+    def workflow(phases: list[WorkflowPhase], runtime: ToolRuntime) -> str | Command:
+        # Catch-all so a bad plan or a step blowup always returns a correctable
+        # message to the model instead of an opaque "Error invoking tool".
+        try:
+            spec, error = _prepare(phases, runtime)
+            if spec is None:
+                return error or "Invalid workflow."
+            return _execute_sync(spec, runtime)
+        except Exception as exc:
+            logger.exception("workflow tool failed")
+            return f"Workflow failed: {exc}"
+
+    async def aworkflow(phases: list[WorkflowPhase], runtime: ToolRuntime) -> str | Command:
+        try:
+            spec, error = _prepare(phases, runtime)
+            if spec is None:
+                return error or "Invalid workflow."
+            return await _execute_async(spec, runtime)
+        except Exception as exc:
+            logger.exception("workflow tool failed")
+            return f"Workflow failed: {exc}"
+
+    return StructuredTool.from_function(
+        name="workflow",
+        func=workflow,
+        coroutine=aworkflow,
+        description=tool_description,
+        infer_schema=False,
+        args_schema=WorkflowToolArgs,
+    )
+
+
+class WorkflowMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
+    """Middleware that exposes a declarative multi-agent `workflow` tool.
+
+    Enabled by `create_deep_agent(..., workflow_mode=True)`. The tool lets the
+    main agent author a phase/step DAG of subagent invocations that the engine
+    runs autonomously — fan-out within a phase, fan-in / pipeline across
+    phases via `{{step_id}}` templating — returning only the final result.
+
+    It draws on the same subagent specs as
+    [`SubAgentMiddleware`][deepagents.middleware.subagents.SubAgentMiddleware],
+    so any subagent reachable through `task` is also reachable through a
+    workflow step.
+
+    Args:
+        subagents: Subagent specs available as workflow steps. At least one is
+            required.
+        system_prompt: Instructions appended to the main agent's system prompt
+            about when and how to author workflows.
+        description: Custom description for the `workflow` tool. Supports the
+            `{available_agents}` placeholder (replaced with the subagent
+            name/description list).
+        private_state_keys: State keys marked `PrivateStateAttr` that are
+            stripped from parent state before invoking subagents.
+        state_schema: Base graph state schema forwarded to raw `SubAgent`
+            specs when their runnables are compiled.
+        model: Optional model that the workflow's step runners use instead of
+            their default (the main agent's) model. Applies to raw `SubAgent`
+            steps only; `CompiledSubAgent` runnables keep the model they were
+            built with. Leave `None` to inherit the main model.
+        max_concurrency: Maximum subagents running at once within a phase.
+            Defaults to a CPU-derived cap.
+        max_steps: Maximum total steps allowed in a single workflow.
+    """
+
+    def __init__(
+        self,
+        *,
+        subagents: Sequence[SubAgent | CompiledSubAgent],
+        system_prompt: str | None = WORKFLOW_SYSTEM_PROMPT,
+        description: str | None = None,
+        private_state_keys: frozenset[str] | None = None,
+        state_schema: type | None = None,
+        model: "BaseChatModel | None" = None,
+        max_concurrency: int | None = None,
+        max_steps: int = DEFAULT_MAX_STEPS,
+    ) -> None:
+        """Initialize the `WorkflowMiddleware`."""
+        super().__init__()
+        if not subagents:
+            msg = "At least one subagent must be specified for workflow mode"
+            raise ValueError(msg)
+        self._subagents = subagents
+        self._description = description
+        self._private_state_keys = private_state_keys or frozenset()
+        self._state_schema = state_schema
+        self._model = model
+        self._max_concurrency = max_concurrency
+        self._max_steps = max_steps
+        self.subagent_names: frozenset[str] = frozenset(spec["name"] for spec in subagents)
+        self.system_prompt = system_prompt
+        self.tools = [self._build_tool()]
+
+    def _build_tool(self) -> BaseTool:
+        return _build_workflow_tool(
+            self._subagents,
+            description=self._description,
+            private_state_keys=self._private_state_keys,
+            state_schema=self._state_schema,
+            model=self._model,
+            max_concurrency=self._max_concurrency,
+            max_steps=self._max_steps,
+        )
+
+    @property
+    def private_state_keys(self) -> frozenset[str]:
+        """State keys stripped from parent state before invoking subagents."""
+        return self._private_state_keys
+
+    @private_state_keys.setter
+    def private_state_keys(self, value: frozenset[str]) -> None:
+        self._private_state_keys = value
+        self.tools = [self._build_tool()]
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], ModelResponse[ResponseT]],
+    ) -> ModelResponse[ResponseT]:
+        """Append workflow-usage instructions to the system message."""
+        if self.system_prompt is not None:
+            new_system_message = append_to_system_message(request.system_message, self.system_prompt)
+            return handler(request.override(system_message=new_system_message))
+        return handler(request)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT]:
+        """(async) Append workflow-usage instructions to the system message."""
+        if self.system_prompt is not None:
+            new_system_message = append_to_system_message(request.system_message, self.system_prompt)
+            return await handler(request.override(system_message=new_system_message))
+        return await handler(request)

--- a/libs/deepagents/examples/workflow_mode_demo.py
+++ b/libs/deepagents/examples/workflow_mode_demo.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python
+"""Demo: a DeepAgent vs. a DeepAgent in workflow mode — actually building software.
+
+The task is something anyone can picture: build a tiny Python utility library.
+For each function, write the code, write a test, and RUN the test to prove it
+works — then run the whole suite. It needs real files and a real shell.
+
+We run the SAME task two ways and compare cost (tokens) and — importantly —
+how the CONTEXT behaves:
+
+  1. DEEPAGENT (no workflow): ONE agent does every step in a single conversation.
+     Each tool call's output stays in the context, so by step N the model
+     re-reads steps 1..N-1 on every turn. Input tokens climb each turn, and a
+     context stuffed with stale prior-step detail raises the risk of
+     context-degradation / hallucination.
+  2. DEEPAGENT + WORKFLOW: each step runs in a FRESH, isolated sub-agent. Step 2
+     never carries step 1's raw context — context stays small and focused per
+     step, so the orchestrator's cost stays flat as the work grows.
+
+The per-turn input-token numbers in the output make the difference visible.
+
+Reads `OPENAI_API_KEY` / `OPENAI_BASE_URL` from the env. Model via `DEMO_MODEL`
+(default `gpt-5.5`); number of functions via `DEMO_FUNCS` (default 5). Runs real
+`python3` in a throwaway temp directory.
+
+    cd libs/deepagents
+    uv run --group test python examples/workflow_mode_demo.py
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from langchain_core.messages import AIMessage, ToolMessage
+from langchain_openai import ChatOpenAI
+
+from deepagents import (
+    GeneralPurposeSubagentProfile,
+    HarnessProfile,
+    create_deep_agent,
+    register_harness_profile,
+)
+from deepagents.backends import LocalShellBackend
+
+MODEL = os.environ.get("DEMO_MODEL", "gpt-5.5")
+WORKFLOW_MODEL = os.environ.get("DEMO_WORKFLOW_MODEL")  # optional cheaper model for workflow workers
+NUM_FUNCS = max(2, min(int(os.environ.get("DEMO_FUNCS", "5")), 8))
+_SUPPORTS_TEMPERATURE = MODEL.startswith(("gpt-4", "gpt-3"))
+MAX_DEPS_SHOWN = 3
+
+# Small, obviously-correct functions so the build is fast and deterministic.
+_FUNCS = [
+    ("add", "add(a, b) returns the sum of two numbers"),
+    ("is_even", "is_even(n) returns True if n is even, else False"),
+    ("reverse_string", "reverse_string(s) returns the string reversed"),
+    ("factorial", "factorial(n) returns n! (n factorial); factorial(0) == 1"),
+    ("celsius_to_fahrenheit", "celsius_to_fahrenheit(c) returns c*9/5 + 32"),
+    ("gcd", "gcd(a, b) returns the greatest common divisor of a and b"),
+    ("clamp", "clamp(x, lo, hi) returns x bounded to the range [lo, hi]"),
+    ("word_count", "word_count(s) returns the number of whitespace-separated words in s"),
+]
+FUNCS = _FUNCS[:NUM_FUNCS]
+SPEC_LINES = "\n".join(f"- {name}.py: {spec}" for name, spec in FUNCS)
+
+SYSTEM_PROMPT = f"""You are a coding agent working in the current directory. You have a shell (the `execute` tool) and filesystem tools.
+
+Build a small Python utility library. Implement these functions, each in its OWN file:
+{SPEC_LINES}
+
+For EVERY function:
+1. Write <name>.py containing just that function.
+2. Write test_<name>.py: a script of `assert` statements that exercise the function and `print("OK")` at the end.
+3. Run `python3 test_<name>.py` and confirm it prints OK (fix the code if it doesn't).
+
+Finally, run every test once more and report which passed.
+
+If a `workflow` tool is available, you MUST do this as ONE workflow, two phases:
+- Phase 1 "Build": one step PER function (ids b1, b2, ...), subagent_type "general-purpose", each with a short `description` like "Build add". Each step writes <name>.py + test_<name>.py and runs the test.
+- Phase 2 "Verify": one step (description "Run all tests") that depends_on ALL build steps, runs every test_*.py, and reports the results.
+Emit the whole plan in a single workflow call.
+
+If no `workflow` tool is available, do it yourself, one function at a time."""
+
+TASK = "Build the utility library described in your instructions and run all the tests. Begin."
+
+# --------------------------------------------------------------------------- #
+# Tiny ANSI + formatting helpers
+# --------------------------------------------------------------------------- #
+_COLORS = {"dim": "2", "bold": "1", "cyan": "36", "green": "32", "yellow": "33", "magenta": "35", "red": "31"}
+
+
+def col(text: str, name: str) -> str:
+    return text if not sys.stdout.isatty() else f"\033[{_COLORS[name]}m{text}\033[0m"
+
+
+def trunc(text: str, n: int = 130) -> str:
+    text = " ".join(str(text).split())
+    return text if len(text) <= n else text[:n] + "…"
+
+
+_THOUSAND = 1000
+_MAX_TURNS_SHOWN = 6
+
+
+def kfmt(n: int) -> str:
+    """Format a token count like 12,400 -> '12.4k'."""
+    return f"{n / _THOUSAND:.1f}k" if n >= _THOUSAND else str(n)
+
+
+def turn_sequence(turns: list[int]) -> str:
+    """Render a per-turn token sequence compactly (first/last when long)."""
+    parts = [kfmt(t) for t in turns]
+    if len(parts) > _MAX_TURNS_SHOWN:
+        parts = [*parts[:2], "…", *parts[-2:]]
+    return " → ".join(parts)
+
+
+# --------------------------------------------------------------------------- #
+# Streaming logger — model turns, the workflow plan preview, step progress, tokens
+# --------------------------------------------------------------------------- #
+class RunLog:
+    def __init__(self) -> None:
+        self.start = time.perf_counter()
+        self.tool_calls: dict[str, int] = {}
+        self.substeps = 0
+        self.turn_inputs: list[int] = []  # input tokens per main-loop turn (shows context growth)
+        self.tok_out = 0
+        self.names: dict[str, str] = {}
+        self.final = ""
+
+    @property
+    def turns(self) -> int:
+        return len(self.turn_inputs)
+
+    @property
+    def tok_in(self) -> int:
+        return sum(self.turn_inputs)
+
+    @property
+    def calls(self) -> int:
+        return sum(self.tool_calls.values())
+
+    def context_note(self, *, workflow_mode: bool) -> str:
+        if workflow_mode:
+            return "← orchestrator only; per-step detail stays in the sub-agents"
+        return "← climbs: step 1 is still in context when it reaches the last step"
+
+    def t(self) -> str:
+        return col(f"[{time.perf_counter() - self.start:5.1f}s]", "dim")
+
+    def handle(self, mode: str, chunk: object) -> None:
+        if mode == "custom" and isinstance(chunk, dict) and "workflow" in chunk:
+            self._workflow(chunk["workflow"])
+        elif mode == "updates" and isinstance(chunk, dict):
+            for update in chunk.values():
+                if isinstance(update, dict):
+                    for msg in update.get("messages", []):
+                        self._message(msg)
+
+    def _message(self, msg: object) -> None:
+        if isinstance(msg, AIMessage):
+            usage = msg.usage_metadata or {}
+            self.turn_inputs.append(usage.get("input_tokens", 0))
+            self.tok_out += usage.get("output_tokens", 0)
+            for call in msg.tool_calls:
+                name = call["name"]
+                self.tool_calls[name] = self.tool_calls.get(name, 0) + 1
+                self.names[call.get("id", "")] = name
+                arg = next((str(v) for k, v in (call.get("args") or {}).items() if k in ("file_path", "command", "description")), "")
+                print(f"{self.t()} {col('🧠 →', 'yellow')} {col(name, 'cyan')} {trunc(arg, 55)}")
+            if not msg.tool_calls and msg.text.strip():
+                self.final = msg.text.strip()
+                print(f"{self.t()} {col('🧠 final', 'green')} ({len(self.final)} chars)")
+        elif isinstance(msg, ToolMessage):
+            print(f"{self.t()}   {col('🔧 ' + self.names.get(msg.tool_call_id, 'tool'), 'cyan')}: {trunc(msg.content)}")
+
+    def _workflow(self, ev: dict) -> None:
+        kind = ev.get("event")
+        if kind == "plan":
+            head = f"{ev['phase_count']} phases / {ev['step_count']} steps"
+            print(f"{self.t()} {col('📋 plan', 'magenta')} {col(head, 'bold')}")
+            for ph in ev["phases"]:
+                steps = ph["steps"]
+                shape = "parallel" if len(steps) > 1 else "single"
+                title = f"Phase {ph['index']} · {ph['title']}"
+                print(f"          {col(title, 'bold')} {col(f'({len(steps)} {shape})', 'dim')}")
+                for s in steps:
+                    deps = s["depends_on"]
+                    overflow = "…" if len(deps) > MAX_DEPS_SHOWN else ""
+                    dep = col(f" ⇐ {','.join(deps[:MAX_DEPS_SHOWN])}{overflow}", "dim") if deps else ""
+                    sub = col(f"[{s['subagent_type']}]", "cyan")
+                    print(f"            {col('•', 'green')} {s['id']} {sub}{dep}  {s.get('description') or ''}")
+        elif kind == "phase_start":
+            print(f"{self.t()} {col('⚙ phase', 'magenta')} #{ev['index']} {col(ev['title'], 'bold')}")
+        elif kind == "step_done":
+            self.substeps += 1
+            print(f"{self.t()}     {col('✓', 'green')} {ev['id']}")
+        elif kind == "step_error":
+            print(f"{self.t()}     {col('✗ ' + str(ev['id']), 'red')}: {trunc(ev.get('error', ''), 80)}")
+
+
+# --------------------------------------------------------------------------- #
+# Objective verification: run the test files the agent produced
+# --------------------------------------------------------------------------- #
+def verify(workdir: str) -> tuple[int, int, int]:
+    """Return (python files written, tests passing, total tests) on disk."""
+    py_files = list(Path(workdir).glob("*.py"))
+    tests = sorted(p for p in py_files if p.name.startswith("test_"))
+
+    def passes(test: Path) -> bool:
+        try:
+            res = subprocess.run([sys.executable, test.name], cwd=workdir, capture_output=True, timeout=30, check=False)  # noqa: S603
+        except (subprocess.SubprocessError, OSError):
+            return False
+        return res.returncode == 0
+
+    return len(py_files), sum(passes(t) for t in tests), len(tests)
+
+
+def run_agent(label: str, *, workflow_mode: bool) -> tuple[RunLog, tuple[int, int, int]]:
+    workdir = tempfile.mkdtemp(prefix="deepagent_demo_")
+    print("\n" + col("=" * 84, "dim"))
+    print(col(f"  {label}  (model={MODEL}, functions={NUM_FUNCS}, workflow_mode={workflow_mode})", "bold"))
+    print(col(f"  workdir: {workdir}", "dim"))
+    print(col("=" * 84, "dim"))
+
+    # Baseline is a plain agent (no sub-agents) so it does the work in its own
+    # loop; workflow mode re-enables the general-purpose worker that backs steps.
+    register_harness_profile("openai", HarnessProfile(general_purpose_subagent=GeneralPurposeSubagentProfile(enabled=workflow_mode)))
+
+    model = ChatOpenAI(model=MODEL, stream_usage=True, **({"temperature": 0} if _SUPPORTS_TEMPERATURE else {}))
+    worker_model = ChatOpenAI(model=WORKFLOW_MODEL, stream_usage=True) if (workflow_mode and WORKFLOW_MODEL) else None
+    agent = create_deep_agent(
+        model=model,
+        system_prompt=SYSTEM_PROMPT,
+        backend=LocalShellBackend(root_dir=workdir, inherit_env=True),
+        workflow_mode=workflow_mode,
+        workflow_model=worker_model,
+    )
+
+    log = RunLog()
+    for mode, chunk in agent.stream({"messages": [{"role": "user", "content": TASK}]}, stream_mode=["updates", "custom"]):
+        log.handle(mode, chunk)
+
+    files, passed, total = verify(workdir)
+    elapsed = time.perf_counter() - log.start
+    tools = ", ".join(f"{k}×{v}" for k, v in sorted(log.tool_calls.items())) or "none"
+    extra = f" · {log.substeps} sub-agent steps" if log.substeps else ""
+    print(col("-" * 84, "dim"))
+    print(f"{col('time', 'bold')} {elapsed:5.1f}s · {log.turns} main-loop turns, {log.calls} tool calls{extra} · {tools}")
+    print(f"{col('built', 'bold')}: {files} files · {col(f'tests {passed}/{total} passing', 'green' if passed == total and total else 'red')}")
+    print(
+        f"{col('input tokens / main-loop turn', 'bold')}: {turn_sequence(log.turn_inputs)}  {col(log.context_note(workflow_mode=workflow_mode), 'dim')}"
+    )
+    print(f"{col('main-loop tokens', 'bold')}: in={log.tok_in:,}  out={log.tok_out:,}")
+    return log, (files, passed, total)
+
+
+def main() -> int:
+    if not os.environ.get("OPENAI_API_KEY"):
+        print("OPENAI_API_KEY is not set.", file=sys.stderr)
+        return 1
+    print(col("Deep Agents — workflow mode demo (build & test a small library)", "bold"))
+    print(f"endpoint: {os.environ.get('OPENAI_BASE_URL', '<default>')}")
+    print(f"task    : implement {NUM_FUNCS} functions, write a test for each, and run them")
+
+    plain, plain_art = run_agent("DEEPAGENT (no workflow)", workflow_mode=False)
+    flow, flow_art = run_agent("DEEPAGENT + WORKFLOW", workflow_mode=True)
+
+    print("\n" + col("=" * 84, "dim"))
+    print(col("  COMPARISON — same task, same result; what differs is the context", "bold"))
+    print(col("=" * 84, "dim"))
+    print(f"  {'':<30}{'DeepAgent':>16}{'+Workflow':>16}")
+
+    def row(name: str, a: object, b: object) -> None:
+        print(f"  {name:<30}{a!s:>16}{b!s:>16}")
+
+    row("main-loop turns", plain.turns, flow.turns)
+    row("main-loop input tokens", f"{plain.tok_in:,}", f"{flow.tok_in:,}")
+    row("main-loop output tokens", f"{plain.tok_out:,}", f"{flow.tok_out:,}")
+    row("per-step context", "1 shared, grows", f"{flow.substeps} isolated")
+    row("files written", plain_art[0], flow_art[0])
+    row("tests passing", f"{plain_art[1]}/{plain_art[2]}", f"{flow_art[1]}/{flow_art[2]}")
+
+    print()
+    print(col("  Why this matters — it's about the context, not only the bill:", "bold"))
+    print(f"  • Without workflow, ONE agent runs the whole job in ONE conversation ({plain.turns} model calls).")
+    print("    Every tool call's output stays in that context, so by the last step the model is still")
+    print("    carrying step 1, and it re-sends the growing history on every turn (the per-turn numbers")
+    print("    above climb). A long, mixed-purpose context costs more tokens and gives the model more")
+    print("    room to drift or hallucinate.")
+    print(f"  • Workflow mode runs each step in a FRESH, isolated sub-agent ({flow.substeps} of them). A step only")
+    print("    sees its own task plus any results explicitly passed in — never step 1's raw history. The")
+    print(f"    orchestrator stayed at {flow.turns} turns / {flow.tok_in:,} input tokens; the per-step work is spread")
+    print("    across small, focused contexts instead of piled into one. (Those sub-agents cost tokens")
+    print("    too — the win is that no single context carries everything.)")
+
+    if flow.final:
+        print("\n" + col("final answer — DeepAgent + workflow (after really running the tests):", "bold"))
+        print(trunc(flow.final, 400))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/libs/deepagents/pyproject.toml
+++ b/libs/deepagents/pyproject.toml
@@ -126,6 +126,19 @@ ignore-var-parameters = true
     "BLE001",  # Blind exception catch — resilience in standalone scripts
     "INP001",  # Missing `__init__.py` — scripts are standalone
 ]
+# Examples: runnable demos — allow prints, missing docstrings, standalone shape
+"examples/**" = [
+    "ARG002",  # Unused method argument — demo stubs / overrides
+    "BLE001",  # Blind exception catch — display helpers must not abort the demo
+    "D1",      # Missing docstrings
+    "E501",    # Line too long — readable inline data tables / prompts
+    "EXE001",  # Shebang present but file not executable
+    "INP001",  # Missing `__init__.py` — examples are standalone
+    "RUF001",  # Ambiguous unicode in strings — intentional log glyphs (→, ·, ✓)
+    "RUF002",  # Ambiguous unicode in docstrings
+    "RUF003",  # Ambiguous unicode in comments
+    "T201",    # `print` found — demos print to stdout
+]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/libs/deepagents/tests/unit_tests/test_workflow.py
+++ b/libs/deepagents/tests/unit_tests/test_workflow.py
@@ -1,0 +1,359 @@
+"""Tests for workflow-mode middleware (declarative multi-agent orchestration).
+
+Covers: tool gating on `workflow_mode`, spec validation, `{{id}}` templating,
+sequential phases with data passing, parallel fan-out within a phase, error
+isolation, and the async execution path.
+"""
+
+import asyncio
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import pytest
+from langchain.agents import create_agent
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel, LanguageModelInput
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
+from langgraph.checkpoint.memory import InMemorySaver
+
+from deepagents import create_deep_agent
+from deepagents.middleware.workflow import (
+    DEFAULT_MAX_STEPS,
+    WorkflowMiddleware,
+    WorkflowSpec,
+    _render_prompt,
+    validate_workflow,
+)
+from tests.unit_tests.chat_model import GenericFakeChatModel
+
+_AVAIL = frozenset({"researcher", "synthesizer", "general-purpose"})
+
+
+class _ConstantChatModel(BaseChatModel):
+    """Stateless fake model that returns a fixed message on every call.
+
+    Thread-safe (no iterator/mutable state), so it is safe to share across the
+    parallel subagent invocations a workflow phase performs.
+    """
+
+    content: str = ""
+
+    @property
+    def _llm_type(self) -> str:
+        return "constant"
+
+    def _generate(
+        self,
+        messages: Sequence[Any],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content=self.content))])
+
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Callable | BaseTool],
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> Runnable[LanguageModelInput, AIMessage]:
+        return self
+
+
+class _EchoChatModel(BaseChatModel):
+    """Stateless fake model that echoes the last human message back verbatim.
+
+    Lets a test assert exactly what prompt a subagent received (proving
+    `{{id}}` templating and cross-phase data passing).
+    """
+
+    @property
+    def _llm_type(self) -> str:
+        return "echo"
+
+    def _generate(
+        self,
+        messages: Sequence[Any],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        text = ""
+        for msg in reversed(list(messages)):
+            if isinstance(msg, HumanMessage):
+                text = msg.text if hasattr(msg, "text") else str(msg.content)
+                break
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content=f"ECHO:{text}"))])
+
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Callable | BaseTool],
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> Runnable[LanguageModelInput, AIMessage]:
+        return self
+
+
+def _parent_model_calling_workflow(phases: list[dict]) -> GenericFakeChatModel:
+    """Parent model that calls the `workflow` tool once then finishes."""
+    return GenericFakeChatModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "workflow", "id": "wf1", "type": "tool_call", "args": {"phases": phases}}],
+                ),
+                AIMessage(content="done"),
+            ]
+        )
+    )
+
+
+class TestWorkflowGating:
+    """The `workflow` tool is exposed only when `workflow_mode=True`."""
+
+    def test_tool_absent_by_default(self) -> None:
+        agent = create_deep_agent(model=GenericFakeChatModel(messages=iter([AIMessage(content="x")])))
+        assert "workflow" not in agent.nodes["tools"].bound._tools_by_name
+
+    def test_tool_present_when_enabled(self) -> None:
+        agent = create_deep_agent(
+            model=GenericFakeChatModel(messages=iter([AIMessage(content="x")])),
+            workflow_mode=True,
+        )
+        tools = agent.nodes["tools"].bound._tools_by_name
+        assert "workflow" in tools
+        # The task tool still coexists with the workflow tool.
+        assert "task" in tools
+
+    def test_middleware_requires_subagents(self) -> None:
+        with pytest.raises(ValueError, match="At least one subagent"):
+            WorkflowMiddleware(subagents=[])
+
+
+class TestWorkflowValidation:
+    """`validate_workflow` rejects malformed specs with actionable messages."""
+
+    def test_valid_spec_returns_none(self) -> None:
+        spec = WorkflowSpec(
+            phases=[
+                {"title": "p", "steps": [{"id": "a", "subagent_type": "researcher", "prompt": "x"}]},
+                {"title": "q", "steps": [{"id": "b", "subagent_type": "synthesizer", "prompt": "use {{a}}", "depends_on": ["a"]}]},
+            ]
+        )
+        assert validate_workflow(spec, available_subagents=_AVAIL) is None
+
+    def test_duplicate_ids_rejected(self) -> None:
+        spec = WorkflowSpec(
+            phases=[
+                {"title": "p", "steps": [{"id": "a", "subagent_type": "researcher", "prompt": "x"}]},
+                {"title": "q", "steps": [{"id": "a", "subagent_type": "researcher", "prompt": "y"}]},
+            ]
+        )
+        assert "Duplicate step id 'a'" in (validate_workflow(spec, available_subagents=_AVAIL) or "")
+
+    def test_same_phase_dependency_rejected(self) -> None:
+        spec = WorkflowSpec(
+            phases=[
+                {
+                    "title": "p",
+                    "steps": [
+                        {"id": "x", "subagent_type": "researcher", "prompt": "{{y}}", "depends_on": ["y"]},
+                        {"id": "y", "subagent_type": "researcher", "prompt": "hi"},
+                    ],
+                }
+            ]
+        )
+        assert "same or a later phase" in (validate_workflow(spec, available_subagents=_AVAIL) or "")
+
+    def test_template_ref_without_depends_on_rejected(self) -> None:
+        spec = WorkflowSpec(
+            phases=[
+                {"title": "p", "steps": [{"id": "a", "subagent_type": "researcher", "prompt": "hi"}]},
+                {"title": "q", "steps": [{"id": "b", "subagent_type": "researcher", "prompt": "use {{a}}"}]},
+            ]
+        )
+        assert "does not list them in `depends_on`" in (validate_workflow(spec, available_subagents=_AVAIL) or "")
+
+    def test_unknown_subagent_rejected(self) -> None:
+        spec = WorkflowSpec(phases=[{"title": "p", "steps": [{"id": "a", "subagent_type": "nope", "prompt": "hi"}]}])
+        assert "unknown subagent 'nope'" in (validate_workflow(spec, available_subagents=_AVAIL) or "")
+
+    def test_max_steps_enforced(self) -> None:
+        steps = [{"id": f"s{i}", "subagent_type": "researcher", "prompt": "x"} for i in range(DEFAULT_MAX_STEPS + 1)]
+        spec = WorkflowSpec(phases=[{"title": "p", "steps": steps}])
+        assert "exceeds the limit" in (validate_workflow(spec, available_subagents=_AVAIL) or "")
+
+    def test_render_prompt_substitutes_refs(self) -> None:
+        assert _render_prompt("a={{a}} b={{ b.output }}", {"a": "1", "b": "2"}) == "a=1 b=2"
+
+    def test_render_prompt_leaves_unknown_refs(self) -> None:
+        assert _render_prompt("x={{missing}}", {}) == "x={{missing}}"
+
+
+class TestWorkflowExecution:
+    """End-to-end workflow execution through `create_deep_agent`."""
+
+    def _make_agent(self, phases: list[dict], synth_model: BaseChatModel | None = None):
+        researcher = create_agent(model=_ConstantChatModel(content="FINDING"))
+        synth = create_agent(model=synth_model or _ConstantChatModel(content="SYNTHESIS"))
+        return create_deep_agent(
+            model=_parent_model_calling_workflow(phases),
+            workflow_mode=True,
+            checkpointer=InMemorySaver(),
+            subagents=[
+                {"name": "researcher", "description": "researches", "runnable": researcher},
+                {"name": "synthesizer", "description": "synthesizes", "runnable": synth},
+            ],
+        )
+
+    def test_sequential_phases_and_data_passing(self) -> None:
+        # The synth echoes its prompt, proving templated upstream outputs arrive.
+        agent = self._make_agent(
+            phases=[
+                {"title": "Research", "steps": [{"id": "a", "subagent_type": "researcher", "prompt": "research A"}]},
+                {
+                    "title": "Synth",
+                    "steps": [{"id": "s", "subagent_type": "synthesizer", "depends_on": ["a"], "prompt": "Got: {{a}}"}],
+                },
+            ],
+            synth_model=_EchoChatModel(),
+        )
+        result = agent.invoke({"messages": [HumanMessage(content="go")]}, config={"configurable": {"thread_id": "seq"}})
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert len(tool_messages) == 1
+        # Final result is the last phase's only step output: the echoed, templated prompt.
+        assert tool_messages[0].content == "ECHO:Got: FINDING"
+
+    def test_parallel_fan_out_then_fan_in(self) -> None:
+        agent = self._make_agent(
+            phases=[
+                {
+                    "title": "Research",
+                    "steps": [
+                        {"id": "a", "subagent_type": "researcher", "prompt": "research A"},
+                        {"id": "b", "subagent_type": "researcher", "prompt": "research B"},
+                    ],
+                },
+                {
+                    "title": "Synth",
+                    "steps": [
+                        {"id": "s", "subagent_type": "synthesizer", "depends_on": ["a", "b"], "prompt": "{{a}} + {{b}}"},
+                    ],
+                },
+            ],
+            synth_model=_EchoChatModel(),
+        )
+        result = agent.invoke({"messages": [HumanMessage(content="go")]}, config={"configurable": {"thread_id": "par"}})
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        # Both parallel researchers ran and both outputs were templated into the synth prompt.
+        assert tool_messages[0].content == "ECHO:FINDING + FINDING"
+
+    def test_invalid_spec_returns_error_to_model(self) -> None:
+        # Forward dependency: validation should fail and surface a ToolMessage, not crash.
+        agent = self._make_agent(
+            phases=[
+                {"title": "p", "steps": [{"id": "x", "subagent_type": "researcher", "prompt": "{{y}}", "depends_on": ["y"]}]},
+                {"title": "q", "steps": [{"id": "y", "subagent_type": "researcher", "prompt": "hi"}]},
+            ]
+        )
+        result = agent.invoke({"messages": [HumanMessage(content="go")]}, config={"configurable": {"thread_id": "bad"}})
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert len(tool_messages) == 1
+        assert "earlier phase" in tool_messages[0].content
+
+    def test_malformed_spec_returns_friendly_error(self) -> None:
+        # A step missing the required `prompt` field fails Pydantic validation.
+        # Because the tool advertises a loose arg schema, this reaches the engine
+        # and comes back as an actionable message instead of crashing the run.
+        agent = self._make_agent(
+            phases=[{"title": "p", "steps": [{"id": "a", "subagent_type": "researcher"}]}],
+        )
+        result = agent.invoke({"messages": [HumanMessage(content="go")]}, config={"configurable": {"thread_id": "malformed"}})
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert len(tool_messages) == 1
+        assert "Invalid workflow spec" in tool_messages[0].content
+
+    def test_non_dict_phase_returns_friendly_error(self) -> None:
+        # A phase element that isn't an object (here a bare string) must not be
+        # rejected at the tool boundary with an opaque error — it should reach
+        # the engine and come back as a correctable message.
+        agent = self._make_agent(phases=["Summarize", {"title": "p", "steps": [{"id": "a", "subagent_type": "researcher", "prompt": "x"}]}])
+        result = agent.invoke({"messages": [HumanMessage(content="go")]}, config={"configurable": {"thread_id": "nondict"}})
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert len(tool_messages) == 1
+        assert "Invalid workflow spec" in tool_messages[0].content
+
+    def test_emits_plan_event_before_phases(self) -> None:
+        # The `plan` event must arrive (with step descriptions) before any
+        # `phase_start`, so a UI can preview the workflow before it runs.
+        agent = self._make_agent(
+            phases=[
+                {
+                    "title": "Research",
+                    "steps": [{"id": "a", "subagent_type": "researcher", "description": "Look into A", "prompt": "research A"}],
+                },
+                {
+                    "title": "Synth",
+                    "steps": [{"id": "s", "subagent_type": "synthesizer", "description": "Combine", "depends_on": ["a"], "prompt": "{{a}}"}],
+                },
+            ],
+        )
+        events = []
+        for mode, chunk in agent.stream(
+            {"messages": [HumanMessage(content="go")]},
+            config={"configurable": {"thread_id": "plan"}},
+            stream_mode=["custom"],
+        ):
+            if mode == "custom" and isinstance(chunk, dict) and "workflow" in chunk:
+                events.append(chunk["workflow"])
+
+        kinds = [e.get("event") for e in events]
+        assert "plan" in kinds
+        assert kinds.index("plan") < kinds.index("phase_start")
+        plan = next(e for e in events if e.get("event") == "plan")
+        assert plan["phase_count"] == 2
+        assert plan["step_count"] == 2
+        assert plan["phases"][0]["steps"][0]["description"] == "Look into A"
+        assert plan["phases"][1]["steps"][0]["depends_on"] == ["a"]
+
+    def test_workflow_model_overrides_step_runner(self) -> None:
+        # With `workflow_model` set, the (raw) general-purpose step runs on it,
+        # not the main model. The worker returns a sentinel the main model never
+        # emits, so the workflow result proves which model executed the step.
+        main = GenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "workflow",
+                                "id": "w",
+                                "type": "tool_call",
+                                "args": {"phases": [{"title": "P", "steps": [{"id": "a", "subagent_type": "general-purpose", "prompt": "do it"}]}]},
+                            }
+                        ],
+                    ),
+                    AIMessage(content="done"),
+                ]
+            )
+        )
+        worker = GenericFakeChatModel(messages=iter([AIMessage(content="FROM_WORKFLOW_MODEL")]))
+        agent = create_deep_agent(model=main, workflow_mode=True, workflow_model=worker, checkpointer=InMemorySaver())
+        result = agent.invoke({"messages": [HumanMessage(content="go")]}, config={"configurable": {"thread_id": "wm"}})
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert tool_messages[0].content == "FROM_WORKFLOW_MODEL"
+
+    def test_async_execution(self) -> None:
+        agent = self._make_agent(
+            phases=[{"title": "P", "steps": [{"id": "only", "subagent_type": "researcher", "prompt": "x"}]}],
+        )
+        result = asyncio.run(agent.ainvoke({"messages": [HumanMessage(content="go")]}, config={"configurable": {"thread_id": "async"}}))
+        tool_messages = [m for m in result["messages"] if m.type == "tool"]
+        assert tool_messages[0].content == "FINDING"


### PR DESCRIPTION
Closes #4320

Adds an opt-in **workflow mode** to `create_deep_agent`. With `workflow_mode=True`, the agent gets a `workflow` tool that lets it author a declarative phase/step plan of sub-agent calls in a single call — phases run sequentially, steps within a phase run in parallel (fan-out), and a later step consumes earlier outputs via `{{step_id}}` (fan-in). The engine runs the plan and returns only the final result, so each step runs in an isolated sub-agent and the orchestrator's context stays small. An optional `workflow_model` runs the step workers on a different model than the orchestrator.

Opt-in and backward compatible: nothing changes unless `workflow_mode=True`. Only `libs/deepagents` is touched; no dependencies were added (the one `pyproject.toml` change is a ruff per-file-ignore for the new `examples/` dir).

**How verified:** `make format`, `make lint`, and `make test` all pass from `libs/deepagents` (added `tests/unit_tests/test_workflow.py`); also ran `examples/workflow_mode_demo.py` end-to-end against an OpenAI-compatible endpoint.

> Disclaimer: this contribution was prepared with the assistance of generative AI (Claude) and reviewed before submission.
