### PR TITLE
fix(code,acp): add ACP session selectors

### DIFF
--- a/libs/acp/deepagents_acp/server.py
+++ b/libs/acp/deepagents_acp/server.py
@@ -41,6 +41,7 @@ from acp.schema import (
     ResourceContentBlock,
     SessionConfigOptionBoolean,
     SessionConfigOptionSelect,
+    SessionConfigSelectGroup,
     SessionConfigSelectOption,
     SessionModeState,
     SseMcpServer,
@@ -224,14 +225,7 @@ class AgentServerACP(ACPAgent):
         # Add model selector if models are configured
         if self._models is not None and len(self._models) > 0:
             current_model = self._session_models.get(session_id, self._models[0]["value"])
-            model_options = [
-                SessionConfigSelectOption(
-                    value=model["value"],
-                    name=model["name"],
-                    description=model.get("description", ""),
-                )
-                for model in self._models
-            ]
+            model_options = self._build_model_select_options()
 
             model_select = SessionConfigOptionSelect(
                 id="model",
@@ -247,6 +241,61 @@ class AgentServerACP(ACPAgent):
             )
 
         return config_options
+
+    def _build_model_select_options(
+        self,
+    ) -> list[SessionConfigSelectOption] | list[SessionConfigSelectGroup]:
+        """Build model selector options, grouped by provider when possible."""
+        if self._models is None:
+            return []
+
+        grouped: dict[str, list[SessionConfigSelectOption]] = {}
+        group_names: dict[str, str] = {}
+        ungrouped: list[SessionConfigSelectOption] = []
+
+        for model in self._models:
+            option = SessionConfigSelectOption(
+                value=model["value"],
+                name=model["name"],
+                description=model.get("description", ""),
+            )
+            group = self._model_group(model)
+            if group is None:
+                ungrouped.append(option)
+                continue
+            grouped.setdefault(group, []).append(option)
+            group_names.setdefault(group, model.get("group_name", group))
+
+        if not grouped or ungrouped:
+            return [
+                SessionConfigSelectOption(
+                    value=model["value"],
+                    name=model["name"],
+                    description=model.get("description", ""),
+                )
+                for model in self._models
+            ]
+
+        return [
+            SessionConfigSelectGroup(
+                group=group,
+                name=group_names[group],
+                options=options,
+            )
+            for group, options in grouped.items()
+        ]
+
+    def _model_group(self, model: dict[str, str]) -> str | None:
+        """Return the provider group for a model selector entry."""
+        if group := model.get("group"):
+            return group
+        if provider := model.get("provider"):
+            return provider
+        value = model.get("value", "")
+        if ":" not in value:
+            return None
+        provider, _model = value.split(":", maxsplit=1)
+        return provider or None
 
     async def initialize(
         self,

--- a/libs/acp/tests/test_agent.py
+++ b/libs/acp/tests/test_agent.py
@@ -17,6 +17,7 @@ from acp.schema import (
     RequestPermissionResponse,
     ResourceContentBlock,
     SessionConfigOptionSelect,
+    SessionConfigSelectGroup,
     SessionMode,
     SessionModeState,
     TextContentBlock,
@@ -1060,6 +1061,43 @@ def test_build_config_options_models_only(monkeypatch: pytest.MonkeyPatch) -> No
 
     assert len(options) == 1
     assert options[0].category == "model"
+
+
+def test_build_config_options_groups_models_by_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Model selector options should be grouped by provider when specs include one."""
+    monkeypatch.setattr(server_module, "SessionConfigOption", None)
+
+    def factory(
+        context: AgentSessionContext,  # noqa: ARG001  # ACP factory signature requires context
+    ) -> CompiledStateGraph:
+        model = GenericFakeChatModel(
+            messages=iter([AIMessage(content="OK")]), stream_delimiter=None
+        )
+        return create_deep_agent(model=model, checkpointer=MemorySaver())
+
+    agent = AgentServerACP(
+        agent=factory,
+        models=[
+            {"value": "anthropic:claude-sonnet-4-6", "name": "claude-sonnet-4-6"},
+            {"value": "openai:gpt-5.2", "name": "gpt-5.2"},
+        ],
+    )
+    options = agent._build_config_options("session-1")
+
+    assert len(options) == 1
+    model_select = options[0]
+    assert isinstance(model_select, SessionConfigOptionSelect)
+    assert all(isinstance(group, SessionConfigSelectGroup) for group in model_select.options)
+    assert [(group.group, group.name) for group in model_select.options] == [
+        ("anthropic", "anthropic"),
+        ("openai", "openai"),
+    ]
+    assert [group.options[0].name for group in model_select.options] == [
+        "claude-sonnet-4-6",
+        "gpt-5.2",
+    ]
 
 
 def test_build_config_options_empty_models_list_omits_entry() -> None:

--- a/libs/acp/tests/test_model_switching.py
+++ b/libs/acp/tests/test_model_switching.py
@@ -102,7 +102,10 @@ async def test_new_session_returns_config_options(agent_factory, models):
     assert model_config.category == "model"
     assert model_config.type == "select"
     assert model_config.current_value == "anthropic:claude-opus-4-6"
-    assert len(model_config.options) == 3
+    assert len(model_config.options) == 1
+    group = model_config.options[0]
+    assert group.group == "anthropic"
+    assert len(group.options) == 3
 
 
 @pytest.mark.asyncio

--- a/libs/code/deepagents_code/acp_prompts.py
+++ b/libs/code/deepagents_code/acp_prompts.py
@@ -1,0 +1,43 @@
+"""ACP-specific prompt fragments."""
+
+from __future__ import annotations
+
+_MODE_PROMPTS: dict[str, tuple[str, str]] = {
+    "plan": (
+        "ACP Planning Mode",
+        (
+            "You are in planning mode. Inspect and reason as needed, then present "
+            "a concrete plan and wait for approval before editing files, running "
+            "shell commands, or making other changes."
+        ),
+    ),
+    "ask": (
+        "ACP Ask Mode",
+        (
+            "You are in ask mode. Answer questions and discuss the codebase, but "
+            "do not edit files, run shell commands, or make other workspace "
+            "changes."
+        ),
+    ),
+}
+
+
+def append_acp_mode_prompt(base_prompt: str, mode: str) -> str:
+    """Append ACP mode-specific instructions to a base system prompt.
+
+    Args:
+        base_prompt: Existing system prompt generated for the agent.
+        mode: ACP session mode identifier.
+
+    Returns:
+        System prompt with ACP mode instructions appended.
+
+    Raises:
+        ValueError: If `mode` has no ACP-specific prompt fragment.
+    """
+    fragment = _MODE_PROMPTS.get(mode)
+    if fragment is None:
+        msg = f"ACP mode {mode!r} has no prompt fragment"
+        raise ValueError(msg)
+    heading, instruction = fragment
+    return f"{base_prompt}\n\n### {heading}\n\n{instruction}"

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 
     from deepagents.backends.sandbox import SandboxBackendProtocol
     from deepagents.middleware.async_subagents import AsyncSubAgent
+    from deepagents.middleware.filesystem import FilesystemPermission
     from deepagents.middleware.subagents import CompiledSubAgent, SubAgent
     from langchain.agents.middleware import InterruptOnConfig
     from langchain.agents.middleware.types import AgentState
@@ -1254,6 +1255,7 @@ def create_cli_agent(
     cwd: str | Path | None = None,
     project_context: ProjectContext | None = None,
     async_subagents: list[AsyncSubAgent] | None = None,
+    permissions: list[FilesystemPermission] | None = None,
 ) -> tuple[Pregel[Any, Any, Any, Any], CompositeBackend]:
     """Create a CLI-configured agent with flexible options.
 
@@ -1336,6 +1338,8 @@ def create_cli_agent(
         async_subagents: Remote LangGraph deployments to expose as async subagent tools.
 
             Loaded from `[async_subagents]` in `config.toml` or passed directly.
+        permissions: Optional filesystem permission rules forwarded to the SDK
+            filesystem tools.
 
     Returns:
         2-tuple of `(agent_graph, backend)`
@@ -1722,6 +1726,7 @@ def create_cli_agent(
         context_schema=CLIContextSchema,
         checkpointer=checkpointer,
         subagents=all_subagents or None,
+        permissions=permissions,
         name=_sanitize_agent_message_name(assistant_id),
     ).with_config(config)
     return agent, composite_backend

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
 
 if TYPE_CHECKING:
+    from langgraph.graph.state import CompiledStateGraph
     from rich.console import Console
 
     from deepagents_code.app import AppResult
@@ -38,6 +39,119 @@ logger = logging.getLogger(__name__)
 
 _SANDBOX_DEFAULT_SENTINEL = "\x00default"
 """Marker stored by `--sandbox` with no value, resolved to `[sandboxes].default`."""
+
+
+_ACP_AGENT_MODE = "agent"
+"""Default ACP session mode for normal agent execution."""
+
+_ACP_PLAN_MODE = "plan"
+"""ACP session mode for planning-oriented clients."""
+
+_ACP_ASK_MODE = "ask"
+"""ACP session mode for Q&A without workspace changes."""
+
+
+def _acp_model_name(spec: str) -> str:
+    """Return a display name for an ACP model selector entry.
+
+    Args:
+        spec: Model spec, usually in `provider:model` form.
+
+    Returns:
+        Human-readable model name for ACP clients.
+    """
+    if ":" not in spec:
+        return spec
+    _provider, model = spec.split(":", maxsplit=1)
+    return model
+
+
+def _is_acp_model_provider_selectable(provider: str) -> bool:
+    """Return whether an ACP model selector should offer a provider.
+
+    Args:
+        provider: Provider name from a `provider:model` spec.
+
+    Returns:
+        `True` when model creation should not be blocked by missing credentials.
+    """
+    from deepagents_code.model_config import get_provider_auth_status
+
+    return not get_provider_auth_status(provider).blocks_start
+
+
+def _build_acp_model_options(current_model: str) -> list[dict[str, str]]:
+    """Build ACP model selector entries with the current model first.
+
+    Args:
+        current_model: Resolved `provider:model` spec currently in use.
+
+    Returns:
+        Model entries shaped for `AgentServerACP`.
+    """
+    from deepagents_code.model_config import get_available_models, load_recent_models
+
+    specs: list[str] = [current_model]
+
+    try:
+        specs.extend(load_recent_models())
+    except Exception:
+        logger.warning("Could not load recent models for ACP selector", exc_info=True)
+
+    try:
+        available = get_available_models()
+    except Exception:
+        logger.warning(
+            "Could not discover available models for ACP selector",
+            exc_info=True,
+        )
+        available = {}
+
+    for provider, models in available.items():
+        specs.extend(f"{provider}:{model}" for model in models)
+
+    unique_specs = list(dict.fromkeys(spec for spec in specs if spec))
+    return [
+        {
+            "value": spec,
+            "name": _acp_model_name(spec),
+            "description": spec,
+        }
+        for spec in unique_specs
+        if spec == current_model
+        or ":" not in spec
+        or _is_acp_model_provider_selectable(spec.split(":", maxsplit=1)[0])
+    ]
+
+
+def _build_acp_modes() -> object:
+    """Build ACP session modes advertised by `dcode --acp`.
+
+    Returns:
+        ACP `SessionModeState` instance.
+    """
+    from acp.schema import SessionMode, SessionModeState
+
+    return SessionModeState(
+        current_mode_id=_ACP_AGENT_MODE,
+        available_modes=[
+            SessionMode(
+                id=_ACP_AGENT_MODE,
+                name="Agent",
+                description="Run normally with approval prompts for gated tools.",
+            ),
+            SessionMode(
+                id=_ACP_PLAN_MODE,
+                name="Plan",
+                description="Plan-oriented session mode for ACP clients.",
+            ),
+            SessionMode(
+                id=_ACP_ASK_MODE,
+                name="Ask",
+                description="Answer questions without file or command changes.",
+            ),
+        ],
+    )
 
 
 def build_version_text() -> str:
@@ -1906,7 +2020,11 @@ async def _run_acp_cli_async(
     Returns:
         Exit code for ACP mode.
     """
-    from deepagents_code.agent import create_cli_agent, load_async_subagents
+    from deepagents_code.agent import (
+        create_cli_agent,
+        get_system_prompt,
+        load_async_subagents,
+    )
     from deepagents_code.config import create_model, settings
     from deepagents_code.model_config import (
         ModelConfigError,
@@ -1964,24 +2082,76 @@ async def _run_acp_cli_async(
 
     async_subagents = load_async_subagents() or None
 
-    try:
-        from langgraph.checkpoint.memory import InMemorySaver
+    from deepagents_acp.server import AgentSessionContext
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    from deepagents_code.acp_prompts import append_acp_mode_prompt
+
+    checkpointer = InMemorySaver()
+    acp_models = _build_acp_model_options(resolved_spec)
+    acp_modes = _build_acp_modes()
+
+    def build_agent(context: AgentSessionContext) -> "CompiledStateGraph":
+        """Build a session-scoped ACP agent from selector state.
+
+        Args:
+            context: ACP session context containing cwd, mode, and model.
+
+        Returns:
+            Compiled CLI agent graph.
+        """
+        selected_model = context.model or resolved_spec
+        selected_model_result = create_model(
+            selected_model,
+            extra_kwargs=model_params,
+            profile_overrides=profile_override,
+        )
+        selected_model_result.apply_to_settings()
+        selected_spec = (
+            f"{selected_model_result.provider}:{selected_model_result.model_name}"
+        )
+        save_recent_model(selected_spec)
+        touch_recent_model(selected_spec)
+        system_prompt = None
+        enable_shell = True
+        permissions = None
+        if context.mode in {_ACP_PLAN_MODE, _ACP_ASK_MODE}:
+            system_prompt = append_acp_mode_prompt(
+                get_system_prompt(
+                    assistant_id=assistant_id,
+                    sandbox_type=None,
+                    interactive=True,
+                    cwd=context.cwd,
+                ),
+                context.mode,
+            )
+        if context.mode == _ACP_ASK_MODE:
+            from deepagents.middleware.filesystem import FilesystemPermission
+
+            enable_shell = False
+            permissions = [
+                FilesystemPermission(
+                    operations=["write"],
+                    paths=["/**"],
+                    mode="deny",
+                )
+            ]
 
         agent_graph, _backend = create_cli_agent(
-            model=model_result.model,
+            model=selected_model_result.model,
             assistant_id=assistant_id,
             tools=tools,
+            system_prompt=system_prompt,
             mcp_server_info=mcp_server_info,
-            checkpointer=InMemorySaver(),
+            checkpointer=checkpointer,
             async_subagents=async_subagents,
+            enable_shell=enable_shell,
+            permissions=permissions,
+            cwd=context.cwd,
         )
-    except Exception as exc:
-        sys.stderr.write(f"Error: failed to create agent: {exc}\n")
-        sys.stderr.flush()
-        logger.debug("ACP agent creation failed", exc_info=True)
-        return 1
+        return agent_graph
 
-    server = agent_server_cls(agent_graph)  # Pregel is a CompiledStateGraph at runtime
+    server = agent_server_cls(build_agent, modes=acp_modes, models=acp_models)
     exit_code = 0
     try:
         await run_acp_agent(server)

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -177,6 +177,7 @@ include = [
 
 [tool.uv.sources]
 deepagents = { path = "../deepagents", editable = true }
+deepagents-acp = { path = "../acp", editable = true }
 langchain-daytona = { path = "../partners/daytona", editable = true }
 langchain-modal = { path = "../partners/modal", editable = true }
 langchain-quickjs = { path = "../partners/quickjs", editable = true }

--- a/libs/code/tests/unit_tests/test_main_acp_mode.py
+++ b/libs/code/tests/unit_tests/test_main_acp_mode.py
@@ -6,11 +6,28 @@ import argparse
 import asyncio
 import sys
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, Protocol
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from deepagents_code.main import cli_main
+from deepagents_code.main import _build_acp_model_options, cli_main
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class _Mode(Protocol):
+    """Small protocol for ACP mode entries in tests."""
+
+    id: str
+
+
+class _ModeState(Protocol):
+    """Small protocol for ACP mode state assertions in tests."""
+
+    current_mode_id: str
+    available_modes: list[_Mode]
 
 
 def _make_acp_args(**overrides: object) -> argparse.Namespace:
@@ -29,8 +46,55 @@ def _make_acp_args(**overrides: object) -> argparse.Namespace:
     return args
 
 
+def test_acp_model_options_filter_missing_credential_providers() -> None:
+    """ACP model selector should not offer providers that cannot start."""
+    from deepagents_code.model_config import (
+        ProviderAuthSource,
+        ProviderAuthState,
+        ProviderAuthStatus,
+    )
+
+    def _auth_status(provider: str) -> ProviderAuthStatus:
+        state = (
+            ProviderAuthState.MISSING
+            if provider == "anthropic"
+            else ProviderAuthState.CONFIGURED
+        )
+        source = (
+            ProviderAuthSource.ENV if state is ProviderAuthState.CONFIGURED else None
+        )
+        return ProviderAuthStatus(
+            state=state,
+            provider=provider,
+            env_var=f"{provider.upper()}_API_KEY",
+            source=source,
+        )
+
+    with (
+        patch("deepagents_code.model_config.load_recent_models", return_value=[]),
+        patch(
+            "deepagents_code.model_config.get_available_models",
+            return_value={
+                "openai": ["gpt-5.5"],
+                "anthropic": ["claude-sonnet-4-6"],
+            },
+        ),
+        patch("deepagents_code.model_config.get_provider_auth_status", _auth_status),
+    ):
+        options = _build_acp_model_options("openai:gpt-5.5")
+
+    assert [option["value"] for option in options] == ["openai:gpt-5.5"]
+    assert [option["name"] for option in options] == ["gpt-5.5"]
+
+
 def test_acp_mode_loads_tools_and_mcp_and_runs_server() -> None:
-    """`--acp` should build the ACP agent with web tools and MCP tools."""
+    """`--acp` should expose selectors and build a factory-backed agent."""
+    from deepagents_code.model_config import (
+        ProviderAuthSource,
+        ProviderAuthState,
+        ProviderAuthStatus,
+    )
+
     args = _make_acp_args(
         model_params='{"temperature": 0.2}',
         profile_override='{"max_input_tokens": 4096}',
@@ -56,6 +120,14 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server() -> None:
     fetch_tool = object()
     thread_tool = object()
     search_tool = object()
+    captured_factory: Callable[[object], object] | None = None
+
+    def _auth_status(provider: str) -> ProviderAuthStatus:
+        return ProviderAuthStatus(
+            state=ProviderAuthState.CONFIGURED,
+            provider=provider,
+            source=ProviderAuthSource.ENV,
+        )
 
     def _resolve_mcp_tools_with_bound_loop(
         *,
@@ -70,6 +142,29 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server() -> None:
         mcp_loop = asyncio.get_running_loop()
         return [mcp_tool], mcp_manager, mcp_server_info
 
+    def _build_acp_server(
+        agent_factory: Callable[[object], object],
+        *,
+        modes: _ModeState,
+        models: list[dict[str, str]],
+    ) -> object:
+        nonlocal captured_factory
+        assert callable(agent_factory)
+        captured_factory = agent_factory
+        assert modes.current_mode_id == "agent"
+        assert [mode.id for mode in modes.available_modes] == ["agent", "plan", "ask"]
+        assert [model["value"] for model in models] == [
+            "anthropic:claude-sonnet-4-6",
+            "anthropic:claude-haiku-4",
+            "openai:gpt-5.2",
+        ]
+        assert [model["name"] for model in models] == [
+            "claude-sonnet-4-6",
+            "claude-haiku-4",
+            "gpt-5.2",
+        ]
+        return server
+
     resolve_mcp_tools = AsyncMock(side_effect=_resolve_mcp_tools_with_bound_loop)
 
     with (
@@ -80,7 +175,20 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server() -> None:
         ),
         patch("deepagents_code.main.parse_args", return_value=args),
         patch("deepagents_code.config.settings", new=SimpleNamespace(has_tavily=True)),
+        patch(
+            "deepagents_code.model_config.get_available_models",
+            return_value={
+                "anthropic": ["claude-sonnet-4-6", "claude-haiku-4"],
+                "openai": ["gpt-5.2"],
+            },
+        ),
+        patch(
+            "deepagents_code.model_config.load_recent_models",
+            return_value=["anthropic:claude-haiku-4"],
+        ),
+        patch("deepagents_code.model_config.get_provider_auth_status", _auth_status),
         patch("deepagents_code.model_config.save_recent_model", return_value=True),
+        patch("deepagents_code.model_config.touch_recent_model", return_value=True),
         patch(
             "deepagents_code.config.create_model", return_value=model_result
         ) as mock_create_model,
@@ -93,8 +201,9 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server() -> None:
         patch(
             "deepagents_code.agent.create_cli_agent", return_value=("graph", object())
         ) as mock_create_agent,
+        patch("deepagents_code.agent.get_system_prompt", return_value="base prompt"),
         patch(
-            "deepagents_acp.server.AgentServerACP", return_value=server
+            "deepagents_acp.server.AgentServerACP", side_effect=_build_acp_server
         ) as mock_server_cls,
         patch("acp.run_agent", run_agent),
         pytest.raises(SystemExit) as exc_info,
@@ -113,20 +222,49 @@ def test_acp_mode_loads_tools_and_mcp_and_runs_server() -> None:
         trust_project_mcp=False,
     )
     model_result.apply_to_settings.assert_called_once_with()
-    mock_create_agent.assert_called_once()
+
+    assert captured_factory is not None
+    graph = captured_factory(
+        SimpleNamespace(cwd="/tmp/acp", mode="plan", model="openai:gpt-5.2")
+    )
+    assert graph == "graph"
+    assert mock_create_model.call_args_list[-1].args == ("openai:gpt-5.2",)
     call_kwargs = mock_create_agent.call_args.kwargs
     assert call_kwargs["model"] is model_obj
     assert call_kwargs["assistant_id"] == "agent"
     assert call_kwargs["tools"] == [fetch_tool, thread_tool, search_tool, mcp_tool]
+    assert "ACP Planning Mode" in call_kwargs["system_prompt"]
     assert call_kwargs["mcp_server_info"] is mcp_server_info
     assert call_kwargs["checkpointer"] is not None
-    mock_server_cls.assert_called_once_with("graph")
+    assert call_kwargs["cwd"] == "/tmp/acp"
+    assert call_kwargs["enable_shell"] is True
+    assert call_kwargs["permissions"] is None
+
+    ask_graph = captured_factory(
+        SimpleNamespace(cwd="/tmp/acp", mode="ask", model="openai:gpt-5.2")
+    )
+    assert ask_graph == "graph"
+    ask_call_kwargs = mock_create_agent.call_args.kwargs
+    assert "ACP Ask Mode" in ask_call_kwargs["system_prompt"]
+    assert ask_call_kwargs["enable_shell"] is False
+    [rule] = ask_call_kwargs["permissions"]
+    assert rule.operations == ["write"]
+    assert rule.paths == ["/**"]
+    assert rule.mode == "deny"
+    assert mock_create_agent.call_count == 2
+    mock_server_cls.assert_called_once()
     run_agent.assert_awaited_once_with(server)
     mcp_manager.cleanup.assert_awaited_once_with()
 
 
 def test_acp_mode_omits_web_search_without_tavily() -> None:
     """`--acp` should skip `web_search` when Tavily is not configured."""
+    from deepagents_code.model_config import (
+        ProviderAuthSource,
+        ProviderAuthState,
+        ProviderAuthStatus,
+    )
+
     args = _make_acp_args()
     model_obj = object()
     model_result = SimpleNamespace(
@@ -141,6 +279,27 @@ def test_acp_mode_omits_web_search_without_tavily() -> None:
     thread_tool = object()
     search_tool = object()
     resolve_mcp_tools = AsyncMock(return_value=([], None, []))
+    captured_factory: Callable[[object], object] | None = None
+
+    def _auth_status(provider: str) -> ProviderAuthStatus:
+        return ProviderAuthStatus(
+            state=ProviderAuthState.CONFIGURED,
+            provider=provider,
+            source=ProviderAuthSource.ENV,
+        )
+
+    def _build_acp_server(
+        agent_factory: Callable[[object], object],
+        *,
+        modes: _ModeState,
+        models: list[dict[str, str]],
+    ) -> object:
+        nonlocal captured_factory
+        assert callable(agent_factory)
+        captured_factory = agent_factory
+        assert modes.current_mode_id == "agent"
+        assert models[0]["value"] == "anthropic:claude-sonnet-4-6"
+        return server
 
     with (
         patch.object(sys, "argv", ["deepagents", "--acp"]),
@@ -150,7 +309,14 @@ def test_acp_mode_omits_web_search_without_tavily() -> None:
         ),
         patch("deepagents_code.main.parse_args", return_value=args),
         patch("deepagents_code.config.settings", new=SimpleNamespace(has_tavily=False)),
+        patch(
+            "deepagents_code.model_config.get_available_models",
+            return_value={"anthropic": ["claude-sonnet-4-6"]},
+        ),
+        patch("deepagents_code.model_config.load_recent_models", return_value=[]),
+        patch("deepagents_code.model_config.get_provider_auth_status", _auth_status),
         patch("deepagents_code.model_config.save_recent_model", return_value=True),
+        patch("deepagents_code.model_config.touch_recent_model", return_value=True),
         patch("deepagents_code.config.create_model", return_value=model_result),
         patch(
             "deepagents_code.mcp_tools.resolve_and_load_mcp_tools", resolve_mcp_tools
@@ -161,18 +327,22 @@ def test_acp_mode_omits_web_search_without_tavily() -> None:
         patch(
             "deepagents_code.agent.create_cli_agent", return_value=("graph", object())
         ) as mock_create_agent,
-        patch("deepagents_acp.server.AgentServerACP", return_value=server),
+        patch("deepagents_acp.server.AgentServerACP", side_effect=_build_acp_server),
         patch("acp.run_agent", run_agent),
         pytest.raises(SystemExit) as exc_info,
     ):
         cli_main()
 
     assert exc_info.value.code == 0
+    assert captured_factory is not None
+    graph = captured_factory(SimpleNamespace(cwd="/tmp/acp", mode="agent", model=None))
+    assert graph == "graph"
     mock_create_agent.assert_called_once()
     call_kwargs = mock_create_agent.call_args.kwargs
     assert call_kwargs["model"] is model_obj
     assert call_kwargs["assistant_id"] == "agent"
     assert call_kwargs["tools"] == [fetch_tool, thread_tool]
+    assert call_kwargs["system_prompt"] is None
     assert call_kwargs["mcp_server_info"] == []
     assert call_kwargs["checkpointer"] is not None
 

--- a/libs/code/uv.lock
+++ b/libs/code/uv.lock
@@ -1066,15 +1066,35 @@ test = [
 [[package]]
 name = "deepagents-acp"
 version = "0.0.8"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../acp" }
 dependencies = [
     { name = "agent-client-protocol" },
     { name = "deepagents" },
     { name = "python-dotenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/4e/586cf7a70161e3eb0c3596ec9513f8249c0739283c2abe08b0c10537197e/deepagents_acp-0.0.8.tar.gz", hash = "sha256:9fb5cecfe9e9238de27e69ac76e7b0bc80a31cbff268c542bf5c9f4727dde1f4", size = 13010377, upload-time = "2026-06-03T18:08:17.321Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/05/5cc23022dcf59543d5d26c5564754cdc8158866feba403d7527ddc788486/deepagents_acp-0.0.8-py3-none-any.whl", hash = "sha256:0380c8e804a5d5c0fa245a5b1d7dfde8a867f7a9a17ef54749a69da31ed341cf", size = 17630, upload-time = "2026-06-03T18:08:15.879Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "agent-client-protocol", specifier = ">=0.10.1" },
+    { name = "deepagents", editable = "../deepagents" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+]
+
+[package.metadata.requires-dev]
+examples = [
+    { name = "langchain-baseten", specifier = ">=0.2.0" },
+    { name = "langchain-openai", specifier = ">=1.2.2" },
+]
+test = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "pytest-socket", specifier = ">=0.8.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0,<3.0.0" },
+    { name = "pytest-watcher", specifier = ">=0.6.3,<1.0.0" },
+    { name = "ruff", specifier = ">=0.15.16,<0.16.0" },
+    { name = "ty", specifier = ">=0.0.46,<1.0.0" },
 ]
 
 [[package]]
@@ -1247,7 +1267,7 @@ test = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.22.1,<1.0.0" },
     { name = "deepagents", editable = "../deepagents" },
-    { name = "deepagents-acp", specifier = ">=0.0.8,<1.0.0" },
+    { name = "deepagents-acp", editable = "../acp" },
     { name = "deepagents-code", extras = ["agentcore", "daytona", "modal", "runloop", "vercel"], marker = "extra == 'all-sandboxes'" },
     { name = "deepagents-code", extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "together", "vertex", "xai"], marker = "extra == 'all-providers'" },
     { name = "httpx", specifier = ">=0.28.1,<1.0.0" },


### PR DESCRIPTION
Closes #4254

---

Adds ACP session selectors for `dcode --acp`, including model and mode configuration exposed through `configOptions`.

The ACP agent is now built per session so model and mode changes take effect, and Ask mode is enforced as read-only by disabling shell access and denying filesystem writes. ACP mode prompt fragments are kept outside the entrypoint.

Model options are filtered to providers that can start with current credentials and are grouped by provider for clients that support grouped select options. `deepagents-code` now uses the local editable `deepagents-acp` package during monorepo development so ACP server changes are tested locally.