### PR TITLE
fix(langchain-vercel-sandbox): truncate command output on UTF-8 byte budget

### DIFF
--- a/libs/partners/vercel/langchain_vercel_sandbox/sandbox.py
+++ b/libs/partners/vercel/langchain_vercel_sandbox/sandbox.py
@@ -119,8 +119,14 @@ class VercelSandbox(BaseSandbox):
             output += f"\n<stderr>{stderr.strip()}</stderr>"
 
         truncated = False
-        if len(output) > MAX_OUTPUT_BYTES:
-            output = output[:MAX_OUTPUT_BYTES]
+        encoded = output.encode("utf-8")
+        if len(encoded) > MAX_OUTPUT_BYTES:
+            # Truncate on the UTF-8 byte budget rather than the code-point count:
+            # `output` is a `str`, so `output[:MAX_OUTPUT_BYTES]` would slice by
+            # code points and overshoot the documented byte limit for multibyte
+            # text. `errors="ignore"` drops a partial trailing multibyte sequence
+            # so the result is always valid text.
+            output = encoded[:MAX_OUTPUT_BYTES].decode("utf-8", errors="ignore")
             output += f"\n\n... Output truncated at {MAX_OUTPUT_BYTES} bytes."
             truncated = True
 

--- a/libs/partners/vercel/tests/unit_tests/test_sandbox.py
+++ b/libs/partners/vercel/tests/unit_tests/test_sandbox.py
@@ -152,6 +152,26 @@ def test_execute_truncates_combined_stdout_and_stderr() -> None:
     assert result.truncated is True
 
 
+def test_execute_truncates_on_utf8_byte_budget() -> None:
+    # Multibyte output: code-point slicing would overshoot the documented byte
+    # budget (each "€" is 3 UTF-8 bytes). Truncation must measure UTF-8 bytes
+    # and never split a multibyte sequence.
+    sandbox = _Sandbox()
+    sandbox.detached_command = _Command(stdout="€" * MAX_OUTPUT_BYTES)
+
+    result = sandbox.as_backend().execute("python emit_unicode.py")
+
+    notice = f"\n\n... Output truncated at {MAX_OUTPUT_BYTES} bytes."
+    assert result.truncated is True
+    assert result.output.endswith(notice)
+    captured = result.output[: -len(notice)]
+    # Captured payload honors the byte budget, not the code-point count...
+    assert len(captured.encode("utf-8")) <= MAX_OUTPUT_BYTES
+    # ...and remains valid text: no replacement char from a split sequence.
+    assert "�" not in captured
+    assert set(captured) == {"€"}
+
+
 def test_execute_enforces_timeout_and_kills_command() -> None:
     sandbox = _Sandbox()
     pending = _Command(exit_code=None)


### PR DESCRIPTION
Fixes #4336

`VercelSandbox.execute()` caps output with `output[:MAX_OUTPUT_BYTES]`, which slices a `str` by code points even though the constant is byte-named and `ExecuteResponse.truncated` is byte-oriented. For multibyte output (accented text, non-Latin scripts, emoji in tracebacks) this overshoots the documented byte limit and can split a character mid-sequence. This measures and slices the UTF-8 encoding instead, decoding with `errors="ignore"` so a partial trailing sequence is dropped and the result stays valid text.

ASCII output is unaffected, so the existing truncation tests pass unchanged; a new test covers the multibyte case.

## How I verified
From `libs/partners/vercel`: `make test` (29 passed), `make lint`, and `make type` all pass.

## AI disclaimer
Drafted with AI assistance and reviewed/verified by me.
