### PR TITLE
fix(talon): copy quickjs partner libs into image

### DIFF
--- a/examples/talon/Dockerfile
+++ b/examples/talon/Dockerfile
@@ -47,6 +47,7 @@ WORKDIR /opt/deepagents-src
 
 COPY libs/deepagents ./libs/deepagents
 COPY libs/code ./libs/code
+COPY libs/partners/quickjs ./libs/partners/quickjs
 COPY libs/talon ./libs/talon
 COPY examples/talon/AGENTS.md /opt/deepagents-talon/AGENTS.md
 


### PR DESCRIPTION
The Talon Docker image syncs `libs/talon` with the checked-in lockfile, which resolves `langchain-quickjs` as an editable source at `../partners/quickjs`. The image context already copied the Deep Agents SDK, code package, and Talon package, but not the QuickJS partner package, so the editable source path was missing during image setup.

This adds `libs/partners/quickjs` to the Docker build context at the path expected by the lockfile.

Verified with `docker build --check -f examples/talon/Dockerfile .`.