### PR TITLE
feat(talon): ingest WhatsApp approval reactions

### DIFF
--- a/libs/talon/deepagents_talon/channels/whatsapp.py
+++ b/libs/talon/deepagents_talon/channels/whatsapp.py
@@ -41,8 +41,10 @@ from deepagents_talon.channels.base import (
 from deepagents_talon.interfaces import (
     ChannelMedia,
     ChannelMessage,
+    ChannelReaction,
     ChannelStatus,
     MessageHandler,
+    ReactionHandler,
     SendResult,
 )
 
@@ -266,6 +268,7 @@ class WhatsAppChannel:
             token=config.bridge_token,
         )
         self._handler: MessageHandler | None = None
+        self._reaction_handler: ReactionHandler | None = None
         self._process: asyncio.subprocess.Process | None = None
         self._bridge_stdout: asyncio.Task[None] | None = None
         self._bridge_stderr: asyncio.Task[None] | None = None
@@ -282,6 +285,14 @@ class WhatsAppChannel:
             handler: Coroutine callback invoked for accepted inbound messages.
         """
         self._handler = handler
+
+    def set_reaction_handler(self, handler: ReactionHandler) -> None:
+        """Register the host callback for inbound reactions.
+
+        Args:
+            handler: Coroutine callback invoked for accepted inbound reactions.
+        """
+        self._reaction_handler = handler
 
     async def start(self) -> None:
         """Start the bridge subprocess and background polling tasks."""
@@ -442,22 +453,41 @@ class WhatsAppChannel:
         while not self._stopped.is_set():
             try:
                 payload = await self._transport.get("/messages")
-                for message in _parse_messages(payload):
-                    if self.config.exposure.allows(message):
-                        checked = _enforce_inbound_media_cap(
-                            message,
-                            max_bytes=self.config.max_media_bytes,
-                        )
-                        await dispatch_message(self._handler, checked, provider="WhatsApp")
-                    else:
-                        logger.debug(
-                            "Dropping WhatsApp message %s from %s due to exposure policy",
-                            message.message_id,
-                            message.conversation_id,
-                        )
+                for item in _parse_queue_entries(payload):
+                    await self._process_queue_entry(item)
             except _WhatsAppBridgeError:
                 logger.exception("Failed to poll WhatsApp bridge messages")
             await asyncio.sleep(self.config.poll_interval_seconds)
+
+    async def _process_queue_entry(self, item: ChannelMessage | ChannelReaction) -> None:
+        if isinstance(item, ChannelReaction):
+            await self._process_reaction(item)
+            return
+        if self.config.exposure.allows(item):
+            checked = _enforce_inbound_media_cap(
+                item,
+                max_bytes=self.config.max_media_bytes,
+            )
+            await dispatch_message(self._handler, checked, provider="WhatsApp")
+        else:
+            logger.debug(
+                "Dropping WhatsApp message %s from %s due to exposure policy",
+                item.message_id,
+                item.conversation_id,
+            )
+
+    async def _process_reaction(self, reaction: ChannelReaction) -> None:
+        if not self.config.exposure.allows(_reaction_exposure_message(reaction)):
+            logger.debug(
+                "Dropping WhatsApp reaction %s from %s due to exposure policy",
+                reaction.message_id,
+                reaction.conversation_id,
+            )
+            return
+        if self._reaction_handler is None:
+            logger.warning("Dropping WhatsApp reaction because no handler is registered")
+            return
+        await self._reaction_handler(reaction)
 
     async def _watch_health(self) -> None:
         while not self._stopped.is_set():
@@ -586,11 +616,30 @@ def _validate_loopback_url(value: str) -> str:
     return value
 
 
-def _parse_messages(payload: object) -> list[ChannelMessage]:
+def _parse_queue_entries(payload: object) -> list[ChannelMessage | ChannelReaction]:
     if not isinstance(payload, list):
         msg = "WhatsApp bridge /messages response must be a list"
         raise _WhatsAppBridgeError(msg)
-    return [_parse_message(item) for item in payload]
+    entries: list[ChannelMessage | ChannelReaction] = []
+    for item in payload:
+        parsed = _parse_queue_entry(item)
+        if parsed is not None:
+            entries.append(parsed)
+    return entries
+
+
+def _parse_queue_entry(payload: object) -> ChannelMessage | ChannelReaction | None:
+    if not isinstance(payload, dict):
+        msg = "WhatsApp bridge queue entry must be an object"
+        raise _WhatsAppBridgeError(msg)
+    values = cast("Mapping[str, object]", payload)
+    event_type = optional_str(values.get("event_type") or values.get("eventType"))
+    if event_type in (None, "message"):
+        return _parse_message(values)
+    if event_type == "reaction":
+        return _parse_reaction(values)
+    logger.warning("Dropping WhatsApp bridge queue entry with unknown event_type %r", event_type)
+    return None
 
 
 def _parse_message(payload: object) -> ChannelMessage:
@@ -637,6 +686,49 @@ def _parse_message(payload: object) -> ChannelMessage:
         media_paths=media_paths,
         mime_types=media_mime_types,
         has_media=has_media,
+    )
+
+
+def _parse_reaction(values: Mapping[str, object]) -> ChannelReaction | None:
+    if _is_reaction_removal(values):
+        return None
+    emoji = optional_str(values.get("emoji") or values.get("reaction"))
+    sender_id = optional_str(values.get("sender_id") or values.get("senderId"))
+    if emoji is None or sender_id is None:
+        return None
+    return ChannelReaction(
+        conversation_id=_required_str_any(values, ("chat_id", "chatId")),
+        message_id=_required_str_any(values, ("message_id", "messageId")),
+        emoji=emoji,
+        sender_id=sender_id,
+        metadata={
+            "provider": "whatsapp",
+            "chat_type": values.get("chat_type") or values.get("chatType"),
+            "chat_name": values.get("chat_name") or values.get("chatName"),
+            "raw_reaction": values.get("raw_reaction") or values.get("rawReaction") or {},
+            "from_self": bool(values.get("from_self") or values.get("fromSelf")),
+        },
+    )
+
+
+def _is_reaction_removal(values: Mapping[str, object]) -> bool:
+    if values.get("removed") is True or values.get("is_removed") is True:
+        return True
+    action = values.get("action") or values.get("reaction_action") or values.get("reactionAction")
+    return isinstance(action, str) and action.lower() in {"remove", "removed", "revoke", "revoked"}
+
+
+def _reaction_exposure_message(reaction: ChannelReaction) -> ChannelMessage:
+    return ChannelMessage(
+        conversation_id=reaction.conversation_id,
+        text="",
+        sender_id=reaction.sender_id,
+        message_id=reaction.message_id,
+        metadata={
+            "provider": "whatsapp",
+            "chat_type": reaction.metadata.get("chat_type"),
+            "from_self": reaction.metadata.get("from_self") is True,
+        },
     )
 
 

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
@@ -93,6 +93,10 @@ client.on("message_create", (message) => {
   void enqueueMessage(message);
 });
 
+client.on("message_reaction", (reaction) => {
+  enqueueReaction(reaction);
+});
+
 async function enqueueMessage(message) {
   if (message.from === "status@broadcast") {
     return;
@@ -125,6 +129,8 @@ async function enqueueMessage(message) {
       : typeof chatId === "string" && chatId.endsWith("@g.us");
 
   const entry = {
+    event_type: "message",
+    eventType: "message",
     text: message.body || "",
     body: message.body || "",
     message_type: message.type || "chat",
@@ -175,6 +181,38 @@ async function enqueueMessage(message) {
   };
 
   console.log(`[bridge] Queued message ${messageId} for ${chatId}`);
+  queue.push(entry);
+}
+
+function enqueueReaction(reaction) {
+  const emoji = typeof reaction.reaction === "string" ? reaction.reaction : "";
+  if (!emoji) {
+    return;
+  }
+  const messageId = reactionMessageId(reaction);
+  const chatId = reactionChatId(reaction);
+  const senderId = normalizeId(reaction.senderId);
+  if (!messageId || !chatId || !senderId) {
+    console.error("Skipping WhatsApp reaction without a message id, chat id, or sender id");
+    return;
+  }
+
+  const entry = {
+    event_type: "reaction",
+    eventType: "reaction",
+    chat_id: chatId,
+    chatId,
+    message_id: messageId,
+    messageId,
+    sender_id: senderId,
+    senderId,
+    emoji,
+    reaction: emoji,
+    raw_reaction: rawReaction(reaction),
+    rawReaction: rawReaction(reaction),
+  };
+
+  console.log(`[bridge] Queued reaction ${emoji} on ${messageId} for ${chatId}`);
   queue.push(entry);
 }
 
@@ -370,6 +408,37 @@ function decodedBase64Size(value) {
 
 function serializedId(value) {
   return value && value._serialized ? value._serialized : null;
+}
+
+function normalizeId(value) {
+  if (typeof value === "string" && value) {
+    return value;
+  }
+  return serializedId(value);
+}
+
+function reactionMessageId(reaction) {
+  const msgId = reaction && reaction.msgId;
+  if (!msgId) {
+    return null;
+  }
+  return serializedId(msgId) || (typeof msgId.id === "string" ? msgId.id : null);
+}
+
+function reactionChatId(reaction) {
+  const msgId = reaction && reaction.msgId;
+  return normalizeId(msgId && msgId.remote);
+}
+
+function rawReaction(reaction) {
+  return {
+    msgId: reactionMessageId(reaction),
+    senderId: normalizeId(reaction && reaction.senderId),
+    reaction: typeof reaction.reaction === "string" ? reaction.reaction : null,
+    orphan: Boolean(reaction.orphan),
+    orphanReason: typeof reaction.orphanReason === "string" ? reaction.orphanReason : null,
+    timestamp: Number.isFinite(Number(reaction.timestamp)) ? Number(reaction.timestamp) : null,
+  };
 }
 
 function normalizeIds(values) {

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
@@ -196,6 +196,7 @@ function enqueueReaction(reaction) {
     console.error("Skipping WhatsApp reaction without a message id, chat id, or sender id");
     return;
   }
+  const fromSelf = senderId === botId;
 
   const entry = {
     event_type: "reaction",
@@ -206,6 +207,8 @@ function enqueueReaction(reaction) {
     messageId,
     sender_id: senderId,
     senderId,
+    from_self: fromSelf,
+    fromSelf,
     emoji,
     reaction: emoji,
     raw_reaction: rawReaction(reaction),

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
@@ -25,6 +25,7 @@ let botId = null;
 const queue = [];
 const sentMessageIds = new Set();
 const sentMessages = new Map();
+const sentMessageChatIds = new Map();
 const recentSentBodies = new Map();
 
 process.on("unhandledRejection", (reason) => {
@@ -190,7 +191,7 @@ function enqueueReaction(reaction) {
     return;
   }
   const messageId = reactionMessageId(reaction);
-  const chatId = reactionChatId(reaction);
+  const chatId = sentMessageChatIds.get(messageId) || reactionChatId(reaction);
   const rawSenderId = normalizeId(reaction.senderId);
   const fromSelf = isSelfReaction(reaction, rawSenderId);
   const senderId = fromSelf && botId ? botId : rawSenderId;
@@ -480,17 +481,22 @@ function isSelfMessage(message) {
   return typeof id === "string" && id.startsWith("true_");
 }
 
-function rememberSentMessage(message, body) {
+function rememberSentMessage(message, body, chatId) {
   const id = serializedId(message && message.id);
   if (!id) {
     return;
   }
   sentMessageIds.add(id);
   sentMessages.set(id, message);
+  if (chatId) {
+    sentMessageChatIds.set(id, chatId);
+  }
   rememberSentBody(body);
   if (sentMessages.size > MAX_CACHED_SENT_MESSAGES) {
     const oldest = sentMessages.keys().next().value;
+    sentMessageIds.delete(oldest);
     sentMessages.delete(oldest);
+    sentMessageChatIds.delete(oldest);
   }
 }
 
@@ -595,7 +601,7 @@ async function handle(req, res) {
       const sent = await client.sendMessage(chatId, text, {
         quotedMessageId: body.replyTo || body.reply_to || undefined,
       });
-      rememberSentMessage(sent, text);
+      rememberSentMessage(sent, text, chatId);
       const messageId = serializedId(sent.id);
       sendJson(res, 200, {
         success: true,
@@ -630,7 +636,7 @@ async function handle(req, res) {
         caption,
         sendMediaAsDocument: body.mediaType === "document",
       });
-      rememberSentMessage(sent, caption || "");
+      rememberSentMessage(sent, caption || "", chatId);
       const messageId = serializedId(sent.id);
       sendJson(res, 200, {
         success: true,
@@ -668,7 +674,7 @@ async function handle(req, res) {
       }
       rememberSentBody(content);
       const edited = await message.edit(content);
-      rememberSentMessage(edited, content);
+      rememberSentMessage(edited, content, sentMessageChatIds.get(messageId));
       const editedId = serializedId(edited.id) || messageId;
       sendJson(res, 200, {
         success: true,

--- a/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
+++ b/libs/talon/deepagents_talon/channels/whatsapp_bridge/bridge.js
@@ -191,12 +191,13 @@ function enqueueReaction(reaction) {
   }
   const messageId = reactionMessageId(reaction);
   const chatId = reactionChatId(reaction);
-  const senderId = normalizeId(reaction.senderId);
+  const rawSenderId = normalizeId(reaction.senderId);
+  const fromSelf = isSelfReaction(reaction, rawSenderId);
+  const senderId = fromSelf && botId ? botId : rawSenderId;
   if (!messageId || !chatId || !senderId) {
     console.error("Skipping WhatsApp reaction without a message id, chat id, or sender id");
     return;
   }
-  const fromSelf = senderId === botId;
 
   const entry = {
     event_type: "reaction",
@@ -430,7 +431,18 @@ function reactionMessageId(reaction) {
 
 function reactionChatId(reaction) {
   const msgId = reaction && reaction.msgId;
-  return normalizeId(msgId && msgId.remote);
+  if (msgId && typeof msgId.remote === "string" && msgId.remote) {
+    return msgId.remote;
+  }
+  if (msgId && typeof msgId.remoteJid === "string" && msgId.remoteJid) {
+    return msgId.remoteJid;
+  }
+  const serialized = serializedId(msgId);
+  if (!serialized) {
+    return null;
+  }
+  const parts = serialized.split("_");
+  return parts.length >= 3 && parts[1] ? parts[1] : null;
 }
 
 function rawReaction(reaction) {
@@ -442,6 +454,18 @@ function rawReaction(reaction) {
     orphanReason: typeof reaction.orphanReason === "string" ? reaction.orphanReason : null,
     timestamp: Number.isFinite(Number(reaction.timestamp)) ? Number(reaction.timestamp) : null,
   };
+}
+
+function isSelfReaction(reaction, senderId) {
+  if (senderId && botId && senderId === botId) {
+    return true;
+  }
+  const id = reaction && reaction.id ? reaction.id : null;
+  if (id && id.fromMe === true) {
+    return true;
+  }
+  const serialized = serializedId(id);
+  return typeof serialized === "string" && serialized.startsWith("true_");
 }
 
 function normalizeIds(values) {

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -241,6 +241,13 @@ class TalonHost:
         conversation_root = self._conversation_root(provider_key, reaction.conversation_id)
         agent_conversation_id = self._agent_conversation_id(conversation_root)
         pending = self._pending_tool_approvals.get(agent_conversation_id)
+        allow_conversation_alias = False
+        if pending is None:
+            pending = self._pending_tool_approval_for_prompt(
+                reaction.message_id,
+                provider=provider_key,
+            )
+            allow_conversation_alias = pending is not None
         if pending is None:
             _log_tool_approval_reaction(
                 self.config.env,
@@ -258,6 +265,7 @@ class TalonHost:
             pending,
             provider=provider_key,
             env=self.config.env,
+            allow_conversation_alias=allow_conversation_alias,
         )
 
     async def _run_agent_turn(
@@ -536,6 +544,7 @@ class TalonHost:
         *,
         provider: str,
         env: Mapping[str, str],
+        allow_conversation_alias: bool = False,
     ) -> None:
         decision = _parse_tool_approval_reaction(reaction.emoji)
         resolution = _reaction_mismatch_resolution(
@@ -543,6 +552,7 @@ class TalonHost:
             pending,
             provider=provider,
             decision=decision,
+            allow_conversation_alias=allow_conversation_alias,
         )
         if resolution is not None:
             _log_tool_approval_reaction(
@@ -568,6 +578,17 @@ class TalonHost:
         )
         if not pending.future.done():
             pending.future.set_result(cast("ToolApprovalDecision", decision))
+
+    def _pending_tool_approval_for_prompt(
+        self,
+        message_id: str,
+        *,
+        provider: str,
+    ) -> _PendingToolApproval | None:
+        for pending in self._pending_tool_approvals.values():
+            if pending.provider == provider and pending.prompt_message_id == message_id:
+                return pending
+        return None
 
     async def _deliver_agent_result(
         self,
@@ -824,12 +845,17 @@ def _reaction_mismatch_resolution(
     *,
     provider: str,
     decision: ToolApprovalDecision | None,
+    allow_conversation_alias: bool = False,
 ) -> str | None:
     checks = (
         (decision is None, "unsupported_emoji"),
         (pending.prompt_message_id is None, "missing_prompt_message_id"),
         (provider != pending.provider, "provider_mismatch"),
-        (reaction.conversation_id != pending.channel_conversation_id, "conversation_mismatch"),
+        (
+            not allow_conversation_alias
+            and reaction.conversation_id != pending.channel_conversation_id,
+            "conversation_mismatch",
+        ),
         (reaction.message_id != pending.prompt_message_id, "message_mismatch"),
         (pending.sender_id is not None and reaction.sender_id is None, "sender_missing"),
         (

--- a/libs/talon/tests/channels/test_whatsapp.py
+++ b/libs/talon/tests/channels/test_whatsapp.py
@@ -880,3 +880,5 @@ def test_bridge_script_registers_reaction_queue_entries() -> None:
     assert "raw_reaction" in script
     assert "from_self: fromSelf" in script
     assert "const senderId = fromSelf && botId ? botId : rawSenderId;" in script
+    assert "const sentMessageChatIds = new Map();" in script
+    assert "sentMessageChatIds.get(messageId) || reactionChatId(reaction)" in script

--- a/libs/talon/tests/channels/test_whatsapp.py
+++ b/libs/talon/tests/channels/test_whatsapp.py
@@ -328,6 +328,49 @@ async def test_channel_polls_and_dispatches_reactions(tmp_path: Path) -> None:
     assert [message.message_id for message in messages] == ["should-not-be-reaction"]
 
 
+async def test_channel_polls_self_reactions_without_operator_id(tmp_path: Path) -> None:
+    transport = RecordingTransport(
+        messages=[
+            {
+                "event_type": "reaction",
+                "chat_id": "chat",
+                "message_id": "approval-message",
+                "sender_id": "operator",
+                "emoji": "👍",
+                "fromSelf": True,
+            },
+            {
+                "event_type": "reaction",
+                "chat_id": "chat",
+                "message_id": "other-message",
+                "sender_id": "other",
+                "emoji": "👍",
+            },
+        ],
+    )
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(
+            session_dir=tmp_path,
+            poll_interval_seconds=60,
+            health_interval_seconds=60,
+        ),
+        transport=cast("_BridgeTransport", transport),
+    )
+    reactions: list[ChannelReaction] = []
+
+    async def record(reaction: ChannelReaction) -> None:
+        reactions.append(reaction)
+
+    channel.set_reaction_handler(record)
+
+    await channel.start()
+    await asyncio.sleep(0)
+    await channel.stop()
+
+    assert [reaction.message_id for reaction in reactions] == ["approval-message"]
+    assert reactions[0].metadata["from_self"] is True
+
+
 async def test_channel_keeps_legacy_message_entries_compatible(tmp_path: Path) -> None:
     transport = RecordingTransport(
         messages=[
@@ -835,3 +878,4 @@ def test_bridge_script_registers_reaction_queue_entries() -> None:
     assert 'event_type: "message"' in script
     assert 'event_type: "reaction"' in script
     assert "raw_reaction" in script
+    assert "from_self: fromSelf" in script

--- a/libs/talon/tests/channels/test_whatsapp.py
+++ b/libs/talon/tests/channels/test_whatsapp.py
@@ -22,7 +22,7 @@ from deepagents_talon.channels.whatsapp import (
     _WhatsAppBridgeError,
 )
 from deepagents_talon.config import TalonConfig
-from deepagents_talon.interfaces import ChannelMedia, ChannelMessage
+from deepagents_talon.interfaces import ChannelMedia, ChannelMessage, ChannelReaction
 
 if TYPE_CHECKING:
     import urllib.request
@@ -263,6 +263,211 @@ async def test_channel_polls_and_dispatches_allowed_messages(tmp_path: Path) -> 
 
     assert [message.text for message in received] == ["allowed"]
     assert received[0].metadata["provider"] == "whatsapp"
+
+
+async def test_channel_polls_and_dispatches_reactions(tmp_path: Path) -> None:
+    transport = RecordingTransport(
+        messages=[
+            {
+                "event_type": "reaction",
+                "chat_id": "chat",
+                "message_id": "approval-message",
+                "sender_id": "operator",
+                "emoji": "👍",
+                "raw_reaction": {"orphan": False},
+            },
+            {
+                "event_type": "message",
+                "text": "",
+                "chat_id": "chat",
+                "user_id": "operator",
+                "message_id": "should-not-be-reaction",
+            },
+        ],
+    )
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(
+            session_dir=tmp_path,
+            exposure=ChannelExposure(operator_ids=frozenset({"operator"})),
+            poll_interval_seconds=60,
+            health_interval_seconds=60,
+        ),
+        transport=cast("_BridgeTransport", transport),
+    )
+    reactions: list[ChannelReaction] = []
+    messages: list[ChannelMessage] = []
+
+    async def record_reaction(reaction: ChannelReaction) -> None:
+        reactions.append(reaction)
+
+    async def record_message(message: ChannelMessage) -> None:
+        messages.append(message)
+
+    channel.set_reaction_handler(record_reaction)
+    channel.set_message_handler(record_message)
+
+    await channel.start()
+    await asyncio.sleep(0)
+    await channel.stop()
+
+    assert reactions == [
+        ChannelReaction(
+            conversation_id="chat",
+            message_id="approval-message",
+            emoji="👍",
+            sender_id="operator",
+            metadata={
+                "provider": "whatsapp",
+                "chat_type": None,
+                "chat_name": None,
+                "raw_reaction": {"orphan": False},
+                "from_self": False,
+            },
+        )
+    ]
+    assert [message.message_id for message in messages] == ["should-not-be-reaction"]
+
+
+async def test_channel_keeps_legacy_message_entries_compatible(tmp_path: Path) -> None:
+    transport = RecordingTransport(
+        messages=[
+            {
+                "text": "legacy",
+                "chat_id": "chat",
+                "user_id": "operator",
+                "message_id": "message-1",
+            },
+        ],
+    )
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(
+            session_dir=tmp_path,
+            exposure=ChannelExposure(operator_ids=frozenset({"operator"})),
+            poll_interval_seconds=60,
+            health_interval_seconds=60,
+        ),
+        transport=cast("_BridgeTransport", transport),
+    )
+    received: list[ChannelMessage] = []
+
+    async def record(message: ChannelMessage) -> None:
+        received.append(message)
+
+    channel.set_message_handler(record)
+
+    await channel.start()
+    await asyncio.sleep(0)
+    await channel.stop()
+
+    assert [message.text for message in received] == ["legacy"]
+
+
+async def test_channel_drops_unknown_whatsapp_queue_event_type(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    transport = RecordingTransport(
+        messages=[
+            {
+                "event_type": "typing",
+                "chat_id": "chat",
+            },
+        ],
+    )
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(
+            session_dir=tmp_path,
+            exposure=ChannelExposure(mode=ExposureMode.OPEN),
+            poll_interval_seconds=60,
+            health_interval_seconds=60,
+        ),
+        transport=cast("_BridgeTransport", transport),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="deepagents_talon.channels.whatsapp"):
+        await channel.start()
+        await asyncio.sleep(0)
+        await channel.stop()
+
+    assert "unknown event_type" in caplog.text
+
+
+async def test_channel_ignores_reaction_removal_events(tmp_path: Path) -> None:
+    transport = RecordingTransport(
+        messages=[
+            {
+                "event_type": "reaction",
+                "chat_id": "chat",
+                "message_id": "approval-message",
+                "sender_id": "operator",
+                "emoji": "👍",
+                "action": "remove",
+            },
+            {
+                "event_type": "reaction",
+                "chat_id": "chat",
+                "message_id": "approval-message",
+                "sender_id": "operator",
+                "reaction": "",
+            },
+        ],
+    )
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(
+            session_dir=tmp_path,
+            exposure=ChannelExposure(mode=ExposureMode.OPEN),
+            poll_interval_seconds=60,
+            health_interval_seconds=60,
+        ),
+        transport=cast("_BridgeTransport", transport),
+    )
+    reactions: list[ChannelReaction] = []
+
+    async def record(reaction: ChannelReaction) -> None:
+        reactions.append(reaction)
+
+    channel.set_reaction_handler(record)
+
+    await channel.start()
+    await asyncio.sleep(0)
+    await channel.stop()
+
+    assert reactions == []
+
+
+async def test_channel_applies_exposure_to_reactions(tmp_path: Path) -> None:
+    transport = RecordingTransport(
+        messages=[
+            {
+                "event_type": "reaction",
+                "chat_id": "chat",
+                "message_id": "approval-message",
+                "sender_id": "other",
+                "emoji": "👍",
+            },
+        ],
+    )
+    channel = WhatsAppChannel(
+        WhatsAppChannelConfig(
+            session_dir=tmp_path,
+            exposure=ChannelExposure(operator_ids=frozenset({"operator"})),
+            poll_interval_seconds=60,
+            health_interval_seconds=60,
+        ),
+        transport=cast("_BridgeTransport", transport),
+    )
+    reactions: list[ChannelReaction] = []
+
+    async def record(reaction: ChannelReaction) -> None:
+        reactions.append(reaction)
+
+    channel.set_reaction_handler(record)
+
+    await channel.start()
+    await asyncio.sleep(0)
+    await channel.stop()
+
+    assert reactions == []
 
 
 async def test_channel_polls_self_messages_without_operator_id(tmp_path: Path) -> None:
@@ -621,3 +826,12 @@ async def test_channel_forwards_bridge_output_to_logs(
 def test_bridge_script_is_packaged() -> None:
     assert _bridge_script_path().name == "bridge.js"
     assert _bridge_script_path().is_file()
+
+
+def test_bridge_script_registers_reaction_queue_entries() -> None:
+    script = _bridge_script_path().read_text(encoding="utf-8")
+
+    assert 'client.on("message_reaction"' in script
+    assert 'event_type: "message"' in script
+    assert 'event_type: "reaction"' in script
+    assert "raw_reaction" in script

--- a/libs/talon/tests/channels/test_whatsapp.py
+++ b/libs/talon/tests/channels/test_whatsapp.py
@@ -879,3 +879,4 @@ def test_bridge_script_registers_reaction_queue_entries() -> None:
     assert 'event_type: "reaction"' in script
     assert "raw_reaction" in script
     assert "from_self: fromSelf" in script
+    assert "const senderId = fromSelf && botId ? botId : rawSenderId;" in script

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -599,6 +599,35 @@ async def test_host_logs_raw_reaction_ids_only_when_enabled(
     assert event["raw_reacting_sender_id"] == "sender-private"
 
 
+async def test_host_routes_tool_approval_reaction_with_conversation_alias(
+    tmp_path: Path,
+) -> None:
+    channel = RecordingChannel("whatsapp")
+    channel.next_message_id = "approval-prompt"
+    agent = ApprovalAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    await host.start()
+
+    await host.receive_message(
+        channel,
+        ChannelMessage(conversation_id="chat@lid", text="run", sender_id="operator"),
+    )
+    await _wait_for_sent_count(channel, 1)
+    await host.receive_reaction(
+        channel,
+        ChannelReaction(
+            conversation_id="123@s.whatsapp.net",
+            message_id="approval-prompt",
+            emoji="👍",
+            sender_id="operator",
+        ),
+    )
+    await _wait_for_sent_count(channel, 2)
+    await host.stop()
+
+    assert channel.sent[1] == ("chat@lid", "decision:approve")
+
+
 async def test_host_ignores_tool_approval_reaction_on_unrelated_message(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Why this is useful

WhatsApp users can approve agent actions via emoji reactions (e.g. 👍 to confirm) instead of typing text replies, matching the existing Telegram flow and lowering friction for human-in-the-loop review. Operators enable reactions in the WhatsApp channel config and the bridge ingests `message_reaction` events; approvals flow through the same reaction handler as Telegram.

---

Stacked on #4345.

Adds WhatsApp reaction ingestion on top of the shared reaction approval contract. The bridge now registers `message_reaction`, emits explicit `event_type` discriminators for new message and reaction queue entries, and normalizes concrete-user emoji reactions with bounded `raw_reaction` metadata. The Python adapter branches on `event_type`, keeps legacy message entries compatible, rejects unknown event types without crashing the poll loop, ignores reaction removals, applies exposure checks, and dispatches accepted reactions through the reaction handler.

Validation run:
- `uv run --group test pytest --disable-socket --allow-unix-socket tests/channels/test_whatsapp.py --timeout 10`
- `make lint_diff`
- `make test`
- `node --check deepagents_talon/channels/whatsapp_bridge/bridge.js`
