### PR TITLE
feat(talon): audit reaction approval attempts

### DIFF
--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -11,7 +11,7 @@ import json
 import logging
 import signal
 from collections import defaultdict
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from types import FrameType
 from typing import TYPE_CHECKING, cast
@@ -37,7 +37,7 @@ from deepagents_talon.media import (
     extract_markdown_media,
     outbound_channel_media,
 )
-from deepagents_talon.observability import langsmith_trace_context
+from deepagents_talon.observability import langsmith_trace_context, log_event, stable_log_ref
 from deepagents_talon.speech import transcribe_voice_message
 
 if TYPE_CHECKING:
@@ -58,6 +58,7 @@ _NEW_CONVERSATION_MESSAGE = "Started a fresh conversation."
 _APPROVE_REPLIES = frozenset({"approve", "approved", "yes", "y"})
 _DENY_REPLIES = frozenset({"deny", "denied", "reject", "rejected", "no", "n"})
 _RESET_THREAD_SEPARATOR = ":talon-reset:"
+_APPROVAL_LOG_RAW_IDS_ENV = "DEEPAGENTS_TALON_APPROVAL_LOG_RAW_IDS"
 _EMOJI_VARIATION_SELECTOR = "\ufe0f"
 _EMOJI_SKIN_TONES = frozenset(
     {
@@ -78,6 +79,15 @@ class _PendingToolApproval:
     agent_conversation_id: str
     prompt_message_id: str | None
     sender_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _ReactionAudit:
+    reaction: ChannelReaction
+    provider: str
+    decision: ToolApprovalDecision | None
+    match_status: str
+    resolution: str
 
 
 class TalonHost:
@@ -232,8 +242,23 @@ class TalonHost:
         agent_conversation_id = self._agent_conversation_id(conversation_root)
         pending = self._pending_tool_approvals.get(agent_conversation_id)
         if pending is None:
+            _log_tool_approval_reaction(
+                self.config.env,
+                _ReactionAudit(
+                    reaction=reaction,
+                    provider=provider_key,
+                    decision=_parse_tool_approval_reaction(reaction.emoji),
+                    match_status="ignored",
+                    resolution="no_pending_approval",
+                ),
+            )
             return
-        self._handle_tool_approval_reaction(reaction, pending, provider=provider_key)
+        self._handle_tool_approval_reaction(
+            reaction,
+            pending,
+            provider=provider_key,
+            env=self.config.env,
+        )
 
     async def _run_agent_turn(
         self,
@@ -510,20 +535,39 @@ class TalonHost:
         pending: _PendingToolApproval,
         *,
         provider: str,
+        env: Mapping[str, str],
     ) -> None:
         decision = _parse_tool_approval_reaction(reaction.emoji)
-        if decision is None or pending.prompt_message_id is None:
+        resolution = _reaction_mismatch_resolution(
+            reaction,
+            pending,
+            provider=provider,
+            decision=decision,
+        )
+        if resolution is not None:
+            _log_tool_approval_reaction(
+                env,
+                _ReactionAudit(
+                    reaction=reaction,
+                    provider=provider,
+                    decision=decision,
+                    match_status="ignored",
+                    resolution=resolution,
+                ),
+            )
             return
-        if provider != pending.provider:
-            return
-        if reaction.conversation_id != pending.channel_conversation_id:
-            return
-        if reaction.message_id != pending.prompt_message_id:
-            return
-        if pending.sender_id is not None and reaction.sender_id != pending.sender_id:
-            return
+        _log_tool_approval_reaction(
+            env,
+            _ReactionAudit(
+                reaction=reaction,
+                provider=provider,
+                decision=decision,
+                match_status="matched",
+                resolution="operator_reaction",
+            ),
+        )
         if not pending.future.done():
-            pending.future.set_result(decision)
+            pending.future.set_result(cast("ToolApprovalDecision", decision))
 
     async def _deliver_agent_result(
         self,
@@ -769,3 +813,59 @@ def _normalize_reaction_emoji(emoji: str) -> str:
         for char in emoji.strip()
         if char != _EMOJI_VARIATION_SELECTOR and char not in _EMOJI_SKIN_TONES
     )
+
+
+def _reaction_mismatch_resolution(
+    reaction: ChannelReaction,
+    pending: _PendingToolApproval,
+    *,
+    provider: str,
+    decision: ToolApprovalDecision | None,
+) -> str | None:
+    checks = (
+        (decision is None, "unsupported_emoji"),
+        (pending.prompt_message_id is None, "missing_prompt_message_id"),
+        (provider != pending.provider, "provider_mismatch"),
+        (reaction.conversation_id != pending.channel_conversation_id, "conversation_mismatch"),
+        (reaction.message_id != pending.prompt_message_id, "message_mismatch"),
+        (pending.sender_id is not None and reaction.sender_id is None, "sender_missing"),
+        (
+            pending.sender_id is not None and reaction.sender_id != pending.sender_id,
+            "sender_mismatch",
+        ),
+    )
+    for failed, resolution in checks:
+        if failed:
+            return resolution
+    return None
+
+
+def _log_tool_approval_reaction(
+    env: Mapping[str, str],
+    audit: _ReactionAudit,
+) -> None:
+    fields: dict[str, object] = {
+        "provider": audit.provider,
+        "channel_conversation_ref": stable_log_ref(audit.reaction.conversation_id),
+        "prompt_message_ref": stable_log_ref(audit.reaction.message_id),
+        "emoji": audit.reaction.emoji,
+        "decision": audit.decision,
+        "match_status": audit.match_status,
+        "resolution": audit.resolution,
+    }
+    if audit.reaction.sender_id is not None:
+        fields["reacting_sender_ref"] = stable_log_ref(audit.reaction.sender_id)
+    if _approval_log_raw_ids(env):
+        fields.update(
+            {
+                "raw_channel_conversation_id": audit.reaction.conversation_id,
+                "raw_prompt_message_id": audit.reaction.message_id,
+            }
+        )
+        if audit.reaction.sender_id is not None:
+            fields["raw_reacting_sender_id"] = audit.reaction.sender_id
+    log_event(logger, "tool_approval.reaction", **fields)
+
+
+def _approval_log_raw_ids(env: Mapping[str, str]) -> bool:
+    return env.get(_APPROVAL_LOG_RAW_IDS_ENV, "").lower() == "true"

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import TYPE_CHECKING, cast
 
 from deepagents_talon.config import TalonConfig
@@ -11,6 +12,7 @@ from deepagents_talon.interfaces import (
     AgentResult,
     ChannelMedia,
     ChannelMessage,
+    ChannelReaction,
     ToolApprovalRequest,
 )
 from tests.conftest import RecordingChannel
@@ -430,11 +432,15 @@ async def test_host_routes_tool_approval_reaction_to_prompt_message(tmp_path: Pa
     assert channel.sent[1] == ("chat", "decision:approve")
 
 
-async def test_host_routes_tool_approval_reaction_denial(tmp_path: Path) -> None:
+async def test_host_routes_tool_approval_reaction_denial(
+    tmp_path: Path,
+    caplog,
+) -> None:
     channel = RecordingChannel()
     channel.next_message_id = "approval-prompt"
     agent = ApprovalAgent()
     host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    caplog.set_level("INFO", logger="deepagents_talon.host")
     await host.start()
 
     await host.receive_message(
@@ -450,7 +456,104 @@ async def test_host_routes_tool_approval_reaction_denial(tmp_path: Path) -> None
     await _wait_for_sent_count(channel, 2)
     await host.stop()
 
+    event = _talon_events(caplog, "tool_approval.reaction")[0]
+    assert event["decision"] == "reject"
+    assert event["match_status"] == "matched"
+    assert event["resolution"] == "operator_reaction"
     assert channel.sent[1] == ("chat", "decision:reject")
+
+
+async def test_host_logs_tool_approval_reaction_without_sensitive_values(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    channel = RecordingChannel()
+    channel.next_message_id = "approval-prompt-private"
+    agent = ApprovalAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    caplog.set_level("INFO", logger="deepagents_talon.host")
+    await host.start()
+
+    await host.receive_message(
+        channel,
+        ChannelMessage(
+            conversation_id="chat-private",
+            text="run private user text",
+            sender_id="sender-private",
+        ),
+    )
+    await _wait_for_sent_count(channel, 1)
+    await host.receive_reaction(
+        channel,
+        ChannelReaction(
+            conversation_id="chat-private",
+            message_id="approval-prompt-private",
+            emoji="👍",
+            sender_id="sender-private",
+            metadata={"raw": "RAW_PROVIDER_METADATA"},
+        ),
+    )
+    await _wait_for_sent_count(channel, 2)
+    await host.stop()
+
+    event = _talon_events(caplog, "tool_approval.reaction")[0]
+    assert event["provider"] == "test"
+    assert event["emoji"] == "👍"
+    assert event["decision"] == "approve"
+    assert event["match_status"] == "matched"
+    assert event["resolution"] == "operator_reaction"
+    assert event["channel_conversation_ref"] != "chat-private"
+    assert event["prompt_message_ref"] != "approval-prompt-private"
+    assert event["reacting_sender_ref"] != "sender-private"
+    assert "raw_channel_conversation_id" not in event
+    assert "raw_prompt_message_id" not in event
+    assert "raw_reacting_sender_id" not in event
+    assert "/secret" not in caplog.text
+    assert "Tool approval required." not in caplog.text
+    assert "run private user text" not in caplog.text
+    assert "RAW_PROVIDER_METADATA" not in caplog.text
+    assert "chat-private" not in caplog.text
+    assert "approval-prompt-private" not in caplog.text
+    assert "sender-private" not in caplog.text
+
+
+async def test_host_logs_raw_reaction_ids_only_when_enabled(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    channel = RecordingChannel()
+    channel.next_message_id = "approval-prompt-private"
+    agent = ApprovalAgent()
+    host = TalonHost(
+        config=_config(tmp_path, {"DEEPAGENTS_TALON_APPROVAL_LOG_RAW_IDS": "true"}),
+        agent=agent,
+        channels=[channel],
+    )
+    caplog.set_level("INFO", logger="deepagents_talon.host")
+    await host.start()
+
+    await host.receive_message(
+        channel,
+        ChannelMessage(
+            conversation_id="chat-private",
+            text="run",
+            sender_id="sender-private",
+        ),
+    )
+    await _wait_for_sent_count(channel, 1)
+    await channel.receive_reaction(
+        "👍",
+        message_id="approval-prompt-private",
+        sender_id="sender-private",
+        conversation_id="chat-private",
+    )
+    await _wait_for_sent_count(channel, 2)
+    await host.stop()
+
+    event = _talon_events(caplog, "tool_approval.reaction")[0]
+    assert event["raw_channel_conversation_id"] == "chat-private"
+    assert event["raw_prompt_message_id"] == "approval-prompt-private"
+    assert event["raw_reacting_sender_id"] == "sender-private"
 
 
 async def test_host_ignores_tool_approval_reaction_on_unrelated_message(
@@ -480,6 +583,42 @@ async def test_host_ignores_tool_approval_reaction_on_unrelated_message(
     await _wait_for_sent_count(channel, 2)
     await host.stop()
 
+    assert channel.sent[1] == ("chat", "decision:reject")
+
+
+async def test_host_logs_ignored_tool_approval_reaction_attempt(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    channel = RecordingChannel()
+    channel.next_message_id = "approval-prompt"
+    agent = ApprovalAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    caplog.set_level("INFO", logger="deepagents_talon.host")
+    await host.start()
+
+    await host.receive_message(
+        channel,
+        ChannelMessage(conversation_id="chat", text="run", sender_id="operator"),
+    )
+    await _wait_for_sent_count(channel, 1)
+    await channel.receive_reaction(
+        "👍",
+        message_id="other-message",
+        sender_id="operator",
+    )
+    await asyncio.sleep(0)
+    await host.receive_message(
+        channel,
+        ChannelMessage(conversation_id="chat", text="deny", sender_id="operator"),
+    )
+    await _wait_for_sent_count(channel, 2)
+    await host.stop()
+
+    event = _talon_events(caplog, "tool_approval.reaction")[0]
+    assert event["decision"] == "approve"
+    assert event["match_status"] == "ignored"
+    assert event["resolution"] == "message_mismatch"
     assert channel.sent[1] == ("chat", "decision:reject")
 
 
@@ -568,6 +707,32 @@ async def test_host_ignores_tool_approval_reaction_without_prompt_message_id(
     assert channel.sent[1] == ("chat", "decision:approve")
 
 
+async def test_host_logs_reaction_without_pending_approval(tmp_path: Path, caplog) -> None:
+    channel = RecordingChannel()
+    agent = BlockingAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent, channels=[channel])
+    caplog.set_level("INFO", logger="deepagents_talon.host")
+    await host.start()
+
+    await host.receive_reaction(
+        channel,
+        ChannelReaction(
+            conversation_id="chat-private",
+            message_id="approval-prompt-private",
+            emoji="🙂",
+            sender_id="sender-private",
+            metadata={"raw": "RAW_PROVIDER_METADATA"},
+        ),
+    )
+    await host.stop()
+
+    event = _talon_events(caplog, "tool_approval.reaction")[0]
+    assert event["decision"] is None
+    assert event["match_status"] == "ignored"
+    assert event["resolution"] == "no_pending_approval"
+    assert "RAW_PROVIDER_METADATA" not in caplog.text
+
+
 async def test_host_runs_scheduled_job_and_delivers_result(tmp_path: Path) -> None:
     channel = RecordingChannel()
     agent = BlockingAgent()
@@ -631,3 +796,13 @@ async def _wait_for_sent_count(channel: RecordingChannel, count: int) -> None:
         await asyncio.sleep(0)
     msg = f"channel sent {len(channel.sent)} message(s), expected {count}"
     raise AssertionError(msg)
+
+
+def _talon_events(caplog, event: str) -> list[dict[str, object]]:
+    return [
+        payload
+        for message in caplog.messages
+        if message.startswith("talon_event ")
+        for payload in [json.loads(message.removeprefix("talon_event "))]
+        if payload.get("event") == event
+    ]


### PR DESCRIPTION
Stacked on #4345.

Adds host-side `tool_approval.reaction` audit events for reaction approval attempts. The event records provider, stable hashed channel conversation/prompt/sender references, emoji, decision, match status, and resolution mode. Raw provider IDs are included only when `DEEPAGENTS_TALON_APPROVAL_LOG_RAW_IDS=true`; raw provider metadata, approval prompt text, arbitrary message text, and tool arguments are not logged. Matched reaction approvals use `operator_reaction` as the resolution so they can be distinguished from text approvals.

## When this is useful

Reaction approvals are a one-tap action that's easy to fire off and easy to miss-context (wrong message, wrong channel, stale prompt). Without an audit trail there's no way to answer "did someone try to approve that tool call, and why didn't it take?" after the fact. These events let operators and security reviewers trace every reaction attempt — matched or ignored — back to a specific provider, conversation, prompt message, and sender, without leaking raw IDs or prompt/message contents by default. Distinguishing `operator_reaction` from text `approve`/`deny` also makes it possible to monitor how often the reaction path is actually used versus the text fallback.

## Example

An operator reacts 👍 to the approval prompt. The host emits a structured `tool_approval.reaction` event:

```json
{
  "event": "tool_approval.reaction",
  "provider": "slack",
  "channel_conversation_ref": "9f1c…a4e2",
  "prompt_message_ref": "b7d3…0c91",
  "reacting_sender_ref": "e2a8…77f0",
  "emoji": "👍",
  "decision": "approve",
  "match_status": "matched",
  "resolution": "operator_reaction"
}
```

Conversation/prompt/sender references are stable hashes (via `stable_log_ref`), so the same IDs correlate across events without exposing the underlying Slack IDs. Ignored attempts are logged too, with a precise `resolution` explaining why:

- `no_pending_approval` — reaction arrived with no pending tool approval
- `unsupported_emoji` — emoji wasn't 👍/👎
- `missing_prompt_message_id` — channel didn't supply a prompt message id (falls back to text)
- `provider_mismatch` / `conversation_mismatch` / `message_mismatch` — reaction didn't target the prompt that issued the request
- `sender_missing` / `sender_mismatch` — reactor wasn't the initiating operator (when sender is known)

For debugging a specific incident, set `DEEPAGENTS_TALON_APPROVAL_LOG_RAW_IDS=true` to additionally include `raw_channel_conversation_id`, `raw_prompt_message_id`, and `raw_reacting_sender_id`. Sensitive values — provider metadata, approval prompt text, arbitrary message text, and tool arguments — are never logged regardless of that flag.

Validation run:
- `uv run --group test pytest --disable-socket --allow-unix-socket tests/test_host.py --timeout 10`
- `make lint_diff`
- `make test`
