### PR TITLE
feat(code): add OpenAI hosted web search

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6255,7 +6255,7 @@ class DeepAgentsApp(App):
                 return
 
             model_spec, provider = result
-            await self._prompt_launch_tavily()
+            await self._prompt_launch_tavily(provider=provider)
             if self._connecting:
                 # Bound the wait so a stuck server never traps onboarding.
                 # Server startup typically completes in seconds; a minute is
@@ -6340,20 +6340,22 @@ class DeepAgentsApp(App):
                 return
         await self._switch_model(model_spec, announce_unchanged=False)
 
-    async def _prompt_launch_tavily(self) -> None:
+    async def _prompt_launch_tavily(self, *, provider: str | None = None) -> None:
         """Optionally collect and store a Tavily web-search key during onboarding.
 
-        Skipped when a Tavily key is already configured (env or stored). A
-        blank submission or Escape stores nothing; a non-empty key is persisted
-        via the same `auth_store` path `/auth` uses. The key is also exported to
-        the process environment (`apply_stored_service_credentials`) so a server
-        respawn this session picks it up; the already-running server keeps its
-        spawn-time tools, so web search takes full effect on the next launch (or
-        after a restart).
+        Skipped when a Tavily key is already configured (env or stored), or when
+        the selected model provider has hosted web search. A blank submission or
+        Escape stores nothing; a non-empty key is persisted via the same
+        `auth_store` path `/auth` uses. The key is also exported to the process
+        environment (`apply_stored_service_credentials`) so a server respawn this
+        session picks it up; the already-running server keeps its spawn-time
+        tools, so web search takes full effect on the next launch (or after a
+        restart).
         """
         from deepagents_code.config import settings
+        from deepagents_code.tools import supports_provider_web_search
 
-        if settings.has_tavily:
+        if settings.has_tavily or supports_provider_web_search(provider):
             return
 
         from deepagents_code.widgets.auth import AuthPromptScreen, AuthResult

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -701,7 +701,34 @@ def _should_ensure_managed_ripgrep() -> bool:
     return rg_path is None or _is_managed_ripgrep_path(rg_path)
 
 
-def check_optional_tools(*, config_path: Path | None = None) -> list[str]:
+def _configured_model_provider(model_spec: str | None) -> str | None:
+    """Return the configured provider used to decide optional tool relevance."""
+    from deepagents_code.config import detect_provider, settings
+    from deepagents_code.model_config import ModelConfig, ModelSpec
+
+    spec = model_spec
+    provider = getattr(settings, "model_provider", None)
+    if spec is None and provider:
+        return provider
+    if spec is None:
+        try:
+            config = ModelConfig.load()
+        except Exception:
+            logger.debug("Could not load model config for tool checks", exc_info=True)
+        else:
+            spec = config.default_model or config.recent_model
+    if not spec:
+        return None
+
+    parsed = ModelSpec.try_parse(spec)
+    if parsed is not None:
+        return parsed.provider
+    return detect_provider(spec)
+
+
+def check_optional_tools(
+    *, config_path: Path | None = None, model_spec: str | None = None
+) -> list[str]:
     """Check for recommended external tools and return missing tool names.
 
     Skips tools that the user has suppressed via
@@ -711,11 +738,14 @@ def check_optional_tools(*, config_path: Path | None = None) -> list[str]:
         config_path: Path to config file.
 
             Defaults to `~/.deepagents/config.toml`.
+        model_spec: Optional configured model spec used to skip Tavily warnings
+            when the active provider has hosted web search.
 
     Returns:
         List of missing tool names (e.g. `["ripgrep"]`).
     """
     from deepagents_code.model_config import is_warning_suppressed
+    from deepagents_code.tools import supports_provider_web_search
 
     missing: list[str] = []
     if _should_ensure_managed_ripgrep() and not is_warning_suppressed(
@@ -725,7 +755,12 @@ def check_optional_tools(*, config_path: Path | None = None) -> list[str]:
 
     from deepagents_code.config import settings
 
-    if not settings.has_tavily and not is_warning_suppressed("tavily", config_path):
+    provider = _configured_model_provider(model_spec)
+    if (
+        not settings.has_tavily
+        and not supports_provider_web_search(provider)
+        and not is_warning_suppressed("tavily", config_path)
+    ):
         missing.append("tavily")
 
     return missing
@@ -1913,7 +1948,7 @@ async def _run_acp_cli_async(
         save_recent_model,
         touch_recent_model,
     )
-    from deepagents_code.tools import fetch_url, get_current_thread_id, web_search
+    from deepagents_code.tools import build_builtin_tools
 
     try:
         model_result = create_model(
@@ -1932,9 +1967,10 @@ async def _run_acp_cli_async(
     save_recent_model(resolved_spec)
     touch_recent_model(resolved_spec)
 
-    tools: list[Any] = [fetch_url, get_current_thread_id]
-    if settings.has_tavily:
-        tools.append(web_search)
+    tools = build_builtin_tools(
+        provider=model_result.provider,
+        has_tavily=settings.has_tavily,
+    )
 
     mcp_session_manager = None
     mcp_server_info = None
@@ -3164,7 +3200,9 @@ def cli_main() -> None:
                 warn_console = None
                 try:
                     warn_console = _Console(stderr=True)
-                    missing_tools = check_optional_tools()
+                    missing_tools = check_optional_tools(
+                        model_spec=getattr(args, "model", None)
+                    )
                     if _should_ensure_managed_ripgrep():
                         missing_tools = _auto_install_ripgrep_cli(
                             warn_console, missing_tools

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -81,6 +81,8 @@ def _get_mcp_session_manager() -> Any:  # noqa: ANN401
 async def _build_tools(
     config: ServerConfig,
     project_context: ProjectContext | None,
+    *,
+    provider: str | None,
 ) -> tuple[list[Any], list[Any] | None]:
     """Assemble the tool list based on server config.
 
@@ -98,6 +100,7 @@ async def _build_tools(
     Args:
         config: Deserialized server configuration.
         project_context: Resolved project context for MCP discovery.
+        provider: Resolved model provider.
 
     Returns:
         Tuple of `(tools, mcp_server_info)`.
@@ -107,11 +110,9 @@ async def _build_tools(
         RuntimeError: If MCP tool loading fails.
     """
     from deepagents_code.config import settings
-    from deepagents_code.tools import fetch_url, get_current_thread_id, web_search
+    from deepagents_code.tools import build_builtin_tools
 
-    tools: list[Any] = [fetch_url, get_current_thread_id]
-    if settings.has_tavily:
-        tools.append(web_search)
+    tools = build_builtin_tools(provider=provider, has_tavily=settings.has_tavily)
 
     mcp_server_info: list[Any] | None = None
     if not config.no_mcp:
@@ -172,7 +173,11 @@ async def _make_graph() -> Any:  # noqa: ANN401
     )
     result.apply_to_settings()
 
-    tools, mcp_server_info = await _build_tools(config, project_context)
+    tools, mcp_server_info = await _build_tools(
+        config,
+        project_context,
+        provider=result.provider,
+    )
 
     # Create sandbox backend if a sandbox provider is configured.
     # The context manager is created here in the factory, but its reference is

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -1092,6 +1092,72 @@ async def execute_task_textual(
 
                             tool_call_buffers.pop(buffer_key, None)
 
+                        elif block_type == "server_tool_call":
+                            tool_name = block.get("name")
+                            tool_id = block.get("id")
+                            tool_args = block.get("args")
+                            if not isinstance(tool_name, str) or not tool_name:
+                                continue
+                            if not isinstance(tool_id, str) or not tool_id:
+                                continue
+                            if not isinstance(tool_args, dict):
+                                tool_args = {}
+
+                            pending_text = pending_text_by_namespace.get(ns_key, "")
+                            if pending_text:
+                                await _flush_assistant_text_ns(
+                                    adapter,
+                                    pending_text,
+                                    ns_key,
+                                    assistant_message_by_namespace,
+                                )
+                                pending_text_by_namespace[ns_key] = ""
+                                assistant_message_by_namespace.pop(ns_key, None)
+
+                            if tool_id in displayed_tool_ids:
+                                continue
+
+                            displayed_tool_ids.add(tool_id)
+                            if adapter._set_spinner:
+                                await adapter._set_spinner(None)
+
+                            logger.debug(
+                                "Mounting server ToolCallMessage: %s(%s)",
+                                tool_name,
+                                repr(tool_args)[:200],
+                            )
+                            tool_msg = ToolCallMessage(tool_name, tool_args)
+                            await adapter._mount_message(tool_msg)
+                            adapter._current_tool_messages[tool_id] = tool_msg
+                            tool_msg.set_running()
+
+                        elif block_type == "server_tool_result":
+                            tool_id = block.get("tool_call_id")
+                            if not isinstance(tool_id, str) or not tool_id:
+                                continue
+
+                            tool_msg = adapter._current_tool_messages.pop(
+                                tool_id, None
+                            )
+                            if tool_msg is None:
+                                continue
+
+                            status = block.get("status")
+                            if status in {None, "success", "completed"}:
+                                tool_msg.set_success("Completed")
+                            else:
+                                tool_msg.set_error(str(status))
+                                await dispatch_hook(
+                                    "tool.error",
+                                    {"tool_names": [tool_msg._tool_name]},
+                                )
+
+                            if (
+                                adapter._set_spinner
+                                and not adapter._current_tool_messages
+                            ):
+                                await adapter._set_spinner("Thinking")
+
                     if getattr(message, "chunk_position", None) == "last":
                         pending_text = pending_text_by_namespace.get(ns_key, "")
                         if pending_text:

--- a/libs/code/deepagents_code/tools.py
+++ b/libs/code/deepagents_code/tools.py
@@ -35,6 +35,31 @@ _MAX_FETCH_REDIRECTS = 5
 # `_pinned_dns`. The patch is process-global, so serializing fetches keeps
 # concurrent calls from clobbering each other's pinned IP set.
 _dns_pin_lock = threading.Lock()
+_PROVIDER_WEB_SEARCH_PROVIDERS = frozenset({"openai", "openai_codex"})
+"""Providers that can use provider-hosted web search."""
+
+
+def supports_provider_web_search(provider: str | None) -> bool:
+    """Return whether `provider` supports provider-hosted web search."""
+    return provider in _PROVIDER_WEB_SEARCH_PROVIDERS
+
+
+def build_builtin_tools(*, provider: str | None, has_tavily: bool) -> list[Any]:
+    """Build the default web/thread tool list for the coding agent.
+
+    Args:
+        provider: Resolved model provider.
+        has_tavily: Whether Tavily credentials are configured.
+
+    Returns:
+        The built-in tool declarations for the selected provider.
+    """
+    tools: list[Any] = [fetch_url, get_current_thread_id]
+    if supports_provider_web_search(provider):
+        tools.append({"type": "web_search"})
+    elif has_tavily:
+        tools.append(web_search)
+    return tools
 
 
 class _UrlValidationError(ValueError):

--- a/libs/code/tests/integration_tests/test_model_provider_web_search.py
+++ b/libs/code/tests/integration_tests/test_model_provider_web_search.py
@@ -1,0 +1,120 @@
+"""Live integration coverage for provider-hosted web search."""
+
+from __future__ import annotations
+
+import os
+import warnings
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping, Sequence
+
+    from langchain_core.messages import BaseMessage
+
+
+_MODEL_ENV = "DEEPAGENTS_CODE_WEB_SEARCH_TEST_MODEL"
+
+
+@contextmanager
+def _ignore_oauth_model_warning() -> Iterator[None]:
+    """Suppress the dependency's expected experimental class warning."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="`_ChatOpenAICodex` is experimental",
+            category=UserWarning,
+        )
+        yield
+
+
+def _has_env(name: str) -> bool:
+    """Return whether an env var has a non-empty value."""
+    return bool(os.environ.get(name))
+
+
+def _resolve_live_model_spec() -> str:
+    """Choose a live model spec for the hosted web search integration test."""
+    if model_spec := os.environ.get(_MODEL_ENV):
+        return model_spec
+
+    if _has_env("OPENAI_API_KEY") or _has_env("DEEPAGENTS_CODE_OPENAI_API_KEY"):
+        return "openai:gpt-5.5"
+
+    from deepagents_code.integrations import openai_codex
+    from deepagents_code.model_config import CODEX_PROVIDER
+
+    if openai_codex.is_logged_in():
+        return f"{CODEX_PROVIDER}:gpt-5.5"
+
+    pytest.skip(
+        f"set {_MODEL_ENV}, OPENAI_API_KEY, or sign in locally to run this test"
+    )
+
+
+def _server_tool_blocks(messages: Sequence[BaseMessage]) -> list[Mapping[str, Any]]:
+    """Extract hosted tool content blocks from provider responses."""
+    from langchain_core.messages import AIMessage
+
+    blocks: list[Mapping[str, Any]] = []
+    for message in messages:
+        if not isinstance(message, AIMessage):
+            continue
+        blocks.extend(
+            block
+            for block in message.content_blocks
+            if isinstance(block, dict)
+            and str(block.get("type", "")).startswith("server_tool_")
+        )
+    return blocks
+
+
+@pytest.mark.timeout(90)
+async def test_provider_web_search_calls_provider_tool() -> None:
+    """A real provider-backed run returns hosted web-search content blocks."""
+    from deepagents_code.agent import create_cli_agent
+    from deepagents_code.config import create_model
+
+    model_spec = _resolve_live_model_spec()
+
+    with _ignore_oauth_model_warning():
+        model_result = create_model(model_spec)
+
+    agent, _backend = create_cli_agent(
+        model=model_result.model,
+        assistant_id="itest-model-provider-web-search",
+        tools=[{"type": "web_search"}],
+        auto_approve=True,
+        enable_ask_user=False,
+        enable_memory=False,
+        enable_skills=False,
+        enable_shell=False,
+        enable_interpreter=False,
+    )
+
+    result = await agent.ainvoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        "Use web search before answering. Search for current "
+                        "fun things to do in New York City, then answer in one "
+                        "short sentence."
+                    ),
+                }
+            ]
+        },
+        config={"recursion_limit": 12},
+    )
+
+    messages = result["messages"]
+    blocks = _server_tool_blocks(messages)
+
+    assert any(
+        block.get("type") == "server_tool_call" and block.get("name") == "web_search"
+        for block in blocks
+    )
+    assert any(block.get("type") == "server_tool_result" for block in blocks)

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -1351,6 +1351,22 @@ class TestStartupSequence:
         push_screen_wait.assert_not_awaited()
         set_stored_key.assert_not_called()
 
+    async def test_prompt_launch_tavily_skips_for_hosted_web_search_provider(
+        self,
+    ) -> None:
+        """Onboarding should not prompt when the selected provider has search."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+        push_screen_wait = AsyncMock(return_value="tvly-key")
+        app._push_screen_wait = push_screen_wait  # ty: ignore
+
+        with patch(
+            "deepagents_code.config.settings",
+            SimpleNamespace(has_tavily=False),
+        ):
+            await app._prompt_launch_tavily(provider="openai")
+
+        push_screen_wait.assert_not_awaited()
+
     async def test_prompt_launch_tavily_clean_save_activates_key(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -1390,10 +1390,36 @@ class TestCheckOptionalTools:
             patch("deepagents_code.main.shutil.which", return_value="/usr/bin/rg"),
             patch(
                 "deepagents_code.config.settings",
-                SimpleNamespace(has_tavily=False),
+                SimpleNamespace(has_tavily=False, model_provider=""),
             ),
         ):
-            missing = check_optional_tools()
+            missing = check_optional_tools(model_spec="anthropic:claude-opus-4-7")
+
+        assert missing == ["tavily"]
+
+    def test_omits_tavily_for_hosted_web_search_provider(self) -> None:
+        """Hosted-search providers should not show the Tavily warning."""
+        with (
+            patch("deepagents_code.main.shutil.which", return_value="/usr/bin/rg"),
+            patch(
+                "deepagents_code.config.settings",
+                SimpleNamespace(has_tavily=False, model_provider=""),
+            ),
+        ):
+            missing = check_optional_tools(model_spec="openai:gpt-5.5")
+
+        assert missing == []
+
+    def test_returns_tavily_for_non_hosted_web_search_provider(self) -> None:
+        """Providers without hosted search still need Tavily for web search."""
+        with (
+            patch("deepagents_code.main.shutil.which", return_value="/usr/bin/rg"),
+            patch(
+                "deepagents_code.config.settings",
+                SimpleNamespace(has_tavily=False, model_provider=""),
+            ),
+        ):
+            missing = check_optional_tools(model_spec="anthropic:claude-opus-4-7")
 
         assert missing == ["tavily"]
 

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -101,6 +101,7 @@ class TestServerGraph:
 
         model_result = SimpleNamespace(
             model=model_obj,
+            provider="anthropic",
             apply_to_settings=MagicMock(),
         )
         config_module = _module_with_attrs(
@@ -117,6 +118,7 @@ class TestServerGraph:
             fetch_url=fetch_tool,
             get_current_thread_id=thread_tool,
             web_search=object(),
+            build_builtin_tools=MagicMock(return_value=[fetch_tool, thread_tool]),
         )
 
         class FakeSessionManager:
@@ -222,6 +224,7 @@ class TestServerGraph:
             fetch_url=fetch_tool,
             get_current_thread_id=thread_tool,
             web_search=object(),
+            build_builtin_tools=MagicMock(return_value=[fetch_tool, thread_tool]),
         )
         mcp_module = _module_with_attrs(
             "deepagents_code.mcp_tools",
@@ -242,6 +245,7 @@ class TestServerGraph:
                 tools, mcp_server_info = await module._build_tools(
                     ServerConfig(no_mcp=True),
                     None,
+                    provider="anthropic",
                 )
 
         assert tools == [fetch_tool, thread_tool]
@@ -274,6 +278,7 @@ class TestServerGraph:
             create_model=MagicMock(
                 return_value=SimpleNamespace(
                     model=model_obj,
+                    provider="anthropic",
                     apply_to_settings=MagicMock(),
                 ),
             ),
@@ -289,6 +294,7 @@ class TestServerGraph:
             fetch_url=object(),
             get_current_thread_id=object(),
             web_search=object(),
+            build_builtin_tools=MagicMock(return_value=[]),
         )
         config = ServerConfig(
             no_mcp=True,
@@ -347,6 +353,7 @@ class TestServerGraph:
             fetch_url=fetch_tool,
             get_current_thread_id=thread_tool,
             web_search=object(),
+            build_builtin_tools=MagicMock(return_value=[fetch_tool, thread_tool]),
         )
 
         class FakeSessionManager:
@@ -375,6 +382,7 @@ class TestServerGraph:
                 tools, mcp_server_info = await module._build_tools(
                     ServerConfig(no_mcp=False),
                     None,
+                    provider="anthropic",
                 )
 
         assert events == ["warmup", "resolver"]

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -1160,6 +1160,14 @@ def _tool_chunk(
     return ((), "messages", (message, {}))
 
 
+def _server_tool_message(blocks: list[dict[str, Any]]) -> tuple[Any, ...]:
+    """Build a message chunk carrying provider-side tool call blocks."""
+    from langchain_core.messages import AIMessage
+
+    content = cast("list[str | dict[Any, Any]]", blocks)
+    return ((), "messages", (AIMessage(content=content), {}))
+
+
 def _usage_chunk(*, input_tokens: int, output_tokens: int) -> tuple[Any, ...]:
     """Build a `messages`-stream chunk carrying only `usage_metadata`."""
     from langchain_core.messages import AIMessageChunk
@@ -1214,6 +1222,59 @@ class TestExecuteTaskTextualUsageStats:
 
 class TestExecuteTaskTextualToolCallStreaming:
     """Tests for incremental tool-call argument accumulation."""
+
+    async def test_server_tool_call_mounts_and_completes(self) -> None:
+        """Hosted provider tool calls should render like local tool rows."""
+        mounted: list[object] = []
+
+        async def mount_message(widget: object) -> None:
+            await asyncio.sleep(0)
+            mounted.append(widget)
+
+        chunks = [
+            _server_tool_message(
+                [
+                    {
+                        "type": "server_tool_call",
+                        "name": "web_search",
+                        "id": "ws_1",
+                        "args": {
+                            "type": "search",
+                            "query": "fun things to do in nyc",
+                            "queries": [
+                                "fun things to do in nyc",
+                                "nyc events this weekend",
+                            ],
+                        },
+                    },
+                    {
+                        "type": "server_tool_result",
+                        "tool_call_id": "ws_1",
+                        "status": "success",
+                    },
+                ]
+            )
+        ]
+
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=_FakeAgent(chunks),
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        tool_msgs = [m for m in mounted if isinstance(m, ToolCallMessage)]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]._tool_name == "web_search"
+        assert tool_msgs[0]._args["query"] == "fun things to do in nyc"
+        assert tool_msgs[0]._status == "success"
 
     async def test_fragmented_args_mount_once_when_json_completes(self) -> None:
         """Args streamed across many fragments parse once the JSON is whole.

--- a/libs/code/tests/unit_tests/test_tools.py
+++ b/libs/code/tests/unit_tests/test_tools.py
@@ -1,0 +1,39 @@
+"""Unit tests for dcode built-in tool selection."""
+
+from __future__ import annotations
+
+from deepagents_code import tools as tools_module
+from deepagents_code.tools import build_builtin_tools
+
+
+def test_build_builtin_tools_uses_provider_web_search_for_openai() -> None:
+    """OpenAI-backed models use the provider-hosted web search declaration."""
+    tools = build_builtin_tools(provider="openai", has_tavily=False)
+
+    assert tools == [
+        tools_module.fetch_url,
+        tools_module.get_current_thread_id,
+        {"type": "web_search"},
+    ]
+
+
+def test_build_builtin_tools_prefers_provider_web_search_over_tavily() -> None:
+    """OpenAI-backed models should not expose both hosted search and Tavily."""
+    tools = build_builtin_tools(provider="openai_codex", has_tavily=True)
+
+    assert tools == [
+        tools_module.fetch_url,
+        tools_module.get_current_thread_id,
+        {"type": "web_search"},
+    ]
+
+
+def test_build_builtin_tools_uses_tavily_for_other_providers() -> None:
+    """Non-OpenAI providers keep the existing Tavily tool behavior."""
+    tools = build_builtin_tools(provider="anthropic", has_tavily=True)
+
+    assert tools == [
+        tools_module.fetch_url,
+        tools_module.get_current_thread_id,
+        tools_module.web_search,
+    ]


### PR DESCRIPTION
Adds provider-hosted web search support for OpenAI-backed models, including rendering hosted search events in the terminal UI and live integration coverage for the provider call path.

<img width="1130" height="272" alt="Screenshot 2026-06-28 at 10 07 50 AM" src="https://github.com/user-attachments/assets/d1ad16ec-8e5d-4576-98d3-b87ad0b50b49" />
