### PR TITLE
style(code): use text fences for raw CLI output

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6860,10 +6860,10 @@ class DeepAgentsApp(App):
             if output:
                 if incognito:
                     await self._mount_message(
-                        AppMessage(f"```\n{output}\n```", markdown=True),
+                        AppMessage(f"```text\n{output}\n```", markdown=True),
                     )
                 else:
-                    msg = AssistantMessage(f"```\n{output}\n```")
+                    msg = AssistantMessage(f"```text\n{output}\n```")
                     await self._mount_message(msg)
                     await msg.write_initial_content()
             else:
@@ -6931,7 +6931,7 @@ class DeepAgentsApp(App):
         self._pending_shell_messages.extend(
             [
                 HumanMessage(content=f"!{command}"),
-                AIMessage(content=f"```\n{body}\n```{status}"),
+                AIMessage(content=f"```text\n{body}\n```{status}"),
             ]
         )
 

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -380,7 +380,7 @@ def _read_mentioned_file(file_path: Path, max_embed_bytes: int) -> str:
             "use read_file tool to view)"
         )
     content = file_path.read_text(encoding="utf-8")
-    return f"\n### {file_path.name}\nPath: `{file_path}`\n```\n{content}\n```"
+    return f"\n### {file_path.name}\nPath: `{file_path}`\n```text\n{content}\n```"
 
 
 def _is_renderable_subagent_event(data: Any, *, is_main_agent: bool) -> bool:  # noqa: ANN401  # custom-stream payload is dynamic

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -54,6 +54,7 @@ from deepagents_code.widgets.launch_init import (
 )
 from deepagents_code.widgets.messages import (
     AppMessage,
+    AssistantMessage,
     ErrorMessage,
     QueuedUserMessage,
     SummarizationMessage,
@@ -6102,7 +6103,8 @@ class TestShellCommandInterrupt:
 
         messages = app._message_store.get_all_messages()
         assert any(
-            msg.type == MessageType.APP and "secret" in msg.content for msg in messages
+            msg.type == MessageType.APP and msg.content == "```text\nsecret\n```"
+            for msg in messages
         )
         assert not any(
             msg.type in {MessageType.USER, MessageType.ASSISTANT}
@@ -6176,7 +6178,42 @@ class TestShellCommandInterrupt:
         assert isinstance(buffered[0], HumanMessage)
         assert buffered[0].content == "!echo hello world"
         assert isinstance(buffered[1], AIMessage)
-        assert "hello world" in buffered[1].content
+        assert buffered[1].content == "```text\nhello world\n```"
+
+    async def test_non_incognito_shell_output_uses_text_fence(self) -> None:
+        """Non-incognito shell output renders in a ```text fenced block."""
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        app._agent.aupdate_state = AsyncMock()
+        app._lc_thread_id = "thread-123"
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"hi\n", b""))
+        mock_proc.returncode = 0
+        mock_proc.pid = 12345
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._schedule_git_branch_refresh = MagicMock()  # ty: ignore
+            app._maybe_drain_deferred = AsyncMock()  # ty: ignore
+            app._process_next_from_queue = AsyncMock()  # ty: ignore
+
+            with (
+                patch(
+                    "asyncio.create_subprocess_shell",
+                    return_value=mock_proc,
+                ),
+                patch(
+                    "deepagents_code.app.AssistantMessage.write_initial_content",
+                    new=AsyncMock(),
+                ),
+            ):
+                await app._run_shell_task("echo hi", incognito=False)
+                await pilot.pause()
+
+            rendered = app.query(AssistantMessage)
+            assert any(w._content == "```text\nhi\n```" for w in rendered)
 
     async def test_pending_shell_flushed_on_next_user_send(self) -> None:
         """Buffered `!` output is written to graph state on the next send."""
@@ -6190,7 +6227,7 @@ class TestShellCommandInterrupt:
         app._session_state = MagicMock()
         app._pending_shell_messages = [
             HumanMessage(content="!echo hi"),
-            AIMessage(content="```\nhi\n```"),
+            AIMessage(content="```text\nhi\n```"),
         ]
 
         async with app.run_test() as pilot:
@@ -6221,7 +6258,7 @@ class TestShellCommandInterrupt:
         app._ui_adapter = MagicMock()
         app._pending_shell_messages = [
             HumanMessage(content="!echo before-chat"),
-            AIMessage(content="```\nbefore-chat\n```"),
+            AIMessage(content="```text\nbefore-chat\n```"),
         ]
 
         async with app.run_test() as pilot:
@@ -6262,7 +6299,7 @@ class TestShellCommandInterrupt:
         app = DeepAgentsApp(agent=agent, thread_id="thread-remote")
         app._pending_shell_messages = [
             HumanMessage(content="!pwd"),
-            AIMessage(content="```\n/tmp/project\n```"),
+            AIMessage(content="```text\n/tmp/project\n```"),
         ]
 
         with patch.object(app, "_remote_agent", return_value=remote):
@@ -6376,7 +6413,7 @@ class TestShellCommandInterrupt:
         app = DeepAgentsApp()
         app._pending_shell_messages = [
             HumanMessage(content="!echo secret"),
-            AIMessage(content="```\nsecret\n```"),
+            AIMessage(content="```text\nsecret\n```"),
         ]
 
         async with app.run_test() as pilot:
@@ -6418,7 +6455,7 @@ class TestShellCommandInterrupt:
         app._lc_thread_id = "thread-123"
         app._pending_shell_messages = [
             HumanMessage(content="!echo hi"),
-            AIMessage(content="```\nhi\n```"),
+            AIMessage(content="```text\nhi\n```"),
         ]
 
         # Must not propagate; buffer is dropped so stale output is not replayed.
@@ -6437,7 +6474,7 @@ class TestShellCommandInterrupt:
         app._session_state = None
         buffered = [
             HumanMessage(content="!echo hi"),
-            AIMessage(content="```\nhi\n```"),
+            AIMessage(content="```text\nhi\n```"),
         ]
         app._pending_shell_messages = list(buffered)
 
@@ -6458,7 +6495,7 @@ class TestShellCommandInterrupt:
         app._session_state = MagicMock()
         app._pending_shell_messages = [
             HumanMessage(content="!echo hi"),
-            AIMessage(content="```\nhi\n```"),
+            AIMessage(content="```text\nhi\n```"),
         ]
 
         async with app.run_test() as pilot:

--- a/libs/code/tests/unit_tests/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/test_textual_adapter.py
@@ -29,6 +29,7 @@ from deepagents_code.textual_adapter import (
     _build_interrupted_ai_message,
     _handle_interrupt_cleanup,
     _is_summarization_chunk,
+    _read_mentioned_file,
     execute_task_textual,
     format_token_count,
     print_usage_table,
@@ -3413,3 +3414,29 @@ class TestPrintUsageTable:
         print_usage_table(stats, wall_time=0.01, console=console)
         output = buf.getvalue()
         assert output.strip() == ""
+
+
+class TestReadMentionedFile:
+    """Tests for `_read_mentioned_file` inline embedding."""
+
+    def test_embeds_small_file_in_text_fence(self, tmp_path: Path) -> None:
+        """A small mentioned file is embedded in a ```text fenced block."""
+        target = tmp_path / "note.txt"
+        target.write_text("alpha\nbeta", encoding="utf-8")
+
+        snippet = _read_mentioned_file(target, max_embed_bytes=1024)
+
+        assert "```text\nalpha\nbeta\n```" in snippet
+        assert f"Path: `{target}`" in snippet
+
+    def test_oversized_file_returns_reference_without_fence(
+        self, tmp_path: Path
+    ) -> None:
+        """A file over the embed threshold is referenced, not fenced."""
+        target = tmp_path / "big.txt"
+        target.write_text("x" * 4096, encoding="utf-8")
+
+        snippet = _read_mentioned_file(target, max_embed_bytes=1024)
+
+        assert "too large to embed" in snippet
+        assert "```" not in snippet


### PR DESCRIPTION
Closes #1411

---

Raw CLI output and inline mentioned-file embeds are displayed as Markdown fences. Bare fences let Textual guess a lexer, which can produce misleading syntax highlighting for arbitrary shell output or raw file snippets; pinning these blocks to `text` keeps them rendered as plain output.

## Changes

- Wrap local `!` shell output, including buffered model-context messages, in explicit `text` fenced blocks.
- Wrap `_read_mentioned_file` inline file snippets in explicit `text` fenced blocks.
- Add focused coverage for shell output rendering and mentioned-file embedding so these paths keep using plain-text fences.
