### PR TITLE
feat(talon): `DEEPAGENTS_TALON_RECURSION_LIMIT` env var

### DIFF
--- a/examples/talon/.env.example
+++ b/examples/talon/.env.example
@@ -2,6 +2,7 @@
 AGENT_ASSISTANT_ID=talon-local
 AGENT_MODEL=openai:gpt-5.2
 DEEPAGENTS_TALON_CONTEXT_SIZE=75000
+DEEPAGENTS_TALON_RECURSION_LIMIT=500
 OPENAI_API_KEY=
 
 # Optional LangSmith tracing. Traces are emitted only when both are set.

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -27,7 +27,7 @@ AGENT_ASSISTANT_ID=local AGENT_MODEL=<provider>:<model-id> uv run deepagents-tal
 
 If `AGENT_MODEL` is unset, Talon starts with the echo runtime. This is useful for checking host lifecycle and channel wiring without provider credentials.
 
-Assistant state lives under `~/.deepagents/<assistant_id>/` by default. The host creates restrictive state directories for the materialized agent manifest, channel sessions, and cron jobs. The default local execution workspace is the current working directory; set `DEEPAGENTS_TALON_WORKSPACE` to use a different directory.
+Assistant state lives under `~/.deepagents/<assistant_id>/` by default. The host creates restrictive state directories for the materialized agent manifest, channel sessions, and cron jobs. The default local execution workspace is the current working directory; set `DEEPAGENTS_TALON_WORKSPACE` to use a different directory. The per-invocation graph recursion limit defaults to `500`; set `DEEPAGENTS_TALON_RECURSION_LIMIT` to tune it.
 
 ## Fleet Exports
 

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -48,12 +48,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_RECURSION_LIMIT = 150
+DEFAULT_RECURSION_LIMIT = 500
 DEFAULT_MAX_RETRIES = 3
 DEFAULT_MAX_CONTINUATIONS = 3
 DEFAULT_MAX_APPROVAL_ROUNDS = 50
 CONTEXT_SIZE_ENV_KEY = "DEEPAGENTS_TALON_CONTEXT_SIZE"
 INTERRUPT_ON_TOOLS_ENV_KEY = "DEEPAGENTS_TALON_INTERRUPT_ON_TOOLS"
+RECURSION_LIMIT_ENV_KEY = "DEEPAGENTS_TALON_RECURSION_LIMIT"
 _WORKSPACE_ENV = "DEEPAGENTS_TALON_WORKSPACE"
 _SAFE_BACKEND_PATH = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 ModelContent = str | list[dict[str, object]]
@@ -302,7 +303,9 @@ class DeepAgentRuntime:
         reload_agent_components: Callable[[], Awaitable[RuntimeAgentComponents]] | None = None,
     ) -> None:
         """Initialize without constructing the graph."""
-        if recursion_limit <= 0:
+        values = os.environ if env is None else env
+        resolved_recursion_limit = _recursion_limit_from_env(values, recursion_limit)
+        if resolved_recursion_limit <= 0:
             msg = "recursion_limit must be positive"
             raise ValueError(msg)
         if max_retries < 1:
@@ -326,7 +329,7 @@ class DeepAgentRuntime:
         self.memory = tuple(memory) if memory is not None else None
         self.checkpointer = checkpointer if checkpointer is not None else InMemorySaver()
         self.include_web_tools = include_web_tools
-        self.recursion_limit = recursion_limit
+        self.recursion_limit = resolved_recursion_limit
         self.max_retries = max_retries
         self.max_continuations = max_continuations
         self.reload_agent_components = reload_agent_components
@@ -862,16 +865,31 @@ def _resolve_model_from_env(
 
 
 def _context_size_from_env(env: Mapping[str, str]) -> int | None:
-    raw = env.get(CONTEXT_SIZE_ENV_KEY)
+    return _positive_int_from_env(env, CONTEXT_SIZE_ENV_KEY)
+
+
+def _recursion_limit_from_env(env: Mapping[str, str], fallback: int) -> int:
+    """Resolve the recursion limit from the environment with a code fallback.
+
+    The `DEEPAGENTS_TALON_RECURSION_LIMIT` env var, when set, overrides the
+    caller-supplied value so operators can tune the graph recursion limit
+    without changing code. Falls back to the caller value when unset.
+    """
+    resolved = _positive_int_from_env(env, RECURSION_LIMIT_ENV_KEY)
+    return resolved if resolved is not None else fallback
+
+
+def _positive_int_from_env(env: Mapping[str, str], key: str) -> int | None:
+    raw = env.get(key)
     if raw is None or not raw.strip():
         return None
     try:
         value = int(raw)
     except ValueError as exc:
-        msg = f"{CONTEXT_SIZE_ENV_KEY} must be a positive integer"
+        msg = f"{key} must be a positive integer"
         raise ValueError(msg) from exc
     if value <= 0:
-        msg = f"{CONTEXT_SIZE_ENV_KEY} must be a positive integer"
+        msg = f"{key} must be a positive integer"
         raise ValueError(msg)
     return value
 

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -583,6 +583,70 @@ async def test_runtime_rejects_invalid_context_size() -> None:
         await runtime.start()
 
 
+async def test_runtime_recursion_limit_defaults_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = RecordingGraph()
+    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", lambda **_kwargs: graph)
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+    )
+    await runtime.start()
+
+    result = await runtime.invoke(AgentRequest(conversation_id="chat", text="hi"))
+    assert graph.calls[0][1]["recursion_limit"] == 500
+    assert result.text == "seen:1"
+
+
+async def test_runtime_recursion_limit_reads_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    graph = RecordingGraph()
+    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", lambda **_kwargs: graph)
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+        env={"DEEPAGENTS_TALON_RECURSION_LIMIT": "1000"},
+    )
+    await runtime.start()
+
+    await runtime.invoke(AgentRequest(conversation_id="chat", text="hi"))
+    assert graph.calls[0][1]["recursion_limit"] == 1000
+
+
+async def test_runtime_recursion_limit_env_overrides_explicit_arg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = RecordingGraph()
+    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", lambda **_kwargs: graph)
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+        recursion_limit=200,
+        env={"DEEPAGENTS_TALON_RECURSION_LIMIT": "750"},
+    )
+    await runtime.start()
+
+    await runtime.invoke(AgentRequest(conversation_id="chat", text="hi"))
+    assert graph.calls[0][1]["recursion_limit"] == 750
+
+
+async def test_runtime_rejects_invalid_recursion_limit_env() -> None:
+    with pytest.raises(ValueError, match="DEEPAGENTS_TALON_RECURSION_LIMIT"):
+        DeepAgentRuntime(
+            model="test:model",
+            include_web_tools=False,
+            skills=(),
+            memory=(),
+            env={"DEEPAGENTS_TALON_RECURSION_LIMIT": "0"},
+        )
+
+
 async def test_runtime_preserves_conversation_thread_across_turns(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Exposes `DEEPAGENTS_TALON_RECURSION_LIMIT` so operators can tune the per-invocation graph recursion limit from the environment without changing code. When set, it overrides the caller-supplied `recursion_limit`; otherwise the existing default applies.

The default recursion limit bumps from `150` to `500` to match the new documented default in the env example, giving longer-running agents more headroom before hitting the limit. Explicit `recursion_limit=` call sites are unaffected, and the env var takes precedence over both.

---

**Changes**

- Adds `RECURSION_LIMIT_ENV_KEY` and `_recursion_limit_from_env` to `DeepAgentRuntime`, resolved in the constructor so an invalid value fails fast at construction (matching the existing `recursion_limit <= 0` guard).
- Extracts the existing positive-int env parsing for `DEEPAGENTS_TALON_CONTEXT_SIZE` into a shared `_positive_int_from_env` helper so both keys share the same validation and error messaging.
- Bumps `DEFAULT_RECURSION_LIMIT` from `150` to `500`.
- Adds `DEEPAGENTS_TALON_RECURSION_LIMIT=500` to the Talon env example.
- Documents the variable in the package README.

**API impact**

The `recursion_limit` constructor parameter is keyword-only and unchanged in position/name; only its default value moved from `150` to `500`. The env var takes precedence, then the explicit arg, then the default. No breaking signature changes.

**Tests**

Unit tests cover: default when env unset, env override, env-beats-explicit-arg, and invalid-value rejection at construction. Full Talon suite passes (`178 passed`); the two pre-existing `ty` diagnostics in `speech.py` are unrelated to this change.