### PR TITLE
fix(acp): defer permission handling until stream closes

### DIFF
--- a/libs/acp/deepagents_acp/server.py
+++ b/libs/acp/deepagents_acp/server.py
@@ -68,11 +68,12 @@ from deepagents_acp.utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
     from acp.interfaces import Client
     from deepagents.graph import Checkpointer
     from langchain_core.runnables import RunnableConfig
+    from langgraph.types import Interrupt
 
 # agent-client-protocol v0.9.0+ removed the SessionConfigOption wrapper; config
 # options are now bare SessionConfigOptionSelect instances. Resolve dynamically
@@ -691,6 +692,7 @@ class AgentServerACP(ACPAgent):
                 self._cancelled = False  # Reset for next prompt
                 return PromptResponse(stop_reason="cancelled")
 
+            pending_interrupts: Sequence[Interrupt] = ()
             async for stream_chunk in agent.astream(
                 Command(resume={"decisions": user_decisions})
                 if user_decisions
@@ -735,12 +737,12 @@ class AgentServerACP(ACPAgent):
                                         {"interrupt_value": interrupt_value},
                                     )
 
-                            current_state = await agent.aget_state(config)
-                            user_decisions = await self._handle_interrupts(
-                                current_state=current_state,
-                                session_id=session_id,
-                            )
-                            break
+                            # The checkpoint backing this update may not be visible until
+                            # the stream iterator has closed. Defer reading state until
+                            # after leaving the async iterator so persistent checkpointers
+                            # do not return a stale, pre-interrupt snapshot.
+                            pending_interrupts = interrupt_objs
+                            continue
 
                     for node_name, update in updates.items():
                         if node_name == "tools" and isinstance(update, dict) and "todos" in update:
@@ -817,8 +819,16 @@ class AgentServerACP(ACPAgent):
             # The loop continues while there are interrupts (line 467)
             # We get the current state to check the loop condition
             current_state = await agent.aget_state(config)
-            # Note: Interrupts are handled during streaming via __interrupt__ updates
-            # This state check is only for the while loop condition
+            if pending_interrupts:
+                user_decisions = await self._handle_interrupts(
+                    current_state=current_state,
+                    session_id=session_id,
+                    pending_interrupts=pending_interrupts,
+                )
+                if user_decisions:
+                    # A stale snapshot has no interrupts and would otherwise end
+                    # the loop before the selected decisions can resume the graph.
+                    current_state = None
 
         return PromptResponse(stop_reason="end_turn")
 
@@ -827,12 +837,14 @@ class AgentServerACP(ACPAgent):
         *,
         current_state: StateSnapshot,
         session_id: str,
+        pending_interrupts: Sequence[Interrupt] | None = None,
     ) -> list[dict[str, Any]]:
         """Handle agent interrupts by requesting permission from the client."""
         user_decisions: list[dict[str, Any]] = []
-        if current_state.next and current_state.interrupts:
+        interrupts = pending_interrupts or current_state.interrupts
+        if (pending_interrupts or current_state.next) and interrupts:
             # Agent is interrupted, request permission from user
-            for interrupt in current_state.interrupts:
+            for interrupt in interrupts:
                 # Get the tool call info from the interrupt
                 tool_call_id = interrupt.id
                 interrupt_value = interrupt.value

--- a/libs/acp/pyproject.toml
+++ b/libs/acp/pyproject.toml
@@ -34,6 +34,7 @@ examples = [
     "langchain-openai>=1.3.3",
 ]
 test = [
+    "langgraph-checkpoint-sqlite>=3.0.0,<4.0.0",
     "pytest>=9.1.1",
     "pytest-asyncio>=1.4.0",
     "pytest-cov>=7.1.0",

--- a/libs/acp/tests/test_agent.py
+++ b/libs/acp/tests/test_agent.py
@@ -30,6 +30,7 @@ from langchain.tools import ToolRuntime
 from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage
 from langchain_core.tools import tool
 from langgraph.checkpoint.memory import MemorySaver
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.types import interrupt
 
@@ -963,6 +964,57 @@ async def test_acp_agent_hitl_requests_permission_only_once() -> None:
         "This indicates the double approval bug has regressed."
     )
     assert permission_requests[0]["tool_call"].title == "Write `/tmp/test.txt`"
+
+
+async def test_acp_agent_hitl_waits_for_persistent_interrupt_checkpoint(tmp_path) -> None:
+    """Test that permission state is read after the interrupt stream closes."""
+    model = GenericFakeChatModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "write_file",
+                            "args": {"file_path": "/tmp/test.txt", "content": "hello"},
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(content="File written successfully"),
+            ]
+        ),
+        stream_delimiter=None,
+    )
+    async with AsyncSqliteSaver.from_conn_string(
+        str(tmp_path / "checkpoints.sqlite")
+    ) as checkpointer:
+        await checkpointer.setup()
+        graph = create_deep_agent(
+            model=model,
+            interrupt_on={"write_file": True},
+            checkpointer=checkpointer,
+        )
+        agent = AgentServerACP(agent=graph)
+        client = FakeACPClient(permission_outcomes=["approve"])
+        agent.on_connect(client)  # type: ignore[arg-type]
+
+        session = await agent.new_session(cwd="/tmp", mcp_servers=[])
+        response = await agent.prompt(
+            [TextContentBlock(type="text", text="Write a test file")],
+            session_id=session.session_id,
+        )
+
+    assert response.stop_reason == "end_turn"
+    permission_requests = [e for e in client.events if e["type"] == "request_permission"]
+    assert len(permission_requests) == 1
+    assert permission_requests[0]["tool_call"].title == "Write `/tmp/test.txt`"
+    assert any(
+        e["update"] == update_agent_message(text_block("File written successfully"))
+        for e in client.events
+        if e["type"] == "session_update"
+    )
 
 
 def _make_server(*, with_modes: bool = True, with_models: bool = True) -> AgentServerACP:

--- a/libs/acp/uv.lock
+++ b/libs/acp/uv.lock
@@ -21,6 +21,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -489,6 +498,7 @@ examples = [
     { name = "langchain-openai" },
 ]
 test = [
+    { name = "langgraph-checkpoint-sqlite" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -513,6 +523,7 @@ examples = [
     { name = "langchain-openai", specifier = ">=1.3.3" },
 ]
 test = [
+    { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.0,<4.0.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -882,6 +893,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint-sqlite"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "langgraph-checkpoint" },
+    { name = "sqlite-vec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ea/83917c2369acf8a10a894d4247655fd063c07924ba5bc4e83c85d2eaeded/langgraph_checkpoint_sqlite-3.1.0.tar.gz", hash = "sha256:f926916ebc1b985d802cc9c820026036e84db9d910d62c97b57e4ba64f67d5ae", size = 147902, upload-time = "2026-05-12T03:34:52.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/07/b342811a16327900af2747c752ea19676172fcddf9b592cc384031076623/langgraph_checkpoint_sqlite-3.1.0-py3-none-any.whl", hash = "sha256:cc9b40df0076feae8a9ad42ae713621b148b00ac23adc09dc1dc66090a46e5ad", size = 38587, upload-time = "2026-05-12T03:34:51.231Z" },
 ]
 
 [[package]]
@@ -1560,6 +1585,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
  Fixes

There is a race condition with persistent checkpointers like AsyncSqliteSaver. ACP reads the graph state before the interrupt is fully saved. It sees no pending interrupt, skips the permission prompt, and leaves the tool call unresolved.

  ---

  Defer HITL permission handling until the interrupt stream closes, preventing persistent checkpointers from returning a stale pre-interrupt snapshot and silently skipping permission requests. Adds an `AsyncSqliteSaver` regression test that
  verifies the permission is requested once and the graph resumes successfully.

  This adds `langgraph-checkpoint-sqlite` as a test-only dependency to reproduce the persistence race; maintainer approval is requested for the dependency and lockfile changes.

  Verified with:

  - `uv run ruff check deepagents_acp/server.py tests/test_agent.py`
  - `uv run pytest tests/test_agent.py -q` — 27 passed