### PR TITLE
hotfix(code): set Fireworks session affinity header

### DIFF
--- a/libs/code/deepagents_code/configurable_model.py
+++ b/libs/code/deepagents_code/configurable_model.py
@@ -82,11 +82,8 @@ _ANTHROPIC_ONLY_SETTINGS: set[str] = {"cache_control"}
 `AnthropicPromptCachingMiddleware`) that are not accepted by other providers and
 must be stripped on cross-provider swap."""
 
-_FIREWORKS_MULTI_TURN_SESSION_HEADER = "x-multi-turn-session-id"
-"""Fireworks header populated from the active Deep Agents Code thread ID."""
-
 _FIREWORKS_SESSION_AFFINITY_HEADER = "x-session-affinity"
-"""Legacy Fireworks prompt-cache affinity header."""
+"""Fireworks prompt-cache affinity header populated from the active thread ID."""
 
 
 def _has_header(headers: Mapping[object, object], target: str) -> bool:
@@ -105,9 +102,9 @@ def _with_fireworks_session_settings(
 ) -> dict[str, Any] | None:
     """Return model settings with Fireworks session settings added if needed.
 
-    Existing settings are preserved and never overwritten. `prompt_cache_key` is
-    the preferred typed form for prompt-cache affinity; the raw
-    `x-session-affinity` header is also treated as caller-provided affinity.
+    Existing settings are preserved and never overwritten. Missing
+    `x-session-affinity` headers are populated directly so Fireworks can route
+    the conversation to the prompt-cache session for the active thread.
 
     Returns:
         A new `model_settings` dict with the missing session settings added, or
@@ -127,13 +124,12 @@ def _with_fireworks_session_settings(
         return None
 
     updated: dict[str, Any] = {}
-    if "prompt_cache_key" not in model_settings and not _has_header(
-        headers, _FIREWORKS_SESSION_AFFINITY_HEADER
-    ):
+    has_session_affinity = _has_header(headers, _FIREWORKS_SESSION_AFFINITY_HEADER)
+    if "prompt_cache_key" not in model_settings and not has_session_affinity:
         updated["prompt_cache_key"] = thread_id
 
-    if not _has_header(headers, _FIREWORKS_MULTI_TURN_SESSION_HEADER):
-        headers[_FIREWORKS_MULTI_TURN_SESSION_HEADER] = thread_id
+    if not has_session_affinity:
+        headers[_FIREWORKS_SESSION_AFFINITY_HEADER] = thread_id
         updated["extra_headers"] = headers
 
     if not updated:

--- a/libs/code/tests/unit_tests/test_configurable_model.py
+++ b/libs/code/tests/unit_tests/test_configurable_model.py
@@ -483,7 +483,7 @@ class TestFireworksSessionSettings:
         assert captured[0].model is request.model
         assert captured[0].model_settings == {
             "prompt_cache_key": "thread-123",
-            "extra_headers": {"x-multi-turn-session-id": "thread-123"},
+            "extra_headers": {"x-session-affinity": "thread-123"},
         }
 
     def test_existing_headers_preserved_and_session_affinity_not_overwritten(
@@ -509,7 +509,6 @@ class TestFireworksSessionSettings:
             "extra_headers": {
                 "Authorization": "Bearer custom",
                 "X-Session-Affinity": "custom-session",
-                "x-multi-turn-session-id": "thread-123",
             }
         }
 
@@ -545,7 +544,7 @@ class TestFireworksSessionSettings:
         assert captured[0].model is override
         assert captured[0].model_settings == {
             "prompt_cache_key": "thread-123",
-            "extra_headers": {"x-multi-turn-session-id": "thread-123"},
+            "extra_headers": {"x-session-affinity": "thread-123"},
         }
 
     async def test_async_fireworks_model_gets_session_settings(self) -> None:
@@ -563,7 +562,7 @@ class TestFireworksSessionSettings:
 
         assert captured[0].model_settings == {
             "prompt_cache_key": "thread-123",
-            "extra_headers": {"x-multi-turn-session-id": "thread-123"},
+            "extra_headers": {"x-session-affinity": "thread-123"},
         }
 
     def test_empty_thread_id_skips_session_settings(self) -> None:
@@ -616,17 +615,15 @@ class TestFireworksSessionSettings:
 
         assert captured[0].model_settings == {
             "prompt_cache_key": "custom-cache",
-            "extra_headers": {"x-multi-turn-session-id": "thread-123"},
+            "extra_headers": {"x-session-affinity": "thread-123"},
         }
 
-    def test_existing_multi_turn_header_case_insensitive(self) -> None:
-        """A differently-cased multi-turn header is not duplicated."""
+    def test_existing_session_affinity_header_case_insensitive(self) -> None:
+        """A differently-cased session-affinity header is not duplicated."""
         request = _make_request(
             self._fireworks_model(),
             context=CLIContext(thread_id="thread-123"),
-            model_settings={
-                "extra_headers": {"X-Multi-Turn-Session-ID": "custom-multi"}
-            },
+            model_settings={"extra_headers": {"X-Session-Affinity": "custom-session"}},
         )
         captured: list[ModelRequest] = []
 
@@ -635,8 +632,7 @@ class TestFireworksSessionSettings:
         )
 
         assert captured[0].model_settings == {
-            "prompt_cache_key": "thread-123",
-            "extra_headers": {"X-Multi-Turn-Session-ID": "custom-multi"},
+            "extra_headers": {"X-Session-Affinity": "custom-session"},
         }
 
     def test_caller_model_settings_not_mutated(self) -> None:


### PR DESCRIPTION
Follow-up to #4360

Deep Agents Code was passing the active thread ID through `x-multi-turn-session-id`, but Fireworks clarified that header is for RL training and not needed for prompt-cache routing. This hotfix now sets `x-session-affinity` directly from the active thread ID for Fireworks model calls, while preserving caller-provided affinity headers.

The focused configurable-model tests cover direct Fireworks calls, model swaps, async calls, existing headers, custom cache keys, and caller settings immutability.
