### PR TITLE
fix(quickjs): correct `eval` await description

### DIFF
--- a/libs/partners/quickjs/langchain_quickjs/_prompt.py
+++ b/libs/partners/quickjs/langchain_quickjs/_prompt.py
@@ -364,7 +364,8 @@ def render_eval_tool_description(*, mode: Literal["thread", "turn", "call"]) -> 
     return (
         "Execute JavaScript in a sandboxed REPL. "
         f"{state_line} No filesystem, network, or real clock. "
-        "Synchronous only — top-level `await` will not resolve."
+        "Top-level `await` is supported; a final-expression Promise resolves "
+        "before the call returns."
     )
 
 

--- a/libs/partners/quickjs/tests/unit_tests/test_prompt_modes.py
+++ b/libs/partners/quickjs/tests/unit_tests/test_prompt_modes.py
@@ -89,4 +89,6 @@ def test_render_eval_tool_description_mode_specific(
 ) -> None:
     description = render_eval_tool_description(mode=mode)
     assert expected_fragment in description
+    assert "Top-level `await` is supported" in description
+    assert "will not resolve" not in description
     assert description.startswith("Execute JavaScript in a sandboxed REPL.")


### PR DESCRIPTION
Closes #4370

`render_eval_tool_description` said top-level `await` would not resolve, contradicting the REPL behavior and system prompt. This updates the public `eval` tool description to state that top-level `await` is supported and that final-expression Promises resolve before returning.

Added a prompt-rendering regression assertion for all persistence modes. Thanks to @parveshsaini for flagging and offering to implement.

Made by [Open SWE](https://openswe.vercel.app/agents/d035df94-2193-26d9-cc9c-942e81cc54e9)