### PR TITLE
fix(sdk): _glob_search_files KeyError on missing modified_at (#4377)

### DIFF
--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -644,7 +644,9 @@ def _glob_search_files(
             relative = file_path[len(normalized_path) + 1 :]  # +1 for the slash
 
         if wcglob.globmatch(relative, effective_pattern, flags=wcglob.BRACE | wcglob.GLOBSTAR):
-            matches.append((file_path, file_data["modified_at"]))
+            # `modified_at` is optional on FileData; fall back to "" (sorts last,
+            # i.e. oldest) so files without a timestamp don't raise a KeyError.
+            matches.append((file_path, file_data.get("modified_at", "")))
 
     matches.sort(key=lambda x: x[1], reverse=True)
 

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -162,6 +162,18 @@ class TestGlobSearchFiles:
         assert "/src/utils/helper.py" in result
         assert "/src/main.py" not in result
 
+    def test_glob_handles_missing_modified_at(self) -> None:
+        """Files without the optional modified_at must not raise KeyError (gh-4377)."""
+        files = {
+            "/a.py": {"modified_at": "2024-01-01T10:00:00"},
+            "/b.py": {},  # modified_at omitted (it is NotRequired on FileData)
+        }
+        result = _glob_search_files(files, "*.py", "/")
+        assert "/a.py" in result
+        assert "/b.py" in result
+        # the timestamped file sorts ahead of the one without a timestamp
+        assert result.index("/a.py") < result.index("/b.py")
+
     def test_no_matches(self, sample_files: dict[str, Any]) -> None:
         """Test no matches returns message."""
         assert _glob_search_files(sample_files, "*.xyz", "/") == "No files found"


### PR DESCRIPTION
Fixes #4377

## What was wrong

`modified_at` is `NotRequired` on `FileData`, but `_glob_search_files` indexed it directly when collecting matches to sort:

```python
matches.append((file_path, file_data["modified_at"]))
```

So any file whose `FileData` omits the optional timestamp raised `KeyError: 'modified_at'`.

## Fix

Use `file_data.get("modified_at", "")`. The empty string sorts last under the existing `reverse=True` sort, so timestamped files still come first and untimestamped files are included instead of crashing the whole search.

## Test

Adds `test_glob_handles_missing_modified_at`. Verified it raises `KeyError` on `main` and passes with this change.