### PR TITLE
fix(code): run stdio MCP server PATH check off the event loop

### DIFF
--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -994,7 +994,7 @@ def load_mcp_config_with_error(
         return None, str(exc)
 
 
-def _check_stdio_server(server_name: str, server_config: dict[str, Any]) -> None:
+async def _check_stdio_server(server_name: str, server_config: dict[str, Any]) -> None:
     """Verify that a stdio server's command exists on PATH.
 
     Args:
@@ -1008,7 +1008,11 @@ def _check_stdio_server(server_name: str, server_config: dict[str, Any]) -> None
     if command is None:
         msg = f"MCP server '{server_name}': missing 'command' in config."
         raise RuntimeError(msg)
-    if shutil.which(command) is None:
+    # Run the sync shutil.which() in a worker thread so it does not block the
+    # event loop under strict async-blocking guards (e.g. langgraph dev's
+    # blockbuster), which choke on shutil.which's internal os.access() call.
+    resolved = await asyncio.to_thread(shutil.which, command)
+    if resolved is None:
         msg = (
             f"MCP server '{server_name}': command '{command}' not found on PATH. "
             "Install it or check your MCP config."
@@ -1442,7 +1446,7 @@ async def _load_tools_from_config(
             if server_type in _SUPPORTED_REMOTE_TYPES:
                 await _check_remote_server(server_name, server_config)
             elif server_type == "stdio":
-                _check_stdio_server(server_name, server_config)
+                await _check_stdio_server(server_name, server_config)
         except RuntimeError as exc:
             logger.warning(
                 "MCP server '%s' skipped: pre-flight failed: %s",


### PR DESCRIPTION
## Problem

Under `langgraph dev`, every stdio MCP server in `.mcp.json` is logged as `tool discovery failed`, and the agent graph readiness check fails with status 500:

```
MCP server 'graphify' skipped: tool discovery failed
Server graph 'agent' failed readiness check (status: 500): BlockingError: Blocking call to os.access
```

## Root cause

`_check_stdio_server` (`libs/code/deepagents_code/mcp_tools.py:997`) runs `shutil.which(command)` synchronously inside the async MCP discovery loop in `_load_tools_from_config`. `shutil.which` internally calls `os.access()` (`shutil._access_check`), and `langgraph dev`'s `blockbuster` async-blocking guard trips on that synchronous `os.access` call, raising `BlockingError`.

That exception kills the stdio MCP task group before `ClientSession.initialize()` can complete, so the server is skipped and — because graph discovery is the last step before readiness — the agent graph build returns 500.

This affects **every** stdio MCP server under `langgraph dev`, not just a specific one. HTTP/SSE servers are unaffected (their pre-flight is `_check_remote_server`, which already uses `httpx` and is async).

## Fix

Make `_check_stdio_server` async and run the `shutil.which` call off the event loop with `asyncio.to_thread`:

```diff
-def _check_stdio_server(...) -> None:
+async def _check_stdio_server(...) -> None:
     ...
-    if shutil.which(command) is None:
+    resolved = await asyncio.to_thread(shutil.which, command)
+    if resolved is None:
```

and `await` it at the call site in `_load_tools_from_config`.

`asyncio` is already imported at the top of the module (line 11), so no new imports.

## Verification

- Reproduced the failure with a stdio MCP server whose binary is on PATH: `langgraph dev` blocked on `shutil.which` → `os.access`, the server's `initialize` handshake never completed, readiness check 500'd.
- After the patch, the same server's `ClientSession.initialize()` completes and the readiness check passes.

## Checklist

- [x] Minimal change scoped to the stdio pre-flight path
- [x] No new dependencies (`asyncio` already imported)
- [x] Preserves the existing `RuntimeError` contract on missing command / not-on-PATH