### PR TITLE
feat(evals): harbor workflow stress-test inputs + sharding

### DIFF
--- a/.github/scripts/shard_matrix.py
+++ b/.github/scripts/shard_matrix.py
@@ -73,6 +73,24 @@ def expand_matrix(model_matrix: dict, n_shards: int) -> dict:
     return {"include": expanded}
 
 
+def effective_shards(n_shards: int, n_tasks: int) -> int:
+    """Cap the shard axis to the amount of selectable work.
+
+    Sharding more ways than there are tasks just spawns empty no-op jobs. When
+    ``n_tasks > 0`` the selection is at most ``n_tasks`` tasks, so the useful
+    shard count is ``min(n_shards, n_tasks)`` — this keeps prep from emitting
+    shard jobs that can only be empty (e.g. ``n_tasks=1 n_shards=4`` -> 1 shard).
+
+    ``n_tasks == 0`` means "all tasks", so no cap is applied. Smaller selections
+    produced by ``include_tasks`` globs can't be sized without the dataset
+    manifest (which prep doesn't resolve); those rarer residual empty shards are
+    handled as a successful no-op in the run job instead.
+    """
+    if n_tasks > 0:
+        return min(n_shards, n_tasks)
+    return n_shards
+
+
 def select_shard_tasks(
     names: list[str],
     include_globs: list[str],
@@ -121,29 +139,40 @@ def select_shard_tasks(
 def main() -> None:
     """Entry point for the prep job: expand the model matrix by shard.
 
-    Reads ``MODEL_MATRIX`` (JSON from ``models.py harbor``) and ``N_SHARDS``,
-    writes ``matrix=<json>`` to ``$GITHUB_OUTPUT`` (or stdout when unset).
-    Config errors become a GitHub ``::error::`` annotation + exit 1.
+    Reads ``MODEL_MATRIX`` (JSON from ``models.py harbor``), ``N_SHARDS`` and
+    ``N_TASKS``, caps the shard axis to the selectable work, and writes both
+    ``matrix=<json>`` and the effective ``n_shards=<int>`` to ``$GITHUB_OUTPUT``
+    (or stdout when unset). The harbor job reads back the effective ``n_shards``
+    so its per-shard partition matches the matrix. Config errors become a GitHub
+    ``::error::`` annotation + exit 1.
     """
     raw_shards = os.environ.get("N_SHARDS", "1").strip() or "1"
     if not raw_shards.isdigit():
         print(f"::error::Invalid n_shards (must be an integer): {raw_shards!r}", file=sys.stderr)  # noqa: T201
         sys.exit(1)
+    raw_tasks = os.environ.get("N_TASKS", "0").strip() or "0"
+    if not raw_tasks.isdigit():
+        print(f"::error::Invalid n_tasks (must be an integer): {raw_tasks!r}", file=sys.stderr)  # noqa: T201
+        sys.exit(1)
 
     try:
         model_matrix = json.loads(os.environ["MODEL_MATRIX"])
-        matrix = expand_matrix(model_matrix, int(raw_shards))
+        n_shards = effective_shards(int(raw_shards), int(raw_tasks))
+        matrix = expand_matrix(model_matrix, n_shards)
     except ShardConfigError as exc:
         print(f"::error::{exc}", file=sys.stderr)  # noqa: T201
         sys.exit(1)
 
-    payload = "matrix=" + json.dumps(matrix, separators=(",", ":"))
+    lines = [
+        "matrix=" + json.dumps(matrix, separators=(",", ":")),
+        f"n_shards={n_shards}",
+    ]
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
         with open(github_output, "a") as f:  # noqa: PTH123
-            f.write(payload + "\n")
+            f.write("\n".join(lines) + "\n")
     else:
-        print(payload)  # noqa: T201
+        print("\n".join(lines))  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/.github/scripts/shard_matrix.py
+++ b/.github/scripts/shard_matrix.py
@@ -1,0 +1,150 @@
+"""Shard math for the Harbor evals workflow (`.github/workflows/harbor.yml`).
+
+Two concerns, two consumers, one tested source of truth:
+
+* ``expand_matrix`` — used by the ``prep`` job to cross-product the model matrix
+  with the shard axis. Guards the result against GitHub Actions' hard 256-job
+  matrix cap (a sharded ``all`` run is ``len(models) * n_shards``).
+* ``select_shard_tasks`` — used by the per-shard ``harbor`` run step to pick this
+  shard's disjoint slice of the dataset. It mirrors Harbor's own task-selection
+  pipeline (``_filter_task_ids`` in ``harbor/models/job/config.py``) so that a
+  sharded run executes exactly the tasks an unsharded ``include_tasks``/``n_tasks``
+  run would — just split across runners.
+
+Run as a script, ``main()`` drives ``expand_matrix`` from env vars and writes the
+matrix to ``$GITHUB_OUTPUT`` (mirroring ``.github/scripts/models.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from fnmatch import fnmatch
+
+# GitHub Actions refuses to start a job matrix with more than this many entries.
+# https://docs.github.com/actions/using-jobs/using-a-matrix-for-your-jobs
+GITHUB_MATRIX_MAX = 256
+
+# Upper bound on the shard axis itself, independent of the matrix cap. Keeps a
+# fat-fingered dispatch (e.g. n_shards=1000) from producing a nonsensical run.
+MAX_SHARDS = 64
+
+
+class ShardConfigError(Exception):
+    """Raised for an invalid shard configuration.
+
+    An explicit exception (never ``assert``) so the check survives ``python -O``
+    and ``main()`` can render it as a GitHub ``::error::`` annotation.
+    """
+
+
+def expand_matrix(model_matrix: dict, n_shards: int) -> dict:
+    """Cross-product each model entry in ``model_matrix`` with the shard axis.
+
+    ``model_matrix`` is the ``{"include": [...]}`` payload emitted by
+    ``models.py harbor``. Each entry gains a ``shard`` key in ``0..n_shards-1``.
+    ``n_shards == 1`` is a no-op cross-product (``shard: 0`` on every entry),
+    identical to the pre-sharding matrix.
+
+    Raises:
+        ShardConfigError: if ``n_shards`` is out of range, or the expanded
+            matrix would exceed GitHub's job cap.
+    """
+    if not isinstance(n_shards, int) or not (1 <= n_shards <= MAX_SHARDS):
+        msg = f"Invalid n_shards (must be an integer 1..{MAX_SHARDS}): {n_shards!r}"
+        raise ShardConfigError(msg)
+
+    include = model_matrix.get("include", [])
+    total = len(include) * n_shards
+    if total > GITHUB_MATRIX_MAX:
+        msg = (
+            f"Sharded matrix is {len(include)} models x {n_shards} shards = "
+            f"{total} jobs, over GitHub's {GITHUB_MATRIX_MAX}-job matrix limit. "
+            "Reduce n_shards or select a smaller model set."
+        )
+        raise ShardConfigError(msg)
+
+    expanded = [
+        {**entry, "shard": shard}
+        for entry in include
+        for shard in range(n_shards)
+    ]
+    return {"include": expanded}
+
+
+def select_shard_tasks(
+    names: list[str],
+    include_globs: list[str],
+    n_tasks: int,
+    n_shards: int,
+    shard_index: int,
+) -> list[str]:
+    """Return this shard's slice of the dataset's task names.
+
+    ``names`` MUST be in the dataset's native manifest order (the order of
+    ``get_dataset_metadata().task_ids``) — the same order Harbor filters at run
+    time. This mirrors Harbor's ``_filter_task_ids``:
+
+    1. keep names matching any ``include_globs`` (``fnmatch``, order preserved);
+       empty ``include_globs`` keeps everything,
+    2. if ``n_tasks > 0``, take the first ``n_tasks`` (a **total** cap, applied
+       before sharding — NOT per shard),
+    3. partition with ``j % n_shards == shard_index``.
+
+    Because the cap is applied to the native-order list before partitioning, the
+    union of every shard's result equals exactly the task set an unsharded
+    ``include_tasks``/``n_tasks`` run would execute. Do not sort ``names``:
+    Harbor's ``--n-tasks`` slices in native order, so sorting would select a
+    different N.
+
+    Raises:
+        ShardConfigError: if ``n_shards``/``shard_index`` are out of range.
+    """
+    if not isinstance(n_shards, int) or n_shards < 1:
+        msg = f"Invalid n_shards (must be >= 1): {n_shards!r}"
+        raise ShardConfigError(msg)
+    if not isinstance(shard_index, int) or not (0 <= shard_index < n_shards):
+        msg = f"Invalid shard_index {shard_index!r} for {n_shards} shards"
+        raise ShardConfigError(msg)
+
+    selected = [n for n in names if n]
+    if include_globs:
+        selected = [
+            n for n in selected if any(fnmatch(n, g) for g in include_globs)
+        ]
+    if n_tasks > 0:
+        selected = selected[:n_tasks]
+    return [name for j, name in enumerate(selected) if j % n_shards == shard_index]
+
+
+def main() -> None:
+    """Entry point for the prep job: expand the model matrix by shard.
+
+    Reads ``MODEL_MATRIX`` (JSON from ``models.py harbor``) and ``N_SHARDS``,
+    writes ``matrix=<json>`` to ``$GITHUB_OUTPUT`` (or stdout when unset).
+    Config errors become a GitHub ``::error::`` annotation + exit 1.
+    """
+    raw_shards = os.environ.get("N_SHARDS", "1").strip() or "1"
+    if not raw_shards.isdigit():
+        print(f"::error::Invalid n_shards (must be an integer): {raw_shards!r}", file=sys.stderr)  # noqa: T201
+        sys.exit(1)
+
+    try:
+        model_matrix = json.loads(os.environ["MODEL_MATRIX"])
+        matrix = expand_matrix(model_matrix, int(raw_shards))
+    except ShardConfigError as exc:
+        print(f"::error::{exc}", file=sys.stderr)  # noqa: T201
+        sys.exit(1)
+
+    payload = "matrix=" + json.dumps(matrix, separators=(",", ":"))
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as f:  # noqa: PTH123
+            f.write(payload + "\n")
+    else:
+        print(payload)  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/shard_matrix.py
+++ b/.github/scripts/shard_matrix.py
@@ -2,17 +2,24 @@
 
 Two concerns, two consumers, one tested source of truth:
 
-* ``expand_matrix`` — used by the ``prep`` job to cross-product the model matrix
-  with the shard axis. Guards the result against GitHub Actions' hard 256-job
-  matrix cap (a sharded ``all`` run is ``len(models) * n_shards``).
-* ``select_shard_tasks`` — used by the per-shard ``harbor`` run step to pick this
-  shard's disjoint slice of the dataset. It mirrors Harbor's own task-selection
-  pipeline (``_filter_task_ids`` in ``harbor/models/job/config.py``) so that a
-  sharded run executes exactly the tasks an unsharded ``include_tasks``/``n_tasks``
-  run would — just split across runners.
+* `expand_matrix` — used by the `prep` job to cross-product the model matrix
+    with the shard axis. Guards the result against GitHub Actions' hard 256-job
+    matrix cap (a sharded `all` run is `len(models) * n_shards`).
+* `select_shard_tasks` — used by the per-shard `harbor` run step to pick this
+    shard's disjoint slice of the dataset. It reproduces the *include-glob +
+    `n_tasks`* subset of Harbor's task-selection pipeline (`_filter_task_ids` in
+    `harbor/models/job/config.py`, as of the pinned Harbor) so that a sharded run
+    executes exactly the tasks an unsharded `include_tasks`/`n_tasks` run would
+  — just split across runners. It intentionally does **not** model Harbor's
+    `exclude_task_names` stage or its empty-include `ValueError` (the workflow
+    exposes no `exclude_tasks` input and fail-fasts on an empty include match
+    itself); see `select_shard_tasks` for the full divergence note.
+* `task_display_name` — used by the run step to turn a Harbor manifest task id
+    into the `org/name` string the shard filter and `--include-task-name` expect,
+    delegating to the task id's own `get_name()` so every id variant resolves.
 
-Run as a script, ``main()`` drives ``expand_matrix`` from env vars and writes the
-matrix to ``$GITHUB_OUTPUT`` (mirroring ``.github/scripts/models.py``).
+Run as a script, `main()` drives `expand_matrix` from env vars and writes the
+matrix to `$GITHUB_OUTPUT` (mirroring `.github/scripts/models.py`).
 """
 
 from __future__ import annotations
@@ -34,21 +41,21 @@ MAX_SHARDS = 64
 class ShardConfigError(Exception):
     """Raised for an invalid shard configuration.
 
-    An explicit exception (never ``assert``) so the check survives ``python -O``
-    and ``main()`` can render it as a GitHub ``::error::`` annotation.
+    An explicit exception (never `assert`) so the check survives `python -O`
+    and `main()` can render it as a GitHub `::error::` annotation.
     """
 
 
 def expand_matrix(model_matrix: dict, n_shards: int) -> dict:
-    """Cross-product each model entry in ``model_matrix`` with the shard axis.
+    """Cross-product each model entry in `model_matrix` with the shard axis.
 
-    ``model_matrix`` is the ``{"include": [...]}`` payload emitted by
-    ``models.py harbor``. Each entry gains a ``shard`` key in ``0..n_shards-1``.
-    ``n_shards == 1`` is a no-op cross-product (``shard: 0`` on every entry),
+    `model_matrix` is the `{"include": [...]}` payload emitted by
+    `models.py harbor`. Each entry gains a `shard` key in `0..n_shards-1`.
+    `n_shards == 1` is a no-op cross-product (`shard: 0` on every entry),
     identical to the pre-sharding matrix.
 
     Raises:
-        ShardConfigError: if ``n_shards`` is out of range, or the expanded
+        ShardConfigError: if `n_shards` is out of range, or the expanded
             matrix would exceed GitHub's job cap.
     """
     if not isinstance(n_shards, int) or not (1 <= n_shards <= MAX_SHARDS):
@@ -66,9 +73,7 @@ def expand_matrix(model_matrix: dict, n_shards: int) -> dict:
         raise ShardConfigError(msg)
 
     expanded = [
-        {**entry, "shard": shard}
-        for entry in include
-        for shard in range(n_shards)
+        {**entry, "shard": shard} for entry in include for shard in range(n_shards)
     ]
     return {"include": expanded}
 
@@ -77,18 +82,48 @@ def effective_shards(n_shards: int, n_tasks: int) -> int:
     """Cap the shard axis to the amount of selectable work.
 
     Sharding more ways than there are tasks just spawns empty no-op jobs. When
-    ``n_tasks > 0`` the selection is at most ``n_tasks`` tasks, so the useful
-    shard count is ``min(n_shards, n_tasks)`` — this keeps prep from emitting
-    shard jobs that can only be empty (e.g. ``n_tasks=1 n_shards=4`` -> 1 shard).
+    `n_tasks > 0` the selection is at most `n_tasks` tasks, so the useful
+    shard count is `min(n_shards, n_tasks)` — this keeps prep from emitting
+    shard jobs that can only be empty (e.g. `n_tasks=1 n_shards=4` -> 1 shard).
 
-    ``n_tasks == 0`` means "all tasks", so no cap is applied. Smaller selections
-    produced by ``include_tasks`` globs can't be sized without the dataset
+    `n_tasks == 0` means "all tasks", so no cap is applied. Smaller selections
+    produced by `include_tasks` globs can't be sized without the dataset
     manifest (which prep doesn't resolve); those rarer residual empty shards are
     handled as a successful no-op in the run job instead.
     """
     if n_tasks > 0:
         return min(n_shards, n_tasks)
     return n_shards
+
+
+def task_display_name(task: object) -> str | None:
+    """Return a Harbor manifest task's `org/name` display string, or `None`.
+
+    The dataset manifest yields task ids of several shapes (`PackageTaskId`,
+    `GitTaskId`, `LocalTaskId`), each of which implements `get_name()` — the
+    canonical name Harbor itself filters and reports on. Delegating to it is what
+    makes every variant resolve: a manual `f"{org}/{name}"` reconstruction only
+    works for `PackageTaskId` and silently returns `None` for the git/local
+    ids, which would drop every task and run an empty shard.
+
+    Falls back to dict-shaped (`{"org", "name"}`) and bare `org`/`name`
+    attribute access for manifests that don't expose `get_name()`. Returns
+    `None` only when no name can be derived, so callers can filter unusable
+    entries (and fail loudly if *every* entry is unusable).
+    """
+    getter = getattr(task, "get_name", None)
+    if callable(getter):
+        name = getter()
+        return name or None
+    if isinstance(task, dict):
+        org = task.get("org")
+        name = task.get("name")
+    else:
+        org = getattr(task, "org", None)
+        name = getattr(task, "name", None)
+    if name and org:
+        return f"{org}/{name}"
+    return name or None
 
 
 def select_shard_tasks(
@@ -100,24 +135,39 @@ def select_shard_tasks(
 ) -> list[str]:
     """Return this shard's slice of the dataset's task names.
 
-    ``names`` MUST be in the dataset's native manifest order (the order of
-    ``get_dataset_metadata().task_ids``) — the same order Harbor filters at run
-    time. This mirrors Harbor's ``_filter_task_ids``:
+    `names` MUST be in the dataset's native manifest order (the order of
+    `get_dataset_metadata().task_ids`) — the same order Harbor filters at run
+    time. This reproduces the *include-glob + `n_tasks`* subset of Harbor's
+    `_filter_task_ids` (`harbor/models/job/config.py`, as of the pinned
+    Harbor):
 
-    1. keep names matching any ``include_globs`` (``fnmatch``, order preserved);
-       empty ``include_globs`` keeps everything,
-    2. if ``n_tasks > 0``, take the first ``n_tasks`` (a **total** cap, applied
-       before sharding — NOT per shard),
-    3. partition with ``j % n_shards == shard_index``.
+    1. keep names matching any `include_globs` (`fnmatch`, order preserved);
+        empty `include_globs` keeps everything,
+    2. if `n_tasks > 0`, take the first `n_tasks` (a **total** cap, applied
+        before sharding — NOT per shard),
+    3. partition with `j % n_shards == shard_index`.
 
     Because the cap is applied to the native-order list before partitioning, the
     union of every shard's result equals exactly the task set an unsharded
-    ``include_tasks``/``n_tasks`` run would execute. Do not sort ``names``:
-    Harbor's ``--n-tasks`` slices in native order, so sorting would select a
+    `include_tasks`/`n_tasks` run would execute. Do not sort `names`:
+    Harbor's `--n-tasks` slices in native order, so sorting would select a
     different N.
 
+    Two stages of `_filter_task_ids` are intentionally **not** reproduced, so
+    keep this in sync if a maintainer wires the corresponding inputs into the
+    workflow:
+
+    * `exclude_task_names` — Harbor applies it between the include filter and
+        the `n_tasks` cap. The workflow exposes no `exclude_tasks` input, so it
+        is omitted. (Parity here is by construction, not test-enforced; a Harbor
+        refactor that renames `_filter_task_ids` won't fail any test here.)
+    * the empty-include `ValueError` — Harbor raises when an include glob
+        matches nothing; this returns an empty selection instead. The run step
+        fail-fasts on an empty include match before calling this, so the divergence
+        is unreachable in the workflow.
+
     Raises:
-        ShardConfigError: if ``n_shards``/``shard_index`` are out of range.
+        ShardConfigError: if `n_shards`/`shard_index` are out of range.
     """
     if not isinstance(n_shards, int) or n_shards < 1:
         msg = f"Invalid n_shards (must be >= 1): {n_shards!r}"
@@ -128,9 +178,7 @@ def select_shard_tasks(
 
     selected = [n for n in names if n]
     if include_globs:
-        selected = [
-            n for n in selected if any(fnmatch(n, g) for g in include_globs)
-        ]
+        selected = [n for n in selected if any(fnmatch(n, g) for g in include_globs)]
     if n_tasks > 0:
         selected = selected[:n_tasks]
     return [name for j, name in enumerate(selected) if j % n_shards == shard_index]
@@ -139,20 +187,26 @@ def select_shard_tasks(
 def main() -> None:
     """Entry point for the prep job: expand the model matrix by shard.
 
-    Reads ``MODEL_MATRIX`` (JSON from ``models.py harbor``), ``N_SHARDS`` and
-    ``N_TASKS``, caps the shard axis to the selectable work, and writes both
-    ``matrix=<json>`` and the effective ``n_shards=<int>`` to ``$GITHUB_OUTPUT``
-    (or stdout when unset). The harbor job reads back the effective ``n_shards``
+    Reads `MODEL_MATRIX` (JSON from `models.py harbor`), `N_SHARDS` and
+    `N_TASKS`, caps the shard axis to the selectable work, and writes both
+    `matrix=<json>` and the effective `n_shards=<int>` to `$GITHUB_OUTPUT`
+    (or stdout when unset). The harbor job reads back the effective `n_shards`
     so its per-shard partition matches the matrix. Config errors become a GitHub
-    ``::error::`` annotation + exit 1.
+    `::error::` annotation + exit 1.
     """
     raw_shards = os.environ.get("N_SHARDS", "1").strip() or "1"
     if not raw_shards.isdigit():
-        print(f"::error::Invalid n_shards (must be an integer): {raw_shards!r}", file=sys.stderr)  # noqa: T201
+        print(
+            f"::error::Invalid n_shards (must be an integer): {raw_shards!r}",
+            file=sys.stderr,
+        )  # noqa: T201
         sys.exit(1)
     raw_tasks = os.environ.get("N_TASKS", "0").strip() or "0"
     if not raw_tasks.isdigit():
-        print(f"::error::Invalid n_tasks (must be an integer): {raw_tasks!r}", file=sys.stderr)  # noqa: T201
+        print(
+            f"::error::Invalid n_tasks (must be an integer): {raw_tasks!r}",
+            file=sys.stderr,
+        )  # noqa: T201
         sys.exit(1)
 
     try:

--- a/.github/scripts/test_shard_matrix.py
+++ b/.github/scripts/test_shard_matrix.py
@@ -1,0 +1,190 @@
+"""Tests for the Harbor shard-matrix helper (`.github/scripts/shard_matrix.py`).
+
+Mirrors `test_models.py`: import-by-path, stdlib + pytest only, so it runs under
+CI's `pytest .github/scripts/test_*.py` (see `.github/workflows/ci.yml`).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARD_SCRIPT = REPO_ROOT / ".github" / "scripts" / "shard_matrix.py"
+
+
+def _load_shard_script() -> ModuleType:
+    """Load `.github/scripts/shard_matrix.py` as a module.
+
+    The script lives outside any importable package, so import-by-path is the
+    only way to exercise its internals from a test.
+    """
+    spec = importlib.util.spec_from_file_location("gha_shard_matrix", SHARD_SCRIPT)
+    if spec is None or spec.loader is None:
+        msg = f"Could not load module spec for {SHARD_SCRIPT}"
+        raise AssertionError(msg)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def shard() -> ModuleType:
+    """Module-scoped handle to the loaded `shard_matrix.py` script."""
+    return _load_shard_script()
+
+
+def _models(n: int) -> dict:
+    """A model matrix with `n` entries, shaped like `models.py harbor` output."""
+    return {"include": [{"model": f"p:m{i}", "artifact_key": f"p-m{i}"} for i in range(n)]}
+
+
+# --------------------------------------------------------------------------- #
+# expand_matrix — model x shard cross-product + GitHub 256-job cap (comment #1)
+# --------------------------------------------------------------------------- #
+
+
+def test_expand_matrix_single_shard_is_backward_compatible(shard: ModuleType) -> None:
+    """n_shards=1 -> one job per model, each tagged shard 0 (no behavior change)."""
+    out = shard.expand_matrix(_models(3), 1)
+
+    assert len(out["include"]) == 3
+    assert all(entry["shard"] == 0 for entry in out["include"])
+    # Original keys are preserved verbatim alongside the new `shard` key.
+    assert out["include"][0] == {"model": "p:m0", "artifact_key": "p-m0", "shard": 0}
+
+
+def test_expand_matrix_cross_products_models_and_shards(shard: ModuleType) -> None:
+    """n_shards=3 -> len(models) * 3 entries with shard indices 0..2 per model."""
+    out = shard.expand_matrix(_models(2), 3)
+
+    assert len(out["include"]) == 2 * 3
+    # Each model appears once per shard index.
+    for model in ("p:m0", "p:m1"):
+        shards = sorted(e["shard"] for e in out["include"] if e["model"] == model)
+        assert shards == [0, 1, 2]
+
+
+def test_expand_matrix_accepts_matrix_at_the_256_cap(shard: ModuleType) -> None:
+    """len(models) * n_shards == 256 is allowed (boundary)."""
+    out = shard.expand_matrix(_models(128), 2)  # 128 * 2 == 256
+    assert len(out["include"]) == 256
+
+
+def test_expand_matrix_rejects_matrix_over_the_256_cap(shard: ModuleType) -> None:
+    """257 jobs is one over the cap and must be rejected before any run."""
+    with pytest.raises(shard.ShardConfigError, match="256-job"):
+        shard.expand_matrix(_models(129), 2)  # 129 * 2 == 258
+
+
+def test_expand_matrix_rejects_real_all_set_overflow(shard: ModuleType) -> None:
+    """The reviewer's concrete case: 56-model `all` set x 5 shards = 280 > 256."""
+    with pytest.raises(shard.ShardConfigError, match="280 jobs"):
+        shard.expand_matrix(_models(56), 5)
+
+
+@pytest.mark.parametrize("bad", [0, 65, -1])
+def test_expand_matrix_rejects_out_of_range_shards(shard: ModuleType, bad: int) -> None:
+    """n_shards must be an integer in 1..64."""
+    with pytest.raises(shard.ShardConfigError, match="Invalid n_shards"):
+        shard.expand_matrix(_models(2), bad)
+
+
+# --------------------------------------------------------------------------- #
+# select_shard_tasks — filter + cap + partition (comment #2)
+# --------------------------------------------------------------------------- #
+
+
+def test_partition_is_disjoint_and_covers_the_whole_selection(shard: ModuleType) -> None:
+    """Across all shards, every task runs exactly once (no gaps, no overlap)."""
+    names = [f"org/t{i}" for i in range(10)]
+    n_shards = 3
+
+    slices = [
+        shard.select_shard_tasks(names, [], 0, n_shards, i) for i in range(n_shards)
+    ]
+
+    flat = [name for s in slices for name in s]
+    assert sorted(flat) == sorted(names)  # covers everything
+    assert len(flat) == len(set(flat))  # no task in two shards
+
+
+def test_include_globs_filter_before_partitioning(shard: ModuleType) -> None:
+    """Only tasks matching an include glob are sharded; others are dropped."""
+    names = ["org/foo-1", "org/bar-1", "org/foo-2", "org/baz"]
+    n_shards = 2
+
+    kept = [
+        name
+        for i in range(n_shards)
+        for name in shard.select_shard_tasks(names, ["org/foo-*"], 0, n_shards, i)
+    ]
+
+    assert sorted(kept) == ["org/foo-1", "org/foo-2"]
+
+
+def test_n_tasks_caps_total_across_shards_not_per_shard(shard: ModuleType) -> None:
+    """n_tasks is a global cap: the shards together run exactly n_tasks tasks.
+
+    This is the comment-#2 regression: an unsharded `--n-tasks 10` must not
+    become 10-per-shard once sharded.
+    """
+    names = [f"org/t{i}" for i in range(20)]
+    n_tasks, n_shards = 10, 4
+
+    total = sum(
+        len(shard.select_shard_tasks(names, [], n_tasks, n_shards, i))
+        for i in range(n_shards)
+    )
+
+    assert total == n_tasks  # not n_tasks * n_shards (== 40)
+
+
+def test_n_tasks_takes_native_order_not_sorted(shard: ModuleType) -> None:
+    """The cap slices the list as given (native manifest order), never sorted.
+
+    Harbor's `--n-tasks` is `filtered_ids[:n_tasks]` in native order, so a
+    sharded run must pick the same first-N as an unsharded run would.
+    """
+    # Deliberately not alphabetical; sorted() would pick a different first 2.
+    names = ["org/zebra", "org/apple", "org/mango", "org/cherry"]
+    n_tasks, n_shards = 2, 2
+
+    selected = [
+        name
+        for i in range(n_shards)
+        for name in shard.select_shard_tasks(names, [], n_tasks, n_shards, i)
+    ]
+
+    # First two in NATIVE order, not sorted(['apple', 'cherry', ...]).
+    assert sorted(selected) == ["org/apple", "org/zebra"]
+
+
+def test_include_and_n_tasks_compose(shard: ModuleType) -> None:
+    """include_globs applies first, then the n_tasks cap, then partitioning."""
+    names = [f"org/keep-{i}" for i in range(6)] + [f"org/drop-{i}" for i in range(6)]
+    n_tasks, n_shards = 3, 2
+
+    selected = [
+        name
+        for i in range(n_shards)
+        for name in shard.select_shard_tasks(names, ["org/keep-*"], n_tasks, n_shards, i)
+    ]
+
+    assert len(selected) == 3
+    assert all(name.startswith("org/keep-") for name in selected)
+
+
+def test_n_shards_one_returns_full_selection(shard: ModuleType) -> None:
+    """n_shards=1 is the whole (filtered/capped) list — the unsharded path."""
+    names = [f"org/t{i}" for i in range(5)]
+    assert shard.select_shard_tasks(names, [], 0, 1, 0) == names
+
+
+def test_select_shard_tasks_rejects_bad_shard_index(shard: ModuleType) -> None:
+    """shard_index must be in range(n_shards)."""
+    with pytest.raises(shard.ShardConfigError, match="shard_index"):
+        shard.select_shard_tasks(["org/t0"], [], 0, 2, 2)

--- a/.github/scripts/test_shard_matrix.py
+++ b/.github/scripts/test_shard_matrix.py
@@ -94,6 +94,39 @@ def test_expand_matrix_rejects_out_of_range_shards(shard: ModuleType, bad: int) 
 
 
 # --------------------------------------------------------------------------- #
+# effective_shards — cap the shard axis so empty jobs aren't spawned
+# --------------------------------------------------------------------------- #
+
+
+def test_effective_shards_no_cap_when_running_all_tasks(shard: ModuleType) -> None:
+    """n_tasks=0 means all tasks: the shard count is used as-is."""
+    assert shard.effective_shards(4, 0) == 4
+
+
+def test_effective_shards_no_cap_when_tasks_exceed_shards(shard: ModuleType) -> None:
+    """n_tasks >= n_shards: every shard gets work, so no reduction."""
+    assert shard.effective_shards(4, 10) == 4
+    assert shard.effective_shards(4, 4) == 4
+
+
+def test_effective_shards_caps_to_task_count(shard: ModuleType) -> None:
+    """n_tasks < n_shards: cap to n_tasks so trailing shards aren't spawned.
+
+    The cited case (n_tasks=1 n_shards=4) collapses to a single shard job.
+    """
+    assert shard.effective_shards(4, 1) == 1
+    assert shard.effective_shards(4, 3) == 3
+
+
+def test_effective_shards_then_expand_emits_only_useful_jobs(shard: ModuleType) -> None:
+    """The capped count feeds expand_matrix: 2 models x 1 effective shard = 2 jobs."""
+    eff = shard.effective_shards(4, 1)
+    out = shard.expand_matrix(_models(2), eff)
+    assert len(out["include"]) == 2
+    assert all(entry["shard"] == 0 for entry in out["include"])
+
+
+# --------------------------------------------------------------------------- #
 # select_shard_tasks — filter + cap + partition (comment #2)
 # --------------------------------------------------------------------------- #
 

--- a/.github/scripts/test_shard_matrix.py
+++ b/.github/scripts/test_shard_matrix.py
@@ -184,6 +184,25 @@ def test_n_shards_one_returns_full_selection(shard: ModuleType) -> None:
     assert shard.select_shard_tasks(names, [], 0, 1, 0) == names
 
 
+def test_fewer_tasks_than_shards_yields_empty_trailing_shards(shard: ModuleType) -> None:
+    """n_tasks < n_shards: early shards get the work, later shards are empty.
+
+    The workflow relies on this to no-op (not fail) empty shard jobs. e.g.
+    n_tasks=1 n_shards=4 -> shard 0 runs the task, shards 1-3 are empty.
+    """
+    names = [f"org/t{i}" for i in range(10)]
+    n_tasks, n_shards = 1, 4
+
+    slices = [
+        shard.select_shard_tasks(names, [], n_tasks, n_shards, i) for i in range(n_shards)
+    ]
+
+    assert slices[0] == ["org/t0"]
+    assert slices[1] == slices[2] == slices[3] == []
+    # Union is still exactly the selected task set (no task lost, none duplicated).
+    assert [name for s in slices for name in s] == ["org/t0"]
+
+
 def test_select_shard_tasks_rejects_bad_shard_index(shard: ModuleType) -> None:
     """shard_index must be in range(n_shards)."""
     with pytest.raises(shard.ShardConfigError, match="shard_index"):

--- a/.github/scripts/test_shard_matrix.py
+++ b/.github/scripts/test_shard_matrix.py
@@ -7,6 +7,7 @@ CI's `pytest .github/scripts/test_*.py` (see `.github/workflows/ci.yml`).
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 from types import ModuleType
 
@@ -240,3 +241,189 @@ def test_select_shard_tasks_rejects_bad_shard_index(shard: ModuleType) -> None:
     """shard_index must be in range(n_shards)."""
     with pytest.raises(shard.ShardConfigError, match="shard_index"):
         shard.select_shard_tasks(["org/t0"], [], 0, 2, 2)
+
+
+# --------------------------------------------------------------------------- #
+# task_display_name — resolve every Harbor task-id shape to org/name
+# --------------------------------------------------------------------------- #
+
+
+class _GetName:
+    """A task id that exposes `get_name()` (every real Harbor TaskId does)."""
+
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def get_name(self) -> str:
+        return self._value
+
+
+class _OrgName:
+    """A `get_name()`-less id carrying bare `org`/`name` attributes (fallback)."""
+
+    def __init__(self, org: str | None, name: str | None) -> None:
+        self.org = org
+        self.name = name
+
+
+def test_task_display_name_prefers_get_name(shard: ModuleType) -> None:
+    """`get_name()` is authoritative — the same name Harbor filters/reports on.
+
+    This is the regression guard: a `PackageTaskId` returns `org/name` from
+    `get_name()`, but a `GitTaskId`/`LocalTaskId` returns `path.name` with no
+    `org`/`name` attributes. Delegating to `get_name()` resolves all of them,
+    where the old `f"{org}/{name}"` reconstruction returned `None` for git/local
+    ids and silently dropped every task.
+    """
+    assert shard.task_display_name(_GetName("acme/widget")) == "acme/widget"
+    assert shard.task_display_name(_GetName("my-task")) == "my-task"
+
+
+def test_task_display_name_dict_fallback(shard: ModuleType) -> None:
+    """Dict-shaped manifest entries fall back to `org`/`name` keys."""
+    assert shard.task_display_name({"org": "acme", "name": "widget"}) == "acme/widget"
+    assert shard.task_display_name({"name": "solo"}) == "solo"
+
+
+def test_task_display_name_attr_fallback(shard: ModuleType) -> None:
+    """Objects without `get_name()` fall back to `org`/`name` attributes."""
+    assert shard.task_display_name(_OrgName("acme", "widget")) == "acme/widget"
+    assert shard.task_display_name(_OrgName(None, "solo")) == "solo"
+
+
+def test_task_display_name_returns_none_when_underivable(shard: ModuleType) -> None:
+    """No derivable name -> None, so the caller can filter and fail loudly.
+
+    An empty `get_name()`, an empty dict, and an attr-less object must all map to
+    `None` rather than `""` or `"None/None"`, so the run step's
+    `[x for ... if x]` filter drops them and the empty-manifest fail-fast fires.
+    """
+    assert shard.task_display_name(_GetName("")) is None
+    assert shard.task_display_name({}) is None
+    assert shard.task_display_name(_OrgName(None, None)) is None
+    assert shard.task_display_name(object()) is None
+
+
+# --------------------------------------------------------------------------- #
+# main — env-driven entry point: matrix + effective n_shards to $GITHUB_OUTPUT
+# --------------------------------------------------------------------------- #
+
+
+def _run_main(
+    shard: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    **env: str,
+) -> dict[str, str]:
+    """Run `main()` with `env` set and return the parsed `$GITHUB_OUTPUT` lines."""
+    output_file = tmp_path / "github_output"
+    output_file.touch()
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    shard.main()
+    written = output_file.read_text().splitlines()
+    return dict(line.split("=", 1) for line in written)
+
+
+def test_main_writes_matrix_and_effective_shards(
+    shard: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`main()` emits both the `matrix=` and `n_shards=` keys the harbor job reads.
+
+    The two-key contract is load-bearing: the run job reads back `n_shards` to
+    partition, so a dropped/renamed key would silently mismatch the matrix and
+    drop tasks. Mirrors `test_models.py`'s `main()` output test.
+    """
+    matrix_in = json.dumps({"include": [{"model": "p:m0"}, {"model": "p:m1"}]})
+    keyed = _run_main(
+        shard, monkeypatch, tmp_path, MODEL_MATRIX=matrix_in, N_SHARDS="3", N_TASKS="0"
+    )
+
+    assert keyed["n_shards"] == "3"
+    matrix = json.loads(keyed["matrix"])
+    assert len(matrix["include"]) == 2 * 3  # cross-product, capped to nothing
+    assert sorted(e["shard"] for e in matrix["include"] if e["model"] == "p:m0") == [
+        0,
+        1,
+        2,
+    ]
+
+
+def test_main_output_is_single_line_per_key(
+    shard: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GitHub Actions parses `key=value\\n`; guards against an `indent=2` refactor."""
+    matrix_in = json.dumps({"include": [{"model": "p:m0"}]})
+    output_file = tmp_path / "github_output"
+    output_file.touch()
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    monkeypatch.setenv("MODEL_MATRIX", matrix_in)
+
+    shard.main()
+
+    lines = output_file.read_text().splitlines()
+    assert all(line.count("=") >= 1 and "\n" not in line for line in lines)
+    assert {line.split("=", 1)[0] for line in lines} == {"matrix", "n_shards"}
+
+
+def test_main_applies_effective_shard_cap(
+    shard: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """N_TASKS < N_SHARDS collapses to n_tasks shards end-to-end (cap reaches output).
+
+    `effective_shards` is unit-tested in isolation; this proves the cap actually
+    flows through `main()` into the emitted matrix (1 shard, not 4).
+    """
+    matrix_in = json.dumps({"include": [{"model": "p:m0"}, {"model": "p:m1"}]})
+    keyed = _run_main(
+        shard, monkeypatch, tmp_path, MODEL_MATRIX=matrix_in, N_SHARDS="4", N_TASKS="1"
+    )
+
+    assert keyed["n_shards"] == "1"
+    matrix = json.loads(keyed["matrix"])
+    assert len(matrix["include"]) == 2  # 2 models x 1 effective shard
+    assert all(entry["shard"] == 0 for entry in matrix["include"])
+
+
+def test_main_defaults_to_single_unsharded_matrix(
+    shard: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unset N_SHARDS/N_TASKS -> n_shards=1, one shard-0 job per model (no change)."""
+    monkeypatch.delenv("N_SHARDS", raising=False)
+    monkeypatch.delenv("N_TASKS", raising=False)
+    matrix_in = json.dumps({"include": [{"model": "p:m0"}, {"model": "p:m1"}]})
+    keyed = _run_main(shard, monkeypatch, tmp_path, MODEL_MATRIX=matrix_in)
+
+    assert keyed["n_shards"] == "1"
+    matrix = json.loads(keyed["matrix"])
+    assert len(matrix["include"]) == 2
+    assert all(entry["shard"] == 0 for entry in matrix["include"])
+
+
+@pytest.mark.parametrize("var", ["N_SHARDS", "N_TASKS"])
+def test_main_rejects_non_integer_env(
+    shard: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, var: str
+) -> None:
+    """A non-integer N_SHARDS/N_TASKS exits 1 (not a stack trace)."""
+    monkeypatch.setenv("MODEL_MATRIX", json.dumps({"include": [{"model": "p:m0"}]}))
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "github_output"))
+    monkeypatch.setenv(var, "not-a-number")
+
+    with pytest.raises(SystemExit) as excinfo:
+        shard.main()
+    assert excinfo.value.code == 1
+
+
+def test_main_rejects_matrix_overflow_as_exit(
+    shard: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A `ShardConfigError` (matrix over the 256 cap) becomes exit 1, not a traceback."""
+    big = json.dumps({"include": [{"model": f"p:m{i}"} for i in range(129)]})
+    monkeypatch.setenv("MODEL_MATRIX", big)
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "github_output"))
+    monkeypatch.setenv("N_SHARDS", "2")  # 129 * 2 = 258 > 256
+
+    with pytest.raises(SystemExit) as excinfo:
+        shard.main()
+    assert excinfo.value.code == 1

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -165,6 +165,21 @@ on:
         required: true
         default: "1"
         type: string
+      agent_timeout_multiplier:
+        description: "Multiplier for the agent EXECUTION timeout (e.g. 0.1 caps each rollout's wall-clock to bound model cost). Setup + env-build timeouts are unaffected, so the agent-setup phase is still tested at full budget — useful for cheap concurrency stress tests."
+        required: false
+        default: "1.0"
+        type: string
+      disable_verification:
+        description: "Skip the task verifier (tests). For setup/concurrency stress tests where task pass/fail is not the goal."
+        required: false
+        default: false
+        type: boolean
+      n_shards:
+        description: "Split the dataset's tasks across N parallel shard jobs per model (each on its own runner at the per-job concurrency). 1 = single job over all tasks (default). Use >1 to spread orchestration load and avoid runner saturation."
+        required: false
+        default: "1"
+        type: string
       harbor_package_override:
         description: "Optional: install Harbor from an arbitrary package spec (e.g. 'harbor[langsmith] @ git+https://github.com/owner/harbor.git@branch') instead of the locked version, to test an unreleased Harbor build. Leave empty to use the pinned Harbor."
         required: false
@@ -183,7 +198,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: evals
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix: ${{ steps.shard-matrix.outputs.matrix }}
     env:
       LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
     steps:
@@ -235,6 +250,28 @@ jobs:
         env:
           HARBOR_MODELS: ${{ inputs.models_override || inputs.models || 'all' }}
 
+      - name: "🔀 Expand matrix by shard"
+        id: shard-matrix
+        env:
+          MODEL_MATRIX: ${{ steps.set-matrix.outputs.matrix }}
+          N_SHARDS: ${{ inputs.n_shards || '1' }}
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os, sys
+
+          raw = os.environ.get("N_SHARDS", "1")
+          if not raw.isdigit() or not (1 <= int(raw) <= 64):
+              print(f"::error::Invalid n_shards (must be 1..64): {raw!r}", file=sys.stderr)
+              sys.exit(1)
+          n = int(raw)
+          mm = json.loads(os.environ["MODEL_MATRIX"])
+          include = mm.get("include", [])
+          # Cross-product each model entry with the shard axis. n=1 -> shard 0 only
+          # (one job per model over the whole dataset; identical to pre-sharding).
+          expanded = [{**entry, "shard": s} for entry in include for s in range(n)]
+          print("matrix=" + json.dumps({"include": expanded}, separators=(",", ":")))
+          PY
+
   harbor:
     name: "📊 Evals - Harbor (${{ matrix.model }} / ${{ inputs.sandbox_env }} / ${{ inputs.agent_impl }})"
     needs: prep
@@ -253,6 +290,10 @@ jobs:
       HARBOR_N_TASKS: ${{ inputs.n_tasks }}
       HARBOR_INCLUDE_TASKS: ${{ inputs.include_tasks }}
       HARBOR_ROLLOUTS_PER_TASK: ${{ inputs.rollouts_per_task }}
+      HARBOR_AGENT_TIMEOUT_MULTIPLIER: ${{ inputs.agent_timeout_multiplier || '1.0' }}
+      HARBOR_DISABLE_VERIFICATION: ${{ inputs.disable_verification || 'false' }}
+      HARBOR_SHARD_INDEX: ${{ matrix.shard }}
+      HARBOR_N_SHARDS: ${{ inputs.n_shards || '1' }}
       HARBOR_SANDBOX_ENV: ${{ inputs.sandbox_env }}
       HARBOR_AGENT_IMPL: ${{ inputs.agent_impl }}
       HARBOR_MODEL: ${{ matrix.model }}
@@ -335,7 +376,9 @@ jobs:
         env:
           # Passed via env (not interpolated into the shell) to avoid injection.
           HARBOR_PACKAGE_OVERRIDE: ${{ inputs.harbor_package_override }}
-        run: uv pip install "$HARBOR_PACKAGE_OVERRIDE"
+        # --reinstall --refresh defeats any stale cached wheel for this git ref,
+        # so re-running with the same override picks up a freshly-built package.
+        run: uv pip install --reinstall --refresh "$HARBOR_PACKAGE_OVERRIDE"
 
       - name: "🔇 Suppress Harbor first-run tips"
         run: |
@@ -385,9 +428,60 @@ jobs:
             echo "::error::Invalid rollouts_per_task: $HARBOR_ROLLOUTS_PER_TASK"
             exit 1
           fi
+          # Positive decimal only; reject all-zero (0, 0.0, ...) which would mean a 0s timeout.
+          if ! [[ "$HARBOR_AGENT_TIMEOUT_MULTIPLIER" =~ ^[0-9]+(\.[0-9]+)?$ ]] || [[ "$HARBOR_AGENT_TIMEOUT_MULTIPLIER" =~ ^0+(\.0+)?$ ]]; then
+            echo "::error::Invalid agent_timeout_multiplier (must be a positive decimal): $HARBOR_AGENT_TIMEOUT_MULTIPLIER"
+            exit 1
+          fi
+          # Allowlist the boolean; only literal true/false accepted.
+          verification_flag=()
+          case "$HARBOR_DISABLE_VERIFICATION" in
+            true)  verification_flag=(--disable-verification) ;;
+            false) ;;
+            *) echo "::error::Invalid disable_verification (true|false): $HARBOR_DISABLE_VERIFICATION"; exit 1 ;;
+          esac
 
           include_args=()
-          if [ -n "$HARBOR_INCLUDE_TASKS" ]; then
+          if [[ "$HARBOR_N_SHARDS" =~ ^[1-9][0-9]*$ ]] && [ "$HARBOR_N_SHARDS" -gt 1 ]; then
+            # Sharding: run only this shard's disjoint slice of the dataset.
+            # Resolve the live task list from Harbor's own manifest (no drift) and
+            # pick indices where i % n_shards == shard_index. Overrides include_tasks.
+            if ! [[ "$HARBOR_SHARD_INDEX" =~ ^[0-9]+$ ]] || [ "$HARBOR_SHARD_INDEX" -ge "$HARBOR_N_SHARDS" ]; then
+              echo "::error::Invalid shard index '$HARBOR_SHARD_INDEX' for $HARBOR_N_SHARDS shards"; exit 1
+            fi
+            uv run python - <<'PY' > shard_tasks.txt
+          import asyncio
+          import os
+          from harbor.registry.client.package import PackageDatasetClient
+
+          ds = os.environ["HARBOR_DATASET"]
+          n = int(os.environ["HARBOR_N_SHARDS"])
+          i = int(os.environ["HARBOR_SHARD_INDEX"])
+          md = asyncio.run(PackageDatasetClient().get_dataset_metadata(f"{ds}@latest"))
+
+          def task_name(t):
+              org = getattr(t, "org", None)
+              name = getattr(t, "name", None)
+              if isinstance(t, dict):
+                  org = org or t.get("org")
+                  name = name or t.get("name")
+              return f"{org}/{name}" if org else name
+
+          names = sorted(x for x in (task_name(t) for t in md.task_ids) if x)
+          print("\n".join(nm for j, nm in enumerate(names) if j % n == i))
+          PY
+            mapfile -t shard_tasks < shard_tasks.txt
+            if [ "${#shard_tasks[@]}" -eq 0 ]; then
+              echo "::error::Shard $HARBOR_SHARD_INDEX/$HARBOR_N_SHARDS resolved 0 tasks"; exit 1
+            fi
+            for t in "${shard_tasks[@]}"; do
+              if ! [[ "$t" =~ ^[A-Za-z0-9._/?*-]+$ ]]; then
+                echo "::error::Invalid resolved shard task name: $t"; exit 1
+              fi
+              include_args+=(--include-task-name "$t")
+            done
+            echo "Shard $HARBOR_SHARD_INDEX of $HARBOR_N_SHARDS -> ${#shard_tasks[@]} tasks: ${shard_tasks[*]}"
+          elif [ -n "$HARBOR_INCLUDE_TASKS" ]; then
             read -r -a include_tasks <<< "$HARBOR_INCLUDE_TASKS"
             for t in "${include_tasks[@]}"; do
               if ! [[ "$t" =~ ^[A-Za-z0-9._/?*-]+$ ]]; then
@@ -471,6 +565,8 @@ jobs:
             --dataset "$HARBOR_DATASET" \
             -n "$HARBOR_CONCURRENCY" \
             --n-attempts "$HARBOR_ROLLOUTS_PER_TASK" \
+            --agent-timeout-multiplier "$HARBOR_AGENT_TIMEOUT_MULTIPLIER" \
+            "${verification_flag[@]}" \
             $n_tasks_flag \
             "${include_args[@]}" \
             "${agent_env_args[@]}" \

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -476,7 +476,12 @@ jobs:
           PY
             mapfile -t shard_tasks < shard_tasks.txt
             if [ "${#shard_tasks[@]}" -eq 0 ]; then
-              echo "::error::Shard $HARBOR_SHARD_INDEX/$HARBOR_N_SHARDS resolved 0 tasks (n_tasks may be smaller than n_shards)"; exit 1
+              # Fewer selected tasks than shards (e.g. n_tasks < n_shards): this
+              # shard's slice is legitimately empty. No-op successfully — the other
+              # shards cover the full selection — instead of failing the workflow.
+              echo "Shard $HARBOR_SHARD_INDEX/$HARBOR_N_SHARDS has no tasks (selection smaller than shard count); skipping."
+              echo "SHARD_EMPTY=true" >> "$GITHUB_ENV"
+              exit 0
             fi
             for t in "${shard_tasks[@]}"; do
               if ! [[ "$t" =~ ^[A-Za-z0-9._/?*-]+$ ]]; then
@@ -587,6 +592,8 @@ jobs:
 
       - name: "🔍 Find latest Harbor job"
         id: latest-job
+        # An empty shard skipped the Harbor run, so there is no job dir to find.
+        if: ${{ env.SHARD_EMPTY != 'true' }}
         run: |
           latest_job=$(python - <<'PY'
           from pathlib import Path
@@ -609,11 +616,15 @@ jobs:
           HARBOR_LANGSMITH_DATASET: ${{ env.HARBOR_LANGSMITH_DATASET }}
           HARBOR_LANGSMITH_EXPERIMENT: ${{ env.HARBOR_LANGSMITH_EXPERIMENT }}
           LATEST_JOB_OUTCOME: ${{ steps.latest-job.outcome }}
+          SHARD_EMPTY: ${{ env.SHARD_EMPTY }}
         run: |
           {
             echo "## Harbor run"
             echo
             echo "- Model: $HARBOR_MODEL"
+            if [ "$SHARD_EMPTY" = "true" ]; then
+              echo "- Shard: $HARBOR_SHARD_INDEX/$HARBOR_N_SHARDS — empty (no tasks assigned), skipped"
+            fi
             echo "- Dataset: ${HARBOR_DATASET}"
             echo "- Sandbox: ${HARBOR_SANDBOX_ENV}"
             echo "- Concurrency: ${HARBOR_CONCURRENCY}"

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -176,7 +176,7 @@ on:
         default: false
         type: boolean
       n_shards:
-        description: "Split the dataset's tasks across N parallel shard jobs per model (each on its own runner at the per-job concurrency). 1 = single job over all tasks (default). Use >1 to spread orchestration load and avoid runner saturation."
+        description: "Split the dataset's tasks across N parallel shard jobs per model (each on its own runner at the per-job concurrency). 1 = single job over all tasks (default). Use >1 to spread orchestration load and avoid runner saturation. Composes with include_tasks/n_tasks: those select the task set first, then it's partitioned across shards (total tasks run is unchanged). Capped so models x shards <= 256 (GitHub's matrix limit)."
         required: false
         default: "1"
         type: string
@@ -252,25 +252,13 @@ jobs:
 
       - name: "🔀 Expand matrix by shard"
         id: shard-matrix
+        # Cross-products the model matrix with the shard axis and guards the
+        # result against GitHub's 256-job matrix cap. See shard_matrix.py
+        # (unit-tested in .github/scripts/test_shard_matrix.py).
         env:
           MODEL_MATRIX: ${{ steps.set-matrix.outputs.matrix }}
           N_SHARDS: ${{ inputs.n_shards || '1' }}
-        run: |
-          python - <<'PY' >> "$GITHUB_OUTPUT"
-          import json, os, sys
-
-          raw = os.environ.get("N_SHARDS", "1")
-          if not raw.isdigit() or not (1 <= int(raw) <= 64):
-              print(f"::error::Invalid n_shards (must be 1..64): {raw!r}", file=sys.stderr)
-              sys.exit(1)
-          n = int(raw)
-          mm = json.loads(os.environ["MODEL_MATRIX"])
-          include = mm.get("include", [])
-          # Cross-product each model entry with the shard axis. n=1 -> shard 0 only
-          # (one job per model over the whole dataset; identical to pre-sharding).
-          expanded = [{**entry, "shard": s} for entry in include for s in range(n)]
-          print("matrix=" + json.dumps({"include": expanded}, separators=(",", ":")))
-          PY
+        run: python .github/scripts/shard_matrix.py
 
   harbor:
     name: "📊 Evals - Harbor (${{ matrix.model }} / ${{ inputs.sandbox_env }} / ${{ inputs.agent_impl }})"
@@ -443,20 +431,32 @@ jobs:
 
           include_args=()
           if [[ "$HARBOR_N_SHARDS" =~ ^[1-9][0-9]*$ ]] && [ "$HARBOR_N_SHARDS" -gt 1 ]; then
-            # Sharding: run only this shard's disjoint slice of the dataset.
-            # Resolve the live task list from Harbor's own manifest (no drift) and
-            # pick indices where i % n_shards == shard_index. Overrides include_tasks.
+            # Sharding: run this shard's disjoint slice of the dataset. Resolve the
+            # live task list from Harbor's own manifest (no drift), compose it with
+            # include_tasks/n_tasks exactly as an unsharded run would, then partition
+            # by i % n_shards. select_shard_tasks mirrors Harbor's _filter_task_ids
+            # (see .github/scripts/shard_matrix.py + its tests).
             if ! [[ "$HARBOR_SHARD_INDEX" =~ ^[0-9]+$ ]] || [ "$HARBOR_SHARD_INDEX" -ge "$HARBOR_N_SHARDS" ]; then
               echo "::error::Invalid shard index '$HARBOR_SHARD_INDEX' for $HARBOR_N_SHARDS shards"; exit 1
             fi
             uv run python - <<'PY' > shard_tasks.txt
           import asyncio
           import os
+          import sys
           from harbor.registry.client.package import PackageDatasetClient
+
+          # shard_matrix.py is pure stdlib; import it from the checkout (repo root).
+          sys.path.insert(0, os.path.join(os.environ["GITHUB_WORKSPACE"], ".github", "scripts"))
+          from shard_matrix import select_shard_tasks
 
           ds = os.environ["HARBOR_DATASET"]
           n = int(os.environ["HARBOR_N_SHARDS"])
           i = int(os.environ["HARBOR_SHARD_INDEX"])
+          include_globs = os.environ.get("HARBOR_INCLUDE_TASKS", "").split()
+          raw_n_tasks = os.environ.get("HARBOR_N_TASKS", "0").strip() or "0"
+          if not raw_n_tasks.isdigit():
+              sys.exit(f"::error::Invalid n_tasks (must be an integer): {raw_n_tasks!r}")
+          n_tasks = int(raw_n_tasks)
           md = asyncio.run(PackageDatasetClient().get_dataset_metadata(f"{ds}@latest"))
 
           def task_name(t):
@@ -467,12 +467,16 @@ jobs:
                   name = name or t.get("name")
               return f"{org}/{name}" if org else name
 
-          names = sorted(x for x in (task_name(t) for t in md.task_ids) if x)
-          print("\n".join(nm for j, nm in enumerate(names) if j % n == i))
+          # Native manifest order (do NOT sort): the n_tasks cap must pick the same
+          # first-N that Harbor's --n-tasks would (filtered_ids[:n_tasks], native order).
+          names = [x for x in (task_name(t) for t in md.task_ids) if x]
+          tasks = select_shard_tasks(names, include_globs, n_tasks, n, i)
+          if tasks:
+              print("\n".join(tasks))
           PY
             mapfile -t shard_tasks < shard_tasks.txt
             if [ "${#shard_tasks[@]}" -eq 0 ]; then
-              echo "::error::Shard $HARBOR_SHARD_INDEX/$HARBOR_N_SHARDS resolved 0 tasks"; exit 1
+              echo "::error::Shard $HARBOR_SHARD_INDEX/$HARBOR_N_SHARDS resolved 0 tasks (n_tasks may be smaller than n_shards)"; exit 1
             fi
             for t in "${shard_tasks[@]}"; do
               if ! [[ "$t" =~ ^[A-Za-z0-9._/?*-]+$ ]]; then
@@ -480,6 +484,10 @@ jobs:
               fi
               include_args+=(--include-task-name "$t")
             done
+            # The n_tasks cap is already applied during selection above; clear the
+            # flag so Harbor doesn't re-cap each shard to n_tasks (which would run up
+            # to n_tasks * n_shards instead of n_tasks total).
+            n_tasks_flag=""
             echo "Shard $HARBOR_SHARD_INDEX of $HARBOR_N_SHARDS -> ${#shard_tasks[@]} tasks: ${shard_tasks[*]}"
           elif [ -n "$HARBOR_INCLUDE_TASKS" ]; then
             read -r -a include_tasks <<< "$HARBOR_INCLUDE_TASKS"

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -199,6 +199,9 @@ jobs:
     environment: evals
     outputs:
       matrix: ${{ steps.shard-matrix.outputs.matrix }}
+      # Effective shard count after capping to the selectable work (<= n_shards).
+      # The harbor job reads this so its partition matches the emitted matrix.
+      n_shards: ${{ steps.shard-matrix.outputs.n_shards }}
     env:
       LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
     steps:
@@ -252,12 +255,14 @@ jobs:
 
       - name: "🔀 Expand matrix by shard"
         id: shard-matrix
-        # Cross-products the model matrix with the shard axis and guards the
-        # result against GitHub's 256-job matrix cap. See shard_matrix.py
-        # (unit-tested in .github/scripts/test_shard_matrix.py).
+        # Cross-products the model matrix with the shard axis, caps the shard
+        # count to the selectable work (min(n_shards, n_tasks)) so empty shard
+        # jobs aren't spawned, and guards against GitHub's 256-job matrix cap.
+        # See shard_matrix.py (unit-tested in test_shard_matrix.py).
         env:
           MODEL_MATRIX: ${{ steps.set-matrix.outputs.matrix }}
           N_SHARDS: ${{ inputs.n_shards || '1' }}
+          N_TASKS: ${{ inputs.n_tasks }}
         run: python .github/scripts/shard_matrix.py
 
   harbor:
@@ -281,7 +286,9 @@ jobs:
       HARBOR_AGENT_TIMEOUT_MULTIPLIER: ${{ inputs.agent_timeout_multiplier || '1.0' }}
       HARBOR_DISABLE_VERIFICATION: ${{ inputs.disable_verification || 'false' }}
       HARBOR_SHARD_INDEX: ${{ matrix.shard }}
-      HARBOR_N_SHARDS: ${{ inputs.n_shards || '1' }}
+      # Effective shard count from prep (capped to selectable work), not the raw
+      # input — the partition must match the matrix or tasks would be dropped.
+      HARBOR_N_SHARDS: ${{ needs.prep.outputs.n_shards || '1' }}
       HARBOR_SANDBOX_ENV: ${{ inputs.sandbox_env }}
       HARBOR_AGENT_IMPL: ${{ inputs.agent_impl }}
       HARBOR_MODEL: ${{ matrix.model }}

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -436,13 +436,19 @@ jobs:
             *) echo "::error::Invalid disable_verification (true|false): $HARBOR_DISABLE_VERIFICATION"; exit 1 ;;
           esac
 
+          if ! [[ "$HARBOR_DATASET" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::Invalid Harbor dataset ref: $HARBOR_DATASET"
+            exit 1
+          fi
+
           include_args=()
           if [[ "$HARBOR_N_SHARDS" =~ ^[1-9][0-9]*$ ]] && [ "$HARBOR_N_SHARDS" -gt 1 ]; then
             # Sharding: run this shard's disjoint slice of the dataset. Resolve the
             # live task list from Harbor's own manifest (no drift), compose it with
             # include_tasks/n_tasks exactly as an unsharded run would, then partition
-            # by i % n_shards. select_shard_tasks mirrors Harbor's _filter_task_ids
-            # (see .github/scripts/shard_matrix.py + its tests).
+            # by i % n_shards. select_shard_tasks reproduces the include-glob +
+            # n_tasks subset of Harbor's _filter_task_ids; task_display_name mirrors
+            # each task id's get_name() (see .github/scripts/shard_matrix.py + tests).
             if ! [[ "$HARBOR_SHARD_INDEX" =~ ^[0-9]+$ ]] || [ "$HARBOR_SHARD_INDEX" -ge "$HARBOR_N_SHARDS" ]; then
               echo "::error::Invalid shard index '$HARBOR_SHARD_INDEX' for $HARBOR_N_SHARDS shards"; exit 1
             fi
@@ -450,11 +456,12 @@ jobs:
           import asyncio
           import os
           import sys
+          from fnmatch import fnmatch
           from harbor.registry.client.package import PackageDatasetClient
 
           # shard_matrix.py is pure stdlib; import it from the checkout (repo root).
           sys.path.insert(0, os.path.join(os.environ["GITHUB_WORKSPACE"], ".github", "scripts"))
-          from shard_matrix import select_shard_tasks
+          from shard_matrix import select_shard_tasks, task_display_name
 
           ds = os.environ["HARBOR_DATASET"]
           n = int(os.environ["HARBOR_N_SHARDS"])
@@ -466,18 +473,31 @@ jobs:
           n_tasks = int(raw_n_tasks)
           md = asyncio.run(PackageDatasetClient().get_dataset_metadata(f"{ds}@latest"))
 
-          def task_name(t):
-              org = getattr(t, "org", None)
-              name = getattr(t, "name", None)
-              if isinstance(t, dict):
-                  org = org or t.get("org")
-                  name = name or t.get("name")
-              return f"{org}/{name}" if org else name
-
           # Native manifest order (do NOT sort): the n_tasks cap must pick the same
           # first-N that Harbor's --n-tasks would (filtered_ids[:n_tasks], native order).
-          names = [x for x in (task_name(t) for t in md.task_ids) if x]
-          tasks = select_shard_tasks(names, include_globs, n_tasks, n, i)
+          names = [x for x in (task_display_name(t) for t in md.task_ids) if x]
+          if not names:
+              # Resolved zero usable names from a non-empty manifest -> the id shape
+              # changed and get_name() stopped yielding a name. Fail loudly instead
+              # of letting every shard collapse into the legitimate-empty no-op
+              # below, which would run the whole sharded job on nothing and report
+              # green. (A genuinely empty selection is handled per-shard, not here.)
+              sys.exit(
+                  f"::error::Resolved 0 usable task names from {ds}@latest "
+                  f"({len(md.task_ids)} task ids in manifest); unexpected task-id "
+                  "shape (get_name() returned nothing)."
+              )
+          selected = names
+          if include_globs:
+              selected = [
+                  name for name in selected if any(fnmatch(name, glob) for glob in include_globs)
+              ]
+              if not selected:
+                  sys.exit(
+                      "::error::No Harbor tasks matched include_tasks filters: "
+                      + " ".join(include_globs)
+                  )
+          tasks = select_shard_tasks(selected, [], n_tasks, n, i)
           if tasks:
               print("\n".join(tasks))
           PY
@@ -510,10 +530,6 @@ jobs:
               fi
               include_args+=(--include-task-name "$t")
             done
-          fi
-          if ! [[ "$HARBOR_DATASET" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-            echo "::error::Invalid Harbor dataset ref: $HARBOR_DATASET"
-            exit 1
           fi
 
           env_flag="--env $HARBOR_SANDBOX_ENV"

--- a/libs/evals/tests/unit_tests/test_harbor_langsmith_integration.py
+++ b/libs/evals/tests/unit_tests/test_harbor_langsmith_integration.py
@@ -94,6 +94,9 @@ def test_harbor_workflow_uses_plugin_instead_of_manual_experiment_steps() -> Non
     ) in workflow
     assert "HARBOR_INCLUDE_TASKS: ${{ inputs.include_tasks }}" in workflow
     assert "HARBOR_ROLLOUTS_PER_TASK: ${{ inputs.rollouts_per_task }}" in workflow
+    assert "from fnmatch import fnmatch" in workflow
+    assert "No Harbor tasks matched include_tasks filters" in workflow
+    assert "select_shard_tasks(selected, [], n_tasks, n, i)" in workflow
     assert 'echo "| \\`dataset\\` | \\`${DATASET}\\` |"' in workflow
     assert "INCLUDE_TASKS: ${{ inputs.include_tasks }}" in workflow
     assert 'echo "| \\`include_tasks\\` | \\`${INCLUDE_TASKS}\\` |"' in workflow


### PR DESCRIPTION
- **`agent_timeout_multiplier`** — scale the agent EXECUTION timeout (e.g. `0.1` to bound per-rollout wall-clock for cheap concurrency stress tests; setup/env-build budgets unaffected).
- **`disable_verification`** — skip the task verifier (tests) for setup/concurrency stress runs.
- **`n_shards`** — split the dataset's tasks across N parallel shard jobs per model
- **`--reinstall --refresh`** on the `harbor_package_override` install, so re-running the same git ref picks up a freshly-built wheel instead of a stale cached one