### PR TITLE
docs(repo): add release note guidance to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,9 @@ Thank you for contributing to Deep Agents! Follow these steps to have your pull 
   - If there are any breaking changes, please clearly describe them.
   - If this PR depends on another PR being merged first, please include "Depends on #PR_NUMBER" in the description.
 
+## Release note
+<!-- Required for net new features or behavior-changing bugfixes. State the user-visible change in release-note-ready language. Omit this section for chores, refactors, or test-only changes. -->
+
 3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.
 
   - We will not consider a PR unless these three are passing in CI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,7 @@ The description *is* the summary — do not add a `# Summary` header.
 - Do **not** cite line numbers; they go stale as soon as the file changes.
 - Rarely include full file paths or filenames. Reference the affected symbol, class, or subsystem by name instead.
 - Wrap class, function, method, parameter, and variable names in backticks.
+- For net new features or behavior-changing bugfixes, PR descriptions should include a `## Release note` section that states the user-visible change in release-note-ready language. Otherwise, omit the header.
 - Skip dedicated "Test plan" or "Testing" sections in most cases. Mention tests only when coverage is non-obvious, risky, or otherwise notable.
 - Call out areas of the change that require careful review.
 


### PR DESCRIPTION
PR descriptions for new features and behavior-changing bugfixes now have an explicit place for release-note-ready text. The template asks authors to include that section only when it applies, and the contributor guidance tells agents to omit the header otherwise.