### PR TITLE
chore(talon): add release-please version marker

### DIFF
--- a/libs/talon/deepagents_talon/_version.py
+++ b/libs/talon/deepagents_talon/_version.py
@@ -1,3 +1,3 @@
 """Version marker managed by release-please."""
 
-__version__ = "0.0.1"
+__version__ = "0.0.1"  # x-release-please-version


### PR DESCRIPTION
Adds the release-please version marker to Talon's importable version constant so future automated release PRs keep it in sync with package metadata.

Verified with `make -C libs/talon format_diff` and `make -C libs/talon lint_diff`.

Made by [Open SWE](https://openswe.vercel.app/agents/93e9e03f-eef2-421b-10e5-b26249dbd9ec)