### PR TITLE
test(code): cover remote auto-approve HITL

### DIFF
--- a/libs/code/deepagents_code/_testing_models.py
+++ b/libs/code/deepagents_code/_testing_models.py
@@ -18,6 +18,21 @@ if TYPE_CHECKING:
     from langchain_core.tools import BaseTool
 
 
+# Prompt markers that drive `ToolCallingIntegrationChatModel`. Each marker is the
+# full token (including the trailing `=`); the file path follows on the same line,
+# e.g. `DCA_TEST_WRITE_FILE=/tmp/out.txt`. These are the single source of truth
+# shared with the integration tests, so the model and tests cannot drift apart.
+DCA_TEST_WRITE_FILE_MARKER = "DCA_TEST_WRITE_FILE="
+DCA_TEST_DELEGATE_WRITE_MARKER = "DCA_TEST_DELEGATE_WRITE="
+DCA_SUBAGENT_WRITE_FILE_MARKER = "DCA_SUBAGENT_WRITE_FILE="
+
+# Distinct file contents per write path, so a test asserting on file content can
+# prove which branch executed — in particular that subagent mode delegated through
+# the `task` tool rather than writing directly.
+TOP_LEVEL_WRITE_CONTENT = "auto-approved"
+SUBAGENT_WRITE_CONTENT = "auto-approved-subagent"
+
+
 class DeterministicIntegrationChatModel(GenericFakeChatModel):
     """Deterministic chat model for integration tests.
 
@@ -141,4 +156,162 @@ class DeterministicIntegrationChatModel(GenericFakeChatModel):
             "messages to summarize" in lowered
             or "condense the following conversation" in lowered
             or "<summary>" in lowered
+        )
+
+
+def _extract_marker_path(prompt: str, marker: str) -> str:
+    """Extract the file path that follows a prompt marker on the same line.
+
+    Args:
+        prompt: The flattened prompt text.
+        marker: The marker token (including its trailing `=`) to locate.
+
+    Returns:
+        The stripped file path immediately following the marker.
+
+    Raises:
+        ValueError: If the marker is present but not followed by a path, so a
+            malformed test prompt fails loudly here instead of silently
+            degrading to a `"done"` reply or raising an opaque `IndexError`.
+    """
+    _, _, tail = prompt.partition(marker)
+    lines = tail.splitlines()
+    file_path = lines[0].strip() if lines else ""
+    if not file_path:
+        msg = (
+            f"Test model saw marker {marker!r} but found no file path after it; "
+            f"check the integration-test prompt construction."
+        )
+        raise ValueError(msg)
+    return file_path
+
+
+def _tool_call_result(name: str, args: dict[str, Any], call_id: str) -> ChatResult:
+    """Build a single-tool-call `ChatResult`.
+
+    Returns:
+        A `ChatResult` wrapping an `AIMessage` with exactly one tool call.
+    """
+    return ChatResult(
+        generations=[
+            ChatGeneration(
+                message=AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": name,
+                            "args": args,
+                            "id": call_id,
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            )
+        ]
+    )
+
+
+class ToolCallingIntegrationChatModel(DeterministicIntegrationChatModel):
+    """Deterministic tool-calling model for auto-approve integration tests.
+
+    Generation is driven entirely by prompt markers (the module-level `DCA_*`
+    constants), so output is restart-safe and independent of call ordering — the
+    same rationale as the parent `DeterministicIntegrationChatModel`:
+
+    - `DCA_TEST_WRITE_FILE=<path>` emits a top-level `write_file` call.
+    - `DCA_TEST_DELEGATE_WRITE=<path>` emits a `task` call delegating to the
+      `general-purpose` subagent, whose prompt then carries
+      `DCA_SUBAGENT_WRITE_FILE=<path>` to trigger the subagent's `write_file`.
+    - `DCA_SUBAGENT_WRITE_FILE=<path>` emits the subagent's `write_file` call.
+
+    Each marker fires only on the agent's first turn (no prior `ToolMessage`),
+    so once the tool result returns the model replies with a plain `"done"` and
+    the agent loop terminates instead of re-issuing the tool call.
+    """
+
+    # Only `_generate` is overridden; the inherited `_stream` would bypass this
+    # marker dispatch entirely, so streaming must be disabled.
+    disable_streaming: bool = True
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,  # noqa: ARG002
+        run_manager: CallbackManagerForLLMRun | None = None,  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002
+    ) -> ChatResult:
+        """Emit a deterministic tool call (or terminal reply) from prompt markers.
+
+        The `has_tool_result` guard ensures each marker fires only on the
+        agent's first turn; once a `ToolMessage` is present the model returns
+        `"done"` so the agent loop terminates.
+
+        A recognized marker with no file path raises `ValueError` (via
+        `_extract_marker_path`) rather than degrading to `"done"`.
+
+        Returns:
+            A single-message `ChatResult`: an `AIMessage` carrying a `task` or
+            `write_file` tool call when a marker matches and no tool result is
+            present yet, otherwise a plain `"done"` reply.
+        """
+        prompt = "\n".join(
+            text
+            for message in messages
+            if (text := self._stringify_message(message)).strip()
+        )
+        has_tool_result = any(message.type == "tool" for message in messages)
+        if not has_tool_result:
+            for marker, build_tool_call in self._marker_dispatch():
+                if marker in prompt:
+                    name, args, call_id = build_tool_call(
+                        _extract_marker_path(prompt, marker)
+                    )
+                    return _tool_call_result(name, args, call_id)
+
+        return ChatResult(
+            generations=[ChatGeneration(message=AIMessage(content="done"))]
+        )
+
+    @staticmethod
+    def _marker_dispatch() -> tuple[
+        tuple[str, Callable[[str], tuple[str, dict[str, Any], str]]], ...
+    ]:
+        """Return ordered `(marker, tool-call builder)` pairs.
+
+        The delegate marker is checked before the plain write markers because
+        its emitted `task` description embeds `DCA_SUBAGENT_WRITE_FILE=`; the
+        first marker found in the prompt wins.
+
+        Returns:
+            Marker-to-builder pairs in precedence order. Each builder maps an
+            extracted file path to a `(tool_name, args, call_id)` triple.
+        """
+        return (
+            (
+                DCA_TEST_DELEGATE_WRITE_MARKER,
+                lambda path: (
+                    "task",
+                    {
+                        "description": f"{DCA_SUBAGENT_WRITE_FILE_MARKER}{path}",
+                        "subagent_type": "general-purpose",
+                    },
+                    "call_task",
+                ),
+            ),
+            (
+                DCA_SUBAGENT_WRITE_FILE_MARKER,
+                lambda path: (
+                    "write_file",
+                    {"file_path": path, "content": SUBAGENT_WRITE_CONTENT},
+                    "call_write_file",
+                ),
+            ),
+            (
+                DCA_TEST_WRITE_FILE_MARKER,
+                lambda path: (
+                    "write_file",
+                    {"file_path": path, "content": TOP_LEVEL_WRITE_CONTENT},
+                    "call_write_file",
+                ),
+            ),
         )

--- a/libs/code/tests/integration_tests/test_auto_approve_remote.py
+++ b/libs/code/tests/integration_tests/test_auto_approve_remote.py
@@ -1,0 +1,198 @@
+"""Integration coverage for TUI auto-approve over the remote server path."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any, Literal
+
+import pytest
+
+from deepagents_code._testing_models import (
+    DCA_TEST_DELEGATE_WRITE_MARKER,
+    DCA_TEST_WRITE_FILE_MARKER,
+    SUBAGENT_WRITE_CONTENT,
+    TOP_LEVEL_WRITE_CONTENT,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_WRITE_MODE = Literal["top_level", "subagent"]
+
+# Per-mode prompt marker and the file content its write path produces. Distinct
+# contents let the auto-approve assertion double as proof that subagent mode
+# actually delegated through the `task` tool (only the subagent branch writes
+# `SUBAGENT_WRITE_CONTENT`).
+_MODE_WRITE: dict[_WRITE_MODE, tuple[str, str]] = {
+    "top_level": (DCA_TEST_WRITE_FILE_MARKER, TOP_LEVEL_WRITE_CONTENT),
+    "subagent": (DCA_TEST_DELEGATE_WRITE_MARKER, SUBAGENT_WRITE_CONTENT),
+}
+
+
+def _write_model_config(home_dir: Path) -> None:
+    """Write a temp config that points the server subprocess at the tool-call model."""
+    config_dir = home_dir / ".deepagents"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "config.toml").write_text(
+        """
+[models.providers.itest]
+class_path = "deepagents_code._testing_models:ToolCallingIntegrationChatModel"
+models = ["fake"]
+""".strip()
+        + "\n"
+    )
+
+
+async def _run_auto_approve_write(
+    *,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mode: _WRITE_MODE,
+    auto_approve: bool = True,
+) -> None:
+    """Drive an end-to-end gated write over the remote server and check HITL.
+
+    Args:
+        tmp_path: Pytest temp dir for the isolated home/project.
+        monkeypatch: Pytest monkeypatch fixture.
+        mode: Whether the write happens at the top level or via a delegated
+            `task` subagent.
+        auto_approve: When `True`, the gated `write_file` must be auto-approved
+            (no approval prompt) and the file written. When `False`, the write
+            must surface for approval; the callback here rejects it, so the file
+            must not be written.
+    """
+    home_dir = tmp_path / "home"
+    project_dir = tmp_path / "project"
+    suffix = f"{mode}-{'auto' if auto_approve else 'manual'}"
+    assistant_id = f"itest-auto-approve-{suffix}"
+
+    home_dir.mkdir()
+    project_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("DEEPAGENTS_CODE_NO_UPDATE_CHECK", "1")
+    monkeypatch.chdir(project_dir)
+    _write_model_config(home_dir)
+
+    from deepagents_code import model_config
+    from deepagents_code.app import TextualSessionState
+    from deepagents_code.config import create_model
+    from deepagents_code.server_manager import server_session
+    from deepagents_code.sessions import generate_thread_id
+    from deepagents_code.textual_adapter import TextualUIAdapter, execute_task_textual
+
+    config_path = home_dir / ".deepagents" / "config.toml"
+    monkeypatch.setattr(model_config, "DEFAULT_CONFIG_DIR", config_path.parent)
+    monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", config_path)
+
+    approvals_requested: list[Any] = []
+
+    async def request_approval(
+        action_requests: list[dict[str, Any]],
+        assistant_id: str | None,
+    ) -> object:
+        # The adapter awaits the return value a second time (`await future`), so
+        # mirror the real UI contract: return an awaitable resolving to the
+        # decision rather than the decision dict itself.
+        await asyncio.sleep(0)
+        approvals_requested.append((action_requests, assistant_id))
+        decision: asyncio.Future[object] = asyncio.get_running_loop().create_future()
+        decision.set_result({"type": "reject"})
+        return decision
+
+    async def mount_message(_: object) -> None:
+        await asyncio.sleep(0)
+
+    def update_status(_: str) -> None:
+        return None
+
+    marker, expected_content = _MODE_WRITE[mode]
+
+    model_config.clear_caches()
+    try:
+        create_model("itest:fake").apply_to_settings()
+        thread_id = generate_thread_id()
+        target = project_dir / f"auto-approved-{suffix}.txt"
+
+        async with server_session(
+            assistant_id=assistant_id,
+            model_name="itest:fake",
+            no_mcp=True,
+            enable_shell=False,
+            interactive=True,
+            sandbox_type="none",
+        ) as (agent, _server_proc):
+            adapter = TextualUIAdapter(
+                mount_message=mount_message,
+                update_status=update_status,
+                request_approval=request_approval,
+            )
+            session_state = TextualSessionState(
+                thread_id=thread_id,
+                auto_approve=auto_approve,
+            )
+
+            await execute_task_textual(
+                user_input=f"{marker}{target}",
+                agent=agent,
+                assistant_id=assistant_id,
+                session_state=session_state,
+                adapter=adapter,
+            )
+
+        if auto_approve:
+            assert approvals_requested == []
+            # Load-bearing: proves the gated write actually executed (and, in
+            # subagent mode, that delegation occurred — only the subagent branch
+            # writes `SUBAGENT_WRITE_CONTENT`).
+            assert target.read_text() == expected_content
+        else:
+            # Without auto-approve the gated write must surface for approval, and
+            # the reject decision must prevent the file from being written.
+            assert approvals_requested, "expected a HITL approval request"
+            assert not target.exists()
+    finally:
+        model_config.clear_caches()
+
+
+@pytest.mark.timeout(180)
+async def test_tui_auto_approve_suppresses_remote_hitl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default TUI remote path should not prompt for HITL in auto mode."""
+    await _run_auto_approve_write(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        mode="top_level",
+    )
+
+
+@pytest.mark.timeout(180)
+async def test_tui_auto_approve_suppresses_remote_subagent_hitl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default TUI remote path should not prompt for subagent HITL in auto mode."""
+    await _run_auto_approve_write(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        mode="subagent",
+    )
+
+
+@pytest.mark.timeout(180)
+async def test_tui_manual_approve_requests_remote_hitl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Control: without auto-approve the remote path must gate the write via HITL.
+
+    This anchors the auto-approve tests — it proves the `write_file` interrupt
+    path is live, so their `approvals_requested == []` means the prompt was
+    suppressed rather than never gated in the first place.
+    """
+    await _run_auto_approve_write(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        mode="top_level",
+        auto_approve=False,
+    )


### PR DESCRIPTION
Adds integration coverage for default TUI auto-approve behavior over the remote server path.

The new tests start the real local server with a deterministic tool-calling model, run through `execute_task_textual`, and verify auto-approve suppresses HITL prompts for both a top-level gated `write_file` call and the same gated call when delegated through the general-purpose subagent. This locks in the healthy baseline while investigating narrower workflow-specific interrupt behavior.