### PR TITLE
chore(deps): raise Talon deepagents cap

### DIFF
--- a/libs/talon/pyproject.toml
+++ b/libs/talon/pyproject.toml
@@ -23,10 +23,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    # `fleet-deepagents-export` 0.0.x imports private `deepagents` 0.6 symbols
-    # from `deepagents.middleware.skills` and `deepagents.backends.utils`.
-    # Keep Talon on the 0.6 line until the library moves to public APIs.
-    "deepagents>=0.6.12,<0.7.0",
+    # Keep Talon aligned with deepagents-code's prerelease deepagents pin.
+    "deepagents>=0.6.12,<0.9.0",
     "deepagents-code>=0.1.27,<1.0.0",
     "fleet-deepagents-export>=0.0.1,<1.0.0",
     "langchain-mcp-adapters>=0.3.0,<1.0.0",


### PR DESCRIPTION
## Summary
- raise `deepagents-talon`'s `deepagents` cap to `<0.9.0`
- shorten the dependency comment to explain alignment with `deepagents-code`

## Testing
- `uv pip compile --no-sources --universal --prerelease allow --all-extras libs/talon/pyproject.toml`