### PR TITLE
hotfix(talon): allow prerelease release dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -909,7 +909,7 @@ jobs:
         # Install directly from the locally-built wheel (no index resolution needed)
         run: |
           uv venv
-          VIRTUAL_ENV=.venv uv pip install dist/*.whl
+          VIRTUAL_ENV=.venv uv pip install --prerelease allow dist/*.whl
 
           # Replace all dashes in the package name with underscores,
           # since that's how Python imports packages with dashes in the name.
@@ -934,7 +934,7 @@ jobs:
           PKG_NAME: ${{ needs.build.outputs.pkg-name }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          VIRTUAL_ENV=.venv uv pip install dist/*.whl
+          VIRTUAL_ENV=.venv uv pip install --prerelease allow dist/*.whl
 
       - name: Run unit tests
         run: make test COV_ARGS= PYTEST_EXTRA="--no-cov -v"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -909,7 +909,11 @@ jobs:
         # Install directly from the locally-built wheel (no index resolution needed)
         run: |
           uv venv
-          VIRTUAL_ENV=.venv uv pip install --prerelease allow dist/*.whl
+          INSTALL_ARGS=(dist/*.whl)
+          if [ "$PKG_NAME" = "deepagents-talon" ]; then
+            INSTALL_ARGS=(--prerelease allow "${INSTALL_ARGS[@]}")
+          fi
+          VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"
 
           # Replace all dashes in the package name with underscores,
           # since that's how Python imports packages with dashes in the name.
@@ -934,7 +938,11 @@ jobs:
           PKG_NAME: ${{ needs.build.outputs.pkg-name }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          VIRTUAL_ENV=.venv uv pip install --prerelease allow dist/*.whl
+          INSTALL_ARGS=(dist/*.whl)
+          if [ "$PKG_NAME" = "deepagents-talon" ]; then
+            INSTALL_ARGS=(--prerelease allow "${INSTALL_ARGS[@]}")
+          fi
+          VIRTUAL_ENV=.venv uv pip install "${INSTALL_ARGS[@]}"
 
       - name: Run unit tests
         run: make test COV_ARGS= PYTEST_EXTRA="--no-cov -v"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -910,6 +910,7 @@ jobs:
         run: |
           uv venv
           INSTALL_ARGS=(dist/*.whl)
+          # Talon transitively requires a prerelease deepagents pin via deepagents-code.
           if [ "$PKG_NAME" = "deepagents-talon" ]; then
             INSTALL_ARGS=(--prerelease allow "${INSTALL_ARGS[@]}")
           fi
@@ -939,6 +940,7 @@ jobs:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           INSTALL_ARGS=(dist/*.whl)
+          # Talon transitively requires a prerelease deepagents pin via deepagents-code.
           if [ "$PKG_NAME" = "deepagents-talon" ]; then
             INSTALL_ARGS=(--prerelease allow "${INSTALL_ARGS[@]}")
           fi

--- a/libs/talon/pyproject.toml
+++ b/libs/talon/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     # Keep Talon aligned with deepagents-code's prerelease deepagents pin.
     "deepagents>=0.6.12,<0.9.0",
-    "deepagents-code>=0.1.27,<1.0.0",
+    "deepagents-code>=0.1.28,<1.0.0",
     "fleet-deepagents-export>=0.0.1,<1.0.0",
     "langchain-mcp-adapters>=0.3.0,<1.0.0",
 ]


### PR DESCRIPTION
The Talon release pre-check installs the built wheel from a clean venv. Talon depends on `deepagents-code`, and the currently published `deepagents-code` line pins the alpha SDK `deepagents==0.7.0a2`, so uv must allow prerelease dependency resolution for Talon's release install checks.

This updates Talon to require the latest `deepagents-code` package and scopes `--prerelease allow` to `deepagents-talon` in the release workflow. Other packages continue to install built wheels with the default stable dependency resolution.
