### PR TITLE
fix(sdk): emit terminal rubric iteration status

### DIFF
--- a/libs/deepagents/deepagents/middleware/rubric.py
+++ b/libs/deepagents/deepagents/middleware/rubric.py
@@ -502,13 +502,22 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
         (sync `_grade` vs `await _agrade`).
         """
         evaluation = self._build_evaluation(graded, grading_run_id, iteration)
+        if graded.result == "needs_revision" and iteration + 1 >= self.max_iterations:
+            # Emit and persist the terminal status rather than a misleading
+            # `needs_revision` event that the middleware will not actually loop on.
+            logger.warning(
+                "RubricMiddleware exhausted max_iterations=%d without 'satisfied' verdict (grading_run_id=%s)",
+                self.max_iterations,
+                evaluation["grading_run_id"],
+            )
+            evaluation["result"] = "max_iterations_reached"
         self._emit(runtime, "rubric_evaluation_end", grading_run_id, iteration, evaluation)
         if self._on_evaluation is not None:
             try:
                 self._on_evaluation(evaluation)
             except Exception:
                 logger.exception("RubricMiddleware on_evaluation callback raised")
-        return self._compose_update(state, evaluation, graded.result)
+        return self._compose_update(state, evaluation)
 
     def _ensure_grader(self) -> Any:  # noqa: ANN401
         if self._grader is not None:
@@ -626,7 +635,6 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
         self,
         state: RubricState,
         evaluation: RubricEvaluation,
-        graded_result: GraderVerdict,
     ) -> dict[str, Any]:
         iteration = evaluation["iteration"]
         next_iteration = iteration + 1
@@ -638,24 +646,7 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
             "_rubric_status": evaluation["result"],
         }
 
-        if graded_result == "satisfied":
-            return update
-
-        if graded_result == "failed":
-            update["_rubric_status"] = "failed"
-            return update
-
-        # needs_revision
-        if next_iteration >= self.max_iterations:
-            # Default logging level is WARNING, so this surfaces under
-            # the default config -- the alternative would be silent: see
-            # the class docstring "Observing non-satisfied terminations".
-            logger.warning(
-                "RubricMiddleware exhausted max_iterations=%d without 'satisfied' verdict (grading_run_id=%s)",
-                self.max_iterations,
-                evaluation["grading_run_id"],
-            )
-            update["_rubric_status"] = "max_iterations_reached"
+        if evaluation["result"] != "needs_revision":
             return update
 
         return {

--- a/libs/deepagents/deepagents/middleware/rubric.py
+++ b/libs/deepagents/deepagents/middleware/rubric.py
@@ -304,6 +304,7 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
     unconditionally in a `create_deep_agent` stack.
 
     !!! note "Observing non-satisfied terminations"
+
         When grading ends with `failed`, `max_iterations_reached`, or
         `grader_error`, the middleware does **not** mutate the response
         messages. The last `AIMessage` in the agent's output is whatever
@@ -315,27 +316,30 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
         - the `on_evaluation` callback,
         - the `rubric_evaluation_end` stream event.
 
-        A `logger.warning` is also emitted when `max_iterations_reached`
-        fires.
+        An info log is also emitted when `max_iterations_reached` fires.
 
     Args:
-        model: Model used by the grader sub-agent. Accepts either a model
-            string like `"provider:model-id"` or a `BaseChatModel`
-            instance.
+        model: Model used by the grader sub-agent.
+
+            Accepts either a model string like `"provider:model-id"` or
+            a `BaseChatModel` instance.
         system_prompt: Custom grading instructions; falls back to the
             built-in grader prompt when not set.
         tools: Tools the grader may call before producing its
-            `GraderResponse`. With none, the grader reasons from the
-            transcript alone.
+            `GraderResponse`.
+
+            With none, the grader reasons from the transcript alone.
         max_iterations: Hard cap on grader iterations per rubric attempt;
-            hard-capped at 20. When the cap is reached without a
-            `satisfied` verdict, the agent terminates with status
-            `'max_iterations_reached'` (see the note above on how to
-            observe this).
+            hard-capped at 20.
+
+            When the cap is reached without a `satisfied` verdict, the agent
+            terminates with status `'max_iterations_reached'` (see the
+            note above on how to observe this).
         on_evaluation: Optional callback one can invoke with each `RubricEvaluation` after
-            grading. Exceptions raised by the callback are logged at
-            error level and suppressed; do not use this callback to
-            enforce control flow.
+            grading.
+
+            Exceptions raised by the callback are logged at error level and
+            suppressed; do not use this callback to enforce control flow.
 
     Raises:
         ValueError: If `max_iterations` is outside `[1, 20]`, or if `model`
@@ -505,7 +509,7 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
         if graded.result == "needs_revision" and iteration + 1 >= self.max_iterations:
             # Emit and persist the terminal status rather than a misleading
             # `needs_revision` event that the middleware will not actually loop on.
-            logger.warning(
+            logger.info(
                 "RubricMiddleware exhausted max_iterations=%d without 'satisfied' verdict (grading_run_id=%s)",
                 self.max_iterations,
                 evaluation["grading_run_id"],

--- a/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
@@ -784,11 +784,16 @@ class TestMaxIterationsObservability:
     ) -> None:
         """The cap fires a `WARNING`-level log so it's visible under default config.
 
-        The terminal `max_iterations_reached` status lives in private state,
-        so this log is the only out-of-band signal a caller gets without
-        explicitly opting into `on_evaluation` or the stream event.
+        The terminal `max_iterations_reached` status is visible through state,
+        callbacks, stream events, and a warning log.
         """
-        mw = RubricMiddleware(model=_STUB_MODEL, max_iterations=1)
+        events: list[dict[str, Any]] = []
+        seen: list[RubricEvaluation] = []
+        mw = RubricMiddleware(
+            model=_STUB_MODEL,
+            max_iterations=1,
+            on_evaluation=seen.append,
+        )
         _stub_grader(
             mw,
             monkeypatch,
@@ -806,8 +811,12 @@ class TestMaxIterationsObservability:
             "_rubric_iterations": 0,
         }
         with caplog.at_level("WARNING", logger="deepagents.middleware.rubric"):
-            update = mw.after_agent(state, _runtime())
+            update = mw.after_agent(state, _runtime(events))
         assert update is not None
         assert update["_rubric_status"] == "max_iterations_reached"
+        assert update["_rubric_evaluations"][0]["result"] == "max_iterations_reached"
         assert "jump_to" not in update
+        assert events[-1]["type"] == "rubric_evaluation_end"
+        assert events[-1]["result"] == "max_iterations_reached"
+        assert seen[0]["result"] == "max_iterations_reached"
         assert any("exhausted max_iterations" in rec.message and "grading-cap" in rec.message for rec in caplog.records)

--- a/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
@@ -329,6 +329,56 @@ class TestAfterAgentDirect:
         assert events[0]["iteration"] == 0
         assert events[1]["result"] == "satisfied"
 
+    def test_needs_revision_below_cap_loops(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        events: list[dict[str, Any]] = []
+        mw = RubricMiddleware(model=_STUB_MODEL, max_iterations=2)
+        _stub_grader(
+            mw,
+            monkeypatch,
+            GraderResponse(
+                result="needs_revision",
+                explanation="tests missing",
+                criteria=[{"name": "tests", "passed": False, "gap": "not run"}],
+            ),
+        )
+
+        update = mw.after_agent(self._state(), _runtime(events))
+
+        assert update is not None
+        assert update["_rubric_status"] == "needs_revision"
+        assert update["_rubric_iterations"] == 1
+        assert update["jump_to"] == "model"
+        injected = update["messages"][0]
+        assert isinstance(injected, HumanMessage)
+        assert injected.name == RUBRIC_GRADER_MESSAGE_SOURCE
+        assert injected.additional_kwargs["lc_source"] == RUBRIC_GRADER_MESSAGE_SOURCE
+        assert "tests missing" in injected.content
+        assert events[-1]["result"] == "needs_revision"
+
+    def test_needs_revision_at_second_iteration_reports_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        events: list[dict[str, Any]] = []
+        mw = RubricMiddleware(model=_STUB_MODEL, max_iterations=2)
+        _stub_grader(
+            mw,
+            monkeypatch,
+            GraderResponse(
+                result="needs_revision",
+                explanation="still missing",
+                criteria=[{"name": "tests", "passed": False, "gap": "not run"}],
+            ),
+        )
+
+        update = mw.after_agent(
+            self._state(_rubric_iterations=1),
+            _runtime(events),
+        )
+
+        assert update is not None
+        assert update["_rubric_status"] == "max_iterations_reached"
+        assert update["_rubric_iterations"] == 2
+        assert "jump_to" not in update
+        assert events[-1]["result"] == "max_iterations_reached"
+
 
 # ---------------------------------------------------------------------- #
 # Grader plumbing
@@ -777,15 +827,15 @@ class TestTranscriptSkipsSelfInjected:
 
 
 class TestMaxIterationsObservability:
-    def test_logger_warning_emitted_when_cap_hits(
+    def test_info_log_emitted_when_cap_hits(
         self,
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """The cap fires a `WARNING`-level log so it's visible under default config.
+        """The cap fires an info log because it is controlled termination.
 
         The terminal `max_iterations_reached` status is visible through state,
-        callbacks, stream events, and a warning log.
+        callbacks, stream events, and an info log.
         """
         events: list[dict[str, Any]] = []
         seen: list[RubricEvaluation] = []
@@ -810,7 +860,7 @@ class TestMaxIterationsObservability:
             "_current_grading_run_id": "grading-cap",
             "_rubric_iterations": 0,
         }
-        with caplog.at_level("WARNING", logger="deepagents.middleware.rubric"):
+        with caplog.at_level("INFO", logger="deepagents.middleware.rubric"):
             update = mw.after_agent(state, _runtime(events))
         assert update is not None
         assert update["_rubric_status"] == "max_iterations_reached"
@@ -820,3 +870,41 @@ class TestMaxIterationsObservability:
         assert events[-1]["result"] == "max_iterations_reached"
         assert seen[0]["result"] == "max_iterations_reached"
         assert any("exhausted max_iterations" in rec.message and "grading-cap" in rec.message for rec in caplog.records)
+
+    async def test_aafter_agent_reports_cap_on_all_surfaces(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        events: list[dict[str, Any]] = []
+        seen: list[RubricEvaluation] = []
+        mw = RubricMiddleware(
+            model=_STUB_MODEL,
+            max_iterations=1,
+            on_evaluation=seen.append,
+        )
+        _stub_grader(
+            mw,
+            monkeypatch,
+            GraderResponse(
+                result="needs_revision",
+                explanation="not yet",
+                criteria=[{"name": "c", "passed": False, "gap": "missing"}],
+            ),
+        )
+        state: dict[str, Any] = {
+            "messages": [HumanMessage(content="do it"), AIMessage(content="draft")],
+            "rubric": "- thing",
+            "_active_rubric": "- thing",
+            "_current_grading_run_id": "async-grading-cap",
+            "_rubric_iterations": 0,
+        }
+
+        update = await mw.aafter_agent(state, _runtime(events))
+
+        assert update is not None
+        assert update["_rubric_status"] == "max_iterations_reached"
+        assert update["_rubric_evaluations"][0]["result"] == "max_iterations_reached"
+        assert "jump_to" not in update
+        assert events[-1]["type"] == "rubric_evaluation_end"
+        assert events[-1]["result"] == "max_iterations_reached"
+        assert seen[0]["result"] == "max_iterations_reached"

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -4350,7 +4350,8 @@ class TestRubricMiddlewareEndToEnd:
         assert state["_rubric_status"] == "max_iterations_reached"
         assert state["_rubric_iterations"] == 2
         assert len(state["_rubric_evaluations"]) == 2
-        assert all(e["result"] == "needs_revision" for e in state["_rubric_evaluations"])
+        results = [e["result"] for e in state["_rubric_evaluations"]]
+        assert results == ["needs_revision", "max_iterations_reached"]
 
     def test_no_rubric_is_noop(self) -> None:
         """Without a rubric on invocation state the middleware does not call the grader."""


### PR DESCRIPTION
`RubricMiddleware` now emits `max_iterations_reached` in terminal rubric events when the iteration cap is exhausted, instead of emitting a final `needs_revision` event that will not loop.

---

`RubricMiddleware` currently emits the raw grader verdict before it converts an exhausted `needs_revision` into `max_iterations_reached`. That means stream-event consumers can render another normal revision request even though the middleware has already decided to stop.

This changes the ordering so the middleware computes the terminal cap status first, then emits and records the same `max_iterations_reached` result through all observability surfaces: private state, `_rubric_evaluations`, `on_evaluation`, stream events, and the warning log.