### PR TITLE
ci(repo): link SDK pin warnings to release tags

### DIFF
--- a/.github/scripts/test_check_sdk_pin.py
+++ b/.github/scripts/test_check_sdk_pin.py
@@ -1,5 +1,6 @@
 """Tests for check_sdk_pin pin/version comparison."""
 
+import re
 import shutil
 import subprocess
 import sys
@@ -220,3 +221,42 @@ def test_script_exits_2_on_unsupported_version(tmp_path) -> None:
     )
     assert result.returncode == 2
     assert "Could not determine SDK pin status" in result.stdout
+
+
+def test_workflow_warning_comments_link_pin_release() -> None:
+    """SDK pin warning comments link the pinned version to its GitHub release.
+
+    Asserts the *contract*, not the exact source spelling: a release-tag URL is
+    built for the `deepagents==<pin>` tag (the scheme GitHub releases actually
+    use — a wrong scheme would 404), the pin is rendered as a markdown link, and
+    that link is interpolated into the warning bodies rather than only defined.
+    The comment logic lives in a `github-script` block embedded in YAML, so it
+    is not importable from pytest; matching the workflow text is the only
+    in-harness option, but these checks tolerate reformatting and renames.
+    """
+    workflow = Path(__file__).parents[1] / "workflows" / "check_sdk_pin.yml"
+    text = workflow.read_text()
+
+    # Release URL targets the `deepagents==<pin>` tag, URL-encoded so `==`
+    # survives as a path segment. The tag scheme is load-bearing: get it wrong
+    # and every rendered link 404s.
+    url_match = re.search(
+        r"releases/tag/\$\{encodeURIComponent\(`deepagents==\$\{(\w+)\}`\)\}",
+        text,
+    )
+    assert url_match, "release URL must encode the `deepagents==<pin>` tag"
+    pin_var = url_match.group(1)
+
+    # The pin is rendered as a markdown link wrapping that release URL.
+    link_match = re.search(
+        rf"const (\w+) = `\[deepagents==\$\{{{pin_var}}}\]\(\$\{{\w+}}\)`;",
+        text,
+    )
+    assert link_match, "pin must render as a markdown link to its release"
+    link_var = link_match.group(1)
+
+    # The link reaches the warning bodies (stale-pin table + prerelease
+    # sentence), not just its own definition line.
+    assert text.count(f"${{{link_var}}}") >= 2, (
+        "pin release link must be interpolated into the warning comment bodies"
+    )

--- a/.github/workflows/check_sdk_pin.yml
+++ b/.github/workflows/check_sdk_pin.yml
@@ -120,6 +120,8 @@ jobs:
             const prerelease = process.env.PIN_PRERELEASE === 'true';
             const sdkVersion = process.env.SDK_VERSION;
             const pkgPin = process.env.PKG_PIN;
+            const pkgPinReleaseUrl = `https://github.com/${owner}/${repo}/releases/tag/${encodeURIComponent(`deepagents==${pkgPin}`)}`;
+            const pkgPinLink = `[deepagents==${pkgPin}](${pkgPinReleaseUrl})`;
 
             if (!sdkVersion || !pkgPin) {
               core.setFailed(
@@ -140,11 +142,11 @@ jobs:
                 '> | | Version |',
                 '> |---|---|',
                 `> | SDK (\`libs/deepagents/pyproject.toml\`) | \`${sdkVersion}\` |`,
-                `> | ${pkgLabel} pin (\`${pkgPyproject}\`) | \`${pkgPin}\` |`,
+                `> | ${pkgLabel} pin (\`${pkgPyproject}\`) | ${pkgPinLink} |`,
                 '>',
                 `> **To fix:** update \`${pkgPyproject}\` to pin \`deepagents==${sdkVersion}\`, then run \`cd ${pkgLockdir} && uv lock\` and commit the lockfile update.`,
                 '>',
-                `> **To bypass:** if you intentionally need to pin an older SDK version, add the \`${sdkPinBypassLabel}\` label before merging so the auto-dispatched release skips this check, or re-run the release workflow with \`dangerous-skip-sdk-pin-check\` enabled after a failure. Ensure the ${pkgLabel} package does not contain any code that depends on functionality introduced after \`deepagents==${pkgPin}\` — otherwise the published package will fail at runtime.`,
+                `> **To bypass:** if you intentionally need to pin an older SDK version, add the \`${sdkPinBypassLabel}\` label before merging so the auto-dispatched release skips this check, or re-run the release workflow with \`dangerous-skip-sdk-pin-check\` enabled after a failure. Ensure the ${pkgLabel} package does not contain any code that depends on functionality introduced after ${pkgPinLink} — otherwise the published package will fail at runtime.`,
                 '>',
                 '> See [`.github/RELEASING.md`](https://github.com/langchain-ai/deepagents/blob/main/.github/RELEASING.md#release-failed-code-sdk-pin-is-older-than-sdk) for the full recovery procedure.',
               ].join('\n');
@@ -153,7 +155,7 @@ jobs:
               body = [
                 marker,
                 '> [!WARNING]',
-                `> **Prerelease SDK pin** — ${pkgLabel} currently pins \`deepagents==${pkgPin}\`, which is a prerelease.`,
+                `> **Prerelease SDK pin** — ${pkgLabel} currently pins ${pkgPinLink}, which is a prerelease.`,
                 '>',
                 '> This is allowed and does not block the release workflow as long as the pin is not older than the workspace SDK. Please verify this prerelease pin is intentional before merging.',
               ].join('\n');


### PR DESCRIPTION
SDK pin warning comments now make the pinned `deepagents` version clickable, pointing reviewers directly at the matching GitHub release tag. That keeps prerelease/stale-pin review context one click away from the advisory comment.

## Changes
- Build a GitHub release-tag URL for the currently pinned `deepagents==<version>` value in the SDK pin warning workflow.
- Render the pin as a Markdown link in stale-pin and prerelease-pin warning comments.
- Add coverage that checks the workflow’s embedded `github-script` contract links the pin to the encoded release tag and interpolates that link into warning bodies.