### PR TITLE
style(code): collapse `grep`/`glob` output preview by default

### DIFF
--- a/libs/code/deepagents_code/widgets/messages.py
+++ b/libs/code/deepagents_code/widgets/messages.py
@@ -1477,10 +1477,18 @@ class ToolCallMessage(Vertical):
         """
         return self._has_expandable_output()
 
+    def _is_search_no_result_output(self, output: str) -> bool:
+        """Return whether search output is a terminal no-result message."""
+        if self._tool_name == "grep":
+            return output.strip() == "No matches found"
+        if self._tool_name == "glob":
+            return output.strip() == "No files found"
+        return False
+
     def _has_expandable_output(self) -> bool:
         """Return whether collapsed output has hidden content to expand."""
         output = self._output.strip()
-        if not output:
+        if not output or self._is_search_no_result_output(output):
             return False
 
         # Tools in `_COLLAPSE_OUTPUT_BY_DEFAULT` (read_file, grep, glob) collapse
@@ -2376,8 +2384,9 @@ class ToolCallMessage(Vertical):
             # success output repeats the status/diff — so the body is noise by
             # default. Collapse it entirely (no preview) while keeping the
             # original output expandable for when the user does want to see it.
-            if self._tool_name in _COLLAPSE_OUTPUT_BY_DEFAULT or (
-                self._tool_name == "edit_file" and self._status == "success"
+            if not self._is_search_no_result_output(self._output) and (
+                self._tool_name in _COLLAPSE_OUTPUT_BY_DEFAULT
+                or (self._tool_name == "edit_file" and self._status == "success")
             ):
                 self._preview_row.display = False
                 ellipsis = get_glyphs().ellipsis

--- a/libs/code/deepagents_code/widgets/messages.py
+++ b/libs/code/deepagents_code/widgets/messages.py
@@ -131,6 +131,17 @@ _TOOLS_WITH_HEADER_INFO: set[str] = {
 }
 
 
+# Tools whose key info (file path / search pattern) is already in the header, so
+# their output body is collapsed entirely by default — an expand affordance
+# replaces the inline preview. `read_file` echoes the file; grep/glob echo the
+# matches for a pattern the header already names.
+_COLLAPSE_OUTPUT_BY_DEFAULT: set[str] = {
+    "read_file",
+    "grep",
+    "glob",
+}
+
+
 _SUCCESS_EXIT_RE = re.compile(r"\n?\[Command succeeded with exit code 0\]\s*$")
 """Strip the SDK's `[Command succeeded with exit code 0]` trailer from tool output."""
 
@@ -1449,18 +1460,20 @@ class ToolCallMessage(Vertical):
         if not output:
             return False
 
-        # Successful `read_file` collapses its content entirely by default (the
-        # header already names the file), so it is always expandable regardless
-        # of size: `output` is non-empty here (guarded above) and the file
-        # formatter only reshapes the line-number gutter, never dropping body
-        # text, so it can never format to nothing. This mirrors the empty-output
-        # guard in `_update_output_display`, which suppresses any body that would
-        # render blank before the collapse branch is reached — the two must move
-        # together if that assumption changes. Errors are excluded because
-        # `set_error` force-expands every error; treating a short error as
-        # always-expandable would offer a collapse that hides it entirely.
-        if self._tool_name == "read_file" and self._status != "error":
-            return True
+        # Tools in `_COLLAPSE_OUTPUT_BY_DEFAULT` (read_file, grep, glob) collapse
+        # their body entirely by default (the header already carries the file
+        # path / search pattern), so any result with something to show is
+        # expandable regardless of size. `read_file`'s formatter never drops body
+        # text, but grep/glob serialize an empty match set as `[]`, which formats
+        # to nothing — so confirm the formatted output is non-empty rather than
+        # trusting the raw string. This mirrors the empty-output guard in
+        # `_update_output_display`, which suppresses any body that would render
+        # blank before the collapse branch is reached. Errors are excluded
+        # because `set_error` force-expands every error; treating a short error
+        # as always-expandable would offer a collapse that hides it entirely.
+        if self._tool_name in _COLLAPSE_OUTPUT_BY_DEFAULT and self._status != "error":
+            formatted = self._format_output(output, is_preview=False)
+            return bool(formatted.content.plain.strip())
 
         if self._tool_name == "write_todos":
             return self._format_output(output, is_preview=True).truncation is not None
@@ -2313,11 +2326,11 @@ class ToolCallMessage(Vertical):
         else:
             # Show collapsed preview
             self._full_row.display = False
-            # `read_file` output just echoes the file the agent asked to read,
-            # and the path is already in the header, so the content is noise by
-            # default. Collapse it entirely (no preview) while keeping it
-            # expandable for when the user does want to see what was read.
-            if self._tool_name == "read_file":
+            # `read_file` echoes the file the agent read, and grep/glob echo the
+            # matches for a pattern the header already names, so the body is noise
+            # by default. Collapse it entirely (no preview) while keeping it
+            # expandable for when the user does want to see the result.
+            if self._tool_name in _COLLAPSE_OUTPUT_BY_DEFAULT:
                 self._preview_row.display = False
                 ellipsis = get_glyphs().ellipsis
                 self._hint_widget.update(

--- a/libs/code/deepagents_code/widgets/messages.py
+++ b/libs/code/deepagents_code/widgets/messages.py
@@ -1478,7 +1478,14 @@ class ToolCallMessage(Vertical):
         return self._has_expandable_output()
 
     def _is_search_no_result_output(self, output: str) -> bool:
-        """Return whether search output is a terminal no-result message."""
+        """Return whether search output is a terminal no-result message.
+
+        These sentinels must match the empty-result strings the SDK emits
+        (`format_grep_matches` and `_format_file_paths` in
+        `deepagents.middleware.filesystem`). If those change, this silently
+        stops matching and empty searches revert to collapsing behind an expand
+        affordance rather than rendering inline.
+        """
         if self._tool_name == "grep":
             return output.strip() == "No matches found"
         if self._tool_name == "glob":
@@ -1494,14 +1501,18 @@ class ToolCallMessage(Vertical):
         # Tools in `_COLLAPSE_OUTPUT_BY_DEFAULT` (read_file, grep, glob) collapse
         # their body entirely by default (the header already carries the file
         # path / search pattern), so any result with something to show is
-        # expandable regardless of size. `read_file`'s formatter never drops body
-        # text, but grep/glob serialize an empty match set as `[]`, which formats
-        # to nothing — so confirm the formatted output is non-empty rather than
-        # trusting the raw string. Successful `edit_file` similarly hides its
-        # redundant success line in the collapsed view while keeping the raw
-        # output expandable. This mirrors the empty-output guard in
-        # `_update_output_display`, which suppresses any body that would render
-        # blank before the collapse branch is reached — the two must move
+        # expandable regardless of size. The exception is a search that finds
+        # nothing: grep/glob return the terminal "No matches found" / "No files
+        # found" message, caught by `_is_search_no_result_output` above so it
+        # renders inline (see `_update_output_display`) instead of hiding a
+        # "nothing found" result behind an expand click. Beyond that, confirm the
+        # formatted output is non-empty rather than trusting the raw string —
+        # output that formats to blank (all whitespace, or a serialized empty
+        # collection like `[]`) has nothing to reveal. Successful `edit_file`
+        # similarly hides its redundant success line in the collapsed view while
+        # keeping the raw output expandable. This mirrors the empty-output guard
+        # in `_update_output_display`, which suppresses any body that would
+        # render blank before the collapse branch is reached — the two must move
         # together if that assumption changes. Errors are excluded because
         # `set_error` force-expands every error; treating a short error as
         # always-expandable would offer a collapse that hides it entirely.
@@ -2341,13 +2352,16 @@ class ToolCallMessage(Vertical):
             total_lines > self._PREVIEW_LINES or total_chars > self._PREVIEW_CHARS
         )
 
-        # Some tools serialize an empty successful result as a non-empty literal
-        # (e.g. glob "[]") that formats to no visible content. The raw `_output`
-        # is truthy, so the early-return guard at the top of this method doesn't
-        # catch it, but rendering it would show an empty box with a misleading
-        # expand affordance. Treat it like empty output and render nothing. This
-        # also subsumes the all-whitespace case (formats to empty), so the
-        # collapsed branch below no longer needs its own empty guard.
+        # Some output is a non-empty raw string that the formatter renders as no
+        # visible content — all whitespace, or a serialized empty collection like
+        # `[]`. The raw `_output` is truthy, so the early-return guard at the top
+        # of this method doesn't catch it, but rendering it would show an empty
+        # box with a misleading expand affordance. Treat it like empty output and
+        # render nothing. (A search that found nothing is not this case: grep/glob
+        # return a human-readable "No matches found" / "No files found" that
+        # formats non-empty and renders inline; see the collapse branch below.)
+        # This also subsumes the all-whitespace case, so the collapsed branch
+        # below no longer needs its own empty guard.
         #
         # This fires for errors too, but never hides one: a real error body is
         # human-readable text that formats non-empty (and execute errors keep
@@ -2384,6 +2398,9 @@ class ToolCallMessage(Vertical):
             # success output repeats the status/diff — so the body is noise by
             # default. Collapse it entirely (no preview) while keeping the
             # original output expandable for when the user does want to see it.
+            # A grep/glob that found nothing is excluded: its terminal "No
+            # matches/files found" message is the whole result, so it renders
+            # inline rather than hiding behind an expand click.
             if not self._is_search_no_result_output(self._output) and (
                 self._tool_name in _COLLAPSE_OUTPUT_BY_DEFAULT
                 or (self._tool_name == "edit_file" and self._status == "success")

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -1007,8 +1007,13 @@ class TestToolCallMessageSearchOutput:
 class TestToolCallMessageExpandHint:
     """Tests for the preview/expand hint on collapsed tool output."""
 
-    async def test_long_single_line_search_output_truncates_and_expands(self) -> None:
-        """Long single-line grep/glob output should use the shared char cap."""
+    async def test_long_single_line_search_output_collapses_and_expands(self) -> None:
+        """Long single-line grep/glob output collapses by default and expands.
+
+        grep/glob collapse their body entirely (the header names the pattern),
+        so even long output shows a count-free expand hint instead of a
+        truncated preview; expanding reveals the full untruncated content.
+        """
         from textual.app import App, ComposeResult
 
         output = "Invalid glob pattern: " + "a" * ToolCallMessage._PREVIEW_CHARS
@@ -1032,8 +1037,12 @@ class TestToolCallMessageExpandHint:
             assert app.msg._hint_widget is not None
             assert app.msg._hint_widget.display is True
             assert app.msg._has_expandable_output() is True
-            preview = app.msg._preview_widget._Static__content  # ty: ignore[unresolved-attribute]
-            assert len(preview.plain) == ToolCallMessage._PREVIEW_CHARS
+            # Preview is collapsed away; a count-free expand affordance is shown.
+            assert app.msg._preview_row is not None
+            assert app.msg._preview_row.display is False
+            hint = app.msg._hint_widget._Static__content  # ty: ignore[unresolved-attribute]
+            assert "expand" in hint.plain
+            assert "more" not in hint.plain
 
             app.msg.toggle_output()
             await pilot.pause()
@@ -1114,7 +1123,7 @@ class TestToolCallMessageExpandHint:
             assert "expand" in collapsed.plain
 
     async def test_long_grep_output_truncates_and_expands(self) -> None:
-        """A multi-line grep result should preview-truncate then expand on toggle."""
+        """A multi-line grep result collapses its preview then expands on toggle."""
         output = "\n".join(f"file.py:{index}:hit {index}" for index in range(8))
         assert output.count("\n") + 1 > ToolCallMessage._PREVIEW_LINES
 
@@ -1126,15 +1135,14 @@ class TestToolCallMessageExpandHint:
 
             assert app.msg._expanded is False
             assert app.msg._has_expandable_output() is True
-            assert app.msg._preview_widget is not None
+            assert app.msg._preview_row is not None
             assert app.msg._full_widget is not None
             assert app.msg._hint_widget is not None
             assert app.msg._hint_widget.display is True
             hint = app.msg._hint_widget._Static__content  # ty: ignore
             assert "expand" in hint.plain
-            # The preview hides the trailing lines.
-            preview = app.msg._preview_widget._Static__content  # ty: ignore
-            assert "hit 7" not in preview.plain
+            # The preview is collapsed away entirely rather than truncated.
+            assert app.msg._preview_row.display is False
 
             app.msg.toggle_output()
             await pilot.pause()
@@ -1319,6 +1327,114 @@ class TestToolCallMessageExpandHint:
             assert app.msg._hint_widget.display is False
             assert app.msg._full_row.display is True
 
+    @pytest.mark.parametrize(
+        ("tool", "output", "expected"),
+        [
+            ("grep", "file.py:1:hit one\nfile.py:2:hit two", "hit one"),
+            ("glob", "['a.py', 'b.py']", "a.py"),
+        ],
+    )
+    async def test_search_collapses_preview_by_default(
+        self, tool: str, output: str, expected: str
+    ) -> None:
+        """`grep`/`glob` hide their result preview by default but stay expandable.
+
+        The search pattern is already shown in the header, so echoing the matches
+        inline is noise. The collapsed view shows an expand hint instead of the
+        preview, and expanding reveals the full content.
+        """
+        app = _tool_msg_app(tool, {"pattern": "x"})
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.msg.set_success(output)
+            await pilot.pause()
+
+            assert app.msg._expanded is False
+            assert app.msg._preview_row is not None
+            assert app.msg._hint_widget is not None
+            # Preview is collapsed away; an expand affordance is shown instead.
+            assert app.msg._preview_row.display is False
+            assert app.msg._has_expandable_output() is True
+            assert app.msg._hint_widget.display is True
+            hint = app.msg._hint_widget._Static__content  # ty: ignore
+            assert "expand" in hint.plain
+
+            # Expanding reveals the full content.
+            app.msg.toggle_output()
+            await pilot.pause()
+            assert app.msg._expanded is True
+            assert app.msg._full_row is not None
+            assert app.msg._full_row.display is True
+            assert app.msg._full_widget is not None
+            full = app.msg._full_widget._Static__content  # ty: ignore
+            assert expected in full.plain
+
+    @pytest.mark.parametrize(
+        "tool",
+        ["grep", "glob"],
+    )
+    async def test_large_search_collapses_preview_regardless_of_size(
+        self, tool: str
+    ) -> None:
+        """Large `grep`/`glob` output collapses with a count-free hint.
+
+        Output well over `_PREVIEW_LINES` would normally render a truncated
+        preview with an "N more lines/files" hint. grep/glob instead hide the
+        preview entirely and show a count-free expand affordance.
+        """
+        line_count = ToolCallMessage._PREVIEW_LINES * 5
+        if tool == "glob":
+            output = repr([f"/tmp/result_{index}.py" for index in range(line_count)])
+        else:
+            output = "\n".join(f"file.py:{index}:hit" for index in range(line_count))
+
+        app = _tool_msg_app(tool, {"pattern": "x"})
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.msg.set_success(output)
+            await pilot.pause()
+
+            assert app.msg._expanded is False
+            assert app.msg._preview_row is not None
+            assert app.msg._hint_widget is not None
+            # Preview stays hidden even though the size would normally truncate.
+            assert app.msg._preview_row.display is False
+            assert app.msg._has_expandable_output() is True
+            assert app.msg._hint_widget.display is True
+            # The hint is count-free — no "N more" prefix other tools show.
+            hint = app.msg._hint_widget._Static__content  # ty: ignore
+            assert "expand" in hint.plain
+            assert "more" not in hint.plain
+
+            # Expanding reveals the full content and offers a collapse affordance.
+            app.msg.toggle_output()
+            await pilot.pause()
+            assert app.msg._expanded is True
+            assert app.msg._full_widget is not None
+            full = app.msg._full_widget._Static__content  # ty: ignore
+            assert f"{line_count - 1}" in full.plain
+            collapse_hint = app.msg._hint_widget._Static__content  # ty: ignore
+            assert "collapse" in collapse_hint.plain
+
+    async def test_search_click_toggles_output(self) -> None:
+        """Clicking a collapsed `grep` expands it via `has_expandable_output`."""
+        output = "file.py:1:hit one\nfile.py:2:hit two"
+
+        app = _tool_msg_app("grep", {"pattern": "x"})
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.msg.set_success(output)
+            await pilot.pause()
+
+            assert app.msg.has_expandable_output is True
+            assert app.msg._expanded is False
+
+            event = MagicMock()
+            app.msg.on_click(event)
+            await pilot.pause()
+            event.stop.assert_called_once()
+            assert app.msg._expanded is True
+
 
 class TestToolCallMessageEmptyResult:
     """Empty file-op results render nothing instead of an empty box."""
@@ -1364,18 +1480,28 @@ class TestToolCallMessageEmptyResult:
             assert app.msg._has_expandable_output() is False
 
     async def test_non_empty_serialized_result_still_renders(self) -> None:
-        """A populated result must still render — the guard can't false-positive."""
+        """A populated result must still render — the guard can't false-positive.
+
+        glob collapses its body by default, so "renders" here means it stays
+        expandable (not hidden by the empty guard) and the content is reachable
+        once expanded, rather than shown inline.
+        """
         app = _tool_msg_app("glob")
         async with app.run_test() as pilot:
             await pilot.pause()
             app.msg.set_success("['a.py', 'b.py']")
             await pilot.pause()
 
-            assert app.msg._preview_row is not None
-            assert app.msg._preview_row.display is True
-            assert app.msg._preview_widget is not None
-            preview = app.msg._preview_widget._Static__content  # ty: ignore[unresolved-attribute]
-            assert "a.py" in preview.plain
+            assert app.msg._has_expandable_output() is True
+            assert app.msg._hint_widget is not None
+            assert app.msg._hint_widget.display is True
+
+            app.msg.toggle_output()
+            await pilot.pause()
+            assert app.msg._expanded is True
+            assert app.msg._full_widget is not None
+            full = app.msg._full_widget._Static__content  # ty: ignore[unresolved-attribute]
+            assert "a.py" in full.plain
 
     async def test_error_body_is_not_hidden(self) -> None:
         """A real (non-empty) error body must stay visible.

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -1152,28 +1152,27 @@ class TestToolCallMessageExpandHint:
             full = app.msg._full_widget._Static__content  # ty: ignore[unresolved-attribute]
             assert full.plain == output
 
-    async def test_short_error_force_expanded_has_no_collapse_hint(self) -> None:
+    @pytest.mark.parametrize(
+        ("tool", "error"),
+        [
+            ("glob", "Error: glob timed out after 20.0s. Try a narrower path."),
+            ("grep", "Error: invalid regex: unterminated character class."),
+        ],
+    )
+    async def test_short_error_force_expanded_has_no_collapse_hint(
+        self, tool: str, error: str
+    ) -> None:
         """A short force-expanded error must not show a collapse affordance.
 
         `set_error` force-expands so the full error is always visible. When the
         error is short enough that the collapsed form would be identical, there
-        is nothing to collapse — so no hint, and toggling is a no-op.
+        is nothing to collapse — so no hint, and toggling is a no-op. grep and
+        glob share the collapse-by-default branch, so both must honor this.
         """
-        from textual.app import App, ComposeResult
-
-        error = "Error: glob timed out after 20.0s. Try a narrower path."
         assert "\n" not in error
         assert len(error) < ToolCallMessage._PREVIEW_CHARS
 
-        class _Harness(App[None]):
-            def __init__(self) -> None:
-                super().__init__()
-                self.msg = ToolCallMessage("glob", {"pattern": "**/*.py"})
-
-            def compose(self) -> ComposeResult:
-                yield self.msg
-
-        app = _Harness()
+        app = _tool_msg_app(tool, {"pattern": "**/*.py"})
         async with app.run_test() as pilot:
             await pilot.pause()
             app.msg.set_error(error)
@@ -1222,7 +1221,7 @@ class TestToolCallMessageExpandHint:
             collapsed = app.msg._hint_widget._Static__content
             assert "expand" in collapsed.plain
 
-    async def test_long_grep_output_truncates_and_expands(self) -> None:
+    async def test_long_grep_output_collapses_and_expands(self) -> None:
         """A multi-line grep result collapses its preview then expands on toggle."""
         output = "\n".join(f"file.py:{index}:hit {index}" for index in range(8))
         assert output.count("\n") + 1 > ToolCallMessage._PREVIEW_LINES
@@ -1556,14 +1555,18 @@ class TestToolCallMessageEmptyResult:
     async def test_empty_serialized_result_hides_output(
         self, tool: str, output: str
     ) -> None:
-        """A non-empty literal that formats to nothing must not render a box.
+        """A non-empty raw string that formats to nothing must not render a box.
 
-        Tools like glob/grep/ls serialize an empty successful result as the
-        literal "[]", which formats to no visible content. The raw output is
-        truthy, so the early empty guard doesn't fire — without the formatted
-        emptiness check the preview row renders as an empty box with a
-        misleading expand affordance. The whitespace-only case ("   ") exercises
-        the same check now that the collapsed branch's own empty guard is gone.
+        `[]` is a synthetic stand-in for output that is a non-empty raw string
+        yet formats to no visible content. It is not what the tools actually
+        emit for an empty result — real grep/glob return "No matches found" /
+        "No files found" (non-empty), which render inline (see
+        `test_search_no_result_message_renders_without_expand_hint`). The raw
+        output here is truthy, so the early empty guard doesn't fire; without the
+        formatted-emptiness check the preview row would render as an empty box
+        with a misleading expand affordance. The whitespace-only case ("   ")
+        exercises the same check now that the collapsed branch's own empty guard
+        is gone.
         """
         app = _tool_msg_app(tool)
         async with app.run_test() as pilot:

--- a/libs/code/tests/unit_tests/test_messages.py
+++ b/libs/code/tests/unit_tests/test_messages.py
@@ -1579,6 +1579,34 @@ class TestToolCallMessageEmptyResult:
             assert app.msg._hint_widget.display is False
             assert app.msg._has_expandable_output() is False
 
+    @pytest.mark.parametrize(
+        ("tool", "output"),
+        [
+            ("grep", "No matches found"),
+            ("glob", "No files found"),
+        ],
+    )
+    async def test_search_no_result_message_renders_without_expand_hint(
+        self, tool: str, output: str
+    ) -> None:
+        """Search no-result messages stay visible and are not expandable."""
+        app = _tool_msg_app(tool)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.msg.set_success(output)
+            await pilot.pause()
+
+            assert app.msg._preview_row is not None
+            assert app.msg._preview_widget is not None
+            assert app.msg._full_row is not None
+            assert app.msg._hint_widget is not None
+            assert app.msg._preview_row.display is True
+            assert app.msg._full_row.display is False
+            assert app.msg._hint_widget.display is False
+            assert app.msg._has_expandable_output() is False
+            preview = app.msg._preview_widget._Static__content  # ty: ignore[unresolved-attribute]
+            assert preview.plain == output
+
     async def test_non_empty_serialized_result_still_renders(self) -> None:
         """A populated result must still render — the guard can't false-positive.
 


### PR DESCRIPTION
`grep` and `glob` tool calls now collapse their output preview by default in the TUI; expand with click or Ctrl+O to view the results.

---

Ports the `read_file` collapse-by-default TUI behavior (#4362) to `grep` and `glob`. The search pattern is already shown in the tool header, so echoing the matches inline is redundant noise. Output collapses entirely with an expand affordance, staying viewable via click/Ctrl+O.

Empty serialized result sets (`[]`) still render nothing and do not show a bogus expand affordance. Human-readable no-result messages from the active tools (`No matches found` / `No files found`) remain visible inline and are not expandable.

Made by [Open SWE](https://openswe.vercel.app/agents/769857e2-ebd8-193a-d249-cc7b6c60dcdd)
