### PR TITLE
chore(code): prune recommended models, add nemotron under openrouter

### DIFF
--- a/libs/code/deepagents_code/widgets/model_selector.py
+++ b/libs/code/deepagents_code/widgets/model_selector.py
@@ -65,7 +65,6 @@ from the per-provider sections below.
 
 _RECOMMENDED_MODELS: frozenset[str] = frozenset(
     {
-        "anthropic:claude-opus-4-6",
         "anthropic:claude-opus-4-7",
         "anthropic:claude-opus-4-8",
         "anthropic:claude-sonnet-5",
@@ -74,13 +73,9 @@ _RECOMMENDED_MODELS: frozenset[str] = frozenset(
         "baseten:nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
         "baseten:zai-org/GLM-5.2",
         "fireworks:accounts/fireworks/models/deepseek-v4-pro",
-        "fireworks:accounts/fireworks/models/glm-5p1",
         "fireworks:accounts/fireworks/models/glm-5p2",
-        "fireworks:accounts/fireworks/models/kimi-k2p6",
         "fireworks:accounts/fireworks/models/kimi-k2p7-code",
-        "fireworks:accounts/fireworks/models/minimax-m2p7",
         "fireworks:accounts/fireworks/models/minimax-m3",
-        "fireworks:accounts/fireworks/models/qwen3p6-plus",
         "fireworks:accounts/fireworks/models/qwen3p7-plus",
         "google_genai:gemini-3.5-flash",
         "google_genai:gemini-3.1-pro-preview",
@@ -109,8 +104,8 @@ _RECOMMENDED_MODELS: frozenset[str] = frozenset(
         "openrouter:deepseek/deepseek-v4-pro",
         "openrouter:google/gemini-3.5-flash",
         "openrouter:google/gemini-3.1-pro-preview",
-        "openrouter:minimax/minimax-m2.7",
         "openrouter:moonshotai/kimi-k2.7-code",
+        "openrouter:nvidia/nemotron-3-ultra-550b-a55b",
         "openrouter:openai/gpt-5.4",
         "openrouter:openai/gpt-5.4-mini",
         "openrouter:openai/gpt-5.4-pro",

--- a/libs/code/tests/unit_tests/test_model_selector.py
+++ b/libs/code/tests/unit_tests/test_model_selector.py
@@ -1646,7 +1646,7 @@ class TestCuratedModelSelection:
             ("openai:gpt-5.4", "openai"),
             ("anthropic:claude-opus-4-7", "anthropic"),
             ("google_genai:gemini-3.1-pro-preview", "google_genai"),
-            ("anthropic:claude-opus-4-6", "anthropic"),
+            ("anthropic:claude-opus-4-8", "anthropic"),
         ]
 
         curated = ModelSelectorScreen._curate_models(all_models)
@@ -1656,21 +1656,21 @@ class TestCuratedModelSelection:
             ("openai:gpt-5.4", "openai"),
             ("anthropic:claude-opus-4-7", "anthropic"),
             ("google_genai:gemini-3.1-pro-preview", "google_genai"),
-            ("anthropic:claude-opus-4-6", "anthropic"),
+            ("anthropic:claude-opus-4-8", "anthropic"),
         ]
 
     def test_curated_models_limit_to_frontier_subset(self) -> None:
         """Current/default models outside the frontier subset should stay hidden."""
         all_models = [
             ("openai:gpt-5.3-codex", "openai"),
-            ("anthropic:claude-opus-4-6", "anthropic"),
+            ("anthropic:claude-opus-4-8", "anthropic"),
             ("anthropic:claude-sonnet-4-5", "anthropic"),
         ]
 
         curated = ModelSelectorScreen._curate_models(all_models)
 
         assert curated == [
-            ("anthropic:claude-opus-4-6", "anthropic"),
+            ("anthropic:claude-opus-4-8", "anthropic"),
         ]
 
     def test_curated_models_fall_back_when_frontier_unavailable(self) -> None:


### PR DESCRIPTION
Prunes six stale specs from the curated `_RECOMMENDED_MODELS` set in `libs/code` (`glm-5p1`, `kimi-k2p6`, `minimax-m2p7`, `qwen3p6-plus` on fireworks; `claude-opus-4-6` on anthropic; `minimax-m2.7` on openrouter) and adds `nvidia/nemotron-3-ultra-550b-a55b` under openrouter. Curation tests that referenced the removed `claude-opus-4-6` spec were updated to a still-recommended opus spec.

Made by [Open SWE](https://openswe.vercel.app/agents/c56b1dcd-d736-47a7-1601-9baf98c9a9dc)