### PR TITLE
feat(talon): add cron wall-clock schedules and active hours

### DIFF
--- a/libs/talon/deepagents_talon/cron/jobs.py
+++ b/libs/talon/deepagents_talon/cron/jobs.py
@@ -7,17 +7,40 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
 import uuid
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
-from typing import Literal, TypedDict, cast
+from typing import Literal, NotRequired, TypedDict, cast
+
+from deepagents_talon.cron.time import (
+    ActiveWindow,
+    ActiveWindowDict,
+    CronTimeError,
+    SchedulerHostClock,
+    SchedulerHostClockDict,
+    active_window_contains,
+    capture_scheduler_host_clock,
+    format_local_run,
+    next_daily_wall_clock_run,
+    next_interval_run,
+    next_wall_clock_run,
+    parse_active_window,
+    parse_local_time,
+    resolve_schedule_timezone,
+)
 
 MIN_GRANULARITY_MINUTES = 1
 
 JobStatus = Literal["ok", "error"]
-ScheduleKind = Literal["one_shot", "recurring"]
+ScheduleKind = Literal["one_shot", "recurring", "wall_clock_once", "wall_clock_daily"]
+
+_WALL_CLOCK_ONCE_RE = re.compile(
+    r"^at (?P<time>.+?)(?: on (?P<date>\d{4}-\d{2}-\d{2}))?$",
+)
+_WALL_CLOCK_DAILY_PREFIX = "every day at "
 
 
 class CronJobError(ValueError):
@@ -36,8 +59,12 @@ class CronScheduleDict(TypedDict):
     """Serialized schedule definition for a job."""
 
     kind: ScheduleKind
-    minutes: int
+    minutes: int | None
     display: str
+    timezone: NotRequired[str | None]
+    wall_time: NotRequired[str | None]
+    wall_date: NotRequired[str | None]
+    active_window: NotRequired[ActiveWindowDict | None]
 
 
 class CronRepeatDict(TypedDict):
@@ -63,6 +90,7 @@ class CronJobDict(TypedDict):
     last_status: JobStatus | None
     last_error: str | None
     origin: CronOriginDict
+    scheduler_host_clock: NotRequired[SchedulerHostClockDict | None]
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,30 +138,59 @@ class CronOrigin:
 
 @dataclass(frozen=True, slots=True)
 class CronSchedule:
-    """Minute-granularity schedule for a cron job.
+    """Minute or wall-clock schedule for a cron job.
 
     Args:
-        kind: Whether the schedule is one-shot or recurring.
-        minutes: Delay or interval in minutes.
+        kind: Schedule type.
+        minutes: Delay or interval in minutes for relative schedules.
         display: Human-readable schedule text supplied by the agent.
+        timezone: IANA time zone used for wall-clock interpretation.
+        wall_time: Local wall-clock time for wall-clock schedules.
+        wall_date: Optional local date for dated one-shot wall-clock schedules.
+        active_window: Optional local active-hour gate.
     """
 
     kind: ScheduleKind
-    minutes: int
+    minutes: int | None
     display: str
+    timezone: str | None = None
+    wall_time: str | None = None
+    wall_date: date | None = None
+    active_window: ActiveWindow | None = None
 
     def __post_init__(self) -> None:
-        """Validate schedule granularity."""
-        if self.minutes < MIN_GRANULARITY_MINUTES:
-            msg = "cron schedules must be at least 1 minute"
+        """Validate schedule granularity and wall-clock fields."""
+        if self.kind in {"one_shot", "recurring"}:
+            if self.minutes is None or self.minutes < MIN_GRANULARITY_MINUTES:
+                msg = "cron schedules must be at least 1 minute"
+                raise CronJobError(msg)
+            return
+        if self.timezone is None or self.wall_time is None:
+            msg = "wall-clock schedules require timezone and wall_time"
             raise CronJobError(msg)
+        if self.kind == "wall_clock_once":
+            return
+        if self.kind == "wall_clock_daily":
+            return
+        msg = f"unsupported schedule kind: {self.kind}"
+        raise CronJobError(msg)
 
     @classmethod
-    def parse(cls, value: str) -> CronSchedule:
+    def parse(
+        cls,
+        value: str,
+        *,
+        timezone: str | None = None,
+        active_start: str | None = None,
+        active_end: str | None = None,
+    ) -> CronSchedule:
         """Parse a supported schedule string.
 
         Args:
-            value: Schedule text such as `in 30m` or `every 15m`.
+            value: Schedule text such as `in 30m`, `at 8pm`, or `every day at 8pm`.
+            timezone: Optional IANA time zone for wall-clock interpretation.
+            active_start: Optional inclusive active-hour start time.
+            active_end: Optional exclusive active-hour end time.
 
         Returns:
             Parsed schedule.
@@ -141,24 +198,164 @@ class CronSchedule:
         Raises:
             CronJobError: If the schedule string is unsupported.
         """
+        try:
+            return cls._parse(
+                value,
+                timezone=timezone,
+                active_start=active_start,
+                active_end=active_end,
+            )
+        except CronTimeError as exc:
+            raise CronJobError(str(exc)) from exc
+
+    @classmethod
+    def _parse(
+        cls,
+        value: str,
+        *,
+        timezone: str | None,
+        active_start: str | None,
+        active_end: str | None,
+    ) -> CronSchedule:
         text = " ".join(value.strip().lower().split())
+        active_window = parse_active_window(
+            timezone=timezone,
+            active_start=active_start,
+            active_end=active_end,
+        )
         if text.startswith("in "):
-            return cls(kind="one_shot", minutes=_parse_duration_minutes(text[3:]), display=value)
-        if text.startswith("every "):
-            return cls(kind="recurring", minutes=_parse_duration_minutes(text[6:]), display=value)
-        msg = "schedule must look like 'in 30m' or 'every 15m'"
+            return cls(
+                kind="one_shot",
+                minutes=_parse_duration_minutes(text[3:]),
+                display=value,
+                timezone=None if active_window is None else active_window.timezone,
+                active_window=active_window,
+            )
+        if text.startswith("every ") and not text.startswith(_WALL_CLOCK_DAILY_PREFIX):
+            return cls(
+                kind="recurring",
+                minutes=_parse_duration_minutes(text[6:]),
+                display=value,
+                timezone=None if active_window is None else active_window.timezone,
+                active_window=active_window,
+            )
+        if text.startswith(_WALL_CLOCK_DAILY_PREFIX):
+            resolved = resolve_schedule_timezone(timezone)
+            wall_time = parse_local_time(text.removeprefix(_WALL_CLOCK_DAILY_PREFIX))
+            return cls(
+                kind="wall_clock_daily",
+                minutes=None,
+                display=value,
+                timezone=resolved,
+                wall_time=wall_time.to_display(),
+                active_window=active_window,
+            )
+        match = _WALL_CLOCK_ONCE_RE.match(text)
+        if match is not None:
+            resolved = resolve_schedule_timezone(timezone)
+            wall_date = _parse_wall_date(match.group("date"))
+            wall_time = parse_local_time(match.group("time"))
+            return cls(
+                kind="wall_clock_once",
+                minutes=None,
+                display=value,
+                timezone=resolved,
+                wall_time=wall_time.to_display(),
+                wall_date=wall_date,
+                active_window=active_window,
+            )
+        msg = (
+            "schedule must look like 'in 30m', 'every 15m', "
+            "'at 8:00pm', or 'every day at 8:00pm'"
+        )
         raise CronJobError(msg)
 
-    def next_after(self, now: datetime) -> datetime:
+    def next_after(self, now: datetime, previous: datetime | None = None) -> datetime:
         """Return the next scheduled run after `now`.
 
         Args:
             now: Current timestamp.
+            previous: Optional previous run candidate for recurring schedules.
 
         Returns:
             Next run timestamp.
         """
-        return now + timedelta(minutes=self.minutes)
+        try:
+            if self.kind == "one_shot":
+                candidate = now + timedelta(minutes=cast("int", self.minutes))
+                return self._validate_one_shot_active_window(candidate)
+            if self.kind == "recurring":
+                candidate = now + timedelta(minutes=cast("int", self.minutes))
+                return next_interval_run(
+                    previous=candidate if previous is None else previous,
+                    now=now,
+                    minutes=cast("int", self.minutes),
+                    active_window=self.active_window,
+                )
+            if self.kind == "wall_clock_once":
+                candidate = next_wall_clock_run(
+                    now=now,
+                    timezone=cast("str", self.timezone),
+                    time=parse_local_time(cast("str", self.wall_time)),
+                    date=self.wall_date,
+                )
+                return self._validate_one_shot_active_window(candidate)
+            return next_daily_wall_clock_run(
+                previous=previous,
+                now=now,
+                timezone=cast("str", self.timezone),
+                time=parse_local_time(cast("str", self.wall_time)),
+                active_window=self.active_window,
+            )
+        except CronTimeError as exc:
+            raise CronJobError(str(exc)) from exc
+
+    def next_run_local(self, value: datetime) -> str | None:
+        """Return a local explanation for a run timestamp.
+
+        Args:
+            value: UTC run timestamp.
+
+        Returns:
+            Local display text when a schedule time zone is known.
+        """
+        timezone = self.timezone or (
+            None if self.active_window is None else self.active_window.timezone
+        )
+        if timezone is None:
+            return None
+        return format_local_run(value, timezone)
+
+    def with_options(
+        self,
+        *,
+        timezone: str | None = None,
+        active_start: str | None = None,
+        active_end: str | None = None,
+    ) -> CronSchedule:
+        """Return this schedule with replacement time-zone options.
+
+        Args:
+            timezone: Optional replacement IANA time zone.
+            active_start: Optional replacement active-hour start time.
+            active_end: Optional replacement active-hour end time.
+
+        Returns:
+            Re-parsed schedule with the requested options applied.
+        """
+        existing_window = self.active_window
+        resolved_timezone = timezone or self.timezone or (
+            None if existing_window is None else existing_window.timezone
+        )
+        if active_start is None and active_end is None and existing_window is not None:
+            active_start = existing_window.start.to_display()
+            active_end = existing_window.end.to_display()
+        return self.parse(
+            self.display,
+            timezone=resolved_timezone,
+            active_start=active_start,
+            active_end=active_end,
+        )
 
     def to_dict(self) -> CronScheduleDict:
         """Serialize this schedule for disk storage.
@@ -166,7 +363,17 @@ class CronSchedule:
         Returns:
             JSON-compatible schedule dictionary.
         """
-        return {"kind": self.kind, "minutes": self.minutes, "display": self.display}
+        return {
+            "kind": self.kind,
+            "minutes": self.minutes,
+            "display": self.display,
+            "timezone": self.timezone,
+            "wall_time": self.wall_time,
+            "wall_date": None if self.wall_date is None else self.wall_date.isoformat(),
+            "active_window": (
+                None if self.active_window is None else self.active_window.to_dict()
+            ),
+        }
 
     @classmethod
     def from_dict(cls, data: CronScheduleDict) -> CronSchedule:
@@ -178,7 +385,24 @@ class CronSchedule:
         Returns:
             Parsed cron schedule.
         """
-        return cls(kind=data["kind"], minutes=data["minutes"], display=data["display"])
+        return cls(
+            kind=data["kind"],
+            minutes=data.get("minutes"),
+            display=data["display"],
+            timezone=data.get("timezone"),
+            wall_time=data.get("wall_time"),
+            wall_date=_parse_wall_date(data.get("wall_date")),
+            active_window=_parse_active_window_dict(data.get("active_window")),
+        )
+
+    def _validate_one_shot_active_window(self, candidate: datetime) -> datetime:
+        if self.active_window is not None and not active_window_contains(
+            candidate,
+            self.active_window,
+        ):
+            msg = "one-shot schedule falls outside active hours"
+            raise CronJobError(msg)
+        return candidate
 
 
 @dataclass(frozen=True, slots=True)
@@ -254,6 +478,7 @@ class CronJob:
         last_status: Last run outcome.
         last_error: Last run error text.
         origin: Conversation that receives results.
+        scheduler_host_clock: Host clock context used to compute `next_run_at`.
     """
 
     id: str
@@ -269,6 +494,7 @@ class CronJob:
     last_status: JobStatus | None
     last_error: str | None
     origin: CronOrigin
+    scheduler_host_clock: SchedulerHostClock | None = None
 
     def to_dict(self) -> CronJobDict:
         """Serialize this job for disk storage.
@@ -290,6 +516,9 @@ class CronJob:
             "last_status": self.last_status,
             "last_error": self.last_error,
             "origin": self.origin.to_dict(),
+            "scheduler_host_clock": (
+                None if self.scheduler_host_clock is None else self.scheduler_host_clock.to_dict()
+            ),
         }
 
     @classmethod
@@ -316,6 +545,7 @@ class CronJob:
             last_status=data["last_status"],
             last_error=data["last_error"],
             origin=CronOrigin.from_dict(data["origin"]),
+            scheduler_host_clock=_parse_scheduler_host_clock(data.get("scheduler_host_clock")),
         )
 
 
@@ -358,9 +588,10 @@ class CronJobStore:
         """
         current = _coerce_utc(now)
         repeat = CronRepeat(times=repeat_times)
-        if schedule.kind == "one_shot" and repeat_times is not None:
+        if schedule.kind in {"one_shot", "wall_clock_once"} and repeat_times is not None:
             msg = "repeat cap is only valid for recurring jobs"
             raise CronJobError(msg)
+        next_run_at = schedule.next_after(current)
         job = CronJob(
             id=uuid.uuid4().hex[:12],
             assistant_id=self.assistant_id,
@@ -370,11 +601,12 @@ class CronJobStore:
             repeat=repeat,
             enabled=True,
             created_at=current,
-            next_run_at=schedule.next_after(current),
+            next_run_at=next_run_at,
             last_run_at=None,
             last_status=None,
             last_error=None,
             origin=origin,
+            scheduler_host_clock=capture_scheduler_host_clock(current),
         )
         jobs = [*self.list_jobs(), job]
         self._write_jobs(jobs)
@@ -467,10 +699,15 @@ class CronJobStore:
             new_schedule = schedule or job.schedule
             new_repeat = job.repeat
             if repeat_times is not None:
-                if new_schedule.kind != "recurring":
+                if new_schedule.kind not in {"recurring", "wall_clock_daily"}:
                     msg = "repeat cap is only valid for recurring jobs"
                     raise CronJobError(msg)
                 new_repeat = CronRepeat(times=repeat_times)
+            scheduler_host_clock = (
+                capture_scheduler_host_clock(current)
+                if schedule is not None
+                else job.scheduler_host_clock
+            )
             updated = replace(
                 job,
                 name=job.name if name is None else name,
@@ -479,6 +716,7 @@ class CronJobStore:
                 repeat=new_repeat,
                 enabled=job.enabled if enabled is None else enabled,
                 next_run_at=next_run_at,
+                scheduler_host_clock=scheduler_host_clock,
             )
             result.append(updated)
         if updated is None:
@@ -527,6 +765,7 @@ class CronJobStore:
         current = _coerce_utc(now)
         jobs = self.list_jobs()
         claimed: CronJob | None = None
+        changed = False
         result: list[CronJob] = []
         for job in jobs:
             if job.id != job_id:
@@ -535,9 +774,12 @@ class CronJobStore:
             if not job.enabled or job.next_run_at is None or job.next_run_at > current:
                 result.append(job)
                 continue
-            claimed = _advance_claimed_job(job, current)
-            result.append(claimed)
-        if claimed is not None:
+            advanced, should_run = _advance_claimed_job(job, current)
+            changed = True
+            if should_run:
+                claimed = advanced
+            result.append(advanced)
+        if changed:
             self._write_jobs(result)
         return claimed
 
@@ -658,19 +900,42 @@ class CronJobStore:
             self.path.chmod(0o600)
 
 
-def _advance_claimed_job(job: CronJob, now: datetime) -> CronJob:
-    if job.schedule.kind == "one_shot":
-        return replace(job, enabled=False, next_run_at=None)
+def _advance_claimed_job(job: CronJob, now: datetime) -> tuple[CronJob, bool]:
+    if job.schedule.kind in {"one_shot", "wall_clock_once"}:
+        return replace(job, enabled=False, next_run_at=None), True
+
+    if _outside_active_window(job, now):
+        return _advance_skipped_job(job, now), False
 
     repeat = job.repeat.claim()
     if repeat.exhausted:
-        return replace(job, repeat=repeat, enabled=False, next_run_at=None)
+        return replace(job, repeat=repeat, enabled=False, next_run_at=None), True
 
-    next_run_at = cast("datetime", job.next_run_at)
-    interval = timedelta(minutes=job.schedule.minutes)
-    while next_run_at <= now:
-        next_run_at += interval
-    return replace(job, repeat=repeat, next_run_at=next_run_at)
+    return (
+        replace(
+            job,
+            repeat=repeat,
+            next_run_at=job.schedule.next_after(now, previous=job.next_run_at),
+            scheduler_host_clock=capture_scheduler_host_clock(now),
+        ),
+        True,
+    )
+
+
+def _advance_skipped_job(job: CronJob, now: datetime) -> CronJob:
+    return replace(
+        job,
+        next_run_at=job.schedule.next_after(now, previous=job.next_run_at),
+        scheduler_host_clock=capture_scheduler_host_clock(now),
+    )
+
+
+def _outside_active_window(job: CronJob, now: datetime) -> bool:
+    return (
+        job.schedule.kind in {"recurring", "wall_clock_daily"}
+        and job.schedule.active_window is not None
+        and not active_window_contains(now, job.schedule.active_window)
+    )
 
 
 def _parse_duration_minutes(value: str) -> int:
@@ -685,6 +950,33 @@ def _parse_duration_minutes(value: str) -> int:
         return _positive_int(text[:-1]) * 60
     msg = "schedule duration must use 'm' for minutes or 'h' for hours"
     raise CronJobError(msg)
+
+
+def _parse_wall_date(value: str | None) -> date | None:
+    if value is None:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        msg = "wall-clock date must use YYYY-MM-DD"
+        raise CronJobError(msg) from exc
+
+
+def _parse_active_window_dict(value: ActiveWindowDict | None) -> ActiveWindow | None:
+    if value is None:
+        return None
+    try:
+        return ActiveWindow.from_dict(value)
+    except CronTimeError as exc:
+        raise CronJobError(str(exc)) from exc
+
+
+def _parse_scheduler_host_clock(
+    value: SchedulerHostClockDict | None,
+) -> SchedulerHostClock | None:
+    if value is None:
+        return None
+    return SchedulerHostClock.from_dict(value)
 
 
 def _positive_int(value: str) -> int:

--- a/libs/talon/deepagents_talon/cron/time.py
+++ b/libs/talon/deepagents_talon/cron/time.py
@@ -1,0 +1,549 @@
+"""Deterministic local-time helpers for Talon cron schedules.
+
+Talon is an experimental runtime and is subject to change or removal at any time.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time, timedelta
+from typing import NotRequired, TypedDict
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+TIMEZONE_ENV = "DEEPAGENTS_TALON_TIMEZONE"
+
+_LOCAL_TIME_RE = re.compile(
+    r"^\s*(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?\s*(?P<period>am|pm)?\s*$",
+)
+_MAX_HOUR = 23
+_MAX_MINUTE = 59
+_HOURS_PER_HALF_DAY = 12
+
+
+class CronTimeError(ValueError):
+    """Raised when local-time schedule conversion fails."""
+
+
+class LocalTimeOfDayDict(TypedDict):
+    """Serialized local time-of-day value."""
+
+    hour: int
+    minute: int
+
+
+class ActiveWindowDict(TypedDict):
+    """Serialized local active-hour window."""
+
+    timezone: str
+    start: str
+    end: str
+
+
+class SchedulerHostClockDict(TypedDict):
+    """Serialized scheduler host clock context."""
+
+    timezone: str
+    utc_offset: str
+    computed_at: str
+    local_now: NotRequired[str]
+
+
+@dataclass(frozen=True, slots=True)
+class LocalTimeOfDay:
+    """Minute-precision local wall-clock time.
+
+    Args:
+        hour: Hour in 24-hour local time.
+        minute: Minute in local time.
+    """
+
+    hour: int
+    minute: int
+
+    def __post_init__(self) -> None:
+        """Validate the local time components."""
+        if not 0 <= self.hour <= _MAX_HOUR:
+            msg = "local time hour must be between 0 and 23"
+            raise CronTimeError(msg)
+        if not 0 <= self.minute <= _MAX_MINUTE:
+            msg = "local time minute must be between 0 and 59"
+            raise CronTimeError(msg)
+
+    @property
+    def minutes_after_midnight(self) -> int:
+        """Return this time as minutes after local midnight."""
+        return self.hour * 60 + self.minute
+
+    def to_display(self) -> str:
+        """Return this time in `HH:MM` form.
+
+        Returns:
+            Zero-padded 24-hour display value.
+        """
+        return f"{self.hour:02d}:{self.minute:02d}"
+
+    @classmethod
+    def from_display(cls, value: str) -> LocalTimeOfDay:
+        """Parse a persisted `HH:MM` time value.
+
+        Args:
+            value: Stored time value.
+
+        Returns:
+            Parsed local time.
+        """
+        return parse_local_time(value)
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveWindow:
+    """Local-time window in which a cron job is allowed to run.
+
+    Args:
+        timezone: IANA time zone used to evaluate the window.
+        start: Inclusive local start time.
+        end: Exclusive local end time.
+    """
+
+    timezone: str
+    start: LocalTimeOfDay
+    end: LocalTimeOfDay
+
+    def __post_init__(self) -> None:
+        """Validate that the active window is non-empty."""
+        resolve_timezone(self.timezone)
+        if self.start == self.end:
+            msg = "active hours start and end must be different"
+            raise CronTimeError(msg)
+
+    def to_dict(self) -> ActiveWindowDict:
+        """Serialize this active window for disk storage.
+
+        Returns:
+            JSON-compatible active-window dictionary.
+        """
+        return {
+            "timezone": self.timezone,
+            "start": self.start.to_display(),
+            "end": self.end.to_display(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: ActiveWindowDict) -> ActiveWindow:
+        """Deserialize an active window from disk.
+
+        Args:
+            data: JSON active-window dictionary.
+
+        Returns:
+            Parsed active window.
+        """
+        return cls(
+            timezone=data["timezone"],
+            start=LocalTimeOfDay.from_display(data["start"]),
+            end=LocalTimeOfDay.from_display(data["end"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulerHostClock:
+    """Scheduler host clock context used to compute a UTC run time.
+
+    Args:
+        timezone: Time zone name reported by the host clock.
+        utc_offset: UTC offset reported by the host clock.
+        computed_at: UTC timestamp used as the computation basis.
+        local_now: Host-local timestamp for diagnostics.
+    """
+
+    timezone: str
+    utc_offset: str
+    computed_at: datetime
+    local_now: datetime
+
+    def to_dict(self) -> SchedulerHostClockDict:
+        """Serialize this host clock context for disk storage.
+
+        Returns:
+            JSON-compatible host clock dictionary.
+        """
+        return {
+            "timezone": self.timezone,
+            "utc_offset": self.utc_offset,
+            "computed_at": _format_time(self.computed_at),
+            "local_now": self.local_now.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: SchedulerHostClockDict) -> SchedulerHostClock:
+        """Deserialize scheduler host clock context.
+
+        Args:
+            data: JSON host clock dictionary.
+
+        Returns:
+            Parsed host clock context.
+        """
+        computed_at = _parse_time(data["computed_at"])
+        local_now = datetime.fromisoformat(data.get("local_now", data["computed_at"]))
+        if local_now.tzinfo is None:
+            local_now = local_now.replace(tzinfo=UTC)
+        return cls(
+            timezone=data["timezone"],
+            utc_offset=data["utc_offset"],
+            computed_at=computed_at,
+            local_now=local_now,
+        )
+
+
+def parse_local_time(value: str) -> LocalTimeOfDay:
+    """Parse a supported local time value.
+
+    Args:
+        value: Time text such as `20:00`, `8:00pm`, `8pm`, or `08:30`.
+
+    Returns:
+        Parsed local time.
+
+    Raises:
+        CronTimeError: If the time is malformed.
+    """
+    match = _LOCAL_TIME_RE.match(value.lower())
+    if match is None:
+        msg = "time must look like '20:00', '8:00pm', or '8pm'"
+        raise CronTimeError(msg)
+
+    minute_text = match.group("minute")
+    period = match.group("period")
+    if minute_text is None and period is None:
+        msg = "24-hour times must include minutes, such as '08:30'"
+        raise CronTimeError(msg)
+
+    hour = int(match.group("hour"))
+    minute = 0 if minute_text is None else int(minute_text)
+    if period is None:
+        return LocalTimeOfDay(hour=hour, minute=minute)
+    if not 1 <= hour <= _HOURS_PER_HALF_DAY:
+        msg = "12-hour times must use an hour between 1 and 12"
+        raise CronTimeError(msg)
+    return LocalTimeOfDay(hour=_convert_12_hour(hour, period), minute=minute)
+
+
+def parse_active_window(
+    *,
+    timezone: str | None,
+    active_start: str | None,
+    active_end: str | None,
+) -> ActiveWindow | None:
+    """Parse optional active-hour inputs.
+
+    Args:
+        timezone: Explicit IANA time zone, or `None` to use the environment default.
+        active_start: Inclusive local start time.
+        active_end: Exclusive local end time.
+
+    Returns:
+        Parsed active window, or `None` when no active hours were supplied.
+
+    Raises:
+        CronTimeError: If only one boundary is supplied or the window is invalid.
+    """
+    if active_start == "" and active_end == "":
+        return None
+    if active_start is None and active_end is None:
+        return None
+    if active_start is None or active_end is None:
+        msg = "active hours require both active_start and active_end"
+        raise CronTimeError(msg)
+    return ActiveWindow(
+        timezone=resolve_schedule_timezone(timezone),
+        start=parse_local_time(active_start),
+        end=parse_local_time(active_end),
+    )
+
+
+def resolve_schedule_timezone(value: str | None) -> str:
+    """Resolve the IANA time zone for a wall-clock schedule.
+
+    Args:
+        value: Explicit IANA time zone, or `None` to use `DEEPAGENTS_TALON_TIMEZONE`.
+
+    Returns:
+        Validated IANA time zone key.
+
+    Raises:
+        CronTimeError: If no IANA time zone is available.
+    """
+    candidate = value or os.environ.get(TIMEZONE_ENV)
+    if candidate is None or not candidate.strip():
+        msg = f"timezone is required for local-time schedules; set {TIMEZONE_ENV}"
+        raise CronTimeError(msg)
+    return resolve_timezone(candidate.strip()).key
+
+
+def resolve_timezone(value: str) -> ZoneInfo:
+    """Load an IANA time zone.
+
+    Args:
+        value: IANA time zone key.
+
+    Returns:
+        Loaded `ZoneInfo` instance.
+
+    Raises:
+        CronTimeError: If the time zone is unknown.
+    """
+    try:
+        return ZoneInfo(value)
+    except ZoneInfoNotFoundError as exc:
+        msg = f"unknown timezone: {value}"
+        raise CronTimeError(msg) from exc
+
+
+def next_wall_clock_run(
+    *,
+    now: datetime,
+    timezone: str,
+    time: LocalTimeOfDay,
+    date: date | None = None,
+) -> datetime:
+    """Return the next UTC run for a local wall-clock schedule.
+
+    Args:
+        now: Current timestamp.
+        timezone: IANA time zone used for local interpretation.
+        time: Local time of day to schedule.
+        date: Optional local calendar date.
+
+    Returns:
+        UTC timestamp for the next run.
+
+    Raises:
+        CronTimeError: If the requested local time is impossible or in the past.
+    """
+    current = _coerce_utc(now)
+    zone = resolve_timezone(timezone)
+    local_now = current.astimezone(zone)
+    run_date = date or local_now.date()
+    target = _localize(run_date, time, zone)
+    if date is None and target <= current:
+        target = _localize(run_date + timedelta(days=1), time, zone)
+    if date is not None and target <= current:
+        msg = "dated wall-clock schedule is in the past"
+        raise CronTimeError(msg)
+    return target
+
+
+def next_daily_wall_clock_run(
+    *,
+    previous: datetime | None,
+    now: datetime,
+    timezone: str,
+    time: LocalTimeOfDay,
+    active_window: ActiveWindow | None = None,
+) -> datetime:
+    """Return the next UTC run for a recurring daily wall-clock schedule.
+
+    Args:
+        previous: Previously scheduled run, if any.
+        now: Current timestamp.
+        timezone: IANA time zone used for local interpretation.
+        time: Local time of day to schedule.
+        active_window: Optional local active-hour gate.
+
+    Returns:
+        UTC timestamp for the next daily wall-clock run.
+    """
+    current = _coerce_utc(now)
+    zone = resolve_timezone(timezone)
+    if previous is None:
+        candidate = next_wall_clock_run(now=current, timezone=timezone, time=time)
+    else:
+        previous_local = _coerce_utc(previous).astimezone(zone)
+        candidate = _localize(previous_local.date() + timedelta(days=1), time, zone)
+        while candidate <= current:
+            candidate = _localize(candidate.astimezone(zone).date() + timedelta(days=1), time, zone)
+    if active_window is not None and not active_window_contains(candidate, active_window):
+        msg = "daily wall-clock schedule time falls outside active hours"
+        raise CronTimeError(msg)
+    return candidate
+
+
+def next_interval_run(
+    *,
+    previous: datetime,
+    now: datetime,
+    minutes: int,
+    active_window: ActiveWindow | None,
+) -> datetime:
+    """Return the next interval run after `now`.
+
+    Args:
+        previous: Previous candidate run timestamp.
+        now: Current timestamp.
+        minutes: Fixed interval in minutes.
+        active_window: Optional local active-hour gate.
+
+    Returns:
+        UTC timestamp for the next allowed interval run.
+    """
+    if minutes < 1:
+        msg = "interval must be at least 1 minute"
+        raise CronTimeError(msg)
+    current = _coerce_utc(now)
+    candidate = _coerce_utc(previous)
+    interval = timedelta(minutes=minutes)
+    while candidate <= current:
+        candidate += interval
+    if active_window is None:
+        return candidate
+    return next_active_window_time(candidate, active_window)
+
+
+def active_window_contains(value: datetime, active_window: ActiveWindow) -> bool:
+    """Return whether a UTC timestamp falls inside an active window.
+
+    Args:
+        value: Timestamp to evaluate.
+        active_window: Local active-hour window.
+
+    Returns:
+        `True` when the timestamp is inside the local window.
+    """
+    zone = resolve_timezone(active_window.timezone)
+    local = _coerce_utc(value).astimezone(zone)
+    minutes = local.hour * 60 + local.minute
+    start = active_window.start.minutes_after_midnight
+    end = active_window.end.minutes_after_midnight
+    if start < end:
+        return start <= minutes < end
+    return minutes >= start or minutes < end
+
+
+def next_active_window_time(value: datetime, active_window: ActiveWindow) -> datetime:
+    """Move a timestamp forward to the next active window if needed.
+
+    Args:
+        value: UTC timestamp to evaluate.
+        active_window: Local active-hour window.
+
+    Returns:
+        `value` when it is already inside the window, otherwise the next local
+        active-window start converted to UTC.
+    """
+    candidate = _coerce_utc(value)
+    if active_window_contains(candidate, active_window):
+        return candidate
+
+    zone = resolve_timezone(active_window.timezone)
+    local = candidate.astimezone(zone)
+    start = active_window.start.minutes_after_midnight
+    end = active_window.end.minutes_after_midnight
+    current = local.hour * 60 + local.minute
+    days = _days_until_window_start(start=start, end=end, current=current)
+    run_date = local.date() + timedelta(days=days)
+    return _localize(run_date, active_window.start, zone)
+
+
+def capture_scheduler_host_clock(now: datetime | None = None) -> SchedulerHostClock:
+    """Capture the scheduler host clock context.
+
+    Args:
+        now: UTC computation basis, or `None` for the current time.
+
+    Returns:
+        Host clock context for diagnostics.
+    """
+    computed_at = _coerce_utc(now)
+    local_now = computed_at.astimezone()
+    return SchedulerHostClock(
+        timezone=_timezone_name(local_now),
+        utc_offset=_format_offset(local_now),
+        computed_at=computed_at,
+        local_now=local_now,
+    )
+
+
+def format_local_run(value: datetime, timezone: str) -> str:
+    """Format a UTC run timestamp in a schedule time zone.
+
+    Args:
+        value: UTC run timestamp.
+        timezone: IANA time zone key.
+
+    Returns:
+        Local display string for tool output.
+    """
+    local = _coerce_utc(value).astimezone(resolve_timezone(timezone))
+    return f"{local:%Y-%m-%d %H:%M} {timezone}"
+
+
+def _localize(day: date, value: LocalTimeOfDay, zone: ZoneInfo) -> datetime:
+    naive = datetime.combine(day, time(value.hour, value.minute))
+    first = naive.replace(tzinfo=zone, fold=0)
+    second = naive.replace(tzinfo=zone, fold=1)
+    first_valid = _round_trips(first, zone, naive)
+    second_valid = _round_trips(second, zone, naive)
+    if not first_valid and not second_valid:
+        msg = (
+            "local time does not exist because of daylight saving transition: "
+            f"{day} {value.to_display()}"
+        )
+        raise CronTimeError(msg)
+    if first_valid:
+        return first.astimezone(UTC)
+    return second.astimezone(UTC)
+
+
+def _round_trips(value: datetime, zone: ZoneInfo, naive: datetime) -> bool:
+    return value.astimezone(UTC).astimezone(zone).replace(tzinfo=None) == naive
+
+
+def _convert_12_hour(hour: int, period: str) -> int:
+    if period == "am":
+        return 0 if hour == _HOURS_PER_HALF_DAY else hour
+    return _HOURS_PER_HALF_DAY if hour == _HOURS_PER_HALF_DAY else hour + _HOURS_PER_HALF_DAY
+
+
+def _days_until_window_start(*, start: int, end: int, current: int) -> int:
+    if start < end:
+        return 0 if current < start else 1
+    return 0 if end <= current < start else 1
+
+
+def _timezone_name(value: datetime) -> str:
+    tzinfo = value.tzinfo
+    key = getattr(tzinfo, "key", None)
+    if isinstance(key, str) and key:
+        return key
+    name = value.tzname()
+    return name or "local"
+
+
+def _format_offset(value: datetime) -> str:
+    offset = value.utcoffset()
+    if offset is None:
+        return "+00:00"
+    total_minutes = int(offset.total_seconds() // 60)
+    sign = "+" if total_minutes >= 0 else "-"
+    total_minutes = abs(total_minutes)
+    hours, minutes = divmod(total_minutes, 60)
+    return f"{sign}{hours:02d}:{minutes:02d}"
+
+
+def _format_time(value: datetime) -> str:
+    return _coerce_utc(value).isoformat()
+
+
+def _parse_time(value: str) -> datetime:
+    return _coerce_utc(datetime.fromisoformat(value))
+
+
+def _coerce_utc(value: datetime | None = None) -> datetime:
+    if value is None:
+        return datetime.now(UTC)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)

--- a/libs/talon/deepagents_talon/cron/tools.py
+++ b/libs/talon/deepagents_talon/cron/tools.py
@@ -10,7 +10,13 @@ from typing import Any
 
 from langchain_core.tools import BaseTool, tool
 
-from deepagents_talon.cron.jobs import CronJob, CronJobStore, CronOrigin, CronSchedule
+from deepagents_talon.cron.jobs import (
+    CronJob,
+    CronJobError,
+    CronJobStore,
+    CronOrigin,
+    CronSchedule,
+)
 
 OriginFactory = Callable[[], CronOrigin]
 _PAIRED_QUOTE_LENGTH = 2
@@ -29,13 +35,16 @@ class CronTools:
         self.store = store
         self.origin = origin
 
-    def create_job(
+    def create_job(  # noqa: PLR0913  # agent tool exposes optional schedule context
         self,
         *,
         prompt: str,
         schedule: str,
         name: str = "",
         repeat_times: int | None = None,
+        timezone: str | None = None,
+        active_start: str | None = None,
+        active_end: str | None = None,
     ) -> dict[str, Any]:
         """Create a scheduled job in the current conversation.
 
@@ -44,13 +53,21 @@ class CronTools:
             schedule: Schedule text such as `in 30m` or `every 15m`.
             name: Optional human-readable label.
             repeat_times: Optional cap for recurring schedules.
+            timezone: Optional IANA time zone for local-time schedules.
+            active_start: Optional inclusive active-hour start time.
+            active_end: Optional exclusive active-hour end time.
 
         Returns:
             Created job as a JSON-compatible dictionary.
         """
         job = self.store.create_job(
             prompt=prompt,
-            schedule=CronSchedule.parse(schedule),
+            schedule=CronSchedule.parse(
+                schedule,
+                timezone=timezone,
+                active_start=active_start,
+                active_end=active_end,
+            ),
             origin=self.origin(),
             name=name,
             repeat_times=repeat_times,
@@ -74,6 +91,9 @@ class CronTools:
         schedule: str | None = None,
         enabled: bool | None = None,
         repeat_times: int | None = None,
+        timezone: str | None = None,
+        active_start: str | None = None,
+        active_end: str | None = None,
     ) -> dict[str, Any]:
         """Edit a scheduled job in the current conversation.
 
@@ -84,15 +104,43 @@ class CronTools:
             schedule: Optional replacement schedule text.
             enabled: Optional enabled flag.
             repeat_times: Optional replacement repeat cap for recurring jobs.
+            timezone: Optional IANA time zone for local-time schedules.
+            active_start: Optional inclusive active-hour start time.
+            active_end: Optional exclusive active-hour end time.
 
         Returns:
             Updated job as a JSON-compatible dictionary.
         """
-        parsed = None if schedule is None else CronSchedule.parse(schedule)
+        origin = self.origin()
+        if schedule is None and _has_schedule_options(
+            timezone=timezone,
+            active_start=active_start,
+            active_end=active_end,
+        ):
+            job = self.store.get_job(job_id, origin=origin)
+            if job is None:
+                msg = f"cron job not found in current conversation: {job_id}"
+                raise CronJobError(msg)
+            parsed = job.schedule.with_options(
+                timezone=timezone,
+                active_start=active_start,
+                active_end=active_end,
+            )
+        else:
+            parsed = (
+                None
+                if schedule is None
+                else CronSchedule.parse(
+                    schedule,
+                    timezone=timezone,
+                    active_start=active_start,
+                    active_end=active_end,
+                )
+            )
         return _tool_job(
             self.store.edit_job(
                 job_id,
-                origin=self.origin(),
+                origin=origin,
                 name=name,
                 prompt=prompt,
                 schedule=parsed,
@@ -132,11 +180,15 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
     """
 
     @tool
-    def create_job(
+    def create_job(  # noqa: PLR0913  # agent tool exposes optional schedule context
         prompt: str,
         schedule: str,
         name: str = "",
         repeat_times: int | None = None,
+        *,
+        timezone: str | None = None,
+        active_start: str | None = None,
+        active_end: str | None = None,
     ) -> dict[str, Any]:
         """Schedule a background task that will later deliver to this conversation.
 
@@ -145,6 +197,9 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
             schedule: Schedule text such as `in 30m` or `every 15m`.
             name: Optional human-readable label for the job.
             repeat_times: Optional cap for recurring schedules.
+            timezone: Optional IANA time zone for local-time schedules.
+            active_start: Optional inclusive active-hour start time.
+            active_end: Optional exclusive active-hour end time.
 
         Returns:
             Created job details, or an error dictionary for invalid input.
@@ -155,6 +210,9 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
                 schedule=schedule,
                 name=name,
                 repeat_times=repeat_times,
+                timezone=timezone,
+                active_start=active_start,
+                active_end=active_end,
             )
         except Exception as exc:  # noqa: BLE001
             return _tool_error(exc)
@@ -180,6 +238,9 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
         *,
         enabled: bool | None = None,
         repeat_times: int | None = None,
+        timezone: str | None = None,
+        active_start: str | None = None,
+        active_end: str | None = None,
     ) -> dict[str, Any]:
         """Update one or more settings on a scheduled job from this conversation.
 
@@ -190,6 +251,9 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
             schedule: Optional replacement schedule text.
             enabled: Optional enabled flag. Use `False` to pause, `True` to resume.
             repeat_times: Optional replacement repeat cap for recurring schedules.
+            timezone: Optional IANA time zone for local-time schedules.
+            active_start: Optional inclusive active-hour start time.
+            active_end: Optional exclusive active-hour end time.
 
         Returns:
             Updated job details, or an error dictionary for invalid input.
@@ -202,6 +266,9 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
                 schedule=_strip_optional_quotes(schedule),
                 enabled=enabled,
                 repeat_times=repeat_times,
+                timezone=_strip_optional_quotes(timezone),
+                active_start=_strip_optional_quotes(active_start),
+                active_end=_strip_optional_quotes(active_end),
             )
         except Exception as exc:  # noqa: BLE001
             return _tool_error(exc)
@@ -226,6 +293,9 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
 
 def _tool_job(job: CronJob) -> dict[str, Any]:
     data = job.to_dict()
+    next_run_local = (
+        None if job.next_run_at is None else job.schedule.next_run_local(job.next_run_at)
+    )
     return {
         "id": data["id"],
         "name": data["name"],
@@ -234,6 +304,8 @@ def _tool_job(job: CronJob) -> dict[str, Any]:
         "repeat": data["repeat"],
         "enabled": data["enabled"],
         "next_run_at": data["next_run_at"],
+        "next_run_local": next_run_local,
+        "scheduler_host_clock": data["scheduler_host_clock"],
         "last_run_at": data["last_run_at"],
         "last_status": data["last_status"],
         "last_error": data["last_error"],
@@ -242,6 +314,15 @@ def _tool_job(job: CronJob) -> dict[str, Any]:
 
 def _tool_error(exc: Exception) -> dict[str, str]:
     return {"error": str(exc)}
+
+
+def _has_schedule_options(
+    *,
+    timezone: str | None,
+    active_start: str | None,
+    active_end: str | None,
+) -> bool:
+    return timezone is not None or active_start is not None or active_end is not None
 
 
 def _strip_optional_quotes(value: str | None) -> str | None:

--- a/libs/talon/tests/cron/test_jobs.py
+++ b/libs/talon/tests/cron/test_jobs.py
@@ -65,6 +65,98 @@ def test_recurring_job_advances_before_run_and_honors_repeat_cap(tmp_path) -> No
     assert second.repeat.completed == 2
 
 
+def test_wall_clock_job_persists_timezone_and_local_output(tmp_path) -> None:
+    now = datetime(2026, 7, 2, 1, tzinfo=UTC)
+    store = _store(tmp_path)
+
+    job = store.create_job(
+        prompt="send reminder",
+        schedule=CronSchedule.parse("at 8:00pm", timezone="America/Los_Angeles"),
+        origin=CronOrigin(conversation_id="chat"),
+        now=now,
+    )
+
+    assert job.next_run_at == datetime(2026, 7, 2, 3, tzinfo=UTC)
+    assert job.schedule.to_dict()["timezone"] == "America/Los_Angeles"
+    assert job.schedule.to_dict()["wall_time"] == "20:00"
+    assert job.scheduler_host_clock is not None
+    assert CronTools(store=store, origin=lambda: CronOrigin(conversation_id="chat")).list_jobs()[0][
+        "next_run_local"
+    ] == "2026-07-01 20:00 America/Los_Angeles"
+
+
+def test_active_window_moves_initial_run_to_next_allowed_time(tmp_path) -> None:
+    now = datetime(2026, 7, 2, 0, 20, tzinfo=UTC)
+    store = _store(tmp_path)
+
+    job = store.create_job(
+        prompt="heartbeat",
+        schedule=CronSchedule.parse(
+            "every 15m",
+            timezone="America/Los_Angeles",
+            active_start="08:30",
+            active_end="17:27",
+        ),
+        origin=CronOrigin(conversation_id="chat"),
+        now=now,
+    )
+
+    assert job.next_run_at == datetime(2026, 7, 2, 15, 30, tzinfo=UTC)
+
+
+def test_active_window_skip_does_not_consume_repeat_cap(tmp_path) -> None:
+    now = datetime(2026, 7, 2, 23, 44, tzinfo=UTC)
+    store = _store(tmp_path)
+    job = store.create_job(
+        prompt="heartbeat",
+        schedule=CronSchedule.parse(
+            "every 15m",
+            timezone="America/Los_Angeles",
+            active_start="08:00",
+            active_end="17:00",
+        ),
+        origin=CronOrigin(conversation_id="chat"),
+        repeat_times=2,
+        now=now,
+    )
+
+    claimed = store.advance_next_run(job.id, now=datetime(2026, 7, 3, 0, 1, tzinfo=UTC))
+
+    updated = store.get_job(job.id)
+    assert claimed is None
+    assert updated is not None
+    assert updated.repeat.completed == 0
+    assert updated.next_run_at == datetime(2026, 7, 3, 15, tzinfo=UTC)
+
+
+def test_tools_edit_active_hours_without_replacing_schedule(tmp_path) -> None:
+    store = _store(tmp_path)
+    current = CronOrigin(conversation_id="chat")
+    tools = CronTools(store=store, origin=lambda: current)
+    job = store.create_job(
+        prompt="heartbeat",
+        schedule=CronSchedule.parse("every 15m"),
+        origin=current,
+        now=datetime(2026, 7, 2, 15, tzinfo=UTC),
+    )
+
+    updated = tools.edit_job(
+        job.id,
+        timezone="America/Los_Angeles",
+        active_start="08:00",
+        active_end="17:00",
+    )
+    cleared = tools.edit_job(job.id, active_start="", active_end="")
+
+    assert updated["schedule"]["active_window"] == {
+        "timezone": "America/Los_Angeles",
+        "start": "08:00",
+        "end": "17:00",
+    }
+    assert updated["schedule"]["display"] == "every 15m"
+    assert cleared["schedule"]["active_window"] is None
+
+
 def test_store_prunes_only_expired_completed_jobs(tmp_path) -> None:
     now = datetime(2026, 1, 31, 12, tzinfo=UTC)
     store = _store(tmp_path)

--- a/libs/talon/tests/cron/test_time.py
+++ b/libs/talon/tests/cron/test_time.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from deepagents_talon.cron.time import (
+    ActiveWindow,
+    CronTimeError,
+    LocalTimeOfDay,
+    active_window_contains,
+    next_wall_clock_run,
+    parse_local_time,
+)
+
+
+def test_parse_local_time_supported_grammar() -> None:
+    assert parse_local_time("20:00") == LocalTimeOfDay(hour=20, minute=0)
+    assert parse_local_time("8:00pm") == LocalTimeOfDay(hour=20, minute=0)
+    assert parse_local_time("8pm") == LocalTimeOfDay(hour=20, minute=0)
+    assert parse_local_time("08:30") == LocalTimeOfDay(hour=8, minute=30)
+
+
+def test_next_wall_clock_run_uses_next_local_occurrence() -> None:
+    now = datetime(2026, 7, 2, 1, tzinfo=UTC)
+
+    result = next_wall_clock_run(
+        now=now,
+        timezone="America/Los_Angeles",
+        time=LocalTimeOfDay(hour=20, minute=0),
+    )
+
+    assert result == datetime(2026, 7, 2, 3, tzinfo=UTC)
+
+
+def test_next_wall_clock_run_uses_first_ambiguous_dst_occurrence() -> None:
+    now = datetime(2026, 11, 1, 0, tzinfo=UTC)
+
+    result = next_wall_clock_run(
+        now=now,
+        timezone="America/Los_Angeles",
+        time=LocalTimeOfDay(hour=1, minute=30),
+        date=datetime(2026, 11, 1, tzinfo=UTC).date(),
+    )
+
+    assert result == datetime(2026, 11, 1, 8, 30, tzinfo=UTC)
+
+
+def test_next_wall_clock_run_rejects_nonexistent_dst_time() -> None:
+    now = datetime(2026, 3, 8, 0, tzinfo=UTC)
+
+    with pytest.raises(CronTimeError, match="does not exist"):
+        next_wall_clock_run(
+            now=now,
+            timezone="America/Los_Angeles",
+            time=LocalTimeOfDay(hour=2, minute=30),
+            date=datetime(2026, 3, 8, tzinfo=UTC).date(),
+        )
+
+
+def test_active_window_supports_cross_midnight() -> None:
+    window = ActiveWindow(
+        timezone="America/Los_Angeles",
+        start=LocalTimeOfDay(hour=22, minute=0),
+        end=LocalTimeOfDay(hour=6, minute=0),
+    )
+
+    assert active_window_contains(datetime(2026, 7, 2, 6, tzinfo=UTC), window)
+    assert active_window_contains(datetime(2026, 7, 2, 12, 30, tzinfo=UTC), window)
+    assert not active_window_contains(datetime(2026, 7, 2, 19, tzinfo=UTC), window)


### PR DESCRIPTION
Adds deterministic cron time handling for Talon so scheduled jobs can use user-local wall-clock schedules and active-hour windows without relying on the model to interpret clock math. The cron store now persists schedule time zones, wall times, active windows, and scheduler host clock context alongside the existing JSON-backed job record.

This keeps the existing relative schedule behavior for `in 30m` and `every 15m`, while adding support for `at 8:00pm`, dated wall-clock one-shots, daily wall-clock recurrence, active windows that can cross midnight, and local `next_run_local` tool output. `create_job` and `edit_job` now accept keyword-only schedule context fields for `timezone`, `active_start`, and `active_end`; `edit_job` can add, replace, or clear active hours without recreating the job.

## Release note
Talon cron jobs can now be scheduled with wall-clock local times and constrained to active-hour windows using deterministic IANA time zone conversion.

Areas worth careful review: DST edge handling, the JSON compatibility path for existing cron records, and the choice that active-window skips do not consume recurring repeat caps.

Follow-ups intentionally left out of this first slice: cron-triggered prompt metadata for schedule-local versus host-local time, `cron.window_skip` / `cron.schedule_error` observability events, and README coverage for the new schedule grammar.