### PR TITLE
style(code): drop env-var hint from `/trace` not-configured message

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7781,8 +7781,7 @@ class DeepAgentsApp(App):
             await self._mount_message(
                 AppMessage(
                     "LangSmith tracing is not configured. "
-                    "Run `/auth` and select LangSmith to enable tracing, or set "
-                    "LANGSMITH_API_KEY and LANGSMITH_TRACING=true.",
+                    "Run `/auth` and select LangSmith to enable tracing.",
                 ),
             )
             return

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -4057,8 +4057,8 @@ class TestTraceCommand:
 
             app_msgs = app.query(AppMessage)
             rendered = "\n".join(str(w._content) for w in app_msgs)
-            assert "LANGSMITH_API_KEY" in rendered
             assert "/auth" in rendered
+            assert "LANGSMITH_API_KEY" not in rendered
 
     async def test_trace_shows_network_error_when_url_fetch_times_out(self) -> None:
         """Should distinguish a network/timeout failure from a config gap.


### PR DESCRIPTION
`/trace` now directs users to `/auth` (only) when LangSmith tracing is not configured.

Made by [Open SWE](https://openswe.vercel.app/agents/dc58d0c4-6dfe-42ae-4af1-28ff95148006)