### PR TITLE
fix(evals): forward `--eval-category-exclude` from the trials subcommand

### DIFF
--- a/libs/evals/deepagents_evals/cli.py
+++ b/libs/evals/deepagents_evals/cli.py
@@ -398,6 +398,8 @@ def _cmd_trials(args: argparse.Namespace, parser: argparse.ArgumentParser) -> in
     rt_argv: list[str] = ["--model", args.model, "--trials", str(args.trials)]
     for cat in args.eval_category or []:
         rt_argv.extend(["--eval-category", cat])
+    for cat in args.eval_category_exclude or []:
+        rt_argv.extend(["--eval-category-exclude", cat])
     for tier in args.eval_tier or []:
         rt_argv.extend(["--eval-tier", tier])
     if args.openai_reasoning_effort:

--- a/libs/evals/scripts/run_trials.py
+++ b/libs/evals/scripts/run_trials.py
@@ -279,6 +279,8 @@ def _build_pytest_args(args: argparse.Namespace, report_path: Path) -> list[str]
     ]
     for cat in args.eval_category or []:
         cmd.extend(["--eval-category", cat])
+    for cat in args.eval_category_exclude or []:
+        cmd.extend(["--eval-category-exclude", cat])
     for tier in args.eval_tier or []:
         cmd.extend(["--eval-tier", tier])
     if args.openai_reasoning_effort:
@@ -487,6 +489,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="append",
         default=[],
         help="Restrict to one eval category (repeatable).",
+    )
+    parser.add_argument(
+        "--eval-category-exclude",
+        action="append",
+        default=[],
+        help="Exclude one eval category (repeatable).",
     )
     parser.add_argument(
         "--eval-tier",

--- a/libs/evals/tests/unit_tests/test_cli.py
+++ b/libs/evals/tests/unit_tests/test_cli.py
@@ -144,6 +144,27 @@ class TestTrialsSubcommand:
         assert "--eval-category" in argv
         assert "tool_use" in argv
 
+    def test_dry_run_forwards_eval_category_exclude(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = cli.main(
+            [
+                "trials",
+                "--model",
+                "openai:gpt-5.5",
+                "--trials",
+                "2",
+                "--eval-category-exclude",
+                "memory",
+                "--dry-run",
+                "--json",
+            ]
+        )
+        assert rc == cli.EXIT_OK
+        argv = json.loads(capsys.readouterr().out)["argv"]
+        assert "--eval-category-exclude" in argv
+        assert argv[argv.index("--eval-category-exclude") + 1] == "memory"
+
     def test_retry_failed_collects_nodeids(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/libs/evals/tests/unit_tests/test_run_trials.py
+++ b/libs/evals/tests/unit_tests/test_run_trials.py
@@ -318,6 +318,7 @@ def _make_args(**overrides: Any) -> argparse.Namespace:
         "model": "openai:gpt-5.5",
         "trials": 1,
         "eval_category": [],
+        "eval_category_exclude": [],
         "eval_tier": [],
         "openai_reasoning_effort": None,
         "openrouter_provider": None,
@@ -350,6 +351,14 @@ class TestBuildPytestArgs:
         assert "tool_use" in cmd
         assert cmd.count("--eval-tier") == 1
         assert "baseline" in cmd
+
+    def test_repeated_category_excludes(self) -> None:
+        args = _make_args(eval_category_exclude=["memory", "tool_use"])
+        cmd = run_trials._build_pytest_args(args, Path("/tmp/r.json"))
+        # Each repeated value should show up as its own --eval-category-exclude flag.
+        assert cmd.count("--eval-category-exclude") == 2
+        assert "memory" in cmd
+        assert "tool_use" in cmd
 
     def test_optional_flags_pass_through(self) -> None:
         args = _make_args(
@@ -417,6 +426,21 @@ class TestParseArgs:
         assert args.aggregate_only == tmp_path
         assert args.model is None
         assert args.trials is None
+
+    def test_accepts_repeated_eval_category_exclude(self) -> None:
+        args = run_trials._parse_args(
+            [
+                "--model",
+                "openai:gpt-5.5",
+                "--trials",
+                "1",
+                "--eval-category-exclude",
+                "memory",
+                "--eval-category-exclude",
+                "tool_use",
+            ]
+        )
+        assert args.eval_category_exclude == ["memory", "tool_use"]
 
     def test_strips_leading_double_dash_from_pytest_extra(self) -> None:
         args = run_trials._parse_args(


### PR DESCRIPTION
Fixes #4440

---

The `trials` subcommand of `deepagents-evals` accepts `--eval-category-exclude` (it's registered for both `run` and `trials` by `_add_run_options`), but `_cmd_trials` never forwards it when it builds the argv for `scripts/run_trials.py`, so the exclusion is silently dropped and every category still runs. This wires the flag through `_cmd_trials` and adds it to `run_trials.py`'s parser and pytest argv, matching how `--eval-category` is already plumbed on both paths.

## Release note

`deepagents-evals trials --eval-category-exclude <category>` now actually excludes the category (matching `deepagents-evals run`). Previously the flag was accepted but ignored, and the full suite ran regardless.

### How I verified

`--dry-run --json` prints the exact argv each path would execute:

- Before: `trials ... --eval-category-exclude memory` → `['--model', ..., '--trials', '2']` (flag dropped), while `run` includes it.
- After: the trials argv includes `--eval-category-exclude memory`, and `run_trials.py` forwards it to `pytest tests/evals`.

Added regression tests (all fail on `main`, pass with the fix):
- `test_cli.py::TestTrialsSubcommand::test_dry_run_forwards_eval_category_exclude`
- `test_run_trials.py::TestBuildPytestArgs::test_repeated_category_excludes`
- `test_run_trials.py::TestParseArgs::test_accepts_repeated_eval_category_exclude`

Without the fix, `run_trials.py` even errors `unrecognized arguments: --eval-category-exclude`, confirming the option was missing there entirely. `ruff format`/`ruff check`/`ty check` are clean on the changed files; the full `libs/evals` unit suite passes (254 passed).

---

_AI-assistance disclaimer: I used an AI coding assistant (Claude) to help write this change. I reviewed every line, reproduced the bug, and verified the fix and tests myself as described above._
