### PR TITLE
feat(talon): add Fleet export validation

### DIFF
--- a/libs/talon/deepagents_talon/fleet.py
+++ b/libs/talon/deepagents_talon/fleet.py
@@ -17,6 +17,7 @@ from urllib.parse import urlsplit
 
 from fleet_deepagents_export import StaticSkillsLoader, load_agent_components
 
+from deepagents_talon.fleet_export import strip_url_query_and_fragment, validate_fleet_export
 from deepagents_talon.observability import log_event
 
 if TYPE_CHECKING:
@@ -70,8 +71,11 @@ async def load_fleet_agent_components(
         Validated Fleet components ready for Talon's runtime wiring.
 
     Raises:
+        FleetExportValidationError: If the Fleet export is missing required
+            files or contains malformed Fleet MCP tool metadata.
         TypeError: If the library returns an unexpected component shape.
     """
+    validate_fleet_export(fleet_dir)
     with _patched_environ(env):
         raw = await load_agent_components(fleet_dir)
     components = _coerce_components(raw)
@@ -373,7 +377,7 @@ def _fleet_log_endpoint(
     if auth_path != "builtin":
         return server_url
     values = os.environ if env is None else env
-    return values.get("BUILTIN_MCP_URL") or server_url
+    return strip_url_query_and_fragment(values.get("BUILTIN_MCP_URL") or server_url)
 
 
 def _is_builtin_fleet_server(

--- a/libs/talon/deepagents_talon/fleet_export.py
+++ b/libs/talon/deepagents_talon/fleet_export.py
@@ -6,7 +6,7 @@ Talon is an experimental runtime and is subject to change or removal at any time
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 from urllib.parse import urlsplit, urlunsplit
@@ -32,16 +32,12 @@ class FleetExportToolEntry:
         tool_name: Requested MCP tool name.
         mcp_server_url: MCP server URL with query string and fragment removed.
         auth_path: Fleet authentication path for the server.
-        server_display_name: Optional human-readable MCP server name from Fleet.
-        server_registry_name: Optional registry MCP server name from Fleet.
     """
 
     scope: str
     tool_name: str
     mcp_server_url: str
     auth_path: str
-    server_display_name: str | None = None
-    server_registry_name: str | None = None
 
 
 def validate_fleet_export(fleet_dir: Path) -> None:
@@ -127,14 +123,6 @@ def _extend_tool_entries(
                 tool_name=name,
                 mcp_server_url=strip_url_query_and_fragment(server_url),
                 auth_path=_fleet_auth_path(tool),
-                server_display_name=_first_tool_str(
-                    tool,
-                    ("server_display_name", "mcp_server_display_name", "display_name"),
-                ),
-                server_registry_name=_first_tool_str(
-                    tool,
-                    ("server_registry_name", "mcp_server_registry_name", "registry_name"),
-                ),
             )
         )
 
@@ -167,14 +155,6 @@ def _required_tool_str(
         return value
     msg = f"Fleet export {path} tools[{index}].{key} must be a non-empty string"
     raise FleetExportValidationError(msg)
-
-
-def _first_tool_str(tool: Mapping[str, object], keys: Sequence[str]) -> str | None:
-    for key in keys:
-        value = tool.get(key)
-        if isinstance(value, str) and value:
-            return value
-    return None
 
 
 def _fleet_auth_path(tool: Mapping[str, object]) -> str:

--- a/libs/talon/deepagents_talon/fleet_export.py
+++ b/libs/talon/deepagents_talon/fleet_export.py
@@ -1,0 +1,202 @@
+"""Fleet export validation and MCP tool requirement extraction.
+
+Talon is an experimental runtime and is subject to change or removal at any time.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+from urllib.parse import urlsplit, urlunsplit
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_REQUIRED_EXPORT_FILES = ("AGENTS.md", "config.json")
+_KNOWN_FLEET_AUTH_PATHS = frozenset({"builtin", "headers", "oauth"})
+
+
+class FleetExportValidationError(ValueError):
+    """Raised when a Fleet export cannot be imported by Talon."""
+
+
+@dataclass(frozen=True, slots=True)
+class FleetExportToolEntry:
+    """MCP tool requirement entry declared by a Fleet export.
+
+    Args:
+        scope: Fleet scope declaring the requirement, such as `root` or
+            `subagent:<name>`.
+        tool_name: Requested MCP tool name.
+        mcp_server_url: MCP server URL with query string and fragment removed.
+        auth_path: Fleet authentication path for the server.
+        server_display_name: Optional human-readable MCP server name from Fleet.
+        server_registry_name: Optional registry MCP server name from Fleet.
+    """
+
+    scope: str
+    tool_name: str
+    mcp_server_url: str
+    auth_path: str
+    server_display_name: str | None = None
+    server_registry_name: str | None = None
+
+
+def validate_fleet_export(fleet_dir: Path) -> None:
+    """Validate required Fleet export files and optional `tools.json` content.
+
+    Args:
+        fleet_dir: Operator-unzipped Fleet export directory.
+
+    Raises:
+        FleetExportValidationError: If the export is missing required files or
+            contains malformed Fleet MCP tool metadata.
+    """
+    if not fleet_dir.is_dir():
+        msg = f"Fleet export {fleet_dir} must be a directory"
+        raise FleetExportValidationError(msg)
+
+    for filename in _REQUIRED_EXPORT_FILES:
+        path = fleet_dir / filename
+        if not path.is_file():
+            msg = f"Fleet export {fleet_dir} is missing required file {filename}"
+            raise FleetExportValidationError(msg)
+
+    fleet_tool_entries(fleet_dir)
+
+
+def fleet_tool_entries(fleet_dir: Path) -> list[FleetExportToolEntry]:
+    """Return validated Fleet MCP tool entries from root and subagent exports.
+
+    Args:
+        fleet_dir: Operator-unzipped Fleet export directory.
+
+    Returns:
+        Deterministic Fleet MCP tool entries.
+
+    Raises:
+        FleetExportValidationError: If a present `tools.json` file is malformed.
+    """
+    entries: list[FleetExportToolEntry] = []
+    _extend_tool_entries(entries, fleet_dir / "tools.json", scope="root")
+
+    subagents_dir = fleet_dir / "subagents"
+    try:
+        subagent_dirs = sorted(path for path in subagents_dir.glob("*") if path.is_dir())
+    except FileNotFoundError:
+        return entries
+    except OSError:
+        return entries
+
+    for subagent_dir in subagent_dirs:
+        _extend_tool_entries(
+            entries,
+            subagent_dir / "tools.json",
+            scope=f"subagent:{subagent_dir.name}",
+        )
+    return entries
+
+
+def _extend_tool_entries(
+    entries: list[FleetExportToolEntry],
+    path: Path,
+    *,
+    scope: str,
+) -> None:
+    if not path.is_file():
+        return
+
+    data = _load_tools_file(path)
+    raw_tools = data.get("tools")
+    if not isinstance(raw_tools, list):
+        msg = f"Fleet export {path} field 'tools' must be a list"
+        raise FleetExportValidationError(msg)
+
+    for index, raw_tool in enumerate(raw_tools):
+        if not isinstance(raw_tool, Mapping):
+            msg = f"Fleet export {path} tools[{index}] must be an object"
+            raise FleetExportValidationError(msg)
+        tool = cast("Mapping[str, object]", raw_tool)
+        name = _required_tool_str(tool, "name", path=path, index=index)
+        server_url = _required_tool_str(tool, "mcp_server_url", path=path, index=index)
+        entries.append(
+            FleetExportToolEntry(
+                scope=scope,
+                tool_name=name,
+                mcp_server_url=strip_url_query_and_fragment(server_url),
+                auth_path=_fleet_auth_path(tool),
+                server_display_name=_first_tool_str(
+                    tool,
+                    ("server_display_name", "mcp_server_display_name", "display_name"),
+                ),
+                server_registry_name=_first_tool_str(
+                    tool,
+                    ("server_registry_name", "mcp_server_registry_name", "registry_name"),
+                ),
+            )
+        )
+
+
+def _load_tools_file(path: Path) -> Mapping[str, object]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        msg = f"Fleet export {path} is not valid JSON"
+        raise FleetExportValidationError(msg) from error
+    except OSError as error:
+        msg = f"Could not read Fleet export {path}"
+        raise FleetExportValidationError(msg) from error
+
+    if not isinstance(data, Mapping):
+        msg = f"Fleet export {path} must contain a JSON object"
+        raise FleetExportValidationError(msg)
+    return cast("Mapping[str, object]", data)
+
+
+def _required_tool_str(
+    tool: Mapping[str, object],
+    key: str,
+    *,
+    path: Path,
+    index: int,
+) -> str:
+    value = tool.get(key)
+    if isinstance(value, str) and value:
+        return value
+    msg = f"Fleet export {path} tools[{index}].{key} must be a non-empty string"
+    raise FleetExportValidationError(msg)
+
+
+def _first_tool_str(tool: Mapping[str, object], keys: Sequence[str]) -> str | None:
+    for key in keys:
+        value = tool.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _fleet_auth_path(tool: Mapping[str, object]) -> str:
+    raw_auth = tool.get("auth_type") or tool.get("auth")
+    if isinstance(raw_auth, str) and raw_auth in _KNOWN_FLEET_AUTH_PATHS:
+        return raw_auth
+    if "headers" in tool:
+        return "headers"
+    return "unknown"
+
+
+def strip_url_query_and_fragment(value: str) -> str:
+    """Return a URL without query string or fragment components.
+
+    Args:
+        value: URL-like value from a Fleet export.
+
+    Returns:
+        Sanitized URL-like value safe to persist in local manifests.
+    """
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        return value.partition("?")[0].partition("#")[0]
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))

--- a/libs/talon/deepagents_talon/fleet_export.py
+++ b/libs/talon/deepagents_talon/fleet_export.py
@@ -14,7 +14,7 @@ from urllib.parse import urlsplit, urlunsplit
 if TYPE_CHECKING:
     from pathlib import Path
 
-_REQUIRED_EXPORT_FILES = ("AGENTS.md", "config.json")
+_REQUIRED_EXPORT_FILES = ("AGENTS.md", "config.json", "tools.json")
 _KNOWN_FLEET_AUTH_PATHS = frozenset({"builtin", "headers", "oauth"})
 
 
@@ -41,7 +41,7 @@ class FleetExportToolEntry:
 
 
 def validate_fleet_export(fleet_dir: Path) -> None:
-    """Validate required Fleet export files and optional `tools.json` content.
+    """Validate required Fleet export files and optional subagent tool content.
 
     Args:
         fleet_dir: Operator-unzipped Fleet export directory.

--- a/libs/talon/deepagents_talon/fleet_manifest.py
+++ b/libs/talon/deepagents_talon/fleet_manifest.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from collections import defaultdict
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -57,34 +56,18 @@ class FleetToolRequirement:
         id: Stable requirement id derived from the requirement content.
         scope: Fleet scope declaring the requirement, such as `root` or
             `subagent:<name>`.
-        tool_names: Requested MCP tool names.
+        tool_name: Requested MCP tool name.
         mcp_server_url: MCP server URL with query string and fragment removed.
         auth_path: Fleet authentication path for the server.
-        loaded_tool_names: Requested tool names exposed by loaded Fleet components.
-        needs_local_mcp: Whether this Fleet MCP server needs a local MCP replacement.
-        server_display_name: Optional human-readable MCP server name from Fleet.
-        server_registry_name: Optional registry MCP server name from Fleet.
+        loaded: Whether the loaded Fleet components currently expose this tool.
     """
 
     id: str
     scope: str
-    tool_names: tuple[str, ...]
+    tool_name: str
     mcp_server_url: str
     auth_path: str
-    loaded_tool_names: tuple[str, ...]
-    needs_local_mcp: bool = True
-    server_display_name: str | None = None
-    server_registry_name: str | None = None
-
-    @property
-    def tool_name(self) -> str:
-        """Return the first requested tool name for legacy callers."""
-        return self.tool_names[0]
-
-    @property
-    def loaded(self) -> bool:
-        """Return whether any requested tool is exposed by loaded Fleet components."""
-        return bool(self.loaded_tool_names)
+    loaded: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -118,6 +101,7 @@ class FleetRunManifest:
         created_at: Creation time in UTC ISO 8601 form.
         local_mcp_config_path: Assistant-local MCP config target for setup tasks.
         tool_requirements: Fleet MCP tool requirements.
+        approval_tool_names: Fleet tools configured for human approval.
         setup_tasks: Follow-up setup tasks.
     """
 
@@ -130,6 +114,7 @@ class FleetRunManifest:
     created_at: str
     local_mcp_config_path: str
     tool_requirements: tuple[FleetToolRequirement, ...]
+    approval_tool_names: tuple[str, ...]
     setup_tasks: tuple[SetupTask, ...]
 
 
@@ -170,7 +155,7 @@ def build_fleet_run_manifest(
         msg = "Fleet run manifests require a configured Fleet directory"
         raise ValueError(msg)
 
-    target_path = str(config.manifest_dir / "tools.json")
+    target_path = str(config.home / ".mcp.json")
     tool_requirements = _fleet_tool_requirements(
         config.fleet_dir,
         components,
@@ -185,6 +170,7 @@ def build_fleet_run_manifest(
         created_at=_created_at(created_at),
         local_mcp_config_path=target_path,
         tool_requirements=tuple(tool_requirements),
+        approval_tool_names=_approval_tool_names(components),
         setup_tasks=tuple(_setup_tasks(tool_requirements, target_path=target_path)),
     )
 
@@ -281,29 +267,21 @@ def _fleet_tool_requirements(
     components: FleetAgentComponents,
 ) -> list[FleetToolRequirement]:
     loaded_tool_names = _component_tool_names(components)
-    grouped = defaultdict(list)
-    for entry in fleet_tool_entries(fleet_dir):
-        grouped.setdefault((entry.scope, entry.mcp_server_url), []).append(entry)
-
     requirements: list[FleetToolRequirement] = []
-    for key in sorted(grouped):
-        group = grouped[key]
-        first = group[0]
-        tool_names = tuple(sorted({entry.tool_name for entry in group}))
-        loaded_names = tuple(name for name in tool_names if name in loaded_tool_names)
-        auth_paths = sorted({entry.auth_path for entry in group})
-        auth_path = auth_paths[0] if len(auth_paths) == 1 else "mixed"
-        requirement_id = _stable_id("tool", first.scope, first.mcp_server_url, *tool_names)
+    seen: set[str] = set()
+    for entry in fleet_tool_entries(fleet_dir):
+        requirement_id = _stable_id("tool", entry.scope, entry.tool_name, entry.mcp_server_url)
+        if requirement_id in seen:
+            continue
+        seen.add(requirement_id)
         requirements.append(
             FleetToolRequirement(
                 id=requirement_id,
-                scope=first.scope,
-                tool_names=tool_names,
-                mcp_server_url=first.mcp_server_url,
-                auth_path=auth_path,
-                loaded_tool_names=loaded_names,
-                server_display_name=_first_present(entry.server_display_name for entry in group),
-                server_registry_name=_first_present(entry.server_registry_name for entry in group),
+                scope=entry.scope,
+                tool_name=entry.tool_name,
+                mcp_server_url=entry.mcp_server_url,
+                auth_path=entry.auth_path,
+                loaded=entry.tool_name in loaded_tool_names,
             )
         )
     return sorted(requirements, key=lambda requirement: requirement.id)
@@ -322,12 +300,14 @@ def _setup_tasks(
             tool_requirement_ids=(requirement.id,),
         )
         for requirement in tool_requirements
-        if requirement.needs_local_mcp
+        if requirement.auth_path != "builtin"
     ]
 
 
-def _first_present(values: Iterable[str | None]) -> str | None:
-    return next((value for value in values if value is not None), None)
+def _approval_tool_names(components: FleetAgentComponents) -> tuple[str, ...]:
+    if components.interrupt_on is None:
+        return ()
+    return tuple(sorted(components.interrupt_on))
 
 
 def _component_tool_names(components: FleetAgentComponents) -> set[str]:
@@ -389,6 +369,7 @@ def _manifest_to_dict(manifest: FleetRunManifest) -> dict[str, object]:
         "model_source": manifest.model_source,
         "schema_version": manifest.schema_version,
         "selected_channel": _channel_to_dict(manifest.selected_channel),
+        "approval_tool_names": list(manifest.approval_tool_names),
         "setup_tasks": [_setup_task_to_dict(task) for task in manifest.setup_tasks],
         "tool_requirements": [
             _tool_requirement_to_dict(requirement) for requirement in manifest.tool_requirements
@@ -407,20 +388,14 @@ def _channel_to_dict(channel: ChannelSelection | None) -> dict[str, object] | No
 
 
 def _tool_requirement_to_dict(requirement: FleetToolRequirement) -> dict[str, object]:
-    data: dict[str, object] = {
+    return {
         "auth_path": requirement.auth_path,
         "id": requirement.id,
-        "loaded_tool_names": list(requirement.loaded_tool_names),
+        "loaded": requirement.loaded,
         "mcp_server_url": requirement.mcp_server_url,
-        "needs_local_mcp": requirement.needs_local_mcp,
         "scope": requirement.scope,
-        "tool_names": list(requirement.tool_names),
+        "tool_name": requirement.tool_name,
     }
-    if requirement.server_display_name is not None:
-        data["server_display_name"] = requirement.server_display_name
-    if requirement.server_registry_name is not None:
-        data["server_registry_name"] = requirement.server_registry_name
-    return data
 
 
 def _setup_task_to_dict(task: SetupTask) -> dict[str, object]:
@@ -456,6 +431,10 @@ def _manifest_from_dict(data: Mapping[str, object], *, path: Path) -> FleetRunMa
             _tool_requirement_from_dict(item, path=path)
             for item in _required_list(data, "tool_requirements", path=path)
         ),
+        approval_tool_names=tuple(
+            _string_value(item, path=path)
+            for item in _required_list(data, "approval_tool_names", path=path)
+        ),
         setup_tasks=tuple(
             _setup_task_from_dict(item, path=path)
             for item in _required_list(data, "setup_tasks", path=path)
@@ -480,18 +459,13 @@ def _optional_channel(value: object, *, path: Path) -> ChannelSelection | None:
 
 def _tool_requirement_from_dict(value: object, *, path: Path) -> FleetToolRequirement:
     data = _require_mapping(value, "tool_requirements[]", path=path)
-    tool_names = _required_list(data, "tool_names", path=path)
-    loaded_tool_names = _required_list(data, "loaded_tool_names", path=path)
     return FleetToolRequirement(
         id=_required_str(data, "id", path=path),
         scope=_required_str(data, "scope", path=path),
-        tool_names=tuple(_string_value(item, path=path) for item in tool_names),
+        tool_name=_required_str(data, "tool_name", path=path),
         mcp_server_url=_required_str(data, "mcp_server_url", path=path),
         auth_path=_required_str(data, "auth_path", path=path),
-        loaded_tool_names=tuple(_string_value(item, path=path) for item in loaded_tool_names),
-        needs_local_mcp=_required_bool(data, "needs_local_mcp", path=path),
-        server_display_name=_optional_str(data.get("server_display_name"), path=path),
-        server_registry_name=_optional_str(data.get("server_registry_name"), path=path),
+        loaded=_required_bool(data, "loaded", path=path),
     )
 
 
@@ -551,13 +525,4 @@ def _string_value(value: object, *, path: Path) -> str:
     if isinstance(value, str) and value:
         return value
     msg = f"Fleet run manifest {path} expected a non-empty string value"
-    raise FleetRunManifestValidationError(msg)
-
-
-def _optional_str(value: object, *, path: Path) -> str | None:
-    if value is None:
-        return None
-    if isinstance(value, str) and value:
-        return value
-    msg = f"Fleet run manifest {path} expected an optional non-empty string value"
     raise FleetRunManifestValidationError(msg)

--- a/libs/talon/deepagents_talon/fleet_manifest.py
+++ b/libs/talon/deepagents_talon/fleet_manifest.py
@@ -8,13 +8,15 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from collections.abc import Mapping, Sequence
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Literal, cast
-from urllib.parse import urlsplit, urlunsplit
+
+from deepagents_talon.fleet_export import fleet_tool_entries
 
 if TYPE_CHECKING:
     from deepagents_talon.config import TalonConfig
@@ -55,18 +57,34 @@ class FleetToolRequirement:
         id: Stable requirement id derived from the requirement content.
         scope: Fleet scope declaring the requirement, such as `root` or
             `subagent:<name>`.
-        tool_name: Requested MCP tool name.
+        tool_names: Requested MCP tool names.
         mcp_server_url: MCP server URL with query string and fragment removed.
         auth_path: Fleet authentication path for the server.
-        loaded: Whether the loaded Fleet components currently expose this tool.
+        loaded_tool_names: Requested tool names exposed by loaded Fleet components.
+        needs_local_mcp: Whether this Fleet MCP server needs a local MCP replacement.
+        server_display_name: Optional human-readable MCP server name from Fleet.
+        server_registry_name: Optional registry MCP server name from Fleet.
     """
 
     id: str
     scope: str
-    tool_name: str
+    tool_names: tuple[str, ...]
     mcp_server_url: str
     auth_path: str
-    loaded: bool
+    loaded_tool_names: tuple[str, ...]
+    needs_local_mcp: bool = True
+    server_display_name: str | None = None
+    server_registry_name: str | None = None
+
+    @property
+    def tool_name(self) -> str:
+        """Return the first requested tool name for legacy callers."""
+        return self.tool_names[0]
+
+    @property
+    def loaded(self) -> bool:
+        """Return whether any requested tool is exposed by loaded Fleet components."""
+        return bool(self.loaded_tool_names)
 
 
 @dataclass(frozen=True, slots=True)
@@ -156,7 +174,6 @@ def build_fleet_run_manifest(
     tool_requirements = _fleet_tool_requirements(
         config.fleet_dir,
         components,
-        env=config.env,
     )
     return FleetRunManifest(
         schema_version=MANIFEST_SCHEMA_VERSION,
@@ -262,25 +279,31 @@ def load_fleet_run_manifest(path: Path) -> FleetRunManifest:
 def _fleet_tool_requirements(
     fleet_dir: Path,
     components: FleetAgentComponents,
-    *,
-    env: Mapping[str, str],
 ) -> list[FleetToolRequirement]:
     loaded_tool_names = _component_tool_names(components)
+    grouped = defaultdict(list)
+    for entry in fleet_tool_entries(fleet_dir):
+        grouped.setdefault((entry.scope, entry.mcp_server_url), []).append(entry)
+
     requirements: list[FleetToolRequirement] = []
-    seen: set[str] = set()
-    for entry in _fleet_tool_entries(fleet_dir, env=env):
-        requirement_id = _stable_id("tool", entry.scope, entry.tool_name, entry.mcp_server_url)
-        if requirement_id in seen:
-            continue
-        seen.add(requirement_id)
+    for key in sorted(grouped):
+        group = grouped[key]
+        first = group[0]
+        tool_names = tuple(sorted({entry.tool_name for entry in group}))
+        loaded_names = tuple(name for name in tool_names if name in loaded_tool_names)
+        auth_paths = sorted({entry.auth_path for entry in group})
+        auth_path = auth_paths[0] if len(auth_paths) == 1 else "mixed"
+        requirement_id = _stable_id("tool", first.scope, first.mcp_server_url, *tool_names)
         requirements.append(
             FleetToolRequirement(
                 id=requirement_id,
-                scope=entry.scope,
-                tool_name=entry.tool_name,
-                mcp_server_url=entry.mcp_server_url,
-                auth_path=entry.auth_path,
-                loaded=entry.tool_name in loaded_tool_names,
+                scope=first.scope,
+                tool_names=tool_names,
+                mcp_server_url=first.mcp_server_url,
+                auth_path=auth_path,
+                loaded_tool_names=loaded_names,
+                server_display_name=_first_present(entry.server_display_name for entry in group),
+                server_registry_name=_first_present(entry.server_registry_name for entry in group),
             )
         )
     return sorted(requirements, key=lambda requirement: requirement.id)
@@ -299,127 +322,12 @@ def _setup_tasks(
             tool_requirement_ids=(requirement.id,),
         )
         for requirement in tool_requirements
-        if requirement.auth_path != "builtin"
+        if requirement.needs_local_mcp
     ]
 
 
-@dataclass(frozen=True, slots=True)
-class _ToolEntry:
-    scope: str
-    tool_name: str
-    mcp_server_url: str
-    auth_path: str
-
-
-def _fleet_tool_entries(fleet_dir: Path, *, env: Mapping[str, str]) -> list[_ToolEntry]:
-    entries: list[_ToolEntry] = []
-    _extend_tool_entries(entries, fleet_dir / "tools.json", scope="root", env=env)
-
-    subagents_dir = fleet_dir / "subagents"
-    try:
-        subagent_dirs = sorted(path for path in subagents_dir.iterdir() if path.is_dir())
-    except OSError:
-        return entries
-
-    for subagent_dir in subagent_dirs:
-        _extend_tool_entries(
-            entries,
-            subagent_dir / "tools.json",
-            scope=f"subagent:{subagent_dir.name}",
-            env=env,
-        )
-    return entries
-
-
-def _extend_tool_entries(
-    entries: list[_ToolEntry],
-    path: Path,
-    *,
-    scope: str,
-    env: Mapping[str, str],
-) -> None:
-    if not path.is_file():
-        return
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError) as exc:
-        msg = f"Could not read Fleet MCP tool entries from {path}"
-        raise FleetRunManifestValidationError(msg) from exc
-    if not isinstance(data, Mapping):
-        return
-
-    raw_tools = data.get("tools")
-    if not isinstance(raw_tools, list):
-        return
-
-    for raw_tool in raw_tools:
-        if not isinstance(raw_tool, Mapping):
-            continue
-        tool = cast("Mapping[str, object]", raw_tool)
-        name = tool.get("name")
-        server_url = tool.get("mcp_server_url")
-        if not isinstance(name, str) or not name:
-            continue
-        if not isinstance(server_url, str) or not server_url:
-            continue
-        auth_path = _fleet_auth_path(tool, server_url, env=env)
-        entries.append(
-            _ToolEntry(
-                scope=scope,
-                tool_name=name,
-                mcp_server_url=_sanitized_server_url(server_url, auth_path=auth_path, env=env),
-                auth_path=auth_path,
-            )
-        )
-
-
-def _fleet_auth_path(
-    tool: Mapping[str, object],
-    server_url: str,
-    *,
-    env: Mapping[str, str],
-) -> str:
-    raw_auth = tool.get("auth_type") or tool.get("auth")
-    if isinstance(raw_auth, str) and raw_auth in {"builtin", "headers", "oauth"}:
-        return raw_auth
-    if _is_builtin_fleet_server(server_url, env=env):
-        return "builtin"
-    if "headers" in tool:
-        return "headers"
-    return "unknown"
-
-
-def _sanitized_server_url(
-    server_url: str,
-    *,
-    auth_path: str,
-    env: Mapping[str, str],
-) -> str:
-    if auth_path == "builtin":
-        server_url = env.get("BUILTIN_MCP_URL") or server_url
-    return _strip_url_query_and_fragment(server_url)
-
-
-def _is_builtin_fleet_server(server_url: str, *, env: Mapping[str, str]) -> bool:
-    builtin = env.get("BUILTIN_MCP_URL")
-    if not builtin:
-        return False
-    return _url_host(server_url) == _url_host(builtin)
-
-
-def _url_host(value: str) -> str | None:
-    try:
-        return urlsplit(value).hostname
-    except ValueError:
-        return None
-
-
-def _strip_url_query_and_fragment(value: str) -> str:
-    try:
-        parts = urlsplit(value)
-    except ValueError:
-        return value.split("?", maxsplit=1)[0].split("#", maxsplit=1)[0]
-    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+def _first_present(values: Iterable[str | None]) -> str | None:
+    return next((value for value in values if value is not None), None)
 
 
 def _component_tool_names(components: FleetAgentComponents) -> set[str]:
@@ -499,14 +407,20 @@ def _channel_to_dict(channel: ChannelSelection | None) -> dict[str, object] | No
 
 
 def _tool_requirement_to_dict(requirement: FleetToolRequirement) -> dict[str, object]:
-    return {
+    data: dict[str, object] = {
         "auth_path": requirement.auth_path,
         "id": requirement.id,
-        "loaded": requirement.loaded,
+        "loaded_tool_names": list(requirement.loaded_tool_names),
         "mcp_server_url": requirement.mcp_server_url,
+        "needs_local_mcp": requirement.needs_local_mcp,
         "scope": requirement.scope,
-        "tool_name": requirement.tool_name,
+        "tool_names": list(requirement.tool_names),
     }
+    if requirement.server_display_name is not None:
+        data["server_display_name"] = requirement.server_display_name
+    if requirement.server_registry_name is not None:
+        data["server_registry_name"] = requirement.server_registry_name
+    return data
 
 
 def _setup_task_to_dict(task: SetupTask) -> dict[str, object]:
@@ -566,13 +480,18 @@ def _optional_channel(value: object, *, path: Path) -> ChannelSelection | None:
 
 def _tool_requirement_from_dict(value: object, *, path: Path) -> FleetToolRequirement:
     data = _require_mapping(value, "tool_requirements[]", path=path)
+    tool_names = _required_list(data, "tool_names", path=path)
+    loaded_tool_names = _required_list(data, "loaded_tool_names", path=path)
     return FleetToolRequirement(
         id=_required_str(data, "id", path=path),
         scope=_required_str(data, "scope", path=path),
-        tool_name=_required_str(data, "tool_name", path=path),
+        tool_names=tuple(_string_value(item, path=path) for item in tool_names),
         mcp_server_url=_required_str(data, "mcp_server_url", path=path),
         auth_path=_required_str(data, "auth_path", path=path),
-        loaded=_required_bool(data, "loaded", path=path),
+        loaded_tool_names=tuple(_string_value(item, path=path) for item in loaded_tool_names),
+        needs_local_mcp=_required_bool(data, "needs_local_mcp", path=path),
+        server_display_name=_optional_str(data.get("server_display_name"), path=path),
+        server_registry_name=_optional_str(data.get("server_registry_name"), path=path),
     )
 
 
@@ -632,4 +551,13 @@ def _string_value(value: object, *, path: Path) -> str:
     if isinstance(value, str) and value:
         return value
     msg = f"Fleet run manifest {path} expected a non-empty string value"
+    raise FleetRunManifestValidationError(msg)
+
+
+def _optional_str(value: object, *, path: Path) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str) and value:
+        return value
+    msg = f"Fleet run manifest {path} expected an optional non-empty string value"
     raise FleetRunManifestValidationError(msg)

--- a/libs/talon/deepagents_talon/fleet_manifest.py
+++ b/libs/talon/deepagents_talon/fleet_manifest.py
@@ -431,10 +431,7 @@ def _manifest_from_dict(data: Mapping[str, object], *, path: Path) -> FleetRunMa
             _tool_requirement_from_dict(item, path=path)
             for item in _required_list(data, "tool_requirements", path=path)
         ),
-        approval_tool_names=tuple(
-            _string_value(item, path=path)
-            for item in _required_list(data, "approval_tool_names", path=path)
-        ),
+        approval_tool_names=_optional_string_tuple(data, "approval_tool_names", path=path),
         setup_tasks=tuple(
             _setup_task_from_dict(item, path=path)
             for item in _required_list(data, "setup_tasks", path=path)
@@ -480,6 +477,21 @@ def _setup_task_from_dict(value: object, *, path: Path) -> SetupTask:
             for item in _required_list(data, "tool_requirement_ids", path=path)
         ),
     )
+
+
+def _optional_string_tuple(
+    data: Mapping[str, object],
+    key: str,
+    *,
+    path: Path,
+) -> tuple[str, ...]:
+    value = data.get(key)
+    if value is None:
+        return ()
+    if isinstance(value, list):
+        return tuple(_string_value(item, path=path) for item in value)
+    msg = f"Fleet run manifest {path} field {key!r} must be a list"
+    raise FleetRunManifestValidationError(msg)
 
 
 def _required_str(data: Mapping[str, object], key: str, *, path: Path) -> str:

--- a/libs/talon/deepagents_talon/mcp.py
+++ b/libs/talon/deepagents_talon/mcp.py
@@ -54,7 +54,7 @@ def discover_mcp_config_paths(config: TalonConfig) -> list[Path]:
     """
     paths = [
         Path.home() / ".deepagents" / ".mcp.json",
-        config.manifest_dir / "tools.json",
+        config.home / ".mcp.json",
     ]
     return [path for path in paths if _is_file(path)]
 
@@ -92,7 +92,7 @@ def print_mcp_config_paths(config: TalonConfig) -> None:
     """
     rows = [
         ("~/.deepagents/.mcp.json", Path.home() / ".deepagents" / ".mcp.json"),
-        ("<assistant-home>/agent/tools.json", config.manifest_dir / "tools.json"),
+        ("<assistant-home>/.mcp.json", config.home / ".mcp.json"),
     ]
     width = max(len(label) for label, _ in rows)
     print("MCP config discovery paths (lowest to highest precedence):")  # noqa: T201
@@ -103,7 +103,7 @@ def print_mcp_config_paths(config: TalonConfig) -> None:
         "Override with DEEPAGENTS_TALON_MCP_CONFIG or MCP_CONFIG as a config file path.",
     )
     print("The highest-precedence existing path is loaded; configs are not merged.")  # noqa: T201
-    print("Edit <assistant-home>/agent/tools.json directly to add Talon MCP servers.")  # noqa: T201
+    print("Create <assistant-home>/.mcp.json to add Talon MCP servers.")  # noqa: T201
 
 
 def _select_mcp_config_path(config: TalonConfig) -> Path | None:

--- a/libs/talon/tests/test_fleet.py
+++ b/libs/talon/tests/test_fleet.py
@@ -50,6 +50,7 @@ def _write_required_fleet_files(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
     (path / "AGENTS.md").write_text("Fleet prompt", encoding="utf-8")
     (path / "config.json").write_text(json.dumps({"model": "fleet:model"}), encoding="utf-8")
+    (path / "tools.json").write_text(json.dumps({"tools": []}), encoding="utf-8")
 
 
 async def test_load_fleet_agent_components_coerces_public_loader_payload(

--- a/libs/talon/tests/test_fleet.py
+++ b/libs/talon/tests/test_fleet.py
@@ -306,7 +306,8 @@ async def test_agent_runtime_loads_fleet_components(
     manifest = load_fleet_run_manifest(manifest_path(config.home))
     assert manifest.assistant_id == "test"
     assert manifest.fleet_dir == str(fleet_dir)
-    assert manifest.local_mcp_config_path == str(tmp_path / "test" / "agent" / "tools.json")
+    assert manifest.local_mcp_config_path == str(tmp_path / "test" / ".mcp.json")
+    assert manifest.approval_tool_names == ("fleet_tool",)
 
     refreshed = await runtime.reload_agent_components()
 

--- a/libs/talon/tests/test_fleet.py
+++ b/libs/talon/tests/test_fleet.py
@@ -17,6 +17,8 @@ from deepagents_talon.mcp import MCPTools
 from deepagents_talon.runtime import INTERRUPT_ON_TOOLS_ENV_KEY, DeepAgentRuntime
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import pytest
 
 
@@ -44,10 +46,17 @@ description: {description}
 """
 
 
+def _write_required_fleet_files(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "AGENTS.md").write_text("Fleet prompt", encoding="utf-8")
+    (path / "config.json").write_text(json.dumps({"model": "fleet:model"}), encoding="utf-8")
+
+
 async def test_load_fleet_agent_components_coerces_public_loader_payload(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _write_required_fleet_files(tmp_path)
     monkeypatch.delenv("LANGSMITH_TENANT_ID", raising=False)
     subagent = {
         "name": "researcher",
@@ -89,6 +98,7 @@ async def test_load_fleet_agent_components_adds_static_skills_loader(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fleet_dir = tmp_path / "fleet"
+    _write_required_fleet_files(fleet_dir)
     fleet_skill = fleet_dir / "skills" / "fleet-skill"
     fleet_skill.mkdir(parents=True)
     (fleet_skill / "SKILL.md").write_text(
@@ -150,7 +160,7 @@ async def test_load_fleet_agent_components_logs_mcp_surface(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fleet_dir = tmp_path / "fleet"
-    fleet_dir.mkdir()
+    _write_required_fleet_files(fleet_dir)
     (fleet_dir / "tools.json").write_text(
         json.dumps(
             {

--- a/libs/talon/tests/test_fleet_export.py
+++ b/libs/talon/tests/test_fleet_export.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from deepagents_talon.config import TalonConfig
+from deepagents_talon.fleet import FleetAgentComponents
+from deepagents_talon.fleet_export import (
+    FleetExportValidationError,
+    fleet_tool_entries,
+    validate_fleet_export,
+)
+from deepagents_talon.fleet_manifest import build_fleet_run_manifest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_validate_fleet_export_rejects_missing_required_files(tmp_path: Path) -> None:
+    fleet_dir = tmp_path / "fleet"
+    fleet_dir.mkdir()
+
+    with pytest.raises(FleetExportValidationError, match=r"AGENTS\.md"):
+        validate_fleet_export(fleet_dir)
+
+    (fleet_dir / "AGENTS.md").write_text("Fleet prompt", encoding="utf-8")
+
+    with pytest.raises(FleetExportValidationError, match=r"config\.json"):
+        validate_fleet_export(fleet_dir)
+
+
+def test_validate_fleet_export_rejects_malformed_tools_json(tmp_path: Path) -> None:
+    fleet_dir = _fleet_export(tmp_path)
+    (fleet_dir / "tools.json").write_text(json.dumps({"tools": [{}]}), encoding="utf-8")
+
+    with pytest.raises(FleetExportValidationError, match=r"tools\[0\]\.name"):
+        validate_fleet_export(fleet_dir)
+
+
+def test_fleet_tool_entries_discovers_subagents_and_strips_url_secrets(tmp_path: Path) -> None:
+    fleet_dir = _fleet_export(tmp_path)
+    _write_tools(
+        fleet_dir / "tools.json",
+        [
+            {
+                "name": "search",
+                "mcp_server_url": "https://tools.example/mcp?token=secret#fragment",
+                "auth_type": "oauth",
+                "server_display_name": "Tools",
+                "server_registry_name": "registry/tools",
+            }
+        ],
+    )
+    subagent_dir = fleet_dir / "subagents" / "researcher"
+    subagent_dir.mkdir(parents=True)
+    _write_tools(
+        subagent_dir / "tools.json",
+        [
+            {
+                "name": "calendar",
+                "mcp_server_url": "https://calendar.example/mcp?token=secret",
+                "headers": {"Authorization": "Bearer secret"},
+            }
+        ],
+    )
+
+    entries = fleet_tool_entries(fleet_dir)
+
+    assert [(entry.scope, entry.tool_name) for entry in entries] == [
+        ("root", "search"),
+        ("subagent:researcher", "calendar"),
+    ]
+    assert entries[0].mcp_server_url == "https://tools.example/mcp"
+    assert entries[0].server_display_name == "Tools"
+    assert entries[0].server_registry_name == "registry/tools"
+    assert entries[1].mcp_server_url == "https://calendar.example/mcp"
+    assert entries[1].auth_path == "headers"
+
+
+def test_manifest_groups_tool_requirements_by_scope_and_server_url(tmp_path: Path) -> None:
+    fleet_dir = _fleet_export(tmp_path)
+    _write_tools(
+        fleet_dir / "tools.json",
+        [
+            {
+                "name": "search",
+                "mcp_server_url": "https://tools.example/mcp?token=one",
+                "display_name": "Tools",
+            },
+            {
+                "name": "crawl",
+                "mcp_server_url": "https://tools.example/mcp?token=two",
+                "registry_name": "registry/tools",
+            },
+        ],
+    )
+    subagent_dir = fleet_dir / "subagents" / "researcher"
+    subagent_dir.mkdir(parents=True)
+    _write_tools(
+        subagent_dir / "tools.json",
+        [{"name": "search", "mcp_server_url": "https://tools.example/mcp?token=three"}],
+    )
+    config = TalonConfig.from_env(
+        {
+            "AGENT_ASSISTANT_ID": "assistant",
+            "DEEPAGENTS_TALON_FLEET_DIR": str(fleet_dir),
+        },
+        base_home=tmp_path,
+    )
+
+    manifest = build_fleet_run_manifest(
+        config,
+        FleetAgentComponents(
+            model="openai:gpt-5-mini",
+            system_prompt="fleet prompt",
+            tools=(SimpleNamespace(name="search"),),
+            subagents=(),
+            interrupt_on=None,
+        ),
+    )
+
+    requirements = {
+        (requirement.scope, requirement.mcp_server_url): requirement
+        for requirement in tuple(manifest.tool_requirements)
+    }
+    root = requirements[("root", "https://tools.example/mcp")]
+    subagent = requirements[("subagent:researcher", "https://tools.example/mcp")]
+    assert root.tool_names == ("crawl", "search")
+    assert root.loaded_tool_names == ("search",)
+    assert root.needs_local_mcp is True
+    assert root.server_display_name == "Tools"
+    assert root.server_registry_name == "registry/tools"
+    assert subagent.tool_names == ("search",)
+    assert len(manifest.setup_tasks) == 2
+
+
+def test_validate_fleet_export_allows_missing_optional_content(tmp_path: Path) -> None:
+    fleet_dir = _fleet_export(tmp_path)
+
+    validate_fleet_export(fleet_dir)
+
+    _write_tools(fleet_dir / "tools.json", [])
+    validate_fleet_export(fleet_dir)
+    assert fleet_tool_entries(fleet_dir) == []
+
+
+def _fleet_export(tmp_path: Path) -> Path:
+    fleet_dir = tmp_path / "fleet"
+    fleet_dir.mkdir()
+    (fleet_dir / "AGENTS.md").write_text("Fleet prompt", encoding="utf-8")
+    (fleet_dir / "config.json").write_text(
+        json.dumps({"model": "openai:gpt-5-mini"}),
+        encoding="utf-8",
+    )
+    return fleet_dir
+
+
+def _write_tools(path: Path, tools: list[dict[str, object]]) -> None:
+    path.write_text(json.dumps({"tools": tools}), encoding="utf-8")

--- a/libs/talon/tests/test_fleet_export.py
+++ b/libs/talon/tests/test_fleet_export.py
@@ -49,8 +49,6 @@ def test_fleet_tool_entries_discovers_subagents_and_strips_url_secrets(tmp_path:
                 "name": "search",
                 "mcp_server_url": "https://tools.example/mcp?token=secret#fragment",
                 "auth_type": "oauth",
-                "server_display_name": "Tools",
-                "server_registry_name": "registry/tools",
             }
         ],
     )
@@ -74,13 +72,11 @@ def test_fleet_tool_entries_discovers_subagents_and_strips_url_secrets(tmp_path:
         ("subagent:researcher", "calendar"),
     ]
     assert entries[0].mcp_server_url == "https://tools.example/mcp"
-    assert entries[0].server_display_name == "Tools"
-    assert entries[0].server_registry_name == "registry/tools"
     assert entries[1].mcp_server_url == "https://calendar.example/mcp"
     assert entries[1].auth_path == "headers"
 
 
-def test_manifest_groups_tool_requirements_by_scope_and_server_url(tmp_path: Path) -> None:
+def test_manifest_summarizes_tool_and_approval_requirements(tmp_path: Path) -> None:
     fleet_dir = _fleet_export(tmp_path)
     _write_tools(
         fleet_dir / "tools.json",
@@ -88,12 +84,10 @@ def test_manifest_groups_tool_requirements_by_scope_and_server_url(tmp_path: Pat
             {
                 "name": "search",
                 "mcp_server_url": "https://tools.example/mcp?token=one",
-                "display_name": "Tools",
             },
             {
                 "name": "crawl",
                 "mcp_server_url": "https://tools.example/mcp?token=two",
-                "registry_name": "registry/tools",
             },
         ],
     )
@@ -118,23 +112,22 @@ def test_manifest_groups_tool_requirements_by_scope_and_server_url(tmp_path: Pat
             system_prompt="fleet prompt",
             tools=(SimpleNamespace(name="search"),),
             subagents=(),
-            interrupt_on=None,
+            interrupt_on={"crawl": True, "send_email": True},
         ),
     )
 
-    requirements = {
-        (requirement.scope, requirement.mcp_server_url): requirement
-        for requirement in tuple(manifest.tool_requirements)
+    requirements = {(item.scope, item.tool_name): item for item in manifest.tool_requirements}
+    assert requirements[("root", "search")].loaded is True
+    assert requirements[("root", "crawl")].loaded is False
+    assert requirements[("subagent:researcher", "search")].loaded is True
+    assert {item.mcp_server_url for item in manifest.tool_requirements} == {
+        "https://tools.example/mcp"
     }
-    root = requirements[("root", "https://tools.example/mcp")]
-    subagent = requirements[("subagent:researcher", "https://tools.example/mcp")]
-    assert root.tool_names == ("crawl", "search")
-    assert root.loaded_tool_names == ("search",)
-    assert root.needs_local_mcp is True
-    assert root.server_display_name == "Tools"
-    assert root.server_registry_name == "registry/tools"
-    assert subagent.tool_names == ("search",)
-    assert len(manifest.setup_tasks) == 2
+    assert manifest.approval_tool_names == ("crawl", "send_email")
+    assert len(manifest.setup_tasks) == 3
+    assert {task.target_path for task in manifest.setup_tasks} == {
+        str(config.home / ".mcp.json")
+    }
 
 
 def test_validate_fleet_export_allows_missing_optional_content(tmp_path: Path) -> None:

--- a/libs/talon/tests/test_fleet_export.py
+++ b/libs/talon/tests/test_fleet_export.py
@@ -31,6 +31,13 @@ def test_validate_fleet_export_rejects_missing_required_files(tmp_path: Path) ->
     with pytest.raises(FleetExportValidationError, match=r"config\.json"):
         validate_fleet_export(fleet_dir)
 
+    (fleet_dir / "config.json").write_text(
+        json.dumps({"model": "openai:gpt-5-mini"}), encoding="utf-8"
+    )
+
+    with pytest.raises(FleetExportValidationError, match=r"tools\.json"):
+        validate_fleet_export(fleet_dir)
+
 
 def test_validate_fleet_export_rejects_malformed_tools_json(tmp_path: Path) -> None:
     fleet_dir = _fleet_export(tmp_path)
@@ -125,18 +132,15 @@ def test_manifest_summarizes_tool_and_approval_requirements(tmp_path: Path) -> N
     }
     assert manifest.approval_tool_names == ("crawl", "send_email")
     assert len(manifest.setup_tasks) == 3
-    assert {task.target_path for task in manifest.setup_tasks} == {
-        str(config.home / ".mcp.json")
-    }
+    assert {task.target_path for task in manifest.setup_tasks} == {str(config.home / ".mcp.json")}
 
 
-def test_validate_fleet_export_allows_missing_optional_content(tmp_path: Path) -> None:
+def test_validate_fleet_export_allows_missing_subagent_tool_content(tmp_path: Path) -> None:
     fleet_dir = _fleet_export(tmp_path)
+    (fleet_dir / "subagents" / "researcher").mkdir(parents=True)
 
     validate_fleet_export(fleet_dir)
 
-    _write_tools(fleet_dir / "tools.json", [])
-    validate_fleet_export(fleet_dir)
     assert fleet_tool_entries(fleet_dir) == []
 
 
@@ -148,6 +152,7 @@ def _fleet_export(tmp_path: Path) -> Path:
         json.dumps({"model": "openai:gpt-5-mini"}),
         encoding="utf-8",
     )
+    _write_tools(fleet_dir / "tools.json", [])
     return fleet_dir
 
 

--- a/libs/talon/tests/test_fleet_manifest.py
+++ b/libs/talon/tests/test_fleet_manifest.py
@@ -161,6 +161,31 @@ def test_manifest_refresh_records_root_and_subagent_tool_requirements(tmp_path: 
     assert "secret" not in manifest_path(config.home).read_text(encoding="utf-8")
 
 
+def test_manifest_load_defaults_missing_approval_tool_names(tmp_path: Path) -> None:
+    path = tmp_path / "fleet-run-manifest.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "assistant_id": "assistant",
+                "fleet_dir": str(tmp_path / "fleet"),
+                "selected_channel": None,
+                "model_source": "fleet",
+                "model": "openai:gpt-5-mini",
+                "created_at": "2026-01-02T03:04:05Z",
+                "local_mcp_config_path": str(tmp_path / "assistant" / ".mcp.json"),
+                "tool_requirements": [],
+                "setup_tasks": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manifest = load_fleet_run_manifest(path)
+
+    assert manifest.approval_tool_names == ()
+
+
 def test_manifest_load_rejects_invalid_schema(tmp_path: Path) -> None:
     path = tmp_path / "fleet-run-manifest.json"
     path.write_text(

--- a/libs/talon/tests/test_fleet_manifest.py
+++ b/libs/talon/tests/test_fleet_manifest.py
@@ -58,8 +58,9 @@ def test_manifest_serializes_empty_tool_requirements(tmp_path: Path) -> None:
     assert loaded.selected_channel == ChannelSelection(provider="telegram", source="cli")
     assert loaded.model_source == "fleet"
     assert loaded.model == "openai:gpt-5-mini"
-    assert loaded.local_mcp_config_path == str(tmp_path / "assistant" / "agent" / "tools.json")
+    assert loaded.local_mcp_config_path == str(tmp_path / "assistant" / ".mcp.json")
     assert loaded.tool_requirements == ()
+    assert loaded.approval_tool_names == ()
     assert loaded.setup_tasks == ()
 
 
@@ -108,7 +109,7 @@ def test_manifest_refresh_records_root_and_subagent_tool_requirements(tmp_path: 
         system_prompt="fleet prompt",
         tools=(SimpleNamespace(name="search"),),
         subagents=({"tools": [SimpleNamespace(name="calendar")]},),
-        interrupt_on=None,
+        interrupt_on={"search": True, "send_email": True},
     )
 
     first = refresh_fleet_run_manifest(
@@ -145,17 +146,17 @@ def test_manifest_refresh_records_root_and_subagent_tool_requirements(tmp_path: 
     assert requirements["calendar"].scope == "subagent:researcher"
     assert requirements["calendar"].mcp_server_url == "https://calendar.example/mcp"
     assert requirements["calendar"].loaded is True
+    assert second.approval_tool_names == ("search", "send_email")
 
     first_ids = [requirement.id for requirement in first.tool_requirements]
     second_ids = [requirement.id for requirement in second.tool_requirements]
     assert second_ids == first_ids
     assert {task.target_path for task in second.setup_tasks} == {
-        str(tmp_path / "assistant" / "agent" / "tools.json")
+        str(tmp_path / "assistant" / ".mcp.json")
     }
     assert {task.tool_requirement_ids[0] for task in second.setup_tasks} == {
         requirements["calendar"].id,
         requirements["missing"].id,
-        requirements["search"].id,
     }
     assert "secret" not in manifest_path(config.home).read_text(encoding="utf-8")
 

--- a/libs/talon/tests/test_fleet_manifest.py
+++ b/libs/talon/tests/test_fleet_manifest.py
@@ -137,7 +137,7 @@ def test_manifest_refresh_records_root_and_subagent_tool_requirements(tmp_path: 
     requirements = {requirement.tool_name: requirement for requirement in second.tool_requirements}
     assert set(requirements) == {"calendar", "missing", "search"}
     assert requirements["search"].scope == "root"
-    assert requirements["search"].mcp_server_url == "https://builtin.example/mcp"
+    assert requirements["search"].mcp_server_url == "https://builtin.example/catalog"
     assert requirements["search"].auth_path == "builtin"
     assert requirements["search"].loaded is True
     assert requirements["missing"].mcp_server_url == "https://missing.example/mcp"
@@ -155,6 +155,7 @@ def test_manifest_refresh_records_root_and_subagent_tool_requirements(tmp_path: 
     assert {task.tool_requirement_ids[0] for task in second.setup_tasks} == {
         requirements["calendar"].id,
         requirements["missing"].id,
+        requirements["search"].id,
     }
     assert "secret" not in manifest_path(config.home).read_text(encoding="utf-8")
 

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -40,7 +40,7 @@ def _fake_code_loader(path: str) -> FakeCodeLoaderResult:
     return tools, None, infos
 
 
-async def test_load_mcp_tools_reads_manifest_config(
+async def test_load_mcp_tools_reads_assistant_config(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -53,8 +53,8 @@ async def test_load_mcp_tools_reads_manifest_config(
     monkeypatch.setattr("deepagents_talon.mcp.get_mcp_tools", fake_loader)
     config = TalonConfig.from_env({"AGENT_ASSISTANT_ID": "test"}, base_home=tmp_path)
     config.ensure_home()
-    tools_path = config.manifest_dir / "tools.json"
-    tools_path.write_text(
+    config_path = config.home / ".mcp.json"
+    config_path.write_text(
         json.dumps(
             {
                 "mcpServers": {
@@ -71,7 +71,7 @@ async def test_load_mcp_tools_reads_manifest_config(
     result = await load_mcp_tools(config)
 
     assert [tool.name for tool in result.tools] == ["files_read", "files_write", "search"]
-    assert seen == [tools_path]
+    assert seen == [config_path]
 
 
 async def test_load_mcp_tools_prefers_env_config_path(
@@ -85,7 +85,7 @@ async def test_load_mcp_tools_prefers_env_config_path(
         return _fake_code_loader(path)
 
     monkeypatch.setattr("deepagents_talon.mcp.get_mcp_tools", fake_loader)
-    env_path = tmp_path / "custom-tools.json"
+    env_path = tmp_path / "custom.mcp.json"
     env_path.write_text(
         json.dumps(
             {
@@ -106,7 +106,7 @@ async def test_load_mcp_tools_prefers_env_config_path(
         base_home=tmp_path,
     )
     config.ensure_home()
-    (config.manifest_dir / "tools.json").write_text(
+    (config.home / ".mcp.json").write_text(
         json.dumps(
             {
                 "mcpServers": {


### PR DESCRIPTION
Fleet direct runs need to turn an operator-unzipped Fleet export into something Talon can run locally. Before this change, invalid exports could get as far as the Fleet loader before failing, and unresolved Fleet MCP dependencies were not represented in a durable, setup-agent-friendly way.

This adds an import-time validator for the Fleet export shape Talon relies on: required `AGENTS.md` and `config.json`, plus optional root and subagent `tools.json` files when present. It also extracts grouped MCP tool requirements by sanitized server URL and declaring scope, preserving Fleet display or registry names when available. That gives follow-up agents a concrete list of local MCP replacement tasks without blocking import just because those replacements have not been configured yet.

The important safety property is that URL query strings and fragments are stripped before requirements are persisted, so secret-bearing Fleet MCP URLs do not leak into the local run manifest.

## Release note
Talon Fleet direct runs now fail early on malformed Fleet exports and write grouped local MCP replacement requirements without persisting secret-bearing URL query strings or fragments.

Stacked on: jkennedyvz/talon/fleet-run-manifest-schema

Made by [Open SWE](https://openswe.vercel.app/agents/3bd8a910-8d95-7ee1-bc2f-0a7f576ce875)
