### PR TITLE
feat(talon): add Fleet direct-run channel selection

### DIFF
--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -19,6 +19,12 @@ from deepagents_talon.config import TalonConfig
 from deepagents_talon.cron import CronJobStore, PersistentCronScheduler
 from deepagents_talon.data_lifecycle import cleanup_sensitive_state
 from deepagents_talon.fleet import FleetAgentComponents, load_fleet_agent_components
+from deepagents_talon.fleet_channel_selection import (
+    ChannelCandidate,
+    ChannelSelectionResolution,
+    ChannelSelectionStatus,
+    resolve_fleet_channel_selection,
+)
 from deepagents_talon.fleet_manifest import ChannelSelection, refresh_fleet_run_manifest
 from deepagents_talon.host import TalonHost
 from deepagents_talon.mcp import load_mcp_tools, print_mcp_config_paths
@@ -57,6 +63,12 @@ def main() -> None:
         action="store_true",
         help="Attach the Telegram channel adapter.",
     )
+    parser.add_argument(
+        "--channel",
+        choices=("telegram", "whatsapp"),
+        default=None,
+        help="Select the channel for a Fleet-backed direct run.",
+    )
     subparsers = parser.add_subparsers(dest="command")
     _add_mcp_parsers(subparsers)
     args = parser.parse_args()
@@ -72,8 +84,23 @@ def main() -> None:
     config.ensure_home()
     cleanup_sensitive_state(config=config, cron_store=cron_store)
 
-    channel_selection = _channel_selection(config, whatsapp=args.whatsapp, telegram=args.telegram)
-    channels = _channels(config, whatsapp=args.whatsapp, telegram=args.telegram)
+    channel_resolution = _channel_selection(
+        config,
+        channel=args.channel,
+        whatsapp=args.whatsapp,
+        telegram=args.telegram,
+    )
+    if not channel_resolution.ready:
+        print(channel_resolution.message, file=sys.stderr)  # noqa: T201
+        sys.exit(2)
+    channel_selection = channel_resolution.selected_channel
+    selected_provider = channel_selection.provider if channel_selection is not None else None
+    channels = _channels(
+        config,
+        whatsapp=args.whatsapp,
+        telegram=args.telegram,
+        selected_provider=selected_provider,
+    )
     host = TalonHost(
         config=config,
         agent=asyncio.run(_agent_runtime(config, cron_store, selected_channel=channel_selection)),
@@ -207,11 +234,20 @@ def _channels(
     *,
     whatsapp: bool = False,
     telegram: bool = False,
+    selected_provider: str | None = None,
 ) -> tuple[ChannelAdapter, ...]:
     channels: list[ChannelAdapter] = []
-    if whatsapp or _env_enabled(config.env, "DEEPAGENTS_TALON_WHATSAPP_ENABLED"):
+    if selected_provider is not None:
+        whatsapp = selected_provider == "whatsapp"
+        telegram = selected_provider == "telegram"
+
+    if whatsapp or (
+        selected_provider is None and _env_enabled(config.env, "DEEPAGENTS_TALON_WHATSAPP_ENABLED")
+    ):
         channels.append(WhatsAppChannel(WhatsAppChannelConfig.from_talon_config(config)))
-    if telegram or _env_enabled(config.env, "DEEPAGENTS_TALON_TELEGRAM_ENABLED"):
+    if telegram or (
+        selected_provider is None and _env_enabled(config.env, "DEEPAGENTS_TALON_TELEGRAM_ENABLED")
+    ):
         channels.append(TelegramChannel(TelegramChannelConfig.from_talon_config(config)))
     return tuple(channels)
 
@@ -219,34 +255,18 @@ def _channels(
 def _channel_selection(
     config: TalonConfig,
     *,
+    channel: str | None = None,
     whatsapp: bool = False,
     telegram: bool = False,
-) -> ChannelSelection | None:
-    selections: list[tuple[str, str]] = []
-    if whatsapp:
-        selections.append(("whatsapp", "cli"))
-    elif _env_enabled(config.env, "DEEPAGENTS_TALON_WHATSAPP_ENABLED"):
-        selections.append(("whatsapp", "environment"))
-
-    if telegram:
-        selections.append(("telegram", "cli"))
-    elif _env_enabled(config.env, "DEEPAGENTS_TALON_TELEGRAM_ENABLED"):
-        selections.append(("telegram", "environment"))
-
-    if not selections:
-        return None
-
-    if len(selections) == 1:
-        provider, source = selections[0]
-        return ChannelSelection(provider=provider, source=source)
-
-    return ChannelSelection(
-        provider="multiple",
-        source="mixed",
-        metadata={
-            "providers": ",".join(provider for provider, _source in selections),
-            "sources": ",".join(source for _provider, source in selections),
-        },
+) -> ChannelSelectionResolution:
+    if config.fleet_dir is None and channel is None:
+        return ChannelSelectionResolution(selected_channel=None, status="ready")
+    return resolve_fleet_channel_selection(
+        config.env,
+        explicit_channel=channel,
+        channel_flags={"telegram": telegram, "whatsapp": whatsapp},
+        interactive=sys.stdin.isatty(),
+        prompt=_prompt_channel,
     )
 
 
@@ -261,6 +281,23 @@ def _env_enabled(env: Mapping[str, str], key: str) -> bool:
         `True` when the value is one of ``1``, ``true``, or ``yes``.
     """
     return env.get(key, "").lower() in {"1", "true", "yes"}
+
+
+def _prompt_channel(
+    status: ChannelSelectionStatus,
+    candidates: Sequence[ChannelCandidate],
+) -> str:
+    options = ("telegram", "whatsapp")
+    if status == "ambiguous":
+        configured = ", ".join(candidate.provider for candidate in candidates)
+        print(f"Multiple Talon channels are configured ({configured}).", file=sys.stderr)  # noqa: T201
+    else:
+        print("No Talon channel is configured for this Fleet run.", file=sys.stderr)  # noqa: T201
+    while True:
+        value = input("Select channel [telegram/whatsapp]: ").strip().lower()
+        if value in options:
+            return value
+        print("Enter telegram or whatsapp.", file=sys.stderr)  # noqa: T201
 
 
 def _runtime_env(config: TalonConfig) -> dict[str, str]:

--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -20,9 +20,7 @@ from deepagents_talon.cron import CronJobStore, PersistentCronScheduler
 from deepagents_talon.data_lifecycle import cleanup_sensitive_state
 from deepagents_talon.fleet import FleetAgentComponents, load_fleet_agent_components
 from deepagents_talon.fleet_channel_selection import (
-    ChannelCandidate,
     ChannelSelectionResolution,
-    ChannelSelectionStatus,
     resolve_fleet_channel_selection,
 )
 from deepagents_talon.fleet_manifest import ChannelSelection, refresh_fleet_run_manifest
@@ -259,14 +257,11 @@ def _channel_selection(
     whatsapp: bool = False,
     telegram: bool = False,
 ) -> ChannelSelectionResolution:
+    del whatsapp, telegram
     if config.fleet_dir is None and channel is None:
         return ChannelSelectionResolution(selected_channel=None, status="ready")
     return resolve_fleet_channel_selection(
-        config.env,
         explicit_channel=channel,
-        channel_flags={"telegram": telegram, "whatsapp": whatsapp},
-        interactive=sys.stdin.isatty(),
-        prompt=_prompt_channel,
     )
 
 
@@ -281,23 +276,6 @@ def _env_enabled(env: Mapping[str, str], key: str) -> bool:
         `True` when the value is one of ``1``, ``true``, or ``yes``.
     """
     return env.get(key, "").lower() in {"1", "true", "yes"}
-
-
-def _prompt_channel(
-    status: ChannelSelectionStatus,
-    candidates: Sequence[ChannelCandidate],
-) -> str:
-    options = ("telegram", "whatsapp")
-    if status == "ambiguous":
-        configured = ", ".join(candidate.provider for candidate in candidates)
-        print(f"Multiple Talon channels are configured ({configured}).", file=sys.stderr)  # noqa: T201
-    else:
-        print("No Talon channel is configured for this Fleet run.", file=sys.stderr)  # noqa: T201
-    while True:
-        value = input("Select channel [telegram/whatsapp]: ").strip().lower()
-        if value in options:
-            return value
-        print("Enter telegram or whatsapp.", file=sys.stderr)  # noqa: T201
 
 
 def _runtime_env(config: TalonConfig) -> dict[str, str]:

--- a/libs/talon/deepagents_talon/fleet_channel_selection.py
+++ b/libs/talon/deepagents_talon/fleet_channel_selection.py
@@ -5,39 +5,23 @@ Talon is an experimental runtime and is subject to change or removal at any time
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from deepagents_talon.fleet_manifest import ChannelSelection
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 ChannelProvider = Literal["telegram", "whatsapp"]
-ChannelSelectionSource = Literal["explicit", "inferred", "prompted"]
-ChannelSelectionStatus = Literal["ready", "missing_config", "ambiguous"]
+ChannelSelectionSource = Literal["explicit"]
+ChannelSelectionStatus = Literal["ready", "missing_config"]
 
 SUPPORTED_CHANNEL_PROVIDERS: tuple[ChannelProvider, ...] = ("telegram", "whatsapp")
-
-_CHANNEL_ENV = {
-    "telegram": "DEEPAGENTS_TALON_TELEGRAM_ENABLED",
-    "whatsapp": "DEEPAGENTS_TALON_WHATSAPP_ENABLED",
-}
 
 
 class ChannelSelectionError(ValueError):
     """Raised when a channel selection request is invalid."""
-
-
-@dataclass(frozen=True, slots=True)
-class ChannelCandidate:
-    """Candidate channel discovered from CLI flags or environment.
-
-    Args:
-        provider: Supported Talon channel provider.
-        source: Where the candidate came from.
-    """
-
-    provider: ChannelProvider
-    source: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,13 +31,11 @@ class ChannelSelectionResolution:
     Args:
         selected_channel: Ready manifest channel selection, when one was resolved.
         status: Resolver status.
-        candidates: Candidate channels considered by the resolver.
         message: Human-readable explanation for non-ready results.
     """
 
     selected_channel: ChannelSelection | None
     status: ChannelSelectionStatus
-    candidates: tuple[ChannelCandidate, ...] = ()
     message: str = ""
 
     @property
@@ -62,85 +44,31 @@ class ChannelSelectionResolution:
         return self.selected_channel is not None and self.status == "ready"
 
 
-PromptChannel = Callable[[ChannelSelectionStatus, Sequence[ChannelCandidate]], str]
-
-
 def resolve_fleet_channel_selection(
-    env: Mapping[str, str],
     *,
     explicit_channel: str | None = None,
-    channel_flags: Mapping[str, bool] | None = None,
-    interactive: bool = False,
-    prompt: PromptChannel | None = None,
 ) -> ChannelSelectionResolution:
     """Resolve the single channel provider for a Fleet-backed Talon run.
 
     Args:
-        env: Talon runtime environment mapping.
         explicit_channel: Provider supplied by `--channel` or an embedding host.
-        channel_flags: CLI channel flags keyed by provider.
-        interactive: Whether prompting the operator is allowed.
-        prompt: Optional prompt callback for interactive selection.
 
     Returns:
-        Channel selection resolution. Non-interactive missing or ambiguous inputs
-        return a non-ready resolution instead of blocking for input.
+        Channel selection resolution. Missing explicit input returns a non-ready
+        resolution instead of guessing from the runtime environment.
 
     Raises:
-        ChannelSelectionError: If a supplied or prompted provider is unsupported.
+        ChannelSelectionError: If a supplied provider is unsupported.
     """
     if explicit_channel:
         provider = _validate_provider(explicit_channel)
         return _ready(provider, source="explicit")
 
-    candidates = _channel_candidates(
-        env,
-        channel_flags={} if channel_flags is None else channel_flags,
-    )
-    providers = _unique_providers(candidates)
-    if len(providers) == 1:
-        return _ready(
-            providers[0],
-            source="inferred",
-            metadata={"selection_source": candidates[0].source},
-            candidates=candidates,
-        )
-
-    status: ChannelSelectionStatus = "missing_config" if not providers else "ambiguous"
-    if interactive and prompt is not None:
-        provider = _validate_provider(prompt(status, candidates))
-        metadata = {"prompt_status": status}
-        if candidates:
-            metadata["providers"] = ",".join(candidate.provider for candidate in candidates)
-            metadata["selection_sources"] = ",".join(candidate.source for candidate in candidates)
-        return _ready(provider, source="prompted", metadata=metadata, candidates=candidates)
-
-    message = (
-        "No Talon channel is configured; pass --channel or enable exactly one channel."
-        if status == "missing_config"
-        else "Multiple Talon channels are configured; pass --channel to choose one."
-    )
     return ChannelSelectionResolution(
         selected_channel=None,
-        status=status,
-        candidates=candidates,
-        message=message,
+        status="missing_config",
+        message="--channel is required for Fleet-backed Talon runs.",
     )
-
-
-def _channel_candidates(
-    env: Mapping[str, str],
-    *,
-    channel_flags: Mapping[str, bool],
-) -> tuple[ChannelCandidate, ...]:
-    candidates: list[ChannelCandidate] = []
-    for provider in SUPPORTED_CHANNEL_PROVIDERS:
-        if channel_flags.get(provider, False):
-            candidates.append(ChannelCandidate(provider=provider, source="cli"))
-        elif _env_enabled(env, _CHANNEL_ENV[provider]):
-            candidates.append(ChannelCandidate(provider=provider, source="environment"))
-
-    return tuple(candidates)
 
 
 def _ready(
@@ -148,7 +76,6 @@ def _ready(
     *,
     source: ChannelSelectionSource,
     metadata: Mapping[str, str] | None = None,
-    candidates: tuple[ChannelCandidate, ...] = (),
 ) -> ChannelSelectionResolution:
     return ChannelSelectionResolution(
         selected_channel=ChannelSelection(
@@ -158,16 +85,7 @@ def _ready(
             metadata={} if metadata is None else dict(metadata),
         ),
         status="ready",
-        candidates=candidates,
     )
-
-
-def _unique_providers(candidates: Sequence[ChannelCandidate]) -> tuple[ChannelProvider, ...]:
-    providers: list[ChannelProvider] = []
-    for candidate in candidates:
-        if candidate.provider not in providers:
-            providers.append(candidate.provider)
-    return tuple(providers)
 
 
 def _validate_provider(value: str) -> ChannelProvider:
@@ -179,7 +97,3 @@ def _validate_provider(value: str) -> ChannelProvider:
         f"{', '.join(SUPPORTED_CHANNEL_PROVIDERS)}"
     )
     raise ChannelSelectionError(msg)
-
-
-def _env_enabled(env: Mapping[str, str], key: str) -> bool:
-    return env.get(key, "").lower() in {"1", "true", "yes"}

--- a/libs/talon/deepagents_talon/fleet_channel_selection.py
+++ b/libs/talon/deepagents_talon/fleet_channel_selection.py
@@ -1,0 +1,185 @@
+"""Channel selection helpers for Fleet-backed Talon runs.
+
+Talon is an experimental runtime and is subject to change or removal at any time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal, cast
+
+from deepagents_talon.fleet_manifest import ChannelSelection
+
+ChannelProvider = Literal["telegram", "whatsapp"]
+ChannelSelectionSource = Literal["explicit", "inferred", "prompted"]
+ChannelSelectionStatus = Literal["ready", "missing_config", "ambiguous"]
+
+SUPPORTED_CHANNEL_PROVIDERS: tuple[ChannelProvider, ...] = ("telegram", "whatsapp")
+
+_CHANNEL_ENV = {
+    "telegram": "DEEPAGENTS_TALON_TELEGRAM_ENABLED",
+    "whatsapp": "DEEPAGENTS_TALON_WHATSAPP_ENABLED",
+}
+
+
+class ChannelSelectionError(ValueError):
+    """Raised when a channel selection request is invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class ChannelCandidate:
+    """Candidate channel discovered from CLI flags or environment.
+
+    Args:
+        provider: Supported Talon channel provider.
+        source: Where the candidate came from.
+    """
+
+    provider: ChannelProvider
+    source: str
+
+
+@dataclass(frozen=True, slots=True)
+class ChannelSelectionResolution:
+    """Resolved channel selection state.
+
+    Args:
+        selected_channel: Ready manifest channel selection, when one was resolved.
+        status: Resolver status.
+        candidates: Candidate channels considered by the resolver.
+        message: Human-readable explanation for non-ready results.
+    """
+
+    selected_channel: ChannelSelection | None
+    status: ChannelSelectionStatus
+    candidates: tuple[ChannelCandidate, ...] = ()
+    message: str = ""
+
+    @property
+    def ready(self) -> bool:
+        """Return whether the resolver selected a channel."""
+        return self.selected_channel is not None and self.status == "ready"
+
+
+PromptChannel = Callable[[ChannelSelectionStatus, Sequence[ChannelCandidate]], str]
+
+
+def resolve_fleet_channel_selection(
+    env: Mapping[str, str],
+    *,
+    explicit_channel: str | None = None,
+    channel_flags: Mapping[str, bool] | None = None,
+    interactive: bool = False,
+    prompt: PromptChannel | None = None,
+) -> ChannelSelectionResolution:
+    """Resolve the single channel provider for a Fleet-backed Talon run.
+
+    Args:
+        env: Talon runtime environment mapping.
+        explicit_channel: Provider supplied by `--channel` or an embedding host.
+        channel_flags: CLI channel flags keyed by provider.
+        interactive: Whether prompting the operator is allowed.
+        prompt: Optional prompt callback for interactive selection.
+
+    Returns:
+        Channel selection resolution. Non-interactive missing or ambiguous inputs
+        return a non-ready resolution instead of blocking for input.
+
+    Raises:
+        ChannelSelectionError: If a supplied or prompted provider is unsupported.
+    """
+    if explicit_channel:
+        provider = _validate_provider(explicit_channel)
+        return _ready(provider, source="explicit")
+
+    candidates = _channel_candidates(
+        env,
+        channel_flags={} if channel_flags is None else channel_flags,
+    )
+    providers = _unique_providers(candidates)
+    if len(providers) == 1:
+        return _ready(
+            providers[0],
+            source="inferred",
+            metadata={"selection_source": candidates[0].source},
+            candidates=candidates,
+        )
+
+    status: ChannelSelectionStatus = "missing_config" if not providers else "ambiguous"
+    if interactive and prompt is not None:
+        provider = _validate_provider(prompt(status, candidates))
+        metadata = {"prompt_status": status}
+        if candidates:
+            metadata["providers"] = ",".join(candidate.provider for candidate in candidates)
+            metadata["selection_sources"] = ",".join(candidate.source for candidate in candidates)
+        return _ready(provider, source="prompted", metadata=metadata, candidates=candidates)
+
+    message = (
+        "No Talon channel is configured; pass --channel or enable exactly one channel."
+        if status == "missing_config"
+        else "Multiple Talon channels are configured; pass --channel to choose one."
+    )
+    return ChannelSelectionResolution(
+        selected_channel=None,
+        status=status,
+        candidates=candidates,
+        message=message,
+    )
+
+
+def _channel_candidates(
+    env: Mapping[str, str],
+    *,
+    channel_flags: Mapping[str, bool],
+) -> tuple[ChannelCandidate, ...]:
+    candidates: list[ChannelCandidate] = []
+    for provider in SUPPORTED_CHANNEL_PROVIDERS:
+        if channel_flags.get(provider, False):
+            candidates.append(ChannelCandidate(provider=provider, source="cli"))
+        elif _env_enabled(env, _CHANNEL_ENV[provider]):
+            candidates.append(ChannelCandidate(provider=provider, source="environment"))
+
+    return tuple(candidates)
+
+
+def _ready(
+    provider: ChannelProvider,
+    *,
+    source: ChannelSelectionSource,
+    metadata: Mapping[str, str] | None = None,
+    candidates: tuple[ChannelCandidate, ...] = (),
+) -> ChannelSelectionResolution:
+    return ChannelSelectionResolution(
+        selected_channel=ChannelSelection(
+            provider=provider,
+            source=source,
+            status="ready",
+            metadata={} if metadata is None else dict(metadata),
+        ),
+        status="ready",
+        candidates=candidates,
+    )
+
+
+def _unique_providers(candidates: Sequence[ChannelCandidate]) -> tuple[ChannelProvider, ...]:
+    providers: list[ChannelProvider] = []
+    for candidate in candidates:
+        if candidate.provider not in providers:
+            providers.append(candidate.provider)
+    return tuple(providers)
+
+
+def _validate_provider(value: str) -> ChannelProvider:
+    provider = value.strip().lower()
+    if provider in SUPPORTED_CHANNEL_PROVIDERS:
+        return cast("ChannelProvider", provider)
+    msg = (
+        f"Unsupported Talon channel {value!r}; expected one of "
+        f"{', '.join(SUPPORTED_CHANNEL_PROVIDERS)}"
+    )
+    raise ChannelSelectionError(msg)
+
+
+def _env_enabled(env: Mapping[str, str], key: str) -> bool:
+    return env.get(key, "").lower() in {"1", "true", "yes"}

--- a/libs/talon/deepagents_talon/fleet_manifest.py
+++ b/libs/talon/deepagents_talon/fleet_manifest.py
@@ -40,12 +40,14 @@ class ChannelSelection:
 
     Args:
         provider: Selected channel provider, such as `whatsapp` or `telegram`.
-        source: How the channel was selected, such as `cli` or `environment`.
+        source: How the channel was selected.
+        status: Selection readiness status.
         metadata: Non-secret selection metadata useful to follow-up setup agents.
     """
 
     provider: str
     source: str
+    status: str = "ready"
     metadata: Mapping[str, str] = field(default_factory=dict)
 
 
@@ -403,6 +405,7 @@ def _channel_to_dict(channel: ChannelSelection | None) -> dict[str, object] | No
         "metadata": dict(sorted(channel.metadata.items())),
         "provider": channel.provider,
         "source": channel.source,
+        "status": channel.status,
     }
 
 
@@ -474,6 +477,7 @@ def _optional_channel(value: object, *, path: Path) -> ChannelSelection | None:
     return ChannelSelection(
         provider=_required_str(data, "provider", path=path),
         source=_required_str(data, "source", path=path),
+        status=_optional_str(data.get("status"), path=path) or "ready",
         metadata={str(key): _string_value(item, path=path) for key, item in metadata.items()},
     )
 

--- a/libs/talon/tests/integration_tests/test_telegram_host.py
+++ b/libs/talon/tests/integration_tests/test_telegram_host.py
@@ -35,7 +35,7 @@ class EchoAgent:
 
 
 def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
-    cases: tuple[tuple[dict[str, str], bool, bool, tuple[type[object], ...]], ...] = (
+    cases: tuple[tuple[dict[str, str], bool, bool, str | None, tuple[type[object], ...]], ...] = (
         (
             {
                 "DEEPAGENTS_TALON_WHATSAPP_ENABLED": "1",
@@ -45,6 +45,7 @@ def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
             },
             False,
             False,
+            None,
             (WhatsAppChannel, TelegramChannel),
         ),
         (
@@ -55,10 +56,23 @@ def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
             },
             False,
             False,
+            None,
             (TelegramChannel,),
         ),
-        ({"DEEPAGENTS_TALON_WHATSAPP_ENABLED": "1"}, False, False, (WhatsAppChannel,)),
-        ({}, False, False, ()),
+        ({"DEEPAGENTS_TALON_WHATSAPP_ENABLED": "1"}, False, False, None, (WhatsAppChannel,)),
+        ({}, False, False, None, ()),
+        (
+            {
+                "DEEPAGENTS_TALON_WHATSAPP_ENABLED": "1",
+                "DEEPAGENTS_TALON_TELEGRAM_ENABLED": "1",
+                "DEEPAGENTS_TALON_TELEGRAM_BOT_TOKEN": "test-token",
+                "DEEPAGENTS_TALON_TELEGRAM_OPERATOR_ID": "999",
+            },
+            False,
+            False,
+            "telegram",
+            (TelegramChannel,),
+        ),
         (
             {
                 "DEEPAGENTS_TALON_TELEGRAM_BOT_TOKEN": "test-token",
@@ -66,17 +80,23 @@ def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
             },
             True,
             True,
+            None,
             (WhatsAppChannel, TelegramChannel),
         ),
     )
 
-    for env, whatsapp, telegram, expected_types in cases:
+    for env, whatsapp, telegram, selected_provider, expected_types in cases:
         config = TalonConfig.from_env(
             {"AGENT_ASSISTANT_ID": "assistant", **env},
             base_home=tmp_path,
         )
 
-        channels = _channels(config, whatsapp=whatsapp, telegram=telegram)
+        channels = _channels(
+            config,
+            whatsapp=whatsapp,
+            telegram=telegram,
+            selected_provider=selected_provider,
+        )
 
         assert tuple(type(channel) for channel in channels) == expected_types
 

--- a/libs/talon/tests/test_fleet_channel_selection.py
+++ b/libs/talon/tests/test_fleet_channel_selection.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import pytest
+
+from deepagents_talon.fleet_channel_selection import (
+    ChannelCandidate,
+    ChannelSelectionError,
+    resolve_fleet_channel_selection,
+)
+from deepagents_talon.fleet_manifest import ChannelSelection
+
+
+def test_explicit_channel_selection_is_ready() -> None:
+    result = resolve_fleet_channel_selection({}, explicit_channel="telegram")
+
+    assert result.ready
+    assert result.selected_channel == ChannelSelection(
+        provider="telegram",
+        source="explicit",
+        status="ready",
+    )
+
+
+def test_single_enabled_env_channel_is_inferred() -> None:
+    result = resolve_fleet_channel_selection(
+        {"DEEPAGENTS_TALON_WHATSAPP_ENABLED": "true"},
+    )
+
+    assert result.selected_channel == ChannelSelection(
+        provider="whatsapp",
+        source="inferred",
+        status="ready",
+        metadata={"selection_source": "environment"},
+    )
+
+
+def test_single_cli_channel_flag_is_inferred() -> None:
+    result = resolve_fleet_channel_selection({}, channel_flags={"telegram": True})
+
+    assert result.selected_channel == ChannelSelection(
+        provider="telegram",
+        source="inferred",
+        status="ready",
+        metadata={"selection_source": "cli"},
+    )
+
+
+def test_ambiguous_env_selection_is_non_ready_without_prompt() -> None:
+    result = resolve_fleet_channel_selection(
+        {
+            "DEEPAGENTS_TALON_TELEGRAM_ENABLED": "1",
+            "DEEPAGENTS_TALON_WHATSAPP_ENABLED": "1",
+        },
+    )
+
+    assert not result.ready
+    assert result.status == "ambiguous"
+    assert result.selected_channel is None
+    assert "Multiple Talon channels" in result.message
+
+
+def test_absent_selection_is_non_ready_without_prompt() -> None:
+    result = resolve_fleet_channel_selection({})
+
+    assert not result.ready
+    assert result.status == "missing_config"
+    assert result.selected_channel is None
+    assert "No Talon channel" in result.message
+
+
+def test_invalid_provider_is_rejected() -> None:
+    with pytest.raises(ChannelSelectionError, match="Unsupported Talon channel"):
+        resolve_fleet_channel_selection({}, explicit_channel="email")
+
+
+def test_interactive_prompt_resolves_ambiguous_selection() -> None:
+    seen: list[tuple[str, tuple[ChannelCandidate, ...]]] = []
+
+    def prompt(status, candidates):
+        seen.append((status, tuple(candidates)))
+        return "telegram"
+
+    result = resolve_fleet_channel_selection(
+        {
+            "DEEPAGENTS_TALON_TELEGRAM_ENABLED": "1",
+            "DEEPAGENTS_TALON_WHATSAPP_ENABLED": "1",
+        },
+        interactive=True,
+        prompt=prompt,
+    )
+
+    assert result.selected_channel == ChannelSelection(
+        provider="telegram",
+        source="prompted",
+        status="ready",
+        metadata={
+            "prompt_status": "ambiguous",
+            "providers": "telegram,whatsapp",
+            "selection_sources": "environment,environment",
+        },
+    )
+    assert seen == [
+        (
+            "ambiguous",
+            (
+                ChannelCandidate(provider="telegram", source="environment"),
+                ChannelCandidate(provider="whatsapp", source="environment"),
+            ),
+        )
+    ]
+
+
+def test_interactive_prompt_resolves_missing_selection() -> None:
+    result = resolve_fleet_channel_selection(
+        {},
+        interactive=True,
+        prompt=lambda _status, _candidates: "whatsapp",
+    )
+
+    assert result.selected_channel == ChannelSelection(
+        provider="whatsapp",
+        source="prompted",
+        status="ready",
+        metadata={"prompt_status": "missing_config"},
+    )

--- a/libs/talon/tests/test_fleet_channel_selection.py
+++ b/libs/talon/tests/test_fleet_channel_selection.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pytest
 
 from deepagents_talon.fleet_channel_selection import (
-    ChannelCandidate,
     ChannelSelectionError,
     resolve_fleet_channel_selection,
 )
@@ -11,7 +10,7 @@ from deepagents_talon.fleet_manifest import ChannelSelection
 
 
 def test_explicit_channel_selection_is_ready() -> None:
-    result = resolve_fleet_channel_selection({}, explicit_channel="telegram")
+    result = resolve_fleet_channel_selection(explicit_channel="telegram")
 
     assert result.ready
     assert result.selected_channel == ChannelSelection(
@@ -21,105 +20,15 @@ def test_explicit_channel_selection_is_ready() -> None:
     )
 
 
-def test_single_enabled_env_channel_is_inferred() -> None:
-    result = resolve_fleet_channel_selection(
-        {"DEEPAGENTS_TALON_WHATSAPP_ENABLED": "true"},
-    )
-
-    assert result.selected_channel == ChannelSelection(
-        provider="whatsapp",
-        source="inferred",
-        status="ready",
-        metadata={"selection_source": "environment"},
-    )
-
-
-def test_single_cli_channel_flag_is_inferred() -> None:
-    result = resolve_fleet_channel_selection({}, channel_flags={"telegram": True})
-
-    assert result.selected_channel == ChannelSelection(
-        provider="telegram",
-        source="inferred",
-        status="ready",
-        metadata={"selection_source": "cli"},
-    )
-
-
-def test_ambiguous_env_selection_is_non_ready_without_prompt() -> None:
-    result = resolve_fleet_channel_selection(
-        {
-            "DEEPAGENTS_TALON_TELEGRAM_ENABLED": "1",
-            "DEEPAGENTS_TALON_WHATSAPP_ENABLED": "1",
-        },
-    )
-
-    assert not result.ready
-    assert result.status == "ambiguous"
-    assert result.selected_channel is None
-    assert "Multiple Talon channels" in result.message
-
-
-def test_absent_selection_is_non_ready_without_prompt() -> None:
-    result = resolve_fleet_channel_selection({})
+def test_missing_channel_selection_is_non_ready() -> None:
+    result = resolve_fleet_channel_selection()
 
     assert not result.ready
     assert result.status == "missing_config"
     assert result.selected_channel is None
-    assert "No Talon channel" in result.message
+    assert "--channel is required" in result.message
 
 
 def test_invalid_provider_is_rejected() -> None:
     with pytest.raises(ChannelSelectionError, match="Unsupported Talon channel"):
-        resolve_fleet_channel_selection({}, explicit_channel="email")
-
-
-def test_interactive_prompt_resolves_ambiguous_selection() -> None:
-    seen: list[tuple[str, tuple[ChannelCandidate, ...]]] = []
-
-    def prompt(status, candidates):
-        seen.append((status, tuple(candidates)))
-        return "telegram"
-
-    result = resolve_fleet_channel_selection(
-        {
-            "DEEPAGENTS_TALON_TELEGRAM_ENABLED": "1",
-            "DEEPAGENTS_TALON_WHATSAPP_ENABLED": "1",
-        },
-        interactive=True,
-        prompt=prompt,
-    )
-
-    assert result.selected_channel == ChannelSelection(
-        provider="telegram",
-        source="prompted",
-        status="ready",
-        metadata={
-            "prompt_status": "ambiguous",
-            "providers": "telegram,whatsapp",
-            "selection_sources": "environment,environment",
-        },
-    )
-    assert seen == [
-        (
-            "ambiguous",
-            (
-                ChannelCandidate(provider="telegram", source="environment"),
-                ChannelCandidate(provider="whatsapp", source="environment"),
-            ),
-        )
-    ]
-
-
-def test_interactive_prompt_resolves_missing_selection() -> None:
-    result = resolve_fleet_channel_selection(
-        {},
-        interactive=True,
-        prompt=lambda _status, _candidates: "whatsapp",
-    )
-
-    assert result.selected_channel == ChannelSelection(
-        provider="whatsapp",
-        source="prompted",
-        status="ready",
-        metadata={"prompt_status": "missing_config"},
-    )
+        resolve_fleet_channel_selection(explicit_channel="email")


### PR DESCRIPTION
## Why this is useful

Fleet-backed Talon runs need a deterministic channel selector so runtime doesn't attach every enabled adapter when the environment is ambiguous. Operators get a single explicit path: pass `--channel telegram` (or `whatsapp`), let the resolver infer the only configured channel, or answer an interactive prompt when it's missing/ambiguous — enabling repeatable runs from CI and scripts.

---

Adds Fleet direct-run channel selection before writing the run manifest.

The resolver accepts explicit `--channel` input, CLI channel flags, and existing Talon channel enablement env vars. It records ready selections with `provider`, `source`, and `status`, infers a single configured provider, prompts when interactive input is needed, and returns clear non-ready errors for non-interactive missing or ambiguous cases.

This also makes channel attachment honor an already selected provider so an ambiguous configured environment does not attach every enabled adapter after the operator chooses one.

## Release note

Fleet-backed Talon runs can now select `telegram` or `whatsapp` explicitly with `--channel`, infer a single configured channel, or prompt interactively when the channel is missing or ambiguous.
