### PR TITLE
feat(talon): add import-fleet CLI subcommand

### DIFF
--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -11,7 +11,8 @@ import importlib
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 from deepagents_talon.channels.telegram import TelegramChannel, TelegramChannelConfig
 from deepagents_talon.channels.whatsapp import WhatsAppChannel, WhatsAppChannelConfig
@@ -20,6 +21,12 @@ from deepagents_talon.cron import CronJobStore, PersistentCronScheduler
 from deepagents_talon.data_lifecycle import cleanup_sensitive_state
 from deepagents_talon.fleet import FleetAgentComponents, load_fleet_agent_components
 from deepagents_talon.host import TalonHost
+from deepagents_talon.import_fleet import (
+    ChannelName,
+    FleetImportError,
+    FleetImportSummary,
+    import_fleet_manifest,
+)
 from deepagents_talon.mcp import load_mcp_tools, print_mcp_config_paths
 from deepagents_talon.runtime import (
     DeepAgentRuntime,
@@ -58,9 +65,13 @@ def main() -> None:
     )
     subparsers = parser.add_subparsers(dest="command")
     _add_mcp_parsers(subparsers)
+    _add_import_fleet_parser(subparsers)
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
+
+    if args.command == "import-fleet":
+        sys.exit(_run_import_fleet_command(args))
 
     config = TalonConfig.from_env()
     if args.command == "mcp":
@@ -103,6 +114,28 @@ def _add_mcp_parsers(
     login = mcp_sub.add_parser("login", help="Run OAuth login for an MCP server")
     login.add_argument("server", help="Server name from mcpServers")
     login.add_argument("--mcp-config", dest="config_path", default=None)
+
+
+def _add_import_fleet_parser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    parser = subparsers.add_parser(
+        "import-fleet",
+        help="Write or refresh an assistant-scoped manifest for a Fleet export",
+    )
+    parser.add_argument("fleet_dir", type=Path, help="Unzipped Fleet export directory")
+    parser.add_argument("--assistant-id", required=True, help="Assistant id for Talon local state")
+    parser.add_argument(
+        "--channel",
+        choices=("telegram", "whatsapp"),
+        default=None,
+        help="Channel provider Talon will run for this Fleet export",
+    )
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Fail instead of prompting when channel selection is missing",
+    )
 
 
 async def _agent_runtime(
@@ -178,6 +211,24 @@ async def _run_mcp_command(args: argparse.Namespace, config: TalonConfig) -> int
     return 2
 
 
+def _run_import_fleet_command(args: argparse.Namespace) -> int:
+    try:
+        channel = _resolve_import_channel(
+            args.channel,
+            non_interactive=args.non_interactive,
+        )
+        summary = import_fleet_manifest(
+            args.fleet_dir,
+            assistant_id=args.assistant_id,
+            channel=channel,
+        )
+    except (FleetImportError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)  # noqa: T201
+        return 2
+    _print_import_summary(summary)
+    return 0
+
+
 async def _run_mcp_login(args: argparse.Namespace) -> int:
     try:
         module = importlib.import_module("deepagents_code.mcp_commands")
@@ -189,6 +240,54 @@ async def _run_mcp_login(args: argparse.Namespace) -> int:
         return 1
     run_mcp_login = module.run_mcp_login
     return await run_mcp_login(server=args.server, config_path=args.config_path)
+
+
+def _resolve_import_channel(
+    channel: str | None,
+    *,
+    non_interactive: bool,
+) -> ChannelName:
+    if channel in {"telegram", "whatsapp"}:
+        return cast("ChannelName", channel)
+
+    env_channel = _import_channel_from_env(os.environ)
+    if env_channel is not None:
+        return env_channel
+
+    if non_interactive:
+        msg = "--channel is required when channel cannot be inferred in non-interactive mode"
+        raise FleetImportError(msg)
+    if not sys.stdin.isatty():
+        msg = "--channel is required when stdin is not interactive"
+        raise FleetImportError(msg)
+
+    while True:
+        value = input("Channel [telegram/whatsapp]: ").strip().lower()
+        if value in {"telegram", "whatsapp"}:
+            return cast("ChannelName", value)
+        print("Enter 'telegram' or 'whatsapp'.", file=sys.stderr)  # noqa: T201
+
+
+def _import_channel_from_env(env: Mapping[str, str]) -> ChannelName | None:
+    enabled: list[ChannelName] = []
+    if _env_enabled(env, "DEEPAGENTS_TALON_TELEGRAM_ENABLED"):
+        enabled.append("telegram")
+    if _env_enabled(env, "DEEPAGENTS_TALON_WHATSAPP_ENABLED"):
+        enabled.append("whatsapp")
+    if len(enabled) == 1:
+        return enabled[0]
+    return None
+
+
+def _print_import_summary(summary: FleetImportSummary) -> None:
+    print("Imported Fleet export for Talon.")  # noqa: T201
+    print(f"  channel: {summary.channel}")  # noqa: T201
+    print(f"  fleet_dir: {summary.fleet_dir}")  # noqa: T201
+    print(f"  assistant_id: {summary.assistant_id}")  # noqa: T201
+    print(f"  replacement_tools: {summary.replacement_tool_count}")  # noqa: T201
+    print(f"  setup_tasks: {summary.setup_task_count}")  # noqa: T201
+    print(f"  local_mcp_config: {summary.mcp_config_target}")  # noqa: T201
+    print(f"  model_source: {summary.model_source}")  # noqa: T201
 
 
 async def _run_once(host: TalonHost) -> None:

--- a/libs/talon/deepagents_talon/import_fleet.py
+++ b/libs/talon/deepagents_talon/import_fleet.py
@@ -205,6 +205,15 @@ def _fleet_model(config: Mapping[str, object]) -> str:
         nested = cast("Mapping[str, object]", agent).get("model")
         if isinstance(nested, str) and nested:
             return nested
+    runtime = config.get("config")
+    if isinstance(runtime, Mapping):
+        configurable = cast("Mapping[str, object]", runtime).get("configurable")
+        if isinstance(configurable, Mapping):
+            model_config = cast("Mapping[str, object]", configurable).get("llm_model_config")
+            if isinstance(model_config, Mapping):
+                model_id = cast("Mapping[str, object]", model_config).get("modelId")
+                if isinstance(model_id, str) and model_id:
+                    return model_id
     msg = "Malformed Fleet config.json: missing model"
     raise FleetImportError(msg)
 

--- a/libs/talon/deepagents_talon/import_fleet.py
+++ b/libs/talon/deepagents_talon/import_fleet.py
@@ -1,0 +1,357 @@
+"""Fleet export import helpers for Talon.
+
+Talon is an experimental runtime and is subject to change or removal at any time.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Literal, cast
+from urllib.parse import urlsplit, urlunsplit
+
+from deepagents_talon.config import TalonConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+ChannelName = Literal["telegram", "whatsapp"]
+
+
+class FleetImportError(ValueError):
+    """Raised when a Fleet export cannot be imported."""
+
+
+@dataclass(frozen=True, slots=True)
+class FleetReplacementTool:
+    """Local MCP replacement needed for a Fleet-requested tool.
+
+    Args:
+        name: Fleet tool name.
+        endpoint: Sanitized Fleet MCP server endpoint.
+        auth_path: Fleet authentication path, when known.
+        scope: Root agent or subagent scope that requested the tool.
+    """
+
+    name: str
+    endpoint: str
+    auth_path: str
+    scope: str
+
+
+@dataclass(frozen=True, slots=True)
+class FleetSetupTask:
+    """Operator task needed before local Talon runtime can replace Fleet MCP.
+
+    Args:
+        endpoint: Sanitized Fleet MCP server endpoint.
+        auth_path: Fleet authentication path, when known.
+        target: Local MCP config path the operator should edit.
+        tool_names: Fleet tools requested from this endpoint.
+    """
+
+    endpoint: str
+    auth_path: str
+    target: str
+    tool_names: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class FleetImportSummary:
+    """Result of importing a Fleet export into an assistant manifest.
+
+    Args:
+        channel: Selected channel provider.
+        fleet_dir: Validated Fleet export directory.
+        assistant_id: Assistant id used to namespace Talon state.
+        replacement_tool_count: Number of Fleet-requested tools requiring local replacement.
+        setup_task_count: Number of local MCP replacement tasks.
+        mcp_config_target: Assistant-scoped MCP config path written by the import.
+        manifest_path: Manifest file written by the import.
+        model_source: Whether the runtime model comes from Fleet or local env override.
+    """
+
+    channel: ChannelName
+    fleet_dir: Path
+    assistant_id: str
+    replacement_tool_count: int
+    setup_task_count: int
+    mcp_config_target: Path
+    manifest_path: Path
+    model_source: Literal["fleet_config", "local_override"]
+
+
+@dataclass(frozen=True, slots=True)
+class _FleetManifestContext:
+    """Values shared by one manifest refresh."""
+
+    target: Path
+    fleet_dir: Path
+    assistant_id: str
+    channel: ChannelName
+    model: str
+    model_source: Literal["fleet_config", "local_override"]
+
+
+def import_fleet_manifest(
+    fleet_dir: Path,
+    *,
+    assistant_id: str,
+    channel: ChannelName,
+    env: Mapping[str, str] | None = None,
+) -> FleetImportSummary:
+    """Write or refresh an assistant-scoped Fleet run manifest.
+
+    Args:
+        fleet_dir: Operator-unzipped Fleet export directory.
+        assistant_id: Talon assistant id whose home receives the manifest.
+        channel: Selected channel provider.
+        env: Environment mapping used to match runtime configuration.
+
+    Returns:
+        Summary of the import result.
+
+    Raises:
+        FleetImportError: If required Fleet export files are missing or malformed.
+    """
+    values = dict(os.environ if env is None else env)
+    values["DEEPAGENTS_TALON_ASSISTANT_ID"] = assistant_id
+    values["DEEPAGENTS_TALON_FLEET_DIR"] = str(fleet_dir)
+    config = TalonConfig.from_env(values)
+
+    source = _validate_fleet_dir(fleet_dir)
+    fleet_config = _read_json_object(source / "config.json", label="Fleet config.json")
+    fleet_model = _fleet_model(fleet_config)
+    model_source: Literal["fleet_config", "local_override"] = (
+        "local_override" if config.model else "fleet_config"
+    )
+    model = config.model or fleet_model
+
+    config.ensure_home()
+    target = config.manifest_dir / "tools.json"
+    replacements = _replacement_tools(source, env=config.env)
+    tasks = _setup_tasks(replacements, target=target)
+    manifest = _manifest_payload(
+        _FleetManifestContext(
+            target=target,
+            fleet_dir=source,
+            assistant_id=config.assistant_id,
+            channel=channel,
+            model=model,
+            model_source=model_source,
+        ),
+        replacements=replacements,
+        tasks=tasks,
+    )
+    target.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    target.chmod(0o600)
+
+    return FleetImportSummary(
+        channel=channel,
+        fleet_dir=source,
+        assistant_id=config.assistant_id,
+        replacement_tool_count=len(replacements),
+        setup_task_count=len(tasks),
+        mcp_config_target=target,
+        manifest_path=target,
+        model_source=model_source,
+    )
+
+
+def _validate_fleet_dir(fleet_dir: Path) -> Path:
+    source = fleet_dir.expanduser()
+    try:
+        source = source.resolve(strict=True)
+    except OSError as exc:
+        msg = f"Fleet directory does not exist: {fleet_dir}"
+        raise FleetImportError(msg) from exc
+    if not source.is_dir():
+        msg = f"Fleet path is not a directory: {fleet_dir}"
+        raise FleetImportError(msg)
+    agents_md = source / "AGENTS.md"
+    if not agents_md.is_file():
+        msg = "Fleet export is missing required AGENTS.md"
+        raise FleetImportError(msg)
+    config_json = source / "config.json"
+    if not config_json.is_file():
+        msg = "Fleet export is missing required config.json"
+        raise FleetImportError(msg)
+    return source
+
+
+def _read_json_object(path: Path, *, label: str) -> Mapping[str, object]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        msg = f"Could not read {label}: {path}"
+        raise FleetImportError(msg) from exc
+    except json.JSONDecodeError as exc:
+        msg = f"Malformed {label}: {path}"
+        raise FleetImportError(msg) from exc
+    if not isinstance(data, Mapping):
+        msg = f"Malformed {label}: expected a JSON object"
+        raise FleetImportError(msg)
+    return cast("Mapping[str, object]", data)
+
+
+def _fleet_model(config: Mapping[str, object]) -> str:
+    raw = config.get("model")
+    if isinstance(raw, str) and raw:
+        return raw
+    agent = config.get("agent")
+    if isinstance(agent, Mapping):
+        nested = cast("Mapping[str, object]", agent).get("model")
+        if isinstance(nested, str) and nested:
+            return nested
+    msg = "Malformed Fleet config.json: missing model"
+    raise FleetImportError(msg)
+
+
+def _replacement_tools(
+    fleet_dir: Path,
+    *,
+    env: Mapping[str, str],
+) -> tuple[FleetReplacementTool, ...]:
+    tools: list[FleetReplacementTool] = []
+    tools.extend(_replacement_tools_from_file(fleet_dir / "tools.json", scope="root", env=env))
+
+    subagents = fleet_dir / "subagents"
+    if not subagents.is_dir():
+        return tuple(tools)
+    for child in sorted(path for path in subagents.iterdir() if path.is_dir()):
+        tools.extend(
+            _replacement_tools_from_file(
+                child / "tools.json",
+                scope=f"subagent:{child.name}",
+                env=env,
+            )
+        )
+    return tuple(sorted(tools, key=lambda tool: (tool.endpoint, tool.scope, tool.name)))
+
+
+def _replacement_tools_from_file(
+    path: Path,
+    *,
+    scope: str,
+    env: Mapping[str, str],
+) -> list[FleetReplacementTool]:
+    if not path.is_file():
+        return []
+    data = _read_json_object(path, label=f"Fleet {path.name}")
+    raw = data.get("tools")
+    if raw is None:
+        return []
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes, bytearray)):
+        msg = f"Malformed Fleet {path.name}: tools must be an array"
+        raise FleetImportError(msg)
+
+    tools: list[FleetReplacementTool] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, Mapping):
+            msg = f"Malformed Fleet {path.name}: tools[{index}] must be an object"
+            raise FleetImportError(msg)
+        tool = cast("Mapping[str, object]", entry)
+        name = tool.get("name")
+        endpoint = tool.get("mcp_server_url")
+        if not isinstance(name, str) or not name:
+            msg = f"Malformed Fleet {path.name}: tools[{index}].name is required"
+            raise FleetImportError(msg)
+        if not isinstance(endpoint, str) or not endpoint:
+            continue
+        auth_path = _fleet_auth_path(tool, endpoint, env=env)
+        if auth_path == "builtin" and env.get("BUILTIN_MCP_URL"):
+            continue
+        tools.append(
+            FleetReplacementTool(
+                name=name,
+                endpoint=_safe_endpoint(endpoint),
+                auth_path=auth_path,
+                scope=scope,
+            )
+        )
+    return tools
+
+
+def _fleet_auth_path(
+    tool: Mapping[str, object],
+    endpoint: str,
+    *,
+    env: Mapping[str, str],
+) -> str:
+    raw = tool.get("auth_type") or tool.get("auth")
+    if isinstance(raw, str) and raw in {"builtin", "headers", "oauth"}:
+        return raw
+    if _same_host(endpoint, env.get("BUILTIN_MCP_URL")):
+        return "builtin"
+    if "headers" in tool:
+        return "headers"
+    return "unknown"
+
+
+def _setup_tasks(
+    replacements: Sequence[FleetReplacementTool],
+    *,
+    target: Path,
+) -> tuple[FleetSetupTask, ...]:
+    grouped: dict[tuple[str, str], set[str]] = {}
+    for tool in replacements:
+        grouped.setdefault((tool.endpoint, tool.auth_path), set()).add(tool.name)
+    return tuple(
+        FleetSetupTask(
+            endpoint=endpoint,
+            auth_path=auth_path,
+            target=str(target),
+            tool_names=tuple(sorted(names)),
+        )
+        for (endpoint, auth_path), names in sorted(grouped.items())
+    )
+
+
+def _manifest_payload(
+    context: _FleetManifestContext,
+    *,
+    replacements: Sequence[FleetReplacementTool],
+    tasks: Sequence[FleetSetupTask],
+) -> dict[str, object]:
+    existing = _read_existing_manifest(context.target)
+    return {
+        "mcpServers": existing.get("mcpServers", {}),
+        "manifest": {
+            "source": "fleet",
+            "fleet_dir": str(context.fleet_dir),
+            "assistant_id": context.assistant_id,
+            "channel": context.channel,
+            "model": context.model,
+            "model_source": context.model_source,
+            "replacement_tools": [asdict(tool) for tool in replacements],
+            "setup_tasks": [asdict(task) for task in tasks],
+        },
+    }
+
+
+def _read_existing_manifest(path: Path) -> Mapping[str, object]:
+    if not path.is_file():
+        return {}
+    data = _read_json_object(path, label="existing Talon manifest")
+    servers = data.get("mcpServers")
+    if servers is None:
+        return {}
+    if not isinstance(servers, Mapping):
+        msg = "Malformed existing Talon manifest: mcpServers must be an object"
+        raise FleetImportError(msg)
+    return {"mcpServers": dict(cast("Mapping[str, object]", servers))}
+
+
+def _safe_endpoint(value: str) -> str:
+    parsed = urlsplit(value)
+    if parsed.scheme and parsed.netloc:
+        return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+    return value.split("?", maxsplit=1)[0].split("#", maxsplit=1)[0]
+
+
+def _same_host(left: str, right: str | None) -> bool:
+    if not right:
+        return False
+    return urlsplit(left).hostname == urlsplit(right).hostname

--- a/libs/talon/tests/test_import_fleet.py
+++ b/libs/talon/tests/test_import_fleet.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from deepagents_talon.__main__ import (
+    _resolve_import_channel,
+    _run_import_fleet_command,
+)
+from deepagents_talon.import_fleet import FleetImportError, import_fleet_manifest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class InteractiveStdin:
+    def isatty(self) -> bool:
+        return True
+
+
+def test_import_fleet_manifest_writes_and_refreshes_assistant_manifest(tmp_path: Path) -> None:
+    fleet = _fleet_export(tmp_path)
+    home = tmp_path / "home"
+    target = home / "agent-1" / "agent" / "tools.json"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "local": {
+                        "type": "stdio",
+                        "command": "local-server",
+                    },
+                },
+                "manifest": {"stale": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    summary = import_fleet_manifest(
+        fleet,
+        assistant_id="agent-1",
+        channel="telegram",
+        env={"DEEPAGENTS_TALON_HOME": str(home), "AGENT_MODEL": "override:model"},
+    )
+    import_fleet_manifest(
+        fleet,
+        assistant_id="agent-1",
+        channel="telegram",
+        env={"DEEPAGENTS_TALON_HOME": str(home), "AGENT_MODEL": "override:model"},
+    )
+
+    manifest = json.loads(target.read_text(encoding="utf-8"))
+    payload = manifest["manifest"]
+    assert summary.manifest_path == target
+    assert summary.model_source == "local_override"
+    assert summary.replacement_tool_count == 4
+    assert summary.setup_task_count == 3
+    assert manifest["mcpServers"] == {
+        "local": {
+            "type": "stdio",
+            "command": "local-server",
+        },
+    }
+    assert payload["assistant_id"] == "agent-1"
+    assert payload["channel"] == "telegram"
+    assert payload["fleet_dir"] == str(fleet.resolve())
+    assert payload["model"] == "override:model"
+    assert payload["model_source"] == "local_override"
+    assert len(payload["replacement_tools"]) == 4
+    assert len(payload["setup_tasks"]) == 3
+    assert target.stat().st_mode & 0o777 == 0o600
+    assert "raw-secret" not in target.read_text(encoding="utf-8")
+
+
+def test_import_fleet_manifest_records_builtin_mcp_as_resolved(tmp_path: Path) -> None:
+    fleet = _fleet_export(tmp_path)
+    summary = import_fleet_manifest(
+        fleet,
+        assistant_id="agent-1",
+        channel="telegram",
+        env={
+            "DEEPAGENTS_TALON_HOME": str(tmp_path / "home"),
+            "BUILTIN_MCP_URL": "https://builtin.example/mcp?api_key=local-secret",
+        },
+    )
+
+    assert summary.model_source == "fleet_config"
+    assert summary.replacement_tool_count == 3
+    assert summary.setup_task_count == 2
+
+
+def test_import_fleet_manifest_fails_on_malformed_required_config(tmp_path: Path) -> None:
+    fleet = tmp_path / "fleet"
+    fleet.mkdir()
+    (fleet / "AGENTS.md").write_text("system prompt", encoding="utf-8")
+    (fleet / "config.json").write_text("[]", encoding="utf-8")
+
+    with pytest.raises(FleetImportError, match=r"Fleet config\.json"):
+        import_fleet_manifest(
+            fleet,
+            assistant_id="agent-1",
+            channel="telegram",
+            env={"DEEPAGENTS_TALON_HOME": str(tmp_path / "home")},
+        )
+
+
+def test_import_fleet_command_fails_without_channel_in_non_interactive_mode(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fleet = _fleet_export(tmp_path)
+    monkeypatch.delenv("DEEPAGENTS_TALON_TELEGRAM_ENABLED", raising=False)
+    monkeypatch.delenv("DEEPAGENTS_TALON_WHATSAPP_ENABLED", raising=False)
+
+    code = _run_import_fleet_command(
+        Namespace(
+            fleet_dir=fleet,
+            assistant_id="agent-1",
+            channel=None,
+            non_interactive=True,
+        )
+    )
+
+    assert code == 2
+    assert "--channel is required" in capsys.readouterr().err
+
+
+def test_resolve_import_channel_prompts_when_interactive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DEEPAGENTS_TALON_TELEGRAM_ENABLED", raising=False)
+    monkeypatch.delenv("DEEPAGENTS_TALON_WHATSAPP_ENABLED", raising=False)
+    monkeypatch.setattr("sys.stdin", InteractiveStdin())
+    answers = iter(["bad", "whatsapp"])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+
+    assert _resolve_import_channel(None, non_interactive=False) == "whatsapp"
+
+
+def test_import_fleet_command_prints_secret_free_summary(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fleet = _fleet_export(tmp_path)
+    monkeypatch.setenv("DEEPAGENTS_TALON_HOME", str(tmp_path / "home"))
+
+    code = _run_import_fleet_command(
+        Namespace(
+            fleet_dir=fleet,
+            assistant_id="agent-1",
+            channel="telegram",
+            non_interactive=True,
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert code == 0
+    assert "channel: telegram" in output
+    assert "assistant_id: agent-1" in output
+    assert "replacement_tools: 4" in output
+    assert "setup_tasks: 3" in output
+    assert "local_mcp_config:" in output
+    assert "raw-secret" not in output
+    assert "header-secret" not in output
+
+
+def _fleet_export(tmp_path: Path) -> Path:
+    fleet = tmp_path / "fleet"
+    fleet.mkdir()
+    (fleet / "AGENTS.md").write_text("system prompt", encoding="utf-8")
+    (fleet / "config.json").write_text(
+        json.dumps({"model": "fleet:model"}),
+        encoding="utf-8",
+    )
+    (fleet / "tools.json").write_text(
+        json.dumps(
+            {
+                "tools": [
+                    {
+                        "name": "search",
+                        "mcp_server_url": "https://missing.example/mcp?token=raw-secret",
+                        "auth_type": "headers",
+                        "headers": {"Authorization": "Bearer header-secret"},
+                    },
+                    {
+                        "name": "lookup",
+                        "mcp_server_url": "https://missing.example/mcp?token=raw-secret",
+                        "auth_type": "headers",
+                    },
+                    {
+                        "name": "builtin_search",
+                        "mcp_server_url": "https://builtin.example/mcp?token=builtin-secret",
+                        "auth_type": "builtin",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    subagent = fleet / "subagents" / "researcher"
+    subagent.mkdir(parents=True)
+    (subagent / "tools.json").write_text(
+        json.dumps(
+            {
+                "tools": [
+                    {
+                        "name": "calendar",
+                        "mcp_server_url": "https://calendar.example/mcp?token=raw-secret",
+                        "auth_type": "oauth",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return fleet

--- a/libs/talon/tests/test_import_fleet.py
+++ b/libs/talon/tests/test_import_fleet.py
@@ -94,6 +94,35 @@ def test_import_fleet_manifest_records_builtin_mcp_as_resolved(tmp_path: Path) -
     assert summary.setup_task_count == 2
 
 
+def test_import_fleet_manifest_reads_nested_fleet_model_config(tmp_path: Path) -> None:
+    fleet = _fleet_export(tmp_path)
+    (fleet / "config.json").write_text(
+        json.dumps(
+            {
+                "config": {
+                    "configurable": {
+                        "llm_model_config": {
+                            "modelId": "openai:gpt-5.5",
+                        },
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    summary = import_fleet_manifest(
+        fleet,
+        assistant_id="agent-1",
+        channel="whatsapp",
+        env={"DEEPAGENTS_TALON_HOME": str(tmp_path / "home")},
+    )
+
+    manifest = json.loads(summary.manifest_path.read_text(encoding="utf-8"))
+    assert summary.model_source == "fleet_config"
+    assert manifest["manifest"]["model"] == "openai:gpt-5.5"
+
+
 def test_import_fleet_manifest_fails_on_malformed_required_config(tmp_path: Path) -> None:
     fleet = tmp_path / "fleet"
     fleet.mkdir()


### PR DESCRIPTION
## Why this is useful

Operators can validate a Fleet export and materialize the assistant-scoped Talon manifest before runtime, so misconfigured exports and unresolved MCP replacement tasks surface at import time instead of partway through a run. Use it with `deepagents-talon import-fleet <fleet-dir> --assistant-id <id>` after unzipping a Fleet export.

---

Adds `deepagents-talon import-fleet` so operators can validate an unzipped Fleet export and materialize the assistant-scoped Talon manifest before runtime.

The command builds Talon config from `--assistant-id` plus the environment, resolves channel selection from `--channel`, channel env, or an interactive prompt, preserves existing local `mcpServers`, records unresolved Fleet MCP replacement tasks, and prints a concise summary without exposing tool secrets.

## Release note
Talon now includes `deepagents-talon import-fleet <fleet-dir> --assistant-id <id>` to create or refresh assistant-scoped Fleet import manifests and local MCP replacement handoff tasks.
