### PR TITLE
feat(talon): add `run-fleet` manifest startup

### DIFF
--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -43,6 +43,18 @@ uv run deepagents-talon --once
 
 In Fleet mode, Talon uses the model from `fleet/config.json` unless `DEEPAGENTS_TALON_MODEL` or `AGENT_MODEL` is set. The Fleet loader resolves MCP registry references through LangSmith, so provide the required `LANGSMITH_API_KEY`, `LANGSMITH_TENANT_ID`, `LANGSMITH_ORGANIZATION_ID`, and when needed `LANGSMITH_USER_ID`, `BUILTIN_MCP_URL`, `LANGSMITH_HOST_URL`, and `HOST_LANGCHAIN_API_URL`. Locally-authored agents without `DEEPAGENTS_TALON_FLEET_DIR` continue to load from the assistant manifest directory and Talon's plain MCP config discovery.
 
+To persist the Fleet directory and selected local channel in the assistant manifest, import the export once and run it by assistant id:
+
+```bash
+uv run deepagents-talon import-fleet ./fleet \
+  --assistant-id fleet-local \
+  --channel telegram
+
+uv run deepagents-talon run-fleet --assistant-id fleet-local --once
+```
+
+`run-fleet` activates the imported channel without requiring `DEEPAGENTS_TALON_<CHANNEL>_ENABLED`. Existing channel flags such as `--whatsapp` and `--telegram` can still be passed to attach additional adapters for the same run.
+
 OAuth-backed Fleet MCP tools must be authorized once from an interactive shell before starting a headless host. Run the host in `--once` mode with the same Fleet directory and LangSmith environment you will use in production, complete the browser authorization if prompted, then start the long-running host:
 
 ```bash

--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -29,7 +29,7 @@ from deepagents_talon.import_fleet import (
     import_fleet_manifest,
     load_fleet_run_manifest,
 )
-from deepagents_talon.mcp import load_mcp_tools, print_mcp_config_paths
+from deepagents_talon.mcp import MCPTools, load_mcp_tools, print_mcp_config_paths
 from deepagents_talon.observability import log_event
 from deepagents_talon.runtime import (
     DeepAgentRuntime,
@@ -40,7 +40,9 @@ from deepagents_talon.runtime import (
 from deepagents_talon.speech import build_voice_transcriber
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Callable, Mapping, Sequence
+
+    from langchain_core.tools import BaseTool
 
     from deepagents_talon.cron import CronJob
     from deepagents_talon.interfaces import ChannelAdapter
@@ -202,11 +204,25 @@ async def _agent_runtime(
     if config.fleet_dir is not None:
         fleet_dir = config.fleet_dir
         components = await load_fleet_agent_components(fleet_dir, env=env)
-        runtime_components = _runtime_components_from_fleet(config, components, env=env)
+        mcp = await load_mcp_tools(config, allow_empty=True)
+        _log_mcp_servers(mcp)
+        runtime_components = _runtime_components_from_fleet(
+            config,
+            components,
+            env=env,
+            local_tools=mcp.tools,
+        )
 
         async def reload_fleet_components() -> RuntimeAgentComponents:
             refreshed = await load_fleet_agent_components(fleet_dir, env=env)
-            return _runtime_components_from_fleet(config, refreshed, env=env)
+            reloaded = await load_mcp_tools(config, allow_empty=True)
+            _log_mcp_servers(reloaded)
+            return _runtime_components_from_fleet(
+                config,
+                refreshed,
+                env=env,
+                local_tools=reloaded.tools,
+            )
 
         return DeepAgentRuntime(
             model=runtime_components.model,
@@ -225,11 +241,7 @@ async def _agent_runtime(
         return EchoAgentRuntime()
 
     mcp = await load_mcp_tools(config)
-    for server in mcp.servers:
-        if server.error is not None:
-            logger.warning("MCP server %s failed: %s", server.name, server.error)
-        else:
-            logger.info("MCP server %s loaded %d tool(s)", server.name, len(server.tools))
+    _log_mcp_servers(mcp)
     return DeepAgentRuntime(
         model=config.model,
         tools=mcp.tools,
@@ -245,16 +257,51 @@ def _runtime_components_from_fleet(
     components: FleetAgentComponents,
     *,
     env: Mapping[str, str],
+    local_tools: Sequence[BaseTool | Callable[..., object]] = (),
 ) -> RuntimeAgentComponents:
     return RuntimeAgentComponents(
         model=config.model or components.model,
-        tools=components.tools,
+        tools=_merge_tools(components.tools, local_tools),
         system_prompt=components.system_prompt,
         subagents=components.subagents,
         skills=components.skills,
         middleware=components.middleware,
         interrupt_on=interrupt_on_with_env_overlay(components.interrupt_on, env),
     )
+
+
+def _log_mcp_servers(mcp: MCPTools) -> None:
+    for server in mcp.servers:
+        if server.error is not None:
+            logger.warning("MCP server %s failed: %s", server.name, server.error)
+        else:
+            logger.info("MCP server %s loaded %d tool(s)", server.name, len(server.tools))
+
+
+def _merge_tools(
+    primary: Sequence[BaseTool | Callable[..., object]],
+    extra: Sequence[BaseTool | Callable[..., object]],
+) -> tuple[BaseTool | Callable[..., object], ...]:
+    tools: list[BaseTool | Callable[..., object]] = list(primary)
+    seen = {_tool_name(tool) for tool in primary}
+    for tool in extra:
+        name = _tool_name(tool)
+        if name is not None and name in seen:
+            continue
+        tools.append(tool)
+        if name is not None:
+            seen.add(name)
+    return tuple(tools)
+
+
+def _tool_name(tool: BaseTool | Callable[..., object]) -> str | None:
+    name = getattr(tool, "name", None)
+    if isinstance(name, str) and name:
+        return name
+    fallback = getattr(tool, "__name__", None)
+    if isinstance(fallback, str) and fallback:
+        return fallback
+    return None
 
 
 async def _run_mcp_command(args: argparse.Namespace, config: TalonConfig) -> int:

--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -25,9 +25,12 @@ from deepagents_talon.import_fleet import (
     ChannelName,
     FleetImportError,
     FleetImportSummary,
+    FleetRunManifest,
     import_fleet_manifest,
+    load_fleet_run_manifest,
 )
 from deepagents_talon.mcp import load_mcp_tools, print_mcp_config_paths
+from deepagents_talon.observability import log_event
 from deepagents_talon.runtime import (
     DeepAgentRuntime,
     EchoAgentRuntime,
@@ -66,23 +69,48 @@ def main() -> None:
     subparsers = parser.add_subparsers(dest="command")
     _add_mcp_parsers(subparsers)
     _add_import_fleet_parser(subparsers)
+    _add_run_fleet_parser(subparsers)
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
 
     if args.command == "import-fleet":
         sys.exit(_run_import_fleet_command(args))
+    if args.command == "run-fleet":
+        sys.exit(_run_fleet_command(args))
 
     config = TalonConfig.from_env()
     if args.command == "mcp":
         sys.exit(asyncio.run(_run_mcp_command(args, config)))
 
+    _run_host(
+        config,
+        once=args.once,
+        whatsapp=args.whatsapp,
+        telegram=args.telegram,
+        selected_channel=None,
+    )
+
+
+def _run_host(
+    config: TalonConfig,
+    *,
+    once: bool,
+    whatsapp: bool,
+    telegram: bool,
+    selected_channel: ChannelName | None,
+) -> None:
     cron_factory = CronJobStore
     cron_store = cron_factory(assistant_id=config.assistant_id, cron_dir=config.cron_dir)
     config.ensure_home()
     cleanup_sensitive_state(config=config, cron_store=cron_store)
 
-    channels = _channels(config, whatsapp=args.whatsapp, telegram=args.telegram)
+    channels = _channels(
+        config,
+        whatsapp=whatsapp,
+        telegram=telegram,
+        selected_channel=selected_channel,
+    )
     host = TalonHost(
         config=config,
         agent=asyncio.run(_agent_runtime(config, cron_store)),
@@ -96,7 +124,7 @@ def main() -> None:
             deliver_result=lambda job, text: _deliver_cron_result(host, channels, job, text),
         )
 
-    if args.once:
+    if once:
         asyncio.run(_run_once(host))
         return
 
@@ -135,6 +163,34 @@ def _add_import_fleet_parser(
         "--non-interactive",
         action="store_true",
         help="Fail instead of prompting when channel selection is missing",
+    )
+
+
+def _add_run_fleet_parser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    parser = subparsers.add_parser(
+        "run-fleet",
+        help="Run a Fleet-backed assistant from its imported manifest",
+    )
+    parser.add_argument("--assistant-id", required=True, help="Assistant id for Talon local state")
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Start and stop immediately after bootstrapping the host.",
+    )
+    parser.add_argument(
+        "--whatsapp",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Also attach the WhatsApp channel adapter.",
+    )
+    parser.add_argument(
+        "--telegram",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Also attach the Telegram channel adapter.",
     )
 
 
@@ -229,6 +285,43 @@ def _run_import_fleet_command(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_fleet_command(args: argparse.Namespace) -> int:
+    try:
+        manifest = load_fleet_run_manifest(assistant_id=args.assistant_id)
+        config = _config_from_fleet_run_manifest(manifest)
+    except (FleetImportError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)  # noqa: T201
+        return 2
+
+    log_event(
+        logger,
+        "fleet.run_startup",
+        assistant_id=manifest.assistant_id,
+        channel=manifest.channel,
+        fleet_dir=str(manifest.fleet_dir),
+        replacement_tool_count=manifest.replacement_tool_count,
+    )
+    _run_host(
+        config,
+        once=args.once,
+        whatsapp=args.whatsapp,
+        telegram=args.telegram,
+        selected_channel=manifest.channel,
+    )
+    return 0
+
+
+def _config_from_fleet_run_manifest(
+    manifest: FleetRunManifest,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> TalonConfig:
+    values = dict(os.environ if env is None else env)
+    values["DEEPAGENTS_TALON_ASSISTANT_ID"] = manifest.assistant_id
+    values["DEEPAGENTS_TALON_FLEET_DIR"] = str(manifest.fleet_dir)
+    return TalonConfig.from_env(values)
+
+
 async def _run_mcp_login(args: argparse.Namespace) -> int:
     try:
         module = importlib.import_module("deepagents_code.mcp_commands")
@@ -300,11 +393,20 @@ def _channels(
     *,
     whatsapp: bool = False,
     telegram: bool = False,
+    selected_channel: ChannelName | None = None,
 ) -> tuple[ChannelAdapter, ...]:
     channels: list[ChannelAdapter] = []
-    if whatsapp or _env_enabled(config.env, "DEEPAGENTS_TALON_WHATSAPP_ENABLED"):
+    if (
+        whatsapp
+        or selected_channel == "whatsapp"
+        or _env_enabled(config.env, "DEEPAGENTS_TALON_WHATSAPP_ENABLED")
+    ):
         channels.append(WhatsAppChannel(WhatsAppChannelConfig.from_talon_config(config)))
-    if telegram or _env_enabled(config.env, "DEEPAGENTS_TALON_TELEGRAM_ENABLED"):
+    if (
+        telegram
+        or selected_channel == "telegram"
+        or _env_enabled(config.env, "DEEPAGENTS_TALON_TELEGRAM_ENABLED")
+    ):
         channels.append(TelegramChannel(TelegramChannelConfig.from_talon_config(config)))
     return tuple(channels)
 

--- a/libs/talon/deepagents_talon/import_fleet.py
+++ b/libs/talon/deepagents_talon/import_fleet.py
@@ -9,13 +9,11 @@ import json
 import os
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING, Literal, cast
+from pathlib import Path
+from typing import Literal, cast
 from urllib.parse import urlsplit, urlunsplit
 
 from deepagents_talon.config import TalonConfig
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 ChannelName = Literal["telegram", "whatsapp"]
 
@@ -81,6 +79,25 @@ class FleetImportSummary:
     mcp_config_target: Path
     manifest_path: Path
     model_source: Literal["fleet_config", "local_override"]
+
+
+@dataclass(frozen=True, slots=True)
+class FleetRunManifest:
+    """Assistant-scoped Fleet run intent persisted by `import-fleet`.
+
+    Args:
+        channel: Selected channel provider to activate when running the manifest.
+        fleet_dir: Validated Fleet export directory.
+        assistant_id: Assistant id used to namespace Talon state.
+        manifest_path: Manifest file that supplied the run intent.
+        replacement_tool_count: Number of Fleet-requested tools requiring local replacement.
+    """
+
+    channel: ChannelName
+    fleet_dir: Path
+    assistant_id: str
+    manifest_path: Path
+    replacement_tool_count: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -157,6 +174,77 @@ def import_fleet_manifest(
         mcp_config_target=target,
         manifest_path=target,
         model_source=model_source,
+    )
+
+
+def load_fleet_run_manifest(
+    *,
+    assistant_id: str,
+    env: Mapping[str, str] | None = None,
+) -> FleetRunManifest:
+    """Load and validate the assistant's Fleet run manifest.
+
+    Args:
+        assistant_id: Talon assistant id whose manifest should be loaded.
+        env: Environment mapping used to resolve the assistant home.
+
+    Returns:
+        Validated Fleet run manifest.
+
+    Raises:
+        FleetImportError: If the manifest is missing, malformed, or points at a
+            stale Fleet export directory.
+    """
+    values = dict(os.environ if env is None else env)
+    values["DEEPAGENTS_TALON_ASSISTANT_ID"] = assistant_id
+    config = TalonConfig.from_env(values)
+    path = config.manifest_dir / "tools.json"
+    if not path.is_file():
+        msg = (
+            f"Fleet run manifest not found for assistant {config.assistant_id!r}. "
+            "Run `deepagents-talon import-fleet` first."
+        )
+        raise FleetImportError(msg)
+
+    data = _read_json_object(path, label="Fleet run manifest")
+    raw = data.get("manifest")
+    if not isinstance(raw, Mapping):
+        msg = "Malformed Fleet run manifest: missing manifest object"
+        raise FleetImportError(msg)
+    manifest = cast("Mapping[str, object]", raw)
+    if manifest.get("source") != "fleet":
+        msg = "Manifest is not a Fleet run manifest"
+        raise FleetImportError(msg)
+
+    manifest_assistant_id = manifest.get("assistant_id")
+    if manifest_assistant_id != config.assistant_id:
+        msg = (
+            "Fleet run manifest assistant id does not match requested assistant "
+            f"{config.assistant_id!r}"
+        )
+        raise FleetImportError(msg)
+
+    channel = manifest.get("channel")
+    if channel not in {"telegram", "whatsapp"}:
+        msg = "Malformed Fleet run manifest: channel must be telegram or whatsapp"
+        raise FleetImportError(msg)
+
+    fleet_dir = manifest.get("fleet_dir")
+    if not isinstance(fleet_dir, str) or not fleet_dir:
+        msg = "Malformed Fleet run manifest: fleet_dir is required"
+        raise FleetImportError(msg)
+
+    replacements = manifest.get("replacement_tools", ())
+    if not isinstance(replacements, Sequence) or isinstance(replacements, (str, bytes, bytearray)):
+        msg = "Malformed Fleet run manifest: replacement_tools must be an array"
+        raise FleetImportError(msg)
+
+    return FleetRunManifest(
+        channel=cast("ChannelName", channel),
+        fleet_dir=_validate_fleet_dir(Path(fleet_dir)),
+        assistant_id=config.assistant_id,
+        manifest_path=path,
+        replacement_tool_count=len(replacements),
     )
 
 

--- a/libs/talon/deepagents_talon/mcp.py
+++ b/libs/talon/deepagents_talon/mcp.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -19,7 +20,7 @@ from deepagents_code.mcp_tools import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Sequence
 
     from langchain_core.tools import BaseTool
 
@@ -48,6 +49,8 @@ def discover_mcp_config_paths(config: TalonConfig) -> list[Path]:
 
     Args:
         config: Talon runtime configuration.
+        allow_empty: Whether an existing config with an empty `mcpServers` object
+            should be treated as no local MCP config.
 
     Returns:
         Existing files, ordered from lowest to highest precedence.
@@ -59,11 +62,17 @@ def discover_mcp_config_paths(config: TalonConfig) -> list[Path]:
     return [path for path in paths if _is_file(path)]
 
 
-async def load_mcp_tools(config: TalonConfig) -> MCPTools:
+async def load_mcp_tools(
+    config: TalonConfig,
+    *,
+    allow_empty: bool = False,
+) -> MCPTools:
     """Load configured MCP tools for a Talon runtime.
 
     Args:
         config: Talon runtime configuration.
+        allow_empty: Whether an existing config with an empty `mcpServers` object
+            should be treated as no local MCP config.
 
     Returns:
         Loaded tools and status for each configured server.
@@ -73,6 +82,8 @@ async def load_mcp_tools(config: TalonConfig) -> MCPTools:
     """
     path = _select_mcp_config_path(config)
     if path is None:
+        return MCPTools(tools=(), servers=())
+    if allow_empty and _mcp_servers_empty(path):
         return MCPTools(tools=(), servers=())
     try:
         tools, manager, infos = await get_mcp_tools(str(path))
@@ -131,3 +142,11 @@ def _is_file(path: Path) -> bool:
     except OSError:
         logger.warning("Could not inspect MCP config path %s", path, exc_info=True)
         return False
+
+
+def _mcp_servers_empty(path: Path) -> bool:
+    try:
+        data = json.loads(path.expanduser().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return isinstance(data, Mapping) and data.get("mcpServers") == {}

--- a/libs/talon/tests/integration_tests/test_telegram_host.py
+++ b/libs/talon/tests/integration_tests/test_telegram_host.py
@@ -35,7 +35,10 @@ class EchoAgent:
 
 
 def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
-    cases: tuple[tuple[dict[str, str], bool, bool, tuple[type[object], ...]], ...] = (
+    cases: tuple[
+        tuple[dict[str, str], bool, bool, str | None, tuple[type[object], ...]],
+        ...,
+    ] = (
         (
             {
                 "DEEPAGENTS_TALON_WHATSAPP_ENABLED": "1",
@@ -45,6 +48,7 @@ def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
             },
             False,
             False,
+            None,
             (WhatsAppChannel, TelegramChannel),
         ),
         (
@@ -55,10 +59,28 @@ def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
             },
             False,
             False,
+            None,
             (TelegramChannel,),
         ),
-        ({"DEEPAGENTS_TALON_WHATSAPP_ENABLED": "1"}, False, False, (WhatsAppChannel,)),
-        ({}, False, False, ()),
+        (
+            {"DEEPAGENTS_TALON_WHATSAPP_ENABLED": "1"},
+            False,
+            False,
+            None,
+            (WhatsAppChannel,),
+        ),
+        ({}, False, False, None, ()),
+        (
+            {
+                "DEEPAGENTS_TALON_TELEGRAM_BOT_TOKEN": "test-token",
+                "DEEPAGENTS_TALON_TELEGRAM_OPERATOR_ID": "999",
+            },
+            False,
+            False,
+            "telegram",
+            (TelegramChannel,),
+        ),
+        ({}, False, False, "whatsapp", (WhatsAppChannel,)),
         (
             {
                 "DEEPAGENTS_TALON_TELEGRAM_BOT_TOKEN": "test-token",
@@ -66,17 +88,23 @@ def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
             },
             True,
             True,
+            None,
             (WhatsAppChannel, TelegramChannel),
         ),
     )
 
-    for env, whatsapp, telegram, expected_types in cases:
+    for env, whatsapp, telegram, selected_channel, expected_types in cases:
         config = TalonConfig.from_env(
             {"AGENT_ASSISTANT_ID": "assistant", **env},
             base_home=tmp_path,
         )
 
-        channels = _channels(config, whatsapp=whatsapp, telegram=telegram)
+        channels = _channels(
+            config,
+            whatsapp=whatsapp,
+            telegram=telegram,
+            selected_channel=selected_channel,
+        )
 
         assert tuple(type(channel) for channel in channels) == expected_types
 

--- a/libs/talon/tests/test_fleet.py
+++ b/libs/talon/tests/test_fleet.py
@@ -255,12 +255,12 @@ async def test_agent_runtime_loads_fleet_components(
             middleware=(middleware,),
         )
 
-    async def fail_load_mcp(_config):
-        msg = "local MCP loader should not run for Fleet sources"
-        raise AssertionError(msg)
+    async def fake_load_mcp(_config, *, allow_empty: bool = False) -> MCPTools:
+        assert allow_empty is True
+        return MCPTools(tools=(cast("Any", local_tool),), servers=())
 
     monkeypatch.setattr("deepagents_talon.__main__.load_fleet_agent_components", fake_load_fleet)
-    monkeypatch.setattr("deepagents_talon.__main__.load_mcp_tools", fail_load_mcp)
+    monkeypatch.setattr("deepagents_talon.__main__.load_mcp_tools", fake_load_mcp)
 
     config = TalonConfig.from_env(
         {
@@ -279,7 +279,7 @@ async def test_agent_runtime_loads_fleet_components(
     assert isinstance(runtime, DeepAgentRuntime)
     assert runtime.model == "fleet:model"
     assert runtime.system_prompt == "fleet prompt"
-    assert runtime.tools == (fleet_tool,)
+    assert runtime.tools == (fleet_tool, local_tool)
     assert runtime.subagents == (subagent,)
     assert runtime.skills == ("/fleet/skills",)
     assert runtime.middleware == (middleware,)
@@ -296,7 +296,7 @@ async def test_agent_runtime_loads_fleet_components(
     refreshed = await runtime.reload_agent_components()
 
     assert refreshed.model == "fleet:model"
-    assert refreshed.tools == (fleet_tool,)
+    assert refreshed.tools == (fleet_tool, local_tool)
     assert refreshed.middleware == (middleware,)
     assert refreshed.interrupt_on == {
         "fleet_tool": True,
@@ -327,7 +327,12 @@ async def test_agent_runtime_allows_fleet_model_override(
             interrupt_on=None,
         )
 
+    async def fake_load_mcp(_config, *, allow_empty: bool = False) -> MCPTools:
+        assert allow_empty is True
+        return MCPTools(tools=(), servers=())
+
     monkeypatch.setattr("deepagents_talon.__main__.load_fleet_agent_components", fake_load_fleet)
+    monkeypatch.setattr("deepagents_talon.__main__.load_mcp_tools", fake_load_mcp)
     config = TalonConfig.from_env(
         {
             "AGENT_ASSISTANT_ID": "test",

--- a/libs/talon/tests/test_import_fleet.py
+++ b/libs/talon/tests/test_import_fleet.py
@@ -7,10 +7,16 @@ from typing import TYPE_CHECKING
 import pytest
 
 from deepagents_talon.__main__ import (
+    _config_from_fleet_run_manifest,
     _resolve_import_channel,
+    _run_fleet_command,
     _run_import_fleet_command,
 )
-from deepagents_talon.import_fleet import FleetImportError, import_fleet_manifest
+from deepagents_talon.import_fleet import (
+    FleetImportError,
+    import_fleet_manifest,
+    load_fleet_run_manifest,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -169,6 +175,192 @@ def test_import_fleet_command_prints_secret_free_summary(
     assert "local_mcp_config:" in output
     assert "raw-secret" not in output
     assert "header-secret" not in output
+
+
+def test_load_fleet_run_manifest_fails_when_manifest_is_missing(tmp_path: Path) -> None:
+    with pytest.raises(FleetImportError, match="Fleet run manifest not found"):
+        load_fleet_run_manifest(
+            assistant_id="agent-1",
+            env={"DEEPAGENTS_TALON_HOME": str(tmp_path / "home")},
+        )
+
+
+def test_load_fleet_run_manifest_fails_when_fleet_dir_is_stale(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    target = home / "agent-1" / "agent" / "tools.json"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        json.dumps(
+            {
+                "manifest": {
+                    "source": "fleet",
+                    "assistant_id": "agent-1",
+                    "channel": "telegram",
+                    "fleet_dir": str(tmp_path / "missing-fleet"),
+                    "replacement_tools": [],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(FleetImportError, match="Fleet directory does not exist"):
+        load_fleet_run_manifest(
+            assistant_id="agent-1",
+            env={"DEEPAGENTS_TALON_HOME": str(home)},
+        )
+
+
+def test_run_fleet_command_starts_selected_telegram_manifest(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fleet = _fleet_export(tmp_path)
+    home = tmp_path / "home"
+    import_fleet_manifest(
+        fleet,
+        assistant_id="agent-1",
+        channel="telegram",
+        env={"DEEPAGENTS_TALON_HOME": str(home)},
+    )
+    monkeypatch.setenv("DEEPAGENTS_TALON_HOME", str(home))
+    captured: dict[str, object] = {}
+
+    def run_host(config: object, **kwargs: object) -> None:
+        captured["config"] = config
+        captured.update(kwargs)
+
+    monkeypatch.setattr("deepagents_talon.__main__._run_host", run_host)
+
+    caplog.set_level("INFO", logger="deepagents_talon.__main__")
+    code = _run_fleet_command(_run_fleet_args("agent-1"))
+
+    config = captured["config"]
+    assert code == 0
+    assert captured["selected_channel"] == "telegram"
+    assert captured["whatsapp"] is False
+    assert captured["telegram"] is False
+    assert config.assistant_id == "agent-1"
+    assert config.fleet_dir == fleet.resolve()
+    event = _talon_events(caplog, event="fleet.run_startup")[0]
+    assert event["assistant_id"] == "agent-1"
+    assert event["channel"] == "telegram"
+    assert event["fleet_dir"] == str(fleet.resolve())
+    assert event["replacement_tool_count"] == 4
+    assert "raw-secret" not in caplog.text
+
+
+def test_run_fleet_command_starts_selected_whatsapp_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fleet = _fleet_export(tmp_path)
+    home = tmp_path / "home"
+    import_fleet_manifest(
+        fleet,
+        assistant_id="agent-1",
+        channel="whatsapp",
+        env={"DEEPAGENTS_TALON_HOME": str(home)},
+    )
+    monkeypatch.setenv("DEEPAGENTS_TALON_HOME", str(home))
+    captured: dict[str, object] = {}
+
+    def run_host(config: object, **kwargs: object) -> None:
+        captured["config"] = config
+        captured.update(kwargs)
+
+    monkeypatch.setattr("deepagents_talon.__main__._run_host", run_host)
+
+    code = _run_fleet_command(_run_fleet_args("agent-1", telegram=True))
+
+    assert code == 0
+    assert captured["selected_channel"] == "whatsapp"
+    assert captured["telegram"] is True
+
+
+def test_run_fleet_config_keeps_environment_model_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fleet = _fleet_export(tmp_path)
+    home = tmp_path / "home"
+    import_fleet_manifest(
+        fleet,
+        assistant_id="agent-1",
+        channel="telegram",
+        env={"DEEPAGENTS_TALON_HOME": str(home)},
+    )
+    manifest = load_fleet_run_manifest(
+        assistant_id="agent-1",
+        env={"DEEPAGENTS_TALON_HOME": str(home)},
+    )
+    monkeypatch.setenv("AGENT_MODEL", "override:model")
+
+    config = _config_from_fleet_run_manifest(
+        manifest,
+        env={"DEEPAGENTS_TALON_HOME": str(home), "AGENT_MODEL": "override:model"},
+    )
+
+    assert config.model == "override:model"
+    assert config.fleet_dir == fleet.resolve()
+
+
+def test_run_fleet_command_passes_once_to_host(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fleet = _fleet_export(tmp_path)
+    home = tmp_path / "home"
+    import_fleet_manifest(
+        fleet,
+        assistant_id="agent-1",
+        channel="telegram",
+        env={"DEEPAGENTS_TALON_HOME": str(home)},
+    )
+    monkeypatch.setenv("DEEPAGENTS_TALON_HOME", str(home))
+    captured: dict[str, object] = {}
+
+    def run_host(config: object, **kwargs: object) -> None:
+        captured["config"] = config
+        captured.update(kwargs)
+
+    monkeypatch.setattr("deepagents_talon.__main__._run_host", run_host)
+
+    code = _run_fleet_command(_run_fleet_args("agent-1", once=True))
+
+    assert code == 0
+    assert captured["once"] is True
+
+
+def _run_fleet_args(
+    assistant_id: str,
+    *,
+    once: bool = False,
+    whatsapp: bool = False,
+    telegram: bool = False,
+) -> Namespace:
+    return Namespace(
+        assistant_id=assistant_id,
+        once=once,
+        whatsapp=whatsapp,
+        telegram=telegram,
+    )
+
+
+def _talon_events(
+    caplog: pytest.LogCaptureFixture,
+    *,
+    event: str,
+) -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+    for message in caplog.messages:
+        if not message.startswith("talon_event "):
+            continue
+        payload = json.loads(message.removeprefix("talon_event "))
+        if payload.get("event") == event:
+            events.append(payload)
+    return events
 
 
 def _fleet_export(tmp_path: Path) -> Path:

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -122,3 +122,17 @@ async def test_load_mcp_tools_prefers_env_config_path(
     await load_mcp_tools(config)
 
     assert seen == [env_path]
+
+
+async def test_load_mcp_tools_allows_empty_manifest_config(tmp_path: Path) -> None:
+    config = TalonConfig.from_env({"AGENT_ASSISTANT_ID": "test"}, base_home=tmp_path)
+    config.ensure_home()
+    (config.manifest_dir / "tools.json").write_text(
+        json.dumps({"mcpServers": {}, "manifest": {"source": "fleet"}}),
+        encoding="utf-8",
+    )
+
+    result = await load_mcp_tools(config, allow_empty=True)
+
+    assert result.tools == ()
+    assert result.servers == ()


### PR DESCRIPTION
## Why this is useful

Talon can now start a Fleet-backed assistant from an imported manifest instead of raw environment variables, so operators get repeatable, channel-activated runs without exporting a channel-enabled env var each launch. Use it with `deepagents-talon run-fleet --assistant-id <id>` after `import-fleet` has materialized the manifest.

---

Stacked on #4445.

Adds a `run-fleet` startup path that loads the assistant-scoped Fleet run manifest written by `import-fleet`, validates the Fleet export directory, and starts the Talon host with the manifest-selected channel. The existing raw environment startup path with `DEEPAGENTS_TALON_FLEET_DIR` is left unchanged, while manifest startup still preserves local environment overrides such as `AGENT_MODEL` and allows explicit extra channel flags.

The startup path emits a secret-free structured log with the assistant id, selected channel, Fleet directory, and replacement-tool count so operators can confirm which manifest was used.

Unit coverage exercises missing and stale manifests, Telegram and WhatsApp channel selection, env override preservation, and `--once` propagation. Ran `make lint` and `make test` for `libs/talon`.

## Release note

Talon can now start a Fleet-backed assistant from an imported Fleet manifest with `deepagents-talon run-fleet --assistant-id <id>`, activating the selected channel without requiring the matching channel-enabled environment variable.
