### PR TITLE
chore(code): automatic PATH setup, snap-curl detection, and temp cleanup in install script

### DIFF
--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -978,13 +978,19 @@ local_bin_in_profile() {
 # Ensure dcode is on PATH for new shell sessions. Creates symlinks and/or
 # modifies the shell profile as needed. Only acts when the binary verified
 # but isn't already on the user's original PATH.
+# Returns: 0 = PATH is fixed for the current shell (symlink in an on-PATH dir),
+#          1 = failure (a specific warning was already printed),
+#          2 = no changes needed, but the current shell still must be reloaded
+#              or sourced before dcode will resolve.
 ensure_path_setup() {
   local binary_name="$1"
   local binary_path="$2"
 
-  # uv's env file already handles PATH setup — no need to duplicate.
+  # uv's env file already handles PATH setup for new shells — no profile
+  # change needed. But the current shell still lacks ~/.local/bin on PATH, so
+  # return 2 to let the caller emit a reload/source hint.
   if [ -f "$HOME/.local/bin/env" ]; then
-    return 0
+    return 2
   fi
 
   # Step 1: try symlinking into a dir already in PATH (no profile change).
@@ -1021,13 +1027,15 @@ ensure_path_setup() {
     return 1
   fi
 
-  # Already in profile? Just tell the user to reload.
+  # Already in profile? No changes needed, but the current shell may still
+  # lack ~/.local/bin on PATH (stale shell). Return 2 so the caller can emit
+  # a reload/source hint instead of silently returning success.
   if local_bin_in_profile "$SHELL_PROFILE"; then
     if [ "$VERBOSE" = "1" ]; then
       # shellcheck disable=SC2088  # display string, literal ~/ is intended for readability
       log_info "~/.local/bin already in ${SHELL_PROFILE}."
     fi
-    return 0
+    return 2
   fi
 
   # Collapse $HOME prefix to ~ for a tidier display path.
@@ -1160,8 +1168,12 @@ fi
 # PATH dir, or add ~/.local/bin to the shell profile — so the binary is
 # immediately usable in a new terminal without manual configuration.
 if [ "$VERIFY_OK" = true ] && [ "$DCODE_ON_PATH" = false ] && [ -n "$DCODE_BIN" ]; then
-  if ! ensure_path_setup "$DCODE_NAME" "$DCODE_BIN"; then
-    # ensure_path_setup already printed a specific warning; add the fallback.
+  path_setup_rc=0
+  ensure_path_setup "$DCODE_NAME" "$DCODE_BIN" || path_setup_rc=$?
+  if [ "$path_setup_rc" -ne 0 ]; then
+    # rc=1: ensure_path_setup printed a specific warning; add the fallback.
+    # rc=2: no profile change needed, but the current shell still lacks
+    #   ~/.local/bin on PATH — emit the same reload/source hint.
     log_warn "  Restart your shell, or run:"
     if [ -f "${HOME}/.local/bin/env" ]; then
       log_warn "  source ~/.local/bin/env"

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -324,7 +324,11 @@ prepare_install_log_dir() {
   [ ! -L "$cache_root" ] || return 1
   [ ! -L "$dir" ] || return 1
   if [ ! -d "$cache_root" ]; then
-    mkdir -m 700 -p "$cache_root" 2>/dev/null || return 1
+    # `-m` with `-p` only sets the mode on the deepest dir (SC2174); any parents
+    # -p creates keep the umask default. Create, then chmod the target itself so
+    # 0700 is reliably applied to cache_root.
+    mkdir -p "$cache_root" 2>/dev/null || return 1
+    chmod 700 "$cache_root" 2>/dev/null || return 1
   fi
   [ -d "$cache_root" ] && [ ! -L "$cache_root" ] || return 1
   if [ -e "$dir" ]; then

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -75,8 +75,22 @@
 # Credits:
 #   Interactive mode detection, color logging, and optional tool install
 #   patterns adapted from hermes-agent (NousResearch/hermes-agent).
+#   Snap curl detection, shell-profile PATH modification, and symlink-first
+#   PATH setup adapted from Amp (https://ampcode.com/install.sh).
 
 set -euo pipefail
+
+# Registry of temp files to clean up on exit or interrupt. Functions that
+# create tempfiles append their paths here; cleanup_on_signal removes them all.
+TEMP_FILES=()
+register_temp() {
+  TEMP_FILES+=("$1")
+}
+cleanup_temp_files() {
+  for f in "${TEMP_FILES[@]:-}"; do
+    rm -f "$f" 2>/dev/null || true
+  done
+}
 
 # Keep the shell PATH the user started with. The installer may source
 # ~/.local/bin/env later so it can find a freshly installed uv, but that does
@@ -103,17 +117,32 @@ log_warn()    { printf "${YELLOW}⚠${NC} %s\n" "$*" >&2; }
 log_error()   { printf "${RED}✖${NC} %s\n" "$*" >&2; }
 
 # ---------------------------------------------------------------------------
-# Exit trap — ensures the user always sees an actionable message on failure
+# Exit / interrupt traps — ensures the user always sees an actionable message
+# on failure and temp files are cleaned up on Ctrl-C / SIGTERM.
 # ---------------------------------------------------------------------------
-cleanup() {
+cleanup_on_signal() {
   local exit_code=$?
+  cleanup_temp_files
   if [ $exit_code -ne 0 ]; then
     echo "" >&2
     log_error "Installation failed (exit code ${exit_code}). See errors above."
     log_error "For help, visit: https://docs.langchain.com/deepagents-code"
   fi
 }
-trap cleanup EXIT
+trap cleanup_on_signal EXIT
+
+cleanup_on_interrupt() {
+  # Disarm the EXIT trap first: exiting from here would otherwise also fire
+  # cleanup_on_signal, appending a contradictory "Installation failed" message
+  # after the friendly interrupt notice below. Temp files are still cleaned up
+  # explicitly here, so nothing leaks despite the disarm.
+  trap - EXIT
+  echo "" >&2
+  log_warn "Installation interrupted."
+  cleanup_temp_files
+  exit 1
+}
+trap cleanup_on_interrupt INT TERM
 
 # ---------------------------------------------------------------------------
 # Interactive mode detection
@@ -425,6 +454,37 @@ fi
 # ---------------------------------------------------------------------------
 # uv installation
 # ---------------------------------------------------------------------------
+
+# Detect whether `curl` is a snap package, which lacks the permissions to
+# download files outside the snap sandbox. On such systems curl appears to
+# work but fails on actual downloads, so callers should fall back to wget.
+is_snap_curl() {
+  if ! command -v curl >/dev/null 2>&1; then
+    return 1
+  fi
+  local curl_path
+  curl_path=$(command -v curl 2>/dev/null) || return 1
+  case "$curl_path" in
+    */snap/*) return 0 ;;
+    *)        return 1 ;;
+  esac
+}
+
+# Download a URL to stdout using the first available working downloader.
+# Prefers curl (unless it's a snap install, which has sandbox permission
+# issues), then falls back to wget. Prints nothing and returns non-zero if no
+# working downloader is available.
+download_to_stdout() {
+  local url="$1" ua="${2:-deepagents-code-install}"
+  if command -v curl >/dev/null 2>&1 && ! is_snap_curl; then
+    curl -fsSL -H "User-Agent: ${ua}" "$url" 2>/dev/null || return $?
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO- --header="User-Agent: ${ua}" "$url" 2>/dev/null || return $?
+  else
+    return 1
+  fi
+}
+
 install_uv() {
   # The upstream uv installer is chatty (download progress, install paths,
   # PATH-setup hints). Capture it and surface the output only when debugging
@@ -434,15 +494,21 @@ install_uv() {
     log_error "mktemp is required to create a secure temp file."
     exit 1
   }
+  register_temp "$uv_install_out"
   # Only the piped `sh` (the installer body) is captured by `>"$uv_install_out"
   # 2>&1`; curl/wget keep their own stderr on the terminal. That's intentional —
   # `-fsSL` includes `-S`, so a failed download still prints curl's error
   # directly (above the "uv installation failed" line) even though the captured
   # file is then empty. Don't assume curl's stderr is in the capture.
-  if command -v curl >/dev/null 2>&1; then
+  if command -v curl >/dev/null 2>&1 && ! is_snap_curl; then
     curl -fsSL https://astral.sh/uv/install.sh | sh >"$uv_install_out" 2>&1 || uv_install_rc=$?
   elif command -v wget >/dev/null 2>&1; then
     wget -qO- https://astral.sh/uv/install.sh | sh >"$uv_install_out" 2>&1 || uv_install_rc=$?
+  elif is_snap_curl; then
+    rm -f "$uv_install_out"
+    log_error "curl is installed as a snap and cannot download files due to sandbox permissions."
+    log_error "Please install wget, or reinstall curl with a different package manager (e.g. apt)."
+    exit 1
   else
     rm -f "$uv_install_out"
     log_error "curl or wget is required to install uv."
@@ -523,11 +589,8 @@ fi
 # already treats as "unknown latest" and recovers from — never a bad install.
 fetch_latest_version() {
   local json="" ua="deepagents-code-install"
-  if command -v curl >/dev/null 2>&1; then
-    json=$(curl -fsSL -H "User-Agent: ${ua}" "$PYPI_JSON_URL" 2>/dev/null) || return 0
-  elif command -v wget >/dev/null 2>&1; then
-    json=$(wget -qO- --header="User-Agent: ${ua}" "$PYPI_JSON_URL" 2>/dev/null) || return 0
-  else
+  json=$(download_to_stdout "$PYPI_JSON_URL" "$ua" 2>/dev/null) || return 0
+  if [ -z "$json" ]; then
     return 0
   fi
   # `|| true` keeps a no-match (grep exit 1 under `pipefail`) from aborting the
@@ -654,6 +717,7 @@ fi
 # status, don't race the warning past later log lines, and can re-scan the
 # raw output for (4) after the awk pass above has already reformatted it.
 uv_stderr=$(mktemp 2>/dev/null) || uv_stderr="/tmp/deepagents-install.$$.err"
+register_temp "$uv_stderr"
 uv_rc=0
 UV_REPORTED_PACKAGE_CHANGES=false
 # Mirror uv's raw output to a persistent log under the XDG cache dir. A
@@ -791,9 +855,209 @@ fi
 # Restore ownership for the log path without recursively chowning a cache path
 # that could have been swapped after creation.
 fix_install_log_owner
+
 # ---------------------------------------------------------------------------
-# Post-install verification + contextual status
+# PATH setup — make dcode immediately findable in a new shell
 # ---------------------------------------------------------------------------
+# After `uv tool install`, dcode lands in ~/.local/bin. If that directory is
+# already in the user's PATH (via ~/.local/bin/env or a shell profile), dcode
+# just works after a shell restart. If it isn't, the user is stuck with a
+# successful install but no callable binary.
+#
+# Strategy (adapted from Amp's installer, https://ampcode.com/install.sh):
+#   1. If a common bin dir (~/.local/bin, ~/bin, ~/.bin) is already in PATH,
+#      create a symlink there — no profile modification needed.
+#   2. Otherwise, create ~/.local/bin, symlink dcode there, then add
+#      ~/.local/bin to the user's shell profile (.zshrc, .bashrc,
+#      .bash_profile, or config.fish). Prompt interactively before writing;
+#      auto-add in non-interactive mode (CI, cron, piped install).
+#   3. Skip the whole thing if the binary is already on PATH or uv's env file
+#      exists (uv's installer already handles PATH setup in that case).
+
+# Check if a directory is in PATH.
+dir_in_path() {
+  local check_dir="$1"
+  [ -d "$check_dir" ] || return 1
+  check_dir=$(cd "$check_dir" 2>/dev/null && pwd) || return 1
+  case ":${PATH:-}:" in
+    *":$check_dir:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Try to symlink the dcode binary into a directory already in PATH. Tries
+# ~/.local/bin, ~/bin, and ~/.bin in order. Returns 0 on success.
+try_symlink_in_path() {
+  local binary_name="$1"
+  local binary_path="$2"
+  local preferred_dirs=("$HOME/.local/bin" "$HOME/bin" "$HOME/.bin")
+  local dir symlink_path
+  for dir in "${preferred_dirs[@]}"; do
+    if dir_in_path "$dir"; then
+      mkdir -p "$dir" 2>/dev/null || continue
+      symlink_path="$dir/$binary_name"
+      if [ "$binary_path" = "$symlink_path" ]; then
+        return 0
+      fi
+      # Remove existing symlink if it points elsewhere or is stale
+      if [ -L "$symlink_path" ]; then
+        rm -f "$symlink_path"
+      fi
+      if ln -sf "$binary_path" "$symlink_path" 2>/dev/null; then
+        fix_owner "$symlink_path" 2>/dev/null || true
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+# Detect the user's shell and return the profile file + PATH export statement.
+# Sets SHELL_PROFILE and PATH_EXPORT as globals.
+detect_shell_profile() {
+  local default_shell="bash"
+  if [ "$OS" = "macos" ]; then
+    default_shell="zsh"
+  fi
+  local shell_name
+  shell_name=$(basename "${SHELL:-$default_shell}" 2>/dev/null) || shell_name="$default_shell"
+  SHELL_PROFILE=""
+  PATH_EXPORT=""
+  case "$shell_name" in
+    zsh)
+      SHELL_PROFILE="$HOME/.zshrc"
+      # shellcheck disable=SC2016  # single-quoted so $HOME/$PATH expand at profile source time, not here
+      PATH_EXPORT='export PATH="$HOME/.local/bin:$PATH"'
+      ;;
+    bash)
+      if [ "$OS" = "macos" ]; then
+        if [ -f "$HOME/.bash_profile" ]; then
+          SHELL_PROFILE="$HOME/.bash_profile"
+        elif [ -f "$HOME/.bashrc" ]; then
+          SHELL_PROFILE="$HOME/.bashrc"
+        else
+          SHELL_PROFILE="$HOME/.bash_profile"
+        fi
+      else
+        if [ -f "$HOME/.bashrc" ]; then
+          SHELL_PROFILE="$HOME/.bashrc"
+        elif [ -f "$HOME/.bash_profile" ]; then
+          SHELL_PROFILE="$HOME/.bash_profile"
+        else
+          SHELL_PROFILE="$HOME/.bashrc"
+        fi
+      fi
+      # shellcheck disable=SC2016  # single-quoted so $HOME/$PATH expand at profile source time, not here
+      PATH_EXPORT='export PATH="$HOME/.local/bin:$PATH"'
+      ;;
+    fish)
+      SHELL_PROFILE="$HOME/.config/fish/config.fish"
+      # shellcheck disable=SC2016  # single-quoted so $HOME expands at profile source time, not here
+      PATH_EXPORT='fish_add_path "$HOME/.local/bin"'
+      ;;
+    *)
+      # Unknown shell — don't modify any profile.
+      ;;
+  esac
+}
+
+# Check if ~/.local/bin is already referenced in the shell profile's PATH
+# config. Matches non-commented lines containing .local/bin in a PATH
+# assignment or fish_add_path. Returns 0 if already present.
+local_bin_in_profile() {
+  local profile="$1"
+  [ -f "$profile" ] || return 1
+  grep -v '^[[:space:]]*#' "$profile" 2>/dev/null | grep -qE 'PATH=.*\.local/bin' \
+    || grep -v '^[[:space:]]*#' "$profile" 2>/dev/null | grep -qE 'fish_add_path.*\.local/bin'
+}
+
+# Ensure dcode is on PATH for new shell sessions. Creates symlinks and/or
+# modifies the shell profile as needed. Only acts when the binary verified
+# but isn't already on the user's original PATH.
+ensure_path_setup() {
+  local binary_name="$1"
+  local binary_path="$2"
+
+  # uv's env file already handles PATH setup — no need to duplicate.
+  if [ -f "$HOME/.local/bin/env" ]; then
+    return 0
+  fi
+
+  # Step 1: try symlinking into a dir already in PATH (no profile change).
+  if try_symlink_in_path "$binary_name" "$binary_path"; then
+    if [ "$VERBOSE" = "1" ]; then
+      log_success "Created symlink in PATH for ${binary_name}."
+    fi
+    return 0
+  fi
+
+  # Step 2: create ~/.local/bin, symlink there, then add to shell profile.
+  mkdir -p "$HOME/.local/bin" 2>/dev/null || {
+    log_warn "Could not create ~/.local/bin."
+    return 1
+  }
+  fix_owner "$HOME/.local/bin"
+  local symlink_path="$HOME/.local/bin/$binary_name"
+  if [ "$binary_path" != "$symlink_path" ]; then
+    if [ -L "$symlink_path" ]; then
+      rm -f "$symlink_path"
+    fi
+    if ! ln -sf "$binary_path" "$symlink_path" 2>/dev/null; then
+      log_warn "Could not create symlink at ${symlink_path}."
+      return 1
+    fi
+    fix_owner "$symlink_path"
+  fi
+
+  # Step 3: detect shell and add ~/.local/bin to profile if needed.
+  detect_shell_profile
+  if [ -z "$SHELL_PROFILE" ]; then
+    log_warn "${binary_name} installed to ~/.local/bin but your shell is unknown."
+    log_warn "  Add ~/.local/bin to your PATH manually."
+    return 1
+  fi
+
+  # Already in profile? Just tell the user to reload.
+  if local_bin_in_profile "$SHELL_PROFILE"; then
+    if [ "$VERBOSE" = "1" ]; then
+      # shellcheck disable=SC2088  # display string, literal ~/ is intended for readability
+      log_info "~/.local/bin already in ${SHELL_PROFILE}."
+    fi
+    return 0
+  fi
+
+  # Collapse $HOME prefix to ~ for a tidier display path.
+  local tilde_profile="${SHELL_PROFILE/#$HOME/\~}"
+
+  # Prompt interactively, or auto-add when non-interactive.
+  local should_add=true
+  if [ "$IS_INTERACTIVE" = true ] && can_prompt; then
+    if ! prompt_yn "Add ~/.local/bin to your PATH in ${tilde_profile}?"; then
+      should_add=false
+    fi
+  fi
+
+  if [ "$should_add" = true ]; then
+    # Create the profile file if it doesn't exist.
+    if [ ! -f "$SHELL_PROFILE" ]; then
+      mkdir -p "$(dirname "$SHELL_PROFILE")" 2>/dev/null || true
+      touch "$SHELL_PROFILE" 2>/dev/null || {
+        log_warn "Could not create ${tilde_profile}. Add ~/.local/bin to PATH manually."
+        return 1
+      }
+    fi
+    {
+      echo ""
+      echo "# Added by deepagents-code installer"
+      echo "$PATH_EXPORT"
+    } >> "$SHELL_PROFILE"
+    fix_owner "$SHELL_PROFILE"
+    log_success "Added ~/.local/bin to PATH in ${tilde_profile}."
+  else
+    log_info "Skipped modifying ${tilde_profile}."
+    log_info "  To use ${binary_name}, add to PATH:  ${PATH_EXPORT}"
+  fi
+}
 DCODE_BIN=""
 DCODE_NAME=""
 # Tracks whether the binary would have resolved via the user's original PATH,
@@ -887,14 +1151,19 @@ fi
 
 # The binary verified via its absolute path but isn't on the current shell's
 # PATH (typical right after a fresh `uv tool install`): typing `dcode` won't
-# work until the shell picks up ~/.local/bin. Point the user at the fix so the
-# "Run: dcode" footer below isn't a dead end.
-if [ "$VERIFY_OK" = true ] && [ "$DCODE_ON_PATH" = false ]; then
-  log_warn "${DCODE_NAME} isn't on your PATH yet${DCODE_BIN_DISPLAY:+ (installed at ${DCODE_BIN_DISPLAY})}. Restart your shell, or run:"
-  if [ -f "${HOME}/.local/bin/env" ]; then
-    log_warn "  source ~/.local/bin/env"
-  else
-    log_warn "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+# work until the shell picks up ~/.local/bin. Instead of just telling the user
+# to restart their shell, try to fix the PATH now — symlink into an existing
+# PATH dir, or add ~/.local/bin to the shell profile — so the binary is
+# immediately usable in a new terminal without manual configuration.
+if [ "$VERIFY_OK" = true ] && [ "$DCODE_ON_PATH" = false ] && [ -n "$DCODE_BIN" ]; then
+  if ! ensure_path_setup "$DCODE_NAME" "$DCODE_BIN"; then
+    # ensure_path_setup already printed a specific warning; add the fallback.
+    log_warn "  Restart your shell, or run:"
+    if [ -f "${HOME}/.local/bin/env" ]; then
+      log_warn "  source ~/.local/bin/env"
+    else
+      log_warn "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+    fi
   fi
 fi
 
@@ -1019,6 +1288,7 @@ if [ "$SKIP_OPTIONAL" != "1" ]; then
       # Quiet path: capture setup output and surface it only on failure, so a
       # broken install stays debuggable without noise in the common case.
       ripgrep_setup_out=$(mktemp 2>/dev/null) || ripgrep_setup_out="/tmp/deepagents-ripgrep-setup.$$.out"
+      register_temp "$ripgrep_setup_out"
       if "$DCODE_BIN" tools install >"$ripgrep_setup_out" 2>&1; then
         fix_owner "${HOME}/.deepagents/bin"
       else

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1100,6 +1100,11 @@ def _run_install_uv(
         "set -euo pipefail\n"
         "log_info() { :; }\n"
         'log_error() { printf "%s\\n" "$*" >&2; }\n'
+        "register_temp() { :; }\n"
+        # install_uv branches on is_snap_curl; stub it to the non-snap answer so
+        # the harness exercises the normal curl path (and emits no stray
+        # "command not found" on stderr).
+        "is_snap_curl() { return 1; }\n"
         f"VERBOSE={'1' if verbose else '0'}\n"
         f"{_extract_shell_function('install_uv')}\n"
         "install_uv\n",
@@ -1154,6 +1159,67 @@ def test_install_uv_requires_secure_temp_file(tmp_path: Path) -> None:
     assert proc.returncode != 0
     assert "mktemp is required to create a secure temp file" in proc.stderr
     assert "UV_INSTALLER_NOISE" not in proc.stderr
+
+
+def _run_signal_traps(tmp_path: Path, *, interrupt: bool) -> str:
+    """Wire the real EXIT + INT/TERM traps from `install.sh` and trip one.
+
+    Extracts the shipped `cleanup_on_signal`/`cleanup_on_interrupt` handlers and
+    installs them exactly as the script does. With `interrupt=True` the process
+    sends itself SIGINT (the Ctrl-C path); otherwise it exits non-zero without a
+    signal (the ordinary-failure path). Returns combined stderr so callers can
+    assert which trap message the user actually sees.
+    """
+    script = tmp_path / "signal_trap_harness.sh"
+    body = "kill -INT $$\nsleep 5\n" if interrupt else "exit 2\n"
+    script.write_text(
+        "set -uo pipefail\n"
+        'log_warn()  { printf "%s\\n" "$*" >&2; }\n'
+        'log_error() { printf "%s\\n" "$*" >&2; }\n'
+        "cleanup_temp_files() { :; }\n"
+        f"{_extract_shell_function('cleanup_on_signal')}\n"
+        f"{_extract_shell_function('cleanup_on_interrupt')}\n"
+        "trap cleanup_on_signal EXIT\n"
+        "trap cleanup_on_interrupt INT TERM\n"
+        f"{body}",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        check=False,
+        start_new_session=True,
+    )
+    return proc.stderr
+
+
+def test_interrupt_shows_notice_without_failure_message(tmp_path: Path) -> None:
+    """Ctrl-C prints only the interrupt notice, not the EXIT trap's failure line.
+
+    `cleanup_on_interrupt` disarms the EXIT trap (`trap - EXIT`) before exiting,
+    so the friendly "Installation interrupted." message isn't followed by a
+    contradictory "Installation failed (exit code 1)". Guards against dropping
+    that disarm, which would surface both messages on a single Ctrl-C.
+    """
+    stderr = _run_signal_traps(tmp_path, interrupt=True)
+
+    assert "Installation interrupted." in stderr
+    assert "Installation failed" not in stderr
+
+
+def test_exit_trap_reports_failure_on_ordinary_error(tmp_path: Path) -> None:
+    """A non-signal, non-zero exit still fires the EXIT trap's failure message.
+
+    The interrupt handler's `trap - EXIT` must be scoped to the interrupt path
+    only: an ordinary failure exit still needs `cleanup_on_signal` to tell the
+    user the install failed and where to get help.
+    """
+    stderr = _run_signal_traps(tmp_path, interrupt=False)
+
+    assert "Installation failed (exit code 2)." in stderr
+    assert "Installation interrupted." not in stderr
 
 
 def test_install_script_macos_without_clt_exits_early(tmp_path: Path) -> None:
@@ -1355,36 +1421,52 @@ def _invoke_with_local_dcode_not_on_path(
     )
 
 
-def test_install_script_warns_when_dcode_installed_but_not_on_path(
+def test_install_script_adds_local_bin_when_dcode_installed_but_not_on_path(
     tmp_path: Path,
 ) -> None:
-    """A fresh install resolved only via ~/.local/bin warns it isn't on PATH.
+    """A fresh install resolved only via ~/.local/bin adds it to PATH setup.
 
     Simulates `uv tool install` dropping the binary in ~/.local/bin without the
     current shell having picked it up: `command -v dcode` misses, the fallback
-    path hits, and the script verifies it directly. The success path must still
-    tell the user the binary isn't callable as `dcode` yet and how to fix it,
-    rather than printing a "Run: dcode" footer that dead-ends.
+    path hits, and the script verifies it directly. The success path should not
+    replace the installed executable with a self-referential symlink when the
+    binary path and intended symlink path are the same.
     """
     proc = _invoke_with_local_dcode_not_on_path(tmp_path)
 
     assert proc.returncode == 0
     combined = proc.stdout + proc.stderr
-    assert "isn't on your PATH yet" in combined
-    assert 'export PATH="$HOME/.local/bin:$PATH"' in combined
+    dcode = tmp_path / "home/.local/bin/dcode"
+    assert not dcode.is_symlink()
+    assert "deepagents-code 0.1.0" in dcode.read_text()
+    assert "Added ~/.local/bin to PATH" in combined
+    assert "isn't on your PATH yet" not in combined
+    profile_texts = [
+        profile.read_text()
+        for profile in (
+            tmp_path / "home/.zshrc",
+            tmp_path / "home/.bashrc",
+            tmp_path / "home/.bash_profile",
+        )
+        if profile.exists()
+    ]
+    assert any('export PATH="$HOME/.local/bin:$PATH"' in text for text in profile_texts)
     assert "source ~/.local/bin/env" not in combined
 
 
 def test_install_script_uses_uv_env_file_path_hint_when_available(
     tmp_path: Path,
 ) -> None:
-    """When uv wrote ~/.local/bin/env, the not-on-PATH hint points to it."""
+    """When uv wrote ~/.local/bin/env, no duplicate PATH setup is needed."""
     proc = _invoke_with_local_dcode_not_on_path(tmp_path, create_env_file=True)
 
     assert proc.returncode == 0
     combined = proc.stdout + proc.stderr
-    assert "isn't on your PATH yet" in combined
-    assert "source ~/.local/bin/env" in combined
+    assert "isn't on your PATH yet" not in combined
+    assert "source ~/.local/bin/env" not in combined
+    assert not (tmp_path / "home/.zshrc").exists()
+    assert not (tmp_path / "home/.bashrc").exists()
+    assert not (tmp_path / "home/.bash_profile").exists()
 
 
 def test_install_script_no_path_warning_when_dcode_on_path(tmp_path: Path) -> None:

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1457,16 +1457,79 @@ def test_install_script_adds_local_bin_when_dcode_installed_but_not_on_path(
 def test_install_script_uses_uv_env_file_path_hint_when_available(
     tmp_path: Path,
 ) -> None:
-    """When uv wrote ~/.local/bin/env, no duplicate PATH setup is needed."""
+    """When uv wrote ~/.local/bin/env, a source hint is shown for stale shells.
+
+    uv's env file handles PATH setup for *new* shells, so no profile
+    modification is needed. But the current shell still lacks ~/.local/bin on
+    PATH (the binary resolved only via the installer's absolute-path fallback),
+    so the script emits a `source ~/.local/bin/env` reload hint instead of
+    silently returning success — a fresh `dcode` invocation would otherwise fail
+    until the user restarts their shell.
+    """
     proc = _invoke_with_local_dcode_not_on_path(tmp_path, create_env_file=True)
 
     assert proc.returncode == 0
     combined = proc.stdout + proc.stderr
     assert "isn't on your PATH yet" not in combined
-    assert "source ~/.local/bin/env" not in combined
+    assert "source ~/.local/bin/env" in combined
     assert not (tmp_path / "home/.zshrc").exists()
     assert not (tmp_path / "home/.bashrc").exists()
     assert not (tmp_path / "home/.bash_profile").exists()
+
+
+def test_install_script_stale_shell_with_profile_already_set_shows_reload_hint(
+    tmp_path: Path,
+) -> None:
+    """~/.local/bin already in the profile still warns when the shell is stale.
+
+    The profile already has the PATH export, so no file modification is needed.
+    But the current shell's PATH lacks ~/.local/bin (the binary resolved only
+    via the installer's absolute-path fallback), so the script must emit a
+    reload/source hint rather than silently returning success — otherwise the
+    user sees "Run: dcode" but dcode won't resolve until they restart.
+    """
+    bin_dir, home, uv = _write_fake_tools(tmp_path, installed_version=None)
+
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    dcode = local_bin / "dcode"
+    dcode.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "${1:-}" = "-v" ]; then printf "deepagents-code 0.1.0\\n"; exit 0; fi\n'
+        "exit 0\n"
+    )
+    _make_executable(dcode)
+
+    # Pre-seed the shell profile so `local_bin_in_profile` returns true.
+    zshrc = home / ".zshrc"
+    zshrc.write_text('export PATH="$HOME/.local/bin:$PATH"\n')
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "XDG_CACHE_HOME": str(home / ".cache"),
+        "PATH": f"{bin_dir}{os.pathsep}{_path_without_dcode()}",
+        "UV_BIN": str(uv),
+        "DEEPAGENTS_CODE_SKIP_OPTIONAL": "1",
+        "SHELL": "/bin/zsh",
+    }
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+    assert proc.returncode == 0
+    combined = proc.stdout + proc.stderr
+    # No duplicate PATH export was appended.
+    assert combined.count('export PATH="$HOME/.local/bin:$PATH"') == 1
+    # But the reload hint is shown because the current shell is stale.
+    assert "Restart your shell, or run:" in combined
+    assert 'export PATH="$HOME/.local/bin:$PATH"' in combined
 
 
 def test_install_script_no_path_warning_when_dcode_on_path(tmp_path: Path) -> None:


### PR DESCRIPTION
The installer now actively fixes `dcode` PATH resolution instead of just warning the user, detects snap-sandboxed `curl` that silently fails downloads, and cleans up temp files on Ctrl-C without printing a contradictory failure message.

## Changes
- **Automatic PATH setup** — `ensure_path_setup` symlinks the verified binary into an existing PATH dir (`~/.local/bin`, `~/bin`, `~/.bin`); if none are on PATH, creates `~/.local/bin`, symlinks there, and appends a PATH export to the detected shell profile (`.zshrc`, `.bashrc`, `.bash_profile`, `config.fish`). Prompts interactively before modifying a profile, auto-adds in non-interactive mode, and skips entirely when uv's `~/.local/bin/env` already handles PATH.
- **Snap `curl` detection** — `is_snap_curl` checks whether `curl` lives under `/snap/`, in which case it has sandbox permission issues that cause silent download failures. `install_uv` and the new `download_to_stdout` helper fall back to `wget`, or emit a clear error if no working downloader exists.
- **Interrupt-safe temp cleanup** — a `TEMP_FILES` registry (`register_temp` / `cleanup_temp_files`) tracks every `mktemp` so they're removed on both normal exit and Ctrl-C. A dedicated `cleanup_on_interrupt` handler for INT/TERM disarms the EXIT trap first, so the user sees only "Installation interrupted." rather than that followed by a contradictory "Installation failed (exit code 1)."
- **`download_to_stdout` helper** — consolidates the duplicated curl-or-wget logic from `install_uv` and `fetch_latest_version` into one function with snap detection built in.