### PR TITLE
fix(evals): forward --eval-category-exclude in trials subcommand

### DIFF
--- a/libs/evals/deepagents_evals/cli.py
+++ b/libs/evals/deepagents_evals/cli.py
@@ -398,6 +398,8 @@ def _cmd_trials(args: argparse.Namespace, parser: argparse.ArgumentParser) -> in
     rt_argv: list[str] = ["--model", args.model, "--trials", str(args.trials)]
     for cat in args.eval_category or []:
         rt_argv.extend(["--eval-category", cat])
+    for cat in args.eval_category_exclude or []:
+        rt_argv.extend(["--eval-category-exclude", cat])
     for tier in args.eval_tier or []:
         rt_argv.extend(["--eval-tier", tier])
     if args.openai_reasoning_effort:

--- a/libs/evals/scripts/run_trials.py
+++ b/libs/evals/scripts/run_trials.py
@@ -279,6 +279,8 @@ def _build_pytest_args(args: argparse.Namespace, report_path: Path) -> list[str]
     ]
     for cat in args.eval_category or []:
         cmd.extend(["--eval-category", cat])
+    for cat in args.eval_category_exclude or []:
+        cmd.extend(["--eval-category-exclude", cat])
     for tier in args.eval_tier or []:
         cmd.extend(["--eval-tier", tier])
     if args.openai_reasoning_effort:
@@ -487,6 +489,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="append",
         default=[],
         help="Restrict to one eval category (repeatable).",
+    )
+    parser.add_argument(
+        "--eval-category-exclude",
+        action="append",
+        default=[],
+        help="Exclude one eval category (repeatable).",
     )
     parser.add_argument(
         "--eval-tier",

--- a/libs/evals/tests/unit_tests/test_cli.py
+++ b/libs/evals/tests/unit_tests/test_cli.py
@@ -144,6 +144,29 @@ class TestTrialsSubcommand:
         assert "--eval-category" in argv
         assert "tool_use" in argv
 
+    def test_dry_run_forwards_eval_category_exclude(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Regression: `trials` accepted --eval-category-exclude but silently
+        # dropped it instead of forwarding it to run_trials. See issue #4440.
+        rc = cli.main(
+            [
+                "trials",
+                "--model",
+                "openai:gpt-5.5",
+                "--trials",
+                "2",
+                "--eval-category-exclude",
+                "memory",
+                "--dry-run",
+                "--json",
+            ]
+        )
+        assert rc == cli.EXIT_OK
+        argv = json.loads(capsys.readouterr().out)["argv"]
+        assert "--eval-category-exclude" in argv
+        assert "memory" in argv
+
     def test_retry_failed_collects_nodeids(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
## Summary

`deepagents-evals trials --eval-category-exclude <cat>` was accepted but silently ignored — the full suite ran as if the flag were never passed (issue #4440).

Root cause: the flag was dropped in two places:
- `_cmd_trials` forwarded `--eval-category` to `run_trials` but not `--eval-category-exclude`.
- `run_trials.py` never defined `--eval-category-exclude`, so even a forwarded flag would be rejected, and it was not passed on to pytest.

## Changes
- `cli._cmd_trials`: forward `--eval-category-exclude` to `run_trials`.
- `run_trials.py`: add the `--eval-category-exclude` argument and forward it to the pytest argv (mirrors `--eval-category`).
- Add regression test `test_dry_run_forwards_eval_category_exclude`.

## Testing
`make test` (evals unit tests) passes; `ruff check` clean on changed files.

Fixes #4440