### PR TITLE
fix(code): prevent `UnicodeEncodeError` crash in non-interactive mode on legacy Windows consoles

### DIFF
--- a/libs/code/deepagents_code/non_interactive.py
+++ b/libs/code/deepagents_code/non_interactive.py
@@ -111,6 +111,28 @@ def _write_newline() -> None:
     sys.stdout.flush()
 
 
+def _make_stdio_encoding_safe() -> None:
+    """Prevent `UnicodeEncodeError` from killing a non-interactive run.
+
+    Legacy Windows consoles default to a locale code page (e.g. cp1252) that
+    cannot encode glyphs like "✓"; the first `console.print()` containing one
+    then crashes the whole run. Reconfiguring the streams with
+    `errors="replace"` degrades unencodable characters to "?" instead. The
+    stream encoding itself is left untouched.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        # Streams replaced by non-reconfigurable objects (e.g. a StringIO in
+        # tests) are left as-is.
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(errors="replace")
+        except (ValueError, OSError):
+            # Closed or detached stream — leave it as-is.
+            continue
+
+
 class _ConsoleSpinner:
     """Animated spinner for non-interactive verbose output.
 
@@ -1134,6 +1156,8 @@ async def run_non_interactive(
             budget was exceeded (matching GNU `timeout`), 130 for keyboard
             interrupt.
     """
+    _make_stdio_encoding_safe()
+
     # stderr=True routes all console.print() to stderr; agent response text
     # uses _write_text() -> sys.stdout directly.
     console = Console(stderr=True) if quiet else Console()

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -27,6 +27,7 @@ from deepagents_code.non_interactive import (
     _build_non_interactive_header,
     _collect_action_request_warnings,
     _make_hitl_decision,
+    _make_stdio_encoding_safe,
     _process_ai_message,
     _process_message_chunk,
     _run_agent_loop,
@@ -1746,3 +1747,36 @@ async def _async_iter(items: Sequence[object]) -> AsyncIterator[object]:  # noqa
     """Create an async iterator from a list for testing."""
     for item in items:
         yield item
+
+
+class TestMakeStdioEncodingSafe:
+    """Tests for `_make_stdio_encoding_safe`."""
+
+    def test_cp1252_stream_survives_unicode_glyphs(self):
+        """Unencodable glyphs degrade to "?" instead of raising."""
+        buffer = io.BytesIO()
+        stream = io.TextIOWrapper(buffer, encoding="cp1252")
+        with patch.object(sys, "stdout", stream), patch.object(sys, "stderr", stream):
+            _make_stdio_encoding_safe()
+            sys.stdout.write("✓ Server ready")
+            sys.stdout.flush()
+
+        assert buffer.getvalue() == b"? Server ready"
+
+    def test_stream_encoding_is_preserved(self):
+        """Only the error handler changes; the encoding stays untouched."""
+        buffer = io.BytesIO()
+        stream = io.TextIOWrapper(buffer, encoding="cp1252")
+        with patch.object(sys, "stdout", stream), patch.object(sys, "stderr", stream):
+            _make_stdio_encoding_safe()
+
+        assert stream.encoding == "cp1252"
+        assert stream.errors == "replace"
+
+    def test_non_reconfigurable_stream_is_left_alone(self):
+        """Streams without `reconfigure` (e.g. StringIO) do not raise."""
+        stream = io.StringIO()
+        with patch.object(sys, "stdout", stream), patch.object(sys, "stderr", stream):
+            _make_stdio_encoding_safe()
+
+        assert not stream.closed


### PR DESCRIPTION
## Problem

On Windows, when stdout is a legacy console using a locale code page (e.g. cp1252), `dcode -n` crashes before producing any output: the first `console.print()` containing a Unicode glyph (`✓ Server ready`, `non_interactive.py`) raises `UnicodeEncodeError` through rich's legacy Windows renderer. The error handler then crashes the same way trying to print the error, so the run dies with a wall of tracebacks — or, when output is redirected, looks like a silent hang.

Repro (Windows, cp1252 console, v0.1.22-0.1.31):
```
dcode -n "say hi" --no-mcp
UnicodeEncodeError: 'charmap' codec can't encode character '✓' in position 0
```

## Fix

Reconfigure `sys.stdout`/`sys.stderr` with `errors="replace"` at `run_non_interactive` entry. Unencodable characters degrade to `?` instead of killing the run; the stream encoding itself is untouched. Streams without `reconfigure` (e.g. `StringIO` in tests) are left as-is.

## Testing

- 3 new unit tests (`TestMakeStdioEncodingSafe`): cp1252 stream survives `✓`, encoding preserved / only error handler changes, non-reconfigurable stream untouched.
- `pytest tests/unit_tests/test_non_interactive.py`: 62 passed (4 pre-existing POSIX-signal failures on Windows unrelated to this change).
- `ruff check` / `ruff format --check` / `ty check`: clean.
- Verified live on Windows 11: the exact crash above no longer reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #4476
