### PR TITLE
feat(code): running session cost in the status bar

### DIFF
--- a/libs/code/deepagents_code/_cost.py
+++ b/libs/code/deepagents_code/_cost.py
@@ -13,8 +13,31 @@ returns `None` and callers leave the running total unchanged rather than crash.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 logger = logging.getLogger(__name__)
+
+
+def cache_tokens_from_usage(usage: Mapping | None) -> tuple[int, int]:
+    """Extract cache read/write token counts from LangChain `usage_metadata`.
+
+    Args:
+        usage: A message's `usage_metadata` mapping, or `None`.
+
+    Returns:
+        A `(cache_read_tokens, cache_write_tokens)` tuple. Missing details
+        yield zeros. `cache_write_tokens` maps to `cache_creation` in
+        LangChain's `input_token_details`.
+    """
+    if not usage:
+        return 0, 0
+    details = usage.get("input_token_details") or {}
+    cache_read = details.get("cache_read", 0) or 0
+    cache_write = details.get("cache_creation", 0) or 0
+    return cache_read, cache_write
 
 
 def estimate_request_cost(
@@ -23,15 +46,30 @@ def estimate_request_cost(
     output_tokens: int,
     model_name: str,
     provider: str = "",
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
 ) -> float | None:
     """Estimate the USD cost of a single LLM request.
 
+    Cached tokens are billed at different rates than uncached input (cache reads
+    are cheaper; cache writes carry a premium), so they are priced separately by
+    `genai-prices`. Both LangChain's `usage_metadata` and `genai-prices` treat
+    `input_tokens` as the grand total of input — inclusive of any cached
+    portion — and `genai-prices` subtracts the cache counts internally to derive
+    the uncached (full-rate) input. The totals are therefore forwarded as-is.
+
     Args:
-        input_tokens: Input (prompt) tokens for the request.
-        output_tokens: Output (completion) tokens for the request.
+        input_tokens: Total input (prompt) tokens for the request, inclusive of
+            any cached tokens per LangChain's `usage_metadata` convention.
+        output_tokens: Output (completion) tokens for the request. Reasoning
+            tokens are already included here by LangChain convention.
         model_name: Model that served the request (e.g. `claude-sonnet-4-5`).
         provider: Provider id that served the model (e.g. `anthropic`). When
             empty, `genai-prices` infers the provider from the model name.
+        cache_read_tokens: Tokens read from the prompt cache (billed at a
+            reduced rate). Sourced from `input_token_details.cache_read`.
+        cache_write_tokens: Tokens written to the prompt cache (billed at a
+            premium). Sourced from `input_token_details.cache_creation`.
 
     Returns:
         The estimated total price in USD, or `None` when the model/provider is
@@ -43,11 +81,24 @@ def estimate_request_cost(
     if input_tokens <= 0 and output_tokens <= 0:
         return None
 
+    # `genai-prices` treats `input_tokens` as the grand total and subtracts the
+    # cache counts internally to derive uncached input, rejecting a negative
+    # result. Clamp the cache counts to `input_tokens` to stay robust to
+    # inconsistent provider reporting where the parts exceed the whole.
+    if input_tokens > 0:
+        cache_read_tokens = min(cache_read_tokens, input_tokens)
+        cache_write_tokens = min(cache_write_tokens, input_tokens - cache_read_tokens)
+
     try:
         from genai_prices import Usage, calc_price
 
         price = calc_price(
-            Usage(input_tokens=input_tokens, output_tokens=output_tokens),
+            Usage(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_tokens=cache_read_tokens or None,
+                cache_write_tokens=cache_write_tokens or None,
+            ),
             model_ref=model_name,
             provider_id=provider or None,
         )

--- a/libs/code/deepagents_code/_cost.py
+++ b/libs/code/deepagents_code/_cost.py
@@ -1,0 +1,92 @@
+"""LLM cost estimation backed by `genai-prices`.
+
+Isolated from `_session_stats.py` so the latter stays free of heavy imports (it
+is imported at module level by `app.py`). `genai_prices` is imported lazily
+inside `estimate_request_cost` so merely importing this module stays cheap and
+off the startup hot path.
+
+Prices are indicative only — see the `genai-prices` project for caveats. When a
+model or provider is not found in the bundled price data, `estimate_request_cost`
+returns `None` and callers leave the running total unchanged rather than crash.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def estimate_request_cost(
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    model_name: str,
+    provider: str = "",
+) -> float | None:
+    """Estimate the USD cost of a single LLM request.
+
+    Args:
+        input_tokens: Input (prompt) tokens for the request.
+        output_tokens: Output (completion) tokens for the request.
+        model_name: Model that served the request (e.g. `claude-sonnet-4-5`).
+        provider: Provider id that served the model (e.g. `anthropic`). When
+            empty, `genai-prices` infers the provider from the model name.
+
+    Returns:
+        The estimated total price in USD, or `None` when the model/provider is
+        not in the bundled price data (or pricing otherwise fails). Returning
+        `None` lets callers skip the request without disturbing a running total.
+    """
+    if not model_name:
+        return None
+    if input_tokens <= 0 and output_tokens <= 0:
+        return None
+
+    try:
+        from genai_prices import Usage, calc_price
+
+        price = calc_price(
+            Usage(input_tokens=input_tokens, output_tokens=output_tokens),
+            model_ref=model_name,
+            provider_id=provider or None,
+        )
+    except LookupError:
+        # Model or provider not present in the bundled price data. Expected for
+        # newer/self-hosted models; degrade quietly.
+        logger.debug(
+            "No price data for model=%s provider=%s; skipping cost estimate",
+            model_name,
+            provider,
+        )
+        return None
+    except Exception:
+        # Never let a pricing failure interrupt agent streaming.
+        logger.warning(
+            "Cost estimation failed for model=%s provider=%s",
+            model_name,
+            provider,
+            exc_info=True,
+        )
+        return None
+
+    return float(price.total_price)
+
+
+def format_cost(cost: float) -> str:
+    """Format a USD cost into a compact status-bar string.
+
+    Uses more decimal places for small amounts so sub-cent sessions still show a
+    meaningful value instead of `$0.00`.
+
+    Args:
+        cost: Cost in USD.
+
+    Returns:
+        Formatted string like `'$0.0042'`, `'$1.23'`, or `'$0'`.
+    """
+    if cost <= 0:
+        return "$0"
+    if cost < 1:  # sub-dollar amounts get extra precision
+        return f"${cost:.4f}"
+    return f"${cost:.2f}"

--- a/libs/code/deepagents_code/_session_stats.py
+++ b/libs/code/deepagents_code/_session_stats.py
@@ -36,6 +36,9 @@ class ModelStats:
     output_tokens: int = 0
     """Cumulative output tokens received from this model."""
 
+    cost: float = 0.0
+    """Cumulative estimated USD cost for requests served by this model."""
+
     provider: str = ""
     """Provider that served this model (e.g. `openai`), or `""` when unknown."""
 
@@ -69,6 +72,13 @@ class SessionStats:
     output_tokens: int = 0
     """Cumulative output tokens across all LLM requests."""
 
+    cost: float = 0.0
+    """Cumulative estimated USD cost across all LLM requests.
+
+    Populated only when `record_request` receives a non-`None` `cost` (i.e. the
+    model was found in the bundled price data). Left at `0.0` otherwise.
+    """
+
     wall_time_seconds: float = 0.0
     """Wall-clock duration from stream start to end."""
 
@@ -86,8 +96,9 @@ class SessionStats:
         input_toks: int,
         output_toks: int,
         provider: str = "",
+        cost: float | None = None,
     ) -> None:
-        """Accumulate token counts for one completed LLM request.
+        """Accumulate token counts (and optional cost) for one LLM request.
 
         Updates both the session totals and the per-model breakdown.
 
@@ -100,10 +111,15 @@ class SessionStats:
             provider: Provider that served the model (e.g. `openai`). Combined
                 with `model_name` to form the per-model key, so the same model
                 served by different providers is tracked separately.
+            cost: Estimated USD cost for this request, or `None` when pricing is
+                unavailable (unknown model/provider). `None` leaves the cost
+                totals unchanged; `0.0` is a valid recorded cost.
         """
         self.request_count += 1
         self.input_tokens += input_toks
         self.output_tokens += output_toks
+        if cost is not None:
+            self.cost += cost
         if model_name:
             key = (provider, model_name)
             entry = self.per_model.setdefault(
@@ -113,6 +129,8 @@ class SessionStats:
             entry.request_count += 1
             entry.input_tokens += input_toks
             entry.output_tokens += output_toks
+            if cost is not None:
+                entry.cost += cost
 
     def merge(self, other: SessionStats) -> None:
         """Merge another `SessionStats` into this one (mutates *self*).
@@ -125,6 +143,7 @@ class SessionStats:
         self.request_count += other.request_count
         self.input_tokens += other.input_tokens
         self.output_tokens += other.output_tokens
+        self.cost += other.cost
         self.wall_time_seconds += other.wall_time_seconds
         for key, ms in other.per_model.items():
             entry = self.per_model.setdefault(
@@ -134,6 +153,7 @@ class SessionStats:
             entry.request_count += ms.request_count
             entry.input_tokens += ms.input_tokens
             entry.output_tokens += ms.output_tokens
+            entry.cost += ms.cost
 
 
 def format_token_count(count: int) -> str:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1358,6 +1358,9 @@ class _ThreadHistoryPayload:
     model_params: dict[str, Any] | None = None
     """Persisted `_model_params` from the checkpoint, if any."""
 
+    session_cost: float = 0.0
+    """Persisted cumulative `_session_cost` from the checkpoint (0.0 if absent)."""
+
     rubric: str | None = None
     """Legacy persisted rubric or graph rubric input, if any."""
 
@@ -2583,6 +2586,14 @@ class DeepAgentsApp(App):
         self._tokens_approximate: bool = False
         """Whether the cached token count is stale (interrupted generation)."""
 
+        self._session_cost: float = 0.0
+        """Local cache of the cumulative session cost (USD) for the status bar.
+
+        Source of truth is `_session_cost` in graph state; this is a sync copy.
+        Unlike `_context_tokens`, this is a monotonic session total, not the
+        current context size, so `/compact` does not reset it.
+        """
+
         # Session lazy state & startup
         self._session_state: TextualSessionState | None = None
         """Auto-approve + thread state shared with `execute_task_textual`.
@@ -3145,6 +3156,9 @@ class DeepAgentsApp(App):
         self._ui_adapter._on_tokens_update = self._on_tokens_update
         self._ui_adapter._on_tokens_pending = self._show_pending_tokens
         self._ui_adapter._on_tokens_show = self._show_tokens
+        # Wire cost display callback and seed the persisted base
+        self._ui_adapter._on_cost_update = self._on_cost_update
+        self._ui_adapter._session_cost_base = self._session_cost
 
         if self._server_startup_deferred:
             await self._mount_deferred_start_notice()
@@ -5553,6 +5567,36 @@ class DeepAgentsApp(App):
         """Show the unknown token count placeholder during streaming."""
         if self._status_bar:
             self._status_bar.show_pending_tokens()
+
+    def _on_cost_update(self, cost: float) -> None:
+        """Update the cached cumulative session cost and the status bar.
+
+        Wired to the adapter's `_on_cost_update`. The value is the full session
+        total (persisted base plus the current turn), so it is assigned rather
+        than accumulated here.
+
+        Args:
+            cost: Cumulative session cost in USD.
+        """
+        self._session_cost = cost
+        if self._status_bar:
+            self._status_bar.set_cost(cost)
+
+    def _seed_session_cost(self, cost: float) -> None:
+        """Seed the cumulative session cost from persisted state.
+
+        Updates the local cache, the status bar, and the adapter's per-turn base
+        so live updates during the next turn build on the restored total. A new
+        (empty) thread seeds `0.0`, resetting the display.
+
+        Args:
+            cost: Cumulative session cost restored from the checkpoint.
+        """
+        self._session_cost = cost
+        if self._ui_adapter is not None:
+            self._ui_adapter._session_cost_base = cost
+        if self._status_bar:
+            self._status_bar.set_cost(cost)
 
     def _check_hydration_needed(self) -> None:
         """Check if we need to hydrate messages from the store.
@@ -8024,6 +8068,7 @@ class DeepAgentsApp(App):
         context_tokens: int,
         model_spec: str,
         model_params: dict[str, Any] | None = None,
+        session_cost: float = 0.0,
     ) -> _ThreadHistoryPayload:
         """Build a thread payload from raw checkpoint channel values.
 
@@ -8037,6 +8082,7 @@ class DeepAgentsApp(App):
             context_tokens: Persisted context-token count.
             model_spec: Persisted model spec, or `""` for legacy threads.
             model_params: Persisted model params, or `None` when absent.
+            session_cost: Persisted cumulative session cost, or `0.0` when absent.
 
         Returns:
             Payload with goal/rubric channels coerced to known types.
@@ -8051,6 +8097,7 @@ class DeepAgentsApp(App):
             context_tokens,
             model_spec,
             model_params,
+            session_cost=session_cost,
             rubric=_as_str(state_values.get("rubric")),
             sticky_rubric=_as_str(state_values.get("_sticky_rubric")),
             sticky_rubric_recorded="_sticky_rubric" in state_values,
@@ -9251,6 +9298,7 @@ class DeepAgentsApp(App):
             self._context_tokens = 0
             self._tokens_approximate = False
             self._update_tokens(0)
+            self._seed_session_cost(0.0)
             self._clear_all_goal_rubric_state()
             self._sync_status_rubric()
             # Clear status message (e.g., "Interrupted" from previous session)
@@ -9377,6 +9425,13 @@ class DeepAgentsApp(App):
                     msg += (
                         f"\n\u251c System prompt + tools: ~{overhead_str}{overhead_unit} (fixed)"  # noqa: E501
                         f"\n\u2514 Conversation: ~{conv_str}{conv_unit}"
+                    )
+
+                if self._session_cost > 0:
+                    from deepagents_code._cost import format_cost
+
+                    msg += (
+                        f"\n\nEstimated session cost: {format_cost(self._session_cost)}"
                     )
 
                 await self._mount_message(AppMessage(msg))
@@ -10607,6 +10662,12 @@ class DeepAgentsApp(App):
         model_spec = raw_spec if isinstance(raw_spec, str) else ""
         raw_params = state_values.get("_model_params")
         model_params = dict(raw_params) if isinstance(raw_params, dict) else None
+        raw_cost = state_values.get("_session_cost")
+        session_cost = (
+            float(raw_cost)
+            if isinstance(raw_cost, (int, float)) and raw_cost >= 0
+            else 0.0
+        )
         if _warn_discarded_goal_channels(state_values):
             self.notify(
                 "Some saved goal/rubric state was corrupted and was not restored.",
@@ -10618,6 +10679,7 @@ class DeepAgentsApp(App):
             context_tokens=context_tokens,
             model_spec=model_spec,
             model_params=model_params,
+            session_cost=session_cost,
         )
         messages = state_values.get("messages", [])
 
@@ -10794,6 +10856,10 @@ class DeepAgentsApp(App):
             # Seed token cache from persisted state
             if payload.context_tokens > 0:
                 self._on_tokens_update(payload.context_tokens)
+
+            # Seed cumulative cost from persisted state so the status bar and
+            # the adapter's per-turn base reflect prior spend on this thread.
+            self._seed_session_cost(payload.session_cost)
 
             # 3. Bulk load into store (sets visible window)
             _archived, visible = self._message_store.bulk_load(payload.messages)
@@ -12999,6 +13065,7 @@ class DeepAgentsApp(App):
                 self._context_tokens = 0
                 self._tokens_approximate = False
                 self._update_tokens(0)
+                self._seed_session_cost(0.0)
                 self._update_status("")
 
                 if self._session_state:
@@ -15679,6 +15746,7 @@ class DeepAgentsApp(App):
             self._context_tokens = 0
             self._tokens_approximate = False
             self._update_tokens(0)
+            self._seed_session_cost(0.0)
             self._update_status("")
 
             # Switch to the selected thread

--- a/libs/code/deepagents_code/non_interactive.py
+++ b/libs/code/deepagents_code/non_interactive.py
@@ -386,9 +386,13 @@ def _process_ai_message(
         total_toks = usage.get("total_tokens", 0)
         active_model = settings.model_name or ""
         active_provider = settings.model_provider or ""
-        from deepagents_code._cost import estimate_request_cost
+        from deepagents_code._cost import (
+            cache_tokens_from_usage,
+            estimate_request_cost,
+        )
 
         if input_toks or output_toks:
+            cache_read, cache_write = cache_tokens_from_usage(usage)
             state.stats.record_request(
                 active_model,
                 input_toks,
@@ -399,6 +403,8 @@ def _process_ai_message(
                     output_tokens=output_toks,
                     model_name=active_model,
                     provider=active_provider,
+                    cache_read_tokens=cache_read,
+                    cache_write_tokens=cache_write,
                 ),
             )
         elif total_toks:

--- a/libs/code/deepagents_code/non_interactive.py
+++ b/libs/code/deepagents_code/non_interactive.py
@@ -386,12 +386,34 @@ def _process_ai_message(
         total_toks = usage.get("total_tokens", 0)
         active_model = settings.model_name or ""
         active_provider = settings.model_provider or ""
+        from deepagents_code._cost import estimate_request_cost
+
         if input_toks or output_toks:
             state.stats.record_request(
-                active_model, input_toks, output_toks, active_provider
+                active_model,
+                input_toks,
+                output_toks,
+                active_provider,
+                cost=estimate_request_cost(
+                    input_tokens=input_toks,
+                    output_tokens=output_toks,
+                    model_name=active_model,
+                    provider=active_provider,
+                ),
             )
         elif total_toks:
-            state.stats.record_request(active_model, total_toks, 0, active_provider)
+            state.stats.record_request(
+                active_model,
+                total_toks,
+                0,
+                active_provider,
+                cost=estimate_request_cost(
+                    input_tokens=total_toks,
+                    output_tokens=0,
+                    model_name=active_model,
+                    provider=active_provider,
+                ),
+            )
 
     if not hasattr(message_obj, "content_blocks"):
         logger.debug("AIMessage missing content_blocks attribute, skipping")

--- a/libs/code/deepagents_code/resume_state.py
+++ b/libs/code/deepagents_code/resume_state.py
@@ -229,13 +229,19 @@ def _estimate_turn_cost(message: AIMessage, spec: object) -> float | None:
         provider = settings.model_provider or ""
         model = settings.model_name or ""
 
-    from deepagents_code._cost import estimate_request_cost
+    from deepagents_code._cost import (
+        cache_tokens_from_usage,
+        estimate_request_cost,
+    )
 
+    cache_read, cache_write = cache_tokens_from_usage(usage)
     return estimate_request_cost(
         input_tokens=input_toks,
         output_tokens=output_toks,
         model_name=model,
         provider=provider,
+        cache_read_tokens=cache_read,
+        cache_write_tokens=cache_write,
     )
 
 

--- a/libs/code/deepagents_code/resume_state.py
+++ b/libs/code/deepagents_code/resume_state.py
@@ -141,6 +141,15 @@ class ResumeState(GoalRubricChannels):
     _context_tokens: Annotated[NotRequired[int], PrivateStateAttr]
     """Total context tokens reported by the model's last `usage_metadata`."""
 
+    _session_cost: Annotated[NotRequired[float], PrivateStateAttr]
+    """Cumulative estimated USD cost across every turn on this thread.
+
+    Unlike `_context_tokens` (which reflects the *current* context size and is
+    reset by `/compact`), this is a monotonically increasing session total. Each
+    turn reads the prior value and adds the latest turn's estimated cost, so
+    resuming a thread restores the accumulated spend.
+    """
+
     _model_spec: Annotated[NotRequired[str], PrivateStateAttr]
     """`provider:model` spec effectively in use for the latest turn."""
 
@@ -171,6 +180,65 @@ def _extract_context_tokens(message: AIMessage) -> int | None:
     return total or None
 
 
+def _split_provider_model(spec: object) -> tuple[str, str]:
+    """Split a persisted `provider:model` spec into its parts.
+
+    Args:
+        spec: Value read from `_model_spec` state (may be absent or malformed).
+
+    Returns:
+        A `(provider, model)` pair. Either element may be `""` when the spec is
+        missing or does not contain a `:` separator (in which case the whole
+        value is treated as the model name).
+    """
+    if not isinstance(spec, str) or not spec:
+        return "", ""
+    provider, sep, model = spec.partition(":")
+    if not sep:
+        return "", provider
+    return provider, model
+
+
+def _estimate_turn_cost(message: AIMessage, spec: object) -> float | None:
+    """Estimate the USD cost of the turn's latest AI message.
+
+    Args:
+        message: The most recent `AIMessage` carrying `usage_metadata`.
+        spec: The persisted `_model_spec` used to recover provider/model.
+
+    Returns:
+        Estimated cost in USD, or `None` when usage or pricing is unavailable.
+    """
+    usage = getattr(message, "usage_metadata", None)
+    if not usage:
+        return None
+    input_toks = usage.get("input_tokens", 0) or 0
+    output_toks = usage.get("output_tokens", 0) or 0
+    if not input_toks and not output_toks:
+        # Only an aggregate total is available; attribute it all to input so the
+        # request is still priced (input is the cheaper rate, so this is a
+        # conservative lower bound rather than an overstatement).
+        input_toks = usage.get("total_tokens", 0) or 0
+    if not input_toks and not output_toks:
+        return None
+
+    provider, model = _split_provider_model(spec)
+    if not model:
+        from deepagents_code.config import settings
+
+        provider = settings.model_provider or ""
+        model = settings.model_name or ""
+
+    from deepagents_code._cost import estimate_request_cost
+
+    return estimate_request_cost(
+        input_tokens=input_toks,
+        output_tokens=output_toks,
+        model_name=model,
+        provider=provider,
+    )
+
+
 class ResumeStateMiddleware(AgentMiddleware[ResumeState, ContextT]):
     """Persists per-checkpoint resume facts after each model call.
 
@@ -186,19 +254,21 @@ class ResumeStateMiddleware(AgentMiddleware[ResumeState, ContextT]):
         state: ResumeState,
         runtime: Runtime[ContextT],  # noqa: ARG002
     ) -> dict[str, Any] | None:
-        """Write `_context_tokens` for the latest turn.
+        """Write `_context_tokens` and accumulate `_session_cost` for the turn.
 
         Model metadata is written by `ConfigurableModelMiddleware` from the
-        actual request that completed successfully; this hook only records token
-        usage from the most recent `AIMessage.usage_metadata`.
+        actual request that completed successfully; this hook records token
+        usage from the most recent `AIMessage.usage_metadata` and folds the
+        turn's estimated cost into the running session total.
 
         Args:
-            state: Current agent state; only `messages` is inspected.
+            state: Current agent state; `messages`, `_model_spec`, and
+                `_session_cost` are inspected.
             runtime: LangGraph runtime required by the middleware interface.
 
         Returns:
-            State update with `_context_tokens`, or `None` when no token count is
-            available.
+            State update with `_context_tokens` and/or `_session_cost`, or `None`
+            when no token count is available.
         """
         update: dict[str, Any] = {}
 
@@ -207,6 +277,10 @@ class ResumeStateMiddleware(AgentMiddleware[ResumeState, ContextT]):
                 tokens = _extract_context_tokens(msg)
                 if tokens is not None:
                     update["_context_tokens"] = tokens
+                turn_cost = _estimate_turn_cost(msg, state.get("_model_spec"))
+                if turn_cost:
+                    prior = state.get("_session_cost") or 0.0
+                    update["_session_cost"] = float(prior) + turn_cost
                 break
 
         return update or None

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -45,6 +45,11 @@ if TYPE_CHECKING:
 
         def __call__(self, *, approximate: bool = False) -> None: ...
 
+    class _CostUpdateCallback(Protocol):
+        """Callback signature for `_on_cost_update`."""
+
+        def __call__(self, cost: float) -> None: ...
+
 
 from deepagents_code._ask_user_types import AskUserRequest
 from deepagents_code._cli_context import CLIContext
@@ -131,11 +136,14 @@ def print_usage_table(
             padding=(0, 2, 0, 0),
             show_edge=False,
         )
+        from deepagents_code._cost import format_cost
+
         table.add_column("Provider", style="dim")
         table.add_column("Model", style="dim")
         table.add_column("Reqs", justify="right", style="dim")
         table.add_column("InputTok", justify="right", style="dim")
         table.add_column("OutputTok", justify="right", style="dim")
+        table.add_column("Cost", justify="right", style="dim")
 
         if multi_model:
             for ms in stats.per_model.values():
@@ -145,6 +153,7 @@ def print_usage_table(
                     str(ms.request_count),
                     format_token_count(ms.input_tokens),
                     format_token_count(ms.output_tokens),
+                    format_cost(ms.cost),
                 )
             table.add_row(
                 "",
@@ -152,6 +161,7 @@ def print_usage_table(
                 str(stats.request_count),
                 format_token_count(stats.input_tokens),
                 format_token_count(stats.output_tokens),
+                format_cost(stats.cost),
             )
         else:
             ms = next(iter(stats.per_model.values()))
@@ -161,6 +171,7 @@ def print_usage_table(
                 str(stats.request_count),
                 format_token_count(stats.input_tokens),
                 format_token_count(stats.output_tokens),
+                format_cost(stats.cost),
             )
 
         console.print()
@@ -360,6 +371,17 @@ class TextualUIAdapter:
 
         self._on_tokens_show: _TokensShowCallback | None = None
         """Called to restore the token display with the cached value."""
+
+        self._on_cost_update: _CostUpdateCallback | None = None
+        """Called with the cumulative session cost (USD) after each response."""
+
+        self._session_cost_base: float = 0.0
+        """Cumulative cost persisted before this session's first live turn.
+
+        Restored from the checkpoint's `_session_cost` on resume so the live
+        display shows total spend across restarts, not just the current run.
+        Per-turn cost accumulated in `turn_stats.cost` is added on top of this.
+        """
 
     def finalize_pending_tools_with_error(self, error: str) -> None:
         """Mark all pending/running tool widgets as error and clear tracking.
@@ -971,6 +993,9 @@ async def execute_task_textual(
                             input_toks = usage.get("input_tokens", 0)
                             output_toks = usage.get("output_tokens", 0)
                             total_toks = usage.get("total_tokens", 0)
+                            from deepagents_code._cost import (
+                                estimate_request_cost,
+                            )
                             from deepagents_code.config import settings
 
                             active_model = settings.model_name or ""
@@ -982,14 +1007,31 @@ async def execute_task_textual(
                                     input_toks,
                                     output_toks,
                                     active_provider,
+                                    cost=estimate_request_cost(
+                                        input_tokens=input_toks,
+                                        output_tokens=output_toks,
+                                        model_name=active_model,
+                                        provider=active_provider,
+                                    ),
                                 )
                                 captured_input_tokens = max(
                                     captured_input_tokens, input_toks + output_toks
                                 )
                             elif total_toks:
-                                # Fallback: model gives only total (no split)
+                                # Fallback: model gives only total (no split).
+                                # Price the aggregate as input tokens (cheaper
+                                # rate) so the request is still costed.
                                 turn_stats.record_request(
-                                    active_model, total_toks, 0, active_provider
+                                    active_model,
+                                    total_toks,
+                                    0,
+                                    active_provider,
+                                    cost=estimate_request_cost(
+                                        input_tokens=total_toks,
+                                        output_tokens=0,
+                                        model_name=active_model,
+                                        provider=active_provider,
+                                    ),
                                 )
                                 captured_input_tokens = max(
                                     captured_input_tokens, total_toks
@@ -1582,6 +1624,7 @@ async def execute_task_textual(
                         captured_input_tokens,
                         captured_output_tokens,
                     )
+                    _report_cost(adapter, turn_stats)
                     return turn_stats
 
                 stream_input = Command(resume=resume_payload)
@@ -1623,6 +1666,7 @@ async def execute_task_textual(
         captured_input_tokens,
         captured_output_tokens,
     )
+    _report_cost(adapter, turn_stats)
     return turn_stats
 
 
@@ -1749,6 +1793,15 @@ async def _handle_interrupt_cleanup(
             captured_total = captured_input_tokens + captured_output_tokens
             if captured_total:
                 cancellation_values["_context_tokens"] = captured_total
+            # `after_model` never ran on the partial turn, so fold this turn's
+            # accumulated cost into the persisted session total here (mirroring
+            # the token piggy-back above). Advance the in-memory base too so a
+            # subsequent turn in the same session keeps building on it.
+            if turn_stats.cost:
+                new_total = adapter._session_cost_base + turn_stats.cost
+                cancellation_values["_session_cost"] = new_total
+                adapter._session_cost_base = new_total
+                turn_stats.cost = 0.0
             await agent.aupdate_state(config, cancellation_values)
     except (httpx.TransportError, httpx.TimeoutException) as e:
         logger.warning("Could not save interrupted state (network): %s", e)
@@ -1782,6 +1835,7 @@ async def _handle_interrupt_cleanup(
         captured_output_tokens,
         approximate=approximate,
     )
+    _report_cost(adapter, turn_stats)
 
 
 def _report_tokens(
@@ -1809,6 +1863,23 @@ def _report_tokens(
             adapter._on_tokens_update(captured_input_tokens, approximate=approximate)
     elif adapter._on_tokens_show:
         adapter._on_tokens_show(approximate=approximate)
+
+
+def _report_cost(adapter: TextualUIAdapter, turn_stats: SessionStats) -> None:
+    """Refresh the running session-cost UI display.
+
+    The displayed value is the cumulative session cost: the persisted base
+    restored on resume (`adapter._session_cost_base`) plus the cost accumulated
+    this turn (`turn_stats.cost`). Persistence of the new total into graph state
+    is owned by `ResumeStateMiddleware.after_model`, not this helper.
+
+    Args:
+        adapter: UI adapter with the cost callback and persisted base.
+        turn_stats: Stats for the current turn, carrying `cost`.
+    """
+    if adapter._on_cost_update is None:
+        return
+    adapter._on_cost_update(adapter._session_cost_base + turn_stats.cost)
 
 
 async def _flush_assistant_text_ns(

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -994,6 +994,7 @@ async def execute_task_textual(
                             output_toks = usage.get("output_tokens", 0)
                             total_toks = usage.get("total_tokens", 0)
                             from deepagents_code._cost import (
+                                cache_tokens_from_usage,
                                 estimate_request_cost,
                             )
                             from deepagents_code.config import settings
@@ -1002,6 +1003,7 @@ async def execute_task_textual(
                             active_provider = settings.model_provider or ""
                             if input_toks or output_toks:
                                 # Model gives split counts — preferred path
+                                cache_read, cache_write = cache_tokens_from_usage(usage)
                                 turn_stats.record_request(
                                     active_model,
                                     input_toks,
@@ -1012,6 +1014,8 @@ async def execute_task_textual(
                                         output_tokens=output_toks,
                                         model_name=active_model,
                                         provider=active_provider,
+                                        cache_read_tokens=cache_read,
+                                        cache_write_tokens=cache_write,
                                     ),
                                 )
                                 captured_input_tokens = max(

--- a/libs/code/deepagents_code/widgets/status.py
+++ b/libs/code/deepagents_code/widgets/status.py
@@ -223,6 +223,12 @@ class StatusBar(Horizontal):
         color: $text-muted;
     }
 
+    StatusBar .status-cost {
+        width: auto;
+        padding: 0 1;
+        color: $text-muted;
+    }
+
     StatusBar .status-rubric {
         width: auto;
         padding: 0 1;
@@ -247,6 +253,7 @@ class StatusBar(Horizontal):
     cwd: reactive[str] = reactive("", init=False)
     branch: reactive[str] = reactive("", init=False)
     tokens: reactive[int] = reactive(0, init=False)
+    cost: reactive[float] = reactive(0.0, init=False)
     rubric_label: reactive[str] = reactive("", init=False)
 
     def __init__(self, cwd: str | Path | None = None, **kwargs: Any) -> None:
@@ -269,8 +276,8 @@ class StatusBar(Horizontal):
         """Compose the status bar layout.
 
         Yields:
-            Widgets for mode, auto-approve, message, cwd, branch, tokens, and
-                model display.
+            Widgets for mode, auto-approve, message, cwd, branch, tokens, cost,
+                and model display.
         """
         yield Static("", classes="status-mode normal", id="mode-indicator")
         yield Static(
@@ -285,6 +292,7 @@ class StatusBar(Horizontal):
             yield Static("", classes="status-branch", id="branch-display")
         yield Static("", classes="status-rubric", id="rubric-display")
         yield Static("", classes="status-tokens", id="tokens-display")
+        yield Static("", classes="status-cost", id="cost-display")
         yield ModelLabel(id="model-display")
 
     _BRANCH_WIDTH_THRESHOLD = 100
@@ -658,6 +666,41 @@ class StatusBar(Horizontal):
             self.query_one("#tokens-display", Static).update("... tokens")
         except NoMatches:
             return
+
+    def watch_cost(self, new_value: float) -> None:
+        """Update cost display when the cumulative session cost changes."""
+        self._render_cost(new_value)
+
+    def _render_cost(self, cost: float) -> None:
+        """Render the cumulative session cost into the display widget.
+
+        Args:
+            cost: Cumulative session cost in USD. Values `<= 0` clear the widget
+                so a session with no priced requests shows nothing.
+        """
+        try:
+            display = self.query_one("#cost-display", Static)
+        except NoMatches:
+            return
+
+        if cost > 0:
+            from deepagents_code._cost import format_cost
+
+            display.update(format_cost(cost))
+        else:
+            display.update("")
+
+    def set_cost(self, cost: float) -> None:
+        """Set the cumulative session cost.
+
+        Args:
+            cost: Cumulative session cost in USD.
+        """
+        if self.cost == cost:
+            # Reactive dedup would skip the watcher — render directly.
+            self._render_cost(cost)
+        else:
+            self.cost = cost
 
     def set_model(self, *, provider: str, model: str, effort: str = "") -> None:
         """Update the model display text.

--- a/libs/code/deepagents_code/widgets/status.py
+++ b/libs/code/deepagents_code/widgets/status.py
@@ -223,12 +223,6 @@ class StatusBar(Horizontal):
         color: $text-muted;
     }
 
-    StatusBar .status-cost {
-        width: auto;
-        padding: 0 1;
-        color: $text-muted;
-    }
-
     StatusBar .status-rubric {
         width: auto;
         padding: 0 1;
@@ -276,8 +270,8 @@ class StatusBar(Horizontal):
         """Compose the status bar layout.
 
         Yields:
-            Widgets for mode, auto-approve, message, cwd, branch, tokens, cost,
-                and model display.
+            Widgets for mode, auto-approve, message, cwd, branch, tokens (with
+                cost), and model display.
         """
         yield Static("", classes="status-mode normal", id="mode-indicator")
         yield Static(
@@ -292,7 +286,6 @@ class StatusBar(Horizontal):
             yield Static("", classes="status-branch", id="branch-display")
         yield Static("", classes="status-rubric", id="rubric-display")
         yield Static("", classes="status-tokens", id="tokens-display")
-        yield Static("", classes="status-cost", id="cost-display")
         yield ModelLabel(id="model-display")
 
     _BRANCH_WIDTH_THRESHOLD = 100
@@ -605,8 +598,44 @@ class StatusBar(Horizontal):
         display.display = bool(new_value)
         display.update(new_value)
 
+    @staticmethod
+    def _tokens_text(count: int, *, approximate: bool = False) -> str:
+        """Build the token portion of the tokens/cost display.
+
+        Args:
+            count: Total context token count.
+            approximate: Append "+" suffix to indicate the count is stale.
+
+        Returns:
+            Formatted token string like `'12.5K tokens'`, or `''` when there is
+                no count yet.
+        """
+        if count <= 0:
+            return ""
+        suffix = "+" if approximate else ""
+        if count >= 1000:  # noqa: PLR2004  # Count formatting threshold
+            return f"{count / 1000:.1f}K{suffix} tokens"
+        return f"{count}{suffix} tokens"
+
+    def _cost_text(self) -> str:
+        """Build the cost portion of the tokens/cost display.
+
+        Returns:
+            Formatted cost string like `'$0.0045'`, or `''` when no priced
+                usage has been recorded this session.
+        """
+        if self.cost <= 0:
+            return ""
+        from deepagents_code._cost import format_cost
+
+        return format_cost(self.cost)
+
     def _render_tokens(self, count: int, *, approximate: bool = False) -> None:
-        """Render the token count into the display widget.
+        """Render the combined token count and session cost into the widget.
+
+        Cost rides in the same slot as the token count (`'12.5K tokens ·
+        $0.0045'`) so it does not consume a separate, always-padded status-bar
+        column and crowd out the model label on narrow terminals.
 
         Args:
             count: Total context token count.
@@ -618,15 +647,10 @@ class StatusBar(Horizontal):
         except NoMatches:
             return
 
-        if count > 0:
-            suffix = "+" if approximate else ""
-            # Format with K suffix for thousands
-            if count >= 1000:  # noqa: PLR2004  # Count formatting threshold
-                display.update(f"{count / 1000:.1f}K{suffix} tokens")
-            else:
-                display.update(f"{count}{suffix} tokens")
-        else:
-            display.update("")
+        tokens_text = self._tokens_text(count, approximate=approximate)
+        cost_text = self._cost_text()
+        parts = [p for p in (tokens_text, cost_text) if p]
+        display.update(" \u00b7 ".join(parts))
 
     def set_rubric_label(self, label: str) -> None:
         """Set the rubric status label.
@@ -659,36 +683,24 @@ class StatusBar(Horizontal):
             self.tokens = count
 
     def show_pending_tokens(self) -> None:
-        """Show an unknown token count placeholder during streaming."""
+        """Show an unknown token count placeholder during streaming.
+
+        Keeps the session cost visible alongside the placeholder so the running
+        total does not blink out mid-turn.
+        """
         if not self._has_token_count:
             return
         try:
-            self.query_one("#tokens-display", Static).update("... tokens")
+            display = self.query_one("#tokens-display", Static)
         except NoMatches:
             return
+        cost_text = self._cost_text()
+        parts = [p for p in ("... tokens", cost_text) if p]
+        display.update(" \u00b7 ".join(parts))
 
-    def watch_cost(self, new_value: float) -> None:
-        """Update cost display when the cumulative session cost changes."""
-        self._render_cost(new_value)
-
-    def _render_cost(self, cost: float) -> None:
-        """Render the cumulative session cost into the display widget.
-
-        Args:
-            cost: Cumulative session cost in USD. Values `<= 0` clear the widget
-                so a session with no priced requests shows nothing.
-        """
-        try:
-            display = self.query_one("#cost-display", Static)
-        except NoMatches:
-            return
-
-        if cost > 0:
-            from deepagents_code._cost import format_cost
-
-            display.update(format_cost(cost))
-        else:
-            display.update("")
+    def watch_cost(self) -> None:
+        """Re-render the tokens/cost slot when the session cost changes."""
+        self._render_tokens(self.tokens, approximate=self._approximate)
 
     def set_cost(self, cost: float) -> None:
         """Set the cumulative session cost.
@@ -697,8 +709,8 @@ class StatusBar(Horizontal):
             cost: Cumulative session cost in USD.
         """
         if self.cost == cost:
-            # Reactive dedup would skip the watcher — render directly.
-            self._render_cost(cost)
+            # Reactive dedup would skip the watcher — re-render directly.
+            self._render_tokens(self.tokens, approximate=self._approximate)
         else:
             self.cost = cost
 

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -66,6 +66,9 @@ dependencies = [
     # Version parsing
     "packaging>=26.2",
 
+    # LLM cost estimation (offline price data, powers the status-bar cost display)
+    "genai-prices>=0.0.34",
+
     # Utilities
     "uuid-utils>=0.16.2,<1.0.0",
     "python-dotenv>=1.2.2,<2.0.0",

--- a/libs/code/tests/unit_tests/test_cost.py
+++ b/libs/code/tests/unit_tests/test_cost.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from deepagents_code._cost import estimate_request_cost, format_cost
+from deepagents_code._cost import (
+    cache_tokens_from_usage,
+    estimate_request_cost,
+    format_cost,
+)
 
 
 class TestEstimateRequestCost:
@@ -74,6 +78,105 @@ class TestEstimateRequestCost:
         assert low is not None
         assert high is not None
         assert high > low
+
+    def test_cache_read_is_cheaper_than_uncached_input(self) -> None:
+        # Cache reads are billed at a reduced rate, so pricing 900 of 1000 input
+        # tokens as cache reads must cost less than pricing all 1000 at full
+        # rate. This is the divergence that made local estimates undershoot
+        # LangSmith before cache tokens were priced.
+        uncached = estimate_request_cost(
+            input_tokens=1000,
+            output_tokens=100,
+            model_name="claude-sonnet-4-5",
+            provider="anthropic",
+        )
+        with_cache_reads = estimate_request_cost(
+            input_tokens=1000,
+            output_tokens=100,
+            model_name="claude-sonnet-4-5",
+            provider="anthropic",
+            cache_read_tokens=900,
+        )
+        assert uncached is not None
+        assert with_cache_reads is not None
+        assert with_cache_reads < uncached
+
+    def test_cache_write_is_pricier_than_uncached_input(self) -> None:
+        # Cache writes carry a premium over ordinary input, so moving input
+        # tokens into the cache-write bucket must not reduce the cost.
+        uncached = estimate_request_cost(
+            input_tokens=1000,
+            output_tokens=100,
+            model_name="claude-sonnet-4-5",
+            provider="anthropic",
+        )
+        with_cache_writes = estimate_request_cost(
+            input_tokens=1000,
+            output_tokens=100,
+            model_name="claude-sonnet-4-5",
+            provider="anthropic",
+            cache_write_tokens=900,
+        )
+        assert uncached is not None
+        assert with_cache_writes is not None
+        assert with_cache_writes > uncached
+
+    def test_cache_tokens_not_double_counted(self) -> None:
+        # `input_tokens` is the grand total including cached tokens. Supplying a
+        # cache_read that equals the full input must not exceed pricing the same
+        # input entirely at the (higher) uncached rate.
+        all_uncached = estimate_request_cost(
+            input_tokens=1000,
+            output_tokens=0,
+            model_name="claude-sonnet-4-5",
+            provider="anthropic",
+        )
+        all_cache_read = estimate_request_cost(
+            input_tokens=1000,
+            output_tokens=0,
+            model_name="claude-sonnet-4-5",
+            provider="anthropic",
+            cache_read_tokens=1000,
+        )
+        assert all_uncached is not None
+        assert all_cache_read is not None
+        # Cache reads are cheaper, and none of the 1000 tokens is billed twice.
+        assert all_cache_read < all_uncached
+
+    def test_cache_tokens_exceeding_input_clamped(self) -> None:
+        # Defensive: if cache counts exceed input_tokens (inconsistent provider
+        # reporting), uncached input clamps to zero rather than going negative.
+        cost = estimate_request_cost(
+            input_tokens=100,
+            output_tokens=0,
+            model_name="claude-sonnet-4-5",
+            provider="anthropic",
+            cache_read_tokens=500,
+        )
+        assert cost is not None
+        assert cost > 0
+
+
+class TestCacheTokensFromUsage:
+    """Tests for cache_tokens_from_usage()."""
+
+    def test_none_usage_returns_zeros(self) -> None:
+        assert cache_tokens_from_usage(None) == (0, 0)
+
+    def test_missing_details_returns_zeros(self) -> None:
+        assert cache_tokens_from_usage({"input_tokens": 100}) == (0, 0)
+
+    def test_extracts_cache_read_and_creation(self) -> None:
+        usage = {
+            "input_tokens": 350,
+            "input_token_details": {"cache_creation": 200, "cache_read": 100},
+        }
+        # Returns (cache_read, cache_write); cache_write maps to cache_creation.
+        assert cache_tokens_from_usage(usage) == (100, 200)
+
+    def test_partial_details(self) -> None:
+        usage = {"input_token_details": {"cache_read": 42}}
+        assert cache_tokens_from_usage(usage) == (42, 0)
 
 
 class TestFormatCost:

--- a/libs/code/tests/unit_tests/test_cost.py
+++ b/libs/code/tests/unit_tests/test_cost.py
@@ -1,0 +1,95 @@
+"""Tests for LLM cost estimation helpers in `_cost`."""
+
+from __future__ import annotations
+
+import pytest
+
+from deepagents_code._cost import estimate_request_cost, format_cost
+
+
+class TestEstimateRequestCost:
+    """Tests for estimate_request_cost()."""
+
+    def test_known_model_returns_positive_cost(self) -> None:
+        cost = estimate_request_cost(
+            input_tokens=1000,
+            output_tokens=100,
+            model_name="claude-sonnet-4-5",
+            provider="anthropic",
+        )
+        assert cost is not None
+        assert cost > 0
+
+    def test_known_model_without_provider(self) -> None:
+        # genai-prices can infer the provider from a well-known model name.
+        cost = estimate_request_cost(
+            input_tokens=1000,
+            output_tokens=100,
+            model_name="gpt-4o",
+        )
+        assert cost is not None
+        assert cost > 0
+
+    def test_unknown_model_returns_none(self) -> None:
+        cost = estimate_request_cost(
+            input_tokens=1000,
+            output_tokens=100,
+            model_name="totally-made-up-model-xyz",
+            provider="nonexistent-provider",
+        )
+        assert cost is None
+
+    def test_empty_model_returns_none(self) -> None:
+        assert (
+            estimate_request_cost(input_tokens=1000, output_tokens=100, model_name="")
+            is None
+        )
+
+    def test_zero_tokens_returns_none(self) -> None:
+        assert (
+            estimate_request_cost(
+                input_tokens=0,
+                output_tokens=0,
+                model_name="claude-sonnet-4-5",
+                provider="anthropic",
+            )
+            is None
+        )
+
+    def test_more_output_costs_more(self) -> None:
+        # Output tokens are billed at a higher rate than input for most models,
+        # so a request with more output should never be cheaper.
+        low = estimate_request_cost(
+            input_tokens=1000,
+            output_tokens=10,
+            model_name="claude-sonnet-4-5",
+            provider="anthropic",
+        )
+        high = estimate_request_cost(
+            input_tokens=1000,
+            output_tokens=1000,
+            model_name="claude-sonnet-4-5",
+            provider="anthropic",
+        )
+        assert low is not None
+        assert high is not None
+        assert high > low
+
+
+class TestFormatCost:
+    """Tests for format_cost()."""
+
+    @pytest.mark.parametrize(
+        ("cost", "expected"),
+        [
+            (0.0, "$0"),
+            (-1.0, "$0"),
+            (0.0045, "$0.0045"),
+            (0.5, "$0.5000"),
+            (1.0, "$1.00"),
+            (1.234, "$1.23"),
+            (12.5, "$12.50"),
+        ],
+    )
+    def test_formatting(self, cost: float, expected: str) -> None:
+        assert format_cost(cost) == expected

--- a/libs/code/tests/unit_tests/test_resume_state.py
+++ b/libs/code/tests/unit_tests/test_resume_state.py
@@ -171,6 +171,70 @@ class TestAfterModelHook:
         result = middleware.after_model({"messages": []}, _runtime(None))  # ty: ignore
         assert result is None
 
+    async def test_accumulates_session_cost_from_model_spec(self) -> None:
+        """Cost is priced from `_model_spec` and added to the running total."""
+        middleware = ResumeStateMiddleware()
+        state: dict[str, Any] = {
+            "messages": [
+                HumanMessage(content="hi"),
+                AIMessage(
+                    content="response",
+                    usage_metadata={
+                        "input_tokens": 1000,
+                        "output_tokens": 100,
+                        "total_tokens": 1100,
+                    },
+                ),
+            ],
+            "_model_spec": "anthropic:claude-sonnet-4-5",
+        }
+        result = middleware.after_model(state, _runtime(None))  # ty: ignore
+        assert result is not None
+        assert result["_context_tokens"] == 1100
+        assert result["_session_cost"] > 0
+
+    async def test_session_cost_adds_to_prior_total(self) -> None:
+        """A prior `_session_cost` is read and the turn's cost is added on top."""
+        middleware = ResumeStateMiddleware()
+        state: dict[str, Any] = {
+            "messages": [
+                HumanMessage(content="hi"),
+                AIMessage(
+                    content="response",
+                    usage_metadata={
+                        "input_tokens": 1000,
+                        "output_tokens": 100,
+                        "total_tokens": 1100,
+                    },
+                ),
+            ],
+            "_model_spec": "anthropic:claude-sonnet-4-5",
+            "_session_cost": 1.0,
+        }
+        result = middleware.after_model(state, _runtime(None))  # ty: ignore
+        assert result is not None
+        assert result["_session_cost"] > 1.0
+
+    async def test_no_session_cost_for_unknown_model(self) -> None:
+        """An unpriceable model records tokens but no cost."""
+        middleware = ResumeStateMiddleware()
+        state: dict[str, Any] = {
+            "messages": [
+                HumanMessage(content="hi"),
+                AIMessage(
+                    content="response",
+                    usage_metadata={
+                        "input_tokens": 1000,
+                        "output_tokens": 100,
+                        "total_tokens": 1100,
+                    },
+                ),
+            ],
+            "_model_spec": "made-up:unknown-model-xyz",
+        }
+        result = middleware.after_model(state, _runtime(None))  # ty: ignore
+        assert result == {"_context_tokens": 1100}
+
     async def test_skips_intervening_tool_messages(self) -> None:
         """Picks up the most recent AIMessage even when followed by tool turns."""
         from langchain_core.messages import ToolMessage

--- a/libs/code/tests/unit_tests/test_session_stats.py
+++ b/libs/code/tests/unit_tests/test_session_stats.py
@@ -57,6 +57,7 @@ class TestModelStats:
         assert stats.request_count == 0
         assert stats.input_tokens == 0
         assert stats.output_tokens == 0
+        assert stats.cost == pytest.approx(0.0)
         assert stats.provider == ""
 
 
@@ -127,6 +128,27 @@ class TestSessionStats:
         assert stats.input_tokens == 100
         assert stats.per_model == {}
 
+    def test_record_request_accumulates_cost(self) -> None:
+        stats = SessionStats()
+        stats.record_request("gpt-5.5", 100, 50, cost=0.01)
+        stats.record_request("gpt-5.5", 200, 75, cost=0.02)
+        assert stats.cost == pytest.approx(0.03)
+        assert stats.per_model["", "gpt-5.5"].cost == pytest.approx(0.03)
+
+    def test_record_request_none_cost_leaves_total_unchanged(self) -> None:
+        stats = SessionStats()
+        stats.record_request("gpt-5.5", 100, 50, cost=0.01)
+        stats.record_request("gpt-5.5", 200, 75, cost=None)
+        assert stats.cost == pytest.approx(0.01)
+        assert stats.per_model["", "gpt-5.5"].cost == pytest.approx(0.01)
+
+    def test_record_request_zero_cost_is_recorded(self) -> None:
+        stats = SessionStats()
+        stats.record_request("free-model", 100, 50, cost=0.0)
+        assert stats.cost == pytest.approx(0.0)
+        # A zero cost is a recorded value, distinct from "no pricing" (None).
+        assert stats.per_model["", "free-model"].cost == pytest.approx(0.0)
+
     def test_merge_combines_totals(self) -> None:
         a = SessionStats(
             request_count=1,
@@ -145,6 +167,15 @@ class TestSessionStats:
         assert a.input_tokens == 300
         assert a.output_tokens == 125
         assert a.wall_time_seconds == pytest.approx(3.5)
+
+    def test_merge_combines_cost(self) -> None:
+        a = SessionStats(cost=0.01)
+        a.record_request("gpt-5.5", 100, 50, cost=0.02)
+        b = SessionStats()
+        b.record_request("gpt-5.5", 200, 75, cost=0.03)
+        a.merge(b)
+        assert a.cost == pytest.approx(0.06)
+        assert a.per_model["", "gpt-5.5"].cost == pytest.approx(0.05)
 
     def test_merge_combines_per_model(self) -> None:
         a = SessionStats()

--- a/libs/code/tests/unit_tests/test_status.py
+++ b/libs/code/tests/unit_tests/test_status.py
@@ -50,33 +50,52 @@ class TestCwdDisplay:
 
 
 class TestCostDisplay:
-    """Tests for the cumulative session cost display in the status bar."""
+    """Tests for the cumulative session cost, shown in the tokens slot."""
 
-    async def test_set_cost_renders_formatted_value(self) -> None:
+    async def test_cost_renders_alongside_tokens(self) -> None:
         async with StatusBarApp().run_test(size=(120, 24)) as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_tokens(12_500)
             bar.set_cost(0.0045)
             await pilot.pause()
-            display = pilot.app.query_one("#cost-display", Static)
-            assert "$0.0045" in str(display.render())
+            display = pilot.app.query_one("#tokens-display", Static)
+            rendered = str(display.render())
+            assert "12.5K tokens" in rendered
+            assert "$0.0045" in rendered
 
-    async def test_set_cost_dollars(self) -> None:
+    async def test_cost_without_tokens(self) -> None:
         async with StatusBarApp().run_test(size=(120, 24)) as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.set_cost(1.5)
             await pilot.pause()
-            display = pilot.app.query_one("#cost-display", Static)
+            display = pilot.app.query_one("#tokens-display", Static)
             assert "$1.50" in str(display.render())
 
-    async def test_zero_cost_clears_display(self) -> None:
+    async def test_zero_cost_shows_only_tokens(self) -> None:
         async with StatusBarApp().run_test(size=(120, 24)) as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_tokens(1000)
             bar.set_cost(1.0)
             await pilot.pause()
             bar.set_cost(0.0)
             await pilot.pause()
-            display = pilot.app.query_one("#cost-display", Static)
-            assert str(display.render()) == ""
+            display = pilot.app.query_one("#tokens-display", Static)
+            rendered = str(display.render())
+            assert "$" not in rendered
+            assert "1.0K tokens" in rendered
+
+    async def test_cost_survives_pending_tokens(self) -> None:
+        async with StatusBarApp().run_test(size=(120, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_tokens(1000)
+            bar.set_cost(0.0045)
+            await pilot.pause()
+            bar.show_pending_tokens()
+            await pilot.pause()
+            display = pilot.app.query_one("#tokens-display", Static)
+            rendered = str(display.render())
+            assert "... tokens" in rendered
+            assert "$0.0045" in rendered
 
 
 class TestBranchDisplay:

--- a/libs/code/tests/unit_tests/test_status.py
+++ b/libs/code/tests/unit_tests/test_status.py
@@ -49,6 +49,36 @@ class TestCwdDisplay:
             assert branch.display is True
 
 
+class TestCostDisplay:
+    """Tests for the cumulative session cost display in the status bar."""
+
+    async def test_set_cost_renders_formatted_value(self) -> None:
+        async with StatusBarApp().run_test(size=(120, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_cost(0.0045)
+            await pilot.pause()
+            display = pilot.app.query_one("#cost-display", Static)
+            assert "$0.0045" in str(display.render())
+
+    async def test_set_cost_dollars(self) -> None:
+        async with StatusBarApp().run_test(size=(120, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_cost(1.5)
+            await pilot.pause()
+            display = pilot.app.query_one("#cost-display", Static)
+            assert "$1.50" in str(display.render())
+
+    async def test_zero_cost_clears_display(self) -> None:
+        async with StatusBarApp().run_test(size=(120, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_cost(1.0)
+            await pilot.pause()
+            bar.set_cost(0.0)
+            await pilot.pause()
+            display = pilot.app.query_one("#cost-display", Static)
+            assert str(display.render()) == ""
+
+
 class TestBranchDisplay:
     """Tests for the git branch display in the status bar."""
 

--- a/libs/code/uv.lock
+++ b/libs/code/uv.lock
@@ -1117,6 +1117,7 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "deepagents" },
     { name = "deepagents-acp" },
+    { name = "genai-prices" },
     { name = "httpx" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
@@ -1290,6 +1291,7 @@ requires-dist = [
     { name = "deepagents-acp", specifier = ">=0.0.8,<1.0.0" },
     { name = "deepagents-code", extras = ["agentcore", "daytona", "modal", "runloop", "vercel"], marker = "extra == 'all-sandboxes'" },
     { name = "deepagents-code", extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "together", "vertex", "xai"], marker = "extra == 'all-providers'" },
+    { name = "genai-prices", specifier = ">=0.0.34" },
     { name = "httpx", specifier = ">=0.28.1,<1.0.0" },
     { name = "langchain", specifier = ">=1.3.11,<2.0.0" },
     { name = "langchain-agentcore-codeinterpreter", marker = "extra == 'agentcore'", specifier = ">=0.0.5,<1.0.0" },
@@ -1683,6 +1685,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[[package]]
+name = "genai-prices"
+version = "0.0.69"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx2" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/17/b9a96d31908f1415b38e3bcba7883691fa2e0e69e18d0d9d6e80bf24be88/genai_prices-0.0.69.tar.gz", hash = "sha256:80ca72c4b59b62ef986be3f04ea528bf4aaac4bc91e1c34f32f354c0c0b23d16", size = 81492, upload-time = "2026-07-02T09:40:21.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/05/6bb176d603210b61d2bf4585c7119dcf5491bbcae195e21254668c5ee07a/genai_prices-0.0.69-py3-none-any.whl", hash = "sha256:281821349e301e938e00ba9a9e8df5be23336e2f04218a4979f6c5f89db083bb", size = 83972, upload-time = "2026-07-02T09:40:20.844Z" },
 ]
 
 [[package]]
@@ -2180,6 +2195,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2257,6 +2285,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a running, cumulative estimate of session spend to the `deepagents-code` status bar, next to the existing token count.

Cost is estimated per request with [`pydantic/genai-prices`](https://github.com/pydantic/genai-prices) (bundled, offline price data — no network on the startup hot path). The estimate is folded into a monotonic session total that is persisted in a new private `_session_cost` checkpoint channel, written from inside the graph by `ResumeStateMiddleware.after_model` so it rides the same checkpoint as `_context_tokens` and is restored on `-r` resume and `/threads` switches.

Unlike the token count — which reflects *current context size* and resets on `/compact` — cost is a cumulative session total, so the two stay distinct. Unknown/self-hosted models that are not in the price data degrade quietly (the running total is left unchanged and nothing is shown) rather than crashing streaming. The cost also appears in `/tokens` and the headless (`-x`) usage table.

`genai-prices` is added as a required dependency of `deepagents-code`; no `deepagents` SDK pin change is needed since this builds on existing middleware APIs.

## Release note

The `deepagents-code` status bar now shows a running estimate of session cost (USD) alongside the token count, persisted across restarts and thread resume. Also surfaced in `/tokens` and the headless usage table.
