### PR TITLE
feat(code): cost tracking middleware with running-cost TUI display

### DIFF
--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -8,7 +8,7 @@ Regenerate this file with `make commands-catalog` after changing command names,
 aliases, descriptions, visibility, or hidden-command metadata.
 
 
-## Public (32)
+## Public (33)
 
 | Command | Aliases | Description |
 | --- | --- | --- |
@@ -18,6 +18,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/changelog` |  | Open the changelog in a browser |
 | `/clear` |  | Clear the chat and start a new thread |
 | `/copy` |  | Copy the latest assistant message to clipboard |
+| `/cost` |  | Show estimated cost |
 | `/docs` |  | Open the docs |
 | `/editor` |  | Open prompt in an external editor ($EDITOR) |
 | `/effort` |  | Set reasoning effort for the current model |

--- a/libs/code/deepagents_code/_session_stats.py
+++ b/libs/code/deepagents_code/_session_stats.py
@@ -42,6 +42,9 @@ class ModelStats:
     model_name: str = ""
     """Model name displayed in usage output."""
 
+    cost_usd: float = 0.0
+    """Cumulative estimated USD cost for this model (0.0 when unpriced)."""
+
 
 ModelStatsKey = tuple[str, str]
 """Per-model dict key: the `(provider, model_name)` pair.
@@ -69,6 +72,14 @@ class SessionStats:
     output_tokens: int = 0
     """Cumulative output tokens across all LLM requests."""
 
+    total_cost_usd: float = 0.0
+    """Cumulative estimated USD cost across all LLM requests.
+
+    Summed from per-request estimates (`genai_prices`). Requests whose model has
+    no known price contribute 0.0, so this is a lower bound when pricing gaps
+    exist rather than an exact figure.
+    """
+
     wall_time_seconds: float = 0.0
     """Wall-clock duration from stream start to end."""
 
@@ -86,6 +97,7 @@ class SessionStats:
         input_toks: int,
         output_toks: int,
         provider: str = "",
+        cost_usd: float = 0.0,
     ) -> None:
         """Accumulate token counts for one completed LLM request.
 
@@ -100,10 +112,13 @@ class SessionStats:
             provider: Provider that served the model (e.g. `openai`). Combined
                 with `model_name` to form the per-model key, so the same model
                 served by different providers is tracked separately.
+            cost_usd: Estimated USD cost for this request (0.0 when the model
+                has no known price).
         """
         self.request_count += 1
         self.input_tokens += input_toks
         self.output_tokens += output_toks
+        self.total_cost_usd += cost_usd
         if model_name:
             key = (provider, model_name)
             entry = self.per_model.setdefault(
@@ -113,6 +128,7 @@ class SessionStats:
             entry.request_count += 1
             entry.input_tokens += input_toks
             entry.output_tokens += output_toks
+            entry.cost_usd += cost_usd
 
     def merge(self, other: SessionStats) -> None:
         """Merge another `SessionStats` into this one (mutates *self*).
@@ -125,6 +141,7 @@ class SessionStats:
         self.request_count += other.request_count
         self.input_tokens += other.input_tokens
         self.output_tokens += other.output_tokens
+        self.total_cost_usd += other.total_cost_usd
         self.wall_time_seconds += other.wall_time_seconds
         for key, ms in other.per_model.items():
             entry = self.per_model.setdefault(
@@ -134,6 +151,7 @@ class SessionStats:
             entry.request_count += ms.request_count
             entry.input_tokens += ms.input_tokens
             entry.output_tokens += ms.output_tokens
+            entry.cost_usd += ms.cost_usd
 
 
 def format_token_count(count: int) -> str:
@@ -150,3 +168,20 @@ def format_token_count(count: int) -> str:
     if count >= 1000:  # noqa: PLR2004
         return f"{count / 1000:.1f}K"
     return str(count)
+
+
+def format_cost(usd: float) -> str:
+    """Format a USD cost into a compact display string.
+
+    Args:
+        usd: Estimated cost in US dollars.
+
+    Returns:
+        A string like `'$0.42'`, or `'<$0.01'` for a tiny but non-zero cost.
+        Costs of `0` (including unpriced sessions) return `'$0.00'`.
+    """
+    if usd <= 0:
+        return "$0.00"
+    if usd < 0.01:  # noqa: PLR2004 — display floor for sub-cent estimates
+        return "<$0.01"
+    return f"${usd:.2f}"

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1565,10 +1565,13 @@ def create_cli_agent(
     # request. The CLI reads them back from `state_values` on thread resume.
     # Goal tools: exposes the read-only `get_goal`/`get_rubric` tools and the
     # constrained `update_goal` tool, and injects goal guidance into the prompt.
+    from deepagents_code.cost_tracking import CostTrackingMiddleware
     from deepagents_code.goal_tools import GoalToolsMiddleware
     from deepagents_code.resume_state import ResumeStateMiddleware
 
-    agent_middleware.extend([ResumeStateMiddleware(), GoalToolsMiddleware()])
+    agent_middleware.extend(
+        [ResumeStateMiddleware(), CostTrackingMiddleware(), GoalToolsMiddleware()]
+    )
 
     # Add ask_user middleware (must be early so its tool is available)
     if enable_ask_user:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -54,6 +54,7 @@ from deepagents_code._git import (
 from deepagents_code._session_stats import (
     SessionStats,
     SpinnerStatus,
+    format_cost,
     format_token_count,
 )
 
@@ -1395,6 +1396,10 @@ class _ThreadHistoryPayload:
     pending_goal_rubric: str | None = None
     """Persisted pending goal criteria, if any."""
 
+    session_cost_usd: float = 0.0
+    """Persisted cumulative `_session_cost_usd` from the checkpoint (0.0 if
+    absent), used to seed the status-bar running cost on resume."""
+
 
 def _new_thread_id() -> str:
     """Deferred-import wrapper around `sessions.generate_thread_id`.
@@ -2610,6 +2615,14 @@ class DeepAgentsApp(App):
         copy for the status bar.
         """
 
+        self._session_cost_usd: float = 0.0
+        """Running cumulative estimated cost (USD) shown in the status bar.
+
+        Accumulated per turn from client-side `estimate_cost` and seeded from the
+        persisted `_session_cost_usd` channel (written by `CostTrackingMiddleware`)
+        on resume, so the displayed cost spans the whole thread's lifetime.
+        """
+
         self._tokens_approximate: bool = False
         """Whether the cached token count is stale (interrupted generation)."""
 
@@ -3175,6 +3188,7 @@ class DeepAgentsApp(App):
         self._ui_adapter._on_tokens_update = self._on_tokens_update
         self._ui_adapter._on_tokens_pending = self._show_pending_tokens
         self._ui_adapter._on_tokens_show = self._show_tokens
+        self._ui_adapter._on_cost_update = self._on_cost_update
 
         if self._server_startup_deferred:
             await self._mount_deferred_start_notice()
@@ -5583,6 +5597,55 @@ class DeepAgentsApp(App):
         """Show the unknown token count placeholder during streaming."""
         if self._status_bar:
             self._status_bar.show_pending_tokens()
+
+    def _update_cost(self) -> None:
+        """Push the running session cost to the status bar."""
+        if self._status_bar:
+            self._status_bar.set_cost(self._session_cost_usd)
+
+    def _on_cost_update(self, turn_cost_usd: float) -> None:
+        """Add a completed turn's cost to the running total and refresh the bar.
+
+        Wired to the adapter's `_on_cost_update`. Receives the per-turn delta;
+        the cumulative total lives here so it can be seeded from persisted state
+        on resume.
+
+        Args:
+            turn_cost_usd: Estimated USD cost of the just-completed turn.
+        """
+        self._session_cost_usd += turn_cost_usd
+        self._update_cost()
+
+    def _format_cost_summary(self) -> str:
+        """Build the message shown by the `/cost` command.
+
+        Returns:
+            A running-total line plus a per-model breakdown (this session), or a
+            friendly placeholder when nothing has been priced yet.
+        """
+        if self._session_cost_usd <= 0:
+            from deepagents_code.config import settings
+
+            model_name = settings.model_name
+            base = "No cost recorded yet"
+            # A session can run without any priced cost if the active model has
+            # no entry in the bundled price data — flag that rather than imply $0.
+            if self._session_stats.request_count > 0:
+                base += " (no price data for this model)"
+            return f"{base} · {model_name}" if model_name else base
+
+        lines = [f"{format_cost(self._session_cost_usd)} estimated cost this thread"]
+        priced = [
+            ms for ms in self._session_stats.per_model.values() if ms.cost_usd > 0
+        ]
+        if len(priced) > 1:
+            for ms in priced:
+                label = (
+                    f"{ms.provider}:{ms.model_name}" if ms.provider else ms.model_name
+                )
+                lines.append(f"├ {label}: {format_cost(ms.cost_usd)}")
+        lines.append("Estimated from token usage via genai-prices.")
+        return "\n".join(lines)
 
     def _check_hydration_needed(self) -> None:
         """Check if we need to hydrate messages from the store.
@@ -8076,6 +8139,13 @@ class DeepAgentsApp(App):
         def _as_str(value: object) -> str | None:
             return value if isinstance(value, str) else None
 
+        raw_cost = state_values.get("_session_cost_usd")
+        session_cost_usd = (
+            float(raw_cost)
+            if isinstance(raw_cost, (int, float)) and raw_cost > 0
+            else 0.0
+        )
+
         return _ThreadHistoryPayload(
             messages,
             context_tokens,
@@ -8094,6 +8164,7 @@ class DeepAgentsApp(App):
             rubric_status=_as_str(state_values.get("_rubric_status")),
             pending_goal_objective=_as_str(state_values.get("_pending_goal_objective")),
             pending_goal_rubric=_as_str(state_values.get("_pending_goal_rubric")),
+            session_cost_usd=session_cost_usd,
         )
 
     def _restore_goal_rubric_state(self, payload: _ThreadHistoryPayload) -> None:
@@ -9231,7 +9302,7 @@ class DeepAgentsApp(App):
                 "/mcp, /model [--model-params JSON] [--default], "
                 "/notifications, /reload, /restart, /rubric, "
                 "/skill:<name>, /remember, "
-                "/skill-creator, /theme, /scrollbar, /timestamps, /tokens, "
+                "/skill-creator, /theme, /scrollbar, /timestamps, /tokens, /cost, "
                 "/threads, /trace, "
                 "/update, /auto-update, /install, /changelog, /docs, "
                 "/feedback, /help\n\n"
@@ -9422,6 +9493,9 @@ class DeepAgentsApp(App):
                     parts.append(model_name)
 
                 await self._mount_message(AppMessage(" · ".join(parts)))
+        elif cmd == "/cost":
+            await self._mount_message(UserMessage(command))
+            await self._mount_message(AppMessage(self._format_cost_summary()))
         elif cmd == "/remember" or cmd.startswith("/remember "):
             # Convenience alias for /skill:remember — shorter and discoverable
             # before skill loading completes.
@@ -10824,6 +10898,12 @@ class DeepAgentsApp(App):
             # Seed token cache from persisted state
             if payload.context_tokens > 0:
                 self._on_tokens_update(payload.context_tokens)
+
+            # Seed the running session cost from persisted state so the status
+            # bar reflects the whole thread's lifetime spend after resume.
+            if payload.session_cost_usd > 0:
+                self._session_cost_usd = payload.session_cost_usd
+                self._update_cost()
 
             # 5. Cache container ref (single query). Queried before the store
             # load so history can be reconciled against widgets already in the

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -177,7 +177,13 @@ COMMANDS: tuple[SlashCommand, ...] = (
         name="/tokens",
         description="Show token usage",
         bypass_tier=BypassTier.QUEUED,
-        hidden_keywords="cost",
+        hidden_keywords="cost price spend",
+    ),
+    SlashCommand(
+        name="/cost",
+        description="Show estimated cost",
+        bypass_tier=BypassTier.QUEUED,
+        hidden_keywords="price spend usage tokens dollars",
     ),
     SlashCommand(
         name="/reload",

--- a/libs/code/deepagents_code/cost_tracking.py
+++ b/libs/code/deepagents_code/cost_tracking.py
@@ -1,0 +1,169 @@
+"""Estimate and accumulate the USD cost of model calls.
+
+Cost is priced with [`genai-prices`](https://github.com/pydantic/genai-prices),
+which ships bundled offline price data for many providers and understands
+Anthropic cache tokens. Two consumers share the single `estimate_cost` helper so
+they can never drift:
+
+- `CostTrackingMiddleware` runs *inside the graph* and accumulates cumulative
+  USD into the private `_session_cost_usd` checkpoint channel. Writing from the
+  model node (rather than a client-side `aupdate_state`) rides the same
+  checkpoint as the response, so cost is persisted, restored on resume, works in
+  headless / non-interactive mode, and behaves identically against remote
+  graphs — the same rationale as `ResumeStateMiddleware` for `_context_tokens`.
+- The TUI client (`textual_adapter.py`) calls `estimate_cost` directly on the
+  `usage_metadata` it already pulls off the stream, updating the live status-bar
+  cost with no extra state round-trip.
+
+Unknown / unpriceable models degrade to `None` (no cost recorded) rather than
+raising, so a pricing gap never breaks a turn.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Annotated, Any, NotRequired
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ContextT,
+    PrivateStateAttr,
+)
+from langchain_core.messages import AIMessage
+
+if TYPE_CHECKING:
+    from decimal import Decimal
+
+    from langgraph.runtime import Runtime
+
+logger = logging.getLogger(__name__)
+
+
+def estimate_cost(
+    usage_metadata: dict[str, Any] | None,
+    model_name: str,
+    provider: str = "",
+) -> Decimal | None:
+    """Estimate the USD cost of a single model call from its token usage.
+
+    Args:
+        usage_metadata: LangChain `AIMessage.usage_metadata`. Its `input_tokens`
+            already includes cached tokens (matching what genai-prices expects);
+            cache detail is read from `input_token_details`
+            (`cache_read` / `cache_creation`).
+        model_name: Model identifier to price (e.g. `claude-sonnet-4-5`).
+        provider: Provider id (e.g. `anthropic`). An empty string lets
+            genai-prices infer the provider from the model name.
+
+    Returns:
+        Total price as a `Decimal`, or `None` when usage/model is missing or
+        genai-prices has no price for the model. Never raises — lookup failures
+        are logged at debug and return `None`.
+    """
+    if not usage_metadata or not model_name:
+        return None
+    input_tokens = usage_metadata.get("input_tokens") or 0
+    output_tokens = usage_metadata.get("output_tokens") or 0
+    if not input_tokens and not output_tokens:
+        return None
+    details = usage_metadata.get("input_token_details") or {}
+    try:
+        from genai_prices import Usage, calc_price
+
+        usage = Usage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=details.get("cache_read") or None,
+            cache_write_tokens=details.get("cache_creation") or None,
+        )
+        price = calc_price(usage, model_ref=model_name, provider_id=provider or None)
+    except Exception:
+        logger.debug(
+            "cost estimate failed for model=%r provider=%r",
+            model_name,
+            provider,
+            exc_info=True,
+        )
+        return None
+    return price.total_price
+
+
+class CostState(AgentState):
+    """Agent state extended with the cumulative session-cost channel."""
+
+    _session_cost_usd: Annotated[NotRequired[float], PrivateStateAttr]
+    """Cumulative estimated USD cost across all model calls in the thread.
+
+    Written by `CostTrackingMiddleware.after_model`, read back by the CLI on
+    resume to seed the status-bar cost. Stored as `float` (not `Decimal`) so it
+    round-trips cleanly through checkpoint JSON serialization.
+    """
+
+
+def _model_ref_and_provider(msg: AIMessage, state: CostState) -> tuple[str, str]:
+    """Resolve `(model_ref, provider)` for pricing a model response in-graph.
+
+    Prefers the message's own `response_metadata`, then the `_model_spec`
+    (`provider:model`) channel written by `ConfigurableModelMiddleware`, then the
+    client `settings`. The returned provider may be `""`, in which case
+    genai-prices infers it from the model name.
+
+    Returns:
+        A `(model_ref, provider)` pair; either element may be `""` when unknown.
+    """
+    meta = getattr(msg, "response_metadata", None) or {}
+    model_ref = meta.get("model_name") or meta.get("model") or ""
+    provider = meta.get("model_provider") or ""
+
+    spec = state.get("_model_spec")
+    if isinstance(spec, str) and ":" in spec:
+        spec_provider, spec_model = spec.split(":", 1)
+        model_ref = model_ref or spec_model
+        provider = provider or spec_provider
+
+    if not model_ref or not provider:
+        from deepagents_code.config import settings
+
+        model_ref = model_ref or (settings.model_name or "")
+        provider = provider or (settings.model_provider or "")
+    return model_ref, provider
+
+
+class CostTrackingMiddleware(AgentMiddleware[CostState, ContextT]):
+    """Accumulate estimated USD cost into the checkpoint after each model call.
+
+    Mirrors `ResumeStateMiddleware.after_model`: the write happens inside the
+    model node so it rides the response's checkpoint (persisted, resumable,
+    remote-safe) instead of a standalone `aupdate_state`. Pricing goes through
+    `estimate_cost`; unpriceable models simply contribute nothing to the total.
+    """
+
+    state_schema = CostState
+
+    def after_model(  # noqa: PLR6301 — AgentMiddleware hook must be an instance method.
+        self,
+        state: CostState,
+        runtime: Runtime[ContextT],  # noqa: ARG002
+    ) -> dict[str, Any] | None:
+        """Add the latest model call's estimated cost to `_session_cost_usd`.
+
+        Args:
+            state: Current agent state; the most recent `AIMessage` is priced.
+            runtime: LangGraph runtime required by the middleware interface.
+
+        Returns:
+            State update with the new cumulative cost, or `None` when the latest
+            call has no priceable usage.
+        """
+        for msg in reversed(state.get("messages") or []):
+            if isinstance(msg, AIMessage):
+                model_ref, provider = _model_ref_and_provider(msg, state)
+                cost = estimate_cost(
+                    getattr(msg, "usage_metadata", None), model_ref, provider
+                )
+                if cost is None:
+                    return None
+                current = state.get("_session_cost_usd") or 0.0
+                return {"_session_cost_usd": current + float(cost)}
+        return None

--- a/libs/code/deepagents_code/non_interactive.py
+++ b/libs/code/deepagents_code/non_interactive.py
@@ -386,12 +386,18 @@ def _process_ai_message(
         total_toks = usage.get("total_tokens", 0)
         active_model = settings.model_name or ""
         active_provider = settings.model_provider or ""
+        from deepagents_code.cost_tracking import estimate_cost
+
+        cost = estimate_cost(usage, active_model, active_provider)
+        cost_usd = float(cost) if cost is not None else 0.0
         if input_toks or output_toks:
             state.stats.record_request(
-                active_model, input_toks, output_toks, active_provider
+                active_model, input_toks, output_toks, active_provider, cost_usd
             )
         elif total_toks:
-            state.stats.record_request(active_model, total_toks, 0, active_provider)
+            state.stats.record_request(
+                active_model, total_toks, 0, active_provider, cost_usd
+            )
 
     if not hasattr(message_obj, "content_blocks"):
         logger.debug("AIMessage missing content_blocks attribute, skipping")

--- a/libs/code/deepagents_code/textual_adapter.py
+++ b/libs/code/deepagents_code/textual_adapter.py
@@ -54,6 +54,7 @@ from deepagents_code._session_stats import (
     ModelStatsKey as ModelStatsKey,
     SessionStats as SessionStats,
     SpinnerStatus as SpinnerStatus,
+    format_cost as format_cost,
     format_token_count as format_token_count,
 )
 from deepagents_code.config import build_stream_config, get_glyphs
@@ -136,6 +137,7 @@ def print_usage_table(
         table.add_column("Reqs", justify="right", style="dim")
         table.add_column("InputTok", justify="right", style="dim")
         table.add_column("OutputTok", justify="right", style="dim")
+        table.add_column("Cost", justify="right", style="dim")
 
         if multi_model:
             for ms in stats.per_model.values():
@@ -145,6 +147,7 @@ def print_usage_table(
                     str(ms.request_count),
                     format_token_count(ms.input_tokens),
                     format_token_count(ms.output_tokens),
+                    format_cost(ms.cost_usd),
                 )
             table.add_row(
                 "",
@@ -152,6 +155,7 @@ def print_usage_table(
                 str(stats.request_count),
                 format_token_count(stats.input_tokens),
                 format_token_count(stats.output_tokens),
+                format_cost(stats.total_cost_usd),
             )
         else:
             ms = next(iter(stats.per_model.values()))
@@ -161,6 +165,7 @@ def print_usage_table(
                 str(stats.request_count),
                 format_token_count(stats.input_tokens),
                 format_token_count(stats.output_tokens),
+                format_cost(stats.total_cost_usd),
             )
 
         console.print()
@@ -360,6 +365,9 @@ class TextualUIAdapter:
 
         self._on_tokens_show: _TokensShowCallback | None = None
         """Called to restore the token display with the cached value."""
+
+        self._on_cost_update: Callable[[float], None] | None = None
+        """Called with cumulative session cost (USD) after each turn."""
 
     def finalize_pending_tools_with_error(self, error: str) -> None:
         """Mark all pending/running tool widgets as error and clear tracking.
@@ -975,6 +983,14 @@ async def execute_task_textual(
 
                             active_model = settings.model_name or ""
                             active_provider = settings.model_provider or ""
+                            # Price this call client-side from the usage we
+                            # already have, so the live status-bar cost needs no
+                            # state round-trip. Shares `estimate_cost` with
+                            # `CostTrackingMiddleware`, so the two never drift.
+                            from deepagents_code.cost_tracking import estimate_cost
+
+                            cost = estimate_cost(usage, active_model, active_provider)
+                            cost_usd = float(cost) if cost is not None else 0.0
                             if input_toks or output_toks:
                                 # Model gives split counts — preferred path
                                 turn_stats.record_request(
@@ -982,6 +998,7 @@ async def execute_task_textual(
                                     input_toks,
                                     output_toks,
                                     active_provider,
+                                    cost_usd,
                                 )
                                 captured_input_tokens = max(
                                     captured_input_tokens, input_toks + output_toks
@@ -989,7 +1006,11 @@ async def execute_task_textual(
                             elif total_toks:
                                 # Fallback: model gives only total (no split)
                                 turn_stats.record_request(
-                                    active_model, total_toks, 0, active_provider
+                                    active_model,
+                                    total_toks,
+                                    0,
+                                    active_provider,
+                                    cost_usd,
                                 )
                                 captured_input_tokens = max(
                                     captured_input_tokens, total_toks
@@ -1582,6 +1603,7 @@ async def execute_task_textual(
                         captured_input_tokens,
                         captured_output_tokens,
                     )
+                    _report_cost(adapter, turn_stats)
                     return turn_stats
 
                 stream_input = Command(resume=resume_payload)
@@ -1623,6 +1645,7 @@ async def execute_task_textual(
         captured_input_tokens,
         captured_output_tokens,
     )
+    _report_cost(adapter, turn_stats)
     return turn_stats
 
 
@@ -1782,6 +1805,7 @@ async def _handle_interrupt_cleanup(
         captured_output_tokens,
         approximate=approximate,
     )
+    _report_cost(adapter, turn_stats)
 
 
 def _report_tokens(
@@ -1809,6 +1833,21 @@ def _report_tokens(
             adapter._on_tokens_update(captured_input_tokens, approximate=approximate)
     elif adapter._on_tokens_show:
         adapter._on_tokens_show(approximate=approximate)
+
+
+def _report_cost(adapter: TextualUIAdapter, turn_stats: SessionStats) -> None:
+    """Report this turn's estimated cost so the app can update the running total.
+
+    Fires the app's `_on_cost_update` callback with the turn's incremental USD
+    cost (0.0 contributes nothing). The app owns the cumulative total; this
+    helper only forwards the per-turn delta.
+
+    Args:
+        adapter: UI adapter carrying the cost callback.
+        turn_stats: Stats for the just-completed turn.
+    """
+    if turn_stats.total_cost_usd and adapter._on_cost_update:
+        adapter._on_cost_update(turn_stats.total_cost_usd)
 
 
 async def _flush_assistant_text_ns(

--- a/libs/code/deepagents_code/widgets/status.py
+++ b/libs/code/deepagents_code/widgets/status.py
@@ -15,6 +15,7 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 from deepagents_code._env_vars import HIDE_CWD, HIDE_GIT_BRANCH, is_env_truthy
+from deepagents_code._session_stats import format_cost
 from deepagents_code.config import get_glyphs
 from deepagents_code.widgets.loading import Spinner
 
@@ -223,6 +224,12 @@ class StatusBar(Horizontal):
         color: $text-muted;
     }
 
+    StatusBar .status-cost {
+        width: auto;
+        padding: 0 1;
+        color: $text-muted;
+    }
+
     StatusBar .status-rubric {
         width: auto;
         padding: 0 1;
@@ -247,6 +254,7 @@ class StatusBar(Horizontal):
     cwd: reactive[str] = reactive("", init=False)
     branch: reactive[str] = reactive("", init=False)
     tokens: reactive[int] = reactive(0, init=False)
+    cost: reactive[float] = reactive(0.0, init=False)
     rubric_label: reactive[str] = reactive("", init=False)
 
     def __init__(self, cwd: str | Path | None = None, **kwargs: Any) -> None:
@@ -285,6 +293,7 @@ class StatusBar(Horizontal):
             yield Static("", classes="status-branch", id="branch-display")
         yield Static("", classes="status-rubric", id="rubric-display")
         yield Static("", classes="status-tokens", id="tokens-display")
+        yield Static("", classes="status-cost", id="cost-display")
         yield ModelLabel(id="model-display")
 
     _BRANCH_WIDTH_THRESHOLD = 100
@@ -658,6 +667,38 @@ class StatusBar(Horizontal):
             self.query_one("#tokens-display", Static).update("... tokens")
         except NoMatches:
             return
+
+    def watch_cost(self, new_value: float) -> None:
+        """Update the cost display when the running total changes."""
+        self._render_cost(new_value)
+
+    def _render_cost(self, usd: float) -> None:
+        """Render the running session cost into the display widget.
+
+        Args:
+            usd: Cumulative estimated session cost in USD. Values `<= 0` render
+                as empty so the widget's padding doesn't leave a gap before the
+                cost has been established.
+        """
+        try:
+            display = self.query_one("#cost-display", Static)
+        except NoMatches:
+            return
+        display.update(format_cost(usd) if usd > 0 else "")
+
+    def set_cost(self, usd: float) -> None:
+        """Set the running session cost shown in the status bar.
+
+        Forces a render even when the value is unchanged, mirroring
+        `set_tokens`, so a repeated identical total still refreshes the widget.
+
+        Args:
+            usd: Cumulative estimated session cost in USD.
+        """
+        if self.cost == usd:
+            self._render_cost(usd)
+        else:
+            self.cost = usd
 
     def set_model(self, *, provider: str, model: str, effort: str = "") -> None:
         """Update the model display text.

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -60,6 +60,9 @@ dependencies = [
     "tavily-python>=0.7.26,<1.0.0",
     "langchain-quickjs>=0.3.2,<0.4.0",
 
+    # Cost tracking (bundled offline price data for the running-cost display)
+    "genai-prices>=0.0.69,<1.0.0",
+
     # Clipboard
     "pyperclip>=1.11.0,<2.0.0",
 

--- a/libs/code/tests/unit_tests/test_cost_tracking.py
+++ b/libs/code/tests/unit_tests/test_cost_tracking.py
@@ -1,0 +1,172 @@
+"""Tests for the cost_tracking module (estimate_cost + CostTrackingMiddleware)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from deepagents_code.cost_tracking import (
+    CostTrackingMiddleware,
+    estimate_cost,
+)
+
+# A model + provider known to genai-prices' bundled price data.
+KNOWN_MODEL = "claude-sonnet-4-5"
+KNOWN_PROVIDER = "anthropic"
+
+
+def _runtime() -> SimpleNamespace:
+    """Build a stand-in `Runtime` (the middleware ignores it)."""
+    return SimpleNamespace(context=None)
+
+
+def _usage(input_tokens: int, output_tokens: int, **extra: object) -> dict:
+    """Build a usage_metadata dict with the required total_tokens field."""
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+        **extra,
+    }
+
+
+def _ai(
+    usage: dict | None, *, model: str = KNOWN_MODEL, provider: str = KNOWN_PROVIDER
+) -> AIMessage:
+    """Build an AIMessage with usage + model metadata for pricing."""
+    return AIMessage(
+        content="hi",
+        usage_metadata=usage,  # type: ignore[arg-type]
+        response_metadata={"model_name": model, "model_provider": provider},
+    )
+
+
+class TestEstimateCost:
+    """Tests for estimate_cost()."""
+
+    def test_known_model_returns_positive_decimal(self) -> None:
+        cost = estimate_cost(
+            {"input_tokens": 1000, "output_tokens": 500},
+            KNOWN_MODEL,
+            KNOWN_PROVIDER,
+        )
+        assert isinstance(cost, Decimal)
+        assert cost > 0
+
+    def test_provider_inferred_when_omitted(self) -> None:
+        cost = estimate_cost({"input_tokens": 1000, "output_tokens": 500}, KNOWN_MODEL)
+        assert cost is not None
+        assert cost > 0
+
+    def test_unknown_model_returns_none(self) -> None:
+        assert (
+            estimate_cost(
+                {"input_tokens": 1000, "output_tokens": 500},
+                "definitely-not-a-real-model-xyz",
+                KNOWN_PROVIDER,
+            )
+            is None
+        )
+
+    def test_missing_usage_returns_none(self) -> None:
+        assert estimate_cost(None, KNOWN_MODEL, KNOWN_PROVIDER) is None
+
+    def test_missing_model_returns_none(self) -> None:
+        assert estimate_cost({"input_tokens": 100, "output_tokens": 50}, "") is None
+
+    def test_zero_tokens_returns_none(self) -> None:
+        assert (
+            estimate_cost(
+                {"input_tokens": 0, "output_tokens": 0}, KNOWN_MODEL, KNOWN_PROVIDER
+            )
+            is None
+        )
+
+    def test_cache_read_tokens_reduce_cost(self) -> None:
+        # Cached input reads are cheaper than uncached input, so pricing the same
+        # token total with most of it served from cache must cost strictly less.
+        base = estimate_cost(
+            {"input_tokens": 1000, "output_tokens": 0},
+            KNOWN_MODEL,
+            KNOWN_PROVIDER,
+        )
+        cached = estimate_cost(
+            {
+                "input_tokens": 1000,
+                "output_tokens": 0,
+                "input_token_details": {"cache_read": 900},
+            },
+            KNOWN_MODEL,
+            KNOWN_PROVIDER,
+        )
+        assert base is not None
+        assert cached is not None
+        assert cached < base
+
+
+class TestCostTrackingMiddleware:
+    """Tests for CostTrackingMiddleware.after_model."""
+
+    def test_accumulates_session_cost(self) -> None:
+        mw = CostTrackingMiddleware()
+        usage = _usage(1000, 500)
+
+        first = mw.after_model({"messages": [_ai(usage)]}, _runtime())  # ty: ignore
+        assert first is not None
+        cost1 = first["_session_cost_usd"]
+        assert cost1 > 0
+
+        # Second call carries the prior cumulative total in state.
+        second = mw.after_model(
+            {"messages": [HumanMessage("q"), _ai(usage)], "_session_cost_usd": cost1},
+            _runtime(),  # ty: ignore
+        )
+        assert second is not None
+        assert second["_session_cost_usd"] > cost1
+
+    def test_prices_latest_ai_message(self) -> None:
+        mw = CostTrackingMiddleware()
+        state: dict[str, Any] = {
+            "messages": [
+                _ai(_usage(10, 5)),
+                HumanMessage("follow up"),
+                _ai(_usage(1000, 500)),
+            ]
+        }
+        result = mw.after_model(state, _runtime())  # ty: ignore
+        expected = estimate_cost(_usage(1000, 500), KNOWN_MODEL, KNOWN_PROVIDER)
+        assert result is not None
+        assert expected is not None
+        assert result["_session_cost_usd"] == pytest.approx(float(expected))
+
+    def test_no_usage_returns_none(self) -> None:
+        mw = CostTrackingMiddleware()
+        assert mw.after_model({"messages": [_ai(None)]}, _runtime()) is None  # ty: ignore
+
+    def test_unpriceable_model_returns_none(self) -> None:
+        mw = CostTrackingMiddleware()
+        msg = _ai(_usage(100, 50), model="no-such-model-xyz")
+        assert mw.after_model({"messages": [msg]}, _runtime()) is None  # ty: ignore
+
+    def test_no_messages_returns_none(self) -> None:
+        mw = CostTrackingMiddleware()
+        assert mw.after_model({"messages": []}, _runtime()) is None  # ty: ignore
+
+    def test_model_spec_fallback_from_state(self) -> None:
+        # No model info on the message; resolved from the `_model_spec` channel.
+        mw = CostTrackingMiddleware()
+        msg = AIMessage(
+            content="hi",
+            usage_metadata=_usage(1000, 500),  # type: ignore[arg-type]
+        )
+        state: dict[str, Any] = {
+            "messages": [msg],
+            "_model_spec": f"{KNOWN_PROVIDER}:{KNOWN_MODEL}",
+        }
+        result = mw.after_model(state, _runtime())  # ty: ignore
+        assert result is not None
+        assert result["_session_cost_usd"] > 0

--- a/libs/code/tests/unit_tests/test_session_stats.py
+++ b/libs/code/tests/unit_tests/test_session_stats.py
@@ -7,8 +7,29 @@ import pytest
 from deepagents_code._session_stats import (
     ModelStats,
     SessionStats,
+    format_cost,
     format_token_count,
 )
+
+
+class TestFormatCost:
+    """Tests for format_cost()."""
+
+    @pytest.mark.parametrize(
+        ("usd", "expected"),
+        [
+            (0.0, "$0.00"),
+            (-1.0, "$0.00"),
+            (0.0001, "<$0.01"),
+            (0.009, "<$0.01"),
+            (0.01, "$0.01"),
+            (0.42, "$0.42"),
+            (12.5, "$12.50"),
+            (1234.5, "$1234.50"),
+        ],
+    )
+    def test_format(self, usd: float, expected: str) -> None:
+        assert format_cost(usd) == expected
 
 
 class TestFormatTokenCount:
@@ -127,6 +148,27 @@ class TestSessionStats:
         assert stats.input_tokens == 100
         assert stats.per_model == {}
 
+    def test_record_request_defaults_cost_to_zero(self) -> None:
+        stats = SessionStats()
+        stats.record_request("gpt-5.5", 100, 50)
+        assert stats.total_cost_usd == pytest.approx(0.0)
+        assert stats.per_model["", "gpt-5.5"].cost_usd == pytest.approx(0.0)
+
+    def test_record_request_accumulates_cost(self) -> None:
+        stats = SessionStats()
+        stats.record_request("gpt-5.5", 100, 50, cost_usd=0.01)
+        stats.record_request("gpt-5.5", 200, 75, cost_usd=0.02)
+        assert stats.total_cost_usd == pytest.approx(0.03)
+        assert stats.per_model["", "gpt-5.5"].cost_usd == pytest.approx(0.03)
+
+    def test_record_request_cost_split_by_model(self) -> None:
+        stats = SessionStats()
+        stats.record_request("gpt-5.5", 100, 50, cost_usd=0.01)
+        stats.record_request("claude-sonnet-4-5", 200, 75, cost_usd=0.05)
+        assert stats.total_cost_usd == pytest.approx(0.06)
+        assert stats.per_model["", "gpt-5.5"].cost_usd == pytest.approx(0.01)
+        assert stats.per_model["", "claude-sonnet-4-5"].cost_usd == pytest.approx(0.05)
+
     def test_merge_combines_totals(self) -> None:
         a = SessionStats(
             request_count=1,
@@ -145,6 +187,18 @@ class TestSessionStats:
         assert a.input_tokens == 300
         assert a.output_tokens == 125
         assert a.wall_time_seconds == pytest.approx(3.5)
+
+    def test_merge_combines_cost(self) -> None:
+        a = SessionStats()
+        a.record_request("gpt-5.5", 100, 50, cost_usd=0.01)
+        b = SessionStats()
+        b.record_request("gpt-5.5", 200, 75, cost_usd=0.02)
+        b.record_request("claude-sonnet-4-5", 300, 100, cost_usd=0.05)
+
+        a.merge(b)
+        assert a.total_cost_usd == pytest.approx(0.08)
+        assert a.per_model["", "gpt-5.5"].cost_usd == pytest.approx(0.03)
+        assert a.per_model["", "claude-sonnet-4-5"].cost_usd == pytest.approx(0.05)
 
     def test_merge_combines_per_model(self) -> None:
         a = SessionStats()

--- a/libs/code/tests/unit_tests/test_status.py
+++ b/libs/code/tests/unit_tests/test_status.py
@@ -287,6 +287,39 @@ class TestTokenDisplay:
             assert "+" not in rendered
 
 
+class TestCostDisplay:
+    """Tests for the running-cost display in the status bar."""
+
+    async def test_set_cost_updates_display(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_cost(0.42)
+            await pilot.pause()
+            display = pilot.app.query_one("#cost-display")
+            assert "$0.42" in str(display.render())
+
+    async def test_cost_empty_by_default(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            display = pilot.app.query_one("#cost-display")
+            assert str(display.render()) == ""
+
+    async def test_zero_cost_renders_empty(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_cost(0.0)
+            await pilot.pause()
+            display = pilot.app.query_one("#cost-display")
+            assert str(display.render()) == ""
+
+    async def test_sub_cent_cost_renders_floor(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_cost(0.003)
+            await pilot.pause()
+            display = pilot.app.query_one("#cost-display")
+            assert "<$0.01" in str(display.render())
+
+
 class TestModeIndicator:
     """Tests for the input-mode indicator in the status bar."""
 

--- a/libs/code/uv.lock
+++ b/libs/code/uv.lock
@@ -1117,6 +1117,7 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "deepagents" },
     { name = "deepagents-acp" },
+    { name = "genai-prices" },
     { name = "httpx" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
@@ -1290,6 +1291,7 @@ requires-dist = [
     { name = "deepagents-acp", specifier = ">=0.0.8,<1.0.0" },
     { name = "deepagents-code", extras = ["agentcore", "daytona", "modal", "runloop", "vercel"], marker = "extra == 'all-sandboxes'" },
     { name = "deepagents-code", extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fireworks", "google-genai", "groq", "huggingface", "ibm", "litellm", "mistralai", "nvidia", "ollama", "openai", "openrouter", "perplexity", "together", "vertex", "xai"], marker = "extra == 'all-providers'" },
+    { name = "genai-prices", specifier = ">=0.0.69,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.1,<1.0.0" },
     { name = "langchain", specifier = ">=1.3.11,<2.0.0" },
     { name = "langchain-agentcore-codeinterpreter", marker = "extra == 'agentcore'", specifier = ">=0.0.5,<1.0.0" },
@@ -1683,6 +1685,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[[package]]
+name = "genai-prices"
+version = "0.0.69"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx2" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/17/b9a96d31908f1415b38e3bcba7883691fa2e0e69e18d0d9d6e80bf24be88/genai_prices-0.0.69.tar.gz", hash = "sha256:80ca72c4b59b62ef986be3f04ea528bf4aaac4bc91e1c34f32f354c0c0b23d16", size = 81492, upload-time = "2026-07-02T09:40:21.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/05/6bb176d603210b61d2bf4585c7119dcf5491bbcae195e21254668c5ee07a/genai_prices-0.0.69-py3-none-any.whl", hash = "sha256:281821349e301e938e00ba9a9e8df5be23336e2f04218a4979f6c5f89db083bb", size = 83972, upload-time = "2026-07-02T09:40:20.844Z" },
 ]
 
 [[package]]
@@ -2180,6 +2195,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2260,6 +2288,22 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2294,9 +2338,9 @@ name = "ibm-cos-sdk"
 version = "2.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ibm-cos-sdk-core" },
-    { name = "ibm-cos-sdk-s3transfer" },
-    { name = "jmespath", version = "1.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "ibm-cos-sdk-core", marker = "python_full_version < '3.15'" },
+    { name = "ibm-cos-sdk-s3transfer", marker = "python_full_version < '3.15'" },
+    { name = "jmespath", version = "1.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/b8/b99f17ece72d4bccd7e75539b9a294d0f73ace5c6c475d8f2631afd6f65b/ibm_cos_sdk-2.14.3.tar.gz", hash = "sha256:643b6f2aa1683adad7f432df23407d11ae5adb9d9ad01214115bee77dc64364a", size = 58831, upload-time = "2025-08-01T06:35:51.722Z" }
 
@@ -2305,10 +2349,10 @@ name = "ibm-cos-sdk-core"
 version = "2.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jmespath", version = "1.0.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "requests" },
-    { name = "urllib3" },
+    { name = "jmespath", version = "1.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.15'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.15'" },
+    { name = "requests", marker = "python_full_version < '3.15'" },
+    { name = "urllib3", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/45/80c23aa1e13175a9deefe43cbf8e853a3d3bfc8dfa8b6d6fe83e5785fe21/ibm_cos_sdk_core-2.14.3.tar.gz", hash = "sha256:85dee7790c92e8db69bf39dae4c02cac211e3c1d81bb86e64fa2d1e929674623", size = 1103637, upload-time = "2025-08-01T06:35:41.645Z" }
 
@@ -2317,7 +2361,7 @@ name = "ibm-cos-sdk-s3transfer"
 version = "2.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ibm-cos-sdk-core" },
+    { name = "ibm-cos-sdk-core", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/ff/c9baf0997266d398ae08347951a2970e5e96ed6232ed0252f649f2b9a7eb/ibm_cos_sdk_s3transfer-2.14.3.tar.gz", hash = "sha256:2251ebfc4a46144401e431f4a5d9f04c262a0d6f95c88a8e71071da056e55f72", size = 139594, upload-time = "2025-08-01T06:35:46.403Z" }
 
@@ -2326,17 +2370,17 @@ name = "ibm-watsonx-ai"
 version = "1.5.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cachetools" },
-    { name = "certifi" },
-    { name = "httpx" },
-    { name = "ibm-cos-sdk" },
-    { name = "lomond" },
-    { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.14.*'" },
+    { name = "cachetools", marker = "python_full_version < '3.15'" },
+    { name = "certifi", marker = "python_full_version < '3.15'" },
+    { name = "httpx", marker = "python_full_version < '3.15'" },
+    { name = "ibm-cos-sdk", marker = "python_full_version < '3.15'" },
+    { name = "lomond", marker = "python_full_version < '3.15'" },
+    { name = "packaging", marker = "python_full_version < '3.15'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.14.*'" },
-    { name = "requests" },
-    { name = "tabulate" },
-    { name = "urllib3" },
+    { name = "requests", marker = "python_full_version < '3.15'" },
+    { name = "tabulate", marker = "python_full_version < '3.15'" },
+    { name = "urllib3", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/a3/c756b534696ab2f3f29882fdb7ca7198b7a5c94e10c0a3a327853d6d6b79/ibm_watsonx_ai-1.5.14.tar.gz", hash = "sha256:a756488bd57e87c0fc51be42dcba871143cfe0ac1e805c497c5047e1e4f13e9d", size = 735804, upload-time = "2026-06-22T12:32:43.85Z" }
 wheels = [
@@ -3434,7 +3478,7 @@ name = "lomond"
 version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
+    { name = "six", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/9e/ef7813c910d4a893f2bc763ce9246269f55cc68db21dc1327e376d6a2d02/lomond-0.3.3.tar.gz", hash = "sha256:427936596b144b4ec387ead99aac1560b77c8a78107d3d49415d3abbe79acbd3", size = 28789, upload-time = "2018-09-21T15:17:43.297Z" }
 wheels = [
@@ -4383,11 +4427,11 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "python-dateutil", marker = "python_full_version < '3.14'" },
+    { name = "pytz", marker = "python_full_version < '3.14'" },
+    { name = "tzdata", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -4443,9 +4487,9 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.14.*'" },
+    { name = "python-dateutil", marker = "python_full_version == '3.14.*'" },
+    { name = "tzdata", marker = "(python_full_version == '3.14.*' and sys_platform == 'emscripten') or (python_full_version == '3.14.*' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -5728,8 +5772,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "(python_full_version != '3.14.*' and sys_platform == 'emscripten') or (python_full_version != '3.14.*' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version != '3.14.*' and sys_platform == 'emscripten') or (python_full_version != '3.14.*' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -6521,11 +6565,11 @@ name = "vercel-workers"
 version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "vercel" },
+    { name = "anyio", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "vercel", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
 wheels = [


### PR DESCRIPTION
## What

Adds cost tracking to `deepagents-code`. Each model call is priced with [`pydantic/genai-prices`](https://github.com/pydantic/genai-prices) (bundled offline price data, understands Anthropic cache tokens) and cumulative cost is surfaced the same way tokens are:

- **Live in the status bar** — a `$0.42` indicator next to the token count, updated per turn.
- **In the usage table** — a new `Cost` column (per-model + total), shown at exit / `/tokens` and in headless runs.
- **Via a new `/cost` command** — running total plus per-model breakdown.
- **Persisted** — survives `dcode -r` resume and works headless / against remote graphs.

## How

One shared `estimate_cost()` helper is the single source of truth, so the two consumers can't drift:

- **`CostTrackingMiddleware`** (new, in the `code` package next to `resume_state.py`) accumulates USD into a private `_session_cost_usd` checkpoint channel from `after_model` — mirroring how `ResumeStateMiddleware` persists `_context_tokens` (writes ride the model node's checkpoint; no standalone `UpdateState` run in LangSmith). This gives persistence + resume + headless/remote coverage.
- **The TUI client** calls the same `estimate_cost()` on the `usage_metadata` it already pulls off the stream, so the live status-bar update needs no extra state round-trip. On resume the running total is seeded from the persisted channel.

Unpriceable models degrade to no-cost (logged at debug) rather than raising, so a pricing gap never breaks a turn.

## Files

- `deepagents_code/cost_tracking.py` — `estimate_cost`, `CostState`, `CostTrackingMiddleware` (new)
- `agent.py` — register the middleware next to `ResumeStateMiddleware`
- `_session_stats.py` — cost fields on `SessionStats`/`ModelStats` + `format_cost`
- `textual_adapter.py` / `non_interactive.py` — client-side cost accumulation + usage-table `Cost` column
- `widgets/status.py` — `#cost-display` widget + `set_cost`
- `app.py` — running-total wiring, resume seeding, `/cost` command
- `command_registry.py` / `COMMANDS.md` — register `/cost`
- Tests: new `test_cost_tracking.py`; extended `test_session_stats.py` and `test_status.py`

## Test plan

- `uv run --group test pytest tests/unit_tests/test_cost_tracking.py test_session_stats.py test_status.py` — all green (lint + `ty` clean).
- Manual: run `dcode`, send a few messages, confirm `$0.xx` appears/increments in the status bar; `/cost` and `/tokens` show the breakdown; exit shows the `Cost` column; `dcode -r` restores the running total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)