### PR TITLE
fix(backends): unwrap nested LsResult entries in CompositeBackend ls/als

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -175,8 +175,21 @@ class CompositeBackend(BackendProtocol):
 
     @staticmethod
     def _coerce_ls_result(raw: LsResult | list[FileInfo]) -> LsResult:
-        """Normalize legacy `list[FileInfo]` returns to `LsResult`."""
+        """Normalize legacy `list[FileInfo]` returns to `LsResult`.
+
+        Also unwraps malformed backends that nest an `LsResult` inside
+        `entries` instead of returning `list[FileInfo]`.
+        """
         if isinstance(raw, LsResult):
+            if raw.error:
+                return raw
+            entries = raw.entries
+            while isinstance(entries, LsResult):
+                if entries.error:
+                    return entries
+                entries = entries.entries
+            if entries is not raw.entries:
+                return LsResult(entries=entries)
             return raw
         return LsResult(entries=raw)
 

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -10,8 +10,10 @@ from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import (
     BackendProtocol,
     ExecuteResponse,
+    FileInfo,
     GlobResult,
     GrepResult,
+    LsResult,
     SandboxBackendProtocol,
     WriteResult,
 )
@@ -1628,3 +1630,24 @@ async def test_composite_adelete_unsupported_route_returns_error() -> None:
     assert result.path is None
     assert result.error is not None
     assert "not supported" in result.error
+
+
+def test_composite_backend_ls_unwraps_nested_lsresult_entries():
+    """ls() tolerates backends that accidentally nest LsResult inside entries."""
+    mem_store = InMemoryStore()
+
+    class BuggyBackend(StoreBackend):
+        def ls(self, path: str) -> LsResult:
+            result = super().ls(path)
+            return LsResult(entries=result)
+
+    composite = CompositeBackend(
+        default=BuggyBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={},
+    )
+
+    result = composite.ls("/")
+
+    assert result.error is None
+    assert result.entries is not None
+    assert all(isinstance(entry, dict) for entry in result.entries)

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
@@ -9,6 +9,8 @@ from deepagents.backends.composite import CompositeBackend
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import (
     ExecuteResponse,
+    FileInfo,
+    LsResult,
     SandboxBackendProtocol,
     WriteResult,
 )
@@ -1077,3 +1079,63 @@ async def test_aedit_result_path_restored_to_full_routed_path():
 
     assert res.error is None
     assert res.path == "/memories/notes.md"  # not "/notes.md"
+
+
+async def test_composite_backend_als_unwraps_nested_lsresult_entries():
+    """als() tolerates backends that accidentally nest LsResult inside entries."""
+    mem_store = InMemoryStore()
+
+    class BuggyBackend(StoreBackend):
+        async def als(self, path: str) -> LsResult:
+            result = await super().als(path)
+            return LsResult(entries=result)
+
+    composite = CompositeBackend(
+        default=BuggyBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={},
+    )
+
+    result = await composite.als("/")
+
+    assert result.error is None
+    assert result.entries is not None
+    assert all(isinstance(entry, dict) for entry in result.entries)
+
+
+async def test_composite_backend_als_unwraps_doubly_nested_lsresult_entries():
+    """als() unwraps multiple levels of nested LsResult entries."""
+    mem_store = InMemoryStore()
+    inner_entries = [FileInfo(path="/file.txt", is_dir=False, size=1, modified_at="")]
+
+    class DoublyNestedBackend(StoreBackend):
+        async def als(self, path: str) -> LsResult:
+            return LsResult(entries=LsResult(entries=LsResult(entries=inner_entries)))
+
+    composite = CompositeBackend(
+        default=DoublyNestedBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={},
+    )
+
+    result = await composite.als("/")
+
+    assert result.error is None
+    assert result.entries == inner_entries
+
+
+async def test_composite_backend_als_propagates_nested_lsresult_error():
+    """als() surfaces errors from nested LsResult entries on routed paths."""
+    mem_store = InMemoryStore()
+
+    class NestedErrorBackend(StoreBackend):
+        async def als(self, path: str) -> LsResult:
+            return LsResult(entries=LsResult(error="not found"))
+
+    composite = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/memories/": NestedErrorBackend(store=mem_store, namespace=lambda _rt: ("memories",))},
+    )
+
+    result = await composite.als("/memories/")
+
+    assert result.error == "not found"
+    assert result.entries is None


### PR DESCRIPTION
## Summary

Normalize malformed `LsResult` values in `CompositeBackend._coerce_ls_result` so `ls()` and `als()` no longer crash when a backend accidentally nests an `LsResult` inside `entries` instead of returning `list[FileInfo]`.

## Motivation

Fixes #4420. When a backend returns `LsResult(entries=<another LsResult>)`, `CompositeBackend.als()` raised `TypeError: 'LsResult' object is not iterable` while iterating entries during root aggregation or routed remapping. This can surface in production when a custom backend wraps its own `als()` result incorrectly.

## Changes

- Extend `_coerce_ls_result` to unwrap nested `LsResult` chains and propagate inner errors.
- Add regression tests for:
  - sync `ls()` with singly nested entries
  - async `als()` with singly and triply nested entries
  - routed-path nested error propagation

## Tests

```bash
pytest tests/unit_tests/backends/test_composite_backend.py::test_composite_backend_ls_unwraps_nested_lsresult_entries \
  tests/unit_tests/backends/test_composite_backend_async.py -k nested_lsresult -v
```

Result: **4 passed**

Also ran full composite backend unit suite: **102 passed, 2 xfailed**

## Notes

- Minimal defensive fix in the shared coercion helper; no behavior change for well-formed backends.
- Root aggregation (`path="/"`) still swallows default-backend errors without nested unwrapping — pre-existing behavior, unchanged by this PR.

Fixes #4420