### PR TITLE
docs(repo): mention `dcode` command in root `AGENTS.md`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,8 @@ For dependency internals, first locate the dependency file from the package envi
 
 ### Deep Agents Code (`libs/code/`)
 
+The `deepagents-code` package ships the interactive terminal coding agent, launched via the `dcode` console command (`dcode` is the short alias for `deepagents-code`).
+
 See `libs/code/AGENTS.md` for package-specific guidance — Textual, startup performance, slash commands, model providers, SDK pin, help-screen drift.
 
 ### Deep Agents CLI (`libs/cli/`)


### PR DESCRIPTION
The root `AGENTS.md` referenced `deepagents-code` and "Deep Agents Code" but never named the `dcode` console command an agent actually runs. This adds a one-line note in the Deep Agents Code section clarifying that `dcode` is the short alias for `deepagents-code`, so repo context can resolve what `dcode` is without spelunking `libs/code`.

Made by [Open SWE](https://openswe.vercel.app/agents/b568e22c-6998-7a9b-944f-3a9ca43ac276)