### PR TITLE
fix(talon): use normal channels for Fleet runs

### DIFF
--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -38,21 +38,14 @@ unzip path/to/fleet-export.zip -d ./fleet
 ```
 
 Import the export once per Talon assistant id. The import validates `AGENTS.md` and
-`config.json`, records the Fleet directory, stores the selected channel, and writes
-Fleet MCP replacement follow-up tasks to the assistant-scoped manifest:
+`config.json`, records the Fleet directory, and writes Fleet MCP replacement
+follow-up tasks to the assistant-scoped manifest:
 
 ```bash
 AGENT_ASSISTANT_ID=fleet-local \
 uv run deepagents-talon import-fleet ./fleet \
-  --assistant-id fleet-local \
-  --channel telegram \
-  --non-interactive
+  --assistant-id fleet-local
 ```
-
-If `--channel` is omitted, `import-fleet` infers the channel only when exactly one
-of `DEEPAGENTS_TALON_TELEGRAM_ENABLED=true` or
-`DEEPAGENTS_TALON_WHATSAPP_ENABLED=true` is set. In non-interactive shells,
-provide `--channel telegram` or `--channel whatsapp` explicitly.
 
 The manifest is written to `<assistant-home>/agent/tools.json`, where
 `<assistant-home>` is `~/.deepagents/<assistant-id>` by default or
@@ -62,17 +55,18 @@ setup tasks, but missing local replacements do not block import. The default
 follow-up target for local MCP replacement configuration is the same manifest file,
 `<assistant-home>/agent/tools.json`.
 
-Run the imported Fleet export through the selected channel by assistant id:
+Run the imported Fleet export by assistant id:
 
 ```bash
 uv run deepagents-talon run-fleet --assistant-id fleet-local
 ```
 
 Use `uv run deepagents-talon run-fleet --assistant-id fleet-local --once` as a
-local startup check before leaving the host running. `run-fleet` activates the
-imported channel without requiring `DEEPAGENTS_TALON_<CHANNEL>_ENABLED`. Existing
-channel flags such as `--whatsapp` and `--telegram` can still be passed to attach
-additional adapters for the same run.
+local startup check before leaving the host running. `run-fleet` uses the same
+channel configuration as normal Talon startup: set
+`DEEPAGENTS_TALON_TELEGRAM_ENABLED=true`, set
+`DEEPAGENTS_TALON_WHATSAPP_ENABLED=true`, or pass `--telegram` / `--whatsapp` to
+attach those adapters for the run.
 
 For Telegram, provide the Bot API token and an exposure policy:
 

--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -12,7 +12,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from deepagents_talon.channels.telegram import TelegramChannel, TelegramChannelConfig
 from deepagents_talon.channels.whatsapp import WhatsAppChannel, WhatsAppChannelConfig
@@ -22,7 +22,6 @@ from deepagents_talon.data_lifecycle import cleanup_sensitive_state
 from deepagents_talon.fleet import FleetAgentComponents, load_fleet_agent_components
 from deepagents_talon.host import TalonHost
 from deepagents_talon.import_fleet import (
-    ChannelName,
     FleetImportError,
     FleetImportSummary,
     FleetRunManifest,
@@ -90,7 +89,6 @@ def main() -> None:
         once=args.once,
         whatsapp=args.whatsapp,
         telegram=args.telegram,
-        selected_channel=None,
     )
 
 
@@ -100,19 +98,13 @@ def _run_host(
     once: bool,
     whatsapp: bool,
     telegram: bool,
-    selected_channel: ChannelName | None,
 ) -> None:
     cron_factory = CronJobStore
     cron_store = cron_factory(assistant_id=config.assistant_id, cron_dir=config.cron_dir)
     config.ensure_home()
     cleanup_sensitive_state(config=config, cron_store=cron_store)
 
-    channels = _channels(
-        config,
-        whatsapp=whatsapp,
-        telegram=telegram,
-        selected_channel=selected_channel,
-    )
+    channels = _channels(config, whatsapp=whatsapp, telegram=telegram)
     host = TalonHost(
         config=config,
         agent=asyncio.run(_agent_runtime(config, cron_store)),
@@ -156,15 +148,9 @@ def _add_import_fleet_parser(
     parser.add_argument("fleet_dir", type=Path, help="Unzipped Fleet export directory")
     parser.add_argument("--assistant-id", required=True, help="Assistant id for Talon local state")
     parser.add_argument(
-        "--channel",
-        choices=("telegram", "whatsapp"),
-        default=None,
-        help="Channel provider Talon will run for this Fleet export",
-    )
-    parser.add_argument(
         "--non-interactive",
         action="store_true",
-        help="Accepted for compatibility; import-fleet requires --channel.",
+        help=argparse.SUPPRESS,
     )
 
 
@@ -316,14 +302,9 @@ async def _run_mcp_command(args: argparse.Namespace, config: TalonConfig) -> int
 
 def _run_import_fleet_command(args: argparse.Namespace) -> int:
     try:
-        channel = _resolve_import_channel(
-            args.channel,
-            non_interactive=args.non_interactive,
-        )
         summary = import_fleet_manifest(
             args.fleet_dir,
             assistant_id=args.assistant_id,
-            channel=channel,
         )
     except (FleetImportError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)  # noqa: T201
@@ -344,7 +325,6 @@ def _run_fleet_command(args: argparse.Namespace) -> int:
         logger,
         "fleet.run_startup",
         assistant_id=manifest.assistant_id,
-        channel=manifest.channel,
         fleet_dir=str(manifest.fleet_dir),
         replacement_tool_count=manifest.replacement_tool_count,
     )
@@ -353,7 +333,6 @@ def _run_fleet_command(args: argparse.Namespace) -> int:
         once=args.once,
         whatsapp=args.whatsapp,
         telegram=args.telegram,
-        selected_channel=manifest.channel,
     )
     return 0
 
@@ -382,22 +361,8 @@ async def _run_mcp_login(args: argparse.Namespace) -> int:
     return await run_mcp_login(server=args.server, config_path=args.config_path)
 
 
-def _resolve_import_channel(
-    channel: str | None,
-    *,
-    non_interactive: bool,
-) -> ChannelName:
-    del non_interactive
-    if channel in {"telegram", "whatsapp"}:
-        return cast("ChannelName", channel)
-
-    msg = "--channel is required for Fleet imports"
-    raise FleetImportError(msg)
-
-
 def _print_import_summary(summary: FleetImportSummary) -> None:
     print("Imported Fleet export for Talon.")  # noqa: T201
-    print(f"  channel: {summary.channel}")  # noqa: T201
     print(f"  fleet_dir: {summary.fleet_dir}")  # noqa: T201
     print(f"  assistant_id: {summary.assistant_id}")  # noqa: T201
     print(f"  replacement_tools: {summary.replacement_tool_count}")  # noqa: T201
@@ -416,14 +381,10 @@ def _channels(
     *,
     whatsapp: bool = False,
     telegram: bool = False,
-    selected_channel: ChannelName | None = None,
 ) -> tuple[ChannelAdapter, ...]:
     channels: list[ChannelAdapter] = []
     whatsapp_selected = whatsapp or _env_enabled(config.env, "DEEPAGENTS_TALON_WHATSAPP_ENABLED")
     telegram_selected = telegram or _env_enabled(config.env, "DEEPAGENTS_TALON_TELEGRAM_ENABLED")
-    if not whatsapp_selected and not telegram_selected:
-        whatsapp_selected = selected_channel == "whatsapp"
-        telegram_selected = selected_channel == "telegram"
 
     if whatsapp_selected:
         channels.append(WhatsAppChannel(WhatsAppChannelConfig.from_talon_config(config)))

--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -164,7 +164,7 @@ def _add_import_fleet_parser(
     parser.add_argument(
         "--non-interactive",
         action="store_true",
-        help="Fail instead of prompting when channel selection is missing",
+        help="Accepted for compatibility; import-fleet requires --channel.",
     )
 
 
@@ -387,36 +387,12 @@ def _resolve_import_channel(
     *,
     non_interactive: bool,
 ) -> ChannelName:
+    del non_interactive
     if channel in {"telegram", "whatsapp"}:
         return cast("ChannelName", channel)
 
-    env_channel = _import_channel_from_env(os.environ)
-    if env_channel is not None:
-        return env_channel
-
-    if non_interactive:
-        msg = "--channel is required when channel cannot be inferred in non-interactive mode"
-        raise FleetImportError(msg)
-    if not sys.stdin.isatty():
-        msg = "--channel is required when stdin is not interactive"
-        raise FleetImportError(msg)
-
-    while True:
-        value = input("Channel [telegram/whatsapp]: ").strip().lower()
-        if value in {"telegram", "whatsapp"}:
-            return cast("ChannelName", value)
-        print("Enter 'telegram' or 'whatsapp'.", file=sys.stderr)  # noqa: T201
-
-
-def _import_channel_from_env(env: Mapping[str, str]) -> ChannelName | None:
-    enabled: list[ChannelName] = []
-    if _env_enabled(env, "DEEPAGENTS_TALON_TELEGRAM_ENABLED"):
-        enabled.append("telegram")
-    if _env_enabled(env, "DEEPAGENTS_TALON_WHATSAPP_ENABLED"):
-        enabled.append("whatsapp")
-    if len(enabled) == 1:
-        return enabled[0]
-    return None
+    msg = "--channel is required for Fleet imports"
+    raise FleetImportError(msg)
 
 
 def _print_import_summary(summary: FleetImportSummary) -> None:
@@ -443,17 +419,15 @@ def _channels(
     selected_channel: ChannelName | None = None,
 ) -> tuple[ChannelAdapter, ...]:
     channels: list[ChannelAdapter] = []
-    if (
-        whatsapp
-        or selected_channel == "whatsapp"
-        or _env_enabled(config.env, "DEEPAGENTS_TALON_WHATSAPP_ENABLED")
-    ):
+    whatsapp_selected = whatsapp or _env_enabled(config.env, "DEEPAGENTS_TALON_WHATSAPP_ENABLED")
+    telegram_selected = telegram or _env_enabled(config.env, "DEEPAGENTS_TALON_TELEGRAM_ENABLED")
+    if not whatsapp_selected and not telegram_selected:
+        whatsapp_selected = selected_channel == "whatsapp"
+        telegram_selected = selected_channel == "telegram"
+
+    if whatsapp_selected:
         channels.append(WhatsAppChannel(WhatsAppChannelConfig.from_talon_config(config)))
-    if (
-        telegram
-        or selected_channel == "telegram"
-        or _env_enabled(config.env, "DEEPAGENTS_TALON_TELEGRAM_ENABLED")
-    ):
+    if telegram_selected:
         channels.append(TelegramChannel(TelegramChannelConfig.from_talon_config(config)))
     return tuple(channels)
 

--- a/libs/talon/deepagents_talon/import_fleet.py
+++ b/libs/talon/deepagents_talon/import_fleet.py
@@ -15,8 +15,6 @@ from urllib.parse import urlsplit, urlunsplit
 
 from deepagents_talon.config import TalonConfig
 
-ChannelName = Literal["telegram", "whatsapp"]
-
 
 class FleetImportError(ValueError):
     """Raised when a Fleet export cannot be imported."""
@@ -61,7 +59,6 @@ class FleetImportSummary:
     """Result of importing a Fleet export into an assistant manifest.
 
     Args:
-        channel: Selected channel provider.
         fleet_dir: Validated Fleet export directory.
         assistant_id: Assistant id used to namespace Talon state.
         replacement_tool_count: Number of Fleet-requested tools requiring local replacement.
@@ -71,7 +68,6 @@ class FleetImportSummary:
         model_source: Whether the runtime model comes from Fleet or local env override.
     """
 
-    channel: ChannelName
     fleet_dir: Path
     assistant_id: str
     replacement_tool_count: int
@@ -86,14 +82,12 @@ class FleetRunManifest:
     """Assistant-scoped Fleet run intent persisted by `import-fleet`.
 
     Args:
-        channel: Selected channel provider to activate when running the manifest.
         fleet_dir: Validated Fleet export directory.
         assistant_id: Assistant id used to namespace Talon state.
         manifest_path: Manifest file that supplied the run intent.
         replacement_tool_count: Number of Fleet-requested tools requiring local replacement.
     """
 
-    channel: ChannelName
     fleet_dir: Path
     assistant_id: str
     manifest_path: Path
@@ -107,7 +101,6 @@ class _FleetManifestContext:
     target: Path
     fleet_dir: Path
     assistant_id: str
-    channel: ChannelName
     model: str
     model_source: Literal["fleet_config", "local_override"]
 
@@ -116,7 +109,6 @@ def import_fleet_manifest(
     fleet_dir: Path,
     *,
     assistant_id: str,
-    channel: ChannelName,
     env: Mapping[str, str] | None = None,
 ) -> FleetImportSummary:
     """Write or refresh an assistant-scoped Fleet run manifest.
@@ -124,7 +116,6 @@ def import_fleet_manifest(
     Args:
         fleet_dir: Operator-unzipped Fleet export directory.
         assistant_id: Talon assistant id whose home receives the manifest.
-        channel: Selected channel provider.
         env: Environment mapping used to match runtime configuration.
 
     Returns:
@@ -155,7 +146,6 @@ def import_fleet_manifest(
             target=target,
             fleet_dir=source,
             assistant_id=config.assistant_id,
-            channel=channel,
             model=model,
             model_source=model_source,
         ),
@@ -166,7 +156,6 @@ def import_fleet_manifest(
     target.chmod(0o600)
 
     return FleetImportSummary(
-        channel=channel,
         fleet_dir=source,
         assistant_id=config.assistant_id,
         replacement_tool_count=len(replacements),
@@ -224,11 +213,6 @@ def load_fleet_run_manifest(
         )
         raise FleetImportError(msg)
 
-    channel = manifest.get("channel")
-    if channel not in {"telegram", "whatsapp"}:
-        msg = "Malformed Fleet run manifest: channel must be telegram or whatsapp"
-        raise FleetImportError(msg)
-
     fleet_dir = manifest.get("fleet_dir")
     if not isinstance(fleet_dir, str) or not fleet_dir:
         msg = "Malformed Fleet run manifest: fleet_dir is required"
@@ -240,7 +224,6 @@ def load_fleet_run_manifest(
         raise FleetImportError(msg)
 
     return FleetRunManifest(
-        channel=cast("ChannelName", channel),
         fleet_dir=_validate_fleet_dir(Path(fleet_dir)),
         assistant_id=config.assistant_id,
         manifest_path=path,
@@ -419,7 +402,6 @@ def _manifest_payload(
             "source": "fleet",
             "fleet_dir": str(context.fleet_dir),
             "assistant_id": context.assistant_id,
-            "channel": context.channel,
             "model": context.model,
             "model_source": context.model_source,
             "replacement_tools": [asdict(tool) for tool in replacements],

--- a/libs/talon/tests/integration_tests/test_telegram_host.py
+++ b/libs/talon/tests/integration_tests/test_telegram_host.py
@@ -72,6 +72,28 @@ def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
         ({}, False, False, None, ()),
         (
             {
+                "DEEPAGENTS_TALON_TELEGRAM_ENABLED": "1",
+                "DEEPAGENTS_TALON_TELEGRAM_BOT_TOKEN": "test-token",
+                "DEEPAGENTS_TALON_TELEGRAM_OPERATOR_ID": "999",
+            },
+            False,
+            False,
+            "whatsapp",
+            (TelegramChannel,),
+        ),
+        (
+            {
+                "DEEPAGENTS_TALON_WHATSAPP_ENABLED": "1",
+                "DEEPAGENTS_TALON_TELEGRAM_BOT_TOKEN": "test-token",
+                "DEEPAGENTS_TALON_TELEGRAM_OPERATOR_ID": "999",
+            },
+            False,
+            True,
+            "whatsapp",
+            (WhatsAppChannel, TelegramChannel),
+        ),
+        (
+            {
                 "DEEPAGENTS_TALON_TELEGRAM_BOT_TOKEN": "test-token",
                 "DEEPAGENTS_TALON_TELEGRAM_OPERATOR_ID": "999",
             },

--- a/libs/talon/tests/integration_tests/test_telegram_host.py
+++ b/libs/talon/tests/integration_tests/test_telegram_host.py
@@ -36,7 +36,7 @@ class EchoAgent:
 
 def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
     cases: tuple[
-        tuple[dict[str, str], bool, bool, str | None, tuple[type[object], ...]],
+        tuple[dict[str, str], bool, bool, tuple[type[object], ...]],
         ...,
     ] = (
         (
@@ -48,7 +48,6 @@ def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
             },
             False,
             False,
-            None,
             (WhatsAppChannel, TelegramChannel),
         ),
         (
@@ -59,28 +58,15 @@ def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
             },
             False,
             False,
-            None,
             (TelegramChannel,),
         ),
         (
             {"DEEPAGENTS_TALON_WHATSAPP_ENABLED": "1"},
             False,
             False,
-            None,
             (WhatsAppChannel,),
         ),
-        ({}, False, False, None, ()),
-        (
-            {
-                "DEEPAGENTS_TALON_TELEGRAM_ENABLED": "1",
-                "DEEPAGENTS_TALON_TELEGRAM_BOT_TOKEN": "test-token",
-                "DEEPAGENTS_TALON_TELEGRAM_OPERATOR_ID": "999",
-            },
-            False,
-            False,
-            "whatsapp",
-            (TelegramChannel,),
-        ),
+        ({}, False, False, ()),
         (
             {
                 "DEEPAGENTS_TALON_WHATSAPP_ENABLED": "1",
@@ -89,7 +75,6 @@ def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
             },
             False,
             True,
-            "whatsapp",
             (WhatsAppChannel, TelegramChannel),
         ),
         (
@@ -97,25 +82,13 @@ def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
                 "DEEPAGENTS_TALON_TELEGRAM_BOT_TOKEN": "test-token",
                 "DEEPAGENTS_TALON_TELEGRAM_OPERATOR_ID": "999",
             },
-            False,
-            False,
-            "telegram",
-            (TelegramChannel,),
-        ),
-        ({}, False, False, "whatsapp", (WhatsAppChannel,)),
-        (
-            {
-                "DEEPAGENTS_TALON_TELEGRAM_BOT_TOKEN": "test-token",
-                "DEEPAGENTS_TALON_TELEGRAM_OPERATOR_ID": "999",
-            },
             True,
             True,
-            None,
             (WhatsAppChannel, TelegramChannel),
         ),
     )
 
-    for env, whatsapp, telegram, selected_channel, expected_types in cases:
+    for env, whatsapp, telegram, expected_types in cases:
         config = TalonConfig.from_env(
             {"AGENT_ASSISTANT_ID": "assistant", **env},
             base_home=tmp_path,
@@ -125,7 +98,6 @@ def test_channels_factory_selects_configured_channels(tmp_path: Path) -> None:
             config,
             whatsapp=whatsapp,
             telegram=telegram,
-            selected_channel=selected_channel,
         )
 
         assert tuple(type(channel) for channel in channels) == expected_types

--- a/libs/talon/tests/test_fleet_direct_run.py
+++ b/libs/talon/tests/test_fleet_direct_run.py
@@ -87,8 +87,6 @@ def _import_fleet_through_cli(
             str(context.fleet),
             "--assistant-id",
             context.assistant_id,
-            "--channel",
-            context.channel,
             "--non-interactive",
         ],
     )
@@ -113,12 +111,11 @@ def _assert_import_result(
 ) -> None:
     del manifest_text
     assert summary.startswith("Imported Fleet export for Talon.")
-    assert f"channel: {context.channel}" in summary
     assert f"assistant_id: {context.assistant_id}" in summary
     assert "replacement_tools: 4" in summary
     assert "setup_tasks: 3" in summary
     assert payload["source"] == "fleet"
-    assert payload["channel"] == context.channel
+    assert "channel" not in payload
     assert payload["assistant_id"] == context.assistant_id
     assert payload["fleet_dir"] == str(context.fleet.resolve())
     assert payload["model"] == "fleet:model"
@@ -211,8 +208,6 @@ def _run_once_startup_path(
     monkeypatch.setattr(talon_main, "DeepAgentRuntime", RecordingRuntime)
     monkeypatch.setattr(talon_main, "TelegramChannel", RecordingTelegramChannel)
     monkeypatch.setattr(talon_main, "WhatsAppChannel", RecordingWhatsAppChannel)
-    monkeypatch.delenv("DEEPAGENTS_TALON_TELEGRAM_ENABLED", raising=False)
-    monkeypatch.delenv("DEEPAGENTS_TALON_WHATSAPP_ENABLED", raising=False)
     monkeypatch.setattr(
         sys,
         "argv",

--- a/libs/talon/tests/test_import_fleet.py
+++ b/libs/talon/tests/test_import_fleet.py
@@ -22,11 +22,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-class InteractiveStdin:
-    def isatty(self) -> bool:
-        return True
-
-
 def test_import_fleet_manifest_writes_and_refreshes_assistant_manifest(tmp_path: Path) -> None:
     fleet = _fleet_export(tmp_path)
     home = tmp_path / "home"
@@ -144,13 +139,13 @@ def test_import_fleet_manifest_fails_on_malformed_required_config(tmp_path: Path
         )
 
 
-def test_import_fleet_command_fails_without_channel_in_non_interactive_mode(
+def test_import_fleet_command_fails_without_channel(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fleet = _fleet_export(tmp_path)
-    monkeypatch.delenv("DEEPAGENTS_TALON_TELEGRAM_ENABLED", raising=False)
+    monkeypatch.setenv("DEEPAGENTS_TALON_TELEGRAM_ENABLED", "true")
     monkeypatch.delenv("DEEPAGENTS_TALON_WHATSAPP_ENABLED", raising=False)
 
     code = _run_import_fleet_command(
@@ -166,16 +161,9 @@ def test_import_fleet_command_fails_without_channel_in_non_interactive_mode(
     assert "--channel is required" in capsys.readouterr().err
 
 
-def test_resolve_import_channel_prompts_when_interactive(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("DEEPAGENTS_TALON_TELEGRAM_ENABLED", raising=False)
-    monkeypatch.delenv("DEEPAGENTS_TALON_WHATSAPP_ENABLED", raising=False)
-    monkeypatch.setattr("sys.stdin", InteractiveStdin())
-    answers = iter(["bad", "whatsapp"])
-    monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
-
-    assert _resolve_import_channel(None, non_interactive=False) == "whatsapp"
+def test_resolve_import_channel_requires_explicit_channel() -> None:
+    with pytest.raises(FleetImportError, match="--channel is required"):
+        _resolve_import_channel(None, non_interactive=False)
 
 
 def test_import_fleet_command_prints_secret_free_summary(

--- a/libs/talon/tests/test_import_fleet.py
+++ b/libs/talon/tests/test_import_fleet.py
@@ -8,7 +8,6 @@ import pytest
 
 from deepagents_talon.__main__ import (
     _config_from_fleet_run_manifest,
-    _resolve_import_channel,
     _run_fleet_command,
     _run_import_fleet_command,
 )
@@ -45,13 +44,11 @@ def test_import_fleet_manifest_writes_and_refreshes_assistant_manifest(tmp_path:
     summary = import_fleet_manifest(
         fleet,
         assistant_id="agent-1",
-        channel="telegram",
         env={"DEEPAGENTS_TALON_HOME": str(home), "AGENT_MODEL": "override:model"},
     )
     import_fleet_manifest(
         fleet,
         assistant_id="agent-1",
-        channel="telegram",
         env={"DEEPAGENTS_TALON_HOME": str(home), "AGENT_MODEL": "override:model"},
     )
 
@@ -68,7 +65,7 @@ def test_import_fleet_manifest_writes_and_refreshes_assistant_manifest(tmp_path:
         },
     }
     assert payload["assistant_id"] == "agent-1"
-    assert payload["channel"] == "telegram"
+    assert "channel" not in payload
     assert payload["fleet_dir"] == str(fleet.resolve())
     assert payload["model"] == "override:model"
     assert payload["model_source"] == "local_override"
@@ -83,7 +80,6 @@ def test_import_fleet_manifest_records_builtin_mcp_as_resolved(tmp_path: Path) -
     summary = import_fleet_manifest(
         fleet,
         assistant_id="agent-1",
-        channel="telegram",
         env={
             "DEEPAGENTS_TALON_HOME": str(tmp_path / "home"),
             "BUILTIN_MCP_URL": "https://builtin.example/mcp?api_key=local-secret",
@@ -115,7 +111,6 @@ def test_import_fleet_manifest_reads_nested_fleet_model_config(tmp_path: Path) -
     summary = import_fleet_manifest(
         fleet,
         assistant_id="agent-1",
-        channel="whatsapp",
         env={"DEEPAGENTS_TALON_HOME": str(tmp_path / "home")},
     )
 
@@ -134,36 +129,8 @@ def test_import_fleet_manifest_fails_on_malformed_required_config(tmp_path: Path
         import_fleet_manifest(
             fleet,
             assistant_id="agent-1",
-            channel="telegram",
             env={"DEEPAGENTS_TALON_HOME": str(tmp_path / "home")},
         )
-
-
-def test_import_fleet_command_fails_without_channel(
-    tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    fleet = _fleet_export(tmp_path)
-    monkeypatch.setenv("DEEPAGENTS_TALON_TELEGRAM_ENABLED", "true")
-    monkeypatch.delenv("DEEPAGENTS_TALON_WHATSAPP_ENABLED", raising=False)
-
-    code = _run_import_fleet_command(
-        Namespace(
-            fleet_dir=fleet,
-            assistant_id="agent-1",
-            channel=None,
-            non_interactive=True,
-        )
-    )
-
-    assert code == 2
-    assert "--channel is required" in capsys.readouterr().err
-
-
-def test_resolve_import_channel_requires_explicit_channel() -> None:
-    with pytest.raises(FleetImportError, match="--channel is required"):
-        _resolve_import_channel(None, non_interactive=False)
 
 
 def test_import_fleet_command_prints_secret_free_summary(
@@ -178,14 +145,12 @@ def test_import_fleet_command_prints_secret_free_summary(
         Namespace(
             fleet_dir=fleet,
             assistant_id="agent-1",
-            channel="telegram",
             non_interactive=True,
         )
     )
 
     output = capsys.readouterr().out
     assert code == 0
-    assert "channel: telegram" in output
     assert "assistant_id: agent-1" in output
     assert "replacement_tools: 4" in output
     assert "setup_tasks: 3" in output
@@ -212,7 +177,6 @@ def test_load_fleet_run_manifest_fails_when_fleet_dir_is_stale(tmp_path: Path) -
                 "manifest": {
                     "source": "fleet",
                     "assistant_id": "agent-1",
-                    "channel": "telegram",
                     "fleet_dir": str(tmp_path / "missing-fleet"),
                     "replacement_tools": [],
                 }
@@ -238,7 +202,6 @@ def test_run_fleet_command_starts_selected_telegram_manifest(
     import_fleet_manifest(
         fleet,
         assistant_id="agent-1",
-        channel="telegram",
         env={"DEEPAGENTS_TALON_HOME": str(home)},
     )
     monkeypatch.setenv("DEEPAGENTS_TALON_HOME", str(home))
@@ -255,20 +218,18 @@ def test_run_fleet_command_starts_selected_telegram_manifest(
 
     config = captured["config"]
     assert code == 0
-    assert captured["selected_channel"] == "telegram"
     assert captured["whatsapp"] is False
     assert captured["telegram"] is False
     assert config.assistant_id == "agent-1"
     assert config.fleet_dir == fleet.resolve()
     event = _talon_events(caplog, event="fleet.run_startup")[0]
     assert event["assistant_id"] == "agent-1"
-    assert event["channel"] == "telegram"
     assert event["fleet_dir"] == str(fleet.resolve())
     assert event["replacement_tool_count"] == 4
     assert "raw-secret" not in caplog.text
 
 
-def test_run_fleet_command_starts_selected_whatsapp_manifest(
+def test_run_fleet_command_passes_runtime_channel_flags(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -277,7 +238,6 @@ def test_run_fleet_command_starts_selected_whatsapp_manifest(
     import_fleet_manifest(
         fleet,
         assistant_id="agent-1",
-        channel="whatsapp",
         env={"DEEPAGENTS_TALON_HOME": str(home)},
     )
     monkeypatch.setenv("DEEPAGENTS_TALON_HOME", str(home))
@@ -292,7 +252,6 @@ def test_run_fleet_command_starts_selected_whatsapp_manifest(
     code = _run_fleet_command(_run_fleet_args("agent-1", telegram=True))
 
     assert code == 0
-    assert captured["selected_channel"] == "whatsapp"
     assert captured["telegram"] is True
 
 
@@ -305,7 +264,6 @@ def test_run_fleet_config_keeps_environment_model_override(
     import_fleet_manifest(
         fleet,
         assistant_id="agent-1",
-        channel="telegram",
         env={"DEEPAGENTS_TALON_HOME": str(home)},
     )
     manifest = load_fleet_run_manifest(
@@ -332,7 +290,6 @@ def test_run_fleet_command_passes_once_to_host(
     import_fleet_manifest(
         fleet,
         assistant_id="agent-1",
-        channel="telegram",
         env={"DEEPAGENTS_TALON_HOME": str(home)},
     )
     monkeypatch.setenv("DEEPAGENTS_TALON_HOME", str(home))


### PR DESCRIPTION
Draft replacement for #4444. Leaves #4444 open while we settle the policy.

Fleet import no longer selects, infers, prompts for, persists, or prints a channel. It only records the Fleet export and local MCP setup information for the assistant.

Fleet runs now attach channels the same way normal Talon startup does: current `DEEPAGENTS_TALON_TELEGRAM_ENABLED`, `DEEPAGENTS_TALON_WHATSAPP_ENABLED`, `--telegram`, and `--whatsapp` determine which adapters run. Imported Fleet config does not override Talon runtime channel configuration.

## Release note

Fleet-backed Talon runs now use the normal Talon channel configuration instead of an imported Fleet channel selection.

Tests: `uv run --frozen --group test pytest tests/test_import_fleet.py tests/test_fleet_direct_run.py tests/integration_tests/test_telegram_host.py`; `uv run --frozen ruff check libs/talon/deepagents_talon/__main__.py libs/talon/deepagents_talon/import_fleet.py libs/talon/tests/test_import_fleet.py libs/talon/tests/test_fleet_direct_run.py libs/talon/tests/integration_tests/test_telegram_host.py`