### PR TITLE
feat(talon): add Fleet zip import command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,7 +143,6 @@ celerybeat.pid
 env.local
 *.env.local
 .venv
-.venv/
 env/
 venv/
 ENV/

--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ celerybeat.pid
 env.local
 *.env.local
 .venv
+.venv/
 env/
 venv/
 ENV/

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -131,6 +131,75 @@ Talon loads MCP servers from one config file. It checks `DEEPAGENTS_TALON_MCP_CO
 
 Run `deepagents-talon mcp config` to print the resolved config paths, and `deepagents-talon mcp login <server>` for OAuth-backed servers.
 
+Fleet zip exports can be materialized into a Talon-local agent directory before
+starting the host:
+
+```bash
+deepagents-talon import-fleet <fleet-export.zip> [--assistant-id <id>] [--target-dir <dir>]
+```
+
+From the repository root:
+
+```bash
+uv run --directory libs/talon deepagents-talon import-fleet ./fleet-export.zip \
+  --assistant-id local
+```
+
+By default, `import-fleet` writes into the selected assistant manifest directory:
+`~/.deepagents/<assistant_id>/agent/`. The selected assistant id comes from
+`DEEPAGENTS_TALON_ASSISTANT_ID`, `AGENT_ASSISTANT_ID`, or `default`; pass
+`--assistant-id <id>` to select a different assistant for the import, or
+`--target-dir <dir>` to write to an explicit directory.
+
+The importer writes Fleet prompts, skills, and subagent prompts. Fleet
+`tools.json` is read only as import input and is not copied into the Talon agent
+directory. Fleet `config.json` is ignored. Talon does not support the old Fleet
+direct-run startup path or its environment variables; import the zip first, then
+run Talon against the materialized local assistant.
+
+When Fleet MCP tools are present, the importer writes `.mcp.json.setup`. This is
+a human-readable setup handoff for the operator, not a runtime config file. Use
+the suggested fragments and your own credentials to create or edit `.mcp.json`,
+which remains the runtime MCP config loaded by Talon:
+
+```json
+{
+  "mcpServers": {
+    "fleet-tools": {
+      "type": "http",
+      "url": "https://tools.example.com/mcp",
+      "auth": "oauth",
+      "allowedTools": ["github_get_file", "github_create_pull_request"]
+    }
+  }
+}
+```
+
+For non-OAuth servers, keep credentials in environment variables or another
+local secret source rather than in committed files:
+
+```json
+{
+  "mcpServers": {
+    "internal-tools": {
+      "command": "internal-mcp-server",
+      "args": ["--token-env", "INTERNAL_MCP_TOKEN"]
+    }
+  }
+}
+```
+
+If the Fleet export contains interrupt-enabled tools, the import summary prints
+the recommended `DEEPAGENTS_TALON_INTERRUPT_ON_TOOLS` value. Set that value when
+starting Talon so those tools continue to require channel approval:
+
+```bash
+DEEPAGENTS_TALON_INTERRUPT_ON_TOOLS=github_create_pull_request,github_update_file \
+AGENT_ASSISTANT_ID=local \
+AGENT_MODEL=<provider>:<model-id> \
+deepagents-talon --telegram
+```
+
 ## Cron Observability
 
 Cron jobs are persisted in `cron/jobs.json` under the assistant state directory. Scheduler lifecycle events are emitted through the standard Python logger as `talon_event` JSON records:

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -146,10 +146,11 @@ uv run --directory libs/talon deepagents-talon import-fleet ./fleet-export.zip \
 ```
 
 By default, `import-fleet` writes into the selected assistant manifest directory:
-`~/.deepagents/<assistant_id>/agent/`. The selected assistant id comes from
+`~/.deepagents/<assistant_id>/agent/`, with subagent prompts in
+`~/.deepagents/<assistant_id>/agents/`. The selected assistant id comes from
 `DEEPAGENTS_TALON_ASSISTANT_ID`, `AGENT_ASSISTANT_ID`, or `default`; pass
 `--assistant-id <id>` to select a different assistant for the import, or
-`--target-dir <dir>` to write to an explicit directory.
+`--target-dir <dir>` to write all imported files under an explicit directory.
 
 The importer writes Fleet prompts, skills, and subagent prompts. Fleet
 `tools.json` is read only as import input and is not copied into the Talon agent

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -157,10 +157,10 @@ directory. Fleet `config.json` is ignored. Talon does not support the old Fleet
 direct-run startup path or its environment variables; import the zip first, then
 run Talon against the materialized local assistant.
 
-When Fleet MCP tools are present, the importer writes `.mcp.json.setup`. This is
-a human-readable setup handoff for the operator, not a runtime config file. Use
-the suggested fragments and your own credentials to create or edit `.mcp.json`,
-which remains the runtime MCP config loaded by Talon:
+When Fleet MCP tools are present, the importer writes `.mcp.json` in the target
+agent directory. This is the runtime MCP config loaded by Talon and contains the
+sanitized OAuth server entries from the Fleet export. The importer also writes
+`.mcp.json.setup` as a human-readable setup handoff for the operator:
 
 ```json
 {
@@ -175,8 +175,8 @@ which remains the runtime MCP config loaded by Talon:
 }
 ```
 
-For non-OAuth servers, keep credentials in environment variables or another
-local secret source rather than in committed files:
+For non-OAuth servers or local edits, keep credentials in environment variables
+or another local secret source rather than in committed files:
 
 ```json
 {

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -29,6 +29,10 @@ If `AGENT_MODEL` is unset, Talon starts with the echo runtime. This is useful fo
 
 Assistant state lives under `~/.deepagents/<assistant_id>/` by default. The host creates restrictive state directories for the materialized agent manifest, channel sessions, and cron jobs. The default local execution workspace is the current working directory; set `DEEPAGENTS_TALON_WORKSPACE` to use a different directory. The per-invocation graph recursion limit defaults to `500`; set `DEEPAGENTS_TALON_RECURSION_LIMIT` to tune it.
 
+## Fleet Exports
+
+The direct Fleet export runtime path (`DEEPAGENTS_TALON_FLEET_DIR`, `AGENT_FLEET_DIR`, `FLEET_DIR`, and the `fleet-deepagents-export` dependency) has been removed. To import a Fleet export into the local materialized-agent layout, use the Fleet zip import flow (`deepagents-talon import-fleet`) instead. Configuration is owned entirely by the local assistant manifest directory and `.mcp.json` MCP discovery.
+
 ## Tool Approval Overrides
 
 Set `DEEPAGENTS_TALON_INTERRUPT_ON_TOOLS` to a comma-separated list of tool names that should always require Talon's channel approval flow. This local override is additive with agent-provided HITL configuration and applies to MCP or local runtime tools.

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -146,7 +146,7 @@ uv run --directory libs/talon deepagents-talon import-fleet ./fleet-export.zip \
 ```
 
 By default, `import-fleet` writes into the selected assistant manifest directory:
-`~/.deepagents/<assistant_id>/agent/`, with subagent prompts in
+`~/.deepagents/<assistant_id>/`, with subagent prompts in
 `~/.deepagents/<assistant_id>/agents/`. The selected assistant id comes from
 `DEEPAGENTS_TALON_ASSISTANT_ID`, `AGENT_ASSISTANT_ID`, or `default`; pass
 `--assistant-id <id>` to select a different assistant for the import, or

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -29,10 +29,6 @@ If `AGENT_MODEL` is unset, Talon starts with the echo runtime. This is useful fo
 
 Assistant state lives under `~/.deepagents/<assistant_id>/` by default. The host creates restrictive state directories for the materialized agent manifest, channel sessions, and cron jobs. The default local execution workspace is the current working directory; set `DEEPAGENTS_TALON_WORKSPACE` to use a different directory. The per-invocation graph recursion limit defaults to `500`; set `DEEPAGENTS_TALON_RECURSION_LIMIT` to tune it.
 
-## Fleet Exports
-
-The direct Fleet export runtime path (`DEEPAGENTS_TALON_FLEET_DIR`, `AGENT_FLEET_DIR`, `FLEET_DIR`, and the `fleet-deepagents-export` dependency) has been removed. To import a Fleet export into the local materialized-agent layout, use the Fleet zip import flow (`deepagents-talon import-fleet`) instead. Configuration is owned entirely by the local assistant manifest directory and `.mcp.json` MCP discovery.
-
 ## Tool Approval Overrides
 
 Set `DEEPAGENTS_TALON_INTERRUPT_ON_TOOLS` to a comma-separated list of tool names that should always require Talon's channel approval flow. This local override is additive with agent-provided HITL configuration and applies to MCP or local runtime tools.

--- a/libs/talon/README.md
+++ b/libs/talon/README.md
@@ -148,9 +148,11 @@ uv run --directory libs/talon deepagents-talon import-fleet ./fleet-export.zip \
 By default, `import-fleet` writes into the selected assistant manifest directory:
 `~/.deepagents/<assistant_id>/`, with subagent prompts in
 `~/.deepagents/<assistant_id>/agents/`. The selected assistant id comes from
-`DEEPAGENTS_TALON_ASSISTANT_ID`, `AGENT_ASSISTANT_ID`, or `default`; pass
-`--assistant-id <id>` to select a different assistant for the import, or
-`--target-dir <dir>` to write all imported files under an explicit directory.
+`DEEPAGENTS_TALON_ASSISTANT_ID` or `AGENT_ASSISTANT_ID`; when neither is set,
+the importer uses the Fleet export filename stem. For example, `crowbar.zip`
+imports into `~/.deepagents/crowbar/`. Pass `--assistant-id <id>` to select a
+different assistant for the import, or `--target-dir <dir>` to write all
+imported files under an explicit directory.
 
 The importer writes Fleet prompts, skills, and subagent prompts. Fleet
 `tools.json` is read only as import input and is not copied into the Talon agent

--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -160,6 +160,14 @@ def _run_import_fleet_command(args: argparse.Namespace, config: TalonConfig) -> 
                 },
                 base_home=config.home.parent,
             )
+        elif not _has_configured_assistant_id(config.env):
+            target_config = TalonConfig.from_env(
+                {
+                    **config.env,
+                    "DEEPAGENTS_TALON_ASSISTANT_ID": args.fleet_export.stem,
+                },
+                base_home=config.home.parent,
+            )
         target_dir = target_config.manifest_dir
         assistant_home = target_config.home
 
@@ -174,6 +182,10 @@ def _run_import_fleet_command(args: argparse.Namespace, config: TalonConfig) -> 
         return 1
     print(format_import_stdout(result), end="")  # noqa: T201
     return 0
+
+
+def _has_configured_assistant_id(env: Mapping[str, str]) -> bool:
+    return "DEEPAGENTS_TALON_ASSISTANT_ID" in env or "AGENT_ASSISTANT_ID" in env
 
 
 async def _agent_runtime(

--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -112,8 +112,9 @@ def _add_import_fleet_parser(
         epilog=(
             "Usage: deepagents-talon import-fleet <fleet-export.zip> "
             "[--assistant-id <id>] [--target-dir <dir>]\n\n"
-            ".mcp.json.setup is a human-readable setup handoff for operators; "
-            ".mcp.json remains the runtime MCP config file. Fleet config.json is "
+            ".mcp.json is generated as the runtime MCP config file; "
+            ".mcp.json.setup is a human-readable setup handoff for operators. "
+            "Fleet config.json is "
             "ignored, Fleet tools.json is import input only, and old Fleet direct-run "
             "environment variables are unsupported. Use import-fleet before running "
             "the Talon host."

--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -11,6 +11,7 @@ import importlib
 import logging
 import os
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from deepagents_talon.channels.telegram import TelegramChannel, TelegramChannelConfig
@@ -18,6 +19,11 @@ from deepagents_talon.channels.whatsapp import WhatsAppChannel, WhatsAppChannelC
 from deepagents_talon.config import TalonConfig
 from deepagents_talon.cron import CronJobStore, PersistentCronScheduler
 from deepagents_talon.data_lifecycle import cleanup_sensitive_state
+from deepagents_talon.fleet_import import (
+    FleetImportError,
+    format_import_stdout,
+    import_fleet_zip,
+)
 from deepagents_talon.host import TalonHost
 from deepagents_talon.mcp import load_mcp_tools, print_mcp_config_paths
 from deepagents_talon.runtime import (
@@ -55,12 +61,15 @@ def main() -> None:
         help="Attach the Telegram channel adapter.",
     )
     subparsers = parser.add_subparsers(dest="command")
+    _add_import_fleet_parser(subparsers)
     _add_mcp_parsers(subparsers)
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
 
     config = TalonConfig.from_env()
+    if args.command == "import-fleet":
+        sys.exit(_run_import_fleet_command(args, config))
     if args.command == "mcp":
         sys.exit(asyncio.run(_run_mcp_command(args, config)))
 
@@ -90,6 +99,25 @@ def main() -> None:
     asyncio.run(host.run_until_stopped())
 
 
+def _add_import_fleet_parser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    importer = subparsers.add_parser(
+        "import-fleet",
+        help="Import a Fleet zip export into a Talon local agent directory",
+    )
+    importer.add_argument("fleet_export", type=Path, help="Fleet zip export to import")
+    importer.add_argument(
+        "--assistant-id",
+        help="Assistant id used for default target directory resolution",
+    )
+    importer.add_argument(
+        "--target-dir",
+        type=Path,
+        help="Directory to receive materialized Talon agent files",
+    )
+
+
 def _add_mcp_parsers(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
@@ -101,6 +129,29 @@ def _add_mcp_parsers(
     login = mcp_sub.add_parser("login", help="Run OAuth login for an MCP server")
     login.add_argument("server", help="Server name from mcpServers")
     login.add_argument("--mcp-config", dest="config_path", default=None)
+
+
+def _run_import_fleet_command(args: argparse.Namespace, config: TalonConfig) -> int:
+    target_dir = args.target_dir
+    if target_dir is None:
+        target_config = config
+        if args.assistant_id:
+            target_config = TalonConfig.from_env(
+                {
+                    **config.env,
+                    "DEEPAGENTS_TALON_ASSISTANT_ID": args.assistant_id,
+                },
+                base_home=config.home.parent,
+            )
+        target_dir = target_config.manifest_dir
+
+    try:
+        result = import_fleet_zip(args.fleet_export, target_dir=target_dir)
+    except FleetImportError as exc:
+        print(f"import-fleet: {exc}", file=sys.stderr)  # noqa: T201
+        return 1
+    print(format_import_stdout(result), end="")  # noqa: T201
+    return 0
 
 
 async def _agent_runtime(

--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -14,6 +14,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from deepagents_talon.async_subagents import load_async_subagents
 from deepagents_talon.channels.telegram import TelegramChannel, TelegramChannelConfig
 from deepagents_talon.channels.whatsapp import WhatsAppChannel, WhatsAppChannelConfig
 from deepagents_talon.config import TalonConfig
@@ -177,6 +178,7 @@ async def _agent_runtime(
     if config.model is None:
         return EchoAgentRuntime()
 
+    async_subagents = tuple(load_async_subagents())
     mcp = await load_mcp_tools(config)
     for server in mcp.servers:
         if server.error is not None:
@@ -187,6 +189,7 @@ async def _agent_runtime(
         model=config.model,
         tools=mcp.tools,
         assistant_dir=config.manifest_dir,
+        subagents=async_subagents or None,
         cron_store=cron_store,
         interrupt_on=interrupt_on_with_env_overlay(None, env),
         env=env,

--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -105,6 +105,20 @@ def _add_import_fleet_parser(
     importer = subparsers.add_parser(
         "import-fleet",
         help="Import a Fleet zip export into a Talon local agent directory",
+        description=(
+            "Import a Fleet zip export into a Talon local agent directory. By default, "
+            "the target directory is the selected assistant manifest directory."
+        ),
+        epilog=(
+            "Usage: deepagents-talon import-fleet <fleet-export.zip> "
+            "[--assistant-id <id>] [--target-dir <dir>]\n\n"
+            ".mcp.json.setup is a human-readable setup handoff for operators; "
+            ".mcp.json remains the runtime MCP config file. Fleet config.json is "
+            "ignored, Fleet tools.json is import input only, and old Fleet direct-run "
+            "environment variables are unsupported. Use import-fleet before running "
+            "the Talon host."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     importer.add_argument("fleet_export", type=Path, help="Fleet zip export to import")
     importer.add_argument(

--- a/libs/talon/deepagents_talon/__main__.py
+++ b/libs/talon/deepagents_talon/__main__.py
@@ -149,6 +149,7 @@ def _add_mcp_parsers(
 
 def _run_import_fleet_command(args: argparse.Namespace, config: TalonConfig) -> int:
     target_dir = args.target_dir
+    assistant_home = None
     if target_dir is None:
         target_config = config
         if args.assistant_id:
@@ -160,9 +161,14 @@ def _run_import_fleet_command(args: argparse.Namespace, config: TalonConfig) -> 
                 base_home=config.home.parent,
             )
         target_dir = target_config.manifest_dir
+        assistant_home = target_config.home
 
     try:
-        result = import_fleet_zip(args.fleet_export, target_dir=target_dir)
+        result = import_fleet_zip(
+            args.fleet_export,
+            target_dir=target_dir,
+            assistant_home=assistant_home,
+        )
     except FleetImportError as exc:
         print(f"import-fleet: {exc}", file=sys.stderr)  # noqa: T201
         return 1

--- a/libs/talon/deepagents_talon/async_subagents.py
+++ b/libs/talon/deepagents_talon/async_subagents.py
@@ -1,0 +1,94 @@
+"""Async subagent configuration loading for Talon.
+
+Talon is an experimental runtime and is subject to change or removal at any time.
+"""
+
+from __future__ import annotations
+
+import logging
+import tomllib
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from deepagents.middleware.async_subagents import AsyncSubAgent
+
+logger = logging.getLogger(__name__)
+
+
+def load_async_subagents(config_path: Path | None = None) -> list[AsyncSubAgent]:
+    """Load async subagent definitions from `config.toml`.
+
+    Reads the `[async_subagents]` section where each sub-table defines a remote
+    LangGraph deployment.
+
+    Args:
+        config_path: Path to config file. Defaults to `~/.deepagents/config.toml`.
+
+    Returns:
+        List of async subagent specs, or an empty list when absent or invalid.
+    """
+    if config_path is None:
+        config_path = Path.home() / ".deepagents" / "config.toml"
+
+    if not config_path.exists():
+        return []
+
+    try:
+        with config_path.open("rb") as file:
+            data = tomllib.load(file)
+    except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
+        logger.warning("Could not read async subagents from %s: %s", config_path, exc)
+        return []
+
+    section = data.get("async_subagents")
+    if not isinstance(section, dict):
+        return []
+
+    agents: list[AsyncSubAgent] = []
+    for name, spec in section.items():
+        agent = _parse_async_subagent(name, spec)
+        if agent is not None:
+            agents.append(agent)
+    return agents
+
+
+def _parse_async_subagent(name: object, spec: object) -> AsyncSubAgent | None:
+    if not isinstance(name, str):
+        logger.warning("Skipping async subagent with non-string name: %r", name)
+        return None
+    if not isinstance(spec, dict):
+        logger.warning("Skipping async subagent '%s': expected a table", name)
+        return None
+
+    data = cast("dict[str, object]", spec)
+    missing = {"description", "graph_id"} - data.keys()
+    if missing:
+        logger.warning("Skipping async subagent '%s': missing fields %s", name, missing)
+        return None
+
+    description = data["description"]
+    graph_id = data["graph_id"]
+    if not isinstance(description, str) or not isinstance(graph_id, str):
+        logger.warning(
+            "Skipping async subagent '%s': description and graph_id must be strings",
+            name,
+        )
+        return None
+
+    agent: AsyncSubAgent = {
+        "name": name,
+        "description": description,
+        "graph_id": graph_id,
+    }
+    url = data.get("url")
+    if isinstance(url, str):
+        agent["url"] = url
+    headers = data.get("headers")
+    if isinstance(headers, dict):
+        agent["headers"] = {
+            key: value
+            for key, value in headers.items()
+            if isinstance(key, str) and isinstance(value, str)
+        }
+    return agent

--- a/libs/talon/deepagents_talon/config.py
+++ b/libs/talon/deepagents_talon/config.py
@@ -72,9 +72,11 @@ class TalonConfig:
             raise TalonConfigError(msg)
         _validate_assistant_id(assistant_id)
 
-        root = Path(values.get("DEEPAGENTS_TALON_HOME", "")) if base_home is None else base_home
-        if not str(root):
-            root = Path.home() / ".deepagents"
+        if base_home is None:
+            configured_home = values.get("DEEPAGENTS_TALON_HOME")
+            root = Path(configured_home) if configured_home else Path.home() / ".deepagents"
+        else:
+            root = base_home
 
         model = _first_present(values, "DEEPAGENTS_TALON_MODEL", "AGENT_MODEL", default=None)
         return cls(

--- a/libs/talon/deepagents_talon/fleet_import.py
+++ b/libs/talon/deepagents_talon/fleet_import.py
@@ -185,7 +185,8 @@ def format_import_stdout(result: FleetImportResult) -> str:
         lines.append("- Review .mcp.json.setup for requested tools and setup details.")
     if result.interrupt_tools:
         lines.append(
-            f"- Add HITL for sensitive tools with {INTERRUPT_ON_TOOLS_ENV_KEY}.",
+            f"- Add HITL for sensitive tools with "
+            f"{INTERRUPT_ON_TOOLS_ENV_KEY}={','.join(result.interrupt_tools)}.",
         )
     return "\n".join(lines) + "\n"
 

--- a/libs/talon/deepagents_talon/fleet_import.py
+++ b/libs/talon/deepagents_talon/fleet_import.py
@@ -477,7 +477,7 @@ def _unique_server_id(server_id: str, servers: Mapping[str, object]) -> str:
 
 def _server_id(summary: _ServerSummary) -> str:
     raw = summary.server_name or urlsplit(summary.server_url).hostname or "server"
-    normalized = re.sub(r"[^A-Za-z0-9_.-]+", "-", raw.strip().lower()).strip("-")
+    normalized = re.sub(r"[^A-Za-z0-9_-]+", "-", raw.strip().lower()).strip("-")
     return normalized or "server"
 
 

--- a/libs/talon/deepagents_talon/fleet_import.py
+++ b/libs/talon/deepagents_talon/fleet_import.py
@@ -244,13 +244,13 @@ def _materialize_staging(
         elif _is_subagent_prompt_path(name):
             subagent = PurePosixPath(name).parts[1]
             _validate_agent_name(subagent, name)
-            _copy_zip_file(archive, info, staging / name)
+            _copy_zip_file(archive, info, staging / "agents" / subagent / "AGENTS.md")
         elif name in {"config.json", "tools.json"}:
             _copy_zip_file(archive, info, staging / name)
         elif _is_subagent_tools_path(name):
             subagent = PurePosixPath(name).parts[1]
             _validate_agent_name(subagent, name)
-            _copy_zip_file(archive, info, staging / name)
+            _copy_zip_file(archive, info, staging / "agents" / subagent / "tools.json")
 
 
 def _copy_zip_file(archive: zipfile.ZipFile, info: zipfile.ZipInfo, target: Path) -> None:
@@ -298,9 +298,9 @@ def _tools_json_paths(staging: Path) -> list[tuple[Path, str]]:
     root = staging / "tools.json"
     if root.is_file():
         paths.append((root, "root"))
-    subagents = staging / "subagents"
-    if subagents.is_dir():
-        for child in sorted(subagents.iterdir(), key=lambda item: item.name):
+    agents = staging / "agents"
+    if agents.is_dir():
+        for child in sorted(agents.iterdir(), key=lambda item: item.name):
             path = child / "tools.json"
             if path.is_file():
                 paths.append((path, child.name))
@@ -490,12 +490,14 @@ def _refresh_target(
     notes: str | None,
     mcp_config: str | None,
 ) -> None:
+    agent_home = target.parent
     target.mkdir(mode=0o700, parents=True, exist_ok=True)
     target.chmod(0o700)
     _replace_file(staging / "AGENTS.md", target / "AGENTS.md")
 
     _replace_tree(staging / "skills", target / "skills")
-    _replace_tree(staging / "subagents", target / "subagents")
+    _replace_tree(staging / "agents", agent_home / "agents")
+    _remove_path(target / "subagents")
 
     setup_path = target / _SETUP_FILENAME
     if notes is None:
@@ -532,16 +534,24 @@ def _replace_tree(source: Path, target: Path) -> None:
         shutil.copytree(source, target)
 
 
+def _remove_path(path: Path) -> None:
+    if path.is_dir():
+        shutil.rmtree(path)
+    elif path.exists():
+        path.unlink()
+
+
 def _subagent_prompt_paths(target: Path) -> list[Path]:
-    subagents = target / "subagents"
-    if not subagents.is_dir():
+    agents = target.parent / "agents"
+    if not agents.is_dir():
         return []
-    return sorted(path for path in subagents.glob("*/AGENTS.md") if path.is_file())
+    return sorted(path for path in agents.glob("*/AGENTS.md") if path.is_file())
 
 
 def _display_path(path: Path) -> str:
     parts = path.parts
-    if "subagents" in parts:
-        index = parts.index("subagents")
-        return "/".join(parts[index:])
+    for directory in ("subagents", "agents"):
+        if directory in parts:
+            index = parts.index(directory)
+            return "/".join(parts[index:])
     return path.name

--- a/libs/talon/deepagents_talon/fleet_import.py
+++ b/libs/talon/deepagents_talon/fleet_import.py
@@ -236,18 +236,14 @@ def _validate_agent_name(name: str, path: str) -> None:
 def _is_subagent_prompt_path(name: str) -> bool:
     parts = PurePosixPath(name).parts
     return (
-        len(parts) == _SUBAGENT_FILE_PARTS
-        and parts[0] == "subagents"
-        and parts[2] == "AGENTS.md"
+        len(parts) == _SUBAGENT_FILE_PARTS and parts[0] == "subagents" and parts[2] == "AGENTS.md"
     )
 
 
 def _is_subagent_tools_path(name: str) -> bool:
     parts = PurePosixPath(name).parts
     return (
-        len(parts) == _SUBAGENT_FILE_PARTS
-        and parts[0] == "subagents"
-        and parts[2] == "tools.json"
+        len(parts) == _SUBAGENT_FILE_PARTS and parts[0] == "subagents" and parts[2] == "tools.json"
     )
 
 

--- a/libs/talon/deepagents_talon/fleet_import.py
+++ b/libs/talon/deepagents_talon/fleet_import.py
@@ -22,6 +22,34 @@ _SETUP_FILENAME = ".mcp.json.setup"
 _ZIP_FILE_TYPE_MASK = 0o170000
 _ZIP_SYMLINK_TYPE = 0o120000
 _SUBAGENT_FILE_PARTS = 3
+_SECRET_PATH_PATTERN = re.compile(
+    r"(?:"
+    r"bearer[-_a-z0-9]*|"
+    r"token[-_a-z0-9]*|"
+    r"key[-_a-z0-9]*|"
+    r"secret[-_a-z0-9]*|"
+    r"cookie[-_a-z0-9]*|"
+    r"oauth[-_a-z0-9]*|"
+    r"sk-[A-Za-z0-9]{20,}|"
+    r"gh[opu]_[A-Za-z0-9]{20,}|"
+    r"lsv2_pt_[A-Za-z0-9]+"
+    r")",
+    re.IGNORECASE,
+)
+_SECRET_PATH_MARKER_PATTERN = re.compile(
+    r"(?:"
+    r"bearer|"
+    r"token|"
+    r"access[-_]?token|"
+    r"refresh[-_]?token|"
+    r"api[-_]?key|"
+    r"key|"
+    r"secret|"
+    r"cookie|"
+    r"oauth"
+    r")",
+    re.IGNORECASE,
+)
 
 
 class FleetImportError(ValueError):
@@ -106,7 +134,7 @@ def import_fleet_zip(zip_path: Path, *, target_dir: Path) -> FleetImportResult:
             with tempfile.TemporaryDirectory(prefix="deepagents-talon-import-") as raw:
                 staging = Path(raw)
                 _materialize_staging(archive, entries, staging)
-                summaries = _mcp_summaries(staging)
+                summaries = _mcp_summaries(staging, source)
                 notes = _format_setup_notes(source.name, summaries)
                 config_ignored = (staging / "config.json").is_file()
                 _refresh_target(staging, target, notes)
@@ -247,10 +275,10 @@ def _is_subagent_tools_path(name: str) -> bool:
     )
 
 
-def _mcp_summaries(staging: Path) -> list[_ServerSummary]:
+def _mcp_summaries(staging: Path, source: Path) -> list[_ServerSummary]:
     grouped: dict[tuple[str, str], _ServerSummary] = {}
     for path, scope in _tools_json_paths(staging):
-        for tool in _load_tool_requests(path, scope):
+        for tool in _load_tool_requests(path, scope, source):
             key = (tool.server_url, tool.server_name)
             summary = grouped.get(key)
             if summary is None:
@@ -274,22 +302,22 @@ def _tools_json_paths(staging: Path) -> list[tuple[Path, str]]:
     return paths
 
 
-def _load_tool_requests(path: Path, scope: str) -> list[_ToolRequest]:
+def _load_tool_requests(path: Path, scope: str, source: Path) -> list[_ToolRequest]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        msg = f"{_display_path(path)}: malformed tools.json: {exc.msg}"
+        msg = f"{source}: {_display_path(path)}: malformed tools.json: {exc.msg}"
         raise FleetImportError(msg) from exc
     except OSError as exc:
-        msg = f"{_display_path(path)}: {exc}"
+        msg = f"{source}: {_display_path(path)}: {exc}"
         raise FleetImportError(msg) from exc
     if not isinstance(data, dict):
-        msg = f"{_display_path(path)}: malformed tools.json: expected object"
+        msg = f"{source}: {_display_path(path)}: malformed tools.json: expected object"
         raise FleetImportError(msg)
 
     raw_tools = data.get("tools")
     if not isinstance(raw_tools, list):
-        msg = f"{_display_path(path)}: malformed tools.json: expected tools list"
+        msg = f"{source}: {_display_path(path)}: malformed tools.json: expected tools list"
         raise FleetImportError(msg)
     interrupt_config = data.get("interrupt_config")
     interrupts = interrupt_config if isinstance(interrupt_config, dict) else {}
@@ -297,12 +325,14 @@ def _load_tool_requests(path: Path, scope: str) -> list[_ToolRequest]:
     requests: list[_ToolRequest] = []
     for index, item in enumerate(raw_tools):
         if not isinstance(item, dict):
-            msg = f"{_display_path(path)}: tools[{index}] must be an object"
+            msg = f"{source}: {_display_path(path)}: tools[{index}] must be an object"
             raise FleetImportError(msg)
         tool = cast("Mapping[str, object]", item)
-        name = _required_str(tool, "name", path, index)
-        server_url = _sanitize_server_url(_required_str(tool, "mcp_server_url", path, index))
-        server_name = _required_str(tool, "mcp_server_name", path, index)
+        name = _required_str(tool, "name", path, index, source)
+        server_url = _sanitize_server_url(
+            _required_str(tool, "mcp_server_url", path, index, source)
+        )
+        server_name = _required_str(tool, "mcp_server_name", path, index, source)
         requests.append(
             _ToolRequest(
                 name=name,
@@ -315,10 +345,16 @@ def _load_tool_requests(path: Path, scope: str) -> list[_ToolRequest]:
     return requests
 
 
-def _required_str(item: Mapping[str, object], key: str, path: Path, index: int) -> str:
+def _required_str(
+    item: Mapping[str, object],
+    key: str,
+    path: Path,
+    index: int,
+    source: Path,
+) -> str:
     value = item.get(key)
     if not isinstance(value, str) or not value:
-        msg = f"{_display_path(path)}: tools[{index}].{key} must be a non-empty string"
+        msg = f"{source}: {_display_path(path)}: tools[{index}].{key} must be a non-empty string"
         raise FleetImportError(msg)
     return value
 
@@ -347,7 +383,29 @@ def _unsanitized_url(item: Mapping[str, object]) -> str:
 
 def _sanitize_server_url(raw: str) -> str:
     parts = urlsplit(raw)
-    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+    hostname = parts.hostname or ""
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    port = f":{parts.port}" if parts.port is not None else ""
+    path = _sanitize_url_path(parts.path)
+    return urlunsplit((parts.scheme, f"{hostname}{port}", path, "", ""))
+
+
+def _sanitize_url_path(path: str) -> str:
+    parts = [part for part in path.split("/") if part]
+    if not parts:
+        return ""
+    sanitized: list[str] = []
+    redact_next = False
+    for part in parts:
+        marker = _SECRET_PATH_MARKER_PATTERN.fullmatch(part) is not None
+        secret = _SECRET_PATH_PATTERN.search(part) is not None
+        if redact_next or marker or secret:
+            sanitized.append("<secret-redacted>")
+        else:
+            sanitized.append(part)
+        redact_next = marker
+    return "/" + "/".join(sanitized)
 
 
 def _format_setup_notes(source_name: str, summaries: Sequence[_ServerSummary]) -> str | None:
@@ -371,6 +429,7 @@ def _format_server_summary(summary: _ServerSummary) -> list[str]:
         "",
         f"Server: {summary.server_name}",
         f"URL: {summary.server_url}",
+        f"Tool count: {len(tools)}",
         f"Scopes: {', '.join(sorted(summary.scopes))}",
         "Requested tools:",
         *[f"- {tool}" for tool in tools],

--- a/libs/talon/deepagents_talon/fleet_import.py
+++ b/libs/talon/deepagents_talon/fleet_import.py
@@ -594,8 +594,7 @@ def _subagent_prompt_paths(assistant_home: Path) -> list[Path]:
 
 def _display_path(path: Path) -> str:
     parts = path.parts
-    for directory in ("subagents", "agents"):
-        if directory in parts:
-            index = parts.index(directory)
-            return "/".join(parts[index:])
+    if "agents" in parts:
+        index = parts.index("agents")
+        return "/".join(parts[index:])
     return path.name

--- a/libs/talon/deepagents_talon/fleet_import.py
+++ b/libs/talon/deepagents_talon/fleet_import.py
@@ -170,20 +170,22 @@ def format_import_stdout(result: FleetImportResult) -> str:
     """
     lines = [
         "Fleet import complete.",
-        f"Target directory: {result.target_dir}",
+        f"Agent files imported to: {result.target_dir}",
         f"Root prompts written: {result.root_prompt_count}",
         f"Subagent prompts written: {result.subagent_prompt_count}",
         f"config.json: {'ignored' if result.config_ignored else 'not present'}",
+        "",
+        "Next steps:",
     ]
     if result.mcp_notes is None:
-        lines.append("MCP setup: no Fleet MCP tool requirements found")
+        lines.append("- No Fleet MCP tool requirements were found.")
+        lines.append("- Add MCP servers to .mcp.json if this assistant needs local tools.")
     else:
-        lines.append("")
-        lines.append(result.mcp_notes.rstrip())
+        lines.append("- Review .mcp.json before running Talon.")
+        lines.append("- Review .mcp.json.setup for requested tools and setup details.")
     if result.interrupt_tools:
-        lines.append("")
         lines.append(
-            f"{INTERRUPT_ON_TOOLS_ENV_KEY}={','.join(result.interrupt_tools)}",
+            f"- Add HITL for sensitive tools with {INTERRUPT_ON_TOOLS_ENV_KEY}.",
         )
     return "\n".join(lines) + "\n"
 

--- a/libs/talon/deepagents_talon/fleet_import.py
+++ b/libs/talon/deepagents_talon/fleet_import.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
 _AGENT_ID_PATTERN = re.compile(r"[A-Za-z0-9_.-]{1,128}")
+_MCP_CONFIG_FILENAME = ".mcp.json"
 _SETUP_FILENAME = ".mcp.json.setup"
 _ZIP_FILE_TYPE_MASK = 0o170000
 _ZIP_SYMLINK_TYPE = 0o120000
@@ -117,7 +118,7 @@ def import_fleet_zip(zip_path: Path, *, target_dir: Path) -> FleetImportResult:
         target_dir: Talon assistant directory to refresh with materialized files.
 
     Returns:
-        Summary of the materialized files and generated MCP setup notes.
+        Summary of the materialized files and generated MCP configuration.
 
     Raises:
         FleetImportError: If the zip is structurally unsafe, missing required
@@ -136,8 +137,9 @@ def import_fleet_zip(zip_path: Path, *, target_dir: Path) -> FleetImportResult:
                 _materialize_staging(archive, entries, staging)
                 summaries = _mcp_summaries(staging, source)
                 notes = _format_setup_notes(source.name, summaries)
+                mcp_config = _format_mcp_config(summaries)
                 config_ignored = (staging / "config.json").is_file()
-                _refresh_target(staging, target, notes)
+                _refresh_target(staging, target, notes, mcp_config)
     except zipfile.BadZipFile as exc:
         msg = f"{source}: invalid zip file"
         raise FleetImportError(msg) from exc
@@ -414,7 +416,7 @@ def _format_setup_notes(source_name: str, summaries: Sequence[_ServerSummary]) -
     lines = [
         f"Fleet MCP setup notes for {source_name}",
         "",
-        "Create or edit .mcp.json after configuring credentials.",
+        "Generated .mcp.json contains the suggested server configuration.",
     ]
     for summary in summaries:
         lines.extend(_format_server_summary(summary))
@@ -440,16 +442,37 @@ def _format_server_summary(summary: _ServerSummary) -> list[str]:
     ]
 
 
+def _format_mcp_config(summaries: Sequence[_ServerSummary]) -> str | None:
+    if not summaries:
+        return None
+    servers: dict[str, dict[str, Any]] = {}
+    for summary in summaries:
+        server_id = _unique_server_id(_server_id(summary), servers)
+        servers[server_id] = _server_config(summary, sorted(summary.tools))
+    return json.dumps({"mcpServers": servers}, indent=2, sort_keys=True) + "\n"
+
+
 def _suggested_config_fragment(summary: _ServerSummary, tools: Sequence[str]) -> dict[str, Any]:
     server_id = _server_id(summary)
+    return {server_id: _server_config(summary, tools)}
+
+
+def _server_config(summary: _ServerSummary, tools: Sequence[str]) -> dict[str, Any]:
     return {
-        server_id: {
-            "type": "http",
-            "url": summary.server_url,
-            "auth": "oauth",
-            "allowedTools": list(tools),
-        }
+        "type": "http",
+        "url": summary.server_url,
+        "auth": "oauth",
+        "allowedTools": list(tools),
     }
+
+
+def _unique_server_id(server_id: str, servers: Mapping[str, object]) -> str:
+    if server_id not in servers:
+        return server_id
+    suffix = 2
+    while f"{server_id}-{suffix}" in servers:
+        suffix += 1
+    return f"{server_id}-{suffix}"
 
 
 def _server_id(summary: _ServerSummary) -> str:
@@ -458,7 +481,12 @@ def _server_id(summary: _ServerSummary) -> str:
     return normalized or "server"
 
 
-def _refresh_target(staging: Path, target: Path, notes: str | None) -> None:
+def _refresh_target(
+    staging: Path,
+    target: Path,
+    notes: str | None,
+    mcp_config: str | None,
+) -> None:
     target.mkdir(mode=0o700, parents=True, exist_ok=True)
     target.chmod(0o700)
     _replace_file(staging / "AGENTS.md", target / "AGENTS.md")
@@ -473,6 +501,14 @@ def _refresh_target(staging: Path, target: Path, notes: str | None) -> None:
     else:
         setup_path.write_text(notes, encoding="utf-8")
         setup_path.chmod(0o600)
+
+    config_path = target / _MCP_CONFIG_FILENAME
+    if mcp_config is None:
+        if config_path.exists():
+            config_path.unlink()
+    else:
+        config_path.write_text(mcp_config, encoding="utf-8")
+        config_path.chmod(0o600)
 
 
 def _replace_file(source: Path, target: Path) -> None:

--- a/libs/talon/deepagents_talon/fleet_import.py
+++ b/libs/talon/deepagents_talon/fleet_import.py
@@ -23,6 +23,10 @@ _SETUP_FILENAME = ".mcp.json.setup"
 _ZIP_FILE_TYPE_MASK = 0o170000
 _ZIP_SYMLINK_TYPE = 0o120000
 _SUBAGENT_FILE_PARTS = 3
+_MAX_ZIP_ENTRY_COUNT = 10_000
+_MAX_ZIP_UNCOMPRESSED_BYTES = 256 * 1024 * 1024
+_MAX_ZIP_COMPRESSION_RATIO = 100
+_COPY_CHUNK_SIZE = 1024 * 1024
 _SECRET_PATH_PATTERN = re.compile(
     r"(?:"
     r"bearer[-_a-z0-9]*|"
@@ -110,12 +114,20 @@ class _ServerSummary:
             self.interrupt_tools.add(tool.name)
 
 
-def import_fleet_zip(zip_path: Path, *, target_dir: Path) -> FleetImportResult:
+def import_fleet_zip(
+    zip_path: Path,
+    *,
+    target_dir: Path,
+    assistant_home: Path | None = None,
+) -> FleetImportResult:
     """Materialize a Fleet zip export into a Talon local agent directory.
 
     Args:
         zip_path: Fleet export zip file to import.
         target_dir: Talon assistant directory to refresh with materialized files.
+        assistant_home: Assistant state directory that should receive local
+            subagents. Defaults to `target_dir`, keeping all writes under the
+            explicit target.
 
     Returns:
         Summary of the materialized files and generated MCP configuration.
@@ -126,6 +138,7 @@ def import_fleet_zip(zip_path: Path, *, target_dir: Path) -> FleetImportResult:
     """
     source = zip_path.expanduser()
     target = target_dir.expanduser()
+    home = assistant_home.expanduser() if assistant_home is not None else target
     try:
         with zipfile.ZipFile(source) as archive:
             entries = _validated_entries(archive)
@@ -139,7 +152,7 @@ def import_fleet_zip(zip_path: Path, *, target_dir: Path) -> FleetImportResult:
                 notes = _format_setup_notes(source.name, summaries)
                 mcp_config = _format_mcp_config(summaries)
                 config_ignored = (staging / "config.json").is_file()
-                _refresh_target(staging, target, notes, mcp_config)
+                _refresh_target(staging, target, home, notes, mcp_config)
     except zipfile.BadZipFile as exc:
         msg = f"{source}: invalid zip file"
         raise FleetImportError(msg) from exc
@@ -150,7 +163,7 @@ def import_fleet_zip(zip_path: Path, *, target_dir: Path) -> FleetImportResult:
     return FleetImportResult(
         target_dir=target,
         root_prompt_count=1,
-        subagent_prompt_count=len(_subagent_prompt_paths(target)),
+        subagent_prompt_count=len(_subagent_prompt_paths(home)),
         config_ignored=config_ignored,
         mcp_notes=notes,
         interrupt_tools=tuple(
@@ -193,6 +206,7 @@ def format_import_stdout(result: FleetImportResult) -> str:
 
 def _validated_entries(archive: zipfile.ZipFile) -> dict[str, zipfile.ZipInfo]:
     entries: dict[str, zipfile.ZipInfo] = {}
+    total_size = 0
     for info in archive.infolist():
         name = _normalized_zip_name(info.filename)
         if name is None:
@@ -203,8 +217,17 @@ def _validated_entries(archive: zipfile.ZipFile) -> dict[str, zipfile.ZipInfo]:
         if _is_symlink(info):
             msg = f"{name}: symlink entries are not supported"
             raise FleetImportError(msg)
-        if not info.is_dir():
-            entries[name] = info
+        if info.is_dir():
+            continue
+        _validate_zip_entry_size(name, info)
+        if len(entries) >= _MAX_ZIP_ENTRY_COUNT:
+            msg = f"{archive.filename}: too many zip entries"
+            raise FleetImportError(msg)
+        total_size += info.file_size
+        if total_size > _MAX_ZIP_UNCOMPRESSED_BYTES:
+            msg = f"{archive.filename}: zip uncompressed size exceeds limit"
+            raise FleetImportError(msg)
+        entries[name] = info
     return entries
 
 
@@ -231,6 +254,17 @@ def _is_symlink(info: zipfile.ZipInfo) -> bool:
     return file_type == _ZIP_SYMLINK_TYPE
 
 
+def _validate_zip_entry_size(name: str, info: zipfile.ZipInfo) -> None:
+    if info.file_size > _MAX_ZIP_UNCOMPRESSED_BYTES:
+        msg = f"{name}: zip entry uncompressed size exceeds limit"
+        raise FleetImportError(msg)
+    if info.compress_size == 0:
+        return
+    if info.file_size > info.compress_size * _MAX_ZIP_COMPRESSION_RATIO:
+        msg = f"{name}: zip entry compression ratio exceeds limit"
+        raise FleetImportError(msg)
+
+
 def _materialize_staging(
     archive: zipfile.ZipFile,
     entries: Mapping[str, zipfile.ZipInfo],
@@ -255,8 +289,14 @@ def _materialize_staging(
 
 def _copy_zip_file(archive: zipfile.ZipFile, info: zipfile.ZipInfo, target: Path) -> None:
     target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    copied = 0
     with archive.open(info) as src, target.open("wb") as dst:
-        shutil.copyfileobj(src, dst)
+        while chunk := src.read(_COPY_CHUNK_SIZE):
+            copied += len(chunk)
+            if copied > info.file_size or copied > _MAX_ZIP_UNCOMPRESSED_BYTES:
+                msg = f"{info.filename}: zip entry expanded beyond declared size"
+                raise FleetImportError(msg)
+            dst.write(chunk)
     target.chmod(0o600)
 
 
@@ -487,16 +527,20 @@ def _server_id(summary: _ServerSummary) -> str:
 def _refresh_target(
     staging: Path,
     target: Path,
+    assistant_home: Path,
     notes: str | None,
     mcp_config: str | None,
 ) -> None:
-    agent_home = target.parent
+    assistant_home.mkdir(mode=0o700, parents=True, exist_ok=True)
+    assistant_home.chmod(0o700)
     target.mkdir(mode=0o700, parents=True, exist_ok=True)
     target.chmod(0o700)
     _replace_file(staging / "AGENTS.md", target / "AGENTS.md")
 
     _replace_tree(staging / "skills", target / "skills")
-    _replace_tree(staging / "agents", agent_home / "agents")
+    _replace_tree(staging / "agents", assistant_home / "agents")
+    if assistant_home != target:
+        _remove_path(target / "agents")
     _remove_path(target / "subagents")
 
     setup_path = target / _SETUP_FILENAME
@@ -541,8 +585,8 @@ def _remove_path(path: Path) -> None:
         path.unlink()
 
 
-def _subagent_prompt_paths(target: Path) -> list[Path]:
-    agents = target.parent / "agents"
+def _subagent_prompt_paths(assistant_home: Path) -> list[Path]:
+    agents = assistant_home / "agents"
     if not agents.is_dir():
         return []
     return sorted(path for path in agents.glob("*/AGENTS.md") if path.is_file())

--- a/libs/talon/deepagents_talon/fleet_import.py
+++ b/libs/talon/deepagents_talon/fleet_import.py
@@ -1,0 +1,453 @@
+"""Fleet zip import support for Talon local agent directories."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import tempfile
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import TYPE_CHECKING, Any, Self, cast
+from urllib.parse import urlsplit, urlunsplit
+
+from deepagents_talon.runtime import INTERRUPT_ON_TOOLS_ENV_KEY
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+_AGENT_ID_PATTERN = re.compile(r"[A-Za-z0-9_.-]{1,128}")
+_SETUP_FILENAME = ".mcp.json.setup"
+_ZIP_FILE_TYPE_MASK = 0o170000
+_ZIP_SYMLINK_TYPE = 0o120000
+_SUBAGENT_FILE_PARTS = 3
+
+
+class FleetImportError(ValueError):
+    """Raised when a Fleet zip cannot be materialized into a Talon agent directory."""
+
+
+@dataclass(frozen=True, slots=True)
+class FleetImportResult:
+    """Summary of a completed Fleet zip import.
+
+    Args:
+        target_dir: Directory that received the materialized Talon agent files.
+        root_prompt_count: Number of root prompt files written.
+        subagent_prompt_count: Number of subagent prompt files written.
+        config_ignored: Whether the Fleet zip contained a root `config.json`.
+        mcp_notes: Human-readable MCP setup notes written to `.mcp.json.setup`.
+        interrupt_tools: Tool names recommended for Talon interrupt configuration.
+    """
+
+    target_dir: Path
+    root_prompt_count: int
+    subagent_prompt_count: int
+    config_ignored: bool
+    mcp_notes: str | None
+    interrupt_tools: tuple[str, ...]
+
+
+@dataclass(slots=True)
+class _ToolRequest:
+    name: str
+    server_url: str
+    server_name: str
+    scope: str
+    interrupt: bool
+
+
+@dataclass(slots=True)
+class _ServerSummary:
+    server_url: str
+    server_name: str
+    scopes: set[str] = field(default_factory=set)
+    tools: set[str] = field(default_factory=set)
+    interrupt_tools: set[str] = field(default_factory=set)
+
+    @classmethod
+    def from_tool(cls, tool: _ToolRequest) -> Self:
+        """Create a server summary initialized from one tool request."""
+        summary = cls(server_url=tool.server_url, server_name=tool.server_name)
+        summary.add(tool)
+        return summary
+
+    def add(self, tool: _ToolRequest) -> None:
+        """Record a requested tool for this MCP server."""
+        self.scopes.add(tool.scope)
+        self.tools.add(tool.name)
+        if tool.interrupt:
+            self.interrupt_tools.add(tool.name)
+
+
+def import_fleet_zip(zip_path: Path, *, target_dir: Path) -> FleetImportResult:
+    """Materialize a Fleet zip export into a Talon local agent directory.
+
+    Args:
+        zip_path: Fleet export zip file to import.
+        target_dir: Talon assistant directory to refresh with materialized files.
+
+    Returns:
+        Summary of the materialized files and generated MCP setup notes.
+
+    Raises:
+        FleetImportError: If the zip is structurally unsafe, missing required
+            prompts, contains malformed `tools.json`, or cannot be written.
+    """
+    source = zip_path.expanduser()
+    target = target_dir.expanduser()
+    try:
+        with zipfile.ZipFile(source) as archive:
+            entries = _validated_entries(archive)
+            if "AGENTS.md" not in entries:
+                msg = "AGENTS.md: missing required root prompt"
+                raise FleetImportError(msg)
+            with tempfile.TemporaryDirectory(prefix="deepagents-talon-import-") as raw:
+                staging = Path(raw)
+                _materialize_staging(archive, entries, staging)
+                summaries = _mcp_summaries(staging)
+                notes = _format_setup_notes(source.name, summaries)
+                config_ignored = (staging / "config.json").is_file()
+                _refresh_target(staging, target, notes)
+    except zipfile.BadZipFile as exc:
+        msg = f"{source}: invalid zip file"
+        raise FleetImportError(msg) from exc
+    except OSError as exc:
+        msg = f"{target}: {exc}"
+        raise FleetImportError(msg) from exc
+
+    return FleetImportResult(
+        target_dir=target,
+        root_prompt_count=1,
+        subagent_prompt_count=len(_subagent_prompt_paths(target)),
+        config_ignored=config_ignored,
+        mcp_notes=notes,
+        interrupt_tools=tuple(
+            sorted({tool for summary in summaries for tool in summary.interrupt_tools})
+        ),
+    )
+
+
+def format_import_stdout(result: FleetImportResult) -> str:
+    """Render a concise user-facing import summary.
+
+    Args:
+        result: Completed import summary.
+
+    Returns:
+        Text suitable for printing to stdout.
+    """
+    lines = [
+        "Fleet import complete.",
+        f"Target directory: {result.target_dir}",
+        f"Root prompts written: {result.root_prompt_count}",
+        f"Subagent prompts written: {result.subagent_prompt_count}",
+        f"config.json: {'ignored' if result.config_ignored else 'not present'}",
+    ]
+    if result.mcp_notes is None:
+        lines.append("MCP setup: no Fleet MCP tool requirements found")
+    else:
+        lines.append("")
+        lines.append(result.mcp_notes.rstrip())
+    if result.interrupt_tools:
+        lines.append("")
+        lines.append(
+            f"{INTERRUPT_ON_TOOLS_ENV_KEY}={','.join(result.interrupt_tools)}",
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _validated_entries(archive: zipfile.ZipFile) -> dict[str, zipfile.ZipInfo]:
+    entries: dict[str, zipfile.ZipInfo] = {}
+    for info in archive.infolist():
+        name = _normalized_zip_name(info.filename)
+        if name is None:
+            continue
+        if _is_unsafe_zip_path(name):
+            msg = f"{info.filename}: unsafe zip path"
+            raise FleetImportError(msg)
+        if _is_symlink(info):
+            msg = f"{name}: symlink entries are not supported"
+            raise FleetImportError(msg)
+        if not info.is_dir():
+            entries[name] = info
+    return entries
+
+
+def _normalized_zip_name(name: str) -> str | None:
+    normalized = name.replace("\\", "/")
+    if not normalized or normalized.endswith("/"):
+        return None
+    return normalized
+
+
+def _is_unsafe_zip_path(name: str) -> bool:
+    posix = PurePosixPath(name)
+    windows = PureWindowsPath(name)
+    return (
+        posix.is_absolute()
+        or windows.is_absolute()
+        or windows.drive != ""
+        or any(part in {"", ".", ".."} for part in posix.parts)
+    )
+
+
+def _is_symlink(info: zipfile.ZipInfo) -> bool:
+    file_type = (info.external_attr >> 16) & _ZIP_FILE_TYPE_MASK
+    return file_type == _ZIP_SYMLINK_TYPE
+
+
+def _materialize_staging(
+    archive: zipfile.ZipFile,
+    entries: Mapping[str, zipfile.ZipInfo],
+    staging: Path,
+) -> None:
+    _copy_zip_file(archive, entries["AGENTS.md"], staging / "AGENTS.md")
+
+    for name, info in entries.items():
+        if name.startswith("skills/"):
+            _copy_zip_file(archive, info, staging / name)
+        elif _is_subagent_prompt_path(name):
+            subagent = PurePosixPath(name).parts[1]
+            _validate_agent_name(subagent, name)
+            _copy_zip_file(archive, info, staging / name)
+        elif name in {"config.json", "tools.json"}:
+            _copy_zip_file(archive, info, staging / name)
+        elif _is_subagent_tools_path(name):
+            subagent = PurePosixPath(name).parts[1]
+            _validate_agent_name(subagent, name)
+            _copy_zip_file(archive, info, staging / name)
+
+
+def _copy_zip_file(archive: zipfile.ZipFile, info: zipfile.ZipInfo, target: Path) -> None:
+    target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    with archive.open(info) as src, target.open("wb") as dst:
+        shutil.copyfileobj(src, dst)
+    target.chmod(0o600)
+
+
+def _validate_agent_name(name: str, path: str) -> None:
+    if not _AGENT_ID_PATTERN.fullmatch(name) or name in {".", ".."}:
+        msg = f"{path}: unsafe subagent name {name!r}"
+        raise FleetImportError(msg)
+
+
+def _is_subagent_prompt_path(name: str) -> bool:
+    parts = PurePosixPath(name).parts
+    return (
+        len(parts) == _SUBAGENT_FILE_PARTS
+        and parts[0] == "subagents"
+        and parts[2] == "AGENTS.md"
+    )
+
+
+def _is_subagent_tools_path(name: str) -> bool:
+    parts = PurePosixPath(name).parts
+    return (
+        len(parts) == _SUBAGENT_FILE_PARTS
+        and parts[0] == "subagents"
+        and parts[2] == "tools.json"
+    )
+
+
+def _mcp_summaries(staging: Path) -> list[_ServerSummary]:
+    grouped: dict[tuple[str, str], _ServerSummary] = {}
+    for path, scope in _tools_json_paths(staging):
+        for tool in _load_tool_requests(path, scope):
+            key = (tool.server_url, tool.server_name)
+            summary = grouped.get(key)
+            if summary is None:
+                grouped[key] = _ServerSummary.from_tool(tool)
+            else:
+                summary.add(tool)
+    return sorted(grouped.values(), key=lambda item: (item.server_name.lower(), item.server_url))
+
+
+def _tools_json_paths(staging: Path) -> list[tuple[Path, str]]:
+    paths: list[tuple[Path, str]] = []
+    root = staging / "tools.json"
+    if root.is_file():
+        paths.append((root, "root"))
+    subagents = staging / "subagents"
+    if subagents.is_dir():
+        for child in sorted(subagents.iterdir(), key=lambda item: item.name):
+            path = child / "tools.json"
+            if path.is_file():
+                paths.append((path, child.name))
+    return paths
+
+
+def _load_tool_requests(path: Path, scope: str) -> list[_ToolRequest]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        msg = f"{_display_path(path)}: malformed tools.json: {exc.msg}"
+        raise FleetImportError(msg) from exc
+    except OSError as exc:
+        msg = f"{_display_path(path)}: {exc}"
+        raise FleetImportError(msg) from exc
+    if not isinstance(data, dict):
+        msg = f"{_display_path(path)}: malformed tools.json: expected object"
+        raise FleetImportError(msg)
+
+    raw_tools = data.get("tools")
+    if not isinstance(raw_tools, list):
+        msg = f"{_display_path(path)}: malformed tools.json: expected tools list"
+        raise FleetImportError(msg)
+    interrupt_config = data.get("interrupt_config")
+    interrupts = interrupt_config if isinstance(interrupt_config, dict) else {}
+
+    requests: list[_ToolRequest] = []
+    for index, item in enumerate(raw_tools):
+        if not isinstance(item, dict):
+            msg = f"{_display_path(path)}: tools[{index}] must be an object"
+            raise FleetImportError(msg)
+        tool = cast("Mapping[str, object]", item)
+        name = _required_str(tool, "name", path, index)
+        server_url = _sanitize_server_url(_required_str(tool, "mcp_server_url", path, index))
+        server_name = _required_str(tool, "mcp_server_name", path, index)
+        requests.append(
+            _ToolRequest(
+                name=name,
+                server_url=server_url,
+                server_name=server_name,
+                scope=scope,
+                interrupt=_tool_interrupt_enabled(tool, interrupts, name, server_url, server_name),
+            )
+        )
+    return requests
+
+
+def _required_str(item: Mapping[str, object], key: str, path: Path, index: int) -> str:
+    value = item.get(key)
+    if not isinstance(value, str) or not value:
+        msg = f"{_display_path(path)}: tools[{index}].{key} must be a non-empty string"
+        raise FleetImportError(msg)
+    return value
+
+
+def _tool_interrupt_enabled(
+    item: Mapping[str, object],
+    interrupts: Mapping[object, object],
+    name: str,
+    server_url: str,
+    server_name: str,
+) -> bool:
+    if item.get("interrupt_config") is True:
+        return True
+    keys = (
+        f"{server_url}::{name}::{server_name}",
+        f"{_unsanitized_url(item)}::{name}::{server_name}",
+        name,
+    )
+    return any(interrupts.get(key) is True for key in keys)
+
+
+def _unsanitized_url(item: Mapping[str, object]) -> str:
+    value = item.get("mcp_server_url")
+    return value if isinstance(value, str) else ""
+
+
+def _sanitize_server_url(raw: str) -> str:
+    parts = urlsplit(raw)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+
+
+def _format_setup_notes(source_name: str, summaries: Sequence[_ServerSummary]) -> str | None:
+    if not summaries:
+        return None
+    lines = [
+        f"Fleet MCP setup notes for {source_name}",
+        "",
+        "Create or edit .mcp.json after configuring credentials.",
+    ]
+    for summary in summaries:
+        lines.extend(_format_server_summary(summary))
+    return "\n".join(lines) + "\n"
+
+
+def _format_server_summary(summary: _ServerSummary) -> list[str]:
+    tools = sorted(summary.tools)
+    interrupts = sorted(summary.interrupt_tools)
+    fragment = _suggested_config_fragment(summary, tools)
+    return [
+        "",
+        f"Server: {summary.server_name}",
+        f"URL: {summary.server_url}",
+        f"Scopes: {', '.join(sorted(summary.scopes))}",
+        "Requested tools:",
+        *[f"- {tool}" for tool in tools],
+        f"Interrupt-enabled tools: {', '.join(interrupts) if interrupts else 'none'}",
+        "",
+        "Suggested .mcp.json fragment:",
+        json.dumps(fragment, indent=2, sort_keys=True),
+    ]
+
+
+def _suggested_config_fragment(summary: _ServerSummary, tools: Sequence[str]) -> dict[str, Any]:
+    server_id = _server_id(summary)
+    return {
+        server_id: {
+            "type": "http",
+            "url": summary.server_url,
+            "auth": "oauth",
+            "allowedTools": list(tools),
+        }
+    }
+
+
+def _server_id(summary: _ServerSummary) -> str:
+    raw = summary.server_name or urlsplit(summary.server_url).hostname or "server"
+    normalized = re.sub(r"[^A-Za-z0-9_.-]+", "-", raw.strip().lower()).strip("-")
+    return normalized or "server"
+
+
+def _refresh_target(staging: Path, target: Path, notes: str | None) -> None:
+    target.mkdir(mode=0o700, parents=True, exist_ok=True)
+    target.chmod(0o700)
+    _replace_file(staging / "AGENTS.md", target / "AGENTS.md")
+
+    _replace_tree(staging / "skills", target / "skills")
+    _replace_tree(staging / "subagents", target / "subagents")
+
+    setup_path = target / _SETUP_FILENAME
+    if notes is None:
+        if setup_path.exists():
+            setup_path.unlink()
+    else:
+        setup_path.write_text(notes, encoding="utf-8")
+        setup_path.chmod(0o600)
+
+
+def _replace_file(source: Path, target: Path) -> None:
+    target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    temp = target.with_name(f".{target.name}.tmp")
+    shutil.copy2(source, temp)
+    temp.chmod(0o600)
+    temp.replace(target)
+
+
+def _replace_tree(source: Path, target: Path) -> None:
+    if target.exists():
+        if target.is_dir():
+            shutil.rmtree(target)
+        else:
+            target.unlink()
+    if source.is_dir():
+        shutil.copytree(source, target)
+
+
+def _subagent_prompt_paths(target: Path) -> list[Path]:
+    subagents = target / "subagents"
+    if not subagents.is_dir():
+        return []
+    return sorted(path for path in subagents.glob("*/AGENTS.md") if path.is_file())
+
+
+def _display_path(path: Path) -> str:
+    parts = path.parts
+    if "subagents" in parts:
+        index = parts.index("subagents")
+        return "/".join(parts[index:])
+    return path.name

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -152,6 +152,7 @@ _CRON_AUTO_DENY_MESSAGE = (
 _CHANNEL_AUTO_DENY_MESSAGE = (
     "Tool approval is unavailable on this channel; skipped the gated tool call."
 )
+_LOCAL_SUBAGENT_NAME_PATTERN = re.compile(r"[A-Za-z0-9_.-]{1,128}")
 
 _CRON_ORIGIN: contextvars.ContextVar[CronOrigin | None] = contextvars.ContextVar(
     "talon_cron_origin",
@@ -879,6 +880,13 @@ def _load_local_subagents(assistant_dir: Path) -> list[SubAgent]:
         path = child / "AGENTS.md"
         if not path.is_file():
             continue
+        if not _valid_local_subagent_name(child.name):
+            logger.warning(
+                "Skipping Talon subagent prompt from %s: unsafe subagent name %r",
+                path,
+                child.name,
+            )
+            continue
         try:
             text = path.read_text(encoding="utf-8")
         except OSError:
@@ -894,6 +902,10 @@ def _load_local_subagents(assistant_dir: Path) -> list[SubAgent]:
             subagent["model"] = model
         subagents.append(subagent)
     return subagents
+
+
+def _valid_local_subagent_name(name: str) -> bool:
+    return _LOCAL_SUBAGENT_NAME_PATTERN.fullmatch(name) is not None and name not in {".", ".."}
 
 
 def _parse_local_subagent_prompt(text: str, name: str) -> tuple[str, str, str | None]:

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -900,8 +900,8 @@ def _manifest_memory_paths(assistant_dir: Path) -> list[str]:
 
 
 def _load_local_subagents(assistant_dir: Path) -> list[SubAgent]:
-    agents_dir = assistant_dir.parent / "agents"
-    if not agents_dir.is_dir():
+    agents_dir = _local_subagents_dir(assistant_dir)
+    if agents_dir is None:
         return []
     subagents: list[SubAgent] = []
     for child in sorted(agents_dir.iterdir(), key=lambda item: item.name):
@@ -932,6 +932,16 @@ def _load_local_subagents(assistant_dir: Path) -> list[SubAgent]:
             subagent["model"] = model
         subagents.append(subagent)
     return subagents
+
+
+def _local_subagents_dir(assistant_dir: Path) -> Path | None:
+    local = assistant_dir / "agents"
+    if local.is_dir():
+        return local
+    sibling = assistant_dir.parent / "agents"
+    if sibling.is_dir():
+        return sibling
+    return None
 
 
 def _valid_local_subagent_name(name: str) -> bool:

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -10,6 +10,7 @@ import contextvars
 import json
 import logging
 import os
+import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -284,7 +285,7 @@ class DeepAgentRuntime:
             model=model,
             tools=tools,
             system_prompt=self._resolve_system_prompt(),
-            subagents=list(self.subagents) if self.subagents is not None else None,
+            subagents=self._resolve_subagents(),
             backend=self.backend,
             skills=self._resolve_skills(),
             middleware=middleware,
@@ -485,6 +486,16 @@ class DeepAgentRuntime:
             if path not in sources:
                 sources.append(path)
         return sources or None
+
+    def _resolve_subagents(self) -> list[SubAgent | CompiledSubAgent | AsyncSubAgent] | None:
+        if self.subagents is not None:
+            return list(self.subagents) or None
+        if self.assistant_dir is None:
+            return None
+        return cast(
+            "list[SubAgent | CompiledSubAgent | AsyncSubAgent] | None",
+            _load_local_subagents(self.assistant_dir) or None,
+        )
 
     def _resolve_memory(self) -> list[str] | None:
         if self.memory is not None:
@@ -855,6 +866,54 @@ def _manifest_memory_paths(assistant_dir: Path) -> list[str]:
             candidate = assistant_dir / candidate
         paths.append(str(candidate))
     return paths
+
+
+def _load_local_subagents(assistant_dir: Path) -> list[SubAgent]:
+    subagents_dir = assistant_dir / "subagents"
+    if not subagents_dir.is_dir():
+        return []
+    subagents: list[SubAgent] = []
+    for child in sorted(subagents_dir.iterdir(), key=lambda item: item.name):
+        if not child.is_dir():
+            continue
+        path = child / "AGENTS.md"
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            logger.warning("Could not read Talon subagent prompt from %s", path, exc_info=True)
+            continue
+        description, system_prompt = _parse_local_subagent_prompt(text, child.name)
+        subagents.append(
+            {
+                "name": child.name,
+                "description": description,
+                "system_prompt": system_prompt,
+            }
+        )
+    return subagents
+
+
+def _parse_local_subagent_prompt(text: str, name: str) -> tuple[str, str]:
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", text, re.DOTALL)
+    if match is None:
+        return _default_subagent_description(name), text
+    description = _frontmatter_description(match.group(1)) or _default_subagent_description(name)
+    return description, match.group(2).lstrip()
+
+
+def _frontmatter_description(frontmatter: str) -> str | None:
+    for line in frontmatter.splitlines():
+        key, separator, value = line.partition(":")
+        if separator and key.strip() == "description":
+            parsed = value.strip().strip("\"'")
+            return parsed or None
+    return None
+
+
+def _default_subagent_description(name: str) -> str:
+    return f"Use the {name} subagent."
 
 
 def _prepare_memory_path(raw: str) -> str | None:

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -870,11 +870,11 @@ def _manifest_memory_paths(assistant_dir: Path) -> list[str]:
 
 
 def _load_local_subagents(assistant_dir: Path) -> list[SubAgent]:
-    subagents_dir = assistant_dir / "subagents"
-    if not subagents_dir.is_dir():
+    agents_dir = assistant_dir.parent / "agents"
+    if not agents_dir.is_dir():
         return []
     subagents: list[SubAgent] = []
-    for child in sorted(subagents_dir.iterdir(), key=lambda item: item.name):
+    for child in sorted(agents_dir.iterdir(), key=lambda item: item.name):
         if not child.is_dir():
             continue
         path = child / "AGENTS.md"

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -39,8 +39,9 @@ from deepagents_talon.interfaces import (
 from deepagents_talon.observability import log_event, stable_log_ref
 
 if TYPE_CHECKING:
-    from deepagents import AsyncSubAgent, CompiledSubAgent, SubAgent
     from deepagents.backends.protocol import BackendProtocol
+    from deepagents.middleware.async_subagents import AsyncSubAgent
+    from deepagents.middleware.subagents import CompiledSubAgent, SubAgent
     from langchain.agents.middleware import InterruptOnConfig
     from langchain.agents.middleware.types import AgentMiddleware
     from langchain_core.language_models import BaseChatModel
@@ -55,6 +56,9 @@ DEFAULT_MAX_CONTINUATIONS = 3
 DEFAULT_MAX_APPROVAL_ROUNDS = 50
 CONTEXT_SIZE_ENV_KEY = "DEEPAGENTS_TALON_CONTEXT_SIZE"
 INTERRUPT_ON_TOOLS_ENV_KEY = "DEEPAGENTS_TALON_INTERRUPT_ON_TOOLS"
+_ASYNC_SUBAGENT_TOOL_NAMES = frozenset(
+    {"start_async_task", "update_async_task", "cancel_async_task"}
+)
 RECURSION_LIMIT_ENV_KEY = "DEEPAGENTS_TALON_RECURSION_LIMIT"
 _WORKSPACE_ENV = "DEEPAGENTS_TALON_WORKSPACE"
 _SAFE_BACKEND_PATH = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
@@ -259,6 +263,7 @@ class DeepAgentRuntime:
         self.tools = tuple(tools)
         self.system_prompt = system_prompt
         self.subagents = tuple(subagents) if subagents is not None else None
+        self._has_async_subagents = _has_async_subagents(self.subagents)
         self.assistant_dir = assistant_dir
         self.cron_store = cron_store
         self.env = dict(os.environ if env is None else env)
@@ -290,7 +295,10 @@ class DeepAgentRuntime:
             backend=self.backend,
             skills=self._resolve_skills(),
             middleware=middleware,
-            interrupt_on=self.interrupt_on,
+            interrupt_on=_interrupt_on_with_async_subagents(
+                self.interrupt_on,
+                has_async_subagents=self._has_async_subagents,
+            ),
             memory=self._resolve_memory(),
             checkpointer=self.checkpointer,
         )
@@ -489,14 +497,12 @@ class DeepAgentRuntime:
         return sources or None
 
     def _resolve_subagents(self) -> list[SubAgent | CompiledSubAgent | AsyncSubAgent] | None:
+        resolved: list[SubAgent | CompiledSubAgent | AsyncSubAgent] = []
+        if self.assistant_dir is not None:
+            resolved.extend(_load_local_subagents(self.assistant_dir))
         if self.subagents is not None:
-            return list(self.subagents) or None
-        if self.assistant_dir is None:
-            return None
-        return cast(
-            "list[SubAgent | CompiledSubAgent | AsyncSubAgent] | None",
-            _load_local_subagents(self.assistant_dir) or None,
-        )
+            resolved.extend(self.subagents)
+        return resolved or None
 
     def _resolve_memory(self) -> list[str] | None:
         if self.memory is not None:
@@ -692,6 +698,30 @@ def _interrupt_on_tools_from_env(env: Mapping[str, str]) -> dict[str, bool]:
     if raw is None or not raw.strip():
         return {}
     return {name: True for name in (part.strip() for part in raw.split(",")) if name}
+
+
+def _interrupt_on_with_async_subagents(
+    interrupt_on: Mapping[str, bool | InterruptOnConfig] | None,
+    *,
+    has_async_subagents: bool,
+) -> dict[str, bool | InterruptOnConfig] | None:
+    if not has_async_subagents:
+        return dict(interrupt_on) if interrupt_on is not None else None
+
+    merged: dict[str, bool | InterruptOnConfig] = {}
+    if interrupt_on is not None:
+        merged.update(interrupt_on)
+    for tool_name in _ASYNC_SUBAGENT_TOOL_NAMES:
+        merged.setdefault(tool_name, True)
+    return merged
+
+
+def _has_async_subagents(
+    subagents: Sequence[SubAgent | CompiledSubAgent | AsyncSubAgent] | None,
+) -> bool:
+    return any(
+        isinstance(subagent, Mapping) and "graph_id" in subagent for subagent in subagents or ()
+    )
 
 
 def _default_backend(env: Mapping[str, str] | None) -> LocalShellBackend:

--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -884,29 +884,33 @@ def _load_local_subagents(assistant_dir: Path) -> list[SubAgent]:
         except OSError:
             logger.warning("Could not read Talon subagent prompt from %s", path, exc_info=True)
             continue
-        description, system_prompt = _parse_local_subagent_prompt(text, child.name)
-        subagents.append(
-            {
-                "name": child.name,
-                "description": description,
-                "system_prompt": system_prompt,
-            }
-        )
+        description, system_prompt, model = _parse_local_subagent_prompt(text, child.name)
+        subagent: SubAgent = {
+            "name": child.name,
+            "description": description,
+            "system_prompt": system_prompt,
+        }
+        if model is not None:
+            subagent["model"] = model
+        subagents.append(subagent)
     return subagents
 
 
-def _parse_local_subagent_prompt(text: str, name: str) -> tuple[str, str]:
+def _parse_local_subagent_prompt(text: str, name: str) -> tuple[str, str, str | None]:
     match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", text, re.DOTALL)
     if match is None:
-        return _default_subagent_description(name), text
-    description = _frontmatter_description(match.group(1)) or _default_subagent_description(name)
-    return description, match.group(2).lstrip()
+        return _default_subagent_description(name), text, None
+    frontmatter = match.group(1)
+    description = _frontmatter_value(frontmatter, "description") or _default_subagent_description(
+        name
+    )
+    return description, match.group(2).lstrip(), _frontmatter_value(frontmatter, "model_id")
 
 
-def _frontmatter_description(frontmatter: str) -> str | None:
+def _frontmatter_value(frontmatter: str, field: str) -> str | None:
     for line in frontmatter.splitlines():
         key, separator, value = line.partition(":")
-        if separator and key.strip() == "description":
+        if separator and key.strip() == field:
             parsed = value.strip().strip("\"'")
             return parsed or None
     return None

--- a/libs/talon/tests/test_async_subagents.py
+++ b/libs/talon/tests/test_async_subagents.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+
+from deepagents_talon.async_subagents import load_async_subagents
+
+
+def test_load_async_subagents_reads_deepagents_config(tmp_path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+[async_subagents.researcher]
+description = "Research agent"
+graph_id = "agent"
+url = "https://deployment.example"
+
+[async_subagents.reviewer]
+description = "Review agent"
+graph_id = "review"
+
+[async_subagents.reviewer.headers]
+Authorization = "Bearer test"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    agents = load_async_subagents(config_path)
+
+    assert agents == [
+        {
+            "name": "researcher",
+            "description": "Research agent",
+            "graph_id": "agent",
+            "url": "https://deployment.example",
+        },
+        {
+            "name": "reviewer",
+            "description": "Review agent",
+            "graph_id": "review",
+            "headers": {"Authorization": "Bearer test"},
+        },
+    ]
+
+
+def test_load_async_subagents_skips_invalid_specs(tmp_path, caplog) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+[async_subagents.valid]
+description = "Valid agent"
+graph_id = "agent"
+
+[async_subagents.missing]
+description = "Missing graph"
+
+[async_subagents.wrong_type]
+description = 123
+graph_id = "agent"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        agents = load_async_subagents(config_path)
+
+    assert agents == [{"name": "valid", "description": "Valid agent", "graph_id": "agent"}]
+    assert "missing fields" in caplog.text
+    assert "description and graph_id must be strings" in caplog.text
+
+
+def test_load_async_subagents_returns_empty_for_absent_config(tmp_path) -> None:
+    assert load_async_subagents(tmp_path / "missing.toml") == []

--- a/libs/talon/tests/test_config.py
+++ b/libs/talon/tests/test_config.py
@@ -35,6 +35,17 @@ def test_from_env_creates_assistant_home(tmp_path: Path) -> None:
     assert config.inbound_media_dir.stat().st_mode & 0o777 == 0o700
 
 
+def test_from_env_defaults_to_deepagents_home(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    config = TalonConfig.from_env({"AGENT_ASSISTANT_ID": "assistant-1"})
+
+    assert config.home == tmp_path / ".deepagents" / "assistant-1"
+
+
 def test_from_env_keeps_langsmith_env(tmp_path: Path) -> None:
     config = TalonConfig.from_env(
         {

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -93,6 +93,26 @@ def test_import_fleet_cli_assistant_id_overrides_default_target(
     assert not (tmp_path / "home" / "default" / "agent" / "AGENTS.md").exists()
 
 
+def test_import_fleet_help_documents_operator_workflow(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["deepagents-talon", "import-fleet", "--help"])
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == 0
+    output = capsys.readouterr().out
+    assert "deepagents-talon import-fleet <fleet-export.zip>" in output
+    assert "selected assistant manifest directory" in output
+    assert ".mcp.json.setup is a human-readable setup handoff" in output
+    assert ".mcp.json remains the runtime MCP config file" in output
+    assert "Fleet config.json is ignored" in output
+    assert "Fleet tools.json is import input only" in output
+    assert "old Fleet direct-run environment variables are unsupported" in output
+
+
 def test_import_fleet_zip_rejects_missing_root_prompt(tmp_path: Path) -> None:
     source = tmp_path / "fleet.zip"
     _write_zip(source, {"subagents/researcher/AGENTS.md": "prompt"})

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import stat
 import sys
 import zipfile
 from typing import TYPE_CHECKING
@@ -40,7 +41,9 @@ def test_import_fleet_zip_materializes_agent_files_and_mcp_notes(tmp_path: Path)
     assert result.config_ignored is True
     assert result.interrupt_tools == ("write_remote",)
     assert (target / "AGENTS.md").read_text(encoding="utf-8") == "root prompt"
-    assert (target / "skills" / "review" / "SKILL.md").is_file()
+    assert (target / "skills" / "review" / "SKILL.md").read_text(encoding="utf-8") == (
+        "---\nname: review\n---\nReview things."
+    )
     assert (target / "subagents" / "researcher" / "AGENTS.md").is_file()
     assert not (target / "tools.json").exists()
     assert not (target / "config.json").exists()
@@ -129,12 +132,33 @@ def test_import_fleet_zip_rejects_malformed_tools_json(tmp_path: Path) -> None:
         import_fleet_zip(source, target_dir=tmp_path / "agent")
 
 
-def test_import_fleet_zip_rejects_unsafe_paths(tmp_path: Path) -> None:
+@pytest.mark.parametrize("path", ["../escape", "/escape", "C:/escape"])
+def test_import_fleet_zip_rejects_unsafe_paths(tmp_path: Path, path: str) -> None:
     source = tmp_path / "fleet.zip"
-    _write_zip(source, {"AGENTS.md": "root prompt", "../escape": "bad"})
+    _write_zip(source, {"AGENTS.md": "root prompt", path: "bad"})
 
-    with pytest.raises(FleetImportError, match=r"\.\./escape: unsafe zip path"):
+    with pytest.raises(FleetImportError, match="unsafe zip path"):
         import_fleet_zip(source, target_dir=tmp_path / "agent")
+
+
+def test_import_fleet_zip_rejects_symlink_entries_before_writing_target(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "fleet.zip"
+    target = tmp_path / "agent"
+    target.mkdir()
+    (target / "AGENTS.md").write_text("existing prompt", encoding="utf-8")
+    symlink = zipfile.ZipInfo("skills/review/SKILL.md")
+    symlink.external_attr = (stat.S_IFLNK | 0o777) << 16
+    with zipfile.ZipFile(source, "w") as archive:
+        archive.writestr("AGENTS.md", "new prompt")
+        archive.writestr(symlink, "../secret")
+
+    with pytest.raises(FleetImportError, match=r"skills/review/SKILL\.md: symlink"):
+        import_fleet_zip(source, target_dir=target)
+
+    assert (target / "AGENTS.md").read_text(encoding="utf-8") == "existing prompt"
+    assert not (target / "skills").exists()
 
 
 def test_import_fleet_zip_rejects_unsafe_subagent_names(tmp_path: Path) -> None:
@@ -153,6 +177,43 @@ def test_import_fleet_zip_stdout_recommends_interrupt_env(tmp_path: Path) -> Non
 
     output = format_import_stdout(result)
     assert f"{INTERRUPT_ON_TOOLS_ENV_KEY}=write_remote" in output
+
+
+def test_import_fleet_zip_repeated_imports_refresh_generated_files(tmp_path: Path) -> None:
+    first = tmp_path / "first.zip"
+    second = tmp_path / "second.zip"
+    target = tmp_path / "agent"
+    _write_zip(
+        first,
+        {
+            "AGENTS.md": "first root",
+            "tools.json": json.dumps(_tools_json("root")),
+            "skills/review/SKILL.md": "first skill",
+            "subagents/researcher/AGENTS.md": "first subagent",
+        },
+    )
+    _write_zip(
+        second,
+        {
+            "AGENTS.md": "second root",
+            "skills/write/SKILL.md": "second skill",
+            "subagents/writer/AGENTS.md": "second subagent",
+        },
+    )
+
+    import_fleet_zip(first, target_dir=target)
+    import_fleet_zip(second, target_dir=target)
+
+    assert (target / "AGENTS.md").read_text(encoding="utf-8") == "second root"
+    assert not (target / ".mcp.json.setup").exists()
+    assert not (target / "skills" / "review").exists()
+    assert (target / "skills" / "write" / "SKILL.md").read_text(encoding="utf-8") == (
+        "second skill"
+    )
+    assert not (target / "subagents" / "researcher").exists()
+    assert (target / "subagents" / "writer" / "AGENTS.md").read_text(
+        encoding="utf-8"
+    ) == "second subagent"
 
 
 def _write_zip(path: Path, files: dict[str, str]) -> None:

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 
+from deepagents_code.mcp_tools import load_mcp_config
 from deepagents_talon.__main__ import main
 from deepagents_talon.fleet_import import FleetImportError, format_import_stdout, import_fleet_zip
 from deepagents_talon.runtime import INTERRUPT_ON_TOOLS_ENV_KEY
@@ -64,6 +65,37 @@ def test_import_fleet_zip_materializes_agent_files_and_mcp_config(tmp_path: Path
             },
         },
     }
+
+
+def test_import_fleet_zip_normalizes_mcp_server_names_for_loader(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    _write_zip(
+        source,
+        {
+            "AGENTS.md": "root prompt",
+            "tools.json": json.dumps(
+                {
+                    "tools": [
+                        {
+                            "name": "read_remote",
+                            "mcp_server_url": "https://tools.example/mcp",
+                            "mcp_server_name": "foo.bar",
+                        },
+                    ],
+                    "interrupt_config": {},
+                }
+            ),
+        },
+    )
+    target = tmp_path / "agent"
+
+    import_fleet_zip(source, target_dir=target)
+
+    config_path = target / ".mcp.json"
+    config = load_mcp_config(str(config_path))
+    assert set(config["mcpServers"]) == {"foo-bar"}
+    notes = (target / ".mcp.json.setup").read_text(encoding="utf-8")
+    assert '"foo-bar": {' in notes
 
 
 def test_import_fleet_cli_defaults_target_to_selected_assistant(

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -133,11 +133,11 @@ def test_import_fleet_cli_resolves_target_assistant(
         main()
 
     assert exc.value.code == 0
-    target = tmp_path / "home" / expected_id / "agent"
+    target = tmp_path / "home" / expected_id
     assert (target / "AGENTS.md").read_text(encoding="utf-8") == "root prompt"
-    assert (tmp_path / "home" / expected_id / "agents" / "researcher" / "AGENTS.md").is_file()
+    assert (target / "agents" / "researcher" / "AGENTS.md").is_file()
     if unexpected_id is not None:
-        assert not (tmp_path / "home" / unexpected_id / "agent" / "AGENTS.md").exists()
+        assert not (tmp_path / "home" / unexpected_id / "AGENTS.md").exists()
 
 
 def test_import_fleet_cli_explicit_target_keeps_subagents_under_target(

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+import sys
+import zipfile
+from typing import TYPE_CHECKING
+
+import pytest
+
+from deepagents_talon.__main__ import main
+from deepagents_talon.fleet_import import FleetImportError, format_import_stdout, import_fleet_zip
+from deepagents_talon.runtime import INTERRUPT_ON_TOOLS_ENV_KEY
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_import_fleet_zip_materializes_agent_files_and_mcp_notes(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    _write_zip(
+        source,
+        {
+            "AGENTS.md": "root prompt",
+            "config.json": "{}",
+            "tools.json": json.dumps(_tools_json("root")),
+            "skills/review/SKILL.md": "---\nname: review\n---\nReview things.",
+            "subagents/researcher/AGENTS.md": (
+                "---\ndescription: Research tasks\n---\nResearch carefully."
+            ),
+            "subagents/researcher/tools.json": json.dumps(_tools_json("researcher")),
+        },
+    )
+    target = tmp_path / "agent"
+
+    result = import_fleet_zip(source, target_dir=target)
+
+    assert result.target_dir == target
+    assert result.root_prompt_count == 1
+    assert result.subagent_prompt_count == 1
+    assert result.config_ignored is True
+    assert result.interrupt_tools == ("write_remote",)
+    assert (target / "AGENTS.md").read_text(encoding="utf-8") == "root prompt"
+    assert (target / "skills" / "review" / "SKILL.md").is_file()
+    assert (target / "subagents" / "researcher" / "AGENTS.md").is_file()
+    assert not (target / "tools.json").exists()
+    assert not (target / "config.json").exists()
+    notes = (target / ".mcp.json.setup").read_text(encoding="utf-8")
+    assert "Server: sample" in notes
+    assert "Scopes: researcher, root" in notes
+    assert "Interrupt-enabled tools: write_remote" in notes
+    assert '"allowedTools": [' in notes
+
+
+def test_import_fleet_cli_defaults_target_to_selected_assistant(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "fleet.zip"
+    _write_zip(source, {"AGENTS.md": "root prompt"})
+    monkeypatch.setenv("DEEPAGENTS_TALON_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("DEEPAGENTS_TALON_ASSISTANT_ID", "default")
+    monkeypatch.setattr(sys, "argv", ["deepagents-talon", "import-fleet", str(source)])
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == 0
+    target = tmp_path / "home" / "default" / "agent"
+    assert (target / "AGENTS.md").read_text(encoding="utf-8") == "root prompt"
+    assert f"Target directory: {target}" in capsys.readouterr().out
+
+
+def test_import_fleet_cli_assistant_id_overrides_default_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "fleet.zip"
+    _write_zip(source, {"AGENTS.md": "root prompt"})
+    monkeypatch.setenv("DEEPAGENTS_TALON_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("DEEPAGENTS_TALON_ASSISTANT_ID", "default")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["deepagents-talon", "import-fleet", str(source), "--assistant-id", "chosen"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == 0
+    assert (tmp_path / "home" / "chosen" / "agent" / "AGENTS.md").is_file()
+    assert not (tmp_path / "home" / "default" / "agent" / "AGENTS.md").exists()
+
+
+def test_import_fleet_zip_rejects_missing_root_prompt(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    _write_zip(source, {"subagents/researcher/AGENTS.md": "prompt"})
+
+    with pytest.raises(FleetImportError, match=r"AGENTS\.md: missing required root prompt"):
+        import_fleet_zip(source, target_dir=tmp_path / "agent")
+
+
+def test_import_fleet_zip_rejects_malformed_tools_json(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    _write_zip(source, {"AGENTS.md": "root prompt", "tools.json": "{bad"})
+
+    with pytest.raises(FleetImportError, match=r"tools\.json: malformed tools\.json"):
+        import_fleet_zip(source, target_dir=tmp_path / "agent")
+
+
+def test_import_fleet_zip_rejects_unsafe_paths(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    _write_zip(source, {"AGENTS.md": "root prompt", "../escape": "bad"})
+
+    with pytest.raises(FleetImportError, match=r"\.\./escape: unsafe zip path"):
+        import_fleet_zip(source, target_dir=tmp_path / "agent")
+
+
+def test_import_fleet_zip_rejects_unsafe_subagent_names(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    _write_zip(source, {"AGENTS.md": "root prompt", "subagents/bad name/AGENTS.md": "bad"})
+
+    with pytest.raises(FleetImportError, match="unsafe subagent name"):
+        import_fleet_zip(source, target_dir=tmp_path / "agent")
+
+
+def test_import_fleet_zip_stdout_recommends_interrupt_env(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    _write_zip(source, {"AGENTS.md": "root prompt", "tools.json": json.dumps(_tools_json("root"))})
+
+    result = import_fleet_zip(source, target_dir=tmp_path / "agent")
+
+    output = format_import_stdout(result)
+    assert f"{INTERRUPT_ON_TOOLS_ENV_KEY}=write_remote" in output
+
+
+def _write_zip(path: Path, files: dict[str, str]) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+
+
+def _tools_json(scope: str) -> dict[str, object]:
+    return {
+        "tools": [
+            {
+                "name": "read_remote",
+                "mcp_server_url": "https://tools.example/mcp?token=secret",
+                "mcp_server_name": "sample",
+                "display_name": f"read_remote_{scope}",
+            },
+            {
+                "name": "write_remote",
+                "mcp_server_url": "https://tools.example/mcp?token=secret",
+                "mcp_server_name": "sample",
+                "display_name": f"write_remote_{scope}",
+            },
+        ],
+        "interrupt_config": {
+            "https://tools.example/mcp?token=secret::write_remote::sample": True,
+        },
+    }

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -32,7 +32,7 @@ def test_import_fleet_zip_materializes_agent_files_and_mcp_config(tmp_path: Path
             "subagents/researcher/tools.json": json.dumps(_tools_json("researcher")),
         },
     )
-    target = tmp_path / "agent"
+    target = tmp_path / "agent-home" / "agent"
 
     result = import_fleet_zip(source, target_dir=target)
 
@@ -45,7 +45,8 @@ def test_import_fleet_zip_materializes_agent_files_and_mcp_config(tmp_path: Path
     assert (target / "skills" / "review" / "SKILL.md").read_text(encoding="utf-8") == (
         "---\nname: review\n---\nReview things."
     )
-    assert (target / "subagents" / "researcher" / "AGENTS.md").is_file()
+    assert (tmp_path / "agent-home" / "agents" / "researcher" / "AGENTS.md").is_file()
+    assert not (target / "subagents").exists()
     assert not (target / "tools.json").exists()
     assert not (target / "config.json").exists()
     notes = (target / ".mcp.json.setup").read_text(encoding="utf-8")
@@ -113,7 +114,13 @@ def test_import_fleet_cli_resolves_target_assistant(
     unexpected_id: str | None,
 ) -> None:
     source = tmp_path / "fleet.zip"
-    _write_zip(source, {"AGENTS.md": "root prompt"})
+    _write_zip(
+        source,
+        {
+            "AGENTS.md": "root prompt",
+            "subagents/researcher/AGENTS.md": "Research carefully.",
+        },
+    )
     monkeypatch.setenv("DEEPAGENTS_TALON_HOME", str(tmp_path / "home"))
     monkeypatch.setenv("DEEPAGENTS_TALON_ASSISTANT_ID", "default")
     monkeypatch.setattr(
@@ -128,6 +135,7 @@ def test_import_fleet_cli_resolves_target_assistant(
     assert exc.value.code == 0
     target = tmp_path / "home" / expected_id / "agent"
     assert (target / "AGENTS.md").read_text(encoding="utf-8") == "root prompt"
+    assert (tmp_path / "home" / expected_id / "agents" / "researcher" / "AGENTS.md").is_file()
     if unexpected_id is not None:
         assert not (tmp_path / "home" / unexpected_id / "agent" / "AGENTS.md").exists()
 
@@ -164,9 +172,11 @@ def test_import_fleet_zip_rejects_symlink_entries_before_writing_target(
     tmp_path: Path,
 ) -> None:
     source = tmp_path / "fleet.zip"
-    target = tmp_path / "agent"
-    target.mkdir()
+    target = tmp_path / "agent-home" / "agent"
+    target.mkdir(parents=True)
     (target / "AGENTS.md").write_text("existing prompt", encoding="utf-8")
+    (target / "subagents" / "stale" / "AGENTS.md").parent.mkdir(parents=True)
+    (target / "subagents" / "stale" / "AGENTS.md").write_text("stale", encoding="utf-8")
     symlink = zipfile.ZipInfo("skills/review/SKILL.md")
     symlink.external_attr = (stat.S_IFLNK | 0o777) << 16
     with zipfile.ZipFile(source, "w") as archive:
@@ -273,7 +283,7 @@ def test_import_fleet_zip_sanitizes_secret_bearing_mcp_urls(tmp_path: Path) -> N
 def test_import_fleet_zip_repeated_imports_refresh_generated_files(tmp_path: Path) -> None:
     first = tmp_path / "first.zip"
     second = tmp_path / "second.zip"
-    target = tmp_path / "agent"
+    target = tmp_path / "agent-home" / "agent"
     _write_zip(
         first,
         {
@@ -302,8 +312,9 @@ def test_import_fleet_zip_repeated_imports_refresh_generated_files(tmp_path: Pat
     assert (target / "skills" / "write" / "SKILL.md").read_text(encoding="utf-8") == (
         "second skill"
     )
-    assert not (target / "subagents" / "researcher").exists()
-    assert (target / "subagents" / "writer" / "AGENTS.md").read_text(
+    assert not (target / "subagents").exists()
+    assert not (tmp_path / "agent-home" / "agents" / "researcher").exists()
+    assert (tmp_path / "agent-home" / "agents" / "writer" / "AGENTS.md").read_text(
         encoding="utf-8"
     ) == "second subagent"
 

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -45,7 +45,7 @@ def test_import_fleet_zip_materializes_agent_files_and_mcp_config(tmp_path: Path
     assert (target / "skills" / "review" / "SKILL.md").read_text(encoding="utf-8") == (
         "---\nname: review\n---\nReview things."
     )
-    assert (tmp_path / "agent-home" / "agents" / "researcher" / "AGENTS.md").is_file()
+    assert (target / "agents" / "researcher" / "AGENTS.md").is_file()
     assert not (target / "subagents").exists()
     assert not (target / "tools.json").exists()
     assert not (target / "config.json").exists()
@@ -140,6 +140,38 @@ def test_import_fleet_cli_resolves_target_assistant(
         assert not (tmp_path / "home" / unexpected_id / "agent" / "AGENTS.md").exists()
 
 
+def test_import_fleet_cli_explicit_target_keeps_subagents_under_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "fleet.zip"
+    _write_zip(
+        source,
+        {
+            "AGENTS.md": "root prompt",
+            "subagents/researcher/AGENTS.md": "Research carefully.",
+        },
+    )
+    sibling_agents = tmp_path / "agents"
+    sibling_agents.mkdir()
+    (sibling_agents / "keep.txt").write_text("keep", encoding="utf-8")
+    target = tmp_path / "imported-agent"
+    monkeypatch.setenv("DEEPAGENTS_TALON_HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["deepagents-talon", "import-fleet", str(source), "--target-dir", str(target)],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == 0
+    assert (target / "AGENTS.md").read_text(encoding="utf-8") == "root prompt"
+    assert (target / "agents" / "researcher" / "AGENTS.md").is_file()
+    assert (sibling_agents / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+
 def test_import_fleet_zip_rejects_missing_root_prompt(tmp_path: Path) -> None:
     source = tmp_path / "fleet.zip"
     _write_zip(source, {"subagents/researcher/AGENTS.md": "prompt"})
@@ -195,6 +227,27 @@ def test_import_fleet_zip_rejects_unsafe_subagent_names(tmp_path: Path) -> None:
     _write_zip(source, {"AGENTS.md": "root prompt", "subagents/bad name/AGENTS.md": "bad"})
 
     with pytest.raises(FleetImportError, match="unsafe subagent name"):
+        import_fleet_zip(source, target_dir=tmp_path / "agent")
+
+
+def test_import_fleet_zip_rejects_high_compression_ratio(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    with zipfile.ZipFile(source, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("AGENTS.md", "root prompt")
+        archive.writestr("skills/bomb/SKILL.md", "0" * 1_000_000)
+
+    with pytest.raises(FleetImportError, match="compression ratio exceeds limit"):
+        import_fleet_zip(source, target_dir=tmp_path / "agent")
+
+
+def test_import_fleet_zip_rejects_too_many_entries(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    with zipfile.ZipFile(source, "w") as archive:
+        archive.writestr("AGENTS.md", "root prompt")
+        for index in range(10_000):
+            archive.writestr(f"skills/skill-{index}/SKILL.md", "skill")
+
+    with pytest.raises(FleetImportError, match="too many zip entries"):
         import_fleet_zip(source, target_dir=tmp_path / "agent")
 
 
@@ -313,8 +366,8 @@ def test_import_fleet_zip_repeated_imports_refresh_generated_files(tmp_path: Pat
         "second skill"
     )
     assert not (target / "subagents").exists()
-    assert not (tmp_path / "agent-home" / "agents" / "researcher").exists()
-    assert (tmp_path / "agent-home" / "agents" / "writer" / "AGENTS.md").read_text(
+    assert not (target / "agents" / "researcher").exists()
+    assert (target / "agents" / "writer" / "AGENTS.md").read_text(
         encoding="utf-8"
     ) == "second subagent"
 

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -97,29 +97,19 @@ def test_import_fleet_zip_normalizes_mcp_server_names_for_loader(tmp_path: Path)
     assert '"foo-bar": {' in notes
 
 
-def test_import_fleet_cli_defaults_target_to_selected_assistant(
+@pytest.mark.parametrize(
+    ("extra_args", "expected_id", "unexpected_id"),
+    [
+        ((), "default", None),
+        (("--assistant-id", "chosen"), "chosen", "default"),
+    ],
+)
+def test_import_fleet_cli_resolves_target_assistant(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    source = tmp_path / "fleet.zip"
-    _write_zip(source, {"AGENTS.md": "root prompt"})
-    monkeypatch.setenv("DEEPAGENTS_TALON_HOME", str(tmp_path / "home"))
-    monkeypatch.setenv("DEEPAGENTS_TALON_ASSISTANT_ID", "default")
-    monkeypatch.setattr(sys, "argv", ["deepagents-talon", "import-fleet", str(source)])
-
-    with pytest.raises(SystemExit) as exc:
-        main()
-
-    assert exc.value.code == 0
-    target = tmp_path / "home" / "default" / "agent"
-    assert (target / "AGENTS.md").read_text(encoding="utf-8") == "root prompt"
-    assert f"Agent files imported to: {target}" in capsys.readouterr().out
-
-
-def test_import_fleet_cli_assistant_id_overrides_default_target(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    extra_args: tuple[str, ...],
+    expected_id: str,
+    unexpected_id: str | None,
 ) -> None:
     source = tmp_path / "fleet.zip"
     _write_zip(source, {"AGENTS.md": "root prompt"})
@@ -128,35 +118,17 @@ def test_import_fleet_cli_assistant_id_overrides_default_target(
     monkeypatch.setattr(
         sys,
         "argv",
-        ["deepagents-talon", "import-fleet", str(source), "--assistant-id", "chosen"],
+        ["deepagents-talon", "import-fleet", str(source), *extra_args],
     )
 
     with pytest.raises(SystemExit) as exc:
         main()
 
     assert exc.value.code == 0
-    assert (tmp_path / "home" / "chosen" / "agent" / "AGENTS.md").is_file()
-    assert not (tmp_path / "home" / "default" / "agent" / "AGENTS.md").exists()
-
-
-def test_import_fleet_help_documents_operator_workflow(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    monkeypatch.setattr(sys, "argv", ["deepagents-talon", "import-fleet", "--help"])
-
-    with pytest.raises(SystemExit) as exc:
-        main()
-
-    assert exc.value.code == 0
-    output = capsys.readouterr().out
-    assert "deepagents-talon import-fleet <fleet-export.zip>" in output
-    assert "selected assistant manifest directory" in output
-    assert ".mcp.json is generated as the runtime MCP config file" in output
-    assert ".mcp.json.setup is a human-readable setup handoff" in output
-    assert "Fleet config.json is ignored" in output
-    assert "Fleet tools.json is import input only" in output
-    assert "old Fleet direct-run environment variables are unsupported" in output
+    target = tmp_path / "home" / expected_id / "agent"
+    assert (target / "AGENTS.md").read_text(encoding="utf-8") == "root prompt"
+    if unexpected_id is not None:
+        assert not (tmp_path / "home" / unexpected_id / "agent" / "AGENTS.md").exists()
 
 
 def test_import_fleet_zip_rejects_missing_root_prompt(tmp_path: Path) -> None:
@@ -233,31 +205,9 @@ def test_import_fleet_zip_stdout_recommends_interrupt_env(tmp_path: Path) -> Non
 
     output = format_import_stdout(result)
     assert result.interrupt_tools == ("approve_remote", "write_remote")
-    assert "Next steps:" in output
-    assert "- Review .mcp.json before running Talon." in output
-    assert "- Review .mcp.json.setup for requested tools and setup details." in output
     assert "- Add HITL for sensitive tools with DEEPAGENTS_TALON_INTERRUPT_ON_TOOLS." in output
     assert "approve_remote" not in output
     assert "write_remote" not in output
-
-
-def test_import_fleet_zip_removes_existing_mcp_artifacts_when_no_tools(tmp_path: Path) -> None:
-    source = tmp_path / "fleet.zip"
-    target = tmp_path / "agent"
-    target.mkdir()
-    (target / ".mcp.json.setup").write_text("stale notes", encoding="utf-8")
-    (target / ".mcp.json").write_text('{"mcpServers": {"stale": {}}}', encoding="utf-8")
-    _write_zip(source, {"AGENTS.md": "root prompt", "tools.json": json.dumps({"tools": []})})
-
-    result = import_fleet_zip(source, target_dir=target)
-
-    assert result.mcp_notes is None
-    assert result.interrupt_tools == ()
-    assert not (target / ".mcp.json.setup").exists()
-    assert not (target / ".mcp.json").exists()
-    output = format_import_stdout(result)
-    assert "- No Fleet MCP tool requirements were found." in output
-    assert "- Add MCP servers to .mcp.json if this assistant needs local tools." in output
 
 
 def test_import_fleet_zip_sanitizes_secret_bearing_mcp_urls(tmp_path: Path) -> None:
@@ -277,37 +227,6 @@ def test_import_fleet_zip_sanitizes_secret_bearing_mcp_urls(tmp_path: Path) -> N
                             ),
                             "mcp_server_name": "secret server",
                         },
-                    ],
-                    "interrupt_config": {},
-                }
-            ),
-        },
-    )
-
-    result = import_fleet_zip(source, target_dir=tmp_path / "agent")
-
-    assert result.mcp_notes is not None
-    assert "operator" not in result.mcp_notes
-    assert "password" not in result.mcp_notes
-    assert "api_key" not in result.mcp_notes
-    assert "secret#oauth" not in result.mcp_notes
-    assert "https://tools.example/tenant/<secret-redacted>/mcp" in result.mcp_notes
-    assert '"auth": "oauth"' in result.mcp_notes
-    config = json.loads((tmp_path / "agent" / ".mcp.json").read_text(encoding="utf-8"))
-    server = config["mcpServers"]["secret-server"]
-    assert server["url"] == "https://tools.example/tenant/<secret-redacted>/mcp"
-    assert server["allowedTools"] == ["secure_lookup"]
-
-
-def test_import_fleet_zip_redacts_values_after_secret_path_markers(tmp_path: Path) -> None:
-    source = tmp_path / "fleet.zip"
-    _write_zip(
-        source,
-        {
-            "AGENTS.md": "root prompt",
-            "tools.json": json.dumps(
-                {
-                    "tools": [
                         {
                             "name": "token_lookup",
                             "mcp_server_url": "https://tools.example/token/abcd1234/mcp",
@@ -328,13 +247,25 @@ def test_import_fleet_zip_redacts_values_after_secret_path_markers(tmp_path: Pat
     result = import_fleet_zip(source, target_dir=tmp_path / "agent")
 
     assert result.mcp_notes is not None
+    assert "operator" not in result.mcp_notes
+    assert "password" not in result.mcp_notes
+    assert "api_key" not in result.mcp_notes
+    assert "secret#oauth" not in result.mcp_notes
     assert "abcd1234" not in result.mcp_notes
     assert "live-secret" not in result.mcp_notes
+    assert "https://tools.example/tenant/<secret-redacted>/mcp" in result.mcp_notes
     assert "https://tools.example/<secret-redacted>/<secret-redacted>/mcp" in result.mcp_notes
-    assert "https://tools.example/<secret-redacted>/<secret-redacted>/mcp" in (
-        tmp_path / "agent" / ".mcp.json.setup"
-    ).read_text(encoding="utf-8")
-    assert "abcd1234" not in (tmp_path / "agent" / ".mcp.json").read_text(encoding="utf-8")
+    config_text = (tmp_path / "agent" / ".mcp.json").read_text(encoding="utf-8")
+    assert "operator" not in config_text
+    assert "password" not in config_text
+    assert "api_key" not in config_text
+    assert "secret#oauth" not in config_text
+    assert "abcd1234" not in config_text
+    assert "live-secret" not in config_text
+    config = json.loads(config_text)
+    server = config["mcpServers"]["secret-server"]
+    assert server["url"] == "https://tools.example/tenant/<secret-redacted>/mcp"
+    assert server["allowedTools"] == ["secure_lookup"]
 
 
 def test_import_fleet_zip_repeated_imports_refresh_generated_files(tmp_path: Path) -> None:

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -11,7 +11,6 @@ import pytest
 from deepagents_code.mcp_tools import load_mcp_config
 from deepagents_talon.__main__ import main
 from deepagents_talon.fleet_import import FleetImportError, format_import_stdout, import_fleet_zip
-from deepagents_talon.runtime import INTERRUPT_ON_TOOLS_ENV_KEY
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -115,7 +114,7 @@ def test_import_fleet_cli_defaults_target_to_selected_assistant(
     assert exc.value.code == 0
     target = tmp_path / "home" / "default" / "agent"
     assert (target / "AGENTS.md").read_text(encoding="utf-8") == "root prompt"
-    assert f"Target directory: {target}" in capsys.readouterr().out
+    assert f"Agent files imported to: {target}" in capsys.readouterr().out
 
 
 def test_import_fleet_cli_assistant_id_overrides_default_target(
@@ -234,7 +233,12 @@ def test_import_fleet_zip_stdout_recommends_interrupt_env(tmp_path: Path) -> Non
 
     output = format_import_stdout(result)
     assert result.interrupt_tools == ("approve_remote", "write_remote")
-    assert f"{INTERRUPT_ON_TOOLS_ENV_KEY}=approve_remote,write_remote" in output
+    assert "Next steps:" in output
+    assert "- Review .mcp.json before running Talon." in output
+    assert "- Review .mcp.json.setup for requested tools and setup details." in output
+    assert "- Add HITL for sensitive tools with DEEPAGENTS_TALON_INTERRUPT_ON_TOOLS." in output
+    assert "approve_remote" not in output
+    assert "write_remote" not in output
 
 
 def test_import_fleet_zip_removes_existing_mcp_artifacts_when_no_tools(tmp_path: Path) -> None:
@@ -251,7 +255,9 @@ def test_import_fleet_zip_removes_existing_mcp_artifacts_when_no_tools(tmp_path:
     assert result.interrupt_tools == ()
     assert not (target / ".mcp.json.setup").exists()
     assert not (target / ".mcp.json").exists()
-    assert "MCP setup: no Fleet MCP tool requirements found" in format_import_stdout(result)
+    output = format_import_stdout(result)
+    assert "- No Fleet MCP tool requirements were found." in output
+    assert "- Add MCP servers to .mcp.json if this assistant needs local tools." in output
 
 
 def test_import_fleet_zip_sanitizes_secret_bearing_mcp_urls(tmp_path: Path) -> None:

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -49,6 +49,7 @@ def test_import_fleet_zip_materializes_agent_files_and_mcp_notes(tmp_path: Path)
     assert not (target / "config.json").exists()
     notes = (target / ".mcp.json.setup").read_text(encoding="utf-8")
     assert "Server: sample" in notes
+    assert "Tool count: 2" in notes
     assert "Scopes: researcher, root" in notes
     assert "Interrupt-enabled tools: write_remote" in notes
     assert '"allowedTools": [' in notes
@@ -128,7 +129,10 @@ def test_import_fleet_zip_rejects_malformed_tools_json(tmp_path: Path) -> None:
     source = tmp_path / "fleet.zip"
     _write_zip(source, {"AGENTS.md": "root prompt", "tools.json": "{bad"})
 
-    with pytest.raises(FleetImportError, match=r"tools\.json: malformed tools\.json"):
+    with pytest.raises(
+        FleetImportError,
+        match=rf"{source}: tools\.json: malformed tools\.json: Expecting property name",
+    ):
         import_fleet_zip(source, target_dir=tmp_path / "agent")
 
 
@@ -171,12 +175,109 @@ def test_import_fleet_zip_rejects_unsafe_subagent_names(tmp_path: Path) -> None:
 
 def test_import_fleet_zip_stdout_recommends_interrupt_env(tmp_path: Path) -> None:
     source = tmp_path / "fleet.zip"
-    _write_zip(source, {"AGENTS.md": "root prompt", "tools.json": json.dumps(_tools_json("root"))})
+    tools = _tools_json("root")
+    tools["tools"].append(
+        {
+            "name": "approve_remote",
+            "mcp_server_url": "https://tools.example/mcp",
+            "mcp_server_name": "sample",
+            "interrupt_config": True,
+        }
+    )
+    _write_zip(source, {"AGENTS.md": "root prompt", "tools.json": json.dumps(tools)})
 
     result = import_fleet_zip(source, target_dir=tmp_path / "agent")
 
     output = format_import_stdout(result)
-    assert f"{INTERRUPT_ON_TOOLS_ENV_KEY}=write_remote" in output
+    assert result.interrupt_tools == ("approve_remote", "write_remote")
+    assert f"{INTERRUPT_ON_TOOLS_ENV_KEY}=approve_remote,write_remote" in output
+
+
+def test_import_fleet_zip_removes_existing_mcp_notes_when_no_tools(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    target = tmp_path / "agent"
+    target.mkdir()
+    (target / ".mcp.json.setup").write_text("stale notes", encoding="utf-8")
+    _write_zip(source, {"AGENTS.md": "root prompt", "tools.json": json.dumps({"tools": []})})
+
+    result = import_fleet_zip(source, target_dir=target)
+
+    assert result.mcp_notes is None
+    assert result.interrupt_tools == ()
+    assert not (target / ".mcp.json.setup").exists()
+    assert "MCP setup: no Fleet MCP tool requirements found" in format_import_stdout(result)
+
+
+def test_import_fleet_zip_sanitizes_secret_bearing_mcp_urls(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    _write_zip(
+        source,
+        {
+            "AGENTS.md": "root prompt",
+            "tools.json": json.dumps(
+                {
+                    "tools": [
+                        {
+                            "name": "secure_lookup",
+                            "mcp_server_url": (
+                                "https://operator:password@tools.example/"
+                                "tenant/bearer-token/mcp?api_key=secret#oauth"
+                            ),
+                            "mcp_server_name": "secret server",
+                        },
+                    ],
+                    "interrupt_config": {},
+                }
+            ),
+        },
+    )
+
+    result = import_fleet_zip(source, target_dir=tmp_path / "agent")
+
+    assert result.mcp_notes is not None
+    assert "operator" not in result.mcp_notes
+    assert "password" not in result.mcp_notes
+    assert "api_key" not in result.mcp_notes
+    assert "secret#oauth" not in result.mcp_notes
+    assert "https://tools.example/tenant/<secret-redacted>/mcp" in result.mcp_notes
+    assert '"auth": "oauth"' in result.mcp_notes
+
+
+def test_import_fleet_zip_redacts_values_after_secret_path_markers(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    _write_zip(
+        source,
+        {
+            "AGENTS.md": "root prompt",
+            "tools.json": json.dumps(
+                {
+                    "tools": [
+                        {
+                            "name": "token_lookup",
+                            "mcp_server_url": "https://tools.example/token/abcd1234/mcp",
+                            "mcp_server_name": "token server",
+                        },
+                        {
+                            "name": "key_lookup",
+                            "mcp_server_url": "https://tools.example/api_key/live-secret/mcp",
+                            "mcp_server_name": "key server",
+                        },
+                    ],
+                    "interrupt_config": {},
+                }
+            ),
+        },
+    )
+
+    result = import_fleet_zip(source, target_dir=tmp_path / "agent")
+
+    assert result.mcp_notes is not None
+    assert "abcd1234" not in result.mcp_notes
+    assert "live-secret" not in result.mcp_notes
+    assert "https://tools.example/<secret-redacted>/<secret-redacted>/mcp" in result.mcp_notes
+    assert "https://tools.example/<secret-redacted>/<secret-redacted>/mcp" in (
+        tmp_path / "agent" / ".mcp.json.setup"
+    ).read_text(encoding="utf-8")
 
 
 def test_import_fleet_zip_repeated_imports_refresh_generated_files(tmp_path: Path) -> None:

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -4,7 +4,7 @@ import json
 import stat
 import sys
 import zipfile
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def test_import_fleet_zip_materializes_agent_files_and_mcp_notes(tmp_path: Path) -> None:
+def test_import_fleet_zip_materializes_agent_files_and_mcp_config(tmp_path: Path) -> None:
     source = tmp_path / "fleet.zip"
     _write_zip(
         source,
@@ -53,6 +53,17 @@ def test_import_fleet_zip_materializes_agent_files_and_mcp_notes(tmp_path: Path)
     assert "Scopes: researcher, root" in notes
     assert "Interrupt-enabled tools: write_remote" in notes
     assert '"allowedTools": [' in notes
+    config = json.loads((target / ".mcp.json").read_text(encoding="utf-8"))
+    assert config == {
+        "mcpServers": {
+            "sample": {
+                "allowedTools": ["read_remote", "write_remote"],
+                "auth": "oauth",
+                "type": "http",
+                "url": "https://tools.example/mcp",
+            },
+        },
+    }
 
 
 def test_import_fleet_cli_defaults_target_to_selected_assistant(
@@ -110,8 +121,8 @@ def test_import_fleet_help_documents_operator_workflow(
     output = capsys.readouterr().out
     assert "deepagents-talon import-fleet <fleet-export.zip>" in output
     assert "selected assistant manifest directory" in output
+    assert ".mcp.json is generated as the runtime MCP config file" in output
     assert ".mcp.json.setup is a human-readable setup handoff" in output
-    assert ".mcp.json remains the runtime MCP config file" in output
     assert "Fleet config.json is ignored" in output
     assert "Fleet tools.json is import input only" in output
     assert "old Fleet direct-run environment variables are unsupported" in output
@@ -176,7 +187,8 @@ def test_import_fleet_zip_rejects_unsafe_subagent_names(tmp_path: Path) -> None:
 def test_import_fleet_zip_stdout_recommends_interrupt_env(tmp_path: Path) -> None:
     source = tmp_path / "fleet.zip"
     tools = _tools_json("root")
-    tools["tools"].append(
+    raw_tools = cast("list[dict[str, object]]", tools["tools"])
+    raw_tools.append(
         {
             "name": "approve_remote",
             "mcp_server_url": "https://tools.example/mcp",
@@ -193,11 +205,12 @@ def test_import_fleet_zip_stdout_recommends_interrupt_env(tmp_path: Path) -> Non
     assert f"{INTERRUPT_ON_TOOLS_ENV_KEY}=approve_remote,write_remote" in output
 
 
-def test_import_fleet_zip_removes_existing_mcp_notes_when_no_tools(tmp_path: Path) -> None:
+def test_import_fleet_zip_removes_existing_mcp_artifacts_when_no_tools(tmp_path: Path) -> None:
     source = tmp_path / "fleet.zip"
     target = tmp_path / "agent"
     target.mkdir()
     (target / ".mcp.json.setup").write_text("stale notes", encoding="utf-8")
+    (target / ".mcp.json").write_text('{"mcpServers": {"stale": {}}}', encoding="utf-8")
     _write_zip(source, {"AGENTS.md": "root prompt", "tools.json": json.dumps({"tools": []})})
 
     result = import_fleet_zip(source, target_dir=target)
@@ -205,6 +218,7 @@ def test_import_fleet_zip_removes_existing_mcp_notes_when_no_tools(tmp_path: Pat
     assert result.mcp_notes is None
     assert result.interrupt_tools == ()
     assert not (target / ".mcp.json.setup").exists()
+    assert not (target / ".mcp.json").exists()
     assert "MCP setup: no Fleet MCP tool requirements found" in format_import_stdout(result)
 
 
@@ -241,6 +255,10 @@ def test_import_fleet_zip_sanitizes_secret_bearing_mcp_urls(tmp_path: Path) -> N
     assert "secret#oauth" not in result.mcp_notes
     assert "https://tools.example/tenant/<secret-redacted>/mcp" in result.mcp_notes
     assert '"auth": "oauth"' in result.mcp_notes
+    config = json.loads((tmp_path / "agent" / ".mcp.json").read_text(encoding="utf-8"))
+    server = config["mcpServers"]["secret-server"]
+    assert server["url"] == "https://tools.example/tenant/<secret-redacted>/mcp"
+    assert server["allowedTools"] == ["secure_lookup"]
 
 
 def test_import_fleet_zip_redacts_values_after_secret_path_markers(tmp_path: Path) -> None:
@@ -278,6 +296,7 @@ def test_import_fleet_zip_redacts_values_after_secret_path_markers(tmp_path: Pat
     assert "https://tools.example/<secret-redacted>/<secret-redacted>/mcp" in (
         tmp_path / "agent" / ".mcp.json.setup"
     ).read_text(encoding="utf-8")
+    assert "abcd1234" not in (tmp_path / "agent" / ".mcp.json").read_text(encoding="utf-8")
 
 
 def test_import_fleet_zip_repeated_imports_refresh_generated_files(tmp_path: Path) -> None:
@@ -307,6 +326,7 @@ def test_import_fleet_zip_repeated_imports_refresh_generated_files(tmp_path: Pat
 
     assert (target / "AGENTS.md").read_text(encoding="utf-8") == "second root"
     assert not (target / ".mcp.json.setup").exists()
+    assert not (target / ".mcp.json").exists()
     assert not (target / "skills" / "review").exists()
     assert (target / "skills" / "write" / "SKILL.md").read_text(encoding="utf-8") == (
         "second skill"

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -11,6 +11,7 @@ import pytest
 from deepagents_code.mcp_tools import load_mcp_config
 from deepagents_talon.__main__ import main
 from deepagents_talon.fleet_import import FleetImportError, format_import_stdout, import_fleet_zip
+from deepagents_talon.runtime import INTERRUPT_ON_TOOLS_ENV_KEY
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -205,9 +206,10 @@ def test_import_fleet_zip_stdout_recommends_interrupt_env(tmp_path: Path) -> Non
 
     output = format_import_stdout(result)
     assert result.interrupt_tools == ("approve_remote", "write_remote")
-    assert "- Add HITL for sensitive tools with DEEPAGENTS_TALON_INTERRUPT_ON_TOOLS." in output
-    assert "approve_remote" not in output
-    assert "write_remote" not in output
+    assert (
+        f"- Add HITL for sensitive tools with "
+        f"{INTERRUPT_ON_TOOLS_ENV_KEY}=approve_remote,write_remote."
+    ) in output
 
 
 def test_import_fleet_zip_sanitizes_secret_bearing_mcp_urls(tmp_path: Path) -> None:

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 
-from deepagents_code.mcp_tools import load_mcp_config
 from deepagents_talon.__main__ import main
 from deepagents_talon.fleet_import import FleetImportError, format_import_stdout, import_fleet_zip
 from deepagents_talon.runtime import INTERRUPT_ON_TOOLS_ENV_KEY
@@ -54,49 +53,10 @@ def test_import_fleet_zip_materializes_agent_files_and_mcp_config(tmp_path: Path
     assert "Tool count: 2" in notes
     assert "Scopes: researcher, root" in notes
     assert "Interrupt-enabled tools: write_remote" in notes
-    assert '"allowedTools": [' in notes
     config = json.loads((target / ".mcp.json").read_text(encoding="utf-8"))
-    assert config == {
-        "mcpServers": {
-            "sample": {
-                "allowedTools": ["read_remote", "write_remote"],
-                "auth": "oauth",
-                "type": "http",
-                "url": "https://tools.example/mcp",
-            },
-        },
-    }
-
-
-def test_import_fleet_zip_normalizes_mcp_server_names_for_loader(tmp_path: Path) -> None:
-    source = tmp_path / "fleet.zip"
-    _write_zip(
-        source,
-        {
-            "AGENTS.md": "root prompt",
-            "tools.json": json.dumps(
-                {
-                    "tools": [
-                        {
-                            "name": "read_remote",
-                            "mcp_server_url": "https://tools.example/mcp",
-                            "mcp_server_name": "foo.bar",
-                        },
-                    ],
-                    "interrupt_config": {},
-                }
-            ),
-        },
-    )
-    target = tmp_path / "agent"
-
-    import_fleet_zip(source, target_dir=target)
-
-    config_path = target / ".mcp.json"
-    config = load_mcp_config(str(config_path))
-    assert set(config["mcpServers"]) == {"foo-bar"}
-    notes = (target / ".mcp.json.setup").read_text(encoding="utf-8")
-    assert '"foo-bar": {' in notes
+    server = config["mcpServers"]["sample"]
+    assert server["url"] == "https://tools.example/mcp"
+    assert server["allowedTools"] == ["read_remote", "write_remote"]
 
 
 @pytest.mark.parametrize(

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -100,6 +100,33 @@ def test_import_fleet_cli_resolves_target_assistant(
         assert not (tmp_path / "home" / unexpected_id / "AGENTS.md").exists()
 
 
+def test_import_fleet_cli_defaults_assistant_to_export_stem(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "crowbar.zip"
+    _write_zip(
+        source,
+        {
+            "AGENTS.md": "root prompt",
+            "subagents/researcher/AGENTS.md": "Research carefully.",
+        },
+    )
+    monkeypatch.setenv("DEEPAGENTS_TALON_HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("DEEPAGENTS_TALON_ASSISTANT_ID", raising=False)
+    monkeypatch.delenv("AGENT_ASSISTANT_ID", raising=False)
+    monkeypatch.setattr(sys, "argv", ["deepagents-talon", "import-fleet", str(source)])
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    assert exc.value.code == 0
+    target = tmp_path / "home" / "crowbar"
+    assert (target / "AGENTS.md").read_text(encoding="utf-8") == "root prompt"
+    assert (target / "agents" / "researcher" / "AGENTS.md").is_file()
+    assert not (tmp_path / "home" / "default" / "AGENTS.md").exists()
+
+
 def test_import_fleet_cli_explicit_target_keeps_subagents_under_target(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/libs/talon/tests/test_mcp.py
+++ b/libs/talon/tests/test_mcp.py
@@ -28,6 +28,7 @@ async def test_load_mcp_tools_delegates_to_deepagents_code_discovery(
 ) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
+    env_path = tmp_path / "custom.mcp.json"
     calls: list[dict[str, object]] = []
     tools = [DummyTool("files_read")]
     infos = [
@@ -47,6 +48,7 @@ async def test_load_mcp_tools_delegates_to_deepagents_code_discovery(
         {
             "AGENT_ASSISTANT_ID": "test",
             "DEEPAGENTS_TALON_WORKSPACE": str(workspace),
+            "DEEPAGENTS_TALON_MCP_CONFIG": str(env_path),
         },
         base_home=tmp_path,
     )
@@ -56,33 +58,8 @@ async def test_load_mcp_tools_delegates_to_deepagents_code_discovery(
     assert result.tools == tuple(tools)
     assert result.servers == tuple(infos)
     assert len(calls) == 1
-    assert calls[0]["explicit_config_path"] is None
+    assert calls[0]["explicit_config_path"] == str(env_path)
     assert calls[0]["trust_project_mcp"] is None
     project_context = calls[0]["project_context"]
     assert isinstance(project_context, ProjectContext)
     assert project_context.user_cwd == workspace.resolve()
-
-
-async def test_load_mcp_tools_layers_env_config_path(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    calls: list[dict[str, object]] = []
-
-    async def fake_resolver(**kwargs: object) -> FakeCodeLoaderResult:
-        calls.append(kwargs)
-        return [], None, []
-
-    monkeypatch.setattr("deepagents_talon.mcp.resolve_and_load_mcp_tools", fake_resolver)
-    env_path = tmp_path / "custom.mcp.json"
-    config = TalonConfig.from_env(
-        {
-            "AGENT_ASSISTANT_ID": "test",
-            "DEEPAGENTS_TALON_MCP_CONFIG": str(env_path),
-        },
-        base_home=tmp_path,
-    )
-
-    await load_mcp_tools(config)
-
-    assert calls[0]["explicit_config_path"] == str(env_path)

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
@@ -244,6 +245,84 @@ async def test_runtime_loads_local_subagents_from_assistant_dir(
             "system_prompt": "Review changes.",
         },
     ]
+
+
+async def test_runtime_skips_local_subagent_dirs_without_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    assistant_dir = tmp_path / "assistant"
+    missing_dir = assistant_dir / "subagents" / "missing"
+    valid_dir = assistant_dir / "subagents" / "valid"
+    missing_dir.mkdir(parents=True)
+    valid_dir.mkdir(parents=True)
+    (valid_dir / "AGENTS.md").write_text("Valid prompt.", encoding="utf-8")
+
+    def fake_create_deep_agent(**kwargs: Any) -> RecordingGraph:
+        captured.update(kwargs)
+        return RecordingGraph()
+
+    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
+
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        assistant_dir=assistant_dir,
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+    )
+
+    await runtime.start()
+
+    assert captured["subagents"] == [
+        {
+            "name": "valid",
+            "description": "Use the valid subagent.",
+            "system_prompt": "Valid prompt.",
+        }
+    ]
+
+
+async def test_runtime_skips_invalid_local_subagent_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    captured: dict[str, Any] = {}
+    assistant_dir = tmp_path / "assistant"
+    bad_dir = assistant_dir / "subagents" / "bad name"
+    good_dir = assistant_dir / "subagents" / "good-name"
+    bad_dir.mkdir(parents=True)
+    good_dir.mkdir(parents=True)
+    (bad_dir / "AGENTS.md").write_text("Bad prompt.", encoding="utf-8")
+    (good_dir / "AGENTS.md").write_text("Good prompt.", encoding="utf-8")
+
+    def fake_create_deep_agent(**kwargs: Any) -> RecordingGraph:
+        captured.update(kwargs)
+        return RecordingGraph()
+
+    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
+    caplog.set_level(logging.WARNING, logger="deepagents_talon.runtime")
+
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        assistant_dir=assistant_dir,
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+    )
+
+    await runtime.start()
+
+    assert captured["subagents"] == [
+        {
+            "name": "good-name",
+            "description": "Use the good-name subagent.",
+            "system_prompt": "Good prompt.",
+        }
+    ]
+    assert "unsafe subagent name 'bad name'" in caplog.text
 
 
 async def test_runtime_passes_middleware_to_create_deep_agent(

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -209,7 +209,7 @@ async def test_runtime_loads_local_subagents_from_assistant_dir(
     researcher_dir.mkdir(parents=True)
     reviewer_dir.mkdir(parents=True)
     (researcher_dir / "AGENTS.md").write_text(
-        "---\ndescription: Research tasks\n---\nResearch carefully.",
+        "---\ndescription: Research tasks\nmodel_id: openai:model\n---\nResearch carefully.",
         encoding="utf-8",
     )
     (reviewer_dir / "AGENTS.md").write_text("Review changes.", encoding="utf-8")
@@ -226,6 +226,7 @@ async def test_runtime_loads_local_subagents_from_assistant_dir(
         include_web_tools=False,
         skills=(),
         memory=(),
+        env={},
     )
 
     await runtime.start()
@@ -235,6 +236,7 @@ async def test_runtime_loads_local_subagents_from_assistant_dir(
             "name": "researcher",
             "description": "Research tasks",
             "system_prompt": "Research carefully.",
+            "model": "openai:model",
         },
         {
             "name": "reviewer",

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -199,6 +199,85 @@ async def test_runtime_wires_subagents(
     assert captured["subagents"] == subagents
 
 
+async def test_runtime_requires_approval_for_async_subagent_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    async_subagent = {
+        "name": "researcher",
+        "description": "Research tasks",
+        "graph_id": "agent",
+    }
+
+    def fake_create_deep_agent(**kwargs: Any) -> RecordingGraph:
+        captured.update(kwargs)
+        return RecordingGraph()
+
+    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
+
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        subagents=cast("Any", [async_subagent]),
+        interrupt_on={"custom_tool": True, "start_async_task": False},
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+    )
+
+    await runtime.start()
+
+    assert captured["subagents"] == [async_subagent]
+    assert captured["interrupt_on"] == {
+        "custom_tool": True,
+        "start_async_task": False,
+        "update_async_task": True,
+        "cancel_async_task": True,
+    }
+
+
+async def test_runtime_merges_local_and_async_subagents(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    assistant_dir = tmp_path / "agent-home" / "agent"
+    researcher_dir = tmp_path / "agent-home" / "agents" / "researcher"
+    researcher_dir.mkdir(parents=True)
+    (researcher_dir / "AGENTS.md").write_text("Research carefully.", encoding="utf-8")
+    async_subagent = {
+        "name": "remote_reviewer",
+        "description": "Remote review tasks",
+        "graph_id": "review",
+    }
+
+    def fake_create_deep_agent(**kwargs: Any) -> RecordingGraph:
+        captured.update(kwargs)
+        return RecordingGraph()
+
+    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
+
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        assistant_dir=assistant_dir,
+        subagents=cast("Any", [async_subagent]),
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+        env={},
+    )
+
+    await runtime.start()
+
+    assert captured["subagents"] == [
+        {
+            "name": "researcher",
+            "description": "Use the researcher subagent.",
+            "system_prompt": "Research carefully.",
+        },
+        async_subagent,
+    ]
+
+
 async def test_runtime_loads_local_subagents_from_user_agents_dir(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -198,6 +198,52 @@ async def test_runtime_wires_subagents(
     assert captured["subagents"] == subagents
 
 
+async def test_runtime_loads_local_subagents_from_assistant_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    assistant_dir = tmp_path / "assistant"
+    researcher_dir = assistant_dir / "subagents" / "researcher"
+    reviewer_dir = assistant_dir / "subagents" / "reviewer"
+    researcher_dir.mkdir(parents=True)
+    reviewer_dir.mkdir(parents=True)
+    (researcher_dir / "AGENTS.md").write_text(
+        "---\ndescription: Research tasks\n---\nResearch carefully.",
+        encoding="utf-8",
+    )
+    (reviewer_dir / "AGENTS.md").write_text("Review changes.", encoding="utf-8")
+
+    def fake_create_deep_agent(**kwargs: Any) -> RecordingGraph:
+        captured.update(kwargs)
+        return RecordingGraph()
+
+    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
+
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        assistant_dir=assistant_dir,
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+    )
+
+    await runtime.start()
+
+    assert captured["subagents"] == [
+        {
+            "name": "researcher",
+            "description": "Research tasks",
+            "system_prompt": "Research carefully.",
+        },
+        {
+            "name": "reviewer",
+            "description": "Use the reviewer subagent.",
+            "system_prompt": "Review changes.",
+        },
+    ]
+
+
 async def test_runtime_passes_middleware_to_create_deep_agent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -199,14 +199,14 @@ async def test_runtime_wires_subagents(
     assert captured["subagents"] == subagents
 
 
-async def test_runtime_loads_local_subagents_from_assistant_dir(
+async def test_runtime_loads_local_subagents_from_user_agents_dir(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, Any] = {}
-    assistant_dir = tmp_path / "assistant"
-    researcher_dir = assistant_dir / "subagents" / "researcher"
-    reviewer_dir = assistant_dir / "subagents" / "reviewer"
+    assistant_dir = tmp_path / "agent-home" / "agent"
+    researcher_dir = tmp_path / "agent-home" / "agents" / "researcher"
+    reviewer_dir = tmp_path / "agent-home" / "agents" / "reviewer"
     researcher_dir.mkdir(parents=True)
     reviewer_dir.mkdir(parents=True)
     (researcher_dir / "AGENTS.md").write_text(
@@ -253,10 +253,10 @@ async def test_runtime_skips_unloadable_local_subagent_dirs(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     captured: dict[str, Any] = {}
-    assistant_dir = tmp_path / "assistant"
-    missing_dir = assistant_dir / "subagents" / "missing"
-    bad_dir = assistant_dir / "subagents" / "bad name"
-    good_dir = assistant_dir / "subagents" / "good-name"
+    assistant_dir = tmp_path / "agent-home" / "agent"
+    missing_dir = tmp_path / "agent-home" / "agents" / "missing"
+    bad_dir = tmp_path / "agent-home" / "agents" / "bad name"
+    good_dir = tmp_path / "agent-home" / "agents" / "good-name"
     missing_dir.mkdir(parents=True)
     bad_dir.mkdir(parents=True)
     good_dir.mkdir(parents=True)

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -326,6 +326,42 @@ async def test_runtime_loads_local_subagents_from_user_agents_dir(
     ]
 
 
+async def test_runtime_loads_subagents_from_explicit_target_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    assistant_dir = tmp_path / "imported-agent"
+    researcher_dir = assistant_dir / "agents" / "researcher"
+    researcher_dir.mkdir(parents=True)
+    (researcher_dir / "AGENTS.md").write_text("Research carefully.", encoding="utf-8")
+
+    def fake_create_deep_agent(**kwargs: Any) -> RecordingGraph:
+        captured.update(kwargs)
+        return RecordingGraph()
+
+    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
+
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        assistant_dir=assistant_dir,
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+        env={},
+    )
+
+    await runtime.start()
+
+    assert captured["subagents"] == [
+        {
+            "name": "researcher",
+            "description": "Use the researcher subagent.",
+            "system_prompt": "Research carefully.",
+        },
+    ]
+
+
 async def test_runtime_skips_unloadable_local_subagent_dirs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -247,52 +247,17 @@ async def test_runtime_loads_local_subagents_from_assistant_dir(
     ]
 
 
-async def test_runtime_skips_local_subagent_dirs_without_prompt(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured: dict[str, Any] = {}
-    assistant_dir = tmp_path / "assistant"
-    missing_dir = assistant_dir / "subagents" / "missing"
-    valid_dir = assistant_dir / "subagents" / "valid"
-    missing_dir.mkdir(parents=True)
-    valid_dir.mkdir(parents=True)
-    (valid_dir / "AGENTS.md").write_text("Valid prompt.", encoding="utf-8")
-
-    def fake_create_deep_agent(**kwargs: Any) -> RecordingGraph:
-        captured.update(kwargs)
-        return RecordingGraph()
-
-    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
-
-    runtime = DeepAgentRuntime(
-        model="test:model",
-        assistant_dir=assistant_dir,
-        include_web_tools=False,
-        skills=(),
-        memory=(),
-    )
-
-    await runtime.start()
-
-    assert captured["subagents"] == [
-        {
-            "name": "valid",
-            "description": "Use the valid subagent.",
-            "system_prompt": "Valid prompt.",
-        }
-    ]
-
-
-async def test_runtime_skips_invalid_local_subagent_names(
+async def test_runtime_skips_unloadable_local_subagent_dirs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     captured: dict[str, Any] = {}
     assistant_dir = tmp_path / "assistant"
+    missing_dir = assistant_dir / "subagents" / "missing"
     bad_dir = assistant_dir / "subagents" / "bad name"
     good_dir = assistant_dir / "subagents" / "good-name"
+    missing_dir.mkdir(parents=True)
     bad_dir.mkdir(parents=True)
     good_dir.mkdir(parents=True)
     (bad_dir / "AGENTS.md").write_text("Bad prompt.", encoding="utf-8")


### PR DESCRIPTION
Adds `deepagents-talon import-fleet` so Fleet zip exports can be materialized into a normal Talon local assistant directory. The importer writes prompts, skills, subagent prompts, and MCP setup handoff notes while rejecting unsafe zip paths, symlinks, missing root prompts, malformed tool manifests, and unsafe subagent names.

This is useful when an assistant starts in Fleet but needs to run locally through Talon channels, cron, and local MCP configuration. For example, the `crowbar.zip` sample can be imported into a `crowbar` assistant and then run with Telegram:

```bash
uv run --directory libs/talon --extra media deepagents-talon import-fleet \
  examples/talon/crowbar.zip \
  --assistant-id crowbar

AGENT_ASSISTANT_ID=crowbar AGENT_MODEL=<provider>:<model-id> \
  uv run --directory libs/talon --extra media deepagents-talon --telegram
```

Fleet `tools.json` remains import input only. When Fleet MCP tools are present, Talon writes `.mcp.json.setup` as operator guidance; `.mcp.json` remains the runtime MCP config file.

## Release note

Talon now supports `deepagents-talon import-fleet <fleet-export.zip>` to import Fleet zip exports into a local Talon agent directory, including MCP setup notes and local subagent prompt loading.