### PR TITLE
fix(talon): generate sanitized Fleet MCP setup notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ celerybeat.pid
 env.local
 *.env.local
 .venv
+.venv/
 env/
 venv/
 ENV/

--- a/libs/talon/deepagents_talon/fleet_import.py
+++ b/libs/talon/deepagents_talon/fleet_import.py
@@ -22,6 +22,20 @@ _SETUP_FILENAME = ".mcp.json.setup"
 _ZIP_FILE_TYPE_MASK = 0o170000
 _ZIP_SYMLINK_TYPE = 0o120000
 _SUBAGENT_FILE_PARTS = 3
+_SECRET_PATH_PATTERN = re.compile(
+    r"(?:"
+    r"bearer[-_a-z0-9]*|"
+    r"token[-_a-z0-9]*|"
+    r"key[-_a-z0-9]*|"
+    r"secret[-_a-z0-9]*|"
+    r"cookie[-_a-z0-9]*|"
+    r"oauth[-_a-z0-9]*|"
+    r"sk-[A-Za-z0-9]{20,}|"
+    r"gh[opu]_[A-Za-z0-9]{20,}|"
+    r"lsv2_pt_[A-Za-z0-9]+"
+    r")",
+    re.IGNORECASE,
+)
 
 
 class FleetImportError(ValueError):
@@ -106,7 +120,7 @@ def import_fleet_zip(zip_path: Path, *, target_dir: Path) -> FleetImportResult:
             with tempfile.TemporaryDirectory(prefix="deepagents-talon-import-") as raw:
                 staging = Path(raw)
                 _materialize_staging(archive, entries, staging)
-                summaries = _mcp_summaries(staging)
+                summaries = _mcp_summaries(staging, source)
                 notes = _format_setup_notes(source.name, summaries)
                 config_ignored = (staging / "config.json").is_file()
                 _refresh_target(staging, target, notes)
@@ -247,10 +261,10 @@ def _is_subagent_tools_path(name: str) -> bool:
     )
 
 
-def _mcp_summaries(staging: Path) -> list[_ServerSummary]:
+def _mcp_summaries(staging: Path, source: Path) -> list[_ServerSummary]:
     grouped: dict[tuple[str, str], _ServerSummary] = {}
     for path, scope in _tools_json_paths(staging):
-        for tool in _load_tool_requests(path, scope):
+        for tool in _load_tool_requests(path, scope, source):
             key = (tool.server_url, tool.server_name)
             summary = grouped.get(key)
             if summary is None:
@@ -274,22 +288,22 @@ def _tools_json_paths(staging: Path) -> list[tuple[Path, str]]:
     return paths
 
 
-def _load_tool_requests(path: Path, scope: str) -> list[_ToolRequest]:
+def _load_tool_requests(path: Path, scope: str, source: Path) -> list[_ToolRequest]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        msg = f"{_display_path(path)}: malformed tools.json: {exc.msg}"
+        msg = f"{source}: {_display_path(path)}: malformed tools.json: {exc.msg}"
         raise FleetImportError(msg) from exc
     except OSError as exc:
-        msg = f"{_display_path(path)}: {exc}"
+        msg = f"{source}: {_display_path(path)}: {exc}"
         raise FleetImportError(msg) from exc
     if not isinstance(data, dict):
-        msg = f"{_display_path(path)}: malformed tools.json: expected object"
+        msg = f"{source}: {_display_path(path)}: malformed tools.json: expected object"
         raise FleetImportError(msg)
 
     raw_tools = data.get("tools")
     if not isinstance(raw_tools, list):
-        msg = f"{_display_path(path)}: malformed tools.json: expected tools list"
+        msg = f"{source}: {_display_path(path)}: malformed tools.json: expected tools list"
         raise FleetImportError(msg)
     interrupt_config = data.get("interrupt_config")
     interrupts = interrupt_config if isinstance(interrupt_config, dict) else {}
@@ -297,12 +311,14 @@ def _load_tool_requests(path: Path, scope: str) -> list[_ToolRequest]:
     requests: list[_ToolRequest] = []
     for index, item in enumerate(raw_tools):
         if not isinstance(item, dict):
-            msg = f"{_display_path(path)}: tools[{index}] must be an object"
+            msg = f"{source}: {_display_path(path)}: tools[{index}] must be an object"
             raise FleetImportError(msg)
         tool = cast("Mapping[str, object]", item)
-        name = _required_str(tool, "name", path, index)
-        server_url = _sanitize_server_url(_required_str(tool, "mcp_server_url", path, index))
-        server_name = _required_str(tool, "mcp_server_name", path, index)
+        name = _required_str(tool, "name", path, index, source)
+        server_url = _sanitize_server_url(
+            _required_str(tool, "mcp_server_url", path, index, source)
+        )
+        server_name = _required_str(tool, "mcp_server_name", path, index, source)
         requests.append(
             _ToolRequest(
                 name=name,
@@ -315,10 +331,16 @@ def _load_tool_requests(path: Path, scope: str) -> list[_ToolRequest]:
     return requests
 
 
-def _required_str(item: Mapping[str, object], key: str, path: Path, index: int) -> str:
+def _required_str(
+    item: Mapping[str, object],
+    key: str,
+    path: Path,
+    index: int,
+    source: Path,
+) -> str:
     value = item.get(key)
     if not isinstance(value, str) or not value:
-        msg = f"{_display_path(path)}: tools[{index}].{key} must be a non-empty string"
+        msg = f"{source}: {_display_path(path)}: tools[{index}].{key} must be a non-empty string"
         raise FleetImportError(msg)
     return value
 
@@ -347,7 +369,22 @@ def _unsanitized_url(item: Mapping[str, object]) -> str:
 
 def _sanitize_server_url(raw: str) -> str:
     parts = urlsplit(raw)
-    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+    hostname = parts.hostname or ""
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    port = f":{parts.port}" if parts.port is not None else ""
+    path = _sanitize_url_path(parts.path)
+    return urlunsplit((parts.scheme, f"{hostname}{port}", path, "", ""))
+
+
+def _sanitize_url_path(path: str) -> str:
+    parts = [part for part in path.split("/") if part]
+    if not parts:
+        return ""
+    sanitized = [
+        "<secret-redacted>" if _SECRET_PATH_PATTERN.search(part) else part for part in parts
+    ]
+    return "/" + "/".join(sanitized)
 
 
 def _format_setup_notes(source_name: str, summaries: Sequence[_ServerSummary]) -> str | None:
@@ -371,6 +408,7 @@ def _format_server_summary(summary: _ServerSummary) -> list[str]:
         "",
         f"Server: {summary.server_name}",
         f"URL: {summary.server_url}",
+        f"Tool count: {len(tools)}",
         f"Scopes: {', '.join(sorted(summary.scopes))}",
         "Requested tools:",
         *[f"- {tool}" for tool in tools],

--- a/libs/talon/deepagents_talon/fleet_import.py
+++ b/libs/talon/deepagents_talon/fleet_import.py
@@ -36,6 +36,20 @@ _SECRET_PATH_PATTERN = re.compile(
     r")",
     re.IGNORECASE,
 )
+_SECRET_PATH_MARKER_PATTERN = re.compile(
+    r"(?:"
+    r"bearer|"
+    r"token|"
+    r"access[-_]?token|"
+    r"refresh[-_]?token|"
+    r"api[-_]?key|"
+    r"key|"
+    r"secret|"
+    r"cookie|"
+    r"oauth"
+    r")",
+    re.IGNORECASE,
+)
 
 
 class FleetImportError(ValueError):
@@ -381,9 +395,16 @@ def _sanitize_url_path(path: str) -> str:
     parts = [part for part in path.split("/") if part]
     if not parts:
         return ""
-    sanitized = [
-        "<secret-redacted>" if _SECRET_PATH_PATTERN.search(part) else part for part in parts
-    ]
+    sanitized: list[str] = []
+    redact_next = False
+    for part in parts:
+        marker = _SECRET_PATH_MARKER_PATTERN.fullmatch(part) is not None
+        secret = _SECRET_PATH_PATTERN.search(part) is not None
+        if redact_next or marker or secret:
+            sanitized.append("<secret-redacted>")
+        else:
+            sanitized.append(part)
+        redact_next = marker
     return "/" + "/".join(sanitized)
 
 

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -46,6 +46,7 @@ def test_import_fleet_zip_materializes_agent_files_and_mcp_notes(tmp_path: Path)
     assert not (target / "config.json").exists()
     notes = (target / ".mcp.json.setup").read_text(encoding="utf-8")
     assert "Server: sample" in notes
+    assert "Tool count: 2" in notes
     assert "Scopes: researcher, root" in notes
     assert "Interrupt-enabled tools: write_remote" in notes
     assert '"allowedTools": [' in notes
@@ -105,7 +106,10 @@ def test_import_fleet_zip_rejects_malformed_tools_json(tmp_path: Path) -> None:
     source = tmp_path / "fleet.zip"
     _write_zip(source, {"AGENTS.md": "root prompt", "tools.json": "{bad"})
 
-    with pytest.raises(FleetImportError, match=r"tools\.json: malformed tools\.json"):
+    with pytest.raises(
+        FleetImportError,
+        match=rf"{source}: tools\.json: malformed tools\.json: Expecting property name",
+    ):
         import_fleet_zip(source, target_dir=tmp_path / "agent")
 
 
@@ -127,12 +131,72 @@ def test_import_fleet_zip_rejects_unsafe_subagent_names(tmp_path: Path) -> None:
 
 def test_import_fleet_zip_stdout_recommends_interrupt_env(tmp_path: Path) -> None:
     source = tmp_path / "fleet.zip"
-    _write_zip(source, {"AGENTS.md": "root prompt", "tools.json": json.dumps(_tools_json("root"))})
+    tools = _tools_json("root")
+    tools["tools"].append(
+        {
+            "name": "approve_remote",
+            "mcp_server_url": "https://tools.example/mcp",
+            "mcp_server_name": "sample",
+            "interrupt_config": True,
+        }
+    )
+    _write_zip(source, {"AGENTS.md": "root prompt", "tools.json": json.dumps(tools)})
 
     result = import_fleet_zip(source, target_dir=tmp_path / "agent")
 
     output = format_import_stdout(result)
-    assert f"{INTERRUPT_ON_TOOLS_ENV_KEY}=write_remote" in output
+    assert result.interrupt_tools == ("approve_remote", "write_remote")
+    assert f"{INTERRUPT_ON_TOOLS_ENV_KEY}=approve_remote,write_remote" in output
+
+
+def test_import_fleet_zip_removes_existing_mcp_notes_when_no_tools(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    target = tmp_path / "agent"
+    target.mkdir()
+    (target / ".mcp.json.setup").write_text("stale notes", encoding="utf-8")
+    _write_zip(source, {"AGENTS.md": "root prompt", "tools.json": json.dumps({"tools": []})})
+
+    result = import_fleet_zip(source, target_dir=target)
+
+    assert result.mcp_notes is None
+    assert result.interrupt_tools == ()
+    assert not (target / ".mcp.json.setup").exists()
+    assert "MCP setup: no Fleet MCP tool requirements found" in format_import_stdout(result)
+
+
+def test_import_fleet_zip_sanitizes_secret_bearing_mcp_urls(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    _write_zip(
+        source,
+        {
+            "AGENTS.md": "root prompt",
+            "tools.json": json.dumps(
+                {
+                    "tools": [
+                        {
+                            "name": "secure_lookup",
+                            "mcp_server_url": (
+                                "https://operator:password@tools.example/"
+                                "tenant/bearer-token/mcp?api_key=secret#oauth"
+                            ),
+                            "mcp_server_name": "secret server",
+                        },
+                    ],
+                    "interrupt_config": {},
+                }
+            ),
+        },
+    )
+
+    result = import_fleet_zip(source, target_dir=tmp_path / "agent")
+
+    assert result.mcp_notes is not None
+    assert "operator" not in result.mcp_notes
+    assert "password" not in result.mcp_notes
+    assert "api_key" not in result.mcp_notes
+    assert "secret#oauth" not in result.mcp_notes
+    assert "https://tools.example/tenant/<secret-redacted>/mcp" in result.mcp_notes
+    assert '"auth": "oauth"' in result.mcp_notes
 
 
 def _write_zip(path: Path, files: dict[str, str]) -> None:

--- a/libs/talon/tests/test_fleet_import.py
+++ b/libs/talon/tests/test_fleet_import.py
@@ -223,6 +223,43 @@ def test_import_fleet_zip_sanitizes_secret_bearing_mcp_urls(tmp_path: Path) -> N
     assert '"auth": "oauth"' in result.mcp_notes
 
 
+def test_import_fleet_zip_redacts_values_after_secret_path_markers(tmp_path: Path) -> None:
+    source = tmp_path / "fleet.zip"
+    _write_zip(
+        source,
+        {
+            "AGENTS.md": "root prompt",
+            "tools.json": json.dumps(
+                {
+                    "tools": [
+                        {
+                            "name": "token_lookup",
+                            "mcp_server_url": "https://tools.example/token/abcd1234/mcp",
+                            "mcp_server_name": "token server",
+                        },
+                        {
+                            "name": "key_lookup",
+                            "mcp_server_url": "https://tools.example/api_key/live-secret/mcp",
+                            "mcp_server_name": "key server",
+                        },
+                    ],
+                    "interrupt_config": {},
+                }
+            ),
+        },
+    )
+
+    result = import_fleet_zip(source, target_dir=tmp_path / "agent")
+
+    assert result.mcp_notes is not None
+    assert "abcd1234" not in result.mcp_notes
+    assert "live-secret" not in result.mcp_notes
+    assert "https://tools.example/<secret-redacted>/<secret-redacted>/mcp" in result.mcp_notes
+    assert "https://tools.example/<secret-redacted>/<secret-redacted>/mcp" in (
+        tmp_path / "agent" / ".mcp.json.setup"
+    ).read_text(encoding="utf-8")
+
+
 def test_import_fleet_zip_repeated_imports_refresh_generated_files(tmp_path: Path) -> None:
     first = tmp_path / "first.zip"
     second = tmp_path / "second.zip"


### PR DESCRIPTION
Linear: https://linear.app/langchain/issue/JKB-3

This tightens Fleet zip import MCP setup output so operators get safe, actionable setup notes instead of runtime config. The importer now includes the source zip in malformed `tools.json` errors, reports server tool counts in the generated notes/stdout, strips userinfo/query/fragment and obvious secret-bearing URL path segments before suggesting `.mcp.json` fragments, and preserves deterministic interrupt tool recommendations by tool name.

A small `.gitignore` hygiene update adds the directory form of `.venv/` required by the repo safety checklist.

## Release note

Talon Fleet zip import now generates safer `.mcp.json.setup` guidance for MCP tools, including tool counts, sanitized server URLs, and deterministic interrupt tool environment recommendations.

Focused validation passes for Fleet import tests and Ruff on the touched files. `ty check deepagents_talon` still fails on an existing `speech.py` pipeline protocol mismatch unrelated to this change.