### PR TITLE
fix(talon): validate local subagent prompt names

### DIFF
--- a/libs/talon/deepagents_talon/runtime.py
+++ b/libs/talon/deepagents_talon/runtime.py
@@ -152,6 +152,7 @@ _CRON_AUTO_DENY_MESSAGE = (
 _CHANNEL_AUTO_DENY_MESSAGE = (
     "Tool approval is unavailable on this channel; skipped the gated tool call."
 )
+_LOCAL_SUBAGENT_NAME_PATTERN = re.compile(r"[A-Za-z0-9_.-]{1,128}")
 
 _CRON_ORIGIN: contextvars.ContextVar[CronOrigin | None] = contextvars.ContextVar(
     "talon_cron_origin",
@@ -879,6 +880,13 @@ def _load_local_subagents(assistant_dir: Path) -> list[SubAgent]:
         path = child / "AGENTS.md"
         if not path.is_file():
             continue
+        if not _valid_local_subagent_name(child.name):
+            logger.warning(
+                "Skipping Talon subagent prompt from %s: unsafe subagent name %r",
+                path,
+                child.name,
+            )
+            continue
         try:
             text = path.read_text(encoding="utf-8")
         except OSError:
@@ -893,6 +901,10 @@ def _load_local_subagents(assistant_dir: Path) -> list[SubAgent]:
             }
         )
     return subagents
+
+
+def _valid_local_subagent_name(name: str) -> bool:
+    return _LOCAL_SUBAGENT_NAME_PATTERN.fullmatch(name) is not None and name not in {".", ".."}
 
 
 def _parse_local_subagent_prompt(text: str, name: str) -> tuple[str, str]:

--- a/libs/talon/tests/test_runtime.py
+++ b/libs/talon/tests/test_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
@@ -242,6 +243,84 @@ async def test_runtime_loads_local_subagents_from_assistant_dir(
             "system_prompt": "Review changes.",
         },
     ]
+
+
+async def test_runtime_skips_local_subagent_dirs_without_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    assistant_dir = tmp_path / "assistant"
+    missing_dir = assistant_dir / "subagents" / "missing"
+    valid_dir = assistant_dir / "subagents" / "valid"
+    missing_dir.mkdir(parents=True)
+    valid_dir.mkdir(parents=True)
+    (valid_dir / "AGENTS.md").write_text("Valid prompt.", encoding="utf-8")
+
+    def fake_create_deep_agent(**kwargs: Any) -> RecordingGraph:
+        captured.update(kwargs)
+        return RecordingGraph()
+
+    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
+
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        assistant_dir=assistant_dir,
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+    )
+
+    await runtime.start()
+
+    assert captured["subagents"] == [
+        {
+            "name": "valid",
+            "description": "Use the valid subagent.",
+            "system_prompt": "Valid prompt.",
+        }
+    ]
+
+
+async def test_runtime_skips_invalid_local_subagent_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    captured: dict[str, Any] = {}
+    assistant_dir = tmp_path / "assistant"
+    bad_dir = assistant_dir / "subagents" / "bad name"
+    good_dir = assistant_dir / "subagents" / "good-name"
+    bad_dir.mkdir(parents=True)
+    good_dir.mkdir(parents=True)
+    (bad_dir / "AGENTS.md").write_text("Bad prompt.", encoding="utf-8")
+    (good_dir / "AGENTS.md").write_text("Good prompt.", encoding="utf-8")
+
+    def fake_create_deep_agent(**kwargs: Any) -> RecordingGraph:
+        captured.update(kwargs)
+        return RecordingGraph()
+
+    monkeypatch.setattr("deepagents_talon.runtime.create_deep_agent", fake_create_deep_agent)
+    caplog.set_level(logging.WARNING, logger="deepagents_talon.runtime")
+
+    runtime = DeepAgentRuntime(
+        model="test:model",
+        assistant_dir=assistant_dir,
+        include_web_tools=False,
+        skills=(),
+        memory=(),
+    )
+
+    await runtime.start()
+
+    assert captured["subagents"] == [
+        {
+            "name": "good-name",
+            "description": "Use the good-name subagent.",
+            "system_prompt": "Good prompt.",
+        }
+    ]
+    assert "unsafe subagent name 'bad name'" in caplog.text
 
 
 async def test_runtime_passes_middleware_to_create_deep_agent(


### PR DESCRIPTION
Linear: JKB-5

Loads local Talon subagent prompt directories defensively by validating materialized subagent directory names before they are passed into Deep Agents `SubAgent` specs. This matches the Fleet import name policy and keeps malformed local directories from leaking into runtime graph construction.

Also adds focused runtime coverage for subagent directories without `AGENTS.md` and invalid subagent directory names.

Verification:
- `uv run --group test pytest tests/test_runtime.py -q`
- `uv run --group test pytest tests -q`
- `uv run --group test ruff format deepagents_talon/runtime.py tests/test_runtime.py --check`
- `uv run --group test ruff check deepagents_talon/runtime.py tests/test_runtime.py`
- `uv run --group test ty check deepagents_talon/runtime.py tests/test_runtime.py`

Note: full `uv run --group test ty check` still fails on existing unrelated diagnostics in `deepagents_talon/speech.py` and `tests/test_observability.py`.