### PR TITLE
feat(talon): add scheduler host clock context

### DIFF
--- a/libs/talon/deepagents_talon/cron/jobs.py
+++ b/libs/talon/deepagents_talon/cron/jobs.py
@@ -264,10 +264,7 @@ class CronSchedule:
                 wall_date=wall_date,
                 active_window=active_window,
             )
-        msg = (
-            "schedule must look like 'in 30m', 'every 15m', "
-            "'at 8:00pm', or 'every day at 8:00pm'"
-        )
+        msg = "schedule must look like 'in 30m', 'every 15m', 'at 8:00pm', or 'every day at 8:00pm'"
         raise CronJobError(msg)
 
     def next_after(self, now: datetime, previous: datetime | None = None) -> datetime:
@@ -344,8 +341,10 @@ class CronSchedule:
             Re-parsed schedule with the requested options applied.
         """
         existing_window = self.active_window
-        resolved_timezone = timezone or self.timezone or (
-            None if existing_window is None else existing_window.timezone
+        resolved_timezone = (
+            timezone
+            or self.timezone
+            or (None if existing_window is None else existing_window.timezone)
         )
         if active_start is None and active_end is None and existing_window is not None:
             active_start = existing_window.start.to_display()
@@ -370,9 +369,7 @@ class CronSchedule:
             "timezone": self.timezone,
             "wall_time": self.wall_time,
             "wall_date": None if self.wall_date is None else self.wall_date.isoformat(),
-            "active_window": (
-                None if self.active_window is None else self.active_window.to_dict()
-            ),
+            "active_window": (None if self.active_window is None else self.active_window.to_dict()),
         }
 
     @classmethod
@@ -606,7 +603,7 @@ class CronJobStore:
             last_status=None,
             last_error=None,
             origin=origin,
-            scheduler_host_clock=capture_scheduler_host_clock(current),
+            scheduler_host_clock=capture_scheduler_host_clock(now),
         )
         jobs = [*self.list_jobs(), job]
         self._write_jobs(jobs)
@@ -704,7 +701,7 @@ class CronJobStore:
                     raise CronJobError(msg)
                 new_repeat = CronRepeat(times=repeat_times)
             scheduler_host_clock = (
-                capture_scheduler_host_clock(current)
+                capture_scheduler_host_clock(now)
                 if schedule is not None
                 else job.scheduler_host_clock
             )
@@ -774,7 +771,7 @@ class CronJobStore:
             if not job.enabled or job.next_run_at is None or job.next_run_at > current:
                 result.append(job)
                 continue
-            advanced, should_run = _advance_claimed_job(job, current)
+            advanced, should_run = _advance_claimed_job(job, current, host_now=now)
             changed = True
             if should_run:
                 claimed = advanced
@@ -900,12 +897,17 @@ class CronJobStore:
             self.path.chmod(0o600)
 
 
-def _advance_claimed_job(job: CronJob, now: datetime) -> tuple[CronJob, bool]:
+def _advance_claimed_job(
+    job: CronJob,
+    now: datetime,
+    *,
+    host_now: datetime | None,
+) -> tuple[CronJob, bool]:
     if job.schedule.kind in {"one_shot", "wall_clock_once"}:
         return replace(job, enabled=False, next_run_at=None), True
 
     if _outside_active_window(job, now):
-        return _advance_skipped_job(job, now), False
+        return _advance_skipped_job(job, now, host_now=host_now), False
 
     repeat = job.repeat.claim()
     if repeat.exhausted:
@@ -916,17 +918,22 @@ def _advance_claimed_job(job: CronJob, now: datetime) -> tuple[CronJob, bool]:
             job,
             repeat=repeat,
             next_run_at=job.schedule.next_after(now, previous=job.next_run_at),
-            scheduler_host_clock=capture_scheduler_host_clock(now),
+            scheduler_host_clock=capture_scheduler_host_clock(host_now),
         ),
         True,
     )
 
 
-def _advance_skipped_job(job: CronJob, now: datetime) -> CronJob:
+def _advance_skipped_job(
+    job: CronJob,
+    now: datetime,
+    *,
+    host_now: datetime | None,
+) -> CronJob:
     return replace(
         job,
         next_run_at=job.schedule.next_after(now, previous=job.next_run_at),
-        scheduler_host_clock=capture_scheduler_host_clock(now),
+        scheduler_host_clock=capture_scheduler_host_clock(host_now),
     )
 
 

--- a/libs/talon/deepagents_talon/cron/time.py
+++ b/libs/talon/deepagents_talon/cron/time.py
@@ -44,10 +44,12 @@ class ActiveWindowDict(TypedDict):
 class SchedulerHostClockDict(TypedDict):
     """Serialized scheduler host clock context."""
 
-    timezone: str
-    utc_offset: str
+    scheduler_timezone: str
+    scheduler_utc_offset: str
     computed_at: str
     local_now: NotRequired[str]
+    timezone: NotRequired[str]
+    utc_offset: NotRequired[str]
 
 
 @dataclass(frozen=True, slots=True)
@@ -170,8 +172,8 @@ class SchedulerHostClock:
             JSON-compatible host clock dictionary.
         """
         return {
-            "timezone": self.timezone,
-            "utc_offset": self.utc_offset,
+            "scheduler_timezone": self.timezone,
+            "scheduler_utc_offset": self.utc_offset,
             "computed_at": _format_time(self.computed_at),
             "local_now": self.local_now.isoformat(),
         }
@@ -191,8 +193,8 @@ class SchedulerHostClock:
         if local_now.tzinfo is None:
             local_now = local_now.replace(tzinfo=UTC)
         return cls(
-            timezone=data["timezone"],
-            utc_offset=data["utc_offset"],
+            timezone=data.get("scheduler_timezone", data.get("timezone", "local")),
+            utc_offset=data.get("scheduler_utc_offset", data.get("utc_offset", "+00:00")),
             computed_at=computed_at,
             local_now=local_now,
         )
@@ -451,17 +453,16 @@ def capture_scheduler_host_clock(now: datetime | None = None) -> SchedulerHostCl
     """Capture the scheduler host clock context.
 
     Args:
-        now: UTC computation basis, or `None` for the current time.
+        now: Host-local computation basis, or `None` for the current host time.
 
     Returns:
         Host clock context for diagnostics.
     """
-    computed_at = _coerce_utc(now)
-    local_now = computed_at.astimezone()
+    local_now = datetime.now().astimezone() if now is None else _coerce_local(now)
     return SchedulerHostClock(
         timezone=_timezone_name(local_now),
         utc_offset=_format_offset(local_now),
-        computed_at=computed_at,
+        computed_at=local_now.astimezone(UTC),
         local_now=local_now,
     )
 
@@ -539,6 +540,12 @@ def _format_time(value: datetime) -> str:
 
 def _parse_time(value: str) -> datetime:
     return _coerce_utc(datetime.fromisoformat(value))
+
+
+def _coerce_local(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
 
 
 def _coerce_utc(value: datetime | None = None) -> datetime:

--- a/libs/talon/deepagents_talon/host.py
+++ b/libs/talon/deepagents_talon/host.py
@@ -17,6 +17,7 @@ from types import FrameType
 from typing import TYPE_CHECKING, cast
 
 from deepagents_talon.channels.base import outbound_media_root_from_env, send_with_retry
+from deepagents_talon.cron.time import format_local_run
 from deepagents_talon.interfaces import (
     AgentRequest,
     AgentResult,
@@ -311,17 +312,19 @@ class TalonHost:
             job.origin.conversation_id,
         )
         conversation_id = self._agent_conversation_id(conversation_root)
+        metadata: dict[str, object] = {
+            "channel": job.origin.channel,
+            "cron_job_id": job.id,
+            "cron_job_name": job.name,
+            "origin_conversation_id": job.origin.conversation_id,
+            "cron_origin_message_id": job.origin.message_id,
+            "trigger": "cron",
+            **_cron_schedule_metadata(job),
+        }
         result = await self._invoke_agent(
             conversation_id=conversation_id,
-            text=job.prompt,
-            metadata={
-                "channel": job.origin.channel,
-                "cron_job_id": job.id,
-                "cron_job_name": job.name,
-                "origin_conversation_id": job.origin.conversation_id,
-                "cron_origin_message_id": job.origin.message_id,
-                "trigger": "cron",
-            },
+            text=_with_cron_preface(job, metadata),
+            metadata=metadata,
         )
         return result.text
 
@@ -697,6 +700,66 @@ def _outbound_media_from_refs(
             path = getattr(ref, "path", None)
             failed.append(getattr(ref, "alt", "") or getattr(path, "name", "attachment"))
     return media, failed
+
+
+def _cron_schedule_metadata(job: CronJob) -> dict[str, str | None]:
+    clock = job.scheduler_host_clock
+    schedule_timezone = _schedule_timezone(job)
+    schedule_local_now = (
+        None
+        if clock is None or schedule_timezone is None
+        else format_local_run(clock.computed_at, schedule_timezone)
+    )
+    return {
+        "schedule_timezone": schedule_timezone,
+        "schedule_local_now": schedule_local_now,
+        "scheduler_host_timezone": None if clock is None else clock.timezone,
+        "scheduler_host_local_now": None
+        if clock is None
+        else _format_scheduler_host_local_now(job),
+    }
+
+
+def _schedule_timezone(job: CronJob) -> str | None:
+    active_window = job.schedule.active_window
+    return job.schedule.timezone or (None if active_window is None else active_window.timezone)
+
+
+def _format_scheduler_host_local_now(job: CronJob) -> str | None:
+    clock = job.scheduler_host_clock
+    if clock is None:
+        return None
+    return f"{clock.local_now:%Y-%m-%d %H:%M} {clock.timezone}"
+
+
+def _with_cron_preface(job: CronJob, metadata: Mapping[str, object]) -> str:
+    preface = _cron_preface(job, metadata)
+    if not preface:
+        return job.prompt
+    return f"{preface}\n\n{job.prompt}"
+
+
+def _cron_preface(job: CronJob, metadata: Mapping[str, object]) -> str:
+    sentences: list[str] = []
+    schedule_timezone = _metadata_text(metadata, "schedule_timezone")
+    schedule_local_now = _metadata_text(metadata, "schedule_local_now")
+    scheduler_host_timezone = _metadata_text(metadata, "scheduler_host_timezone")
+    scheduler_host_local_now = _metadata_text(metadata, "scheduler_host_local_now")
+    if schedule_timezone is not None:
+        context = "active hours" if job.schedule.active_window is not None else "schedule time"
+        sentences.append(f"This scheduled run is evaluated against {schedule_timezone} {context}.")
+    if schedule_local_now is not None:
+        sentences.append(f"The current schedule-local time is {schedule_local_now}.")
+    if scheduler_host_local_now is not None:
+        sentences.append(f"The scheduler host reports local time as {scheduler_host_local_now}.")
+    elif scheduler_host_timezone is not None:
+        sentences.append(f"The scheduler host reports time zone {scheduler_host_timezone}.")
+    return " ".join(sentences)
+
+
+def _metadata_text(metadata: Mapping[str, object], key: str) -> str | None:
+    value = metadata.get(key)
+    return value if isinstance(value, str) and value else None
 
 
 def _conversation_key(provider: str, conversation_id: str) -> str:

--- a/libs/talon/tests/cron/test_jobs.py
+++ b/libs/talon/tests/cron/test_jobs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -80,9 +81,69 @@ def test_wall_clock_job_persists_timezone_and_local_output(tmp_path) -> None:
     assert job.schedule.to_dict()["timezone"] == "America/Los_Angeles"
     assert job.schedule.to_dict()["wall_time"] == "20:00"
     assert job.scheduler_host_clock is not None
-    assert CronTools(store=store, origin=lambda: CronOrigin(conversation_id="chat")).list_jobs()[0][
-        "next_run_local"
-    ] == "2026-07-01 20:00 America/Los_Angeles"
+    assert (
+        CronTools(store=store, origin=lambda: CronOrigin(conversation_id="chat")).list_jobs()[0][
+            "next_run_local"
+        ]
+        == "2026-07-01 20:00 America/Los_Angeles"
+    )
+
+
+def test_scheduler_host_clock_records_injected_utc_context(tmp_path) -> None:
+    now = datetime(2026, 7, 2, 15, 30, tzinfo=UTC)
+    store = _store(tmp_path)
+
+    job = store.create_job(
+        prompt="heartbeat",
+        schedule=CronSchedule.parse("every 15m"),
+        origin=CronOrigin(conversation_id="chat"),
+        now=now,
+    )
+
+    assert job.to_dict()["scheduler_host_clock"] == {
+        "scheduler_timezone": "UTC",
+        "scheduler_utc_offset": "+00:00",
+        "computed_at": "2026-07-02T15:30:00+00:00",
+        "local_now": "2026-07-02T15:30:00+00:00",
+    }
+
+
+def test_scheduler_host_clock_records_injected_named_timezone(tmp_path) -> None:
+    now = datetime(2026, 7, 2, 8, 30, tzinfo=ZoneInfo("America/Los_Angeles"))
+    store = _store(tmp_path)
+
+    job = store.create_job(
+        prompt="heartbeat",
+        schedule=CronSchedule.parse("every 15m"),
+        origin=CronOrigin(conversation_id="chat"),
+        now=now,
+    )
+
+    assert job.to_dict()["scheduler_host_clock"] == {
+        "scheduler_timezone": "America/Los_Angeles",
+        "scheduler_utc_offset": "-07:00",
+        "computed_at": "2026-07-02T15:30:00+00:00",
+        "local_now": "2026-07-02T08:30:00-07:00",
+    }
+
+
+def test_scheduler_host_clock_records_injected_offset_timezone(tmp_path) -> None:
+    now = datetime(2026, 7, 2, 21, tzinfo=timezone(timedelta(hours=5, minutes=30)))
+    store = _store(tmp_path)
+
+    job = store.create_job(
+        prompt="heartbeat",
+        schedule=CronSchedule.parse("every 15m"),
+        origin=CronOrigin(conversation_id="chat"),
+        now=now,
+    )
+
+    assert job.to_dict()["scheduler_host_clock"] == {
+        "scheduler_timezone": "UTC+05:30",
+        "scheduler_utc_offset": "+05:30",
+        "computed_at": "2026-07-02T15:30:00+00:00",
+        "local_now": "2026-07-02T21:00:00+05:30",
+    }
 
 
 def test_active_window_moves_initial_run_to_next_allowed_time(tmp_path) -> None:

--- a/libs/talon/tests/test_host.py
+++ b/libs/talon/tests/test_host.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, cast
 
 from deepagents_talon.config import TalonConfig
@@ -133,6 +134,39 @@ async def test_host_starts_and_stops_components(tmp_path: Path) -> None:
     assert channel.started is True
     assert channel.stopped is True
     assert channel.handler is not None
+
+
+async def test_run_scheduled_job_adds_cron_clock_metadata_and_preface(tmp_path: Path) -> None:
+    store = CronJobStore(assistant_id="test", cron_dir=tmp_path / "cron")
+    job = store.create_job(
+        prompt="check status",
+        schedule=CronSchedule.parse(
+            "every 15m",
+            timezone="America/Los_Angeles",
+            active_start="08:00",
+            active_end="17:00",
+        ),
+        origin=CronOrigin(conversation_id="chat", channel="whatsapp", message_id="message-1"),
+        name="status",
+        now=datetime(2026, 7, 2, 15, 30, tzinfo=UTC),
+    )
+    agent = BlockingAgent()
+    host = TalonHost(config=_config(tmp_path), agent=agent)
+
+    text = await host.run_scheduled_job(job)
+
+    request = agent.requests[0]
+    assert text == f"reply:{request.text}"
+    assert request.metadata["schedule_timezone"] == "America/Los_Angeles"
+    assert request.metadata["schedule_local_now"] == "2026-07-02 08:30 America/Los_Angeles"
+    assert request.metadata["scheduler_host_timezone"] == "UTC"
+    assert request.metadata["scheduler_host_local_now"] == "2026-07-02 15:30 UTC"
+    assert request.text == (
+        "This scheduled run is evaluated against America/Los_Angeles active hours. "
+        "The current schedule-local time is 2026-07-02 08:30 America/Los_Angeles. "
+        "The scheduler host reports local time as 2026-07-02 15:30 UTC.\n\n"
+        "check status"
+    )
 
 
 async def test_host_serializes_messages_per_conversation(tmp_path: Path) -> None:
@@ -785,6 +819,7 @@ async def test_host_runs_scheduled_job_and_delivers_result(tmp_path: Path) -> No
         prompt="scheduled prompt",
         schedule=CronSchedule.parse("in 5m"),
         origin=CronOrigin(conversation_id="chat"),
+        now=datetime(2026, 7, 2, 15, 30, tzinfo=UTC),
     )
     await host.start()
 
@@ -792,9 +827,12 @@ async def test_host_runs_scheduled_job_and_delivers_result(tmp_path: Path) -> No
     await host.deliver_scheduled_result(channel, job, text)
     await host.stop()
 
-    assert [request.text for request in agent.requests] == ["scheduled prompt"]
+    expected_text = (
+        "The scheduler host reports local time as 2026-07-02 15:30 UTC.\n\nscheduled prompt"
+    )
+    assert [request.text for request in agent.requests] == [expected_text]
     assert agent.requests[0].metadata["trigger"] == "cron"
-    assert channel.sent == [("chat", "reply:scheduled prompt")]
+    assert channel.sent == [("chat", f"reply:{expected_text}")]
 
 
 async def test_host_transcribes_voice_before_agent(tmp_path: Path) -> None:


### PR DESCRIPTION
Adds scheduler-host clock context to Talon cron-triggered agent metadata and prepends a prompt preface that distinguishes schedule-local time from the scheduler host's local clock. Host-clock capture now preserves injected aware datetimes for deterministic tests while production reads the host-local clock.

## Release note
Talon cron-triggered runs now include schedule-local and scheduler-host clock context in agent metadata and prompt context.

Made by [Open SWE](https://openswe.vercel.app/agents/75a30779-1dc8-adfb-9f4b-6bb5071670e9)