### PR TITLE
feat(talon): add cron wall-clock schedules [closes JKB-10]

### DIFF
--- a/libs/talon/deepagents_talon/cron/jobs.py
+++ b/libs/talon/deepagents_talon/cron/jobs.py
@@ -7,17 +7,40 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
 import uuid
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
-from typing import Literal, TypedDict, cast
+from typing import Literal, NotRequired, TypedDict, cast
+
+from deepagents_talon.cron.time import (
+    ActiveWindow,
+    ActiveWindowDict,
+    CronTimeError,
+    SchedulerHostClock,
+    SchedulerHostClockDict,
+    active_window_contains,
+    capture_scheduler_host_clock,
+    format_local_run,
+    next_daily_wall_clock_run,
+    next_interval_run,
+    next_wall_clock_run,
+    parse_active_window,
+    parse_local_time,
+    resolve_schedule_timezone,
+)
 
 MIN_GRANULARITY_MINUTES = 1
 
 JobStatus = Literal["ok", "error"]
-ScheduleKind = Literal["one_shot", "recurring"]
+ScheduleKind = Literal["one_shot", "recurring", "wall_clock_once", "wall_clock_daily"]
+
+_WALL_CLOCK_ONCE_RE = re.compile(
+    r"^at (?P<time>.+?)(?: on (?P<date>\d{4}-\d{2}-\d{2}))?$",
+)
+_WALL_CLOCK_DAILY_PREFIX = "every day at "
 
 
 class CronJobError(ValueError):
@@ -36,8 +59,12 @@ class CronScheduleDict(TypedDict):
     """Serialized schedule definition for a job."""
 
     kind: ScheduleKind
-    minutes: int
+    minutes: int | None
     display: str
+    timezone: NotRequired[str | None]
+    wall_time: NotRequired[str | None]
+    wall_date: NotRequired[str | None]
+    active_window: NotRequired[ActiveWindowDict | None]
 
 
 class CronRepeatDict(TypedDict):
@@ -63,6 +90,7 @@ class CronJobDict(TypedDict):
     last_status: JobStatus | None
     last_error: str | None
     origin: CronOriginDict
+    scheduler_host_clock: NotRequired[SchedulerHostClockDict | None]
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,30 +138,59 @@ class CronOrigin:
 
 @dataclass(frozen=True, slots=True)
 class CronSchedule:
-    """Minute-granularity schedule for a cron job.
+    """Minute or wall-clock schedule for a cron job.
 
     Args:
-        kind: Whether the schedule is one-shot or recurring.
-        minutes: Delay or interval in minutes.
+        kind: Schedule type.
+        minutes: Delay or interval in minutes for relative schedules.
         display: Human-readable schedule text supplied by the agent.
+        timezone: IANA time zone used for wall-clock interpretation.
+        wall_time: Local wall-clock time for wall-clock schedules.
+        wall_date: Optional local date for dated one-shot wall-clock schedules.
+        active_window: Optional local active-hour gate.
     """
 
     kind: ScheduleKind
-    minutes: int
+    minutes: int | None
     display: str
+    timezone: str | None = None
+    wall_time: str | None = None
+    wall_date: date | None = None
+    active_window: ActiveWindow | None = None
 
     def __post_init__(self) -> None:
-        """Validate schedule granularity."""
-        if self.minutes < MIN_GRANULARITY_MINUTES:
-            msg = "cron schedules must be at least 1 minute"
+        """Validate schedule granularity and wall-clock fields."""
+        if self.kind in {"one_shot", "recurring"}:
+            if self.minutes is None or self.minutes < MIN_GRANULARITY_MINUTES:
+                msg = "cron schedules must be at least 1 minute"
+                raise CronJobError(msg)
+            return
+        if self.timezone is None or self.wall_time is None:
+            msg = "wall-clock schedules require timezone and wall_time"
             raise CronJobError(msg)
+        if self.kind == "wall_clock_once":
+            return
+        if self.kind == "wall_clock_daily":
+            return
+        msg = f"unsupported schedule kind: {self.kind}"
+        raise CronJobError(msg)
 
     @classmethod
-    def parse(cls, value: str) -> CronSchedule:
+    def parse(
+        cls,
+        value: str,
+        *,
+        timezone: str | None = None,
+        active_start: str | None = None,
+        active_end: str | None = None,
+    ) -> CronSchedule:
         """Parse a supported schedule string.
 
         Args:
-            value: Schedule text such as `in 30m` or `every 15m`.
+            value: Schedule text such as `in 30m`, `at 8pm`, or `every day at 8pm`.
+            timezone: Optional IANA time zone for wall-clock interpretation.
+            active_start: Optional inclusive active-hour start time.
+            active_end: Optional exclusive active-hour end time.
 
         Returns:
             Parsed schedule.
@@ -141,24 +198,162 @@ class CronSchedule:
         Raises:
             CronJobError: If the schedule string is unsupported.
         """
+        try:
+            return cls._parse(
+                value,
+                timezone=timezone,
+                active_start=active_start,
+                active_end=active_end,
+            )
+        except CronTimeError as exc:
+            raise CronJobError(str(exc)) from exc
+
+    @classmethod
+    def _parse(
+        cls,
+        value: str,
+        *,
+        timezone: str | None,
+        active_start: str | None,
+        active_end: str | None,
+    ) -> CronSchedule:
         text = " ".join(value.strip().lower().split())
+        active_window = parse_active_window(
+            timezone=timezone,
+            active_start=active_start,
+            active_end=active_end,
+        )
         if text.startswith("in "):
-            return cls(kind="one_shot", minutes=_parse_duration_minutes(text[3:]), display=value)
-        if text.startswith("every "):
-            return cls(kind="recurring", minutes=_parse_duration_minutes(text[6:]), display=value)
-        msg = "schedule must look like 'in 30m' or 'every 15m'"
+            return cls(
+                kind="one_shot",
+                minutes=_parse_duration_minutes(text[3:]),
+                display=value,
+                timezone=None if active_window is None else active_window.timezone,
+                active_window=active_window,
+            )
+        if text.startswith("every ") and not text.startswith(_WALL_CLOCK_DAILY_PREFIX):
+            return cls(
+                kind="recurring",
+                minutes=_parse_duration_minutes(text[6:]),
+                display=value,
+                timezone=None if active_window is None else active_window.timezone,
+                active_window=active_window,
+            )
+        if text.startswith(_WALL_CLOCK_DAILY_PREFIX):
+            resolved = resolve_schedule_timezone(timezone)
+            wall_time = parse_local_time(text.removeprefix(_WALL_CLOCK_DAILY_PREFIX))
+            return cls(
+                kind="wall_clock_daily",
+                minutes=None,
+                display=value,
+                timezone=resolved,
+                wall_time=wall_time.to_display(),
+                active_window=active_window,
+            )
+        match = _WALL_CLOCK_ONCE_RE.match(text)
+        if match is not None:
+            resolved = resolve_schedule_timezone(timezone)
+            wall_date = _parse_wall_date(match.group("date"))
+            wall_time = parse_local_time(match.group("time"))
+            return cls(
+                kind="wall_clock_once",
+                minutes=None,
+                display=value,
+                timezone=resolved,
+                wall_time=wall_time.to_display(),
+                wall_date=wall_date,
+                active_window=active_window,
+            )
+        msg = "schedule must look like 'in 30m', 'every 15m', 'at 8:00pm', or 'every day at 8:00pm'"
         raise CronJobError(msg)
 
-    def next_after(self, now: datetime) -> datetime:
+    def next_after(self, now: datetime, previous: datetime | None = None) -> datetime:
         """Return the next scheduled run after `now`.
 
         Args:
             now: Current timestamp.
+            previous: Optional previous run candidate for recurring schedules.
 
         Returns:
             Next run timestamp.
         """
-        return now + timedelta(minutes=self.minutes)
+        try:
+            if self.kind == "one_shot":
+                candidate = now + timedelta(minutes=cast("int", self.minutes))
+                return self._validate_one_shot_active_window(candidate)
+            if self.kind == "recurring":
+                return next_interval_run(
+                    previous=now if previous is None else previous,
+                    now=now,
+                    minutes=cast("int", self.minutes),
+                    active_window=self.active_window,
+                )
+            if self.kind == "wall_clock_once":
+                candidate = next_wall_clock_run(
+                    now=now,
+                    timezone=cast("str", self.timezone),
+                    time=parse_local_time(cast("str", self.wall_time)),
+                    date=self.wall_date,
+                )
+                return self._validate_one_shot_active_window(candidate)
+            return next_daily_wall_clock_run(
+                previous=previous,
+                now=now,
+                timezone=cast("str", self.timezone),
+                time=parse_local_time(cast("str", self.wall_time)),
+                active_window=self.active_window,
+            )
+        except CronTimeError as exc:
+            raise CronJobError(str(exc)) from exc
+
+    def next_run_local(self, value: datetime) -> str | None:
+        """Return a local explanation for a run timestamp.
+
+        Args:
+            value: UTC run timestamp.
+
+        Returns:
+            Local display text when a schedule time zone is known.
+        """
+        timezone = self.timezone or (
+            None if self.active_window is None else self.active_window.timezone
+        )
+        if timezone is None:
+            return None
+        return format_local_run(value, timezone)
+
+    def with_options(
+        self,
+        *,
+        timezone: str | None = None,
+        active_start: str | None = None,
+        active_end: str | None = None,
+    ) -> CronSchedule:
+        """Return this schedule with replacement time-zone options.
+
+        Args:
+            timezone: Optional replacement IANA time zone.
+            active_start: Optional replacement active-hour start time.
+            active_end: Optional replacement active-hour end time.
+
+        Returns:
+            Re-parsed schedule with the requested options applied.
+        """
+        existing_window = self.active_window
+        resolved_timezone = (
+            timezone
+            or self.timezone
+            or (None if existing_window is None else existing_window.timezone)
+        )
+        if active_start is None and active_end is None and existing_window is not None:
+            active_start = existing_window.start.to_display()
+            active_end = existing_window.end.to_display()
+        return self.parse(
+            self.display,
+            timezone=resolved_timezone,
+            active_start=active_start,
+            active_end=active_end,
+        )
 
     def to_dict(self) -> CronScheduleDict:
         """Serialize this schedule for disk storage.
@@ -166,7 +361,15 @@ class CronSchedule:
         Returns:
             JSON-compatible schedule dictionary.
         """
-        return {"kind": self.kind, "minutes": self.minutes, "display": self.display}
+        return {
+            "kind": self.kind,
+            "minutes": self.minutes,
+            "display": self.display,
+            "timezone": self.timezone,
+            "wall_time": self.wall_time,
+            "wall_date": None if self.wall_date is None else self.wall_date.isoformat(),
+            "active_window": (None if self.active_window is None else self.active_window.to_dict()),
+        }
 
     @classmethod
     def from_dict(cls, data: CronScheduleDict) -> CronSchedule:
@@ -178,7 +381,24 @@ class CronSchedule:
         Returns:
             Parsed cron schedule.
         """
-        return cls(kind=data["kind"], minutes=data["minutes"], display=data["display"])
+        return cls(
+            kind=data["kind"],
+            minutes=data.get("minutes"),
+            display=data["display"],
+            timezone=data.get("timezone"),
+            wall_time=data.get("wall_time"),
+            wall_date=_parse_wall_date(data.get("wall_date")),
+            active_window=_parse_active_window_dict(data.get("active_window")),
+        )
+
+    def _validate_one_shot_active_window(self, candidate: datetime) -> datetime:
+        if self.active_window is not None and not active_window_contains(
+            candidate,
+            self.active_window,
+        ):
+            msg = "one-shot schedule falls outside active hours"
+            raise CronJobError(msg)
+        return candidate
 
 
 @dataclass(frozen=True, slots=True)
@@ -254,6 +474,7 @@ class CronJob:
         last_status: Last run outcome.
         last_error: Last run error text.
         origin: Conversation that receives results.
+        scheduler_host_clock: Host clock context used to compute `next_run_at`.
     """
 
     id: str
@@ -269,6 +490,7 @@ class CronJob:
     last_status: JobStatus | None
     last_error: str | None
     origin: CronOrigin
+    scheduler_host_clock: SchedulerHostClock | None = None
 
     def to_dict(self) -> CronJobDict:
         """Serialize this job for disk storage.
@@ -290,6 +512,9 @@ class CronJob:
             "last_status": self.last_status,
             "last_error": self.last_error,
             "origin": self.origin.to_dict(),
+            "scheduler_host_clock": (
+                None if self.scheduler_host_clock is None else self.scheduler_host_clock.to_dict()
+            ),
         }
 
     @classmethod
@@ -316,6 +541,7 @@ class CronJob:
             last_status=data["last_status"],
             last_error=data["last_error"],
             origin=CronOrigin.from_dict(data["origin"]),
+            scheduler_host_clock=_parse_scheduler_host_clock(data.get("scheduler_host_clock")),
         )
 
 
@@ -358,9 +584,10 @@ class CronJobStore:
         """
         current = _coerce_utc(now)
         repeat = CronRepeat(times=repeat_times)
-        if schedule.kind == "one_shot" and repeat_times is not None:
+        if schedule.kind in {"one_shot", "wall_clock_once"} and repeat_times is not None:
             msg = "repeat cap is only valid for recurring jobs"
             raise CronJobError(msg)
+        next_run_at = schedule.next_after(current)
         job = CronJob(
             id=uuid.uuid4().hex[:12],
             assistant_id=self.assistant_id,
@@ -370,11 +597,12 @@ class CronJobStore:
             repeat=repeat,
             enabled=True,
             created_at=current,
-            next_run_at=schedule.next_after(current),
+            next_run_at=next_run_at,
             last_run_at=None,
             last_status=None,
             last_error=None,
             origin=origin,
+            scheduler_host_clock=capture_scheduler_host_clock(current),
         )
         jobs = [*self.list_jobs(), job]
         self._write_jobs(jobs)
@@ -467,10 +695,15 @@ class CronJobStore:
             new_schedule = schedule or job.schedule
             new_repeat = job.repeat
             if repeat_times is not None:
-                if new_schedule.kind != "recurring":
+                if new_schedule.kind not in {"recurring", "wall_clock_daily"}:
                     msg = "repeat cap is only valid for recurring jobs"
                     raise CronJobError(msg)
                 new_repeat = CronRepeat(times=repeat_times)
+            scheduler_host_clock = (
+                capture_scheduler_host_clock(current)
+                if schedule is not None
+                else job.scheduler_host_clock
+            )
             updated = replace(
                 job,
                 name=job.name if name is None else name,
@@ -479,6 +712,7 @@ class CronJobStore:
                 repeat=new_repeat,
                 enabled=job.enabled if enabled is None else enabled,
                 next_run_at=next_run_at,
+                scheduler_host_clock=scheduler_host_clock,
             )
             result.append(updated)
         if updated is None:
@@ -527,6 +761,7 @@ class CronJobStore:
         current = _coerce_utc(now)
         jobs = self.list_jobs()
         claimed: CronJob | None = None
+        changed = False
         result: list[CronJob] = []
         for job in jobs:
             if job.id != job_id:
@@ -535,9 +770,12 @@ class CronJobStore:
             if not job.enabled or job.next_run_at is None or job.next_run_at > current:
                 result.append(job)
                 continue
-            claimed = _advance_claimed_job(job, current)
-            result.append(claimed)
-        if claimed is not None:
+            advanced, should_run = _advance_claimed_job(job, current)
+            changed = True
+            if should_run:
+                claimed = advanced
+            result.append(advanced)
+        if changed:
             self._write_jobs(result)
         return claimed
 
@@ -658,19 +896,42 @@ class CronJobStore:
             self.path.chmod(0o600)
 
 
-def _advance_claimed_job(job: CronJob, now: datetime) -> CronJob:
-    if job.schedule.kind == "one_shot":
-        return replace(job, enabled=False, next_run_at=None)
+def _advance_claimed_job(job: CronJob, now: datetime) -> tuple[CronJob, bool]:
+    if job.schedule.kind in {"one_shot", "wall_clock_once"}:
+        return replace(job, enabled=False, next_run_at=None), True
+
+    if _outside_active_window(job, now):
+        return _advance_skipped_job(job, now), False
 
     repeat = job.repeat.claim()
     if repeat.exhausted:
-        return replace(job, repeat=repeat, enabled=False, next_run_at=None)
+        return replace(job, repeat=repeat, enabled=False, next_run_at=None), True
 
-    next_run_at = cast("datetime", job.next_run_at)
-    interval = timedelta(minutes=job.schedule.minutes)
-    while next_run_at <= now:
-        next_run_at += interval
-    return replace(job, repeat=repeat, next_run_at=next_run_at)
+    return (
+        replace(
+            job,
+            repeat=repeat,
+            next_run_at=job.schedule.next_after(now, previous=job.next_run_at),
+            scheduler_host_clock=capture_scheduler_host_clock(now),
+        ),
+        True,
+    )
+
+
+def _advance_skipped_job(job: CronJob, now: datetime) -> CronJob:
+    return replace(
+        job,
+        next_run_at=job.schedule.next_after(now, previous=job.next_run_at),
+        scheduler_host_clock=capture_scheduler_host_clock(now),
+    )
+
+
+def _outside_active_window(job: CronJob, now: datetime) -> bool:
+    return (
+        job.schedule.kind in {"recurring", "wall_clock_daily"}
+        and job.schedule.active_window is not None
+        and not active_window_contains(now, job.schedule.active_window)
+    )
 
 
 def _parse_duration_minutes(value: str) -> int:
@@ -685,6 +946,33 @@ def _parse_duration_minutes(value: str) -> int:
         return _positive_int(text[:-1]) * 60
     msg = "schedule duration must use 'm' for minutes or 'h' for hours"
     raise CronJobError(msg)
+
+
+def _parse_wall_date(value: str | None) -> date | None:
+    if value is None:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        msg = "wall-clock date must use YYYY-MM-DD"
+        raise CronJobError(msg) from exc
+
+
+def _parse_active_window_dict(value: ActiveWindowDict | None) -> ActiveWindow | None:
+    if value is None:
+        return None
+    try:
+        return ActiveWindow.from_dict(value)
+    except CronTimeError as exc:
+        raise CronJobError(str(exc)) from exc
+
+
+def _parse_scheduler_host_clock(
+    value: SchedulerHostClockDict | None,
+) -> SchedulerHostClock | None:
+    if value is None:
+        return None
+    return SchedulerHostClock.from_dict(value)
 
 
 def _positive_int(value: str) -> int:

--- a/libs/talon/deepagents_talon/cron/time.py
+++ b/libs/talon/deepagents_talon/cron/time.py
@@ -1,0 +1,414 @@
+"""Pure-function time helpers for cron scheduling.
+
+Provides IANA time zone conversion, local-time parsing, wall-clock
+next-occurrence computation, and DST edge-case handling. No I/O, no side
+effects, fully deterministic and unit-testable without sleeping.
+
+Talon is an experimental runtime and is subject to change or removal at any time.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+__all__ = [
+    "ActiveWindow",
+    "CronTimeError",
+    "LocalTimeOfDay",
+    "next_interval_run",
+    "next_wall_clock_run",
+    "parse_local_time",
+]
+
+_MAX_HOUR = 23
+_MAX_MINUTE = 59
+_AMPM_HOUR_BOUND = 12  # 12-hour clock upper bound before wrapping to 0
+
+
+class CronTimeError(ValueError):
+    """Raised when a cron time request is invalid or impossible."""
+
+
+@dataclass(frozen=True, slots=True)
+class LocalTimeOfDay:
+    """Local clock time with minute precision.
+
+    Args:
+        hour: Hour of day (0-23).
+        minute: Minute of hour (0-59).
+    """
+
+    hour: int
+    minute: int
+
+    def __post_init__(self) -> None:
+        """Validate the clock-time components."""
+        if not 0 <= self.hour <= _MAX_HOUR:
+            msg = f"hour must be 0-23, got {self.hour}"
+            raise CronTimeError(msg)
+        if not 0 <= self.minute <= _MAX_MINUTE:
+            msg = f"minute must be 0-59, got {self.minute}"
+            raise CronTimeError(msg)
+
+    def to_timedelta(self) -> timedelta:
+        """Return this clock time as a `timedelta` since midnight.
+
+        Returns:
+            Duration since midnight.
+        """
+        return timedelta(hours=self.hour, minutes=self.minute)
+
+    @property
+    def total_minutes(self) -> int:
+        """Minutes since midnight."""
+        return self.hour * 60 + self.minute
+
+    def __lt__(self, other: LocalTimeOfDay) -> bool:
+        """Compare ordering by minutes since midnight."""
+        return self.total_minutes < other.total_minutes
+
+    def __le__(self, other: LocalTimeOfDay) -> bool:
+        """Compare ordering by minutes since midnight."""
+        return self.total_minutes <= other.total_minutes
+
+    def __gt__(self, other: LocalTimeOfDay) -> bool:
+        """Compare ordering by minutes since midnight."""
+        return self.total_minutes > other.total_minutes
+
+    def __ge__(self, other: LocalTimeOfDay) -> bool:
+        """Compare ordering by minutes since midnight."""
+        return self.total_minutes >= other.total_minutes
+
+    def __str__(self) -> str:
+        """Return a `HH:MM` string.
+
+        Returns:
+            Zero-padded `HH:MM` representation.
+        """
+        return f"{self.hour:02d}:{self.minute:02d}"
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveWindow:
+    """Local-time window during which recurring jobs may run.
+
+    Windows that cross midnight (`end <= start`) are supported and
+    interpreted as `start <= local < 24:00` OR `00:00 <= local < end`.
+
+    Args:
+        timezone: IANA time zone name used to evaluate the window.
+        start: Inclusive local start time.
+        end: Exclusive local end time.
+    """
+
+    timezone: str
+    start: LocalTimeOfDay
+    end: LocalTimeOfDay
+
+    def __post_init__(self) -> None:
+        """Validate the active window."""
+        if self.start == self.end:
+            msg = "active window start must differ from end"
+            raise CronTimeError(msg)
+
+    @property
+    def crosses_midnight(self) -> bool:
+        """Whether this window spans midnight."""
+        return self.end <= self.start
+
+    def contains(self, local: LocalTimeOfDay) -> bool:
+        """Return whether `local` falls inside this window.
+
+        Args:
+            local: Local clock time to test.
+
+        Returns:
+            `True` when `local` is inside the active window.
+        """
+        if self.crosses_midnight:
+            return local >= self.start or local < self.end
+        return self.start <= local < self.end
+
+    def zone(self) -> ZoneInfo:
+        """Return the zoneinfo for this window.
+
+        Returns:
+            Resolved `ZoneInfo`.
+
+        Raises:
+            CronTimeError: If the time zone is unknown.
+        """
+        return _resolve_zone(self.timezone)
+
+
+# --- Parsing -----------------------------------------------------------------
+
+_AM_PM = re.compile(
+    r"^(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?\s*(?P<suffix>am|pm)$",
+    re.IGNORECASE,
+)
+_24H = re.compile(r"^(?P<hour>\d{1,2}):(?P<minute>\d{2})$")
+_HOUR_ONLY = re.compile(r"^(?P<hour>\d{1,2})$")
+
+
+def parse_local_time(value: str) -> LocalTimeOfDay:
+    """Parse a local clock time string.
+
+    Supports the grammar forms: `20:00`, `8:00pm`, `8pm`, `08:30`, `17:27`.
+
+    Args:
+        value: Local time text.
+
+    Returns:
+        Parsed local time of day.
+
+    Raises:
+        CronTimeError: If the input is malformed or out of range.
+    """
+    text = value.strip().lower()
+    if not text:
+        msg = "local time must not be empty"
+        raise CronTimeError(msg)
+
+    m = _AM_PM.match(text)
+    if m:
+        hour = int(m.group("hour"))
+        minute = int(m.group("minute") or "0")
+        if not 0 <= hour <= _AMPM_HOUR_BOUND:
+            msg = f"12-hour clock hour out of range: {value!r}"
+            raise CronTimeError(msg)
+        if hour == _AMPM_HOUR_BOUND:
+            hour = 0
+        suffix = m.group("suffix").lower()
+        if suffix == "pm":
+            hour += _AMPM_HOUR_BOUND
+        return LocalTimeOfDay(hour=hour, minute=minute)
+
+    m = _24H.match(text)
+    if m:
+        return LocalTimeOfDay(hour=int(m.group("hour")), minute=int(m.group("minute")))
+
+    m = _HOUR_ONLY.match(text)
+    if m and text.isdigit():
+        return LocalTimeOfDay(hour=int(m.group("hour")), minute=0)
+
+    msg = f"unrecognized local time format: {value!r}"
+    raise CronTimeError(msg)
+
+
+# --- Zone resolution ---------------------------------------------------------
+
+
+def _resolve_zone(timezone: str) -> ZoneInfo:
+    """Resolve an IANA zone name, re-raising unknown zones as `CronTimeError`.
+
+    Args:
+        timezone: IANA time zone name.
+
+    Returns:
+        Resolved `ZoneInfo`.
+
+    Raises:
+        CronTimeError: If the time zone is unknown.
+    """
+    try:
+        return ZoneInfo(timezone)
+    except ZoneInfoNotFoundError as exc:
+        msg = f"unknown time zone: {timezone!r}"
+        raise CronTimeError(msg) from exc
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Return `dt` converted to UTC.
+
+    Args:
+        dt: A timezone-aware datetime.
+
+    Returns:
+        The same instant as a UTC datetime.
+    """
+    return dt.astimezone(UTC)
+
+
+def _local_time_of(dt: datetime) -> LocalTimeOfDay:
+    """Return the local clock-time components of `dt`.
+
+    Args:
+        dt: A timezone-aware datetime.
+
+    Returns:
+        Local-time-of-day at `dt`.
+    """
+    return LocalTimeOfDay(hour=dt.hour, minute=dt.minute)
+
+
+# --- Wall-clock next occurrence ----------------------------------------------
+
+
+def next_wall_clock_run(
+    *,
+    now: datetime,
+    timezone: str,
+    time: LocalTimeOfDay,
+    date: date | None = None,
+) -> datetime:
+    """Return the next UTC occurrence of `time` in `timezone`.
+
+    If no `date` is provided, the next occurrence is today when the local
+    clock has not yet reached `time`, otherwise tomorrow. When `date` is
+    provided, that local calendar date's occurrence is returned.
+
+    DST fall-back ambiguous times resolve to the first occurrence (`fold=0`).
+    DST spring-forward nonexistent local times raise a structured error
+    rather than silently shifting.
+
+    Args:
+        now: Current instant, timezone-aware.
+        timezone: IANA time zone for wall-clock interpretation.
+        time: Target local clock time.
+        date: Optional explicit local calendar date.
+
+    Returns:
+        Next occurrence of `time` in `timezone`, as a UTC datetime.
+
+    Raises:
+        CronTimeError: If the timezone is unknown, `now` is naive, or the
+            requested local time does not exist due to DST spring-forward.
+    """
+    zone = _resolve_zone(timezone)
+    now_utc = _as_utc(now)
+
+    if date is None:
+        now_local = now_utc.astimezone(zone)
+        candidate_date = now_local.date()
+        candidate = _build_local(zone, candidate_date, time, fold=0)
+        if candidate <= now_utc:
+            candidate = _build_local(
+                zone,
+                candidate_date + timedelta(days=1),
+                time,
+                fold=0,
+            )
+    else:
+        candidate = _build_local(zone, date, time, fold=0)
+
+    return _as_utc(candidate)
+
+
+def _build_local(zone: ZoneInfo, target_date: date, time: LocalTimeOfDay, *, fold: int) -> datetime:
+    """Construct a local datetime at `time` on `target_date` in `zone`.
+
+    Detects nonexistent spring-forward local times by constructing the
+    datetime and verifying the round-trip wall clock matches the request.
+
+    Args:
+        zone: Target time zone.
+        target_date: Local calendar date.
+        time: Local clock time.
+        fold: `fold` value to disambiguate repeated fall-back wall times.
+
+    Returns:
+        Timezone-aware datetime in `zone`.
+
+    Raises:
+        CronTimeError: If the local time does not exist on `target_date` in
+            `zone` (spring-forward gap).
+    """
+    naive = datetime(  # noqa: DTZ001  # naive constructed intentionally; tzinfo attached next line
+        target_date.year,
+        target_date.month,
+        target_date.day,
+        time.hour,
+        time.minute,
+        fold=fold,
+    )
+    aware = naive.replace(tzinfo=zone)
+    roundtrip = aware.astimezone(UTC).astimezone(zone)
+    if roundtrip.hour != time.hour or roundtrip.minute != time.minute:
+        msg = (
+            f"local time {time} does not exist on {target_date.isoformat()} "
+            f"in {zone!s} (spring-forward gap)"
+        )
+        raise CronTimeError(msg)
+    return aware
+
+
+# --- Interval next run with optional active window ----------------------------
+
+
+def next_interval_run(
+    *,
+    previous: datetime,
+    now: datetime,
+    minutes: int,
+    active_window: ActiveWindow | None,
+) -> datetime:
+    """Return the next interval run, gated by an optional active window.
+
+    Without an active window, the next run is `previous + minutes`, advanced
+    forward until it is strictly greater than `now` (one step is guaranteed).
+
+    With an active window, the next run is advanced forward by `minutes`
+    increments until it lands inside the window. When an interval lands
+    outside the window, the next in-window time after it is used, which may
+    fast-forward across inactive spans (e.g. overnight).
+
+    Args:
+        previous: Previous scheduled run instant, timezone-aware.
+        now: Current instant, timezone-aware.
+        minutes: Interval in minutes (>= 1).
+        active_window: Optional local-time window.
+
+    Returns:
+        Next run instant as a UTC datetime.
+
+    Raises:
+        CronTimeError: If `minutes` is not positive.
+    """
+    if minutes < 1:
+        msg = "interval minutes must be positive"
+        raise CronTimeError(msg)
+
+    step = timedelta(minutes=minutes)
+    candidate = _as_utc(previous) + step
+    if candidate <= _as_utc(now):
+        candidate = _as_utc(now) + step
+
+    if active_window is None:
+        return candidate
+
+    return _advance_into_window(candidate, active_window)
+
+
+def _advance_into_window(
+    candidate: datetime,
+    window: ActiveWindow,
+) -> datetime:
+    """Fast-forward `candidate` to the next window-start when it is outside `window`.
+
+    The interval step itself was already applied by the caller. When the
+    stepped candidate lands inside the window, it is returned unchanged;
+    otherwise the function jumps to the next in-zone window-start that is
+    strictly later than the candidate. This avoids looping and guarantees
+    a single deterministic fast-forward.
+
+    Args:
+        candidate: UTC candidate run instant (after the interval step).
+        window: Active window to satisfy.
+
+    Returns:
+        The next in-window run instant as a UTC datetime.
+    """
+    zone = window.zone()
+    local = candidate.astimezone(zone)
+    local_time = _local_time_of(local)
+    if window.contains(local_time):
+        return candidate
+
+    start_today_utc = _as_utc(_build_local(zone, local.date(), window.start, fold=0))
+    if start_today_utc >= candidate:
+        return start_today_utc
+    return _as_utc(_build_local(zone, local.date() + timedelta(days=1), window.start, fold=0))

--- a/libs/talon/deepagents_talon/cron/time.py
+++ b/libs/talon/deepagents_talon/cron/time.py
@@ -110,7 +110,6 @@ _WEEKDAY_ALIASES: dict[str, Weekday] = {
     "m": Weekday.MONDAY,
     "mon": Weekday.MONDAY,
     "monday": Weekday.MONDAY,
-    "t": Weekday.TUESDAY,
     "tue": Weekday.TUESDAY,
     "tues": Weekday.TUESDAY,
     "tuesday": Weekday.TUESDAY,
@@ -547,8 +546,8 @@ def _build_local(zone: ZoneInfo, target_date: date, time: LocalTimeOfDay, *, fol
         fold=fold,
     )
     aware = naive.replace(tzinfo=zone)
-    roundtrip = _local_time_of(aware.astimezone(UTC).astimezone(zone))
-    if roundtrip != time:
+    roundtrip = aware.astimezone(UTC).astimezone(zone)
+    if roundtrip.date() != target_date or _local_time_of(roundtrip) != time:
         msg = (
             f"local time {time} does not exist on {target_date.isoformat()} "
             f"in {zone!s} (spring-forward gap)"
@@ -595,8 +594,9 @@ def next_interval_run(
 
     step = timedelta(minutes=minutes)
     candidate = _as_utc(previous) + step
-    if candidate <= _as_utc(now):
-        candidate = _as_utc(now) + step
+    now_utc = _as_utc(now)
+    while candidate <= now_utc:
+        candidate += step
 
     if active_window is None:
         return candidate

--- a/libs/talon/deepagents_talon/cron/time.py
+++ b/libs/talon/deepagents_talon/cron/time.py
@@ -12,25 +12,236 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
+from enum import IntEnum
 from functools import total_ordering
+from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 __all__ = [
     "ActiveWindow",
     "CronTimeError",
+    "DaysOfWeek",
     "LocalTimeOfDay",
+    "Weekday",
     "next_interval_run",
     "next_wall_clock_run",
+    "parse_days_of_week",
     "parse_local_time",
+    "parse_weekday",
 ]
 
 _MAX_HOUR = 23
 _MAX_MINUTE = 59
 _AMPM_HOUR_BOUND = 12  # 12-hour clock upper bound before wrapping to 0
+_DAYS_IN_WEEK = 7
 
 
 class CronTimeError(ValueError):
     """Raised when a cron time request is invalid or impossible."""
+
+
+class Weekday(IntEnum):
+    """Day of week using Python's `datetime.weekday()` numbering.
+
+    Args:
+        value: Integer day index where Monday is `0` and Sunday is `6`.
+    """
+
+    MONDAY = 0
+    TUESDAY = 1
+    WEDNESDAY = 2
+    THURSDAY = 3
+    FRIDAY = 4
+    SATURDAY = 5
+    SUNDAY = 6
+
+    @property
+    def label(self) -> str:
+        """Return the lowercase full day name."""
+        return _WEEKDAY_LABELS[self]
+
+    @property
+    def abbreviation(self) -> str:
+        """Return the lowercase three-letter day abbreviation."""
+        return self.label[:3]
+
+    @classmethod
+    def from_date(cls, value: date) -> Weekday:
+        """Return the weekday for a calendar date.
+
+        Args:
+            value: Calendar date to inspect.
+
+        Returns:
+            Matching weekday.
+        """
+        return cls(value.weekday())
+
+    @classmethod
+    def from_datetime(cls, value: datetime) -> Weekday:
+        """Return the weekday for a datetime's local date.
+
+        Args:
+            value: Datetime to inspect.
+
+        Returns:
+            Matching weekday.
+        """
+        return cls(value.weekday())
+
+    def __str__(self) -> str:
+        """Return the lowercase full day name."""
+        return self.label
+
+
+_WEEKDAY_LABELS: dict[Weekday, str] = {
+    Weekday.MONDAY: "monday",
+    Weekday.TUESDAY: "tuesday",
+    Weekday.WEDNESDAY: "wednesday",
+    Weekday.THURSDAY: "thursday",
+    Weekday.FRIDAY: "friday",
+    Weekday.SATURDAY: "saturday",
+    Weekday.SUNDAY: "sunday",
+}
+_WEEKDAY_ALIASES: dict[str, Weekday] = {
+    "m": Weekday.MONDAY,
+    "mon": Weekday.MONDAY,
+    "monday": Weekday.MONDAY,
+    "t": Weekday.TUESDAY,
+    "tue": Weekday.TUESDAY,
+    "tues": Weekday.TUESDAY,
+    "tuesday": Weekday.TUESDAY,
+    "w": Weekday.WEDNESDAY,
+    "wed": Weekday.WEDNESDAY,
+    "weds": Weekday.WEDNESDAY,
+    "wednesday": Weekday.WEDNESDAY,
+    "th": Weekday.THURSDAY,
+    "thu": Weekday.THURSDAY,
+    "thur": Weekday.THURSDAY,
+    "thurs": Weekday.THURSDAY,
+    "thursday": Weekday.THURSDAY,
+    "f": Weekday.FRIDAY,
+    "fri": Weekday.FRIDAY,
+    "friday": Weekday.FRIDAY,
+    "sa": Weekday.SATURDAY,
+    "sat": Weekday.SATURDAY,
+    "saturday": Weekday.SATURDAY,
+    "su": Weekday.SUNDAY,
+    "sun": Weekday.SUNDAY,
+    "sunday": Weekday.SUNDAY,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DaysOfWeek:
+    """Immutable set of active weekdays for a timer.
+
+    Args:
+        days: Weekdays when a timer may run. Duplicates are removed and the
+            stored tuple is sorted Monday through Sunday.
+    """
+
+    days: tuple[Weekday, ...]
+
+    def __post_init__(self) -> None:
+        """Normalize and validate the weekday collection."""
+        try:
+            normalized = tuple(sorted({Weekday(day) for day in self.days}, key=int))
+        except ValueError as exc:
+            msg = "days of week contains an invalid weekday"
+            raise CronTimeError(msg) from exc
+        if not normalized:
+            msg = "days of week must include at least one day"
+            raise CronTimeError(msg)
+        object.__setattr__(self, "days", normalized)
+
+    @classmethod
+    def all(cls) -> DaysOfWeek:
+        """Return all seven days.
+
+        Returns:
+            Days of week containing Monday through Sunday.
+        """
+        return cls(tuple(Weekday))
+
+    @classmethod
+    def weekdays(cls) -> DaysOfWeek:
+        """Return Monday through Friday.
+
+        Returns:
+            Business weekdays.
+        """
+        return cls(
+            (
+                Weekday.MONDAY,
+                Weekday.TUESDAY,
+                Weekday.WEDNESDAY,
+                Weekday.THURSDAY,
+                Weekday.FRIDAY,
+            ),
+        )
+
+    @classmethod
+    def weekends(cls) -> DaysOfWeek:
+        """Return Saturday and Sunday.
+
+        Returns:
+            Weekend days.
+        """
+        return cls((Weekday.SATURDAY, Weekday.SUNDAY))
+
+    def contains_date(self, value: date) -> bool:
+        """Return whether `value` falls on an active weekday.
+
+        Args:
+            value: Calendar date to inspect.
+
+        Returns:
+            `True` when the date's weekday is active.
+        """
+        return Weekday.from_date(value) in self.days
+
+    def contains_datetime(self, value: datetime) -> bool:
+        """Return whether `value` falls on an active weekday.
+
+        Args:
+            value: Datetime to inspect using its local date.
+
+        Returns:
+            `True` when the datetime's weekday is active.
+        """
+        return Weekday.from_datetime(value) in self.days
+
+    def next_date_on_or_after(self, value: date) -> date:
+        """Return the first active date on or after `value`.
+
+        Args:
+            value: Starting calendar date.
+
+        Returns:
+            `value` when active, otherwise the next active date within one week.
+        """
+        for offset in range(_DAYS_IN_WEEK):
+            candidate = value + timedelta(days=offset)
+            if self.contains_date(candidate):
+                return candidate
+        msg = "days of week must include at least one reachable day"
+        raise CronTimeError(msg)
+
+    def __contains__(self, day: object) -> bool:
+        """Return whether `day` is active."""
+        return day in self.days
+
+    def __iter__(self) -> Iterator[Weekday]:
+        """Iterate over active weekdays in Monday-through-Sunday order."""
+        return iter(self.days)
+
+    def __str__(self) -> str:
+        """Return comma-separated weekday labels."""
+        return ", ".join(day.label for day in self.days)
 
 
 @total_ordering
@@ -134,6 +345,68 @@ _AM_PM = re.compile(
 )
 _24H = re.compile(r"^(?P<hour>\d{1,2}):(?P<minute>\d{2})$")
 _HOUR_ONLY = re.compile(r"^(?P<hour>\d{1,2})$")
+_DAY_SEPARATORS = re.compile(r"[\s,;/+&]+")
+_DAY_JOINERS = {"and", "or", "on"}
+_ALL_DAYS_TEXT = {"all", "all days", "any day", "anyday", "daily", "every day", "everyday"}
+_WEEKDAYS_TEXT = {"weekday", "weekdays"}
+_WEEKENDS_TEXT = {"weekend", "weekends"}
+
+
+def parse_weekday(value: str) -> Weekday:
+    """Parse a weekday name or abbreviation.
+
+    Supports full day names and common abbreviations such as `mon`, `monday`,
+    `thu`, `thurs`, `sat`, and `sunday`.
+
+    Args:
+        value: Weekday text.
+
+    Returns:
+        Parsed weekday.
+
+    Raises:
+        CronTimeError: If the input is empty, ambiguous, or unsupported.
+    """
+    text = value.strip().lower().rstrip(".")
+    if not text:
+        msg = "weekday must not be empty"
+        raise CronTimeError(msg)
+    if text in _WEEKDAY_ALIASES:
+        return _WEEKDAY_ALIASES[text]
+    if text.endswith("s") and text[:-1] in _WEEKDAY_ALIASES:
+        return _WEEKDAY_ALIASES[text[:-1]]
+    msg = f"unrecognized weekday: {value!r}"
+    raise CronTimeError(msg)
+
+
+def parse_days_of_week(value: str) -> DaysOfWeek:
+    """Parse timer day-of-week text.
+
+    Supports `daily`, `every day`, `weekdays`, `weekends`, and separated day
+    names such as `mon wed fri`, `monday, wednesday, friday`, or `sat/sun`.
+
+    Args:
+        value: Day-of-week text.
+
+    Returns:
+        Parsed immutable day set.
+
+    Raises:
+        CronTimeError: If the input is empty or contains an unsupported day.
+    """
+    text = " ".join(value.strip().lower().split())
+    if not text:
+        msg = "days of week must not be empty"
+        raise CronTimeError(msg)
+    if text in _ALL_DAYS_TEXT:
+        return DaysOfWeek.all()
+    if text in _WEEKDAYS_TEXT:
+        return DaysOfWeek.weekdays()
+    if text in _WEEKENDS_TEXT:
+        return DaysOfWeek.weekends()
+
+    tokens = [token for token in _DAY_SEPARATORS.split(text) if token and token not in _DAY_JOINERS]
+    return DaysOfWeek(tuple(parse_weekday(token) for token in tokens))
 
 
 def parse_local_time(value: str) -> LocalTimeOfDay:

--- a/libs/talon/deepagents_talon/cron/time.py
+++ b/libs/talon/deepagents_talon/cron/time.py
@@ -595,8 +595,9 @@ def next_interval_run(
     step = timedelta(minutes=minutes)
     candidate = _as_utc(previous) + step
     now_utc = _as_utc(now)
-    while candidate <= now_utc:
-        candidate += step
+    if candidate <= now_utc:
+        missed = (now_utc - candidate) // step + 1
+        candidate += missed * step
 
     if active_window is None:
         return candidate

--- a/libs/talon/deepagents_talon/cron/time.py
+++ b/libs/talon/deepagents_talon/cron/time.py
@@ -517,6 +517,8 @@ def next_wall_clock_run(
     if date is None:
         now_local = now_utc.astimezone(zone)
         candidate_date = now_local.date()
+        if _local_time_of(now_local) >= time:
+            candidate_date += timedelta(days=1)
         candidate = _build_local(zone, candidate_date, time, fold=0)
         if candidate <= now_utc:
             candidate = _build_local(

--- a/libs/talon/deepagents_talon/cron/time.py
+++ b/libs/talon/deepagents_talon/cron/time.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
+from functools import total_ordering
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 __all__ = [
@@ -32,6 +33,7 @@ class CronTimeError(ValueError):
     """Raised when a cron time request is invalid or impossible."""
 
 
+@total_ordering
 @dataclass(frozen=True, slots=True)
 class LocalTimeOfDay:
     """Local clock time with minute precision.
@@ -53,14 +55,6 @@ class LocalTimeOfDay:
             msg = f"minute must be 0-59, got {self.minute}"
             raise CronTimeError(msg)
 
-    def to_timedelta(self) -> timedelta:
-        """Return this clock time as a `timedelta` since midnight.
-
-        Returns:
-            Duration since midnight.
-        """
-        return timedelta(hours=self.hour, minutes=self.minute)
-
     @property
     def total_minutes(self) -> int:
         """Minutes since midnight."""
@@ -69,18 +63,6 @@ class LocalTimeOfDay:
     def __lt__(self, other: LocalTimeOfDay) -> bool:
         """Compare ordering by minutes since midnight."""
         return self.total_minutes < other.total_minutes
-
-    def __le__(self, other: LocalTimeOfDay) -> bool:
-        """Compare ordering by minutes since midnight."""
-        return self.total_minutes <= other.total_minutes
-
-    def __gt__(self, other: LocalTimeOfDay) -> bool:
-        """Compare ordering by minutes since midnight."""
-        return self.total_minutes > other.total_minutes
-
-    def __ge__(self, other: LocalTimeOfDay) -> bool:
-        """Compare ordering by minutes since midnight."""
-        return self.total_minutes >= other.total_minutes
 
     def __str__(self) -> str:
         """Return a `HH:MM` string.
@@ -177,7 +159,7 @@ def parse_local_time(value: str) -> LocalTimeOfDay:
     if m:
         hour = int(m.group("hour"))
         minute = int(m.group("minute") or "0")
-        if not 0 <= hour <= _AMPM_HOUR_BOUND:
+        if not 1 <= hour <= _AMPM_HOUR_BOUND:
             msg = f"12-hour clock hour out of range: {value!r}"
             raise CronTimeError(msg)
         if hour == _AMPM_HOUR_BOUND:
@@ -203,17 +185,7 @@ def parse_local_time(value: str) -> LocalTimeOfDay:
 
 
 def _resolve_zone(timezone: str) -> ZoneInfo:
-    """Resolve an IANA zone name, re-raising unknown zones as `CronTimeError`.
-
-    Args:
-        timezone: IANA time zone name.
-
-    Returns:
-        Resolved `ZoneInfo`.
-
-    Raises:
-        CronTimeError: If the time zone is unknown.
-    """
+    """Resolve an IANA zone name, re-raising unknown zones as `CronTimeError`."""
     try:
         return ZoneInfo(timezone)
     except ZoneInfoNotFoundError as exc:
@@ -222,26 +194,15 @@ def _resolve_zone(timezone: str) -> ZoneInfo:
 
 
 def _as_utc(dt: datetime) -> datetime:
-    """Return `dt` converted to UTC.
-
-    Args:
-        dt: A timezone-aware datetime.
-
-    Returns:
-        The same instant as a UTC datetime.
-    """
+    """Return `dt` converted to UTC, rejecting naive datetimes."""
+    if dt.tzinfo is None or dt.utcoffset() is None:
+        msg = "datetime must be timezone-aware"
+        raise CronTimeError(msg)
     return dt.astimezone(UTC)
 
 
 def _local_time_of(dt: datetime) -> LocalTimeOfDay:
-    """Return the local clock-time components of `dt`.
-
-    Args:
-        dt: A timezone-aware datetime.
-
-    Returns:
-        Local-time-of-day at `dt`.
-    """
+    """Return the local clock-time components of `dt`."""
     return LocalTimeOfDay(hour=dt.hour, minute=dt.minute)
 
 
@@ -301,21 +262,8 @@ def next_wall_clock_run(
 def _build_local(zone: ZoneInfo, target_date: date, time: LocalTimeOfDay, *, fold: int) -> datetime:
     """Construct a local datetime at `time` on `target_date` in `zone`.
 
-    Detects nonexistent spring-forward local times by constructing the
-    datetime and verifying the round-trip wall clock matches the request.
-
-    Args:
-        zone: Target time zone.
-        target_date: Local calendar date.
-        time: Local clock time.
-        fold: `fold` value to disambiguate repeated fall-back wall times.
-
-    Returns:
-        Timezone-aware datetime in `zone`.
-
-    Raises:
-        CronTimeError: If the local time does not exist on `target_date` in
-            `zone` (spring-forward gap).
+    Detects nonexistent spring-forward local times by verifying the
+    round-trip wall clock matches the request.
     """
     naive = datetime(  # noqa: DTZ001  # naive constructed intentionally; tzinfo attached next line
         target_date.year,
@@ -326,8 +274,8 @@ def _build_local(zone: ZoneInfo, target_date: date, time: LocalTimeOfDay, *, fol
         fold=fold,
     )
     aware = naive.replace(tzinfo=zone)
-    roundtrip = aware.astimezone(UTC).astimezone(zone)
-    if roundtrip.hour != time.hour or roundtrip.minute != time.minute:
+    roundtrip = _local_time_of(aware.astimezone(UTC).astimezone(zone))
+    if roundtrip != time:
         msg = (
             f"local time {time} does not exist on {target_date.isoformat()} "
             f"in {zone!s} (spring-forward gap)"
@@ -387,21 +335,7 @@ def _advance_into_window(
     candidate: datetime,
     window: ActiveWindow,
 ) -> datetime:
-    """Fast-forward `candidate` to the next window-start when it is outside `window`.
-
-    The interval step itself was already applied by the caller. When the
-    stepped candidate lands inside the window, it is returned unchanged;
-    otherwise the function jumps to the next in-zone window-start that is
-    strictly later than the candidate. This avoids looping and guarantees
-    a single deterministic fast-forward.
-
-    Args:
-        candidate: UTC candidate run instant (after the interval step).
-        window: Active window to satisfy.
-
-    Returns:
-        The next in-window run instant as a UTC datetime.
-    """
+    """Fast-forward `candidate` to the next window-start when it is outside `window`."""
     zone = window.zone()
     local = candidate.astimezone(zone)
     local_time = _local_time_of(local)

--- a/libs/talon/deepagents_talon/cron/time.py
+++ b/libs/talon/deepagents_talon/cron/time.py
@@ -9,12 +9,13 @@ Talon is an experimental runtime and is subject to change or removal at any time
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from enum import IntEnum
 from functools import total_ordering
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NotRequired, TypedDict
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 if TYPE_CHECKING:
@@ -22,21 +23,48 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ActiveWindow",
+    "ActiveWindowDict",
     "CronTimeError",
     "DaysOfWeek",
     "LocalTimeOfDay",
+    "SchedulerHostClock",
+    "SchedulerHostClockDict",
     "Weekday",
+    "active_window_contains",
+    "capture_scheduler_host_clock",
+    "format_local_run",
+    "next_daily_wall_clock_run",
     "next_interval_run",
     "next_wall_clock_run",
+    "parse_active_window",
     "parse_days_of_week",
     "parse_local_time",
     "parse_weekday",
+    "resolve_schedule_timezone",
 ]
 
 _MAX_HOUR = 23
 _MAX_MINUTE = 59
 _AMPM_HOUR_BOUND = 12  # 12-hour clock upper bound before wrapping to 0
 _DAYS_IN_WEEK = 7
+TIMEZONE_ENV = "DEEPAGENTS_TALON_TIMEZONE"
+
+
+class ActiveWindowDict(TypedDict):
+    """Serialized local active-hour window."""
+
+    timezone: str
+    start: str
+    end: str
+
+
+class SchedulerHostClockDict(TypedDict):
+    """Serialized scheduler host clock context."""
+
+    timezone: str
+    utc_offset: str
+    computed_at: str
+    local_now: NotRequired[str]
 
 
 class CronTimeError(ValueError):
@@ -274,13 +302,27 @@ class LocalTimeOfDay:
         """Compare ordering by minutes since midnight."""
         return self.total_minutes < other.total_minutes
 
+    @property
+    def minutes_after_midnight(self) -> int:
+        """Minutes since midnight."""
+        return self.total_minutes
+
+    def to_display(self) -> str:
+        """Return a `HH:MM` string."""
+        return f"{self.hour:02d}:{self.minute:02d}"
+
+    @classmethod
+    def from_display(cls, value: str) -> LocalTimeOfDay:
+        """Parse a persisted `HH:MM` time value."""
+        return parse_local_time(value)
+
     def __str__(self) -> str:
         """Return a `HH:MM` string.
 
         Returns:
             Zero-padded `HH:MM` representation.
         """
-        return f"{self.hour:02d}:{self.minute:02d}"
+        return self.to_display()
 
 
 @dataclass(frozen=True, slots=True)
@@ -324,6 +366,23 @@ class ActiveWindow:
             return local >= self.start or local < self.end
         return self.start <= local < self.end
 
+    def to_dict(self) -> ActiveWindowDict:
+        """Serialize this active window for disk storage."""
+        return {
+            "timezone": self.timezone,
+            "start": self.start.to_display(),
+            "end": self.end.to_display(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: ActiveWindowDict) -> ActiveWindow:
+        """Deserialize an active window from disk."""
+        return cls(
+            timezone=data["timezone"],
+            start=LocalTimeOfDay.from_display(data["start"]),
+            end=LocalTimeOfDay.from_display(data["end"]),
+        )
+
     def zone(self) -> ZoneInfo:
         """Return the zoneinfo for this window.
 
@@ -334,6 +393,46 @@ class ActiveWindow:
             CronTimeError: If the time zone is unknown.
         """
         return _resolve_zone(self.timezone)
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulerHostClock:
+    """Scheduler host clock context used to compute a UTC run time.
+
+    Args:
+        timezone: Time zone name reported by the host clock.
+        utc_offset: UTC offset reported by the host clock.
+        computed_at: UTC timestamp used as the computation basis.
+        local_now: Host-local timestamp for diagnostics.
+    """
+
+    timezone: str
+    utc_offset: str
+    computed_at: datetime
+    local_now: datetime
+
+    def to_dict(self) -> SchedulerHostClockDict:
+        """Serialize this host clock context for disk storage."""
+        return {
+            "timezone": self.timezone,
+            "utc_offset": self.utc_offset,
+            "computed_at": _format_time(self.computed_at),
+            "local_now": self.local_now.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: SchedulerHostClockDict) -> SchedulerHostClock:
+        """Deserialize scheduler host clock context."""
+        computed_at = _parse_time(data["computed_at"])
+        local_now = datetime.fromisoformat(data.get("local_now", data["computed_at"]))
+        if local_now.tzinfo is None or local_now.utcoffset() is None:
+            local_now = local_now.replace(tzinfo=UTC)
+        return cls(
+            timezone=data["timezone"],
+            utc_offset=data["utc_offset"],
+            computed_at=computed_at,
+            local_now=local_now,
+        )
 
 
 # --- Parsing -----------------------------------------------------------------
@@ -453,6 +552,38 @@ def parse_local_time(value: str) -> LocalTimeOfDay:
     raise CronTimeError(msg)
 
 
+def parse_active_window(
+    *,
+    timezone: str | None,
+    active_start: str | None,
+    active_end: str | None,
+) -> ActiveWindow | None:
+    """Parse optional active-hour inputs."""
+    if active_start == "" and active_end == "":
+        return None
+    if active_start is None and active_end is None:
+        return None
+    if active_start is None or active_end is None:
+        msg = "active hours require both active_start and active_end"
+        raise CronTimeError(msg)
+    return ActiveWindow(
+        timezone=resolve_schedule_timezone(timezone),
+        start=parse_local_time(active_start),
+        end=parse_local_time(active_end),
+    )
+
+
+def resolve_schedule_timezone(value: str | None) -> str:
+    """Resolve the IANA time zone for a wall-clock schedule."""
+    candidate = value or os.environ.get(TIMEZONE_ENV)
+    if candidate is None or not candidate.strip():
+        msg = f"timezone is required for local-time schedules; set {TIMEZONE_ENV}"
+        raise CronTimeError(msg)
+    zone = _resolve_zone(candidate.strip())
+    key = getattr(zone, "key", None)
+    return key if isinstance(key, str) and key else candidate.strip()
+
+
 # --- Zone resolution ---------------------------------------------------------
 
 
@@ -529,8 +660,40 @@ def next_wall_clock_run(
             )
     else:
         candidate = _build_local(zone, date, time, fold=0)
+        if candidate <= now_utc:
+            msg = "dated wall-clock schedule is in the past"
+            raise CronTimeError(msg)
 
     return _as_utc(candidate)
+
+
+def next_daily_wall_clock_run(
+    *,
+    previous: datetime | None,
+    now: datetime,
+    timezone: str,
+    time: LocalTimeOfDay,
+    active_window: ActiveWindow | None = None,
+) -> datetime:
+    """Return the next UTC run for a recurring daily wall-clock schedule."""
+    now_utc = _as_utc(now)
+    zone = _resolve_zone(timezone)
+    if previous is None:
+        candidate = next_wall_clock_run(now=now_utc, timezone=timezone, time=time)
+    else:
+        previous_local = _as_utc(previous).astimezone(zone)
+        candidate = _as_utc(
+            _build_local(zone, previous_local.date() + timedelta(days=1), time, fold=0)
+        )
+        while candidate <= now_utc:
+            candidate_local = candidate.astimezone(zone)
+            candidate = _as_utc(
+                _build_local(zone, candidate_local.date() + timedelta(days=1), time, fold=0)
+            )
+    if active_window is not None and not active_window_contains(candidate, active_window):
+        msg = "daily wall-clock schedule time falls outside active hours"
+        raise CronTimeError(msg)
+    return candidate
 
 
 def _build_local(zone: ZoneInfo, target_date: date, time: LocalTimeOfDay, *, fold: int) -> datetime:
@@ -622,3 +785,55 @@ def _advance_into_window(
     if start_today_utc >= candidate:
         return start_today_utc
     return _as_utc(_build_local(zone, local.date() + timedelta(days=1), window.start, fold=0))
+
+
+def active_window_contains(value: datetime, active_window: ActiveWindow) -> bool:
+    """Return whether a UTC timestamp falls inside an active window."""
+    local = _as_utc(value).astimezone(active_window.zone())
+    return active_window.contains(LocalTimeOfDay(local.hour, local.minute))
+
+
+def capture_scheduler_host_clock(now: datetime | None = None) -> SchedulerHostClock:
+    """Capture the scheduler host clock context."""
+    computed_at = datetime.now(UTC) if now is None else _as_utc(now)
+    local_now = computed_at.astimezone()
+    return SchedulerHostClock(
+        timezone=_timezone_name(local_now),
+        utc_offset=_format_offset(local_now),
+        computed_at=computed_at,
+        local_now=local_now,
+    )
+
+
+def format_local_run(value: datetime, timezone: str) -> str:
+    """Format a UTC run timestamp in a schedule time zone."""
+    local = _as_utc(value).astimezone(_resolve_zone(timezone))
+    return f"{local:%Y-%m-%d %H:%M} {timezone}"
+
+
+def _timezone_name(value: datetime) -> str:
+    tzinfo = value.tzinfo
+    key = getattr(tzinfo, "key", None)
+    if isinstance(key, str) and key:
+        return key
+    name = value.tzname()
+    return name or "local"
+
+
+def _format_offset(value: datetime) -> str:
+    offset = value.utcoffset()
+    if offset is None:
+        return "+00:00"
+    total_minutes = int(offset.total_seconds() // 60)
+    sign = "+" if total_minutes >= 0 else "-"
+    total_minutes = abs(total_minutes)
+    hours, minutes = divmod(total_minutes, 60)
+    return f"{sign}{hours:02d}:{minutes:02d}"
+
+
+def _format_time(value: datetime) -> str:
+    return _as_utc(value).isoformat()
+
+
+def _parse_time(value: str) -> datetime:
+    return _as_utc(datetime.fromisoformat(value))

--- a/libs/talon/deepagents_talon/cron/tools.py
+++ b/libs/talon/deepagents_talon/cron/tools.py
@@ -10,7 +10,13 @@ from typing import Any
 
 from langchain_core.tools import BaseTool, tool
 
-from deepagents_talon.cron.jobs import CronJob, CronJobStore, CronOrigin, CronSchedule
+from deepagents_talon.cron.jobs import (
+    CronJob,
+    CronJobError,
+    CronJobStore,
+    CronOrigin,
+    CronSchedule,
+)
 
 OriginFactory = Callable[[], CronOrigin]
 _PAIRED_QUOTE_LENGTH = 2
@@ -29,13 +35,16 @@ class CronTools:
         self.store = store
         self.origin = origin
 
-    def create_job(
+    def create_job(  # noqa: PLR0913  # agent tool exposes optional schedule context
         self,
         *,
         prompt: str,
         schedule: str,
         name: str = "",
         repeat_times: int | None = None,
+        timezone: str | None = None,
+        active_start: str | None = None,
+        active_end: str | None = None,
     ) -> dict[str, Any]:
         """Create a scheduled job in the current conversation.
 
@@ -44,13 +53,21 @@ class CronTools:
             schedule: Schedule text such as `in 30m` or `every 15m`.
             name: Optional human-readable label.
             repeat_times: Optional cap for recurring schedules.
+            timezone: Optional IANA time zone for local-time schedules.
+            active_start: Optional inclusive active-hour start time.
+            active_end: Optional exclusive active-hour end time.
 
         Returns:
             Created job as a JSON-compatible dictionary.
         """
         job = self.store.create_job(
             prompt=prompt,
-            schedule=CronSchedule.parse(schedule),
+            schedule=CronSchedule.parse(
+                schedule,
+                timezone=timezone,
+                active_start=active_start,
+                active_end=active_end,
+            ),
             origin=self.origin(),
             name=name,
             repeat_times=repeat_times,
@@ -74,6 +91,9 @@ class CronTools:
         schedule: str | None = None,
         enabled: bool | None = None,
         repeat_times: int | None = None,
+        timezone: str | None = None,
+        active_start: str | None = None,
+        active_end: str | None = None,
     ) -> dict[str, Any]:
         """Edit a scheduled job in the current conversation.
 
@@ -84,15 +104,43 @@ class CronTools:
             schedule: Optional replacement schedule text.
             enabled: Optional enabled flag.
             repeat_times: Optional replacement repeat cap for recurring jobs.
+            timezone: Optional IANA time zone for local-time schedules.
+            active_start: Optional inclusive active-hour start time.
+            active_end: Optional exclusive active-hour end time.
 
         Returns:
             Updated job as a JSON-compatible dictionary.
         """
-        parsed = None if schedule is None else CronSchedule.parse(schedule)
+        origin = self.origin()
+        if schedule is None and _has_schedule_options(
+            timezone=timezone,
+            active_start=active_start,
+            active_end=active_end,
+        ):
+            job = self.store.get_job(job_id, origin=origin)
+            if job is None:
+                msg = f"cron job not found in current conversation: {job_id}"
+                raise CronJobError(msg)
+            parsed = job.schedule.with_options(
+                timezone=timezone,
+                active_start=active_start,
+                active_end=active_end,
+            )
+        else:
+            parsed = (
+                None
+                if schedule is None
+                else CronSchedule.parse(
+                    schedule,
+                    timezone=timezone,
+                    active_start=active_start,
+                    active_end=active_end,
+                )
+            )
         return _tool_job(
             self.store.edit_job(
                 job_id,
-                origin=self.origin(),
+                origin=origin,
                 name=name,
                 prompt=prompt,
                 schedule=parsed,
@@ -132,11 +180,15 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
     """
 
     @tool
-    def create_job(
+    def create_job(  # noqa: PLR0913  # agent tool exposes optional schedule context
         prompt: str,
         schedule: str,
         name: str = "",
         repeat_times: int | None = None,
+        *,
+        timezone: str | None = None,
+        active_start: str | None = None,
+        active_end: str | None = None,
     ) -> dict[str, Any]:
         """Schedule a background task that will later deliver to this conversation.
 
@@ -145,6 +197,9 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
             schedule: Schedule text such as `in 30m` or `every 15m`.
             name: Optional human-readable label for the job.
             repeat_times: Optional cap for recurring schedules.
+            timezone: Optional IANA time zone for local-time schedules.
+            active_start: Optional inclusive active-hour start time.
+            active_end: Optional exclusive active-hour end time.
 
         Returns:
             Created job details, or an error dictionary for invalid input.
@@ -155,6 +210,9 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
                 schedule=schedule,
                 name=name,
                 repeat_times=repeat_times,
+                timezone=timezone,
+                active_start=active_start,
+                active_end=active_end,
             )
         except Exception as exc:  # noqa: BLE001
             return _tool_error(exc)
@@ -180,6 +238,9 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
         *,
         enabled: bool | None = None,
         repeat_times: int | None = None,
+        timezone: str | None = None,
+        active_start: str | None = None,
+        active_end: str | None = None,
     ) -> dict[str, Any]:
         """Update one or more settings on a scheduled job from this conversation.
 
@@ -190,6 +251,9 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
             schedule: Optional replacement schedule text.
             enabled: Optional enabled flag. Use `False` to pause, `True` to resume.
             repeat_times: Optional replacement repeat cap for recurring schedules.
+            timezone: Optional IANA time zone for local-time schedules.
+            active_start: Optional inclusive active-hour start time.
+            active_end: Optional exclusive active-hour end time.
 
         Returns:
             Updated job details, or an error dictionary for invalid input.
@@ -202,6 +266,9 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
                 schedule=_strip_optional_quotes(schedule),
                 enabled=enabled,
                 repeat_times=repeat_times,
+                timezone=_strip_optional_quotes(timezone),
+                active_start=_strip_optional_quotes(active_start),
+                active_end=_strip_optional_quotes(active_end),
             )
         except Exception as exc:  # noqa: BLE001
             return _tool_error(exc)
@@ -226,6 +293,9 @@ def build_cron_tools(cron: CronTools) -> list[BaseTool]:
 
 def _tool_job(job: CronJob) -> dict[str, Any]:
     data = job.to_dict()
+    next_run_local = (
+        None if job.next_run_at is None else job.schedule.next_run_local(job.next_run_at)
+    )
     return {
         "id": data["id"],
         "name": data["name"],
@@ -234,6 +304,8 @@ def _tool_job(job: CronJob) -> dict[str, Any]:
         "repeat": data["repeat"],
         "enabled": data["enabled"],
         "next_run_at": data["next_run_at"],
+        "next_run_local": next_run_local,
+        "scheduler_host_clock": data["scheduler_host_clock"],
         "last_run_at": data["last_run_at"],
         "last_status": data["last_status"],
         "last_error": data["last_error"],
@@ -242,6 +314,15 @@ def _tool_job(job: CronJob) -> dict[str, Any]:
 
 def _tool_error(exc: Exception) -> dict[str, str]:
     return {"error": str(exc)}
+
+
+def _has_schedule_options(
+    *,
+    timezone: str | None,
+    active_start: str | None,
+    active_end: str | None,
+) -> bool:
+    return timezone is not None or active_start is not None or active_end is not None
 
 
 def _strip_optional_quotes(value: str | None) -> str | None:

--- a/libs/talon/tests/cron/test_jobs.py
+++ b/libs/talon/tests/cron/test_jobs.py
@@ -65,6 +65,101 @@ def test_recurring_job_advances_before_run_and_honors_repeat_cap(tmp_path) -> No
     assert second.repeat.completed == 2
 
 
+def test_wall_clock_job_persists_timezone_and_local_output(tmp_path) -> None:
+    now = datetime(2026, 7, 2, 1, tzinfo=UTC)
+    store = _store(tmp_path)
+
+    job = store.create_job(
+        prompt="send reminder",
+        schedule=CronSchedule.parse("at 8:00pm", timezone="America/Los_Angeles"),
+        origin=CronOrigin(conversation_id="chat"),
+        now=now,
+    )
+
+    assert job.next_run_at == datetime(2026, 7, 2, 3, tzinfo=UTC)
+    assert job.schedule.to_dict()["timezone"] == "America/Los_Angeles"
+    assert job.schedule.to_dict()["wall_time"] == "20:00"
+    assert job.scheduler_host_clock is not None
+    assert (
+        CronTools(store=store, origin=lambda: CronOrigin(conversation_id="chat")).list_jobs()[0][
+            "next_run_local"
+        ]
+        == "2026-07-01 20:00 America/Los_Angeles"
+    )
+
+
+def test_active_window_moves_initial_run_to_next_allowed_time(tmp_path) -> None:
+    now = datetime(2026, 7, 2, 0, 20, tzinfo=UTC)
+    store = _store(tmp_path)
+
+    job = store.create_job(
+        prompt="heartbeat",
+        schedule=CronSchedule.parse(
+            "every 15m",
+            timezone="America/Los_Angeles",
+            active_start="08:30",
+            active_end="17:27",
+        ),
+        origin=CronOrigin(conversation_id="chat"),
+        now=now,
+    )
+
+    assert job.next_run_at == datetime(2026, 7, 2, 15, 30, tzinfo=UTC)
+
+
+def test_active_window_skip_does_not_consume_repeat_cap(tmp_path) -> None:
+    now = datetime(2026, 7, 2, 23, 44, tzinfo=UTC)
+    store = _store(tmp_path)
+    job = store.create_job(
+        prompt="heartbeat",
+        schedule=CronSchedule.parse(
+            "every 15m",
+            timezone="America/Los_Angeles",
+            active_start="08:00",
+            active_end="17:00",
+        ),
+        origin=CronOrigin(conversation_id="chat"),
+        repeat_times=2,
+        now=now,
+    )
+
+    claimed = store.advance_next_run(job.id, now=datetime(2026, 7, 3, 0, 1, tzinfo=UTC))
+
+    updated = store.get_job(job.id)
+    assert claimed is None
+    assert updated is not None
+    assert updated.repeat.completed == 0
+    assert updated.next_run_at == datetime(2026, 7, 3, 15, tzinfo=UTC)
+
+
+def test_tools_edit_active_hours_without_replacing_schedule(tmp_path) -> None:
+    store = _store(tmp_path)
+    current = CronOrigin(conversation_id="chat")
+    tools = CronTools(store=store, origin=lambda: current)
+    job = store.create_job(
+        prompt="heartbeat",
+        schedule=CronSchedule.parse("every 15m"),
+        origin=current,
+        now=datetime(2026, 7, 2, 15, tzinfo=UTC),
+    )
+
+    updated = tools.edit_job(
+        job.id,
+        timezone="America/Los_Angeles",
+        active_start="08:00",
+        active_end="17:00",
+    )
+    cleared = tools.edit_job(job.id, active_start="", active_end="")
+
+    assert updated["schedule"]["active_window"] == {
+        "timezone": "America/Los_Angeles",
+        "start": "08:00",
+        "end": "17:00",
+    }
+    assert updated["schedule"]["display"] == "every 15m"
+    assert cleared["schedule"]["active_window"] is None
+
+
 def test_store_prunes_only_expired_completed_jobs(tmp_path) -> None:
     now = datetime(2026, 1, 31, 12, tzinfo=UTC)
     store = _store(tmp_path)

--- a/libs/talon/tests/cron/test_time.py
+++ b/libs/talon/tests/cron/test_time.py
@@ -234,6 +234,16 @@ def test_dst_spring_forward_nonexistent_raises() -> None:
         )
 
 
+def test_next_wall_clock_run_after_spring_forward_gap_rolls_to_tomorrow() -> None:
+    # At 03:30 local, today's nonexistent 02:30 has already passed.
+    result = next_wall_clock_run(
+        now=_utc(2026, 3, 8, 10, 30),
+        timezone=LA,
+        time=LocalTimeOfDay(2, 30),
+    )
+    assert result == _utc(2026, 3, 9, 9, 30)
+
+
 def test_skipped_local_date_raises() -> None:
     # Pacific/Apia skipped 2011-12-30 entirely when it moved west of the date line.
     with pytest.raises(CronTimeError, match="does not exist"):

--- a/libs/talon/tests/cron/test_time.py
+++ b/libs/talon/tests/cron/test_time.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from deepagents_talon.cron.time import (
+    ActiveWindow,
+    CronTimeError,
+    LocalTimeOfDay,
+    next_interval_run,
+    next_wall_clock_run,
+    parse_local_time,
+)
+
+LA = "America/Los_Angeles"
+LA_ZONE = ZoneInfo(LA)
+NY = "America/New_York"
+
+
+def _utc(year: int, month: int, day: int, hour: int, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+# --- parse_local_time --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("20:00", (20, 0)),
+        ("8:00pm", (20, 0)),
+        ("8pm", (20, 0)),
+        ("08:30", (8, 30)),
+        ("17:27", (17, 27)),
+        ("12am", (0, 0)),
+        ("12pm", (12, 0)),
+        ("11:59pm", (23, 59)),
+        ("00:00", (0, 0)),
+    ],
+)
+def test_parse_local_time_accepts_grammar_forms(text: str, expected: tuple[int, int]) -> None:
+    parsed = parse_local_time(text)
+    assert (parsed.hour, parsed.minute) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["", "  ", "25:00", "8:60pm", "abc", "13pm", "-1:00", "8:00 xm"],
+)
+def test_parse_local_time_rejects_malformed(text: str) -> None:
+    with pytest.raises(CronTimeError):
+        parse_local_time(text)
+
+
+def test_local_time_of_day_str_and_validation() -> None:
+    assert str(LocalTimeOfDay(8, 30)) == "08:30"
+    assert LocalTimeOfDay(8, 30).to_timedelta() == timedelta(hours=8, minutes=30)
+    with pytest.raises(CronTimeError):
+        LocalTimeOfDay(24, 0)
+    with pytest.raises(CronTimeError):
+        LocalTimeOfDay(8, 60)
+
+
+# --- next_wall_clock_run ------------------------------------------------------
+
+
+def test_next_wall_clock_run_today() -> None:
+    now = _utc(2026, 7, 2, 15, 0)  # 8am LA
+    target = LocalTimeOfDay(12, 0)  # noon LA = 19:00 UTC
+    result = next_wall_clock_run(now=now, timezone=LA, time=target)
+    assert result == _utc(2026, 7, 2, 19, 0)
+
+
+def test_next_wall_clock_run_tomorrow_when_already_passed() -> None:
+    now = _utc(2026, 7, 2, 20, 30)  # 1:30pm LA — noon already passed
+    target = LocalTimeOfDay(12, 0)
+    result = next_wall_clock_run(now=now, timezone=LA, time=target)
+    assert result == _utc(2026, 7, 3, 19, 0)
+
+
+def test_next_wall_clock_run_explicit_date() -> None:
+    now = _utc(2026, 7, 2, 15, 0)
+    target = LocalTimeOfDay(20, 0)
+    result = next_wall_clock_run(
+        now=now,
+        timezone=LA,
+        time=target,
+        date=date(2026, 7, 5),
+    )
+    # July 5 20:00 LA = July 6 03:00 UTC
+    assert result == _utc(2026, 7, 6, 3, 0)
+
+
+def test_next_wall_clock_run_unknown_timezone() -> None:
+    with pytest.raises(CronTimeError):
+        next_wall_clock_run(
+            now=_utc(2026, 7, 2, 15, 0),
+            timezone="Mars/Olympus",
+            time=LocalTimeOfDay(8, 0),
+        )
+
+
+# --- DST handling ------------------------------------------------------------
+
+
+def test_dst_fall_back_ambiguous_uses_first_occurrence() -> None:
+    # America/Los_Angeles falls back on 2026-11-01 at 02:00 local.
+    # 01:30 is ambiguous (occurs twice). fold=0 selects the PDT instance.
+    result = next_wall_clock_run(
+        now=_utc(2026, 11, 1, 7, 0),  # just after midnight UTC = 2026-10-31 PT
+        timezone=LA,
+        time=LocalTimeOfDay(1, 30),
+        date=date(2026, 11, 1),
+    )
+    # PDT offset is UTC-7; 01:30 PDT = 08:30 UTC.
+    assert result == _utc(2026, 11, 1, 8, 30)
+    assert result.utcoffset() == timedelta(0)
+
+
+def test_dst_spring_forward_nonexistent_raises() -> None:
+    # America/Los_Angeles springs forward on 2026-03-08 at 02:00 local.
+    # 02:30 local does not exist on that date.
+    with pytest.raises(CronTimeError, match="spring-forward"):
+        next_wall_clock_run(
+            now=_utc(2026, 3, 8, 9, 0),
+            timezone=LA,
+            time=LocalTimeOfDay(2, 30),
+            date=date(2026, 3, 8),
+        )
+
+
+# --- next_interval_run -------------------------------------------------------
+
+
+def test_next_interval_run_without_window_advances_by_minutes() -> None:
+    previous = _utc(2026, 7, 2, 12, 0)
+    now = _utc(2026, 7, 2, 12, 5)
+    result = next_interval_run(previous=previous, now=now, minutes=15, active_window=None)
+    assert result == previous + timedelta(minutes=15)
+
+
+def test_next_interval_run_without_window_jumps_after_lag() -> None:
+    previous = _utc(2026, 7, 2, 12, 0)
+    now = _utc(2026, 7, 2, 12, 30)  # more than 15m after previous
+    result = next_interval_run(previous=previous, now=now, minutes=15, active_window=None)
+    assert result == now + timedelta(minutes=15)
+
+
+def test_next_interval_run_rejects_non_positive_minutes() -> None:
+    with pytest.raises(CronTimeError):
+        next_interval_run(
+            previous=_utc(2026, 7, 2, 12, 0),
+            now=_utc(2026, 7, 2, 12, 0),
+            minutes=0,
+            active_window=None,
+        )
+
+
+def _window(start: tuple[int, int], end: tuple[int, int], tz: str = LA) -> ActiveWindow:
+    return ActiveWindow(
+        timezone=tz,
+        start=LocalTimeOfDay(*start),
+        end=LocalTimeOfDay(*end),
+    )
+
+
+def test_next_interval_run_inside_window_returns_first_step() -> None:
+    window = _window((8, 0), (17, 0))
+    previous = _utc(2026, 7, 2, 16, 0)  # 9am LA — inside
+    now = _utc(2026, 7, 2, 15, 55)
+    result = next_interval_run(previous=previous, now=now, minutes=15, active_window=window)
+    assert result == previous + timedelta(minutes=15)
+
+
+def test_next_interval_run_outside_window_advances_inside() -> None:
+    window = _window((8, 0), (17, 0))
+    previous = _utc(2026, 7, 2, 16, 50)  # 9:50am LA — inside, last step lands outside
+    now = _utc(2026, 7, 2, 16, 45)
+    result = next_interval_run(previous=previous, now=now, minutes=15, active_window=window)
+    local = result.astimezone(LA_ZONE)
+    assert window.contains(LocalTimeOfDay(local.hour, local.minute))
+
+
+def test_next_interval_run_skips_overnight_inactive_span() -> None:
+    # Daytime-only window 08:00-17:00 in LA. Previous at 4:45pm LA (last in-window slot).
+    # Next 15m step lands at 17:00 LA — exclusive end — so it falls outside; the
+    # run should fast-forward to next day's 08:00 LA.
+    window = _window((8, 0), (17, 0))
+    previous = _utc(2026, 7, 2, 23, 45)  # 16:45 LA — inside
+    now = _utc(2026, 7, 3, 1, 0)
+    result = next_interval_run(previous=previous, now=now, minutes=15, active_window=window)
+    local = result.astimezone(LA_ZONE)
+    # Fast-forward should land at next day's 08:00 LA.
+    assert (local.hour, local.minute) == (8, 0)
+    assert local.date() == date(2026, 7, 3)
+    assert window.contains(LocalTimeOfDay(local.hour, local.minute))
+
+
+def test_next_interval_run_midnight_crossing_window_includes_late_runs() -> None:
+    # 22:00-06:00 crosses midnight; a run at 23:00 LA should be allowed.
+    window = _window((22, 0), (6, 0))
+    previous = _utc(2026, 7, 2, 5, 30)  # 22:30 previous day LA
+    now = _utc(2026, 7, 3, 2, 0)
+    result = next_interval_run(previous=previous, now=now, minutes=60, active_window=window)
+    local = result.astimezone(LA_ZONE)
+    assert window.contains(LocalTimeOfDay(local.hour, local.minute))
+
+
+def test_active_window_rejects_zero_length() -> None:
+    with pytest.raises(CronTimeError):
+        ActiveWindow(
+            timezone=LA,
+            start=LocalTimeOfDay(8, 0),
+            end=LocalTimeOfDay(8, 0),
+        )
+
+
+def test_active_window_unknown_timezone_resolves_lazily() -> None:
+    window = ActiveWindow(
+        timezone="Mars/Olympus",
+        start=LocalTimeOfDay(8, 0),
+        end=LocalTimeOfDay(17, 0),
+    )
+    with pytest.raises(CronTimeError):
+        window.zone()
+
+
+def test_active_window_contains_helpers() -> None:
+    daytime = _window((8, 0), (17, 0))
+    assert daytime.contains(LocalTimeOfDay(12, 0))
+    assert not daytime.contains(LocalTimeOfDay(22, 0))
+    assert not daytime.crosses_midnight
+
+    overnight = _window((22, 0), (6, 0))
+    assert overnight.contains(LocalTimeOfDay(23, 30))
+    assert overnight.contains(LocalTimeOfDay(2, 0))
+    assert not overnight.contains(LocalTimeOfDay(12, 0))
+    assert overnight.crosses_midnight

--- a/libs/talon/tests/cron/test_time.py
+++ b/libs/talon/tests/cron/test_time.py
@@ -8,10 +8,14 @@ import pytest
 from deepagents_talon.cron.time import (
     ActiveWindow,
     CronTimeError,
+    DaysOfWeek,
     LocalTimeOfDay,
+    Weekday,
     next_interval_run,
     next_wall_clock_run,
+    parse_days_of_week,
     parse_local_time,
+    parse_weekday,
 )
 
 LA = "America/Los_Angeles"
@@ -20,6 +24,87 @@ LA_ZONE = ZoneInfo(LA)
 
 def _utc(year: int, month: int, day: int, hour: int, minute: int = 0) -> datetime:
     return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+# --- days of week ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("m", Weekday.MONDAY),
+        ("Mon", Weekday.MONDAY),
+        ("mondays", Weekday.MONDAY),
+        ("tues", Weekday.TUESDAY),
+        ("weds", Weekday.WEDNESDAY),
+        ("thurs", Weekday.THURSDAY),
+        ("fri", Weekday.FRIDAY),
+        ("sa", Weekday.SATURDAY),
+        ("sun.", Weekday.SUNDAY),
+    ],
+)
+def test_parse_weekday_accepts_common_names(text: str, expected: Weekday) -> None:
+    assert parse_weekday(text) is expected
+
+
+@pytest.mark.parametrize("text", ["", "  ", "s", "tueth", "funday"])
+def test_parse_weekday_rejects_unknown_or_ambiguous_names(text: str) -> None:
+    with pytest.raises(CronTimeError):
+        parse_weekday(text)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("daily", tuple(Weekday)),
+        ("every day", tuple(Weekday)),
+        (
+            "weekdays",
+            (
+                Weekday.MONDAY,
+                Weekday.TUESDAY,
+                Weekday.WEDNESDAY,
+                Weekday.THURSDAY,
+                Weekday.FRIDAY,
+            ),
+        ),
+        ("weekends", (Weekday.SATURDAY, Weekday.SUNDAY)),
+        ("mon wed fri", (Weekday.MONDAY, Weekday.WEDNESDAY, Weekday.FRIDAY)),
+        ("monday, wednesday, and friday", (Weekday.MONDAY, Weekday.WEDNESDAY, Weekday.FRIDAY)),
+        ("sat/sun", (Weekday.SATURDAY, Weekday.SUNDAY)),
+    ],
+)
+def test_parse_days_of_week_accepts_timer_forms(text: str, expected: tuple[Weekday, ...]) -> None:
+    assert parse_days_of_week(text).days == expected
+
+
+def test_days_of_week_deduplicates_and_sorts() -> None:
+    days = DaysOfWeek((Weekday.FRIDAY, Weekday.MONDAY, Weekday.FRIDAY))
+
+    assert days.days == (Weekday.MONDAY, Weekday.FRIDAY)
+    assert str(days) == "monday, friday"
+
+
+def test_days_of_week_contains_dates_and_datetimes() -> None:
+    days = DaysOfWeek.weekdays()
+
+    assert days.contains_date(date(2026, 7, 3))  # Friday
+    assert days.contains_datetime(_utc(2026, 7, 3, 12))
+    assert not days.contains_date(date(2026, 7, 4))  # Saturday
+
+
+def test_days_of_week_next_date_on_or_after() -> None:
+    days = DaysOfWeek((Weekday.MONDAY, Weekday.WEDNESDAY))
+
+    assert days.next_date_on_or_after(date(2026, 7, 6)) == date(2026, 7, 6)
+    assert days.next_date_on_or_after(date(2026, 7, 7)) == date(2026, 7, 8)
+    assert days.next_date_on_or_after(date(2026, 7, 9)) == date(2026, 7, 13)
+
+
+@pytest.mark.parametrize("value", ["", "holiday"])
+def test_parse_days_of_week_rejects_invalid_values(value: str) -> None:
+    with pytest.raises(CronTimeError):
+        parse_days_of_week(value)
 
 
 # --- parse_local_time --------------------------------------------------------

--- a/libs/talon/tests/cron/test_time.py
+++ b/libs/talon/tests/cron/test_time.py
@@ -16,7 +16,6 @@ from deepagents_talon.cron.time import (
 
 LA = "America/Los_Angeles"
 LA_ZONE = ZoneInfo(LA)
-NY = "America/New_York"
 
 
 def _utc(year: int, month: int, day: int, hour: int, minute: int = 0) -> datetime:
@@ -47,7 +46,7 @@ def test_parse_local_time_accepts_grammar_forms(text: str, expected: tuple[int, 
 
 @pytest.mark.parametrize(
     "text",
-    ["", "  ", "25:00", "8:60pm", "abc", "13pm", "-1:00", "8:00 xm"],
+    ["", "  ", "25:00", "8:60pm", "abc", "13pm", "-1:00", "8:00 xm", "0am", "0pm"],
 )
 def test_parse_local_time_rejects_malformed(text: str) -> None:
     with pytest.raises(CronTimeError):
@@ -56,7 +55,7 @@ def test_parse_local_time_rejects_malformed(text: str) -> None:
 
 def test_local_time_of_day_str_and_validation() -> None:
     assert str(LocalTimeOfDay(8, 30)) == "08:30"
-    assert LocalTimeOfDay(8, 30).to_timedelta() == timedelta(hours=8, minutes=30)
+    assert LocalTimeOfDay(12, 0).total_minutes == 720
     with pytest.raises(CronTimeError):
         LocalTimeOfDay(24, 0)
     with pytest.raises(CronTimeError):
@@ -99,6 +98,25 @@ def test_next_wall_clock_run_unknown_timezone() -> None:
             now=_utc(2026, 7, 2, 15, 0),
             timezone="Mars/Olympus",
             time=LocalTimeOfDay(8, 0),
+        )
+
+
+def test_next_wall_clock_run_rejects_naive_now() -> None:
+    with pytest.raises(CronTimeError):
+        next_wall_clock_run(
+            now=datetime(2026, 7, 2, 15, 0),  # noqa: DTZ001  # naive by design
+            timezone=LA,
+            time=LocalTimeOfDay(12, 0),
+        )
+
+
+def test_next_interval_run_rejects_naive_previous() -> None:
+    with pytest.raises(CronTimeError):
+        next_interval_run(
+            previous=datetime(2026, 7, 2, 12, 0),  # noqa: DTZ001  # naive by design
+            now=_utc(2026, 7, 2, 12, 5),
+            minutes=15,
+            active_window=None,
         )
 
 

--- a/libs/talon/tests/cron/test_time.py
+++ b/libs/talon/tests/cron/test_time.py
@@ -47,7 +47,7 @@ def test_parse_weekday_accepts_common_names(text: str, expected: Weekday) -> Non
     assert parse_weekday(text) is expected
 
 
-@pytest.mark.parametrize("text", ["", "  ", "s", "tueth", "funday"])
+@pytest.mark.parametrize("text", ["", "  ", "s", "t", "tueth", "funday"])
 def test_parse_weekday_rejects_unknown_or_ambiguous_names(text: str) -> None:
     with pytest.raises(CronTimeError):
         parse_weekday(text)
@@ -234,6 +234,17 @@ def test_dst_spring_forward_nonexistent_raises() -> None:
         )
 
 
+def test_skipped_local_date_raises() -> None:
+    # Pacific/Apia skipped 2011-12-30 entirely when it moved west of the date line.
+    with pytest.raises(CronTimeError, match="does not exist"):
+        next_wall_clock_run(
+            now=_utc(2011, 12, 29, 0, 0),
+            timezone="Pacific/Apia",
+            time=LocalTimeOfDay(12, 0),
+            date=date(2011, 12, 30),
+        )
+
+
 # --- next_interval_run -------------------------------------------------------
 
 
@@ -244,11 +255,11 @@ def test_next_interval_run_without_window_advances_by_minutes() -> None:
     assert result == previous + timedelta(minutes=15)
 
 
-def test_next_interval_run_without_window_jumps_after_lag() -> None:
+def test_next_interval_run_without_window_preserves_cadence_after_lag() -> None:
     previous = _utc(2026, 7, 2, 12, 0)
-    now = _utc(2026, 7, 2, 12, 30)  # more than 15m after previous
+    now = _utc(2026, 7, 2, 12, 16)  # more than 15m after previous
     result = next_interval_run(previous=previous, now=now, minutes=15, active_window=None)
-    assert result == now + timedelta(minutes=15)
+    assert result == previous + timedelta(minutes=30)
 
 
 def test_next_interval_run_rejects_non_positive_minutes() -> None:


### PR DESCRIPTION
Closes JKB-10

---

## Description
Adds deterministic Talon cron support for local wall-clock schedules and active-hour windows on top of the cron time helpers. Existing relative schedules remain compatible while persisted jobs include timezone/window metadata, local run output, and scheduler host-clock diagnostics.

## Release Note
Talon cron jobs can now use local wall-clock schedules and active-hour windows with IANA timezone handling.

## Test Plan
- [x] `uv run --project libs/talon pytest libs/talon/tests/cron/test_time.py libs/talon/tests/cron/test_jobs.py --no-header --no-summary -q`; `uv run --project libs/talon ruff check ...`; `uv run --project libs/talon ty check ...`

Made by [Open SWE](https://openswe.vercel.app/agents/b16117ec-46b8-db67-7d11-a75f241a9408)