### PR TITLE
feat(talon): add cron days-of-week helpers module

### DIFF
--- a/libs/talon/deepagents_talon/cron/days_of_week.py
+++ b/libs/talon/deepagents_talon/cron/days_of_week.py
@@ -1,0 +1,296 @@
+"""Pure-function day-of-week helpers for cron scheduling.
+
+Provides weekday parsing, an immutable weekday set, and helpers for
+determining which weekdays a timer may run. No I/O, no side effects, fully
+deterministic and unit-testable without sleeping.
+
+Talon is an experimental runtime and is subject to change or removal at any time.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from enum import IntEnum
+from typing import TYPE_CHECKING
+
+from deepagents_talon.cron.time import CronTimeError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+__all__ = [
+    "DaysOfWeek",
+    "Weekday",
+    "parse_days_of_week",
+    "parse_weekday",
+]
+
+_DAYS_IN_WEEK = 7
+
+
+class Weekday(IntEnum):
+    """Day of week using Python's `datetime.weekday()` numbering.
+
+    Args:
+        value: Integer day index where Monday is `0` and Sunday is `6`.
+    """
+
+    MONDAY = 0
+    TUESDAY = 1
+    WEDNESDAY = 2
+    THURSDAY = 3
+    FRIDAY = 4
+    SATURDAY = 5
+    SUNDAY = 6
+
+    @property
+    def label(self) -> str:
+        """Return the lowercase full day name."""
+        return _WEEKDAY_LABELS[self]
+
+    @property
+    def abbreviation(self) -> str:
+        """Return the lowercase three-letter day abbreviation."""
+        return self.label[:3]
+
+    @classmethod
+    def from_date(cls, value: date) -> Weekday:
+        """Return the weekday for a calendar date.
+
+        Args:
+            value: Calendar date to inspect.
+
+        Returns:
+            Matching weekday.
+        """
+        return cls(value.weekday())
+
+    @classmethod
+    def from_datetime(cls, value: datetime) -> Weekday:
+        """Return the weekday for a datetime's local date.
+
+        Args:
+            value: Datetime to inspect.
+
+        Returns:
+            Matching weekday.
+        """
+        return cls(value.weekday())
+
+    def __str__(self) -> str:
+        """Return the lowercase full day name."""
+        return self.label
+
+
+_WEEKDAY_LABELS: dict[Weekday, str] = {
+    Weekday.MONDAY: "monday",
+    Weekday.TUESDAY: "tuesday",
+    Weekday.WEDNESDAY: "wednesday",
+    Weekday.THURSDAY: "thursday",
+    Weekday.FRIDAY: "friday",
+    Weekday.SATURDAY: "saturday",
+    Weekday.SUNDAY: "sunday",
+}
+_WEEKDAY_ALIASES: dict[str, Weekday] = {
+    "m": Weekday.MONDAY,
+    "mon": Weekday.MONDAY,
+    "monday": Weekday.MONDAY,
+    "tue": Weekday.TUESDAY,
+    "tues": Weekday.TUESDAY,
+    "tuesday": Weekday.TUESDAY,
+    "w": Weekday.WEDNESDAY,
+    "wed": Weekday.WEDNESDAY,
+    "weds": Weekday.WEDNESDAY,
+    "wednesday": Weekday.WEDNESDAY,
+    "th": Weekday.THURSDAY,
+    "thu": Weekday.THURSDAY,
+    "thur": Weekday.THURSDAY,
+    "thurs": Weekday.THURSDAY,
+    "thursday": Weekday.THURSDAY,
+    "f": Weekday.FRIDAY,
+    "fri": Weekday.FRIDAY,
+    "friday": Weekday.FRIDAY,
+    "sa": Weekday.SATURDAY,
+    "sat": Weekday.SATURDAY,
+    "saturday": Weekday.SATURDAY,
+    "su": Weekday.SUNDAY,
+    "sun": Weekday.SUNDAY,
+    "sunday": Weekday.SUNDAY,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DaysOfWeek:
+    """Immutable set of active weekdays for a timer.
+
+    Args:
+        days: Weekdays when a timer may run. Duplicates are removed and the
+            stored tuple is sorted Monday through Sunday.
+    """
+
+    days: tuple[Weekday, ...]
+
+    def __post_init__(self) -> None:
+        """Normalize and validate the weekday collection."""
+        try:
+            normalized = tuple(sorted({Weekday(day) for day in self.days}, key=int))
+        except ValueError as exc:
+            msg = "days of week contains an invalid weekday"
+            raise CronTimeError(msg) from exc
+        if not normalized:
+            msg = "days of week must include at least one day"
+            raise CronTimeError(msg)
+        object.__setattr__(self, "days", normalized)
+
+    @classmethod
+    def all(cls) -> DaysOfWeek:
+        """Return all seven days.
+
+        Returns:
+            Days of week containing Monday through Sunday.
+        """
+        return cls(tuple(Weekday))
+
+    @classmethod
+    def weekdays(cls) -> DaysOfWeek:
+        """Return Monday through Friday.
+
+        Returns:
+            Business weekdays.
+        """
+        return cls(
+            (
+                Weekday.MONDAY,
+                Weekday.TUESDAY,
+                Weekday.WEDNESDAY,
+                Weekday.THURSDAY,
+                Weekday.FRIDAY,
+            ),
+        )
+
+    @classmethod
+    def weekends(cls) -> DaysOfWeek:
+        """Return Saturday and Sunday.
+
+        Returns:
+            Weekend days.
+        """
+        return cls((Weekday.SATURDAY, Weekday.SUNDAY))
+
+    def contains_date(self, value: date) -> bool:
+        """Return whether `value` falls on an active weekday.
+
+        Args:
+            value: Calendar date to inspect.
+
+        Returns:
+            `True` when the date's weekday is active.
+        """
+        return Weekday.from_date(value) in self.days
+
+    def contains_datetime(self, value: datetime) -> bool:
+        """Return whether `value` falls on an active weekday.
+
+        Args:
+            value: Datetime to inspect using its local date.
+
+        Returns:
+            `True` when the datetime's weekday is active.
+        """
+        return Weekday.from_datetime(value) in self.days
+
+    def next_date_on_or_after(self, value: date) -> date:
+        """Return the first active date on or after `value`.
+
+        Args:
+            value: Starting calendar date.
+
+        Returns:
+            `value` when active, otherwise the next active date within one week.
+        """
+        for offset in range(_DAYS_IN_WEEK):
+            candidate = value + timedelta(days=offset)
+            if self.contains_date(candidate):
+                return candidate
+        msg = "days of week must include at least one reachable day"
+        raise CronTimeError(msg)
+
+    def __contains__(self, day: object) -> bool:
+        """Return whether `day` is active."""
+        return day in self.days
+
+    def __iter__(self) -> Iterator[Weekday]:
+        """Iterate over active weekdays in Monday-through-Sunday order."""
+        return iter(self.days)
+
+    def __str__(self) -> str:
+        """Return comma-separated weekday labels."""
+        return ", ".join(day.label for day in self.days)
+
+
+# --- Parsing -----------------------------------------------------------------
+
+_DAY_SEPARATORS = re.compile(r"[\s,;/+&]+")
+_DAY_JOINERS = {"and", "or", "on"}
+_ALL_DAYS_TEXT = {"all", "all days", "any day", "anyday", "daily", "every day", "everyday"}
+_WEEKDAYS_TEXT = {"weekday", "weekdays"}
+_WEEKENDS_TEXT = {"weekend", "weekends"}
+
+
+def parse_weekday(value: str) -> Weekday:
+    """Parse a weekday name or abbreviation.
+
+    Supports full day names and common abbreviations such as `mon`, `monday`,
+    `thu`, `thurs`, `sat`, and `sunday`.
+
+    Args:
+        value: Weekday text.
+
+    Returns:
+        Parsed weekday.
+
+    Raises:
+        CronTimeError: If the input is empty, ambiguous, or unsupported.
+    """
+    text = value.strip().lower().rstrip(".")
+    if not text:
+        msg = "weekday must not be empty"
+        raise CronTimeError(msg)
+    if text in _WEEKDAY_ALIASES:
+        return _WEEKDAY_ALIASES[text]
+    if text.endswith("s") and text[:-1] in _WEEKDAY_ALIASES:
+        return _WEEKDAY_ALIASES[text[:-1]]
+    msg = f"unrecognized weekday: {value!r}"
+    raise CronTimeError(msg)
+
+
+def parse_days_of_week(value: str) -> DaysOfWeek:
+    """Parse timer day-of-week text.
+
+    Supports `daily`, `every day`, `weekdays`, `weekends`, and separated day
+    names such as `mon wed fri`, `monday, wednesday, friday`, or `sat/sun`.
+
+    Args:
+        value: Day-of-week text.
+
+    Returns:
+        Parsed immutable day set.
+
+    Raises:
+        CronTimeError: If the input is empty or contains an unsupported day.
+    """
+    text = " ".join(value.strip().lower().split())
+    if not text:
+        msg = "days of week must not be empty"
+        raise CronTimeError(msg)
+    if text in _ALL_DAYS_TEXT:
+        return DaysOfWeek.all()
+    if text in _WEEKDAYS_TEXT:
+        return DaysOfWeek.weekdays()
+    if text in _WEEKENDS_TEXT:
+        return DaysOfWeek.weekends()
+
+    tokens = [token for token in _DAY_SEPARATORS.split(text) if token and token not in _DAY_JOINERS]
+    return DaysOfWeek(tuple(parse_weekday(token) for token in tokens))

--- a/libs/talon/deepagents_talon/cron/time.py
+++ b/libs/talon/deepagents_talon/cron/time.py
@@ -1,0 +1,343 @@
+"""Pure-function time helpers for cron scheduling.
+
+Provides IANA time zone conversion, local-time parsing, wall-clock
+next-occurrence computation, and DST edge-case handling. No I/O, no side
+effects, fully deterministic and unit-testable without sleeping.
+
+Talon is an experimental runtime and is subject to change or removal at any time.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from functools import total_ordering
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+__all__ = [
+    "ActiveWindow",
+    "CronTimeError",
+    "LocalTimeOfDay",
+    "next_interval_run",
+    "next_wall_clock_run",
+    "parse_local_time",
+]
+
+_MAX_HOUR = 23
+_MAX_MINUTE = 59
+_AMPM_HOUR_BOUND = 12  # 12-hour clock upper bound before wrapping to 0
+
+
+class CronTimeError(ValueError):
+    """Raised when a cron time request is invalid or impossible."""
+
+
+@total_ordering
+@dataclass(frozen=True, slots=True)
+class LocalTimeOfDay:
+    """Local clock time with minute precision.
+
+    Args:
+        hour: Hour of day (0-23).
+        minute: Minute of hour (0-59).
+    """
+
+    hour: int
+    minute: int
+
+    def __post_init__(self) -> None:
+        """Validate the clock-time components."""
+        if not 0 <= self.hour <= _MAX_HOUR:
+            msg = f"hour must be 0-23, got {self.hour}"
+            raise CronTimeError(msg)
+        if not 0 <= self.minute <= _MAX_MINUTE:
+            msg = f"minute must be 0-59, got {self.minute}"
+            raise CronTimeError(msg)
+
+    @property
+    def total_minutes(self) -> int:
+        """Minutes since midnight."""
+        return self.hour * 60 + self.minute
+
+    def __lt__(self, other: LocalTimeOfDay) -> bool:
+        """Compare ordering by minutes since midnight."""
+        return self.total_minutes < other.total_minutes
+
+    def __str__(self) -> str:
+        """Return a `HH:MM` string.
+
+        Returns:
+            Zero-padded `HH:MM` representation.
+        """
+        return f"{self.hour:02d}:{self.minute:02d}"
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveWindow:
+    """Local-time window during which recurring jobs may run.
+
+    Windows that cross midnight (`end <= start`) are supported and
+    interpreted as `start <= local < 24:00` OR `00:00 <= local < end`.
+
+    Args:
+        timezone: IANA time zone name used to evaluate the window.
+        start: Inclusive local start time.
+        end: Exclusive local end time.
+    """
+
+    timezone: str
+    start: LocalTimeOfDay
+    end: LocalTimeOfDay
+
+    def __post_init__(self) -> None:
+        """Validate the active window."""
+        if self.start == self.end:
+            msg = "active window start must differ from end"
+            raise CronTimeError(msg)
+
+    @property
+    def crosses_midnight(self) -> bool:
+        """Whether this window spans midnight."""
+        return self.end <= self.start
+
+    def contains(self, local: LocalTimeOfDay) -> bool:
+        """Return whether `local` falls inside this window.
+
+        Args:
+            local: Local clock time to test.
+
+        Returns:
+            `True` when `local` is inside the active window.
+        """
+        if self.crosses_midnight:
+            return local >= self.start or local < self.end
+        return self.start <= local < self.end
+
+    def zone(self) -> ZoneInfo:
+        """Return the zoneinfo for this window.
+
+        Returns:
+            Resolved `ZoneInfo`.
+
+        Raises:
+            CronTimeError: If the time zone is unknown.
+        """
+        return _resolve_zone(self.timezone)
+
+
+# --- Parsing -----------------------------------------------------------------
+
+_AM_PM = re.compile(
+    r"^(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?\s*(?P<suffix>am|pm)$",
+    re.IGNORECASE,
+)
+_24H = re.compile(r"^(?P<hour>\d{1,2}):(?P<minute>\d{2})$")
+_HOUR_ONLY = re.compile(r"^(?P<hour>\d{1,2})$")
+
+
+def parse_local_time(value: str) -> LocalTimeOfDay:
+    """Parse a local clock time string.
+
+    Supports the grammar forms: `20:00`, `8:00pm`, `8pm`, `08:30`, `17:27`.
+
+    Args:
+        value: Local time text.
+
+    Returns:
+        Parsed local time of day.
+
+    Raises:
+        CronTimeError: If the input is malformed or out of range.
+    """
+    text = value.strip().lower()
+    if not text:
+        msg = "local time must not be empty"
+        raise CronTimeError(msg)
+
+    m = _AM_PM.match(text)
+    if m:
+        hour = int(m.group("hour"))
+        minute = int(m.group("minute") or "0")
+        if not 1 <= hour <= _AMPM_HOUR_BOUND:
+            msg = f"12-hour clock hour out of range: {value!r}"
+            raise CronTimeError(msg)
+        if hour == _AMPM_HOUR_BOUND:
+            hour = 0
+        suffix = m.group("suffix").lower()
+        if suffix == "pm":
+            hour += _AMPM_HOUR_BOUND
+        return LocalTimeOfDay(hour=hour, minute=minute)
+
+    m = _24H.match(text)
+    if m:
+        return LocalTimeOfDay(hour=int(m.group("hour")), minute=int(m.group("minute")))
+
+    m = _HOUR_ONLY.match(text)
+    if m and text.isdigit():
+        return LocalTimeOfDay(hour=int(m.group("hour")), minute=0)
+
+    msg = f"unrecognized local time format: {value!r}"
+    raise CronTimeError(msg)
+
+
+# --- Zone resolution ---------------------------------------------------------
+
+def _resolve_zone(timezone: str) -> ZoneInfo:
+    """Resolve an IANA zone name, re-raising unknown zones as `CronTimeError`."""
+    try:
+        return ZoneInfo(timezone)
+    except ZoneInfoNotFoundError as exc:
+        msg = f"unknown time zone: {timezone!r}"
+        raise CronTimeError(msg) from exc
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Return `dt` converted to UTC, rejecting naive datetimes."""
+    if dt.tzinfo is None or dt.utcoffset() is None:
+        msg = "datetime must be timezone-aware"
+        raise CronTimeError(msg)
+    return dt.astimezone(UTC)
+
+
+def _local_time_of(dt: datetime) -> LocalTimeOfDay:
+    """Return the local clock-time components of `dt`."""
+    return LocalTimeOfDay(hour=dt.hour, minute=dt.minute)
+
+
+# --- Wall-clock next occurrence ----------------------------------------------
+
+def next_wall_clock_run(
+    *,
+    now: datetime,
+    timezone: str,
+    time: LocalTimeOfDay,
+    date: date | None = None,
+) -> datetime:
+    """Return the next UTC occurrence of `time` in `timezone`.
+
+    If no `date` is provided, the next occurrence is today when the local
+    clock has not yet reached `time`, otherwise tomorrow. When `date` is
+    provided, that local calendar date's occurrence is returned.
+
+    DST fall-back ambiguous times resolve to the first occurrence (`fold=0`).
+    DST spring-forward nonexistent local times raise a structured error
+    rather than silently shifting.
+
+    Args:
+        now: Current instant, timezone-aware.
+        timezone: IANA time zone for wall-clock interpretation.
+        time: Target local clock time.
+        date: Optional explicit local calendar date.
+
+    Returns:
+        Next occurrence of `time` in `timezone`, as a UTC datetime.
+
+    Raises:
+        CronTimeError: If the timezone is unknown, `now` is naive, or the
+            requested local time does not exist due to DST spring-forward.
+    """
+    zone = _resolve_zone(timezone)
+    now_utc = _as_utc(now)
+
+    if date is None:
+        now_local = now_utc.astimezone(zone)
+        candidate_date = now_local.date()
+        if _local_time_of(now_local) >= time:
+            candidate_date += timedelta(days=1)
+        candidate = _build_local(zone, candidate_date, time, fold=0)
+    else:
+        candidate = _build_local(zone, date, time, fold=0)
+
+    return _as_utc(candidate)
+
+
+def _build_local(zone: ZoneInfo, target_date: date, time: LocalTimeOfDay, *, fold: int) -> datetime:
+    """Construct a local datetime at `time` on `target_date` in `zone`.
+
+    Detects nonexistent spring-forward local times by verifying the
+    round-trip wall clock matches the request.
+    """
+    naive = datetime(  # noqa: DTZ001  # naive constructed intentionally; tzinfo attached next line
+        target_date.year,
+        target_date.month,
+        target_date.day,
+        time.hour,
+        time.minute,
+        fold=fold,
+    )
+    aware = naive.replace(tzinfo=zone)
+    roundtrip = aware.astimezone(UTC).astimezone(zone)
+    if roundtrip.date() != target_date or _local_time_of(roundtrip) != time:
+        msg = (
+            f"local time {time} does not exist on {target_date.isoformat()} "
+            f"in {zone!s} (spring-forward gap)"
+        )
+        raise CronTimeError(msg)
+    return aware
+
+
+# --- Interval next run with optional active window ----------------------------
+
+
+def next_interval_run(
+    *,
+    previous: datetime,
+    now: datetime,
+    minutes: int,
+    active_window: ActiveWindow | None,
+) -> datetime:
+    """Return the next interval run, gated by an optional active window.
+
+    Without an active window, the next run is `previous + minutes`, advanced
+    forward until it is strictly greater than `now` (one step is guaranteed).
+
+    With an active window, the next run is advanced forward by `minutes`
+    increments until it lands inside the window. When an interval lands
+    outside the window, the next in-window time after it is used, which may
+    fast-forward across inactive spans (e.g. overnight).
+
+    Args:
+        previous: Previous scheduled run instant, timezone-aware.
+        now: Current instant, timezone-aware.
+        minutes: Interval in minutes (>= 1).
+        active_window: Optional local-time window.
+
+    Returns:
+        Next run instant as a UTC datetime.
+
+    Raises:
+        CronTimeError: If `minutes` is not positive.
+    """
+    if minutes < 1:
+        msg = "interval minutes must be positive"
+        raise CronTimeError(msg)
+
+    step = timedelta(minutes=minutes)
+    candidate = _as_utc(previous) + step
+    now_utc = _as_utc(now)
+    if candidate <= now_utc:
+        missed = (now_utc - candidate) // step + 1
+        candidate += missed * step
+
+    if active_window is None:
+        return candidate
+
+    return _advance_into_window(candidate, active_window)
+
+
+def _advance_into_window(
+    candidate: datetime,
+    window: ActiveWindow,
+) -> datetime:
+    """Fast-forward `candidate` to the next window-start when it is outside `window`."""
+    zone = window.zone()
+    local = candidate.astimezone(zone)
+    local_time = _local_time_of(local)
+    if window.contains(local_time):
+        return candidate
+
+    start_today_utc = _as_utc(_build_local(zone, local.date(), window.start, fold=0))
+    if start_today_utc >= candidate:
+        return start_today_utc
+    return _as_utc(_build_local(zone, local.date() + timedelta(days=1), window.start, fold=0))

--- a/libs/talon/tests/cron/test_days_of_week.py
+++ b/libs/talon/tests/cron/test_days_of_week.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+
+from deepagents_talon.cron.days_of_week import (
+    DaysOfWeek,
+    Weekday,
+    parse_days_of_week,
+    parse_weekday,
+)
+from deepagents_talon.cron.time import CronTimeError
+
+
+def _utc(year: int, month: int, day: int, hour: int) -> datetime:
+    return datetime(year, month, day, hour, tzinfo=UTC)
+
+
+# --- parse_weekday -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("m", Weekday.MONDAY),
+        ("Mon", Weekday.MONDAY),
+        ("mondays", Weekday.MONDAY),
+        ("tues", Weekday.TUESDAY),
+        ("weds", Weekday.WEDNESDAY),
+        ("thurs", Weekday.THURSDAY),
+        ("fri", Weekday.FRIDAY),
+        ("sa", Weekday.SATURDAY),
+        ("sun.", Weekday.SUNDAY),
+    ],
+)
+def test_parse_weekday_accepts_common_names(text: str, expected: Weekday) -> None:
+    assert parse_weekday(text) is expected
+
+
+@pytest.mark.parametrize("text", ["", "  ", "s", "t", "tueth", "funday"])
+def test_parse_weekday_rejects_unknown_or_ambiguous_names(text: str) -> None:
+    with pytest.raises(CronTimeError):
+        parse_weekday(text)
+
+
+# --- parse_days_of_week ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("daily", tuple(Weekday)),
+        ("every day", tuple(Weekday)),
+        (
+            "weekdays",
+            (
+                Weekday.MONDAY,
+                Weekday.TUESDAY,
+                Weekday.WEDNESDAY,
+                Weekday.THURSDAY,
+                Weekday.FRIDAY,
+            ),
+        ),
+        ("weekends", (Weekday.SATURDAY, Weekday.SUNDAY)),
+        ("mon wed fri", (Weekday.MONDAY, Weekday.WEDNESDAY, Weekday.FRIDAY)),
+        ("monday, wednesday, and friday", (Weekday.MONDAY, Weekday.WEDNESDAY, Weekday.FRIDAY)),
+        ("sat/sun", (Weekday.SATURDAY, Weekday.SUNDAY)),
+    ],
+)
+def test_parse_days_of_week_accepts_timer_forms(text: str, expected: tuple[Weekday, ...]) -> None:
+    assert parse_days_of_week(text).days == expected
+
+
+def test_days_of_week_deduplicates_and_sorts() -> None:
+    days = DaysOfWeek((Weekday.FRIDAY, Weekday.MONDAY, Weekday.FRIDAY))
+
+    assert days.days == (Weekday.MONDAY, Weekday.FRIDAY)
+    assert str(days) == "monday, friday"
+
+
+def test_days_of_week_contains_dates_and_datetimes() -> None:
+    days = DaysOfWeek.weekdays()
+
+    assert days.contains_date(date(2026, 7, 3))  # Friday
+    assert days.contains_datetime(_utc(2026, 7, 3, 12))
+    assert not days.contains_date(date(2026, 7, 4))  # Saturday
+
+
+def test_days_of_week_next_date_on_or_after() -> None:
+    days = DaysOfWeek((Weekday.MONDAY, Weekday.WEDNESDAY))
+
+    assert days.next_date_on_or_after(date(2026, 7, 6)) == date(2026, 7, 6)
+    assert days.next_date_on_or_after(date(2026, 7, 7)) == date(2026, 7, 8)
+    assert days.next_date_on_or_after(date(2026, 7, 9)) == date(2026, 7, 13)
+
+
+@pytest.mark.parametrize("value", ["", "holiday"])
+def test_parse_days_of_week_rejects_invalid_values(value: str) -> None:
+    with pytest.raises(CronTimeError):
+        parse_days_of_week(value)
+
+
+def test_days_of_week_rejects_empty() -> None:
+    with pytest.raises(CronTimeError):
+        DaysOfWeek(())
+
+
+def test_weekday_from_date_and_datetime_agree_with_python_weekday() -> None:
+    # 2026-07-03 is a Friday (weekday() == 4)
+    assert Weekday.from_date(date(2026, 7, 3)) is Weekday.FRIDAY
+    assert Weekday.from_datetime(_utc(2026, 7, 3, 12)) is Weekday.FRIDAY
+    assert int(Weekday.FRIDAY) == 4
+
+
+def test_weekday_label_and_abbreviation() -> None:
+    assert Weekday.MONDAY.label == "monday"
+    assert Weekday.WEDNESDAY.abbreviation == "wed"
+    assert str(Weekday.SUNDAY) == "sunday"

--- a/libs/talon/tests/cron/test_time.py
+++ b/libs/talon/tests/cron/test_time.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from deepagents_talon.cron.time import (
+    ActiveWindow,
+    CronTimeError,
+    LocalTimeOfDay,
+    next_interval_run,
+    next_wall_clock_run,
+    parse_local_time,
+)
+
+LA = "America/Los_Angeles"
+LA_ZONE = ZoneInfo(LA)
+
+
+def _utc(year: int, month: int, day: int, hour: int, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+# --- parse_local_time --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("20:00", (20, 0)),
+        ("8:00pm", (20, 0)),
+        ("8pm", (20, 0)),
+        ("08:30", (8, 30)),
+        ("17:27", (17, 27)),
+        ("12am", (0, 0)),
+        ("12pm", (12, 0)),
+        ("11:59pm", (23, 59)),
+        ("00:00", (0, 0)),
+    ],
+)
+def test_parse_local_time_accepts_grammar_forms(text: str, expected: tuple[int, int]) -> None:
+    parsed = parse_local_time(text)
+    assert (parsed.hour, parsed.minute) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["", "  ", "25:00", "8:60pm", "abc", "13pm", "-1:00", "8:00 xm", "0am", "0pm"],
+)
+def test_parse_local_time_rejects_malformed(text: str) -> None:
+    with pytest.raises(CronTimeError):
+        parse_local_time(text)
+
+
+def test_local_time_of_day_str_and_validation() -> None:
+    assert str(LocalTimeOfDay(8, 30)) == "08:30"
+    assert LocalTimeOfDay(12, 0).total_minutes == 720
+    with pytest.raises(CronTimeError):
+        LocalTimeOfDay(24, 0)
+    with pytest.raises(CronTimeError):
+        LocalTimeOfDay(8, 60)
+
+
+# --- next_wall_clock_run ------------------------------------------------------
+
+
+def test_next_wall_clock_run_today() -> None:
+    now = _utc(2026, 7, 2, 15, 0)  # 8am LA
+    target = LocalTimeOfDay(12, 0)  # noon LA = 19:00 UTC
+    result = next_wall_clock_run(now=now, timezone=LA, time=target)
+    assert result == _utc(2026, 7, 2, 19, 0)
+
+
+def test_next_wall_clock_run_tomorrow_when_already_passed() -> None:
+    now = _utc(2026, 7, 2, 20, 30)  # 1:30pm LA — noon already passed
+    target = LocalTimeOfDay(12, 0)
+    result = next_wall_clock_run(now=now, timezone=LA, time=target)
+    assert result == _utc(2026, 7, 3, 19, 0)
+
+
+def test_next_wall_clock_run_explicit_date() -> None:
+    now = _utc(2026, 7, 2, 15, 0)
+    target = LocalTimeOfDay(20, 0)
+    result = next_wall_clock_run(
+        now=now,
+        timezone=LA,
+        time=target,
+        date=date(2026, 7, 5),
+    )
+    # July 5 20:00 LA = July 6 03:00 UTC
+    assert result == _utc(2026, 7, 6, 3, 0)
+
+
+def test_next_wall_clock_run_unknown_timezone() -> None:
+    with pytest.raises(CronTimeError):
+        next_wall_clock_run(
+            now=_utc(2026, 7, 2, 15, 0),
+            timezone="Mars/Olympus",
+            time=LocalTimeOfDay(8, 0),
+        )
+
+
+def test_next_wall_clock_run_rejects_naive_now() -> None:
+    with pytest.raises(CronTimeError):
+        next_wall_clock_run(
+            now=datetime(2026, 7, 2, 15, 0),  # noqa: DTZ001  # naive by design
+            timezone=LA,
+            time=LocalTimeOfDay(12, 0),
+        )
+
+
+def test_next_interval_run_rejects_naive_previous() -> None:
+    with pytest.raises(CronTimeError):
+        next_interval_run(
+            previous=datetime(2026, 7, 2, 12, 0),  # noqa: DTZ001  # naive by design
+            now=_utc(2026, 7, 2, 12, 5),
+            minutes=15,
+            active_window=None,
+        )
+
+
+# --- DST handling ------------------------------------------------------------
+
+
+def test_dst_fall_back_ambiguous_uses_first_occurrence() -> None:
+    # America/Los_Angeles falls back on 2026-11-01 at 02:00 local.
+    # 01:30 is ambiguous (occurs twice). fold=0 selects the PDT instance.
+    result = next_wall_clock_run(
+        now=_utc(2026, 11, 1, 7, 0),  # just after midnight UTC = 2026-10-31 PT
+        timezone=LA,
+        time=LocalTimeOfDay(1, 30),
+        date=date(2026, 11, 1),
+    )
+    # PDT offset is UTC-7; 01:30 PDT = 08:30 UTC.
+    assert result == _utc(2026, 11, 1, 8, 30)
+    assert result.utcoffset() == timedelta(0)
+
+
+def test_dst_spring_forward_nonexistent_raises() -> None:
+    # America/Los_Angeles springs forward on 2026-03-08 at 02:00 local.
+    # 02:30 local does not exist on that date.
+    with pytest.raises(CronTimeError, match="spring-forward"):
+        next_wall_clock_run(
+            now=_utc(2026, 3, 8, 9, 0),
+            timezone=LA,
+            time=LocalTimeOfDay(2, 30),
+            date=date(2026, 3, 8),
+        )
+
+
+def test_next_wall_clock_run_after_spring_forward_gap_rolls_to_tomorrow() -> None:
+    # At 03:30 local, today's nonexistent 02:30 has already passed.
+    result = next_wall_clock_run(
+        now=_utc(2026, 3, 8, 10, 30),
+        timezone=LA,
+        time=LocalTimeOfDay(2, 30),
+    )
+    assert result == _utc(2026, 3, 9, 9, 30)
+
+
+def test_skipped_local_date_raises() -> None:
+    # Pacific/Apia skipped 2011-12-30 entirely when it moved west of the date line.
+    with pytest.raises(CronTimeError, match="does not exist"):
+        next_wall_clock_run(
+            now=_utc(2011, 12, 29, 0, 0),
+            timezone="Pacific/Apia",
+            time=LocalTimeOfDay(12, 0),
+            date=date(2011, 12, 30),
+        )
+
+
+# --- next_interval_run -------------------------------------------------------
+
+
+def test_next_interval_run_without_window_advances_by_minutes() -> None:
+    previous = _utc(2026, 7, 2, 12, 0)
+    now = _utc(2026, 7, 2, 12, 5)
+    result = next_interval_run(previous=previous, now=now, minutes=15, active_window=None)
+    assert result == previous + timedelta(minutes=15)
+
+
+def test_next_interval_run_without_window_preserves_cadence_after_lag() -> None:
+    previous = _utc(2026, 7, 2, 12, 0)
+    now = _utc(2026, 7, 2, 12, 16)  # more than 15m after previous
+    result = next_interval_run(previous=previous, now=now, minutes=15, active_window=None)
+    assert result == previous + timedelta(minutes=30)
+
+
+def test_next_interval_run_rejects_non_positive_minutes() -> None:
+    with pytest.raises(CronTimeError):
+        next_interval_run(
+            previous=_utc(2026, 7, 2, 12, 0),
+            now=_utc(2026, 7, 2, 12, 0),
+            minutes=0,
+            active_window=None,
+        )
+
+
+def _window(start: tuple[int, int], end: tuple[int, int], tz: str = LA) -> ActiveWindow:
+    return ActiveWindow(
+        timezone=tz,
+        start=LocalTimeOfDay(*start),
+        end=LocalTimeOfDay(*end),
+    )
+
+
+def test_next_interval_run_inside_window_returns_first_step() -> None:
+    window = _window((8, 0), (17, 0))
+    previous = _utc(2026, 7, 2, 16, 0)  # 9am LA — inside
+    now = _utc(2026, 7, 2, 15, 55)
+    result = next_interval_run(previous=previous, now=now, minutes=15, active_window=window)
+    assert result == previous + timedelta(minutes=15)
+
+
+def test_next_interval_run_outside_window_advances_inside() -> None:
+    window = _window((8, 0), (17, 0))
+    previous = _utc(2026, 7, 2, 16, 50)  # 9:50am LA — inside, last step lands outside
+    now = _utc(2026, 7, 2, 16, 45)
+    result = next_interval_run(previous=previous, now=now, minutes=15, active_window=window)
+    local = result.astimezone(LA_ZONE)
+    assert window.contains(LocalTimeOfDay(local.hour, local.minute))
+
+
+def test_next_interval_run_skips_overnight_inactive_span() -> None:
+    # Daytime-only window 08:00-17:00 in LA. Previous at 4:45pm LA (last in-window slot).
+    # Next 15m step lands at 17:00 LA — exclusive end — so it falls outside; the
+    # run should fast-forward to next day's 08:00 LA.
+    window = _window((8, 0), (17, 0))
+    previous = _utc(2026, 7, 2, 23, 45)  # 16:45 LA — inside
+    now = _utc(2026, 7, 3, 1, 0)
+    result = next_interval_run(previous=previous, now=now, minutes=15, active_window=window)
+    local = result.astimezone(LA_ZONE)
+    # Fast-forward should land at next day's 08:00 LA.
+    assert (local.hour, local.minute) == (8, 0)
+    assert local.date() == date(2026, 7, 3)
+    assert window.contains(LocalTimeOfDay(local.hour, local.minute))
+
+
+def test_next_interval_run_midnight_crossing_window_includes_late_runs() -> None:
+    # 22:00-06:00 crosses midnight; a run at 23:00 LA should be allowed.
+    window = _window((22, 0), (6, 0))
+    previous = _utc(2026, 7, 2, 5, 30)  # 22:30 previous day LA
+    now = _utc(2026, 7, 3, 2, 0)
+    result = next_interval_run(previous=previous, now=now, minutes=60, active_window=window)
+    local = result.astimezone(LA_ZONE)
+    assert window.contains(LocalTimeOfDay(local.hour, local.minute))
+
+
+def test_active_window_rejects_zero_length() -> None:
+    with pytest.raises(CronTimeError):
+        ActiveWindow(
+            timezone=LA,
+            start=LocalTimeOfDay(8, 0),
+            end=LocalTimeOfDay(8, 0),
+        )
+
+
+def test_active_window_unknown_timezone_resolves_lazily() -> None:
+    window = ActiveWindow(
+        timezone="Mars/Olympus",
+        start=LocalTimeOfDay(8, 0),
+        end=LocalTimeOfDay(17, 0),
+    )
+    with pytest.raises(CronTimeError):
+        window.zone()
+
+
+def test_active_window_contains_helpers() -> None:
+    daytime = _window((8, 0), (17, 0))
+    assert daytime.contains(LocalTimeOfDay(12, 0))
+    assert not daytime.contains(LocalTimeOfDay(22, 0))
+    assert not daytime.crosses_midnight
+
+    overnight = _window((22, 0), (6, 0))
+    assert overnight.contains(LocalTimeOfDay(23, 30))
+    assert overnight.contains(LocalTimeOfDay(2, 0))
+    assert not overnight.contains(LocalTimeOfDay(12, 0))
+    assert overnight.crosses_midnight


### PR DESCRIPTION
Closes JKB-15

---

Split out of PR #4426 (JKB-9) after review flagged the day-of-week types as out of scope for the time-helpers PR boundary. This PR gives them a focused home ahead of downstream schedule-parsing and tool-contract tickets.

## Why

JKB-9 shipped overreach into day-of-week territory with `Weekday`, `DaysOfWeek`, `parse_weekday`, and `parse_days_of_week`. These don't appear anywhere in JKB-9's scope/acceptance criteria and need their own home so JKB-9 can merge as a focused time-helpers PR while the day-of-week types ship separately and become importable for schedule parsing (JKB-10) and the cron tool contract (JKB-14).

## Stacked PR note

This branch sits on top of #4426 (JKB-9). GitHub's diff view on this PR is against `main`, so it shows **both** the time-helpers module (from #4426) **and** the day-of-week module (this PR). The **incremental** contribution of this PR is 415 insertions across 2 files:

- `libs/talon/deepagents_talon/cron/days_of_week.py` (296 lines)
- `libs/talon/tests/cron/test_days_of_week.py` (119 lines)

`time.py` and `test_time.py` appear in the GitHub diff only because they haven't merged via #4426 yet. **Merge #4426 first**, then this PR resolves to just the two DoW files.

## What landed

`deepagents_talon/cron/days_of_week.py`:

- `Weekday` — `IntEnum` with Monday=0 through Sunday=6, matching `datetime.weekday()` numbering. `label`/`abbreviation` properties, `from_date`/`from_datetime` classmethods.
- `DaysOfWeek` — frozen dataclass (`days: tuple[Weekday, ...]`), normalized (deduped + sorted Monday through Sunday) in `__post_init__`, rejected when empty. `all()`/`weekdays()`/`weekends()` constructors, `contains_date`/`contains_datetime`/`next_date_on_or_after` helpers.
- `parse_weekday(value) -> Weekday` — full names (`monday`), abbreviations (`mon`, `thu`, `sat`), single letters (`m`, `f`); strips trailing `s` and `.`. Rejects empty, ambiguous single letters (`s`, `t`), and unknown tokens with `CronTimeError`.
- `parse_days_of_week(value) -> DaysOfWeek` — accepts `daily`/`every day`/`everyday`/`any day`/`weekdays`/`weekends`, plus spaced/comma/slash/plus-separated day lists (`mon wed fri`, `monday, wednesday, and friday`, `sat/sun`).
- Reuses `CronTimeError` from the time helpers module — no new error type.
- All functions deterministic, no I/O, no system-clock reads.

## Tests

`tests/cron/test_days_of_week.py` — 30 deterministic unit tests covering:

- `parse_weekday` accepts common names/abbreviations, rejects unknown/ambiguous.
- `parse_days_of_week` accepts timer forms, rejects invalid values.
- `DaysOfWeek` dedupes, sorts, contains dates/datetimes, and computes `next_date_on_or_after`.
- `Weekday.from_date`/`from_datetime` agree with `date.weekday()`.

## Merge order

Depends on #4426 (JKB-9) for `CronTimeError`. Branch sits on top of the JKB-9 commit; merge #4426 first, then this.

## Review notes

- The module file is named `days_of_week.py` rather than folding into `time.py` to keep the JKB-9 time-helpers module focused and to make the downstream import surface explicit. Open to collapsing if a reviewer prefers.
- Trailing-`s` plural stripping in `parse_weekday` (`mondays` -> `monday`) is intentional — natural language from the model often includes plurals. Ambiguous single letters (`s` for Saturday/Sunday, `t` for Tuesday/Thursday) are rejected rather than guessing.

## Release note

Add `deepagents_talon.cron.days_of_week` pure-function module with `Weekday`, `DaysOfWeek`, `parse_weekday`, and `parse_days_of_week`. Downstream schedule-parsing and tool-contract tickets import from this module.
