### PR TITLE
style(code): drop redundant `/mcp` reference in disabled-server message

### DIFF
--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -1914,7 +1914,7 @@ async def resolve_and_load_mcp_tools(
                         if isinstance(server_config, dict)
                         else "unknown",
                         status="disabled",
-                        error="Disabled by user (`/mcp` F2 to re-enable).",
+                        error="Disabled by user (F2 to re-enable).",
                     ),
                 )
             else:


### PR DESCRIPTION
The disabled-server status in the `/mcp` viewer read `Disabled by user (`/mcp` F2 to re-enable).`, but the user is already inside the `/mcp` switcher when they see it, so mentioning `/mcp` is redundant. Now reads `Disabled by user (F2 to re-enable).`

Made by [Open SWE](https://openswe.vercel.app/agents/dffdbedb-8544-790e-1312-42984fbc7684)