### PR TITLE
chore(code): add `--help`/`--version` flags and verify uv installer download

### DIFF
--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -10,6 +10,10 @@
 # Override uv's pre-release strategy when resolving the latest version:
 #   curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_PRERELEASE="allow" bash
 #
+# Options:
+#   --help, -h     Show this help message and exit
+#   --version, -v  Print installer version and exit
+#
 # By default, the installer uses uv's `allow` pre-release strategy so stable
 # deepagents-code releases that pin a pre-release dependency can resolve.
 # DEEPAGENTS_CODE_VERSION and an explicit DEEPAGENTS_CODE_PRERELEASE are mutually
@@ -45,7 +49,7 @@
 #         all-providers
 #       Sandbox providers: agentcore, daytona, modal, runloop, vercel,
 #         all-sandboxes
-#       Standalone integrations: quickjs
+#       Standalone integrations: media, quickjs
 #   DEEPAGENTS_CODE_VERSION — exact version to install, e.g. "0.1.0rc1"
 #     (mutually exclusive with DEEPAGENTS_CODE_PRERELEASE)
 #   DEEPAGENTS_CODE_PRERELEASE — uv pre-release strategy applied when
@@ -79,6 +83,80 @@
 #   PATH setup adapted from Amp (https://ampcode.com/install.sh).
 
 set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# CLI flags — --help / --version short-circuit before any install work
+# ---------------------------------------------------------------------------
+INSTALLER_VERSION="deepagents-code installer 1.0"
+
+print_help() {
+  cat <<'HELP'
+Install deepagents-code.
+
+Usage:
+  curl -LsSf https://langch.in/dcode | bash
+  curl -LsSf https://langch.in/dcode | bash -s -- [options]
+
+Options:
+  --help, -h        Show this help message and exit
+  --version, -v     Print installer version and exit
+
+Environment variables:
+  DEEPAGENTS_CODE_EXTRAS — comma-separated pip extras, e.g. "ollama",
+    "ollama,groq", or "daytona". Valid extras (see pyproject.toml for the
+    authoritative list):
+      Model providers: anthropic, baseten, bedrock, cohere, deepseek,
+        fireworks, google-genai, groq, huggingface, ibm, litellm, mistralai,
+        nvidia, ollama, openai, openrouter, perplexity, together, vertex, xai,
+        all-providers
+      Sandbox providers: agentcore, daytona, modal, runloop, vercel,
+        all-sandboxes
+      Standalone integrations: media, quickjs
+  DEEPAGENTS_CODE_VERSION — exact version to install, e.g. "0.1.0rc1"
+    (mutually exclusive with DEEPAGENTS_CODE_PRERELEASE)
+  DEEPAGENTS_CODE_PRERELEASE — uv pre-release strategy applied when
+    resolving the latest version: disallow, allow, if-necessary, explicit,
+    or if-necessary-or-explicit (default: allow; explicitly setting it is
+    mutually exclusive with DEEPAGENTS_CODE_VERSION)
+  DEEPAGENTS_CODE_PYTHON — Python version to use (default: 3.13)
+  DEEPAGENTS_CODE_YES — set to 1 to accept an available update without
+    prompting (assume "yes")
+  DEEPAGENTS_CODE_SKIP_OPTIONAL — set to 1 to skip optional tool checks
+  DEEPAGENTS_CODE_RIPGREP_INSTALLER — how to provision ripgrep:
+    "managed" (default) eagerly installs the pinned, SHA-256-verified binary
+    into ~/.deepagents/bin (no sudo) via `dcode tools install`; "system"
+    keeps the interactive package-manager install (brew/apt/cargo/...). Set
+    DEEPAGENTS_CODE_OFFLINE=1 to skip the managed download entirely.
+  DEEPAGENTS_CODE_SKIP_XCODE_CHECK — set to 1 to bypass the macOS Xcode
+    Command Line Tools preflight check
+  DEEPAGENTS_CODE_VERBOSE — set to 1 to show uv's raw stderr and additional
+    status lines
+  UV_BIN — path to uv binary (auto-detected if unset)
+
+For full documentation: https://docs.langchain.com/deepagents-code
+HELP
+}
+
+for _arg in "$@"; do
+  case "$_arg" in
+    --help|-h)
+      print_help
+      exit 0
+      ;;
+    --version|-v)
+      printf '%s\n' "$INSTALLER_VERSION"
+      exit 0
+      ;;
+    *)
+      # Reject unknown flags instead of silently ignoring them, so a typo
+      # (e.g. --verison) surfaces as an error rather than a silent full install.
+      # log_* helpers aren't defined yet at this point, so write plainly.
+      printf 'Unrecognized argument: %s\n' "$_arg" >&2
+      printf 'Run with --help to see available options.\n' >&2
+      exit 2
+      ;;
+  esac
+done
 
 # Registry of temp files to clean up on exit or interrupt. Functions that
 # create tempfiles append their paths here; cleanup_on_signal removes them all.
@@ -493,35 +571,76 @@ install_uv() {
   # The upstream uv installer is chatty (download progress, install paths,
   # PATH-setup hints). Capture it and surface the output only when debugging
   # or when the install fails — by default it's noise the user doesn't need.
+  # This same tempfile also captures the downloader's stderr, so a failed
+  # download surfaces curl/wget's own error (DNS, TLS, HTTP status) instead of
+  # a generic message; the installer's stdout/stderr overwrites it afterward.
   local uv_install_out uv_install_rc=0
   uv_install_out=$(mktemp 2>/dev/null) || {
     log_error "mktemp is required to create a secure temp file."
     exit 1
   }
   register_temp "$uv_install_out"
-  # Only the piped `sh` (the installer body) is captured by `>"$uv_install_out"
-  # 2>&1`; curl/wget keep their own stderr on the terminal. That's intentional —
-  # `-fsSL` includes `-S`, so a failed download still prints curl's error
-  # directly (above the "uv installation failed" line) even though the captured
-  # file is then empty. Don't assume curl's stderr is in the capture.
+
+  # Download the installer to a tempfile first instead of piping curl straight
+  # to sh, so we can verify the first line is a shell shebang before executing.
+  # A transparent proxy or captive portal returning 200 with HTML would
+  # otherwise pipe straight into sh with unpredictable results. curl's `-f`
+  # catches HTTP errors, but a 200-with-HTML response passes that check.
+  local uv_script
+  uv_script=$(mktemp 2>/dev/null) || {
+    log_error "mktemp is required to create a secure temp file."
+    exit 1
+  }
+  register_temp "$uv_script"
+
+  # Capture the downloader's stderr (2>"$uv_install_out") rather than discarding
+  # it: on failure it holds the actionable cause (curl: (6) Could not resolve
+  # host, SSL errors, HTTP status), which the failure branch below surfaces.
+  # curl -sS and wget -nv stay quiet on success, so this adds no noise then.
   if command -v curl >/dev/null 2>&1 && ! is_snap_curl; then
-    curl -fsSL https://astral.sh/uv/install.sh | sh >"$uv_install_out" 2>&1 || uv_install_rc=$?
+    curl -fsSL https://astral.sh/uv/install.sh -o "$uv_script" 2>"$uv_install_out" || uv_install_rc=$?
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO- https://astral.sh/uv/install.sh | sh >"$uv_install_out" 2>&1 || uv_install_rc=$?
+    wget -nv -O "$uv_script" https://astral.sh/uv/install.sh 2>"$uv_install_out" || uv_install_rc=$?
   elif is_snap_curl; then
-    rm -f "$uv_install_out"
+    rm -f "$uv_install_out" "$uv_script"
     log_error "curl is installed as a snap and cannot download files due to sandbox permissions."
     log_error "Please install wget, or reinstall curl with a different package manager (e.g. apt)."
     exit 1
   else
-    rm -f "$uv_install_out"
+    rm -f "$uv_install_out" "$uv_script"
     log_error "curl or wget is required to install uv."
     exit 1
   fi
+
+  if [ "$uv_install_rc" -ne 0 ]; then
+    # Surface the downloader's own error (captured above) before the generic
+    # line, so the user sees the real cause and the downloader's exit code.
+    cat "$uv_install_out" >&2
+    rm -f "$uv_install_out" "$uv_script"
+    log_error "Failed to download uv installer (exit ${uv_install_rc}) from https://astral.sh/uv/install.sh"
+    log_error "  Try again, or install uv manually: https://docs.astral.sh/uv/getting-started/installation/"
+    exit 1
+  fi
+
+  # Verify the downloaded script starts with a shell shebang before executing
+  # it. This catches a non-shell response — an HTML error page or JSON from a
+  # proxy or captive portal that returned 200 — that would otherwise fail
+  # unpredictably when run by sh. It only inspects the first line, so it is a
+  # sanity check on the response type, not an integrity guarantee: it won't
+  # detect a truncated or tampered body.
+  if ! head -1 "$uv_script" | grep -qE '^#!.*(sh|bash)'; then
+    rm -f "$uv_install_out" "$uv_script"
+    log_error "uv installer download does not start with a shell shebang."
+    log_error "  The URL may have returned an error page (proxy, captive portal, or outage)."
+    log_error "  Try again, or install uv manually: https://docs.astral.sh/uv/getting-started/installation/"
+    exit 1
+  fi
+
+  sh "$uv_script" >"$uv_install_out" 2>&1 || uv_install_rc=$?
   if [ "$VERBOSE" = "1" ] || [ "$uv_install_rc" -ne 0 ]; then
     cat "$uv_install_out" >&2
   fi
-  rm -f "$uv_install_out"
+  rm -f "$uv_install_out" "$uv_script"
   if [ "$uv_install_rc" -ne 0 ]; then
     log_error "uv installation failed. See errors above."
     exit 1

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1075,36 +1075,74 @@ def _run_install_uv(
     verbose: bool,
     fails: bool = False,
     mktemp_fails: bool = False,
+    no_shebang: bool = False,
+    download_fails: bool = False,
+    use_wget: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     """Run the real `install_uv` from `install.sh` against a fake uv installer.
 
-    A fake `curl` emits a trivial "installer" that prints a noise line; the
-    function pipes it to `sh`, so the noise lands in its captured output. When
-    `fails` is set, that installer also exits non-zero, exercising the
-    surface-output-on-failure branch. Returns the completed process so callers
-    can assert on whether the noise reached the terminal and on the exit code.
+    A fake downloader (``curl`` by default, or ``wget`` when ``use_wget`` is set)
+    writes a trivial "installer" to the file named by its output flag (``-o`` for
+    curl, ``-O`` for wget); the harness runs it via ``sh``, so the noise lands in
+    the captured output. When ``fails`` is set, that installer also exits
+    non-zero, exercising the surface-output-on-failure branch. When ``no_shebang``
+    is set, the installer content starts with an HTML tag instead of a shell
+    shebang, exercising the shebang-verification rejection. When ``download_fails``
+    is set, the fake downloader writes an error to stderr and exits non-zero
+    *without* creating the file, exercising the download-failure branch and
+    proving the downloader's own error is surfaced. Returns the completed process
+    so callers can assert on whether the noise reached the terminal and on the
+    exit code.
     """
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    curl = bin_dir / "curl"
-    installer = "'echo UV_INSTALLER_NOISE'" + (" 'exit 3'" if fails else "")
-    curl.write_text(f"#!/usr/bin/env bash\nprintf '%s\\n' {installer}\n")
-    _make_executable(curl)
+    first_line = "'<html>error</html>'" if no_shebang else "'#!/bin/sh'"
+    installer = first_line + " 'echo UV_INSTALLER_NOISE'"
+    if fails:
+        installer += " 'exit 3'"
+
+    # The fake downloader must handle its output flag (curl ``-o`` / wget ``-O``)
+    # and write the installer content there instead of stdout. With
+    # ``download_fails`` it instead emits an error to stderr and exits non-zero
+    # without creating the file, so install_uv sees a failed download.
+    downloader_name = "wget" if use_wget else "curl"
+    out_flag = "-O" if use_wget else "-o"
+    if download_fails:
+        write_body = (
+            "printf 'DOWNLOADER_ERROR: could not resolve host\\n' >&2\nexit 7\n"
+        )
+    else:
+        write_body = f"printf '%s\\n' {installer} >\"${{out:-/dev/stdout}}\"\n"
+    downloader = bin_dir / downloader_name
+    downloader.write_text(
+        "#!/usr/bin/env bash\n"
+        "out=''\n"
+        "while [ $# -gt 0 ]; do\n"
+        '  case "$1" in\n'
+        f'    {out_flag}) out="$2"; shift 2 ;;\n'
+        "    *) shift ;;\n"
+        "  esac\n"
+        "done\n" + write_body
+    )
+    _make_executable(downloader)
     if mktemp_fails:
         mktemp = bin_dir / "mktemp"
         mktemp.write_text("#!/usr/bin/env bash\nexit 1\n")
         _make_executable(mktemp)
 
+    # install_uv branches on is_snap_curl. For the curl path, stub it to the
+    # non-snap answer so the normal curl branch runs (and no stray "command not
+    # found" hits stderr). For the wget path, report curl as a snap so install_uv
+    # skips the curl branch and falls through to the wget branch — regardless of
+    # a real curl on the host PATH.
+    is_snap_curl_rc = "0" if use_wget else "1"
     script = tmp_path / "install_uv_harness.sh"
     script.write_text(
         "set -euo pipefail\n"
         "log_info() { :; }\n"
         'log_error() { printf "%s\\n" "$*" >&2; }\n'
         "register_temp() { :; }\n"
-        # install_uv branches on is_snap_curl; stub it to the non-snap answer so
-        # the harness exercises the normal curl path (and emits no stray
-        # "command not found" on stderr).
-        "is_snap_curl() { return 1; }\n"
+        f"is_snap_curl() {{ return {is_snap_curl_rc}; }}\n"
         f"VERBOSE={'1' if verbose else '0'}\n"
         f"{_extract_shell_function('install_uv')}\n"
         "install_uv\n",
@@ -1159,6 +1197,52 @@ def test_install_uv_requires_secure_temp_file(tmp_path: Path) -> None:
     assert proc.returncode != 0
     assert "mktemp is required to create a secure temp file" in proc.stderr
     assert "UV_INSTALLER_NOISE" not in proc.stderr
+
+
+def test_install_uv_rejects_non_shell_response(tmp_path: Path) -> None:
+    """A download that doesn't start with a shell shebang is rejected before exec.
+
+    Simulates a transparent proxy or captive portal returning 200 with HTML
+    instead of the uv installer. The shebang check must catch it and exit with
+    an actionable error, rather than piping the HTML into ``sh``.
+    """
+    proc = _run_install_uv(tmp_path, verbose=False, no_shebang=True)
+
+    assert proc.returncode != 0
+    assert "does not start with a shell shebang" in proc.stderr
+    assert "UV_INSTALLER_NOISE" not in proc.stderr
+    assert "UV_INSTALLER_NOISE" not in proc.stdout
+
+
+def test_install_uv_surfaces_download_failure(tmp_path: Path) -> None:
+    """A failed download exits non-zero and surfaces the downloader's own error.
+
+    Exercises the download-failure branch (`uv_install_rc -ne 0`): the fake curl
+    exits non-zero and writes its error to stderr without creating the installer
+    file. `install_uv` must relay that captured error — not just a generic
+    message — include the downloader's exit code, and never execute a payload.
+    """
+    proc = _run_install_uv(tmp_path, verbose=False, download_fails=True)
+
+    assert proc.returncode != 0
+    assert "Failed to download uv installer" in proc.stderr
+    # The downloader's captured stderr is surfaced, not discarded to /dev/null.
+    assert "DOWNLOADER_ERROR: could not resolve host" in proc.stderr
+    assert "UV_INSTALLER_NOISE" not in proc.stderr
+    assert "UV_INSTALLER_NOISE" not in proc.stdout
+
+
+def test_install_uv_downloads_via_wget(tmp_path: Path) -> None:
+    """The wget branch downloads to `-O <file>` and the script then runs it.
+
+    curl is reported as a snap so `install_uv` falls through to the wget branch.
+    Verbose mode surfaces the installer's output, proving wget wrote a valid
+    shebang file that passed verification and executed.
+    """
+    proc = _run_install_uv(tmp_path, verbose=True, use_wget=True)
+
+    assert proc.returncode == 0, proc.stderr
+    assert "UV_INSTALLER_NOISE" in proc.stderr
 
 
 def _run_signal_traps(tmp_path: Path, *, interrupt: bool) -> str:
@@ -1665,3 +1749,79 @@ def test_install_script_skips_managed_install_when_verify_failed(
 
     assert proc.returncode == 0, proc.stderr
     assert not (tmp_path / "dcode-tools.txt").exists(), proc.stdout + proc.stderr
+
+
+@pytest.mark.parametrize("flag", ["--help", "-h"])
+def test_install_script_help_flag_prints_usage_and_exits(
+    tmp_path: Path, flag: str
+) -> None:
+    """`--help` / `-h` prints the env-var reference and exits 0 before any install.
+
+    Guards the early-returns in the CLI-flag loop: the script must not reach uv
+    or any network probe. The output must mention key environment variables so
+    the user can discover their options without reading source.
+    """
+    env = _env(tmp_path, {}, installed_version=None, latest_version="0.2.0")
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), flag],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    assert proc.returncode == 0
+    assert "DEEPAGENTS_CODE_VERSION" in proc.stdout
+    assert "DEEPAGENTS_CODE_EXTRAS" in proc.stdout
+    assert "baseten" in proc.stdout
+    assert "basesten" not in proc.stdout
+    assert "DEEPAGENTS_CODE_PYTHON" in proc.stdout
+    assert not (tmp_path / "uv-args.txt").exists()
+
+
+@pytest.mark.parametrize("flag", ["--version", "-v"])
+def test_install_script_version_flag_prints_version_and_exits(
+    tmp_path: Path, flag: str
+) -> None:
+    """`--version` / `-v` prints the installer version and exits 0."""
+    env = _env(tmp_path, {}, installed_version=None, latest_version="0.2.0")
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), flag],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    assert proc.returncode == 0
+    # Assert the exact version string, not just a substring: the help body also
+    # contains "installer", so a weaker check wouldn't catch --version being
+    # mis-wired to print_help. The absent "Usage:" marker pins that distinction
+    # and doubles as a drift guard on INSTALLER_VERSION.
+    assert "deepagents-code installer 1.0" in proc.stdout
+    assert "Usage:" not in proc.stdout
+    assert not (tmp_path / "uv-args.txt").exists()
+
+
+def test_install_script_rejects_unknown_flag(tmp_path: Path) -> None:
+    """An unrecognized argument exits non-zero before any install work.
+
+    Guards the `*)` arm of the CLI-flag loop: a typo like `--verison` must
+    surface an error and skip the install, rather than being silently ignored
+    and proceeding to a full install.
+    """
+    env = _env(tmp_path, {}, installed_version=None, latest_version="0.2.0")
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), "--verison"],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    assert proc.returncode == 2
+    assert "Unrecognized argument" in proc.stderr
+    assert not (tmp_path / "uv-args.txt").exists()


### PR DESCRIPTION
The `dcode` install script now supports `--help`/`-h` and `--version`/`-v` flags, and the uv installer download is verified before execution to guard against non-shell responses from proxies or captive portals.

## Release note

- `curl -LsSf https://langch.in/dcode | bash -s -- --help` now prints a full usage reference (all environment variables, valid extras, and a docs link) and exits 0 without touching the network. `--version`/`-v` prints the installer version string and exits 0. Unknown flags (e.g. a typo like `--verison`) are rejected with a non-zero exit and an actionable message instead of silently proceeding to a full install.
- The uv bootstrap no longer pipes the downloader directly into `sh`. It downloads the installer to a tempfile first, verifies the first line is a shell shebang, and only then executes it. A 200 response containing HTML from a transparent proxy or captive portal is caught and rejected with a clear error before it can reach `sh`.
- On a failed download, the downloader's own stderr (curl DNS errors, TLS failures, HTTP status) is now surfaced to the user alongside the generic failure message, instead of being discarded.

## Changes

- Added a CLI-flag loop at the top of `install.sh` that handles `--help`/`-h` (prints a `print_help` reference of all env vars and valid extras), `--version`/`-v` (prints `INSTALLER_VERSION`), and rejects unknown flags with exit code 2 — all before any install work begins.
- Rewrote `install_uv` to download the uv installer to a tempfile via `curl -o` / `wget -O` (capturing the downloader's stderr) instead of piping directly to `sh`. On download failure, the captured stderr is printed before the generic error. On success, the script's first line is checked for a shell shebang (`^#!.*(sh|bash)`) before execution; a non-shell response exits with an actionable message.
- Updated the `media` extra in the env-var documentation within the help text (was previously listed only as `quickjs` under standalone integrations).
- Added unit tests covering: `--help`/`-h` output and early exit, `--version`/`-v` output and early exit, unknown-flag rejection, shebang verification rejection (HTML response), download-failure error surfacing, and the wget download path with verbose output.