### PR TITLE
chore(code): remove /theme labels/keys tip from welcome footer

### DIFF
--- a/libs/code/deepagents_code/widgets/welcome.py
+++ b/libs/code/deepagents_code/widgets/welcome.py
@@ -55,7 +55,6 @@ _TIPS: dict[str, int] = {
     "Type /update to check for and install updates": 1,
     "Use /install <extra> to add optional dependencies (e.g. /install daytona)": 1,
     "Use /theme to customize the TUI's colors": 1,
-    "In /theme, press N to toggle labels/keys, T to set for the current terminal": 1,
     "Use /skill-creator to build reusable agent skills": 1,
     "Ask for a workflow to fan work out to subagents in parallel": 3,
     "Use /auto-update to toggle automatic updates": 1,


### PR DESCRIPTION
Removes the rotating welcome-footer tip "In /theme, press N to toggle labels/keys, T to set for the current terminal" from the `_TIPS` list in the code TUI welcome widget, as requested.

Made by [Open SWE](https://openswe.vercel.app/agents/9df0d7d8-bcf8-d9e8-aa9e-7f2c850129de)