### PR TITLE
fix(sdk): stop CompositeBackend.glob leaking results from unrelated routes

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -418,7 +418,7 @@ class CompositeBackend(BackendProtocol):
         # Path specified but doesn't match a route - search only default
         return self._coerce_grep_result(await self.default.agrep(pattern, path, glob))
 
-    def glob(self, pattern: str, path: str | None = None) -> GlobResult:
+    def glob(self, pattern: str, path: str | None = None) -> GlobResult:  # noqa: PLR0911  # one return per routing disposition (routed / non-route / merge)
         """Find files matching a glob pattern, routing by path prefix."""
         results: list[FileInfo] = []
 
@@ -438,7 +438,16 @@ class CompositeBackend(BackendProtocol):
                     truncated=_glob_truncated(glob_result),
                 )
 
-        # Path doesn't match any specific route - search default backend AND all routed backends
+            # Path specified but matches no route (and isn't root): search only
+            # the default backend, mirroring grep(). Merging routed backends here
+            # would leak results from unrelated routes into a path-scoped search.
+            if path != "/":
+                default_only = self.default.glob(pattern, path)
+                if isinstance(default_only, GlobResult):
+                    return default_only
+                return GlobResult(matches=default_only or [])
+
+        # Path is None or root - search default backend AND all routed backends
         truncated = False
         default_result = self.default.glob(pattern, path)
         # A backend error must not be swallowed as a partial success (mirrors the
@@ -462,7 +471,7 @@ class CompositeBackend(BackendProtocol):
         results.sort(key=lambda x: x.get("path", ""))
         return GlobResult(matches=results, truncated=truncated)
 
-    async def aglob(self, pattern: str, path: str | None = None) -> GlobResult:
+    async def aglob(self, pattern: str, path: str | None = None) -> GlobResult:  # noqa: PLR0911  # one return per routing disposition (routed / non-route / merge)
         """Async version of glob."""
         results: list[FileInfo] = []
 
@@ -482,7 +491,17 @@ class CompositeBackend(BackendProtocol):
                     truncated=_glob_truncated(glob_result),
                 )
 
-        # Path doesn't match any specific route - search default backend AND all routed backends
+            # Path specified but matches no route (and isn't root): search only
+            # the default backend, mirroring agrep(). Merging routed backends
+            # here would leak results from unrelated routes into a path-scoped
+            # search.
+            if path != "/":
+                default_only = await self.default.aglob(pattern, path)
+                if isinstance(default_only, GlobResult):
+                    return default_only
+                return GlobResult(matches=default_only or [])
+
+        # Path is None or root - search default backend AND all routed backends
         truncated = False
         default_result = await self.default.aglob(pattern, path)
         # A backend error must not be swallowed as a partial success (mirrors the

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -262,6 +262,30 @@ def test_composite_backend_grep_path_isolation():
     assert not any("/memories/" in p for p in match_paths), f"grep path=/tools should not return /memories results, but got: {match_paths}"
 
 
+def test_composite_backend_glob_path_isolation():
+    """Non-route glob path must stay within the default backend and not leak routes (mirrors grep)."""
+    mem_store = InMemoryStore()
+
+    default = StoreBackend(store=mem_store, namespace=lambda _rt: ("default",))
+    store_be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+
+    comp = CompositeBackend(default=default, routes={"/memories/": store_be})
+
+    # Write matching files to both the default backend and the /memories route.
+    comp.write("/tools/hammer.md", "content")
+    comp.write("/tools/saw.md", "content")
+    comp.write("/memories/secret.md", "content")
+
+    # Glob scoped to /tools (a non-route path) must stay within the default backend.
+    result = comp.glob("*.md", path="/tools")
+    match_paths = [fi["path"] for fi in (result.matches or [])]
+
+    assert any("/tools/hammer.md" in p for p in match_paths)
+    assert any("/tools/saw.md" in p for p in match_paths)
+    # Must NOT leak /memories results into a /tools-scoped search.
+    assert not any("/memories/" in p for p in match_paths), f"glob path=/tools should not return /memories results, but got: {match_paths}"
+
+
 def test_composite_grep_and_glob_propagate_truncated(monkeypatch: pytest.MonkeyPatch):
     """A truncated result from a routed/default backend must surface through the composite."""
     mem_store = InMemoryStore()

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend_async.py
@@ -75,6 +75,23 @@ async def test_composite_state_backend_routes_and_search_async(tmp_path: Path): 
     assert any(i["path"] == "/memories/readme.md" for i in g)
 
 
+async def test_composite_backend_aglob_path_isolation():
+    """Non-route aglob path must stay within the default backend and not leak routes (mirrors agrep)."""
+    mem_store = InMemoryStore()
+    comp = CompositeBackend(
+        default=StoreBackend(store=mem_store, namespace=lambda _rt: ("default",)),
+        routes={"/memories/": StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))},
+    )
+
+    await comp.awrite("/tools/hammer.md", "content")
+    await comp.awrite("/memories/secret.md", "content")
+
+    match_paths = [fi["path"] for fi in ((await comp.aglob("*.md", path="/tools")).matches or [])]
+
+    assert any("/tools/hammer.md" in p for p in match_paths)
+    assert not any("/memories/" in p for p in match_paths), f"aglob path=/tools should not return /memories results, but got: {match_paths}"
+
+
 async def test_composite_backend_filesystem_plus_store_async(tmp_path: Path):
     """Test async operations with filesystem and store backends."""
     root = tmp_path


### PR DESCRIPTION
Closes #4510

## Summary

`CompositeBackend.grep` restricts a search scoped to an explicit path that matches no route to the **default backend only**. `glob`/`aglob` were missing that guard: when `path` was set but matched no route (and was not `/`), they fell through to the merge branch that also searches **every** routed backend.

As a result, a path-scoped call leaked files from unrelated routes:

```python
comp = CompositeBackend(default=..., routes={"/memories/": ...})
comp.write("/tools/hammer.md", "content")
comp.write("/memories/secret.md", "content")

comp.grep("content", path="/tools")   # -> ['/tools/hammer.md']                        (correct)
comp.glob("*.md", path="/tools")      # -> ['/memories/secret.md', '/tools/hammer.md']  (leak)
```

This breaks the same path-isolation invariant that `test_composite_backend_grep_path_isolation` already guards for `grep`. With sensitive data behind a route, it's an information-disclosure bug.

## Fix

Mirror `grep`/`agrep`'s logic in both `glob` and `aglob`: for a non-root `path` that matches no route, search only the default backend instead of merging in routed backends.

## Tests

- Added `test_composite_backend_glob_path_isolation` (sync) and `test_composite_backend_aglob_path_isolation` (async), mirroring the existing grep isolation test. Both **fail on `main`** and **pass with this change**.
- Full backend suite: `753 passed, 5 skipped, 2 xfailed`.
- `ruff` and `ty` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
