### PR TITLE
hotfix(code): fix branch display test truncating at default terminal width

### DIFF
--- a/libs/code/tests/unit_tests/test_status.py
+++ b/libs/code/tests/unit_tests/test_status.py
@@ -114,7 +114,7 @@ class TestBranchDisplay:
 
     async def test_branch_display_with_feature_branch(self) -> None:
         """Feature branch names with slashes should display correctly."""
-        async with StatusBarApp().run_test() as pilot:
+        async with StatusBarApp().run_test(size=(120, 24)) as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.branch = "feat/new-feature"
             await pilot.pause()


### PR DESCRIPTION
The `test_branch_display_with_feature_branch` test did not specify a terminal size, so Textual defaulted to 80×24. The `BranchLabel` widget truncates branch names from the right with an ellipsis when they overflow the allocated width — at 80 columns, `feat/new-feature` (17 chars with icon) was truncated to `↗ feat/new-featu…`, failing the substring assertion.

Add `size=(120, 24)` to `run_test()` so the full branch name fits.