### PR TITLE
chore(code): bump `deepagents` SDK alpha

### DIFF
--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     # Framework
-    "deepagents==0.7.0a3",
+    "deepagents==0.7.0a4",
     "langchain>=1.3.11,<2.0.0",
     "langgraph-checkpoint-sqlite>=3.1.0,<4.0.0",
 


### PR DESCRIPTION
Bumps the `deepagents-code` SDK pin to the latest `deepagents` alpha so released `dcode` installs pick up the newer prerelease SDK.