### PR TITLE
docs(code): clarify /offload command summarizes messages

### DIFF
--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -29,7 +29,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/mcp` |  | Manage MCP servers and authentication |
 | `/model` |  | Switch models or edit model settings |
 | `/notifications` |  | Configure startup warnings |
-| `/offload` | `/compact` | Offload older messages to free context |
+| `/offload` | `/compact` | Summarize and offload older messages to free context |
 | `/quit` | `/q` | Exit app |
 | `/reload` |  | Reload environment and config |
 | `/remember` |  | Save useful context to memory or skills |

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -145,7 +145,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     ),
     SlashCommand(
         name="/offload",
-        description="Offload older messages to free context",
+        description="Summarize and offload older messages to free context",
         bypass_tier=BypassTier.QUEUED,
         hidden_keywords="compact",
         aliases=("/compact",),


### PR DESCRIPTION
New users were confused that `/offload` (alias `/compact`) only "offloads" context, when it actually runs an LLM summarization of older messages before writing the originals to a recovery file. This updates the slash-command description to mention summarization, staying under 60 characters ("Summarize and offload older messages to free context", 52 chars), and regenerates the `COMMANDS.md` catalog to match.

Made by [Open SWE](https://openswe.vercel.app/agents/d78e6bda-ad23-13f1-e566-a01f25a05364)