### PR TITLE
refactor(code): move Textual adapter into tui package

### DIFF
--- a/libs/code/THREAT_MODEL.md
+++ b/libs/code/THREAT_MODEL.md
@@ -12,7 +12,7 @@
 
 - `deepagents_code/` — all Python source modules shipped as the `deepagents-code` package
 - CLI entry point (`main.py`, `__init__.py`)
-- Interactive TUI (`app.py`, `textual_adapter.py`, `widgets/`)
+- Interactive TUI (`app.py`, `tui/textual_adapter.py`, `tui/widgets/`)
 - Non-interactive pipeline runner (`client/non_interactive.py`)
 - Agent creation (`agent.py`)
 - Built-in tools (`tools.py`: `http_request`, `web_search`, `fetch_url`)

--- a/libs/code/deepagents_code/_session_stats.py
+++ b/libs/code/deepagents_code/_session_stats.py
@@ -1,6 +1,8 @@
-"""Lightweight session statistics and token formatting utilities.
+"""Lightweight session statistics, token formatting, and usage-table rendering.
 
-This module is intentionally kept free of heavy dependencies (no pydantic, no
+Holds `SessionStats`/`ModelStats`, the `format_token_count` formatter, and
+`print_usage_table` (which imports `rich.table` lazily). The module is
+intentionally kept free of heavy top-level dependencies (no pydantic, no
 config, no widget imports) so that `app.py` can import `SessionStats` and
 `format_token_count` at module level without pulling in the full
 `textual_adapter` dependency tree.
@@ -9,7 +11,12 @@ config, no widget imports) so that `app.py` can import `SessionStats` and
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+from deepagents_code.formatting import format_duration
+
+if TYPE_CHECKING:
+    from rich.console import Console
 
 SpinnerStatus = (
     Literal[
@@ -150,3 +157,79 @@ def format_token_count(count: int) -> str:
     if count >= 1000:  # noqa: PLR2004
         return f"{count / 1000:.1f}K"
     return str(count)
+
+
+def print_usage_table(
+    stats: SessionStats,
+    wall_time: float,
+    console: Console,
+) -> None:
+    """Print a model-usage stats table to a Rich console.
+
+    Each row shows the serving provider alongside the model name. When the
+    session spans multiple models each gets its own row with a totals row
+    appended; single-model sessions show one row.
+
+    Args:
+        stats: Cumulative session stats.
+        wall_time: Total wall-clock time in seconds.
+        console: Rich console for output.
+    """
+    from rich.table import Table
+
+    has_time = wall_time >= 0.1  # noqa: PLR2004
+    if not (stats.request_count or stats.input_tokens or has_time):
+        return
+
+    if stats.per_model:
+        multi_model = len(stats.per_model) > 1
+
+        table = Table(
+            show_header=True,
+            header_style="bold",
+            box=None,
+            padding=(0, 2, 0, 0),
+            show_edge=False,
+        )
+        table.add_column("Provider", style="dim")
+        table.add_column("Model", style="dim")
+        table.add_column("Reqs", justify="right", style="dim")
+        table.add_column("InputTok", justify="right", style="dim")
+        table.add_column("OutputTok", justify="right", style="dim")
+
+        if multi_model:
+            for ms in stats.per_model.values():
+                table.add_row(
+                    ms.provider,
+                    ms.model_name,
+                    str(ms.request_count),
+                    format_token_count(ms.input_tokens),
+                    format_token_count(ms.output_tokens),
+                )
+            table.add_row(
+                "",
+                "Total",
+                str(stats.request_count),
+                format_token_count(stats.input_tokens),
+                format_token_count(stats.output_tokens),
+            )
+        else:
+            ms = next(iter(stats.per_model.values()))
+            table.add_row(
+                ms.provider,
+                ms.model_name,
+                str(stats.request_count),
+                format_token_count(stats.input_tokens),
+                format_token_count(stats.output_tokens),
+            )
+
+        console.print()
+        console.print("[bold]Usage Stats[/bold]")
+        console.print(table)
+    if has_time:
+        console.print()
+        console.print(
+            f"Agent active  {format_duration(wall_time)}",
+            style="dim",
+            highlight=False,
+        )

--- a/libs/code/deepagents_code/_tool_stream.py
+++ b/libs/code/deepagents_code/_tool_stream.py
@@ -3,7 +3,7 @@
 Both execution surfaces reassemble the same streamed tool-call state and fire
 the same `tool.use` / `tool.result` / `tool.error` hook payloads:
 
-- the interactive Textual TUI (`deepagents_code.textual_adapter`), and
+- the interactive Textual TUI (`deepagents_code.tui.textual_adapter`), and
 - the headless runner (`deepagents_code.client.non_interactive`).
 
 This module holds the single implementation of the buffering, argument parsing,

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -351,7 +351,7 @@ if TYPE_CHECKING:
     from deepagents_code.model_config import MissingProviderPackageError
     from deepagents_code.resume_state import GoalStatus
     from deepagents_code.skills.load import ExtendedSkillMetadata
-    from deepagents_code.textual_adapter import TextualUIAdapter
+    from deepagents_code.tui.textual_adapter import TextualUIAdapter
     from deepagents_code.tui.widgets.approval import ApprovalMenu
     from deepagents_code.tui.widgets.ask_user import AskUserMenu
     from deepagents_code.tui.widgets.goal_review import GoalReviewMenu, GoalReviewResult
@@ -3257,7 +3257,7 @@ class DeepAgentsApp(App):
         # Create UI adapter unconditionally — it only holds UI callbacks and
         # doesn't depend on the agent. The agent is injected later at
         # execute_task_textual() call time.
-        from deepagents_code.textual_adapter import TextualUIAdapter
+        from deepagents_code.tui.textual_adapter import TextualUIAdapter
 
         self._ui_adapter = TextualUIAdapter(
             mount_message=self._mount_message,
@@ -4266,7 +4266,7 @@ class DeepAgentsApp(App):
         from deepagents_code.config import settings  # noqa: F401
         from deepagents_code.hooks import dispatch_hook  # noqa: F401
         from deepagents_code.model_config import ModelSpec  # noqa: F401
-        from deepagents_code.textual_adapter import TextualUIAdapter  # noqa: F401
+        from deepagents_code.tui.textual_adapter import TextualUIAdapter  # noqa: F401
         from deepagents_code.update_check import is_update_check_enabled  # noqa: F401
 
         try:
@@ -10573,7 +10573,7 @@ class DeepAgentsApp(App):
         # Caller ensures _ui_adapter is set (checked in _handle_user_message)
         if self._ui_adapter is None:
             return
-        from deepagents_code.textual_adapter import execute_task_textual
+        from deepagents_code.tui.textual_adapter import execute_task_textual
 
         # Create the stats object up-front and store on the app so
         # exit() can merge it synchronously if the worker is cancelled

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -40,6 +40,7 @@ from rich.style import Style
 from rich.text import Text
 
 from deepagents_code._cli_context import CLIContext
+from deepagents_code._session_stats import SessionStats, print_usage_table
 from deepagents_code._tool_stream import (
     UNRENDERABLE_TOOL_OUTPUT,
     ToolCallBuffer,
@@ -69,7 +70,6 @@ from deepagents_code.hooks import (
 )
 from deepagents_code.model_config import ModelConfigError
 from deepagents_code.sessions import generate_thread_id
-from deepagents_code.textual_adapter import SessionStats, print_usage_table
 from deepagents_code.tool_display import format_tool_message_content
 from deepagents_code.unicode_security import (
     check_url_safety,

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1980,7 +1980,7 @@ async def run_textual_cli_async(
     # Never pass auto_approve to the server — the interactive server must
     # always configure full HITL interrupts so that Shift+Tab can toggle
     # approval mode mid-session. The -y flag is handled client-side via
-    # session_state.auto_approve in textual_adapter.py.
+    # session_state.auto_approve in `tui.textual_adapter`.
     server_kwargs: dict[str, Any] = {
         "assistant_id": assistant_id,
         "model_name": model_name or resolved_spec or None,
@@ -2334,7 +2334,7 @@ def _print_session_stats(stats: Any, console: Any) -> None:  # noqa: ANN401
         stats: The cumulative session stats from the Textual app.
         console: Rich console for output.
     """
-    from deepagents_code.textual_adapter import SessionStats, print_usage_table
+    from deepagents_code._session_stats import SessionStats, print_usage_table
 
     if not isinstance(stats, SessionStats):
         return

--- a/libs/code/deepagents_code/offload.py
+++ b/libs/code/deepagents_code/offload.py
@@ -14,8 +14,8 @@ from typing import TYPE_CHECKING, Any, cast
 from langchain_core.messages import get_buffer_string
 from langchain_core.messages.utils import count_tokens_approximately
 
+from deepagents_code._session_stats import format_token_count
 from deepagents_code.config import create_model
-from deepagents_code.textual_adapter import format_token_count
 
 if TYPE_CHECKING:
     from deepagents.backends.protocol import BackendProtocol

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -1,5 +1,4 @@
 """Textual UI adapter for agent execution."""
-# This module has complex streaming logic ported from execution.py
 
 from __future__ import annotations
 
@@ -27,7 +26,6 @@ if TYPE_CHECKING:
     from langchain_core.runnables import RunnableConfig
     from langgraph.types import Command, Interrupt
     from pydantic import TypeAdapter
-    from rich.console import Console
 
     from deepagents_code._ask_user_types import AskUserWidgetResult, Question
 
@@ -54,6 +52,7 @@ from deepagents_code._session_stats import (
     SessionStats as SessionStats,
     SpinnerStatus as SpinnerStatus,
     format_token_count as format_token_count,
+    print_usage_table as print_usage_table,
 )
 from deepagents_code._tool_stream import (
     UNRENDERABLE_TOOL_OUTPUT,
@@ -69,7 +68,6 @@ from deepagents_code._tool_stream import (
 )
 from deepagents_code.config import build_stream_config, get_glyphs
 from deepagents_code.file_ops import FileOpTracker
-from deepagents_code.formatting import format_duration
 from deepagents_code.hooks import (
     dispatch_hook,
     dispatch_hook_fire_and_forget,
@@ -186,82 +184,6 @@ def _get_hitl_request_adapter(hitl_request_type: type) -> TypeAdapter:
 
         _hitl_adapter_cache = TypeAdapter(hitl_request_type)
     return _hitl_adapter_cache
-
-
-def print_usage_table(
-    stats: SessionStats,
-    wall_time: float,
-    console: Console,
-) -> None:
-    """Print a model-usage stats table to a Rich console.
-
-    Each row shows the serving provider alongside the model name. When the
-    session spans multiple models each gets its own row with a totals row
-    appended; single-model sessions show one row.
-
-    Args:
-        stats: Cumulative session stats.
-        wall_time: Total wall-clock time in seconds.
-        console: Rich console for output.
-    """
-    from rich.table import Table
-
-    has_time = wall_time >= 0.1  # noqa: PLR2004
-    if not (stats.request_count or stats.input_tokens or has_time):
-        return
-
-    if stats.per_model:
-        multi_model = len(stats.per_model) > 1
-
-        table = Table(
-            show_header=True,
-            header_style="bold",
-            box=None,
-            padding=(0, 2, 0, 0),
-            show_edge=False,
-        )
-        table.add_column("Provider", style="dim")
-        table.add_column("Model", style="dim")
-        table.add_column("Reqs", justify="right", style="dim")
-        table.add_column("InputTok", justify="right", style="dim")
-        table.add_column("OutputTok", justify="right", style="dim")
-
-        if multi_model:
-            for ms in stats.per_model.values():
-                table.add_row(
-                    ms.provider,
-                    ms.model_name,
-                    str(ms.request_count),
-                    format_token_count(ms.input_tokens),
-                    format_token_count(ms.output_tokens),
-                )
-            table.add_row(
-                "",
-                "Total",
-                str(stats.request_count),
-                format_token_count(stats.input_tokens),
-                format_token_count(stats.output_tokens),
-            )
-        else:
-            ms = next(iter(stats.per_model.values()))
-            table.add_row(
-                ms.provider,
-                ms.model_name,
-                str(stats.request_count),
-                format_token_count(stats.input_tokens),
-                format_token_count(stats.output_tokens),
-            )
-
-        console.print()
-        console.print("[bold]Usage Stats[/bold]")
-        console.print(table)
-    if has_time:
-        console.print()
-        console.print(
-            f"Agent active  {format_duration(wall_time)}",
-            style="dim",
-            highlight=False,
-        )
 
 
 _ask_user_adapter_cache: TypeAdapter | None = None

--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -1401,7 +1401,7 @@ class ModelSelectorScreen(ModalScreen[tuple[str, str] | None]):
         Returns:
             Styled `Content` for the 4-line footer.
         """
-        from deepagents_code.textual_adapter import format_token_count
+        from deepagents_code._session_stats import format_token_count
 
         if profile_entry is None or not profile_entry["profile"]:
             return Content.styled("Model profile not available :(\n\n\n", "dim")

--- a/libs/code/tests/integration_tests/benchmarks/test_codspeed_import_benchmarks.py
+++ b/libs/code/tests/integration_tests/benchmarks/test_codspeed_import_benchmarks.py
@@ -114,7 +114,7 @@ class TestStartupPathBenchmarks:
 
         def do_import() -> None:
             _evict_modules()
-            import deepagents_code.textual_adapter
+            import deepagents_code.tui.textual_adapter
 
         benchmark(do_import)
 

--- a/libs/code/tests/integration_tests/benchmarks/test_startup_benchmarks.py
+++ b/libs/code/tests/integration_tests/benchmarks/test_startup_benchmarks.py
@@ -146,7 +146,7 @@ class TestImportIsolation:
             "import deepagents_code.skills.commands",
             "from deepagents_code._cli_context import CLIContext",
             "import deepagents_code._ask_user_types",
-            "import deepagents_code.textual_adapter",
+            "import deepagents_code.tui.textual_adapter",
             "import deepagents_code.tool_display",
             "import deepagents_code.file_ops",
         ],

--- a/libs/code/tests/integration_tests/test_auto_approve_remote.py
+++ b/libs/code/tests/integration_tests/test_auto_approve_remote.py
@@ -80,7 +80,10 @@ async def _run_auto_approve_write(
     from deepagents_code.client.launch.server_manager import server_session
     from deepagents_code.config import create_model
     from deepagents_code.sessions import generate_thread_id
-    from deepagents_code.textual_adapter import TextualUIAdapter, execute_task_textual
+    from deepagents_code.tui.textual_adapter import (
+        TextualUIAdapter,
+        execute_task_textual,
+    )
 
     config_path = home_dir / ".deepagents" / "config.toml"
     monkeypatch.setattr(model_config, "DEFAULT_CONFIG_DIR", config_path.parent)

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -4660,7 +4660,7 @@ class TestRunAgentTaskMediaTracker:
             assert app._ui_adapter is not None
 
             with patch(
-                "deepagents_code.textual_adapter.execute_task_textual",
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
                 new_callable=AsyncMock,
             ) as mock_execute:
                 await app._run_agent_task("hello")
@@ -4681,7 +4681,7 @@ class TestRunAgentTaskMediaTracker:
             app._ui_adapter._current_tool_messages = {"tool-1": pending_tool}
 
             with patch(
-                "deepagents_code.textual_adapter.execute_task_textual",
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
                 new_callable=AsyncMock,
                 side_effect=RuntimeError("boom"),
             ):
@@ -4718,7 +4718,7 @@ class TestRunAgentTaskMediaTracker:
                 {"error": "ToolException", "message": "An internal error occurred"}
             )
             with patch(
-                "deepagents_code.textual_adapter.execute_task_textual",
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
                 new_callable=AsyncMock,
                 side_effect=exc,
             ):
@@ -4750,7 +4750,7 @@ class TestRunAgentTaskMediaTracker:
                 {"error": "PermissionDeniedError", "message": "An internal error"}
             )
             with patch(
-                "deepagents_code.textual_adapter.execute_task_textual",
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
                 new_callable=AsyncMock,
                 side_effect=exc,
             ):
@@ -4781,7 +4781,7 @@ class TestRunAgentTaskMediaTracker:
                     lambda _provider: "OPENAI_API_KEY",
                 ),
                 patch(
-                    "deepagents_code.textual_adapter.execute_task_textual",
+                    "deepagents_code.tui.textual_adapter.execute_task_textual",
                     new_callable=AsyncMock,
                     side_effect=exc,
                 ),
@@ -6368,7 +6368,7 @@ class TestRubricCommand:
             )
 
             with patch(
-                "deepagents_code.textual_adapter.execute_task_textual",
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
                 new_callable=AsyncMock,
             ) as mock_execute:
                 await app._run_agent_task("hello")
@@ -6399,7 +6399,7 @@ class TestRubricCommand:
                 return SessionStats()
 
             with patch(
-                "deepagents_code.textual_adapter.execute_task_textual",
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
                 new=AsyncMock(side_effect=execute_stub),
             ) as mock_execute:
                 await app._handle_user_message("I added the provider credentials")
@@ -6439,7 +6439,7 @@ class TestRubricCommand:
                 return SessionStats()
 
             with patch(
-                "deepagents_code.textual_adapter.execute_task_textual",
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
                 new=AsyncMock(side_effect=execute_stub),
             ):
                 await app._handle_user_message("Credentials are configured now")
@@ -6477,7 +6477,7 @@ class TestRubricCommand:
                 return SessionStats()
 
             with patch(
-                "deepagents_code.textual_adapter.execute_task_textual",
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
                 new=AsyncMock(side_effect=execute_stub),
             ) as mock_execute:
                 await app._handle_user_message("keep going")
@@ -6513,7 +6513,7 @@ class TestRubricCommand:
                 return SessionStats()
 
             with patch(
-                "deepagents_code.textual_adapter.execute_task_textual",
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
                 new=AsyncMock(side_effect=execute_stub),
             ):
                 await app._handle_user_message("Credentials are configured now")
@@ -6544,7 +6544,7 @@ class TestRubricCommand:
                 return SessionStats()
 
             with patch(
-                "deepagents_code.textual_adapter.execute_task_textual",
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
                 new=AsyncMock(side_effect=execute_stub),
             ):
                 await app._handle_user_message("Credentials are configured now")
@@ -6579,7 +6579,7 @@ class TestRubricCommand:
                 return SessionStats()
 
             with patch(
-                "deepagents_code.textual_adapter.execute_task_textual",
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
                 new=AsyncMock(side_effect=execute_stub),
             ) as mock_execute:
                 await app._send_to_agent("/skill:foo envelope prompt")
@@ -6618,7 +6618,7 @@ class TestRubricCommand:
                 return SessionStats()
 
             with patch(
-                "deepagents_code.textual_adapter.execute_task_textual",
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
                 new=AsyncMock(side_effect=execute_stub),
             ) as mock_execute:
                 await app._handle_user_message("Credentials are configured now")
@@ -6650,7 +6650,7 @@ class TestRubricCommand:
             )
 
             with patch(
-                "deepagents_code.textual_adapter.execute_task_textual",
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
                 new_callable=AsyncMock,
             ) as mock_execute:
                 await app._run_agent_task("hello")
@@ -6756,7 +6756,7 @@ class TestRubricCommand:
 
             with (
                 patch(
-                    "deepagents_code.textual_adapter.execute_task_textual",
+                    "deepagents_code.tui.textual_adapter.execute_task_textual",
                     new_callable=AsyncMock,
                 ),
                 patch.object(
@@ -6807,7 +6807,7 @@ class TestRubricCommand:
             )
 
             with patch(
-                "deepagents_code.textual_adapter.execute_task_textual",
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
                 new_callable=AsyncMock,
             ):
                 await app._run_agent_task("hello")

--- a/libs/code/tests/unit_tests/test_offload.py
+++ b/libs/code/tests/unit_tests/test_offload.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.messages import BaseMessage
 
+from deepagents_code._session_stats import format_token_count
 from deepagents_code.app import DeepAgentsApp
 from deepagents_code.command_registry import SLASH_COMMANDS
 from deepagents_code.config import settings
@@ -18,7 +19,6 @@ from deepagents_code.offload import (
     format_offload_limit,
     offload_messages_to_backend,
 )
-from deepagents_code.textual_adapter import format_token_count
 from deepagents_code.tui.widgets.messages import AppMessage, ErrorMessage
 
 # Patch target for perform_offload (business logic)

--- a/libs/code/tests/unit_tests/test_session_stats.py
+++ b/libs/code/tests/unit_tests/test_session_stats.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from io import StringIO
+
 import pytest
+from rich.console import Console
 
 from deepagents_code._session_stats import (
     ModelStats,
     SessionStats,
     format_token_count,
+    print_usage_table,
 )
 
 
@@ -185,3 +189,94 @@ class TestSessionStats:
         a.merge(b)
         assert a.request_count == 5
         assert a.input_tokens == 500
+
+
+class TestPrintUsageTable:
+    """Tests for `print_usage_table` output."""
+
+    def test_no_model_called_skips_unknown_row(self) -> None:
+        """When no model was called, the table should not show 'unknown'."""
+        stats = SessionStats()
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True)
+        print_usage_table(stats, wall_time=1.5, console=console)
+        output = buf.getvalue()
+        assert "unknown" not in output
+        assert "Usage Stats" not in output
+        assert "Agent active" in output
+
+    def test_single_model_shows_name(self) -> None:
+        """Single-model session should display the model name."""
+        stats = SessionStats()
+        stats.record_request("gpt-4", 100, 50)
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True)
+        print_usage_table(stats, wall_time=2.0, console=console)
+        output = buf.getvalue()
+        assert "gpt-4" in output
+        assert "unknown" not in output
+
+    def test_shows_provider_name(self) -> None:
+        """The table should include the provider for each model."""
+        stats = SessionStats()
+        stats.record_request("gpt-4", 100, 50, provider="openai")
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True)
+        print_usage_table(stats, wall_time=2.0, console=console)
+        output = buf.getvalue()
+        assert "Provider" in output
+        assert "openai" in output
+        assert "gpt-4" in output
+
+    def test_multi_model_shows_all_names_and_total(self) -> None:
+        """Multi-model session should show each model and a Total row."""
+        stats = SessionStats()
+        stats.record_request("gpt-4", 100, 50)
+        stats.record_request("claude-opus-4-6", 200, 80)
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True)
+        print_usage_table(stats, wall_time=2.0, console=console)
+        output = buf.getvalue()
+        assert "gpt-4" in output
+        assert "claude-opus-4-6" in output
+        assert "Total" in output
+        assert "unknown" not in output
+
+    def test_same_model_with_different_providers_shows_separate_rows(self) -> None:
+        """Same-name models from different providers should render separately."""
+        stats = SessionStats()
+        stats.record_request("gpt-4", 100, 50, provider="openai")
+        stats.record_request("gpt-4", 200, 80, provider="azure")
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True)
+        print_usage_table(stats, wall_time=2.0, console=console)
+        output = buf.getvalue()
+        assert "openai" in output
+        assert "azure" in output
+        assert "Total" in output
+        # Two distinct rows, not a collapsed one: each provider's per-row token
+        # counts must appear (100/50 and 200/80), alongside the 300/130 totals.
+        assert "100" in output
+        assert "50" in output
+        assert "200" in output
+        assert "80" in output
+
+    def test_tokens_with_no_wall_time_omits_timing_line(self) -> None:
+        """Token table should print but timing line should be absent."""
+        stats = SessionStats()
+        stats.record_request("gpt-4", 100, 50)
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True)
+        print_usage_table(stats, wall_time=0.0, console=console)
+        output = buf.getvalue()
+        assert "gpt-4" in output
+        assert "Agent active" not in output
+
+    def test_no_requests_no_time_prints_nothing(self) -> None:
+        """Empty stats with negligible wall time should print nothing."""
+        stats = SessionStats()
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True)
+        print_usage_table(stats, wall_time=0.01, console=console)
+        output = buf.getvalue()
+        assert output.strip() == ""

--- a/libs/code/tests/unit_tests/tui/test_subagent_stream.py
+++ b/libs/code/tests/unit_tests/tui/test_subagent_stream.py
@@ -7,7 +7,7 @@ main agent's namespace are forwarded.
 
 from __future__ import annotations
 
-from deepagents_code.textual_adapter import _is_renderable_subagent_event
+from deepagents_code.tui.textual_adapter import _is_renderable_subagent_event
 
 
 def _event(**overrides: object) -> dict:

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -5,7 +5,6 @@ import sys
 from asyncio import Future
 from collections.abc import AsyncIterator, Awaitable, Callable, Generator
 from datetime import datetime
-from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
@@ -30,8 +29,7 @@ from deepagents_code.client.non_interactive import (
     _process_message_chunk,
 )
 from deepagents_code.config import ASCII_GLYPHS, UNICODE_GLYPHS, build_stream_config
-from deepagents_code.textual_adapter import (
-    ModelStats,
+from deepagents_code.tui.textual_adapter import (
     SessionStats,
     TextualUIAdapter,
     _build_interrupted_ai_message,
@@ -40,8 +38,6 @@ from deepagents_code.textual_adapter import (
     _is_summarization_chunk,
     _read_mentioned_file,
     execute_task_textual,
-    format_token_count,
-    print_usage_table,
 )
 from deepagents_code.tui.widgets.messages import (
     AppMessage,
@@ -195,7 +191,7 @@ class TestTextualUIAdapterInit:
         adapter._current_tool_messages = {"call-1": tool_widget}
 
         with patch(
-            "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+            "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
         ) as mock_dispatch:
             adapter.finalize_pending_tools_with_error("Agent error: boom")
 
@@ -252,7 +248,7 @@ class TestInterruptCleanup:
         config = {"configurable": {"thread_id": "t-1"}}
 
         with patch(
-            "deepagents_code.textual_adapter.time.monotonic", return_value=101.0
+            "deepagents_code.tui.textual_adapter.time.monotonic", return_value=101.0
         ):
             await _handle_interrupt_cleanup(
                 adapter=adapter,
@@ -303,7 +299,7 @@ class TestInterruptCleanup:
         agent = SimpleNamespace(aupdate_state=AsyncMock())
 
         with patch(
-            "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+            "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
         ) as mock_dispatch:
             await _handle_interrupt_cleanup(
                 adapter=adapter,
@@ -367,7 +363,7 @@ class TestInterruptCleanup:
             order.append(f"dispatch:{event}")
 
         with patch(
-            "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget",
+            "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget",
             side_effect=_record_dispatch,
         ):
             await _handle_interrupt_cleanup(
@@ -1199,7 +1195,7 @@ class TestFormatRubricEvent:
         CI; `test_ascii_mode_degrades_to_ascii_glyphs` covers the ASCII path.
         """
         with patch(
-            "deepagents_code.textual_adapter.get_glyphs",
+            "deepagents_code.tui.textual_adapter.get_glyphs",
             return_value=UNICODE_GLYPHS,
         ):
             yield
@@ -1309,7 +1305,7 @@ class TestFormatRubricEvent:
     def test_ascii_mode_degrades_to_ascii_glyphs(self) -> None:
         """In ASCII mode the transcript glyphs must degrade, not stay Unicode."""
         with patch(
-            "deepagents_code.textual_adapter.get_glyphs",
+            "deepagents_code.tui.textual_adapter.get_glyphs",
             return_value=ASCII_GLYPHS,
         ):
             start = _format_rubric_event(
@@ -2627,7 +2623,8 @@ class TestExecuteTaskTextualTextThenToolSpinner:
         fake_msg = AsyncMock()
         fake_msg.id = "asst-test"
         with patch(
-            "deepagents_code.textual_adapter.AssistantMessage", return_value=fake_msg
+            "deepagents_code.tui.textual_adapter.AssistantMessage",
+            return_value=fake_msg,
         ):
             await execute_task_textual(
                 user_input="hi",
@@ -2651,9 +2648,9 @@ class TestExecuteTaskTextualTextThenToolSpinner:
 
         After a tool cycle completes, the tool_call handler pops the previous
         AssistantMessage from `assistant_message_by_namespace`, so the next
-        text chunk mounts a fresh widget. The new re-anchor call at
-        `textual_adapter.py:780-784` must fire for that second text burst so
-        the spinner stays visible between it and any follow-up tool call.
+        text chunk mounts a fresh widget. The re-anchor call must fire for that
+        second text burst so the spinner stays visible between it and any
+        follow-up tool call.
         """
         statuses: list[str | None] = []
 
@@ -2678,7 +2675,8 @@ class TestExecuteTaskTextualTextThenToolSpinner:
         fake_msg = AsyncMock()
         fake_msg.id = "asst-test"
         with patch(
-            "deepagents_code.textual_adapter.AssistantMessage", return_value=fake_msg
+            "deepagents_code.tui.textual_adapter.AssistantMessage",
+            return_value=fake_msg,
         ):
             await execute_task_textual(
                 user_input="hi",
@@ -2689,9 +2687,9 @@ class TestExecuteTaskTextualTextThenToolSpinner:
             )
 
         # Expected Thinking calls:
-        #   1. Before astream (line 517)
-        #   2. After first AssistantMessage mount (re-anchor, line 784)
-        #   3. After tool result (line 705)
+        #   1. Before astream
+        #   2. After first AssistantMessage mount (re-anchor)
+        #   3. After tool result
         #   4. After second AssistantMessage mount (re-anchor again)
         thinking_count = sum(1 for s in statuses if s == "Thinking")
         assert thinking_count >= 4, (
@@ -2729,7 +2727,8 @@ class TestExecuteTaskTextualTextThenToolSpinner:
         fake_msg = AsyncMock()
         fake_msg.id = "asst-test"
         with patch(
-            "deepagents_code.textual_adapter.AssistantMessage", return_value=fake_msg
+            "deepagents_code.tui.textual_adapter.AssistantMessage",
+            return_value=fake_msg,
         ):
             await execute_task_textual(
                 user_input="hi",
@@ -2810,11 +2809,11 @@ class TestExecuteTaskTextualRubricRevisionStreaming:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.AssistantMessage",
+                "deepagents_code.tui.textual_adapter.AssistantMessage",
                 side_effect=FakeAssistantMessage,
             ),
             patch(
-                "deepagents_code.textual_adapter.get_glyphs",
+                "deepagents_code.tui.textual_adapter.get_glyphs",
                 return_value=UNICODE_GLYPHS,
             ),
         ):
@@ -3564,7 +3563,7 @@ class TestExecuteTaskTextualAskUser:
         )
 
         with patch(
-            "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+            "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
         ) as mock_dispatch:
             await execute_task_textual(
                 user_input="hello",
@@ -3947,240 +3946,6 @@ class TestDictIterationSafety:
 
 
 # ---------------------------------------------------------------------------
-# SessionStats tests
-# ---------------------------------------------------------------------------
-
-
-class TestSessionStats:
-    """Tests for `SessionStats` recording and merging."""
-
-    def test_record_request_named_model(self) -> None:
-        """record_request updates totals and per_model for a named model."""
-        stats = SessionStats()
-        stats.record_request("gpt-4", 100, 50)
-
-        assert stats.request_count == 1
-        assert stats.input_tokens == 100
-        assert stats.output_tokens == 50
-        assert ("", "gpt-4") in stats.per_model
-        assert stats.per_model["", "gpt-4"].request_count == 1
-        assert stats.per_model["", "gpt-4"].input_tokens == 100
-        assert stats.per_model["", "gpt-4"].output_tokens == 50
-
-    def test_record_request_empty_model(self) -> None:
-        """record_request with empty model skips per_model entry."""
-        stats = SessionStats()
-        stats.record_request("", 200, 80)
-
-        assert stats.request_count == 1
-        assert stats.input_tokens == 200
-        assert stats.output_tokens == 80
-        assert stats.per_model == {}
-
-    def test_record_request_multiple_models(self) -> None:
-        """Multiple models create separate per_model entries."""
-        stats = SessionStats()
-        stats.record_request("gpt-4", 100, 50)
-        stats.record_request("claude-opus-4-6", 200, 80)
-
-        assert stats.request_count == 2
-        assert stats.input_tokens == 300
-        assert stats.output_tokens == 130
-        assert len(stats.per_model) == 2
-        assert stats.per_model["", "gpt-4"].request_count == 1
-        assert stats.per_model["", "claude-opus-4-6"].request_count == 1
-
-    def test_record_request_splits_same_model_by_provider(self) -> None:
-        """Provider-specific model names should not collapse into one entry."""
-        stats = SessionStats()
-        stats.record_request("gpt-4", 100, 50, provider="openai")
-        stats.record_request("gpt-4", 200, 80, provider="azure")
-
-        assert len(stats.per_model) == 2
-        assert stats.per_model["openai", "gpt-4"].request_count == 1
-        assert stats.per_model["azure", "gpt-4"].request_count == 1
-
-    def test_merge(self) -> None:
-        """merge() folds another SessionStats into self."""
-        a = SessionStats(
-            request_count=1, input_tokens=100, output_tokens=50, wall_time_seconds=1.0
-        )
-        a.per_model["", "gpt-4"] = ModelStats(
-            request_count=1, input_tokens=100, output_tokens=50, model_name="gpt-4"
-        )
-
-        b = SessionStats(
-            request_count=2, input_tokens=300, output_tokens=120, wall_time_seconds=2.5
-        )
-        b.per_model["", "claude-opus-4-6"] = ModelStats(
-            request_count=2,
-            input_tokens=300,
-            output_tokens=120,
-            model_name="claude-opus-4-6",
-        )
-
-        a.merge(b)
-
-        assert a.request_count == 3
-        assert a.input_tokens == 400
-        assert a.output_tokens == 170
-        assert a.wall_time_seconds == pytest.approx(3.5)
-        assert len(a.per_model) == 2
-        assert a.per_model["", "claude-opus-4-6"].request_count == 2
-
-    def test_merge_overlapping_models(self) -> None:
-        """merge() combines per_model entries for the same model."""
-        a = SessionStats()
-        a.record_request("gpt-4", 100, 50)
-
-        b = SessionStats()
-        b.record_request("gpt-4", 200, 80)
-
-        a.merge(b)
-
-        assert a.request_count == 2
-        assert a.input_tokens == 300
-        assert a.output_tokens == 130
-        assert a.per_model["", "gpt-4"].request_count == 2
-        assert a.per_model["", "gpt-4"].input_tokens == 300
-        assert a.per_model["", "gpt-4"].output_tokens == 130
-
-    def test_merge_splits_same_model_by_provider(self) -> None:
-        """merge() preserves provider-specific entries for the same model."""
-        a = SessionStats()
-        a.record_request("gpt-4", 100, 50, provider="openai")
-
-        b = SessionStats()
-        b.record_request("gpt-4", 200, 80, provider="azure")
-
-        a.merge(b)
-
-        assert len(a.per_model) == 2
-        assert a.per_model["openai", "gpt-4"].input_tokens == 100
-        assert a.per_model["azure", "gpt-4"].input_tokens == 200
-
-
-# ---------------------------------------------------------------------------
-# format_token_count tests
-# ---------------------------------------------------------------------------
-
-
-class TestFormatTokenCount:
-    """Tests for `format_token_count` shared formatter."""
-
-    def test_small_count(self) -> None:
-        assert format_token_count(500) == "500"
-
-    def test_thousands(self) -> None:
-        assert format_token_count(12_500) == "12.5K"
-
-    def test_millions(self) -> None:
-        assert format_token_count(1_200_000) == "1.2M"
-
-    def test_exact_thousand(self) -> None:
-        assert format_token_count(1000) == "1.0K"
-
-    def test_zero(self) -> None:
-        assert format_token_count(0) == "0"
-
-
-# ---------------------------------------------------------------------------
-# print_usage_table tests
-# ---------------------------------------------------------------------------
-
-
-class TestPrintUsageTable:
-    """Tests for `print_usage_table` output."""
-
-    def test_no_model_called_skips_unknown_row(self) -> None:
-        """When no model was called, the table should not show 'unknown'."""
-        stats = SessionStats()
-        buf = StringIO()
-        console = Console(file=buf, force_terminal=True)
-        print_usage_table(stats, wall_time=1.5, console=console)
-        output = buf.getvalue()
-        assert "unknown" not in output
-        assert "Usage Stats" not in output
-        assert "Agent active" in output
-
-    def test_single_model_shows_name(self) -> None:
-        """Single-model session should display the model name."""
-        stats = SessionStats()
-        stats.record_request("gpt-4", 100, 50)
-        buf = StringIO()
-        console = Console(file=buf, force_terminal=True)
-        print_usage_table(stats, wall_time=2.0, console=console)
-        output = buf.getvalue()
-        assert "gpt-4" in output
-        assert "unknown" not in output
-
-    def test_shows_provider_name(self) -> None:
-        """The table should include the provider for each model."""
-        stats = SessionStats()
-        stats.record_request("gpt-4", 100, 50, provider="openai")
-        buf = StringIO()
-        console = Console(file=buf, force_terminal=True)
-        print_usage_table(stats, wall_time=2.0, console=console)
-        output = buf.getvalue()
-        assert "Provider" in output
-        assert "openai" in output
-        assert "gpt-4" in output
-
-    def test_multi_model_shows_all_names_and_total(self) -> None:
-        """Multi-model session should show each model and a Total row."""
-        stats = SessionStats()
-        stats.record_request("gpt-4", 100, 50)
-        stats.record_request("claude-opus-4-6", 200, 80)
-        buf = StringIO()
-        console = Console(file=buf, force_terminal=True)
-        print_usage_table(stats, wall_time=2.0, console=console)
-        output = buf.getvalue()
-        assert "gpt-4" in output
-        assert "claude-opus-4-6" in output
-        assert "Total" in output
-        assert "unknown" not in output
-
-    def test_same_model_with_different_providers_shows_separate_rows(self) -> None:
-        """Same-name models from different providers should render separately."""
-        stats = SessionStats()
-        stats.record_request("gpt-4", 100, 50, provider="openai")
-        stats.record_request("gpt-4", 200, 80, provider="azure")
-        buf = StringIO()
-        console = Console(file=buf, force_terminal=True)
-        print_usage_table(stats, wall_time=2.0, console=console)
-        output = buf.getvalue()
-        assert "openai" in output
-        assert "azure" in output
-        assert "Total" in output
-        # Two distinct rows, not a collapsed one: each provider's per-row token
-        # counts must appear (100/50 and 200/80), alongside the 300/130 totals.
-        assert "100" in output
-        assert "50" in output
-        assert "200" in output
-        assert "80" in output
-
-    def test_tokens_with_no_wall_time_omits_timing_line(self) -> None:
-        """Token table should print but timing line should be absent."""
-        stats = SessionStats()
-        stats.record_request("gpt-4", 100, 50)
-        buf = StringIO()
-        console = Console(file=buf, force_terminal=True)
-        print_usage_table(stats, wall_time=0.0, console=console)
-        output = buf.getvalue()
-        assert "gpt-4" in output
-        assert "Agent active" not in output
-
-    def test_no_requests_no_time_prints_nothing(self) -> None:
-        """Empty stats with negligible wall time should print nothing."""
-        stats = SessionStats()
-        buf = StringIO()
-        console = Console(file=buf, force_terminal=True)
-        print_usage_table(stats, wall_time=0.01, console=console)
-        output = buf.getvalue()
-        assert output.strip() == ""
-
-
-# ---------------------------------------------------------------------------
 # tool.use / tool.result hook dispatch (textual path)
 # ---------------------------------------------------------------------------
 
@@ -4214,7 +3979,7 @@ class TestToolHooksTextual:
         )
 
         with patch(
-            "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget",
+            "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget",
             side_effect=record_dispatch,
         ) as mock_dispatch:
             await execute_task_textual(
@@ -4273,12 +4038,12 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook",
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
                 new_callable=AsyncMock,
                 side_effect=fail_if_tool_result,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch,
         ):
             await execute_task_textual(
@@ -4339,11 +4104,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.format_tool_message_content",
+                "deepagents_code.tui.textual_adapter.format_tool_message_content",
                 side_effect=boom,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch,
         ):
             await execute_task_textual(
@@ -4398,7 +4163,7 @@ class TestToolHooksTextual:
         )
 
         with patch(
-            "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+            "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
         ) as mock_dispatch:
             await execute_task_textual(
                 user_input="hello",
@@ -4469,7 +4234,7 @@ class TestToolHooksTextual:
         with (
             patch.object(ToolCallMessage, "set_success", flaky_set_success),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch,
         ):
             await execute_task_textual(
@@ -4510,7 +4275,7 @@ class TestToolHooksTextual:
         )
 
         with patch(
-            "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+            "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
         ) as mock_dispatch:
             await execute_task_textual(
                 user_input="hello",
@@ -4571,9 +4336,9 @@ class TestToolHooksTextual:
         )
 
         with (
-            caplog.at_level("WARNING", logger="deepagents_code.textual_adapter"),
+            caplog.at_level("WARNING", logger="deepagents_code.tui.textual_adapter"),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch,
         ):
             await execute_task_textual(
@@ -4646,10 +4411,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -4730,10 +4496,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -4817,10 +4584,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -4871,10 +4639,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -4945,10 +4714,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -5020,10 +4790,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -5111,10 +4882,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -5241,7 +5013,7 @@ class TestToolHooksTextual:
         )
 
         with patch(
-            "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+            "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
         ) as mock_dispatch:
             await execute_task_textual(
                 user_input="hello",
@@ -5291,10 +5063,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -5350,10 +5123,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -5451,10 +5225,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -5530,10 +5305,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -5606,10 +5382,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -5666,10 +5443,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -5732,10 +5510,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -5852,10 +5631,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -5918,10 +5698,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -5986,10 +5767,11 @@ class TestToolHooksTextual:
 
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook", new_callable=AsyncMock
+                "deepagents_code.tui.textual_adapter.dispatch_hook",
+                new_callable=AsyncMock,
             ),
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
             ) as mock_dispatch_background,
         ):
             await execute_task_textual(
@@ -6033,7 +5815,7 @@ class TestToolHooksTextual:
         )
 
         with patch(
-            "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+            "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
         ) as mock_dispatch:
             await execute_task_textual(
                 user_input="hello",
@@ -6067,7 +5849,7 @@ class TestToolHooksTextual:
         )
 
         with patch(
-            "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+            "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
         ) as mock_dispatch:
             await execute_task_textual(
                 user_input="hello",
@@ -6113,7 +5895,7 @@ class TestToolHooksTextual:
         )
 
         with patch(
-            "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"
+            "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"
         ) as mock_dispatch:
             await execute_task_textual(
                 user_input="hello",
@@ -6202,7 +5984,7 @@ async def _run_textual_surface(
         request_approval=_mock_approval,
     )
     with patch(
-        "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget",
+        "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget",
         side_effect=_capture,
     ):
         await execute_task_textual(
@@ -6537,8 +6319,8 @@ class TestTextualEndOfStreamDiagnostics:
             _tool_chunk(name="g", args='{"b": 2}', chunk_id=None, index=1),
         ]
         with (
-            patch("deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"),
-            caplog.at_level("INFO", logger="deepagents_code.textual_adapter"),
+            patch("deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"),
+            caplog.at_level("INFO", logger="deepagents_code.tui.textual_adapter"),
         ):
             await execute_task_textual(
                 user_input="hello",
@@ -6568,8 +6350,8 @@ class TestTextualEndOfStreamDiagnostics:
         # Args never close -> unparsed, no tool.use, buffer retained to the exit.
         chunks = [_tool_chunk(name="f", args='{"a": ', chunk_id="t1", index=0)]
         with (
-            patch("deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"),
-            caplog.at_level("INFO", logger="deepagents_code.textual_adapter"),
+            patch("deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"),
+            caplog.at_level("INFO", logger="deepagents_code.tui.textual_adapter"),
             pytest.raises(RuntimeError, match="boom"),
         ):
             await execute_task_textual(
@@ -6596,12 +6378,12 @@ class TestTextualEndOfStreamDiagnostics:
         )
         chunks = [_tool_chunk(name="f", args='{"a": ', chunk_id="t1", index=0)]
         with (
-            patch("deepagents_code.textual_adapter.dispatch_hook_fire_and_forget"),
+            patch("deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget"),
             patch(
-                "deepagents_code.textual_adapter._handle_interrupt_cleanup",
+                "deepagents_code.tui.textual_adapter._handle_interrupt_cleanup",
                 new_callable=AsyncMock,
             ),
-            caplog.at_level("INFO", logger="deepagents_code.textual_adapter"),
+            caplog.at_level("INFO", logger="deepagents_code.tui.textual_adapter"),
         ):
             await execute_task_textual(
                 user_input="hello",
@@ -6645,7 +6427,7 @@ class TestTextualNonCleanExitTerminalHooks:
         )
         with (
             patch(
-                "deepagents_code.textual_adapter.dispatch_hook_fire_and_forget",
+                "deepagents_code.tui.textual_adapter.dispatch_hook_fire_and_forget",
                 side_effect=record_dispatch,
             ),
             pytest.raises(RuntimeError, match="boom"),


### PR DESCRIPTION
Continues the dcode package restructure by giving the Textual execution adapter a canonical home under `deepagents_code.tui`. Shared session stats formatting now lives outside the TUI layer so headless and client paths do not need to import Textual-facing code.

## Changes
- Moves `TextualUIAdapter` and `execute_task_textual` under the TUI package and updates app, integration, benchmark, and unit-test imports to use the new canonical path.
- Keeps `client/non_interactive` and shared command logic independent of `deepagents_code.tui` by moving `print_usage_table` alongside `SessionStats` and `format_token_count`.
- Relocates adapter-specific tests under the matching `tests/unit_tests/tui` layout and moves shared session-stat coverage to the existing `_session_stats` test module.
- Refreshes threat-model and inline references that described the old flat adapter location.
