### PR TITLE
fix(code): show `(local)` tag under ANSI themes

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/welcome.py
+++ b/libs/code/deepagents_code/tui/widgets/welcome.py
@@ -110,6 +110,22 @@ def _langsmith_project_link_style(
     return TStyle(foreground=TColor.parse(colors.primary), link=link)
 
 
+def _local_tag_style(*, ansi: bool, colors: theme.ThemeColors) -> str | TStyle:
+    """Build the style for the editable-install `(local)` tag.
+
+    Args:
+        ansi: Whether the active theme is an ANSI terminal theme.
+        colors: Active Deep Agents theme colors.
+
+    Returns:
+        A bold markup style under ANSI themes (whose palette the terminal owns,
+        so a parsed color could be invisible) or a bold themed color otherwise.
+    """
+    if ansi:
+        return "bold"
+    return TStyle(foreground=TColor.parse(colors.tool), bold=True)
+
+
 def _home_prefixed(cwd: str) -> str:
     """Format a directory path, using `~` for the home directory when possible.
 
@@ -362,13 +378,8 @@ class WelcomeBanner(Static):
         ]
         if not self._hide_version:
             parts.append((f"  v{__version__}", "dim"))
-            if not ansi and _is_editable_install():
-                parts.append(
-                    (
-                        " (local)",
-                        TStyle(foreground=TColor.parse(colors.tool), bold=True),
-                    )
-                )
+            if _is_editable_install():
+                parts.append((" (local)", _local_tag_style(ansi=ansi, colors=colors)))
 
         # Row labels share a common column width so values stay aligned; the
         # longest label ("directory:") needs 11 columns including its space.

--- a/libs/code/deepagents_code/tui/widgets/welcome.py
+++ b/libs/code/deepagents_code/tui/widgets/welcome.py
@@ -119,7 +119,8 @@ def _local_tag_style(*, ansi: bool, colors: theme.ThemeColors) -> str | TStyle:
 
     Returns:
         A bold markup style under ANSI themes (whose palette the terminal owns,
-        so a parsed color could be invisible) or a bold themed color otherwise.
+            so a parsed color could be invisible) or a bold themed
+            color otherwise.
     """
     if ansi:
         return "bold"

--- a/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
@@ -21,6 +21,7 @@ from deepagents_code.tui.widgets.welcome import (
     _home_prefixed,
     _langsmith_project_link,
     _langsmith_project_link_style,
+    _local_tag_style,
 )
 
 _EDITABLE = "deepagents_code.tui.widgets.welcome._is_editable_install"
@@ -160,6 +161,28 @@ class TestLangsmithLinkHelpers:
         )
         assert style.bold is True
         assert style.link is not None
+
+
+class TestLocalTagStyle:
+    """Tests for the editable-install `(local)` tag style."""
+
+    def test_ansi_uses_bold_markup(self) -> None:
+        """Under ANSI themes the tag stays visible via bold terminal text."""
+        from deepagents_code.theme import DARK_COLORS
+
+        assert _local_tag_style(ansi=True, colors=DARK_COLORS) == "bold"
+
+    def test_non_ansi_uses_themed_color(self) -> None:
+        """Non-ANSI themes color the tag with the theme's tool color."""
+        from textual.color import Color as TColor
+        from textual.style import Style as TStyle
+
+        from deepagents_code.theme import DARK_COLORS
+
+        style = _local_tag_style(ansi=False, colors=DARK_COLORS)
+        assert isinstance(style, TStyle)
+        assert style.bold is True
+        assert style.foreground == TColor.parse(DARK_COLORS.tool)
 
 
 class TestTitle:


### PR DESCRIPTION
Fix the `(local)` editable-install tag being invisible in the welcome banner under ANSI terminal themes.

Made by [Open SWE](https://openswe.vercel.app/agents/0ca0401e-9050-df33-374a-b0fa543b4a4c)