### PR TITLE
fix(code): keep TUI input responsive during /restart reconnect

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2502,6 +2502,11 @@ class DeepAgentsApp(App):
         self._shell_worker: Worker[None] | None = None
         """Active `!` shell-command worker, tracked for interruption."""
 
+        self._restart_worker: Worker[None] | None = None
+        """Active `/restart` respawn worker. The respawn runs off the Textual
+        message pump so key events keep reaching the chat input during the
+        reconnect; tracked to skip a duplicate `/restart` while one is running."""
+
         self._shell_running = False
         """True while a `!` shell command is executing."""
 
@@ -15285,10 +15290,26 @@ class DeepAgentsApp(App):
         dying subprocess would otherwise raise into the Textual reactor
         after the new server advertises ready, leaving the UI wedged.
 
+        The respawn itself runs on a background worker (`_run_restart_task`)
+        rather than being awaited here: awaiting the multi-second reconnect
+        inside the Textual message handler would block the app message pump
+        from forwarding key events to the chat input, freezing the text input
+        for the whole reconnect. This mirrors `_handle_shell_command` /
+        `_run_agent_task`, which run in a worker to keep the event loop free.
+
         Args:
             command: Raw command string for echoing back to chat.
         """
         await self._mount_message(UserMessage(command))
+
+        # A respawn is already in flight (the input stays live during a
+        # reconnect now, so a user can resubmit `/restart`). Skip the duplicate
+        # rather than racing a second `server_proc.restart()` on the same proc.
+        if self._restart_worker is not None and self._restart_worker.is_running:
+            await self._mount_message(
+                AppMessage("A restart is already in progress."),
+            )
+            return
 
         # Sever in-flight work bound to the dying subprocess. `_cancel_worker`
         # discards the queued backlog too — those messages would otherwise
@@ -15362,6 +15383,21 @@ class DeepAgentsApp(App):
                 )
             return
 
+        # Respawn on a worker so the message pump stays free to forward key
+        # events; awaiting the reconnect here would freeze the chat input.
+        self._restart_worker = self.run_worker(
+            self._run_restart_task(),
+            exclusive=False,
+            group="server-restart",
+        )
+
+    async def _run_restart_task(self) -> None:
+        """Respawn the app-owned server for `/restart` on a background worker.
+
+        Split out of `_handle_restart_command` so the multi-second reconnect
+        runs off the Textual message pump, keeping the chat input responsive
+        (mirrors `_run_shell_task` / `_run_agent_task`).
+        """
         restarting = await self._mount_transient_app_message("Restarting server...")
         restarted = False
         try:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -19427,6 +19427,8 @@ class TestRestartCommand:
             monkeypatch.setattr(app, "_restart_server_manual", _fake_restart)
 
             await app._handle_command("/restart")
+            assert app._restart_worker is not None
+            await app._restart_worker.wait()
             await pilot.pause()
 
             assert reload_called
@@ -19437,6 +19439,101 @@ class TestRestartCommand:
             # restart succeeds; only the completion banner remains.
             assert not any("Restarting server" in m for m in app_msgs)
             assert any("Restart complete" in m for m in app_msgs)
+
+    async def test_respawn_runs_off_message_pump_so_input_stays_live(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`/restart` must not await the respawn inside the message handler.
+
+        Regression: awaiting the multi-second reconnect in the message handler
+        blocks the Textual message pump from forwarding key events, freezing
+        the chat input. The respawn runs on a worker, so the handler returns
+        immediately while the reconnect is still in flight.
+        """
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._server_proc = MagicMock()
+            app._server_kwargs = {}
+
+            release = asyncio.Event()
+            restart_started = asyncio.Event()
+
+            async def _blocking_restart() -> bool:
+                restart_started.set()
+                await release.wait()
+                return True
+
+            from deepagents_code.config import settings
+
+            monkeypatch.setattr(settings, "reload_from_environment", list)
+            monkeypatch.setattr(
+                "deepagents_code.model_config.clear_caches", lambda: None
+            )
+            monkeypatch.setattr(app, "_restart_server_manual", _blocking_restart)
+
+            # The handler returns even though the respawn is still blocked.
+            await asyncio.wait_for(app._handle_command("/restart"), timeout=2)
+            await asyncio.wait_for(restart_started.wait(), timeout=2)
+
+            assert app._restart_worker is not None
+            assert app._restart_worker.is_running
+
+            # Release the respawn and let the worker finish cleanly.
+            release.set()
+            await app._restart_worker.wait()
+            await pilot.pause()
+
+            app_msgs = [str(w._content) for w in app.query(AppMessage)]
+            assert any("Restart complete." in m for m in app_msgs)
+
+    async def test_duplicate_restart_while_running_is_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A second `/restart` while one is in flight must not respawn twice."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            app._server_proc = MagicMock()
+            app._server_kwargs = {}
+
+            release = asyncio.Event()
+            restart_started = asyncio.Event()
+            calls = 0
+
+            async def _blocking_restart() -> bool:
+                nonlocal calls
+                calls += 1
+                restart_started.set()
+                await release.wait()
+                return True
+
+            from deepagents_code.config import settings
+
+            monkeypatch.setattr(settings, "reload_from_environment", list)
+            monkeypatch.setattr(
+                "deepagents_code.model_config.clear_caches", lambda: None
+            )
+            monkeypatch.setattr(app, "_restart_server_manual", _blocking_restart)
+
+            await asyncio.wait_for(app._handle_command("/restart"), timeout=2)
+            await asyncio.wait_for(restart_started.wait(), timeout=2)
+            first_worker = app._restart_worker
+
+            # Second `/restart` while the first respawn is still blocked.
+            await asyncio.wait_for(app._handle_command("/restart"), timeout=2)
+
+            assert app._restart_worker is first_worker
+            app_msgs = [str(w._content) for w in app.query(AppMessage)]
+            assert any("already in progress" in m for m in app_msgs)
+
+            release.set()
+            assert app._restart_worker is not None
+            await app._restart_worker.wait()
+            await pilot.pause()
+            assert calls == 1
 
     async def test_failed_restart_removes_transient_and_suppresses_completion(
         self, monkeypatch: pytest.MonkeyPatch
@@ -19475,6 +19572,8 @@ class TestRestartCommand:
             monkeypatch.setattr(app, "_restart_server_manual", _fake_restart)
 
             await app._handle_command("/restart")
+            assert app._restart_worker is not None
+            await app._restart_worker.wait()
             await pilot.pause()
 
             assert restart_called
@@ -19489,7 +19588,7 @@ class TestRestartCommand:
 
         The transient "Restarting server..." status is mounted before
         `_restart_server_manual()` is awaited, so the `try/finally` in
-        `_handle_restart_command` exists solely to remove it when the restart
+        `_run_restart_task` exists solely to remove it when the restart
         raises (not merely returns `False`). On a raise the transient must be
         gone, the misleading completion banner must never mount, and the
         exception must propagate rather than be swallowed.
@@ -19518,7 +19617,7 @@ class TestRestartCommand:
             monkeypatch.setattr(app, "_restart_server_manual", _boom)
 
             with pytest.raises(RuntimeError, match="respawn exploded"):
-                await app._handle_restart_command("/restart")
+                await app._run_restart_task()
             await pilot.pause()
 
             assert restart_called


### PR DESCRIPTION
Fixed the chat input locking up while `/restart` reconnects to the server.

---

`/restart` awaited the multi-second server respawn directly inside the Textual message handler (`on_chat_input_submitted` → `_handle_restart_command` → `_respawn_server`), which blocks the app message pump from forwarding key events to the focused chat input — freezing the text input for the whole reconnect. This moves the respawn onto a background worker (`_run_restart_task`), mirroring the existing `_run_shell_task`/`_run_agent_task` pattern that keeps the event loop free, and skips a duplicate `/restart` while one is already in flight. Fast setup (echo, cancel in-flight work, config reload, guards) stays inline.

Made by [Open SWE](https://openswe.vercel.app/agents/2928bcfd-f148-5bc7-27a0-59f4deb461f3)