### PR TITLE
fix(code): add `/exit` alias for quit

### DIFF
--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -30,7 +30,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/model` |  | Switch models or edit model settings |
 | `/notifications` |  | Configure startup warnings |
 | `/offload` | `/compact` | Summarize and offload older messages to free context |
-| `/quit` | `/q` | Exit app |
+| `/quit` | `/q`, `/exit` | Exit app |
 | `/reload` |  | Reload environment and config |
 | `/remember` |  | Save useful context to memory or skills |
 | `/restart` |  | Restart the agent server |

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -9325,7 +9325,7 @@ class DeepAgentsApp(App):
 
         cmd = command.lower().strip()
 
-        if cmd in {"/quit", "/q"}:
+        if cmd in {"/quit", "/q", "/exit"}:
             self.exit()
         elif cmd == "/help":
             await self._mount_message(UserMessage(command))

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -267,7 +267,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
         description="Exit app",
         bypass_tier=BypassTier.ALWAYS,
         hidden_keywords="close leave",
-        aliases=("/q",),
+        aliases=("/q", "/exit"),
     ),
 )
 """All slash commands."""

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -11225,6 +11225,20 @@ class TestSlashCommandBypass:
             exit_mock.assert_called_once()
             assert len(app._pending_messages) == 0
 
+    async def test_exit_alias_bypasses_queue(self) -> None:
+        """/exit alias should also bypass the queue."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+
+            with patch.object(app, "exit") as exit_mock:
+                app.post_message(ChatInput.Submitted("/exit", "command"))
+                await pilot.pause()
+
+            exit_mock.assert_called_once()
+            assert len(app._pending_messages) == 0
+
     async def test_force_clear_bypasses_queue_when_agent_running(self) -> None:
         """/force-clear should process immediately when agent is running."""
         app = DeepAgentsApp()


### PR DESCRIPTION
Adds `/exit` as an alias for `/quit` so users can exit the TUI with either command.

Also updates the generated command catalog and covers the alias in slash-command bypass tests.
