### PR TITLE
chore(code): bump deepagents to 0.7.0a6

### DIFF
--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     # Framework
-    "deepagents==0.7.0a5",
+    "deepagents==0.7.0a6",
     "langchain>=1.3.11,<2.0.0",
     "langgraph-checkpoint-sqlite>=3.1.0,<4.0.0",
 


### PR DESCRIPTION
Bumps `deepagents` SDK pin to `0.7.0a6`.