### PR TITLE
hotfix(code): fix release runtime dependency test

### DIFF
--- a/libs/code/tests/unit_tests/test_server_manager.py
+++ b/libs/code/tests/unit_tests/test_server_manager.py
@@ -312,15 +312,24 @@ class TestWritePyproject:
 
         assert dependency == f"deepagents-code @ {package_root.as_uri()}"
 
-    def test_runtime_dependency_default_uses_package_project_root(self) -> None:
+    def test_runtime_dependency_default_uses_package_project_root(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """The default root should not depend on `server_manager.py` depth."""
         from pathlib import Path
+
+        import deepagents_code
 
         # Derive the expected project root independently, from this test file's
         # own location (libs/code/tests/unit_tests/ -> libs/code), rather than
         # reusing the implementation's package-anchored expression. Mirroring the
         # implementation would let a bug in that expression pass unnoticed.
         project_root = Path(__file__).resolve().parents[2]
+        monkeypatch.setattr(
+            deepagents_code,
+            "__file__",
+            str(project_root / "deepagents_code" / "__init__.py"),
+        )
 
         dependency = _runtime_package_dependency()
 


### PR DESCRIPTION
The deepagents-code release workflow installs the built wheel before running the checkout test suite. That makes `_runtime_package_dependency()` correctly resolve to the installed version pin, but the unit test assumed the imported package always came from the source checkout.

This updates the source-checkout-specific assertion to mock `deepagents_code.__file__` to the checkout package path before calling `_runtime_package_dependency()`, keeping the test focused on the package-root calculation without depending on how the package was installed in the test environment.