### PR TITLE
refactor(code): rename in-app nomenclature to `dcode`

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7119,7 +7119,7 @@ class DeepAgentsApp(App):
         if not os.environ.get("TAVILY_API_KEY"):
             self.notify(
                 "Saved your Tavily key, but couldn't activate it this "
-                "session. Restart Deep Agents Code, or re-add it with /auth.",
+                "session. Restart dcode, or re-add it with /auth.",
                 severity="warning",
                 markup=False,
             )

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -577,9 +577,9 @@ def _build_orphaned_tracing_disabled_notice() -> str:
     if shutil.which("langsmith"):
         return (
             f"{base} Set LANGSMITH_API_KEY or run `langsmith auth login`, "
-            "then restart Deep Agents Code."
+            "then restart dcode."
         )
-    return f"{base} Set LANGSMITH_API_KEY, then restart Deep Agents Code."
+    return f"{base} Set LANGSMITH_API_KEY, then restart dcode."
 
 
 def consume_orphaned_tracing_disabled_notice() -> str | None:

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -742,7 +742,7 @@ def check_cli_dependencies() -> None:
 
     if missing:
         print("\nMissing required dependencies!")  # noqa: T201  # App output for missing dependencies
-        print("\nThe following packages are required to use Deep Agents Code:")  # noqa: T201  # App output for missing dependencies
+        print("\nThe following packages are required to use dcode:")  # noqa: T201  # App output for missing dependencies
         for pkg in missing:
             print(f"  - {pkg}")  # noqa: T201  # CLI output for missing dependencies
         print("\nReinstall dcode with the recommended installer:")  # noqa: T201  # CLI output for missing dependencies
@@ -3070,7 +3070,7 @@ def cli_main() -> None:
                 # so confirm before pulling third-party code into the tool env.
                 console.print(
                     f"This will install the package '{escape(package)}' into "
-                    "the Deep Agents Code environment (this runs third-party "
+                    "the dcode environment (this runs third-party "
                     "code).",
                     highlight=False,
                 )

--- a/libs/code/deepagents_code/system_prompt.md
+++ b/libs/code/deepagents_code/system_prompt.md
@@ -1,4 +1,4 @@
-# dcode
+# Deep Agents Code (dcode)
 
 You are a deep agent, an AI assistant running in {mode_description}. You help with tasks like coding, debugging, research, analysis, and more.
 

--- a/libs/code/deepagents_code/system_prompt.md
+++ b/libs/code/deepagents_code/system_prompt.md
@@ -1,4 +1,4 @@
-# Deep Agents Code
+# dcode
 
 You are a deep agent, an AI assistant running in {mode_description}. You help with tasks like coding, debugging, research, analysis, and more.
 

--- a/libs/code/deepagents_code/tui/widgets/agent_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/agent_selector.py
@@ -142,7 +142,7 @@ class AgentSelectorScreen(ModalScreen[str | None]):
             else:
                 yield Static(
                     "No agents found in ~/.deepagents/.\n"
-                    "Run Deep Agents Code with -a <name> to create one.",
+                    "Run dcode with -a <name> to create one.",
                     classes="agent-selector-help",
                 )
                 help_text = f"{glyphs.bullet} Esc close"

--- a/libs/code/deepagents_code/tui/widgets/auth.py
+++ b/libs/code/deepagents_code/tui/widgets/auth.py
@@ -768,9 +768,7 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
                     "This scoped env var takes priority. A saved key will be used "
                     f"only when {env_var} is unset."
                     if is_scoped_env
-                    else (
-                        "Paste a key below to use a different key for Deep Agents Code."
-                    )
+                    else ("Paste a key below to use a different key for dcode.")
                 )
                 yield Static(
                     Content.assemble(
@@ -814,7 +812,7 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
             storage_note: Content | None
             if self._is_langsmith:
                 storage_note = Content.from_markup(
-                    "Deep Agents Code stores the above key locally and turns on "
+                    "dcode stores the above key locally and turns on "
                     "LangSmith tracing. To pause tracing without removing the key, "
                     "set [bold]DEEPAGENTS_CODE_LANGSMITH_TRACING=false[/bold]."
                 )
@@ -825,7 +823,7 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
                 storage_note = None
             else:
                 storage_note = Content.from_markup(
-                    "Deep Agents Code stores the above key locally and uses it "
+                    "dcode stores the above key locally and uses it "
                     "when you select [bold]$provider[/bold] models.",
                     provider=provider_label,
                 )
@@ -846,8 +844,7 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
                         "Alternatively, environment variables can be used in place "
                         "of the key stored above. Set ",
                         (f"DEEPAGENTS_CODE_{self._env_var}", TStyle(bold=True)),
-                        " for a Deep Agents Code-only key; it has the highest "
-                        "priority. Set ",
+                        " for a dcode-only key; it has the highest priority. Set ",
                         (self._env_var, TStyle(bold=True)),
                         " to share a key with other provider SDK tools; it is used "
                         "only when no scoped or stored key exists. ",
@@ -1035,7 +1032,7 @@ class AuthPromptScreen(ModalScreen[AuthResult]):
                 (
                     (
                         "Subscription plans (Claude Pro/Max, Claude Code) cannot "
-                        "be used for Anthropic calls in Deep Agents Code. Only a "
+                        "be used for Anthropic calls in dcode. Only a "
                         "standard API key with pay-as-you-go billing works here."
                     ),
                     "italic $text-muted",

--- a/libs/code/deepagents_code/tui/widgets/install_confirm.py
+++ b/libs/code/deepagents_code/tui/widgets/install_confirm.py
@@ -92,7 +92,7 @@ class InstallPackageConfirmScreen(ModalScreen[bool]):
             yield Static(
                 Content.from_markup(
                     "Installing [bold]$name[/bold] runs third-party code in "
-                    "the Deep Agents Code environment.",
+                    "the dcode environment.",
                     name=self._package,
                 ),
                 classes="install-confirm-body",
@@ -203,7 +203,7 @@ class InstallProviderConfirmScreen(ModalScreen[bool]):
         )
         if self._model_spec is not None:
             body = Content.from_markup(
-                "To use [bold]$model[/bold], Deep Agents Code needs to "
+                "To use [bold]$model[/bold], dcode needs to "
                 "install the [bold]$extra[/bold] integration. This will add "
                 "the provider package to your dcode environment.",
                 model=self._model_spec,
@@ -211,7 +211,7 @@ class InstallProviderConfirmScreen(ModalScreen[bool]):
             )
         else:
             body = Content.from_markup(
-                "To add a key for [bold]$provider[/bold], Deep Agents Code "
+                "To add a key for [bold]$provider[/bold], dcode "
                 "needs to install the [bold]$extra[/bold] integration. This "
                 "will add the provider package to your dcode environment.",
                 provider=provider,

--- a/libs/code/deepagents_code/tui/widgets/launch_init.py
+++ b/libs/code/deepagents_code/tui/widgets/launch_init.py
@@ -145,7 +145,7 @@ class LaunchNameScreen(ModalScreen[str | None]):
             Widgets for the modal content.
         """
         with Vertical():
-            yield Static("Welcome to dcode", classes="launch-init-title")
+            yield Static("Welcome to Deep Agents Code", classes="launch-init-title")
             yield Static(
                 Content.assemble("What should Deep Agents call you?"),
                 classes="launch-init-copy",

--- a/libs/code/deepagents_code/tui/widgets/launch_init.py
+++ b/libs/code/deepagents_code/tui/widgets/launch_init.py
@@ -145,7 +145,7 @@ class LaunchNameScreen(ModalScreen[str | None]):
             Widgets for the modal content.
         """
         with Vertical():
-            yield Static("Welcome to Deep Agents Code", classes="launch-init-title")
+            yield Static("Welcome to dcode", classes="launch-init-title")
             yield Static(
                 Content.assemble("What should Deep Agents call you?"),
                 classes="launch-init-copy",

--- a/libs/code/deepagents_code/tui/widgets/update_progress.py
+++ b/libs/code/deepagents_code/tui/widgets/update_progress.py
@@ -146,7 +146,7 @@ class UpdateProgressScreen(ModalScreen[None]):
             Static widgets for status, command, output tail, log path, and help.
         """
         with Vertical():
-            yield Static("Updating Deep Agents Code", classes="up-title")
+            yield Static("Updating dcode", classes="up-title")
             with Horizontal(classes="up-status-row"):
                 self._spinner_widget = Static(
                     self._spinner.current_frame(),
@@ -202,8 +202,7 @@ class UpdateProgressScreen(ModalScreen[None]):
         self._done = True
         self._done_glyph = get_glyphs().checkmark
         self._status = (
-            f"Update complete. Quit and relaunch Deep Agents Code to use "
-            f"v{self._latest}."
+            f"Update complete. Quit and relaunch dcode to use v{self._latest}."
         )
         self._stop_spinner_timer()
         self._refresh_status()

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -2580,7 +2580,7 @@ def editable_package_hint(package: str) -> str:
     """
     return (
         f"Add '{package}' to your editable checkout's environment (the one your "
-        "editable install of Deep Agents Code runs from), then relaunch."
+        "editable install of dcode runs from), then relaunch."
     )
 
 
@@ -2700,21 +2700,21 @@ async def perform_install_package(
     if method == "brew":
         return False, (
             "Homebrew install detected — packages can't be added to a brew "
-            "install. Reinstall Deep Agents Code as a uv-managed tool (see the "
+            "install. Reinstall dcode as a uv-managed tool (see the "
             "installation docs) to enable adding packages."
         )
     if method == "other":
         return False, (
             "Unsupported install method detected — cannot add packages without "
-            "knowing which environment provides `dcode`. Reinstall Deep Agents "
-            "Code as a uv-managed tool (see the installation docs) to enable "
+            "knowing which environment provides `dcode`. Reinstall dcode "
+            "as a uv-managed tool (see the installation docs) to enable "
             "adding packages."
         )
 
     if not shutil.which("uv"):
         return False, (
-            "Package installs require uv, which was not found. Reinstall Deep "
-            "Agents Code following the installation docs so packages can be "
+            "Package installs require uv, which was not found. Reinstall "
+            "dcode following the installation docs so packages can be "
             "added."
         )
 

--- a/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
+++ b/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
@@ -1,4 +1,4 @@
-# dcode
+# Deep Agents Code (dcode)
 
 You are a deep agent, an AI assistant running in an interactive TUI on the user's computer. You help with tasks like coding, debugging, research, analysis, and more.
 

--- a/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
+++ b/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
@@ -1,4 +1,4 @@
-# Deep Agents Code
+# dcode
 
 You are a deep agent, an AI assistant running in an interactive TUI on the user's computer. You help with tasks like coding, debugging, research, analysis, and more.
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_auth_widgets.py
@@ -279,9 +279,7 @@ class TestAuthPromptScreen:
             assert "Sign in to Anthropic" in str(instructions.content)
             assert "create or copy an API key" in str(instructions.content)
             assert "Anthropic key page" in str(instructions.content)
-            assert "Deep Agents Code stores the above key locally" in str(
-                storage_note.content
-            )
+            assert "dcode stores the above key locally" in str(storage_note.content)
             assert "Advanced (F2)" in str(toggle.content)
             assert base_url_label.display is False
             assert "Base URL override" in str(base_url_label.content)
@@ -304,7 +302,7 @@ class TestAuthPromptScreen:
             assert get_glyphs().checkmark in str(title.content)
             assert "Replace key for OpenAI" in str(title.content)
             assert "set from environment variable OPENAI_API_KEY" in str(status.content)
-            assert "use a different key for Deep Agents Code" in str(status.content)
+            assert "use a different key for dcode" in str(status.content)
             content = cast("Content", status.content)
             assert any("$success" in str(span.style) for span in content.spans)
 
@@ -1262,13 +1260,13 @@ api_key_url = "javascript:alert(1)"
             await pilot.pause()
             meta = app.screen.query_one("#auth-prompt-key-meta", Static)
             text = str(meta.content)
-            assert "Deep Agents Code stores" not in text
+            assert "dcode stores" not in text
             assert (
                 "Alternatively, environment variables can be used in place "
                 "of the key stored above." in text
             )
             assert "DEEPAGENTS_CODE_OPENAI_API_KEY" in text
-            assert "Deep Agents Code-only key" in text
+            assert "dcode-only key" in text
             assert "highest priority" in text
             assert "OPENAI_API_KEY" in text
             assert "share a key with other provider SDK tools" in text


### PR DESCRIPTION
Rebrand in-app references from "Deep Agents Code" to `dcode`.

---

Switches the in-app product name in `libs/code` from "Deep Agents Code" to `dcode` so the running app matches the `dcode` CLI/branding. Covers user-visible runtime strings only: Textual TUI widget copy (auth, install-confirm, launch-init, update-progress, agent-selector), CLI/console output in `main.py`, user notices in `app.py`/`config.py`, install/update status messages in `update_check.py`, and the system-prompt title (with its snapshot). Related UI test assertions updated to match.

Intentionally left unchanged (not in-app nomenclature): external contract/metadata identifiers `CODING_AGENT_RUNTIME` and `_OPENROUTER_APP_TITLE` (coding-agent-v1 validator + attribution), docstrings/comments, and markdown docs. Standalone "Deep Agents" (SDK/framework) references were also left as-is since the request targeted "Deep Agents Code".

Made by [Open SWE](https://openswe.vercel.app/agents/60a3d442-7e8d-bd18-4575-a533ca9f9614)