### PR TITLE
chore(code): simplify MCP reconnect prompt copy

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/mcp_reconnect.py
+++ b/libs/code/deepagents_code/tui/widgets/mcp_reconnect.py
@@ -101,7 +101,7 @@ class MCPReconnectPromptScreen(ModalScreen[ReconnectChoice]):
                 markup=False,
             )
             yield Static(
-                "Reconnect to load new tools, or defer with `/mcp reconnect`.",
+                "Reconnect to load new tools.",
                 classes="mcp-reconnect-body",
                 markup=False,
             )


### PR DESCRIPTION
The MCP reconnect overlay body said "Reconnect to load new tools, or defer with `/mcp reconnect`." The defer hint is redundant with the "Esc to defer" help line right below it, so this drops that trailing clause.

Made by [Open SWE](https://openswe.vercel.app/agents/07a6957f-deda-9e24-91c7-522059a7c6b9)