### PR TITLE
chore(code): install script enhancements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This document provides context to understand the Deep Agents Python project and assist with development.
 
+For environment setup, pre-commit installation, and the standard edit-test-lint loop, see [`libs/DEVELOPMENT.md`](libs/DEVELOPMENT.md). The rest of this document covers conventions and architecture reference.
+
 ## Project architecture and context
 
 ### Monorepo structure

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -189,7 +189,6 @@ done
 # create tempfiles append their paths here; cleanup_on_signal removes them all.
 TEMP_FILES=()
 INSTALL_LOCK_KIND=""
-INSTALL_LOCK_FILE=""
 INSTALL_LOCK_DIR=""
 # How old a mkdir-based lock (dead/unknown holder) must be before it's treated
 # as abandoned and reclaimed. 10 min comfortably exceeds a normal install.
@@ -567,30 +566,40 @@ install_lock_is_stale() {
 }
 
 # Serialize concurrent installs (racing `curl | bash` runs corrupting a shared
-# uv tool dir). Prefer flock's kernel advisory lock, which self-releases if the
-# holder dies; otherwise fall back to an atomic mkdir lock dir with a PID +
-# timestamp so a crashed holder's lock can be aged out (see install_lock_is_stale).
-# fd 9 is held open for the flock path and closed by release_install_lock.
+# uv tool dir). Use an atomic mkdir lock dir with a PID + timestamp so a crashed
+# holder's lock can be aged out (see install_lock_is_stale). Avoid shell
+# redirection to a lock file here: when the installer runs as root and HOME is
+# user-writable, opening ~/.deepagents/install.lock would follow a symlink before
+# any post-open validation can run.
 acquire_install_lock() {
   local lock_root="$HOME/.deepagents"
   mkdir -p "$lock_root"
   fix_owner "$lock_root"
 
-  INSTALL_LOCK_FILE="$lock_root/install.lock"
   INSTALL_LOCK_DIR="$lock_root/install.lock.d"
-
-  if command -v flock >/dev/null 2>&1; then
-    exec 9>"$INSTALL_LOCK_FILE"
-    fix_owner "$INSTALL_LOCK_FILE"
-    flock 9
-    INSTALL_LOCK_KIND="flock"
-    return 0
-  fi
 
   while ! mkdir "$INSTALL_LOCK_DIR" 2>/dev/null; do
     if install_lock_is_stale; then
       log_warn "Removing stale installer lock at $INSTALL_LOCK_DIR"
-      rm -rf "$INSTALL_LOCK_DIR"
+      # Reclaim without clobbering a lock another installer may acquire
+      # concurrently: rename the stale directory to a private per-PID name and
+      # delete that, so our `rm` never targets the canonical path a fresh owner
+      # would occupy. The rename is atomic on POSIX filesystems. (It narrows,
+      # but cannot fully close, the check->reclaim race: a fresh owner that wins
+      # mkdir before our rename can still be moved aside — acceptable for a
+      # 10-minute-stale fallback lock.)
+      local _stale_reclaim="${INSTALL_LOCK_DIR}.reclaim.$$"
+      if mv "$INSTALL_LOCK_DIR" "$_stale_reclaim" 2>/dev/null; then
+        rm -rf "$_stale_reclaim" 2>/dev/null || true
+      elif install_lock_is_stale && ! rm -rf "$INSTALL_LOCK_DIR" 2>/dev/null; then
+        # The stale lock can be neither renamed nor removed (typically it is
+        # owned by another user). Fail loudly rather than spin: `continue` skips
+        # the `sleep` below, so silently swallowing this error would busy-loop
+        # and spam the warning above forever.
+        log_error "Cannot reclaim stale installer lock at $INSTALL_LOCK_DIR."
+        log_error "Remove it manually or rerun as its owner, then retry."
+        exit 1
+      fi
       continue
     fi
     sleep 1
@@ -606,9 +615,6 @@ release_install_lock() {
   case "${INSTALL_LOCK_KIND:-}" in
     mkdir)
       rm -rf "$INSTALL_LOCK_DIR" 2>/dev/null || true
-      ;;
-    flock)
-      exec 9>&- 2>/dev/null || true
       ;;
   esac
   INSTALL_LOCK_KIND=""

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -3,9 +3,11 @@
 #
 # Usage:
 #   curl -LsSf https://langch.in/dcode | bash
+#   curl -LsSf https://langch.in/dcode | bash -s -- VERSION
 #
 # Install an exact pre-release version:
 #   curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_VERSION="0.1.0rc1" bash
+#   curl -LsSf https://langch.in/dcode | bash -s -- 0.1.0rc1
 #
 # Override uv's pre-release strategy when resolving the latest version:
 #   curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_PRERELEASE="allow" bash
@@ -96,10 +98,14 @@ Install deepagents-code.
 Usage:
   curl -LsSf https://langch.in/dcode | bash
   curl -LsSf https://langch.in/dcode | bash -s -- [options]
+  curl -LsSf https://langch.in/dcode | bash -s -- VERSION
 
 Options:
   --help, -h        Show this help message and exit
   --version, -v     Print installer version and exit
+
+Target:
+  VERSION           Install an exact version, e.g. 0.1.0rc1
 
 Environment variables:
   DEEPAGENTS_CODE_EXTRAS — comma-separated pip extras, e.g. "ollama",
@@ -137,6 +143,7 @@ For full documentation: https://docs.langchain.com/deepagents-code
 HELP
 }
 
+POSITIONAL_TARGET=""
 for _arg in "$@"; do
   case "$_arg" in
     --help|-h)
@@ -147,13 +154,33 @@ for _arg in "$@"; do
       printf '%s\n' "$INSTALLER_VERSION"
       exit 0
       ;;
-    *)
-      # Reject unknown flags instead of silently ignoring them, so a typo
-      # (e.g. --verison) surfaces as an error rather than a silent full install.
+    -*)
+      # Reject unknown flags (single- or double-dash) instead of silently
+      # ignoring them, so a typo (e.g. --verison, -V) surfaces as an error
+      # rather than a silent full install. Matching every dash-led token here
+      # also keeps such typos out of the positional-target arm below, where a
+      # leading dash would otherwise be reported as an "invalid version".
       # log_* helpers aren't defined yet at this point, so write plainly.
       printf 'Unrecognized argument: %s\n' "$_arg" >&2
       printf 'Run with --help to see available options.\n' >&2
       exit 2
+      ;;
+    *)
+      if [ -n "$POSITIONAL_TARGET" ]; then
+        printf 'Only one target is allowed. Got both %s and %s.\n' "$POSITIONAL_TARGET" "$_arg" >&2
+        printf 'Run with --help to see available options.\n' >&2
+        exit 2
+      fi
+      # Same validation (and rationale) as the DEEPAGENTS_CODE_VERSION check
+      # further down: require a leading alphanumeric and a class free of shell
+      # metacharacters, so the value is a version, not a smuggled option, and is
+      # safe to interpolate into the single argv token passed to uv.
+      if [[ ! "$_arg" =~ ^[A-Za-z0-9][A-Za-z0-9_.!+-]*$ ]]; then
+        printf 'Invalid version target: %s\n' "$_arg" >&2
+        printf 'Use an exact version like 0.1.0rc1.\n' >&2
+        exit 2
+      fi
+      POSITIONAL_TARGET="$_arg"
       ;;
   esac
 done
@@ -161,6 +188,12 @@ done
 # Registry of temp files to clean up on exit or interrupt. Functions that
 # create tempfiles append their paths here; cleanup_on_signal removes them all.
 TEMP_FILES=()
+INSTALL_LOCK_KIND=""
+INSTALL_LOCK_FILE=""
+INSTALL_LOCK_DIR=""
+# How old a mkdir-based lock (dead/unknown holder) must be before it's treated
+# as abandoned and reclaimed. 10 min comfortably exceeds a normal install.
+INSTALL_LOCK_STALE_AFTER_SECS=600
 register_temp() {
   TEMP_FILES+=("$1")
 }
@@ -194,6 +227,32 @@ log_success() { printf "${GREEN}✔${NC} %s\n" "$*"; }
 log_warn()    { printf "${YELLOW}⚠${NC} %s\n" "$*" >&2; }
 log_error()   { printf "${RED}✖${NC} %s\n" "$*" >&2; }
 
+is_linux_os() {
+  [ "${OS:-}" = "linux" ] || [ "$(uname -s 2>/dev/null)" = "Linux" ]
+}
+
+restore_terminal_after_signal() {
+  local exit_code="$1"
+  if [ "$exit_code" -ge 128 ] && [ -t 0 ]; then
+    stty sane 2>/dev/null || true
+  fi
+}
+
+log_signal_failure_hint() {
+  local exit_code="$1"
+  if [ "${SIGNAL_FAILURE_HINT_SHOWN:-false}" = true ]; then
+    return 0
+  fi
+  if [ "$exit_code" -eq 137 ] && is_linux_os; then
+    log_error "Installation was killed before it could finish (exit code 137). This usually means the system ran out of memory."
+    log_error "Free up memory or use a machine with more memory, then run this installer again."
+    SIGNAL_FAILURE_HINT_SHOWN=true
+  elif [ "$exit_code" -ge 128 ]; then
+    log_error "Installation was killed before it could finish (exit code ${exit_code})."
+    SIGNAL_FAILURE_HINT_SHOWN=true
+  fi
+}
+
 # ---------------------------------------------------------------------------
 # Exit / interrupt traps — ensures the user always sees an actionable message
 # on failure and temp files are cleaned up on Ctrl-C / SIGTERM.
@@ -201,8 +260,13 @@ log_error()   { printf "${RED}✖${NC} %s\n" "$*" >&2; }
 cleanup_on_signal() {
   local exit_code=$?
   cleanup_temp_files
+  if declare -F release_install_lock >/dev/null 2>&1; then
+    release_install_lock
+  fi
   if [ $exit_code -ne 0 ]; then
+    restore_terminal_after_signal "$exit_code"
     echo "" >&2
+    log_signal_failure_hint "$exit_code"
     log_error "Installation failed (exit code ${exit_code}). See errors above."
     log_error "For help, visit: https://docs.langchain.com/deepagents-code"
   fi
@@ -215,9 +279,15 @@ cleanup_on_interrupt() {
   # after the friendly interrupt notice below. Temp files are still cleaned up
   # explicitly here, so nothing leaks despite the disarm.
   trap - EXIT
+  if [ -t 0 ]; then
+    stty sane 2>/dev/null || true
+  fi
   echo "" >&2
   log_warn "Installation interrupted."
   cleanup_temp_files
+  if declare -F release_install_lock >/dev/null 2>&1; then
+    release_install_lock
+  fi
   exit 1
 }
 trap cleanup_on_interrupt INT TERM
@@ -450,12 +520,114 @@ copy_install_log() {
   ln "$uv_stderr" "$INSTALL_LOG" 2>/dev/null
 }
 
+# Epoch mtime of the lock directory, used as a fallback reference time when the
+# started_at metadata is missing. Portable across BSD (macOS) and GNU stat.
+lock_dir_mtime() {
+  stat -f %m "$INSTALL_LOCK_DIR" 2>/dev/null \
+    || stat -c %Y "$INSTALL_LOCK_DIR" 2>/dev/null \
+    || printf '0'
+}
+
+# Decide whether an existing mkdir-based lock may be reclaimed. Only ever called
+# in the mkdir fallback path (kernel advisory locks self-release on holder death,
+# so they need no staleness heuristic).
+install_lock_is_stale() {
+  [ -d "$INSTALL_LOCK_DIR" ] || return 1
+
+  local pid started_at now
+  pid="$(cat "$INSTALL_LOCK_DIR/pid" 2>/dev/null || true)"
+  started_at="$(cat "$INSTALL_LOCK_DIR/started_at" 2>/dev/null || true)"
+  now="$(date +%s 2>/dev/null || printf '0')"
+
+  # A live owner is authoritative: never reclaim a lock whose PID is running.
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    return 1
+  fi
+
+  # When started_at is missing or not yet written, fall back to the lock dir's
+  # mtime. This covers the window between `mkdir` winning and the metadata being
+  # written by the new owner: treating that window as "stale" would let a racing
+  # installer delete a lock that was just acquired, so age it out via mtime
+  # instead of reclaiming it on sight.
+  case "$started_at" in
+    ''|*[!0-9]*) started_at="$(lock_dir_mtime)" ;;
+  esac
+  case "$started_at" in
+    ''|*[!0-9]*) started_at=0 ;;
+  esac
+
+  # Without a usable reference or current time we cannot prove the lock is old.
+  # Be conservative and keep waiting rather than risk deleting a live lock; a
+  # working host always has these, so this only guards pathological environments.
+  if [ "$started_at" -eq 0 ] || [ "$now" -eq 0 ]; then
+    return 1
+  fi
+
+  [ $((now - started_at)) -ge "$INSTALL_LOCK_STALE_AFTER_SECS" ]
+}
+
+# Serialize concurrent installs (racing `curl | bash` runs corrupting a shared
+# uv tool dir). Prefer flock's kernel advisory lock, which self-releases if the
+# holder dies; otherwise fall back to an atomic mkdir lock dir with a PID +
+# timestamp so a crashed holder's lock can be aged out (see install_lock_is_stale).
+# fd 9 is held open for the flock path and closed by release_install_lock.
+acquire_install_lock() {
+  local lock_root="$HOME/.deepagents"
+  mkdir -p "$lock_root"
+  fix_owner "$lock_root"
+
+  INSTALL_LOCK_FILE="$lock_root/install.lock"
+  INSTALL_LOCK_DIR="$lock_root/install.lock.d"
+
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>"$INSTALL_LOCK_FILE"
+    fix_owner "$INSTALL_LOCK_FILE"
+    flock 9
+    INSTALL_LOCK_KIND="flock"
+    return 0
+  fi
+
+  while ! mkdir "$INSTALL_LOCK_DIR" 2>/dev/null; do
+    if install_lock_is_stale; then
+      log_warn "Removing stale installer lock at $INSTALL_LOCK_DIR"
+      rm -rf "$INSTALL_LOCK_DIR"
+      continue
+    fi
+    sleep 1
+  done
+
+  printf '%s\n' "$$" >"$INSTALL_LOCK_DIR/pid"
+  date +%s >"$INSTALL_LOCK_DIR/started_at" 2>/dev/null || true
+  fix_owner "$INSTALL_LOCK_DIR"
+  INSTALL_LOCK_KIND="mkdir"
+}
+
+release_install_lock() {
+  case "${INSTALL_LOCK_KIND:-}" in
+    mkdir)
+      rm -rf "$INSTALL_LOCK_DIR" 2>/dev/null || true
+      ;;
+    flock)
+      exec 9>&- 2>/dev/null || true
+      ;;
+  esac
+  INSTALL_LOCK_KIND=""
+}
+
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
 EXTRAS="${DEEPAGENTS_CODE_EXTRAS:-}"
 VERSION="${DEEPAGENTS_CODE_VERSION:-}"
 PRERELEASE_REQUESTED="${DEEPAGENTS_CODE_PRERELEASE:-}"
+if [ -n "$POSITIONAL_TARGET" ]; then
+  if [ -n "$VERSION" ]; then
+    log_error "Do not combine a positional version with DEEPAGENTS_CODE_VERSION."
+    log_error "Use either the version argument, or the environment variable — not both."
+    exit 1
+  fi
+  VERSION="$POSITIONAL_TARGET"
+fi
 PRERELEASE="${PRERELEASE_REQUESTED:-allow}"
 PYTHON_REQUESTED=false
 if [[ -n "${DEEPAGENTS_CODE_PYTHON:-}" ]]; then
@@ -464,7 +636,11 @@ fi
 PYTHON_VERSION="${DEEPAGENTS_CODE_PYTHON:-3.13}"
 SKIP_OPTIONAL="${DEEPAGENTS_CODE_SKIP_OPTIONAL:-0}"
 VERBOSE="${DEEPAGENTS_CODE_VERBOSE:-0}"
-ASSUME_YES="${DEEPAGENTS_CODE_YES:-0}"
+ASSUME_YES="$(printf '%s' "${DEEPAGENTS_CODE_YES:-0}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+case "$ASSUME_YES" in
+  1|true|yes) ASSUME_YES="1" ;;
+  *)          ASSUME_YES="0" ;;
+esac
 # How ripgrep gets provisioned: "managed" (default) eagerly fetches the
 # pinned, SHA-256-verified binary into ~/.deepagents/bin via `dcode tools
 # install`; "system" keeps the interactive package-manager path below. Any
@@ -615,11 +791,17 @@ install_uv() {
   if [ "$uv_install_rc" -ne 0 ]; then
     # Surface the downloader's own error (captured above) before the generic
     # line, so the user sees the real cause and the downloader's exit code.
+    if declare -F restore_terminal_after_signal >/dev/null 2>&1; then
+      restore_terminal_after_signal "$uv_install_rc"
+    fi
     cat "$uv_install_out" >&2
     rm -f "$uv_install_out" "$uv_script"
+    if declare -F log_signal_failure_hint >/dev/null 2>&1; then
+      log_signal_failure_hint "$uv_install_rc"
+    fi
     log_error "Failed to download uv installer (exit ${uv_install_rc}) from https://astral.sh/uv/install.sh"
     log_error "  Try again, or install uv manually: https://docs.astral.sh/uv/getting-started/installation/"
-    exit 1
+    exit "$uv_install_rc"
   fi
 
   # Verify the downloaded script starts with a shell shebang before executing
@@ -642,8 +824,14 @@ install_uv() {
   fi
   rm -f "$uv_install_out" "$uv_script"
   if [ "$uv_install_rc" -ne 0 ]; then
+    if declare -F restore_terminal_after_signal >/dev/null 2>&1; then
+      restore_terminal_after_signal "$uv_install_rc"
+    fi
+    if declare -F log_signal_failure_hint >/dev/null 2>&1; then
+      log_signal_failure_hint "$uv_install_rc"
+    fi
     log_error "uv installation failed. See errors above."
-    exit 1
+    exit "$uv_install_rc"
   fi
 }
 
@@ -689,6 +877,7 @@ if ! resolve_uv_bin; then
     log_error "UV_BIN is set but does not point to an executable uv: ${UV_BIN}"
     exit 1
   fi
+  acquire_install_lock
   log_info "uv not found — installing..."
   install_uv
   fix_owner "${HOME}/.local/bin"  # root installs: restore user ownership
@@ -869,6 +1058,9 @@ if [ -n "$cache_root" ]; then
     fi
   fi
 fi
+if [ -z "$INSTALL_LOCK_KIND" ]; then
+  acquire_install_lock
+fi
 if [[ -z "$VERSION" ]]; then
   "$UV_BIN" tool install -U --python "$PYTHON_VERSION" \
     --prerelease "$PRERELEASE" "$PACKAGE" 2>"$uv_stderr" || uv_rc=$?
@@ -959,6 +1151,8 @@ if [ -n "$INSTALL_LOG" ]; then
 fi
 rm -f "$uv_stderr"
 if [ "$uv_rc" -ne 0 ]; then
+  restore_terminal_after_signal "$uv_rc"
+  log_signal_failure_hint "$uv_rc"
   log_error "Failed to install ${PACKAGE}. See errors above."
   # The log captured uv's full stderr (copied just above, before this exit), so
   # point the user at it — non-verbose mode trims uv's lines from the terminal
@@ -967,7 +1161,7 @@ if [ "$uv_rc" -ne 0 ]; then
     log_error "Full install log: ${INSTALL_LOG_DISPLAY}"
   fi
   log_error "Common fixes: check your network, try a different Python version (DEEPAGENTS_CODE_PYTHON=3.12), or install manually."
-  exit 1
+  exit "$uv_rc"
 fi
 fix_owner "${HOME}/.local/bin" "${HOME}/.local/share/uv"  # uv binaries + tool data
 if [ "$OS" = "macos" ] && [ -d "${HOME}/Library/Caches/uv" ]; then
@@ -1094,6 +1288,74 @@ local_bin_in_profile() {
     || grep -v '^[[:space:]]*#' "$profile" 2>/dev/null | grep -qE 'fish_add_path.*\.local/bin'
 }
 
+managed_path_block_present() {
+  local profile="$1"
+  [ -f "$profile" ] || return 1
+  grep -F '# >>> deepagents-code installer >>>' "$profile" >/dev/null 2>&1
+}
+
+managed_path_block_has_line() {
+  local profile="$1" path_export="$2"
+  [ -f "$profile" ] || return 1
+  grep -F "$path_export" "$profile" >/dev/null 2>&1
+}
+
+append_managed_path_block() {
+  local profile="$1" path_export="$2"
+  {
+    echo ""
+    echo "# >>> deepagents-code installer >>>"
+    echo "$path_export"
+    echo "# <<< deepagents-code installer <<<"
+  } >>"$profile"
+}
+
+rewrite_managed_path_block() {
+  local profile="$1" path_export="$2" tmp_profile mode
+  tmp_profile=$(mktemp "$(dirname "$profile")/.deepagents-code-profile.XXXXXX") || return 1
+  register_temp "$tmp_profile"
+
+  awk -v begin="# >>> deepagents-code installer >>>" \
+    -v end="# <<< deepagents-code installer <<<" \
+    -v line="$path_export" '
+    BEGIN { in_block = 0; replaced = 0 }
+    $0 == begin {
+      # Emit the replacement only for the first marker: any accidental
+      # duplicate managed blocks are collapsed into this single one.
+      if (!replaced) {
+        print begin
+        print line
+        print end
+        replaced = 1
+      }
+      in_block = 1
+      next
+    }
+    in_block {
+      if ($0 == end) {
+        in_block = 0
+      }
+      next
+    }
+    { print }
+    END {
+      # A begin marker with no matching end marker means the block is malformed.
+      # Fail so the caller keeps the original profile (the mv below is skipped)
+      # rather than writing back a truncated file.
+      if (in_block != 0) {
+        exit 1
+      }
+    }
+  ' "$profile" >"$tmp_profile" || return 1
+  # mktemp created tmp_profile as 0600; carry over the profile's real perms so
+  # an in-place rewrite doesn't silently tighten (e.g.) a 0644 ~/.zshrc.
+  mode=$(stat -f '%OLp' "$profile" 2>/dev/null || stat -c '%a' "$profile" 2>/dev/null || true)
+  if [ -n "$mode" ]; then
+    chmod "$mode" "$tmp_profile" 2>/dev/null || true
+  fi
+  mv "$tmp_profile" "$profile"
+}
+
 # Ensure dcode is on PATH for new shell sessions. Creates symlinks and/or
 # modifies the shell profile as needed. Only acts when the binary verified
 # but isn't already on the user's original PATH.
@@ -1146,19 +1408,35 @@ ensure_path_setup() {
     return 1
   fi
 
+  # Collapse $HOME prefix to ~ for a tidier display path.
+  local tilde_profile="${SHELL_PROFILE/#$HOME/\~}"
+
+  if managed_path_block_present "$SHELL_PROFILE"; then
+    if managed_path_block_has_line "$SHELL_PROFILE" "$PATH_EXPORT"; then
+      if [ "$VERBOSE" = "1" ]; then
+        log_info "deepagents-code PATH block already configured in ${tilde_profile}."
+      fi
+      return 2
+    fi
+    if rewrite_managed_path_block "$SHELL_PROFILE" "$PATH_EXPORT"; then
+      fix_owner "$SHELL_PROFILE"
+      log_success "Updated deepagents-code PATH block in ${tilde_profile}."
+      return 2
+    fi
+    log_warn "Could not update deepagents-code PATH block in ${tilde_profile}."
+    return 1
+  fi
+
   # Already in profile? No changes needed, but the current shell may still
   # lack ~/.local/bin on PATH (stale shell). Return 2 so the caller can emit
   # a reload/source hint instead of silently returning success.
   if local_bin_in_profile "$SHELL_PROFILE"; then
     if [ "$VERBOSE" = "1" ]; then
       # shellcheck disable=SC2088  # display string, literal ~/ is intended for readability
-      log_info "~/.local/bin already in ${SHELL_PROFILE}."
+      log_info "~/.local/bin already in ${tilde_profile}."
     fi
     return 2
   fi
-
-  # Collapse $HOME prefix to ~ for a tidier display path.
-  local tilde_profile="${SHELL_PROFILE/#$HOME/\~}"
 
   # Prompt interactively, or auto-add when non-interactive.
   local should_add=true
@@ -1177,11 +1455,7 @@ ensure_path_setup() {
         return 1
       }
     fi
-    {
-      echo ""
-      echo "# Added by deepagents-code installer"
-      echo "$PATH_EXPORT"
-    } >> "$SHELL_PROFILE"
+    append_managed_path_block "$SHELL_PROFILE" "$PATH_EXPORT"
     fix_owner "$SHELL_PROFILE"
     log_success "Added ~/.local/bin to PATH in ${tilde_profile}."
   else
@@ -1189,6 +1463,43 @@ ensure_path_setup() {
     log_info "  To use ${binary_name}, add to PATH:  ${PATH_EXPORT}"
   fi
 }
+
+classify_shadowing_command() {
+  local path="$1"
+  case "$path" in
+    /opt/homebrew/*|/usr/local/*)
+      if [ "$OS" = "macos" ]; then
+        printf 'Homebrew-managed'
+        return 0
+      fi
+      ;;
+    *pipx*)
+      printf 'pipx-managed'
+      return 0
+      ;;
+    */.local/bin/*)
+      printf 'user-local'
+      return 0
+      ;;
+  esac
+  printf 'existing'
+}
+
+detect_shadowing_install() {
+  local candidate expected original manager
+  for candidate in dcode deepagents-code; do
+    expected="${HOME}/.local/bin/${candidate}"
+    [ -x "$expected" ] || continue
+    original=$(PATH="$ORIGINAL_PATH" command -v "$candidate" 2>/dev/null || true)
+    [ -n "$original" ] || continue
+    [ "$original" = "$expected" ] && continue
+    manager=$(classify_shadowing_command "$original")
+    log_warn "Detected ${manager} ${candidate} at ${original}."
+    log_warn "PATH order may run that binary instead of the uv tool at ${expected}."
+    log_warn "Restart your shell after this installer updates PATH, or remove the older install."
+  done
+}
+
 DCODE_BIN=""
 DCODE_NAME=""
 # Tracks whether the binary would have resolved via the user's original PATH,
@@ -1198,19 +1509,27 @@ DCODE_NAME=""
 # restarted or the env file is sourced.
 DCODE_ON_PATH=false
 for candidate in dcode deepagents-code; do
-  if resolved=$(command -v "$candidate" 2>/dev/null) && [ -n "$resolved" ]; then
-    DCODE_BIN="$resolved"
+  if [ -x "${HOME}/.local/bin/${candidate}" ]; then
+    DCODE_BIN="${HOME}/.local/bin/${candidate}"
     DCODE_NAME="$candidate"
-    if PATH="$ORIGINAL_PATH" command -v "$candidate" >/dev/null 2>&1; then
+    if [ "$(PATH="$ORIGINAL_PATH" command -v "$candidate" 2>/dev/null || true)" = "$DCODE_BIN" ]; then
       DCODE_ON_PATH=true
     fi
     break
-  elif [ -x "${HOME}/.local/bin/${candidate}" ]; then
-    DCODE_BIN="${HOME}/.local/bin/${candidate}"
-    DCODE_NAME="$candidate"
-    break
   fi
 done
+if [ -z "$DCODE_BIN" ]; then
+  for candidate in dcode deepagents-code; do
+    if resolved=$(command -v "$candidate" 2>/dev/null) && [ -n "$resolved" ]; then
+      DCODE_BIN="$resolved"
+      DCODE_NAME="$candidate"
+      if [ "$(PATH="$ORIGINAL_PATH" command -v "$candidate" 2>/dev/null || true)" = "$DCODE_BIN" ]; then
+        DCODE_ON_PATH=true
+      fi
+      break
+    fi
+  done
+fi
 
 # Collapse $HOME prefix to ~ for a tidier display path. Used in user-facing
 # log lines only; DCODE_BIN keeps the absolute path for any exec needs.
@@ -1220,6 +1539,8 @@ if [ -n "$DCODE_BIN" ] && [ -n "${HOME:-}" ]; then
     "$HOME"/*) DCODE_BIN_DISPLAY="~${DCODE_BIN#"$HOME"}" ;;
   esac
 fi
+
+detect_shadowing_install
 
 NEW_VERSION=""
 VERIFY_OK=false

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -190,6 +190,10 @@ done
 TEMP_FILES=()
 INSTALL_LOCK_KIND=""
 INSTALL_LOCK_DIR=""
+INSTALL_LOCK_TOKEN=""
+INSTALL_LOCK_STALE_ID=""
+INSTALL_LOCK_RECLAIM_DIR=""
+INSTALL_LOCK_RECLAIM_TOKEN=""
 # How old a mkdir-based lock (dead/unknown holder) must be before it's treated
 # as abandoned and reclaimed. 10 min comfortably exceeds a normal install.
 INSTALL_LOCK_STALE_AFTER_SECS=600
@@ -522,15 +526,48 @@ copy_install_log() {
 # Epoch mtime of the lock directory, used as a fallback reference time when the
 # started_at metadata is missing. Portable across BSD (macOS) and GNU stat.
 lock_dir_mtime() {
-  stat -f %m "$INSTALL_LOCK_DIR" 2>/dev/null \
-    || stat -c %Y "$INSTALL_LOCK_DIR" 2>/dev/null \
-    || printf '0'
+  local dir="${1:-$INSTALL_LOCK_DIR}"
+  local mtime
+  mtime="$(stat -f %m "$dir" 2>/dev/null || true)"
+  case "$mtime" in
+    ''|*[!0-9]*) ;;
+    *) printf '%s' "$mtime"; return 0 ;;
+  esac
+
+  mtime="$(stat -c %Y "$dir" 2>/dev/null || true)"
+  case "$mtime" in
+    ''|*[!0-9]*) printf '0' ;;
+    *) printf '%s' "$mtime" ;;
+  esac
+}
+
+# A fingerprint of the lock instance currently at the canonical path, used to
+# detect whether it is still the same lock a prior check inspected (see the
+# reclaim path in acquire_install_lock). Prints four newline-separated fields —
+# token, pid, started_at, dir mtime — compared only by string equality, so the
+# field set and order are load-bearing. Returns 1 (empty output) when the lock
+# dir is gone; an unreadable field reads as empty, i.e. is treated as absent.
+install_lock_identity() {
+  [ -d "$INSTALL_LOCK_DIR" ] || return 1
+
+  local token pid started_at mtime
+  token="$(cat "$INSTALL_LOCK_DIR/token" 2>/dev/null || true)"
+  pid="$(cat "$INSTALL_LOCK_DIR/pid" 2>/dev/null || true)"
+  started_at="$(cat "$INSTALL_LOCK_DIR/started_at" 2>/dev/null || true)"
+  mtime="$(lock_dir_mtime)"
+  printf '%s\n%s\n%s\n%s' "$token" "$pid" "$started_at" "$mtime"
 }
 
 # Decide whether an existing mkdir-based lock may be reclaimed. Only ever called
 # in the mkdir fallback path (kernel advisory locks self-release on holder death,
-# so they need no staleness heuristic).
+# so they need no staleness heuristic). On a "stale" result, also sets the global
+# INSTALL_LOCK_STALE_ID to the lock's identity fingerprint (consumed by the
+# reclaim path in acquire_install_lock); clears it otherwise. Must be called in a
+# condition context (`if install_lock_is_stale`) so `set -e` is suppressed for
+# its body: the bare `[ -n ... ]` test near the end returns non-zero on the
+# not-stale branch and would otherwise abort the script.
 install_lock_is_stale() {
+  INSTALL_LOCK_STALE_ID=""
   [ -d "$INSTALL_LOCK_DIR" ] || return 1
 
   local pid started_at now
@@ -562,7 +599,88 @@ install_lock_is_stale() {
     return 1
   fi
 
+  if [ $((now - started_at)) -ge "$INSTALL_LOCK_STALE_AFTER_SECS" ]; then
+    # Capture the identity for the reclaim guard. If the lock dir vanished
+    # between the age check and here, the fingerprint is empty; the bare test
+    # then returns non-zero, so `return` reports "not stale" (see header note on
+    # why this is safe under `set -e`).
+    INSTALL_LOCK_STALE_ID="$(install_lock_identity 2>/dev/null || true)"
+    [ -n "$INSTALL_LOCK_STALE_ID" ]
+    return
+  fi
+  return 1
+}
+
+install_lock_reclaim_guard_is_stale() {
+  local started_at
+  local now
+
+  started_at="$(cat "$INSTALL_LOCK_RECLAIM_DIR/started_at" 2>/dev/null || true)"
+  now="$(date +%s 2>/dev/null || printf '0')"
+
+  case "$started_at" in
+    ''|*[!0-9]*) started_at="$(lock_dir_mtime "$INSTALL_LOCK_RECLAIM_DIR")" ;;
+  esac
+  case "$started_at" in
+    ''|*[!0-9]*) started_at=0 ;;
+  esac
+
+  if [ "$started_at" -eq 0 ] || [ "$now" -eq 0 ]; then
+    return 1
+  fi
+
   [ $((now - started_at)) -ge "$INSTALL_LOCK_STALE_AFTER_SECS" ]
+}
+
+wait_for_install_lock_reclaim_guard() {
+  if [ ! -d "$INSTALL_LOCK_RECLAIM_DIR" ]; then
+    return 0
+  fi
+
+  if install_lock_reclaim_guard_is_stale; then
+    log_error "Installer lock reclaim is stuck at $INSTALL_LOCK_RECLAIM_DIR."
+    log_error "Remove it manually, then retry."
+    exit 1
+  fi
+
+  sleep 1
+  return 1
+}
+
+acquire_install_lock_reclaim_guard() {
+  local token
+
+  token="$$:$(date +%s 2>/dev/null || printf '0'):${RANDOM:-0}"
+  if ! mkdir "$INSTALL_LOCK_RECLAIM_DIR" 2>/dev/null; then
+    if [ -d "$INSTALL_LOCK_RECLAIM_DIR" ]; then
+      return 1
+    fi
+    log_error "Cannot reclaim stale installer lock at $INSTALL_LOCK_DIR."
+    log_error "Cannot create reclaim guard at $INSTALL_LOCK_RECLAIM_DIR."
+    exit 1
+  fi
+
+  if ! printf '%s\n' "$token" >"$INSTALL_LOCK_RECLAIM_DIR/token" 2>/dev/null; then
+    rm -rf "$INSTALL_LOCK_RECLAIM_DIR" 2>/dev/null || true
+    log_error "Cannot reclaim stale installer lock at $INSTALL_LOCK_DIR."
+    log_error "Cannot write reclaim guard metadata at $INSTALL_LOCK_RECLAIM_DIR."
+    exit 1
+  fi
+
+  INSTALL_LOCK_RECLAIM_TOKEN="$token"
+  printf '%s\n' "$$" >"$INSTALL_LOCK_RECLAIM_DIR/pid" 2>/dev/null || true
+  date +%s >"$INSTALL_LOCK_RECLAIM_DIR/started_at" 2>/dev/null || true
+  return 0
+}
+
+release_install_lock_reclaim_guard() {
+  # Token-guarded like release_install_lock: only drop the guard if it is still
+  # ours (see that function for why an unreadable token errs toward keeping it).
+  if [ -n "${INSTALL_LOCK_RECLAIM_TOKEN:-}" ] && \
+    [ "$(cat "$INSTALL_LOCK_RECLAIM_DIR/token" 2>/dev/null || true)" = "$INSTALL_LOCK_RECLAIM_TOKEN" ]; then
+    rm -rf "$INSTALL_LOCK_RECLAIM_DIR" 2>/dev/null || true
+  fi
+  INSTALL_LOCK_RECLAIM_TOKEN=""
 }
 
 # Serialize concurrent installs (racing `curl | bash` runs corrupting a shared
@@ -577,21 +695,41 @@ acquire_install_lock() {
   fix_owner "$lock_root"
 
   INSTALL_LOCK_DIR="$lock_root/install.lock.d"
+  INSTALL_LOCK_RECLAIM_DIR="$lock_root/install.lock.reclaim.d"
 
-  while ! mkdir "$INSTALL_LOCK_DIR" 2>/dev/null; do
+  while true; do
+    wait_for_install_lock_reclaim_guard || continue
+
+    if mkdir "$INSTALL_LOCK_DIR" 2>/dev/null; then
+      break
+    fi
+
     if install_lock_is_stale; then
+      local _stale_id="${INSTALL_LOCK_STALE_ID:-}"
+      if [ -z "$_stale_id" ] || ! acquire_install_lock_reclaim_guard; then
+        continue
+      fi
+      if [ "$(install_lock_identity 2>/dev/null || true)" != "$_stale_id" ]; then
+        release_install_lock_reclaim_guard
+        continue
+      fi
+
       log_warn "Removing stale installer lock at $INSTALL_LOCK_DIR"
-      # Reclaim without clobbering a lock another installer may acquire
-      # concurrently: rename the stale directory to a private per-PID name and
-      # delete that, so our `rm` never targets the canonical path a fresh owner
-      # would occupy. The rename is atomic on POSIX filesystems. (It narrows,
-      # but cannot fully close, the check->reclaim race: a fresh owner that wins
-      # mkdir before our rename can still be moved aside — acceptable for a
-      # 10-minute-stale fallback lock.)
+      # Only reclaim the exact lock instance that was inspected as stale, so this
+      # rename can never move a fresh owner's lock aside. Two mechanisms cover
+      # the window: the identity re-check above rejects a lock that was already
+      # replaced before we took the reclaim guard, and the guard then blocks
+      # peers (via wait_for_install_lock_reclaim_guard) from creating a fresh
+      # lock at the canonical path until this rename completes.
       local _stale_reclaim="${INSTALL_LOCK_DIR}.reclaim.$$"
       if mv "$INSTALL_LOCK_DIR" "$_stale_reclaim" 2>/dev/null; then
         rm -rf "$_stale_reclaim" 2>/dev/null || true
-      elif install_lock_is_stale && ! rm -rf "$INSTALL_LOCK_DIR" 2>/dev/null; then
+        release_install_lock_reclaim_guard
+      elif [ "$(install_lock_identity 2>/dev/null || true)" != "$_stale_id" ]; then
+        release_install_lock_reclaim_guard
+        continue
+      else
+        release_install_lock_reclaim_guard
         # The stale lock can be neither renamed nor removed (typically it is
         # owned by another user). Fail loudly rather than spin: `continue` skips
         # the `sleep` below, so silently swallowing this error would busy-loop
@@ -605,6 +743,12 @@ acquire_install_lock() {
     sleep 1
   done
 
+  INSTALL_LOCK_TOKEN="$$:$(date +%s 2>/dev/null || printf '0'):${RANDOM:-0}"
+  if ! printf '%s\n' "$INSTALL_LOCK_TOKEN" >"$INSTALL_LOCK_DIR/token" 2>/dev/null; then
+    rm -rf "$INSTALL_LOCK_DIR" 2>/dev/null || true
+    log_error "Cannot write installer lock metadata at $INSTALL_LOCK_DIR."
+    exit 1
+  fi
   printf '%s\n' "$$" >"$INSTALL_LOCK_DIR/pid"
   date +%s >"$INSTALL_LOCK_DIR/started_at" 2>/dev/null || true
   fix_owner "$INSTALL_LOCK_DIR"
@@ -614,10 +758,21 @@ acquire_install_lock() {
 release_install_lock() {
   case "${INSTALL_LOCK_KIND:-}" in
     mkdir)
-      rm -rf "$INSTALL_LOCK_DIR" 2>/dev/null || true
+      # Remove the lock only while the on-disk token is still ours. A clean read
+      # that differs means a reclaimer took over the canonical path — never
+      # delete their live lock. An unreadable token is treated the same (skip):
+      # we cannot prove ownership, and erring toward a leak is safe because a
+      # stale lock ages out via install_lock_is_stale, whereas removing on an
+      # unverifiable read could delete a reclaimer's lock. Do not turn this into
+      # an unconditional `rm -rf`.
+      if [ -n "${INSTALL_LOCK_TOKEN:-}" ] && [ "$(cat "$INSTALL_LOCK_DIR/token" 2>/dev/null || true)" = "$INSTALL_LOCK_TOKEN" ]; then
+        rm -rf "$INSTALL_LOCK_DIR" 2>/dev/null || true
+      fi
       ;;
   esac
+  release_install_lock_reclaim_guard
   INSTALL_LOCK_KIND=""
+  INSTALL_LOCK_TOKEN=""
 }
 
 # ---------------------------------------------------------------------------

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -63,6 +63,18 @@ if [ "${{1:-}}" = "tool" ] && [ "${{2:-}}" = "dir" ]; then
 fi
 if [ "${{1:-}}" = "tool" ] && [ "${{2:-}}" = "install" ]; then
   printf '%s\n' "$@" > {str(tmp_path / "uv-args.txt")!r}
+  if [ "${{FAKE_UV_CREATE_LOCAL_DCODE:-}}" = "1" ]; then
+    mkdir -p "$HOME/.local/bin"
+    cat > "$HOME/.local/bin/dcode" <<'DCODE'
+#!/usr/bin/env bash
+if [ "${{1:-}}" = "-v" ]; then
+  printf 'deepagents-code %s\n' "${{FAKE_LOCAL_DCODE_VERSION:-0.2.0}}"
+  exit 0
+fi
+exit 0
+DCODE
+    chmod +x "$HOME/.local/bin/dcode"
+  fi
   if [ -n "${{FAKE_UV_INSTALL_STDERR:-}}" ]; then
     printf '%s\n' "$FAKE_UV_INSTALL_STDERR" >&2
   fi
@@ -381,8 +393,121 @@ def test_install_script_rejects_version_and_prerelease_together(
     assert "mutually exclusive" in proc.stderr
 
 
+def _run_with_args(
+    tmp_path: Path,
+    args: tuple[str, ...],
+    extra_env: dict[str, str] | None = None,
+    *,
+    installed_version: str | None = None,
+    latest_version: str | None = "0.2.0",
+) -> subprocess.CompletedProcess[str]:
+    """Run `install.sh` with positional `args` and the fake tools on `PATH`."""
+    env = _env(
+        tmp_path,
+        extra_env or {},
+        installed_version=installed_version,
+        latest_version=latest_version,
+    )
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def test_install_script_positional_version_installs_exact_version(
+    tmp_path: Path,
+) -> None:
+    """A positional VERSION pins that exact version, mirroring the env var."""
+    proc = _run_with_args(tmp_path, ("0.1.0rc1",), installed_version="0.0.1")
+
+    assert proc.returncode == 0, proc.stderr
+    args = (tmp_path / "uv-args.txt").read_text().splitlines()
+    assert args[:3] == ["tool", "install", "-U"]
+    assert args[-1] == "deepagents-code==0.1.0rc1"
+
+
+def test_install_script_positional_version_with_extras(tmp_path: Path) -> None:
+    """A positional VERSION feeds the same spec builder as the env var path."""
+    proc = _run_with_args(
+        tmp_path,
+        ("0.1.0rc1",),
+        {"DEEPAGENTS_CODE_EXTRAS": "ollama"},
+        installed_version="0.0.1",
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    args = (tmp_path / "uv-args.txt").read_text().splitlines()
+    assert args[-1] == "deepagents-code[ollama]==0.1.0rc1"
+
+
+@pytest.mark.parametrize(
+    "bad_target",
+    [
+        "0.1.0; rm -rf /",  # shell metacharacters
+        "1.0 --force",  # whitespace + smuggled flag
+        ">=1.0",  # range operator, not an exact pin
+    ],
+)
+def test_install_script_rejects_invalid_positional_version(
+    tmp_path: Path, bad_target: str
+) -> None:
+    """An invalid positional target is rejected before uv runs (injection guard).
+
+    The positional arg is a brand-new untrusted input that flows into uv's argv;
+    this pins the `^[A-Za-z0-9][A-Za-z0-9_.!+-]*$` guard that blocks metacharacter
+    and smuggled-flag payloads independently of the DEEPAGENTS_CODE_VERSION check.
+    """
+    proc = _run_with_args(tmp_path, (bad_target,))
+
+    assert proc.returncode == 2
+    assert "Invalid version target" in proc.stderr
+    assert not (tmp_path / "uv-args.txt").exists()
+
+
+def test_install_script_rejects_single_dash_typo_as_flag(tmp_path: Path) -> None:
+    """A single-dash typo is reported as an unknown flag, not an invalid version."""
+    proc = _run_with_args(tmp_path, ("-V",))
+
+    assert proc.returncode == 2
+    assert "Unrecognized argument" in proc.stderr
+    assert "Invalid version target" not in proc.stderr
+    assert not (tmp_path / "uv-args.txt").exists()
+
+
+def test_install_script_rejects_multiple_positional_targets(tmp_path: Path) -> None:
+    """Two positional targets fail before uv runs."""
+    proc = _run_with_args(tmp_path, ("0.1.0", "0.2.0"))
+
+    assert proc.returncode == 2
+    assert "Only one target is allowed" in proc.stderr
+    assert not (tmp_path / "uv-args.txt").exists()
+
+
+def test_install_script_rejects_positional_version_with_env_version(
+    tmp_path: Path,
+) -> None:
+    """Combining a positional version with DEEPAGENTS_CODE_VERSION is rejected."""
+    proc = _run_with_args(
+        tmp_path, ("0.2.0rc1",), {"DEEPAGENTS_CODE_VERSION": "0.1.0rc1"}
+    )
+
+    assert proc.returncode == 1
+    assert "Do not combine a positional version" in proc.stderr
+    assert not (tmp_path / "uv-args.txt").exists()
+
+
 def test_install_script_already_up_to_date_skips_uv(tmp_path: Path) -> None:
-    """When the installed version matches PyPI's latest, uv is not invoked."""
+    """When installed matches PyPI's latest, uv is skipped and no lock is taken.
+
+    The `~/.deepagents` assertion pins that the early up-to-date exit returns
+    before `acquire_install_lock`, so the no-op path leaves no lock directory
+    behind.
+    """
     proc, args_path = _invoke(
         tmp_path, {}, installed_version="0.1.0", latest_version="0.1.0"
     )
@@ -390,6 +515,7 @@ def test_install_script_already_up_to_date_skips_uv(tmp_path: Path) -> None:
     assert proc.returncode == 0
     assert not args_path.exists()
     assert "already up to date" in proc.stdout
+    assert not (tmp_path / "home/.deepagents").exists()
 
 
 def test_install_script_latest_version_with_extras_installs_requested_extra(
@@ -481,6 +607,24 @@ def test_install_script_assume_yes_updates_without_prompt(tmp_path: Path) -> Non
 
     assert args[:3] == ["tool", "install", "-U"]
     assert args[-1] == "deepagents-code"
+
+
+@pytest.mark.parametrize("assume_yes", ["true", "TRUE", "yes", " YES "])
+def test_install_script_assume_yes_accepts_codex_style_truthy_values(
+    tmp_path: Path, assume_yes: str
+) -> None:
+    """`DEEPAGENTS_CODE_YES` accepts common non-interactive truthy values."""
+    code, output, args_path = _invoke_interactive(
+        tmp_path,
+        {"DEEPAGENTS_CODE_YES": assume_yes},
+        answer="n",
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert code == 0
+    assert "Keeping deepagents-code" not in output
+    assert args_path.read_text().splitlines()[:3] == ["tool", "install", "-U"]
 
 
 def test_install_script_unreachable_pypi_falls_back_to_upgrade(tmp_path: Path) -> None:
@@ -969,6 +1113,212 @@ def test_install_script_failed_install_points_to_log(tmp_path: Path) -> None:
     )
 
 
+def test_install_script_propagates_uv_exit_code(tmp_path: Path) -> None:
+    """A failed install propagates uv's real exit code, not a flat `1`.
+
+    137 is the SIGKILL/OOM code the signal hint keys off. Asserting the exact
+    code catches a revert to `exit 1` (which the != 0 check above would miss)
+    and confirms the killed-before-finishing hint fires on a ≥128 exit.
+    """
+    proc, _ = _invoke(
+        tmp_path,
+        {"FAKE_UV_INSTALL_RC": "137"},
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 137
+    assert "Failed to install" in proc.stderr
+    # Portable across macOS/Linux: both the generic and the Linux-OOM hint begin
+    # with this phrase, so the assertion holds regardless of the test host's OS.
+    assert "killed before it could finish" in proc.stderr
+
+
+def _run_signal_failure_hint(
+    tmp_path: Path,
+    *,
+    exit_code: int,
+    os_name: str,
+    uname: str,
+    already_shown: bool = False,
+) -> str:
+    """Run the real `log_signal_failure_hint` in isolation and return its stderr.
+
+    A fake `uname` is placed on `PATH` so `is_linux_os` is fully determined by
+    (`os_name`, `uname`) rather than the test host's kernel — the OOM message is
+    gated on Linux, and this makes that gate deterministic on any CI runner.
+    """
+    bin_dir = tmp_path / "hintbin"
+    bin_dir.mkdir(exist_ok=True)
+    fake_uname = bin_dir / "uname"
+    fake_uname.write_text(f'#!/usr/bin/env bash\nprintf "%s\\n" {uname!r}\n')
+    _make_executable(fake_uname)
+
+    script = tmp_path / "signal_hint_harness.sh"
+    shown = "true" if already_shown else "false"
+    script.write_text(
+        'log_error() { printf "%s\\n" "$*" >&2; }\n'
+        f"OS={os_name!r}\n"
+        f"SIGNAL_FAILURE_HINT_SHOWN={shown}\n"
+        f"{_extract_shell_function('is_linux_os')}\n"
+        f"{_extract_shell_function('log_signal_failure_hint')}\n"
+        f"log_signal_failure_hint {exit_code}\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        ["bash", str(script)],
+        env={**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"},
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        check=False,
+    )
+    return proc.stderr
+
+
+def test_signal_hint_reports_oom_on_linux(tmp_path: Path) -> None:
+    """Exit 137 on Linux surfaces the out-of-memory explanation."""
+    stderr = _run_signal_failure_hint(
+        tmp_path, exit_code=137, os_name="linux", uname="Linux"
+    )
+
+    assert "ran out of memory" in stderr
+
+
+def test_signal_hint_omits_oom_off_linux(tmp_path: Path) -> None:
+    """Exit 137 off Linux gives the generic hint, not the OOM explanation."""
+    stderr = _run_signal_failure_hint(
+        tmp_path, exit_code=137, os_name="macos", uname="Darwin"
+    )
+
+    assert "killed before it could finish (exit code 137)" in stderr
+    assert "ran out of memory" not in stderr
+
+
+def test_signal_hint_generic_for_other_signal_exit(tmp_path: Path) -> None:
+    """A non-137 signal exit (e.g. 143/SIGTERM) uses the generic hint only."""
+    stderr = _run_signal_failure_hint(
+        tmp_path, exit_code=143, os_name="linux", uname="Linux"
+    )
+
+    assert "killed before it could finish (exit code 143)" in stderr
+    assert "ran out of memory" not in stderr
+
+
+def test_signal_hint_silent_below_128(tmp_path: Path) -> None:
+    """An ordinary failure (exit < 128) emits no signal hint."""
+    stderr = _run_signal_failure_hint(
+        tmp_path, exit_code=1, os_name="linux", uname="Linux"
+    )
+
+    assert stderr.strip() == ""
+
+
+def test_signal_hint_deduped_when_already_shown(tmp_path: Path) -> None:
+    """The hint is printed once: a prior SIGNAL_FAILURE_HINT_SHOWN suppresses it."""
+    stderr = _run_signal_failure_hint(
+        tmp_path,
+        exit_code=137,
+        os_name="linux",
+        uname="Linux",
+        already_shown=True,
+    )
+
+    assert stderr.strip() == ""
+
+
+# A PID above every platform's pid_max, so `kill -0` always reports it dead.
+_DEAD_PID = "2147483647"
+
+
+def _eval_install_lock_is_stale(
+    tmp_path: Path,
+    *,
+    pid: str | None,
+    started_at: str | None,
+    stale_after: int = 600,
+    make_dir: bool = True,
+) -> bool:
+    """Run the real `install_lock_is_stale` against a synthetic lock directory.
+
+    Returns True when the function reports the lock as stale (exit 0). Threshold
+    extremes (0 / huge) let the age comparison be exercised without depending on
+    wall-clock timing.
+    """
+    lock_dir = tmp_path / "install.lock.d"
+    if make_dir:
+        lock_dir.mkdir()
+        if pid is not None:
+            (lock_dir / "pid").write_text(f"{pid}\n")
+        if started_at is not None:
+            (lock_dir / "started_at").write_text(f"{started_at}\n")
+
+    script = tmp_path / "stale_harness.sh"
+    script.write_text(
+        f"INSTALL_LOCK_DIR={str(lock_dir)!r}\n"
+        f"INSTALL_LOCK_STALE_AFTER_SECS={stale_after}\n"
+        f"{_extract_shell_function('lock_dir_mtime')}\n"
+        f"{_extract_shell_function('install_lock_is_stale')}\n"
+        "install_lock_is_stale\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        check=False,
+    )
+    return proc.returncode == 0
+
+
+def test_install_lock_live_owner_is_never_stale(tmp_path: Path) -> None:
+    """A lock whose PID is still running is never reclaimed, regardless of age."""
+    assert not _eval_install_lock_is_stale(
+        tmp_path, pid=str(os.getpid()), started_at="1"
+    )
+
+
+def test_install_lock_dead_owner_old_timestamp_is_stale(tmp_path: Path) -> None:
+    """A dead owner past the staleness window is reclaimable."""
+    assert _eval_install_lock_is_stale(tmp_path, pid=_DEAD_PID, started_at="1")
+
+
+def test_install_lock_dead_owner_within_window_is_not_stale(tmp_path: Path) -> None:
+    """A dead owner still inside the staleness window is left alone."""
+    # Threshold must exceed the current epoch (~1.8e9) so `now - 1` stays inside
+    # the window; 1e10 comfortably clears it without depending on wall-clock now.
+    assert not _eval_install_lock_is_stale(
+        tmp_path, pid=_DEAD_PID, started_at="1", stale_after=10**10
+    )
+
+
+def test_install_lock_fresh_lock_without_metadata_is_not_stale(
+    tmp_path: Path,
+) -> None:
+    """A just-created lock (pid/timestamp not yet written) is respected.
+
+    Guards the mkdir-race fix: the window between `mkdir` winning and the owner
+    writing its metadata must not read as "stale", or a racing installer would
+    delete a lock that was just acquired. The dir mtime (≈ now) keeps it fresh.
+    """
+    assert not _eval_install_lock_is_stale(tmp_path, pid=None, started_at=None)
+
+
+def test_install_lock_without_metadata_ages_out_via_mtime(tmp_path: Path) -> None:
+    """With no metadata, staleness falls back to the lock dir's mtime."""
+    assert _eval_install_lock_is_stale(
+        tmp_path, pid=None, started_at=None, stale_after=0
+    )
+
+
+def test_install_lock_missing_dir_is_not_stale(tmp_path: Path) -> None:
+    """No lock directory means nothing to reclaim."""
+    assert not _eval_install_lock_is_stale(
+        tmp_path, pid=None, started_at=None, make_dir=False
+    )
+
+
 def test_install_script_upgrade_marks_removed_packages(tmp_path: Path) -> None:
     """An upgrade that drops a transitive dependency labels it `(removed)`."""
     proc, _ = _invoke(
@@ -1028,6 +1378,7 @@ def _invoke_with_os(
     installed_version: str | None = None,
     latest_version: str | None = None,
     extra_env: dict[str, str] | None = None,
+    fail_if_lockf_called: bool = False,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
     """Run `install.sh` with faked `uname`/`xcode-select` os probes.
 
@@ -1047,6 +1398,14 @@ def _invoke_with_os(
     xcode_select = bin_dir / "xcode-select"
     xcode_select.write_text(f"#!/usr/bin/env bash\nexit {xcode_select_rc}\n")
     _make_executable(xcode_select)
+    if fail_if_lockf_called:
+        lockf = bin_dir / "lockf"
+        lockf.write_text(
+            "#!/usr/bin/env bash\n"
+            "printf 'lockf must not be used for installer locking\\n' >&2\n"
+            "exit 64\n"
+        )
+        _make_executable(lockf)
 
     env = {
         **os.environ,
@@ -1261,6 +1620,12 @@ def _run_signal_traps(tmp_path: Path, *, interrupt: bool) -> str:
         'log_warn()  { printf "%s\\n" "$*" >&2; }\n'
         'log_error() { printf "%s\\n" "$*" >&2; }\n'
         "cleanup_temp_files() { :; }\n"
+        # cleanup_on_signal now calls these unconditionally; extract the real
+        # implementations so the harness exercises shipped code without emitting
+        # "command not found" noise (which would otherwise pass tests by luck).
+        f"{_extract_shell_function('is_linux_os')}\n"
+        f"{_extract_shell_function('restore_terminal_after_signal')}\n"
+        f"{_extract_shell_function('log_signal_failure_hint')}\n"
         f"{_extract_shell_function('cleanup_on_signal')}\n"
         f"{_extract_shell_function('cleanup_on_interrupt')}\n"
         "trap cleanup_on_signal EXIT\n"
@@ -1291,6 +1656,9 @@ def test_interrupt_shows_notice_without_failure_message(tmp_path: Path) -> None:
 
     assert "Installation interrupted." in stderr
     assert "Installation failed" not in stderr
+    # The harness must define every helper cleanup_on_signal calls; a missing
+    # one would still pass the asserts above but corrupt the exercised path.
+    assert "command not found" not in stderr
 
 
 def test_exit_trap_reports_failure_on_ordinary_error(tmp_path: Path) -> None:
@@ -1304,6 +1672,7 @@ def test_exit_trap_reports_failure_on_ordinary_error(tmp_path: Path) -> None:
 
     assert "Installation failed (exit code 2)." in stderr
     assert "Installation interrupted." not in stderr
+    assert "command not found" not in stderr
 
 
 def test_install_script_macos_without_clt_exits_early(tmp_path: Path) -> None:
@@ -1360,6 +1729,22 @@ def test_install_script_macos_with_clt_proceeds_to_install(tmp_path: Path) -> No
 
     assert proc.returncode == 0
     assert "Xcode Command Line Tools" not in proc.stderr
+    assert uv_args.exists()
+
+
+def test_install_script_macos_does_not_use_lockf(tmp_path: Path) -> None:
+    """The macOS `lockf` is command-scoped, not a file-descriptor lock."""
+    proc, uv_args = _invoke_with_os(
+        tmp_path,
+        uname_os="Darwin",
+        xcode_select_rc=0,
+        installed_version="0.0.1",
+        latest_version="0.2.0",
+        fail_if_lockf_called=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert "lockf must not be used" not in proc.stderr
     assert uv_args.exists()
 
 
@@ -1535,7 +1920,9 @@ def test_install_script_adds_local_bin_when_dcode_installed_but_not_on_path(
         )
         if profile.exists()
     ]
+    assert any("# >>> deepagents-code installer >>>" in text for text in profile_texts)
     assert any('export PATH="$HOME/.local/bin:$PATH"' in text for text in profile_texts)
+    assert any("# <<< deepagents-code installer <<<" in text for text in profile_texts)
     assert "source ~/.local/bin/env" not in combined
 
 
@@ -1615,6 +2002,77 @@ def test_install_script_stale_shell_with_profile_already_set_shows_reload_hint(
     # But the reload hint is shown because the current shell is stale.
     assert "Restart your shell, or run:" in combined
     assert 'export PATH="$HOME/.local/bin:$PATH"' in combined
+
+
+def test_install_script_rewrites_existing_managed_path_block(tmp_path: Path) -> None:
+    """An old installer-owned PATH block is rewritten in place."""
+    bin_dir, home, uv = _write_fake_tools(tmp_path, installed_version=None)
+
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    dcode = local_bin / "dcode"
+    dcode.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "${1:-}" = "-v" ]; then printf "deepagents-code 0.1.0\\n"; exit 0; fi\n'
+        "exit 0\n"
+    )
+    _make_executable(dcode)
+
+    zshrc = home / ".zshrc"
+    zshrc.write_text(
+        "before\n"
+        "# >>> deepagents-code installer >>>\n"
+        'export PATH="$HOME/old-bin:$PATH"\n'
+        "# <<< deepagents-code installer <<<\n"
+        "after\n"
+    )
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "XDG_CACHE_HOME": str(home / ".cache"),
+        "PATH": f"{bin_dir}{os.pathsep}{_path_without_dcode()}",
+        "UV_BIN": str(uv),
+        "DEEPAGENTS_CODE_SKIP_OPTIONAL": "1",
+        "SHELL": "/bin/zsh",
+    }
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+    assert proc.returncode == 0
+    profile = zshrc.read_text()
+    assert profile.count("# >>> deepagents-code installer >>>") == 1
+    assert 'export PATH="$HOME/.local/bin:$PATH"' in profile
+    assert "$HOME/old-bin" not in profile
+    assert profile.startswith("before\n")
+    assert profile.endswith("after\n")
+
+
+def test_install_script_warns_when_original_path_shadows_uv_tool(
+    tmp_path: Path,
+) -> None:
+    """An older `dcode` earlier on PATH is reported instead of silently used."""
+    proc, _ = _invoke(
+        tmp_path,
+        {
+            "FAKE_UV_CREATE_LOCAL_DCODE": "1",
+            "FAKE_LOCAL_DCODE_VERSION": "0.2.0",
+        },
+        installed_version="0.1.0",
+        latest_version="0.2.0",
+    )
+
+    assert proc.returncode == 0
+    assert "deepagents-code updated: 0.1.0 → 0.2.0" in proc.stdout
+    assert "Detected existing dcode" in proc.stderr
+    assert "PATH order may run that binary instead of the uv tool" in proc.stderr
 
 
 def test_install_script_no_path_warning_when_dcode_on_path(tmp_path: Path) -> None:

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1319,6 +1319,164 @@ def test_install_lock_missing_dir_is_not_stale(tmp_path: Path) -> None:
     )
 
 
+def test_install_script_ignores_symlinked_legacy_lock_file(tmp_path: Path) -> None:
+    """A symlinked legacy `install.lock` is not followed when flock is available.
+
+    Guards the root-install symlink hardening: a non-root
+    user who can write `~/.deepagents` could pre-create `install.lock` as a
+    symlink to a root-writable path. The installer must use the directory lock
+    instead of opening `install.lock`, so the target is never truncated by the
+    shell's `>` redirect.
+
+    macOS lacks `flock`, so a fake `flock` shim is staged on `PATH` to force
+    the regression case where flock would otherwise be available.
+    """
+    bin_dir, home, uv = _write_fake_tools(
+        tmp_path, installed_version="0.0.1", latest_version="0.1.0"
+    )
+    # Stage a fake `flock` so the flock path is taken even on macOS.
+    flock = bin_dir / "flock"
+    flock.write_text("#!/usr/bin/env bash\nexit 0\n")
+    _make_executable(flock)
+
+    deepagents = home / ".deepagents"
+    deepagents.mkdir()
+    target = tmp_path / "secret.txt"
+    target.write_text("precious")
+    (deepagents / "install.lock").symlink_to(target)
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "XDG_CACHE_HOME": str(home / ".cache"),
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "UV_BIN": str(uv),
+        "DEEPAGENTS_CODE_SKIP_OPTIONAL": "1",
+    }
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+    assert proc.returncode == 0
+    # The symlink target must not have been truncated by the `>` redirect.
+    assert target.read_text() == "precious"
+    # The legacy lock path is ignored rather than replaced.
+    lock_file = deepagents / "install.lock"
+    assert lock_file.is_symlink()
+    assert lock_file.resolve() == target
+
+
+def test_install_script_does_not_redirect_to_legacy_lock_file() -> None:
+    """Pin the TOCTOU fix: post-open symlink checks are too late."""
+    script = SCRIPT.read_text(encoding="utf-8")
+
+    assert "INSTALL_LOCK_FILE" not in script
+    assert '>"$lock_root/install.lock"' not in script
+    assert '>"$HOME/.deepagents/install.lock"' not in script
+
+
+def test_install_script_reclaims_stale_mkdir_lock(tmp_path: Path) -> None:
+    """A stale mkdir lock left by a dead owner is reclaimed, and install proceeds.
+
+    Drives the full `acquire_install_lock` mkdir path (not just the
+    `install_lock_is_stale` predicate): a pre-existing `install.lock.d` with a
+    dead PID and an old `started_at` must be renamed aside, removed, and the
+    install allowed to continue. Guards against a regression to a plain
+    `rm -rf "$INSTALL_LOCK_DIR"`, which would reintroduce the reclaim race the
+    rename-then-delete fixes.
+    """
+    bin_dir, home, uv = _write_fake_tools(
+        tmp_path, installed_version="0.0.1", latest_version="0.1.0"
+    )
+    lock_dir = home / ".deepagents" / "install.lock.d"
+    lock_dir.mkdir(parents=True)
+    (lock_dir / "pid").write_text(f"{_DEAD_PID}\n")
+    (lock_dir / "started_at").write_text("1\n")  # 1970 => well past the window
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "XDG_CACHE_HOME": str(home / ".cache"),
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "UV_BIN": str(uv),
+        "DEEPAGENTS_CODE_SKIP_OPTIONAL": "1",
+    }
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+        timeout=60,  # a reclaim regression could busy-loop; fail fast instead
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert "Removing stale installer lock" in proc.stderr
+    # The install ran (lock acquired) rather than aborting on the stale lock.
+    assert (tmp_path / "uv-args.txt").is_file()
+    # The lock is released on exit, leaving no lock dir and no reclaim leftovers.
+    deepagents = home / ".deepagents"
+    assert not (deepagents / "install.lock.d").exists()
+    assert not list(deepagents.glob("install.lock.d.reclaim.*"))
+
+
+@pytest.mark.skipif(
+    os.geteuid() == 0, reason="root bypasses the directory permission bits"
+)
+def test_install_script_aborts_on_unremovable_stale_lock(tmp_path: Path) -> None:
+    """An unremovable stale lock aborts loudly instead of spinning forever.
+
+    When the stale `install.lock.d` can be neither renamed nor removed (here,
+    its parent is read-only), the reclaim must `exit 1` with an actionable
+    message. Regression guard for the busy-loop: `continue` skips the retry
+    `sleep`, so a silently swallowed `rm` failure would spin on `mkdir` and
+    spam the warning indefinitely. The `timeout` turns that hang into a
+    failure rather than letting the test run wedge.
+    """
+    bin_dir, home, uv = _write_fake_tools(
+        tmp_path, installed_version="0.0.1", latest_version="0.1.0"
+    )
+    deepagents = home / ".deepagents"
+    lock_dir = deepagents / "install.lock.d"
+    lock_dir.mkdir(parents=True)
+    (lock_dir / "pid").write_text(f"{_DEAD_PID}\n")
+    (lock_dir / "started_at").write_text("1\n")
+    # Read+execute only: entries inside cannot be renamed or unlinked, so both
+    # the `mv` and the fallback `rm -rf` fail with EACCES.
+    deepagents.chmod(0o555)
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "XDG_CACHE_HOME": str(home / ".cache"),
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "UV_BIN": str(uv),
+        "DEEPAGENTS_CODE_SKIP_OPTIONAL": "1",
+    }
+    try:
+        proc = subprocess.run(
+            ["bash", str(SCRIPT)],
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+            timeout=60,
+        )
+    finally:
+        # Restore write access so tmp_path teardown can remove the tree.
+        deepagents.chmod(0o755)
+
+    assert proc.returncode == 1, proc.stderr
+    assert "Cannot reclaim stale installer lock" in proc.stderr
+
+
 def test_install_script_upgrade_marks_removed_packages(tmp_path: Path) -> None:
     """An upgrade that drops a transitive dependency labels it `(removed)`."""
     proc, _ = _invoke(

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -1258,6 +1258,7 @@ def _eval_install_lock_is_stale(
         f"INSTALL_LOCK_DIR={str(lock_dir)!r}\n"
         f"INSTALL_LOCK_STALE_AFTER_SECS={stale_after}\n"
         f"{_extract_shell_function('lock_dir_mtime')}\n"
+        f"{_extract_shell_function('install_lock_identity')}\n"
         f"{_extract_shell_function('install_lock_is_stale')}\n"
         "install_lock_is_stale\n",
         encoding="utf-8",
@@ -1380,15 +1381,260 @@ def test_install_script_does_not_redirect_to_legacy_lock_file() -> None:
     assert '>"$HOME/.deepagents/install.lock"' not in script
 
 
+def test_install_script_reclaim_skips_new_lock_after_stale_check(
+    tmp_path: Path,
+) -> None:
+    """The reclaim re-check skips `mv` when the lock changed after stale detection.
+
+    Simulates a peer reclaimer that clears the stale lock between this process's
+    staleness check and its own identity re-check. `install_lock_identity` is
+    stubbed to report the inspected fingerprint on its first call (so the lock
+    reads as stale and that fingerprint is captured) and then, on the re-check,
+    to remove the lock dir and report a different (empty) fingerprint. The
+    mismatch must abort the rename so this process never moves a lock it did not
+    inspect aside; it then acquires the now-free path cleanly and `mv` is never
+    called. A filesystem marker sequences the two calls: each runs in a `$(...)`
+    subshell, so a shell-variable counter would not carry across them.
+    """
+    lock_root = tmp_path / ".deepagents"
+    lock_dir = lock_root / "install.lock.d"
+    lock_dir.mkdir(parents=True)
+    (lock_dir / "pid").write_text(f"{_DEAD_PID}\n")
+    (lock_dir / "started_at").write_text("1\n")
+    marker = tmp_path / "mv-called"
+    checked = tmp_path / "identity-checked"
+    script = tmp_path / "reclaim_race_harness.sh"
+    script.write_text(
+        f"HOME={str(tmp_path)!r}\n"
+        "INSTALL_LOCK_KIND=''\n"
+        "INSTALL_LOCK_DIR=''\n"
+        "INSTALL_LOCK_RECLAIM_DIR=''\n"
+        "INSTALL_LOCK_RECLAIM_TOKEN=''\n"
+        "INSTALL_LOCK_STALE_AFTER_SECS=600\n"
+        "fix_owner() { return 0; }\n"
+        "log_warn() { return 0; }\n"
+        "log_error() { printf '%s\\n' \"$*\" >&2; }\n"
+        f"{_extract_shell_function('lock_dir_mtime')}\n"
+        # First call (inside install_lock_is_stale) reports the inspected
+        # fingerprint so the lock reads as stale. The re-check call then clears
+        # the lock — as a racing reclaimer would — and reports a different
+        # (empty) fingerprint, which must make acquire_install_lock skip the mv.
+        "install_lock_identity() {\n"
+        f"  if [ ! -f {str(checked)!r} ]; then\n"
+        f"    : >{str(checked)!r}\n"
+        "    printf 'stale-fingerprint'\n"
+        "    return 0\n"
+        "  fi\n"
+        '  rm -rf "$INSTALL_LOCK_DIR"\n'
+        "  return 1\n"
+        "}\n"
+        f"{_extract_shell_function('install_lock_is_stale')}\n"
+        f"{_extract_shell_function('install_lock_reclaim_guard_is_stale')}\n"
+        f"{_extract_shell_function('wait_for_install_lock_reclaim_guard')}\n"
+        f"{_extract_shell_function('acquire_install_lock_reclaim_guard')}\n"
+        f"{_extract_shell_function('release_install_lock_reclaim_guard')}\n"
+        f"{_extract_shell_function('acquire_install_lock')}\n"
+        f"{_extract_shell_function('release_install_lock')}\n"
+        "mv() {\n"
+        f"  printf 'called\\n' >{str(marker)!r}\n"
+        "  return 1\n"
+        "}\n"
+        "acquire_install_lock\n"
+        "release_install_lock\n"
+        f"test ! -f {str(marker)!r}\n",
+        encoding="utf-8",
+    )
+
+    proc = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        check=False,
+        timeout=60,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_install_script_reclaim_holds_guard_while_renaming_stale_lock(
+    tmp_path: Path,
+) -> None:
+    """Stale reclaim renames the canonical lock only while peers are guarded."""
+    lock_root = tmp_path / ".deepagents"
+    lock_dir = lock_root / "install.lock.d"
+    lock_dir.mkdir(parents=True)
+    (lock_dir / "pid").write_text(f"{_DEAD_PID}\n")
+    (lock_dir / "started_at").write_text("1\n")
+    missing_guard = tmp_path / "missing-guard"
+    script = tmp_path / "reclaim_guard_harness.sh"
+    script.write_text(
+        f"HOME={str(tmp_path)!r}\n"
+        "INSTALL_LOCK_KIND=''\n"
+        "INSTALL_LOCK_DIR=''\n"
+        "INSTALL_LOCK_RECLAIM_DIR=''\n"
+        "INSTALL_LOCK_RECLAIM_TOKEN=''\n"
+        "INSTALL_LOCK_STALE_AFTER_SECS=600\n"
+        "fix_owner() { return 0; }\n"
+        "log_warn() { return 0; }\n"
+        "log_error() { printf '%s\\n' \"$*\" >&2; }\n"
+        f"{_extract_shell_function('lock_dir_mtime')}\n"
+        f"{_extract_shell_function('install_lock_identity')}\n"
+        f"{_extract_shell_function('install_lock_is_stale')}\n"
+        f"{_extract_shell_function('install_lock_reclaim_guard_is_stale')}\n"
+        f"{_extract_shell_function('wait_for_install_lock_reclaim_guard')}\n"
+        f"{_extract_shell_function('acquire_install_lock_reclaim_guard')}\n"
+        f"{_extract_shell_function('release_install_lock_reclaim_guard')}\n"
+        f"{_extract_shell_function('acquire_install_lock')}\n"
+        f"{_extract_shell_function('release_install_lock')}\n"
+        "mv() {\n"
+        '  if [ "$1" = "$INSTALL_LOCK_DIR" ] && \\\n'
+        '    [ ! -d "$INSTALL_LOCK_RECLAIM_DIR" ]; then\n'
+        f"    printf 'missing\\n' >{str(missing_guard)!r}\n"
+        "    return 1\n"
+        "  fi\n"
+        '  command mv "$@"\n'
+        "}\n"
+        "acquire_install_lock\n"
+        "release_install_lock\n"
+        f"test ! -f {str(missing_guard)!r}\n"
+        f"test ! -d {str(lock_root / 'install.lock.reclaim.d')!r}\n",
+        encoding="utf-8",
+    )
+
+    proc = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        check=False,
+        timeout=60,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+
+
+@pytest.mark.parametrize(
+    ("our_token", "on_disk_token", "expected_removed"),
+    [
+        # We still hold the lock: the on-disk token matches ours -> remove it.
+        ("mine", "mine", True),
+        # A reclaimer took over the canonical path (different token) -> keep it.
+        ("mine", "other", False),
+        # We never recorded a token, so ownership is unprovable -> keep it.
+        ("", "mine", False),
+    ],
+)
+def test_install_script_release_removes_lock_only_when_token_matches(
+    tmp_path: Path, our_token: str, on_disk_token: str, expected_removed: bool
+) -> None:
+    """release_install_lock removes the lock dir iff the on-disk token is ours.
+
+    Guards the release ownership check: a regression to an unconditional
+    `rm -rf "$INSTALL_LOCK_DIR"` would let a slow installer delete a lock a fresh
+    owner now holds. The reclaim guard is left untouched here
+    (INSTALL_LOCK_RECLAIM_TOKEN empty), so only the canonical lock is exercised.
+    """
+    lock_root = tmp_path / ".deepagents"
+    lock_dir = lock_root / "install.lock.d"
+    lock_dir.mkdir(parents=True)
+    (lock_dir / "token").write_text(f"{on_disk_token}\n")
+    script = tmp_path / "release_harness.sh"
+    script.write_text(
+        f"INSTALL_LOCK_DIR={str(lock_dir)!r}\n"
+        f"INSTALL_LOCK_RECLAIM_DIR={str(lock_root / 'install.lock.reclaim.d')!r}\n"
+        "INSTALL_LOCK_KIND='mkdir'\n"
+        f"INSTALL_LOCK_TOKEN={our_token!r}\n"
+        "INSTALL_LOCK_RECLAIM_TOKEN=''\n"
+        f"{_extract_shell_function('release_install_lock_reclaim_guard')}\n"
+        f"{_extract_shell_function('release_install_lock')}\n"
+        "release_install_lock\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        check=False,
+        timeout=30,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert (not lock_dir.exists()) == expected_removed
+
+
+def test_install_script_aborts_when_lock_token_cannot_be_written(
+    tmp_path: Path,
+) -> None:
+    """A failed lock-token write aborts loudly and removes the half-made lock.
+
+    After winning `mkdir`, the metadata write must succeed or the acquire has to
+    `exit 1` and clean up. Here a stubbed `mkdir` plants a *directory* named
+    `token` inside the fresh lock so `>"$INSTALL_LOCK_DIR/token"` fails. Guards
+    against a regression that drops either the cleanup (orphan lock nobody can
+    release) or the `exit` (install proceeds tokenless, so release never matches
+    and the lock leaks permanently).
+    """
+    lock_root = tmp_path / ".deepagents"
+    lock_root.mkdir(parents=True)
+    script = tmp_path / "token_write_harness.sh"
+    script.write_text(
+        f"HOME={str(tmp_path)!r}\n"
+        "INSTALL_LOCK_KIND=''\n"
+        "INSTALL_LOCK_DIR=''\n"
+        "INSTALL_LOCK_RECLAIM_DIR=''\n"
+        "INSTALL_LOCK_RECLAIM_TOKEN=''\n"
+        "INSTALL_LOCK_STALE_AFTER_SECS=600\n"
+        "fix_owner() { return 0; }\n"
+        "log_warn() { return 0; }\n"
+        "log_error() { printf '%s\\n' \"$*\" >&2; }\n"
+        f"{_extract_shell_function('lock_dir_mtime')}\n"
+        f"{_extract_shell_function('install_lock_identity')}\n"
+        f"{_extract_shell_function('install_lock_is_stale')}\n"
+        f"{_extract_shell_function('install_lock_reclaim_guard_is_stale')}\n"
+        f"{_extract_shell_function('wait_for_install_lock_reclaim_guard')}\n"
+        f"{_extract_shell_function('acquire_install_lock_reclaim_guard')}\n"
+        f"{_extract_shell_function('release_install_lock_reclaim_guard')}\n"
+        f"{_extract_shell_function('acquire_install_lock')}\n"
+        # Win the mkdir, but plant a directory named `token` inside the lock so
+        # the metadata write `>"$INSTALL_LOCK_DIR/token"` fails.
+        "mkdir() {\n"
+        '  if [ "$1" = "$INSTALL_LOCK_DIR" ]; then\n'
+        '    command mkdir "$INSTALL_LOCK_DIR" || return 1\n'
+        '    command mkdir "$INSTALL_LOCK_DIR/token"\n'
+        "    return 0\n"
+        "  fi\n"
+        '  command mkdir "$@"\n'
+        "}\n"
+        "acquire_install_lock\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        check=False,
+        timeout=30,
+    )
+
+    assert proc.returncode == 1, proc.stderr
+    assert "Cannot write installer lock metadata" in proc.stderr
+    assert not (lock_root / "install.lock.d").exists()
+
+
 def test_install_script_reclaims_stale_mkdir_lock(tmp_path: Path) -> None:
     """A stale mkdir lock left by a dead owner is reclaimed, and install proceeds.
 
     Drives the full `acquire_install_lock` mkdir path (not just the
     `install_lock_is_stale` predicate): a pre-existing `install.lock.d` with a
     dead PID and an old `started_at` must be renamed aside, removed, and the
-    install allowed to continue. Guards against a regression to a plain
-    `rm -rf "$INSTALL_LOCK_DIR"`, which would reintroduce the reclaim race the
-    rename-then-delete fixes.
+    install allowed to continue. The concurrent-replacement cases are covered
+    separately by test_install_script_reclaim_skips_new_lock_after_stale_check
+    (identity changed before reclaim) and
+    test_install_script_reclaim_holds_guard_while_renaming_stale_lock (peers held
+    by the reclaim guard during the rename).
     """
     bin_dir, home, uv = _write_fake_tools(
         tmp_path, installed_version="0.0.1", latest_version="0.1.0"
@@ -1424,6 +1670,7 @@ def test_install_script_reclaims_stale_mkdir_lock(tmp_path: Path) -> None:
     deepagents = home / ".deepagents"
     assert not (deepagents / "install.lock.d").exists()
     assert not list(deepagents.glob("install.lock.d.reclaim.*"))
+    assert not (deepagents / "install.lock.reclaim.d").exists()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
**deepagents-code installer (`install.sh`):**
- Accepts a positional version: `curl -LsSf https://langch.in/dcode | bash -s -- 0.1.0rc1`
- Uses a managed, rewriteable PATH block in shell profiles (`# >>> deepagents-code installer >>>`)
- Warns when an existing `dcode`/`deepagents-code` on `PATH` shadows the uv tool install
- Shows actionable hints for signal kills (e.g., OOM on Linux: exit 137)
- Serializes concurrent installs with a cross-process lock (`flock`/`mkdir` fallback)
- Accepts `DEEPAGENTS_CODE_YES=true|yes|TRUE| YES ` for non-interactive installs
- Propagates uv's real exit code on failure

---

### User-facing changes
- **Positional version argument**: `curl ... | bash -s -- 0.1.0rc1` now works alongside the existing `DEEPAGENTS_CODE_VERSION` env var
- **Managed PATH block**: Shell profiles now get a delimited `# >>> deepagents-code installer >>>` block that the installer owns and rewrites in place (instead of appending loose lines)
- **Shadowing detection**: Warns when an older `dcode`/`deepagents-code` binary earlier on `PATH` would be used instead of the newly installed uv tool
- **Signal-aware failure hints**: Exit codes ≥128 now surface actionable messages (e.g., exit 137 on Linux → "ran out of memory, free up memory or use a larger machine")
- **Concurrent install safety**: A cross-process lock (`flock` preferred, `mkdir` fallback with stale-lock reclamation) prevents racing `curl | bash` runs from corrupting the shared uv tool directory

### Internal hardening
- `DEEPAGENTS_CODE_YES` now accepts truthy values (`true`, `TRUE`, `yes`, ` YES `)
- Installer propagates uv's real exit code instead of flattening to `1`
- Early up-to-date exit no longer creates a lock directory
- macOS path avoids `lockf` (command-scoped, not fd-based)