### PR TITLE
chore(code): trim up-to-date installer output

### DIFF
--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -1134,7 +1134,7 @@ elif [ -n "$PRE_VERSION" ] && [ -z "$VERSION" ] && [ -z "$PRERELEASE_REQUESTED" 
   # release literal would merely re-prompt an up-to-date user, never silently
   # skip a real upgrade. A shell installer can't import `packaging` to compare
   # semantically the way `update_check.py` does.
-  log_info "deepagents-code ${PRE_VERSION} found — checking for updates..."
+  log_info "dcode ${PRE_VERSION} found — checking for updates..."
   LATEST_VERSION=$(fetch_latest_version)
   if [ -z "$LATEST_VERSION" ]; then
     log_warn "Could not determine the latest version from PyPI — continuing with an upgrade attempt."
@@ -1145,7 +1145,7 @@ elif [ -n "$PRE_VERSION" ] && [ -z "$VERSION" ] && [ -z "$PRERELEASE_REQUESTED" 
       log_info "Updating deepagents-code ${PRE_VERSION} → ${LATEST_VERSION} with requested options..."
     fi
   elif [ "$LATEST_VERSION" = "$PRE_VERSION" ]; then
-    log_success "deepagents-code is already up to date."
+    log_success "Already up to date!"
     exit 0
   elif [ "$ASSUME_YES" = "1" ]; then
     log_info "Updating deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}..."
@@ -1164,7 +1164,7 @@ elif [ -n "$PRE_VERSION" ] && [ -z "$VERSION" ] && [ -z "$PRERELEASE_REQUESTED" 
     log_info "deepagents-code ${LATEST_VERSION} available — updating (no TTY to prompt)."
   fi
 elif [ -n "$PRE_VERSION" ]; then
-  log_info "deepagents-code ${PRE_VERSION} found — checking for updates..."
+  log_info "dcode ${PRE_VERSION} found — checking for updates..."
 else
   log_info "Installing ${PACKAGE}..."
 fi

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -514,7 +514,7 @@ def test_install_script_already_up_to_date_skips_uv(tmp_path: Path) -> None:
 
     assert proc.returncode == 0
     assert not args_path.exists()
-    assert "already up to date" in proc.stdout
+    assert "Already up to date!" in proc.stdout
     assert not (tmp_path / "home/.deepagents").exists()
 
 


### PR DESCRIPTION
The installer's "already installed / up to date" message is now more concise.

Before:
```
▸ deepagents-code 0.1.34 found — checking for updates...
✔ deepagents-code is already up to date.
```
After:
```
▸ dcode 0.1.34 found — checking for updates...
✔ Already up to date!
```

Made by [Open SWE](https://openswe.vercel.app/agents/6b29a6dc-fc2b-12bc-52d1-98a3bed3785d)