### PR TITLE
chore(code): compare installs by inode in shadowing check

### DIFF
--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -1442,11 +1442,18 @@ detect_shell_profile() {
 # Check if ~/.local/bin is already referenced in the shell profile's PATH
 # config. Matches non-commented lines containing .local/bin in a PATH
 # assignment or fish_add_path. Returns 0 if already present.
+#
+# The alternation also recognizes the un-normalized ~/.local/share/../bin
+# spelling (share/.. collapses to .local, so it resolves to the same directory
+# as ~/.local/bin). Some tools write that spelling into a profile from
+# $XDG_DATA_HOME/../bin; without this we'd fail to see ~/.local/bin as already
+# on PATH and append a duplicate entry. This covers the common alias only — it
+# is not a full path normalizer, so other exotic spellings still slip through.
 local_bin_in_profile() {
   local profile="$1"
   [ -f "$profile" ] || return 1
-  grep -v '^[[:space:]]*#' "$profile" 2>/dev/null | grep -qE 'PATH=.*\.local/bin' \
-    || grep -v '^[[:space:]]*#' "$profile" 2>/dev/null | grep -qE 'fish_add_path.*\.local/bin'
+  grep -v '^[[:space:]]*#' "$profile" 2>/dev/null | grep -qE 'PATH=.*(\.local/bin|\.local/share/\.\./bin)' \
+    || grep -v '^[[:space:]]*#' "$profile" 2>/dev/null | grep -qE 'fish_add_path.*(\.local/bin|\.local/share/\.\./bin)'
 }
 
 managed_path_block_present() {
@@ -1653,7 +1660,10 @@ detect_shadowing_install() {
     [ -x "$expected" ] || continue
     original=$(PATH="$ORIGINAL_PATH" command -v "$candidate" 2>/dev/null || true)
     [ -n "$original" ] || continue
-    [ "$original" = "$expected" ] && continue
+    # Same file reached via a different PATH spelling (e.g. ~/.local/share/../bin
+    # vs ~/.local/bin) is not a shadowing install. Compare by inode, not string,
+    # so `..`/symlink aliases don't trigger a false "existing install" warning.
+    { [ "$original" = "$expected" ] || [ "$original" -ef "$expected" ]; } && continue
     manager=$(classify_shadowing_command "$original")
     log_warn "Detected ${manager} ${candidate} at ${original}."
     log_warn "PATH order may run that binary instead of the uv tool at ${expected}."

--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -1661,8 +1661,11 @@ detect_shadowing_install() {
     original=$(PATH="$ORIGINAL_PATH" command -v "$candidate" 2>/dev/null || true)
     [ -n "$original" ] || continue
     # Same file reached via a different PATH spelling (e.g. ~/.local/share/../bin
-    # vs ~/.local/bin) is not a shadowing install. Compare by inode, not string,
-    # so `..`/symlink aliases don't trigger a false "existing install" warning.
+    # vs ~/.local/bin) is not a shadowing install. Keep the string equality as a
+    # fast path, but also accept `-ef` (true when both paths are the same device
+    # and inode, resolving `..` and symlinks) so aliases don't trigger a false
+    # "existing install" warning. A genuinely different binary has a distinct
+    # inode and still fails both checks, so only the false positive is skipped.
     { [ "$original" = "$expected" ] || [ "$original" -ef "$expected" ]; } && continue
     manager=$(classify_shadowing_command "$original")
     log_warn "Detected ${manager} ${candidate} at ${original}."

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -2480,6 +2480,147 @@ def test_install_script_warns_when_original_path_shadows_uv_tool(
     assert "PATH order may run that binary instead of the uv tool" in proc.stderr
 
 
+def _run_detect_shadowing_install(
+    tmp_path: Path,
+    *,
+    original_path: str,
+    stage_shadow: bool = False,
+) -> str:
+    """Run the real `detect_shadowing_install` in isolation; return its stderr.
+
+    `HOME/.local/bin/dcode` is always created as the freshly-installed uv tool.
+    The caller controls `ORIGINAL_PATH` (the user's pre-installer PATH) to decide
+    what `command -v dcode` resolves to. With `stage_shadow`, a genuinely
+    different `dcode` (distinct inode) is also placed under `HOME/shadow` so the
+    caller can put it earlier on `ORIGINAL_PATH` to exercise the warning path.
+    """
+    home = tmp_path / "home"
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    dcode = local_bin / "dcode"
+    dcode.write_text("#!/usr/bin/env bash\nexit 0\n")
+    _make_executable(dcode)
+    # The intermediate `share` dir must exist for the kernel to resolve the
+    # `~/.local/share/../bin` alias; without it the path is ENOENT and
+    # `command -v` finds nothing, so the `-ef` branch would never be reached.
+    (home / ".local" / "share").mkdir()
+
+    if stage_shadow:
+        shadow_dir = home / "shadow"
+        shadow_dir.mkdir()
+        shadow = shadow_dir / "dcode"
+        shadow.write_text("#!/usr/bin/env bash\nexit 0\n")
+        _make_executable(shadow)
+
+    script = tmp_path / "shadowing_harness.sh"
+    script.write_text(
+        'log_warn() { printf "%s\\n" "$*" >&2; }\n'
+        'OS="linux"\n'
+        f"HOME={str(home)!r}\n"
+        f"ORIGINAL_PATH={original_path!r}\n"
+        f"{_extract_shell_function('classify_shadowing_command')}\n"
+        f"{_extract_shell_function('detect_shadowing_install')}\n"
+        "detect_shadowing_install\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        ["bash", str(script)],
+        env={**os.environ, "HOME": str(home)},
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        check=False,
+    )
+    return proc.stderr
+
+
+def test_detect_shadowing_install_skips_same_file_alias(tmp_path: Path) -> None:
+    """A same-file PATH alias of ~/.local/bin does not warn (the fixed bug).
+
+    `~/.local/share/../bin` collapses to `~/.local/bin`, so `command -v` resolves
+    to the very uv tool the installer just created. The `-ef` inode check must
+    short-circuit here; a string-only compare (the pre-fix behavior) would see a
+    different spelling and emit a spurious "existing install" warning.
+    """
+    home = tmp_path / "home"
+    stderr = _run_detect_shadowing_install(
+        tmp_path,
+        original_path=f"{home}/.local/share/../bin",
+    )
+
+    assert stderr.strip() == ""
+
+
+def test_detect_shadowing_install_warns_on_distinct_binary(tmp_path: Path) -> None:
+    """A genuinely different binary earlier on PATH still warns.
+
+    Positive control for the alias test above: it proves the harness does emit
+    a warning when it should, so the empty-stderr assertion there reflects the
+    `-ef` skip rather than a silent harness. The shadow binary is a distinct
+    inode, so both the string and `-ef` checks fail and the warning fires.
+    """
+    home = tmp_path / "home"
+    stderr = _run_detect_shadowing_install(
+        tmp_path,
+        original_path=f"{home}/shadow{os.pathsep}{home}/.local/bin",
+        stage_shadow=True,
+    )
+
+    assert "Detected existing dcode" in stderr
+    assert "PATH order may run that binary instead of the uv tool" in stderr
+
+
+def _eval_local_bin_in_profile(tmp_path: Path, profile_body: str) -> bool:
+    """Run the real `local_bin_in_profile` against a profile file's contents.
+
+    Returns True when the function reports ~/.local/bin as already configured
+    (exit 0).
+    """
+    profile = tmp_path / "profile"
+    profile.write_text(profile_body, encoding="utf-8")
+    script = tmp_path / "profile_harness.sh"
+    script.write_text(
+        f"{_extract_shell_function('local_bin_in_profile')}\n"
+        f"local_bin_in_profile {str(profile)!r}\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        ["bash", str(script)],
+        env={**os.environ},
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        check=False,
+    )
+    return proc.returncode == 0
+
+
+@pytest.mark.parametrize(
+    ("profile_body", "expected"),
+    [
+        # Canonical spelling (regression guard for the pre-existing behavior).
+        ('export PATH="$HOME/.local/bin:$PATH"\n', True),
+        # Un-normalized alias in a PATH assignment (share/.. collapses to .local).
+        ('export PATH="$HOME/.local/share/../bin:$PATH"\n', True),
+        # Same alias via fish_add_path.
+        ('fish_add_path "$HOME/.local/share/../bin"\n', True),
+        # Commented-out lines must not count as configured.
+        ('# export PATH="$HOME/.local/share/../bin:$PATH"\n', False),
+        # An unrelated directory is not a match.
+        ('export PATH="$HOME/somewhere/else:$PATH"\n', False),
+    ],
+)
+def test_local_bin_in_profile_recognizes_alias_spelling(
+    tmp_path: Path, profile_body: str, expected: bool
+) -> None:
+    """`local_bin_in_profile` recognizes the ~/.local/share/../bin alias too.
+
+    Without this, a profile written with the alias spelling would be treated as
+    not configured and the installer would append a duplicate PATH entry.
+    """
+    assert _eval_local_bin_in_profile(tmp_path, profile_body) is expected
+
+
 def test_install_script_no_path_warning_when_dcode_on_path(tmp_path: Path) -> None:
     """When `dcode` resolves via PATH, the not-on-PATH hint is suppressed."""
     proc, _ = _invoke(tmp_path, {}, installed_version="0.1.0", latest_version="0.2.0")


### PR DESCRIPTION
The installer no longer prints a spurious "shadowing install" warning when `~/.local/bin` appears on `PATH` under a non-normalized alias (such as `~/.local/share/../bin`) that resolves to the same directory.

---

The `deepagents-code` installer printed a spurious "shadowing install" warning on every run for users whose `PATH` contains a non-normalized alias of `~/.local/bin` — most commonly `~/.local/share/../bin`, where `share/..` collapses back to `.local`. Some third-party tools write that un-normalized spelling into a shell profile (derived from `$XDG_DATA_HOME/../bin`), and it can sort before the canonical entry. Both spellings resolve to the same uv-tool symlink the installer just created, but `detect_shadowing_install` compared `PATH` strings, so the alias looked like a separate, older install.

The primary fix makes the guard compare by inode using bash's `-ef` test (same device+inode, resolves `..` and symlinks) in addition to the existing string equality, so same-file aliases short-circuit and never warn. Both operands are guaranteed to exist at that point, and a genuinely different binary at a distinct inode still fails `-ef` and correctly warns, so only the false positive is suppressed. Secondarily, `local_bin_in_profile` now also recognizes the `~/.local/share/../bin` spelling so the installer doesn't append a duplicate `~/.local/bin` PATH line; this covers the common alias only and isn't a full path normalizer.

Made by [Open SWE](https://openswe.vercel.app/agents/870c16ab-41c7-3eee-e0d1-55385367ec4f)