### PR TITLE
fix(code): make `/threads` dropdown hover visible under ANSI themes

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/thread_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/thread_selector.py
@@ -785,6 +785,17 @@ class ThreadSelectorScreen(ModalScreen[str | None]):
         margin-bottom: 1;
     }
 
+    /* ANSI themes resolve `$block-hover-background` to the terminal default
+       color, which has no contrast, so mouse-hover over the scope/sort/agent
+       dropdown options is invisible. Reverse the default option colors under
+       ANSI so the hovered row stays visible in both light and dark terminals
+       without hardcoding a palette-specific color. */
+    ThreadSelectorScreen ContainedSelectOverlay:ansi > .option-list--option-hover {
+        background: ansi_default;
+        color: ansi_default;
+        text-style: reverse;
+    }
+
     ThreadSelectorScreen .thread-column-toggle {
         width: 1fr;
         height: auto;

--- a/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_thread_selector.py
@@ -222,6 +222,41 @@ class TestContainedSelect:
         assert not select.expanded
 
 
+class TestThreadSelectorOptionHover:
+    """Tests for dropdown option-hover visibility across themes."""
+
+    async def test_ansi_theme_reverses_option_hover(self) -> None:
+        """ANSI themes must reverse the hovered option so it stays visible.
+
+        Under ANSI themes `$block-hover-background` resolves to the terminal
+        default color (no contrast), so the mouse-hover highlight on the
+        scope/sort/agent dropdown options is invisible without an override.
+        """
+        with _patch_list_threads(), _patch_columns():
+            app = ThreadSelectorTestApp()
+            async with app.run_test() as pilot:
+                app.theme = "ansi-dark"
+                app.show_selector()
+                await pilot.pause()
+
+                overlay = app.screen.query(ContainedSelectOverlay).first()
+                styles = overlay.get_component_styles("option-list--option-hover")
+                assert styles.text_style.reverse is True
+
+    async def test_non_ansi_theme_keeps_default_option_hover(self) -> None:
+        """Non-ANSI themes should keep Textual's default subtle hover."""
+        with _patch_list_threads(), _patch_columns():
+            app = ThreadSelectorTestApp()
+            async with app.run_test() as pilot:
+                app.theme = "textual-dark"
+                app.show_selector()
+                await pilot.pause()
+
+                overlay = app.screen.query(ContainedSelectOverlay).first()
+                styles = overlay.get_component_styles("option-list--option-hover")
+                assert styles.text_style.reverse is not True
+
+
 class TestThreadSelectorEscapeKey:
     """Tests for ESC key dismissing the modal."""
 


### PR DESCRIPTION
Fixed the `/threads` switcher so the scope/sort/agent dropdown options show a visible mouse-hover highlight when using an ANSI theme.

---

In the `/threads` switcher, the mouse-hover highlight on the "Show threads from", "Sort threads by", and "Show agent" dropdown options was invisible under ANSI themes (notably `ansi-dark`). ANSI themes resolve `$block-hover-background` to the terminal default color, which has no contrast against the option background, so hovering an option produced no visible feedback.

The fix scopes an ANSI-only override (`:ansi` pseudo-class) on the dropdown overlay that reverses the hovered option's default colors, keeping it visible in both light and dark terminals without hardcoding a palette-specific color. Non-ANSI themes keep Textual's default subtle hover.

Made by [Open SWE](https://openswe.vercel.app/agents/717afe0f-923b-d3fe-a879-eb4b799152f2)