### PR TITLE
fix(code): handle legacy `read_file` gutters

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -1982,18 +1982,19 @@ class ToolCallMessage(Vertical):
 
     @staticmethod
     def _compact_line_gutter(output: str) -> str:
-        r"""Tighten `read_file`'s cat -n line-number gutter for display.
+        r"""Tighten legacy `read_file` cat-n line-number gutters for display.
 
-        The tool emits `f"{line_num:6d}\t{line}"` — a 6-wide right-justified
-        number plus a tab — so even single-digit line numbers carry five
-        leading spaces and the tab pushes content to a distant tab stop. The
-        model needs that raw format for edits, but the TUI renders a compact
-        gutter instead: numbers right-justified to the widest number actually
-        present, then two spaces, mirroring how grep/glob results sit flush
-        left. Source indentation after the gutter is preserved untouched.
+        Older tool output used `f"{line_num:6d}\t{line}"` — a 6-wide
+        right-justified number plus a tab — so even single-digit line numbers
+        carried five leading spaces and the tab pushed content to a distant tab
+        stop. The TUI renders that legacy gutter in the newer compact shape:
+        numbers right-justified to the widest number actually present, then two
+        spaces, mirroring how grep/glob results sit flush left. Source
+        indentation after the gutter is preserved untouched.
 
-        Lines that don't match the cat -n shape (e.g. test fixtures or
-        non-numbered output) are passed through unchanged.
+        Lines that don't match the legacy cat-n shape (e.g. current compact
+        read output, test fixtures, or non-numbered output) are passed through
+        unchanged.
 
         Returns:
             The output with compacted gutters, or the original string if no

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -2760,14 +2760,14 @@ class TestToolCallMessageFileOutput:
     def test_format_output_compacts_line_number_gutter(self) -> None:
         r"""Line-number gutters are tightened, all rows aligned to one column.
 
-        `read_file` emits `f"{line_num:6d}\t{line}"` — a 6-wide right-justified
-        number plus a tab — which renders far from the line numbers and (when
-        the first row's padding was stripped) misaligned. The TUI recomputes a
-        compact gutter: numbers right-justified to the widest number present,
-        two spaces, then the original source indentation.
+        Legacy `read_file` output used `f"{line_num:6d}\t{line}"` — a 6-wide
+        right-justified number plus a tab — which renders far from the line
+        numbers and (when the first row's padding was stripped) misaligned. The
+        TUI recomputes a compact gutter: numbers right-justified to the widest
+        number present, two spaces, then the original source indentation.
         """
         msg = ToolCallMessage("read_file", {"path": "/tmp/a.py"})
-        # cat -n style: 6-wide right-justified number + tab + source line.
+        # Legacy cat-n style: 6-wide right-justified number + tab + source line.
         output = '     1\t"""doc"""\n     2\t\n     3\t    indented'
         result = msg._format_output(output, is_preview=False)
 


### PR DESCRIPTION
Depends on #4561

The base branch updates `read_file` output to use a compact, unambiguous two-space separator. This PR keeps the TUI display compaction compatible with older cat-n style `read_file` output by treating that shape as legacy, while leaving current compact read output unchanged.