### PR TITLE
fix(code): strip input before `Ctrl+C` copy-input fallback

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -12259,7 +12259,8 @@ class DeepAgentsApp(App):
         4. If ask_user menu is active, cancel it
         5. If agent is running, interrupt it (preserve input)
         6. If double press (quit_pending), quit
-        7. If a focused input has text, copy the whole draft (no selection)
+        7. If a focused input has non-whitespace text, copy the whole draft
+            (no selection)
         8. Otherwise show quit hint
 
         Rapid escape hatch: the clipboard-copy branches (1 and 7) are skipped
@@ -12370,13 +12371,14 @@ class DeepAgentsApp(App):
         return copy_text_with_feedback(self, selected_text, failure_noun="selection")
 
     def _copy_focused_input_text(self) -> bool:
-        """Copy the focused input's full text to the clipboard, if non-empty.
+        """Copy the focused input's full text to the clipboard, if meaningful.
 
         Ctrl+C fallback used when there is no active selection, so the whole
-        draft is copied instead of arming quit.
+        draft is copied instead of arming quit. A whitespace-only draft is
+        treated as empty and left to fall through to quit handling.
 
         Returns:
-            `True` when non-empty text was handled by a clipboard attempt.
+            `True` when non-whitespace text was handled by a clipboard attempt.
         """
         from textual.widgets import Input, TextArea
 
@@ -12387,7 +12389,10 @@ class DeepAgentsApp(App):
             return False
 
         text = widget.text if isinstance(widget, TextArea) else widget.value
-        if not text:
+        # Strip before deciding whether there is anything to copy: a
+        # whitespace-only draft carries no meaningful content, so Ctrl+C should
+        # fall through to arming quit rather than copying blank space.
+        if not text.strip():
             return False
 
         from deepagents_code.clipboard import copy_text_with_feedback

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -23027,6 +23027,28 @@ class TestCopyFocusedInputText:
         assert app._copy_focused_input_text() is False
         assert copied == []
 
+    def test_no_copy_when_input_whitespace_only(self, monkeypatch) -> None:
+        """A whitespace-only draft is treated as empty and not copied."""
+        from textual.widgets import TextArea
+
+        import deepagents_code.clipboard as clipboard_module
+
+        copied: list[str] = []
+
+        def fake_copy(_app: object, text: str) -> tuple[bool, str | None]:
+            copied.append(text)
+            return True, None
+
+        monkeypatch.setattr(clipboard_module, "copy_text_to_clipboard", fake_copy)
+
+        app = self._make_app()
+        text_area = TextArea()
+        text_area.text = "   \n\t  "
+        monkeypatch.setattr(type(app), "focused", property(lambda _self: text_area))
+
+        assert app._copy_focused_input_text() is False
+        assert copied == []
+
     def test_no_copy_when_nothing_focused(self, monkeypatch) -> None:
         """When the focused widget is not an input, nothing is copied."""
         app = self._make_app()


### PR DESCRIPTION
`Ctrl+C` no longer copies a whitespace-only input draft; such a draft is treated as empty so the quit flow proceeds.

Made by [Open SWE](https://openswe.vercel.app/agents/839a0ad0-e2da-4fd1-cf9b-ab14a2042c7e)