### PR TITLE
chore(code): reframe dcode pyproject description as coding agent

### DIFF
--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "deepagents-code"
 version = "0.1.36"
-description = "Terminal interface for Deep Agents - interactive AI agent with file operations, shell access, and sub-agent capabilities."
+description = "Terminal coding agent built on the Deep Agents SDK - works with any model, with persistent memory, customizable skills, subagents, and approval controls."
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.11,<4.0"


### PR DESCRIPTION
The `deepagents-code` (`dcode`) `pyproject.toml` description still framed the package as a generic "terminal interface for Deep Agents." It's now the terminal coding agent, so this updates the description to match how it's presented in the [Deep Agents Code docs](https://docs.langchain.com/oss/python/deepagents/code/overview) — a coding agent built on the Deep Agents SDK that works with any model and offers persistent memory, skills, subagents, and approval controls.

Made by [Open SWE](https://openswe.vercel.app/agents/4029725a-6556-b6f4-d30c-9929727823e0)