### PR TITLE
feat(sdk): support prefixed skill sources

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -363,7 +363,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     system_prompt: str | SystemMessage | SystemPromptConfig | None = None,
     middleware: Sequence[AgentMiddleware[StateT_co, ContextT]] = (),
     subagents: Sequence[SubAgent | CompiledSubAgent | AsyncSubAgent] | None = None,
-    skills: list[SkillSource] | None = None,
+    skills: Sequence[SkillSource] | None = None,
     memory: list[str] | None = None,
     permissions: list[FilesystemPermission] | None = None,
     backend: BackendProtocol | BackendFactory | None = None,

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -51,7 +51,7 @@ from deepagents.middleware.async_subagents import AsyncSubAgent, AsyncSubAgentMi
 from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemPermission
 from deepagents.middleware.memory import MemoryMiddleware
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.skills import SkillsMiddleware
+from deepagents.middleware.skills import SkillsMiddleware, SkillSource
 from deepagents.middleware.subagents import (
     GENERAL_PURPOSE_SUBAGENT,
     CompiledSubAgent,
@@ -363,7 +363,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     system_prompt: str | SystemMessage | SystemPromptConfig | None = None,
     middleware: Sequence[AgentMiddleware[StateT_co, ContextT]] = (),
     subagents: Sequence[SubAgent | CompiledSubAgent | AsyncSubAgent] | None = None,
-    skills: list[str] | None = None,
+    skills: list[SkillSource] | None = None,
     memory: list[str] | None = None,
     permissions: list[FilesystemPermission] | None = None,
     backend: BackendProtocol | BackendFactory | None = None,
@@ -526,7 +526,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             `general_purpose_subagent=GeneralPurposeSubagentProfile(enabled=False)`
             — the `task` tool is not exposed. Async subagents are independent.
 
-        skills: List of skill source paths (e.g., `["/skills/user/", "/skills/project/"]`).
+        skills: List of skill sources.
 
             Paths must be specified using POSIX conventions (forward slashes)
             and are relative to the backend's root. When using
@@ -534,6 +534,8 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             `invoke(files={...})`. With `FilesystemBackend`, skills are loaded
             from disk relative to the backend's `root_dir`. Later sources
             override earlier ones for skills with the same name (last one wins).
+            Each source can be a path, a `(path, label)` tuple, or a
+            `(path, label, name_prefix)` tuple.
         memory: List of memory file paths (`AGENTS.md` files) to load
             (e.g., `["/memory/AGENTS.md"]`).
 

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -63,7 +63,7 @@ from deepagents.middleware.rubric import (
     RubricResult,
     RubricState,
 )
-from deepagents.middleware.skills import SkillsMiddleware
+from deepagents.middleware.skills import SkillsMiddleware, SkillSource
 from deepagents.middleware.subagents import (
     CompiledSubAgent,
     SubAgent,
@@ -95,6 +95,7 @@ __all__ = [
     "RubricMiddleware",
     "RubricResult",
     "RubricState",
+    "SkillSource",
     "SkillsMiddleware",
     "SubAgent",
     "SubAgentMiddleware",

--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -53,14 +53,15 @@ Parsed from YAML frontmatter per Agent Skills specification:
 
 ## Sources
 
-Sources point to skill directories in the backend. Each source is either a bare
-path or a `(path, label)` tuple. With a bare path the label is derived from the
-last path component capitalized (e.g., `/skills/user/` -> `User`), with two
-special cases: `built_in_skills` collapses to `Built-in`, and a literal `skills`
-leaf climbs one level so `~/.claude/skills` renders as `Claude` rather than the
-duplicative `Skills Skills`. Pass an explicit tuple to disambiguate sources
-whose leaf directories would collide (e.g. user- vs project-scoped
-`.claude/skills`).
+Sources point to skill directories in the backend. Each source is a bare path,
+a `(path, label)` tuple, or a `(path, label, name_prefix)` tuple. With a bare
+path the label is derived from the last path component capitalized (e.g.,
+`/skills/user/` -> `User`), with two special cases: `built_in_skills` collapses
+to `Built-in`, and a literal `skills` leaf climbs one level so
+`~/.claude/skills` renders as `Claude` rather than the duplicative
+`Skills Skills`. Pass an explicit tuple to disambiguate labels or qualify names
+from a source. Prefixes are applied after source skill validation, so qualified
+names may use namespace separators that are not valid in source frontmatter.
 
 Example sources:
 ```python
@@ -69,6 +70,7 @@ Example sources:
     "/skills/project/",
     ("/home/me/.claude/skills", "User Claude"),
     ("/repo/.claude/skills", "Project Claude"),
+    ("/plugins/review/skills", "Review Plugin", "review:"),
 ]
 ```
 
@@ -140,6 +142,7 @@ logger = logging.getLogger(__name__)
 MAX_SKILL_FILE_SIZE = 10 * 1024 * 1024
 MAX_SKILLS_LOAD_WARNINGS = 20
 MAX_SKILL_LOAD_WARNING_LENGTH = 1000
+_SKILL_SOURCE_WITH_PREFIX_LEN = 3
 _SKILL_LOAD_WARNING_TRUNCATION_SUFFIX = "... [truncated]"
 
 # Agent Skills specification constraints (https://agentskills.io/specification)
@@ -147,14 +150,18 @@ MAX_SKILL_NAME_LENGTH = 64
 MAX_SKILL_DESCRIPTION_LENGTH = 1024
 MAX_SKILL_COMPATIBILITY_LENGTH = 500
 
-SkillSource = str | tuple[str, str]
-"""A skill source: either a bare path or a `(path, label)` pair.
+SkillSource = str | tuple[str, str] | tuple[str, str, str]
+"""A skill source: a bare path, `(path, label)`, or `(path, label, name_prefix)`.
 
 When only a path is given, the label is derived from the final path
 component. Supply a tuple to override the default (e.g. to distinguish
 user-scoped from project-scoped directories that share the same leaf
 name). The label is rendered as `**{label} Skills**` in the system
 prompt; do not include the trailing "Skills" yourself.
+
+The optional third tuple element prefixes discovered skill names. This is used
+for plugin namespaces such as `formatter:review` while preserving the same
+underlying skill directory layout.
 """
 
 
@@ -166,11 +173,12 @@ def _validate_tuple_source(source: tuple[object, ...]) -> None:
     middleware or a silently-coerced non-string path downstream.
     """
     if (
-        len(source) != 2  # noqa: PLR2004  # SkillSource tuple is exactly (path, label)
+        len(source) not in {2, _SKILL_SOURCE_WITH_PREFIX_LEN}
         or not isinstance(source[0], str)
         or not isinstance(source[1], str)
+        or (len(source) == _SKILL_SOURCE_WITH_PREFIX_LEN and not isinstance(source[2], str))
     ):
-        msg = f"Invalid skill source: expected str or (str, str) tuple, got {source!r}"
+        msg = f"Invalid skill source: expected str, (str, str), or (str, str, str) tuple, got {source!r}"
         raise TypeError(msg)
 
 
@@ -188,6 +196,14 @@ def _truncate_skill_load_warning(error: str) -> str:
         return error
     length = MAX_SKILL_LOAD_WARNING_LENGTH - len(_SKILL_LOAD_WARNING_TRUNCATION_SUFFIX)
     return f"{error[:length]}{_SKILL_LOAD_WARNING_TRUNCATION_SUFFIX}"
+
+
+def _source_name_prefix(source: SkillSource) -> str:
+    """Return an optional prefix applied to skill names from a source."""
+    if isinstance(source, str):
+        return ""
+    _validate_tuple_source(source)
+    return source[2] if len(source) == _SKILL_SOURCE_WITH_PREFIX_LEN else ""
 
 
 def _derive_source_label(source: SkillSource) -> str:
@@ -587,11 +603,19 @@ def _format_skills_source_error(source_path: str, error: str) -> str:
     return f"Cannot load skills from '{source_path}': {error}"
 
 
+def _apply_skill_name_prefix(skills: list[SkillMetadata], prefix: str) -> list[SkillMetadata]:
+    """Return skill metadata with `prefix` prepended to each skill name."""
+    if not prefix:
+        return skills
+    return [SkillMetadata({**skill, "name": f"{prefix}{skill['name']}"}) for skill in skills]
+
+
 def _list_skills_with_errors(backend: BackendProtocol, source_path: str) -> tuple[list[SkillMetadata], str | None]:
     """List all skills from a backend source.
 
-    Scans backend for subdirectories containing `SKILL.md` files, downloads
-    their content, parses YAML frontmatter, and returns skill metadata.
+    Scans backend for `SKILL.md` directly under the source and for
+    subdirectories containing `SKILL.md` files, downloads their content, parses
+    YAML frontmatter, and returns skill metadata.
 
     Expected structure:
 
@@ -610,6 +634,12 @@ def _list_skills_with_errors(backend: BackendProtocol, source_path: str) -> tupl
         Tuple of skill metadata and an optional source-level loading error.
     """
     skills: list[SkillMetadata] = []
+    direct_skill_md_path = str(PurePosixPath(to_posix_path(source_path)) / "SKILL.md")
+    direct_response = backend.download_files([direct_skill_md_path])[0]
+    direct_skill = _skill_metadata_from_response(direct_response, source_path, direct_skill_md_path)
+    if direct_skill is not None:
+        skills.append(direct_skill)
+
     source_error: str | None = None
     ls_result = backend.ls(source_path)
     if isinstance(ls_result, LsResult) and ls_result.error:
@@ -627,7 +657,7 @@ def _list_skills_with_errors(backend: BackendProtocol, source_path: str) -> tupl
         skill_dirs.append(item["path"])
 
     if not skill_dirs:
-        return [], source_error
+        return skills, source_error
 
     # For each skill directory, check if SKILL.md exists and download it
     skill_md_paths = []
@@ -656,8 +686,9 @@ def _list_skills(backend: BackendProtocol, source_path: str) -> list[SkillMetada
 async def _alist_skills_with_errors(backend: BackendProtocol, source_path: str) -> tuple[list[SkillMetadata], str | None]:
     """List all skills from a backend source (async version).
 
-    Scans backend for subdirectories containing `SKILL.md` files, downloads
-    their content, parses YAML frontmatter, and returns skill metadata.
+    Scans backend for `SKILL.md` directly under the source and for
+    subdirectories containing `SKILL.md` files, downloads their content, parses
+    YAML frontmatter, and returns skill metadata.
 
     Expected structure:
 
@@ -676,6 +707,12 @@ async def _alist_skills_with_errors(backend: BackendProtocol, source_path: str) 
         Tuple of skill metadata and an optional source-level loading error.
     """
     skills: list[SkillMetadata] = []
+    direct_skill_md_path = str(PurePosixPath(to_posix_path(source_path)) / "SKILL.md")
+    direct_response = (await backend.adownload_files([direct_skill_md_path]))[0]
+    direct_skill = _skill_metadata_from_response(direct_response, source_path, direct_skill_md_path)
+    if direct_skill is not None:
+        skills.append(direct_skill)
+
     source_error: str | None = None
     ls_result = await backend.als(source_path)
     if isinstance(ls_result, LsResult) and ls_result.error:
@@ -693,7 +730,7 @@ async def _alist_skills_with_errors(backend: BackendProtocol, source_path: str) 
         skill_dirs.append(item["path"])
 
     if not skill_dirs:
-        return [], source_error
+        return skills, source_error
 
     # For each skill directory, check if SKILL.md exists and download it
     skill_md_paths = []
@@ -814,10 +851,11 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
             sources: List of skill sources.
 
                 Each entry is either a bare path (e.g. `'/skills/user/'`) or
-                a `(path, label)` tuple
-                (e.g. `('/home/me/.claude/skills', 'User Claude')`). Labels
-                are rendered as `**{label} Skills**` in the system prompt
-                (do not include the trailing `Skills` in your label).
+                a `(path, label)` tuple, or a
+                `(path, label, name_prefix)` tuple. Labels are rendered as
+                `**{label} Skills**` in the system prompt (do not include the
+                trailing `Skills` in your label). The optional prefix qualifies
+                each loaded skill name after source metadata validation.
             system_prompt: System-prompt fragment template. Must contain
                 `{skills_locations}`, `{skills_load_warnings}`, and
                 `{skills_list}` slots for runtime substitution. Pass `None`
@@ -825,9 +863,9 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
                 `state["skills_metadata"]`).
 
         Raises:
-            TypeError: If a tuple entry in `sources` is not exactly a
-                `(str, str)` pair, or if `system_prompt` is not `str` or
-                `None`.
+            TypeError: If a tuple entry in `sources` is not a two- or
+                three-item tuple of strings, or if `system_prompt` is not
+                `str` or `None`.
             ValueError: If `system_prompt` is a string missing any of the
                 required format slots.
         """
@@ -846,6 +884,7 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
         # information is mirrored on `self.source_labels` at the same index.
         self.sources: list[str] = [_source_path(s) for s in sources]
         self.source_labels: list[str] = [_derive_source_label(s) for s in sources]
+        self.source_name_prefixes: list[str] = [_source_name_prefix(s) for s in sources]
         self.system_prompt_template = system_prompt
 
     def _get_backend(self, state: SkillsState, runtime: Runtime, config: RunnableConfig) -> BackendProtocol:
@@ -984,11 +1023,11 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
 
         # Load skills from each source in order
         # Later sources override earlier ones (last one wins)
-        for source_path in self.sources:
+        for source_path, name_prefix in zip(self.sources, self.source_name_prefixes, strict=True):
             source_skills, source_error = _list_skills_with_errors(backend, source_path)
             if source_error is not None:
                 skills_load_errors.append(source_error)
-            for skill in source_skills:
+            for skill in _apply_skill_name_prefix(source_skills, name_prefix):
                 all_skills[skill["name"]] = skill
 
         skills = list(all_skills.values())
@@ -1030,11 +1069,11 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
 
         # Load skills from each source in order
         # Later sources override earlier ones (last one wins)
-        for source_path in self.sources:
+        for source_path, name_prefix in zip(self.sources, self.source_name_prefixes, strict=True):
             source_skills, source_error = await _alist_skills_with_errors(backend, source_path)
             if source_error is not None:
                 skills_load_errors.append(source_error)
-            for skill in source_skills:
+            for skill in _apply_skill_name_prefix(source_skills, name_prefix):
                 all_skills[skill["name"]] = skill
 
         skills = list(all_skills.values())
@@ -1082,4 +1121,4 @@ class SkillsMiddleware(AgentMiddleware[SkillsState, ContextT, ResponseT]):
         return await handler(modified_request)
 
 
-__all__ = ["SkillMetadata", "SkillsMiddleware"]
+__all__ = ["SkillMetadata", "SkillSource", "SkillsMiddleware"]

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel, Field
 from deepagents.backends.protocol import BackendFactory, BackendProtocol
 from deepagents.middleware._utils import append_to_system_message
 from deepagents.middleware.filesystem import FilesystemPermission
+from deepagents.middleware.skills import SkillSource
 
 SUBAGENT_RESPONSE_FORMAT_CONFIG_KEY = "__deepagents_subagent_response_format"
 """Configurable key used by task-tool callers to request dynamic response format."""
@@ -68,10 +69,10 @@ class SubAgent(TypedDict):
         interrupt_on: Configure human-in-the-loop for specific tools.
 
             Requires a checkpointer.
-        skills: Skill source paths for `SkillsMiddleware`.
+        skills: Skill sources for `SkillsMiddleware`.
 
-            List of paths to skill directories
-            (e.g., `["/skills/user/", "/skills/project/"]`).
+            Each source can be a path, a `(path, label)` tuple, or a
+            `(path, label, name_prefix)` tuple.
         permissions: Filesystem permission rules for this subagent.
 
             If omitted, inherits the parent agent's permissions. If provided,
@@ -110,8 +111,8 @@ class SubAgent(TypedDict):
     interrupt_on: NotRequired[dict[str, bool | InterruptOnConfig]]
     """Configure human-in-the-loop for specific tools."""
 
-    skills: NotRequired[list[str]]
-    """Skill source paths for `SkillsMiddleware`."""
+    skills: NotRequired[list[SkillSource]]
+    """Skill sources for `SkillsMiddleware`."""
 
     permissions: NotRequired[list[FilesystemPermission]]
     """List of `FilesystemPermission` rules for this subagent.

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -111,7 +111,7 @@ class SubAgent(TypedDict):
     interrupt_on: NotRequired[dict[str, bool | InterruptOnConfig]]
     """Configure human-in-the-loop for specific tools."""
 
-    skills: NotRequired[list[SkillSource]]
+    skills: NotRequired[Sequence[SkillSource]]
     """Skill sources for `SkillsMiddleware`."""
 
     permissions: NotRequired[list[FilesystemPermission]]

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
@@ -1884,7 +1884,7 @@ def test_create_deep_agent_with_skills_and_filesystem_backend(tmp_path: Path) ->
     # Create agent with skills parameter and FilesystemBackend
     agent = create_deep_agent(
         backend=backend,
-        skills=[str(skills_dir)],
+        skills=[(str(skills_dir), "Plugin", "plugin:")],
         model=GenericFakeChatModel(messages=iter([AIMessage(content="I see the test-skill in the system prompt.")])),
     )
 

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 from langchain.agents import create_agent
@@ -31,6 +31,7 @@ from deepagents.backends.protocol import FileDownloadResponse, FileInfo, LsResul
 from deepagents.backends.state import StateBackend
 from deepagents.backends.store import StoreBackend
 from deepagents.graph import create_deep_agent
+from deepagents.middleware import SkillSource as PublicSkillSource
 from deepagents.middleware.skills import (
     MAX_SKILL_COMPATIBILITY_LENGTH,
     MAX_SKILL_DESCRIPTION_LENGTH,
@@ -656,6 +657,31 @@ def test_list_skills_from_backend_single_skill(tmp_path: Path) -> None:
     ]
 
 
+def test_list_skills_from_backend_root_skill_md(tmp_path: Path) -> None:
+    """Test listing a SKILL.md placed directly under the source path."""
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+    skill_root = tmp_path / "plugin-skill"
+    skill_path = (skill_root / "SKILL.md").as_posix()
+    skill_content = make_skill_content("root-skill", "Root skill")
+
+    responses = backend.upload_files([(skill_path, skill_content.encode("utf-8"))])
+    assert responses[0].error is None
+
+    skills = _list_skills(backend, skill_root.as_posix())
+
+    assert skills == [
+        {
+            "name": "root-skill",
+            "description": "Root skill",
+            "path": skill_path,
+            "metadata": {},
+            "license": None,
+            "compatibility": None,
+            "allowed_tools": [],
+        }
+    ]
+
+
 def test_list_skills_from_backend_multiple_skills(tmp_path: Path) -> None:
     """Test listing multiple skills from filesystem backend."""
     backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
@@ -715,13 +741,14 @@ def test_list_skills_logs_ls_error(caplog: pytest.LogCaptureFixture) -> None:
     """A backend listing error should not look like a normal empty source."""
     backend = MagicMock()
     backend.ls.return_value = LsResult(error="Cannot list '/bad': denied", entries=[])
+    backend.download_files.return_value = [FileDownloadResponse(path="/bad/SKILL.md", content=None, error="file_not_found")]
 
     with caplog.at_level(logging.WARNING):
         skills = _list_skills(backend, "/bad")
 
     assert skills == []
     assert "Cannot load skills from '/bad'" in caplog.text
-    backend.download_files.assert_not_called()
+    backend.download_files.assert_called_once_with(["/bad/SKILL.md"])
 
 
 def test_list_skills_loads_partial_results_with_ls_error(caplog: pytest.LogCaptureFixture) -> None:
@@ -732,7 +759,10 @@ def test_list_skills_loads_partial_results_with_ls_error(caplog: pytest.LogCaptu
 
     backend = MagicMock()
     backend.ls.return_value = LsResult(error="Cannot list '/skills/loop': symlink loop", entries=[FileInfo(path=skill_dir_path, is_dir=True)])
-    backend.download_files.return_value = [FileDownloadResponse(path=skill_md_path, content=skill_content.encode("utf-8"), error=None)]
+    backend.download_files.side_effect = [
+        [FileDownloadResponse(path="/skills/SKILL.md", content=None, error="file_not_found")],
+        [FileDownloadResponse(path=skill_md_path, content=skill_content.encode("utf-8"), error=None)],
+    ]
 
     with caplog.at_level(logging.WARNING):
         skills = _list_skills(backend, "/skills")
@@ -740,7 +770,10 @@ def test_list_skills_loads_partial_results_with_ls_error(caplog: pytest.LogCaptu
     assert len(skills) == 1
     assert skills[0]["name"] == "valid-skill"
     assert "Cannot load skills from '/skills'" in caplog.text
-    backend.download_files.assert_called_once_with([skill_md_path])
+    assert backend.download_files.call_args_list == [
+        call(["/skills/SKILL.md"]),
+        call([skill_md_path]),
+    ]
 
 
 def test_list_skills_from_backend_missing_skill_md(tmp_path: Path) -> None:
@@ -873,23 +906,30 @@ def test_list_skills_with_windows_style_paths(skill_dir_path: str, source_path: 
     """
     skill_content = make_skill_content("my-skill", "My test skill")
     expected_skill_md_path = str(PurePosixPath(skill_dir_path.replace("\\", "/")) / "SKILL.md")
+    direct_skill_md_path = str(PurePosixPath(source_path.replace("\\", "/")) / "SKILL.md")
 
     backend = MagicMock()
     backend.ls = MagicMock(return_value=LsResult(entries=[FileInfo(path=skill_dir_path, is_dir=True)]))
     backend.download_files = MagicMock(
-        return_value=[
-            FileDownloadResponse(
-                path=expected_skill_md_path,
-                content=skill_content.encode("utf-8"),
-                error=None,
-            )
+        side_effect=[
+            [FileDownloadResponse(path=direct_skill_md_path, content=None, error="file_not_found")],
+            [
+                FileDownloadResponse(
+                    path=expected_skill_md_path,
+                    content=skill_content.encode("utf-8"),
+                    error=None,
+                )
+            ],
         ]
     )
 
     skills = _list_skills(backend, source_path)
 
     # Pins the whole fix: the normalized POSIX path must be what gets requested.
-    backend.download_files.assert_called_once_with([expected_skill_md_path])
+    assert backend.download_files.call_args_list == [
+        call([direct_skill_md_path]),
+        call([expected_skill_md_path]),
+    ]
     assert len(skills) == 1
     assert skills[0]["name"] == "my-skill"
     assert skills[0]["description"] == "My test skill"
@@ -1086,11 +1126,12 @@ def test_format_skills_locations_empty_path_fallback(empty_path: str) -> None:
     "bad_source",
     [
         ("/only-one-element",),
-        ("/one", "two", "three"),
+        ("/one", "two", "three", "four"),
         ("/path", 42),
         (None, "label"),
+        ("/path", "label", 42),
     ],
-    ids=["one-tuple", "three-tuple", "non-string-label", "non-string-path"],
+    ids=["one-tuple", "four-tuple", "non-string-label", "non-string-path", "non-string-prefix"],
 )
 def test_malformed_tuple_source_raises_type_error(bad_source: object) -> None:
     """Malformed tuple sources raise `TypeError` at construction time.
@@ -1099,7 +1140,10 @@ def test_malformed_tuple_source_raises_type_error(bad_source: object) -> None:
     `IndexError` in the middleware or a silently-coerced non-string path
     downstream.
     """
-    with pytest.raises(TypeError, match=r"expected str or \(str, str\) tuple"):
+    with pytest.raises(
+        TypeError,
+        match=r"expected str, \(str, str\), or \(str, str, str\) tuple",
+    ):
         SkillsMiddleware(
             backend=None,  # type: ignore[arg-type]
             sources=[bad_source],  # type: ignore[list-item]
@@ -1122,6 +1166,10 @@ def test_sources_attribute_is_paths_only() -> None:
 
     assert middleware.sources == ["/skills/user/", "/home/me/.claude/skills"]
     assert middleware.source_labels == ["User", "User Claude"]
+
+
+def test_skill_source_is_exported_from_middleware() -> None:
+    assert PublicSkillSource is not None
 
 
 def test_format_skills_locations_single_registry() -> None:

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware_async.py
@@ -127,13 +127,14 @@ async def test_alist_skills_logs_ls_error(caplog: pytest.LogCaptureFixture) -> N
     """A backend listing error should not look like a normal empty source."""
     backend = MagicMock()
     backend.als = AsyncMock(return_value=LsResult(error="Cannot list '/bad': denied", entries=[]))
+    backend.adownload_files = AsyncMock(return_value=[FileDownloadResponse(path="/bad/SKILL.md", content=None, error="file_not_found")])
 
     with caplog.at_level(logging.WARNING):
         skills = await _alist_skills(backend, "/bad")
 
     assert skills == []
     assert "Cannot load skills from '/bad'" in caplog.text
-    backend.adownload_files.assert_not_called()
+    backend.adownload_files.assert_awaited_once_with(["/bad/SKILL.md"])
 
 
 async def test_alist_skills_loads_partial_results_with_ls_error(caplog: pytest.LogCaptureFixture) -> None:
@@ -146,7 +147,12 @@ async def test_alist_skills_loads_partial_results_with_ls_error(caplog: pytest.L
     backend.als = AsyncMock(
         return_value=LsResult(error="Cannot list '/skills/loop': symlink loop", entries=[FileInfo(path=skill_dir_path, is_dir=True)])
     )
-    backend.adownload_files = AsyncMock(return_value=[FileDownloadResponse(path=skill_md_path, content=skill_content.encode("utf-8"), error=None)])
+    backend.adownload_files = AsyncMock(
+        side_effect=[
+            [FileDownloadResponse(path="/skills/SKILL.md", content=None, error="file_not_found")],
+            [FileDownloadResponse(path=skill_md_path, content=skill_content.encode("utf-8"), error=None)],
+        ]
+    )
 
     with caplog.at_level(logging.WARNING):
         skills = await _alist_skills(backend, "/skills")
@@ -154,7 +160,10 @@ async def test_alist_skills_loads_partial_results_with_ls_error(caplog: pytest.L
     assert len(skills) == 1
     assert skills[0]["name"] == "valid-skill"
     assert "Cannot load skills from '/skills'" in caplog.text
-    backend.adownload_files.assert_called_once_with([skill_md_path])
+    assert [call.args for call in backend.adownload_files.await_args_list] == [
+        (["/skills/SKILL.md"],),
+        ([skill_md_path],),
+    ]
 
 
 async def test_alist_skills_from_backend_missing_skill_md(tmp_path: Path) -> None:
@@ -498,22 +507,29 @@ async def test_alist_skills_with_windows_style_paths(skill_dir_path: str, source
     """Async counterpart of `test_list_skills_with_windows_style_paths`."""
     skill_content = make_skill_content("my-skill", "My test skill")
     expected_skill_md_path = str(PurePosixPath(skill_dir_path.replace("\\", "/")) / "SKILL.md")
+    direct_skill_md_path = str(PurePosixPath(source_path.replace("\\", "/")) / "SKILL.md")
 
     backend = MagicMock()
     backend.als = AsyncMock(return_value=LsResult(entries=[FileInfo(path=skill_dir_path, is_dir=True)]))
     backend.adownload_files = AsyncMock(
-        return_value=[
-            FileDownloadResponse(
-                path=expected_skill_md_path,
-                content=skill_content.encode("utf-8"),
-                error=None,
-            )
+        side_effect=[
+            [FileDownloadResponse(path=direct_skill_md_path, content=None, error="file_not_found")],
+            [
+                FileDownloadResponse(
+                    path=expected_skill_md_path,
+                    content=skill_content.encode("utf-8"),
+                    error=None,
+                )
+            ],
         ]
     )
 
     skills = await _alist_skills(backend, source_path)
 
-    backend.adownload_files.assert_awaited_once_with([expected_skill_md_path])
+    assert [call.args for call in backend.adownload_files.await_args_list] == [
+        ([direct_skill_md_path],),
+        ([expected_skill_md_path],),
+    ]
     assert len(skills) == 1
     assert skills[0]["name"] == "my-skill"
     assert skills[0]["description"] == "My test skill"

--- a/libs/deepagents/tests/unit_tests/test_subagents.py
+++ b/libs/deepagents/tests/unit_tests/test_subagents.py
@@ -2626,7 +2626,7 @@ class TestSubAgents:
                     system_prompt="You are a custom worker with skills.",
                     model=custom_subagent_model,
                     tools=[capture_subagent_state],
-                    skills=[str(skills_dir)],  # Custom subagent with skills
+                    skills=[(str(skills_dir), "Plugin", "plugin:")],
                 )
             ],
         )
@@ -2646,7 +2646,7 @@ class TestSubAgents:
         # Verify the skill name is in the skills_metadata
         skills_metadata = subagent_state["skills_metadata"]
         skill_names = [s["name"] for s in skills_metadata]
-        assert "custom-skill" in skill_names, f"Custom subagent should have 'custom-skill' in skills_metadata. Found skills: {skill_names}"
+        assert "plugin:custom-skill" in skill_names
 
     def test_custom_subagent_with_skills_multiple_sources(self, tmp_path: Path) -> None:
         """Test that a custom SubAgent with multiple skill sources loads skills with proper override.


### PR DESCRIPTION
Skill sources can now provide an optional name prefix and can point directly at a skill directory containing `SKILL.md`.

---

Consumers that aggregate skills from multiple independent sources need to qualify names without modifying source files or maintaining a projected cache.

`SkillsMiddleware` now accepts `(path, label, name_prefix)` sources and applies the prefix after validating the underlying skill metadata. Sources can also point directly to a skill directory containing `SKILL.md`. Existing string and two-item source forms retain their behavior.