### PR TITLE
feat(infra): expand GitHub Action inputs

### DIFF
--- a/.github/scripts/test_github_action.py
+++ b/.github/scripts/test_github_action.py
@@ -1,23 +1,18 @@
 """Tests for the root GitHub Action wrapper."""
 
-import argparse
+import ast
 import os
 import re
 import shutil
 import subprocess
-import sys
-from collections.abc import Sequence
 from pathlib import Path
-from typing import cast
-from unittest.mock import patch
 
 import pytest
 import yaml
 
-from deepagents_code.main import parse_args
-
-ROOT = Path(__file__).resolve().parents[4]
+ROOT = Path(__file__).resolve().parents[2]
 ACTION_PATH = ROOT / "action.yml"
+MAIN_PATH = ROOT / "libs" / "code" / "deepagents_code" / "main.py"
 
 EXPECTED_DCODE_INPUT_FLAGS = {
     "agent_name": ("--agent",),
@@ -73,30 +68,50 @@ def _run_dcode_body() -> str:
 
 
 def _root_parser_flags() -> set[str]:
-    original = argparse.ArgumentParser.parse_args
-    parsers: list[argparse.ArgumentParser] = []
+    tree = ast.parse(MAIN_PATH.read_text())
+    parse_args = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "parse_args"
+    )
+    flags: set[str] = set()
 
-    def spy(
-        self: argparse.ArgumentParser,
-        args: Sequence[str] | None = None,
-        namespace: argparse.Namespace | None = None,
-    ) -> argparse.Namespace:
-        parsers.append(self)
-        return cast("argparse.Namespace", original(self, args, namespace))
+    for node in ast.walk(parse_args):
+        if not isinstance(node, ast.Call):
+            continue
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_argument"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "parser"
+        ):
+            options = {
+                arg.value
+                for arg in node.args
+                if isinstance(arg, ast.Constant)
+                and isinstance(arg.value, str)
+                and arg.value.startswith("--")
+            }
+            flags.update(options)
+            if any(
+                keyword.arg == "action"
+                and isinstance(keyword.value, ast.Attribute)
+                and keyword.value.attr == "BooleanOptionalAction"
+                for keyword in node.keywords
+            ):
+                flags.update(
+                    f"--no-{option.removeprefix('--')}" for option in options
+                )
+        elif (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "add_json_output_arg"
+            and node.args
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id == "parser"
+        ):
+            flags.add("--json")
 
-    with (
-        patch.object(argparse.ArgumentParser, "parse_args", spy),
-        patch.object(sys, "argv", ["deepagents", "--non-interactive", "noop"]),
-    ):
-        parse_args()
-
-    root = parsers[0]
-    return {
-        option
-        for action in root._actions
-        for option in action.option_strings
-        if option.startswith("--")
-    }
+    return flags
 
 
 def test_root_action_dcode_flags_match_parser() -> None:

--- a/.github/scripts/test_github_action.py
+++ b/.github/scripts/test_github_action.py
@@ -420,7 +420,7 @@ def test_full_run_stdin_ignores_producer_sigpipe(tmp_path: Path) -> None:
     rc, out = _run_full(
         tmp_path,
         INPUT_STDIN="true",
-        INPUT_PROMPT="x" * 200_000,
+        INPUT_PROMPT="x" * 100_000,
         dcode_body="head -c 1 >/dev/null; exit 0",
     )
     assert rc == 0

--- a/ACTION.md
+++ b/ACTION.md
@@ -1,0 +1,59 @@
+# Deep Agents Code GitHub Action
+
+This repository's root `action.yml` runs `dcode` non-interactively in GitHub Actions.
+
+## Example
+
+```yaml
+name: dcode
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: langchain-ai/deepagents@main
+        with:
+          prompt: "Review this repository and summarize the highest-risk issues."
+          model: "openai:gpt-5.5"
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          shell_allow_list: "recommended,git,gh"
+          max_turns: "8"
+          quiet: "true"
+```
+
+For production workflows, pin `langchain-ai/deepagents` to a reviewed commit SHA instead of `main`.
+
+## Common inputs
+
+- `prompt`: Task text passed to `dcode`.
+- `model`: Model as `provider:model` (e.g. `openai:gpt-5.5`) or a bare name (`claude-*`, `gpt-*`, `gemini-*`) with the provider auto-detected.
+- `*_api_key`: Provider API keys (`openai_api_key`, `anthropic_api_key`, `google_api_key`).
+- `shell_allow_list`: Commands allowed for headless shell execution, such as `recommended,git,gh`.
+- `max_turns`: Maximum agentic turns before stopping.
+- `task_timeout`: `dcode --timeout` in seconds. The action-level `timeout` input is in minutes.
+- `quiet`: Clean stdout output for piping.
+- `json`: Emit machine-readable `dcode` JSON output.
+
+## Advanced inputs
+
+The action also forwards headless `dcode` options for skills, startup commands, sandboxes, MCP config, interpreter tools, rubric grading, stdin, and model/profile overrides. Interactive-only options such as `--auto-approve` are intentionally not exposed; use `shell_allow_list` to permit shell commands in workflows. See `action.yml` for the full input list and defaults.
+
+## Outputs
+
+- `response`: The agent's full output (stdout and stderr combined). This is raw, unfiltered agent output — do not assume it is free of secrets or safe to echo into other services.
+- `exit_code`: The agent's exit code (also `124` on task timeout).
+- `cache_hit`: Whether agent memory was restored from cache (empty when `enable_memory` is `false`).
+
+## Memory
+
+Persistent memory is enabled by default through `actions/cache`. Use:
+
+- `enable_memory: "false"` to disable cache restore/save.
+- `memory_scope: pr`, `branch`, or `repo` to control cache sharing.
+- `agent_name` to separate memory between multiple action identities.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Deep Agents Code"
-description: "Run Deep Agents Code in GitHub workflows"
+description: "Run dcode in GitHub workflows"
 author: "LangChain"
 branding:
   icon: "cpu"
@@ -10,8 +10,20 @@ inputs:
     description: "The prompt/instruction to send to the agent"
     required: true
   model:
-    description: "Model to use (claude-*, gpt-*, gemini-*). Auto-detects provider."
+    description: "Model to use, as provider:model (e.g. openai:gpt-5.5, anthropic:claude-opus-4-6) or a bare name (claude-*, gpt-*, gemini-*) with the provider auto-detected."
     required: false
+  model_params:
+    description: "JSON model kwargs passed to --model-params"
+    required: false
+    default: ""
+  max_retries:
+    description: "Maximum transient model retries passed to --max-retries"
+    required: false
+    default: ""
+  profile_override:
+    description: "JSON model profile overrides passed to --profile-override"
+    required: false
+    default: ""
   anthropic_api_key:
     description: "Anthropic API key"
     required: false
@@ -53,8 +65,88 @@ inputs:
     description: "Comma-separated shell allow list passed to --shell-allow-list (default: recommended,git,gh)"
     required: false
     default: "recommended,git,gh"
+  skill:
+    description: "Skill name to invoke before running the prompt"
+    required: false
+    default: ""
+  startup_cmd:
+    description: "Shell command to run at startup before the prompt"
+    required: false
+    default: ""
+  sandbox:
+    description: "Sandbox provider passed to --sandbox (empty = local execution)"
+    required: false
+    default: ""
+  sandbox_id:
+    description: "Existing sandbox ID passed to --sandbox-id"
+    required: false
+    default: ""
+  sandbox_snapshot_name:
+    description: "Snapshot or blueprint name passed to --sandbox-snapshot-name"
+    required: false
+    default: ""
+  sandbox_setup:
+    description: "Setup script path passed to --sandbox-setup"
+    required: false
+    default: ""
+  mcp_config:
+    description: "MCP config path passed to --mcp-config"
+    required: false
+    default: ""
+  no_mcp:
+    description: "Pass --no-mcp to disable MCP loading"
+    required: false
+    default: "false"
+  trust_project_mcp:
+    description: "Pass --trust-project-mcp to skip project MCP approval"
+    required: false
+    default: "false"
+  interpreter:
+    description: "Set to true for --interpreter, false for --no-interpreter, empty for dcode default"
+    required: false
+    default: ""
+  interpreter_tools:
+    description: "PTC allowlist passed to --interpreter-tools"
+    required: false
+    default: ""
+  max_turns:
+    description: "Maximum agentic turns passed to --max-turns"
+    required: false
+    default: ""
+  task_timeout:
+    description: "dcode task timeout in seconds passed to --timeout"
+    required: false
+    default: ""
+  rubric:
+    description: "Acceptance criteria passed to --rubric (literal text or @path)"
+    required: false
+    default: ""
+  rubric_model:
+    description: "Model passed to --rubric-model"
+    required: false
+    default: ""
+  rubric_max_iterations:
+    description: "Maximum rubric grader iterations passed to --rubric-max-iterations"
+    required: false
+    default: ""
+  quiet:
+    description: "Pass --quiet for clean stdout"
+    required: false
+    default: "false"
+  no_stream:
+    description: "Pass --no-stream to buffer the full response"
+    required: false
+    default: "false"
+  json:
+    description: "Pass --json for machine-readable dcode output"
+    required: false
+    default: "false"
+  stdin:
+    description: "Pass --stdin and pipe prompt as standard input instead of using --non-interactive"
+    required: false
+    default: "false"
   timeout:
-    description: "Maximum agent runtime in minutes (default: 30)"
+    description: "Maximum action runtime in minutes (default: 30)"
     required: false
     default: "30"
 
@@ -90,7 +182,6 @@ runs:
         PREFIX="deepagents-memory-${INPUT_AGENT_NAME}"
         case "$INPUT_MEMORY_SCOPE" in
           pr)
-            # Use PR number if available, fall back to ref
             if [ -n "$EVENT_PR_NUMBER" ]; then
               SCOPE_KEY="pr-${EVENT_PR_NUMBER}"
             else
@@ -104,7 +195,7 @@ runs:
             SCOPE_KEY="repo"
             ;;
           *)
-            # Fallback to pr-scoped (most conservative) rather than repo-scoped to limit blast radius
+            # Fall back to pr-scoped (most conservative) rather than repo-scoped to limit blast radius
             echo "::warning::Unknown memory_scope '${INPUT_MEMORY_SCOPE}', defaulting to 'pr'"
             if [ -n "$EVENT_PR_NUMBER" ]; then
               SCOPE_KEY="pr-${EVENT_PR_NUMBER}"
@@ -125,6 +216,8 @@ runs:
         path: |
           ~/.deepagents/${{ inputs.agent_name }}/
           ~/.deepagents/.state/sessions.db
+          ~/.deepagents/.state/sessions.db-wal
+          ~/.deepagents/.state/sessions.db-shm
           ${{ inputs.working_directory }}/.deepagents/AGENTS.md
         key: ${{ steps.cache-key.outputs.key }}-${{ github.run_id }}
         restore-keys: |
@@ -136,7 +229,11 @@ runs:
       env:
         INPUT_CLI_VERSION: ${{ inputs.cli_version }}
       run: |
-        # Action requires --agent, --shell-allow-list, -n (available since 0.1.0)
+        # 0.1.0 is the floor for the always-present flags (--agent,
+        # --shell-allow-list, --non-interactive). Optional inputs below may map
+        # to flags added in later releases, so pinning an old cli_version while
+        # setting a newer optional input can still hit an "unknown flag" error
+        # from dcode that this floor check won't catch.
         MIN_CLI_VERSION="0.1.0"
 
         if [ -n "$INPUT_CLI_VERSION" ]; then
@@ -145,9 +242,9 @@ runs:
             echo "::error::cli_version '${INPUT_CLI_VERSION}' is below the minimum '${MIN_CLI_VERSION}' required by this action"
             exit 1
           fi
-          uvx --from "deepagents-code==${INPUT_CLI_VERSION}" deepagents-code --version
+          uvx --from "deepagents-code==${INPUT_CLI_VERSION}" dcode --version
         else
-          uvx --from deepagents-code deepagents-code --version
+          uvx --from deepagents-code dcode --version
         fi
 
     - name: Install skills
@@ -188,7 +285,6 @@ runs:
           exit 1
         fi
 
-        # Copy skill directories (those containing SKILL.md) into the skills dir
         SKILL_COUNT=0
         while IFS= read -r skill_file; do
           skill_dir=$(dirname "$skill_file")
@@ -203,7 +299,7 @@ runs:
           exit 1
         fi
 
-    - name: Run Deep Agents
+    - name: Run dcode
       id: run-agent
       shell: bash
       working-directory: ${{ inputs.working_directory }}
@@ -213,54 +309,222 @@ runs:
         GOOGLE_API_KEY: ${{ inputs.google_api_key }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_MODEL: ${{ inputs.model }}
+        INPUT_MODEL_PARAMS: ${{ inputs.model_params }}
+        INPUT_MAX_RETRIES: ${{ inputs.max_retries }}
+        INPUT_PROFILE_OVERRIDE: ${{ inputs.profile_override }}
         INPUT_PROMPT: ${{ inputs.prompt }}
         INPUT_AGENT_NAME: ${{ inputs.agent_name }}
         INPUT_CLI_VERSION: ${{ inputs.cli_version }}
         INPUT_TIMEOUT: ${{ inputs.timeout }}
         INPUT_SHELL_ALLOW_LIST: ${{ inputs.shell_allow_list }}
+        INPUT_SKILL: ${{ inputs.skill }}
+        INPUT_STARTUP_CMD: ${{ inputs.startup_cmd }}
+        INPUT_SANDBOX: ${{ inputs.sandbox }}
+        INPUT_SANDBOX_ID: ${{ inputs.sandbox_id }}
+        INPUT_SANDBOX_SNAPSHOT_NAME: ${{ inputs.sandbox_snapshot_name }}
+        INPUT_SANDBOX_SETUP: ${{ inputs.sandbox_setup }}
+        INPUT_MCP_CONFIG: ${{ inputs.mcp_config }}
+        INPUT_NO_MCP: ${{ inputs.no_mcp }}
+        INPUT_TRUST_PROJECT_MCP: ${{ inputs.trust_project_mcp }}
+        INPUT_INTERPRETER: ${{ inputs.interpreter }}
+        INPUT_INTERPRETER_TOOLS: ${{ inputs.interpreter_tools }}
+        INPUT_MAX_TURNS: ${{ inputs.max_turns }}
+        INPUT_TASK_TIMEOUT: ${{ inputs.task_timeout }}
+        INPUT_RUBRIC: ${{ inputs.rubric }}
+        INPUT_RUBRIC_MODEL: ${{ inputs.rubric_model }}
+        INPUT_RUBRIC_MAX_ITERATIONS: ${{ inputs.rubric_max_iterations }}
+        INPUT_QUIET: ${{ inputs.quiet }}
+        INPUT_NO_STREAM: ${{ inputs.no_stream }}
+        INPUT_JSON: ${{ inputs.json }}
+        INPUT_STDIN: ${{ inputs.stdin }}
       run: |
-        # Build command (pin version if specified, matching the install step)
+        append_value_flag() {
+          local value="$1"
+          local flag="$2"
+          if [ -n "$value" ]; then
+            CMD+=("$flag" "$value")
+          fi
+        }
+
+        append_bool_flag() {
+          local value="$1"
+          local flag="$2"
+          case "$value" in
+            true)
+              CMD+=("$flag")
+              ;;
+            false|"")
+              ;;
+            *)
+              echo "::error::Input for ${flag} must be 'true' or 'false', got '${value}'"
+              exit 1
+              ;;
+          esac
+        }
+
+        validate_positive_int() {
+          local value="$1"
+          local input_name="$2"
+          # 10#$value forces base-10 so leading-zero values (e.g. 08) don't trip
+          # bash's octal parsing in the -eq test.
+          if [ -n "$value" ] && { ! [[ "$value" =~ ^[0-9]+$ ]] || [ "$((10#$value))" -eq 0 ]; }; then
+            echo "::error::Invalid ${input_name} '${value}' — must be a positive integer"
+            exit 1
+          fi
+        }
+
+        validate_non_negative_int() {
+          local value="$1"
+          local input_name="$2"
+          if [ -n "$value" ] && ! [[ "$value" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid ${input_name} '${value}' — must be a non-negative integer"
+            exit 1
+          fi
+        }
+
+        validate_json_object() {
+          local value="$1"
+          local input_name="$2"
+          # Best-effort: only validate when jq is present. dcode still rejects
+          # malformed JSON, but this surfaces an error naming the offending input.
+          if [ -n "$value" ] && command -v jq >/dev/null 2>&1; then
+            if ! printf '%s' "$value" | jq -e 'type == "object"' >/dev/null 2>&1; then
+              echo "::error::Invalid ${input_name} — must be a JSON object"
+              exit 1
+            fi
+          fi
+        }
+
         if [ -n "$INPUT_CLI_VERSION" ]; then
-          CMD=(uvx --from "deepagents-code==${INPUT_CLI_VERSION}" deepagents-code)
+          CMD=(uvx --from "deepagents-code==${INPUT_CLI_VERSION}" dcode)
         else
-          CMD=(uvx --from deepagents-code deepagents-code)
+          CMD=(uvx --from deepagents-code dcode)
         fi
 
-        CMD+=(--agent "$INPUT_AGENT_NAME")
-        CMD+=(--shell-allow-list "$INPUT_SHELL_ALLOW_LIST")
+        validate_positive_int "$INPUT_TIMEOUT" "timeout"
+        validate_non_negative_int "$INPUT_MAX_RETRIES" "max_retries"
+        validate_positive_int "$INPUT_MAX_TURNS" "max_turns"
+        validate_positive_int "$INPUT_TASK_TIMEOUT" "task_timeout"
+        validate_positive_int "$INPUT_RUBRIC_MAX_ITERATIONS" "rubric_max_iterations"
+        validate_json_object "$INPUT_MODEL_PARAMS" "model_params"
+        validate_json_object "$INPUT_PROFILE_OVERRIDE" "profile_override"
 
-        if [ -n "$INPUT_MODEL" ]; then
-          CMD+=(--model "$INPUT_MODEL")
+        append_value_flag "$INPUT_AGENT_NAME" "--agent"
+        append_value_flag "$INPUT_SHELL_ALLOW_LIST" "--shell-allow-list"
+        append_value_flag "$INPUT_MODEL" "--model"
+        append_value_flag "$INPUT_MODEL_PARAMS" "--model-params"
+        append_value_flag "$INPUT_MAX_RETRIES" "--max-retries"
+        append_value_flag "$INPUT_PROFILE_OVERRIDE" "--profile-override"
+        append_value_flag "$INPUT_SKILL" "--skill"
+        append_value_flag "$INPUT_STARTUP_CMD" "--startup-cmd"
+        append_value_flag "$INPUT_SANDBOX" "--sandbox"
+        append_value_flag "$INPUT_SANDBOX_ID" "--sandbox-id"
+        append_value_flag "$INPUT_SANDBOX_SNAPSHOT_NAME" "--sandbox-snapshot-name"
+        append_value_flag "$INPUT_SANDBOX_SETUP" "--sandbox-setup"
+        append_value_flag "$INPUT_MCP_CONFIG" "--mcp-config"
+        append_bool_flag "$INPUT_NO_MCP" "--no-mcp"
+        append_bool_flag "$INPUT_TRUST_PROJECT_MCP" "--trust-project-mcp"
+        case "$INPUT_INTERPRETER" in
+          true)
+            CMD+=("--interpreter")
+            ;;
+          false)
+            CMD+=("--no-interpreter")
+            ;;
+          "")
+            ;;
+          *)
+            echo "::error::Input for interpreter must be 'true', 'false', or empty, got '${INPUT_INTERPRETER}'"
+            exit 1
+            ;;
+        esac
+        append_value_flag "$INPUT_INTERPRETER_TOOLS" "--interpreter-tools"
+        append_value_flag "$INPUT_MAX_TURNS" "--max-turns"
+        append_value_flag "$INPUT_TASK_TIMEOUT" "--timeout"
+        append_value_flag "$INPUT_RUBRIC" "--rubric"
+        append_value_flag "$INPUT_RUBRIC_MODEL" "--rubric-model"
+        append_value_flag "$INPUT_RUBRIC_MAX_ITERATIONS" "--rubric-max-iterations"
+        append_bool_flag "$INPUT_QUIET" "--quiet"
+        append_bool_flag "$INPUT_NO_STREAM" "--no-stream"
+        append_bool_flag "$INPUT_JSON" "--json"
+        case "$INPUT_STDIN" in
+          true|false|"")
+            ;;
+          *)
+            echo "::error::Input for stdin must be 'true' or 'false', got '${INPUT_STDIN}'"
+            exit 1
+            ;;
+        esac
+
+        # stdin + skill can't run headless: with --skill and no positional prompt,
+        # dcode routes piped input to the interactive TUI path. The non-stdin path
+        # passes the prompt via --non-interactive, which supports --skill fine.
+        if [ "$INPUT_STDIN" = "true" ] && [ -n "$INPUT_SKILL" ]; then
+          echo "::error::stdin cannot be combined with skill — use stdin: false so the prompt is passed via --non-interactive"
+          exit 1
         fi
 
-        # Validate timeout is a positive integer
-        if ! [[ "$INPUT_TIMEOUT" =~ ^[0-9]+$ ]] || [ "$INPUT_TIMEOUT" -eq 0 ]; then
-          echo "::error::Invalid timeout '${INPUT_TIMEOUT}' — must be a positive integer (minutes)"
+        if [ -z "$INPUT_PROMPT" ]; then
+          echo "::error::prompt is empty — provide the task for dcode to run"
           exit 1
         fi
 
         OUTPUT_FILE=$(mktemp)
         trap 'rm -f "$OUTPUT_FILE"' EXIT
 
-        # set +e: allow non-zero exit so we can capture the code; pipefail: propagate the agent's exit code through tee
-        TIMEOUT_SECS=$((INPUT_TIMEOUT * 60))
+        # 10#$INPUT_TIMEOUT forces base-10: validate_positive_int accepts
+        # leading-zero values (e.g. 08), which bare arithmetic would misparse as
+        # octal and abort on (8 and 9 aren't valid octal digits).
+        TIMEOUT_SECS=$((10#$INPUT_TIMEOUT * 60))
+        # set +e: let a non-zero agent exit through so we can capture it below
+        # instead of aborting the step (composite bash runs with set -e).
         set +e
-        set -o pipefail
-        timeout "${TIMEOUT_SECS}" "${CMD[@]}" -n "$INPUT_PROMPT" 2>&1 | tee "$OUTPUT_FILE"
-        EXIT_CODE=$?
-        set +o pipefail
-        set -e
+        if [ "$INPUT_STDIN" = "true" ]; then
+          # stdin is special-cased: the prompt is piped in rather than passed
+          # positionally. Feed it via process substitution so the agent — not
+          # printf — is the pipeline head; a classic `printf | timeout` pipe
+          # would surface printf's SIGPIPE (agent closes stdin early on a large
+          # prompt) as the captured exit code.
+          timeout "${TIMEOUT_SECS}" "${CMD[@]}" "--stdin" < <(printf '%s' "$INPUT_PROMPT") 2>&1 | tee "$OUTPUT_FILE"
+        else
+          timeout "${TIMEOUT_SECS}" "${CMD[@]}" "--non-interactive" "$INPUT_PROMPT" 2>&1 | tee "$OUTPUT_FILE"
+        fi
+        # PIPESTATUS[0] is the agent/timeout stage (the pipeline head), so tee's
+        # exit can't mask the agent's real code. Read before any other command
+        # runs, since PIPESTATUS reflects the most recent pipeline.
+        EXIT_CODE=${PIPESTATUS[0]}
 
-        # Set outputs using heredoc with random delimiter
-        DELIMITER="DEEPAGENTS_$(openssl rand -hex 16)"
-        {
-          echo "exit_code=$EXIT_CODE"
-          echo "response<<${DELIMITER}"
-          cat "$OUTPUT_FILE"
-          echo "${DELIMITER}"
-        } >> "$GITHUB_OUTPUT"
+        # The random delimiter stops untrusted agent output from forging extra
+        # $GITHUB_OUTPUT entries (a line equal to the delimiter would close the
+        # heredoc early). If openssl is unavailable, fall back to /dev/urandom
+        # rather than silently degrading to the guessable constant "DEEPAGENTS_".
+        RAND_HEX=$(openssl rand -hex 16 2>/dev/null)
+        if [ -z "$RAND_HEX" ]; then
+          RAND_HEX=$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')
+        fi
+        if [ -z "$RAND_HEX" ]; then
+          echo "::error::could not generate a random output delimiter"
+          # Preserve a failing agent code; otherwise fail with 1 since we can't
+          # safely emit output.
+          [ "$EXIT_CODE" -ne 0 ] && exit "$EXIT_CODE"
+          exit 1
+        fi
+        DELIMITER="DEEPAGENTS_${RAND_HEX}"
 
-        exit $EXIT_CODE
+        # Keep `set -e` disabled while writing outputs so a write failure can't
+        # mask the agent's exit code — but surface it as a warning so an empty
+        # or truncated `response` output isn't mistaken for the agent producing
+        # no output.
+        if ! {
+              echo "exit_code=$EXIT_CODE"
+              echo "response<<${DELIMITER}"
+              cat "$OUTPUT_FILE"
+              echo "${DELIMITER}"
+            } >> "$GITHUB_OUTPUT"; then
+          echo "::warning::failed to write agent output to \$GITHUB_OUTPUT — the 'response' output may be empty or truncated"
+        fi
+
+        exit "$EXIT_CODE"
 
     - name: Save agent memory
       if: inputs.enable_memory == 'true' && steps.cache-key.outputs.key != '' && always()
@@ -269,5 +533,7 @@ runs:
         path: |
           ~/.deepagents/${{ inputs.agent_name }}/
           ~/.deepagents/.state/sessions.db
+          ~/.deepagents/.state/sessions.db-wal
+          ~/.deepagents/.state/sessions.db-shm
           ${{ inputs.working_directory }}/.deepagents/AGENTS.md
         key: ${{ steps.cache-key.outputs.key }}-${{ github.run_id }}

--- a/libs/code/tests/unit_tests/test_github_action.py
+++ b/libs/code/tests/unit_tests/test_github_action.py
@@ -1,0 +1,412 @@
+"""Tests for the root GitHub Action wrapper."""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from deepagents_code.main import parse_args
+
+ROOT = Path(__file__).resolve().parents[4]
+ACTION_PATH = ROOT / "action.yml"
+
+EXPECTED_DCODE_INPUT_FLAGS = {
+    "agent_name": ("--agent",),
+    "interpreter": ("--interpreter", "--no-interpreter"),
+    "interpreter_tools": ("--interpreter-tools",),
+    "json": ("--json",),
+    "max_retries": ("--max-retries",),
+    "max_turns": ("--max-turns",),
+    "mcp_config": ("--mcp-config",),
+    "model": ("--model",),
+    "model_params": ("--model-params",),
+    "no_mcp": ("--no-mcp",),
+    "no_stream": ("--no-stream",),
+    "profile_override": ("--profile-override",),
+    "prompt": ("--non-interactive",),
+    "quiet": ("--quiet",),
+    "rubric": ("--rubric",),
+    "rubric_max_iterations": ("--rubric-max-iterations",),
+    "rubric_model": ("--rubric-model",),
+    "sandbox": ("--sandbox",),
+    "sandbox_id": ("--sandbox-id",),
+    "sandbox_setup": ("--sandbox-setup",),
+    "sandbox_snapshot_name": ("--sandbox-snapshot-name",),
+    "shell_allow_list": ("--shell-allow-list",),
+    "skill": ("--skill",),
+    "startup_cmd": ("--startup-cmd",),
+    "stdin": ("--stdin",),
+    "task_timeout": ("--timeout",),
+    "trust_project_mcp": ("--trust-project-mcp",),
+}
+
+
+def _load_action() -> dict:
+    return yaml.safe_load(ACTION_PATH.read_text())
+
+
+def _action_input_names() -> set[str]:
+    return set(_load_action()["inputs"])
+
+
+def _run_dcode_body() -> str:
+    """Return the shell body of the "Run dcode" step.
+
+    Reads the step's ``run:`` block scalar directly from the parsed YAML (which
+    yields it already dedented), so later steps can be reordered or renamed
+    without truncating the capture.
+    """
+    for step in _load_action()["runs"]["steps"]:
+        if step.get("name") == "Run dcode":
+            return step["run"]
+    msg = "could not locate the 'Run dcode' step"
+    raise AssertionError(msg)
+
+
+def _root_parser_flags() -> set[str]:
+    original = argparse.ArgumentParser.parse_args
+    parsers: list[argparse.ArgumentParser] = []
+
+    def spy(
+        self: argparse.ArgumentParser,
+        args: Sequence[str] | None = None,
+        namespace: argparse.Namespace | None = None,
+    ) -> argparse.Namespace:
+        parsers.append(self)
+        return cast("argparse.Namespace", original(self, args, namespace))
+
+    with (
+        patch.object(argparse.ArgumentParser, "parse_args", spy),
+        patch.object(sys, "argv", ["deepagents", "--non-interactive", "noop"]),
+    ):
+        parse_args()
+
+    root = parsers[0]
+    return {
+        option
+        for action in root._actions
+        for option in action.option_strings
+        if option.startswith("--")
+    }
+
+
+def test_root_action_dcode_flags_match_parser() -> None:
+    action_inputs = _action_input_names()
+    run_body = _run_dcode_body()
+    run_flags = set(re.findall(r'"(--[a-z0-9-]+)"', run_body))
+    parser_flags = _root_parser_flags()
+
+    expected_inputs = set(EXPECTED_DCODE_INPUT_FLAGS)
+    assert expected_inputs <= action_inputs
+
+    expected_flags = {
+        flag for flags in EXPECTED_DCODE_INPUT_FLAGS.values() for flag in flags
+    }
+    assert expected_flags <= run_flags
+    assert run_flags <= parser_flags
+
+
+def test_root_action_does_not_forward_interactive_auto_approve() -> None:
+    assert "auto_approve" not in _action_input_names()
+    assert "--auto-approve" not in _run_dcode_body()
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests: execute the real shell from action.yml in a bash subprocess
+# (never dcode itself), so they cover the actual action rather than a
+# reimplementation. Two harnesses:
+#
+#   _run_setup — runs the "Run dcode" body up to `OUTPUT_FILE=$(mktemp)`: the
+#     pure setup that defines helpers, validates inputs, and assembles `CMD`,
+#     with no side effects beyond `exit 1` on invalid input. Inspects the exit
+#     code and the assembled command.
+#   _run_full  — runs the entire body with `uvx`/`timeout` stubbed on PATH, so
+#     the execution/exit-code region below that marker runs for real without
+#     launching dcode.
+#
+# Both prefix the script with `set -eo pipefail` to match GitHub's composite
+# `bash` shell, and skip (rather than error) when bash is unavailable — the
+# pure-Python drift tests above stay active on a bash-less runner.
+# ---------------------------------------------------------------------------
+
+_SETUP_MARKER = "OUTPUT_FILE=$(mktemp)"
+
+# Valid baseline: prompt is required and non-empty; everything else is unset
+# (empty string), matching how GitHub passes omitted inputs.
+_BASE_INPUTS = {
+    "INPUT_PROMPT": "do the thing",
+    "INPUT_AGENT_NAME": "deepagents",
+    "INPUT_SHELL_ALLOW_LIST": "recommended,git,gh",
+}
+
+
+def _action_setup_script() -> str:
+    body = _run_dcode_body()
+    setup = body.split(_SETUP_MARKER, 1)[0]
+    # Fail loudly if the marker moved/renamed: without the split the slice would
+    # include the real dcode invocation instead of stopping at CMD assembly.
+    assert setup != body, f"setup marker {_SETUP_MARKER!r} not found in run body"
+    assert "CMD=(" in setup, "setup slice should include CMD assembly"
+    # Print the assembled command so tests can assert flag presence/absence.
+    return setup + '\nprintf "%s\\n" "${CMD[@]}"\n'
+
+
+def _run_setup(**overrides: str) -> tuple[int, list[str]]:
+    if shutil.which("bash") is None:
+        pytest.skip("bash is required for action.yml tests")
+    env = {**os.environ, **_BASE_INPUTS, **overrides}
+    proc = subprocess.run(
+        ["bash", "-c", "set -eo pipefail\n" + _action_setup_script()],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    cmd = proc.stdout.splitlines() if proc.returncode == 0 else []
+    return proc.returncode, cmd
+
+
+def _run_full(
+    tmp_path: Path, *, dcode_body: str | None = None, **overrides: str
+) -> tuple[int, str]:
+    """Run the whole "Run dcode" body with `uvx`/`timeout` stubbed on PATH.
+
+    Substitutes a fake for the real dcode call so the execution/exit-code region
+    below ``OUTPUT_FILE=$(mktemp)`` runs for real — the timeout arithmetic, the
+    stdin vs ``--non-interactive`` dispatch, the ``PIPESTATUS`` capture, and the
+    ``$GITHUB_OUTPUT`` write — without ever launching dcode. Returns the process
+    exit code and the text written to ``$GITHUB_OUTPUT``.
+    """
+    if shutil.which("bash") is None:
+        pytest.skip("bash is required for action.yml tests")
+    # Default fake dcode: emit a line, then exit with $FAKE_DCODE_EXIT (0).
+    agent = dcode_body or 'printf "AGENT OUTPUT\\n"; exit "${FAKE_DCODE_EXIT:-0}"'
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    # `timeout` shim drops the duration and execs the rest (also lets this run on
+    # macOS, which ships no GNU `timeout`). `uvx` shim ignores the
+    # `--from PKG dcode` prefix and runs the fake agent body.
+    (bindir / "timeout").write_text('#!/usr/bin/env bash\nshift\nexec "$@"\n')
+    (bindir / "uvx").write_text(f"#!/usr/bin/env bash\n{agent}\n")
+    (bindir / "timeout").chmod(0o755)
+    (bindir / "uvx").chmod(0o755)
+
+    gh_output = tmp_path / "github_output"
+    gh_output.write_text("")
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+        "GITHUB_OUTPUT": str(gh_output),
+        **_BASE_INPUTS,
+        **overrides,
+    }
+    proc = subprocess.run(
+        ["bash", "-c", "set -eo pipefail\n" + _run_dcode_body()],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.returncode, gh_output.read_text()
+
+
+@pytest.mark.parametrize(
+    ("value", "should_pass"),
+    [
+        ("", True),  # unset → skipped
+        ("30", True),
+        ("1", True),
+        ("08", True),  # leading zero must not trip octal parsing
+        ("0", False),  # zero is not positive
+        ("-1", False),
+        ("1.5", False),
+        ("abc", False),
+    ],
+)
+def test_validate_positive_int(value: str, should_pass: bool) -> None:
+    rc, _ = _run_setup(INPUT_TIMEOUT=value)
+    assert (rc == 0) is should_pass
+
+
+@pytest.mark.parametrize(
+    ("value", "should_pass"),
+    [
+        ("", True),
+        ("0", True),  # non-negative accepts zero (the key distinction)
+        ("3", True),
+        ("-1", False),
+        ("abc", False),
+    ],
+)
+def test_validate_non_negative_int(value: str, should_pass: bool) -> None:
+    rc, _ = _run_setup(INPUT_MAX_RETRIES=value)
+    assert (rc == 0) is should_pass
+
+
+def test_positive_and_non_negative_validators_differ_on_zero() -> None:
+    # Guards against a copy-paste swap of the two validators: max_turns must
+    # reject 0 while max_retries must accept it.
+    assert _run_setup(INPUT_MAX_TURNS="0")[0] != 0
+    assert _run_setup(INPUT_MAX_RETRIES="0")[0] == 0
+
+
+@pytest.mark.parametrize(
+    ("value", "expect_flag", "should_pass"),
+    [
+        ("true", True, True),
+        ("false", False, True),
+        ("", False, True),
+        ("maybe", False, False),
+        ("1", False, False),
+    ],
+)
+def test_append_bool_flag(value: str, expect_flag: bool, should_pass: bool) -> None:
+    rc, cmd = _run_setup(INPUT_QUIET=value)
+    assert (rc == 0) is should_pass
+    if should_pass:
+        assert ("--quiet" in cmd) is expect_flag
+
+
+def test_append_value_flag_omits_when_empty_and_appends_with_value() -> None:
+    rc, cmd = _run_setup(INPUT_MODEL="")
+    assert rc == 0
+    assert "--model" not in cmd
+
+    rc, cmd = _run_setup(INPUT_MODEL="openai:gpt-5.5")
+    assert rc == 0
+    assert cmd[cmd.index("--model") + 1] == "openai:gpt-5.5"
+
+
+def test_value_inputs_map_to_expected_flags() -> None:
+    # The input→flag mapping is real, not decorative: setting the input places
+    # its flag+value in the assembled command.
+    rc, cmd = _run_setup(
+        INPUT_MODEL_PARAMS='{"temperature":0}',
+        INPUT_MAX_RETRIES="2",
+        INPUT_RUBRIC_MODEL="anthropic:claude-sonnet-4-6",
+    )
+    assert rc == 0
+    assert cmd[cmd.index("--model-params") + 1] == '{"temperature":0}'
+    assert cmd[cmd.index("--max-retries") + 1] == "2"
+    assert cmd[cmd.index("--rubric-model") + 1] == "anthropic:claude-sonnet-4-6"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected", "should_pass"),
+    [
+        ("true", "--interpreter", True),
+        ("false", "--no-interpreter", True),
+        ("", None, True),
+        ("bogus", None, False),
+    ],
+)
+def test_interpreter_tristate(
+    value: str, expected: str | None, should_pass: bool
+) -> None:
+    rc, cmd = _run_setup(INPUT_INTERPRETER=value)
+    assert (rc == 0) is should_pass
+    if should_pass:
+        assert ("--interpreter" in cmd) is (expected == "--interpreter")
+        assert ("--no-interpreter" in cmd) is (expected == "--no-interpreter")
+
+
+@pytest.mark.parametrize(
+    ("value", "should_pass"),
+    [("true", True), ("false", True), ("", True), ("yes", False)],
+)
+def test_stdin_validation(value: str, should_pass: bool) -> None:
+    rc, _ = _run_setup(INPUT_STDIN=value)
+    assert (rc == 0) is should_pass
+
+
+@pytest.mark.parametrize(
+    ("stdin", "skill", "should_pass"),
+    [
+        ("true", "", True),
+        ("false", "review", True),  # skill is fine on the non-stdin path
+        ("", "review", True),
+        ("true", "review", False),  # stdin + skill would run interactively
+    ],
+)
+def test_stdin_skill_mutually_exclusive(
+    stdin: str, skill: str, should_pass: bool
+) -> None:
+    rc, _ = _run_setup(INPUT_STDIN=stdin, INPUT_SKILL=skill)
+    assert (rc == 0) is should_pass
+
+
+def test_empty_prompt_is_rejected() -> None:
+    assert _run_setup(INPUT_PROMPT="")[0] != 0
+
+
+def test_version_pinning_in_assembled_command() -> None:
+    rc, cmd = _run_setup(INPUT_CLI_VERSION="0.1.36")
+    assert rc == 0
+    assert "deepagents-code==0.1.36" in cmd
+    assert cmd[cmd.index("deepagents-code==0.1.36") + 1] == "dcode"
+
+    rc, cmd = _run_setup(INPUT_CLI_VERSION="")
+    assert rc == 0
+    assert "deepagents-code" in cmd
+    assert "dcode" in cmd
+
+
+@pytest.mark.skipif(shutil.which("jq") is None, reason="jq not installed")
+@pytest.mark.parametrize(
+    ("value", "should_pass"),
+    [
+        ("", True),
+        ('{"temperature":0}', True),
+        ("{not json", False),
+        ("[1, 2]", False),  # valid JSON but not an object
+    ],
+)
+def test_validate_json_object(value: str, should_pass: bool) -> None:
+    rc, _ = _run_setup(INPUT_MODEL_PARAMS=value)
+    assert (rc == 0) is should_pass
+
+
+# ---------------------------------------------------------------------------
+# Execution-region tests: run the full body (past `OUTPUT_FILE=$(mktemp)`) with
+# uvx/timeout stubbed — covering timeout arithmetic, exit-code capture, and the
+# stdin pipeline, which the setup-slice tests above deliberately exclude.
+# ---------------------------------------------------------------------------
+
+
+def test_full_run_leading_zero_timeout_does_not_crash(tmp_path: Path) -> None:
+    # validate_positive_int accepts "08"; bare $((08 * 60)) would abort as
+    # invalid octal, so the consumer must force base-10 (10#).
+    rc, out = _run_full(tmp_path, INPUT_TIMEOUT="08")
+    assert rc == 0
+    assert "exit_code=0" in out
+
+
+def test_full_run_propagates_agent_exit_code(tmp_path: Path) -> None:
+    # A non-zero agent must fail the step (via the final `exit $EXIT_CODE`) and
+    # be recorded in the exit_code output, not masked by tee.
+    rc, out = _run_full(tmp_path, FAKE_DCODE_EXIT="3")
+    assert rc == 3
+    assert "exit_code=3" in out
+
+
+def test_full_run_stdin_ignores_producer_sigpipe(tmp_path: Path) -> None:
+    # Agent reads one byte and exits 0 without draining stdin. A classic
+    # `printf | timeout` pipe would surface printf's SIGPIPE (141); process
+    # substitution + PIPESTATUS[0] must report the agent's real code instead.
+    rc, out = _run_full(
+        tmp_path,
+        INPUT_STDIN="true",
+        INPUT_PROMPT="x" * 200_000,
+        dcode_body="head -c 1 >/dev/null; exit 0",
+    )
+    assert rc == 0
+    assert "exit_code=0" in out


### PR DESCRIPTION
The Deep Agents Code GitHub Action now supports headless options for model configuration, skills, startup commands, sandboxes, MCP, interpreter tools, turn and task limits, rubric grading, stdin, quiet output, buffered output, and JSON output.

---

The root GitHub Action exposed only a small subset of headless `dcode` options, so workflows could not configure skills, sandboxes, MCP, interpreter tools, rubric grading, model parameters, or output modes without bypassing the Action.

This expands the Action input surface to match supported headless `dcode` behavior while deliberately keeping interactive-only `--auto-approve` out of workflows. Inputs are assembled as shell argument arrays, typed values are validated before launch, stdin and timeout handling preserve the agent's actual exit code, and memory caching now includes SQLite WAL files. `ACTION.md` documents the common inputs, outputs, memory behavior, and the need to treat agent output as untrusted.

The Action tests compare forwarded flags with the CLI parser and execute the real command-assembly shell against stubbed processes, covering validation, timeout arithmetic, stdin behavior, and exit-code propagation.