### PR TITLE
perf(infra): install only the model integrations a Harbor job needs

### DIFF
--- a/.github/scripts/prune_agent_deps.py
+++ b/.github/scripts/prune_agent_deps.py
@@ -128,14 +128,19 @@ def main() -> None:
     deps = config.get("dependencies", [])
 
     if provider not in PROVIDER_TO_PACKAGE:
-        # Ad-hoc / newly-added provider (e.g. a one-off `models_override`): we
-        # can't know which package to keep, so leave the deps untouched rather
-        # than guess wrong. Mirrors the credential-check step's warning fallback.
-        print(  # noqa: T201
-            f"::warning::Unknown provider {provider!r}; leaving all agent provider "
-            "dependencies in place."
+        # An unmapped provider is non-functional in this workflow anyway:
+        # harbor.yml only wires credentials and agent env for the providers in
+        # PROVIDER_TO_PACKAGE, and langgraph.json ships only their packages.
+        # Leaving deps in place would keep langchain-fireworks (a prerelease
+        # dependency) and fail the agent-env install with a cryptic resolver
+        # error; fail fast here with an actionable one instead.
+        supported = ", ".join(sorted(PROVIDER_TO_PACKAGE))
+        raise SystemExit(
+            f"::error::Unsupported model provider {provider!r} (from {model!r}). "
+            f"Supported providers: {supported}. To add one, extend "
+            "PROVIDER_TO_PACKAGE and wire its package into langgraph.json plus "
+            "the credential and agent-env steps in harbor.yml."
         )
-        return
 
     pruned = prune_dependencies(deps, provider)
     config["dependencies"] = pruned

--- a/.github/scripts/prune_agent_deps.py
+++ b/.github/scripts/prune_agent_deps.py
@@ -1,0 +1,156 @@
+"""Prune the Harbor LangGraph agent's provider deps to the active model.
+
+The agent (`deepagents_harbor/langgraph_project/langgraph_agent.py`) picks its
+chat model at runtime through `langchain.chat_models.init_chat_model`, which
+lazily imports only the provider package matching the model spec's `provider:`
+prefix. The committed `langgraph.json` therefore lists *every* provider so a
+local `langgraph dev` can run any model — but a single CI job only ever runs one
+model, and installing the other providers just slows the sandbox env build.
+
+This script rewrites a `langgraph.json` in place, dropping every provider
+package except the one matching `HARBOR_MODEL`'s provider. Non-provider
+dependencies (langchain core, the staged local packages, MCP adapters, etc.)
+are always kept. It runs in CI against the ephemeral checkout
+(`.github/workflows/harbor.yml`); the committed file is left untouched.
+
+Usage:
+    HARBOR_MODEL=fireworks:accounts/... \\
+        python prune_agent_deps.py path/to/langgraph.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+PROVIDER_TO_PACKAGE: dict[str, str] = {
+    "anthropic": "langchain-anthropic",
+    "baseten": "langchain-baseten",
+    "fireworks": "langchain-fireworks",
+    "google_genai": "langchain-google-genai",
+    "groq": "langchain-groq",
+    "nvidia": "langchain-nvidia-ai-endpoints",
+    "ollama": "langchain-ollama",
+    "openai": "langchain-openai",
+    "openrouter": "langchain-openrouter",
+    "xai": "langchain-xai",
+}
+"""Model-spec provider prefix -> pip package that supplies it.
+
+Must stay in sync with the provider packages listed in `langgraph.json`. Keep
+this hardcoded (not derived): it is the single source of truth for which
+packages are prunable and what each provider maps to. The `prune_dependencies`
+drift guard fails the run if the matched package is missing from the file, so a
+stale entry here surfaces loudly rather than silently shipping an agent env with
+no provider.
+"""
+
+PRUNABLE_PACKAGES: frozenset[str] = frozenset(PROVIDER_TO_PACKAGE.values())
+"""Provider packages subject to pruning.
+
+A dependency is removed only when its package name is in this set *and* does not
+match the active provider; every other dependency (langchain core, local path
+deps, MCP adapters, aiohttp, toml, ...) is kept verbatim.
+"""
+
+_NAME_DELIMITERS = ("<", ">", "=", "!", "~", " ", "[", ";", ",")
+"""Characters that terminate the package-name head of a PEP 508 requirement.
+
+Splitting on these (no regex) recovers the bare package name from a spec like
+`langchain-openai>=1.3.0,<1.4.0`, `pkg[extra]`, or `pkg; python_version<'3.13'`.
+"""
+
+
+def dependency_package(dep: str) -> str:
+    """Return the bare package name at the head of a dependency string.
+
+    Truncates at the first version specifier, extra, or marker. Local path
+    deps (e.g. `./.local_deps/deepagents`) contain no delimiter and are
+    returned unchanged; they are never in `PRUNABLE_PACKAGES`, so they are
+    always kept.
+    """
+    head = dep.strip()
+    for sep in _NAME_DELIMITERS:
+        head = head.split(sep, 1)[0]
+    return head.strip()
+
+
+def prune_dependencies(deps: list[str], provider: str) -> list[str]:
+    """Return `deps` with every provider package removed except `provider`'s.
+
+    Args:
+        deps: The `dependencies` array from a `langgraph.json`.
+        provider: Model-spec provider prefix (e.g. `fireworks`). Must be a key
+            of `PROVIDER_TO_PACKAGE`.
+
+    Returns:
+        The filtered dependency list, in the original order.
+
+    Raises:
+        KeyError: If `provider` is not a known provider.
+        ValueError: If the provider's package is absent from `deps` — a drift
+            between `PROVIDER_TO_PACKAGE` and `langgraph.json` that would
+            otherwise ship an agent env with no usable provider.
+    """
+    keep = PROVIDER_TO_PACKAGE[provider]
+    kept = [
+        dep
+        for dep in deps
+        if dependency_package(dep) not in PRUNABLE_PACKAGES
+        or dependency_package(dep) == keep
+    ]
+    if not any(dependency_package(dep) == keep for dep in kept):
+        msg = (
+            f"Expected provider package {keep!r} for provider {provider!r} not "
+            "found in langgraph.json dependencies; PROVIDER_TO_PACKAGE is out of "
+            "sync with the agent config."
+        )
+        raise ValueError(msg)
+    return kept
+
+
+def main() -> None:
+    """Rewrite the langgraph.json at argv[1], pruning to HARBOR_MODEL's provider."""
+    if len(sys.argv) != 2:  # noqa: PLR2004
+        raise SystemExit(f"Usage: {sys.argv[0]} <path-to-langgraph.json>")
+
+    path = sys.argv[1]
+    model = os.environ.get("HARBOR_MODEL", "").strip()
+    if not model or ":" not in model:
+        raise SystemExit(
+            f"::error::HARBOR_MODEL must be a 'provider:model' spec (got {model!r})"
+        )
+    provider = model.split(":", 1)[0]
+
+    with open(path, encoding="utf-8") as f:  # noqa: PTH123
+        config = json.load(f)
+    deps = config.get("dependencies", [])
+
+    if provider not in PROVIDER_TO_PACKAGE:
+        # Ad-hoc / newly-added provider (e.g. a one-off `models_override`): we
+        # can't know which package to keep, so leave the deps untouched rather
+        # than guess wrong. Mirrors the credential-check step's warning fallback.
+        print(  # noqa: T201
+            f"::warning::Unknown provider {provider!r}; leaving all agent provider "
+            "dependencies in place."
+        )
+        return
+
+    pruned = prune_dependencies(deps, provider)
+    config["dependencies"] = pruned
+
+    with open(path, "w", encoding="utf-8") as f:  # noqa: PTH123
+        json.dump(config, f, indent=2)
+        f.write("\n")
+
+    removed = [dependency_package(d) for d in deps if d not in pruned]
+    print(  # noqa: T201
+        f"Pruned agent provider deps for {provider!r}: kept "
+        f"{PROVIDER_TO_PACKAGE[provider]}"
+        + (f", removed {len(removed)}: {', '.join(removed)}" if removed else "")
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/prune_agent_deps.py
+++ b/.github/scripts/prune_agent_deps.py
@@ -1,21 +1,23 @@
 """Prune the Harbor LangGraph agent's provider deps to the active model.
 
-The agent (`deepagents_harbor/langgraph_project/langgraph_agent.py`) picks its
-chat model at runtime through `langchain.chat_models.init_chat_model`, which
-lazily imports only the provider package matching the model spec's `provider:`
-prefix. The committed `langgraph.json` therefore lists *every* provider so a
-local `langgraph dev` can run any model — but a single CI job only ever runs one
-model, and installing the other providers just slows the sandbox env build.
+The agent (`libs/evals/deepagents_harbor/langgraph_project/langgraph_agent.py`)
+picks its chat model at runtime through `langchain.chat_models.init_chat_model`,
+which lazily imports only the provider package matching the model spec's
+`provider:` prefix. The committed `langgraph.json` therefore lists *every*
+provider so a local `langgraph dev` can run any model — but a single CI job only
+ever runs one model, and installing the other providers just slows the sandbox
+env build.
 
 This script rewrites a `langgraph.json` in place, dropping every provider
 package except the one matching `HARBOR_MODEL`'s provider. Non-provider
 dependencies (langchain core, the staged local packages, MCP adapters, etc.)
 are always kept. It runs in CI against the ephemeral checkout
-(`.github/workflows/harbor.yml`); the committed file is left untouched.
+(`.github/workflows/harbor.yml`, from the `libs/evals` working directory); the
+committed file is left untouched.
 
 Usage:
     HARBOR_MODEL=fireworks:accounts/... \\
-        python prune_agent_deps.py path/to/langgraph.json
+        python3 prune_agent_deps.py path/to/langgraph.json
 """
 
 from __future__ import annotations
@@ -123,17 +125,26 @@ def main() -> None:
         )
     provider = model.split(":", 1)[0]
 
-    with open(path, encoding="utf-8") as f:  # noqa: PTH123
-        config = json.load(f)
+    try:
+        with open(path, encoding="utf-8") as f:  # noqa: PTH123
+            config = json.load(f)
+    except OSError as exc:
+        raise SystemExit(f"::error::Could not read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"::error::{path} is not valid JSON: {exc}") from exc
+    if not isinstance(config, dict):
+        raise SystemExit(f"::error::{path} must contain a top-level JSON object.")
     deps = config.get("dependencies", [])
 
     if provider not in PROVIDER_TO_PACKAGE:
         # An unmapped provider is non-functional in this workflow anyway:
         # harbor.yml only wires credentials and agent env for the providers in
         # PROVIDER_TO_PACKAGE, and langgraph.json ships only their packages.
-        # Leaving deps in place would keep langchain-fireworks (a prerelease
-        # dependency) and fail the agent-env install with a cryptic resolver
-        # error; fail fast here with an actionable one instead.
+        # Leaving deps in place would keep langchain-fireworks, whose transitive
+        # fireworks-ai dependency is a prerelease (>=1.2.0a71); that fails the
+        # agent-env install unless UV_PRERELEASE=allow is set — and harbor.yml
+        # sets it only for the fireworks arm. Fail fast with an actionable error
+        # here instead of a cryptic resolver failure later.
         supported = ", ".join(sorted(PROVIDER_TO_PACKAGE))
         raise SystemExit(
             f"::error::Unsupported model provider {provider!r} (from {model!r}). "
@@ -142,12 +153,21 @@ def main() -> None:
             "the credential and agent-env steps in harbor.yml."
         )
 
-    pruned = prune_dependencies(deps, provider)
+    try:
+        pruned = prune_dependencies(deps, provider)
+    except ValueError as exc:
+        # Drift between PROVIDER_TO_PACKAGE and the config: surface it as a
+        # GitHub annotation (like the paths above) rather than a raw traceback.
+        raise SystemExit(f"::error::{exc}") from exc
     config["dependencies"] = pruned
 
-    with open(path, "w", encoding="utf-8") as f:  # noqa: PTH123
+    # Write atomically (temp file + os.replace) so an interrupted run can never
+    # leave a truncated langgraph.json for the subsequent Harbor steps to read.
+    tmp_path = f"{path}.tmp"
+    with open(tmp_path, "w", encoding="utf-8") as f:  # noqa: PTH123
         json.dump(config, f, indent=2)
         f.write("\n")
+    os.replace(tmp_path, path)  # noqa: PTH105
 
     removed = [dependency_package(d) for d in deps if d not in pruned]
     print(  # noqa: T201

--- a/.github/scripts/test_prune_agent_deps.py
+++ b/.github/scripts/test_prune_agent_deps.py
@@ -165,17 +165,23 @@ def test_main_rewrites_file_in_place(
     assert written["graphs"] == {"g": "x:y"}
 
 
-def test_main_unknown_provider_leaves_file_unchanged(
+def test_main_unknown_provider_fails_without_writing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An unknown provider warns and no-ops rather than dropping every provider."""
+    """An unmapped provider hard-fails (its plumbing isn't wired in harbor.yml).
+
+    Failing fast beats the no-op fallback, which would retain langchain-fireworks
+    (a prerelease dep) and fail the agent-env install with a cryptic resolver
+    error. The file is left untouched because we fail before writing.
+    """
     config_path = tmp_path / "langgraph.json"
     _write_config(config_path, SAMPLE_DEPS)
     original = config_path.read_text()
     monkeypatch.setenv("HARBOR_MODEL", "some-new-provider:whatever")
     monkeypatch.setattr("sys.argv", [str(PRUNE_SCRIPT), str(config_path)])
 
-    prune.main()
+    with pytest.raises(SystemExit):
+        prune.main()
 
     assert config_path.read_text() == original
 

--- a/.github/scripts/test_prune_agent_deps.py
+++ b/.github/scripts/test_prune_agent_deps.py
@@ -1,0 +1,194 @@
+"""Tests for the agent-dep pruner (`.github/scripts/prune_agent_deps.py`).
+
+Mirrors `test_shard_matrix.py`: import-by-path, stdlib + pytest only, so it runs
+under CI's `pytest .github/scripts/test_*.py` (see `.github/workflows/ci.yml`).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRUNE_SCRIPT = REPO_ROOT / ".github" / "scripts" / "prune_agent_deps.py"
+
+
+def _load_prune_script() -> ModuleType:
+    """Load `.github/scripts/prune_agent_deps.py` as a module.
+
+    The script lives outside any importable package, so import-by-path is the
+    only way to exercise its internals from a test.
+    """
+    spec = importlib.util.spec_from_file_location("gha_prune_agent_deps", PRUNE_SCRIPT)
+    if spec is None or spec.loader is None:
+        msg = f"Could not load module spec for {PRUNE_SCRIPT}"
+        raise AssertionError(msg)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+prune = _load_prune_script()
+
+
+# A representative langgraph.json `dependencies` array: two local path deps,
+# langchain core, every prunable provider, and assorted non-provider deps.
+SAMPLE_DEPS: list[str] = [
+    "./.local_deps/deepagents",
+    "./.local_deps/deepagents-code",
+    "langchain>=1.3.9,<2.0.0",
+    "langchain-anthropic>=1.4.6,<1.5.0",
+    "langchain-baseten>=0.2.0,<0.3.0",
+    "langchain-fireworks>=1.4.2,<1.5.0",
+    "langchain-google-genai>=4.2.4,<4.3.0",
+    "langchain-groq>=1.1.3,<1.2.0",
+    "langchain-nvidia-ai-endpoints>=1.4.1,<1.5.0",
+    "langchain-ollama>=1.1.0,<1.2.0",
+    "langchain-openai>=1.3.0,<1.4.0",
+    "langchain-openrouter>=0.2.3,<0.3.0",
+    "langchain-xai>=1.2.2,<1.3.0",
+    "langchain-mcp-adapters>=0.3.0,<0.4.0",
+    "aiohttp>=3.14.0,<4.0.0",
+    "toml>=0.10.2,<1.0.0",
+]
+
+# Deps that must survive pruning no matter which provider is selected.
+NON_PROVIDER_DEPS: list[str] = [
+    "./.local_deps/deepagents",
+    "./.local_deps/deepagents-code",
+    "langchain>=1.3.9,<2.0.0",
+    "langchain-mcp-adapters>=0.3.0,<0.4.0",
+    "aiohttp>=3.14.0,<4.0.0",
+    "toml>=0.10.2,<1.0.0",
+]
+
+
+@pytest.mark.parametrize("provider", sorted(prune.PROVIDER_TO_PACKAGE))
+def test_keeps_exactly_one_provider(provider: str) -> None:
+    """Every provider prunes to its own package plus all non-provider deps."""
+    kept = prune.prune_dependencies(SAMPLE_DEPS, provider)
+    kept_provider_pkgs = [
+        prune.dependency_package(d)
+        for d in kept
+        if prune.dependency_package(d) in prune.PRUNABLE_PACKAGES
+    ]
+    assert kept_provider_pkgs == [prune.PROVIDER_TO_PACKAGE[provider]]
+    # Non-provider deps are untouched.
+    for dep in NON_PROVIDER_DEPS:
+        assert dep in kept
+
+
+def test_order_is_preserved() -> None:
+    """Pruning filters in place without reordering the surviving deps."""
+    kept = prune.prune_dependencies(SAMPLE_DEPS, "fireworks")
+    assert kept == [d for d in SAMPLE_DEPS if d in kept]
+
+
+def test_openai_openrouter_do_not_collide() -> None:
+    """`langchain-openai` and `langchain-openrouter` share a prefix.
+
+    Name-boundary matching (not prefix matching) must keep only the selected
+    one — the whole reason for parsing the package name rather than `startswith`.
+    """
+    openai_kept = prune.prune_dependencies(SAMPLE_DEPS, "openai")
+    assert "langchain-openai>=1.3.0,<1.4.0" in openai_kept
+    assert "langchain-openrouter>=0.2.3,<0.3.0" not in openai_kept
+
+    openrouter_kept = prune.prune_dependencies(SAMPLE_DEPS, "openrouter")
+    assert "langchain-openrouter>=0.2.3,<0.3.0" in openrouter_kept
+    assert "langchain-openai>=1.3.0,<1.4.0" not in openrouter_kept
+
+
+def test_nvidia_package_name_differs_from_prefix() -> None:
+    """`nvidia` maps to `langchain-nvidia-ai-endpoints`, not `langchain-nvidia`."""
+    kept = prune.prune_dependencies(SAMPLE_DEPS, "nvidia")
+    assert "langchain-nvidia-ai-endpoints>=1.4.1,<1.5.0" in kept
+
+
+def test_unknown_provider_raises_key_error() -> None:
+    """A provider absent from the map is a programming error, not a silent no-op."""
+    with pytest.raises(KeyError):
+        prune.prune_dependencies(SAMPLE_DEPS, "mistral")
+
+
+def test_missing_provider_package_raises_value_error() -> None:
+    """Drift guard: the selected provider's package must be present in deps."""
+    deps_without_fireworks = [d for d in SAMPLE_DEPS if "fireworks" not in d]
+    with pytest.raises(ValueError, match="fireworks"):
+        prune.prune_dependencies(deps_without_fireworks, "fireworks")
+
+
+@pytest.mark.parametrize(
+    ("dep", "expected"),
+    [
+        ("langchain-openai>=1.3.0,<1.4.0", "langchain-openai"),
+        ("langchain-openrouter>=0.2.3,<0.3.0", "langchain-openrouter"),
+        ("langchain-nvidia-ai-endpoints>=1.4.1,<1.5.0", "langchain-nvidia-ai-endpoints"),
+        ("langchain>=1.3.9,<2.0.0", "langchain"),
+        ("./.local_deps/deepagents", "./.local_deps/deepagents"),
+        ("pkg[extra]>=1.0", "pkg"),
+        ("pkg ; python_version < '3.13'", "pkg"),
+        ("bare-package", "bare-package"),
+    ],
+)
+def test_dependency_package_parsing(dep: str, expected: str) -> None:
+    """Package-name extraction handles specifiers, extras, markers, path deps."""
+    assert prune.dependency_package(dep) == expected
+
+
+def _write_config(path: Path, deps: list[str]) -> None:
+    path.write_text(json.dumps({"dependencies": deps, "graphs": {"g": "x:y"}}))
+
+
+def test_main_rewrites_file_in_place(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`main` prunes the file and leaves unrelated keys (`graphs`) intact."""
+    config_path = tmp_path / "langgraph.json"
+    _write_config(config_path, SAMPLE_DEPS)
+    monkeypatch.setenv("HARBOR_MODEL", "fireworks:accounts/fireworks/models/glm-5")
+    monkeypatch.setattr("sys.argv", [str(PRUNE_SCRIPT), str(config_path)])
+
+    prune.main()
+
+    written = json.loads(config_path.read_text())
+    provider_pkgs = [
+        prune.dependency_package(d)
+        for d in written["dependencies"]
+        if prune.dependency_package(d) in prune.PRUNABLE_PACKAGES
+    ]
+    assert provider_pkgs == ["langchain-fireworks"]
+    assert written["graphs"] == {"g": "x:y"}
+
+
+def test_main_unknown_provider_leaves_file_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unknown provider warns and no-ops rather than dropping every provider."""
+    config_path = tmp_path / "langgraph.json"
+    _write_config(config_path, SAMPLE_DEPS)
+    original = config_path.read_text()
+    monkeypatch.setenv("HARBOR_MODEL", "some-new-provider:whatever")
+    monkeypatch.setattr("sys.argv", [str(PRUNE_SCRIPT), str(config_path)])
+
+    prune.main()
+
+    assert config_path.read_text() == original
+
+
+@pytest.mark.parametrize("bad_model", ["", "no-colon-here"])
+def test_main_rejects_malformed_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, bad_model: str
+) -> None:
+    """A missing or colon-less HARBOR_MODEL fails loudly."""
+    config_path = tmp_path / "langgraph.json"
+    _write_config(config_path, SAMPLE_DEPS)
+    monkeypatch.setenv("HARBOR_MODEL", bad_model)
+    monkeypatch.setattr("sys.argv", [str(PRUNE_SCRIPT), str(config_path)])
+
+    with pytest.raises(SystemExit):
+        prune.main()

--- a/.github/scripts/test_prune_agent_deps.py
+++ b/.github/scripts/test_prune_agent_deps.py
@@ -66,6 +66,31 @@ NON_PROVIDER_DEPS: list[str] = [
     "toml>=0.10.2,<1.0.0",
 ]
 
+# The real config the CI step rewrites (see harbor.yml). The sync tests below
+# read it directly so drift between the pruner and the shipped file fails here,
+# at PR time, instead of much later inside a Harbor eval run.
+REAL_CONFIG = (
+    REPO_ROOT
+    / "libs"
+    / "evals"
+    / "deepagents_harbor"
+    / "langgraph_project"
+    / "langgraph.json"
+)
+
+# `langchain`-family deps in the real config that are deliberately NOT provider
+# integrations (core + MCP adapters), so they belong in neither
+# PROVIDER_TO_PACKAGE nor the pruned set. The reverse-drift guard allowlists
+# them; any *other* langchain package must be a mapped provider.
+NON_PROVIDER_LANGCHAIN_PACKAGES: frozenset[str] = frozenset(
+    {"langchain", "langchain-mcp-adapters"}
+)
+
+
+def _real_dependencies() -> list[str]:
+    """Return the `dependencies` array from the committed langgraph.json."""
+    return json.loads(REAL_CONFIG.read_text())["dependencies"]
+
 
 @pytest.mark.parametrize("provider", sorted(prune.PROVIDER_TO_PACKAGE))
 def test_keeps_exactly_one_provider(provider: str) -> None:
@@ -91,8 +116,9 @@ def test_order_is_preserved() -> None:
 def test_openai_openrouter_do_not_collide() -> None:
     """`langchain-openai` and `langchain-openrouter` share a prefix.
 
-    Name-boundary matching (not prefix matching) must keep only the selected
-    one — the whole reason for parsing the package name rather than `startswith`.
+    Name-boundary matching must keep only the selected one — the whole reason
+    for parsing the bare package name rather than prefix/substring matching on
+    the shared `langchain-open` stem.
     """
     openai_kept = prune.prune_dependencies(SAMPLE_DEPS, "openai")
     assert "langchain-openai>=1.3.0,<1.4.0" in openai_kept
@@ -133,6 +159,12 @@ def test_missing_provider_package_raises_value_error() -> None:
         ("pkg[extra]>=1.0", "pkg"),
         ("pkg ; python_version < '3.13'", "pkg"),
         ("bare-package", "bare-package"),
+        # Every other operator in _NAME_DELIMITERS as the leading specifier.
+        ("langchain-openai==1.3.0", "langchain-openai"),
+        ("pkg~=1.0", "pkg"),
+        ("pkg!=1.0", "pkg"),
+        ("pkg<2.0", "pkg"),
+        ("  spaced-pkg >=1.0  ", "spaced-pkg"),
     ],
 )
 def test_dependency_package_parsing(dep: str, expected: str) -> None:
@@ -155,7 +187,8 @@ def test_main_rewrites_file_in_place(
 
     prune.main()
 
-    written = json.loads(config_path.read_text())
+    raw = config_path.read_text()
+    written = json.loads(raw)
     provider_pkgs = [
         prune.dependency_package(d)
         for d in written["dependencies"]
@@ -163,6 +196,11 @@ def test_main_rewrites_file_in_place(
     ]
     assert provider_pkgs == ["langchain-fireworks"]
     assert written["graphs"] == {"g": "x:y"}
+    # The committed file is 2-space-indented with a trailing newline; main()
+    # writes json.dump(indent=2) + "\n". Assert the format at the byte level —
+    # json.loads round-trips would hide a reformat that reads back identically.
+    assert raw.endswith("\n")
+    assert '\n  "graphs"' in raw
 
 
 def test_main_unknown_provider_fails_without_writing(
@@ -171,8 +209,9 @@ def test_main_unknown_provider_fails_without_writing(
     """An unmapped provider hard-fails (its plumbing isn't wired in harbor.yml).
 
     Failing fast beats the no-op fallback, which would retain langchain-fireworks
-    (a prerelease dep) and fail the agent-env install with a cryptic resolver
-    error. The file is left untouched because we fail before writing.
+    — whose transitive fireworks-ai dep is a prerelease — and fail the agent-env
+    install with a cryptic resolver error (no UV_PRERELEASE=allow off the
+    fireworks arm). The file is left untouched because we fail before writing.
     """
     config_path = tmp_path / "langgraph.json"
     _write_config(config_path, SAMPLE_DEPS)
@@ -198,3 +237,130 @@ def test_main_rejects_malformed_model(
 
     with pytest.raises(SystemExit):
         prune.main()
+
+
+def test_main_handles_multi_colon_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`provider:model:tag` specs split on the first colon only.
+
+    Several matrix models carry a trailing tag (e.g. `ollama:glm-5:cloud`); the
+    provider must still resolve via `split(':', 1)`.
+    """
+    config_path = tmp_path / "langgraph.json"
+    _write_config(config_path, SAMPLE_DEPS)
+    monkeypatch.setenv("HARBOR_MODEL", "ollama:glm-5:cloud")
+    monkeypatch.setattr("sys.argv", [str(PRUNE_SCRIPT), str(config_path)])
+
+    prune.main()
+
+    written = json.loads(config_path.read_text())
+    provider_pkgs = [
+        prune.dependency_package(d)
+        for d in written["dependencies"]
+        if prune.dependency_package(d) in prune.PRUNABLE_PACKAGES
+    ]
+    assert provider_pkgs == ["langchain-ollama"]
+
+
+@pytest.mark.parametrize("argv_tail", [[], ["a", "b"]])
+def test_main_rejects_wrong_arg_count(
+    monkeypatch: pytest.MonkeyPatch, argv_tail: list[str]
+) -> None:
+    """Missing or extra CLI arguments produce a usage error before any work."""
+    monkeypatch.setenv("HARBOR_MODEL", "fireworks:accounts/fireworks/models/glm-5")
+    monkeypatch.setattr("sys.argv", [str(PRUNE_SCRIPT), *argv_tail])
+
+    with pytest.raises(SystemExit):
+        prune.main()
+
+
+def test_main_prints_summary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The operator-facing summary names the kept package and removed count."""
+    config_path = tmp_path / "langgraph.json"
+    _write_config(config_path, SAMPLE_DEPS)
+    monkeypatch.setenv("HARBOR_MODEL", "fireworks:accounts/fireworks/models/glm-5")
+    monkeypatch.setattr("sys.argv", [str(PRUNE_SCRIPT), str(config_path)])
+
+    prune.main()
+
+    out = capsys.readouterr().out
+    assert "langchain-fireworks" in out
+    # Every prunable provider but the selected one is removed.
+    assert f"removed {len(prune.PRUNABLE_PACKAGES) - 1}" in out
+
+
+@pytest.mark.parametrize("dependencies", [[], [d for d in SAMPLE_DEPS if "openai" in d]])
+def test_main_annotates_drift_without_writing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, dependencies: list[str]
+) -> None:
+    """A config missing the selected provider fails with a `::error::` annotation.
+
+    Covers both an empty `dependencies` array and one that omits the selected
+    provider; either way the drift guard fires, the message is annotated (not a
+    raw traceback), and the file is left untouched.
+    """
+    config_path = tmp_path / "langgraph.json"
+    _write_config(config_path, dependencies)
+    original = config_path.read_text()
+    monkeypatch.setenv("HARBOR_MODEL", "fireworks:accounts/fireworks/models/glm-5")
+    monkeypatch.setattr("sys.argv", [str(PRUNE_SCRIPT), str(config_path)])
+
+    with pytest.raises(SystemExit) as excinfo:
+        prune.main()
+
+    assert "::error::" in str(excinfo.value)
+    assert config_path.read_text() == original
+
+
+def test_main_annotates_malformed_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Invalid JSON fails with a `::error::` annotation rather than a traceback."""
+    config_path = tmp_path / "langgraph.json"
+    config_path.write_text("{not valid json")
+    monkeypatch.setenv("HARBOR_MODEL", "fireworks:accounts/fireworks/models/glm-5")
+    monkeypatch.setattr("sys.argv", [str(PRUNE_SCRIPT), str(config_path)])
+
+    with pytest.raises(SystemExit, match="::error::"):
+        prune.main()
+
+
+def test_sample_deps_match_real_config() -> None:
+    """The in-file fixture must mirror the committed langgraph.json verbatim.
+
+    SAMPLE_DEPS is a hand-copy; pinning it here stops the suite from silently
+    passing against a stale snapshot after someone edits the real config.
+    """
+    assert SAMPLE_DEPS == _real_dependencies()
+
+
+@pytest.mark.parametrize("provider", sorted(prune.PROVIDER_TO_PACKAGE))
+def test_real_config_prunes_for_every_provider(provider: str) -> None:
+    """Forward drift guard: every mapped package is present in the real config.
+
+    Enforced at PR time. Without it, renaming or dropping a provider package in
+    the committed langgraph.json only fails later — inside the one Harbor eval
+    that runs that provider — as a bare `ValueError`.
+    """
+    prune.prune_dependencies(_real_dependencies(), provider)  # raises on drift
+
+
+def test_real_config_has_no_unmapped_provider() -> None:
+    """Reverse drift guard: no langchain provider package escapes the map.
+
+    A new `langchain-<provider>` added to the committed config without a
+    PROVIDER_TO_PACKAGE entry would never be pruned — it would ship to every
+    job. Core/infra langchain packages are allowlisted; anything else must be a
+    mapped, prunable provider.
+    """
+    for dep in _real_dependencies():
+        pkg = prune.dependency_package(dep)
+        if pkg.startswith("langchain") and pkg not in NON_PROVIDER_LANGCHAIN_PACKAGES:
+            assert pkg in prune.PRUNABLE_PACKAGES, (
+                f"{pkg!r} looks like a provider integration but is not in "
+                "PROVIDER_TO_PACKAGE; add it (and wire harbor.yml) or add it to "
+                "NON_PROVIDER_LANGCHAIN_PACKAGES if it is core/infra."
+            )

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -386,8 +386,12 @@ jobs:
         # provider (for local `langgraph dev`); a single job needs just one, so
         # drop the rest before Harbor builds the agent env. In-place edit of the
         # ephemeral checkout only — the committed file is untouched. Pure stdlib,
-        # unit-tested in .github/scripts/test_prune_agent_deps.py.
-        run: python3 "$GITHUB_WORKSPACE/.github/scripts/prune_agent_deps.py" deepagents_harbor/langgraph_project/langgraph.json
+        # unit-tested in .github/scripts/test_prune_agent_deps.py. Both paths are
+        # absolute ($GITHUB_WORKSPACE) so this step doesn't depend on the job's
+        # `working-directory: libs/evals` default.
+        run: |
+          python3 "$GITHUB_WORKSPACE/.github/scripts/prune_agent_deps.py" \
+            "$GITHUB_WORKSPACE/libs/evals/deepagents_harbor/langgraph_project/langgraph.json"
 
       - name: "⚓ Run Harbor"
         env:

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -380,6 +380,15 @@ jobs:
           mkdir -p ~/.cache/harbor
           echo '{"seen":["registry-datasets-hint"]}' > ~/.cache/harbor/notifications.json
 
+      - name: "✂️ Prune agent provider deps to selected model"
+        # The agent loads its model via init_chat_model, which lazily imports
+        # only the provider matching HARBOR_MODEL. langgraph.json ships every
+        # provider (for local `langgraph dev`); a single job needs just one, so
+        # drop the rest before Harbor builds the agent env. In-place edit of the
+        # ephemeral checkout only — the committed file is untouched. Pure stdlib,
+        # unit-tested in .github/scripts/test_prune_agent_deps.py.
+        run: python3 "$GITHUB_WORKSPACE/.github/scripts/prune_agent_deps.py" deepagents_harbor/langgraph_project/langgraph.json
+
       - name: "⚓ Run Harbor"
         env:
           ANTHROPIC_API_KEY: ${{ startsWith(matrix.model, 'anthropic:') && secrets.ANTHROPIC_API_KEY || '' }}


### PR DESCRIPTION
Only include the model integrations that the model list needs to improve the performance of Harbor jobs.

Also fixes an issue where non-Fireworks jobs failed to install because of the Fireworks prerelease dependency: `langchain-fireworks` was being installed every time but without `prerelease=allow`.