### PR TITLE
feat(infra): give Harbor eval shards a shared per-dispatch LangSmith experiment

### DIFF
--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -604,7 +604,7 @@ jobs:
             nvidia)       agent_env_args+=(--agent-env 'NVIDIA_API_KEY=${NVIDIA_API_KEY}') ;;
           esac
 
-          echo "LangSmith plugin experiment base: $HARBOR_LANGSMITH_EXPERIMENT"
+          echo "LangSmith plugin experiment: $HARBOR_LANGSMITH_EXPERIMENT"
           echo "Agent implementation: $HARBOR_AGENT_LABEL ($HARBOR_AGENT_GRAPH)"
           echo ""
 
@@ -679,7 +679,7 @@ jobs:
             echo "- Rollouts per task: ${HARBOR_ROLLOUTS_PER_TASK}"
             echo "- Agent: Harbor LangGraph ${HARBOR_AGENT_LABEL} (${HARBOR_AGENT_GRAPH})"
             echo "- LangSmith dataset: ${HARBOR_LANGSMITH_DATASET}"
-            echo "- LangSmith experiment base: ${HARBOR_LANGSMITH_EXPERIMENT}"
+            echo "- LangSmith experiment: ${HARBOR_LANGSMITH_EXPERIMENT}"
             if [ "$LATEST_JOB_OUTCOME" = "success" ]; then
               echo "- Harbor job dir: $HARBOR_JOB_DIR"
             fi

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -570,7 +570,11 @@ jobs:
           experiment_model=$(printf '%s' "$HARBOR_MODEL" | tr '/:' '--' | tr -c '[:alnum:]._-' '-')
           experiment_agent=$(printf '%s' "$HARBOR_AGENT_IMPL" | tr -c '[:alnum:]._-' '-')
           HARBOR_LANGSMITH_DATASET="$HARBOR_DATASET"
-          HARBOR_LANGSMITH_EXPERIMENT="deepagents-harbor-${experiment_agent}-${experiment_model}"
+          # Include the run id + attempt so all shards of this dispatch share one
+          # experiment name (Harbor's LangSmith plugin uses an explicit name
+          # verbatim and create-or-reuses it, converging the shards) while a
+          # later dispatch or re-run gets its own experiment.
+          HARBOR_LANGSMITH_EXPERIMENT="deepagents-harbor-${experiment_agent}-${experiment_model}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "HARBOR_AGENT_GRAPH=$HARBOR_AGENT_GRAPH" >> "$GITHUB_ENV"
           echo "HARBOR_AGENT_LABEL=$HARBOR_AGENT_LABEL" >> "$GITHUB_ENV"
           echo "HARBOR_LANGSMITH_DATASET=$HARBOR_LANGSMITH_DATASET" >> "$GITHUB_ENV"


### PR DESCRIPTION
Converge a model's Harbor eval shards into one LangSmith experiment instead of one per shard.

**Change:** append `${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}` to the experiment name (+5/−1). Shards already share the name; the run suffix keeps each dispatch/re-run its own experiment. `RUN_ID` = per dispatch, `RUN_ATTEMPT` = per re-run.

**Why the suffix is newly needed:** Harbor's LangSmith plugin now uses `experiment_name` verbatim (create-or-reuse by name), so same-named shards converge, but it dropped the random per-job `-{job.id}` suffix that used to keep runs distinct. Without our suffix, every dispatch would reuse the first one's experiment.

**Not a dependency / safe to merge anytime:** passing an experiment name is unchanged behavior. Convergence just activates once the running Harbor has the verbatim-name behavior (`harbor-langsmith 9940730f`); on older builds it falls back to per-job experiments.

**Tested:** haiku, `n_shards=2`, override → feature build; both shards used the same experiment, run passed.