### PR TITLE
docs(code): warn that `system_prompt` override bypasses generated prompt

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1347,8 +1347,18 @@ def create_cli_agent(
             Used for system prompt generation.
         system_prompt: Override the default system prompt.
 
-            If `None`, generates one based on `sandbox_type`, `assistant_id`,
-            and `interactive`.
+            If `None`, a system prompt is auto-generated with dynamic context
+            interpolated in (model identity, working directory, sandbox vs.
+            local execution mode, skills path, and interactive-vs-headless
+            guidance).
+
+            !!! warning
+
+                Passing a value here replaces that auto-generated prompt
+                entirely — none of the dynamic context above is added, and
+                `sandbox_type` and `interactive` no longer influence the
+                prompt. Only pass an explicit prompt when you intend to take
+                full ownership of the system prompt's content.
         interactive: When `False`, the auto-generated system prompt is
             tailored for headless non-interactive execution. Ignored when
             `system_prompt` is provided explicitly.


### PR DESCRIPTION
The `system_prompt` parameter of `create_cli_agent` was documented only as "override the default system prompt," which understates its effect. Passing an explicit value replaces the auto-generated prompt *entirely*, dropping all interpolated dynamic context (model identity, working directory, sandbox-vs-local execution mode, skills path, and interactive-vs-headless guidance), and rendering `sandbox_type`/`interactive` inert for prompt purposes. This clarifies the behavior in general terms — a reader does not need to know the internal prompt-builder helper to understand the tradeoff.

Made by [Open SWE](https://openswe.vercel.app/agents/25d7a0c1-a171-ddde-8532-4424d56578bd)