### PR TITLE
docs(acp): call out `dcode --acp` option

### DIFF
--- a/libs/acp/README.md
+++ b/libs/acp/README.md
@@ -6,6 +6,9 @@ This directory contains an [Agent Client Protocol (ACP)](https://agentclientprot
 
 It includes an example coding agent that uses Anthropic's Claude models to write code with its built-in filesystem tools and shell, but you can also connect any Deep Agent with additional tools or different agent architectures!
 
+> [!TIP]
+> Want a ready-made coding agent instead of wiring up your own? The [`deepagents-code`](https://pypi.org/project/deepagents-code/) package (the `dcode` terminal coding agent) can expose its prebuilt coding agent as an ACP server with a single command — no custom agent code required. See [Use the prebuilt Deep Agents Code agent (`dcode --acp`)](#use-the-prebuilt-deep-agents-code-agent-dcode---acp) below. The rest of this guide covers running a bare/general Deep Agent, which does not include the `dcode` coding agent.
+
 ## Getting started
 
 First, make sure you have [Zed](https://zed.dev/) and [`uv`](https://docs.astral.sh/uv/) installed.
@@ -116,6 +119,46 @@ toad acp "python path/to/your_server.py" .
 # or
 toad acp "uv run python path/to/your_server.py" .
 ```
+
+## Use the prebuilt Deep Agents Code agent (`dcode --acp`)
+
+If you don't need a custom agent, [`deepagents-code`](https://pypi.org/project/deepagents-code/) — the `dcode` terminal coding agent — can run its prebuilt coding agent as an ACP server over stdio. This ships the full `dcode` coding agent (filesystem tools, shell, MCP support, and subagents), unlike the bare/general Deep Agent used elsewhere in this guide.
+
+Install `deepagents-code` together with the ACP dependencies:
+
+```sh
+uv tool install -U deepagents-code --with deepagents-acp
+```
+
+Then point your ACP-compatible editor at `dcode --acp`. For Zed, add this to your `settings.json`:
+
+```json
+{
+  "agent_servers": {
+    "Deep Agents Code": {
+      "type": "custom",
+      "command": "dcode",
+      "args": ["--acp"]
+    }
+  }
+}
+```
+
+Select a model by passing `--model` (in `provider:model-name` form) to the command:
+
+```json
+{
+  "agent_servers": {
+    "Deep Agents Code": {
+      "type": "custom",
+      "command": "dcode",
+      "args": ["--acp", "--model", "anthropic:claude-sonnet-4-5"]
+    }
+  }
+}
+```
+
+`dcode` reads provider API keys from the environment (e.g. `ANTHROPIC_API_KEY`), the same way it does in the terminal. Run `dcode --help` to see the other flags supported in ACP mode, such as `--mcp-config` and `--no-mcp`.
 
 ## Model Switching
 


### PR DESCRIPTION
The `libs/acp` README only documents running a bare/general Deep Agent, but many users just want a ready-made coding agent. `deepagents-code` (`dcode`) can already expose its prebuilt coding agent as an ACP server via `dcode --acp`, so this adds a top-of-README tip and a dedicated section covering install, Zed configuration, and model selection with `--model`.

Made by [Open SWE](https://openswe.vercel.app/agents/4228d9b3-8ca4-4d7f-9a12-e734d40b8b9e)