### PR TITLE
fix: tolerate missing modified_at in glob sort key

### DIFF
--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -779,7 +779,7 @@ def _glob_search_files(
             relative = file_path[len(normalized_path) + 1 :]  # +1 for the slash
 
         if wcglob.globmatch(relative, effective_pattern, flags=wcglob.BRACE | wcglob.GLOBSTAR):
-            matches.append((file_path, file_data["modified_at"]))
+            matches.append((file_path, file_data.get("modified_at", "")))
 
     matches.sort(key=lambda x: x[1], reverse=True)
 

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -233,6 +233,25 @@ class TestGlobSearchFiles:
         result = _glob_search_files(sample_files, "*.py", "../etc/")
         assert result == "No files found"
 
+    def test_glob_tolerates_missing_modified_at(self) -> None:
+        """A file without ``modified_at`` must not crash glob.
+
+        ``modified_at`` is ``NotRequired`` on ``FileData`` and is accessed
+        defensively everywhere else (ls/glob use ``fd.get(...)``). A
+        caller-supplied file (e.g. via the files state channel, which stores
+        the dict verbatim) can legitimately omit it, so glob must not raise.
+        """
+        files = {
+            "/a.py": {"content": "a"},  # no modified_at
+            "/b.py": {"modified_at": "2024-01-01T10:00:00"},
+        }
+        result = _glob_search_files(files, "*.py", "/")
+        assert "/a.py" in result
+        assert "/b.py" in result
+        # The file with a timestamp sorts first (reverse=True); the one
+        # missing a timestamp sorts last rather than crashing.
+        assert result.strip().split("\n")[0] == "/b.py"
+
     def test_leading_slash_in_pattern(self, sample_files: dict[str, Any]) -> None:
         """Patterns with a leading slash should still match (models often produce them)."""
         result = _glob_search_files(sample_files, "/src/**/*.py", "/")


### PR DESCRIPTION
## Why

`_glob_search_files` (used by `StateBackend.glob` and `StoreBackend.glob`, which back the FilesystemMiddleware `glob` tool) builds its sort key from `modified_at` **unconditionally**:

```python
matches.append((file_path, file_data["modified_at"]))
```

But `modified_at` is `NotRequired` on `FileData` (`protocol.py`) and every other consumer reads it defensively — `ls`/`glob` size logic uses `fd.get("modified_at", "")`, and `read()`/`update_file_data` only copy it `if "modified_at" in file_data`.

So a file dict that legitimately omits `modified_at` makes `glob` raise `KeyError`. This is reachable from public API:

- The files state channel reducer (`_file_data_delta_reducer`) stores caller-supplied file dicts **verbatim**, with no timestamp injection. Invoking an agent with `files={"/a.py": {"content": "x"}}` and then having the model call `glob("*.py")` hits it.
- `StoreBackend._convert_store_item_to_file_data` omits `modified_at` when the store item lacks it.

Through the tool boundary the `KeyError` surfaces as `Error: glob failed: modified_at`, so **every otherwise-valid match is dropped** whenever any one candidate file lacks the key. Called directly it raises uncaught.

## What

Use `file_data.get("modified_at", "")` for the sort key, matching the defensive access already used throughout the codebase. Untimestamped files sort last (under `reverse=True`) instead of crashing. Public signature unchanged.

## Tests

New `TestGlobSearchFiles::test_glob_tolerates_missing_modified_at`: a file dict without `modified_at` is still matched (not dropped) and does not raise; the timestamped file sorts first. The existing `TestGlobSearchFiles` fixtures always included `modified_at`, which is why this slipped through.

`test_utils.py` (88 passed), the full `backends` suite (765 passed), `ruff check`, `ruff format --check`, and `ty check` all pass.

---
*Disclosure: this contribution was prepared with the assistance of an AI agent (Claude Code). The root-cause analysis, fix, and test were reviewed by me before submission.*