### PR TITLE
fix: treat null SKILL.md frontmatter fields as missing, not 'None'

### DIFF
--- a/libs/deepagents/deepagents/middleware/skills.py
+++ b/libs/deepagents/deepagents/middleware/skills.py
@@ -413,8 +413,8 @@ def _parse_skill_metadata(
         logger.warning("Skipping %s: frontmatter is not a mapping", skill_path)
         return None
 
-    name = str(frontmatter_data.get("name", "")).strip()
-    description = str(frontmatter_data.get("description", "")).strip()
+    name = str(frontmatter_data.get("name") or "").strip()
+    description = str(frontmatter_data.get("description") or "").strip()
     if not name or not description:
         logger.warning("Skipping %s: missing required 'name' or 'description'", skill_path)
         return None
@@ -446,7 +446,7 @@ def _parse_skill_metadata(
 
     allowed_tools = _parse_allowed_tools(frontmatter_data.get("allowed-tools"), skill_path)
 
-    compatibility_str = str(frontmatter_data.get("compatibility", "")).strip() or None
+    compatibility_str = str(frontmatter_data.get("compatibility") or "").strip() or None
     if compatibility_str and len(compatibility_str) > MAX_SKILL_COMPATIBILITY_LENGTH:
         logger.warning(
             "Skill compatibility in %s is %d characters, over the Agent Skills "
@@ -465,7 +465,7 @@ def _parse_skill_metadata(
         description=description_str,
         path=skill_path,
         metadata=_validate_metadata(frontmatter_data.get("metadata", {}), skill_path),
-        license=str(frontmatter_data.get("license", "")).strip() or None,
+        license=str(frontmatter_data.get("license") or "").strip() or None,
         compatibility=compatibility_str,
         allowed_tools=allowed_tools,
     )

--- a/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_skills_middleware.py
@@ -254,6 +254,50 @@ Content
     assert result is None
 
 
+def test_parse_skill_metadata_null_fields() -> None:
+    """A present-but-null YAML field is treated as missing, not the string 'None'.
+
+    ``yaml.safe_load`` returns ``None`` for a bare ``description:`` line.
+    ``str(None)`` is the truthy string ``"None"``, which would otherwise bypass
+    the required-field guard (loading a bogus skill) and render ``License: None``
+    in the system prompt.
+    """
+    # description present but null -> treated as missing -> skipped
+    content = """---
+name: test-skill
+description:
+---
+
+Content
+"""
+    assert _parse_skill_metadata(content, "/skills/test/SKILL.md", "test-skill") is None
+
+    # name present but null -> treated as missing -> skipped
+    content = """---
+name:
+description: Test skill
+---
+
+Content
+"""
+    assert _parse_skill_metadata(content, "/skills/test/SKILL.md", "test") is None
+
+    # null license/compatibility become None, not the literal string "None"
+    content = """---
+name: valid-skill
+description: A valid skill
+license:
+compatibility:
+---
+
+Content
+"""
+    result = _parse_skill_metadata(content, "/skills/test/SKILL.md", "valid-skill")
+    assert result is not None
+    assert result["license"] is None
+    assert result["compatibility"] is None
+
+
 def test_parse_skill_metadata_description_truncation(caplog: pytest.LogCaptureFixture) -> None:
     """Test _parse_skill_metadata truncates long descriptions with an actionable warning."""
     long_description = "A" * (MAX_SKILL_DESCRIPTION_LENGTH + 100)


### PR DESCRIPTION
## Why

`_parse_skill_metadata` reads frontmatter fields like this:

```python
name = str(frontmatter_data.get("name", "")).strip()
description = str(frontmatter_data.get("description", "")).strip()
```

The `""` default only applies when the key is **absent**. When a key is *present but null* — a bare `description:` line, which `yaml.safe_load` returns as `None` — `str(None).strip()` yields the literal string `"None"`.

Consequences (all model-facing):

- `name` / `description`: `"None"` is truthy, so the guard `if not name or not description: ... return None` is bypassed. A skill that should be skipped is loaded with `description == "None"` and rendered to the model as `- **skill**: None`.
- `license` / `compatibility`: a null value renders as `License: None` in the system prompt (`str(None).strip() or None` → `"None"`).

A present-but-empty field is a plausible authoring mistake in a user-provided `SKILL.md`, and `_skill_metadata_from_response` forwards the raw content with no validation, so this reaches `_parse_skill_metadata` directly via `SkillsMiddleware`.

## What

Read the four fields with `(get(key) or "")` instead of `get(key, "")`, so an explicit YAML `null` is treated the same as a missing key. Null `name`/`description` now correctly skip the skill; null `license`/`compatibility` become `None` rather than the string `"None"`. Public signatures unchanged.

## Tests

New `test_parse_skill_metadata_null_fields`: a null `description` or `name` causes the skill to be skipped (returns `None`), and a null `license`/`compatibility` on an otherwise-valid skill becomes `None` rather than `"None"`. Existing `test_parse_skill_metadata_missing_required_fields` (absent keys) stays green.

Full `middleware` suite (438 passed), `ruff check`, `ruff format --check`, and `ty check` all pass.

---
*Disclosure: this contribution was prepared with the assistance of an AI agent (Claude Code). The analysis, fix, and tests were reviewed by me before submission.*