### PR TITLE
feat(code): notify when a background async task finishes

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -392,6 +392,15 @@ state as the single app-wide progress indicator.
 _UPDATE_RECHECK_INTERVAL_SECONDS = 60 * 60
 """How often long-running TUI sessions quietly re-check for app updates."""
 
+_ASYNC_TASK_POLL_INTERVAL_SECONDS = 15
+"""How often to check tracked async subagent tasks for a terminal status.
+
+Purely a TUI-side poll against checkpointed state (`_get_thread_state_values`)
+so a user who starts a background task and looks away finds out when it's
+done — the agent itself is explicitly told not to poll `check_async_task` in
+a loop, so nothing else surfaces this.
+"""
+
 _MODAL_WATCHDOG_TIMEOUT_SECONDS = 600.0
 """Upper bound on awaiting a confirmation modal's dismissal.
 
@@ -2270,6 +2279,13 @@ class DeepAgentsApp(App):
         self._pending_mcp_disable_reconnect_servers: set[str] = set()
         """MCP servers with disable-state changes waiting for reconnect."""
 
+        self._async_task_notified: set[str] = set()
+        """Async subagent `task_id`s already surfaced by `_notify_async_task_done`.
+
+        Prevents `_poll_async_tasks` from re-toasting the same completed task
+        on every subsequent poll tick.
+        """
+
         self._mcp_tool_count = sum(len(s.tools) for s in (mcp_server_info or []))
         """Total tool count across MCP servers, displayed in the status bar."""
 
@@ -3358,6 +3374,19 @@ class DeepAgentsApp(App):
                 exclusive=True,
                 group="startup-whats-new",
             )
+
+        # Watch for background async subagent tasks completing while the
+        # user's attention is elsewhere. Unconditional (not gated behind a
+        # config flag): `_poll_async_tasks` is a no-op whenever the current
+        # thread has no tracked async tasks, which is the common case.
+        self.set_interval(
+            _ASYNC_TASK_POLL_INTERVAL_SECONDS,
+            lambda: self.run_worker(
+                self._poll_async_tasks(),
+                exclusive=True,
+                group="async-task-poll",
+            ),
+        )
 
         # Prewarm model discovery and profile caches unconditionally so
         # /model opens instantly even before the agent/server is ready.
@@ -11201,6 +11230,64 @@ class DeepAgentsApp(App):
         if state and state.values:
             return dict(state.values)
         return {}
+
+    async def _poll_async_tasks(self) -> None:
+        """Check the current thread's tracked async subagent tasks for completion.
+
+        Runs on a `set_interval` tick (`_ASYNC_TASK_POLL_INTERVAL_SECONDS`),
+        entirely out-of-band from the agent loop — the model is explicitly
+        told not to poll `check_async_task` itself (see
+        `AsyncSubAgentMiddleware`'s tool description), so this is the only
+        thing that notices a background task finished while the user's
+        attention is elsewhere.
+
+        A no-op whenever `async_tasks` is empty or absent, so idle sessions
+        (the common case — most sessions never start an async task) pay for
+        nothing beyond the state fetch itself.
+        """
+        if not self._agent or not self._lc_thread_id:
+            return
+
+        state_values = await self._get_thread_state_values(self._lc_thread_id)
+        tasks = state_values.get("async_tasks")
+        if not tasks:
+            return
+
+        for task_id, task in tasks.items():
+            if task_id in self._async_task_notified:
+                continue
+            if task.get("status") in {"success", "error", "cancelled"}:
+                self._notify_async_task_done(task)
+                self._async_task_notified.add(task_id)
+
+    def _notify_async_task_done(self, task: dict[str, Any]) -> None:
+        """Toast and dispatch a hook for an async task reaching a terminal status.
+
+        Args:
+            task: The `AsyncTask` dict (see
+                `deepagents.middleware.async_subagents.AsyncTask`) that just
+                transitioned to `success`, `error`, or `cancelled`.
+        """
+        status = task.get("status", "unknown")
+        agent_name = task.get("agent_name", "unknown")
+        severity = "warning" if status in {"error", "cancelled"} else "information"
+        self.notify(
+            f"Background task '{agent_name}' finished ({status}).",
+            severity=severity,
+            timeout=8,
+            markup=False,
+        )
+
+        from deepagents_code.hooks import dispatch_hook_fire_and_forget
+
+        dispatch_hook_fire_and_forget(
+            "async_task.complete",
+            {
+                "task_id": task.get("task_id"),
+                "agent_name": agent_name,
+                "status": status,
+            },
+        )
 
     async def _fetch_thread_history_data(self, thread_id: str) -> _ThreadHistoryPayload:
         """Fetch and convert stored messages for a thread.

--- a/libs/code/deepagents_code/hooks.py
+++ b/libs/code/deepagents_code/hooks.py
@@ -65,6 +65,15 @@ in-order, so the program-order guarantee holds. `input.required` and
 `user.name.set` are the exceptions with no program-order guarantee:
 `user.name.set` is always dispatched fire-and-forget, and `input.required` is
 fire-and-forget on the headless surface (awaited only in the interactive TUI).
+
+`async_task.complete` (interactive TUI only) fires fire-and-forget from a
+periodic background poll (`DeepAgentsApp._poll_async_tasks`) whenever a
+tracked async subagent task (started via `start_async_task`) reaches
+`success`, `error`, or `cancelled`. It has no relationship to program order —
+it can fire at any point relative to the main conversation turn, since the
+task it reports on runs on a separate remote thread. Payload:
+`{"task_id": ..., "agent_name": ..., "status": ...}`. Distinct from
+`task.complete`, which reports only the current headless run finishing.
 """
 
 from __future__ import annotations

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -17352,6 +17352,117 @@ class TestNotificationCenterIntegration:
             assert isinstance(app.screen, NotificationCenterScreen)
 
 
+class TestAsyncTaskCompletionNotifications:
+    """`_poll_async_tasks` toasts and dispatches a hook for finished background tasks.
+
+    The agent is explicitly instructed not to poll `check_async_task` in a
+    loop, so `_poll_async_tasks` (driven by `set_interval` in
+    `_post_paint_init`) is the only thing that notices a tracked async
+    subagent task finished while the user's attention is elsewhere.
+    """
+
+    async def test_notifies_on_terminal_status(self) -> None:
+        """A task already in a terminal state on first poll triggers one toast."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        task = {
+            "task_id": "task-1",
+            "agent_name": "researcher",
+            "status": "success",
+        }
+        fetch = AsyncMock(return_value={"async_tasks": {"task-1": task}})
+
+        with (
+            patch.object(app, "_get_thread_state_values", fetch),
+            patch.object(app, "notify") as notify_mock,
+        ):
+            await app._poll_async_tasks()
+
+        notify_mock.assert_called_once()
+        message = notify_mock.call_args.args[0]
+        assert "researcher" in message
+        assert "success" in message
+        assert "task-1" in app._async_task_notified
+
+    async def test_no_duplicate_notification_on_repeated_poll(self) -> None:
+        """A second poll after notifying does not toast again for the same task."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        task = {"task_id": "task-1", "agent_name": "researcher", "status": "success"}
+        fetch = AsyncMock(return_value={"async_tasks": {"task-1": task}})
+
+        with (
+            patch.object(app, "_get_thread_state_values", fetch),
+            patch.object(app, "notify") as notify_mock,
+        ):
+            await app._poll_async_tasks()
+            await app._poll_async_tasks()
+
+        notify_mock.assert_called_once()
+
+    async def test_ignores_running_tasks(self) -> None:
+        """A task still `running` produces no toast and is not marked notified."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        task = {"task_id": "task-1", "agent_name": "researcher", "status": "running"}
+        fetch = AsyncMock(return_value={"async_tasks": {"task-1": task}})
+
+        with (
+            patch.object(app, "_get_thread_state_values", fetch),
+            patch.object(app, "notify") as notify_mock,
+        ):
+            await app._poll_async_tasks()
+
+        notify_mock.assert_not_called()
+        assert "task-1" not in app._async_task_notified
+
+    async def test_dispatches_hook_with_expected_payload(self) -> None:
+        """A terminal task fires `async_task.complete` with the expected payload."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        task = {"task_id": "task-1", "agent_name": "researcher", "status": "error"}
+        fetch = AsyncMock(return_value={"async_tasks": {"task-1": task}})
+
+        with (
+            patch.object(app, "_get_thread_state_values", fetch),
+            patch.object(app, "notify"),
+            patch(
+                "deepagents_code.hooks.dispatch_hook_fire_and_forget"
+            ) as dispatch_hook,
+        ):
+            await app._poll_async_tasks()
+
+        dispatch_hook.assert_called_once_with(
+            "async_task.complete",
+            {"task_id": "task-1", "agent_name": "researcher", "status": "error"},
+        )
+
+    async def test_noop_when_no_async_tasks(self) -> None:
+        """No tracked tasks means no toast and no hook dispatch."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        fetch = AsyncMock(return_value={})
+
+        with (
+            patch.object(app, "_get_thread_state_values", fetch),
+            patch.object(app, "notify") as notify_mock,
+            patch(
+                "deepagents_code.hooks.dispatch_hook_fire_and_forget"
+            ) as dispatch_hook,
+        ):
+            await app._poll_async_tasks()
+
+        fetch.assert_awaited_once()
+        notify_mock.assert_not_called()
+        dispatch_hook.assert_not_called()
+
+    async def test_noop_without_agent(self) -> None:
+        """No agent means the poll returns before touching thread state at all."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        app._agent = None
+        fetch = AsyncMock(return_value={"async_tasks": {}})
+
+        with patch.object(app, "_get_thread_state_values", fetch):
+            await app._poll_async_tasks()
+
+        fetch.assert_not_awaited()
+
+
 class TestFatalErrorRedaction:
     """`_fatal_error` must not leak local variables (which carry secrets).
 


### PR DESCRIPTION
Fixes #4656

---

Async subagent tasks started via `start_async_task` are tracked in `AsyncSubAgentState.async_tasks`, but the tool description explicitly tells the model not to poll `check_async_task` in a loop — which is the right call for the model, but left nothing telling the *user* when a background task finishes. Someone who kicks off a long-running async task and looks away had no way to find out short of manually asking the agent to check again.

This adds a lightweight, TUI-side background poll (`_poll_async_tasks`, driven by a `set_interval` tick registered in `_post_paint_init`) that checks the current thread's `async_tasks` state every 15 seconds. The first time a tracked task reaches `success`, `error`, or `cancelled`, it shows a toast via `self.notify(...)` and dispatches a new `async_task.complete` hook event. It's entirely out-of-band from the agent loop, so it costs no tokens and never touches model reasoning, and it's a no-op whenever the current thread has no tracked async tasks (the common case).

A new hook event name (`async_task.complete`) is used rather than reusing the existing `task.complete`, which already reports something different — the current headless run finishing — so overloading it would make a hook script unable to tell the two apart.

## How did you verify your code works?

**Automated:**
- Added `TestAsyncTaskCompletionNotifications` (6 tests) in `tests/unit_tests/test_app.py`: notifies on terminal status, no duplicate notification on a repeated poll, ignores `running` tasks, dispatches the hook with the expected payload, no-op when there are no tracked async tasks, no-op when there's no agent yet.
- `uv run --group test ruff check .`, `ruff format --check .`, and `ty check .` — all clean.
- `uv run --group test pytest tests/unit_tests/ -q` — full suite: 8470 passed, 3 skipped, plus the 6 new tests. 4 unrelated failures (`test_auth_display.py`, `test_status.py::TestBranchDisplay` — glyph/branch-icon rendering, nothing touched by this change) reproduce identically on `main` and pass when run in isolation, confirming pre-existing test-order flakiness, not a regression from this change.

**Manual, against the real running app:**
Standing up a real remote async-subagent server just to get a task to `success` is heavyweight for a one-off check, so I stubbed only the two things that server would normally produce (`agent=MagicMock()` — the same stand-in the app's own test suite already uses — and a patched `_get_thread_state_values` returning an `async_tasks` dict with one task at `status: "success"`), then ran the real, unmodified `DeepAgentsApp` in a real terminal (via `tmux`) with the poll interval shortened to 1s. The toast "Background task 'researcher' finished (success)." appeared exactly as expected. 

<img width="1400" height="1400" alt="async_task_notification" src="https://github.com/user-attachments/assets/97aa503e-419c-4f59-bd57-e14742f6d6c2" />
