### PR TITLE
feat(sdk): add ToolSelectionMiddleware to filter tools sent to the model per turn

### DIFF
--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -75,6 +75,7 @@ from deepagents.middleware.summarization import (
     SummarizationToolMiddleware,
     create_summarization_tool_middleware,
 )
+from deepagents.middleware.tool_selection import ToolSelectionMiddleware
 
 __all__ = [
     "DEEPAGENTS_DEFAULT_SUMMARY_PROMPT",
@@ -100,5 +101,6 @@ __all__ = [
     "SubAgentMiddleware",
     "SummarizationMiddleware",
     "SummarizationToolMiddleware",
+    "ToolSelectionMiddleware",
     "create_summarization_tool_middleware",
 ]

--- a/libs/deepagents/deepagents/middleware/tool_selection.py
+++ b/libs/deepagents/deepagents/middleware/tool_selection.py
@@ -122,10 +122,7 @@ def _lexical_score(tool: BaseTool | dict[str, Any], query_tokens: set[str]) -> f
     tool_tokens = _tokenize(f"{_tool_name(tool) or ''} {_tool_description(tool)}")
     if not tool_tokens:
         return 0.0
-    union = tool_tokens | query_tokens
-    if not union:
-        return 0.0
-    return len(tool_tokens & query_tokens) / len(union)
+    return len(tool_tokens & query_tokens) / len(tool_tokens | query_tokens)
 
 
 def _cosine_similarity(a: list[float], b: list[float]) -> float:

--- a/libs/deepagents/deepagents/middleware/tool_selection.py
+++ b/libs/deepagents/deepagents/middleware/tool_selection.py
@@ -34,37 +34,34 @@ Scoring defaults to zero-dependency lexical token overlap between the latest
 Embeddings` instance for cosine-similarity scoring instead.
 """
 
-from __future__ import annotations
-
 import re
-from typing import TYPE_CHECKING, Annotated, Any, NotRequired
+from collections.abc import Awaitable, Callable
+from typing import Annotated, Any, NotRequired
 
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,
     ContextT,
+    ExtendedModelResponse,
+    ModelRequest,
+    ModelResponse,
     PrivateStateAttr,
     ResponseT,
 )
-from langchain.tools import (
-    ToolRuntime,  # noqa: TC002  # must stay a real import: the tool node resolves this annotation at runtime to inject `ToolRuntime`
-)
-from langchain_core.messages import HumanMessage, ToolMessage
-from langchain_core.tools import StructuredTool
+from langchain.tools import ToolRuntime
+from langchain_core.embeddings import Embeddings
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
+from langchain_core.tools import BaseTool, StructuredTool
 from langgraph.types import Command
 from pydantic import BaseModel, Field
 
-if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-
-    from langchain.agents.middleware.types import (
-        ExtendedModelResponse,
-        ModelRequest,
-        ModelResponse,
-    )
-    from langchain_core.embeddings import Embeddings
-    from langchain_core.messages import AIMessage, AnyMessage
-    from langchain_core.tools import BaseTool
+# NOTE: this module intentionally does NOT use `from __future__ import annotations`.
+# `discover_tools` below relies on the `runtime: ToolRuntime` parameter annotation
+# being a real, live type at function-definition time -- the tool node's injection
+# detection (`StructuredTool._injected_args_keys`) inspects `inspect.signature(fn)`
+# directly and only recognizes injected params when the annotation is an actual
+# class, not a postponed (stringified) one. Same reasoning as `async_subagents.py`
+# and `subagents.py`, which also omit the future import for this reason.
 
 DEFAULT_ALWAYS_INCLUDE: frozenset[str] = frozenset({"read_file", "write_file", "edit_file", "ls", "task"})
 DISCOVER_TOOLS_NAME = "discover_tools"

--- a/libs/deepagents/deepagents/middleware/tool_selection.py
+++ b/libs/deepagents/deepagents/middleware/tool_selection.py
@@ -1,0 +1,265 @@
+"""Middleware for filtering the tool list sent to the model per turn.
+
+## Overview
+
+The tool list an agent is constructed with is normally sent to the model on
+every call, regardless of whether the current turn touches any of it. With a
+few MCP servers and skills wired in, that can easily be 25-30+ schemas on
+every request. `ToolSelectionMiddleware` scores tools against the latest
+user message and only sends the top-K most relevant ones (plus an
+always-include set) to the model, while leaving the full tool set registered
+and callable.
+
+## Escape hatch
+
+A `discover_tools` tool is injected alongside the middleware so the model is
+never permanently blind to a tool that didn't make the cut. Calling it
+searches the full tool registry and pins the best match into the
+always-include set for the rest of the conversation.
+
+## Usage
+
+```python
+from deepagents.middleware.tool_selection import ToolSelectionMiddleware
+
+agent = create_deep_agent(
+    model="anthropic:claude-sonnet-5",
+    tools=[...],
+    middleware=[ToolSelectionMiddleware(top_k=15)],
+)
+```
+
+Scoring defaults to zero-dependency lexical token overlap between the latest
+`HumanMessage` and each tool's name + description. Pass an `embeddings:
+Embeddings` instance for cosine-similarity scoring instead.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Annotated, Any, NotRequired
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ContextT,
+    PrivateStateAttr,
+    ResponseT,
+)
+from langchain.tools import (
+    ToolRuntime,  # noqa: TC002  # must stay a real import: the tool node resolves this annotation at runtime to inject `ToolRuntime`
+)
+from langchain_core.messages import HumanMessage, ToolMessage
+from langchain_core.tools import StructuredTool
+from langgraph.types import Command
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain.agents.middleware.types import (
+        ExtendedModelResponse,
+        ModelRequest,
+        ModelResponse,
+    )
+    from langchain_core.embeddings import Embeddings
+    from langchain_core.messages import AIMessage, AnyMessage
+    from langchain_core.tools import BaseTool
+
+DEFAULT_ALWAYS_INCLUDE: frozenset[str] = frozenset({"read_file", "write_file", "edit_file", "ls", "task"})
+DISCOVER_TOOLS_NAME = "discover_tools"
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+DISCOVER_TOOLS_DESCRIPTION = """Search the full tool registry for a tool relevant to a query.
+
+The tool list you see each turn is filtered down to the most relevant tools --
+use this when you suspect a tool exists that isn't currently visible to you.
+A match found here stays available for the rest of the conversation.
+"""
+
+
+class DiscoverToolsSchema(BaseModel):
+    """Arguments for the `discover_tools` escape-hatch tool."""
+
+    query: str = Field(description="What you're trying to do, in plain language.")
+
+
+class ToolSelectionState(AgentState):
+    """State schema for `ToolSelectionMiddleware`.
+
+    Attributes:
+        tool_selection_pinned: Tool names pinned by `discover_tools`, bypassing
+            the top-k relevance cutoff for the rest of the conversation.
+    """
+
+    tool_selection_pinned: NotRequired[Annotated[list[str], PrivateStateAttr]]
+
+
+def _tool_name(tool: BaseTool | dict[str, Any]) -> str | None:
+    """Extract tool name from a `BaseTool` or dict tool."""
+    if isinstance(tool, dict):
+        name = tool.get("name")
+        return name if isinstance(name, str) else None
+    name = getattr(tool, "name", None)
+    return name if isinstance(name, str) else None
+
+
+def _tool_description(tool: BaseTool | dict[str, Any]) -> str:
+    """Extract tool description from a `BaseTool` or dict tool."""
+    if isinstance(tool, dict):
+        description = tool.get("description", "")
+        return description if isinstance(description, str) else ""
+    description = getattr(tool, "description", "")
+    return description if isinstance(description, str) else ""
+
+
+def _tokenize(text: str) -> set[str]:
+    """Lowercase, alphanumeric-only tokenization."""
+    return {match.group(0) for match in _TOKEN_RE.finditer(text.lower())}
+
+
+def _lexical_score(tool: BaseTool | dict[str, Any], query_tokens: set[str]) -> float:
+    """Jaccard overlap between a tool's name + description tokens and the query tokens."""
+    if not query_tokens:
+        return 0.0
+    tool_tokens = _tokenize(f"{_tool_name(tool) or ''} {_tool_description(tool)}")
+    if not tool_tokens:
+        return 0.0
+    union = tool_tokens | query_tokens
+    if not union:
+        return 0.0
+    return len(tool_tokens & query_tokens) / len(union)
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Cosine similarity between two equal-length vectors."""
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    norm_a = sum(x * x for x in a) ** 0.5
+    norm_b = sum(y * y for y in b) ** 0.5
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def _latest_human_message_text(messages: list[AnyMessage]) -> str:
+    """Text of the most recent `HumanMessage`, or an empty string if there isn't one."""
+    for message in reversed(messages):
+        if isinstance(message, HumanMessage):
+            return message.text
+    return ""
+
+
+class ToolSelectionMiddleware(AgentMiddleware[ToolSelectionState, ContextT, ResponseT]):
+    """Filters the tool list sent to the model down to the top-K most relevant tools.
+
+    Should be placed late in the middleware stack (after all tool-injecting
+    middleware) so it scores and filters the fully assembled tool list, same
+    placement requirement as `_ToolExclusionMiddleware`.
+
+    Args:
+        top_k: Maximum number of tools sent to the model per turn, beyond
+            `always_include`. If the request already has `top_k` tools or
+            fewer, filtering is skipped entirely.
+        always_include: Tool names that are never filtered out.
+        embeddings: Optional `Embeddings` instance for cosine-similarity
+            scoring. Falls back to zero-dependency lexical token overlap.
+    """
+
+    state_schema = ToolSelectionState
+
+    def __init__(
+        self,
+        *,
+        top_k: int = 15,
+        always_include: frozenset[str] = DEFAULT_ALWAYS_INCLUDE,
+        embeddings: Embeddings | None = None,
+    ) -> None:
+        """Initialize the tool selection middleware."""
+        self._top_k = top_k
+        self._always_include = always_include | {DISCOVER_TOOLS_NAME}
+        self._embeddings = embeddings
+        self._embedding_cache: dict[str, list[float]] = {}
+        self.tools = [self._build_discover_tools_tool()]
+
+    def _scorer(self, query: str) -> Callable[[BaseTool | dict[str, Any]], float]:
+        """Build a per-turn scoring function, doing any one-time query prep up front."""
+        if self._embeddings is not None:
+            embeddings = self._embeddings
+            query_vector = embeddings.embed_query(query)
+
+            def _embedding_score(tool: BaseTool | dict[str, Any]) -> float:
+                name = _tool_name(tool) or repr(tool)
+                if name not in self._embedding_cache:
+                    text = f"{_tool_name(tool) or ''}: {_tool_description(tool)}"
+                    self._embedding_cache[name] = embeddings.embed_documents([text])[0]
+                return _cosine_similarity(self._embedding_cache[name], query_vector)
+
+            return _embedding_score
+
+        query_tokens = _tokenize(query)
+        return lambda tool: _lexical_score(tool, query_tokens)
+
+    def _build_discover_tools_tool(self) -> BaseTool:
+        """Build the `discover_tools` escape-hatch tool bound to this middleware instance."""
+
+        def discover_tools(query: str, runtime: ToolRuntime) -> Command:
+            scorer = self._scorer(query)
+            candidates = [t for t in runtime.tools if _tool_name(t) != DISCOVER_TOOLS_NAME]
+            match = max(candidates, key=scorer, default=None)
+            pinned: list[str] = list(runtime.state.get("tool_selection_pinned") or [])
+            if match is not None and scorer(match) > 0:
+                name = _tool_name(match)
+                if name is not None and name not in pinned:
+                    pinned.append(name)
+                content = f"Found tool `{name}`: {_tool_description(match)}\n\nIt is now available for the rest of this conversation."
+            else:
+                content = f"No tool found matching: {query!r}"
+            return Command(
+                update={
+                    "tool_selection_pinned": pinned,
+                    "messages": [ToolMessage(content, tool_call_id=runtime.tool_call_id)],
+                }
+            )
+
+        return StructuredTool.from_function(
+            name=DISCOVER_TOOLS_NAME,
+            func=discover_tools,
+            description=DISCOVER_TOOLS_DESCRIPTION,
+            infer_schema=False,
+            args_schema=DiscoverToolsSchema,
+        )
+
+    def _filter_request(self, request: ModelRequest[Any]) -> ModelRequest[Any]:
+        """Filter `request.tools` down to the top-K most relevant, plus always-include."""
+        if len(request.tools) <= self._top_k:
+            return request
+
+        pinned = set(request.state.get("tool_selection_pinned") or [])
+        keep_names = self._always_include | pinned
+        candidates = [t for t in request.tools if _tool_name(t) not in keep_names]
+
+        query = _latest_human_message_text(request.messages)
+        scorer = self._scorer(query)
+        ranked = sorted(candidates, key=scorer, reverse=True)
+        selected_names = {_tool_name(t) for t in ranked[: self._top_k]}
+
+        filtered = [t for t in request.tools if _tool_name(t) in keep_names or _tool_name(t) in selected_names]
+        if len(filtered) == len(request.tools):
+            return request
+        return request.override(tools=filtered)
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any]:
+        """Filter the tool list down to the top-K most relevant tools for this turn."""
+        return handler(self._filter_request(request))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT] | AIMessage | ExtendedModelResponse[ResponseT]:
+        """Async variant of `wrap_model_call`."""
+        return await handler(self._filter_request(request))

--- a/libs/deepagents/tests/unit_tests/middleware/test_tool_selection.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_tool_selection.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
+from langchain.agents import create_agent
 from langchain.agents.middleware.types import ModelRequest
 from langchain.tools import ToolRuntime
 from langchain_core.embeddings import Embeddings
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.tools import tool as tool_decorator
 
 from deepagents.middleware.tool_selection import DISCOVER_TOOLS_NAME, ToolSelectionMiddleware
 from tests.unit_tests.chat_model import GenericFakeChatModel
@@ -223,3 +225,40 @@ def test_discover_tools_name_always_kept_when_present() -> None:
 
     names = {t["name"] for t in filtered.tools}
     assert DISCOVER_TOOLS_NAME in names
+
+
+def test_discover_tools_runs_through_real_tool_node() -> None:
+    """`discover_tools` must work when invoked by the framework's own ToolNode, not just by calling `.func()` directly.
+
+    Regression test: `ToolRuntime` injection is detected by inspecting the tool's raw
+    function signature (`inspect.signature(fn).parameters[...].annotation`). If that
+    annotation isn't a live type at definition time (e.g. `runtime: ToolRuntime` stored as
+    a postponed string because the module used `from __future__ import annotations`), the
+    tool node fails to recognize `runtime` as injectable and raises `TypeError: missing 1
+    required positional argument: 'runtime'` at call time -- a failure calling `.func()`
+    directly never exercises, since that bypasses the framework's injection path entirely.
+    """
+    middleware = ToolSelectionMiddleware(top_k=1, always_include=frozenset())
+
+    @tool_decorator
+    def calculator(expression: str) -> str:
+        """Evaluate a basic arithmetic expression."""
+        return expression
+
+    fake_model = GenericFakeChatModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": DISCOVER_TOOLS_NAME, "args": {"query": "arithmetic expression"}, "id": "call_1"}],
+                ),
+                AIMessage(content="Found it."),
+            ]
+        )
+    )
+    agent = create_agent(model=fake_model, tools=[calculator], middleware=[middleware])
+
+    result = agent.invoke({"messages": [HumanMessage(content="do some math")]})
+
+    tool_message = next(m for m in result["messages"] if getattr(m, "tool_call_id", None) == "call_1")
+    assert "Found tool `calculator`" in tool_message.content

--- a/libs/deepagents/tests/unit_tests/middleware/test_tool_selection.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_tool_selection.py
@@ -1,0 +1,225 @@
+"""Unit tests for `ToolSelectionMiddleware`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain.agents.middleware.types import ModelRequest
+from langchain.tools import ToolRuntime
+from langchain_core.embeddings import Embeddings
+from langchain_core.messages import HumanMessage
+
+from deepagents.middleware.tool_selection import DISCOVER_TOOLS_NAME, ToolSelectionMiddleware
+from tests.unit_tests.chat_model import GenericFakeChatModel
+
+
+def _tool(name: str, description: str) -> dict[str, Any]:
+    return {"name": name, "description": description}
+
+
+def _request(
+    tools: list[dict[str, Any]],
+    *,
+    query: str = "hello",
+    pinned: list[str] | None = None,
+) -> ModelRequest:
+    state: dict[str, Any] = {"messages": []}
+    if pinned is not None:
+        state["tool_selection_pinned"] = pinned
+    return ModelRequest(
+        model=GenericFakeChatModel(messages=iter([])),
+        messages=[HumanMessage(content=query)],
+        tools=tools,
+        state=state,
+    )
+
+
+def _tool_runtime(
+    tools: list[dict[str, Any]],
+    *,
+    pinned: list[str] | None = None,
+    tool_call_id: str = "call-1",
+) -> ToolRuntime:
+    return ToolRuntime(
+        state={"tool_selection_pinned": pinned or []},
+        context=None,
+        config={},
+        stream_writer=None,
+        tool_call_id=tool_call_id,
+        store=None,
+        tools=tools,
+    )
+
+
+def test_no_op_below_top_k() -> None:
+    """When total tool count is already <= top_k, filtering is skipped entirely."""
+    middleware = ToolSelectionMiddleware(top_k=5)
+    tools = [_tool(f"tool_{i}", f"description {i}") for i in range(3)]
+    request = _request(tools)
+
+    filtered = middleware._filter_request(request)
+
+    assert filtered is request
+    assert filtered.tools == tools
+
+
+def test_top_k_limits_tool_count() -> None:
+    """Non always-include tools are limited to top_k after filtering."""
+    middleware = ToolSelectionMiddleware(top_k=2, always_include=frozenset())
+    tools = [_tool(f"tool_{i}", "search the web for info") for i in range(10)]
+    request = _request(tools, query="search the web for info")
+
+    filtered = middleware._filter_request(request)
+
+    assert len(filtered.tools) == 2
+
+
+def test_always_include_never_filtered() -> None:
+    """Tools named in `always_include` survive filtering regardless of score."""
+    middleware = ToolSelectionMiddleware(top_k=1, always_include=frozenset({"read_file"}))
+    tools = [
+        _tool("read_file", "completely unrelated to the query"),
+        *[_tool(f"other_{i}", "irrelevant filler tool") for i in range(5)],
+        _tool("matching_tool", "banana apple orange fruit query"),
+    ]
+    request = _request(tools, query="banana apple orange fruit query")
+
+    filtered = middleware._filter_request(request)
+
+    names = {t["name"] for t in filtered.tools}
+    assert "read_file" in names
+    assert "matching_tool" in names  # highest lexical score, fills the single top_k slot
+
+
+def test_lexical_scoring_ranks_relevant_tools_higher() -> None:
+    """A tool whose description overlaps the query keywords ranks above an unrelated one."""
+    middleware = ToolSelectionMiddleware(top_k=1, always_include=frozenset())
+    relevant = _tool("weather_lookup", "get the current weather forecast for a city")
+    unrelated = _tool("stock_price", "look up the stock price for a ticker symbol")
+    request = _request([relevant, unrelated], query="what is the weather forecast today")
+
+    filtered = middleware._filter_request(request)
+
+    names = {t["name"] for t in filtered.tools}
+    assert "weather_lookup" in names
+    assert "stock_price" not in names
+
+
+def test_discover_tools_pins_match_for_next_turn() -> None:
+    """Calling `discover_tools` with a matching query pins the tool for future turns."""
+    middleware = ToolSelectionMiddleware(top_k=1, always_include=frozenset())
+    hidden_tool = _tool("weather_lookup", "get the current weather forecast for a city")
+    unrelated = _tool("stock_price", "look up the stock price for a ticker symbol")
+    all_tools = [hidden_tool, unrelated]
+
+    discover = middleware.tools[0]
+    runtime = _tool_runtime(all_tools)
+    result = discover.func(query="weather forecast", runtime=runtime)
+
+    assert result.update["tool_selection_pinned"] == ["weather_lookup"]
+
+    # Next turn: the pinned tool survives filtering even though top_k=1 would
+    # otherwise favor `unrelated` for this query.
+    request = _request(all_tools, query="stock price lookup", pinned=result.update["tool_selection_pinned"])
+    filtered = middleware._filter_request(request)
+
+    names = {t["name"] for t in filtered.tools}
+    assert "weather_lookup" in names
+
+
+def test_discover_tools_reports_no_match() -> None:
+    """`discover_tools` reports no match found and pins nothing when nothing scores above zero."""
+    middleware = ToolSelectionMiddleware(top_k=1, always_include=frozenset())
+    tools = [_tool("stock_price", "look up the stock price for a ticker symbol")]
+
+    discover = middleware.tools[0]
+    runtime = _tool_runtime(tools)
+    result = discover.func(query="completely unrelated gibberish xyzzy", runtime=runtime)
+
+    assert result.update["tool_selection_pinned"] == []
+    assert "No tool found" in result.update["messages"][0].content
+
+
+class _FakeEmbeddings(Embeddings):
+    """Deterministic fake embeddings: exact text lookup into a hand-picked vector table."""
+
+    def __init__(self, vectors: dict[str, list[float]]) -> None:
+        self._vectors = vectors
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [self._vectors[text] for text in texts]
+
+    def embed_query(self, text: str) -> list[float]:
+        return self._vectors[text]
+
+
+def test_embeddings_scorer_used_when_provided() -> None:
+    """When `embeddings` is provided, scoring goes through cosine similarity, not lexical overlap."""
+    relevant = _tool("weather_lookup", "forecast")
+    unrelated = _tool("stock_price", "ticker")
+    vectors = {
+        "weather forecast query": [1.0, 0.0],
+        "weather_lookup: forecast": [1.0, 0.0],
+        "stock_price: ticker": [0.0, 1.0],
+    }
+    middleware = ToolSelectionMiddleware(top_k=1, always_include=frozenset(), embeddings=_FakeEmbeddings(vectors))
+    request = _request([relevant, unrelated], query="weather forecast query")
+
+    filtered = middleware._filter_request(request)
+
+    names = {t["name"] for t in filtered.tools}
+    assert "weather_lookup" in names
+    assert "stock_price" not in names
+
+
+def test_wrap_model_call_filters_tools() -> None:
+    """`wrap_model_call` applies filtering before invoking the handler."""
+    middleware = ToolSelectionMiddleware(top_k=1, always_include=frozenset())
+    relevant = _tool("weather_lookup", "get the current weather forecast for a city")
+    unrelated = _tool("stock_price", "look up the stock price for a ticker symbol")
+    request = _request([relevant, unrelated], query="what is the weather forecast today")
+
+    captured: dict[str, Any] = {}
+
+    def handler(req: ModelRequest) -> str:
+        captured["tools"] = req.tools
+        return "ok"
+
+    middleware.wrap_model_call(request, handler)
+
+    names = {t["name"] for t in captured["tools"]}
+    assert "weather_lookup" in names
+    assert "stock_price" not in names
+
+
+async def test_awrap_model_call_filters_tools() -> None:
+    """`awrap_model_call` applies the same filtering as the sync path."""
+    middleware = ToolSelectionMiddleware(top_k=1, always_include=frozenset())
+    relevant = _tool("weather_lookup", "get the current weather forecast for a city")
+    unrelated = _tool("stock_price", "look up the stock price for a ticker symbol")
+    request = _request([relevant, unrelated], query="what is the weather forecast today")
+
+    captured: dict[str, Any] = {}
+
+    async def handler(req: ModelRequest) -> str:
+        captured["tools"] = req.tools
+        return "ok"
+
+    await middleware.awrap_model_call(request, handler)
+
+    names = {t["name"] for t in captured["tools"]}
+    assert "weather_lookup" in names
+    assert "stock_price" not in names
+
+
+def test_discover_tools_name_always_kept_when_present() -> None:
+    """The `discover_tools` tool itself is never filtered out of the request."""
+    middleware = ToolSelectionMiddleware(top_k=1, always_include=frozenset())
+    discover_dict = _tool(DISCOVER_TOOLS_NAME, "search the full tool registry")
+    filler = [_tool(f"other_{i}", "irrelevant filler tool") for i in range(5)]
+    request = _request([discover_dict, *filler], query="totally unrelated query text")
+
+    filtered = middleware._filter_request(request)
+
+    names = {t["name"] for t in filtered.tools}
+    assert DISCOVER_TOOLS_NAME in names


### PR DESCRIPTION

[tool_selection_middleware_demo.py](https://github.com/user-attachments/files/29931715/tool_selection_middleware_demo.py)
[tool_selection_middleware_demo_before_main.py](https://github.com/user-attachments/files/29931716/tool_selection_middleware_demo_before_main.py)
Fixes #4658

---

The middleware stack assembles the tool list once at agent construction and it stays fixed for the life of the session. `_ToolExclusionMiddleware` can drop tools, but only statically — a name is either excluded for the whole session or it isn't; there's no way to change what's visible turn-to-turn based on what the agent is actually doing. With just the built-in tools you're already at roughly a dozen schemas; add an MCP server or two and a session is well past 25-30 tool schemas sent on *every* model call, regardless of whether that turn touches any of them.

This adds an opt-in `ToolSelectionMiddleware` that scores `request.tools` against the latest human message in `wrap_model_call`/`awrap_model_call` and filters down to the top-K most relevant tools plus a configurable `always_include` set, following the same `request.override(tools=...)` pattern `_ToolExclusionMiddleware` already uses. Scoring defaults to zero-dependency lexical token overlap (no new dependency needed); passing an `embeddings: Embeddings` instance switches to cosine-similarity scoring instead — `langchain_core.embeddings.Embeddings` is already part of the existing `langchain-core` dependency, so this costs nothing new.

The important part is the escape hatch: alongside the middleware, a `discover_tools` tool is injected that searches the *full* tool registry (via `ToolRuntime.tools`, which always holds the complete set the `ToolNode` was constructed with, unaffected by what a given turn filtered down to) and pins a match into the always-include set for the rest of the conversation. This is what makes filtering safe — worst case the model spends one extra tool call finding what it needs, instead of silently never knowing a tool exists. The pin is tracked as private per-thread graph state (`tool_selection_pinned`), not middleware-instance state, so it can't leak between concurrent sessions sharing the same middleware instance.

One implementation detail worth flagging for review: `discover_tools` takes a `runtime: ToolRuntime` parameter that the `ToolNode` injects automatically at call time, and this only works because the module does *not* use `from __future__ import annotations` — the injection detection inspects the tool's live function signature, and a postponed (stringified) annotation breaks it silently until the tool is actually invoked through a real agent. `async_subagents.py` and `subagents.py` already avoid the future import for the same reason; this follows that precedent.

Fully opt-in via `create_deep_agent(middleware=[ToolSelectionMiddleware(top_k=15)])` — no change to any existing default behavior.

## How did you verify your code works?

Added `test_tool_selection.py` (11 tests) covering top-k limiting, `always_include` handling, lexical scoring, `discover_tools` pinning and no-match reporting, embeddings-based scoring, both sync and async `wrap_model_call`, and — most importantly — a regression test that drives `discover_tools` through a real `create_agent` + `ToolNode` invocation rather than calling the tool's underlying function directly. That last test exists because the direct-call style of the other tests didn't catch a real bug during manual verification: running the middleware end-to-end through an actual agent turned up the `ToolRuntime` injection issue described above, which unit tests calling `.func()` directly never exercised. `uv run --group test pytest`, `ruff check`, `ruff format --check`, and `ty check` are all clean, and the full existing middleware + graph test suites (561 tests) pass with no regressions.


I also ran the same 3-turn scenario (4 domain tools, a weather question, a math question, a translation question) against a real checkpointed agent both with and without the middleware, to see the actual effect on what gets sent to the model:

- Without the middleware (current `main` behavior): all 4 tool schemas are sent on every single turn, regardless of relevance.
- With `ToolSelectionMiddleware(top_k=1)`: the weather turn sends only `weather_lookup` + `discover_tools`; the math turn (worded so `calculator` doesn't score highly, forcing a real `discover_tools` call) correctly finds and pins `calculator`; the translation turn sends `translate_text` + the now-pinned `calculator` + `discover_tools` — `calculator` staying visible in a turn that has nothing to do with math is the pin surviving across the checkpointed thread, not a fluke.


Before the changes from this PR:
<img width="635" height="349" alt="image" src="https://github.com/user-attachments/assets/6066a079-8b9d-4729-8db0-1bb69c89868b" />

After the changes from this PR: 
<img width="646" height="393" alt="image" src="https://github.com/user-attachments/assets/0c2bd41d-a14d-422f-96c2-769b88e94ebe" />

