### PR TITLE
feat(code): support configured OAuth clients for remote MCP

### DIFF
--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -32,6 +32,7 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 from filelock import FileLock, Timeout
 from mcp.client.auth import OAuthClientProvider, TokenStorage
+from mcp.client.auth.oauth2 import get_client_metadata_scopes
 from mcp.client.auth.utils import (
     build_oauth_authorization_server_metadata_discovery_urls,
     build_protected_resource_metadata_discovery_urls,
@@ -1496,7 +1497,10 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
             self.context.protocol_version = request.headers.get(MCP_PROTOCOL_VERSION)
             if (
                 not self.context.is_token_valid()
-                and self.context.can_refresh_token()
+                and (
+                    self.context.can_refresh_token()
+                    or self._configured_client_info is not None
+                )
                 and self.context.oauth_metadata is None
             ):
                 # Pre-empt the SDK's 401-path discovery so its refresh branch
@@ -1551,6 +1555,26 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
                         self.context.server_url,
                         type(exc).__name__,
                     )
+
+            if (
+                self._configured_client_info is not None
+                and not self.context.is_token_valid()
+                and self.context.protected_resource_metadata is not None
+                and self.context.oauth_metadata is not None
+            ):
+                # Some servers, including Google's Gmail MCP endpoint, allow
+                # unauthenticated initialization and tool discovery but require
+                # a bearer token for tool calls. A configured client has all
+                # credentials needed for authorization, so do not wait for a
+                # 401 challenge that will never occur during `mcp login`.
+                self.context.client_metadata.scope = get_client_metadata_scopes(
+                    None,
+                    self.context.protected_resource_metadata,
+                    self.context.oauth_metadata,
+                )
+                token_request = await self._perform_authorization()
+                token_response = yield token_request  # noqa: ASYNC119  # auth generator protocol
+                await self._handle_token_response(token_response)
 
             if (
                 not self.context.is_token_valid()

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -1495,57 +1495,68 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
             if not self._initialized:
                 await self._initialize()
             self.context.protocol_version = request.headers.get(MCP_PROTOCOL_VERSION)
-            if (
-                not self.context.is_token_valid()
-                and (
+            if not self.context.is_token_valid() and (
+                (
                     self.context.can_refresh_token()
-                    or self._configured_client_info is not None
+                    and self.context.oauth_metadata is None
                 )
-                and self.context.oauth_metadata is None
+                or (
+                    self._configured_client_info is not None
+                    and (
+                        self.context.protected_resource_metadata is None
+                        or self.context.oauth_metadata is None
+                    )
+                )
             ):
                 # Pre-empt the SDK's 401-path discovery so its refresh branch
                 # finds populated `oauth_metadata` and uses the advertised token
                 # endpoint instead of guessing `/token`. The resource-metadata
                 # URL is `None`: no 401 yet, so no `WWW-Authenticate` to read.
                 try:
-                    prm_urls = build_protected_resource_metadata_discovery_urls(
-                        None,
-                        self.context.server_url,
-                    )
-                    for url in prm_urls:
-                        # ASYNC119: yielding the request to receive its response is
-                        # this auth generator's handshake protocol, not a value
-                        # escaping a context manager.
-                        response = yield create_oauth_metadata_request(url)  # noqa: ASYNC119
-                        prm = await handle_protected_resource_response(response)
-                        if prm is None:
-                            logger.debug(
-                                "Protected resource metadata discovery failed: %s",
-                                url,
+                    if self.context.protected_resource_metadata is None:
+                        prm_urls = build_protected_resource_metadata_discovery_urls(
+                            None,
+                            self.context.server_url,
+                        )
+                        for url in prm_urls:
+                            # ASYNC119: yielding the request to receive its response is
+                            # this auth generator's handshake protocol, not a value
+                            # escaping a context manager.
+                            response = yield create_oauth_metadata_request(url)  # noqa: ASYNC119
+                            prm = await handle_protected_resource_response(response)
+                            if prm is None:
+                                logger.debug(
+                                    "Protected resource metadata discovery failed: %s",
+                                    url,
+                                )
+                                continue
+                            self.context.protected_resource_metadata = prm
+                            self.context.auth_server_url = str(
+                                prm.authorization_servers[0]
                             )
-                            continue
-                        self.context.protected_resource_metadata = prm
-                        self.context.auth_server_url = str(prm.authorization_servers[0])
-                        break
-
-                    asm_urls = build_oauth_authorization_server_metadata_discovery_urls(
-                        self.context.auth_server_url,
-                        self.context.server_url,
-                    )
-                    for url in asm_urls:
-                        # ASYNC119: yielding the request to receive its response is
-                        # this auth generator's handshake protocol, not a value
-                        # escaping a context manager.
-                        response = yield create_oauth_metadata_request(url)  # noqa: ASYNC119
-                        ok, metadata = await handle_auth_metadata_response(response)
-                        if not ok:
                             break
-                        if metadata is None:
-                            logger.debug("OAuth metadata discovery failed: %s", url)
-                            continue
-                        self.context.oauth_metadata = metadata
-                        await self._persist_oauth_metadata()
-                        break
+
+                    if self.context.oauth_metadata is None:
+                        asm_urls = (
+                            build_oauth_authorization_server_metadata_discovery_urls(
+                                self.context.auth_server_url,
+                                self.context.server_url,
+                            )
+                        )
+                        for url in asm_urls:
+                            # ASYNC119: yielding the request to receive its response is
+                            # this auth generator's handshake protocol, not a value
+                            # escaping a context manager.
+                            response = yield create_oauth_metadata_request(url)  # noqa: ASYNC119
+                            ok, metadata = await handle_auth_metadata_response(response)
+                            if not ok:
+                                break
+                            if metadata is None:
+                                logger.debug("OAuth metadata discovery failed: %s", url)
+                                continue
+                            self.context.oauth_metadata = metadata
+                            await self._persist_oauth_metadata()
+                            break
                 except httpx.HTTPError as exc:
                     # Log only the exception type, never its payload — discovery
                     # responses travel the same channel as bearer tokens.

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -319,9 +319,7 @@ def _interpolate(s: str, *, field: str, server_name: str | None) -> str:
         var_name = match.group(1)
         val = os.environ.get(var_name)
         if val is None:
-            where = (
-                f"mcpServers.{server_name}.{field}" if server_name else field
-            )
+            where = f"mcpServers.{server_name}.{field}" if server_name else field
             msg = (
                 f"{where} references unset env var {var_name}. "
                 f"Set {var_name} in the environment or remove the reference."
@@ -420,6 +418,21 @@ class FileTokenStorage(TokenStorage):
             data["expires_at"] = time.time() + tokens.expires_in
         else:
             data.pop("expires_at", None)
+        self._write(data)
+
+    async def clear_tokens(self) -> None:
+        """Remove stored tokens while preserving public OAuth state.
+
+        A configured OAuth client cannot reuse tokens issued to a different
+        client ID. Keep the prior registration and discovered metadata so the
+        token file remains structurally valid, but require a fresh grant for
+        the configured client.
+        """
+        data = self._read()
+        if data is None:
+            return
+        data.pop("tokens", None)
+        data.pop("expires_at", None)
         self._write(data)
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
@@ -1267,6 +1280,17 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
             # Configured credentials are intentionally not written to token
             # storage. They also take precedence over an older DCR result for
             # the same server URL, which may otherwise have been restored above.
+            if (
+                self.context.client_info is not None
+                and self.context.client_info.client_id
+                != self._configured_client_info.client_id
+            ):
+                # Tokens are issued to a client, not merely a server URL. Do
+                # not let an existing DCR token suppress authorization for the
+                # configured client or later fail its refresh grant.
+                self.context.clear_tokens()
+                if isinstance(self.context.storage, FileTokenStorage):
+                    await self.context.storage.clear_tokens()
             self.context.client_info = self._configured_client_info
         await self._apply_stored_expiry()
 

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -41,7 +41,9 @@ from mcp.client.auth.utils import (
 )
 from mcp.client.streamable_http import MCP_PROTOCOL_VERSION
 from mcp.shared.auth import (
+    AnyUrl,
     OAuthClientInformationFull,
+    OAuthClientMetadata,
     OAuthMetadata,
     OAuthToken,
 )
@@ -90,6 +92,9 @@ class McpServerSpec(TypedDict, total=False):
     auth: Literal["oauth"]
     """Authentication mode for remote MCP servers that require OAuth login."""
 
+    oauth: OAuthClientConfig
+    """Optional configured OAuth client credentials for a remote server."""
+
     type: Literal["stdio", "http", "sse"]
     """Transport type when the config uses the `type` key."""
 
@@ -110,6 +115,19 @@ class McpServerSpec(TypedDict, total=False):
 
     env: dict[str, str]
     """Environment overrides for launching a stdio MCP server."""
+
+
+class OAuthClientConfig(TypedDict):
+    """Configured OAuth client credentials for a remote MCP server."""
+
+    clientId: str
+    """OAuth client ID, optionally with `${VAR}` references."""
+
+    clientSecret: str
+    """OAuth client secret, optionally with `${VAR}` references."""
+
+    redirectUri: str
+    """Registered loopback callback URI, optionally with `${VAR}` references."""
 
 
 logger = logging.getLogger(__name__)
@@ -215,16 +233,79 @@ def resolve_headers(
             where = f"mcpServers.{server_name}.headers.{name}" if server_name else name
             msg = f"{where} must be a string, got {type(value).__name__}"
             raise TypeError(msg)
-        resolved[name] = _interpolate(value, header=name, server_name=server_name)
+        resolved[name] = _interpolate(
+            value,
+            field=f"headers.{name}",
+            server_name=server_name,
+        )
     return resolved
 
 
-def _interpolate(s: str, *, header: str, server_name: str | None) -> str:
+def resolve_oauth_client_config(
+    config: OAuthClientConfig,
+    *,
+    server_name: str,
+) -> OAuthClientInformationFull:
+    """Resolve a configured OAuth client only when its server is activated.
+
+    Args:
+        config: Validated configured OAuth client values from MCP configuration.
+        server_name: Owning MCP server name for interpolation errors.
+
+    Returns:
+        Static client information for the OAuth authorization-code flow.
+
+    Raises:
+        ValueError: If interpolation produces a non-local callback URI.
+    """
+    redirect_uri = _interpolate(
+        config["redirectUri"],
+        field="oauth.redirectUri",
+        server_name=server_name,
+    )
+    if not _is_loopback_callback_uri(redirect_uri):
+        msg = (
+            f"mcpServers.{server_name}.oauth.redirectUri must be an exact "
+            "http://localhost:<port>/callback URI."
+        )
+        raise ValueError(msg)
+    return OAuthClientInformationFull(
+        client_id=_interpolate(
+            config["clientId"], field="oauth.clientId", server_name=server_name
+        ),
+        client_secret=_interpolate(
+            config["clientSecret"],
+            field="oauth.clientSecret",
+            server_name=server_name,
+        ),
+        redirect_uris=[AnyUrl(redirect_uri)],
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        token_endpoint_auth_method="client_secret_post",  # noqa: S106  # OAuth method, not a secret
+    )
+
+
+def _is_loopback_callback_uri(uri: str) -> bool:
+    """Return whether `uri` is a canonical local OAuth callback URI."""
+    try:
+        parsed = urlparse(uri)
+        port = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme == "http"
+        and parsed.hostname == _LOOPBACK_URI_HOST
+        and port is not None
+        and uri == f"http://{_LOOPBACK_URI_HOST}:{port}{_LOOPBACK_CALLBACK_PATH}"
+    )
+
+
+def _interpolate(s: str, *, field: str, server_name: str | None) -> str:
     """Expand `${VAR}` references in `s` against the current environment.
 
     Args:
         s: Raw header value.
-        header: Header name, used in error messages.
+        field: Configuration field name, used in error messages.
         server_name: Owning server name for error messages.
 
     Returns:
@@ -239,7 +320,7 @@ def _interpolate(s: str, *, header: str, server_name: str | None) -> str:
         val = os.environ.get(var_name)
         if val is None:
             where = (
-                f"mcpServers.{server_name}.headers.{header}" if server_name else header
+                f"mcpServers.{server_name}.{field}" if server_name else field
             )
             msg = (
                 f"{where} references unset env var {var_name}. "
@@ -1167,6 +1248,7 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self._configured_client_info = kwargs.pop("configured_client_info", None)
         self._suppress_expected_reauth_logs = bool(
             kwargs.pop("suppress_expected_reauth_logs", False)
         )
@@ -1181,6 +1263,11 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
         # fail loudly rather than silently regress to the 401-on-restart
         # bug this class exists to prevent.
         await super()._initialize()
+        if self._configured_client_info is not None:
+            # Configured credentials are intentionally not written to token
+            # storage. They also take precedence over an older DCR result for
+            # the same server URL, which may otherwise have been restored above.
+            self.context.client_info = self._configured_client_info
         await self._apply_stored_expiry()
 
     async def _apply_stored_expiry(self) -> None:
@@ -1248,9 +1335,12 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
         whole identity+client token family.
         """
         self.context.current_tokens = await self.context.storage.get_tokens()
-        client_info = await self.context.storage.get_client_info()
-        if client_info is not None:
-            self.context.client_info = client_info
+        if self._configured_client_info is not None:
+            self.context.client_info = self._configured_client_info
+        else:
+            client_info = await self.context.storage.get_client_info()
+            if client_info is not None:
+                self.context.client_info = client_info
         await self._apply_stored_expiry()
 
     async def _acquire_refresh_lock(self, lock: FileLock) -> bool:
@@ -1510,6 +1600,7 @@ def build_oauth_provider(
     server_url: str,
     storage: TokenStorage,
     extra_auth_params: dict[str, str] | None = None,
+    oauth_config: OAuthClientConfig | None = None,
     interactive: bool = True,
     ui: OAuthInteraction | None = None,
 ) -> OAuthClientProvider:
@@ -1520,20 +1611,46 @@ def build_oauth_provider(
         server_url: Remote MCP server URL.
         storage: Token storage implementation for this server.
         extra_auth_params: Optional query params for the interactive auth URL.
+        oauth_config: Optional validated static OAuth client configuration.
         interactive: Whether the provider may prompt on stdin.
         ui: Interaction surface used for URL display and paste-back
             input in interactive mode.
 
     Returns:
         A configured `OAuthClientProvider`.
+
+    Raises:
+        ValueError: If configured callback validation fails.
     """
     from deepagents_code.mcp_providers import resolve_provider
 
     policy = resolve_provider(server_url)
+    configured_client_info = (
+        resolve_oauth_client_config(oauth_config, server_name=server_name)
+        if oauth_config is not None
+        else None
+    )
     redirect_uri: str | None = None
 
     if interactive:
-        if policy.supports_loopback_callback():
+        if configured_client_info is not None:
+            configured_redirect_uris = configured_client_info.redirect_uris
+            if not configured_redirect_uris:  # Constructed above with one URI.
+                msg = "Configured OAuth client has no redirect URI"
+                raise ValueError(msg)
+            configured_redirect_uri = str(configured_redirect_uris[0])
+            configured_port = urlparse(configured_redirect_uri).port
+            if configured_port is None:  # Validated config makes this unreachable.
+                msg = "Configured OAuth redirect URI has no port"
+                raise ValueError(msg)
+            callback_server = _LoopbackOAuthCallbackServer(port=configured_port)
+            redirect_uri = configured_redirect_uri
+            redirect, callback = _make_loopback_handlers(
+                callback_server=callback_server,
+                extra_auth_params=extra_auth_params,
+                ui=ui,
+            )
+        elif policy.supports_loopback_callback():
             fixed = policy.loopback_port()
             if fixed is not None:
                 port = fixed
@@ -1580,11 +1697,20 @@ def build_oauth_provider(
     else:
         redirect, callback = _make_reauth_required_handlers(server_name=server_name)
 
-    metadata = (
-        policy.client_metadata(redirect_uri=redirect_uri)
-        if redirect_uri is not None
-        else policy.client_metadata()
-    )
+    if configured_client_info is not None:
+        metadata = OAuthClientMetadata(
+            client_name="deepagents-code",
+            redirect_uris=configured_client_info.redirect_uris,
+            grant_types=configured_client_info.grant_types,
+            response_types=configured_client_info.response_types,
+            token_endpoint_auth_method="client_secret_post",  # noqa: S106  # OAuth method, not a secret
+        )
+    else:
+        metadata = (
+            policy.client_metadata(redirect_uri=redirect_uri)
+            if redirect_uri is not None
+            else policy.client_metadata()
+        )
 
     return _ExpiryAwareOAuthClientProvider(
         server_url=server_url,
@@ -1592,6 +1718,7 @@ def build_oauth_provider(
         storage=storage,
         redirect_handler=redirect,
         callback_handler=callback,
+        configured_client_info=configured_client_info,
         suppress_expected_reauth_logs=not interactive,
     )
 
@@ -1940,6 +2067,7 @@ async def login(
         server_url=server_config["url"],
         storage=storage,
         extra_auth_params=result.extra_auth_params or None,
+        oauth_config=server_config.get("oauth"),
         ui=ui,
     )
     conn: StreamableHttpConnection | SSEConnection

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -745,6 +745,10 @@ class _LoopbackCallbackUnavailableError(RuntimeError):
     """Raised when the local callback server cannot be started."""
 
 
+class _AuthorizationChallengeMissingError(RuntimeError):
+    """Raised when a server completes login without requesting authorization."""
+
+
 def _choose_loopback_port() -> int:
     """Return a high local TCP port candidate without opening a socket.
 
@@ -1893,6 +1897,7 @@ def format_login_failure(exc: BaseException) -> str:
     safe_types = (
         _LoopbackCallbackTimeoutError,
         _LoopbackCallbackUnavailableError,
+        _AuthorizationChallengeMissingError,
     )
     if isinstance(exc, safe_types):
         return f"{type(exc).__name__}: {exc}"
@@ -2045,8 +2050,8 @@ async def login(
 
     Raises:
         ValueError: If `server_config` isn't an http/sse server.
-        RuntimeError: If header env-var interpolation fails, the device
-            flow fails or times out, or the OAuth handshake aborts.
+        _AuthorizationChallengeMissingError: If the server completes a
+            connection without starting an authorization flow.
     """
     from langchain_mcp_adapters.sessions import (
         SSEConnection,
@@ -2122,5 +2127,5 @@ async def login(
             "MCP servers must return an OAuth challenge before dcode can open the "
             "authorization URL."
         )
-        raise RuntimeError(msg)
+        raise _AuthorizationChallengeMissingError(msg)
     await ui.show_success(success_message)

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -2047,7 +2047,7 @@ async def login(
         ValueError: If `server_config` isn't an http/sse server.
         RuntimeError: If header env-var interpolation fails, the device
             flow fails or times out, or the OAuth handshake aborts.
-    """  # noqa: DOC502 - `RuntimeError` surfaces via `resolve_headers` / `_run_device_flow`
+    """
     from langchain_mcp_adapters.sessions import (
         SSEConnection,
         StreamableHttpConnection,
@@ -2115,4 +2115,12 @@ async def login(
         )
 
     await _drive_handshake({server_name: conn})
+    if await storage.get_tokens() is None:
+        msg = (
+            f"MCP server '{server_name}' completed the connection without starting "
+            "OAuth, so no token was saved. Verify the server URL: OAuth-protected "
+            "MCP servers must return an OAuth challenge before dcode can open the "
+            "authorization URL."
+        )
+        raise RuntimeError(msg)
     await ui.show_success(success_message)

--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -20,6 +20,7 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, overload
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Mapping, Sequence
@@ -556,7 +557,70 @@ def _validate_server_config(server_name: str, server_config: dict[str, Any]) -> 
             )
             raise ValueError(msg)
 
+    oauth_config = server_config.get("oauth")
+    if oauth_config is not None:
+        if server_type == "stdio":
+            msg = (
+                f"Server '{server_name}' uses stdio transport; "
+                "configured OAuth clients are only valid for http/sse transports."
+            )
+            raise ValueError(msg)
+        if not isinstance(oauth_config, dict):
+            msg = f"Server '{server_name}' 'oauth' must be a dictionary"
+            raise TypeError(msg)
+        required_fields = {"clientId", "clientSecret", "redirectUri"}
+        actual_fields = set(oauth_config)
+        if actual_fields != required_fields:
+            missing = sorted(required_fields - actual_fields)
+            unexpected = sorted(actual_fields - required_fields)
+            details = []
+            if missing:
+                details.append(f"missing {', '.join(missing)}")
+            if unexpected:
+                details.append(f"unexpected {', '.join(unexpected)}")
+            msg = (
+                f"Server '{server_name}' 'oauth' must contain exactly "
+                f"clientId, clientSecret, and redirectUri ({'; '.join(details)})."
+            )
+            raise ValueError(msg)
+        for field, value in oauth_config.items():
+            if not isinstance(value, str):
+                msg = (
+                    f"Server '{server_name}' oauth.{field} must be a string, "
+                    f"got {type(value).__name__}"
+                )
+                raise TypeError(msg)
+        redirect_uri = oauth_config["redirectUri"]
+        if "${" not in redirect_uri and not _is_local_callback_uri(redirect_uri):
+            msg = (
+                f"Server '{server_name}' oauth.redirectUri must be an exact "
+                "http://localhost:<port>/callback URI."
+            )
+            raise ValueError(msg)
+        header_names = {name.lower() for name in (server_config.get("headers") or {})}
+        if "authorization" in header_names:
+            msg = (
+                f"Server '{server_name}' cannot combine configured OAuth "
+                "credentials with an 'Authorization' header."
+            )
+            raise ValueError(msg)
+
     _validate_tool_filter_fields(server_name, server_config)
+
+
+def _is_local_callback_uri(uri: str) -> bool:
+    """Return whether `uri` is a canonical configured OAuth callback URI."""
+    try:
+        parsed = urlparse(uri)
+        port = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme == "http"
+        and parsed.hostname == "localhost"
+        and port is not None
+        and uri == f"http://localhost:{port}/callback"
+    )
 
 
 def _validate_tool_filter_fields(
@@ -1680,7 +1744,7 @@ async def _load_tools_from_config(
                     )
                     return ("unauthenticated", auth_msg)
 
-                if explicit_oauth or (
+                if explicit_oauth or "oauth" in server_config or (
                     stored_tokens is not None and not has_authorization_header
                 ):
                     # Attach the provider when the user opted in, or when a
@@ -1691,6 +1755,7 @@ async def _load_tools_from_config(
                         server_name=server_name,
                         server_url=server_config["url"],
                         storage=storage,
+                        oauth_config=server_config.get("oauth"),
                         interactive=False,
                     )
 

--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -618,7 +618,7 @@ def _is_local_callback_uri(uri: str) -> bool:
     return (
         parsed.scheme == "http"
         and parsed.hostname == "localhost"
-        and port is not None
+        and port not in {None, 0}
         and uri == f"http://localhost:{port}/callback"
     )
 
@@ -1744,8 +1744,10 @@ async def _load_tools_from_config(
                     )
                     return ("unauthenticated", auth_msg)
 
-                if explicit_oauth or "oauth" in server_config or (
-                    stored_tokens is not None and not has_authorization_header
+                if (
+                    explicit_oauth
+                    or "oauth" in server_config
+                    or (stored_tokens is not None and not has_authorization_header)
                 ):
                     # Attach the provider when the user opted in, or when a
                     # prior login (possibly triggered by 401 auto-detection)

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -1534,6 +1534,18 @@ class TestFormatLoginFailure:
         assert "Callback timed out" in summary
         assert "_LoopbackCallbackTimeoutError" in summary
 
+    def test_includes_message_for_missing_authorization_challenge(self) -> None:
+        """Missing authorization challenges have a safe remediation message."""
+        from deepagents_code.mcp_auth import _AuthorizationChallengeMissingError
+
+        exc = _AuthorizationChallengeMissingError(
+            "Server did not request authorization"
+        )
+
+        assert format_login_failure(exc) == (
+            "_AuthorizationChallengeMissingError: Server did not request authorization"
+        )
+
     def test_walks_cause_chain_into_class_names(self) -> None:
         """A chained unknown exception still surfaces every link's class name."""
 

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -19,6 +19,7 @@ from mcp.shared.auth import OAuthToken
 from deepagents_code.mcp_auth import (
     FileTokenStorage,
     MCPReauthRequiredError,
+    OAuthClientConfig,
     find_oauth_challenge,
     find_reauth_required,
     format_login_failure,
@@ -100,7 +101,7 @@ class TestConfiguredOAuthClient:
         """Configured values expand at provider creation, not config loading."""
         from deepagents_code.mcp_auth import resolve_oauth_client_config
 
-        config = {
+        config: OAuthClientConfig = {
             "clientId": "${CLIENT_ID}",
             "clientSecret": "${CLIENT_SECRET}",
             "redirectUri": "${REDIRECT_URI}",
@@ -148,6 +149,31 @@ class TestConfiguredOAuthClient:
         assert "configured-secret" not in storage.path.read_text()
 
     @pytest.mark.usefixtures("fake_home")
+    async def test_configured_client_discards_tokens_for_prior_client(self) -> None:
+        """Tokens issued to an old DCR client cannot serve a static client."""
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        storage = FileTokenStorage("gmail", server_url="https://mcp.example.com/mcp")
+        await storage.set_client_info(_make_client_info())
+        await storage.set_tokens(_make_tokens())
+        provider = build_oauth_provider(
+            server_name="gmail",
+            server_url="https://mcp.example.com/mcp",
+            storage=storage,
+            oauth_config={
+                "clientId": "configured-client",
+                "clientSecret": "configured-secret",
+                "redirectUri": "http://localhost:8765/callback",
+            },
+            interactive=False,
+        )
+
+        await provider._initialize()
+
+        assert provider.context.current_tokens is None
+        assert await storage.get_tokens() is None
+
+    @pytest.mark.usefixtures("fake_home")
     def test_configured_client_binds_its_registered_callback_port(self) -> None:
         """Interactive login uses the exact configured loopback callback URI."""
         from deepagents_code.mcp_auth import build_oauth_provider
@@ -163,9 +189,9 @@ class TestConfiguredOAuthClient:
             },
         )
 
-        assert [str(uri) for uri in provider.context.client_metadata.redirect_uris] == [
-            "http://localhost:8765/callback"
-        ]
+        redirect_uris = provider.context.client_metadata.redirect_uris
+        assert redirect_uris is not None
+        assert [str(uri) for uri in redirect_uris] == ["http://localhost:8765/callback"]
 
     @pytest.mark.usefixtures("fake_home")
     async def test_configured_client_uses_secret_post_for_refresh(self) -> None:

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -90,6 +90,108 @@ class TestResolveHeaders:
         assert resolve_headers({"X-Plain": "hello"}) == {"X-Plain": "hello"}
 
 
+class TestConfiguredOAuthClient:
+    """Tests for static OAuth client configuration."""
+
+    def test_resolves_values_only_when_server_is_activated(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Configured values expand at provider creation, not config loading."""
+        from deepagents_code.mcp_auth import resolve_oauth_client_config
+
+        config = {
+            "clientId": "${CLIENT_ID}",
+            "clientSecret": "${CLIENT_SECRET}",
+            "redirectUri": "${REDIRECT_URI}",
+        }
+        with pytest.raises(RuntimeError, match="unset env var"):
+            resolve_oauth_client_config(config, server_name="gmail")
+
+        monkeypatch.setenv("CLIENT_ID", "configured-client")
+        monkeypatch.setenv("CLIENT_SECRET", "configured-secret")
+        monkeypatch.setenv("REDIRECT_URI", "http://localhost:8765/callback")
+        client_info = resolve_oauth_client_config(config, server_name="gmail")
+
+        assert client_info.client_id == "configured-client"
+        assert client_info.token_endpoint_auth_method == "client_secret_post"
+
+    @pytest.mark.usefixtures("fake_home")
+    async def test_configured_client_overrides_storage_and_is_not_persisted(
+        self,
+    ) -> None:
+        """Static clients override DCR state without being written to disk."""
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        storage = FileTokenStorage("gmail", server_url="https://mcp.example.com/mcp")
+        await storage.set_client_info(_make_client_info())
+        provider = build_oauth_provider(
+            server_name="gmail",
+            server_url="https://mcp.example.com/mcp",
+            storage=storage,
+            oauth_config={
+                "clientId": "configured-client",
+                "clientSecret": "configured-secret",
+                "redirectUri": "http://localhost:8765/callback",
+            },
+            interactive=False,
+        )
+
+        await provider._initialize()
+
+        assert provider.context.client_info is not None
+        assert provider.context.client_info.client_id == "configured-client"
+        assert (
+            provider.context.client_info.token_endpoint_auth_method
+            == "client_secret_post"
+        )
+        assert "configured-secret" not in storage.path.read_text()
+
+    @pytest.mark.usefixtures("fake_home")
+    def test_configured_client_binds_its_registered_callback_port(self) -> None:
+        """Interactive login uses the exact configured loopback callback URI."""
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        provider = build_oauth_provider(
+            server_name="gmail",
+            server_url="https://mcp.example.com/mcp",
+            storage=FileTokenStorage("gmail"),
+            oauth_config={
+                "clientId": "configured-client",
+                "clientSecret": "configured-secret",
+                "redirectUri": "http://localhost:8765/callback",
+            },
+        )
+
+        assert [str(uri) for uri in provider.context.client_metadata.redirect_uris] == [
+            "http://localhost:8765/callback"
+        ]
+
+    @pytest.mark.usefixtures("fake_home")
+    async def test_configured_client_uses_secret_post_for_refresh(self) -> None:
+        """Configured clients include their secret in refresh-token exchanges."""
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        storage = FileTokenStorage("gmail", server_url="https://mcp.example.com/mcp")
+        await storage.set_tokens(_make_tokens())
+        provider = build_oauth_provider(
+            server_name="gmail",
+            server_url="https://mcp.example.com/mcp",
+            storage=storage,
+            oauth_config={
+                "clientId": "configured-client",
+                "clientSecret": "configured-secret",
+                "redirectUri": "http://localhost:8765/callback",
+            },
+            interactive=False,
+        )
+        await provider._initialize()
+
+        request = await provider._refresh_token()
+
+        assert b"client_secret=configured-secret" in request.content
+
+
 def _make_tokens(access_token: str = "at"):
     return OAuthToken(
         access_token=access_token,

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -1812,6 +1812,75 @@ class TestBuildOAuthProvider:
         assert str(stored.token_endpoint) == token_endpoint
         await flow.aclose()
 
+    async def test_configured_client_authorizes_before_unauthenticated_request(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Configured clients do not wait for a 401 issued only on tool calls."""
+        import httpx
+
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        storage = FileTokenStorage("gmail", server_url="https://mcp.example.com/mcp")
+        provider = build_oauth_provider(
+            server_name="gmail",
+            server_url="https://mcp.example.com/mcp",
+            storage=storage,
+            oauth_config={
+                "clientId": "configured-client",
+                "clientSecret": "configured-secret",
+                "redirectUri": "http://localhost:8765/callback",
+            },
+            interactive=False,
+        )
+
+        async def _perform_authorization() -> httpx.Request:
+            return httpx.Request("POST", "https://auth.example/token")
+
+        monkeypatch.setattr(provider, "_perform_authorization", _perform_authorization)
+        flow = provider.async_auth_flow(
+            httpx.Request("POST", "https://mcp.example.com/mcp")
+        )
+
+        resource_metadata_request = await anext(flow)
+        authorization_metadata_request = await flow.asend(
+            httpx.Response(
+                200,
+                request=resource_metadata_request,
+                json={
+                    "resource": "https://mcp.example.com/mcp",
+                    "authorization_servers": ["https://auth.example"],
+                    "scopes_supported": ["gmail.readonly", "gmail.modify"],
+                },
+            )
+        )
+        token_request = await flow.asend(
+            httpx.Response(
+                200,
+                request=authorization_metadata_request,
+                json={
+                    "issuer": "https://auth.example",
+                    "authorization_endpoint": "https://auth.example/authorize",
+                    "token_endpoint": "https://auth.example/token",
+                    "response_types_supported": ["code"],
+                    "grant_types_supported": ["authorization_code", "refresh_token"],
+                },
+            )
+        )
+
+        assert str(token_request.url) == "https://auth.example/token"
+        request = await flow.asend(
+            httpx.Response(
+                200,
+                request=token_request,
+                json={"access_token": "new", "token_type": "Bearer"},
+            )
+        )
+
+        assert request.headers["Authorization"] == "Bearer new"
+        assert provider.context.client_metadata.scope == "gmail.readonly gmail.modify"
+        await flow.aclose()
+
     async def test_refresh_falls_back_when_preemptive_metadata_discovery_raises(
         self,
         fake_home: Path,

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -2746,6 +2746,33 @@ class TestLogin:
         assert tokens is not None
         assert tokens.access_token == "new"
 
+    async def test_login_rejects_connection_that_does_not_save_a_token(self) -> None:
+        """A successful unauthenticated handshake must not report OAuth success."""
+        from deepagents_code.mcp_auth import login
+        from deepagents_code.mcp_oauth_ui import CliOAuthInteraction
+
+        async def _fake_handshake(connections: dict) -> None:
+            del connections
+
+        with (
+            patch("deepagents_code.mcp_auth._drive_handshake", _fake_handshake),
+            pytest.raises(RuntimeError, match="no token was saved"),
+        ):
+            await login(
+                server_name="gmail",
+                server_config={
+                    "transport": "http",
+                    "url": "https://mcp.example.com/mcp",
+                    "auth": "oauth",
+                    "oauth": {
+                        "clientId": "configured-client",
+                        "clientSecret": "configured-secret",
+                        "redirectUri": "http://localhost:8765/callback",
+                    },
+                },
+                ui=CliOAuthInteraction(),
+            )
+
     async def test_login_rejects_stdio_server(self) -> None:
         """OAuth login is limited to HTTP/SSE transports."""
         from deepagents_code.mcp_auth import login
@@ -2770,7 +2797,12 @@ class TestLogin:
 
         async def _fake_handshake(connections: dict) -> None:
             await asyncio.sleep(0)
-            captured.update(next(iter(connections.values())))
+            server_name, connection = next(iter(connections.items()))
+            captured.update(connection)
+            storage = FileTokenStorage(server_name, server_url=connection["url"])
+            await storage.set_tokens(
+                OAuthToken(access_token="new", token_type="Bearer")
+            )
 
         from deepagents_code.mcp_oauth_ui import CliOAuthInteraction
 

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -1881,6 +1881,53 @@ class TestBuildOAuthProvider:
         assert provider.context.client_metadata.scope == "gmail.readonly gmail.modify"
         await flow.aclose()
 
+    async def test_configured_client_discovers_resource_metadata_when_auth_is_cached(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Cached auth metadata does not skip resource discovery or authorization."""
+        import httpx
+
+        from deepagents_code.mcp_auth import build_oauth_provider
+
+        storage = FileTokenStorage("gmail", server_url="https://mcp.example.com/mcp")
+        await storage.set_oauth_metadata(_make_oauth_metadata())
+        provider = build_oauth_provider(
+            server_name="gmail",
+            server_url="https://mcp.example.com/mcp",
+            storage=storage,
+            oauth_config={
+                "clientId": "configured-client",
+                "clientSecret": "configured-secret",
+                "redirectUri": "http://localhost:8765/callback",
+            },
+            interactive=False,
+        )
+
+        async def _perform_authorization() -> httpx.Request:
+            return httpx.Request("POST", "https://auth.example/token")
+
+        monkeypatch.setattr(provider, "_perform_authorization", _perform_authorization)
+        flow = provider.async_auth_flow(
+            httpx.Request("POST", "https://mcp.example.com/mcp")
+        )
+
+        resource_metadata_request = await anext(flow)
+        token_request = await flow.asend(
+            httpx.Response(
+                200,
+                request=resource_metadata_request,
+                json={
+                    "resource": "https://mcp.example.com/mcp",
+                    "authorization_servers": ["https://auth.example"],
+                    "scopes_supported": ["gmail.readonly"],
+                },
+            )
+        )
+
+        assert str(token_request.url) == "https://auth.example/token"
+        await flow.aclose()
+
     async def test_refresh_falls_back_when_preemptive_metadata_discovery_raises(
         self,
         fake_home: Path,

--- a/libs/code/tests/unit_tests/test_mcp_tools.py
+++ b/libs/code/tests/unit_tests/test_mcp_tools.py
@@ -231,7 +231,16 @@ class TestLoadMCPConfig:
         [
             {"clientId": "id", "clientSecret": "secret"},
             {"clientId": "id", "clientSecret": "secret", "redirectUri": 1},
-            {"clientId": "id", "clientSecret": "secret", "redirectUri": "https://example.com/callback"},
+            {
+                "clientId": "id",
+                "clientSecret": "secret",
+                "redirectUri": "https://example.com/callback",
+            },
+            {
+                "clientId": "id",
+                "clientSecret": "secret",
+                "redirectUri": "http://localhost:0/callback",
+            },
         ],
     )
     def test_load_config_rejects_invalid_configured_oauth_client(

--- a/libs/code/tests/unit_tests/test_mcp_tools.py
+++ b/libs/code/tests/unit_tests/test_mcp_tools.py
@@ -226,6 +226,81 @@ class TestLoadMCPConfig:
         with pytest.raises(ValueError, match="Authorization"):
             load_mcp_config(path)
 
+    @pytest.mark.parametrize(
+        "oauth",
+        [
+            {"clientId": "id", "clientSecret": "secret"},
+            {"clientId": "id", "clientSecret": "secret", "redirectUri": 1},
+            {"clientId": "id", "clientSecret": "secret", "redirectUri": "https://example.com/callback"},
+        ],
+    )
+    def test_load_config_rejects_invalid_configured_oauth_client(
+        self,
+        write_config: Callable[..., str],
+        oauth: dict[str, object],
+    ) -> None:
+        """Configured OAuth clients must be complete and use a local callback."""
+        path = write_config(
+            {
+                "mcpServers": {
+                    "gmail": {
+                        "type": "http",
+                        "url": "https://mcp.example.com/mcp",
+                        "oauth": oauth,
+                    }
+                }
+            }
+        )
+
+        with pytest.raises((TypeError, ValueError), match=r"oauth|redirectUri"):
+            load_mcp_config(path)
+
+    def test_load_config_defers_configured_oauth_interpolation(
+        self,
+        write_config: Callable[..., str],
+    ) -> None:
+        """Unset configured-client variables do not break unrelated config loading."""
+        path = write_config(
+            {
+                "mcpServers": {
+                    "gmail": {
+                        "type": "http",
+                        "url": "https://mcp.example.com/mcp",
+                        "oauth": {
+                            "clientId": "${GMAIL_CLIENT_ID}",
+                            "clientSecret": "${GMAIL_CLIENT_SECRET}",
+                            "redirectUri": "${GMAIL_REDIRECT_URI}",
+                        },
+                    }
+                }
+            }
+        )
+
+        assert "gmail" in load_mcp_config(path)["mcpServers"]
+
+    def test_load_config_rejects_configured_oauth_for_stdio_or_auth_header(
+        self,
+        write_config: Callable[..., str],
+    ) -> None:
+        """Configured credentials cannot be sent to local or header-auth servers."""
+        client = {
+            "clientId": "id",
+            "clientSecret": "secret",
+            "redirectUri": "http://localhost:8765/callback",
+        }
+        for server in (
+            {"command": "local", "oauth": client},
+            {
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"Authorization": "Bearer static"},
+                "oauth": client,
+            },
+        ):
+            path = write_config({"mcpServers": {"gmail": server}})
+            with pytest.raises(ValueError, match=r"OAuth|Authorization|stdio"):
+                load_mcp_config(path)
+
     def test_load_config_unset_header_env_var_defers_to_activation(
         self,
         write_config: Callable[..., str],
@@ -1318,6 +1393,48 @@ class TestLoadToolsFromConfigOAuth:
                         "transport": "http",
                         "url": "https://mcp.notion.com/mcp",
                         "auth": "oauth",
+                    }
+                }
+            }
+            tools, manager, _ = await _load_tools_from_config(config)
+
+        assert tools == []
+        assert isinstance(manager, MCPSessionManager)
+        assert isinstance(recorded[0].get("auth"), OAuthClientProvider)
+        await manager.cleanup()
+
+    async def test_configured_client_attaches_provider_without_saved_tokens(
+        self,
+    ) -> None:
+        """Configured OAuth clients load at runtime before the first login."""
+        from mcp.client.auth import OAuthClientProvider
+
+        recorded: list[dict[str, Any]] = []
+        session = AsyncMock()
+        session.initialize = AsyncMock()
+        session.list_tools = AsyncMock(return_value=_make_tool_page([]))
+
+        @asynccontextmanager
+        async def _fake(
+            connection: dict[str, Any],
+            *,
+            _mcp_callbacks: object | None = None,
+        ) -> AsyncIterator[AsyncMock]:
+            await asyncio.sleep(0)
+            recorded.append(connection)
+            yield session
+
+        with patch("langchain_mcp_adapters.sessions.create_session", _fake):
+            config = {
+                "mcpServers": {
+                    "gmail": {
+                        "transport": "http",
+                        "url": "https://mcp.example.com/mcp",
+                        "oauth": {
+                            "clientId": "configured-client",
+                            "clientSecret": "configured-secret",
+                            "redirectUri": "http://localhost:8765/callback",
+                        },
                     }
                 }
             }


### PR DESCRIPTION
Closes DCD-42

---

Remote MCP servers that require pre-registered OAuth applications, including Google Gmail MCP, cannot use dynamic client registration. This adds an optional `oauth` client configuration for remote HTTP and SSE servers.

This is useful for providers that require users to create their own OAuth application and register an exact callback URI before authorization. Without configured credentials, dcode can only use the generic dynamic-registration flow, which Google does not support for Gmail MCP.

For Gmail MCP, create an OAuth web client in Google Cloud, register a loopback callback such as `http://localhost:8765/callback`, and configure dcode with environment-backed credentials:

```json
{
  "mcpServers": {
    "gmail": {
      "type": "http",
      "url": "https://gmail.mcp.example/mcp",
      "auth": "oauth",
      "oauth": {
        "clientId": "${GOOGLE_CLIENT_ID}",
        "clientSecret": "${GOOGLE_CLIENT_SECRET}",
        "redirectUri": "http://localhost:8765/callback"
      }
    }
  }
}
```

Run `dcode mcp login gmail` to authorize the account. dcode binds the configured callback port and uses the exact URI for authorization and token exchange. Keep the client secret in an environment variable; it is resolved only when Gmail MCP is activated and is not persisted with tokens.

The configured client is validated before use, resolves environment references only when the selected server activates, binds the registered loopback callback port for interactive login, and uses `client_secret_post` for authorization-code and refresh exchanges. Client secrets remain in memory and configured credentials take precedence over stale dynamic registrations.

## Release note

`dcode` remote MCP configurations can now supply pre-registered OAuth client credentials for providers that do not support dynamic client registration.