### PR TITLE
docs(code): document Gmail MCP OAuth setup

### DIFF
--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -633,10 +633,14 @@ def _print_mcp_discovery_paths() -> None:
 _MCP_CONFIG_FORMAT_EXAMPLE = """\
   {
     "mcpServers": {
-      "notion": {
+      "gmail": {
         "transport": "http",
-        "url": "https://mcp.notion.com/mcp",
-        "auth": "oauth"
+        "url": "https://gmail.mcp.googleapis.com/mcp",
+        "oauth": {
+          "clientId": "${GMAIL_MCP_CLIENT_ID}",
+          "clientSecret": "${GMAIL_MCP_CLIENT_SECRET}",
+          "redirectUri": "${GMAIL_MCP_REDIRECT_URI}"
+        }
       }
     }
   }"""
@@ -683,6 +687,25 @@ def show_mcp_login_help() -> None:
     console.print()
     console.print("[bold]Config format:[/bold]", style=theme.PRIMARY)
     console.print(_MCP_CONFIG_FORMAT_EXAMPLE, style=theme.MUTED)
+    console.print()
+    console.print("[bold]Google Gmail OAuth setup:[/bold]", style=theme.PRIMARY)
+    console.print(
+        "  Create a Web application OAuth client in Google Cloud and register the"
+        " exact callback URI http://localhost:8765/callback. Set"
+        " GMAIL_MCP_REDIRECT_URI to that same value.",
+    )
+    console.print(
+        "  dcode supports only http://localhost:<port>/callback redirects;"
+        " non-loopback callbacks are not supported.",
+    )
+    console.print(
+        "  Set GMAIL_MCP_CLIENT_ID and GMAIL_MCP_CLIENT_SECRET in your shell or"
+        " a user-only secret store. Do not commit configured credentials.",
+    )
+    console.print(
+        "  Existing remote servers using auth: \"oauth\" without an oauth block"
+        " remain supported.",
+    )
     console.print()
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
     console.print("  dcode mcp login notion")

--- a/libs/code/tests/unit_tests/test_ui.py
+++ b/libs/code/tests/unit_tests/test_ui.py
@@ -1,8 +1,11 @@
 """Unit tests for UI rendering utilities."""
 
 import argparse
+import io
+from unittest.mock import patch
 
 import pytest
+from rich.console import Console
 
 from deepagents_code.config import get_glyphs
 from deepagents_code.tool_display import (
@@ -12,7 +15,28 @@ from deepagents_code.tool_display import (
     format_tool_message_content,
     truncate_value,
 )
-from deepagents_code.ui import non_negative_int, positive_int
+from deepagents_code.ui import non_negative_int, positive_int, show_mcp_login_help
+
+
+class TestMcpLoginHelp:
+    """Tests for the MCP login configuration guidance."""
+
+    def test_documents_configured_gmail_oauth_client(self) -> None:
+        """The help screen shows the supported Gmail OAuth configuration."""
+        buffer = io.StringIO()
+        console = Console(file=buffer, highlight=False, width=200)
+
+        with patch("deepagents_code.ui.console", console):
+            show_mcp_login_help()
+
+        output = buffer.getvalue()
+        assert "https://gmail.mcp.googleapis.com/mcp" in output
+        assert "${GMAIL_MCP_CLIENT_ID}" in output
+        assert "${GMAIL_MCP_CLIENT_SECRET}" in output
+        assert "${GMAIL_MCP_REDIRECT_URI}" in output
+        assert "http://localhost:8765/callback" in output
+        assert "non-loopback callbacks are not supported" in output
+        assert 'auth: "oauth"' in output
 
 
 class TestFormatTimeout:


### PR DESCRIPTION
Closes DCD-43

---

Document the configured OAuth-client workflow directly in `dcode mcp login --help`, using Google Gmail MCP as a complete example. The guidance shows environment-variable references for client credentials, requires the same localhost callback URI in Google Cloud, and makes the loopback-only limitation explicit.

This keeps sensitive credentials out of project configuration while preserving the existing `auth: "oauth"` flow for remote servers without a configured client.

The rendered help screen has focused regression coverage.