### PR TITLE
fix(code): remove misleading agent names from help

### DIFF
--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1464,7 +1464,7 @@ def parse_args() -> argparse.Namespace:
         default=None,
         metavar="NAME",
         help=(
-            "Agent to use (e.g., coder, researcher). "
+            "Agent to use. "
             "If omitted, falls back to [agents].default, then "
             "[agents].recent, then "
             f"the '{DEFAULT_AGENT_NAME}' built-in default."

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -125,7 +125,7 @@ def show_help() -> None:
     console.print(
         "  -r, --resume [ID]          Resume thread: -r for most recent, -r ID for specific"  # noqa: E501
     )
-    console.print("  -a, --agent NAME           Agent to use (e.g., coder, researcher)")
+    console.print("  -a, --agent NAME           Agent to use")
     console.print("  -M, --model MODEL          Model to use (e.g., gpt-5.5)")
     console.print(
         "  --model-params JSON        Extra model kwargs (e.g., '{\"temperature\": 0.7}')"  # noqa: E501
@@ -301,8 +301,8 @@ def show_agents_help() -> None:
     console.print()
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
     console.print("  dcode agents list")
-    console.print("  dcode agents reset --agent coder")
-    console.print("  dcode agents reset --agent coder --target researcher")
+    console.print("  dcode agents reset --agent NAME")
+    console.print("  dcode agents reset --agent NAME --target SOURCE")
     console.print()
 
 
@@ -329,9 +329,9 @@ def show_reset_help() -> None:
     )
     console.print()
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
-    console.print("  dcode reset --agent coder")
-    console.print("  dcode reset --agent coder --target researcher")
-    console.print("  dcode reset --agent coder --dry-run")
+    console.print("  dcode reset --agent NAME")
+    console.print("  dcode reset --agent NAME --target SOURCE")
+    console.print("  dcode reset --agent NAME --dry-run")
     console.print()
 
 

--- a/libs/code/tests/unit_tests/test_agent_friendly.py
+++ b/libs/code/tests/unit_tests/test_agent_friendly.py
@@ -66,7 +66,7 @@ class TestHelpScreenExamples:
         text = self._render(show_agents_help)
         assert "Examples:" in text
         assert "dcode agents list" in text
-        assert "dcode agents reset --agent coder" in text
+        assert "dcode agents reset --agent NAME" in text
 
     def test_update_help_has_examples(self) -> None:
         text = self._render(show_update_help)


### PR DESCRIPTION
The CLI help used `coder` and `researcher` as examples even though dcode does not ship those agents. This could make them look built in.

This replaces the named examples with `NAME` and `SOURCE` placeholders in the top-level and reset help.