### PR TITLE
feat(sdk): add TimeBudgetMiddleware for run-level time budgets

### DIFF
--- a/libs/deepagents/deepagents/__init__.py
+++ b/libs/deepagents/deepagents/__init__.py
@@ -15,6 +15,7 @@ from deepagents.middleware.subagents import (
     SubAgent,
     SubAgentMiddleware,
 )
+from deepagents.middleware.time_budget import TimeBudgetMiddleware
 from deepagents.profiles.harness.harness_profiles import (
     GeneralPurposeSubagentProfile,
     HarnessProfile,
@@ -43,6 +44,7 @@ __all__ = [
     "SubAgent",
     "SubAgentMiddleware",
     "SystemPromptConfig",
+    "TimeBudgetMiddleware",
     "__version__",
     "create_deep_agent",
     "register_harness_profile",

--- a/libs/deepagents/deepagents/middleware/__init__.py
+++ b/libs/deepagents/deepagents/middleware/__init__.py
@@ -75,6 +75,12 @@ from deepagents.middleware.summarization import (
     SummarizationToolMiddleware,
     create_summarization_tool_middleware,
 )
+from deepagents.middleware.time_budget import (
+    OnExceed,
+    TimeBudgetMiddleware,
+    TimeBudgetState,
+    TimeBudgetStatus,
+)
 
 __all__ = [
     "DEEPAGENTS_DEFAULT_SUMMARY_PROMPT",
@@ -91,6 +97,7 @@ __all__ = [
     "GraderResponse",
     "GraderVerdict",
     "MemoryMiddleware",
+    "OnExceed",
     "RubricEvaluation",
     "RubricMiddleware",
     "RubricResult",
@@ -100,5 +107,8 @@ __all__ = [
     "SubAgentMiddleware",
     "SummarizationMiddleware",
     "SummarizationToolMiddleware",
+    "TimeBudgetMiddleware",
+    "TimeBudgetState",
+    "TimeBudgetStatus",
     "create_summarization_tool_middleware",
 ]

--- a/libs/deepagents/deepagents/middleware/time_budget.py
+++ b/libs/deepagents/deepagents/middleware/time_budget.py
@@ -1,0 +1,358 @@
+"""Time budget middleware for Deep Agents.
+
+`TimeBudgetMiddleware` gives a run a wall-clock budget for *agent-active
+time* -- the time spent inside model calls and tool calls -- and enforces
+it when the budget is exhausted.
+
+Why "agent-active time" and not a fixed deadline? Metering the summed
+duration of model and tool calls (rather than an absolute wall-clock
+deadline) makes the budget robust to two things a naive deadline gets
+wrong:
+
+- **Human-in-the-loop pauses.** Interrupts happen *between* actions, so a
+    human taking minutes to approve a tool call never counts against the
+    budget.
+- **Checkpoint / resume.** Consumed time is persisted in graph state as an
+    accumulated number of seconds, not as a deadline timestamp, so a run
+    that pauses overnight and resumes tomorrow is not instantly "over
+    budget".
+
+Enforcement happens at action boundaries (middleware can gate *between*
+actions but cannot preempt one already running):
+
+- ``on_exceed="wind_down"`` (default): once the budget is spent, the next
+    model call has its tools stripped and a "finalize now" instruction
+    injected, forcing the model to produce a final answer from what it
+    already has.
+- ``on_exceed="hard_stop"``: once the budget is spent, the run ends
+    immediately with a short notice message instead of calling the model
+    again.
+
+While under budget, the middleware can also inject a short awareness note
+("~120s of 360s remaining") so the model can pace itself.
+
+The middleware is a no-op to *include* only in the sense that it must be
+given a positive ``total_seconds``; to run without a budget, simply do not
+add it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Literal,
+    NotRequired,
+)
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ContextT,
+    ModelResponse,
+    PrivateStateAttr,
+    ResponseT,
+    hook_config,
+)
+from langchain_core._api import beta
+from langchain_core.messages import AIMessage
+from langgraph.types import Command
+
+from deepagents.middleware._utils import append_to_system_message
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain.agents.middleware.types import ModelRequest
+    from langchain_core.messages import ToolMessage
+    from langgraph.runtime import Runtime
+
+logger = logging.getLogger(__name__)
+
+
+OnExceed = Literal["wind_down", "hard_stop"]
+"""What the middleware does once the time budget is exhausted.
+
+- ``"wind_down"``: strip tools and inject a "finalize now" instruction on
+    the next model call so the model returns a final answer.
+- ``"hard_stop"``: end the run immediately with a notice message.
+"""
+
+TimeBudgetStatus = Literal["ok", "warning", "wind_down", "hard_stop"]
+"""Per-model-call budget status, recorded on state and passed to ``on_event``.
+
+- ``"ok"``: comfortably within budget.
+- ``"warning"``: past the warn threshold but not yet exhausted.
+- ``"wind_down"``: budget exhausted; the run is being wound down.
+- ``"hard_stop"``: budget exhausted; the run was hard-stopped.
+"""
+
+TIME_BUDGET_EVENT_SOURCE = "time_budget"
+"""``lc_source`` tag stamped on the synthetic message injected on a hard stop."""
+
+
+def _add_seconds(left: float | None, right: float | None) -> float:
+    """Reducer that accumulates consumed seconds across (possibly parallel) actions."""
+    return (left or 0.0) + (right or 0.0)
+
+
+class TimeBudgetState(AgentState):
+    """State schema for [`TimeBudgetMiddleware`][deepagents.middleware.time_budget.TimeBudgetMiddleware].
+
+    All fields are bookkeeping and annotated with
+    [`PrivateStateAttr`][langchain.agents.middleware.types.PrivateStateAttr]
+    so they are omitted from the agent's input/output schemas. They remain
+    readable via ``agent.get_state(config).values`` on a checkpointed thread,
+    and the same numbers are delivered to the ``on_event`` callback.
+    """
+
+    _time_budget_consumed: NotRequired[Annotated[float, PrivateStateAttr, _add_seconds]]
+    """Accumulated agent-active seconds (sum of model- and tool-call durations)."""
+
+    _time_budget_model_start: NotRequired[Annotated[float | None, PrivateStateAttr]]
+    """Clock reading captured in ``before_model``; consumed by ``after_model``."""
+
+    _time_budget_status: NotRequired[Annotated[TimeBudgetStatus | None, PrivateStateAttr]]
+    """Status recorded for the most recent model step."""
+
+
+@beta(obj_type="middleware")
+class TimeBudgetMiddleware(AgentMiddleware[TimeBudgetState, ContextT, ResponseT]):
+    """Meter agent-active time and enforce a total budget.
+
+    Add it to a deep agent via the ``middleware`` parameter::
+
+        from deepagents import create_deep_agent
+        from deepagents.middleware import TimeBudgetMiddleware
+
+        agent = create_deep_agent(
+            model="anthropic:claude-sonnet-4-6",
+            middleware=[TimeBudgetMiddleware(total_seconds=360)],
+        )
+
+    Args:
+        total_seconds: The agent-active time budget, in seconds. Must be
+            positive. To run without a budget, do not add the middleware.
+        warn_fraction: Fraction of the budget consumed at which the status
+            becomes ``"warning"`` and (if ``inject_awareness``) the awareness
+            note starts telling the model to wrap up. Must be in ``(0, 1]``.
+            Defaults to ``0.8``.
+        on_exceed: Behavior once the budget is exhausted. ``"wind_down"``
+            (default) strips tools and forces a final answer; ``"hard_stop"``
+            ends the run with a notice message.
+        inject_awareness: When ``True`` (default), a short remaining-budget
+            note is appended to the system prompt on each model call so the
+            model can pace itself.
+        clock: Zero-argument callable returning a monotonically increasing
+            time in seconds. Defaults to ``time.monotonic``. Injectable so
+            tests can advance time deterministically.
+        on_event: Optional callback invoked once per model step with a dict
+            describing the budget state (``status``, ``consumed``,
+            ``remaining``, ``total``). Exceptions raised by the callback are
+            logged and swallowed.
+
+    Raises:
+        ValueError: If ``total_seconds <= 0`` or ``warn_fraction`` is outside
+            ``(0, 1]``.
+    """
+
+    state_schema = TimeBudgetState
+
+    def __init__(  # noqa: D107
+        self,
+        total_seconds: float,
+        *,
+        warn_fraction: float = 0.8,
+        on_exceed: OnExceed = "wind_down",
+        inject_awareness: bool = True,
+        clock: Callable[[], float] | None = None,
+        on_event: Callable[[dict[str, Any]], None] | None = None,
+    ) -> None:
+        super().__init__()
+        if total_seconds <= 0:
+            msg = f"total_seconds must be positive, got {total_seconds}"
+            raise ValueError(msg)
+        if not 0 < warn_fraction <= 1:
+            msg = f"warn_fraction must be in (0, 1], got {warn_fraction}"
+            raise ValueError(msg)
+        self.total_seconds = float(total_seconds)
+        self.warn_fraction = float(warn_fraction)
+        self.on_exceed: OnExceed = on_exceed
+        self.inject_awareness = inject_awareness
+        self._on_event = on_event
+        if clock is None:
+            import time  # noqa: PLC0415
+
+            clock = time.monotonic
+        self._clock = clock
+
+    @property
+    def _warn_threshold(self) -> float:
+        return self.total_seconds * self.warn_fraction
+
+    @staticmethod
+    def _consumed(state: AgentState[Any]) -> float:
+        return state.get("_time_budget_consumed", 0.0) or 0.0
+
+    def _remaining(self, consumed: float) -> float:
+        return self.total_seconds - consumed
+
+    def _status_for(self, consumed: float) -> TimeBudgetStatus:
+        """Status implied by the time already consumed *before* a model call.
+
+        Uses the consumed-at-start value so the reported status matches the
+        enforcement decision taken for that same call.
+        """
+        if self._remaining(consumed) <= 0:
+            return "wind_down" if self.on_exceed == "wind_down" else "hard_stop"
+        if consumed >= self._warn_threshold:
+            return "warning"
+        return "ok"
+
+    def _emit(self, status: TimeBudgetStatus, consumed: float) -> None:
+        if self._on_event is None:
+            return
+        event = {
+            "source": TIME_BUDGET_EVENT_SOURCE,
+            "status": status,
+            "consumed": consumed,
+            "remaining": max(0.0, self._remaining(consumed)),
+            "total": self.total_seconds,
+        }
+        try:
+            self._on_event(event)
+        except Exception:
+            logger.exception("TimeBudgetMiddleware on_event callback raised")
+
+    def _awareness_text(self, remaining: float) -> str:
+        if remaining <= self.total_seconds * (1 - self.warn_fraction):
+            return (
+                f"[time budget] Running low: about {remaining:.0f}s of "
+                f"{self.total_seconds:.0f}s remaining. Start finalizing your answer "
+                "and avoid starting long new tasks."
+            )
+        return f"[time budget] About {remaining:.0f}s of {self.total_seconds:.0f}s remaining. Pace your work accordingly."
+
+    def _wind_down_text(self) -> str:
+        return (
+            f"[time budget] Time is up (budget was {self.total_seconds:.0f}s). Provide your "
+            "final answer now using only the information you already have. Do not call any more tools."
+        )
+
+    def _hard_stop_notice(self) -> str:
+        return f"Stopped: the agent's time budget of {self.total_seconds:.0f}s was exhausted before a final answer was produced."
+
+    @hook_config(can_jump_to=["end"])
+    def before_model(self, state: TimeBudgetState, runtime: Runtime[ContextT]) -> dict[str, Any] | None:  # noqa: ARG002
+        """Hard-stop the run if over budget; otherwise stamp the model start time."""
+        return self._before_model(state)
+
+    @hook_config(can_jump_to=["end"])
+    async def abefore_model(self, state: TimeBudgetState, runtime: Runtime[ContextT]) -> dict[str, Any] | None:  # noqa: ARG002
+        """Async variant of `before_model`."""
+        return self._before_model(state)
+
+    def _before_model(self, state: TimeBudgetState) -> dict[str, Any] | None:
+        consumed = self._consumed(state)
+        if self.on_exceed == "hard_stop" and self._remaining(consumed) <= 0:
+            self._emit("hard_stop", consumed)
+            return {
+                "jump_to": "end",
+                "_time_budget_status": "hard_stop",
+                "messages": [
+                    AIMessage(
+                        content=self._hard_stop_notice(),
+                        additional_kwargs={"lc_source": TIME_BUDGET_EVENT_SOURCE},
+                    )
+                ],
+            }
+        return {"_time_budget_model_start": self._clock()}
+
+    def after_model(self, state: TimeBudgetState, runtime: Runtime[ContextT]) -> dict[str, Any] | None:  # noqa: ARG002
+        """Record the model call's duration and the resulting budget status."""
+        return self._after_model(state)
+
+    async def aafter_model(self, state: TimeBudgetState, runtime: Runtime[ContextT]) -> dict[str, Any] | None:  # noqa: ARG002
+        """Async variant of `after_model`."""
+        return self._after_model(state)
+
+    def _after_model(self, state: TimeBudgetState) -> dict[str, Any] | None:
+        start = state.get("_time_budget_model_start")
+        if start is None:
+            return None
+        consumed_at_start = self._consumed(state)
+        delta = max(0.0, self._clock() - start)
+        status = self._status_for(consumed_at_start)
+        self._emit(status, consumed_at_start + delta)
+        return {
+            "_time_budget_consumed": delta,
+            "_time_budget_status": status,
+            "_time_budget_model_start": None,
+        }
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], ModelResponse[ResponseT]],
+    ) -> ModelResponse[ResponseT]:
+        """Inject awareness / wind-down instructions before the model runs."""
+        return handler(self._modify_request(request))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT]:
+        """Async variant of `wrap_model_call`."""
+        return await handler(self._modify_request(request))
+
+    def _modify_request(self, request: ModelRequest[ContextT]) -> ModelRequest[ContextT]:
+        consumed = self._consumed(request.state)
+        remaining = self._remaining(consumed)
+
+        if self.on_exceed == "wind_down" and remaining <= 0:
+            no_tools = request.override(tools=[])
+            new_system = append_to_system_message(request.system_message, self._wind_down_text())
+            return no_tools.override(system_message=new_system)
+        if self.inject_awareness:
+            new_system = append_to_system_message(request.system_message, self._awareness_text(remaining))
+            return request.override(system_message=new_system)
+        return request
+
+    def wrap_tool_call(
+        self,
+        request: Any,  # noqa: ANN401
+        handler: Callable[[Any], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Time the tool call and fold its duration into the budget."""
+        start = self._clock()
+        result = handler(request)
+        return self._attach_tool_delta(result, max(0.0, self._clock() - start))
+
+    async def awrap_tool_call(
+        self,
+        request: Any,  # noqa: ANN401
+        handler: Callable[[Any], Awaitable[ToolMessage | Command[Any]]],
+    ) -> ToolMessage | Command[Any]:
+        """Async variant of `wrap_tool_call`."""
+        start = self._clock()
+        result = await handler(request)
+        return self._attach_tool_delta(result, max(0.0, self._clock() - start))
+
+    @staticmethod
+    def _attach_tool_delta(result: ToolMessage | Command[Any], delta: float) -> ToolMessage | Command[Any]:
+        """Fold ``delta`` seconds into ``_time_budget_consumed`` alongside the tool result.
+
+        A tool may return a plain ``ToolMessage`` or a ``Command`` (e.g.
+        filesystem tools that also update state). In both cases the duration
+        is merged into the ``_time_budget_consumed`` channel via its additive
+        reducer.
+        """
+        if isinstance(result, Command):
+            if isinstance(result.update, dict):
+                result.update["_time_budget_consumed"] = _add_seconds(result.update.get("_time_budget_consumed"), delta)
+
+            return result
+        return Command(update={"messages": [result], "_time_budget_consumed": delta})

--- a/libs/deepagents/tests/unit_tests/test_time_budget_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_time_budget_middleware.py
@@ -1,0 +1,324 @@
+"""Tests for `TimeBudgetMiddleware`.
+
+Coverage is split into three layers:
+
+- **Unit** tests exercise the middleware's methods directly (budget math,
+    request transformation, tool-delta accounting, the model hooks) with
+    hand-built inputs so assertions do not depend on agent-loop or
+    fake-model quirks.
+- **End-to-end** tests drive `create_agent` with a scripted fake model and
+    a deterministic step clock, covering consumed accounting, wind-down,
+    hard-stop, the event callback, and the async path.
+- **Integration** tests confirm the middleware composes inside the full
+    `create_deep_agent` stack.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from langchain.agents import create_agent
+from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.types import Command
+
+from deepagents import TimeBudgetMiddleware, create_deep_agent
+from deepagents.middleware.time_budget import TIME_BUDGET_EVENT_SOURCE
+from tests.unit_tests.chat_model import GenericFakeChatModel
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+pytestmark = pytest.mark.filterwarnings("ignore:.*is in beta")
+
+
+class StepClock:
+    """Deterministic clock that advances a fixed step on every read.
+
+    Because the middleware reads the clock twice per timed action (start and
+    end), a fixed step makes every model call and every tool call consume
+    exactly ``step`` seconds, regardless of interleaving.
+    """
+
+    def __init__(self, step: float = 1.0, start: float = 0.0) -> None:
+        self.now = start
+        self.step = step
+
+    def __call__(self) -> float:
+        value = self.now
+        self.now += self.step
+        return value
+
+
+@tool
+def slow_tool(x: int) -> int:
+    """Return x unchanged (stands in for a time-consuming tool)."""
+    return x
+
+
+def _make_request(
+    *,
+    consumed: float,
+    tools: list | None = None,
+    system_text: str | None = "base system",
+) -> ModelRequest:
+    """Build a `ModelRequest` with a given consumed-budget state."""
+    system_message = SystemMessage(content=system_text) if system_text is not None else None
+    return ModelRequest(
+        model=GenericFakeChatModel(messages=iter([])),
+        messages=[HumanMessage(content="hello")],
+        system_message=system_message,
+        tools=list(tools) if tools is not None else [slow_tool],
+        state={"messages": [], "_time_budget_consumed": consumed},
+    )
+
+
+class TestValidation:
+    def test_rejects_nonpositive_total(self) -> None:
+        with pytest.raises(ValueError, match="total_seconds must be positive"):
+            TimeBudgetMiddleware(total_seconds=0)
+        with pytest.raises(ValueError, match="total_seconds must be positive"):
+            TimeBudgetMiddleware(total_seconds=-5)
+
+    def test_rejects_bad_warn_fraction(self) -> None:
+        with pytest.raises(ValueError, match="warn_fraction must be in"):
+            TimeBudgetMiddleware(total_seconds=10, warn_fraction=0)
+        with pytest.raises(ValueError, match="warn_fraction must be in"):
+            TimeBudgetMiddleware(total_seconds=10, warn_fraction=1.5)
+
+    def test_defaults(self) -> None:
+        mw = TimeBudgetMiddleware(total_seconds=360)
+        assert mw.total_seconds == 360.0
+        assert mw.warn_fraction == 0.8
+        assert mw.on_exceed == "wind_down"
+        assert mw.inject_awareness is True
+        assert mw._warn_threshold == pytest.approx(288.0)
+
+
+class TestStatus:
+    def test_status_ok(self) -> None:
+        mw = TimeBudgetMiddleware(total_seconds=100)
+        assert mw._status_for(0.0) == "ok"
+        assert mw._status_for(79.0) == "ok"
+
+    def test_status_warning(self) -> None:
+        mw = TimeBudgetMiddleware(total_seconds=100, warn_fraction=0.8)
+        assert mw._status_for(80.0) == "warning"
+        assert mw._status_for(99.0) == "warning"
+
+    def test_status_wind_down_when_exhausted(self) -> None:
+        mw = TimeBudgetMiddleware(total_seconds=100, on_exceed="wind_down")
+        assert mw._status_for(100.0) == "wind_down"
+        assert mw._status_for(150.0) == "wind_down"
+
+    def test_status_hard_stop_when_exhausted(self) -> None:
+        mw = TimeBudgetMiddleware(total_seconds=100, on_exceed="hard_stop")
+        assert mw._status_for(100.0) == "hard_stop"
+
+
+class TestModifyRequest:
+    def test_awareness_injected_under_budget(self) -> None:
+        mw = TimeBudgetMiddleware(total_seconds=100)
+        req = _make_request(consumed=10.0)
+        out = mw._modify_request(req)
+        assert out is not req
+        assert len(out.tools) == 1
+        assert "remaining" in out.system_message.text
+        assert "base system" in out.system_message.text
+
+    def test_awareness_warning_text_in_warn_zone(self) -> None:
+        mw = TimeBudgetMiddleware(total_seconds=100, warn_fraction=0.8)
+        out = mw._modify_request(_make_request(consumed=90.0))
+        assert "Running low" in out.system_message.text
+        assert len(out.tools) == 1
+
+    def test_awareness_disabled_returns_request_unchanged(self) -> None:
+        mw = TimeBudgetMiddleware(total_seconds=100, inject_awareness=False)
+        req = _make_request(consumed=10.0)
+        assert mw._modify_request(req) is req
+
+    def test_wind_down_strips_tools_and_injects_finalize(self) -> None:
+        mw = TimeBudgetMiddleware(total_seconds=100, on_exceed="wind_down")
+        out = mw._modify_request(_make_request(consumed=120.0))
+        assert out.tools == []
+        assert "Time is up" in out.system_message.text
+
+    def test_wind_down_preserves_original_system_message(self) -> None:
+        mw = TimeBudgetMiddleware(total_seconds=100)
+        out = mw._modify_request(_make_request(consumed=120.0, system_text="IMPORTANT RULES"))
+        assert "IMPORTANT RULES" in out.system_message.text
+
+
+class TestAttachToolDelta:
+    def test_toolmessage_wrapped_in_command_with_delta(self) -> None:
+        tm = ToolMessage(content="result", tool_call_id="c1")
+        out = TimeBudgetMiddleware._attach_tool_delta(tm, 3.0)
+        assert isinstance(out, Command)
+        assert out.update["_time_budget_consumed"] == 3.0
+        assert out.update["messages"] == [tm]
+
+    def test_command_result_gets_delta_merged(self) -> None:
+        tm = ToolMessage(content="fs", tool_call_id="c2")
+        cmd = Command(update={"messages": [tm], "files": {"a.txt": "x"}})
+        out = TimeBudgetMiddleware._attach_tool_delta(cmd, 2.5)
+        assert out is cmd
+        assert out.update["_time_budget_consumed"] == 2.5
+        assert out.update["files"] == {"a.txt": "x"}
+        assert out.update["messages"] == [tm]
+
+    def test_command_with_existing_delta_accumulates(self) -> None:
+        cmd = Command(update={"_time_budget_consumed": 1.0})
+        out = TimeBudgetMiddleware._attach_tool_delta(cmd, 2.0)
+        assert out.update["_time_budget_consumed"] == 3.0
+
+
+class TestModelHooks:
+    def test_before_model_stamps_start_under_budget(self) -> None:
+        clock = StepClock(step=1.0, start=42.0)
+        mw = TimeBudgetMiddleware(total_seconds=100, clock=clock)
+        update = mw._before_model({"_time_budget_consumed": 10.0})
+        assert update == {"_time_budget_model_start": 42.0}
+
+    def test_before_model_hard_stop_when_over(self) -> None:
+        events: list[dict[str, Any]] = []
+        mw = TimeBudgetMiddleware(total_seconds=100, on_exceed="hard_stop", on_event=events.append)
+        update = mw._before_model({"_time_budget_consumed": 150.0})
+        assert update["jump_to"] == "end"
+        assert update["_time_budget_status"] == "hard_stop"
+        (msg,) = update["messages"]
+        assert isinstance(msg, AIMessage)
+        assert "time budget" in msg.content.lower()
+        assert msg.additional_kwargs["lc_source"] == TIME_BUDGET_EVENT_SOURCE
+        assert events and events[-1]["status"] == "hard_stop"
+
+    def test_before_model_wind_down_does_not_hard_stop(self) -> None:
+        clock = StepClock(step=1.0, start=7.0)
+        mw = TimeBudgetMiddleware(total_seconds=100, on_exceed="wind_down", clock=clock)
+        update = mw._before_model({"_time_budget_consumed": 150.0})
+        assert update == {"_time_budget_model_start": 7.0}
+
+    def test_after_model_records_delta_and_status(self) -> None:
+        clock = StepClock(step=1.0, start=50.0)
+        mw = TimeBudgetMiddleware(total_seconds=100, clock=clock)
+        update = mw._after_model({"_time_budget_model_start": 45.0, "_time_budget_consumed": 10.0})
+        assert update["_time_budget_consumed"] == pytest.approx(5.0)
+        assert update["_time_budget_status"] == "ok"
+        assert update["_time_budget_model_start"] is None
+
+    def test_after_model_noop_without_start(self) -> None:
+        mw = TimeBudgetMiddleware(total_seconds=100, clock=StepClock())
+        assert mw._after_model({"_time_budget_consumed": 10.0}) is None
+
+    def test_after_model_status_warning(self) -> None:
+        clock = StepClock(step=1.0, start=100.0)
+        mw = TimeBudgetMiddleware(total_seconds=100, warn_fraction=0.8, clock=clock)
+        update = mw._after_model({"_time_budget_model_start": 99.0, "_time_budget_consumed": 90.0})
+        assert update["_time_budget_status"] == "warning"
+
+
+class _ToolSpy(AgentMiddleware):
+    """Records how many tools the (inner) handler sees on each model call."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.tools_seen: list[int] = []
+
+    def wrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], ModelResponse]) -> ModelResponse:
+        self.tools_seen.append(len(request.tools))
+        return handler(request)
+
+
+def _tool_then_final_model() -> GenericFakeChatModel:
+    """Model that calls a tool once, then returns a final answer."""
+    return GenericFakeChatModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "slow_tool", "args": {"x": 1}, "id": "c1", "type": "tool_call"}],
+                ),
+                AIMessage(content="Final answer."),
+            ]
+        )
+    )
+
+
+class TestEndToEnd:
+    def test_consumed_accounting_model_and_tool(self) -> None:
+        events: list[dict[str, Any]] = []
+        mw = TimeBudgetMiddleware(total_seconds=1000, clock=StepClock(step=100.0), on_event=events.append)
+        agent = create_agent(model=_tool_then_final_model(), tools=[slow_tool], middleware=[mw])
+        result = agent.invoke({"messages": [HumanMessage(content="go")]})
+        assert result["messages"][-1].content == "Final answer."
+        assert events[-1]["consumed"] == pytest.approx(300.0)
+        assert events[-1]["remaining"] == pytest.approx(700.0)
+
+    def test_wind_down_forces_final_answer_and_strips_tools(self) -> None:
+        events: list[dict[str, Any]] = []
+        mw = TimeBudgetMiddleware(total_seconds=150, on_exceed="wind_down", clock=StepClock(step=100.0), on_event=events.append)
+        spy = _ToolSpy()
+        agent = create_agent(model=_tool_then_final_model(), tools=[slow_tool], middleware=[mw, spy])
+        result = agent.invoke({"messages": [HumanMessage(content="go")]})
+        assert result["messages"][-1].content == "Final answer."
+        assert spy.tools_seen[-1] == 0
+        assert spy.tools_seen[0] == 1
+        assert any(e["status"] == "wind_down" for e in events)
+
+    def test_hard_stop_ends_run_with_notice(self) -> None:
+        events: list[dict[str, Any]] = []
+        model = _tool_then_final_model()
+        mw = TimeBudgetMiddleware(total_seconds=150, on_exceed="hard_stop", clock=StepClock(step=100.0), on_event=events.append)
+        agent = create_agent(model=model, tools=[slow_tool], middleware=[mw])
+        result = agent.invoke({"messages": [HumanMessage(content="go")]})
+        last = result["messages"][-1]
+        assert isinstance(last, AIMessage)
+        assert "time budget" in last.content.lower()
+        assert "Final answer." not in last.content
+        assert len(model.call_history) == 1
+        assert events[-1]["status"] == "hard_stop"
+
+    async def test_async_wind_down(self) -> None:
+        events: list[dict[str, Any]] = []
+        mw = TimeBudgetMiddleware(total_seconds=150, on_exceed="wind_down", clock=StepClock(step=100.0), on_event=events.append)
+        agent = create_agent(model=_tool_then_final_model(), tools=[slow_tool], middleware=[mw])
+        result = await agent.ainvoke({"messages": [HumanMessage(content="go")]})
+        assert result["messages"][-1].content == "Final answer."
+        assert any(e["status"] == "wind_down" for e in events)
+
+    def test_no_awareness_leaves_system_prompt_clean(self) -> None:
+        recorded: list[str] = []
+
+        class _SysSpy(AgentMiddleware):
+            def wrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], ModelResponse]) -> ModelResponse:
+                recorded.append(request.system_message.text if request.system_message else "")
+                return handler(request)
+
+        mw = TimeBudgetMiddleware(total_seconds=1000, inject_awareness=False, clock=StepClock(step=1.0))
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="done")]))
+        agent = create_agent(model=model, middleware=[mw, _SysSpy()], system_prompt="ROOT")
+        agent.invoke({"messages": [HumanMessage(content="go")]})
+        assert all("time budget" not in s for s in recorded)
+
+
+class TestDeepAgentIntegration:
+    def test_composes_in_deep_agent_stack(self) -> None:
+        events: list[dict[str, Any]] = []
+        mw = TimeBudgetMiddleware(total_seconds=1000, clock=StepClock(step=100.0), on_event=events.append)
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="Done, no tools needed.")]))
+        agent = create_deep_agent(model=model, middleware=[mw])
+        result = agent.invoke({"messages": [HumanMessage(content="say hi")]})
+        assert result["messages"][-1].content == "Done, no tools needed."
+        assert events[-1]["consumed"] == pytest.approx(100.0)
+        assert events[-1]["status"] == "ok"
+
+    def test_state_schema_readable_via_get_state(self) -> None:
+        mw = TimeBudgetMiddleware(total_seconds=1000, clock=StepClock(step=100.0))
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="hi")]))
+        agent = create_deep_agent(model=model, middleware=[mw], checkpointer=InMemorySaver())
+        config = {"configurable": {"thread_id": "t1"}}
+        agent.invoke({"messages": [HumanMessage(content="go")]}, config)
+        values = agent.get_state(config).values
+        assert values["_time_budget_consumed"] == pytest.approx(100.0)


### PR DESCRIPTION
Fixes #4670

---

Adds `TimeBudgetMiddleware`, which gives a run a wall-clock budget for agent-active time (model + tool execution) and, once it's spent, either winds the run down gracefully (strips tools and forces a final answer) or hard-stops it. Enabled through the existing `middleware=` parameter, so `create_deep_agent` assembly is untouched.

## Release note

`TimeBudgetMiddleware` (beta) lets you cap a deep agent's active run time — e.g. `middleware=[TimeBudgetMiddleware(total_seconds=360)]`. It meters time spent in model and tool calls, injects a remaining-time note so the model can pace itself, and on exhaustion either winds down to a final answer (default) or hard-stops with a notice.

## Breaking changes

None. The middleware is opt-in and only active when added.

## How did you verify your code works?

- Added `tests/unit_tests/test_time_budget_middleware.py` — 28 tests across three layers:
  - **Unit**: validation, budget-math/status thresholds, request transformation (awareness injection + wind-down tool-stripping), tool-delta accounting (`ToolMessage` and `Command` results), and the `before/after_model` hooks — asserted directly on the middleware.
  - **End-to-end** (`create_agent`, scripted fake model + injectable step clock): consumed accounting across model+tool+model, wind-down forcing a final answer with tools stripped on the finalizing call, hard-stop ending the run with a notice, the `on_event` callback, and the async (`ainvoke`) path.
  - **Integration** (`create_deep_agent`): composes in the full stack; consumed time readable via `get_state`.
- From `libs/deepagents`:
  - `make test` → `test_time_budget_middleware.py`: 28 passed; full `tests/unit_tests/`: 2269 passed, 100 skipped, 4 xfailed (no regressions).
  - `make lint` → ruff check + format: clean.
  - `make type` → `ty check deepagents`: clean.

