### PR TITLE
feat(infra): add package Git log to release notes

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -216,7 +216,7 @@ The [release workflow (`.github/workflows/release.yml`)](https://github.com/lang
 
 1. **Setup** - Resolves package name to working directory
 2. **Build** - Creates distribution package
-3. **Release Notes** + **Pre-release Checks** - Run in parallel; release notes extracts changelog and collects contributor shoutouts; pre-release checks run tests against the built package
+3. **Release Notes** + **Pre-release Checks** - Run in parallel; release notes extracts the changelog, appends a collapsible package-scoped Git log (newest commit first, up to 100 commits, truncated further if the log grows large), and collects contributor shoutouts; pre-release checks run tests against the built package
 4. **Test PyPI** - Publishes to test.pypi.org for validation (after pre-release checks pass)
 5. **Publish** - Publishes to PyPI (requires Test PyPI to succeed)
 6. **Mark Release** - Creates a published GitHub release with the built artifacts; updates PR labels. For the SDK (`libs/deepagents`), we set it as the repository's `latest` (unless it's a pre-release).
@@ -381,7 +381,7 @@ Alpha releases use a **throwaway branch** + [manual release](#manual-release). T
      -f dangerous-nonmain-release=true
    ```
 
-6. **Verify the GitHub release** — the workflow automatically detects PEP 440 pre-release versions (`a`, `b`, `rc`, `.dev`) and marks the GitHub release as a **pre-release**. Pre-releases are never set as the repository's "Latest" release. The release body will contain a warning banner, contributor shoutouts (no changelog or git log), and — because the branch is not `main` — a "Released from" line linking the originating branch and the release commit.
+6. **Verify the GitHub release** — the workflow automatically detects PEP 440 pre-release versions (`a`, `b`, `rc`, `.dev`) and marks the GitHub release as a **pre-release**. Pre-releases are never set as the repository's "Latest" release. The release body will contain a warning banner, a collapsible package-scoped Git log, contributor shoutouts (but no changelog), and — because the branch is not `main` — a "Released from" line linking the originating branch and the release commit.
 
 7. **Clean up** — delete the branch after the workflow succeeds:
 

--- a/.github/scripts/test_release_git_log.py
+++ b/.github/scripts/test_release_git_log.py
@@ -1,0 +1,638 @@
+"""Test the package Git log included in GitHub release notes."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "release.yml"
+PACKAGE_PATH = Path("libs/example")
+REPOSITORY = "langchain-ai/deepagents"
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(repo: Path) -> None:
+    _git(repo, "init", "--initial-branch=main")
+    _git(repo, "config", "user.email", "release-test@example.com")
+    _git(repo, "config", "user.name", "Release Test")
+    _git(repo, "config", "commit.gpgSign", "false")
+
+
+def _commit(repo: Path, path: Path, content: str, message: str) -> str:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+    _git(repo, "add", str(path))
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _workflow_step(step_id: str) -> str:
+    with WORKFLOW_PATH.open() as file:
+        workflow = yaml.safe_load(file)
+    steps = workflow["jobs"]["release-notes"]["steps"]
+    return next(step["run"] for step in steps if step.get("id") == step_id)
+
+
+def _run_git_log_step(
+    repo: Path,
+    *,
+    previous_tag: str,
+    release_sha: str,
+) -> str:
+    output = repo / "github-output.txt"
+    env = {
+        **os.environ,
+        "GITHUB_OUTPUT": str(output),
+        "PREV_TAG": previous_tag,
+        "RELEASE_SHA": release_sha,
+        "REPOSITORY": REPOSITORY,
+        "WORKING_DIR": str(PACKAGE_PATH),
+    }
+    subprocess.run(
+        ["bash", "-eo", "pipefail", "-c", _workflow_step("generate-git-log")],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return _read_multiline_output(output, "details")
+
+
+def _read_multiline_output(output: Path, name: str) -> str:
+    contents = output.read_text()
+    prefix = f"{name}<<EOF\n"
+    suffix = "\nEOF\n"
+    assert contents.startswith(prefix)
+    assert contents.endswith(suffix)
+    return contents.removeprefix(prefix).removesuffix(suffix)
+
+
+class _ResolveRefs(NamedTuple):
+    """Result of the resolve-refs step.
+
+    ``outputs`` holds the parsed ``$GITHUB_OUTPUT`` values; ``stdout`` holds the
+    step's stdout, where GitHub ``::warning::`` workflow commands are emitted so
+    tests can assert on them.
+    """
+
+    outputs: dict[str, str]
+    stdout: str
+
+
+def _run_resolve_refs_step(repo: Path, *, version: str) -> _ResolveRefs:
+    output = repo / "resolve-refs-output.txt"
+    env = {
+        **os.environ,
+        "GITHUB_OUTPUT": str(output),
+        "PKG_NAME": "example",
+        "RELEASE_SHA": _git(repo, "rev-parse", "HEAD"),
+        "VERSION": version,
+        "WORKING_DIR": str(PACKAGE_PATH),
+    }
+    result = subprocess.run(
+        ["bash", "-eo", "pipefail", "-c", _workflow_step("resolve-refs")],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    outputs = dict(
+        line.split("=", maxsplit=1) for line in output.read_text().splitlines()
+    )
+    return _ResolveRefs(outputs=outputs, stdout=result.stdout)
+
+
+class _FinalizeBody(NamedTuple):
+    """Result of the finalize-release-body step.
+
+    ``release_body`` is the finalized ``$GITHUB_OUTPUT`` value; ``stdout`` holds
+    the step's stdout, where GitHub ``::warning::`` workflow commands are emitted.
+    """
+
+    release_body: str
+    stdout: str
+
+
+def _run_finalize_release_body_step(
+    directory: Path,
+    *,
+    base_release_body: str,
+    git_log_details: str,
+) -> _FinalizeBody:
+    output = directory / "finalize-output.txt"
+    output.unlink(missing_ok=True)
+    env = {
+        **os.environ,
+        "BASE_RELEASE_BODY": base_release_body,
+        "GITHUB_OUTPUT": str(output),
+        "GIT_LOG_DETAILS": git_log_details,
+    }
+    result = subprocess.run(
+        ["bash", "-eo", "pipefail", "-c", _workflow_step("finalize-release-body")],
+        cwd=directory,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return _FinalizeBody(
+        release_body=_read_multiline_output(output, "release-body"),
+        stdout=result.stdout,
+    )
+
+
+def _create_history(repo: Path) -> dict[str, str]:
+    _init_repo(repo)
+
+    config = {
+        "packages": {
+            str(PACKAGE_PATH): {
+                "exclude-paths": [str(PACKAGE_PATH / "tests")],
+            }
+        }
+    }
+    (repo / "release-please-config.json").write_text(json.dumps(config))
+    (repo / PACKAGE_PATH / "tests").mkdir(parents=True)
+    (repo / PACKAGE_PATH / "module.py").write_text("BASE = 1\n")
+    (repo / PACKAGE_PATH / "tests" / "test_module.py").write_text("baseline\n")
+    _git(repo, "add", "release-please-config.json", str(PACKAGE_PATH))
+    _git(repo, "commit", "-m", "feat(example): initial package")
+    baseline = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "tag", "example==1.0.0")
+
+    feature = _commit(
+        repo,
+        PACKAGE_PATH / "module.py",
+        "BASE = 1\nFEATURE = 2\n",
+        "feat(example): add feature",
+    )
+    unrelated = _commit(
+        repo,
+        Path("libs/other/module.py"),
+        "OTHER = 1\n",
+        "feat(other): unrelated change",
+    )
+    test_only = _commit(
+        repo,
+        PACKAGE_PATH / "tests" / "test_module.py",
+        "baseline\nnew test\n",
+        "test(example): add coverage",
+    )
+    fix = _commit(
+        repo,
+        PACKAGE_PATH / "module.py",
+        "BASE = 1\nFEATURE = 3\n",
+        "fix(example): correct feature",
+    )
+    release = _commit(
+        repo,
+        PACKAGE_PATH / "CHANGELOG.md",
+        "## 1.0.1\n",
+        "release(example): 1.0.1",
+    )
+    hotfix = _commit(
+        repo,
+        PACKAGE_PATH / "module.py",
+        "BASE = 1\nFEATURE = 4\n",
+        "hotfix(example): repair release",
+    )
+    return {
+        "baseline": baseline,
+        "feature": feature,
+        "unrelated": unrelated,
+        "test_only": test_only,
+        "fix": fix,
+        "release": release,
+        "hotfix": hotfix,
+    }
+
+
+def _entry(sha: str, subject: str) -> str:
+    return f"- [`{sha[:7]}`](https://github.com/{REPOSITORY}/commit/{sha}) {subject}"
+
+
+def test_previous_tag_must_be_in_release_history(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit(
+        tmp_path,
+        PACKAGE_PATH / "CHANGELOG.md",
+        "## 1.0.0\n",
+        "release(example): 1.0.0",
+    )
+    _git(tmp_path, "tag", "example==1.0.0")
+
+    _git(tmp_path, "checkout", "-b", "newer-version-line")
+    _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "NEWER = 1\n",
+        "fix(example): newer line",
+    )
+    _git(tmp_path, "tag", "example==1.0.1")
+
+    _git(tmp_path, "checkout", "main")
+    _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "CURRENT = 1\n",
+        "fix(example): current line",
+    )
+    release = _commit(
+        tmp_path,
+        PACKAGE_PATH / "CHANGELOG.md",
+        "## 1.0.2\n",
+        "release(example): 1.0.2",
+    )
+
+    outputs = _run_resolve_refs_step(tmp_path, version="1.0.2").outputs
+
+    assert outputs["prev-tag"] == "example==1.0.0"
+    assert outputs["release-commit"] == release
+
+
+def test_temporary_repo_disables_inherited_commit_signing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    global_config = tmp_path / "global.gitconfig"
+    global_config.write_text("[commit]\n\tgpgSign = true\n")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    commits = _create_history(repo)
+
+    assert commits["hotfix"] == _git(repo, "rev-parse", "HEAD")
+    assert _git(repo, "config", "--local", "--bool", "commit.gpgSign") == "false"
+
+
+def test_finalize_release_body_respects_github_size_limit(tmp_path: Path) -> None:
+    body = _run_finalize_release_body_step(
+        tmp_path,
+        base_release_body="Release notes",
+        git_log_details="<details>Git log</details>",
+    ).release_body
+    assert body == "Release notes\n\n<details>Git log</details>"
+
+    body = _run_finalize_release_body_step(
+        tmp_path,
+        base_release_body="x" * 119_800,
+        git_log_details="y" * 1_000,
+    ).release_body
+    assert len(body.encode()) <= 120_000
+    assert "Git log omitted because" in body
+    assert "y" * 1_000 not in body
+
+
+def test_release_without_changelog_includes_git_log_once(tmp_path: Path) -> None:
+    base_step = _workflow_step("generate-release-body")
+    assert "Falling back to git log for release notes" not in base_step
+
+    details = "<details>\n<summary>Git log</summary>\n\nOne commit\n\n</details>"
+    body = _run_finalize_release_body_step(
+        tmp_path,
+        base_release_body="",
+        git_log_details=details,
+    ).release_body
+
+    assert body == details
+    assert body.count("One commit") == 1
+
+
+def test_stable_release_git_log_includes_package_history_newest_first(
+    tmp_path: Path,
+) -> None:
+    commits = _create_history(tmp_path)
+
+    details = _run_git_log_step(
+        tmp_path,
+        previous_tag="example==1.0.0",
+        release_sha=commits["hotfix"],
+    )
+
+    hotfix = _entry(commits["hotfix"], "hotfix(example): repair release")
+    release = _entry(commits["release"], "release(example): 1.0.1")
+    fix = _entry(commits["fix"], "fix(example): correct feature")
+    test_only = _entry(commits["test_only"], "test(example): add coverage")
+    feature = _entry(commits["feature"], "feat(example): add feature")
+    assert details == (
+        "<details>\n"
+        "<summary>Git log since example==1.0.0</summary>\n\n"
+        "This commit history includes changes to this package. Commits are "
+        "listed newest first.\n\n"
+        f"{hotfix}\n{release}\n{fix}\n{test_only}\n{feature}\n\n"
+        "</details>"
+    )
+    assert commits["unrelated"] not in details
+
+
+def test_git_log_escapes_and_limits_commit_subjects(tmp_path: Path) -> None:
+    _create_history(tmp_path)
+    subject = f"fix(example): escape </details><!--{'x' * 250}"
+    tip = _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "ESCAPED = 1\n",
+        subject,
+    )
+
+    details = _run_git_log_step(
+        tmp_path,
+        previous_tag="example==1.0.0",
+        release_sha=tip,
+    )
+
+    assert "escape &lt;/details&gt;&lt;!--" in details
+    assert "escape </details><!--" not in details
+    assert "…" in details
+
+
+def test_git_log_limits_large_release_history(tmp_path: Path) -> None:
+    commits = _create_history(tmp_path)
+    tip = commits["hotfix"]
+    for index in range(101):
+        tip = _commit(
+            tmp_path,
+            PACKAGE_PATH / "module.py",
+            f"VALUE = {index}\n",
+            f"fix(example): generated {index}",
+        )
+
+    details = _run_git_log_step(
+        tmp_path,
+        previous_tag="example==1.0.0",
+        release_sha=tip,
+    )
+
+    assert details.count(f"https://github.com/{REPOSITORY}/commit/") == 100
+    assert (
+        "The log is truncated to the newest 100 commits to keep the release "
+        "notes a reasonable size."
+    ) in details
+    assert "fix(example): generated 100" in details
+    assert "fix(example): generated 0\n" not in details
+
+
+def test_git_log_applies_byte_limit_after_html_escaping(tmp_path: Path) -> None:
+    commits = _create_history(tmp_path)
+    tip = commits["hotfix"]
+    for index in range(30):
+        tip = _commit(
+            tmp_path,
+            PACKAGE_PATH / "module.py",
+            f"VALUE = {index}\n",
+            f"fix(example): {index} {'&' * 250}",
+        )
+
+    details = _run_git_log_step(
+        tmp_path,
+        previous_tag="example==1.0.0",
+        release_sha=tip,
+    )
+
+    assert len(details.encode()) < 26_000
+    assert details.count(f"https://github.com/{REPOSITORY}/commit/") < 30
+    assert "The log is truncated to the newest" in details
+
+
+def test_initial_release_git_log_includes_package_root_commit(tmp_path: Path) -> None:
+    commits = _create_history(tmp_path)
+
+    details = _run_git_log_step(
+        tmp_path,
+        previous_tag="",
+        release_sha=commits["release"],
+    )
+
+    assert "<summary>Git log for initial release</summary>" in details
+    assert _entry(commits["baseline"], "feat(example): initial package") in details
+    assert _entry(commits["release"], "release(example): 1.0.1") in details
+
+
+def test_manual_release_includes_release_sha_tip(tmp_path: Path) -> None:
+    commits = _create_history(tmp_path)
+
+    details = _run_git_log_step(
+        tmp_path,
+        previous_tag="example==1.0.0",
+        release_sha=commits["fix"],
+    )
+
+    assert _entry(commits["fix"], "fix(example): correct feature") in details
+
+
+def test_git_log_reports_no_commits_for_empty_range(tmp_path: Path) -> None:
+    commits = _create_history(tmp_path)
+    # A tag on the release tip yields an empty PREV_TAG..RELEASE_SHA range.
+    _git(tmp_path, "tag", "example==2.0.0", commits["hotfix"])
+
+    details = _run_git_log_step(
+        tmp_path,
+        previous_tag="example==2.0.0",
+        release_sha=commits["hotfix"],
+    )
+
+    assert "No commits found." in details
+    assert "Git log unavailable" not in details
+
+
+def test_git_log_reports_failure_for_unresolvable_range(tmp_path: Path) -> None:
+    _create_history(tmp_path)
+
+    # An unresolvable previous tag makes `git log` fail. The step must surface the
+    # failure with a distinct message and still exit 0 (a swallowed error would be
+    # indistinguishable from a genuinely empty history).
+    details = _run_git_log_step(
+        tmp_path,
+        previous_tag="example==9.9.9",
+        release_sha=_git(tmp_path, "rev-parse", "HEAD"),
+    )
+
+    assert "Git log unavailable" in details
+    assert "No commits found." not in details
+
+
+def test_git_log_truncates_before_escaping_html(tmp_path: Path) -> None:
+    _create_history(tmp_path)
+    # Place a literal ampersand at index 199 so it is the last character kept by
+    # the 200-char truncation. Truncating before escaping keeps the entity intact
+    # ("&amp;"); escaping first would shift it past the limit and cut it mid-entity
+    # (leaving a bare "&" immediately before the ellipsis).
+    subject = "x" * 199 + "&" + "x" * 60
+    tip = _commit(tmp_path, PACKAGE_PATH / "module.py", "ORDER = 1\n", subject)
+
+    details = _run_git_log_step(
+        tmp_path,
+        previous_tag="example==1.0.0",
+        release_sha=tip,
+    )
+
+    assert "&amp;…" in details
+    assert "&…" not in details
+
+
+def test_finalize_release_body_drops_git_log_when_no_room(tmp_path: Path) -> None:
+    # Base body so large that neither the full log nor the compact notice fits;
+    # the step must fall back to the bare base body and stay under the byte cap.
+    base = "x" * 119_990
+    body = _run_finalize_release_body_step(
+        tmp_path,
+        base_release_body=base,
+        git_log_details="y" * 1_000,
+    ).release_body
+
+    assert body == base
+    assert len(body.encode()) <= 120_000
+    assert "Git log omitted because" not in body
+
+
+def test_finalize_release_body_flags_oversized_base_body(tmp_path: Path) -> None:
+    # When the base body alone exceeds the budget, nothing here can shrink it: the
+    # step must forward it unchanged, append no Git log, and warn about the *base
+    # body* rather than misattributing the size to the Git log.
+    base = "x" * 120_001
+    result = _run_finalize_release_body_step(
+        tmp_path,
+        base_release_body=base,
+        git_log_details="<details>Git log</details>",
+    )
+
+    assert result.release_body == base
+    assert "<details>Git log</details>" not in result.release_body
+    assert "Base release body" in result.stdout
+    assert "Full Git log omitted" not in result.stdout
+
+
+def test_prerelease_resolve_refs_uses_base_version_predecessor(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit(tmp_path, PACKAGE_PATH / "module.py", "V = 1\n", "feat(example): v1")
+    _git(tmp_path, "tag", "example==1.0.1")
+    head = _commit(tmp_path, PACKAGE_PATH / "module.py", "V = 2\n", "feat(example): v2")
+
+    # Every PEP 440 pre-release form must strip to the same base version, be
+    # detected as a pre-release, and use HEAD as the release commit.
+    for version in ("1.0.1a1", "1.0.1rc1", "1.0.1b2", "1.0.1.dev3", "1.0.1-rc.1"):
+        outputs = _run_resolve_refs_step(tmp_path, version=version).outputs
+        assert outputs["is-prerelease"] == "true", version
+        assert outputs["prev-tag"] == "example==1.0.1", version
+        assert outputs["release-commit"] == head, version
+
+
+def test_latest_stable_tag_selects_highest_reachable_version(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit(tmp_path, PACKAGE_PATH / "module.py", "V = 0\n", "feat(example): base")
+    _git(tmp_path, "tag", "example==1.0.0")
+    _commit(tmp_path, PACKAGE_PATH / "module.py", "V = 10\n", "fix(example): ten")
+    _git(tmp_path, "tag", "example==1.0.10")
+    # Tag 1.0.9 last so neither creation order nor lexical order matches version
+    # order; only a correct `--sort=-version:refname` picks 1.0.10 as the highest
+    # (a lexical sort would rank "1.0.9" above "1.0.10").
+    _commit(tmp_path, PACKAGE_PATH / "module.py", "V = 9\n", "fix(example): nine")
+    _git(tmp_path, "tag", "example==1.0.9")
+    # 2.0.0 is X.Y.0, so there is no computed predecessor tag and resolve-refs
+    # must fall back to the highest reachable stable tag.
+    _commit(
+        tmp_path,
+        PACKAGE_PATH / "CHANGELOG.md",
+        "## 2.0.0\n",
+        "release(example): 2.0.0",
+    )
+
+    result = _run_resolve_refs_step(tmp_path, version="2.0.0")
+
+    assert result.outputs["prev-tag"] == "example==1.0.10"
+    assert "No prior stable tag reachable" not in result.stdout
+
+
+@pytest.mark.parametrize("version", ["1.0.1", "1.1.0"])
+def test_resolve_refs_warns_when_stable_tag_exists_but_is_unreachable(
+    tmp_path: Path,
+    version: str,
+) -> None:
+    # The only stable tag lives on a divergent branch, so it is not reachable from
+    # the release commit on main. This is anomalous for both a patch (1.0.1) and a
+    # minor bump (1.1.0) — the warning must fire in both cases, not only when the
+    # patch component is non-zero.
+    _init_repo(tmp_path)
+    _commit(tmp_path, PACKAGE_PATH / "module.py", "BASE = 1\n", "feat(example): base")
+    _git(tmp_path, "checkout", "-b", "divergent")
+    _commit(tmp_path, PACKAGE_PATH / "module.py", "OLD = 1\n", "fix(example): old")
+    _git(tmp_path, "tag", "example==1.0.0")
+    _git(tmp_path, "checkout", "main")
+    _commit(tmp_path, PACKAGE_PATH / "module.py", "CUR = 1\n", "fix(example): current")
+    _commit(
+        tmp_path,
+        PACKAGE_PATH / "CHANGELOG.md",
+        f"## {version}\n",
+        f"release(example): {version}",
+    )
+
+    result = _run_resolve_refs_step(tmp_path, version=version)
+
+    assert result.outputs["prev-tag"] == ""
+    assert "No prior stable tag reachable" in result.stdout
+
+
+def test_resolve_refs_initial_release_has_no_predecessor_or_warning(
+    tmp_path: Path,
+) -> None:
+    # A genuine first release has no prior stable tag at all, so the empty
+    # predecessor is expected and the anomaly warning must stay silent.
+    _init_repo(tmp_path)
+    _commit(tmp_path, PACKAGE_PATH / "module.py", "BASE = 1\n", "feat(example): base")
+    _commit(
+        tmp_path,
+        PACKAGE_PATH / "CHANGELOG.md",
+        "## 1.0.0\n",
+        "release(example): 1.0.0",
+    )
+
+    result = _run_resolve_refs_step(tmp_path, version="1.0.0")
+
+    assert result.outputs["prev-tag"] == ""
+    assert "No prior stable tag reachable" not in result.stdout
+
+
+def test_git_log_includes_exactly_max_commits_without_truncation(
+    tmp_path: Path,
+) -> None:
+    # Exactly MAX_COMMITS (100) in-range package commits must yield 100 entries and
+    # no truncation banner — the boundary where the `--max-count=N+1` fetch and the
+    # `-ge`/`-gt` checks could hide an off-by-one.
+    _init_repo(tmp_path)
+    _commit(tmp_path, PACKAGE_PATH / "module.py", "BASE = 0\n", "feat(example): base")
+    _git(tmp_path, "tag", "example==1.0.0")
+    tip = ""
+    for index in range(100):
+        tip = _commit(
+            tmp_path,
+            PACKAGE_PATH / "module.py",
+            f"VALUE = {index}\n",
+            f"fix(example): generated {index}",
+        )
+
+    details = _run_git_log_step(
+        tmp_path,
+        previous_tag="example==1.0.0",
+        release_sha=tip,
+    )
+
+    assert details.count(f"https://github.com/{REPOSITORY}/commit/") == 100
+    assert "The log is truncated to the newest" not in details

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,10 +469,8 @@ jobs:
   #     has-memory-benchmarks: true
   #   secrets: inherit
 
-  # Validates every helper script under .github/scripts/test_*.py — currently
-  # `test_release_options.py` (release dropdown ↔ package directories) and
-  # `test_models.py` (eval matrix outputs ↔ evals.yml). Job id/name are kept
-  # for branch-protection compatibility; rename only with a coordinated PR.
+  # Validates every helper script under .github/scripts/test_*.py. Job id/name
+  # are kept for branch-protection compatibility; rename only with a coordinated PR.
   check-release-options:
     name: "Validate Release Options"
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,8 +410,8 @@ jobs:
             exit 1
           fi
 
-  # Generate release notes from CHANGELOG.md (with git log fallback)
-  # and collect contributor shoutouts from merged PRs
+  # Generate release notes from CHANGELOG.md, append the package commit history,
+  # and collect contributor shoutouts
   release-notes:
     name: 📝 Generate release notes
     needs:
@@ -424,7 +424,7 @@ jobs:
     env:
       WORKING_DIR: ${{ needs.setup.outputs.working-dir }}
     outputs:
-      release-body: ${{ steps.generate-release-body.outputs.release-body }}
+      release-body: ${{ steps.finalize-release-body.outputs.release-body }}
       tag: ${{ steps.check-tags.outputs.tag }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -448,6 +448,7 @@ jobs:
         id: resolve-refs
         env:
           PKG_NAME: ${{ needs.build.outputs.pkg-name }}
+          RELEASE_SHA: ${{ needs.setup.outputs.release-sha }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           # Detect PEP 440 pre-release versions:
@@ -459,7 +460,46 @@ jobs:
           fi
           echo "is-prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
 
-          # Determine previous tag
+          # Fail loudly if RELEASE_SHA does not resolve. The helpers below pass it
+          # to git as the second arg of `merge-base --is-ancestor` and to `git tag
+          # --merged`, where an unresolvable value exits 128 — indistinguishable
+          # from "no predecessor" — and would silently mislabel the Git log as an
+          # initial release. Verifying it once here rules that failure mode out.
+          if ! git rev-parse -q --verify "$RELEASE_SHA^{commit}" >/dev/null; then
+            echo "::error::RELEASE_SHA '$RELEASE_SHA' does not resolve to a commit"
+            exit 1
+          fi
+
+          valid_previous_tag() {
+            local tag="$1"
+            # merge-base --is-ancestor exits 1 for "not an ancestor" and 128 on
+            # error; both are treated as "invalid predecessor" and trigger the
+            # fallback below. Both arguments are known to resolve — the tag via the
+            # rev-parse --verify below, and RELEASE_SHA via the check above — so a
+            # non-zero exit reflects ancestry, not a bad ref, and the fallback is
+            # the safe response.
+            [ -n "$tag" ] \
+              && [ "$tag" != "$PKG_NAME==0.0.0" ] \
+              && git rev-parse -q --verify "refs/tags/$tag^{commit}" >/dev/null \
+              && git merge-base --is-ancestor "$tag" "$RELEASE_SHA"
+          }
+
+          latest_stable_tag() {
+            local tag
+            local tag_version
+            while IFS= read -r tag; do
+              [ "$tag" = "$PKG_NAME==$VERSION" ] && continue
+              tag_version="${tag#"$PKG_NAME=="}"
+              if [[ "$tag_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                printf '%s' "$tag"
+                return
+              fi
+            done < <(git tag --merged "$RELEASE_SHA" --sort=-version:refname \
+              --list "$PKG_NAME==*")
+          }
+
+          # Prefer the expected predecessor, then fall back to the highest stable
+          # package tag that is actually in the release commit's history.
           if [ "$IS_PRERELEASE" = "true" ]; then
             # Strip pre-release suffix to get base version (e.g. 0.5.2a1 -> 0.5.2)
             # Strip suffixes inside-out: dash first, then .dev, then a/b/rc
@@ -470,26 +510,30 @@ jobs:
               echo "::warning::BASE_VERSION '$BASE_VERSION' is not a clean X.Y.Z after stripping pre-release suffixes from '$VERSION'"
             fi
 
-            # Try exact base version tag first (e.g. deepagents==0.5.2)
-            PREV_TAG=$(git tag --sort=-creatordate | (grep -E "^${PKG_NAME}==${BASE_VERSION}$" || true) | head -1)
-            if [ -z "$PREV_TAG" ]; then
-              # Fall back to latest stable release tag
-              PREV_TAG=$(git tag --sort=-creatordate | (grep -E "^${PKG_NAME}==[0-9]+\.[0-9]+\.[0-9]+$" || true) | head -1)
-            fi
+            PREV_TAG="$PKG_NAME==$BASE_VERSION"
           else
             PREV_TAG="$PKG_NAME==${VERSION%.*}.$(( ${VERSION##*.} - 1 ))"
             [[ "${VERSION##*.}" -eq 0 ]] && PREV_TAG=""
-            if [ -z "$PREV_TAG" ]; then
-              PREV_TAG=$(git tag --sort=-creatordate | (grep -E "^${PKG_NAME}==[0-9]+\.[0-9]+\.[0-9]+$" || true) | head -1)
-            fi
           fi
 
-          # Validate prev tag exists
-          if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$PKG_NAME==0.0.0" ]; then
-            GIT_TAG_RESULT=$(git tag -l "$PREV_TAG")
-            [ -z "$GIT_TAG_RESULT" ] && PREV_TAG=""
-          else
-            PREV_TAG=""
+          if ! valid_previous_tag "$PREV_TAG"; then
+            PREV_TAG=$(latest_stable_tag)
+          fi
+
+          # A stable release with no reachable predecessor tag is anomalous unless
+          # this is genuinely the package's first release. Distinguish the two by
+          # whether any prior stable package tag exists at all: none means a true
+          # initial release (the log spanning full history is expected); some, but
+          # none reachable from the release commit, means the log would wrongly span
+          # the full history and be labeled an initial release — surface that. This
+          # covers minor/major bumps (X.Y.0), not just patches.
+          if [ -z "$PREV_TAG" ] && [ "$IS_PRERELEASE" != "true" ]; then
+            PRIOR_STABLE_TAGS=$(git tag --list "$PKG_NAME==*" \
+              | (grep -Ev "^${PKG_NAME}==${VERSION}$" || true) \
+              | (grep -E "^${PKG_NAME}==[0-9]+\.[0-9]+\.[0-9]+$" || true))
+            if [ -n "$PRIOR_STABLE_TAGS" ]; then
+              echo "::warning::No prior stable tag reachable from $RELEASE_SHA for $PKG_NAME==$VERSION; Git log will span the package's full history"
+            fi
           fi
 
           echo "Previous tag: $PREV_TAG"
@@ -513,6 +557,96 @@ jobs:
           fi
           echo "Release commit: $RELEASE_COMMIT"
           echo "release-commit=$RELEASE_COMMIT" >> "$GITHUB_OUTPUT"
+
+      - name: Generate package Git log
+        id: generate-git-log
+        env:
+          PREV_TAG: ${{ steps.resolve-refs.outputs.prev-tag }}
+          RELEASE_SHA: ${{ needs.setup.outputs.release-sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          RANGE="$RELEASE_SHA"
+          SUMMARY="Git log for initial release"
+          if [ -n "$PREV_TAG" ]; then
+            RANGE="$PREV_TAG..$RELEASE_SHA"
+            SUMMARY="Git log since $PREV_TAG"
+          fi
+
+          MAX_COMMITS=100
+          MAX_GIT_LOG_BYTES=25000
+          MAX_SUBJECT_LENGTH=200
+          COMMIT_COUNT=0
+          GIT_LOG_BYTES=0
+          TRUNCATED=false
+          GIT_LOG_FAILED=false
+          GIT_LOG=""
+
+          # Capture the SHAs first so a `git log` failure is caught here. A command
+          # inside a `< <(...)` process substitution is exempt from `set -e`, so its
+          # failure would otherwise be swallowed and mistaken for an empty history.
+          if ! COMMITS=$(git log --date-order --max-count=$((MAX_COMMITS + 1)) \
+            --format=%H "$RANGE" -- "$WORKING_DIR"); then
+            echo "::warning::git log failed for range '$RANGE'; the Git log section will note the failure"
+            GIT_LOG_FAILED=true
+            COMMITS=""
+          fi
+
+          while IFS= read -r SHA; do
+            if [ -z "$SHA" ]; then
+              continue
+            fi
+            SUBJECT=$(git show -s --format=%s "$SHA")
+
+            if [ "$COMMIT_COUNT" -ge "$MAX_COMMITS" ]; then
+              TRUNCATED=true
+              break
+            fi
+            if [ "${#SUBJECT}" -gt "$MAX_SUBJECT_LENGTH" ]; then
+              SUBJECT="${SUBJECT:0:$MAX_SUBJECT_LENGTH}…"
+            fi
+            SUBJECT=$(printf '%s' "$SUBJECT" \
+              | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
+
+            SHORT_SHA=$(git rev-parse --short=7 "$SHA")
+            ENTRY="- [\`$SHORT_SHA\`](https://github.com/$REPOSITORY/commit/$SHA) $SUBJECT"
+            ENTRY_BYTES=$(printf '%s' "$ENTRY" | wc -c | tr -d ' ')
+            SEPARATOR_BYTES=0
+            if [ -n "$GIT_LOG" ]; then
+              SEPARATOR_BYTES=1
+            fi
+            if [ $((GIT_LOG_BYTES + SEPARATOR_BYTES + ENTRY_BYTES)) \
+              -gt "$MAX_GIT_LOG_BYTES" ]; then
+              TRUNCATED=true
+              break
+            fi
+
+            if [ -z "$GIT_LOG" ]; then
+              GIT_LOG="$ENTRY"
+            else
+              GIT_LOG=$(printf "%s\n%s" "$GIT_LOG" "$ENTRY")
+            fi
+            GIT_LOG_BYTES=$((GIT_LOG_BYTES + SEPARATOR_BYTES + ENTRY_BYTES))
+            COMMIT_COUNT=$((COMMIT_COUNT + 1))
+          done <<< "$COMMITS"
+
+          if [ "$GIT_LOG_FAILED" = "true" ]; then
+            GIT_LOG="Git log unavailable: \`git log\` failed for range \`$RANGE\`."
+          elif [ -z "$GIT_LOG" ]; then
+            GIT_LOG="No commits found."
+          fi
+
+          DESCRIPTION="This commit history includes changes to this package. Commits are listed newest first."
+          if [ "$TRUNCATED" = "true" ]; then
+            DESCRIPTION="$DESCRIPTION The log is truncated to the newest $COMMIT_COUNT commits to keep the release notes a reasonable size."
+          fi
+          DETAILS=$(printf '<details>\n<summary>%s</summary>\n\n%s\n\n%s\n\n</details>' "$SUMMARY" "$DESCRIPTION" "$GIT_LOG")
+          {
+            echo 'details<<EOF'
+            echo "$DETAILS"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
 
       # Resolve the human who shipped this release so release notes can credit
       # them. Primary source is whoever merged the release PR (the release commit
@@ -594,9 +728,9 @@ jobs:
           CHANGELOG_PATH="$WORKING_DIR/CHANGELOG.md"
           RELEASE_BODY=""
 
-          # Try to extract current version's section from CHANGELOG.md
-          # (Pre-releases won't have a CHANGELOG entry and the git log fallback is
-          # also skipped for them — they get the banner + contributors only)
+          # Try to extract the current version's section from CHANGELOG.md. When
+          # there is no matching section, the package Git log appended below
+          # serves as the release notes instead.
           if [ -f "$CHANGELOG_PATH" ]; then
             echo "Found CHANGELOG.md, extracting version $VERSION section..."
 
@@ -618,23 +752,6 @@ jobs:
             fi
           else
             echo "No CHANGELOG.md found at $CHANGELOG_PATH"
-          fi
-
-          # Fallback to git log if CHANGELOG extraction failed
-          # (Skip for pre-releases — they get the banner + contributors only)
-          if [ -z "$RELEASE_BODY" ] && [ "$IS_PRERELEASE" != "true" ]; then
-            echo "Falling back to git log for release notes..."
-
-            FALLBACK_PREV="$PREV_TAG"
-            if [ -z "$FALLBACK_PREV" ]; then
-              PREAMBLE="Initial release"
-              FALLBACK_PREV=$(git rev-list --max-parents=0 "$RELEASE_COMMIT")
-            else
-              PREAMBLE="Changes since $FALLBACK_PREV"
-            fi
-
-            GIT_LOG=$(git log --format="%s" "$FALLBACK_PREV".."$RELEASE_COMMIT" -- "$WORKING_DIR")
-            RELEASE_BODY=$(printf "%s\n%s" "$PREAMBLE" "$GIT_LOG")
           fi
 
           # ── Collect contributors from merged PRs ──
@@ -815,6 +932,57 @@ jobs:
           fi
 
           # Output release body using heredoc for proper multiline handling
+          {
+            echo 'release-body<<EOF'
+            echo "$RELEASE_BODY"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Add package Git log to release body
+        id: finalize-release-body
+        env:
+          BASE_RELEASE_BODY: ${{ steps.generate-release-body.outputs.release-body }}
+          GIT_LOG_DETAILS: ${{ steps.generate-git-log.outputs.details }}
+        run: |
+          set -euo pipefail
+
+          # Keep the generated output below 120,000 bytes as a conservative margin
+          # beneath GitHub's 125,000-character release-body limit. Replace the log
+          # with a small notice when room is tight, or drop it entirely if even the
+          # notice would not fit.
+          MAX_RELEASE_BODY_BYTES=120000
+          BODY_BYTES=$(printf '%s' "$BASE_RELEASE_BODY" | wc -c | tr -d ' ')
+          DETAILS_BYTES=$(printf '%s' "$GIT_LOG_DETAILS" | wc -c | tr -d ' ')
+          RELEASE_BODY="$BASE_RELEASE_BODY"
+          SEPARATOR_BYTES=0
+          if [ -n "$BASE_RELEASE_BODY" ]; then
+            SEPARATOR_BYTES=2
+          fi
+          # The base body alone can exceed the budget (e.g. a very large CHANGELOG
+          # section). Nothing here can shrink it, so surface that accurately rather
+          # than blaming the Git log in the branch below, and append nothing —
+          # RELEASE_BODY stays as the base body initialized above.
+          if [ "$BODY_BYTES" -gt "$MAX_RELEASE_BODY_BYTES" ]; then
+            echo "::warning::Base release body ($BODY_BYTES bytes) already exceeds the ${MAX_RELEASE_BODY_BYTES}-byte budget before the Git log is added; GitHub may reject it"
+          elif [ $((BODY_BYTES + DETAILS_BYTES + SEPARATOR_BYTES)) -le "$MAX_RELEASE_BODY_BYTES" ]; then
+            if [ -n "$BASE_RELEASE_BODY" ]; then
+              RELEASE_BODY=$(printf "%s\n\n%s" "$BASE_RELEASE_BODY" "$GIT_LOG_DETAILS")
+            else
+              RELEASE_BODY="$GIT_LOG_DETAILS"
+            fi
+          else
+            echo "::warning::Full Git log omitted to keep the release body within GitHub's size limit"
+            COMPACT_DETAILS=$(printf '<details>\n<summary>Git log</summary>\n\nGit log omitted because the rest of these release notes is near GitHub'"'"'s size limit.\n\n</details>')
+            COMPACT_BYTES=$(printf '%s' "$COMPACT_DETAILS" | wc -c | tr -d ' ')
+            if [ $((BODY_BYTES + COMPACT_BYTES + SEPARATOR_BYTES)) -le "$MAX_RELEASE_BODY_BYTES" ]; then
+              if [ -n "$BASE_RELEASE_BODY" ]; then
+                RELEASE_BODY=$(printf "%s\n\n%s" "$BASE_RELEASE_BODY" "$COMPACT_DETAILS")
+              else
+                RELEASE_BODY="$COMPACT_DETAILS"
+              fi
+            fi
+          fi
+
           {
             echo 'release-body<<EOF'
             echo "$RELEASE_BODY"


### PR DESCRIPTION
GitHub release descriptions now include a collapsible, package-scoped commit history.

---

GitHub releases currently use package changelog entries when available. That leaves out commit-level package history.

This change appends a collapsible, package-scoped Git log to every release body. The log uses the latest stable package tag that is reachable from the release commit, so releases from version branches do not accidentally compare against a newer tag from another line. Initial and divergent histories are identified separately, and commit subjects, log length, and the final release body are bounded to stay within GitHub's limits.