### PR TITLE
chore(repo): update issue template areas

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -46,8 +46,7 @@ body:
       description: Which area of the repository does this issue relate to? Select at least one.
       options:
         - label: deepagents (SDK)
-        - label: cli
-        - label: code
+        - label: dcode
         - label: talon
         - label: acp
         - label: evals

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -43,8 +43,7 @@ body:
       description: Which area of the repository does this request relate to? Select at least one.
       options:
         - label: deepagents (SDK)
-        - label: cli
-        - label: code
+        - label: dcode
         - label: talon
         - label: acp
         - label: evals

--- a/.github/ISSUE_TEMPLATE/privileged.yml
+++ b/.github/ISSUE_TEMPLATE/privileged.yml
@@ -30,8 +30,7 @@ body:
         Please select area(s) that this issue is related to.
       options:
         - label: deepagents (SDK)
-        - label: cli
-        - label: code
+        - label: dcode
         - label: talon
         - label: acp
         - label: evals

--- a/.github/workflows/auto-label-by-package.yml
+++ b/.github/workflows/auto-label-by-package.yml
@@ -38,6 +38,7 @@ jobs:
               "cli": "cli",
               "acp": "acp",
               "code": "dcode",
+              "dcode": "dcode",
               "talon": "talon",
               "evals": "evals",
               "harbor": "harbor",


### PR DESCRIPTION
The standalone deployment CLI is no longer an issue-template area, while Deep Agents Code is presented to users as `dcode`. This updates all issue templates so reports and requests use the current area names.