### PR TITLE
feat(code): poll `.git/HEAD` so footer branch tracks external checkouts

### DIFF
--- a/libs/code/deepagents_code/_git.py
+++ b/libs/code/deepagents_code/_git.py
@@ -239,6 +239,33 @@ def resolve_git_branch(path: str | Path) -> str:
     return read_git_branch_via_subprocess(path)
 
 
+def read_git_head_stamp(path: str | Path) -> tuple[int, int] | None:
+    """Read a cheap change token for the repository's `HEAD` file.
+
+    Branch-name changes (`git checkout`, `git switch`) rewrite `.git/HEAD`, so
+    watching its modification time and size is enough to detect them without
+    re-parsing the file or shelling out to git on every poll. Git writes `HEAD`
+    atomically via a rename, which bumps the modification time even when the new
+    contents are the same length.
+
+    Args:
+        path: Directory or file path inside a repository.
+
+    Returns:
+        A `(mtime_ns, size)` token for the current `HEAD` file, or `None` when
+        `path` is not inside a repository or the file cannot be stat-ed.
+    """
+    git_dir = find_git_dir(path)
+    if git_dir is None:
+        return None
+    try:
+        stat = (git_dir / "HEAD").stat()
+    except OSError:
+        logger.debug("Failed to stat git HEAD in %s", git_dir, exc_info=True)
+        return None
+    return (stat.st_mtime_ns, stat.st_size)
+
+
 _GIT_SHA_RE = re.compile(r"\A[0-9a-f]{40}(?:[0-9a-f]{24})?\Z")
 """Matches a full 40-char SHA-1 (or 64-char SHA-256) git object id."""
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -50,6 +50,7 @@ from deepagents_code._constants import (
 from deepagents_code._git import (
     read_git_branch_from_filesystem,
     read_git_branch_via_subprocess,
+    read_git_head_stamp,
 )
 from deepagents_code._session_stats import (
     SessionStats,
@@ -393,6 +394,14 @@ state as the single app-wide progress indicator.
 
 _UPDATE_RECHECK_INTERVAL_SECONDS = 60 * 60
 """How often long-running TUI sessions quietly re-check for app updates."""
+
+_GIT_BRANCH_POLL_INTERVAL_SECONDS = 1.0
+"""How often to stat `.git/HEAD` so external branch switches update the footer.
+
+Event-driven refreshes (tool/shell/agent-turn completion) miss a `git checkout`
+made in another terminal while the session is idle. A once-a-second `stat` of a
+single file is negligible and only triggers a real refresh when `HEAD` changes.
+"""
 
 _MODAL_WATCHDOG_TIMEOUT_SECONDS = 600.0
 """Upper bound on awaiting a confirmation modal's dismissal.
@@ -2783,6 +2792,9 @@ class DeepAgentsApp(App):
         self._git_branch_refresh_task: asyncio.Task[None] | None = None
         """Latest background git-branch refresh task, if one is running."""
 
+        self._git_head_stamp: tuple[int, int] | None = None
+        """Last-seen `(mtime_ns, size)` of `.git/HEAD`, tracked by the poller."""
+
         self._graceful_exit_task: asyncio.Task[None] | None = None
         """Fire-and-forget task for deferred exit after agent worker cancellation."""
 
@@ -3228,6 +3240,7 @@ class DeepAgentsApp(App):
         """
         try:
             cwd = self._cwd
+            self._git_head_stamp = read_git_head_stamp(cwd)
             branch = read_git_branch_from_filesystem(cwd)
             if branch is None:
                 branch = await asyncio.to_thread(read_git_branch_via_subprocess, cwd)
@@ -3300,6 +3313,28 @@ class DeepAgentsApp(App):
 
         refresh_task.add_done_callback(_finalize_git_branch_refresh)
 
+    def _poll_git_head_for_changes(self) -> None:
+        """Refresh the footer when `.git/HEAD` changed since the last check.
+
+        Runs on a Textual `set_interval` so a `git checkout` made in another
+        terminal while the session is idle is reflected within the poll
+        interval, not only after the next tool/shell/agent-turn event. The
+        `stat`-based token keeps the idle case to a single sub-millisecond
+        syscall and defers the actual branch read to `_schedule_git_branch_refresh`
+        only when `HEAD` actually moved.
+        """
+        if self._exit:
+            return
+        try:
+            stamp = read_git_head_stamp(self._cwd)
+        except Exception:
+            logger.warning("Git HEAD poll failed", exc_info=True)
+            return
+        if stamp == self._git_head_stamp:
+            return
+        self._git_head_stamp = stamp
+        self._schedule_git_branch_refresh()
+
     async def _resolve_git_branch_and_continue(self) -> None:
         """Resolve git branch, then schedule remaining init workers.
 
@@ -3359,6 +3394,14 @@ class DeepAgentsApp(App):
         )
 
         self.run_worker(self._init_session_state, exclusive=True, group="session-init")
+
+        # Keep the footer branch fresh when HEAD changes outside a tool/shell
+        # event (e.g. a `git checkout` in another terminal). The tick only stats
+        # a single file; the branch read happens solely when HEAD moved.
+        self.set_interval(
+            _GIT_BRANCH_POLL_INTERVAL_SECONDS,
+            self._poll_git_head_for_changes,
+        )
 
         # Server startup (model creation + server process)
         if self._server_kwargs is not None and not self._server_startup_deferred:

--- a/libs/code/tests/unit_tests/test_git.py
+++ b/libs/code/tests/unit_tests/test_git.py
@@ -1,5 +1,6 @@
 """Unit tests for the deepagents_code._git module."""
 
+import os
 import subprocess
 from collections.abc import Iterator
 from pathlib import Path
@@ -20,6 +21,7 @@ from deepagents_code._git import (
     read_git_branch_via_subprocess,
     read_git_commit_sha_from_filesystem,
     read_git_commit_sha_via_subprocess,
+    read_git_head_stamp,
     read_git_remote_url_from_filesystem,
     read_git_remote_url_via_subprocess,
     resolve_git_branch,
@@ -217,6 +219,40 @@ class TestReadGitBranchFromFilesystem:
 
     def test_read_not_in_repo(self, tmp_path: Path) -> None:
         assert read_git_branch_from_filesystem(tmp_path) == ""
+
+
+class TestReadGitHeadStamp:
+    def test_stamp_for_named_branch(self, tmp_path: Path) -> None:
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+
+        stamp = read_git_head_stamp(tmp_path)
+        assert stamp is not None
+        assert len(stamp) == 2
+
+    def test_stamp_changes_after_checkout(self, tmp_path: Path) -> None:
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        head_file = git_dir / "HEAD"
+        head_file.write_text("ref: refs/heads/main\n")
+        before = read_git_head_stamp(tmp_path)
+
+        # Simulate a checkout: rewrite HEAD with a bumped mtime.
+        head_file.write_text("ref: refs/heads/feature-branch\n")
+        stat = head_file.stat()
+        os.utime(head_file, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+
+        assert read_git_head_stamp(tmp_path) != before
+
+    def test_stamp_missing_head(self, tmp_path: Path) -> None:
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+
+        assert read_git_head_stamp(tmp_path) is None
+
+    def test_stamp_not_in_repo(self, tmp_path: Path) -> None:
+        assert read_git_head_stamp(tmp_path) is None
 
 
 class TestReadGitBranchViaSubprocess:


### PR DESCRIPTION
The `deepagents-code` status-bar branch now updates automatically after a `git checkout`/`git switch` run outside the session (e.g. in another terminal), within about a second, instead of only after the next tool or agent activity.

---

Today the status-bar branch is refreshed only on discrete events — startup, tool completion, shell-command exit, and agent-turn end. A `git checkout`/`git switch` made in another terminal while the session is idle therefore isn't reflected until the next such event, which is where the perceived staleness comes from. There is no periodic timer or filesystem watcher on `HEAD`.

This adds a lightweight poll that mirrors the approach used by other harnesses, but stays dependency-free: a once-a-second Textual `set_interval` calls `read_git_head_stamp`, which `stat`s the resolved `.git/HEAD` and returns a cheap `(mtime_ns, size)` token. The actual branch read (`_schedule_git_branch_refresh`) only runs when that token changes, so the idle path is a single sub-millisecond syscall. Git rewrites `HEAD` atomically via rename on checkout, so the mtime always moves.

This is intentionally the pragmatic POC: a true native fs-watcher (e.g. `watchdog`) would be event-driven with no interval, but pulls in a dependency and platform quirks (atomic-rename inode churn, WSL/`/mnt` inotify gaps that still need a stat fallback). The 1s stat poll gets ~all the benefit here.

Made by [Open SWE](https://openswe.vercel.app/agents/48fb1415-9a32-1c28-8a4a-6d67db8a713e)