### PR TITLE
hotfix(code): restore `Shift+Tab` in debug console

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1937,6 +1937,11 @@ class DeepAgentsApp(App):
         Binding("ctrl+d", "quit_app", "Quit", show=False, priority=True),
         Binding("ctrl+t", "toggle_auto_approve", "Toggle Auto-Approve", show=False),
         Binding("ctrl+g", "toggle_subagent_panel", "Toggle Subagents", show=False),
+        # `check_action` steps this binding aside (returns `False`) while a
+        # `DebugConsoleScreen` is active so the console's own `shift+tab`
+        # reverse-focus traversal runs instead; keep the action name in sync
+        # there. That branch keys on the `toggle_auto_approve` action, so it also
+        # steps aside the `ctrl+t` binding above while the console is open.
         Binding(
             "shift+tab",
             "toggle_auto_approve",
@@ -14405,26 +14410,42 @@ class DeepAgentsApp(App):
         action: str,
         parameters: tuple[object, ...],  # noqa: ARG002  # Textual override signature
     ) -> bool | None:
-        """Disable `open_notifications` while the model selector is open.
+        """Step aside priority app bindings that the active screen needs.
 
-        Textual resolves `priority=True` bindings App-first, so the App's
-        `ctrl+n -> open_notifications` binding (see `BINDINGS`) would otherwise
-        win over `ModelSelectorScreen`'s own priority `ctrl+n -> toggle_names`.
-        Returning `False` here disables the App's binding for this dispatch, so
-        resolution falls through to the selector, whose binding then runs.
+        Textual resolves `priority=True` bindings App-first, so these app actions
+        would otherwise consume the key before the active screen sees it.
+        Returning `False` disables the app binding for this dispatch so the key
+        reverts to the active screen's own handling. Depending on the screen that
+        is either a competing screen binding or default key handling:
 
-        Branches on the action name, not the key, so it stays correct if
-        `ctrl+n` is ever rebound.
+        - `open_notifications` (`ctrl+n`): `ModelSelectorScreen` has its own
+          priority `ctrl+n -> toggle_names` binding that then wins.
+        - `toggle_auto_approve` (`shift+tab`): `DebugConsoleScreen` has no
+          binding for the key; stepping aside lets it fall through to the
+          console's `key_shift_tab` reverse-focus traversal. Without this the
+          binding fires `action_toggle_auto_approve`, which no-ops under any
+          `ModalScreen`, so the key would be silently swallowed. Note this keys
+          on the action, and `toggle_auto_approve` is also bound to `ctrl+t`, so
+          that (harmless, already a no-op under modals) binding is stepped aside
+          too while the console is open.
+
+        Branches on action names, not keys, so this stays correct if a binding is
+        ever rebound.
 
         Returns:
-            `False` to disable `open_notifications` while a `ModelSelectorScreen`
-                is active, letting the selector handle Ctrl+N; `True` otherwise,
-                leaving the binding enabled.
+            `False` to disable the app binding for this dispatch (letting the
+                active screen or default key handling take the key); `True` to
+                leave it enabled.
         """
         if action == "open_notifications":
             from deepagents_code.tui.widgets.model_selector import ModelSelectorScreen
 
             if isinstance(self.screen, ModelSelectorScreen):
+                return False
+        if action == "toggle_auto_approve":
+            from deepagents_code.tui.widgets.debug_console import DebugConsoleScreen
+
+            if isinstance(self.screen, DebugConsoleScreen):
                 return False
         return True
 

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -724,6 +724,38 @@ class TestDebugConsoleToggle:
             await pilot.pause()
             assert not isinstance(app.screen, DebugConsoleScreen)
 
+    async def test_shift_tab_reverses_focus_despite_app_toggle_binding(
+        self,
+    ) -> None:
+        """Shift+Tab reverses console focus instead of toggling auto-approve.
+
+        Must drive the real `DeepAgentsApp` (not `_Harness`): the App defines a
+        priority `shift+tab -> toggle_auto_approve` binding that would otherwise
+        consume the key App-first. This guards the `check_action` step-aside that
+        lets the console's own reverse-focus traversal run; a `_Harness`-based
+        test has no such binding and would pass regardless of that logic.
+        """
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+backslash")
+            await pilot.pause()
+            screen = cast("DebugConsoleScreen", app.screen)
+            log = screen.query_one("#debug-log", _DebugLogView)
+            select = screen.query_one("#debug-level-filter", Select)
+            assert screen.focused is log
+            assert app._auto_approve is False
+
+            await pilot.press("tab")
+            await pilot.pause()
+            assert screen.focused is select
+
+            await pilot.press("shift+tab")
+            await pilot.pause()
+            assert screen.focused is log
+            # Shift+Tab navigated; it must not have fired the auto-approve toggle.
+            assert app._auto_approve is False
+
     async def test_toggle_action_closes_open_console(self) -> None:
         app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
         async with app.run_test() as pilot:


### PR DESCRIPTION
`Shift+Tab` now moves focus backward in the in-app Debug Console instead of being ignored.

---

Inside the Debug Console, the app-level priority `Shift+Tab` binding intercepted the key before the modal's reverse-focus handler could run. As a result, `Tab` moved focus forward, but `Shift+Tab` appeared to do nothing.

This lets the app binding step aside while `DebugConsoleScreen` is active, allowing the console's existing reverse traversal to handle the key. The integration coverage uses the real `DeepAgentsApp` so the priority-binding conflict remains tested.
