### PR TITLE
ci(infra): make CodSpeed benchmarks advisory

### DIFF
--- a/.github/workflows/_benchmark.yml
+++ b/.github/workflows/_benchmark.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      advisory:
+        description: "Whether benchmark failures should be non-blocking"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -35,6 +40,7 @@ jobs:
   benchmark:
     name: "CodSpeed"
     runs-on: codspeed-macro
+    continue-on-error: ${{ inputs.advisory }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,7 +440,7 @@ jobs:
           echo "$STATUS"
           echo "$STATUS" | grep 'nothing to commit, working tree clean'
 
-  # Run CodSpeed benchmarks on SDK changes
+  # Run advisory CodSpeed benchmarks on SDK changes
   benchmark-deepagents:
     name: "⏱️ Benchmark deepagents"
     needs: changes
@@ -448,9 +448,10 @@ jobs:
     uses: ./.github/workflows/_benchmark.yml
     with:
       working-directory: "libs/deepagents"
+      advisory: true
     secrets: inherit
 
-  # Run CodSpeed benchmarks on code changes
+  # Run advisory CodSpeed benchmarks on code changes
   benchmark-code:
     name: "⏱️ Benchmark code"
     needs: changes
@@ -458,6 +459,7 @@ jobs:
     uses: ./.github/workflows/_benchmark.yml
     with:
       working-directory: "libs/code"
+      advisory: true
     secrets: inherit
 
   # # TODO(hntrl): re-enable when bench flakiness is under control
@@ -469,6 +471,7 @@ jobs:
   #   with:
   #     working-directory: "libs/partners/quickjs"
   #     has-memory-benchmarks: true
+  #     advisory: true
   #   secrets: inherit
 
   # Validates every helper script under .github/scripts/test_*.py. Job id/name


### PR DESCRIPTION
CodSpeed jobs are intentionally excluded from the required `✅ CI Success` aggregation, but a benchmark failure still marks the overall CI workflow as failed.

This makes the regular CI callers opt into advisory benchmark failures while preserving CodSpeed instrumentation and reporting. The reusable workflow remains strict by default, so scheduled nightly benchmarks continue to surface failures.
