### PR TITLE
ci(infra): run CodSpeed benchmarks nightly only

### DIFF
--- a/.github/workflows/_benchmark.yml
+++ b/.github/workflows/_benchmark.yml
@@ -24,11 +24,6 @@ on:
         required: false
         type: boolean
         default: false
-      advisory:
-        description: "Whether benchmark failures should be non-blocking"
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -40,7 +35,6 @@ jobs:
   benchmark:
     name: "CodSpeed"
     runs-on: codspeed-macro
-    continue-on-error: ${{ inputs.advisory }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ concurrency:
 
 permissions:
   contents: read
-  # Required for CodSpeed OIDC authentication in _benchmark.yml
-  id-token: write
 
 env:
   UV_NO_SYNC: "true"
@@ -77,14 +75,12 @@ jobs:
               - '.github/workflows/ci.yml'
               - '.github/workflows/_lint.yml'
               - '.github/workflows/_test.yml'
-              - '.github/workflows/_benchmark.yml'
               - '.github/actions/**'
             code:
               - 'libs/code/**'
               - '.github/workflows/ci.yml'
               - '.github/workflows/_lint.yml'
               - '.github/workflows/_test.yml'
-              - '.github/workflows/_benchmark.yml'
               - '.github/actions/**'
             talon:
               - 'libs/talon/**'
@@ -147,7 +143,6 @@ jobs:
               - '.github/workflows/ci.yml'
               - '.github/workflows/_lint.yml'
               - '.github/workflows/_test.yml'
-              - '.github/workflows/_benchmark.yml'
               - '.github/actions/**'
   # Run linting on changed packages
   lint-deepagents:
@@ -439,40 +434,6 @@ jobs:
           STATUS="$(git status)"
           echo "$STATUS"
           echo "$STATUS" | grep 'nothing to commit, working tree clean'
-
-  # Run advisory CodSpeed benchmarks on SDK changes
-  benchmark-deepagents:
-    name: "⏱️ Benchmark deepagents"
-    needs: changes
-    if: needs.changes.outputs.deepagents == 'true' || github.event_name == 'push'
-    uses: ./.github/workflows/_benchmark.yml
-    with:
-      working-directory: "libs/deepagents"
-      advisory: true
-    secrets: inherit
-
-  # Run advisory CodSpeed benchmarks on code changes
-  benchmark-code:
-    name: "⏱️ Benchmark code"
-    needs: changes
-    if: needs.changes.outputs.code == 'true' || github.event_name == 'push'
-    uses: ./.github/workflows/_benchmark.yml
-    with:
-      working-directory: "libs/code"
-      advisory: true
-    secrets: inherit
-
-  # # TODO(hntrl): re-enable when bench flakiness is under control
-  # benchmark-quickjs:
-  #   name: "⏱️ Benchmark quickjs"
-  #   needs: changes
-  #   if: needs.changes.outputs.quickjs == 'true' || github.event_name == 'push'
-  #   uses: ./.github/workflows/_benchmark.yml
-  #   with:
-  #     working-directory: "libs/partners/quickjs"
-  #     has-memory-benchmarks: true
-  #     advisory: true
-  #   secrets: inherit
 
   # Validates every helper script under .github/scripts/test_*.py. Job id/name
   # are kept for branch-protection compatibility; rename only with a coordinated PR.


### PR DESCRIPTION
Following #4686

---

CodSpeed reports exhausted macro-runner budgets through a separate GitHub App check before the Actions job starts. Marking the job with `continue-on-error` therefore cannot make that check advisory: pull requests still show `CodSpeed Macro Runners — Macro Runners budget exceeded`, and the benchmark jobs remain queued.

Run macro benchmarks only from the scheduled or manually dispatched nightly workflow. This preserves strict wall-time measurements on CodSpeed's dedicated runners while removing macro-runner requests from pull request and normal push CI.

This trades per-PR macro reports for predictable runner usage and post-merge nightly regression detection.
