### PR TITLE
feat(code): improve `/goal` clarity

### DIFF
--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -23,7 +23,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/effort` |  | Set reasoning effort for the current model |
 | `/feedback` |  | Send feedback or report an issue |
 | `/force-clear` |  | Stop active work, clear the chat, and start a new thread |
-| `/goal` |  | Set a persistent objective by drafting acceptance criteria |
+| `/goal` |  | Turn an outcome into acceptance criteria and pursue it |
 | `/help` |  | Show help and available commands |
 | `/install` |  | Install an optional integration |
 | `/mcp` |  | Manage MCP servers and authentication |
@@ -34,7 +34,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/reload` |  | Reload environment and config |
 | `/remember` |  | Save useful context to memory or skills |
 | `/restart` |  | Restart the agent server |
-| `/rubric` | `/criteria` | Set explicit acceptance criteria for rubric grading |
+| `/rubric` | `/criteria` | Use acceptance criteria you already have |
 | `/scrollbar` |  | Show or hide the chat scrollbar |
 | `/skill-creator` |  | Create or refine agent skills |
 | `/theme` |  | Change color theme |

--- a/libs/code/deepagents_code/_constants.py
+++ b/libs/code/deepagents_code/_constants.py
@@ -13,6 +13,8 @@ from typing import Final
 DEFAULT_AGENT_NAME: Final[str] = "agent"
 """Default agent / assistant identifier when no `-a` flag is given."""
 
+DEFAULT_RUBRIC_MAX_ITERATIONS: Final[int] = 3
+
 FIREWORKS_PROVIDER_ID_PREFIX: Final[str] = "accounts/fireworks/"
 """Prefix used to infer Fireworks from fully-qualified IDs."""
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -46,6 +46,7 @@ from deepagents_code import (
 from deepagents_code._cli_context import CLIContext
 from deepagents_code._constants import (
     DEFAULT_AGENT_NAME as DEFAULT_ASSISTANT_ID,
+    DEFAULT_RUBRIC_MAX_ITERATIONS,
     MCP_REENABLED_PENDING_ERROR,
     SYSTEM_MESSAGE_PREFIX,
 )
@@ -1989,7 +1990,7 @@ class DeepAgentsApp(App):
             priority=True,
         ),
         Binding("ctrl+d", "quit_app", "Quit", show=False, priority=True),
-        Binding("ctrl+t", "toggle_auto_approve", "Toggle Auto-Approve", show=False),
+        Binding("ctrl+t", "toggle_auto_approve", "Toggle Unrestricted", show=False),
         Binding("ctrl+g", "toggle_subagent_panel", "Toggle Subagents", show=False),
         # `check_action` steps this binding aside (returns `False`) while a
         # `DebugConsoleScreen` is active so the console's own `shift+tab`
@@ -1999,7 +2000,7 @@ class DeepAgentsApp(App):
         Binding(
             "shift+tab",
             "toggle_auto_approve",
-            "Toggle Auto-Approve",
+            "Toggle Unrestricted",
             show=False,
             priority=True,
         ),
@@ -2045,8 +2046,8 @@ class DeepAgentsApp(App):
         Binding("enter", "approval_select", "Select", show=False),
         Binding("y", "approval_yes", "Yes", show=False),
         Binding("1", "approval_yes", "Yes", show=False),
-        Binding("2", "approval_auto", "Auto", show=False),
-        Binding("a", "approval_auto", "Auto", show=False),
+        Binding("2", "approval_auto", "Unrestricted", show=False),
+        Binding("a", "approval_auto", "Unrestricted", show=False),
         Binding("3", "approval_no", "No", show=False),
         Binding("n", "approval_no", "No", show=False),
     ]
@@ -6638,7 +6639,7 @@ class DeepAgentsApp(App):
             self._session_state.auto_approve = True
             if not await self._write_live_approval_mode():
                 self._warn_live_approval_mode_unavailable(
-                    "Auto-approve could not sync to the running agent; "
+                    "Unrestricted permissions could not sync to the running agent; "
                     "approval prompts may continue."
                 )
 
@@ -8845,6 +8846,18 @@ class DeepAgentsApp(App):
             text = f"{text}\n\n{note}"
         await self._mount_message(AppMessage(text))
 
+    async def _clear_completed_goal(self) -> None:
+        """Remove a completed goal so later turns are not evaluated against it."""
+        self._clear_all_goal_rubric_state()
+        self._sync_status_rubric()
+        if not await self._persist_goal_rubric_state():
+            await self._mount_message(
+                ErrorMessage(
+                    "The goal completed for this session, but its saved state could "
+                    "not be cleared from the thread."
+                )
+            )
+
     async def _commit_pending_goal_completion(
         self,
         note: str,
@@ -8856,21 +8869,68 @@ class DeepAgentsApp(App):
         self._goal_status_note = note
         self._pending_goal_completion_note = None
         self._sync_status_rubric()
-        persisted = await self._persist_goal_rubric_state()
         await self._announce_goal_status_transition(previous_status)
-        if not persisted:
-            await self._mount_message(
-                ErrorMessage(
-                    "Goal marked complete for this session, but it could not "
-                    "be saved to the thread."
-                )
-            )
+        await self._clear_completed_goal()
 
     async def _clear_pending_goal_completion(self, message: str) -> None:
         """Clear a completion request that did not become complete."""
         self._pending_goal_completion_note = None
         persisted = await self._persist_goal_rubric_state()
         await self._mount_goal_rubric_result(message, persisted=persisted)
+
+    @staticmethod
+    def _remaining_unmet_criteria(
+        state_values: dict[str, Any],
+    ) -> list[tuple[str, str | None]]:
+        """Return failed criteria from the latest exhausted grading evaluation."""
+        evaluations = state_values.get("_rubric_evaluations")
+        if not isinstance(evaluations, list):
+            return []
+        for evaluation in reversed(evaluations):
+            if not isinstance(evaluation, dict):
+                continue
+            if evaluation.get("result") != "max_iterations_reached":
+                continue
+            criteria = evaluation.get("criteria")
+            if not isinstance(criteria, list):
+                return []
+            remaining: list[tuple[str, str | None]] = []
+            for criterion in criteria:
+                if (
+                    not isinstance(criterion, dict)
+                    or criterion.get("passed") is not False
+                ):
+                    continue
+                name = str(criterion.get("name") or "Unnamed criterion")
+                gap_value = criterion.get("gap")
+                gap = str(gap_value).strip() if gap_value is not None else ""
+                remaining.append((name, gap or None))
+            return remaining
+        return []
+
+    async def _announce_goal_iteration_exhaustion(
+        self,
+        state_values: dict[str, Any],
+    ) -> None:
+        """Explain how to continue after automatic goal iteration is exhausted."""
+        if not self._active_goal:
+            return
+        parts: list[str | Content] = [
+            (
+                "Automatic iteration stopped because the grading iteration limit "
+                "was reached. The goal remains active."
+            )
+        ]
+        remaining = self._remaining_unmet_criteria(state_values)
+        if remaining:
+            parts.append("\n\nRemaining unmet criteria:")
+            for name, gap in remaining:
+                parts.append(f"\n- {name}" + (f": {gap}" if gap else ""))
+        parts.append(
+            "\n\nSend a follow-up to retry or resume, use `/goal <revised objective>` "
+            "to amend or replace it, or `/goal clear`."
+        )
+        await self._mount_message(AppMessage(Content.assemble(*parts)))
 
     async def _resolve_pending_goal_completion(
         self,
@@ -9033,6 +9093,10 @@ class DeepAgentsApp(App):
         )
         if not completion_committed:
             await self._announce_goal_status_transition(previous_status)
+            if self._goal_status == "complete":
+                await self._clear_completed_goal()
+        if payload.rubric_status == "max_iterations_reached":
+            await self._announce_goal_iteration_exhaustion(state_values)
         if one_shot_rubric_consumed:
             await self._persist_goal_rubric_state()
         await self._remount_pending_goal_rubric_review()
@@ -9090,6 +9154,14 @@ class DeepAgentsApp(App):
             return
         await self._set_rubric_max_iterations(value)
 
+    def _grader_iteration_limit_display(self) -> str:
+        """Return the known iteration limit or an honest server-default label."""
+        if self._rubric_max_iterations is not None:
+            return str(self._rubric_max_iterations)
+        if self._server_kwargs is None and self._remote_agent() is not None:
+            return "server default"
+        return f"{DEFAULT_RUBRIC_MAX_ITERATIONS} (default)"
+
     def _grader_display_values(self) -> tuple[str, str]:
         """Return display strings for the shared grader model and iteration cap.
 
@@ -9097,12 +9169,7 @@ class DeepAgentsApp(App):
         `/goal show` and `/rubric show` so the default wording stays in sync.
         """
         model = self._rubric_model or "current chat model"
-        iterations = (
-            str(self._rubric_max_iterations)
-            if self._rubric_max_iterations is not None
-            else "SDK default"
-        )
-        return model, iterations
+        return model, self._grader_iteration_limit_display()
 
     async def _handle_goal_command(self, command: str) -> None:
         """Handle `/goal` as a user-approved rubric proposal workflow."""
@@ -9148,9 +9215,23 @@ class DeepAgentsApp(App):
 
         if subcommand == "clear":
             await self._mount_message(UserMessage(command))
+            has_goal_state = bool(
+                self._active_goal
+                or self._goal_status
+                or self._goal_status_note
+                or self._pending_goal_completion_note
+                or self._pending_goal_objective
+                or self._pending_goal_rubric
+            )
+            if not has_goal_state:
+                await self._mount_message(AppMessage("No active goal to clear."))
+                return
             self._cancel_goal_proposal_worker()
             await self._cancel_pending_goal_review(context="goal-clear cleanup")
-            self._clear_all_goal_rubric_state()
+            if self._active_goal:
+                self._clear_all_goal_rubric_state()
+            else:
+                self._reset_goal_tracking()
             self._sync_status_rubric()
             persisted = await self._persist_goal_rubric_state()
             await self._mount_goal_rubric_result("Goal cleared.", persisted=persisted)
@@ -9179,8 +9260,8 @@ class DeepAgentsApp(App):
             "  /goal max-iterations <N|clear>\n\n"
             "Use /goal when you have a plain-language objective; dcode will "
             "draft a checklist and ask before applying it. Once accepted, the "
-            "goal stays active for this thread until completed, blocked, or "
-            "cleared. Follow-up prompts continue working toward that goal."
+            "goal remains active across follow-up turns until it is completed, "
+            "blocked, paused, replaced, or cleared."
         )
 
     async def _show_goal_state(self) -> None:
@@ -9212,9 +9293,8 @@ class DeepAgentsApp(App):
             )
             if self._active_goal and self._goal_status == "active":
                 lines.append(
-                    "Goal is active for this thread until completed, blocked, or "
-                    "cleared.\nFollow-up prompts will continue working toward this "
-                    "goal."
+                    "Goal remains active across follow-up turns until it is "
+                    "completed, blocked, paused, replaced, or cleared."
                 )
             lines.append(
                 "Commands:\n/goal clear\n/goal show\n"
@@ -9363,6 +9443,10 @@ class DeepAgentsApp(App):
             if result["type"] == "accepted":
                 await self._accept_goal_rubric(self._pending_goal_rubric or "")
                 return
+            if result["type"] == "accepted_unrestricted":
+                await self._on_auto_approve_enabled()
+                await self._accept_goal_rubric(self._pending_goal_rubric or "")
+                return
             if result["type"] == "edited":
                 await self._accept_goal_rubric(result["criteria"])
                 return
@@ -9433,11 +9517,13 @@ class DeepAgentsApp(App):
         self._pending_goal_rubric = None
         self._sync_status_rubric()
         persisted = await self._persist_goal_rubric_state()
+        iteration_limit = self._grader_iteration_limit_display()
         await self._mount_message(
             AppMessage(
-                "Goal accepted. It will stay active for this thread until completed, "
-                "blocked, or cleared.\nUse /goal show to inspect it or /goal clear "
-                "to remove it."
+                f"Goal accepted · grading iteration limit: {iteration_limit}.\n"
+                "It remains active across follow-up turns until it is completed, "
+                "blocked, paused, replaced, or cleared.\n"
+                "Use /goal to inspect it."
             )
         )
         if not persisted:
@@ -9462,6 +9548,8 @@ class DeepAgentsApp(App):
             self._status_bar.set_rubric_label(f"{glyphs.checkmark} Goal complete")
         elif self._active_goal and self._goal_status == "blocked":
             self._status_bar.set_rubric_label(f"{glyphs.warning} Goal blocked")
+        elif self._active_goal:
+            self._status_bar.set_rubric_label(f"{glyphs.checkmark} Goal active")
         elif self._next_rubric:
             self._status_bar.set_rubric_label(f"{glyphs.checkmark} Rubric: next turn")
         elif self._active_rubric:
@@ -9950,7 +10038,7 @@ class DeepAgentsApp(App):
                 "  Ctrl+X          Open prompt in external editor\n"
                 "  Ctrl+N          Review pending notifications\n"
                 "  Ctrl+\\          Toggle the debug console\n"
-                "  Shift+Tab       Toggle auto-approve mode\n"
+                "  Shift+Tab       Toggle unrestricted permissions\n"
                 "  @filename       Auto-complete files and inject content\n"
                 "  /command        Slash commands (/help, /clear, /quit)\n"
                 "  !command        Run shell commands directly\n"
@@ -10939,29 +11027,10 @@ class DeepAgentsApp(App):
                 else None
             )
 
-            # `_reset_blocked_goal_for_user_turn` flips a blocked goal to active
-            # just above, so the status alone can't distinguish an already-active
-            # goal from one resumed this turn. Branch the wording on the reset
-            # signal instead. The status guard still holds: a failed reset rolls
-            # the status back to blocked, so no notice fires in that case.
-            #
-            # The `message != _active_goal` check suppresses the notice on the
-            # goal-setting turn, and works only because acceptance sends the
-            # objective verbatim as the message. If a future change wraps or
-            # annotates the objective before sending (as the skill path already
-            # does with its envelope prompt), the equality would no longer match
-            # and the notice would wrongly fire on the initial turn.
-            if (
-                self._active_goal
-                and self._goal_status == "active"
-                and message.strip() != self._active_goal.strip()
-            ):
-                notice = (
-                    f"Resuming previously blocked goal: {self._active_goal}"
-                    if resuming_blocked
-                    else f"Continuing active goal: {self._active_goal}"
+            if resuming_blocked and self._active_goal:
+                await self._mount_message(
+                    AppMessage(f"Resuming previously blocked goal: {self._active_goal}")
                 )
-                await self._mount_message(AppMessage(notice))
 
             if self._chat_input:
                 self._chat_input.set_cursor_active(active=False)
@@ -11250,10 +11319,11 @@ class DeepAgentsApp(App):
             spec = self._effective_model_spec()
             panel.prepare_turn(model_label=_display_model_label(spec))
 
-        rubric = self._next_rubric or self._active_rubric
+        active_rubric = None if self._goal_status == "complete" else self._active_rubric
+        rubric = self._next_rubric or active_rubric
         if self._next_rubric is not None:
             self._last_consumed_next_rubric = self._next_rubric
-            self._last_consumed_next_previous_rubric = self._active_rubric
+            self._last_consumed_next_previous_rubric = active_rubric
             await self._persist_goal_rubric_state()
             self._next_rubric = None
             self._sync_status_rubric()
@@ -11752,6 +11822,8 @@ class DeepAgentsApp(App):
                 else await self._fetch_thread_history_data(history_thread_id)
             )
             self._restore_goal_rubric_state(payload)
+            if self._goal_status == "complete":
+                await self._clear_completed_goal()
 
             # Adopt the resumed thread's model (session-only) so the session
             # continues on the model it was last using, not the global default.
@@ -13276,7 +13348,7 @@ class DeepAgentsApp(App):
             if not await self._write_live_approval_mode():
                 if self._auto_approve:
                     self._warn_live_approval_mode_unavailable(
-                        "Auto-approve could not sync to the running agent; "
+                        "Unrestricted permissions could not sync to the running agent; "
                         "approval prompts may continue."
                     )
                 elif self._agent_running:
@@ -14797,7 +14869,10 @@ class DeepAgentsApp(App):
             _safe("Model", lambda: self._effective_model_spec() or "(not configured)"),
             _safe("Thread", lambda: self._lc_thread_id or "(none)"),
             _safe("CWD", lambda: self._cwd),
-            _safe("Auto-approve", lambda: "on" if self._auto_approve else "off"),
+            _safe(
+                "Permissions",
+                lambda: "unrestricted" if self._auto_approve else "manual",
+            ),
             _safe("Sandbox", lambda: self._sandbox_type or "local"),
             _safe("MCP servers", _mcp),
             _safe("Tokens", _tokens),

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -746,8 +746,19 @@ def _process_rubric_event(
                 console.print(f"[yellow]  ✗ {name}{detail}[/yellow]", highlight=False)
     elif result == "max_iterations_reached":
         console.print(
-            "[yellow]⚠ Acceptance criteria not satisfied "
-            "(iteration limit reached)[/yellow]",
+            "[yellow]⚠ Automatic iteration stopped: acceptance criteria remain "
+            "unmet (iteration limit reached)[/yellow]",
+            highlight=False,
+        )
+        for criterion in data.get("criteria", []):
+            if isinstance(criterion, dict) and criterion.get("passed") is False:
+                name = escape_markup(str(criterion.get("name", "criterion")))
+                gap = escape_markup(str(criterion.get("gap", "")).strip())
+                detail = f" — {gap}" if gap else ""
+                console.print(f"[yellow]  ✗ {name}{detail}[/yellow]", highlight=False)
+        console.print(
+            "[dim]Retry with another message, amend the goal or rubric, or clear "
+            "it before continuing.[/dim]",
             highlight=False,
         )
     elif result in {"failed", "grader_error"}:

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -106,7 +106,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     ),
     SlashCommand(
         name="/goal",
-        description="Set a persistent objective by drafting acceptance criteria",
+        description="Turn an outcome into acceptance criteria and pursue it",
         bypass_tier=BypassTier.QUEUED,
         hidden_keywords=(
             "objective criteria acceptance rubric grader grading model iterations"
@@ -194,7 +194,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     ),
     SlashCommand(
         name="/rubric",
-        description="Set explicit acceptance criteria for rubric grading",
+        description="Use acceptance criteria you already have",
         bypass_tier=BypassTier.IMMEDIATE_UI,
         hidden_keywords="criteria acceptance grader grading evaluation iterations",
         argument_hint="[set|next|file|show|clear|model|max-iterations]",

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -1278,7 +1278,10 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
     ConfigOption(
         key="startup.mode",
         group="Startup",
-        summary="Default approval mode at launch ('manual' or 'dangerously-auto').",
+        summary=(
+            "Default permission mode at launch ('manual' or legacy "
+            "'dangerously-auto' for unrestricted permissions)."
+        ),
         kind=OptionKind.STARTUP_MODE_DELEGATE,
         default="manual",
         toml_keys=("startup", "mode"),

--- a/libs/code/deepagents_code/goal_tools.py
+++ b/libs/code/deepagents_code/goal_tools.py
@@ -43,10 +43,12 @@ RubricSource = Literal["goal", "sticky", "invocation"]
 
 GOAL_TOOLS_SYSTEM_PROMPT = """## Goal and Rubric Tools
 
+Only call `get_goal`, `get_rubric`, or `update_goal` when a goal or rubric was set
+earlier in this session. If neither is active, do not call these tools.
 Use `get_rubric` to inspect active acceptance criteria before deciding whether work is
-complete.
-When a goal is active, use `get_goal` to inspect the objective and current status.
-Use `update_goal` only when you have evidence that the goal is complete or blocked."""
+complete. When a goal is active, use `get_goal` to inspect the objective and current
+status. Use `update_goal` only when you have evidence that the goal is complete or
+blocked."""
 """Model-visible guidance injected before each request by `GoalToolsMiddleware`."""
 
 ResponseT = TypeVar("ResponseT")
@@ -219,6 +221,34 @@ def _goal_snapshot(state: dict[str, Any]) -> GoalSnapshot:
     }
 
 
+_GOAL_TOOL_NAMES = frozenset({"get_goal", "get_rubric", "update_goal"})
+
+
+def _has_active_goal_or_rubric(state: dict[str, Any]) -> bool:
+    """Return whether goal tools are relevant to the current request."""
+    goal = _goal_snapshot(state)
+    if goal["active"]:
+        return True
+    rubric = _rubric_snapshot(state)
+    return rubric["active"] and rubric["source"] != "goal"
+
+
+def _request_tool_name(value: object) -> str | None:
+    """Return a model-request tool name from supported tool representations."""
+    if isinstance(value, dict):
+        name = value.get("name")
+        if isinstance(name, str):
+            return name
+        function = value.get("function")
+        if isinstance(function, dict):
+            function_name = function.get("name")
+            if isinstance(function_name, str):
+                return function_name
+        return None
+    name = getattr(value, "name", None)
+    return name if isinstance(name, str) else None
+
+
 def _update_goal_command(
     *,
     status: Literal["complete", "blocked"],
@@ -386,11 +416,21 @@ class GoalToolsMiddleware(AgentMiddleware[GoalToolState, ContextT]):
     def _request_with_goal_system_context(
         request: ModelRequest[ContextT],
     ) -> ModelRequest[ContextT]:
-        """Inject goal guidance and any one-turn retry context.
+        """Expose goal tools and guidance only when goal context is active.
 
         Returns:
-            Model request with goal context appended to the system prompt.
+            Model request with goal context appended, or with goal tools removed
+            when no goal or rubric is active.
         """
+        state = cast("dict[str, Any]", request.state or {})
+        if not _has_active_goal_or_rubric(state):
+            tools = [
+                value
+                for value in request.tools
+                if _request_tool_name(value) not in _GOAL_TOOL_NAMES
+            ]
+            return request.override(tools=tools)
+
         retry_context = _runtime_blocked_goal_retry_context(request.runtime.context)
         prompt_parts = [GOAL_TOOLS_SYSTEM_PROMPT]
         if retry_context is not None:

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1717,14 +1717,15 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         default=None,
         help=(
-            "Interactive mode only: auto-approve all tool calls without prompting "
-            "(disables human-in-the-loop). Affected tools: shell execution, file "
+            "Interactive mode only: Unrestricted (auto) runs all tool calls without "
+            "prompting. Affected tools: shell execution, file "
             "writes/edits, web search, and URL fetch. Headless mode approves "
             "non-shell tools; shell is disabled unless allowed via "
             "--shell-allow-list. "
             "Use with caution — the agent can execute arbitrary commands. When "
             "omitted, the launch default comes from [startup].mode in "
-            "~/.deepagents/config.toml ('manual' or 'dangerously-auto')."
+            "~/.deepagents/config.toml ('manual' or legacy 'dangerously-auto', "
+            "which enables unrestricted permissions)."
         ),
     )
 

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -264,10 +264,18 @@ def _format_rubric_event(data: dict[str, Any]) -> str | None:
                 lines.append(f"  {glyphs.error} {name}" + (f" — {gap}" if gap else ""))
         return "\n".join(lines)
     if result == "max_iterations_reached":
-        return (
-            f"{glyphs.warning} Acceptance criteria not satisfied "
-            "(iteration limit reached)"
-        )
+        lines = [
+            (
+                f"{glyphs.warning} Automatic iteration stopped: "
+                "acceptance criteria remain unmet (iteration limit reached)"
+            )
+        ]
+        for criterion in data.get("criteria", []):
+            if isinstance(criterion, dict) and criterion.get("passed") is False:
+                name = str(criterion.get("name", "criterion"))
+                gap = str(criterion.get("gap", "")).strip()
+                lines.append(f"  {glyphs.error} {name}" + (f" — {gap}" if gap else ""))
+        return "\n".join(lines)
     if result in {"failed", "grader_error"}:
         label = "grader failed" if result == "failed" else "grader error"
         return (

--- a/libs/code/deepagents_code/tui/widgets/approval.py
+++ b/libs/code/deepagents_code/tui/widgets/approval.py
@@ -111,8 +111,8 @@ class ApprovalMenu(Container):
         Binding("enter", "select", "Select", show=False),
         Binding("1", "select_approve", "Approve", show=False),
         Binding("y", "select_approve", "Approve", show=False),
-        Binding("2", "select_auto", "Auto-approve", show=False),
-        Binding("a", "select_auto", "Auto-approve", show=False),
+        Binding("2", "select_auto", "Unrestricted", show=False),
+        Binding("a", "select_auto", "Unrestricted", show=False),
         Binding("3", "select_reject", "Reject", show=False),
         Binding("n", "select_reject", "Reject", show=False),
         Binding("e", "toggle_expand", "Expand command", show=False),
@@ -410,13 +410,13 @@ class ApprovalMenu(Container):
         if count == 1:
             options = [
                 "1. Approve (y)",
-                "2. Auto-approve for this thread (a)",
+                "2. Use unrestricted permissions for this thread (a)",
                 "3. Reject (n)",
             ]
         else:
             options = [
                 f"1. Approve all {count} (y)",
-                "2. Auto-approve for this thread (a)",
+                "2. Use unrestricted permissions for this thread (a)",
                 f"3. Reject all {count} (n)",
             ]
 

--- a/libs/code/deepagents_code/tui/widgets/goal_review.py
+++ b/libs/code/deepagents_code/tui/widgets/goal_review.py
@@ -23,10 +23,14 @@ from deepagents_code.tui.widgets.ask_user import AskUserTextArea
 # Menu options in display order: (label, `action_*` suffix). The list index is
 # the cursor position, so labels and dispatch stay aligned from one source.
 _OPTIONS: tuple[tuple[str, str], ...] = (
-    ("1. Accept proposed criteria (y)", "accept"),
-    ("2. Edit criteria (e)", "edit"),
-    ("3. Reject with message (r)", "reject_with_message"),
-    ("4. Cancel (n)", "cancel"),
+    ("1. Accept and run (y)", "accept"),
+    (
+        "2. Accept and run automatically with unrestricted permissions (a)",
+        "accept_unrestricted",
+    ),
+    ("3. Edit (e)", "edit"),
+    ("4. Reject with feedback (r)", "reject_with_message"),
+    ("5. Cancel (n)", "cancel"),
 )
 
 
@@ -35,6 +39,13 @@ class GoalReviewAccepted(TypedDict):
 
     type: Literal["accepted"]
     """Discriminator tag for accepting generated criteria unchanged."""
+
+
+class GoalReviewAcceptedUnrestricted(TypedDict):
+    """Widget result when criteria are accepted with unrestricted execution."""
+
+    type: Literal["accepted_unrestricted"]
+    """Discriminator tag for accepting and enabling unrestricted execution."""
 
 
 class GoalReviewEdited(TypedDict):
@@ -65,7 +76,11 @@ class GoalReviewCancelled(TypedDict):
 
 
 GoalReviewResult = (
-    GoalReviewAccepted | GoalReviewEdited | GoalReviewRejected | GoalReviewCancelled
+    GoalReviewAccepted
+    | GoalReviewAcceptedUnrestricted
+    | GoalReviewEdited
+    | GoalReviewRejected
+    | GoalReviewCancelled
 )
 
 
@@ -102,11 +117,13 @@ class GoalReviewMenu(Container):
         Binding("enter", "select", "Select", show=False),
         Binding("1", "accept", "Accept", show=False),
         Binding("y", "accept", "Accept", show=False),
-        Binding("2", "edit", "Edit", show=False),
+        Binding("2", "accept_unrestricted", "Accept automatically", show=False),
+        Binding("a", "accept_unrestricted", "Accept automatically", show=False),
+        Binding("3", "edit", "Edit", show=False),
         Binding("e", "edit", "Edit", show=False),
-        Binding("3", "reject_with_message", "Reject with message", show=False),
-        Binding("r", "reject_with_message", "Reject with message", show=False),
-        Binding("4", "cancel", "Cancel", show=False),
+        Binding("4", "reject_with_message", "Reject with feedback", show=False),
+        Binding("r", "reject_with_message", "Reject with feedback", show=False),
+        Binding("5", "cancel", "Cancel", show=False),
         Binding("n", "cancel", "Cancel", show=False),
         Binding("escape", "cancel", "Cancel", show=False),
     ]
@@ -239,6 +256,12 @@ class GoalReviewMenu(Container):
         if self._input_mode is not None:
             return
         self._submit({"type": "accepted"})
+
+    def action_accept_unrestricted(self) -> None:
+        """Accept the criteria and request unrestricted execution."""
+        if self._input_mode is not None:
+            return
+        self._submit({"type": "accepted_unrestricted"})
 
     def action_edit(self) -> None:
         """Open the inline editor for revised criteria."""
@@ -376,6 +399,6 @@ class GoalReviewMenu(Container):
             return
         self._help_widget.update(
             f"{glyphs.arrow_up}/{glyphs.arrow_down} navigate {glyphs.bullet} "
-            f"Enter select {glyphs.bullet} y/e/r/n quick keys {glyphs.bullet} "
+            f"Enter select {glyphs.bullet} y/a/e/r/n quick keys {glyphs.bullet} "
             "Esc cancel"
         )

--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -36,7 +36,7 @@ _TIPS: dict[str, int] = {
     "Use /timestamps to show or hide message timestamp footers": 1,
     "Use /agents to browse and switch between your available agents": 2,
     "In /agents, press Ctrl+S to set the highlighted agent as your default": 1,
-    "Press Shift+Tab to toggle auto-approve mode": 2,
+    "Press Shift+Tab to toggle unrestricted permissions": 2,
     "Use --startup-cmd to run a shell command before the first prompt": 1,
     "Launch with dcode -s <name> to auto-invoke a skill at startup": 1,
     "Use !! for incognito shell commands that stay out of model context": 1,

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -466,7 +466,7 @@ class StatusBar(Horizontal):
         indicator.remove_class("on", "off")
 
         if new_value:
-            indicator.update("auto")
+            indicator.update("unrestricted")
             indicator.add_class("on")
         else:
             indicator.update("manual")

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -140,7 +140,7 @@ def show_help() -> None:
         "  --startup-cmd CMD          Shell command to run at startup, before first prompt"  # noqa: E501
     )
     console.print(
-        "  -y, --auto-approve         Auto-approve all tool calls in interactive mode (toggle: Shift+Tab)"  # noqa: E501
+        "  -y, --auto-approve         Unrestricted (auto): run tools without approval (toggle: Shift+Tab)"  # noqa: E501
     )
     console.print("  --sandbox TYPE             Remote sandbox for execution")
     console.print(

--- a/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
+++ b/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
@@ -379,13 +379,6 @@ Available subagent types:
 
 - general-purpose: General-purpose agent for researching complex questions, searching for files and content, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you. This agent has access to all tools as the main agent.
 
-## Goal and Rubric Tools
-
-Use `get_rubric` to inspect active acceptance criteria before deciding whether work is
-complete.
-When a goal is active, use `get_goal` to inspect the objective and current status.
-Use `update_goal` only when you have evidence that the goal is complete or blocked.
-
 ## `ask_user`
 
 You have access to the `ask_user` tool to ask the user questions when you need clarification or input.

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -5521,7 +5521,8 @@ class TestGoalCommand:
 
         assert "Use /goal when you have a plain-language objective" in usage
         assert "draft a checklist and ask before applying it" in usage
-        assert "the goal stays active for this thread" in usage
+        assert "goal remains active across follow-up turns" in usage
+        assert "paused, replaced, or cleared" in usage
         assert "when you want dcode to propose" not in usage
 
     def test_goal_usage_text_mentions_grader_settings(self) -> None:
@@ -5628,8 +5629,23 @@ class TestGoalCommand:
 
             rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
             assert (
-                "Grader: current chat model · max iterations: SDK default" in rendered
+                "Grader: current chat model · max iterations: 3 (default)" in rendered
             )
+
+    async def test_goal_show_uses_server_default_for_external_graph(self) -> None:
+        """External graphs should not be assigned the bundled SDK default."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._active_goal = "ship the feature"
+            app._goal_status = "active"
+
+            with patch.object(app, "_remote_agent", return_value=object()):
+                await app._handle_command("/goal show")
+            await pilot.pause()
+
+            rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
+            assert "max iterations: server default" in rendered
 
     async def test_goal_show_footer_lists_grader_aliases(self) -> None:
         """`/goal show` should advertise the grader-alias commands in its footer."""
@@ -6044,9 +6060,31 @@ class TestGoalCommand:
             assert app._pending_goal_rubric is None
             assert app._status_bar is not None
             assert app._status_bar.rubric_label == _rubric_status_label(
-                "checkmark", "Rubric set"
+                "checkmark", "Goal active"
             )
             handle.assert_awaited_once_with("add refresh tokens")
+
+    async def test_goal_accept_unrestricted_enables_mode_and_starts_work(self) -> None:
+        """Enable unrestricted mode and start work without leaving review."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._pending_goal_objective = "add refresh tokens"
+            app._pending_goal_rubric = "- tests pass"
+            future = self._goal_review_future({"type": "accepted_unrestricted"})
+            enable = AsyncMock()
+            handle = AsyncMock()
+
+            with (
+                patch.object(app, "_on_auto_approve_enabled", enable),
+                patch.object(app, "_handle_user_message", handle),
+            ):
+                await app._finish_pending_goal_rubric_review(future)
+
+            enable.assert_awaited_once()
+            handle.assert_awaited_once_with("add refresh tokens")
+            assert app._active_goal == "add refresh tokens"
+            assert app._active_rubric == "- tests pass"
 
     async def test_goal_accept_persists_thread_metadata(self) -> None:
         """Accepted goals should be checkpointed on the current thread."""
@@ -6133,6 +6171,22 @@ class TestGoalCommand:
 
             handle.assert_awaited_once_with("add refresh tokens")
             assert app._initial_goal is None
+
+    async def test_goal_acceptance_shows_configured_iteration_limit(self) -> None:
+        """Starting goal execution should show the configured grading limit."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._pending_goal_objective = "add refresh tokens"
+            app._pending_goal_rubric = "- tests pass"
+            app._rubric_max_iterations = 5
+
+            with patch.object(app, "_handle_user_message", AsyncMock()):
+                await app._accept_goal_rubric("- tests pass")
+            await pilot.pause()
+
+            rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
+            assert "Goal accepted · grading iteration limit: 5" in rendered
 
     async def test_goal_review_accepts_revised_criteria(self) -> None:
         """The review widget's free-text answer should accept revised criteria."""
@@ -6439,10 +6493,13 @@ class TestGoalCommand:
                 await app._sync_goal_rubric_state_from_thread()
 
             fetch.assert_awaited_once_with("thread-1")
-            assert app._active_goal == "add refresh tokens"
-            assert app._goal_status == "complete"
-            assert app._goal_status_note == "tests pass"
-            assert app._active_rubric == "- tests pass"
+            assert app._active_goal is None
+            assert app._goal_status is None
+            assert app._goal_status_note is None
+            assert app._active_rubric is None
+            rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
+            assert "Goal marked complete by the agent." in rendered
+            assert "tests pass" in rendered
 
     async def test_sync_goal_completion_auto_commits_after_rubric_satisfied(
         self,
@@ -6472,12 +6529,17 @@ class TestGoalCommand:
             with patch.object(app, "_get_thread_state_values", fetch):
                 await app._sync_goal_rubric_state_from_thread()
 
-            assert app._goal_status == "complete"
-            assert app._goal_status_note == "tests pass"
+            assert app._active_goal is None
+            assert app._goal_status is None
+            assert app._goal_status_note is None
+            assert app._active_rubric is None
             assert app._pending_goal_completion_note is None
             assert updater.aupdate_state.await_args is not None
             state_update = updater.aupdate_state.await_args.args[1]
-            assert state_update["_goal_status"] == "complete"
+            assert state_update["_goal_status"] is None
+            assert state_update["_goal_objective"] is None
+            assert state_update["_goal_rubric"] is None
+            assert state_update["rubric"] is None
             assert state_update["_pending_goal_completion_note"] is None
 
     async def test_sync_goal_completion_rejects_when_rubric_not_satisfied(
@@ -6513,6 +6575,58 @@ class TestGoalCommand:
             assert app._pending_goal_completion_note is None
             rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
             assert "rubric was not satisfied" in rendered
+
+    async def test_iteration_exhaustion_preserves_goal_and_shows_next_steps(
+        self,
+    ) -> None:
+        """Exhaustion should preserve the unmet goal and explain recovery paths."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._lc_thread_id = "thread-1"
+            app._active_goal = "add refresh tokens"
+            app._goal_status = "active"
+            app._active_rubric = "- tests pass\n- docs updated"
+            app._rubric_max_iterations = 2
+            fetch = AsyncMock(
+                return_value={
+                    "_goal_objective": "add refresh tokens",
+                    "_goal_status": "active",
+                    "_goal_rubric": "- tests pass\n- docs updated",
+                    "_rubric_status": "max_iterations_reached",
+                    "_rubric_evaluations": [
+                        {
+                            "result": "max_iterations_reached",
+                            "criteria": [
+                                {
+                                    "name": "tests pass",
+                                    "passed": False,
+                                    "gap": "one test still fails",
+                                },
+                                {"name": "docs updated", "passed": True},
+                            ],
+                        }
+                    ],
+                }
+            )
+
+            with patch.object(app, "_get_thread_state_values", fetch):
+                await app._sync_goal_rubric_state_from_thread()
+                await pilot.pause()
+
+            assert app._active_goal == "add refresh tokens"
+            assert app._goal_status == "active"
+            assert app._active_rubric == "- tests pass\n- docs updated"
+            rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
+            assert (
+                "Automatic iteration stopped because the grading iteration limit "
+                "was reached" in rendered
+            )
+            assert "Remaining unmet criteria:" in rendered
+            assert "tests pass: one test still fails" in rendered
+            assert "retry or resume" in rendered
+            assert "/goal <revised objective>" in rendered
+            assert "/goal clear" in rendered
 
     async def test_sync_goal_completion_requests_manual_approval(
         self,
@@ -6553,7 +6667,9 @@ class TestGoalCommand:
             action_requests = request_approval.await_args.args[0]
             assert action_requests[0]["name"] == "update_goal"
             assert action_requests[0]["args"]["status"] == "complete"
-            assert app._goal_status == "complete"
+            assert app._active_goal is None
+            assert app._goal_status is None
+            assert app._active_rubric is None
             assert app._pending_goal_completion_note is None
 
     async def test_sync_goal_rubric_state_drops_unknown_status(self) -> None:
@@ -6698,10 +6814,8 @@ class TestGoalCommand:
             assert "Goal:\nmake the app start faster" in rendered
             assert "Status:\nactive" in rendered
             assert "Criteria:\n- measure baseline\n- improve startup" in rendered
-            assert "Goal is active for this thread until completed" in rendered
-            assert (
-                "Follow-up prompts will continue working toward this goal." in rendered
-            )
+            assert "Goal remains active across follow-up turns" in rendered
+            assert "paused, replaced, or cleared" in rendered
             assert "Commands:\n/goal clear\n/goal show" in rendered
             assert "Goal status:" not in rendered
             assert "Accepted criteria:" not in rendered
@@ -6811,6 +6925,46 @@ class TestGoalCommand:
                 str(w._content) == "Goal cleared." for w in app.query(AppMessage)
             )
 
+    async def test_goal_clear_without_active_goal_reports_noop(self) -> None:
+        """`/goal clear` should report when there is no goal and preserve rubrics."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._active_rubric = "- standalone rubric"
+
+            await app._handle_command("/goal clear")
+            await pilot.pause()
+
+            assert app._active_rubric == "- standalone rubric"
+            assert any(
+                str(widget._content) == "No active goal to clear."
+                for widget in app.query(AppMessage)
+            )
+
+    async def test_goal_clear_removes_orphaned_metadata_and_preserves_rubric(
+        self,
+    ) -> None:
+        """Orphaned goal fields should remain clearable without deleting a rubric."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._active_rubric = "- standalone rubric"
+            app._goal_status = "blocked"
+            app._goal_status_note = "orphaned note"
+            app._pending_goal_completion_note = "orphaned completion"
+
+            await app._handle_command("/goal clear")
+            await pilot.pause()
+
+            assert app._active_rubric == "- standalone rubric"
+            assert app._goal_status is None
+            assert app._goal_status_note is None
+            assert app._pending_goal_completion_note is None
+            assert any(
+                str(widget._content) == "Goal cleared."
+                for widget in app.query(AppMessage)
+            )
+
     @pytest.mark.parametrize("verb", ["show", "status", "accept", "edit", "clear"])
     async def test_goal_reserved_word_objective_drafts_goal(self, verb: str) -> None:
         """Reserved words only act as `/goal` subcommands when used alone."""
@@ -6867,7 +7021,7 @@ class TestGoalCommand:
             # does not render the accepted criteria as an error body.
             assert app._active_goal == "add refresh tokens"
             assert any(
-                "Goal accepted. It will stay active for this thread" in str(w._content)
+                "Goal accepted · grading iteration limit: 3" in str(w._content)
                 for w in app.query(AppMessage)
             )
             assert any(
@@ -7108,6 +7262,24 @@ class TestRubricCommand:
             assert mock_execute.await_args.kwargs["rubric"] == "tests pass"
             assert app._active_rubric == "tests pass"
 
+    async def test_completed_goal_rubric_is_not_applied_to_later_turn(self) -> None:
+        """Completed criteria must not grade an unrelated follow-up turn."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._active_goal = "completed goal"
+            app._active_rubric = "old criteria"
+            app._goal_status = "complete"
+
+            with patch(
+                "deepagents_code.tui.textual_adapter.execute_task_textual",
+                new_callable=AsyncMock,
+            ) as mock_execute:
+                await app._run_agent_task("unrelated follow-up")
+
+            assert mock_execute.await_args is not None
+            assert mock_execute.await_args.kwargs["rubric"] is None
+
     async def test_blocked_goal_resets_to_active_before_user_turn(self) -> None:
         """A user response should retry a blocked goal instead of stale state."""
         app = DeepAgentsApp(agent=MagicMock())
@@ -7147,7 +7319,7 @@ class TestRubricCommand:
             assert app._goal_status == "active"
             assert app._goal_status_note is None
             assert app._status_bar.rubric_label == _rubric_status_label(
-                "checkmark", "Rubric set"
+                "checkmark", "Goal active"
             )
 
     async def test_blocked_goal_reset_is_persisted_before_user_turn(self) -> None:
@@ -7191,8 +7363,10 @@ class TestRubricCommand:
                 },
             )
 
-    async def test_active_goal_is_not_reset_and_sends_no_retry_context(self) -> None:
-        """A non-blocked goal turn must not flip state or inject retry context."""
+    async def test_active_goal_persists_without_repetitive_transcript_notice(
+        self,
+    ) -> None:
+        """Keep follow-up goal visibility out of the transcript."""
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -7200,6 +7374,7 @@ class TestRubricCommand:
             app._active_rubric = "tests pass"
             app._goal_status = "active"
             app._goal_status_note = None
+            app._sync_status_rubric()
             started = asyncio.Event()
 
             def execute_stub(*_args: object, **_kwargs: object) -> SessionStats:
@@ -7216,11 +7391,16 @@ class TestRubricCommand:
             assert mock_execute.await_args is not None
             assert mock_execute.await_args.kwargs["user_input"] == "keep going"
             assert mock_execute.await_args.kwargs["blocked_goal_retry_context"] is None
-            assert any(
-                str(w._content) == "Continuing active goal: add refresh tokens"
+            assert mock_execute.await_args.kwargs["rubric"] == "tests pass"
+            assert not any(
+                str(w._content).startswith("Continuing active goal")
                 for w in app.query(AppMessage)
             )
             assert app._goal_status == "active"
+            assert app._status_bar is not None
+            assert app._status_bar.rubric_label == _rubric_status_label(
+                "checkmark", "Goal active"
+            )
 
     async def test_resume_notice_wording_when_goal_was_blocked(self) -> None:
         """Resuming a blocked goal announces a resume, not a plain continue.
@@ -7834,8 +8014,8 @@ class TestRubricCommand:
             rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
             assert "Rubric max iterations: 7" in rendered
 
-    async def test_rubric_state_reports_sdk_default_when_cap_unset(self) -> None:
-        """`/rubric show` labels an unset cap as the SDK default."""
+    async def test_rubric_state_reports_default_limit_when_cap_unset(self) -> None:
+        """`/rubric show` exposes the default iteration limit."""
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -7845,7 +8025,7 @@ class TestRubricCommand:
             await pilot.pause()
 
             rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
-            assert "Rubric max iterations: SDK default" in rendered
+            assert "Rubric max iterations: 3 (default)" in rendered
 
     async def test_set_rubric_max_iterations_rejects_without_owned_server(self) -> None:
         """External graph sessions cannot change construction-time rubric caps."""
@@ -19461,8 +19641,7 @@ class TestLiveApprovalModeWrites:
         assert app._session_state.auto_approve is True
         force.assert_not_called()
         notify.assert_called_once()
-        # Toggling on emits the auto-approve warning, not the manual one.
-        assert "Auto-approve could not sync" in notify.call_args.args[0]
+        assert "Unrestricted permissions could not sync" in notify.call_args.args[0]
 
     async def test_auto_approve_all_failed_write_warns(self) -> None:
         app = DeepAgentsApp(auto_approve=False)

--- a/libs/code/tests/unit_tests/test_args.py
+++ b/libs/code/tests/unit_tests/test_args.py
@@ -787,6 +787,19 @@ class TestHelpScreenDrift:
             "Add them to the Options section in ui.show_help()."
         )
 
+    def test_auto_approve_flag_is_described_as_unrestricted(self) -> None:
+        """Legacy flag spelling should use clear permission-mode display copy."""
+        help_buf = io.StringIO()
+        test_console = Console(file=help_buf, highlight=False, width=200)
+
+        with patch("deepagents_code.ui.console", test_console):
+            show_help()
+
+        help_text = help_buf.getvalue()
+        assert "--auto-approve" in help_text
+        assert "Unrestricted (auto)" in help_text
+        assert "Auto-approve all tool calls" not in help_text
+
     def test_threads_list_flags_appear_in_help(self) -> None:
         """Every `threads list`-specific --flag must appear in show_threads_list_help().
 

--- a/libs/code/tests/unit_tests/test_command_registry.py
+++ b/libs/code/tests/unit_tests/test_command_registry.py
@@ -252,6 +252,25 @@ class TestGoalCommand:
         assert "acceptance" in goal_cmd.hidden_keywords.split()
 
 
+class TestGoalAndRubricDescriptions:
+    """Validate the primary goal and rubric command copy and compatibility alias."""
+
+    def test_primary_descriptions_are_outcome_focused(self) -> None:
+        descriptions = {command.name: command.description for command in COMMANDS}
+
+        assert descriptions["/goal"] == (
+            "Turn an outcome into acceptance criteria and pursue it"
+        )
+        assert descriptions["/rubric"] == "Use acceptance criteria you already have"
+
+    def test_criteria_is_hidden_compatibility_alias(self) -> None:
+        rubric = next(command for command in COMMANDS if command.name == "/rubric")
+        visible = {entry.name for entry in SLASH_COMMANDS}
+
+        assert "/criteria" in rubric.aliases
+        assert "/criteria" not in visible
+
+
 class TestCopyCommand:
     """Validate the `/copy` entry specifically."""
 

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -830,7 +830,7 @@ class TestDebugConsoleToggle:
             assert snapshot["Thread"] == "thread-xyz"
             assert snapshot["CWD"] == "/tmp/work"
             assert "Version" in snapshot
-            assert "Auto-approve" in snapshot
+            assert snapshot["Permissions"] == "manual"
             assert snapshot["MCP servers"] == "none"
 
     async def test_build_snapshot_formats_mcp_servers(self) -> None:

--- a/libs/code/tests/unit_tests/test_goal_tools.py
+++ b/libs/code/tests/unit_tests/test_goal_tools.py
@@ -272,19 +272,95 @@ def _fake_request(
     system_message: SystemMessage | None,
     *,
     context: object | None = None,
+    state: dict[str, object] | None = None,
+    tools: list[object] | None = None,
 ) -> SimpleNamespace:
     """Build a `ModelRequest`-shaped double with an `override` that mirrors it."""
-    return SimpleNamespace(
-        system_message=system_message,
-        runtime=SimpleNamespace(context=context or {}),
-        override=lambda **kw: SimpleNamespace(**kw),
+    values = {
+        "system_message": system_message,
+        "runtime": SimpleNamespace(context=context or {}),
+        "state": state or {},
+        "tools": tools or [],
+    }
+
+    def override(**updates: object) -> SimpleNamespace:
+        return SimpleNamespace(**(values | updates))
+
+    return SimpleNamespace(**values, override=override)
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {},
+        {
+            "_goal_objective": "finished",
+            "_goal_status": "complete",
+            "_goal_rubric": "tests pass",
+        },
+    ],
+)
+def test_wrap_model_call_removes_goal_tools_without_active_context(
+    state: dict[str, object],
+) -> None:
+    """Inactive and completed goal state should not influence ordinary turns."""
+    middleware = GoalToolsMiddleware()
+    captured: dict[str, SimpleNamespace] = {}
+    execute = SimpleNamespace(name="execute")
+    request = _fake_request(
+        SystemMessage(content="base instructions"),
+        state=state,
+        tools=[execute, *middleware.tools],
     )
+
+    middleware.wrap_model_call(
+        request,  # ty: ignore[invalid-argument-type]
+        _capturing_handler(captured),  # ty: ignore[invalid-argument-type]
+    )
+
+    forwarded = captured["request"]
+    assert forwarded.system_message.content == "base instructions"
+    assert [tool.name for tool in forwarded.tools] == ["execute"]
+
+
+def test_wrap_model_call_preserves_goal_tools_for_standalone_rubric() -> None:
+    """A standalone rubric should retain goal-tool access and guidance."""
+    middleware = GoalToolsMiddleware()
+    captured: dict[str, SimpleNamespace] = {}
+    request = _fake_request(
+        None,
+        state={"_sticky_rubric": "tests pass"},
+        tools=list(middleware.tools),
+    )
+
+    middleware.wrap_model_call(
+        request,  # ty: ignore[invalid-argument-type]
+        _capturing_handler(captured),  # ty: ignore[invalid-argument-type]
+    )
+
+    forwarded = captured["request"]
+    assert [tool.name for tool in forwarded.tools] == [
+        "get_rubric",
+        "get_goal",
+        "update_goal",
+    ]
+    assert GOAL_TOOLS_SYSTEM_PROMPT in forwarded.system_message.content[0]["text"]
+
+
+def test_goal_tool_prompt_forbids_calls_without_session_context() -> None:
+    """The model instructions should state the inactive-tool precondition."""
+    prompt = GOAL_TOOLS_SYSTEM_PROMPT.replace("\n", " ")
+    assert "when a goal or rubric was set earlier" in prompt
+    assert "If neither is active, do not call these tools" in prompt
 
 
 def test_wrap_model_call_appends_guidance_to_existing_prompt() -> None:
     """Guidance should append to an existing system message's blocks."""
     captured: dict[str, SimpleNamespace] = {}
-    request = _fake_request(SystemMessage(content="base instructions"))
+    request = _fake_request(
+        SystemMessage(content="base instructions"),
+        state={"_goal_objective": "ship it", "_goal_status": "active"},
+    )
 
     result = GoalToolsMiddleware().wrap_model_call(
         request,  # ty: ignore[invalid-argument-type]
@@ -302,7 +378,7 @@ def test_wrap_model_call_appends_guidance_to_existing_prompt() -> None:
 def test_wrap_model_call_seeds_guidance_without_system_message() -> None:
     """Guidance should seed a fresh system message when none exists."""
     captured: dict[str, SimpleNamespace] = {}
-    request = _fake_request(None)
+    request = _fake_request(None, state={"_sticky_rubric": "tests pass"})
 
     GoalToolsMiddleware().wrap_model_call(
         request,  # ty: ignore[invalid-argument-type]
@@ -319,6 +395,7 @@ def test_wrap_model_call_appends_blocked_goal_retry_context() -> None:
     request = _fake_request(
         None,
         context={"blocked_goal_retry_context": "<dcode_blocked_goal_retry_context />"},
+        state={"_goal_objective": "ship it", "_goal_status": "blocked"},
     )
 
     GoalToolsMiddleware().wrap_model_call(
@@ -340,7 +417,10 @@ async def test_awrap_model_call_appends_guidance_to_existing_prompt() -> None:
         captured["request"] = request
         return "response"
 
-    request = _fake_request(SystemMessage(content="base instructions"))
+    request = _fake_request(
+        SystemMessage(content="base instructions"),
+        state={"_goal_objective": "ship it", "_goal_status": "active"},
+    )
 
     result = await GoalToolsMiddleware().awrap_model_call(
         request,  # ty: ignore[invalid-argument-type]

--- a/libs/code/tests/unit_tests/test_rubric_cli.py
+++ b/libs/code/tests/unit_tests/test_rubric_cli.py
@@ -306,9 +306,21 @@ class TestProcessRubricEvent:
 
     def test_max_iterations(self) -> None:
         out = _render_event(
-            {"type": "rubric_evaluation_end", "result": "max_iterations_reached"}
+            {
+                "type": "rubric_evaluation_end",
+                "result": "max_iterations_reached",
+                "criteria": [
+                    {"name": "tests", "passed": False, "gap": "still failing"},
+                    {"name": "docs", "passed": True},
+                ],
+            }
         )
+        assert "Automatic iteration stopped" in out
         assert "iteration limit reached" in out
+        assert "tests" in out
+        assert "still failing" in out
+        assert "docs" not in out
+        assert "Retry with another message" in out
 
     def test_failed(self) -> None:
         out = _render_event(

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -1279,11 +1279,19 @@ class TestFormatRubricEvent:
 
     def test_max_iterations_reached_event(self) -> None:
         """Hitting the iteration cap should warn the user it is unsatisfied."""
-        assert (
-            _format_rubric_event(
-                {"type": "rubric_evaluation_end", "result": "max_iterations_reached"},
-            )
-            == "⚠ Acceptance criteria not satisfied (iteration limit reached)"
+        assert _format_rubric_event(
+            {
+                "type": "rubric_evaluation_end",
+                "result": "max_iterations_reached",
+                "criteria": [
+                    {"name": "tests pass", "passed": False, "gap": "not run"},
+                    {"name": "docs", "passed": True},
+                ],
+            },
+        ) == (
+            "⚠ Automatic iteration stopped: acceptance criteria remain unmet "
+            "(iteration limit reached)\n"
+            "  ✗ tests pass — not run"
         )
 
     def test_grader_failure_results_render_warning(self) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_approval.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_approval.py
@@ -284,7 +284,22 @@ class TestGetCommandDisplayGuard:
 
 
 class TestOptionOrdering:
-    """Tests for the HITL option ordering: approve, auto-approve, reject."""
+    """Tests for the HITL option ordering and compatibility decisions."""
+
+    def test_unrestricted_option_uses_clear_user_facing_copy(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The legacy auto decision should display as unrestricted permissions."""
+        menu = ApprovalMenu({"name": "execute", "args": {"command": "echo hi"}})
+        options = [MagicMock(), MagicMock(), MagicMock()]
+        monkeypatch.setattr(menu, "_option_widgets", options)
+
+        menu._update_options()
+
+        automatic = options[1].update.call_args.args[0]
+        assert "Use unrestricted permissions for this thread" in automatic
+        assert "Auto-approve" not in automatic
 
     @pytest.mark.parametrize(
         ("index", "expected_type"),

--- a/libs/code/tests/unit_tests/tui/widgets/test_goal_review.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_goal_review.py
@@ -36,6 +36,26 @@ class TestGoalReviewMenu:
             assert "- tests pass" in markdown.source
             assert "Proposed criteria" in markdown.source
 
+    async def test_actions_explain_execution_and_feedback(self) -> None:
+        """Every review action should state its effect clearly."""
+        app = _GoalReviewTestApp()
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            options = [
+                str(widget.content)
+                for widget in app.query(".goal-review-option").results(Static)
+            ]
+
+        assert any("Accept and run (y)" in option for option in options)
+        assert any(
+            "Accept and run automatically with unrestricted permissions (a)" in option
+            for option in options
+        )
+        assert any("Edit (e)" in option for option in options)
+        assert any("Reject with feedback (r)" in option for option in options)
+        assert any("Cancel (n)" in option for option in options)
+
     async def test_accept_resolves_accepted(self) -> None:
         """Accept should resolve with the accepted result."""
         app = _GoalReviewTestApp()
@@ -51,6 +71,22 @@ class TestGoalReviewMenu:
             menu.action_accept()
 
             assert await future == {"type": "accepted"}
+
+    async def test_accept_unrestricted_resolves_automatic_result(self) -> None:
+        """Automatic acceptance should return its distinct execution decision."""
+        app = _GoalReviewTestApp()
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            menu = app.query_one("#goal-review", GoalReviewMenu)
+            future: asyncio.Future[GoalReviewResult] = (
+                asyncio.get_running_loop().create_future()
+            )
+            menu.set_future(future)
+
+            menu.action_accept_unrestricted()
+
+            assert await future == {"type": "accepted_unrestricted"}
 
     async def test_edit_prefills_and_submits_revised_criteria(self) -> None:
         """Edit should prefill generated criteria and submit revisions."""
@@ -118,6 +154,22 @@ class TestGoalReviewMenu:
 
             assert await future == {"type": "accepted"}
 
+    async def test_keypress_automatic_acceptance_resolves_distinct_result(self) -> None:
+        """The automatic quick-key should enable the unattended execution path."""
+        app = _GoalReviewTestApp()
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            menu = app.query_one("#goal-review", GoalReviewMenu)
+            future: asyncio.Future[GoalReviewResult] = (
+                asyncio.get_running_loop().create_future()
+            )
+            menu.set_future(future)
+
+            await pilot.press("a")
+
+            assert await future == {"type": "accepted_unrestricted"}
+
     async def test_keypress_reject_enters_reject_mode(self) -> None:
         """The reject quick-key opens the feedback editor without resolving."""
         app = _GoalReviewTestApp()
@@ -170,7 +222,7 @@ class TestGoalReviewMenu:
             assert await future == {"type": "cancelled"}
 
     async def test_arrow_navigation_then_enter_selects_highlighted(self) -> None:
-        """Down+Enter dispatches `action_select` to the highlighted option (edit)."""
+        """Arrow navigation dispatches the highlighted edit action."""
         app = _GoalReviewTestApp()
 
         async with app.run_test() as pilot:
@@ -181,10 +233,10 @@ class TestGoalReviewMenu:
             )
             menu.set_future(future)
 
-            await pilot.press("down", "enter")
+            await pilot.press("down", "down", "enter")
 
             text_input = menu.query_one(".goal-review-edit-input", AskUserTextArea)
-            assert menu._selected == 1
+            assert menu._selected == 2
             assert text_input.display is True
             assert future.done() is False
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -76,6 +76,23 @@ class TestCwdDisplay:
             assert cwd.styles.padding.right == 1
 
 
+class TestPermissionModeDisplay:
+    """Tests for user-facing permission-mode terminology."""
+
+    async def test_unrestricted_mode_uses_clear_copy(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            display = pilot.app.query_one("#auto-approve-indicator", Static)
+
+            bar.set_auto_approve(enabled=True)
+            await pilot.pause()
+            assert str(display.render()) == "unrestricted"
+
+            bar.set_auto_approve(enabled=False)
+            await pilot.pause()
+            assert str(display.render()) == "manual"
+
+
 class TestBranchDisplay:
     """Tests for the git branch display in the status bar."""
 


### PR DESCRIPTION
Potentially not needed

Improved `/goal` criteria review, lifecycle visibility, iteration-limit feedback, and permission-mode terminology. Completed goals no longer affect later turns, and inactive goal tools no longer influence ordinary conversations.

---

As a dcode user pursuing an outcome, I want criteria approval and goal lifecycle feedback to be clear without leaving the review flow or letting finished goals affect unrelated follow-up turns.

The inline criteria review now distinguishes accepting and running, accepting with unrestricted permissions, editing, rejecting with feedback, and cancelling. Goal activation explains persistence and the grading iteration limit, while the status bar keeps an active goal visible without adding a repeated transcript message on every follow-up.

Completed goals are cleared before later turns, and iteration exhaustion keeps unmet goals active while showing remaining criteria and concrete retry, resume, amend, and clear paths. Goal tools are omitted from ordinary model requests until a goal or rubric is active.

`/goal` and `/rubric` now use outcome-focused descriptions. `/criteria` remains executable as a compatibility alias without appearing as a separate completion or help entry. Existing `--auto-approve`, `dangerously-auto`, keybindings, configuration values, and serialized state remain compatible, but user-facing permission copy now describes the mode as unrestricted.
