### PR TITLE
feat(sdk): support surrounding lines in filesystem grep results

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -675,27 +675,43 @@ class FilesystemBackend(BackendProtocol):
 
         # Try ripgrep first (with -F flag for literal search)
         results, truncated = self._ripgrep_search(pattern, base_full, glob)
+        context_newline = "\n"
         partial_error: str | None = None
         if results is None:
             # Python fallback does literal substring matching on the raw pattern.
             results, truncated, partial_error = self._python_search(pattern, base_full, glob)
+            context_newline = None
 
         matches: list[GrepMatch] = []
         for fpath, items in results.items():
             for line_num, line_text in items:
                 matches.append({"path": fpath, "line": int(line_num), "text": line_text})
         if context_lines:
-            partial_error = self._apply_grep_context(matches, context_lines, partial_error)
+            partial_error = self._apply_grep_context(
+                matches,
+                context_lines,
+                partial_error,
+                pattern,
+                newline=context_newline,
+            )
         return GrepResult(error=partial_error, matches=matches, truncated=truncated)
 
-    def _apply_grep_context(self, matches: list[GrepMatch], context_lines: int, partial_error: str | None) -> str | None:
+    def _apply_grep_context(
+        self,
+        matches: list[GrepMatch],
+        context_lines: int,
+        partial_error: str | None,
+        pattern: str,
+        *,
+        newline: str | None,
+    ) -> str | None:
         """Attach context to matches, folding any unreadable-file failures into `partial_error`.
 
         The search engines (ripgrep and the Python fallback) return only matching
         lines, so surrounding context must be re-read from disk afterward rather
         than captured during the search itself.
         """
-        unreadable = self._add_grep_context(matches, context_lines)
+        unreadable = self._add_grep_context(matches, context_lines, pattern, newline=newline)
         if not unreadable:
             return partial_error
         joined = ", ".join(sorted(unreadable))
@@ -715,11 +731,20 @@ class FilesystemBackend(BackendProtocol):
                 line_ranges.append((start, end))
         return line_ranges
 
-    def _read_grep_context(self, file_path: str, line_ranges: list[tuple[int, int]]) -> tuple[dict[int, str], bool]:
+    def _read_grep_context(
+        self,
+        file_path: str,
+        line_ranges: list[tuple[int, int]],
+        *,
+        newline: str | None = None,
+    ) -> tuple[dict[int, str], bool]:
         """Return text for the merged line ranges needed for grep context.
 
         The file is scanned sequentially from line 1 up to the last requested
-        range; only lines inside a range are retained.
+        range; only lines inside a range are retained. `line_ranges` must be
+        sorted ascending and non-overlapping (as produced by
+        `_grep_context_ranges`): the scan advances through them monotonically
+        and never revisits an earlier range.
 
         Returns:
             `(context, ok)` where `context` maps line number to text and `ok` is
@@ -730,7 +755,7 @@ class FilesystemBackend(BackendProtocol):
         context: dict[int, str] = {}
         try:
             resolved_path = self._resolve_path(file_path)
-            with resolved_path.open(encoding="utf-8", errors="strict") as handle:
+            with resolved_path.open(encoding="utf-8", errors="strict", newline=newline) as handle:
                 range_index = 0
                 for line_num, raw_line in enumerate(handle, 1):
                     while range_index < len(line_ranges) and line_num > line_ranges[range_index][1]:
@@ -749,7 +774,14 @@ class FilesystemBackend(BackendProtocol):
             return {}, False
         return context, True
 
-    def _add_grep_context(self, matches: list[GrepMatch], context_lines: int) -> list[str]:
+    def _add_grep_context(
+        self,
+        matches: list[GrepMatch],
+        context_lines: int,
+        pattern: str,
+        *,
+        newline: str | None,
+    ) -> list[str]:
         """Attach requested surrounding lines to grep matches in place.
 
         Returns the paths of matched files whose context could not be read.
@@ -760,14 +792,20 @@ class FilesystemBackend(BackendProtocol):
 
         unreadable: list[str] = []
         for file_path, file_matches in matches_by_path.items():
-            context, ok = self._read_grep_context(file_path, self._grep_context_ranges(file_matches, context_lines))
+            context, ok = self._read_grep_context(
+                file_path,
+                self._grep_context_ranges(file_matches, context_lines),
+                newline=newline,
+            )
             if not ok:
                 unreadable.append(file_path)
             match_numbers = {match["line"] for match in file_matches}
             # `bisect_*` below require ascending `context_numbers`; sort here so
             # correctness never depends on `_read_grep_context`'s insertion order.
             sorted_context = sorted(context.items())
-            context_items: list[ContextLine] = [{"line": number, "text": text} for number, text in sorted_context if number not in match_numbers]
+            context_items: list[ContextLine] = [
+                {"line": number, "text": text} for number, text in sorted_context if number not in match_numbers and pattern not in text
+            ]
             context_numbers = [item["line"] for item in context_items]
             for match in file_matches:
                 line_num = match["line"]
@@ -795,6 +833,12 @@ class FilesystemBackend(BackendProtocol):
         Raises:
             ValueError: If `context_lines` is negative.
         """
+        # Validate eagerly rather than letting `self.grep` raise inside the
+        # worker thread, mirroring the sync path and avoiding a pointless
+        # `to_thread` hop just to surface a programming error.
+        if context_lines < 0:
+            msg = "context_lines must be non-negative"
+            raise ValueError(msg)
         if context_lines == 0:
             return await super().agrep(pattern, path, glob)
         try:

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -1,5 +1,6 @@
 """`FilesystemBackend`: Read and write files directly from the filesystem."""
 
+import asyncio
 import base64
 import errno
 import functools
@@ -9,17 +10,20 @@ import os
 import shutil
 import subprocess
 import time
+from bisect import bisect_left, bisect_right
 from datetime import datetime
 from pathlib import Path
 
 from deepagents._api.deprecation import warn_deprecated
 from deepagents.backends.protocol import (
+    ASYNC_GREP_TIMEOUT,
     DEFAULT_GREP_TIMEOUT,
     FILE_NOT_FOUND,
     INVALID_PATH,
     IS_DIRECTORY,
     PERMISSION_DENIED,
     BackendProtocol,
+    ContextLine,
     DeleteResult,
     EditResult,
     FileData,
@@ -624,6 +628,8 @@ class FilesystemBackend(BackendProtocol):
         pattern: str,
         path: str | None = None,
         glob: str | None = None,
+        *,
+        context_lines: int = 0,
     ) -> GrepResult:
         """Search for a literal text pattern in files.
 
@@ -633,10 +639,24 @@ class FilesystemBackend(BackendProtocol):
             pattern: Literal string to search for (NOT regex).
             path: Directory or file path to search in. Defaults to current directory.
             glob: Optional glob pattern to filter which files to search.
+            context_lines: Number of lines to include before and after each match.
+
+                This is a backend-level API. It is deliberately not exposed
+                through the agent-facing `grep` tool (`GrepSchema`), so matches
+                returned via that tool never carry context.
 
         Returns:
-            `GrepResult` with matches or error.
+            `GrepResult` with matches or error. When `context_lines > 0` and some
+            matched files cannot be re-read for context, the matches are still
+            returned and the failure is reported in `GrepResult.error`.
+
+        Raises:
+            ValueError: If `context_lines` is negative.
         """
+        if context_lines < 0:
+            msg = "context_lines must be non-negative"
+            raise ValueError(msg)
+
         # Resolve base path
         try:
             base_full = self._resolve_path(path or ".")
@@ -664,7 +684,126 @@ class FilesystemBackend(BackendProtocol):
         for fpath, items in results.items():
             for line_num, line_text in items:
                 matches.append({"path": fpath, "line": int(line_num), "text": line_text})
+        if context_lines:
+            partial_error = self._apply_grep_context(matches, context_lines, partial_error)
         return GrepResult(error=partial_error, matches=matches, truncated=truncated)
+
+    def _apply_grep_context(self, matches: list[GrepMatch], context_lines: int, partial_error: str | None) -> str | None:
+        """Attach context to matches, folding any unreadable-file failures into `partial_error`.
+
+        The search engines (ripgrep and the Python fallback) return only matching
+        lines, so surrounding context must be re-read from disk afterward rather
+        than captured during the search itself.
+        """
+        unreadable = self._add_grep_context(matches, context_lines)
+        if not unreadable:
+            return partial_error
+        joined = ", ".join(sorted(unreadable))
+        context_error = f"Error: could not read context for {len(unreadable)} file(s) (non-UTF-8 or unreadable): {joined}"
+        return f"{partial_error}\n{context_error}" if partial_error else context_error
+
+    @staticmethod
+    def _grep_context_ranges(file_matches: list[GrepMatch], context_lines: int) -> list[tuple[int, int]]:
+        """Return merged line ranges needed for a file's grep context."""
+        line_ranges: list[tuple[int, int]] = []
+        for line_num in sorted(match["line"] for match in file_matches):
+            start = max(1, line_num - context_lines)
+            end = line_num + context_lines
+            if line_ranges and start <= line_ranges[-1][1] + 1:
+                line_ranges[-1] = (line_ranges[-1][0], max(line_ranges[-1][1], end))
+            else:
+                line_ranges.append((start, end))
+        return line_ranges
+
+    def _read_grep_context(self, file_path: str, line_ranges: list[tuple[int, int]]) -> tuple[dict[int, str], bool]:
+        """Return text for the merged line ranges needed for grep context.
+
+        The file is scanned sequentially from line 1 up to the last requested
+        range; only lines inside a range are retained.
+
+        Returns:
+            `(context, ok)` where `context` maps line number to text and `ok` is
+            `False` if the file could not be read (a file the search engine just
+            matched should normally be readable, so a failure is surfaced by the
+            caller rather than silently dropped).
+        """
+        context: dict[int, str] = {}
+        try:
+            resolved_path = self._resolve_path(file_path)
+            with resolved_path.open(encoding="utf-8", errors="strict") as handle:
+                range_index = 0
+                for line_num, raw_line in enumerate(handle, 1):
+                    while range_index < len(line_ranges) and line_num > line_ranges[range_index][1]:
+                        range_index += 1
+                    if range_index == len(line_ranges):
+                        break
+                    if line_num >= line_ranges[range_index][0]:
+                        context[line_num] = raw_line.rstrip("\n")
+        except (OSError, UnicodeDecodeError, ValueError) as e:
+            # A matched file that cannot be re-read (e.g. non-UTF-8 bytes ripgrep
+            # tolerated, a mid-search deletion, or a path that no longer resolves)
+            # is an anomaly worth surfacing, not routine noise.
+            logger.warning("Could not read grep context for %s: %s", file_path, e, exc_info=True)
+            return {}, False
+        return context, True
+
+    def _add_grep_context(self, matches: list[GrepMatch], context_lines: int) -> list[str]:
+        """Attach requested surrounding lines to grep matches in place.
+
+        Returns the paths of matched files whose context could not be read.
+        """
+        matches_by_path: dict[str, list[GrepMatch]] = {}
+        for match in matches:
+            matches_by_path.setdefault(match["path"], []).append(match)
+
+        unreadable: list[str] = []
+        for file_path, file_matches in matches_by_path.items():
+            context, ok = self._read_grep_context(file_path, self._grep_context_ranges(file_matches, context_lines))
+            if not ok:
+                unreadable.append(file_path)
+            context_items: list[ContextLine] = [{"line": number, "text": text} for number, text in context.items()]
+            context_numbers = list(context)
+            for match in file_matches:
+                line_num = match["line"]
+                before_start = bisect_left(context_numbers, max(1, line_num - context_lines))
+                before_end = bisect_left(context_numbers, line_num)
+                after_start = bisect_right(context_numbers, line_num)
+                after_end = bisect_right(context_numbers, line_num + context_lines)
+                match["context_before"] = context_items[before_start:before_end]
+                match["context_after"] = context_items[after_start:after_end]
+        return unreadable
+
+    async def agrep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        glob: str | None = None,
+        *,
+        context_lines: int = 0,
+    ) -> GrepResult:
+        """Async version of `grep`, with optional surrounding context lines.
+
+        As in the base `agrep`, the async timeout bounds how long the caller
+        waits; it does not stop the worker thread spawned by `asyncio.to_thread`.
+        """
+        if context_lines == 0:
+            return await super().agrep(pattern, path, glob)
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(self.grep, pattern, path, glob, context_lines=context_lines),
+                timeout=ASYNC_GREP_TIMEOUT,
+            )
+        except TimeoutError:
+            logger.warning(
+                "agrep timed out after %ds (pattern=%r, path=%r, glob=%r)",
+                ASYNC_GREP_TIMEOUT,
+                pattern,
+                path,
+                glob,
+            )
+            return GrepResult(
+                error=f"Error: grep timed out after {ASYNC_GREP_TIMEOUT}s. Try a more specific pattern or a narrower path.",
+            )
 
     def _ripgrep_search(self, pattern: str, base_full: Path, include_glob: str | None) -> tuple[dict[str, list[tuple[int, str]]] | None, bool]:  # noqa: C901, PLR0912, PLR0915  # except clauses split per-exception for targeted logging (timeout vs exec-race vs ripgrep hard-error)
         """Search using ripgrep with fixed-string (literal) mode.

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -763,7 +763,8 @@ class FilesystemBackend(BackendProtocol):
                     if range_index == len(line_ranges):
                         break
                     if line_num >= line_ranges[range_index][0]:
-                        context[line_num] = raw_line.rstrip("\n")
+                        text = raw_line[:-2] if raw_line.endswith("\r\n") else raw_line.removesuffix("\n")
+                        context[line_num] = text
         except (OSError, RuntimeError, UnicodeDecodeError, ValueError) as e:
             # A matched file that cannot be re-read (e.g. non-UTF-8 bytes ripgrep
             # tolerated, a symlink loop, a mid-search deletion, or a path that no

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -761,8 +761,9 @@ class FilesystemBackend(BackendProtocol):
             context, ok = self._read_grep_context(file_path, self._grep_context_ranges(file_matches, context_lines))
             if not ok:
                 unreadable.append(file_path)
-            context_items: list[ContextLine] = [{"line": number, "text": text} for number, text in context.items()]
-            context_numbers = list(context)
+            match_numbers = {match["line"] for match in file_matches}
+            context_items: list[ContextLine] = [{"line": number, "text": text} for number, text in context.items() if number not in match_numbers]
+            context_numbers = [item["line"] for item in context_items]
             for match in file_matches:
                 line_num = match["line"]
                 before_start = bisect_left(context_numbers, max(1, line_num - context_lines))

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -739,11 +739,13 @@ class FilesystemBackend(BackendProtocol):
                         break
                     if line_num >= line_ranges[range_index][0]:
                         context[line_num] = raw_line.rstrip("\n")
-        except (OSError, UnicodeDecodeError, ValueError) as e:
+        except (OSError, RuntimeError, UnicodeDecodeError, ValueError) as e:
             # A matched file that cannot be re-read (e.g. non-UTF-8 bytes ripgrep
-            # tolerated, a mid-search deletion, or a path that no longer resolves)
-            # is an anomaly worth surfacing, not routine noise.
-            logger.warning("Could not read grep context for %s: %s", file_path, e, exc_info=True)
+            # tolerated, a symlink loop, a mid-search deletion, or a path that no
+            # longer resolves) is surfaced to the caller via `GrepResult.error`.
+            # Log at debug for diagnostics, matching `_python_search`'s handling
+            # of unreadable files, rather than spamming warnings for benign binaries.
+            logger.debug("Could not read grep context for %s: %s", file_path, e)
             return {}, False
         return context, True
 
@@ -762,7 +764,10 @@ class FilesystemBackend(BackendProtocol):
             if not ok:
                 unreadable.append(file_path)
             match_numbers = {match["line"] for match in file_matches}
-            context_items: list[ContextLine] = [{"line": number, "text": text} for number, text in context.items() if number not in match_numbers]
+            # `bisect_*` below require ascending `context_numbers`; sort here so
+            # correctness never depends on `_read_grep_context`'s insertion order.
+            sorted_context = sorted(context.items())
+            context_items: list[ContextLine] = [{"line": number, "text": text} for number, text in sorted_context if number not in match_numbers]
             context_numbers = [item["line"] for item in context_items]
             for match in file_matches:
                 line_num = match["line"]
@@ -786,6 +791,9 @@ class FilesystemBackend(BackendProtocol):
 
         As in the base `agrep`, the async timeout bounds how long the caller
         waits; it does not stop the worker thread spawned by `asyncio.to_thread`.
+
+        Raises:
+            ValueError: If `context_lines` is negative.
         """
         if context_lines == 0:
             return await super().agrep(pattern, path, glob)

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -151,6 +151,16 @@ class FileInfo(TypedDict):
     """ISO 8601 timestamp of last modification, if known."""
 
 
+class ContextLine(TypedDict):
+    """A non-matching line surrounding a grep match, used for `context_lines`."""
+
+    line: int
+    """1-indexed line number of the context line."""
+
+    text: str
+    """Content of the context line."""
+
+
 class GrepMatch(TypedDict):
     """A single match from a grep search."""
 
@@ -162,6 +172,17 @@ class GrepMatch(TypedDict):
 
     text: str
     """Content of the matching line."""
+
+    context_before: NotRequired[list[ContextLine]]
+    """Context lines before the match.
+
+    Present (alongside `context_after`) only when a backend was asked for
+    `context_lines > 0`; both keys are set together on every match or on none.
+    An empty list means the requested context ran into the start of the file.
+    """
+
+    context_after: NotRequired[list[ContextLine]]
+    """Context lines after the match. See `context_before` for presence rules."""
 
 
 class FileData(TypedDict):

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -177,8 +177,12 @@ class GrepMatch(TypedDict):
     """Context lines before the match.
 
     Present (alongside `context_after`) only when a backend was asked for
-    `context_lines > 0`; both keys are set together on every match or on none.
-    An empty list means the requested context ran into the start of the file.
+    `context_lines > 0` (via a backend-specific argument, e.g.
+    `FilesystemBackend.grep`); both keys are set together on every match or on
+    none. An empty list means no context lines were available on that side: the
+    match sits at the file boundary, the adjacent line was itself a match
+    (matches are never repeated as context), or the file could not be re-read
+    (in which case the failure is reported in `GrepResult.error`).
     """
 
     context_after: NotRequired[list[ContextLine]]

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -871,7 +871,57 @@ def format_grep_matches(
     """Format structured grep matches using existing formatting logic."""
     if not matches:
         return "No matches found"
-    return _format_grep_results(build_grep_results_dict(matches), output_mode)
+
+    # Presence of the context keys signals "context mode" for the whole result;
+    # the producer sets both keys on every match or none. `_format_grep_with_context`
+    # still tolerates a hand-built mix of matches with and without context, since
+    # this is a public helper.
+    if output_mode != "content" or not any("context_before" in match or "context_after" in match for match in matches):
+        return _format_grep_results(build_grep_results_dict(matches), output_mode)
+    return _format_grep_with_context(matches)
+
+
+def _format_grep_with_context(matches: list[GrepMatch]) -> str:
+    """Render `content`-mode grep output including surrounding context lines.
+
+    Matched lines are marked with `:` and context lines with `-`. Non-adjacent
+    line groups within a file are separated by a `--` line, mirroring `grep -C`.
+    """
+    matches_by_path: dict[str, list[GrepMatch]] = {}
+    for match in matches:
+        matches_by_path.setdefault(match["path"], []).append(match)
+
+    lines: list[str] = []
+    for file_path in sorted(matches_by_path):
+        file_matches = matches_by_path[file_path]
+        matching_lines = {match["line"] for match in file_matches}
+        displayed_lines: dict[int, str] = {}
+        for match in file_matches:
+            for context_line in match.get("context_before", []):
+                displayed_lines[context_line["line"]] = context_line["text"]
+            displayed_lines[match["line"]] = match["text"]
+            for context_line in match.get("context_after", []):
+                displayed_lines[context_line["line"]] = context_line["text"]
+
+        lines.append(f"{file_path}:")
+        for group_index, group in enumerate(_group_adjacent_lines(displayed_lines)):
+            if group_index:
+                lines.append("  --")
+            for line_num, text in group:
+                separator = ":" if line_num in matching_lines else "-"
+                lines.append(f"  {line_num}{separator} {text}")
+    return "\n".join(lines)
+
+
+def _group_adjacent_lines(displayed_lines: dict[int, str]) -> list[list[tuple[int, str]]]:
+    """Split `{line_number: text}` into runs of consecutive line numbers."""
+    groups: list[list[tuple[int, str]]] = []
+    for item in sorted(displayed_lines.items()):
+        if not groups or item[0] > groups[-1][-1][0] + 1:
+            groups.append([item])
+        else:
+            groups[-1].append(item)
+    return groups
 
 
 _REGEX_SIGNAL_RE = re.compile(

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -874,8 +874,8 @@ def format_grep_matches(
 
     # Presence of the context keys signals "context mode" for the whole result;
     # the producer sets both keys on every match or none. `_format_grep_with_context`
-    # still tolerates a hand-built mix of matches with and without context, since
-    # this is a public helper.
+    # still tolerates a hand-built mix of matches with and without context, because
+    # `format_grep_matches` is public and may be handed such input.
     if output_mode != "content" or not any("context_before" in match or "context_after" in match for match in matches):
         return _format_grep_results(build_grep_results_dict(matches), output_mode)
     return _format_grep_with_context(matches)

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -15,7 +15,8 @@ from langchain_core.messages import ToolMessage
 from deepagents._api.deprecation import LangChainDeprecationWarning
 from deepagents.backends import filesystem as fs_module
 from deepagents.backends.filesystem import FilesystemBackend
-from deepagents.backends.protocol import DeleteResult, EditResult, ReadResult, WriteResult
+from deepagents.backends.protocol import DeleteResult, EditResult, GrepMatch, ReadResult, WriteResult
+from deepagents.backends.utils import format_grep_matches
 from deepagents.middleware.filesystem import GLOB_TIMEOUT, FilesystemMiddleware
 
 
@@ -1574,6 +1575,168 @@ class TestGrepPythonFallbackTimeout:
         # Partial matches collected before the timeout are preserved.
         assert result.matches
         assert result.matches[0]["path"] == "/file.txt"
+
+
+class TestFilesystemGrepContext:
+    def test_default_and_zero_preserve_existing_matches(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        target = tmp_path / "sample.txt"
+        target.write_text("before\nneedle\nafter\n")
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+
+        def fail_if_called(*_args: object) -> None:
+            pytest.fail("context collection should not run when context_lines is disabled")
+
+        monkeypatch.setattr(backend, "_add_grep_context", fail_if_called)
+        expected = [{"path": "/sample.txt", "line": 2, "text": "needle"}]
+
+        assert backend.grep("needle", path="/").matches == expected
+        assert backend.grep("needle", path="/", context_lines=0).matches == expected
+
+    def test_negative_context_lines_rejected(self, tmp_path: Path) -> None:
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+
+        with pytest.raises(ValueError, match="context_lines must be non-negative"):
+            backend.grep("needle", path="/", context_lines=-1)
+
+    def test_context_respects_file_boundaries_and_merges_overlap(self, tmp_path: Path) -> None:
+        target = tmp_path / "sample.txt"
+        target.write_text("needle start\ntwo\nmiddle\nfour\nneedle end")
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+
+        result = backend.grep("needle", path="/", context_lines=2)
+
+        assert result.matches == [
+            {
+                "path": "/sample.txt",
+                "line": 1,
+                "text": "needle start",
+                "context_before": [],
+                "context_after": [{"line": 2, "text": "two"}, {"line": 3, "text": "middle"}],
+            },
+            {
+                "path": "/sample.txt",
+                "line": 5,
+                "text": "needle end",
+                "context_before": [{"line": 3, "text": "middle"}, {"line": 4, "text": "four"}],
+                "context_after": [],
+            },
+        ]
+        assert format_grep_matches(result.matches, "content") == (
+            "/sample.txt:\n  1: needle start\n  2- two\n  3- middle\n  4- four\n  5: needle end"
+        )
+
+    def test_context_lines_larger_than_file_iterate_only_existing_lines(self, tmp_path: Path) -> None:
+        target = tmp_path / "sample.txt"
+        target.write_text("needle")
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+
+        result = backend.grep("needle", path="/", context_lines=10**9)
+
+        assert result.matches == [
+            {
+                "path": "/sample.txt",
+                "line": 1,
+                "text": "needle",
+                "context_before": [],
+                "context_after": [],
+            }
+        ]
+
+    def test_context_formatting_groups_matches_in_one_pass(self) -> None:
+        class CountingMatches(list[GrepMatch]):
+            iterations = 0
+
+            def __iter__(self) -> Iterator[GrepMatch]:
+                self.iterations += 1
+                return super().__iter__()
+
+        matches = CountingMatches(
+            {
+                "path": f"/file-{index}.txt",
+                "line": 1,
+                "text": "needle",
+                "context_before": [],
+                "context_after": [],
+            }
+            for index in range(100)
+        )
+
+        output = format_grep_matches(matches, "content")
+
+        assert matches.iterations <= 2
+        assert output.count(":\n  1: needle") == 100
+
+    def test_context_merges_overlapping_windows_and_separates_groups(self, tmp_path: Path) -> None:
+        target = tmp_path / "sample.txt"
+        target.write_text("one\ntwo\nneedle three\nfour\nneedle five\nsix\nseven\neight\nnine\nneedle ten\neleven")
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+
+        matches = backend.grep("needle", path="/", context_lines=1).matches
+
+        assert matches is not None
+        assert format_grep_matches(matches, "content") == (
+            "/sample.txt:\n  2- two\n  3: needle three\n  4- four\n  5: needle five\n  6- six\n  --\n  9- nine\n  10: needle ten\n  11- eleven"
+        )
+
+    def test_context_does_not_change_file_or_count_modes(self, tmp_path: Path) -> None:
+        target = tmp_path / "sample.txt"
+        target.write_text("needle\ncontext\nneedle\n")
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+
+        without_context = backend.grep("needle", path="/").matches
+        with_context = backend.grep("needle", path="/", context_lines=1).matches
+
+        assert without_context is not None
+        assert with_context is not None
+        for output_mode in ("files_with_matches", "count"):
+            assert format_grep_matches(with_context, output_mode) == format_grep_matches(without_context, output_mode)
+        assert format_grep_matches(with_context, "files_with_matches") == "/sample.txt"
+        assert format_grep_matches(with_context, "count") == "/sample.txt: 2"
+
+    def test_context_is_scoped_per_file(self, tmp_path: Path) -> None:
+        (tmp_path / "a.txt").write_text("alpha\nneedle a\nbravo\n")
+        (tmp_path / "b.txt").write_text("charlie\nneedle b\ndelta\n")
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+
+        result = backend.grep("needle", path="/", context_lines=1)
+
+        assert result.error is None
+        by_path = {match["path"]: match for match in result.matches or []}
+        # Each match carries context only from its own file — no cross-file bleed.
+        assert by_path["/a.txt"]["context_before"] == [{"line": 1, "text": "alpha"}]
+        assert by_path["/a.txt"]["context_after"] == [{"line": 3, "text": "bravo"}]
+        assert by_path["/b.txt"]["context_before"] == [{"line": 1, "text": "charlie"}]
+        assert by_path["/b.txt"]["context_after"] == [{"line": 3, "text": "delta"}]
+        assert format_grep_matches(result.matches or [], "content") == (
+            "/a.txt:\n  1- alpha\n  2: needle a\n  3- bravo\n/b.txt:\n  1- charlie\n  2: needle b\n  3- delta"
+        )
+
+    def test_context_read_failure_keeps_matches_and_surfaces_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        target = tmp_path / "sample.txt"
+        target.write_text("before\nneedle\nafter\n")
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+
+        # Simulate a matched file that cannot be re-read for context.
+        monkeypatch.setattr(backend, "_read_grep_context", lambda *_args: ({}, False))
+
+        result = backend.grep("needle", path="/", context_lines=1)
+
+        # The match survives with empty context, and the failure is not silent.
+        assert result.matches == [{"path": "/sample.txt", "line": 2, "text": "needle", "context_before": [], "context_after": []}]
+        assert result.error is not None
+        assert "/sample.txt" in result.error
+        assert "context" in result.error.lower()
+
+    def test_read_grep_context_reports_unreadable_file(self, tmp_path: Path) -> None:
+        # A file ripgrep can match but that is not valid strict UTF-8.
+        target = tmp_path / "latin1.txt"
+        target.write_bytes(b"needle\n\xff\xfe not utf-8\n")
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+
+        context, ok = backend._read_grep_context("/latin1.txt", [(1, 2)])
+
+        assert ok is False
+        assert context == {}
 
 
 class TestGrepPythonFallbackIncludeGlob:

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -1751,6 +1751,29 @@ class TestFilesystemGrepContext:
         assert "/sample.txt" in result.error
         assert "context" in result.error.lower()
 
+    def test_context_resolver_runtime_error_keeps_matches_and_surfaces_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        target = tmp_path / "sample.txt"
+        target.write_text("before\nneedle\nafter\n")
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        resolve_path = backend._resolve_path
+
+        def resolve_with_context_failure(path: str) -> Path:
+            if path == "/sample.txt":
+                msg = "symlink loop"
+                raise RuntimeError(msg)
+            return resolve_path(path)
+
+        # Python 3.11 and 3.12 raise RuntimeError when Path.resolve() encounters
+        # a symlink loop after the initial search but before the context read.
+        monkeypatch.setattr(backend, "_resolve_path", resolve_with_context_failure)
+
+        result = backend.grep("needle", path="/", context_lines=1)
+
+        assert result.matches == [{"path": "/sample.txt", "line": 2, "text": "needle", "context_before": [], "context_after": []}]
+        assert result.error is not None
+        assert "/sample.txt" in result.error
+        assert "context" in result.error.lower()
+
     def test_read_grep_context_reports_unreadable_file(self, tmp_path: Path) -> None:
         # A file ripgrep can match but that is not valid strict UTF-8.
         target = tmp_path / "latin1.txt"
@@ -1761,6 +1784,45 @@ class TestFilesystemGrepContext:
 
         assert ok is False
         assert context == {}
+
+    def test_context_error_is_appended_to_existing_partial_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A pre-existing search error (e.g. ripgrep partial failure) must survive
+        # alongside the context-read failure rather than being overwritten.
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        matches: list[GrepMatch] = [{"path": "/a.txt", "line": 1, "text": "needle"}]
+        monkeypatch.setattr(backend, "_add_grep_context", lambda *_args: ["/a.txt"])
+
+        combined = backend._apply_grep_context(matches, 1, "Error: ripgrep partial failure")
+
+        assert combined is not None
+        assert combined.startswith("Error: ripgrep partial failure\n")
+        assert "could not read context" in combined
+        assert "/a.txt" in combined
+
+    def test_context_uses_python_fallback_when_ripgrep_unavailable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Force the Python fallback so context collection is exercised
+        # deterministically regardless of whether ripgrep is installed.
+        target = tmp_path / "sample.txt"
+        target.write_text("before\nneedle\nafter\n")
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        monkeypatch.setattr(backend, "_ripgrep_search", lambda *_args, **_kwargs: (None, False))
+
+        result = backend.grep("needle", path="/", context_lines=1)
+
+        assert result.error is None
+        assert format_grep_matches(result.matches or [], "content") == "/sample.txt:\n  1- before\n  2: needle\n  3- after"
+
+    def test_content_format_sorts_files_regardless_of_input_order(self) -> None:
+        # `_format_grep_with_context` must sort by path itself; the ordering here
+        # is not guaranteed by the caller when matches are hand-built.
+        matches: list[GrepMatch] = [
+            {"path": "/z.txt", "line": 1, "text": "zeta", "context_before": [], "context_after": []},
+            {"path": "/a.txt", "line": 1, "text": "alpha", "context_before": [], "context_after": []},
+        ]
+
+        output = format_grep_matches(matches, "content")
+
+        assert output == "/a.txt:\n  1: alpha\n/z.txt:\n  1: zeta"
 
 
 class TestGrepPythonFallbackIncludeGlob:

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -1649,6 +1649,32 @@ class TestFilesystemGrepContext:
             },
         ]
 
+    def test_ripgrep_context_strips_crlf_terminators(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "sample.txt"
+        target.write_bytes(b"before\r\nneedle\r\nafter\r\n")
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        monkeypatch.setattr(
+            backend,
+            "_ripgrep_search",
+            lambda *_args: ({"/sample.txt": [(2, "needle")]}, False),
+        )
+
+        result = backend.grep("needle", path="/", context_lines=1)
+
+        assert result.matches == [
+            {
+                "path": "/sample.txt",
+                "line": 2,
+                "text": "needle",
+                "context_before": [{"line": 1, "text": "before"}],
+                "context_after": [{"line": 3, "text": "after"}],
+            }
+        ]
+
     def test_ripgrep_context_treats_bare_carriage_returns_as_text(
         self,
         tmp_path: Path,

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -1649,6 +1649,59 @@ class TestFilesystemGrepContext:
             },
         ]
 
+    def test_ripgrep_context_treats_bare_carriage_returns_as_text(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "sample.txt"
+        target.write_bytes(b"before\rneedle\rafter\r")
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        monkeypatch.setattr(
+            backend,
+            "_ripgrep_search",
+            lambda *_args: ({"/sample.txt": [(1, "before\rneedle\rafter\r")]}, False),
+        )
+
+        result = backend.grep("needle", path="/", context_lines=1)
+
+        assert result.matches == [
+            {
+                "path": "/sample.txt",
+                "line": 1,
+                "text": "before\rneedle\rafter\r",
+                "context_before": [],
+                "context_after": [],
+            }
+        ]
+
+    def test_omitted_match_is_not_returned_as_truncated_context(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "sample.txt"
+        target.write_text("before\nneedle returned\nneedle omitted\nafter\n")
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        monkeypatch.setattr(
+            backend,
+            "_ripgrep_search",
+            lambda *_args: ({"/sample.txt": [(2, "needle returned")]}, True),
+        )
+
+        result = backend.grep("needle", path="/", context_lines=2)
+
+        assert result.truncated is True
+        assert result.matches == [
+            {
+                "path": "/sample.txt",
+                "line": 2,
+                "text": "needle returned",
+                "context_before": [{"line": 1, "text": "before"}],
+                "context_after": [{"line": 4, "text": "after"}],
+            }
+        ]
+
     def test_context_lines_larger_than_file_iterate_only_existing_lines(self, tmp_path: Path) -> None:
         target = tmp_path / "sample.txt"
         target.write_text("needle")
@@ -1666,7 +1719,11 @@ class TestFilesystemGrepContext:
             }
         ]
 
-    def test_context_formatting_groups_matches_in_one_pass(self) -> None:
+    def test_context_formatting_uses_constant_number_of_passes(self) -> None:
+        # Guards against an O(n^2) regression where formatting re-scans the whole
+        # match list once per match. Asserting a *constant* number of full passes
+        # (independent of input size) rather than an exact count keeps the test
+        # from breaking on a still-linear refactor that adds a pass.
         class CountingMatches(list[GrepMatch]):
             iterations = 0
 
@@ -1687,7 +1744,7 @@ class TestFilesystemGrepContext:
 
         output = format_grep_matches(matches, "content")
 
-        assert matches.iterations <= 2
+        assert matches.iterations < len(matches)
         assert output.count(":\n  1: needle") == 100
 
     def test_context_merges_overlapping_windows_and_separates_groups(self, tmp_path: Path) -> None:
@@ -1741,7 +1798,7 @@ class TestFilesystemGrepContext:
         backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
 
         # Simulate a matched file that cannot be re-read for context.
-        monkeypatch.setattr(backend, "_read_grep_context", lambda *_args: ({}, False))
+        monkeypatch.setattr(backend, "_read_grep_context", lambda *_args, **_kwargs: ({}, False))
 
         result = backend.grep("needle", path="/", context_lines=1)
 
@@ -1790,9 +1847,15 @@ class TestFilesystemGrepContext:
         # alongside the context-read failure rather than being overwritten.
         backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
         matches: list[GrepMatch] = [{"path": "/a.txt", "line": 1, "text": "needle"}]
-        monkeypatch.setattr(backend, "_add_grep_context", lambda *_args: ["/a.txt"])
+        monkeypatch.setattr(backend, "_add_grep_context", lambda *_args, **_kwargs: ["/a.txt"])
 
-        combined = backend._apply_grep_context(matches, 1, "Error: ripgrep partial failure")
+        combined = backend._apply_grep_context(
+            matches,
+            1,
+            "Error: ripgrep partial failure",
+            "needle",
+            newline="\n",
+        )
 
         assert combined is not None
         assert combined.startswith("Error: ripgrep partial failure\n")

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -1625,6 +1625,30 @@ class TestFilesystemGrepContext:
             "/sample.txt:\n  1: needle start\n  2- two\n  3- middle\n  4- four\n  5: needle end"
         )
 
+    def test_neighboring_matches_are_excluded_from_context(self, tmp_path: Path) -> None:
+        target = tmp_path / "sample.txt"
+        target.write_text("before\nneedle one\nneedle two\nafter\n")
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+
+        result = backend.grep("needle", path="/", context_lines=1)
+
+        assert result.matches == [
+            {
+                "path": "/sample.txt",
+                "line": 2,
+                "text": "needle one",
+                "context_before": [{"line": 1, "text": "before"}],
+                "context_after": [],
+            },
+            {
+                "path": "/sample.txt",
+                "line": 3,
+                "text": "needle two",
+                "context_before": [],
+                "context_after": [{"line": 4, "text": "after"}],
+            },
+        ]
+
     def test_context_lines_larger_than_file_iterate_only_existing_lines(self, tmp_path: Path) -> None:
         target = tmp_path / "sample.txt"
         target.write_text("needle")

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend_async.py
@@ -1,13 +1,16 @@
 """Async tests for FilesystemBackend."""
 
+import time
 from pathlib import Path
 
 import pytest
 from langchain.tools import ToolRuntime
 from langchain_core.messages import ToolMessage
 
+from deepagents.backends import filesystem as fs_module
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.backends.protocol import EditResult, ReadResult, WriteResult
+from deepagents.backends.utils import format_grep_matches
 from deepagents.middleware.filesystem import FilesystemMiddleware
 
 
@@ -509,6 +512,37 @@ async def test_filesystem_agrep_with_glob(tmp_path: Path):
     assert any("test.py" in p for p in py_files)
     assert any("main.py" in p for p in py_files)
     assert not any("test.txt" in p for p in py_files)
+
+
+async def test_filesystem_agrep_with_context(tmp_path: Path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\nneedle\nafter\n")
+    backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+
+    result = await backend.agrep("needle", path="/", context_lines=1)
+
+    assert result.matches is not None
+    assert format_grep_matches(result.matches, "content") == "/sample.txt:\n  1- before\n  2: needle\n  3- after"
+    with pytest.raises(ValueError, match="context_lines must be non-negative"):
+        await backend.agrep("needle", path="/", context_lines=-1)
+
+
+async def test_filesystem_agrep_with_context_times_out(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\nneedle\nafter\n")
+    backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+
+    def slow_grep(*_args: object, **_kwargs: object) -> None:
+        time.sleep(0.5)
+
+    monkeypatch.setattr(fs_module, "ASYNC_GREP_TIMEOUT", 0.01)
+    monkeypatch.setattr(backend, "grep", slow_grep)
+
+    result = await backend.agrep("needle", path="/", context_lines=1)
+
+    assert result.matches is None
+    assert result.error is not None
+    assert "timed out" in result.error
 
 
 async def test_filesystem_aglob_recursive(tmp_path: Path):


### PR DESCRIPTION
Closes #3109

Thank you to @i-anubhav-anand for taking an initial stab at this!

`FilesystemBackend.grep()` and `FilesystemBackend.agrep()` now accept an optional keyword-only `context_lines` argument for direct callers that need surrounding lines in content-formatted search results.

This PR intentionally does not expose `context_lines` through the agent-facing `grep` tool yet. Doing so would require adding it to `BackendProtocol` and forwarding it through every backend, potentially breaking custom backend implementations. The narrower API is intended to unblock experimentation in applications such as Deep Agents Code while we determine whether broader usage justifies that protocol-level change.

Users can experiment today by passing a custom `FilesystemBackend` to `create_deep_agent(backend=...)` that applies a nonzero `context_lines` value by default. If the model should control the value, [#4251](https://github.com/langchain-ai/deepagents/pull/4251) allows applications to replace the built-in `FilesystemMiddleware`: pass a custom middleware instance with the same `.name` through `create_deep_agent(middleware=[...])`, expose `context_lines` in its `grep` schema, and delegate to `FilesystemBackend.grep(..., context_lines=...)`.

---

Direct callers of the local `FilesystemBackend` currently receive only matching lines from `grep`, which often requires a separate file read to understand the surrounding code. This adds a keyword-only `context_lines` option to the concrete synchronous and asynchronous methods so callers can request nearby lines in the same search.

The default remains `0`, preserving the existing result shape and avoiding context reads. When enabled, matching lines retain the existing `:` marker, context lines use `-`, overlapping windows are merged, and separate groups are divided by `--`. File-only and count output continue to operate on actual matches rather than context lines.

This is intentionally a local-backend API rather than a new agent capability: the model-facing grep tool and schema, `BackendProtocol`, `CompositeBackend`, and other backends remain unchanged.
