### PR TITLE
fix(code): align context diff rows with changed rows

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/diff.py
+++ b/libs/code/deepagents_code/tui/widgets/diff.py
@@ -137,7 +137,7 @@ def _compose_diff_content(
             yield Static(
                 Content.assemble(
                     (f"{glyphs.box_vertical}{old_num:>{width}}", "dim"),
-                    f"  {content}",
+                    f" {content}",
                 ),
             )
             old_num += 1

--- a/libs/code/tests/unit_tests/tui/widgets/test_diff.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_diff.py
@@ -120,6 +120,16 @@ class TestComposeDiffLines:
         assert "diff-line-removed" in removed
         assert context == set()
 
+    def test_content_columns_align_across_line_types(self) -> None:
+        """Context/added/removed rows start their content at the same column."""
+        texts = _texts(_rendered(_SAMPLE_DIFF))
+        ctx = next(t for t in texts if "ctx" in t)
+        removed = next(t for t in texts if "removed" in t)
+        added1 = next(t for t in texts if "added1" in t)
+        # The gutter glyph, right-aligned line number, and separator must be
+        # the same width on every row so the diff body lines up vertically.
+        assert ctx.index("ctx") == removed.index("removed") == added1.index("added1")
+
     def test_max_lines_truncates_with_marker(self) -> None:
         """Beyond `max_lines`, a truncation marker replaces remaining rows."""
         diff = "\n".join(["@@ -1,5 +1,5 @@", *(f"+line{i}" for i in range(5))])


### PR DESCRIPTION
Fixed a one-character horizontal misalignment between unchanged and changed lines in the interactive diff view.

---

In the terminal diff widget, unchanged (context) rows put two spaces after the right-aligned line number while added/removed rows use one. That made unchanged content render one column to the right of changed content, so the diff body looked misaligned by a single character. Standardizing on a single separator space for every row type lines the content up vertically.

Made by [Open SWE](https://openswe.vercel.app/agents/408eb040-6f08-7f47-c9d0-3ebf4693c6a5)