### PR TITLE
fix(infra): compare prereleases to previous prerelease

### DIFF
--- a/.github/scripts/test_release_git_log.py
+++ b/.github/scripts/test_release_git_log.py
@@ -41,10 +41,10 @@ def _commit(repo: Path, path: Path, content: str, message: str) -> str:
     return _git(repo, "rev-parse", "HEAD")
 
 
-def _workflow_step(step_id: str) -> str:
+def _workflow_step(step_id: str, *, job: str = "release-notes") -> str:
     with WORKFLOW_PATH.open() as file:
         workflow = yaml.safe_load(file)
-    steps = workflow["jobs"]["release-notes"]["steps"]
+    steps = workflow["jobs"][job]["steps"]
     return next(step["run"] for step in steps if step.get("id") == step_id)
 
 
@@ -230,6 +230,25 @@ def _create_history(repo: Path) -> dict[str, str]:
     }
 
 
+def _create_sibling_prerelease_tag(
+    repo: Path,
+    *,
+    base: str,
+    version: str,
+    index: int,
+) -> None:
+    branch = f"prerelease-{index}"
+    _git(repo, "checkout", "-b", branch, base)
+    _commit(
+        repo,
+        PACKAGE_PATH / "module.py",
+        f"VERSION = {index}\n",
+        f"hotfix(example): prerelease {version}",
+    )
+    _git(repo, "tag", f"example=={version}")
+    _git(repo, "checkout", "main")
+
+
 def _entry(sha: str, subject: str) -> str:
     return f"- [`{sha[:7]}`](https://github.com/{REPOSITORY}/commit/{sha}) {subject}"
 
@@ -287,6 +306,94 @@ def test_temporary_repo_disables_inherited_commit_signing(
 
     assert commits["hotfix"] == _git(repo, "rev-parse", "HEAD")
     assert _git(repo, "config", "--local", "--bool", "commit.gpgSign") == "false"
+
+
+@pytest.mark.parametrize(
+    ("input_sha", "source"),
+    [
+        ("", "workflow SHA fallback because dangerous-nonmain-release is enabled"),
+        ("HEAD", "explicit release-sha input"),
+    ],
+)
+def test_resolve_release_sha_outputs_canonical_target_summary(
+    tmp_path: Path,
+    input_sha: str,
+    source: str,
+) -> None:
+    _init_repo(tmp_path)
+    sha = _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "BASE = 1\n",
+        "feat(example): base",
+    )
+    output = tmp_path / "setup-output.txt"
+    summary = tmp_path / "step-summary.md"
+    env = {
+        **os.environ,
+        "GITHUB_OUTPUT": str(output),
+        "GITHUB_REPOSITORY": REPOSITORY,
+        "GITHUB_SERVER_URL": "https://github.com",
+        "GITHUB_SHA_FALLBACK": "HEAD",
+        "GITHUB_STEP_SUMMARY": str(summary),
+        "INPUT_SHA": input_sha,
+        "INPUT_VERSION": "1.1.0a1",
+        "IS_DANGEROUS": "true",
+        "PACKAGE": "example",
+        "WORKING_DIR": str(PACKAGE_PATH),
+    }
+
+    subprocess.run(
+        ["bash", "-eo", "pipefail", "-c", _workflow_step("resolve-sha", job="setup")],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    outputs = dict(
+        line.split("=", maxsplit=1) for line in output.read_text().splitlines()
+    )
+    assert outputs["sha"] == sha
+    assert (
+        f"| Release SHA | [`{sha[:7]}`](https://github.com/{REPOSITORY}/commit/{sha}) |"
+        in summary.read_text()
+    )
+    assert f"| Resolution | {source} |" in summary.read_text()
+
+
+def test_resolve_release_sha_rejects_unresolvable_sha(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _commit(tmp_path, PACKAGE_PATH / "module.py", "BASE = 1\n", "feat(example): base")
+    output = tmp_path / "setup-output.txt"
+    env = {
+        **os.environ,
+        "GITHUB_OUTPUT": str(output),
+        "GITHUB_REPOSITORY": REPOSITORY,
+        "GITHUB_SERVER_URL": "https://github.com",
+        "GITHUB_SHA_FALLBACK": "HEAD",
+        "GITHUB_STEP_SUMMARY": str(tmp_path / "step-summary.md"),
+        "INPUT_SHA": "does-not-exist",
+        "INPUT_VERSION": "1.1.0a1",
+        "IS_DANGEROUS": "true",
+        "PACKAGE": "example",
+        "WORKING_DIR": str(PACKAGE_PATH),
+    }
+
+    result = subprocess.run(
+        ["bash", "-eo", "pipefail", "-c", _workflow_step("resolve-sha", job="setup")],
+        cwd=tmp_path,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "does not resolve to a commit" in result.stdout
+    # The failure aborts before the `sha=` output is written.
+    assert not output.exists() or "sha=" not in output.read_text()
 
 
 def test_finalize_release_body_respects_github_size_limit(tmp_path: Path) -> None:
@@ -541,6 +648,185 @@ def test_prerelease_resolve_refs_uses_base_version_predecessor(tmp_path: Path) -
         assert outputs["is-prerelease"] == "true", version
         assert outputs["prev-tag"] == "example==1.0.1", version
         assert outputs["release-commit"] == head, version
+
+
+@pytest.mark.parametrize(
+    ("version", "tags", "expected"),
+    [
+        ("1.1.0a7", ("1.1.0a1", "1.1.0a6", "1.1.0a8"), "1.1.0a6"),
+        ("1.1.0b2", ("1.1.0a9", "1.1.0b1", "1.1.0b3"), "1.1.0b1"),
+        ("1.1.0rc2", ("1.1.0b9", "1.1.0rc1", "1.1.0rc3"), "1.1.0rc1"),
+        (
+            "1.1.0.dev3",
+            ("1.1.0.dev1", "1.1.0.dev2", "1.1.0.dev4"),
+            "1.1.0.dev2",
+        ),
+        ("1.1.0-rc.7", ("1.1.0-rc.6", "1.1.0-rc.8"), "1.1.0-rc.6"),
+        # Serials compare numerically, not lexically: a10 must beat a6.
+        ("1.1.0a11", ("1.1.0a6", "1.1.0a10"), "1.1.0a10"),
+        # Zero-padded serials parse as base-10 (a08 -> 8), never octal.
+        ("1.1.0a9", ("1.1.0a1", "1.1.0a08"), "1.1.0a08"),
+        # dev sorts before a/b/rc, so the latest dev is the predecessor of a1.
+        ("1.1.0a1", ("1.1.0.dev1", "1.1.0.dev5"), "1.1.0.dev5"),
+        # dev does not outrank a later phase: b1 wins over dev9.
+        ("1.1.0rc1", ("1.1.0.dev9", "1.1.0b1"), "1.1.0b1"),
+        # Dash-form alias: alpha maps to the `a` rank.
+        ("1.1.0-beta.1", ("1.1.0-alpha.9",), "1.1.0-alpha.9"),
+        # Dash-form alias: preview maps to the `rc` rank.
+        ("1.1.0-rc.2", ("1.1.0-preview.1",), "1.1.0-preview.1"),
+        # Optional separator: 1.1.0-rc7 (no dot) parses like 1.1.0-rc.7.
+        ("1.1.0-rc7", ("1.1.0-rc6",), "1.1.0-rc6"),
+    ],
+)
+def test_prerelease_resolve_refs_prefers_latest_earlier_sibling_tag(
+    tmp_path: Path,
+    version: str,
+    tags: tuple[str, ...],
+    expected: str,
+) -> None:
+    _init_repo(tmp_path)
+    base = _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "BASE = 1\n",
+        "feat(example): base",
+    )
+    _git(tmp_path, "tag", "example==1.0.0")
+    for index, tag in enumerate(tags):
+        _create_sibling_prerelease_tag(
+            tmp_path,
+            base=base,
+            version=tag,
+            index=index,
+        )
+
+    _git(tmp_path, "checkout", "-b", "current-prerelease", base)
+    release = _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "CURRENT = 1\n",
+        f"hotfix(example): prerelease {version}",
+    )
+
+    outputs = _run_resolve_refs_step(tmp_path, version=version).outputs
+
+    assert outputs["prev-tag"] == f"example=={expected}"
+    assert outputs["release-commit"] == release
+    details = _run_git_log_step(
+        tmp_path,
+        previous_tag=outputs["prev-tag"],
+        release_sha=release,
+    )
+    assert f"<summary>Git log since example=={expected}</summary>" in details
+    assert _entry(release, f"hotfix(example): prerelease {version}") in details
+
+
+def test_prerelease_resolve_refs_rejects_tag_ahead_of_release(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "BASE = 1\n",
+        "feat(example): base",
+    )
+    _git(tmp_path, "tag", "example==1.0.0")
+    release = _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "CURRENT = 1\n",
+        "hotfix(example): prerelease 1.1.0a7",
+    )
+    _git(tmp_path, "checkout", "-b", "future-prerelease")
+    _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "FUTURE = 1\n",
+        "hotfix(example): prerelease 1.1.0a6",
+    )
+    _git(tmp_path, "tag", "example==1.1.0a6")
+    _git(tmp_path, "checkout", "main")
+
+    outputs = _run_resolve_refs_step(tmp_path, version="1.1.0a7").outputs
+
+    # Fixture precondition: `checkout main` left HEAD (the resolve-refs RELEASE_SHA)
+    # on `release`, behind the 1.1.0a6 tag, so the "tag ahead" scenario truly holds.
+    assert _git(tmp_path, "rev-parse", "HEAD") == release
+    # a6 is a valid version-ordering candidate but descends from the release commit,
+    # so it is rejected; no example==1.1.0 base tag exists, so selection falls through
+    # to the latest stable tag.
+    assert outputs["prev-tag"] == "example==1.0.0"
+
+
+def test_prerelease_resolve_refs_falls_back_to_latest_stable_tag(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    _commit(tmp_path, PACKAGE_PATH / "module.py", "BASE = 1\n", "feat(example): base")
+    _git(tmp_path, "tag", "example==1.0.0")
+    release = _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "CURRENT = 1\n",
+        "hotfix(example): prerelease 1.1.0a1",
+    )
+
+    outputs = _run_resolve_refs_step(tmp_path, version="1.1.0a1").outputs
+
+    # First alpha of a new minor: no 1.1.0a* sibling and no example==1.1.0 base tag,
+    # so the three-tier fallback lands on the latest reachable stable tag.
+    assert outputs["prev-tag"] == "example==1.0.0"
+    assert outputs["release-commit"] == release
+
+
+def test_prerelease_resolve_refs_ignores_different_base_prerelease(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    base = _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "BASE = 1\n",
+        "feat(example): base",
+    )
+    _git(tmp_path, "tag", "example==1.0.0")
+    # A lower-ranked pre-release from a DIFFERENT base version (1.0.5a1, rank a) would
+    # pass the rank/serial filter against the current 1.1.0rc1 (rank rc); only the
+    # base-version guard excludes it. If that guard regressed it would be selected.
+    _create_sibling_prerelease_tag(tmp_path, base=base, version="1.0.5a1", index=0)
+
+    _git(tmp_path, "checkout", "-b", "current-prerelease", base)
+    _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "CURRENT = 1\n",
+        "hotfix(example): prerelease 1.1.0rc1",
+    )
+
+    outputs = _run_resolve_refs_step(tmp_path, version="1.1.0rc1").outputs
+
+    assert outputs["prev-tag"] == "example==1.0.0"
+
+
+def test_prerelease_resolve_refs_warns_on_unparseable_prerelease(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    _commit(tmp_path, PACKAGE_PATH / "module.py", "BASE = 1\n", "feat(example): base")
+    _git(tmp_path, "tag", "example==1.0.0")
+    _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "CURRENT = 1\n",
+        "hotfix(example): prerelease 1.1.0-canary",
+    )
+
+    # '1.1.0-canary' trips the loose IS_PRERELEASE detector but not parse_prerelease.
+    result = _run_resolve_refs_step(tmp_path, version="1.1.0-canary")
+
+    assert "does not match a recognized pre-release format" in result.stdout
+    assert result.outputs["prev-tag"] == "example==1.0.0"
 
 
 def test_latest_stable_tag_selects_highest_reachable_version(tmp_path: Path) -> None:

--- a/.github/scripts/test_release_git_log.py
+++ b/.github/scripts/test_release_git_log.py
@@ -809,6 +809,39 @@ def test_prerelease_resolve_refs_ignores_different_base_prerelease(
     assert outputs["prev-tag"] == "example==1.0.0"
 
 
+def test_prerelease_resolve_refs_ignores_later_phase_sibling(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    base = _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "BASE = 1\n",
+        "feat(example): base",
+    )
+    _git(tmp_path, "tag", "example==1.0.0")
+    # A later-phase sibling of the SAME base version (1.1.0rc1, rank rc) is not a valid
+    # predecessor of an earlier phase (1.1.0b1, rank b). It shares history with the
+    # release and does not descend from it, so it survives both the history-sharing and
+    # future-sibling ancestry checks; only the `candidate_rank > current_rank` guard
+    # excludes it. If that guard regressed it would be selected as the predecessor.
+    _create_sibling_prerelease_tag(tmp_path, base=base, version="1.1.0rc1", index=0)
+
+    _git(tmp_path, "checkout", "-b", "current-prerelease", base)
+    _commit(
+        tmp_path,
+        PACKAGE_PATH / "module.py",
+        "CURRENT = 1\n",
+        "hotfix(example): prerelease 1.1.0b1",
+    )
+
+    outputs = _run_resolve_refs_step(tmp_path, version="1.1.0b1").outputs
+
+    # No earlier sibling and no example==1.1.0 base tag, so selection falls through to
+    # the latest reachable stable tag.
+    assert outputs["prev-tag"] == "example==1.0.0"
+
+
 def test_prerelease_resolve_refs_warns_on_unparseable_prerelease(
     tmp_path: Path,
 ) -> None:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,13 +249,6 @@ jobs:
             SHA="$INPUT_SHA"
           fi
 
-          # Canonicalize to a full 40-char commit SHA so the `sha` output and the
-          # summary permalink below never carry a symbolic ref (HEAD, a branch, or a
-          # short SHA). Use `-q --verify` (as resolve-refs does): it prints only the
-          # SHA on success and stays silent otherwise, so git's stderr is never folded
-          # into the value — plain `--verify` with `2>&1` would capture the
-          # "refname is ambiguous" warning (emitted on success for a name that is both
-          # a branch and a tag) and corrupt SHA into a multi-line string.
           REQUESTED_SHA="$SHA"
           if ! RESOLVED_SHA=$(git rev-parse -q --verify "${REQUESTED_SHA}^{commit}"); then
             echo "::error::release-sha $REQUESTED_SHA does not resolve to a commit in this repository"
@@ -524,20 +517,6 @@ jobs:
               --list "$PKG_NAME==*")
           }
 
-          # Parse a version into comparable pre-release components, returned via the
-          # globals PRE_BASE / PRE_RANK / PRE_SERIAL (an out-param idiom: read them
-          # immediately, before the next parse_prerelease call overwrites them).
-          # Returns non-zero for anything not a recognized pre-release.
-          #
-          # PRE_RANK encodes PEP 440 phase precedence: dev(0) < a(1) < b(2) < rc(3).
-          # Three spellings of that ordering are accepted:
-          #   1. PEP 440 canonical dev:    X.Y.Z.devN
-          #   2. PEP 440 canonical a/b/rc: X.Y.ZaN / X.Y.ZbN / X.Y.ZrcN
-          #   3. Dash form with aliases:   X.Y.Z-<phase>[.-]?N
-          # In the dash form, alpha/beta alias a/b, and pre/preview are a project
-          # convention mapped to the rc rank (not a PEP 440 rule). The $((10#...))
-          # prefix forces base-10 so a zero-padded serial (e.g. a08/a09) is not read
-          # as invalid octal, which would abort the step under `set -e`.
           parse_prerelease() {
             local version="$1"
             PRE_BASE=""
@@ -570,19 +549,6 @@ jobs:
             fi
           }
 
-          # Find the immediately-preceding sibling pre-release tag for $VERSION: the
-          # highest same-base pre-release that is strictly earlier in PEP 440 order
-          # and not ahead of the release commit. The result is returned via the global
-          # EARLIER_PRERELEASE_TAG (empty if none), which keeps stdout free for the
-          # ::warning:: commands below.
-          #
-          # Unlike latest_stable_tag, this scans ALL package tags (`git tag --list`,
-          # not `--merged`): sibling pre-releases are cut on short-lived parallel
-          # branches that are never merged into this pre-release's commit, so
-          # `--merged` (and valid_previous_tag's `--is-ancestor "$tag" "$RELEASE_SHA"`)
-          # would reject them and defeat the purpose. Ancestry is therefore only
-          # constrained to "not a descendant of RELEASE_SHA"; selecting a same-base
-          # sibling from a divergent branch is a deliberate, accepted trade-off.
           latest_earlier_prerelease_tag() {
             local best_rank=-1
             local best_serial=-1
@@ -600,10 +566,6 @@ jobs:
             EARLIER_PRERELEASE_TAG=""
 
             if ! parse_prerelease "$VERSION"; then
-              # IS_PRERELEASE (set by a looser test above) flagged this as a
-              # pre-release, but it does not match a grammar we can order. Warn so the
-              # divergence between the two notions is visible, then let the caller fall
-              # back to the base-version / latest-stable tag.
               echo "::warning::VERSION '$VERSION' is treated as a pre-release but does not match a recognized pre-release format; predecessor selection will fall back to the base-version or latest stable tag"
               return
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
             if [ -n "${INPUT_SHA}" ]; then
               echo "| \`release-sha\` | \`$(escape_cell "${INPUT_SHA}")\` |"
             else
-              echo "| \`release-sha\` | (not provided — only dangerous non-main releases resolve this to the workflow SHA; otherwise invalid) |"
+              echo "| \`release-sha\` | (not provided — resolved to the workflow SHA only when \`dangerous-nonmain-release\` is enabled; otherwise invalid) |"
             fi
             if [ "${IS_DANGEROUS}" = "true" ]; then
               echo "| \`dangerous-nonmain-release\` | ⚠️ enabled |"
@@ -611,10 +611,15 @@ jobs:
               # Skip "future" siblings: a tag that descends from RELEASE_SHA cannot be a
               # predecessor. --is-ancestor exits 0 (ancestor -> skip), 1 (not -> keep),
               # or 128 (error); treat any non-1 as skip so a git error never silently
-              # accepts a bad candidate.
+              # accepts a bad candidate. Warn on the error case (non-0, non-1) so it is
+              # not silently bucketed with the expected future-sibling skip, matching
+              # the git-tag-list and parse-failure warnings above.
               ahead_status=0
               git merge-base --is-ancestor "$RELEASE_SHA" "$tag" || ahead_status=$?
               if [ "$ahead_status" -ne 1 ]; then
+                if [ "$ahead_status" -ne 0 ]; then
+                  echo "::warning::git merge-base --is-ancestor exited $ahead_status for '$tag'; skipping as a predecessor candidate"
+                fi
                 continue
               fi
               # Track the latest earlier sibling: highest rank, then highest serial.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
             if [ -n "${INPUT_SHA}" ]; then
               echo "| \`release-sha\` | \`$(escape_cell "${INPUT_SHA}")\` |"
             else
-              echo "| \`release-sha\` | (empty) |"
+              echo "| \`release-sha\` | (not provided — only dangerous non-main releases resolve this to the workflow SHA; otherwise invalid) |"
             fi
             if [ "${IS_DANGEROUS}" = "true" ]; then
               echo "| \`dangerous-nonmain-release\` | ⚠️ enabled |"
@@ -249,10 +249,19 @@ jobs:
             SHA="$INPUT_SHA"
           fi
 
-          if ! err=$(git cat-file -e "${SHA}^{commit}" 2>&1); then
-            echo "::error::release-sha $SHA does not resolve to a commit in this repository: $err"
+          # Canonicalize to a full 40-char commit SHA so the `sha` output and the
+          # summary permalink below never carry a symbolic ref (HEAD, a branch, or a
+          # short SHA). Use `-q --verify` (as resolve-refs does): it prints only the
+          # SHA on success and stays silent otherwise, so git's stderr is never folded
+          # into the value — plain `--verify` with `2>&1` would capture the
+          # "refname is ambiguous" warning (emitted on success for a name that is both
+          # a branch and a tag) and corrupt SHA into a multi-line string.
+          REQUESTED_SHA="$SHA"
+          if ! RESOLVED_SHA=$(git rev-parse -q --verify "${REQUESTED_SHA}^{commit}"); then
+            echo "::error::release-sha $REQUESTED_SHA does not resolve to a commit in this repository"
             exit 1
           fi
+          SHA="$RESOLVED_SHA"
 
           # Validate that pyproject.toml at this SHA declares the requested version.
           # This is what we actually care about: the wheel built from this SHA must
@@ -287,6 +296,21 @@ jobs:
           fi
 
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$INPUT_SHA" ]; then
+            RELEASE_SHA_SOURCE="explicit release-sha input"
+          else
+            RELEASE_SHA_SOURCE="workflow SHA fallback because dangerous-nonmain-release is enabled"
+          fi
+          {
+            echo "### Resolved release target"
+            echo ""
+            echo "| Target | Value |"
+            echo "|---|---|"
+            echo "| Release SHA | [\`${SHA:0:7}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${SHA}) |"
+            echo "| Resolution | ${RELEASE_SHA_SOURCE} |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY" || echo "::warning::Failed to write resolved release target to GITHUB_STEP_SUMMARY (non-fatal, continuing)"
 
   # Build the distribution package and extract version info
   # Runs in isolated environment with minimal permissions for security
@@ -451,6 +475,8 @@ jobs:
           RELEASE_SHA: ${{ needs.setup.outputs.release-sha }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
+          set -euo pipefail
+
           # Detect PEP 440 pre-release versions:
           #   - Dash separator: 1.0.0-rc.1
           #   - PEP 440 suffixes: 1.0.0a1, 1.0.0b1, 1.0.0rc1, 1.0.0.dev1
@@ -498,8 +524,152 @@ jobs:
               --list "$PKG_NAME==*")
           }
 
-          # Prefer the expected predecessor, then fall back to the highest stable
-          # package tag that is actually in the release commit's history.
+          # Parse a version into comparable pre-release components, returned via the
+          # globals PRE_BASE / PRE_RANK / PRE_SERIAL (an out-param idiom: read them
+          # immediately, before the next parse_prerelease call overwrites them).
+          # Returns non-zero for anything not a recognized pre-release.
+          #
+          # PRE_RANK encodes PEP 440 phase precedence: dev(0) < a(1) < b(2) < rc(3).
+          # Three spellings of that ordering are accepted:
+          #   1. PEP 440 canonical dev:    X.Y.Z.devN
+          #   2. PEP 440 canonical a/b/rc: X.Y.ZaN / X.Y.ZbN / X.Y.ZrcN
+          #   3. Dash form with aliases:   X.Y.Z-<phase>[.-]?N
+          # In the dash form, alpha/beta alias a/b, and pre/preview are a project
+          # convention mapped to the rc rank (not a PEP 440 rule). The $((10#...))
+          # prefix forces base-10 so a zero-padded serial (e.g. a08/a09) is not read
+          # as invalid octal, which would abort the step under `set -e`.
+          parse_prerelease() {
+            local version="$1"
+            PRE_BASE=""
+            PRE_RANK=-1
+            PRE_SERIAL=-1
+
+            if [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)\.dev([0-9]+)$ ]]; then
+              PRE_BASE="${BASH_REMATCH[1]}"
+              PRE_RANK=0
+              PRE_SERIAL=$((10#${BASH_REMATCH[2]}))
+            elif [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)(a|b|rc)([0-9]+)$ ]]; then
+              PRE_BASE="${BASH_REMATCH[1]}"
+              PRE_SERIAL=$((10#${BASH_REMATCH[3]}))
+              case "${BASH_REMATCH[2]}" in
+                a) PRE_RANK=1 ;;
+                b) PRE_RANK=2 ;;
+                rc) PRE_RANK=3 ;;
+              esac
+            elif [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-(dev|a|alpha|b|beta|rc|pre|preview)[.-]?([0-9]+)$ ]]; then
+              PRE_BASE="${BASH_REMATCH[1]}"
+              PRE_SERIAL=$((10#${BASH_REMATCH[3]}))
+              case "${BASH_REMATCH[2]}" in
+                dev) PRE_RANK=0 ;;
+                a|alpha) PRE_RANK=1 ;;
+                b|beta) PRE_RANK=2 ;;
+                rc|pre|preview) PRE_RANK=3 ;;
+              esac
+            else
+              return 1
+            fi
+          }
+
+          # Find the immediately-preceding sibling pre-release tag for $VERSION: the
+          # highest same-base pre-release that is strictly earlier in PEP 440 order
+          # and not ahead of the release commit. The result is returned via the global
+          # EARLIER_PRERELEASE_TAG (empty if none), which keeps stdout free for the
+          # ::warning:: commands below.
+          #
+          # Unlike latest_stable_tag, this scans ALL package tags (`git tag --list`,
+          # not `--merged`): sibling pre-releases are cut on short-lived parallel
+          # branches that are never merged into this pre-release's commit, so
+          # `--merged` (and valid_previous_tag's `--is-ancestor "$tag" "$RELEASE_SHA"`)
+          # would reject them and defeat the purpose. Ancestry is therefore only
+          # constrained to "not a descendant of RELEASE_SHA"; selecting a same-base
+          # sibling from a divergent branch is a deliberate, accepted trade-off.
+          latest_earlier_prerelease_tag() {
+            local best_rank=-1
+            local best_serial=-1
+            local candidate_base
+            local candidate_rank
+            local candidate_serial
+            local current_base
+            local current_rank
+            local current_serial
+            local tag
+            local tag_version
+            local tags
+            local ahead_status
+
+            EARLIER_PRERELEASE_TAG=""
+
+            if ! parse_prerelease "$VERSION"; then
+              # IS_PRERELEASE (set by a looser test above) flagged this as a
+              # pre-release, but it does not match a grammar we can order. Warn so the
+              # divergence between the two notions is visible, then let the caller fall
+              # back to the base-version / latest-stable tag.
+              echo "::warning::VERSION '$VERSION' is treated as a pre-release but does not match a recognized pre-release format; predecessor selection will fall back to the base-version or latest stable tag"
+              return
+            fi
+            current_base="$PRE_BASE"
+            current_rank="$PRE_RANK"
+            current_serial="$PRE_SERIAL"
+
+            # Capture the tag list up front so a `git tag` failure surfaces instead of
+            # being swallowed by process substitution (exempt from `set -e`) and
+            # masquerading as "no earlier pre-release".
+            if ! tags=$(git tag --list "$PKG_NAME==*"); then
+              echo "::warning::git tag --list failed; skipping earlier-prerelease predecessor detection"
+              return
+            fi
+
+            while IFS= read -r tag; do
+              [ -z "$tag" ] && continue
+              [ "$tag" = "$PKG_NAME==$VERSION" ] && continue
+              tag_version="${tag#"$PKG_NAME=="}"
+              if ! parse_prerelease "$tag_version"; then
+                continue
+              fi
+              candidate_base="$PRE_BASE"
+              candidate_rank="$PRE_RANK"
+              candidate_serial="$PRE_SERIAL"
+
+              # Keep only same-base candidates strictly earlier than $VERSION. On equal
+              # rank, `>=` (not `>`) excludes an equal serial: that is either $VERSION
+              # itself under a different tag spelling, or a same-precedence duplicate —
+              # neither is a valid predecessor.
+              if [ "$candidate_base" != "$current_base" ] \
+                || (( candidate_rank > current_rank )) \
+                || (( candidate_rank == current_rank && candidate_serial >= current_serial )); then
+                continue
+              fi
+              # Skip tags that don't resolve, or that share no history with the release
+              # commit (disjoint/grafted history — nearly always false within one repo,
+              # but cheap insurance).
+              if ! git rev-parse -q --verify "refs/tags/$tag^{commit}" >/dev/null \
+                || ! git merge-base "$tag" "$RELEASE_SHA" >/dev/null; then
+                continue
+              fi
+              # Skip "future" siblings: a tag that descends from RELEASE_SHA cannot be a
+              # predecessor. --is-ancestor exits 0 (ancestor -> skip), 1 (not -> keep),
+              # or 128 (error); treat any non-1 as skip so a git error never silently
+              # accepts a bad candidate.
+              ahead_status=0
+              git merge-base --is-ancestor "$RELEASE_SHA" "$tag" || ahead_status=$?
+              if [ "$ahead_status" -ne 1 ]; then
+                continue
+              fi
+              # Track the latest earlier sibling: highest rank, then highest serial.
+              if (( candidate_rank > best_rank )) \
+                || (( candidate_rank == best_rank && candidate_serial > best_serial )); then
+                EARLIER_PRERELEASE_TAG="$tag"
+                best_rank="$candidate_rank"
+                best_serial="$candidate_serial"
+              fi
+            done <<< "$tags"
+          }
+
+          # Choose the predecessor tag whose `..RELEASE_SHA` range defines the log.
+          # Pre-releases use a three-tier fallback: (1) the latest earlier sibling
+          # pre-release of the same base version, else (2) the base-version tag if it
+          # is reachable, else (3) the highest stable tag in the release's history.
+          # Stable releases use the immediate previous patch, else the highest stable.
           if [ "$IS_PRERELEASE" = "true" ]; then
             # Strip pre-release suffix to get base version (e.g. 0.5.2a1 -> 0.5.2)
             # Strip suffixes inside-out: dash first, then .dev, then a/b/rc
@@ -510,14 +680,20 @@ jobs:
               echo "::warning::BASE_VERSION '$BASE_VERSION' is not a clean X.Y.Z after stripping pre-release suffixes from '$VERSION'"
             fi
 
-            PREV_TAG="$PKG_NAME==$BASE_VERSION"
+            latest_earlier_prerelease_tag
+            PREV_TAG="$EARLIER_PRERELEASE_TAG"
+            if [ -z "$PREV_TAG" ]; then
+              PREV_TAG="$PKG_NAME==$BASE_VERSION"
+              if ! valid_previous_tag "$PREV_TAG"; then
+                PREV_TAG=$(latest_stable_tag)
+              fi
+            fi
           else
             PREV_TAG="$PKG_NAME==${VERSION%.*}.$(( ${VERSION##*.} - 1 ))"
             [[ "${VERSION##*.}" -eq 0 ]] && PREV_TAG=""
-          fi
-
-          if ! valid_previous_tag "$PREV_TAG"; then
-            PREV_TAG=$(latest_stable_tag)
+            if ! valid_previous_tag "$PREV_TAG"; then
+              PREV_TAG=$(latest_stable_tag)
+            fi
           fi
 
           # A stable release with no reachable predecessor tag is anomalous unless


### PR DESCRIPTION
Alpha releases are cut from throwaway branches, so the previous alpha tag is a sibling of the next release commit rather than its ancestor. The release workflow therefore rejected `deepagents==0.7.0a6` while preparing `0.7.0a7` and fell back to the latest stable tag, producing “Git log since deepagents==0.6.12”.

This makes prerelease resolution prefer the highest earlier prerelease tag with the same base version. Sibling tags are accepted when they share history with the release commit and are not ahead of it; the first prerelease still falls back to the base-version or latest stable tag. For example, `deepagents==0.7.0a7` now produces “Git log since deepagents==0.7.0a6”.

The release setup summary also distinguishes an omitted `release-sha` input from the canonical commit selected by the workflow, so alpha runs show the exact commit they publish instead of only `(empty)`.

The workflow shell coverage exercises sibling branches, future-tag rejection, prerelease phase and serial ordering, stable fallbacks, malformed prereleases, and canonical release-target summaries.