### PR TITLE
test(sdk): handle expected middleware warnings

### DIFF
--- a/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
@@ -38,6 +38,8 @@ from deepagents.middleware.rubric import (
 )
 from tests.unit_tests.chat_model import GenericFakeChatModel
 
+pytestmark = pytest.mark.filterwarnings(r"ignore:The middleware `RubricMiddleware` is in beta\..*")
+
 # Placeholder model identifier used wherever the grader is stubbed via
 # `monkeypatch` and the value would never reach a real provider client.
 _STUB_MODEL = "stub:test"

--- a/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
@@ -736,7 +736,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config():
+        with mock_get_config(), pytest.warns(UserWarning, match="could not be offloaded"):
             call_wrap_model_call(middleware, state, runtime)
 
         image_uploads = [(p, c) for p, c in backend.write_calls if p.startswith("/conversation_history/media/")]
@@ -778,7 +778,7 @@ class TestOffloadingBasic:
         state = cast("AgentState[Any]", {"messages": messages})
         runtime = make_mock_runtime()
 
-        with mock_get_config():
+        with mock_get_config(), pytest.warns(UserWarning, match="could not be offloaded"):
             call_wrap_model_call(middleware, state, runtime)
 
         archive_write = next((p, c) for p, c in backend.write_calls if p.endswith(".md"))
@@ -3564,7 +3564,7 @@ async def test_async_upload_response_error_writes_placeholder() -> None:
     state = cast("AgentState[Any]", {"messages": messages})
     runtime = make_mock_runtime()
 
-    with mock_get_config():
+    with mock_get_config(), pytest.warns(UserWarning, match="could not be offloaded"):
         await call_awrap_model_call(middleware, state, runtime)
 
     image_uploads = [(p, c) for p, c in backend.write_calls if p.startswith("/conversation_history/media/")]

--- a/libs/deepagents/tests/unit_tests/test_deep_agent_streaming.py
+++ b/libs/deepagents/tests/unit_tests/test_deep_agent_streaming.py
@@ -11,6 +11,7 @@ from collections.abc import Callable, Sequence
 from contextlib import suppress
 from typing import Any
 
+import pytest
 from langchain.agents._subagent_transformer import (
     AsyncSubagentRunStream,
     SubagentRunStream,
@@ -25,6 +26,8 @@ from langgraph.graph.state import CompiledStateGraph
 from pydantic import Field
 
 from deepagents import create_deep_agent
+
+pytestmark = pytest.mark.filterwarnings(r"ignore:The v3 streaming protocol on Pregel is experimental\.")
 
 
 class _Scripted(BaseChatModel):

--- a/libs/deepagents/tests/unit_tests/test_end_to_end.py
+++ b/libs/deepagents/tests/unit_tests/test_end_to_end.py
@@ -4325,6 +4325,7 @@ def test_summarization_clips_vanilla_tool_batch_on_overflow() -> None:
         assert f"/large_tool_results/{tcid}" in files, f"missing offload file for {tcid}"
 
 
+@pytest.mark.filterwarnings(r"ignore:The middleware `RubricMiddleware` is in beta\..*")
 class TestRubricMiddlewareEndToEnd:
     """End-to-end tests for `RubricMiddleware` wired into `create_deep_agent`.
 


### PR DESCRIPTION
Expected beta warnings from `RubricMiddleware` and Pregel v3 streaming currently flood unit-test output, while media-offload failure warnings are emitted without being asserted.

This scopes exact-message warning filters to the tests that intentionally exercise those beta APIs and captures the media-offload warnings with `pytest.warns`. Unrelated warnings remain visible.
