### PR TITLE
style(code): rename "auto" approval-mode label to "YOLO"

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -466,7 +466,7 @@ class StatusBar(Horizontal):
         indicator.remove_class("on", "off")
 
         if new_value:
-            indicator.update("auto")
+            indicator.update("YOLO")
             indicator.add_class("on")
         else:
             indicator.update("manual")


### PR DESCRIPTION
The interactive TUI now labels the enabled auto-approve mode as "YOLO" in the status bar.

---

Renames the user-facing auto-approve mode indicator shown in the TUI status bar from `auto` to `YOLO`. This is a display-string-only change in `libs/code/deepagents_code/tui/widgets/status.py`; internal identifiers (`auto_approve`), the `--auto-approve` CLI flag, the `dangerously-auto` config value, and env vars are intentionally left unchanged to avoid breaking changes.

Made by [Open SWE](https://openswe.vercel.app/agents/e160ef65-607d-d8db-2c0e-c8d2b1824b5d)