### PR TITLE
fix(infra): harden `dcode` release automation

### DIFF
--- a/.github/scripts/dcode-release-notes.js
+++ b/.github/scripts/dcode-release-notes.js
@@ -841,8 +841,15 @@ async function checkCuratedState({
     return { status: 'bypassed' };
   }
 
-  let comments = await listComments(github, owner, repo, number);
-  let override = latestOverride(comments, login, id, version);
+  let comments = [];
+  let override = null;
+  try {
+    comments = await listComments(github, owner, repo, number);
+    override = latestOverride(comments, login, id, version);
+  } catch (error) {
+    if (initialDraftPollAttempts === 0) throw error;
+    core.warning(`Reading comments before polling for the curated release-note draft failed; retrying: ${error instanceof Error ? error.message : String(error)}`);
+  }
   if (!override && initialDraftPollAttempts > 0) {
     core.info('Waiting for the automatic curated release-note draft to be published');
     for (let attempt = 0; attempt < initialDraftPollAttempts && !override; attempt += 1) {

--- a/.github/scripts/dcode-release-notes.js
+++ b/.github/scripts/dcode-release-notes.js
@@ -627,12 +627,12 @@ async function prepareApply({ github, owner, repo, number, expectedHead, changel
   return JSON.parse(fs.readFileSync(stateFile, 'utf8'));
 }
 
-async function validateApplySnapshot({ github, owner, repo, state, login, id, expectedHead }) {
+async function validateApplySnapshot({ github, owner, repo, state, login, id, expectedHead, checkPrHead = true }) {
   const pr = await getPr(github, owner, repo, state.number);
   if (
     !isReleasePr(pr) ||
     pr.draft ||
-    pr.head.sha !== expectedHead ||
+    (checkPrHead && pr.head.sha !== expectedHead) ||
     exactSha256(pr.body ?? '') !== state.originalBodyHash
   ) {
     throw new Error('Release PR changed while apply was preparing; refusing to publish stale metadata');
@@ -648,6 +648,13 @@ async function validateApplySnapshot({ github, owner, repo, state, login, id, ex
     throw new Error('Curated release-note draft changed while apply was preparing; re-run apply');
   }
   return comments;
+}
+
+async function validateReleaseBranchHead({ github, owner, repo, expectedHead }) {
+  const ref = await github.rest.git.getRef({ owner, repo, ref: `heads/${RELEASE_BRANCH}` });
+  if (ref.data.object.sha !== expectedHead) {
+    throw new Error('Release branch changed while apply was preparing; refusing to publish stale metadata');
+  }
 }
 
 async function createApplyCommit({ github, owner, repo, stateFile, changelogFile, appSlug, login, id }) {
@@ -697,7 +704,17 @@ async function createApplyCommit({ github, owner, repo, stateFile, changelogFile
 async function publishAppliedState({ github, owner, repo, stateFile, appliedHead, appSlug, login, id }) {
   await authenticatedBot(github, appSlug, login, id);
   const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
-  const comments = await validateApplySnapshot({ github, owner, repo, state, login, id, expectedHead: appliedHead });
+  const comments = await validateApplySnapshot({
+    github,
+    owner,
+    repo,
+    state,
+    login,
+    id,
+    expectedHead: appliedHead,
+    checkPrHead: false,
+  });
+  await validateReleaseBranchHead({ github, owner, repo, expectedHead: appliedHead });
   await github.rest.pulls.update({ owner, repo, pull_number: state.number, body: state.body });
   return upsertOwnMarkedComment({
     github,
@@ -768,7 +785,18 @@ function warnUnparsableMarkedComments({ core, comments, login, id }) {
   }
 }
 
-async function checkCuratedState({ github, context, core, number, login, id, expectedHead = null }) {
+async function checkCuratedState({
+  github,
+  context,
+  core,
+  number,
+  login,
+  id,
+  expectedHead = null,
+  initialDraftPollAttempts = 0,
+  initialDraftPollIntervalMs = 10_000,
+  sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+}) {
   const { owner, repo } = context.repo;
   const pr = await getPr(github, owner, repo, number);
   if (expectedHead !== null && pr.head.sha !== expectedHead) {
@@ -813,8 +841,41 @@ async function checkCuratedState({ github, context, core, number, login, id, exp
     return { status: 'bypassed' };
   }
 
-  const comments = await listComments(github, owner, repo, number);
-  const override = latestOverride(comments, login, id, version);
+  let comments = await listComments(github, owner, repo, number);
+  let override = latestOverride(comments, login, id, version);
+  if (!override && initialDraftPollAttempts > 0) {
+    core.info('Waiting for the automatic curated release-note draft to be published');
+    for (let attempt = 0; attempt < initialDraftPollAttempts && !override; attempt += 1) {
+      await sleep(initialDraftPollIntervalMs);
+      // A transient read failure must not abort the wait the loop exists to
+      // provide: warn and keep polling. If reads never recover, `override` stays
+      // falsy and control falls through to the fail-closed `missing` return below.
+      try {
+        comments = await listComments(github, owner, repo, number);
+        override = latestOverride(comments, login, id, version);
+      } catch (error) {
+        core.warning(`Polling for the curated release-note draft failed (attempt ${attempt + 1}/${initialDraftPollAttempts}); retrying: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+
+    // Polling can outlive the state that made curated notes mandatory. Honor a
+    // newly-drafted PR or bypass label, while still failing closed for any other
+    // snapshot change before using comments collected during the wait.
+    const live = await getPr(github, owner, repo, number);
+    const liveLabels = labelNames(live);
+    if (live.draft) {
+      core.info('Draft release PR; curated release notes are not required yet');
+      return { status: 'draft' };
+    }
+    if (liveLabels.includes(BYPASS_LABEL)) {
+      core.warning(`Bypassing curated release notes because ${BYPASS_LABEL} is set`);
+      return { status: 'bypassed' };
+    }
+    if (prSnapshotChanged(live)) {
+      core.setFailed('The release PR changed while waiting for the automatic curated release-note draft');
+      return { status: 'changed' };
+    }
+  }
   const applied = latestApplied(comments, login, id, version);
   warnUnparsableMarkedComments({ core, comments, login, id });
   if (!override) {
@@ -825,11 +886,17 @@ async function checkCuratedState({ github, context, core, number, login, id, exp
   const changelog = await fetchChangelog(github, owner, repo, pr.head.sha);
   const currentSection = extractVersionSection(changelog, version);
   const currentFingerprint = changelogFingerprint(currentSection);
+  // True when the generated changelog has drifted from the curated override.
+  // Reused for the new-entries warning below and for the missing-vs-unapplied
+  // split in the !applied branch.
+  const generatedEntriesChanged =
+    currentSection !== override.section &&
+    currentFingerprint !== override.metadata['changelog-fingerprint'];
   // Warn (idempotently; deduped by head+fingerprint) when the changelog has moved
-  // away from the curated override. Same condition and args at both call sites: the
-  // pre-applied miss and the post-applied mismatch below.
+  // away from the curated override. Invoked at both the pre-applied miss and the
+  // post-applied mismatch below.
   const maybeWarnNewEntries = async () => {
-    if (currentSection !== override.section && currentFingerprint !== override.metadata['changelog-fingerprint']) {
+    if (generatedEntriesChanged) {
       // Best-effort courtesy comment: if posting it fails (rate limit, transient
       // 5xx) it must not throw, or the raw API error would replace the specific,
       // actionable gate reason (the setFailed message / failures list) reported
@@ -843,8 +910,27 @@ async function checkCuratedState({ github, context, core, number, login, id, exp
   };
   if (!applied) {
     await maybeWarnNewEntries();
-    core.setFailed(`Run ${COMMAND_MENTION} draft and then ${COMMAND_MENTION} apply before merging`);
-    return { status: 'missing' };
+    let draftMetadataChanged = false;
+    if (!generatedEntriesChanged) {
+      const currentHeading = currentSection.split('\n')[0];
+      const overrideHeading = override.section.split('\n')[0];
+      const headingChanged =
+        sha256(overrideHeading) !== override.metadata['release-heading-hash'] ||
+        (currentSection !== override.section && overrideHeading !== currentHeading);
+      draftMetadataChanged = headingChanged || !(await isDescendant(
+        github,
+        owner,
+        repo,
+        override.metadata['release-pr-head'],
+        pr.head.sha,
+      ));
+    }
+    if (generatedEntriesChanged || draftMetadataChanged) {
+      core.setFailed(`Run ${COMMAND_MENTION} draft and then ${COMMAND_MENTION} apply before merging`);
+      return { status: 'missing' };
+    }
+    core.setFailed(`Review the curated release-note draft, then run ${COMMAND_MENTION} apply before merging`);
+    return { status: 'unapplied' };
   }
 
   const appliedMetadata = applied.metadata;

--- a/.github/scripts/dcode-release-notes.test.js
+++ b/.github/scripts/dcode-release-notes.test.js
@@ -871,6 +871,31 @@ test('required check keeps polling through a transient read failure', async () =
   assert.ok(core.warnings.some(message => /Polling for the curated release-note draft failed/.test(message)));
 });
 
+test('required check retries when the initial comments read fails', async () => {
+  let sleeps = 0;
+  const comments = [];
+  const run = makeGithub({
+    comments,
+    onListComments: ({ count }) => {
+      if (count === 1) throw new Error('transient 502');
+      if (count === 2) comments.push(overrideComment());
+    },
+  });
+  const core = makeCore();
+  const result = await releaseNotes.checkCuratedState({
+    github: run.github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core,
+    number: 123,
+    ...BOT_AUTH,
+    initialDraftPollAttempts: 5,
+    sleep: async () => { sleeps += 1; },
+  });
+  assert.equal(result.status, 'unapplied');
+  assert.equal(sleeps, 1);
+  assert.ok(core.warnings.some(message => /Reading comments before polling.*transient 502/.test(message)));
+});
+
 test('required check stops polling as soon as the draft appears', async () => {
   let sleeps = 0;
   const comments = [];

--- a/.github/scripts/dcode-release-notes.test.js
+++ b/.github/scripts/dcode-release-notes.test.js
@@ -105,11 +105,13 @@ function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adm
     getByUsername: [],
     getCommit: [],
     getContent: [],
+    getRef: [],
     updateComment: [],
     updatePr: [],
     updateRef: [],
   };
   let livePr = structuredClone(pr);
+  let liveBranchHead = pr.head.sha;
   let getPrCount = 0;
   let listCommentsCount = 0;
   const github = {
@@ -164,6 +166,10 @@ function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adm
           calls.getCommit.push(params);
           return { data: { tree: { sha: 'tree-base' } } };
         },
+        getRef: async params => {
+          calls.getRef.push(params);
+          return { data: { object: { sha: liveBranchHead } } };
+        },
         createBlob: async params => {
           calls.createBlob.push(params);
           return { data: { sha: 'blob-curated' } };
@@ -178,6 +184,7 @@ function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adm
         },
         updateRef: async params => {
           calls.updateRef.push(params);
+          liveBranchHead = params.sha;
           livePr.head.sha = params.sha;
           return { data: { object: { sha: params.sha } } };
         },
@@ -191,7 +198,13 @@ function makeGithub({ pr = releasePr(), comments = [], permission = 'write', adm
     },
     paginate: async (method, params) => (await method(params)).data,
   };
-  return { github, calls, getPr: () => livePr, setPr: value => { livePr = structuredClone(value); } };
+  return {
+    github,
+    calls,
+    getPr: () => livePr,
+    setBranchHead: value => { liveBranchHead = value; },
+    setPr: value => { livePr = structuredClone(value); },
+  };
 }
 
 function tempWorkspace(section = GENERATED_SECTION) {
@@ -724,6 +737,178 @@ test('required check fails when curated draft or applied metadata is missing', a
   assert.match(core.failed, /draft and then/);
 });
 
+test('required check waits for the first automatic draft before validating', async () => {
+  const comments = [];
+  const run = makeGithub({
+    comments,
+    onListComments: ({ count }) => {
+      if (count === 2) comments.push(overrideComment());
+    },
+  });
+  const core = makeCore();
+  const result = await releaseNotes.checkCuratedState({
+    github: run.github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core,
+    number: 123,
+    ...BOT_AUTH,
+    initialDraftPollAttempts: 1,
+    sleep: async () => {},
+  });
+  assert.equal(result.status, 'unapplied');
+  assert.match(core.failed, /Review the curated release-note draft.*apply/);
+  assert.ok(core.infos.some(message => /Waiting for the automatic/.test(message)));
+  assert.equal(run.calls.getContent.length, 1);
+});
+
+test('required check honors draft and bypass state added while polling', async () => {
+  for (const exemption of ['draft', 'bypass']) {
+    const run = makeGithub({
+      comments: [],
+      onGetPr: ({ count, pr }) => {
+        if (count !== 2) return;
+        if (exemption === 'draft') pr.draft = true;
+        else pr.labels = [{ name: releaseNotes.BYPASS_LABEL }];
+      },
+    });
+    const core = makeCore();
+    const result = await releaseNotes.checkCuratedState({
+      github: run.github,
+      context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+      core,
+      number: 123,
+      ...BOT_AUTH,
+      initialDraftPollAttempts: 1,
+      sleep: async () => {},
+    });
+    assert.equal(result.status, exemption === 'draft' ? 'draft' : 'bypassed');
+    assert.equal(core.failed, null);
+    assert.equal(run.calls.getContent.length, 0);
+  }
+});
+
+test('required check requires a fresh draft when heading or release ancestry drifted', async () => {
+  const changedHeading = HEADING.replace('(2026-07-09)', '(2026-07-10)');
+  const headingSection = GENERATED_SECTION.replace(HEADING, changedHeading);
+  const headingPr = releasePr({
+    body: `Release notes preview\n\n${headingSection}\n_End release notes preview._\n`,
+  });
+  const headingFiles = new Map([[HEAD, changelog(headingSection)]]);
+  const headingRun = makeGithub({ pr: headingPr, comments: [overrideComment()], files: headingFiles });
+  const headingCore = makeCore();
+  const headingResult = await releaseNotes.checkCuratedState({
+    github: headingRun.github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core: headingCore,
+    number: 123,
+    ...BOT_AUTH,
+  });
+  assert.equal(headingResult.status, 'missing');
+  assert.match(headingCore.failed, /draft and then.*apply/);
+
+  const rewrittenHead = 'd'.repeat(40);
+  const rewrittenPr = releasePr({ head: { ...releasePr().head, sha: rewrittenHead } });
+  const rewrittenFiles = new Map([[rewrittenHead, changelog()]]);
+  const rewrittenRun = makeGithub({
+    pr: rewrittenPr,
+    comments: [overrideComment()],
+    files: rewrittenFiles,
+    comparison: 'diverged',
+  });
+  const rewrittenCore = makeCore();
+  const rewrittenResult = await releaseNotes.checkCuratedState({
+    github: rewrittenRun.github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core: rewrittenCore,
+    number: 123,
+    ...BOT_AUTH,
+  });
+  assert.equal(rewrittenResult.status, 'missing');
+  assert.match(rewrittenCore.failed, /draft and then.*apply/);
+});
+
+test('required check gives up and reports missing when the draft never arrives', async () => {
+  let sleeps = 0;
+  const run = makeGithub({ comments: [] }); // override never appears
+  const core = makeCore();
+  const result = await releaseNotes.checkCuratedState({
+    github: run.github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core,
+    number: 123,
+    ...BOT_AUTH,
+    initialDraftPollAttempts: 3,
+    sleep: async () => { sleeps += 1; },
+  });
+  assert.equal(result.status, 'missing');
+  assert.match(core.failed, /draft and then/);
+  assert.equal(sleeps, 3); // polled to exhaustion, not short-circuited early
+  assert.equal(run.calls.getContent.length, 0); // returned before fetching the changelog
+});
+
+test('required check keeps polling through a transient read failure', async () => {
+  let sleeps = 0;
+  const comments = [];
+  const run = makeGithub({
+    comments,
+    onListComments: ({ count }) => {
+      if (count === 2) throw new Error('transient 502');
+      if (count === 3) comments.push(overrideComment());
+    },
+  });
+  const core = makeCore();
+  const result = await releaseNotes.checkCuratedState({
+    github: run.github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core,
+    number: 123,
+    ...BOT_AUTH,
+    initialDraftPollAttempts: 5,
+    sleep: async () => { sleeps += 1; },
+  });
+  assert.equal(result.status, 'unapplied'); // recovered after the blip; draft found
+  assert.equal(sleeps, 2); // one failed poll, one that found the draft
+  assert.ok(core.warnings.some(message => /Polling for the curated release-note draft failed/.test(message)));
+});
+
+test('required check stops polling as soon as the draft appears', async () => {
+  let sleeps = 0;
+  const comments = [];
+  const run = makeGithub({
+    comments,
+    onListComments: ({ count }) => {
+      if (count === 2) comments.push(overrideComment());
+    },
+  });
+  const core = makeCore();
+  await releaseNotes.checkCuratedState({
+    github: run.github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core,
+    number: 123,
+    ...BOT_AUTH,
+    initialDraftPollAttempts: 5,
+    sleep: async () => { sleeps += 1; },
+  });
+  assert.equal(sleeps, 1); // exited on the first successful poll, not all 5 attempts
+});
+
+test('required check does not poll when polling is disabled', async () => {
+  const run = makeGithub({ comments: [] });
+  const core = makeCore();
+  const result = await releaseNotes.checkCuratedState({
+    github: run.github,
+    context: { repo: { owner: 'langchain-ai', repo: 'deepagents' } },
+    core,
+    number: 123,
+    ...BOT_AUTH,
+    initialDraftPollAttempts: 0,
+    sleep: async () => { throw new Error('sleep must not be called when polling is disabled'); },
+  });
+  assert.equal(result.status, 'missing');
+  assert.ok(!core.infos.some(message => /Waiting for the automatic/.test(message)));
+});
+
 test('required check fails when applied metadata references an older override', async () => {
   const pr = releasePr({
     head: { ...releasePr().head, sha: APPLIED_HEAD },
@@ -838,6 +1023,61 @@ test('apply uses an exact-parent commit and a non-force branch update', async t 
   assert.ok(parsed, 'applied comment should parse');
   assert.equal(parsed.metadata['override-content-hash'], releaseNotes.sha256(CURATED_SECTION));
   assert.equal(parsed.metadata['applied-head'], APPLIED_HEAD);
+  assert.deepEqual(calls.getRef, [{
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    ref: `heads/${releaseNotes.RELEASE_BRANCH}`,
+  }]);
+});
+
+test('apply publishes when the PR head has not caught up with the release branch', async t => {
+  const workspace = tempWorkspace();
+  t.after(() => fs.rmSync(workspace.root, { recursive: true, force: true }));
+  const stateFile = path.join(workspace.root, 'apply.json');
+  const run = makeGithub({ comments: [overrideComment()] });
+  await releaseNotes.prepareApply({
+    github: run.github, owner: 'langchain-ai', repo: 'deepagents', number: 123, expectedHead: HEAD,
+    changelogFile: workspace.file, stateFile, ...BOT_AUTH,
+  });
+  await releaseNotes.createApplyCommit({
+    github: run.github, owner: 'langchain-ai', repo: 'deepagents', stateFile,
+    changelogFile: workspace.file, ...BOT_AUTH,
+  });
+  run.setPr(releasePr());
+
+  await releaseNotes.publishAppliedState({
+    github: run.github, owner: 'langchain-ai', repo: 'deepagents', stateFile,
+    appliedHead: APPLIED_HEAD, ...BOT_AUTH,
+  });
+
+  assert.equal(run.calls.updatePr.length, 1);
+  assert.equal(run.calls.createComment.length, 1);
+});
+
+test('apply refuses a concurrent branch move before publishing metadata', async t => {
+  const workspace = tempWorkspace();
+  t.after(() => fs.rmSync(workspace.root, { recursive: true, force: true }));
+  const stateFile = path.join(workspace.root, 'apply.json');
+  const run = makeGithub({ comments: [overrideComment()] });
+  await releaseNotes.prepareApply({
+    github: run.github, owner: 'langchain-ai', repo: 'deepagents', number: 123, expectedHead: HEAD,
+    changelogFile: workspace.file, stateFile, ...BOT_AUTH,
+  });
+  await releaseNotes.createApplyCommit({
+    github: run.github, owner: 'langchain-ai', repo: 'deepagents', stateFile,
+    changelogFile: workspace.file, ...BOT_AUTH,
+  });
+  run.setBranchHead('f'.repeat(40));
+
+  await assert.rejects(
+    releaseNotes.publishAppliedState({
+      github: run.github, owner: 'langchain-ai', repo: 'deepagents', stateFile,
+      appliedHead: APPLIED_HEAD, ...BOT_AUTH,
+    }),
+    /Release branch changed while apply was preparing/,
+  );
+  assert.equal(run.calls.updatePr.length, 0);
+  assert.equal(run.calls.createComment.length, 0);
 });
 
 test('apply refuses a concurrent branch move before updating the ref', async t => {

--- a/.github/scripts/test_check_sdk_pin.py
+++ b/.github/scripts/test_check_sdk_pin.py
@@ -260,3 +260,13 @@ def test_workflow_warning_comments_link_pin_release() -> None:
     assert text.count(f"${{{link_var}}}") >= 2, (
         "pin release link must be interpolated into the warning comment bodies"
     )
+
+
+def test_workflow_prerelease_warning_has_release_dependency_tip() -> None:
+    """Prerelease warnings explain how to acknowledge intentional release ordering."""
+    workflow = Path(__file__).parents[1] / "workflows" / "check_sdk_pin.yml"
+    text = workflow.read_text()
+
+    assert 'RELEASE_DEPS_BYPASS_LABEL: "release-deps: acknowledged"' in text
+    assert "${releaseDepsBypassLabel}" in text
+    assert "release dependency check fails" in text

--- a/.github/scripts/test_dcode_release_notes.py
+++ b/.github/scripts/test_dcode_release_notes.py
@@ -64,12 +64,18 @@ def test_required_check_is_attached_to_the_validated_pr_head() -> None:
     job = workflow["jobs"]["curated-release-notes"]
     assert "github.event_name == 'pull_request'" in job["name"]
     assert "curated release notes" in job["name"]
+    assert job["timeout-minutes"] == 15
     checkout = job["steps"][0]
     assert checkout["with"]["ref"] == "main"
     assert checkout["with"]["persist-credentials"] is False
     assert "environment" not in job
     check_workflow = CHECK_WORKFLOW.read_text()
     assert "expectedHead: pr.head.sha" in check_workflow
+    assert "initialDraftPollAttempts: context.eventName === 'issue_comment' ? 0 : 72" in check_workflow
+    # A cancelled/timed-out poll must not leave the refresh check spinning forever:
+    # an always() finalizer closes an interrupted in_progress check.
+    assert "if: always() && steps.validate.outputs.refresh_check_id != ''" in check_workflow
+    assert "github.rest.checks.get" in check_workflow
     assert "head_sha: pr.head.sha" in check_workflow
     assert "github.rest.checks.create" in check_workflow
     assert "github.rest.checks.update" in check_workflow

--- a/.github/workflows/check_sdk_pin.yml
+++ b/.github/workflows/check_sdk_pin.yml
@@ -88,6 +88,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SDK_PIN_BYPASS_LABEL: "release: skip sdk pin check"
+          RELEASE_DEPS_BYPASS_LABEL: "release-deps: acknowledged"
           SDK_VERSION: ${{ steps.check.outputs.sdk_version }}
           PKG_PIN: ${{ steps.check.outputs.pkg_pin }}
           PIN_STALE: ${{ steps.check.outputs.stale }}
@@ -106,6 +107,7 @@ jobs:
             const pkgPyproject = process.env.PKG_PYPROJECT;
             const pkgLockdir = process.env.PKG_LOCKDIR;
             const sdkPinBypassLabel = process.env.SDK_PIN_BYPASS_LABEL;
+            const releaseDepsBypassLabel = process.env.RELEASE_DEPS_BYPASS_LABEL;
             const marker = `<!-- sdk-pin-check:${pkgName} -->`;
             const { owner, repo } = context.repo;
             const prNumber = context.payload.pull_request.number;
@@ -158,6 +160,8 @@ jobs:
                 `> **Prerelease SDK pin** — ${pkgLabel} currently pins ${pkgPinLink}, which is a prerelease.`,
                 '>',
                 '> This is allowed and does not block the release workflow as long as the pin is not older than the workspace SDK. Please verify this prerelease pin is intentional before merging.',
+                '>',
+                `> **Tip:** if this pin is part of an intentional cross-package release sequence and the release dependency check fails because the SDK prerelease is not on PyPI yet, add the \`${releaseDepsBypassLabel}\` label to acknowledge and skip that check.`,
               ].join('\n');
               warning = `${pkgLabel} pins prerelease SDK deepagents==${pkgPin}; verify this is intentional.`;
             }

--- a/.github/workflows/dcode_release_notes_check.yml
+++ b/.github/workflows/dcode_release_notes_check.yml
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request
     name: ${{ github.event_name == 'pull_request' && 'curated release notes' || 'Refresh curated release notes check' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: Checkout trusted validator
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -42,6 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate current curated release-note state
+        id: validate
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
@@ -76,6 +77,9 @@ jobs:
                 },
               });
               refreshCheck = check.id;
+              // Expose the id so the always() finalizer below can close this check
+              // if the job is cancelled or times out mid-poll before it completes.
+              core.setOutput('refresh_check_id', String(refreshCheck));
             }
             try {
               const result = await checkCuratedState({
@@ -86,6 +90,7 @@ jobs:
                 expectedHead: pr.head.sha,
                 login: process.env.BOT_LOGIN,
                 id: process.env.BOT_ID,
+                initialDraftPollAttempts: context.eventName === 'issue_comment' ? 0 : 72,
               });
               core.info(`Curated release-note state: ${result.status}.`);
               if (refreshCheck !== null) {
@@ -102,8 +107,12 @@ jobs:
                   output: {
                     title: passing.has(result.status)
                       ? 'Curated release notes are valid'
-                      : 'Curated release notes need attention',
-                    summary: `Validation result: ${result.status}.`,
+                      : result.status === 'unapplied'
+                        ? 'Curated release notes are ready for review'
+                        : 'Curated release notes need attention',
+                    summary: result.status === 'unapplied'
+                      ? 'Review the bot-authored draft, then run `@dcode-release-bot apply`.'
+                      : `Validation result: ${result.status}.`,
                   },
                 });
               }
@@ -117,9 +126,43 @@ jobs:
                   conclusion: 'failure',
                   output: {
                     title: 'Curated release-note validation failed',
-                    summary: 'The validator encountered an unexpected workflow error.',
+                    summary: `The validator hit an error talking to GitHub: ${error instanceof Error ? error.message : String(error)}. This is often transient — re-run the check.`,
                   },
                 });
               }
               core.setFailed(error instanceof Error ? error.message : String(error));
+            }
+
+      # The validate step creates the refresh check as `in_progress` before it
+      # polls (up to ~12 min) for the automatic draft. A job timeout or cancellation
+      # kills that step before it can conclude the check, leaving a required check
+      # spinning forever. Close it here so an interrupted run reads as a re-runnable
+      # failure rather than a silent hang. No-ops on the happy path (already
+      # completed) and when no refresh check was created (pull_request runs).
+      - name: Close an interrupted refresh check
+        if: always() && steps.validate.outputs.refresh_check_id != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REFRESH_CHECK_ID: ${{ steps.validate.outputs.refresh_check_id }}
+        with:
+          script: |
+            const checkRunId = Number(process.env.REFRESH_CHECK_ID);
+            const { owner, repo } = context.repo;
+            try {
+              const { data: check } = await github.rest.checks.get({ owner, repo, check_run_id: checkRunId });
+              if (check.status === 'completed') return;
+              await github.rest.checks.update({
+                owner,
+                repo,
+                check_run_id: checkRunId,
+                status: 'completed',
+                conclusion: 'failure',
+                output: {
+                  title: 'Curated release-note validation was interrupted',
+                  summary: 'The validator did not finish — it was likely cancelled or timed out while waiting for the automatic draft. Re-run this check.',
+                },
+              });
+            } catch (error) {
+              // Never fail the finalizer itself; the required check stays red either way.
+              core.warning(`Could not finalize the interrupted refresh check: ${error instanceof Error ? error.message : String(error)}`);
             }


### PR DESCRIPTION
Release PR checks can start before the automatic curated-note draft is published, immediately marking the PR red even though the draft is still being generated. Applying those notes can also report a stale-head failure after successfully updating the release branch because the pull-request API may lag behind the branch ref.

This makes the release flow tolerate those expected ordering delays without weakening its concurrency checks:

- The required check waits for the initial automatic draft on PR events, distinguishes a valid but unapplied draft from missing or stale metadata, and continues through transient GitHub read failures.
- Interrupted refresh runs explicitly close their in-progress check instead of leaving it spinning indefinitely.
- Post-apply validation reads the canonical release branch ref while continuing to reject PR-body edits, curated-draft edits, and concurrent branch movement.
- The prerelease SDK-pin warning points maintainers to `release-deps: acknowledged` when an intentional cross-package release sequence has not reached PyPI yet.

Regression coverage exercises delayed draft publication, state changes during polling, stale pull-request heads after apply, and concurrent release-branch updates.
