### PR TITLE
fix(code): hydrate transcript tail when scrolled to the bottom edge

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6184,6 +6184,7 @@ class DeepAgentsApp(App):
             chat.scroll_y,
             chat.size.height,
             bottom_spacer_top,
+            max_scroll=chat.max_scroll_y,
         ):
             self.call_later(self._hydrate_messages_below)
 

--- a/libs/code/deepagents_code/tui/widgets/message_store.py
+++ b/libs/code/deepagents_code/tui/widgets/message_store.py
@@ -893,6 +893,8 @@ class MessageStore:
         scroll_position: float,
         viewport_height: int,
         bottom_spacer_top: int,
+        *,
+        max_scroll: float | None = None,
     ) -> bool:
         """Check if we should hydrate messages below the current view.
 
@@ -900,12 +902,22 @@ class MessageStore:
             scroll_position: Current scroll Y position.
             viewport_height: Height of the viewport.
             bottom_spacer_top: Estimated row where the bottom spacer begins.
+            max_scroll: Maximum scroll offset of the viewport, when known. When
+                the view is scrolled to this edge but history is still archived
+                below, hydration must run regardless of the spacer-distance
+                heuristic: the user cannot scroll any further, and estimated
+                spacer heights can drift from the real DOM layout enough to
+                leave the distance check just short of its threshold, stranding
+                the tail. Mirrors how scrolling to the top (offset 0) always
+                hydrates above.
 
         Returns:
-            True if the viewport is near the bottom spacer.
+            True if the viewport is near (or at) the bottom spacer.
         """
         if not self.has_messages_below:
             return False
+        if max_scroll is not None and scroll_position >= max_scroll:
+            return True
         viewport_bottom = scroll_position + viewport_height
         distance_from_bottom_spacer = bottom_spacer_top - viewport_bottom
         threshold = viewport_height * 2

--- a/libs/code/tests/unit_tests/tui/widgets/test_message_store.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_message_store.py
@@ -615,6 +615,58 @@ class TestMessageStore:
             bottom_spacer_top=bottom_spacer_top,
         )
 
+    def test_should_hydrate_below_at_bottom_edge(self):
+        """Reaching the scroll edge must hydrate even if the distance check misses.
+
+        Estimated spacer heights can drift from the real DOM layout, leaving the
+        viewport parked at `max_scroll` while the spacer-distance heuristic sits
+        exactly at (or just past) its threshold. Without the edge guarantee the
+        archived tail is stranded — the flaky-hydration failure this reproduces.
+        """
+        store = MessageStore()
+        for i in range(100):
+            store.append(
+                MessageData(type=MessageType.USER, content=f"msg{i}", id=f"id-{i}")
+            )
+        store._visible_start = 16
+        store._visible_end = 19
+
+        bottom_spacer_top = store.range_height(0, store.get_visible_range()[1])
+        # Geometry where distance_from_bottom_spacer == threshold, so the plain
+        # heuristic returns False forever.
+        scroll_position = 10.0
+        viewport_height = 3
+        assert not store.should_hydrate_below(
+            scroll_position=scroll_position,
+            viewport_height=viewport_height,
+            bottom_spacer_top=bottom_spacer_top,
+        )
+        # Same geometry, but scrolled to the edge: hydration must run.
+        assert store.should_hydrate_below(
+            scroll_position=scroll_position,
+            viewport_height=viewport_height,
+            bottom_spacer_top=bottom_spacer_top,
+            max_scroll=scroll_position,
+        )
+
+    def test_should_hydrate_below_at_edge_with_no_messages_below(self):
+        """The bottom edge never hydrates when the window already ends the store."""
+        store = MessageStore()
+        for i in range(10):
+            store.append(
+                MessageData(type=MessageType.USER, content=f"msg{i}", id=f"id-{i}")
+            )
+        store._visible_start = 0
+        store._visible_end = 10
+
+        assert not store.has_messages_below
+        assert not store.should_hydrate_below(
+            scroll_position=5.0,
+            viewport_height=3,
+            bottom_spacer_top=store.range_height(0, 10),
+            max_scroll=5.0,
+        )
+
     def test_visible_range(self):
         """Test getting visible range."""
         store = MessageStore()


### PR DESCRIPTION
Fix newest transcript messages sometimes failing to reappear when scrolling to the bottom of a long, virtualized chat history.

---

`test_scroll_down_hydrates_tail_below` was flaky (~30% `TimeoutError`) because scroll-driven tail hydration compared the message store's *estimated* `bottom_spacer_top` against the *real* DOM scroll geometry (`scroll_y`/`max_scroll_y`). When estimated spacer heights drift from the rendered layout — which depends on the viewport height Textual happens to allocate — the distance heuristic can sit exactly at its threshold while the view is already parked at `max_scroll`, so `should_hydrate_below` returns `False` forever and the archived tail is never remounted.

`should_hydrate_below` now hydrates whenever the view is at the scroll edge but history remains archived below, mirroring how scrolling to offset 0 always hydrates above. This is a real user-facing fix, not just a test tweak: a user who scrolls to the very bottom while the tail is archived would otherwise be stranded on a blank spacer.

Made by [Open SWE](https://openswe.vercel.app/agents/9bce6e12-3555-8aa4-3e10-0a96a898db03)