### PR TITLE
fix(code): close subprocess transport on install teardown

### DIFF
--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -1649,6 +1649,18 @@ async def _terminate_install_process(proc: asyncio.subprocess.Process) -> None:
             proc.kill()
     with suppress(OSError, TimeoutError):
         await asyncio.wait_for(proc.wait(), timeout=_TERMINATE_WAIT_TIMEOUT)
+    # Reaping the process is not enough: when this cleanup runs after we stopped
+    # draining stdout/stderr (timeout/cancellation), those pipes never reach EOF,
+    # so the pipe transports — and the parent subprocess transport — stay open
+    # until garbage collection. If the event loop has closed by then,
+    # `BaseSubprocessTransport.__del__` retries the close on a dead loop and
+    # raises "Event loop is closed" (surfaced as PytestUnraisableExceptionWarning
+    # under pytest). Close it eagerly while the loop is still alive. `_transport`
+    # is the only handle asyncio exposes, and close() must not break teardown.
+    transport = getattr(proc, "_transport", None)
+    if transport is not None:
+        with suppress(Exception):
+            transport.close()
 
 
 async def _run_install_subprocess(

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -3936,6 +3936,52 @@ class TestRunInstallSubprocessFailureModes:
         # The EPERM fallback (`proc.kill()`) must have reaped the child.
         assert proc.returncode is not None
 
+    async def test_terminate_closes_real_subprocess_transport(self) -> None:
+        """Cleanup leaves the real subprocess transport closed, not pending.
+
+        A subprocess transport that is merely reaped (`proc.wait()`) but never
+        closed lingers until GC. If the event loop has closed by then,
+        `BaseSubprocessTransport.__del__` retries the close on a dead loop and
+        raises "Event loop is closed" — the `PytestUnraisableExceptionWarning`
+        seen in CI. `_terminate_install_process` must close the transport while
+        the loop is still alive, so it is never `is_closing() == False` on
+        return.
+        """
+        if os.name != "posix":
+            pytest.skip("process groups are POSIX-specific")
+        proc = await asyncio.create_subprocess_shell(
+            "sleep 30",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        await _terminate_install_process(proc)
+
+        assert proc.returncode is not None
+        transport = getattr(proc, "_transport", None)
+        assert transport is not None
+        assert transport.is_closing()
+
+    async def test_terminate_closes_transport_after_reaping(self) -> None:
+        """`_terminate_install_process` explicitly closes the transport.
+
+        Deterministic guard for the CI `PytestUnraisableExceptionWarning`: real
+        subprocesses can close their transport naturally depending on timing, so
+        this pins the contract that cleanup closes it regardless. Fails if the
+        eager `transport.close()` is dropped and the transport is left pending.
+        """
+        proc = MagicMock()
+        proc.pid = 987654
+        proc.returncode = -9
+        proc.wait = AsyncMock(return_value=-9)
+        transport = MagicMock()
+        proc._transport = transport
+        # Patch `killpg` so the fake pid never signals a real process group.
+        with patch("deepagents_code.update_check.os.killpg"):
+            await _terminate_install_process(proc)
+        transport.close.assert_called_once_with()
+
     async def test_oserror_includes_exception_detail(self, tmp_path) -> None:
         """An OSError during exec must surface the exception class + message."""
         log_path = tmp_path / "install.log"


### PR DESCRIPTION
`_terminate_install_process` reaped the install subprocess but never closed its transport. On the timeout/cancellation paths stdout/stderr are abandoned before cleanup, so the pipes never reach EOF and the `BaseSubprocessTransport` lingers until GC — and if the event loop has closed by then, `__del__` retries the close on a dead loop and raises `RuntimeError: Event loop is closed`, surfaced as a `PytestUnraisableExceptionWarning` (GC-attributed to whichever test is running, hence the timing/version sensitivity). Fix closes the transport eagerly while the loop is still alive.

Made by [Open SWE](https://openswe.vercel.app/agents/b9f0f3c9-273c-9b06-d5c9-e9dc9ca9ca2f)