### PR TITLE
docs(code): define input surface nomenclature in AGENTS.md

### DIFF
--- a/libs/code/AGENTS.md
+++ b/libs/code/AGENTS.md
@@ -67,6 +67,17 @@ For Textual tests that intentionally replace concrete app methods with `MagicMoc
 
 Casts are acceptable when the type violation is the point of the test (for example, passing a wrong runtime type to exercise defensive validation) or when a third-party overload is narrower than verified runtime behavior. In those cases, keep the cast narrowly scoped and add a short comment explaining why it is intentional.
 
+## Input surface nomenclature
+
+The REPL has **many** text-entry surfaces, so "the input" / "the input box" is ambiguous. Use these precise terms in code, comments, commit messages, and when talking to an agent. Each maps to a concrete class so there is a single, greppable referent.
+
+- **Chat input** (a.k.a. the composer): the primary prompt field at the bottom of the REPL where the user types messages to the agent. The widget is `ChatInput` (`tui/widgets/chat_input.py`), a container whose bordered box has id `#input-box`. Its editable field is the `ChatTextArea` with id `#chat-input`. When an unqualified "the input box" is used, it means **this** — but prefer "chat input" to stay unambiguous.
+- **Inline prompt**: a multi-line `TextArea` rendered inline in the message flow (not the chat input, not inside a modal). Base class `InlinePromptTextArea` (`tui/widgets/_inline_prompt.py`), subclassed by `AskUserTextArea` (free-text answers to agent `ask_user` questions, `ask_user.py`) and `GoalReviewTextArea` (editing goal text, `goal_review.py`).
+- **Modal field**: a single-line Textual `Input` inside a modal screen. Refer to it by its owner, e.g. the *auth key field* (`auth.py`), *MCP login field* (`#ml-input`, `mcp_login.py`), or the *rejection reason field* (`approval.py`).
+- **Filter input**: the single-line `Input` that filters an `OptionList`/`Select` in a picker — the *model-selector filter* (`model_selector.py`), *thread-selector filter* (`thread_selector.py`), and *MCP viewer filter* (`#mcp-filter`, `mcp_viewer.py`). A specialized modal field; call it a "filter input" when the point is filtering.
+
+Rule of thumb: say **chat input** for the main composer and name any other surface by its owner (`<owner> field` / `<owner> filter`). Reserve bare "input box" for the chat input only.
+
 ## SDK dependency pin
 
 `deepagents-code` pins an exact `deepagents==X.Y.Z` version in `pyproject.toml`. When developing features that depend on new SDK functionality, bump this pin as part of the same PR. A CI check verifies the pin is not older than the current SDK version at release time (unless bypassed with `dangerous-skip-sdk-pin-check`); pins ahead of the workspace SDK are allowed for intentional prerelease coordination.


### PR DESCRIPTION
The `deepagents-code` REPL has many text-entry surfaces — the primary chat input, inline prompts, single-line modal fields, and picker filter inputs — so "the input" / "the input box" is ambiguous and routinely confuses both humans and agents about which field is meant. This adds an **Input surface nomenclature** section to `libs/code/AGENTS.md` that fixes precise, function-based terms and maps each to a concrete class (`ChatInput`/`ChatTextArea`, `InlinePromptTextArea`, modal `Input`s, filter `Input`s) so there is a single greppable referent per surface.

Docs only; no behavior change. Naming is a judgment call, so wording is open to bikeshedding in review.

Made by [Open SWE](https://openswe.vercel.app/agents/d23898f0-cac9-2b5e-e737-69903b582d2d)