### PR TITLE
fix(code): surface tool calls awaiting approval

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6784,6 +6784,8 @@ class DeepAgentsApp(App):
             while self._pending_approval_widget is not None:  # noqa: ASYNC110  # Simple polling is sufficient here
                 await asyncio.sleep(0.1)
 
+        self._reveal_pending_tool_calls()
+
         # Pause the elapsed-time counter while the user decides, then resume it
         # when the decision future completes. Resolve, reject, and cancel all
         # fire the done-callback; the `_set_spinner` backstop covers the
@@ -13654,6 +13656,17 @@ class DeepAgentsApp(App):
         if pruned_ids:
             self._message_store.mark_pruned_below(pruned_ids)
             self._sync_transcript_spacers(messages_container)
+
+    def _reveal_pending_tool_calls(self) -> None:
+        """Surface grouped tool calls before asking for approval."""
+        group = self._active_tool_group
+        self._close_active_tool_group()
+        if group is None or not group.is_attached:
+            return
+        try:
+            group.reveal_pending()
+        except Exception:
+            logger.exception("Failed to reveal pending tool calls")
 
     def _close_active_tool_group(self) -> None:
         """Finalize the open tool group into its collapsed past-tense form."""

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -3095,6 +3095,32 @@ class ToolGroupSummary(Static):
             # Every tool failed and was ejected — nothing left to summarize.
             self.remove()
 
+    def reveal_pending(self) -> None:
+        """Remove unfinished tool calls from the collapsed group."""
+        pending = [tool for tool in self._tools if tool.is_pending]
+        if not pending:
+            return
+        for tool in pending:
+            self._tools.remove(tool)
+            if tool in self._collapsible:
+                self._collapsible.remove(tool)
+            tool.remove_class("-grouped")
+            if tool.is_attached and not tool._awaiting_approval:
+                tool.display = True
+        self._present_text = self._past_text = None
+        if self._tools:
+            self._render_line()
+            self._sync_timer()
+            return
+        self._stop_timer()
+        for widget in self._collapsible:
+            widget.remove_class("-grouped")
+            if widget.is_attached:
+                widget.display = True
+        self._collapsible.clear()
+        if self.is_attached:
+            self.remove()
+
     @property
     def has_attached_members(self) -> bool:
         """Whether any collapsed widget is still attached to the DOM."""

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -12298,11 +12298,15 @@ class TestRequestApprovalBranching:
         ]
         future = asyncio.get_running_loop().create_future()
 
-        with patch.object(asyncio, "get_running_loop") as mock_loop:
+        with (
+            patch.object(asyncio, "get_running_loop") as mock_loop,
+            patch.object(app, "_reveal_pending_tool_calls") as reveal_pending,
+        ):
             mock_loop.return_value.create_future.return_value = future
             returned = await app._request_approval(action_requests, None)
 
         assert returned is future
+        reveal_pending.assert_called_once_with()
         assert ApprovalMenu in mounted_types, (
             f"Expected ApprovalMenu to be mounted, got {mounted_types}"
         )
@@ -25672,6 +25676,45 @@ class TestToolGroupCollapse:
                 tool.set_error("boom")
         await pilot.pause()
         return tools
+
+    async def test_approval_reveals_pending_calls_and_closes_live_group(self) -> None:
+        """Approval surfaces unfinished rows without reusing the pre-approval group."""
+        from deepagents_code.tui.widgets.messages import ToolGroupSummary
+
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t-approval-group")
+        app._load_thread_history = AsyncMock()  # ty: ignore
+        async with app.run_test() as pilot:
+            messages = app.query_one("#messages", Container)
+            stale = ToolCallMessage("grep", {"pattern": "old"})
+            await messages.mount(stale)
+            stale_group = ToolGroupSummary(tools=[stale], collapsible=[stale])
+            stale.add_class("-grouped")
+            await messages.mount(stale_group, before=stale)
+
+            completed = ToolCallMessage("read_file", {"file_path": "a.py"})
+            pending = ToolCallMessage("execute", {"command": "rm scratch.txt"})
+            await app._mount_message(completed)
+            completed.set_success("done")
+            await app._mount_message(pending)
+            await pilot.pause()
+
+            summary = app._active_tool_group
+            assert summary is not None
+            assert stale.display is False
+            assert completed.display is False
+            assert pending.display is False
+
+            app._reveal_pending_tool_calls()
+            await pilot.pause()
+
+            assert app._active_tool_group is None
+            assert stale.display is False
+            assert stale_group.is_attached
+            assert completed.display is False
+            assert pending.display is True
+            assert not pending.has_class("-grouped")
+            assert summary._finalized is True
+            assert summary._tools == [completed]
 
     async def test_regroup_collapses_success_run(self) -> None:
         """A run of successful tools folds into one collapsed summary."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -4088,6 +4088,50 @@ class TestLiveToolGroupSummary:
             assert summary.is_attached
             assert bool(pilot.app.query(ToolGroupSummary))
 
+    async def test_pending_member_is_revealed_for_approval(self) -> None:
+        """Only unfinished calls leave the collapsed group before approval."""
+        from deepagents_code.tui.widgets.messages import ToolGroupSummary
+
+        async with _LiveToolGroupApp().run_test() as pilot:
+            summary = pilot.app.query_one("#summary", ToolGroupSummary)
+            completed = pilot.app.query_one("#t1", ToolCallMessage)
+            pending = pilot.app.query_one("#t2", ToolCallMessage)
+
+            summary.add_member(completed)
+            summary.add_member(pending)
+            completed.set_success("done")
+            summary.reveal_pending()
+            await pilot.pause()
+
+            assert completed.display is False
+            assert completed.has_class("-grouped")
+            assert pending.display is True
+            assert not pending.has_class("-grouped")
+            assert summary._tools == [completed]
+            rendered = summary.render()
+            assert isinstance(rendered, Content)
+            assert "Ran 1 shell command" in rendered.plain
+
+    async def test_suppressed_pending_member_stays_hidden(self) -> None:
+        """A command mirrored in the approval menu is detached without duplication."""
+        from deepagents_code.tui.widgets.messages import ToolGroupSummary
+
+        async with _LiveToolGroupApp().run_test() as pilot:
+            summary = pilot.app.query_one("#summary", ToolGroupSummary)
+            pending = pilot.app.query_one("#t1", ToolCallMessage)
+
+            summary.add_member(pending)
+            pending.set_awaiting_approval()
+            summary.reveal_pending()
+            await pilot.pause()
+
+            assert pending.display is False
+            assert not pending.has_class("-grouped")
+            assert not summary.is_attached
+
+            pending.clear_awaiting_approval()
+            assert pending.display is True
+
     async def test_failed_member_is_evicted_on_close(self) -> None:
         from deepagents_code.tui.widgets.messages import ToolGroupSummary
 


### PR DESCRIPTION
`dcode` now surfaces the tool calls that require approval instead of hiding them in a collapsed group.

---

Approval-blocked tool calls could remain hidden inside the collapsed live group, leaving only a generic batch prompt. Finalize the active group at the approval boundary and detach pending rows while preserving single-command duplicate suppression.

Made by [Open SWE](https://openswe.vercel.app/agents/3f2b94f6-67ee-d5d4-d2a5-250adeacac5e)