### PR TITLE
fix(code): put local offloaded tool results on the real filesystem

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -7,7 +7,6 @@ import logging
 import os
 import re
 import shutil
-import tempfile
 import tomllib
 import warnings
 from pathlib import Path, PurePosixPath
@@ -86,7 +85,7 @@ from deepagents_code.local_context import (
     _AsyncExecutableBackend,
     _ExecutableBackend,
 )
-from deepagents_code.offload import _offload_fallback_root
+from deepagents_code.offload import _artifacts_root, _offload_fallback_root
 from deepagents_code.offload_middleware import _create_cli_compaction_middleware
 from deepagents_code.project_utils import ProjectContext, get_server_project_context
 from deepagents_code.reliable_rubric import ReliableRubricMiddleware
@@ -200,20 +199,48 @@ def _todo_list_middleware_override() -> list[AgentMiddleware]:
     return [stand_in]
 
 
-_RUBRIC_GRADER_READ_FILE_PREFIX = "/large_tool_results/"
-_RUBRIC_GRADER_SYSTEM_PROMPT = (
-    GRADER_SYSTEM_PROMPT
-    + "\n\nWhen the transcript says a tool result was saved under "
-    + f"`{_RUBRIC_GRADER_READ_FILE_PREFIX}`, use the `read_file` tool to inspect "
-    + "the referenced evidence before deciding that a criterion lacks support. "
-    + "Only read paths that are explicitly present in the transcript."
-)
+def _rubric_grader_read_file_prefix(backend: CompositeBackend) -> str:
+    """Return the offloaded-results directory the rubric grader is allowed to read.
+
+    Mirrors how `FilesystemMiddleware` derives its large-tool-results prefix from
+    the backend's `artifacts_root`, so the grader's read allow-list tracks wherever
+    offloaded results actually land (a real per-session `/tmp` dir in local mode,
+    or `/large_tool_results/` when `artifacts_root` is the default `/`).
+
+    Args:
+        backend: The composite backend the agent uses.
+
+    Returns:
+        The large-tool-results prefix, always ending with a trailing slash.
+    """
+    root = backend.artifacts_root.rstrip("/")
+    return f"{root}/large_tool_results/"
 
 
-def _validate_rubric_grader_read_path(file_path: str) -> str | None:
+def _rubric_grader_system_prompt(read_file_prefix: str) -> str:
+    """Build the rubric grader system prompt for a given offload prefix.
+
+    Args:
+        read_file_prefix: The directory under which offloaded tool results live.
+
+    Returns:
+        The grader system prompt naming that prefix as the readable evidence dir.
+    """
+    return (
+        GRADER_SYSTEM_PROMPT
+        + "\n\nWhen the transcript says a tool result was saved under "
+        + f"`{read_file_prefix}`, use the `read_file` tool to inspect "
+        + "the referenced evidence before deciding that a criterion lacks support. "
+        + "Only read paths that are explicitly present in the transcript."
+    )
+
+
+def _validate_rubric_grader_read_path(
+    file_path: str, read_file_prefix: str
+) -> str | None:
     normalized = file_path.replace("\\", "/")
-    if not normalized.startswith(_RUBRIC_GRADER_READ_FILE_PREFIX):
-        return "Rubric grader can only read files under /large_tool_results/."
+    if not normalized.startswith(read_file_prefix):
+        return f"Rubric grader can only read files under {read_file_prefix}."
     parts = PurePosixPath(normalized).parts
     if ".." in parts or "~" in parts:
         return "Invalid path."
@@ -221,6 +248,7 @@ def _validate_rubric_grader_read_path(file_path: str) -> str | None:
 
 
 def _create_rubric_grader_tools(backend: CompositeBackend) -> list[BaseTool]:
+    read_file_prefix = _rubric_grader_read_file_prefix(backend)
     filesystem = FilesystemMiddleware(backend=backend)
     sdk_read_file: StructuredTool | None = None
     for candidate in filesystem.tools:
@@ -249,7 +277,7 @@ def _create_rubric_grader_tools(backend: CompositeBackend) -> list[BaseTool]:
             The SDK `read_file` tool result, or an error message when the path is
             outside the grader evidence directory.
         """
-        if error := _validate_rubric_grader_read_path(file_path):
+        if error := _validate_rubric_grader_read_path(file_path, read_file_prefix):
             return error
         return sdk_read_file_func(
             file_path=file_path,
@@ -1908,15 +1936,22 @@ def create_cli_agent(
         # Full HITL for destructive operations
         interrupt_on = _add_interrupt_on()  # ty: ignore[invalid-assignment]  # InterruptOnConfig is compatible at runtime
 
-    # Set up composite backend with routing
-    # For local FilesystemBackend, route large tool results to /tmp to avoid polluting
-    # the working directory. For sandbox backends, no special routing is needed.
+    # Set up composite backend with routing.
     if sandbox is None:
-        # Local mode: Route large results to a unique temp directory
-        large_results_backend = FilesystemBackend(
-            root_dir=tempfile.mkdtemp(prefix="deepagents_large_results_"),
-            virtual_mode=True,
-        )
+        # Local mode: put large tool results on the REAL filesystem, under a
+        # stable, hardened per-user artifacts dir, instead of a hidden virtual
+        # route. The SDK middleware derives its offload prefixes from
+        # `artifacts_root` (`<root>/large_tool_results/` and
+        # `<root>/conversation_history/`), so pointing `artifacts_root` at a real
+        # dir and NOT routing `large_tool_results` makes offloaded results fall
+        # through to the default `LocalShellBackend` at a real path. The agent
+        # can then inspect them with `execute` (jq/grep/python) using the exact
+        # path the offload message hands it -- no virtual-path translation or
+        # copy-out/in. The root is stable across process restarts so paths
+        # embedded in a resumed thread's history stay resolvable. Conversation
+        # history keeps a dedicated route to persistent storage (`~/.deepagents`)
+        # so `/offload` archives survive restarts (and reboots).
+        artifacts_root = _artifacts_root()
         conversation_history_backend = FilesystemBackend(
             root_dir=_offload_fallback_root() / "conversation_history",
             virtual_mode=True,
@@ -1924,9 +1959,9 @@ def create_cli_agent(
         composite_backend = CompositeBackend(
             default=backend,
             routes={
-                "/large_tool_results/": large_results_backend,
-                "/conversation_history/": conversation_history_backend,
+                f"{artifacts_root}/conversation_history/": conversation_history_backend,
             },
+            artifacts_root=str(artifacts_root),
         )
     else:
         # Sandbox mode: No special routing needed
@@ -1947,7 +1982,9 @@ def create_cli_agent(
         )
         rubric_kwargs: dict[str, Any] = {
             "model": rubric_model if rubric_model is not None else model,
-            "system_prompt": _RUBRIC_GRADER_SYSTEM_PROMPT,
+            "system_prompt": _rubric_grader_system_prompt(
+                _rubric_grader_read_file_prefix(composite_backend)
+            ),
             "tools": _create_rubric_grader_tools(composite_backend),
         }
         if rubric_max_iterations is not None:

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -37,6 +37,7 @@ else:
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Sequence
 
+    from deepagents.backends.protocol import BackendProtocol
     from deepagents.backends.sandbox import SandboxBackendProtocol
     from deepagents.middleware.async_subagents import AsyncSubAgent
     from deepagents.middleware.subagents import CompiledSubAgent, SubAgent
@@ -85,7 +86,11 @@ from deepagents_code.local_context import (
     _AsyncExecutableBackend,
     _ExecutableBackend,
 )
-from deepagents_code.offload import _artifacts_root, _offload_fallback_root
+from deepagents_code.offload import (
+    _FALLBACK_ARTIFACTS_ROOT,
+    _artifacts_root,
+    _offload_fallback_root,
+)
 from deepagents_code.offload_middleware import _create_cli_compaction_middleware
 from deepagents_code.project_utils import ProjectContext, get_server_project_context
 from deepagents_code.reliable_rubric import ReliableRubricMiddleware
@@ -1938,30 +1943,36 @@ def create_cli_agent(
 
     # Set up composite backend with routing.
     if sandbox is None:
-        # Local mode: put large tool results on the REAL filesystem, under a
-        # stable, hardened per-user artifacts dir, instead of a hidden virtual
-        # route. The SDK middleware derives its offload prefixes from
-        # `artifacts_root` (`<root>/large_tool_results/` and
-        # `<root>/conversation_history/`), so pointing `artifacts_root` at a real
-        # dir and NOT routing `large_tool_results` makes offloaded results fall
-        # through to the default `LocalShellBackend` at a real path. The agent
-        # can then inspect them with `execute` (jq/grep/python) using the exact
-        # path the offload message hands it -- no virtual-path translation or
-        # copy-out/in. The root is stable across process restarts so paths
-        # embedded in a resumed thread's history stay resolvable. Conversation
-        # history keeps a dedicated route to persistent storage (`~/.deepagents`)
-        # so `/offload` archives survive restarts (and reboots).
-        artifacts_root = _artifacts_root()
+        # Local mode normally lets large results fall through to the default
+        # backend at the real, hardened `artifacts_root`, so filesystem tools and
+        # `execute` receive the same host path. If that predictable directory is
+        # unusable, `_artifacts_root` supplies a stable virtual root plus private
+        # temporary storage, and `large_tool_results` is routed there explicitly.
+        # Conversation history always has a dedicated route to persistent storage.
+        # The fallback alias remains installed even after the predictable directory
+        # recovers, so archive paths saved during fallback stay resolvable.
+        artifacts_storage = _artifacts_root()
+        artifacts_root = artifacts_storage.root
         conversation_history_backend = FilesystemBackend(
             root_dir=_offload_fallback_root() / "conversation_history",
             virtual_mode=True,
         )
+        fallback_history_root = f"{_FALLBACK_ARTIFACTS_ROOT}/conversation_history/"
+        artifact_routes: dict[str, BackendProtocol] = {
+            f"{artifacts_root}/conversation_history/": conversation_history_backend,
+            fallback_history_root: conversation_history_backend,
+        }
+        if artifacts_storage.large_results_dir is not None:
+            artifact_routes[f"{artifacts_root}/large_tool_results/"] = (
+                FilesystemBackend(
+                    root_dir=artifacts_storage.large_results_dir,
+                    virtual_mode=True,
+                )
+            )
         composite_backend = CompositeBackend(
             default=backend,
-            routes={
-                f"{artifacts_root}/conversation_history/": conversation_history_backend,
-            },
-            artifacts_root=str(artifacts_root),
+            routes=artifact_routes,
+            artifacts_root=artifacts_root,
         )
     else:
         # Sandbox mode: No special routing needed

--- a/libs/code/deepagents_code/offload.py
+++ b/libs/code/deepagents_code/offload.py
@@ -6,9 +6,30 @@ import logging
 import os
 import stat
 import tempfile
-from pathlib import Path
+from pathlib import Path, PurePath
 
 logger = logging.getLogger(__name__)
+
+
+def _filesystem_tool_path(path: PurePath) -> str:
+    """Represent an absolute host path in the filesystem tool path format.
+
+    Drive-qualified paths are rejected by the SDK's virtual path validation. The
+    Windows extended-length form keeps the drive while starting with the `/`
+    required by filesystem tools; `pathlib` and Windows APIs still resolve it to
+    the same host directory.
+
+    Args:
+        path: Absolute host path to represent.
+
+    Returns:
+        A forward-slash path accepted by the filesystem tool contract.
+    """
+    normalized = path.as_posix()
+    if path.drive and not path.drive.startswith("\\\\"):
+        return f"//?/{normalized}"
+    return normalized
+
 
 _EPHEMERAL_OFFLOAD_STORAGE = False
 """Whether the most recent `_offload_fallback_root` fell back to temp storage."""
@@ -75,7 +96,7 @@ def _probe_writable(path: Path) -> None:
         pass
 
 
-def _artifacts_root() -> Path:
+def _artifacts_root() -> str:
     """Return a stable, private per-user directory for offloaded artifacts.
 
     In local mode, large tool results are written here on the real filesystem
@@ -99,7 +120,7 @@ def _artifacts_root() -> Path:
     across restarts, but it never trusts a directory owned by someone else.
 
     Returns:
-        A private, writable directory for offloaded artifacts.
+        The private, writable directory in the filesystem tool path format.
     """
     getuid = getattr(os, "getuid", None)
     suffix = str(getuid()) if getuid is not None else str(os.getpid())
@@ -119,8 +140,8 @@ def _artifacts_root() -> Path:
         )
         _harden_dir(unique)
         _probe_writable(unique)
-        return unique
-    return root
+        return _filesystem_tool_path(unique)
+    return _filesystem_tool_path(root)
 
 
 def _offload_fallback_root() -> Path:

--- a/libs/code/deepagents_code/offload.py
+++ b/libs/code/deepagents_code/offload.py
@@ -6,9 +6,20 @@ import logging
 import os
 import stat
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path, PurePath
 
 logger = logging.getLogger(__name__)
+
+_FALLBACK_ARTIFACTS_ROOT = "/dcode-artifacts-fallback"
+
+
+@dataclass(frozen=True)
+class _ArtifactsStorage:
+    """Agent-visible artifacts root and optional routed large-result directory."""
+
+    root: str
+    large_results_dir: Path | None = None
 
 
 def _filesystem_tool_path(path: PurePath) -> str:
@@ -96,31 +107,18 @@ def _probe_writable(path: Path) -> None:
         pass
 
 
-def _artifacts_root() -> str:
-    """Return a stable, private per-user directory for offloaded artifacts.
+def _artifacts_root() -> _ArtifactsStorage:
+    """Return storage configuration for offloaded artifacts.
 
-    In local mode, large tool results are written here on the real filesystem
-    (rather than a hidden virtual backend) so the agent can inspect them with
-    `execute` (`jq`, `grep`, `python`) using the exact path the offload message
-    hands it. The directory is:
-
-    - stable across process restarts (keyed by user id) so paths embedded in a
-      resumed thread's history stay resolvable, and
-    - hardened to `0o700` and owned by the current user so other local accounts
-      cannot read offloaded results.
-
-    It is used as the `CompositeBackend` `artifacts_root`, which the SDK
-    filesystem and summarization middleware turn into the
-    `<root>/large_tool_results/` and `<root>/conversation_history/` prefixes.
-
-    If the predictable per-user path is unusable -- e.g. squatted by another
-    local user or symlinked (rejected by `_harden_dir`'s ownership / `S_ISDIR`
-    guards) -- this falls back to a private unique directory rather than reusing
-    a foreign-owned path or failing agent startup. The fallback is not stable
-    across restarts, but it never trusts a directory owned by someone else.
+    The normal path is a stable, hardened host directory that filesystem tools
+    and shell commands can use directly. If that predictable directory is
+    unusable, large results use a private unique directory behind a stable virtual
+    root. Keeping the virtual root stable lets conversation archive paths persisted
+    in thread state continue matching their dedicated route after a restart.
 
     Returns:
-        The private, writable directory in the filesystem tool path format.
+        The agent-visible artifacts root and an optional directory to which large
+        results must be routed.
     """
     getuid = getattr(os, "getuid", None)
     suffix = str(getuid()) if getuid is not None else str(os.getpid())
@@ -131,8 +129,8 @@ def _artifacts_root() -> str:
         _probe_writable(root)
     except (OSError, RuntimeError):
         logger.warning(
-            "Predictable per-user artifacts directory is unavailable; creating "
-            "a private unique directory (paths will not be stable across restarts)",
+            "Predictable per-user artifacts directory is unavailable; routing "
+            "large results from a stable virtual prefix to private temporary storage",
             exc_info=True,
         )
         unique = Path(
@@ -140,8 +138,11 @@ def _artifacts_root() -> str:
         )
         _harden_dir(unique)
         _probe_writable(unique)
-        return _filesystem_tool_path(unique)
-    return _filesystem_tool_path(root)
+        return _ArtifactsStorage(
+            root=_FALLBACK_ARTIFACTS_ROOT,
+            large_results_dir=unique,
+        )
+    return _ArtifactsStorage(root=_filesystem_tool_path(root))
 
 
 def _offload_fallback_root() -> Path:

--- a/libs/code/deepagents_code/offload.py
+++ b/libs/code/deepagents_code/offload.py
@@ -32,6 +32,97 @@ def offload_storage_is_ephemeral() -> bool:
     return _EPHEMERAL_OFFLOAD_STORAGE
 
 
+def _harden_dir(path: Path) -> None:
+    """Create `path` if needed and restrict it to the current user.
+
+    Only ever call this on directories owned by this process's storage (a temp
+    dir or a dedicated subdirectory), never on the shared `~/.deepagents` config
+    root.
+
+    Args:
+        path: Directory to create and harden to `0o700`.
+
+    Raises:
+        OSError: If the path exists but is not a directory, or the directory
+            cannot be created or its mode changed (e.g. a read-only mount).
+        PermissionError: If the existing directory is owned by another local user.
+    """
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    info = path.lstat()
+    if not stat.S_ISDIR(info.st_mode):
+        msg = f"Path is not a directory: {path}"
+        raise OSError(msg)
+    getuid = getattr(os, "getuid", None)
+    if getuid is not None and info.st_uid != getuid():
+        msg = f"Directory is owned by another user: {path}"
+        raise PermissionError(msg)
+    # `mkdir(mode=...)` does not tighten an existing directory. These directories
+    # can hold conversation data and offloaded tool results, so they must remain
+    # inaccessible to other local accounts regardless of the process umask.
+    path.chmod(0o700)
+
+
+def _probe_writable(path: Path) -> None:
+    """Confirm `path` accepts new files (catches read-only mounts).
+
+    Creating the directory is insufficient when it already exists on a read-only
+    mount; a temporary file proves writes can succeed.
+
+    Args:
+        path: Directory to probe.
+    """
+    with tempfile.NamedTemporaryFile(dir=path, prefix=".write-test-"):
+        pass
+
+
+def _artifacts_root() -> Path:
+    """Return a stable, private per-user directory for offloaded artifacts.
+
+    In local mode, large tool results are written here on the real filesystem
+    (rather than a hidden virtual backend) so the agent can inspect them with
+    `execute` (`jq`, `grep`, `python`) using the exact path the offload message
+    hands it. The directory is:
+
+    - stable across process restarts (keyed by user id) so paths embedded in a
+      resumed thread's history stay resolvable, and
+    - hardened to `0o700` and owned by the current user so other local accounts
+      cannot read offloaded results.
+
+    It is used as the `CompositeBackend` `artifacts_root`, which the SDK
+    filesystem and summarization middleware turn into the
+    `<root>/large_tool_results/` and `<root>/conversation_history/` prefixes.
+
+    If the predictable per-user path is unusable -- e.g. squatted by another
+    local user or symlinked (rejected by `_harden_dir`'s ownership / `S_ISDIR`
+    guards) -- this falls back to a private unique directory rather than reusing
+    a foreign-owned path or failing agent startup. The fallback is not stable
+    across restarts, but it never trusts a directory owned by someone else.
+
+    Returns:
+        A private, writable directory for offloaded artifacts.
+    """
+    getuid = getattr(os, "getuid", None)
+    suffix = str(getuid()) if getuid is not None else str(os.getpid())
+    temp_root = Path(tempfile.gettempdir())
+    root = temp_root / f"dcode-artifacts-{suffix}"
+    try:
+        _harden_dir(root)
+        _probe_writable(root)
+    except (OSError, RuntimeError):
+        logger.warning(
+            "Predictable per-user artifacts directory is unavailable; creating "
+            "a private unique directory (paths will not be stable across restarts)",
+            exc_info=True,
+        )
+        unique = Path(
+            tempfile.mkdtemp(prefix=f"dcode-artifacts-{suffix}-", dir=temp_root)
+        )
+        _harden_dir(unique)
+        _probe_writable(unique)
+        return unique
+    return root
+
+
 def _offload_fallback_root() -> Path:
     """Return a writable base directory for offloaded conversation history.
 
@@ -63,47 +154,13 @@ def _offload_fallback_root() -> Path:
         writable.
     """
 
-    def _harden(path: Path) -> None:
-        """Create `path` if needed and restrict it to the current user.
-
-        Only ever called on directories owned by offload (a fresh temp dir or
-        the dedicated `conversation_history` subdirectory), never on the shared
-        `~/.deepagents` config root.
-
-        Raises:
-            OSError: If the path exists but is not a directory, or the
-                directory cannot be created or its mode changed (e.g. a
-                read-only mount).
-            PermissionError: If the existing directory is owned by another
-                local user.
-        """
-        path.mkdir(mode=0o700, parents=True, exist_ok=True)
-        info = path.lstat()
-        if not stat.S_ISDIR(info.st_mode):
-            msg = f"Offload path is not a directory: {path}"
-            raise OSError(msg)
-        getuid = getattr(os, "getuid", None)
-        if getuid is not None and info.st_uid != getuid():
-            msg = f"Offload directory is owned by another user: {path}"
-            raise PermissionError(msg)
-        # `mkdir(mode=...)` does not tighten an existing directory. Archives
-        # contain conversation data, so the offload directory must remain
-        # inaccessible to other local accounts regardless of the process umask.
-        path.chmod(0o700)
-
-    def _probe_writable(path: Path) -> None:
-        # Creating the directory is insufficient when it already exists on a
-        # read-only mount. A temporary file proves archive writes can succeed.
-        with tempfile.NamedTemporaryFile(dir=path, prefix=".write-test-"):
-            pass
-
     def _prepare_user_dir() -> Path:
         base = Path.home() / ".deepagents"
         # Ensure the shared config root exists and is usable, but leave its
         # permissions untouched -- hardening belongs on the archive subdir only.
         base.mkdir(parents=True, exist_ok=True)
         archive_dir = base / "conversation_history"
-        _harden(archive_dir)
+        _harden_dir(archive_dir)
         _probe_writable(archive_dir)
         return base
 
@@ -111,7 +168,7 @@ def _offload_fallback_root() -> Path:
         # A temp dir is created solely for offload and is not shared config, so
         # hardening the whole directory (which protects its archive subdir) is
         # both safe and necessary in world-writable temp locations.
-        _harden(path)
+        _harden_dir(path)
         _probe_writable(path)
         return path
 

--- a/libs/code/tests/integration_tests/test_compact_resume.py
+++ b/libs/code/tests/integration_tests/test_compact_resume.py
@@ -241,8 +241,13 @@ async def test_compact_resumed_thread_uses_persisted_history(
             cutoff = _event_field(summarization_event, "cutoff_index")
             assert isinstance(cutoff, int)
             assert cutoff > 0
-            archive_path = f"/conversation_history/{thread_id}.md"
-            assert _event_field(summarization_event, "file_path") == archive_path
+            # In local mode the history prefix lives under a stable per-user
+            # `artifacts_root`, so assert the suffix rather than a fixed prefix.
+            # The path stays resolvable after restart because `artifacts_root`
+            # is deterministic (Server 3 below reuses it).
+            archive_path = _event_field(summarization_event, "file_path")
+            assert isinstance(archive_path, str)
+            assert archive_path.endswith(f"/conversation_history/{thread_id}.md")
 
             # The archive must be readable THROUGH THE AGENT, proving the bytes
             # live in the agent's own composite backend server-side rather than

--- a/libs/code/tests/integration_tests/test_offload_server_side.py
+++ b/libs/code/tests/integration_tests/test_offload_server_side.py
@@ -235,8 +235,11 @@ async def test_offload_runs_server_side_and_is_agent_readable(
             cutoff = _event_field(summarization_event, "cutoff_index")
             assert isinstance(cutoff, int)
             assert cutoff > 0
-            archive_path = f"/conversation_history/{thread_id}.md"
-            assert _event_field(summarization_event, "file_path") == archive_path
+            # In local mode the history prefix lives under a per-session
+            # `artifacts_root`, so assert the suffix rather than a fixed prefix.
+            archive_path = _event_field(summarization_event, "file_path")
+            assert isinstance(archive_path, str)
+            assert archive_path.endswith(f"/conversation_history/{thread_id}.md")
 
             # CRUCIAL: the archive must be readable THROUGH THE AGENT, proving
             # the bytes exist in the agent's own backend server-side.

--- a/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
+++ b/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
@@ -341,6 +341,7 @@ Do not assume that a path returned by a file tool can be used directly in a shel
 
 Host path mappings:
 - `<tmp_path>/dcode-artifacts/conversation_history/` -> `<tmp_path>/.deepagents/conversation_history/` (e.g. `<tmp_path>/dcode-artifacts/conversation_history/dir/x.py` -> `<tmp_path>/.deepagents/conversation_history/dir/x.py`)
+- `/dcode-artifacts-fallback/conversation_history/` -> `<tmp_path>/.deepagents/conversation_history/` (e.g. `/dcode-artifacts-fallback/conversation_history/dir/x.py` -> `<tmp_path>/.deepagents/conversation_history/dir/x.py`)
 
 ## `task` (subagent spawner)
 

--- a/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
+++ b/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
@@ -319,7 +319,7 @@ All file paths must start with a /. Follow the tool docs for the available tools
 
 ## Large Tool Results
 
-When a tool result is too large, it may be offloaded into the filesystem instead of being returned inline. In those cases, use `read_file` to inspect the saved result in chunks, or use `grep` within `/large_tool_results/` if you need to search across offloaded tool results and do not know the exact file path. Offloaded tool results are stored under `/large_tool_results/<tool_call_id>`.
+When a tool result is too large, it may be offloaded into the filesystem instead of being returned inline. In those cases, use `read_file` to inspect the saved result in chunks, or use `grep` within `<tmp_path>/dcode-artifacts/large_tool_results/` if you need to search across offloaded tool results and do not know the exact file path. Offloaded tool results are stored under `<tmp_path>/dcode-artifacts/large_tool_results/<tool_call_id>`.
 
 ## Execute Tool `execute`
 
@@ -340,8 +340,7 @@ Some paths returned by the file tools are virtual mounts:
 Do not assume that a path returned by a file tool can be used directly in a shell command.
 
 Host path mappings:
-- `/conversation_history/` -> `<tmp_path>/.deepagents/conversation_history/` (e.g. `/conversation_history/dir/x.py` -> `<tmp_path>/.deepagents/conversation_history/dir/x.py`)
-- `/large_tool_results/` -> `<tmp_path>/deepagents_large_results/` (e.g. `/large_tool_results/dir/x.py` -> `<tmp_path>/deepagents_large_results/dir/x.py`)
+- `<tmp_path>/dcode-artifacts/conversation_history/` -> `<tmp_path>/.deepagents/conversation_history/` (e.g. `<tmp_path>/dcode-artifacts/conversation_history/dir/x.py` -> `<tmp_path>/.deepagents/conversation_history/dir/x.py`)
 
 ## `task` (subagent spawner)
 

--- a/libs/code/tests/unit_tests/smoke_tests/test_system_prompt.py
+++ b/libs/code/tests/unit_tests/smoke_tests/test_system_prompt.py
@@ -20,6 +20,7 @@ from pydantic import Field
 
 from deepagents_code.agent import create_cli_agent
 from deepagents_code.config import Settings
+from deepagents_code.offload import _ArtifactsStorage
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Sequence
@@ -137,7 +138,9 @@ def _mock_settings(tmp_path: Path) -> Generator[None, None, None]:
         with (
             patch(
                 "deepagents_code.agent._artifacts_root",
-                return_value=tmp_path / "dcode-artifacts",
+                return_value=_ArtifactsStorage(
+                    root=(tmp_path / "dcode-artifacts").as_posix()
+                ),
             ),
             patch(
                 "deepagents_code.agent._offload_fallback_root",

--- a/libs/code/tests/unit_tests/smoke_tests/test_system_prompt.py
+++ b/libs/code/tests/unit_tests/smoke_tests/test_system_prompt.py
@@ -134,11 +134,11 @@ def _mock_settings(tmp_path: Path) -> Generator[None, None, None]:
 
         # Patch generated backend roots so host-path mappings are deterministic
         # across machines and runs.
-        def _fake_mkdtemp(prefix: str = "", **_kw: Any) -> str:
-            return str(tmp_path / prefix.rstrip("_"))
-
         with (
-            patch("deepagents_code.agent.tempfile.mkdtemp", _fake_mkdtemp),
+            patch(
+                "deepagents_code.agent._artifacts_root",
+                return_value=tmp_path / "dcode-artifacts",
+            ),
             patch(
                 "deepagents_code.agent._offload_fallback_root",
                 return_value=tmp_path / ".deepagents",

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -125,12 +125,45 @@ def test_local_conversation_history_route_is_persistent(tmp_path: Path) -> None:
             cwd=tmp_path,
         )
 
-    result = backend.write("/conversation_history/thread.md", "archived")
+    # Conversation history is addressed under the backend's `artifacts_root`
+    # (a per-session temp dir in local mode) and routed to persistent storage.
+    result = backend.write(
+        f"{backend.artifacts_root}/conversation_history/thread.md", "archived"
+    )
 
     assert result.error is None
     assert (
         history_root / "conversation_history" / "thread.md"
     ).read_text() == "archived"
+
+
+def test_local_large_tool_results_land_on_real_filesystem(tmp_path: Path) -> None:
+    """Offloaded large results write to the real default fs, not a virtual mount.
+
+    `<artifacts_root>/large_tool_results/` has no composite route, so writes fall
+    through to the default backend at a real path the agent can inspect with
+    `execute` -- the whole point of the local-mode rewire.
+    """
+    artifacts_root = tmp_path / "artifacts"
+    model = _make_fake_chat_model()
+
+    with patch("deepagents_code.agent._artifacts_root", return_value=artifacts_root):
+        _agent, backend = create_cli_agent(
+            model=model,
+            assistant_id="test-agent",
+            enable_memory=False,
+            enable_skills=False,
+            enable_shell=False,
+            system_prompt="test prompt",
+            cwd=tmp_path,
+        )
+
+    assert backend.artifacts_root == str(artifacts_root)
+    result = backend.write(f"{artifacts_root}/large_tool_results/call-1", "payload")
+
+    assert result.error is None
+    # The bytes are on the real filesystem at the advertised path.
+    assert (artifacts_root / "large_tool_results" / "call-1").read_text() == "payload"
 
 
 def _request_with_context(
@@ -3665,6 +3698,27 @@ class TestCreateCliAgentInterpreterWiring:
         assert "1  first" in allowed.content
         assert "2  second" in allowed.content
         assert "can only read" in denied
+
+    def test_rubric_grader_prefix_tracks_artifacts_root(self, tmp_path: Path) -> None:
+        """The grader read allow-list follows the backend's `artifacts_root`.
+
+        With a non-default `artifacts_root`, offloaded results live under
+        `<root>/large_tool_results/`, so the grader must allow that prefix and
+        reject the old, unrelated `/large_tool_results/` path.
+        """
+        from deepagents.backends import CompositeBackend
+        from deepagents.backends.filesystem import FilesystemBackend
+
+        project = FilesystemBackend(root_dir=tmp_path / "project", virtual_mode=False)
+        backend = CompositeBackend(
+            default=project, routes={}, artifacts_root="/srv/art"
+        )
+        read_tool = cast("Any", _create_rubric_grader_tools(backend)[0])
+
+        runtime = SimpleNamespace(tool_call_id="grader-read")
+        denied = read_tool.func(file_path="/large_tool_results/x", runtime=runtime)
+
+        assert "can only read files under /srv/art/large_tool_results/" in denied
 
     def test_appends_interpreter_middleware_when_enabled(self, tmp_path: Path) -> None:
         from langchain_quickjs import CodeInterpreterMiddleware

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -47,6 +47,7 @@ from deepagents_code.agent import (
 )
 from deepagents_code.config import Settings, get_glyphs
 from deepagents_code.managed_tools import BIN_DIR
+from deepagents_code.offload import _filesystem_tool_path
 from deepagents_code.project_utils import ProjectContext
 
 
@@ -145,9 +146,10 @@ def test_local_large_tool_results_land_on_real_filesystem(tmp_path: Path) -> Non
     `execute` -- the whole point of the local-mode rewire.
     """
     artifacts_root = tmp_path / "artifacts"
+    tool_root = _filesystem_tool_path(artifacts_root)
     model = _make_fake_chat_model()
 
-    with patch("deepagents_code.agent._artifacts_root", return_value=artifacts_root):
+    with patch("deepagents_code.agent._artifacts_root", return_value=tool_root):
         _agent, backend = create_cli_agent(
             model=model,
             assistant_id="test-agent",
@@ -158,8 +160,8 @@ def test_local_large_tool_results_land_on_real_filesystem(tmp_path: Path) -> Non
             cwd=tmp_path,
         )
 
-    assert backend.artifacts_root == str(artifacts_root)
-    result = backend.write(f"{artifacts_root}/large_tool_results/call-1", "payload")
+    assert backend.artifacts_root == tool_root
+    result = backend.write(f"{tool_root}/large_tool_results/call-1", "payload")
 
     assert result.error is None
     # The bytes are on the real filesystem at the advertised path.

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -47,7 +47,11 @@ from deepagents_code.agent import (
 )
 from deepagents_code.config import Settings, get_glyphs
 from deepagents_code.managed_tools import BIN_DIR
-from deepagents_code.offload import _filesystem_tool_path
+from deepagents_code.offload import (
+    _FALLBACK_ARTIFACTS_ROOT,
+    _ArtifactsStorage,
+    _filesystem_tool_path,
+)
 from deepagents_code.project_utils import ProjectContext
 
 
@@ -149,7 +153,10 @@ def test_local_large_tool_results_land_on_real_filesystem(tmp_path: Path) -> Non
     tool_root = _filesystem_tool_path(artifacts_root)
     model = _make_fake_chat_model()
 
-    with patch("deepagents_code.agent._artifacts_root", return_value=tool_root):
+    with patch(
+        "deepagents_code.agent._artifacts_root",
+        return_value=_ArtifactsStorage(root=tool_root),
+    ):
         _agent, backend = create_cli_agent(
             model=model,
             assistant_id="test-agent",
@@ -166,6 +173,63 @@ def test_local_large_tool_results_land_on_real_filesystem(tmp_path: Path) -> Non
     assert result.error is None
     # The bytes are on the real filesystem at the advertised path.
     assert (artifacts_root / "large_tool_results" / "call-1").read_text() == "payload"
+
+
+def test_fallback_artifacts_root_keeps_archive_path_resolvable(
+    tmp_path: Path,
+) -> None:
+    """A resumed archive path keeps matching after fallback storage changes."""
+    history_root = tmp_path / ".deepagents"
+    first_results = tmp_path / "large-results-1"
+    recovered_root = _filesystem_tool_path(tmp_path / "recovered-artifacts")
+    model = _make_fake_chat_model()
+
+    with (
+        patch(
+            "deepagents_code.agent._artifacts_root",
+            side_effect=[
+                _ArtifactsStorage(
+                    root=_FALLBACK_ARTIFACTS_ROOT,
+                    large_results_dir=first_results,
+                ),
+                _ArtifactsStorage(root=recovered_root),
+            ],
+        ),
+        patch(
+            "deepagents_code.agent._offload_fallback_root",
+            return_value=history_root,
+        ),
+    ):
+        _first_agent, first_backend = create_cli_agent(
+            model=model,
+            assistant_id="test-agent",
+            enable_memory=False,
+            enable_skills=False,
+            enable_shell=False,
+            system_prompt="test prompt",
+            cwd=tmp_path,
+        )
+        _second_agent, second_backend = create_cli_agent(
+            model=model,
+            assistant_id="test-agent",
+            enable_memory=False,
+            enable_skills=False,
+            enable_shell=False,
+            system_prompt="test prompt",
+            cwd=tmp_path,
+        )
+
+    assert second_backend.artifacts_root == recovered_root
+    archive_path = f"{_FALLBACK_ARTIFACTS_ROOT}/conversation_history/thread.md"
+    assert first_backend.write(archive_path, "initial").error is None
+    assert second_backend.write(archive_path, "resumed").error is None
+    assert (
+        history_root / "conversation_history" / "thread.md"
+    ).read_text() == "resumed"
+
+    result_path = f"{_FALLBACK_ARTIFACTS_ROOT}/large_tool_results/call-1"
+    assert first_backend.write(result_path, "payload").error is None
+    assert (first_results / "call-1").read_text() == "payload"
 
 
 def _request_with_context(

--- a/libs/code/tests/unit_tests/test_end_to_end.py
+++ b/libs/code/tests/unit_tests/test_end_to_end.py
@@ -231,8 +231,10 @@ class TestDeepAgentsCLIEndToEnd:
             assert "summary goes here" in summary_message.content
             assert agent_response.generations[0].message.content == "response"
 
-            # Verify conversation history was offloaded to backend
-            assert backend.ls("/conversation_history/").entries
+            # Verify conversation history was offloaded to backend. In local
+            # mode the history prefix lives under the backend's `artifacts_root`
+            # (a per-session temp dir), routed to persistent storage.
+            assert backend.ls(f"{backend.artifacts_root}/conversation_history/").entries
 
     def test_cli_agent_with_fake_llm_with_tools(self, tmp_path: Path) -> None:
         """Test CLI agent with tools using a fake LLM model.

--- a/libs/code/tests/unit_tests/test_offload.py
+++ b/libs/code/tests/unit_tests/test_offload.py
@@ -1203,13 +1203,14 @@ class TestArtifactsRoot:
 
         monkeypatch.setattr(tempfile, "gettempdir", lambda: str(temp_dir))
 
-        root = _artifacts_root()
-        root_path = Path(root)
+        storage = _artifacts_root()
+        root_path = Path(storage.root)
 
+        assert storage.large_results_dir is None
         assert root_path.samefile(temp_dir / f"dcode-artifacts-{uid}")
         assert stat.S_IMODE(root_path.stat().st_mode) == 0o700
         # Stable across calls (paths embedded in resumed threads stay resolvable).
-        assert _artifacts_root() == root
+        assert _artifacts_root() == storage
 
     def test_windows_artifacts_root_is_accepted_by_filesystem_tools(self) -> None:
         """A Windows temp path retains its drive without a rejected drive prefix."""
@@ -1251,12 +1252,17 @@ class TestArtifactsRoot:
         monkeypatch.setattr(tempfile, "gettempdir", lambda: str(temp_dir))
         monkeypatch.setattr(Path, "lstat", fake_lstat)
 
-        root = _artifacts_root()
-        root_path = Path(root)
+        storage = _artifacts_root()
+        next_storage = _artifacts_root()
 
-        assert not root_path.samefile(reserved)
-        assert root_path.name.startswith(f"dcode-artifacts-{uid}-")
-        assert stat.S_IMODE(root_path.stat().st_mode) == 0o700
+        assert storage.root == "/dcode-artifacts-fallback"
+        assert next_storage.root == storage.root
+        assert storage.large_results_dir is not None
+        assert next_storage.large_results_dir is not None
+        assert not storage.large_results_dir.samefile(reserved)
+        assert storage.large_results_dir.name.startswith(f"dcode-artifacts-{uid}-")
+        assert stat.S_IMODE(storage.large_results_dir.stat().st_mode) == 0o700
+        assert next_storage.large_results_dir != storage.large_results_dir
 
 
 class TestOffloadStorageCaveat:

--- a/libs/code/tests/unit_tests/test_offload.py
+++ b/libs/code/tests/unit_tests/test_offload.py
@@ -6,16 +6,21 @@ import os
 import stat
 import tempfile
 from contextlib import nullcontext
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from deepagents.backends.utils import validate_path
 
 from deepagents_code._session_stats import format_token_count
 from deepagents_code.app import DeepAgentsApp
 from deepagents_code.command_registry import SLASH_COMMANDS
-from deepagents_code.offload import _artifacts_root, _offload_fallback_root
+from deepagents_code.offload import (
+    _artifacts_root,
+    _filesystem_tool_path,
+    _offload_fallback_root,
+)
 from deepagents_code.tui.widgets.messages import AppMessage, ErrorMessage
 
 
@@ -1199,11 +1204,25 @@ class TestArtifactsRoot:
         monkeypatch.setattr(tempfile, "gettempdir", lambda: str(temp_dir))
 
         root = _artifacts_root()
+        root_path = Path(root)
 
-        assert root == temp_dir / f"dcode-artifacts-{uid}"
-        assert stat.S_IMODE(root.stat().st_mode) == 0o700
+        assert root_path.samefile(temp_dir / f"dcode-artifacts-{uid}")
+        assert stat.S_IMODE(root_path.stat().st_mode) == 0o700
         # Stable across calls (paths embedded in resumed threads stay resolvable).
         assert _artifacts_root() == root
+
+    def test_windows_artifacts_root_is_accepted_by_filesystem_tools(self) -> None:
+        """A Windows temp path retains its drive without a rejected drive prefix."""
+        disk_root = PureWindowsPath(
+            "C:/Users/test/AppData/Local/Temp/dcode-artifacts-123"
+        )
+
+        root = _filesystem_tool_path(disk_root)
+        result_path = f"{root}/large_tool_results/tool-call-id"
+
+        assert root == "//?/C:/Users/test/AppData/Local/Temp/dcode-artifacts-123"
+        assert PureWindowsPath(root).is_absolute()
+        assert validate_path(result_path) == result_path
 
     def test_artifacts_root_falls_back_when_predictable_path_foreign_owned(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1233,10 +1252,11 @@ class TestArtifactsRoot:
         monkeypatch.setattr(Path, "lstat", fake_lstat)
 
         root = _artifacts_root()
+        root_path = Path(root)
 
-        assert root != reserved
-        assert root.name.startswith(f"dcode-artifacts-{uid}-")
-        assert stat.S_IMODE(root.stat().st_mode) == 0o700
+        assert not root_path.samefile(reserved)
+        assert root_path.name.startswith(f"dcode-artifacts-{uid}-")
+        assert stat.S_IMODE(root_path.stat().st_mode) == 0o700
 
 
 class TestOffloadStorageCaveat:

--- a/libs/code/tests/unit_tests/test_offload.py
+++ b/libs/code/tests/unit_tests/test_offload.py
@@ -15,7 +15,7 @@ import pytest
 from deepagents_code._session_stats import format_token_count
 from deepagents_code.app import DeepAgentsApp
 from deepagents_code.command_registry import SLASH_COMMANDS
-from deepagents_code.offload import _offload_fallback_root
+from deepagents_code.offload import _artifacts_root, _offload_fallback_root
 from deepagents_code.tui.widgets.messages import AppMessage, ErrorMessage
 
 
@@ -1182,6 +1182,61 @@ class TestOffloadFallbackRoot:
         from deepagents_code.offload import offload_storage_is_ephemeral
 
         assert offload_storage_is_ephemeral() is False
+
+
+class TestArtifactsRoot:
+    """Cover the real-filesystem artifacts root for offloaded tool results."""
+
+    def test_artifacts_root_is_stable_and_hardened(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The per-user artifacts dir is predictable, private, and reused."""
+        temp_dir = tmp_path / "tmp"
+        temp_dir.mkdir()
+        getuid = getattr(os, "getuid", None)
+        uid = getuid() if getuid is not None else os.getpid()
+
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(temp_dir))
+
+        root = _artifacts_root()
+
+        assert root == temp_dir / f"dcode-artifacts-{uid}"
+        assert stat.S_IMODE(root.stat().st_mode) == 0o700
+        # Stable across calls (paths embedded in resumed threads stay resolvable).
+        assert _artifacts_root() == root
+
+    def test_artifacts_root_falls_back_when_predictable_path_foreign_owned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A predictable dir owned by another user is rejected for a unique one."""
+        from types import SimpleNamespace
+
+        getuid = getattr(os, "getuid", None)
+        if getuid is None:
+            pytest.skip("uid ownership check requires os.getuid")
+
+        temp_dir = tmp_path / "tmp"
+        temp_dir.mkdir()
+        uid = getuid()
+        reserved = temp_dir / f"dcode-artifacts-{uid}"
+        reserved.mkdir()  # a real, us-owned directory; lstat is faked below
+
+        real_lstat = Path.lstat
+
+        def fake_lstat(self: Path) -> Any:  # noqa: ANN401
+            info = real_lstat(self)
+            if self == reserved:
+                return SimpleNamespace(st_mode=info.st_mode, st_uid=info.st_uid + 1)
+            return info
+
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(temp_dir))
+        monkeypatch.setattr(Path, "lstat", fake_lstat)
+
+        root = _artifacts_root()
+
+        assert root != reserved
+        assert root.name.startswith(f"dcode-artifacts-{uid}-")
+        assert stat.S_IMODE(root.stat().st_mode) == 0o700
 
 
 class TestOffloadStorageCaveat:


### PR DESCRIPTION
In dcode local mode, offloaded large tool results previously lived behind a virtual `CompositeBackend` route backed by a hidden `mkdtemp` `FilesystemBackend`. Because `execute` always runs on the default backend (never path-routed), the agent could not open those results with `jq`/`grep`/`python` by the path it was handed — the `/large_tool_results/` prefix wasn't a real inode, and the temp root was intentionally hidden.

This points `CompositeBackend.artifacts_root` at a stable, hardened per-user temp dir and drops the `/large_tool_results/` route, so offloaded results fall through to the default `LocalShellBackend` at a real path. The agent can now inspect them with `execute` using the exact path the offload message hands it — no virtual-path translation, no copy-out/in. Conversation history keeps a dedicated route to persistent `~/.deepagents` storage so `/offload` archives survive restarts, and its address stays stable across restarts because the artifacts root is deterministic per user.

This uses the existing `artifacts_root` support on `CompositeBackend` (already consumed by both the filesystem and summarization middleware), so it is a dcode-only change with no SDK edit. The artifacts dir is created `0o700` with an ownership/`S_ISDIR` guard and falls back to a private unique dir if the predictable path is squatted; consolidating on one per-user dir also removes the old unbounded `mkdtemp`-per-session leak.

The rubric grader's read allow-list now derives its permitted prefix from `artifacts_root` rather than a hardcoded `/large_tool_results/`.

Made by [Open SWE](https://openswe.vercel.app/agents/e815e778-3188-4f2e-1068-e52819c024a7)

## References
- Plan: https://openswe.vercel.app/agents/e815e778-3188-4f2e-1068-e52819c024a7/plan