### PR TITLE
feat(code): toast to re-paste when a chat paste collapses

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -131,6 +131,10 @@ def _should_collapse_chat_paste(text: str) -> bool:
     return detect_mode_prefix(text) is None and should_collapse_paste(text)
 
 
+_PASTE_COLLAPSED_TOAST = "Large paste collapsed. Paste again to expand it inline."
+"""Toast shown when a paste is collapsed into a `[Pasted text #N]` placeholder."""
+
+
 class CompletionOption(Static):
     """A clickable completion option in the autocomplete popup."""
 
@@ -2374,6 +2378,7 @@ class ChatInput(Vertical):
         self._pasted_contents[paste_id] = PastedContent(content=text)
         placeholder = format_paste_ref(paste_id, count_lines(text))
         self._text_area.insert(placeholder)
+        self.app.notify(_PASTE_COLLAPSED_TOAST, timeout=5, markup=False)
 
     def _apply_inline_dropped_path_replacement(self, text: str) -> bool:
         """Replace full dropped-path payload text with image placeholders.

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -132,7 +132,11 @@ def _should_collapse_chat_paste(text: str) -> bool:
 
 
 _PASTE_COLLAPSED_TOAST = "Large paste collapsed. Paste again to expand it inline."
-"""Toast shown when a paste is collapsed into a `[Pasted text #N]` placeholder."""
+"""Toast shown when a paste collapses into a `[Pasted text #N]` placeholder.
+
+Emitted only for a new collapse, not when a repeat paste expands an existing
+placeholder back to full text.
+"""
 
 
 class CompletionOption(Static):

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -232,6 +232,23 @@ class _RecordingApp(App[None]):
         self.submitted.append(event)
 
 
+def _capture_notifications(
+    monkeypatch: pytest.MonkeyPatch, app: App[None]
+) -> list[tuple[str, dict[str, object]]]:
+    """Patch ``app.notify`` and return a list recording each call.
+
+    Each entry is ``(message, kwargs)`` so tests can assert both the toast
+    text and the notification options (e.g. ``markup``, ``timeout``).
+    """
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def _record(message: str, *_args: object, **kwargs: object) -> None:
+        calls.append((str(message), kwargs))
+
+    monkeypatch.setattr(app, "notify", _record)
+    return calls
+
+
 async def _noop() -> None:
     pass
 
@@ -4944,11 +4961,14 @@ class TestPasteCollapseIntegration:
             assert chat._pasted_contents[1].content == text
             assert chat._pasted_contents[2].content == text
 
-    async def test_bracketed_paste_event_collapses(self) -> None:
+    async def test_bracketed_paste_event_collapses(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A real Paste event over the threshold collapses to a placeholder.
 
         Exercises the production path (`_on_paste` -> `PastedText` message ->
-        `on_chat_text_area_pasted_text`) rather than `handle_external_paste`.
+        `on_chat_text_area_pasted_text`) rather than `handle_external_paste`,
+        and asserts the collapse toast fires on that path too.
         """
         big_text = "z" * 900
         app = _RecordingApp()
@@ -4956,12 +4976,20 @@ class TestPasteCollapseIntegration:
             chat = app.query_one(ChatInput)
             assert chat._text_area is not None
 
+            calls = _capture_notifications(monkeypatch, app)
+
             await chat._text_area._on_paste(events.Paste(big_text))
             await pilot.pause()
 
             assert "[Pasted text #1]" in chat._text_area.text
             assert big_text not in chat._text_area.text
             assert chat._pasted_contents[1].content == big_text
+            assert calls == [
+                (
+                    chat_input_module._PASTE_COLLAPSED_TOAST,
+                    {"timeout": 5, "markup": False},
+                )
+            ]
 
     async def test_collapse_emits_expand_toast(
         self, monkeypatch: pytest.MonkeyPatch
@@ -4973,20 +5001,20 @@ class TestPasteCollapseIntegration:
             chat = app.query_one(ChatInput)
             assert chat._text_area is not None
 
-            messages: list[str] = []
-
-            def _capture_notify(
-                message: str, *_args: object, **_kwargs: object
-            ) -> None:
-                messages.append(str(message))
-
-            monkeypatch.setattr(app, "notify", _capture_notify)
+            calls = _capture_notifications(monkeypatch, app)
 
             chat.handle_external_paste(text)
             await pilot.pause()
 
             assert chat._text_area.text == "[Pasted text #1]"
-            assert messages == [chat_input_module._PASTE_COLLAPSED_TOAST]
+            # Render the message literally (no markup) so bracketed text like
+            # `[Pasted text #N]` is never interpreted as Textual markup.
+            assert calls == [
+                (
+                    chat_input_module._PASTE_COLLAPSED_TOAST,
+                    {"timeout": 5, "markup": False},
+                )
+            ]
 
     async def test_repeat_paste_expansion_does_not_emit_toast(
         self, monkeypatch: pytest.MonkeyPatch
@@ -5002,28 +5030,55 @@ class TestPasteCollapseIntegration:
             await pilot.pause()
             assert chat._text_area.text == "[Pasted text #1]"
 
-            messages: list[str] = []
-
-            def _capture_notify(
-                message: str, *_args: object, **_kwargs: object
-            ) -> None:
-                messages.append(str(message))
-
-            monkeypatch.setattr(app, "notify", _capture_notify)
+            # Patch after the first (expected) toast so only the repeat-paste
+            # expansion branch is recorded.
+            calls = _capture_notifications(monkeypatch, app)
 
             chat.handle_external_paste(text)
             await pilot.pause()
 
             assert chat._text_area.text == text
-            assert messages == []
+            assert calls == []
 
-    async def test_paste_burst_flush_collapses_large_payload(self) -> None:
-        """A large buffered paste burst collapses to a placeholder on flush."""
+    async def test_distinct_pastes_each_emit_toast(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Each distinct large paste collapses to its own placeholder + toast."""
+        first = "A" * 900
+        second = "B" * 900
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            calls = _capture_notifications(monkeypatch, app)
+
+            chat.handle_external_paste(first)
+            await pilot.pause()
+            chat.handle_external_paste(second)
+            await pilot.pause()
+
+            assert chat._text_area.text == "[Pasted text #1][Pasted text #2]"
+            toast = (
+                chat_input_module._PASTE_COLLAPSED_TOAST,
+                {"timeout": 5, "markup": False},
+            )
+            assert calls == [toast, toast]
+
+    async def test_paste_burst_flush_collapses_large_payload(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A large buffered paste burst collapses to a placeholder on flush.
+
+        Also asserts the collapse toast fires on the burst-flush path.
+        """
         big_text = "q" * 900
         app = _RecordingApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
             assert chat._text_area is not None
+
+            calls = _capture_notifications(monkeypatch, app)
 
             chat._text_area._paste_burst_buffer = big_text
             await chat._text_area._flush_paste_burst()
@@ -5032,6 +5087,12 @@ class TestPasteCollapseIntegration:
             assert "[Pasted text #1]" in chat._text_area.text
             assert big_text not in chat._text_area.text
             assert chat._pasted_contents[1].content == big_text
+            assert calls == [
+                (
+                    chat_input_module._PASTE_COLLAPSED_TOAST,
+                    {"timeout": 5, "markup": False},
+                )
+            ]
 
     async def test_backspace_removes_full_paste_placeholder(self) -> None:
         """Backspace deletes a [Pasted text #N] placeholder as a single token."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -4963,6 +4963,60 @@ class TestPasteCollapseIntegration:
             assert big_text not in chat._text_area.text
             assert chat._pasted_contents[1].content == big_text
 
+    async def test_collapse_emits_expand_toast(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Collapsing a paste notifies the user they can paste again to expand."""
+        text = "T" * 900
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            messages: list[str] = []
+
+            def _capture_notify(
+                message: str, *_args: object, **_kwargs: object
+            ) -> None:
+                messages.append(str(message))
+
+            monkeypatch.setattr(app, "notify", _capture_notify)
+
+            chat.handle_external_paste(text)
+            await pilot.pause()
+
+            assert chat._text_area.text == "[Pasted text #1]"
+            assert messages == [chat_input_module._PASTE_COLLAPSED_TOAST]
+
+    async def test_repeat_paste_expansion_does_not_emit_toast(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Expanding an existing placeholder via repeat paste emits no toast."""
+        text = "T" * 900
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat.handle_external_paste(text)
+            await pilot.pause()
+            assert chat._text_area.text == "[Pasted text #1]"
+
+            messages: list[str] = []
+
+            def _capture_notify(
+                message: str, *_args: object, **_kwargs: object
+            ) -> None:
+                messages.append(str(message))
+
+            monkeypatch.setattr(app, "notify", _capture_notify)
+
+            chat.handle_external_paste(text)
+            await pilot.pause()
+
+            assert chat._text_area.text == text
+            assert messages == []
+
     async def test_paste_burst_flush_collapses_large_payload(self) -> None:
         """A large buffered paste burst collapses to a placeholder on flush."""
         big_text = "q" * 900


### PR DESCRIPTION
Pasting large multi-line text into the chat input now shows a toast noting the paste was collapsed and can be pasted again to expand it inline.

---

Pasting a large, multi-line clipboard payload into the chat input collapses it into a compact `[Pasted text #N]` placeholder. That behavior is discoverable only if you already know that pasting the identical content a second time expands it inline. This surfaces a short toast at the moment of collapse so the affordance is visible.

The notification fires only when a *new* placeholder is inserted — repeat-paste expansion of an existing placeholder stays silent — and it routes through the single collapse funnel (`ChatInput._collapse_and_insert_paste`), so bracketed pastes, paste bursts, and app-level paste routing all get it. The message is a static literal sent with `markup=False`.

Made by [Open SWE](https://openswe.vercel.app/agents/100a1495-af57-cbd8-abbb-5f682db12646)