### PR TITLE
fix(code): targeted uv constraints for dcode prerelease deps

### DIFF
--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -25,8 +25,8 @@ import sys
 import tempfile
 import time
 import tomllib
-from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
-from contextlib import suppress
+from collections.abc import Awaitable, Callable, Iterable, Iterator, Mapping, Sequence
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -76,8 +76,36 @@ INSTALLED_STALE_NOTICE_DAYS = 14
 _SDK_RELEASE_TIMES_KEY = "sdk_release_times"
 """`CACHE_FILE` key for cached SDK upload timestamps, keyed by version string."""
 
-_RELEASE_PRERELEASE_DEPS_KEY = "release_requires_prereleases"
-"""`CACHE_FILE` key for release versions that require pre-release dependencies."""
+_RELEASE_PRERELEASE_PINS_KEY = "release_prerelease_pins"
+"""`CACHE_FILE` key mapping a release version to its targeted pre-release pins.
+
+Values are lists of exact pin strings (e.g. `["deepagents==0.7.0a7"]`) that a
+stable `deepagents-code` release mandates as direct, unconditional dependencies.
+An empty list means the release needs no pre-release admission.
+
+This intentionally replaces (rather than reuses) the older
+`"release_requires_prereleases"` cache key, whose values were marker-agnostic
+booleans: an old `True` said only that *some* specifier named a pre-release
+(including upper bounds like `pydantic<2.14.0a0` or exclusions like
+`package!=1.0rc1`), never *which* requirement to pin. Those booleans are not
+authoritative under the targeted-constraint semantics, so the new code never
+reads that legacy key.
+"""
+
+_UV_TARGETED_PRERELEASE_STRATEGY = "if-necessary-or-explicit"
+"""uv `--prerelease` strategy paired with targeted first-party constraints.
+
+Unlike the global `allow` strategy, `if-necessary-or-explicit` only admits a
+pre-release when a constraint pins it exactly (explicit) or no stable release
+can satisfy the requirement (if-necessary). Combined with a constraints file
+listing the exact SDK pin, it lets a stable dcode target install its required
+pre-release dependency without widening the candidate set for unrelated
+optional providers — the bug behind #4524, where a global `allow` pulled in an
+unbuildable `litellm` RC.
+"""
+
+_PRERELEASE_CONSTRAINTS_FILE_PREFIX = "dcode-prereleases-"
+"""Temp-file prefix for the targeted pre-release uv constraints file."""
 
 InstallMethod = Literal["uv", "brew", "other", "unknown"]
 
@@ -295,7 +323,7 @@ def get_last_update_check_time() -> float | None:
 
     Reads the `checked_at` stamp recorded in `CACHE_FILE` when the update cache
     is written (primarily by `get_latest_version`; also seeded by
-    `_write_release_requires_prereleases`). Missing, corrupt, or non-numeric
+    `_write_release_prerelease_pins`). Missing, corrupt, or non-numeric
     data fail-soft to `None` so callers can render an "unknown" state without
     contacting the network.
     """
@@ -312,24 +340,49 @@ def get_last_update_check_time() -> float | None:
     return _coerce_checked_at(checked_at)
 
 
-def _requires_prerelease_dependency(requirements: Sequence[object] | None) -> bool:
-    """Return whether any requirement specifier names a pre-release version.
+def _prerelease_pin_requirements(
+    requirements: Sequence[object] | None,
+) -> list[str]:
+    """Return the mandatory, unconditional, exact pre-release pins in a metadata list.
 
     Accepts the raw `Requires-Dist` list from PyPI metadata, which may contain
     non-string or non-PEP-508 junk; such entries are skipped rather than raising
     so one malformed line cannot poison the whole check.
 
-    The check is intentionally operator- and marker-agnostic: it returns `True`
-    if *any* specifier across *any* requirement pins a pre-release version,
-    regardless of the operator (`==`, `>=`, even `!=`) or environment markers
-    (extras, `python_version`). This errs toward `True`, which is the safe
-    direction — opting `uv` into `--prerelease allow` still resolves stable
-    releases correctly, so a false positive only widens the candidate set and
-    never strands a user. Do not "tighten" this to the dangerous direction
-    without revisiting the fallback asymmetry in `release_requires_prereleases`.
+    A `Requires-Dist` entry qualifies as a *targeted pre-release constraint* only
+    when it is safe to pass to uv as a first-party constraint that admits exactly
+    one pre-release without widening the candidate set for anything else. The
+    supported contract, deliberately conservative, is:
+
+    - a **direct** dependency of the release (every `Requires-Dist` entry is);
+    - **mandatory** — no environment marker at all, so it is neither gated behind
+      an optional `extra` (`; extra == "litellm"`) nor conditioned on the target
+      interpreter/platform (`; python_version >= "3.10"`);
+    - a **positive exact pin** — the specifier set is a single `==`/`===` clause;
+    - whose pinned version is a **pre-release** (`0.7.0a7`, `1.2.0rc1`, ...).
+
+    Everything else is ignored, matching the constraints uv would actually need:
+
+    - upper bounds such as `pydantic<2.14.0a0` (not a positive pin);
+    - exclusions such as `package!=1.0rc1` (not a positive pin);
+    - extra-gated pins such as `package==1.0rc1; extra == "x"` (not mandatory);
+    - interpreter/platform-gated pins such as `pkg==1a1; python_version < "3.0"`.
+
+    Marker-bearing pins are intentionally out of the supported contract: the uv
+    tool receipt may target a different interpreter than the one currently
+    running dcode, so evaluating `python_version`/`sys_platform` markers here
+    could resolve them against the wrong environment. Rather than guess, the
+    initial contract is limited to unconditional exact pins (which covers the
+    real-world `deepagents==0.7.0a7` SDK pin); widening it later must evaluate
+    markers against the *target* environment, not the running one.
+
+    Returns:
+        A sorted list of canonical pin strings (e.g. `["deepagents==0.7.0a7"]`).
+            Empty when the release needs no targeted pre-release admission.
     """
     if not requirements:
-        return False
+        return []
+    pins: set[str] = set()
     for raw in requirements:
         if not isinstance(raw, str):
             continue
@@ -338,18 +391,39 @@ def _requires_prerelease_dependency(requirements: Sequence[object] | None) -> bo
         except InvalidRequirement:
             logger.debug("Skipping unparseable Requires-Dist entry: %r", raw)
             continue
-        for specifier in requirement.specifier:
-            try:
-                version = Version(specifier.version)
-            except InvalidVersion:
-                logger.debug(
-                    "Skipping unparseable requirement version: %r",
-                    specifier.version,
-                )
-                continue
-            if version.is_prerelease:
-                return True
-    return False
+        # Mandatory means unconditional: any marker (extra-gated or
+        # interpreter/platform-gated) falls outside the supported contract.
+        if requirement.marker is not None:
+            continue
+        specifiers = list(requirement.specifier)
+        if len(specifiers) != 1:
+            continue
+        specifier = specifiers[0]
+        if specifier.operator not in {"==", "==="}:
+            continue
+        try:
+            version = Version(specifier.version)
+        except InvalidVersion:
+            logger.debug(
+                "Skipping unparseable requirement version: %r",
+                specifier.version,
+            )
+            continue
+        if not version.is_prerelease:
+            continue
+        pins.add(f"{canonicalize_name(requirement.name)}=={version}")
+    return sorted(pins)
+
+
+def _requires_prerelease_dependency(requirements: Sequence[object] | None) -> bool:
+    """Return whether a metadata list carries a targeted pre-release pin.
+
+    Thin boolean view over `_prerelease_pin_requirements`; `True` iff at least
+    one mandatory, unconditional, exact pre-release pin is present. Retained for
+    the display-only callers (`release_requires_prereleases`) that only need to
+    know *whether* a release requires pre-release admission, not which pins.
+    """
+    return bool(_prerelease_pin_requirements(requirements))
 
 
 def _atomic_write_cache(data: dict[str, Any]) -> None:
@@ -379,8 +453,8 @@ def _atomic_write_cache(data: dict[str, Any]) -> None:
         raise
 
 
-def _write_release_requires_prereleases(version: str, requires: bool) -> None:
-    """Cache whether a release needs uv's pre-release resolver opt-in."""
+def _write_release_prerelease_pins(version: str, pins: Sequence[str]) -> None:
+    """Cache the targeted pre-release pins a release requires (versioned cache)."""
     try:
         data: dict[str, Any]
         if CACHE_FILE.exists():
@@ -388,16 +462,16 @@ def _write_release_requires_prereleases(version: str, requires: bool) -> None:
             data = loaded if isinstance(loaded, dict) else {}
         else:
             data = {}
-        values = data.get(_RELEASE_PRERELEASE_DEPS_KEY)
+        values = data.get(_RELEASE_PRERELEASE_PINS_KEY)
         if not isinstance(values, dict):
             values = {}
-        values[version] = requires
-        data[_RELEASE_PRERELEASE_DEPS_KEY] = values
+        values[version] = list(pins)
+        data[_RELEASE_PRERELEASE_PINS_KEY] = values
         data.setdefault("checked_at", time.time())
         _atomic_write_cache(data)
     except (OSError, json.JSONDecodeError, TypeError):
         logger.debug(
-            "Failed to write release pre-release dependency cache",
+            "Failed to write release pre-release pins cache",
             exc_info=True,
         )
 
@@ -471,9 +545,7 @@ def get_latest_version(
         if not releases:
             logger.debug("PyPI response missing or empty 'releases' key")
         prerelease = _latest_from_releases(releases, include_prereleases=True)
-        stable_requires_prereleases = _requires_prerelease_dependency(
-            info.get("requires_dist")
-        )
+        stable_prerelease_pins = _prerelease_pin_requirements(info.get("requires_dist"))
     except (requests.RequestException, OSError, KeyError, json.JSONDecodeError):
         logger.debug("Failed to fetch latest version from PyPI", exc_info=True)
         return cached_version
@@ -482,22 +554,22 @@ def get_latest_version(
         payload, stable=stable, prerelease=prerelease, installed=__version__
     )
 
-    # Preserve per-version pre-release-dependency entries written by
-    # `_write_release_requires_prereleases` for *other* versions; this refresh
-    # only knows the answer for `stable`, so merge rather than overwrite the map
+    # Preserve per-version pre-release-pin entries written by
+    # `_write_release_prerelease_pins` for *other* versions; this refresh only
+    # knows the pins for `stable`, so merge rather than overwrite the map
     # (otherwise a routine check would evict a cached answer and force a re-fetch
-    # that, on a PyPI hiccup, falls back to the unsafe stable-only default).
-    prerelease_deps: dict[str, Any] = {}
+    # that, on a PyPI hiccup, falls back to the conservative empty-pins default).
+    prerelease_pins: dict[str, Any] = {}
     try:
         if CACHE_FILE.exists():
             existing = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
             if isinstance(existing, dict):
-                cached_deps = existing.get(_RELEASE_PRERELEASE_DEPS_KEY)
-                if isinstance(cached_deps, dict):
-                    prerelease_deps = cached_deps
+                cached_pins = existing.get(_RELEASE_PRERELEASE_PINS_KEY)
+                if isinstance(cached_pins, dict):
+                    prerelease_pins = cached_pins
     except (OSError, json.JSONDecodeError, TypeError):
-        logger.debug("Failed to read cached pre-release deps before refresh")
-    prerelease_deps[stable] = stable_requires_prereleases
+        logger.debug("Failed to read cached pre-release pins before refresh")
+    prerelease_pins[stable] = stable_prerelease_pins
 
     try:
         _atomic_write_cache(
@@ -505,7 +577,7 @@ def get_latest_version(
                 "version": stable,
                 "version_prerelease": prerelease,
                 "release_times": release_times,
-                _RELEASE_PRERELEASE_DEPS_KEY: prerelease_deps,
+                _RELEASE_PRERELEASE_PINS_KEY: prerelease_pins,
                 "checked_at": time.time(),
             }
         )
@@ -515,44 +587,57 @@ def get_latest_version(
     return prerelease if include_prereleases else stable
 
 
-def release_requires_prereleases(
+def release_prerelease_pins(
     version: str | None,
     *,
     bypass_cache: bool = False,
-) -> bool:
-    """Return whether installing `version` needs uv pre-release resolution.
+) -> list[str]:
+    """Return the targeted pre-release pins installing `version` requires.
+
+    A stable `deepagents-code` release may mandate an exact pre-release
+    dependency (for example `deepagents==0.7.0a7`). This resolves those pins from
+    the release's PyPI metadata so command builders can pass them to uv as
+    first-party constraints — admitting *only* the named pre-release rather than
+    opting the whole resolution into pre-releases with a global `--prerelease
+    allow`.
 
     Args:
         version: `deepagents-code` version to inspect.
         bypass_cache: Skip cached release metadata and fetch PyPI directly.
 
     Returns:
-        `True` when the release metadata pins or bounds a pre-release dependency.
+        A sorted list of exact pin strings (e.g. `["deepagents==0.7.0a7"]`), or
+            an empty list when the release needs no targeted pre-release
+            admission.
 
     Note:
         On any lookup failure (no `requests`, network/parse error) this returns
-        `False` — i.e. "stable-only resolution". That is deliberately
-        conservative rather than fail-safe: the truly safe default would be to
-        allow pre-releases, but a spurious `True` would make
+        `[]` — "no pre-release admission". That is deliberately conservative
+        rather than fail-safe: the truly safe default would be to admit
+        pre-releases, but a spurious non-empty result would make
         `prerelease_upgrade_supported` *refuse* the upgrade outright on non-uv
-        installs (Homebrew/other), regressing the common case. `False` keeps
-        those installs upgradable; the cost is that, during a PyPI outage, a
-        stable release that genuinely pins a pre-release dependency may be
-        installed stable-only. Failures are logged at `warning` so the blind
-        decision is at least visible.
+        installs (Homebrew/other), regressing the common case. `[]` keeps those
+        installs upgradable; the cost is that, during a PyPI outage, a stable
+        release that genuinely pins a pre-release dependency may be installed
+        stable-only (and may then fail to resolve). Failures are logged at
+        `warning` so the blind decision is at least visible.
     """
     if not version:
-        return False
+        return []
     try:
         if not bypass_cache and CACHE_FILE.exists():
             data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
             if isinstance(data, dict):
-                values = data.get(_RELEASE_PRERELEASE_DEPS_KEY)
-                if isinstance(values, dict) and isinstance(values.get(version), bool):
-                    return values[version]
+                values = data.get(_RELEASE_PRERELEASE_PINS_KEY)
+                if isinstance(values, dict):
+                    cached = values.get(version)
+                    if isinstance(cached, list) and all(
+                        isinstance(pin, str) for pin in cached
+                    ):
+                        return [pin for pin in cached if isinstance(pin, str)]
     except (OSError, json.JSONDecodeError, TypeError):
         logger.debug(
-            "Failed to read release pre-release dependency cache",
+            "Failed to read release pre-release pins cache",
             exc_info=True,
         )
 
@@ -561,10 +646,10 @@ def release_requires_prereleases(
     except ImportError:
         logger.warning(
             "requests package not installed — cannot check whether v%s pins a "
-            "pre-release dependency; assuming stable-only resolution",
+            "pre-release dependency; assuming no pre-release admission",
             version,
         )
-        return False
+        return []
 
     try:
         url = f"{PYPI_URL.removesuffix('/json')}/{version}/json"
@@ -577,18 +662,37 @@ def release_requires_prereleases(
         payload = resp.json()
         info = payload.get("info")
         requires = info.get("requires_dist") if isinstance(info, dict) else None
-        result = _requires_prerelease_dependency(requires)
+        pins = _prerelease_pin_requirements(requires)
     except (requests.RequestException, OSError, KeyError, json.JSONDecodeError):
         logger.warning(
             "Failed to fetch dependency metadata for v%s from PyPI; assuming "
-            "stable-only resolution",
+            "no pre-release admission",
             version,
             exc_info=True,
         )
-        return False
+        return []
 
-    _write_release_requires_prereleases(version, result)
-    return result
+    _write_release_prerelease_pins(version, pins)
+    return pins
+
+
+def release_requires_prereleases(
+    version: str | None,
+    *,
+    bypass_cache: bool = False,
+) -> bool:
+    """Return whether installing `version` needs uv pre-release admission.
+
+    Boolean view over `release_prerelease_pins`, kept for display-only callers
+    that only decide *whether* to show a pre-release-aware upgrade hint, not
+    which pins to constrain. `True` iff the release mandates at least one exact
+    pre-release dependency.
+
+    Args:
+        version: `deepagents-code` version to inspect.
+        bypass_cache: Skip cached release metadata and fetch PyPI directly.
+    """
+    return bool(release_prerelease_pins(version, bypass_cache=bypass_cache))
 
 
 def _extract_release_times(
@@ -1822,62 +1926,101 @@ async def perform_upgrade(
             "manager originally used for this install."
         )
     resolved_include_prereleases = _resolve_include_prereleases(include_prereleases)
+    # Targeted pre-release admission: a *stable* dcode target that mandates an
+    # exact pre-release dependency (e.g. `deepagents==0.7.0a7`). Rather than opt
+    # the whole resolution into pre-releases with a global `--prerelease allow`
+    # — which let an unrelated optional provider float to an unbuildable RC in
+    # #4524 — pin that dependency in a uv constraints file and use the scoped
+    # `if-necessary-or-explicit` strategy so only the named pre-release is
+    # admitted. Kept separate from the explicit pre-release *channel* below,
+    # where the user deliberately follows dcode's own pre-release feed.
+    targeted_pins: list[str] = []
     pin_target_version: str | None = None
-    if (
-        not resolved_include_prereleases
-        and include_prereleases is None
-        and release_requires_prereleases(target_version)
-    ):
-        resolved_include_prereleases = True
-        pin_target_version = target_version
-    if resolved_include_prereleases:
+    if not resolved_include_prereleases and include_prereleases is None:
+        targeted_pins = release_prerelease_pins(target_version)
+        if targeted_pins:
+            pin_target_version = target_version
+
+    if resolved_include_prereleases or targeted_pins:
         supported, reason = prerelease_upgrade_supported(method)
         if not supported:
             return False, reason or _PRERELEASE_UNSUPPORTED_MESSAGE
 
-    fell_back_to_bare_command = False
-    if method == "uv":
-        # Prefer the receipt-aware `uv tool install -U` builder so installed
-        # extras / `--with` packages survive the upgrade and any stale
-        # `==<version>` pin in the receipt is cleared. Fall back to the bare
-        # display command when extras or receipt introspection fails — the
-        # fallback might drop extras, but a successful unpinned upgrade is
-        # still strictly better than a pinned "upgrade" that quietly stays
-        # on the old version.
-        from deepagents_code.extras_info import ExtrasIntrospectionError
-
-        try:
-            cmd = upgrade_install_command(
-                include_prereleases=resolved_include_prereleases,
-                version=pin_target_version,
-            )
-        except (ExtrasIntrospectionError, ToolRequirementIntrospectionError) as exc:
-            logger.warning(
-                "Could not build receipt-aware uv upgrade command (%s: %s); "
-                "falling back to the bare command. Installed extras may be "
-                "dropped.",
-                type(exc).__name__,
-                exc,
-            )
-            fell_back_to_bare_command = True
-            cmd = upgrade_command(
-                method,
-                include_prereleases=resolved_include_prereleases,
-                version=pin_target_version,
-            )
-    else:
-        cmd = upgrade_command(
-            method,
-            include_prereleases=resolved_include_prereleases,
-        )
-
-    # Skip brew if binary not on PATH
+    # Skip brew if binary not on PATH (before touching temp files).
     if method == "brew" and not shutil.which("brew"):
         return False, "brew not found on PATH."
 
-    success, output = await _run_install_subprocess(
-        cmd, progress=progress, log_path=log_path
-    )
+    prerelease_strategy = _UV_TARGETED_PRERELEASE_STRATEGY if targeted_pins else None
+    try:
+        with _prerelease_constraints_file(targeted_pins) as constraints_path:
+            fell_back_to_bare_command = False
+            if method == "uv":
+                # Prefer the receipt-aware `uv tool install -U` builder so
+                # installed extras / `--with` packages survive the upgrade and
+                # any stale `==<version>` pin in the receipt is cleared. Fall
+                # back to the bare display command when extras or receipt
+                # introspection fails — the fallback might drop extras, but a
+                # successful unpinned upgrade is still strictly better than a
+                # pinned "upgrade" that quietly stays on the old version.
+                from deepagents_code.extras_info import ExtrasIntrospectionError
+
+                try:
+                    cmd = upgrade_install_command(
+                        include_prereleases=resolved_include_prereleases,
+                        version=pin_target_version,
+                        constraints_path=constraints_path,
+                        prerelease_strategy=prerelease_strategy,
+                    )
+                except (
+                    ExtrasIntrospectionError,
+                    ToolRequirementIntrospectionError,
+                ) as exc:
+                    logger.warning(
+                        "Could not build receipt-aware uv upgrade command "
+                        "(%s: %s); falling back to the bare command. Installed "
+                        "extras may be dropped.",
+                        type(exc).__name__,
+                        exc,
+                    )
+                    fell_back_to_bare_command = True
+                    cmd = upgrade_command(
+                        method,
+                        include_prereleases=resolved_include_prereleases,
+                        version=pin_target_version,
+                    )
+                    # The bare display command has no constraints knob, so add
+                    # the targeted flags here too — the fallback must not revert
+                    # to a global `--prerelease allow`.
+                    cmd = _append_uv_prerelease_flags(
+                        cmd,
+                        constraints_path=constraints_path,
+                        prerelease_strategy=prerelease_strategy,
+                    )
+            else:
+                cmd = upgrade_command(
+                    method,
+                    include_prereleases=resolved_include_prereleases,
+                )
+
+            success, output = await _run_install_subprocess(
+                cmd, progress=progress, log_path=log_path
+            )
+    except OSError as exc:
+        # Constraint-generation failure: we know the target needs a pinned
+        # pre-release but could not stage the constraints file, so refuse rather
+        # than fall back to a global `--prerelease allow`. The existing install
+        # is untouched because no subprocess ran.
+        logger.warning(
+            "Could not create pre-release constraints file for v%s",
+            target_version,
+            exc_info=True,
+        )
+        return False, (
+            "Could not prepare the pre-release dependency constraints required "
+            f"to install v{target_version}; the existing installation was left "
+            f"unchanged.\n{type(exc).__name__}: {exc}"
+        )
+
     if success and fell_back_to_bare_command:
         # Surface the dropped-extras caveat only now that the bare upgrade has
         # actually succeeded. Emitting it before `_run_install_subprocess` ran
@@ -2317,13 +2460,17 @@ def _uv_tool_install_command(
     extras_to_add: Iterable[str] = (),
     with_packages_to_add: Iterable[str] = (),
     reinstall: bool = False,
+    constraints_path: str | Path | None = None,
+    prerelease_strategy: str | None = None,
 ) -> str:
     """Return the receipt-preserving `uv tool install -U` command.
 
     Args:
         version: Optional exact `deepagents-code` version pin.
         include_prereleases: Whether to include alpha/beta/rc releases. When
-            `None`, follows the installed version's channel.
+            `None`, follows the installed version's channel. Ignored when
+            `prerelease_strategy` is set (targeted constraints drive the
+            resolver instead of the global channel).
         distribution_name: Name of the installed distribution to inspect.
         extras_to_add: Extra names to merge with already-installed extras.
         with_packages_to_add: Package names to merge with the receipt's existing
@@ -2339,6 +2486,16 @@ def _uv_tool_install_command(
             an `ImportError`; the preserved `--python` interpreter and `--with`
             packages still apply, so the rebuild keeps the existing tool
             context.
+        constraints_path: Optional path to a uv constraints file, appended as
+            `--constraints <path>`. Used to pin an exact pre-release dependency
+            as a first-party constraint rather than admitting pre-releases
+            globally. Callers own the file's lifecycle (see
+            `_prerelease_constraints_file`); the builder only references it.
+        prerelease_strategy: Optional uv `--prerelease` strategy (e.g.
+            `if-necessary-or-explicit`). When set, it is emitted verbatim and
+            takes precedence over the `include_prereleases`-driven global
+            `allow`, so a stable target can admit exactly its constrained
+            pre-release pins without widening the candidate set.
 
     Raises:
         ExtrasIntrospectionError: If a metadata-sourced extra name fails PEP 508
@@ -2376,9 +2533,86 @@ def _uv_tool_install_command(
             known.add(canonicalize_name(package))
     for package in with_packages:
         cmd += f" --with {shlex.quote(package)}"
+    if constraints_path is not None or prerelease_strategy is not None:
+        return _append_uv_prerelease_flags(
+            cmd,
+            constraints_path=constraints_path,
+            prerelease_strategy=prerelease_strategy,
+        )
     if _resolve_include_prereleases(include_prereleases):
         cmd += " --prerelease allow"
     return cmd
+
+
+def _append_uv_prerelease_flags(
+    cmd: str,
+    *,
+    constraints_path: str | Path | None,
+    prerelease_strategy: str | None,
+) -> str:
+    """Append targeted `--constraints`/`--prerelease` flags to a uv command.
+
+    Shared by the receipt-aware builder and `perform_upgrade`'s bare-command
+    fallback so both emit the scoped pre-release form identically: a constraints
+    file pinning the exact pre-release dependency plus a non-`allow` strategy
+    (e.g. `if-necessary-or-explicit`). The constraints path is `shlex.quote`-d;
+    the strategy is a fixed internal literal.
+
+    Returns:
+        `cmd` with any `--constraints`/`--prerelease` flags appended.
+    """
+    if constraints_path is not None:
+        cmd += f" --constraints {shlex.quote(str(constraints_path))}"
+    if prerelease_strategy is not None:
+        cmd += f" --prerelease {prerelease_strategy}"
+    return cmd
+
+
+@contextmanager
+def _prerelease_constraints_file(pins: Sequence[str]) -> Iterator[Path | None]:
+    """Yield a temp uv constraints file listing `pins`, removed on exit.
+
+    Writes one pin per line (e.g. `deepagents==0.7.0a7`) to a `mkstemp` file so
+    the exact pre-release dependency can be handed to uv as a first-party
+    constraint. Yields `None` when `pins` is empty so callers can use one code
+    path regardless of whether targeted constraints are needed.
+
+    The file is created with `mkstemp` (mode `0600`) and unlinked in `finally`,
+    so it stays alive for the full subprocess invocation and is cleaned up even
+    when the install raises. Cleanup errors are logged but never raised, so a
+    failed unlink cannot mask the install's own result.
+
+    Raises:
+        OSError: If the constraints file cannot be created or written. Callers
+            treat this as a constraint-generation failure and must not run the
+            install (the alternative — a global `--prerelease allow` fallback —
+            is exactly the behavior this strategy exists to avoid).
+    """
+    if not pins:
+        yield None
+        return
+    fd, name = tempfile.mkstemp(
+        prefix=_PRERELEASE_CONSTRAINTS_FILE_PREFIX, suffix=".txt"
+    )
+    path = Path(name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write("\n".join(pins) + "\n")
+    except OSError:
+        with suppress(OSError):
+            path.unlink()
+        raise
+    try:
+        yield path
+    finally:
+        try:
+            path.unlink()
+        except OSError:
+            logger.debug(
+                "Failed to remove temporary pre-release constraints file %s",
+                path,
+                exc_info=True,
+            )
 
 
 def upgrade_install_command(
@@ -2386,6 +2620,8 @@ def upgrade_install_command(
     include_prereleases: bool | None = None,
     distribution_name: str = "deepagents-code",
     version: str | None = None,
+    constraints_path: str | Path | None = None,
+    prerelease_strategy: str | None = None,
 ) -> str:
     """Return the uv command that upgrades dcode while clearing stale pins.
 
@@ -2409,6 +2645,11 @@ def upgrade_install_command(
             already-installed extras.
         version: Optional exact target version. Use only when pre-release
             dependency resolution must not also select a root app pre-release.
+        constraints_path: Optional uv constraints file pinning the exact
+            pre-release dependency, forwarded as `--constraints <path>`.
+        prerelease_strategy: Optional uv `--prerelease` strategy (e.g.
+            `if-necessary-or-explicit`) that admits only the constrained
+            pre-release instead of a global `allow`.
 
     Returns:
         Shell command string suitable for execution via the shell.
@@ -2425,6 +2666,8 @@ def upgrade_install_command(
         version=version,
         include_prereleases=include_prereleases,
         distribution_name=distribution_name,
+        constraints_path=constraints_path,
+        prerelease_strategy=prerelease_strategy,
     )
 
 

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -358,8 +358,8 @@ def _canonical_prerelease_pin(raw: object) -> str | None:
     without widening the candidate set for anything else — only when it is:
 
     - **mandatory** — no environment marker at all, so it is neither gated behind
-      an optional `extra` (`; extra == "litellm"`) nor conditioned on the target
-      interpreter/platform (`; python_version >= "3.10"`);
+        an optional `extra` (`; extra == "litellm"`) nor conditioned on
+        the target interpreter/platform (`; python_version >= "3.10"`);
     - a **positive exact pin** — the specifier set is a single `==`/`===` clause;
     - whose pinned version is a **pre-release** (`0.7.0a7`, `1.2.0rc1`, ...).
 

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -92,7 +92,15 @@ authoritative under the targeted-constraint semantics, so the new code never
 reads that legacy key.
 """
 
-_UV_TARGETED_PRERELEASE_STRATEGY = "if-necessary-or-explicit"
+UvPrereleaseStrategy = Literal["if-necessary-or-explicit"]
+"""Type of the targeted uv `--prerelease` strategy.
+
+A one-member `Literal` rather than a bare `str`: the only non-`None` strategy
+the targeted-constraints path ever emits is `_UV_TARGETED_PRERELEASE_STRATEGY`,
+so the type says exactly that and rejects arbitrary strings at the boundary.
+"""
+
+_UV_TARGETED_PRERELEASE_STRATEGY: UvPrereleaseStrategy = "if-necessary-or-explicit"
 """uv `--prerelease` strategy paired with targeted first-party constraints.
 
 Unlike the global `allow` strategy, `if-necessary-or-explicit` only admits a
@@ -340,28 +348,23 @@ def get_last_update_check_time() -> float | None:
     return _coerce_checked_at(checked_at)
 
 
-def _prerelease_pin_requirements(
-    requirements: Sequence[object] | None,
-) -> list[str]:
-    """Return the mandatory, unconditional, exact pre-release pins in a metadata list.
+def _canonical_prerelease_pin(raw: object) -> str | None:
+    """Return the canonical targeted pre-release pin for `raw`, or `None`.
 
-    Accepts the raw `Requires-Dist` list from PyPI metadata, which may contain
-    non-string or non-PEP-508 junk; such entries are skipped rather than raising
-    so one malformed line cannot poison the whole check.
+    `raw` is a single `Requires-Dist`-style requirement string (from PyPI
+    metadata or a round-tripped cache entry, which may be non-string or
+    non-PEP-508 junk). It qualifies as a *targeted pre-release constraint* — safe
+    to hand uv as a first-party constraint that admits exactly one pre-release
+    without widening the candidate set for anything else — only when it is:
 
-    A `Requires-Dist` entry qualifies as a *targeted pre-release constraint* only
-    when it is safe to pass to uv as a first-party constraint that admits exactly
-    one pre-release without widening the candidate set for anything else. The
-    supported contract, deliberately conservative, is:
-
-    - a **direct** dependency of the release (every `Requires-Dist` entry is);
     - **mandatory** — no environment marker at all, so it is neither gated behind
       an optional `extra` (`; extra == "litellm"`) nor conditioned on the target
       interpreter/platform (`; python_version >= "3.10"`);
     - a **positive exact pin** — the specifier set is a single `==`/`===` clause;
     - whose pinned version is a **pre-release** (`0.7.0a7`, `1.2.0rc1`, ...).
 
-    Everything else is ignored, matching the constraints uv would actually need:
+    Everything else returns `None`, matching the constraints uv would actually
+    need:
 
     - upper bounds such as `pydantic<2.14.0a0` (not a positive pin);
     - exclusions such as `package!=1.0rc1` (not a positive pin);
@@ -377,6 +380,60 @@ def _prerelease_pin_requirements(
     markers against the *target* environment, not the running one.
 
     Returns:
+        The canonical pin string (e.g. `"deepagents==0.7.0a7"`), or `None` when
+            `raw` falls outside the contract above.
+    """
+    if not isinstance(raw, str):
+        return None
+    try:
+        requirement = Requirement(raw)
+    except InvalidRequirement:
+        logger.debug("Skipping unparseable Requires-Dist entry: %r", raw)
+        return None
+    specifiers = list(requirement.specifier)
+    if len(specifiers) != 1:
+        return None
+    specifier = specifiers[0]
+    if specifier.operator not in {"==", "==="}:
+        return None
+    try:
+        version = Version(specifier.version)
+    except InvalidVersion:
+        logger.debug(
+            "Skipping unparseable requirement version: %r",
+            specifier.version,
+        )
+        return None
+    if not version.is_prerelease:
+        return None
+    # Only reached for a single positive `==`/`===` pin to a pre-release — the
+    # one shape inside the contract. A marker still disqualifies it (see the
+    # docstring), but because it would *otherwise* qualify, log the drop so a
+    # future marker-gated SDK pin that silently resolves to no admission is
+    # greppable. Checking the marker here (rather than first) keeps this quiet
+    # for ordinary extra-gated optional deps, which never reach this point.
+    if requirement.marker is not None:
+        logger.debug(
+            "Skipping marker-gated pre-release pin outside the targeted "
+            "contract (marker %r): %r",
+            str(requirement.marker),
+            raw,
+        )
+        return None
+    return f"{canonicalize_name(requirement.name)}=={version}"
+
+
+def _prerelease_pin_requirements(
+    requirements: Sequence[object] | None,
+) -> list[str]:
+    """Return the mandatory, unconditional, exact pre-release pins in a metadata list.
+
+    Accepts the raw `Requires-Dist` list from PyPI metadata, which may contain
+    non-string or non-PEP-508 junk; such entries are skipped rather than raising
+    so one malformed line cannot poison the whole check. Each entry is classified
+    by `_canonical_prerelease_pin`; see it for the supported contract.
+
+    Returns:
         A sorted list of canonical pin strings (e.g. `["deepagents==0.7.0a7"]`).
             Empty when the release needs no targeted pre-release admission.
     """
@@ -384,46 +441,10 @@ def _prerelease_pin_requirements(
         return []
     pins: set[str] = set()
     for raw in requirements:
-        if not isinstance(raw, str):
-            continue
-        try:
-            requirement = Requirement(raw)
-        except InvalidRequirement:
-            logger.debug("Skipping unparseable Requires-Dist entry: %r", raw)
-            continue
-        # Mandatory means unconditional: any marker (extra-gated or
-        # interpreter/platform-gated) falls outside the supported contract.
-        if requirement.marker is not None:
-            continue
-        specifiers = list(requirement.specifier)
-        if len(specifiers) != 1:
-            continue
-        specifier = specifiers[0]
-        if specifier.operator not in {"==", "==="}:
-            continue
-        try:
-            version = Version(specifier.version)
-        except InvalidVersion:
-            logger.debug(
-                "Skipping unparseable requirement version: %r",
-                specifier.version,
-            )
-            continue
-        if not version.is_prerelease:
-            continue
-        pins.add(f"{canonicalize_name(requirement.name)}=={version}")
+        pin = _canonical_prerelease_pin(raw)
+        if pin is not None:
+            pins.add(pin)
     return sorted(pins)
-
-
-def _requires_prerelease_dependency(requirements: Sequence[object] | None) -> bool:
-    """Return whether a metadata list carries a targeted pre-release pin.
-
-    Thin boolean view over `_prerelease_pin_requirements`; `True` iff at least
-    one mandatory, unconditional, exact pre-release pin is present. Retained for
-    the display-only callers (`release_requires_prereleases`) that only need to
-    know *whether* a release requires pre-release admission, not which pins.
-    """
-    return bool(_prerelease_pin_requirements(requirements))
 
 
 def _atomic_write_cache(data: dict[str, Any]) -> None:
@@ -568,7 +589,9 @@ def get_latest_version(
                 if isinstance(cached_pins, dict):
                     prerelease_pins = cached_pins
     except (OSError, json.JSONDecodeError, TypeError):
-        logger.debug("Failed to read cached pre-release pins before refresh")
+        logger.debug(
+            "Failed to read cached pre-release pins before refresh", exc_info=True
+        )
     prerelease_pins[stable] = stable_prerelease_pins
 
     try:
@@ -631,10 +654,22 @@ def release_prerelease_pins(
                 values = data.get(_RELEASE_PRERELEASE_PINS_KEY)
                 if isinstance(values, dict):
                     cached = values.get(version)
-                    if isinstance(cached, list) and all(
-                        isinstance(pin, str) for pin in cached
-                    ):
-                        return [pin for pin in cached if isinstance(pin, str)]
+                    if isinstance(cached, list):
+                        # Re-validate every stored entry against the current
+                        # contract rather than trusting the raw JSON: these
+                        # strings are written verbatim into a uv constraints
+                        # file, which honors directives like `-r`/`-c`/`--hash`.
+                        # A dropped or altered entry means the value drifted or
+                        # was tampered with (CACHE_FILE is user-local state), so
+                        # fall through to a fresh fetch rather than feed a
+                        # partial or mutated constraint set to uv.
+                        revalidated: set[str] = set()
+                        for raw_pin in cached:
+                            pin = _canonical_prerelease_pin(raw_pin)
+                            if pin is not None:
+                                revalidated.add(pin)
+                        if len(revalidated) == len(cached):
+                            return sorted(revalidated)
     except (OSError, json.JSONDecodeError, TypeError):
         logger.debug(
             "Failed to read release pre-release pins cache",
@@ -1914,6 +1949,12 @@ async def perform_upgrade(
 
     Returns:
         `(success, output)` — *output* is the combined stdout/stderr.
+
+    Raises:
+        OSError: Propagated from building the upgrade command or running the
+            install subprocess (e.g. unreadable distribution metadata). An
+            `OSError` from *staging* the pre-release constraints file is handled
+            internally and reported as a `(False, output)` failure instead.
     """
     method = detect_install_method()
     if method == "unknown":
@@ -1951,8 +1992,13 @@ async def perform_upgrade(
         return False, "brew not found on PATH."
 
     prerelease_strategy = _UV_TARGETED_PRERELEASE_STRATEGY if targeted_pins else None
+    constraints_staged = False
     try:
         with _prerelease_constraints_file(targeted_pins) as constraints_path:
+            # The constraints file (if any) is now written; any OSError past
+            # this point originates in command-building or the subprocess
+            # wrapper, not constraint staging.
+            constraints_staged = True
             fell_back_to_bare_command = False
             if method == "uv":
                 # Prefer the receipt-aware `uv tool install -U` builder so
@@ -2006,10 +2052,19 @@ async def perform_upgrade(
                 cmd, progress=progress, log_path=log_path
             )
     except OSError as exc:
+        if constraints_staged:
+            # The constraints file was written successfully, so this OSError
+            # came from command-building or the subprocess wrapper — not from
+            # staging. Don't misreport it as a constraints-generation failure
+            # (which, on the common non-targeted path, would even claim to
+            # "install vNone"). Re-raise to surface the real error, matching the
+            # pre-targeted-constraints behavior where these propagated.
+            raise
         # Constraint-generation failure: we know the target needs a pinned
         # pre-release but could not stage the constraints file, so refuse rather
-        # than fall back to a global `--prerelease allow`. The existing install
-        # is untouched because no subprocess ran.
+        # than fall back to a global `--prerelease allow`. Staging happens before
+        # the install subprocess, so no subprocess ran and the existing install
+        # is untouched.
         logger.warning(
             "Could not create pre-release constraints file for v%s",
             target_version,
@@ -2460,8 +2515,8 @@ def _uv_tool_install_command(
     extras_to_add: Iterable[str] = (),
     with_packages_to_add: Iterable[str] = (),
     reinstall: bool = False,
-    constraints_path: str | Path | None = None,
-    prerelease_strategy: str | None = None,
+    constraints_path: Path | None = None,
+    prerelease_strategy: UvPrereleaseStrategy | None = None,
 ) -> str:
     """Return the receipt-preserving `uv tool install -U` command.
 
@@ -2469,8 +2524,8 @@ def _uv_tool_install_command(
         version: Optional exact `deepagents-code` version pin.
         include_prereleases: Whether to include alpha/beta/rc releases. When
             `None`, follows the installed version's channel. Ignored when
-            `prerelease_strategy` is set (targeted constraints drive the
-            resolver instead of the global channel).
+            `constraints_path` or `prerelease_strategy` is set (targeted
+            constraints drive the resolver instead of the global channel).
         distribution_name: Name of the installed distribution to inspect.
         extras_to_add: Extra names to merge with already-installed extras.
         with_packages_to_add: Package names to merge with the receipt's existing
@@ -2547,8 +2602,8 @@ def _uv_tool_install_command(
 def _append_uv_prerelease_flags(
     cmd: str,
     *,
-    constraints_path: str | Path | None,
-    prerelease_strategy: str | None,
+    constraints_path: Path | None,
+    prerelease_strategy: UvPrereleaseStrategy | None,
 ) -> str:
     """Append targeted `--constraints`/`--prerelease` flags to a uv command.
 
@@ -2599,6 +2654,12 @@ def _prerelease_constraints_file(pins: Sequence[str]) -> Iterator[Path | None]:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write("\n".join(pins) + "\n")
     except OSError:
+        # If `os.fdopen` itself raised, it never took ownership of `fd`, so the
+        # raw descriptor would leak — close it explicitly. When `fdopen`
+        # succeeded and `write` failed, the `with` already closed `fd`, so this
+        # `os.close` raises `OSError` (bad fd) and the `suppress` absorbs it.
+        with suppress(OSError):
+            os.close(fd)
         with suppress(OSError):
             path.unlink()
         raise
@@ -2620,8 +2681,8 @@ def upgrade_install_command(
     include_prereleases: bool | None = None,
     distribution_name: str = "deepagents-code",
     version: str | None = None,
-    constraints_path: str | Path | None = None,
-    prerelease_strategy: str | None = None,
+    constraints_path: Path | None = None,
+    prerelease_strategy: UvPrereleaseStrategy | None = None,
 ) -> str:
     """Return the uv command that upgrades dcode while clearing stale pins.
 

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -10,6 +10,7 @@ import shlex
 import shutil
 import signal
 import sys
+import tempfile
 import time
 import tomllib
 from collections.abc import Mapping, Sequence  # noqa: TC003
@@ -36,7 +37,6 @@ from deepagents_code.update_check import (
     _parse_version,
     _prerelease_constraints_file,
     _prerelease_pin_requirements,
-    _requires_prerelease_dependency,
     _run_install_subprocess,
     _terminate_install_process,
     _uv_tool_bin_dir,
@@ -618,6 +618,9 @@ class TestPrereleasePinRequirements:
             # (1) Unconditional exact pre-release pin is extracted (canonical).
             (("deepagents==0.7.0a7",), ["deepagents==0.7.0a7"]),
             (("deepagents==0.7.0rc1",), ["deepagents==0.7.0rc1"]),
+            # A valid `===` (arbitrary-equality) pin is also admitted and
+            # normalized to `==`.
+            (("deepagents===0.7.0a7",), ["deepagents==0.7.0a7"]),
             # (2) A stable exact pin is ignored.
             (("deepagents==0.7.0",), []),
             # (3) A prerelease upper bound is ignored.
@@ -661,19 +664,6 @@ class TestPrereleasePinRequirements:
             ("zeta==2.0rc1", "alpha==1.0a1", "alpha==1.0a1")
         ) == ["alpha==1.0a1", "zeta==2.0rc1"]
 
-    @pytest.mark.parametrize(
-        ("requirements", "expected"),
-        [
-            (None, False),
-            (("deepagents==0.7.0a7",), True),
-            (("deepagents==0.7.0",), False),
-            (("pydantic<2.14.0a0",), False),
-            (('deepagents==0.7.0a2; extra=="x"',), False),
-        ],
-    )
-    def test_boolean_view_tracks_pins(self, requirements, expected) -> None:
-        assert _requires_prerelease_dependency(requirements) is expected
-
 
 class TestPrereleaseConstraintsFile:
     """Unit tests for the temporary uv constraints-file context manager."""
@@ -708,18 +698,62 @@ class TestPrereleaseConstraintsFile:
         assert not captured.exists()
 
     def test_cleanup_error_is_swallowed(self, caplog) -> None:
-        """(10) A failing unlink is logged, not raised — it can't mask a result."""
+        """A failing unlink is logged, not raised — it can't mask a result."""
+        captured: Path | None = None
+        with caplog.at_level(logging.DEBUG, logger="deepagents_code.update_check"):
+            with (
+                patch(
+                    "deepagents_code.update_check.Path.unlink",
+                    side_effect=OSError("busy"),
+                ),
+                _prerelease_constraints_file(["deepagents==0.7.0a7"]) as path,
+            ):
+                assert path is not None
+                captured = path
+                # Exiting the context did not raise despite the unlink failure.
+            assert any(
+                "constraints file" in record.message for record in caplog.records
+            )
+        # The patched unlink blocked the context manager's own cleanup; remove
+        # the real temp file now that the patch is lifted so nothing leaks.
+        if captured is not None:
+            captured.unlink(missing_ok=True)
+
+    def test_write_failure_unlinks_and_raises(self) -> None:
+        """A failed write removes the temp file and propagates the OSError.
+
+        Distinct from the body-raise and unlink-failure paths: here the write to
+        the freshly created `mkstemp` file fails, so the context manager must
+        clean up the file and re-raise (callers treat that as a
+        constraint-generation failure rather than falling back to a global
+        `--prerelease allow`).
+        """
+        created: list[Path] = []
+        real_mkstemp = tempfile.mkstemp
+
+        def _tracking_mkstemp(
+            *, prefix: str | None = None, suffix: str | None = None
+        ) -> tuple[int, str]:
+            fd, name = real_mkstemp(prefix=prefix, suffix=suffix)
+            created.append(Path(name))
+            return fd, name
+
         with (
-            caplog.at_level(logging.DEBUG, logger="deepagents_code.update_check"),
             patch(
-                "deepagents_code.update_check.Path.unlink",
-                side_effect=OSError("busy"),
+                "deepagents_code.update_check.tempfile.mkstemp",
+                side_effect=_tracking_mkstemp,
             ),
-            _prerelease_constraints_file(["deepagents==0.7.0a7"]) as path,
+            patch(
+                "deepagents_code.update_check.os.fdopen",
+                side_effect=OSError("disk full"),
+            ),
+            pytest.raises(OSError, match="disk full"),
+            _prerelease_constraints_file(["deepagents==0.7.0a7"]),
         ):
-            assert path is not None
-            # Exiting the context did not raise despite the unlink failure.
-        assert any("constraints file" in record.message for record in caplog.records)
+            pass
+
+        assert created, "mkstemp should have created a file"
+        assert all(not path.exists() for path in created)
 
 
 class TestReleasePrereleasePins:
@@ -761,6 +795,56 @@ class TestReleasePrereleasePins:
         """
         cache_file.write_text(
             json.dumps({"release_requires_prereleases": {"1.1.0": True}}),
+            encoding="utf-8",
+        )
+        with patch(
+            "requests.get",
+            return_value=_mock_pypi_response(
+                "1.1.0", requires_dist=("deepagents==0.7.0a2",)
+            ),
+        ) as get_mock:
+            assert release_prerelease_pins("1.1.0") == ["deepagents==0.7.0a2"]
+        get_mock.assert_called_once()
+
+    def test_corrupt_cache_falls_through_to_fetch(self, cache_file) -> None:
+        """Undecodable cache JSON is ignored and structured metadata re-fetched."""
+        cache_file.write_text("{ not valid json", encoding="utf-8")
+        with patch(
+            "requests.get",
+            return_value=_mock_pypi_response(
+                "1.1.0", requires_dist=("deepagents==0.7.0a2",)
+            ),
+        ) as get_mock:
+            assert release_prerelease_pins("1.1.0") == ["deepagents==0.7.0a2"]
+        get_mock.assert_called_once()
+
+    def test_cached_non_string_entries_are_not_trusted(self, cache_file) -> None:
+        """A cached list with a non-string element re-fetches instead of trusting."""
+        cache_file.write_text(
+            json.dumps(
+                {"release_prerelease_pins": {"1.1.0": ["deepagents==0.7.0a2", 123]}}
+            ),
+            encoding="utf-8",
+        )
+        with patch(
+            "requests.get",
+            return_value=_mock_pypi_response(
+                "1.1.0", requires_dist=("deepagents==0.7.0a2",)
+            ),
+        ) as get_mock:
+            assert release_prerelease_pins("1.1.0") == ["deepagents==0.7.0a2"]
+        get_mock.assert_called_once()
+
+    def test_cached_out_of_contract_entry_is_revalidated(self, cache_file) -> None:
+        """A drifted/tampered cache entry is re-validated, not fed to uv verbatim.
+
+        The stored strings are written verbatim into a uv constraints file, which
+        honors directives like `-r`/`-c`. A value that no longer parses as a
+        targeted pin (here an `-r` injection) must not be trusted: the lookup
+        drops it, the length check fails, and it re-fetches structured metadata.
+        """
+        cache_file.write_text(
+            json.dumps({"release_prerelease_pins": {"1.1.0": ["-r /etc/passwd"]}}),
             encoding="utf-8",
         )
         with patch(
@@ -2209,7 +2293,7 @@ class TestUpdateLogs:
         assert "deepagents-code==1.1.0" in cmd
         assert "--prerelease if-necessary-or-explicit" in cmd
         assert "--prerelease allow" not in cmd
-        # (9) constraints present during the subprocess, removed afterwards.
+        # Constraints file is present during the subprocess, removed afterwards.
         assert seen["existed_during_run"] is True
         assert seen["contents"] == "deepagents==0.7.0a7\n"
         path = seen["path"]
@@ -2219,7 +2303,7 @@ class TestUpdateLogs:
     async def test_perform_upgrade_preserves_extras_with_and_python(
         self, cache_file
     ) -> None:
-        """(8) Extras, receipt `--with` packages, and interpreter survive.
+        """Extras, receipt `--with` packages, and interpreter survive.
 
         The targeted-constraint path still preserves everything the receipt-aware
         builder normally carries over.
@@ -2313,7 +2397,7 @@ class TestUpdateLogs:
     async def test_perform_upgrade_constraints_file_failure_leaves_install(
         self, cache_file
     ) -> None:
-        """(11) A constraint-generation failure aborts before touching install."""
+        """A constraint-generation failure aborts before touching the install."""
         cache_file.write_text(
             json.dumps(
                 {
@@ -2550,6 +2634,30 @@ class TestUpdateLogs:
         assert success is False
         assert "Pre-release updates aren't supported for this install" in output
         # The refusal must short-circuit before shelling out to `brew`.
+        run_mock.assert_not_awaited()
+
+    async def test_perform_upgrade_reports_missing_brew_binary(self) -> None:
+        """A brew install with no `brew` on PATH aborts before any subprocess.
+
+        This PR relocated the check ahead of constraints-file creation; pin the
+        early return so a future refactor cannot silently drop it.
+        """
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="brew",
+            ),
+            patch("deepagents_code.update_check.shutil.which", return_value=None),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+            ) as run_mock,
+        ):
+            success, output = await perform_upgrade()
+
+        assert success is False
+        assert output == "brew not found on PATH."
         run_mock.assert_not_awaited()
 
     def test_upgrade_command_prerelease(self) -> None:
@@ -2992,6 +3100,53 @@ class TestUpgradeInstallCommand:
                 "uv tool install -U 'deepagents-code[nvidia,quickjs]' "
                 "--prerelease allow"
             )
+
+    def test_targeted_flags_take_precedence_over_global_allow(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Constraints + strategy win over the `include_prereleases` global allow.
+
+        In the real `perform_upgrade` flow the targeted-pins path and the
+        `include_prereleases` channel are mutually exclusive, so this guards the
+        documented precedence directly: even with `include_prereleases=True`, a
+        supplied constraints file and strategy must emit the scoped form and
+        never a global `--prerelease allow`.
+        """
+        _write_uv_receipt(tmp_path, '{ name = "deepagents-code" }')
+        monkeypatch.setattr("sys.prefix", str(tmp_path))
+        with patch(
+            "deepagents_code.extras_info.installed_extra_names",
+            return_value=frozenset(),
+        ):
+            cmd = upgrade_install_command(
+                include_prereleases=True,
+                constraints_path=Path("/tmp/pins.txt"),
+                prerelease_strategy="if-necessary-or-explicit",
+            )
+        assert "--constraints /tmp/pins.txt" in cmd
+        assert "--prerelease if-necessary-or-explicit" in cmd
+        assert "--prerelease allow" not in cmd
+
+    def test_quotes_constraints_path_with_spaces(self, tmp_path, monkeypatch) -> None:
+        """A constraints path containing spaces is shell-quoted, not word-split.
+
+        Every production path reaches this builder with a `mkstemp` path that has
+        no spaces, so a dropped `shlex.quote` would only surface on a temp dir
+        containing a space. Lock it explicitly.
+        """
+        _write_uv_receipt(tmp_path, '{ name = "deepagents-code" }')
+        monkeypatch.setattr("sys.prefix", str(tmp_path))
+        spaced = tmp_path / "dir with space" / "pins.txt"
+        with patch(
+            "deepagents_code.extras_info.installed_extra_names",
+            return_value=frozenset(),
+        ):
+            cmd = upgrade_install_command(
+                constraints_path=spaced,
+                prerelease_strategy="if-necessary-or-explicit",
+            )
+        assert f"--constraints {shlex.quote(str(spaced))}" in cmd
+        assert f"--constraints {spaced}" not in cmd
 
     def test_preserves_with_packages(self, tmp_path, monkeypatch) -> None:
         """Packages installed via `--with` must survive the unpinned reinstall."""
@@ -5321,7 +5476,7 @@ def _build_wheel(
 
 
 class TestTargetedPrereleaseResolution:
-    """(14) End-to-end resolver check: targeted constraints beat global allow.
+    """End-to-end resolver check: targeted constraints beat global allow.
 
     Uses a hand-built local wheelhouse so the resolution is deterministic and
     needs no network. A stable app pins `core==1.0a1` and offers an optional

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -7,11 +7,13 @@ import json
 import logging
 import os
 import shlex
+import shutil
 import signal
 import sys
 import time
 import tomllib
 from collections.abc import Mapping, Sequence  # noqa: TC003
+from itertools import starmap
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
@@ -32,6 +34,8 @@ from deepagents_code.update_check import (
     _latest_from_releases,
     _note_install_baseline,
     _parse_version,
+    _prerelease_constraints_file,
+    _prerelease_pin_requirements,
     _requires_prerelease_dependency,
     _run_install_subprocess,
     _terminate_install_process,
@@ -87,6 +91,7 @@ from deepagents_code.update_check import (
     perform_install_package,
     perform_upgrade,
     prerelease_upgrade_supported,
+    release_prerelease_pins,
     release_requires_prereleases,
     set_auto_update,
     should_announce_auto_update_default,
@@ -363,23 +368,23 @@ class TestGetLatestVersion:
         assert data["version"] == "2.0.0"
         assert "checked_at" in data
 
-    def test_fresh_fetch_caches_prerelease_dependency_requirement(
-        self, cache_file
-    ) -> None:
+    def test_fresh_fetch_caches_prerelease_dependency_pins(self, cache_file) -> None:
         """Stable dcode releases can intentionally pin pre-release dependencies."""
         with patch(
             "requests.get",
             return_value=_mock_pypi_response(
                 "2.0.0",
-                requires_dist=("deepagents==0.7.0a2",),
+                requires_dist=("deepagents==0.7.0a2", "litellm<1.93.0a0"),
             ),
         ):
             result = get_latest_version()
 
         assert result == "2.0.0"
-        assert release_requires_prereleases("2.0.0") is True
+        # Only the mandatory exact pre-release pin is cached; the pre-release
+        # upper bound on litellm is not a targeted constraint.
+        assert release_prerelease_pins("2.0.0") == ["deepagents==0.7.0a2"]
         data = json.loads(cache_file.read_text())
-        assert data["release_requires_prereleases"] == {"2.0.0": True}
+        assert data["release_prerelease_pins"] == {"2.0.0": ["deepagents==0.7.0a2"]}
 
     def test_fresh_fetch_prerelease(self, cache_file) -> None:
         """PyPI fetch with include_prereleases returns pre-release version."""
@@ -551,11 +556,11 @@ class TestGetLatestVersion:
     def test_fresh_fetch_preserves_other_release_prerelease_entries(
         self, cache_file
     ) -> None:
-        """A refresh keeps cached pre-release answers for unrelated versions."""
+        """A refresh keeps cached pre-release pins for unrelated versions."""
         cache_file.write_text(
             json.dumps(
                 {
-                    "release_requires_prereleases": {"1.0.0": True},
+                    "release_prerelease_pins": {"1.0.0": ["deepagents==0.6.0a1"]},
                     "checked_at": time.time(),
                 }
             ),
@@ -566,7 +571,10 @@ class TestGetLatestVersion:
 
         assert result == "2.0.0"
         data = json.loads(cache_file.read_text())
-        assert data["release_requires_prereleases"] == {"1.0.0": True, "2.0.0": False}
+        assert data["release_prerelease_pins"] == {
+            "1.0.0": ["deepagents==0.6.0a1"],
+            "2.0.0": [],
+        }
 
     def test_fresh_fetch_non_dict_info_returns_cached(self, cache_file) -> None:
         """A PyPI payload whose `info` is not an object falls back to cache."""
@@ -591,80 +599,196 @@ class TestGetLatestVersion:
         assert not cache_file.exists()
 
 
-class TestRequiresPrereleaseDependency:
-    """Unit tests for the `Requires-Dist` pre-release detection helper."""
+class TestPrereleasePinRequirements:
+    """Unit tests for the targeted `Requires-Dist` pre-release pin extractor.
+
+    The supported contract is deliberately narrow: only a mandatory,
+    unconditional (marker-free), positive exact (`==`) pin of a pre-release
+    version is admitted, because that is the only shape safe to hand uv as a
+    first-party constraint without widening the candidate set. Everything
+    else — upper bounds, exclusions, extra-gated pins, interpreter/platform
+    markers — is ignored so a global `--prerelease allow` is never needed.
+    """
+
+    @pytest.mark.parametrize(
+        ("requirements", "expected"),
+        [
+            (None, []),
+            ((), []),
+            # (1) Unconditional exact pre-release pin is extracted (canonical).
+            (("deepagents==0.7.0a7",), ["deepagents==0.7.0a7"]),
+            (("deepagents==0.7.0rc1",), ["deepagents==0.7.0rc1"]),
+            # (2) A stable exact pin is ignored.
+            (("deepagents==0.7.0",), []),
+            # (3) A prerelease upper bound is ignored.
+            (("pydantic<2.14.0a0",), []),
+            (("deepagents>=0.7.0a2",), []),
+            (("deepagents~=0.7.0a2",), []),
+            # (4) A prerelease exclusion is ignored.
+            (("package!=1.0rc1",), []),
+            (("deepagents!=0.7.0a1",), []),
+            # (5) An extra-only prerelease requirement is ignored (not mandatory).
+            (('package==1.0rc1; extra == "unused-extra"',), []),
+            (('deepagents==0.7.0a2; extra=="x"',), []),
+            # (6) Environment markers are outside the unconditional-pin contract:
+            # both an applicable-looking and an inapplicable marker are ignored,
+            # because evaluating them here could target the wrong interpreter.
+            (('deepagents==0.7.0a7; python_version >= "3.8"',), []),
+            (('deepagents==0.7.0a7; python_version < "3.0"',), []),
+            # Compound specifiers are not a single positive exact pin.
+            (("deepagents>=0.7.0a2,<0.8",), []),
+            (("deepagents",), []),  # no version specifier
+            # One qualifying pin among many is still extracted.
+            (("requests>=2", "deepagents==0.7.0a2"), ["deepagents==0.7.0a2"]),
+            (("not a valid requirement !!!",), []),  # unparseable -> skipped
+            (("deepagents===not.a.version",), []),  # unparseable version
+            ((123, "deepagents==0.7.0a2"), ["deepagents==0.7.0a2"]),  # non-str skip
+            ((123, 456), []),  # all non-str entries
+        ],
+    )
+    def test_extracts_targeted_pins(self, requirements, expected) -> None:
+        assert _prerelease_pin_requirements(requirements) == expected
+
+    def test_names_are_canonicalized(self) -> None:
+        """Pin names are normalized so downstream constraints match uv output."""
+        assert _prerelease_pin_requirements(("Deep_Agents==0.7.0a7",)) == [
+            "deep-agents==0.7.0a7"
+        ]
+
+    def test_multiple_pins_sorted(self) -> None:
+        """Several qualifying pins come back sorted and de-duplicated."""
+        assert _prerelease_pin_requirements(
+            ("zeta==2.0rc1", "alpha==1.0a1", "alpha==1.0a1")
+        ) == ["alpha==1.0a1", "zeta==2.0rc1"]
 
     @pytest.mark.parametrize(
         ("requirements", "expected"),
         [
             (None, False),
-            ((), False),
+            (("deepagents==0.7.0a7",), True),
             (("deepagents==0.7.0",), False),
-            (("deepagents==0.7.0a2",), True),
-            (("deepagents>=0.7.0a2",), True),
-            (("deepagents~=0.7.0a2",), True),
-            # Operator-agnostic by design: even an exclusion of a pre-release
-            # flags the release. Errs toward enabling --prerelease (safe).
-            (("deepagents!=0.7.0a1",), True),
-            # Marker-gated pre-release pins still flag the release (conservative).
-            (('deepagents==0.7.0a2; extra=="x"',), True),
-            (("deepagents>=0.7.0,<0.8",), False),
-            (("deepagents",), False),  # no version specifier
-            (("requests>=2", "deepagents==0.7.0a2"), True),  # one of many
-            (("not a valid requirement !!!",), False),  # unparseable -> skipped
-            (("deepagents===not.a.version",), False),  # unparseable version
-            ((123, "deepagents==0.7.0a2"), True),  # non-str entry skipped
-            ((123, 456), False),  # all non-str entries
+            (("pydantic<2.14.0a0",), False),
+            (('deepagents==0.7.0a2; extra=="x"',), False),
         ],
     )
-    def test_detects_prerelease_specifiers(self, requirements, expected) -> None:
+    def test_boolean_view_tracks_pins(self, requirements, expected) -> None:
         assert _requires_prerelease_dependency(requirements) is expected
 
 
-class TestReleaseRequiresPrereleases:
-    """Unit tests for `release_requires_prereleases`."""
+class TestPrereleaseConstraintsFile:
+    """Unit tests for the temporary uv constraints-file context manager."""
 
-    def test_none_version_is_false(self) -> None:
-        """A missing version never needs the pre-release resolver."""
+    def test_empty_pins_yield_none(self) -> None:
+        """No pins means no file and a `None` handle for a single code path."""
+        with _prerelease_constraints_file([]) as path:
+            assert path is None
+
+    def test_writes_pins_and_cleans_up(self) -> None:
+        """The file lists one pin per line and is removed on exit."""
+        with _prerelease_constraints_file(["deepagents==0.7.0a7"]) as path:
+            assert path is not None
+            assert path.exists()
+            assert path.read_text(encoding="utf-8") == "deepagents==0.7.0a7\n"
+            captured = path
+        assert not captured.exists()
+
+    def test_removes_file_even_on_error(self) -> None:
+        """A raised body still triggers cleanup in `finally`."""
+        captured: Path | None = None
+        err = RuntimeError("install blew up")
+        with (  # noqa: PT012
+            pytest.raises(RuntimeError),
+            _prerelease_constraints_file(["deepagents==0.7.0a7"]) as path,
+        ):
+            captured = path
+            assert path is not None
+            assert path.exists()
+            raise err
+        assert captured is not None
+        assert not captured.exists()
+
+    def test_cleanup_error_is_swallowed(self, caplog) -> None:
+        """(10) A failing unlink is logged, not raised — it can't mask a result."""
+        with (
+            caplog.at_level(logging.DEBUG, logger="deepagents_code.update_check"),
+            patch(
+                "deepagents_code.update_check.Path.unlink",
+                side_effect=OSError("busy"),
+            ),
+            _prerelease_constraints_file(["deepagents==0.7.0a7"]) as path,
+        ):
+            assert path is not None
+            # Exiting the context did not raise despite the unlink failure.
+        assert any("constraints file" in record.message for record in caplog.records)
+
+
+class TestReleasePrereleasePins:
+    """Unit tests for `release_prerelease_pins` and its boolean wrapper."""
+
+    def test_none_version_is_empty(self) -> None:
+        """A missing version never needs pre-release admission."""
+        assert release_prerelease_pins(None) == []
         assert release_requires_prereleases(None) is False
 
-    def test_cache_hit_true(self, cache_file) -> None:
-        """A cached `True` short-circuits without a network call."""
+    def test_cache_hit_pins(self, cache_file) -> None:
+        """A cached pin list short-circuits without a network call."""
+        cache_file.write_text(
+            json.dumps({"release_prerelease_pins": {"1.1.0": ["deepagents==0.7.0a2"]}}),
+            encoding="utf-8",
+        )
+        with patch("requests.get") as get_mock:
+            assert release_prerelease_pins("1.1.0") == ["deepagents==0.7.0a2"]
+            assert release_requires_prereleases("1.1.0") is True
+        get_mock.assert_not_called()
+
+    def test_cache_hit_empty(self, cache_file) -> None:
+        """A cached empty list short-circuits without a network call."""
+        cache_file.write_text(
+            json.dumps({"release_prerelease_pins": {"1.1.0": []}}),
+            encoding="utf-8",
+        )
+        with patch("requests.get") as get_mock:
+            assert release_prerelease_pins("1.1.0") == []
+            assert release_requires_prereleases("1.1.0") is False
+        get_mock.assert_not_called()
+
+    def test_legacy_boolean_cache_is_ignored(self, cache_file) -> None:
+        """The stale marker-agnostic boolean key is not read as authoritative.
+
+        A pre-migration cache may still carry `release_requires_prereleases`
+        booleans. Those cannot name a pin, so the new lookup ignores them and
+        re-fetches structured metadata instead.
+        """
         cache_file.write_text(
             json.dumps({"release_requires_prereleases": {"1.1.0": True}}),
             encoding="utf-8",
         )
-        with patch("requests.get") as get_mock:
-            assert release_requires_prereleases("1.1.0") is True
-        get_mock.assert_not_called()
-
-    def test_cache_hit_false(self, cache_file) -> None:
-        """A cached `False` short-circuits without a network call."""
-        cache_file.write_text(
-            json.dumps({"release_requires_prereleases": {"1.1.0": False}}),
-            encoding="utf-8",
-        )
-        with patch("requests.get") as get_mock:
-            assert release_requires_prereleases("1.1.0") is False
-        get_mock.assert_not_called()
-
-    def test_cache_miss_fetches_and_writes(self, cache_file) -> None:
-        """A cache miss fetches per-version metadata and caches the result."""
         with patch(
             "requests.get",
             return_value=_mock_pypi_response(
                 "1.1.0", requires_dist=("deepagents==0.7.0a2",)
             ),
         ) as get_mock:
-            assert release_requires_prereleases("1.1.0") is True
+            assert release_prerelease_pins("1.1.0") == ["deepagents==0.7.0a2"]
+        get_mock.assert_called_once()
+
+    def test_cache_miss_fetches_and_writes(self, cache_file) -> None:
+        """A cache miss fetches per-version metadata and caches the pins."""
+        with patch(
+            "requests.get",
+            return_value=_mock_pypi_response(
+                "1.1.0", requires_dist=("deepagents==0.7.0a2",)
+            ),
+        ) as get_mock:
+            assert release_prerelease_pins("1.1.0") == ["deepagents==0.7.0a2"]
         assert get_mock.call_args.args[0].endswith("/deepagents-code/1.1.0/json")
         data = json.loads(cache_file.read_text())
-        assert data["release_requires_prereleases"]["1.1.0"] is True
+        assert data["release_prerelease_pins"]["1.1.0"] == ["deepagents==0.7.0a2"]
 
     def test_bypass_cache_forces_fetch(self, cache_file) -> None:
         """`bypass_cache` re-fetches even when a cached value exists."""
         cache_file.write_text(
-            json.dumps({"release_requires_prereleases": {"1.1.0": False}}),
+            json.dumps({"release_prerelease_pins": {"1.1.0": []}}),
             encoding="utf-8",
         )
         with patch(
@@ -673,34 +797,34 @@ class TestReleaseRequiresPrereleases:
                 "1.1.0", requires_dist=("deepagents==0.7.0a2",)
             ),
         ) as get_mock:
-            result = release_requires_prereleases("1.1.0", bypass_cache=True)
-        assert result is True
+            result = release_prerelease_pins("1.1.0", bypass_cache=True)
+        assert result == ["deepagents==0.7.0a2"]
         get_mock.assert_called_once()
 
-    def test_network_failure_returns_false(self, cache_file) -> None:
-        """A PyPI failure conservatively reports stable-only resolution."""
+    def test_network_failure_returns_empty(self, cache_file) -> None:
+        """A PyPI failure conservatively reports no pre-release admission."""
         import requests
 
         with patch("requests.get", side_effect=requests.RequestException("boom")):
-            assert release_requires_prereleases("1.1.0") is False
+            assert release_prerelease_pins("1.1.0") == []
         # Nothing cached, so a later successful lookup can still self-correct.
         assert not cache_file.exists()
 
-    def test_missing_requests_returns_false(self, cache_file) -> None:
-        """Without `requests`, the lookup degrades to stable-only resolution."""
+    def test_missing_requests_returns_empty(self, cache_file) -> None:
+        """Without `requests`, the lookup degrades to no pre-release admission."""
         with patch.dict(sys.modules, {"requests": None}):
-            assert release_requires_prereleases("1.1.0") is False
+            assert release_prerelease_pins("1.1.0") == []
         assert not cache_file.exists()
 
-    def test_malformed_info_returns_false(self, cache_file) -> None:
-        """A payload with a non-object `info` is treated as no requirement."""
+    def test_malformed_info_returns_empty(self, cache_file) -> None:
+        """A payload with a non-object `info` is treated as no pins."""
         resp = MagicMock()
         resp.json.return_value = {"info": "not-a-dict"}
         resp.raise_for_status = MagicMock()
         with patch("requests.get", return_value=resp):
-            assert release_requires_prereleases("1.1.0") is False
+            assert release_prerelease_pins("1.1.0") == []
         data = json.loads(cache_file.read_text())
-        assert data["release_requires_prereleases"]["1.1.0"] is False
+        assert data["release_prerelease_pins"]["1.1.0"] == []
 
 
 class TestIsUpdateAvailable:
@@ -2022,19 +2146,38 @@ class TestUpdateLogs:
             "uv tool install -U deepagents-code --prerelease allow"
         )
 
-    async def test_perform_upgrade_allows_prereleases_for_target_dependency(
+    async def test_perform_upgrade_uses_targeted_constraints_for_target_dependency(
         self, cache_file
     ) -> None:
-        """A stable target that pins an alpha dependency opts uv into prereleases."""
+        """A stable target pinning an alpha dependency uses scoped constraints.
+
+        Instead of a global `--prerelease allow` (which let an unrelated RC in
+        #4524), the command pins the exact dcode target, passes the SDK pin
+        through a temporary constraints file, and uses uv's
+        `if-necessary-or-explicit` strategy. The constraints file is present
+        while the subprocess runs and removed afterwards.
+        """
         cache_file.write_text(
             json.dumps(
                 {
-                    "release_requires_prereleases": {"1.1.0": True},
+                    "release_prerelease_pins": {"1.1.0": ["deepagents==0.7.0a7"]},
                     "checked_at": time.time(),
                 }
             ),
             encoding="utf-8",
         )
+        seen: dict[str, object] = {}
+
+        def _capture(cmd: str, **_kwargs: object) -> tuple[bool, str]:
+            args = shlex.split(cmd)
+            idx = args.index("--constraints")
+            constraints_path = Path(args[idx + 1])
+            seen["cmd"] = cmd
+            seen["existed_during_run"] = constraints_path.exists()
+            seen["contents"] = constraints_path.read_text(encoding="utf-8")
+            seen["path"] = constraints_path
+            return True, ""
+
         with (
             patch("deepagents_code.update_check.__version__", "1.0.0"),
             patch(
@@ -2056,27 +2199,84 @@ class TestUpdateLogs:
             patch(
                 "deepagents_code.update_check._run_install_subprocess",
                 new_callable=AsyncMock,
+                side_effect=_capture,
+            ),
+        ):
+            success, _output = await perform_upgrade(target_version="1.1.0")
+
+        assert success is True
+        cmd = str(seen["cmd"])
+        assert "deepagents-code==1.1.0" in cmd
+        assert "--prerelease if-necessary-or-explicit" in cmd
+        assert "--prerelease allow" not in cmd
+        # (9) constraints present during the subprocess, removed afterwards.
+        assert seen["existed_during_run"] is True
+        assert seen["contents"] == "deepagents==0.7.0a7\n"
+        path = seen["path"]
+        assert isinstance(path, Path)
+        assert not path.exists()
+
+    async def test_perform_upgrade_preserves_extras_with_and_python(
+        self, cache_file
+    ) -> None:
+        """(8) Extras, receipt `--with` packages, and interpreter survive.
+
+        The targeted-constraint path still preserves everything the receipt-aware
+        builder normally carries over.
+        """
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "release_prerelease_pins": {"1.1.0": ["deepagents==0.7.0a7"]},
+                    "checked_at": time.time(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.extras_info.installed_extra_names",
+                return_value=frozenset({"litellm", "openai"}),
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_python",
+                return_value="3.13",
+            ),
+            patch(
+                "deepagents_code.update_check._uv_tool_with_packages",
+                return_value=("langchain-custom",),
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
                 return_value=(True, ""),
             ) as run_mock,
         ):
             success, _output = await perform_upgrade(target_version="1.1.0")
 
         assert success is True
-        run_mock.assert_awaited_once()
         await_args = run_mock.await_args
         assert await_args is not None
-        assert await_args.args[0] == (
-            "uv tool install -U deepagents-code==1.1.0 --prerelease allow"
-        )
+        cmd = str(await_args.args[0])
+        assert "--python 3.13" in cmd
+        assert "'deepagents-code[litellm,openai]==1.1.0'" in cmd
+        assert "--with langchain-custom" in cmd
+        assert "--prerelease if-necessary-or-explicit" in cmd
+        assert "--prerelease allow" not in cmd
 
-    async def test_perform_upgrade_fallback_pins_target_with_prerelease_deps(
+    async def test_perform_upgrade_fallback_uses_targeted_constraints(
         self, cache_file
     ) -> None:
-        """The bare fallback also avoids floating stable targets to app prereleases."""
+        """The bare fallback also uses targeted constraints, never global allow."""
         cache_file.write_text(
             json.dumps(
                 {
-                    "release_requires_prereleases": {"1.1.0": True},
+                    "release_prerelease_pins": {"1.1.0": ["deepagents==0.7.0a7"]},
                     "checked_at": time.time(),
                 }
             ),
@@ -2104,9 +2304,47 @@ class TestUpdateLogs:
         run_mock.assert_awaited_once()
         await_args = run_mock.await_args
         assert await_args is not None
-        assert await_args.args[0] == (
-            "uv tool install -U deepagents-code==1.1.0 --prerelease allow"
+        cmd = str(await_args.args[0])
+        assert cmd.startswith("uv tool install -U deepagents-code==1.1.0")
+        assert "--constraints " in cmd
+        assert "--prerelease if-necessary-or-explicit" in cmd
+        assert "--prerelease allow" not in cmd
+
+    async def test_perform_upgrade_constraints_file_failure_leaves_install(
+        self, cache_file
+    ) -> None:
+        """(11) A constraint-generation failure aborts before touching install."""
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "release_prerelease_pins": {"1.1.0": ["deepagents==0.7.0a7"]},
+                    "checked_at": time.time(),
+                }
+            ),
+            encoding="utf-8",
         )
+        with (
+            patch("deepagents_code.update_check.__version__", "1.0.0"),
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.update_check.tempfile.mkstemp",
+                side_effect=OSError("no space left on device"),
+            ),
+            patch(
+                "deepagents_code.update_check._run_install_subprocess",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as run_mock,
+        ):
+            success, output = await perform_upgrade(target_version="1.1.0")
+
+        assert success is False
+        assert "left" in output
+        assert "unchanged" in output
+        run_mock.assert_not_awaited()
 
     async def test_perform_upgrade_follows_installed_prerelease_channel(self) -> None:
         """Omitted pre-release preference follows an installed pre-release."""
@@ -5025,3 +5263,131 @@ class TestShouldShowWhatsNew:
         path = tmp_path / "config.toml"
         with patch("deepagents_code.update_check.DEFAULT_CONFIG_PATH", path):
             yield path
+
+
+def _build_wheel(
+    wheelhouse: Path,
+    name: str,
+    version: str,
+    *,
+    requires: tuple[str, ...] = (),
+    extras: tuple[str, ...] = (),
+) -> None:
+    """Write a minimal pure-Python wheel into `wheelhouse` for resolver tests.
+
+    Builds just enough of the wheel format (METADATA, WHEEL, RECORD, and an
+    empty top-level module) for uv to resolve against a `--find-links`
+    directory without a build backend or network access.
+    """
+    import base64
+    import hashlib
+    import zipfile
+
+    module = name.replace("-", "_")
+    dist_info = f"{module}-{version}.dist-info"
+    metadata_lines = [
+        "Metadata-Version: 2.1",
+        f"Name: {name}",
+        f"Version: {version}",
+    ]
+    metadata_lines.extend(f"Provides-Extra: {extra}" for extra in extras)
+    metadata_lines.extend(f"Requires-Dist: {req}" for req in requires)
+    metadata = "\n".join(metadata_lines) + "\n"
+    wheel_meta = (
+        "Wheel-Version: 1.0\n"
+        "Generator: test-suite\n"
+        "Root-Is-Purelib: true\n"
+        "Tag: py3-none-any\n"
+    )
+    files = {
+        f"{module}/__init__.py": "",
+        f"{dist_info}/METADATA": metadata,
+        f"{dist_info}/WHEEL": wheel_meta,
+    }
+
+    def _record_line(path: str, data: str) -> str:
+        digest = hashlib.sha256(data.encode("utf-8")).digest()
+        b64 = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+        return f"{path},sha256={b64},{len(data.encode('utf-8'))}"
+
+    record = "\n".join(starmap(_record_line, files.items()))
+    record += f"\n{dist_info}/RECORD,,\n"
+    files[f"{dist_info}/RECORD"] = record
+
+    wheel_path = wheelhouse / f"{module}-{version}-py3-none-any.whl"
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        for path, data in files.items():
+            zf.writestr(path, data)
+
+
+class TestTargetedPrereleaseResolution:
+    """(14) End-to-end resolver check: targeted constraints beat global allow.
+
+    Uses a hand-built local wheelhouse so the resolution is deterministic and
+    needs no network. A stable app pins `core==1.0a1` and offers an optional
+    provider with a stable `1.0` and a pre-release `1.1rc1`. A global
+    `--prerelease allow` selects the RC provider (the #4524 failure mode);
+    targeted constraints plus `if-necessary-or-explicit` select the required
+    core pre-release while keeping the provider on its stable release.
+    """
+
+    def _resolve(self, wheelhouse: Path, *extra_args: str) -> str:
+        import subprocess
+
+        cmd = [
+            "uv",
+            "pip",
+            "install",
+            "--dry-run",
+            "--python",
+            sys.executable,
+            "--no-index",
+            "--offline",
+            "--find-links",
+            str(wheelhouse),
+            "app[provider]==1.0",
+            *extra_args,
+        ]
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        return f"{proc.stdout}\n{proc.stderr}"
+
+    @pytest.mark.skipif(
+        shutil.which("uv") is None, reason="uv is required for resolver test"
+    )
+    def test_targeted_constraints_keep_provider_stable(self, tmp_path) -> None:
+        wheelhouse = tmp_path / "wheelhouse"
+        wheelhouse.mkdir()
+        _build_wheel(
+            wheelhouse,
+            "app",
+            "1.0",
+            requires=("core==1.0a1", 'provider ; extra == "provider"'),
+            extras=("provider",),
+        )
+        _build_wheel(wheelhouse, "core", "1.0a1")
+        _build_wheel(wheelhouse, "provider", "1.0")
+        _build_wheel(wheelhouse, "provider", "1.1rc1")
+
+        # Global allow: the RC provider slips in (the regression #4524 exposed).
+        allow_output = self._resolve(wheelhouse, "--prerelease", "allow")
+        assert "provider==1.1rc1" in allow_output
+
+        # Targeted: pin core's prerelease via constraints + scoped strategy.
+        constraints = tmp_path / "constraints.txt"
+        constraints.write_text("core==1.0a1\n", encoding="utf-8")
+        targeted_output = self._resolve(
+            wheelhouse,
+            "--constraints",
+            str(constraints),
+            "--prerelease",
+            "if-necessary-or-explicit",
+        )
+        assert "core==1.0a1" in targeted_output
+        assert "provider==1.0" in targeted_output
+        assert "provider==1.1rc1" not in targeted_output


### PR DESCRIPTION
Closes #4524

`dcode` updates that require a prerelease SDK dependency no longer allow unrelated optional providers to install prerelease versions, avoiding failed upgrades from unbuildable release candidates.

---

Stable `deepagents-code` releases can intentionally require an exact prerelease hard dependency (e.g. `deepagents==0.7.0a7`). The updater handled this by adding a global `--prerelease allow`, which widens the resolver's candidate set for *every* package — so an unrelated optional provider could float to an unbuildable prerelease. That is what caused #4524 (a `litellm` RC failing to build on Python 3.14).

`perform_upgrade()` now identifies the mandatory, unconditional, exact prerelease pins from the target release's PyPI metadata, writes them to a temporary uv constraints file, and runs with `--constraints <file> --prerelease if-necessary-or-explicit`. uv then admits only the named prerelease (e.g. the SDK alpha) while unrelated optional dependencies stay on their stable releases. The exact dcode target pin, installed extras, receipt `--with` packages, interpreter selection, and transactional uv-tool behavior are all preserved. The explicit dcode prerelease-*channel* path (installed prerelease or `--prerelease`) is unchanged and still uses `--prerelease allow`.

The marker-agnostic boolean cache (`release_requires_prereleases`) is redesigned into a structured, versioned per-version pin cache (`release_prerelease_pins`); the legacy boolean key is never read as authoritative. `release_requires_prereleases()` is kept as a backward-compatible boolean wrapper for the display-only callers in `app.py`/`main.py`. The requirement classifier is deliberately limited to unconditional exact pins — marker-bearing pins (extra-gated or interpreter/platform-gated) are ignored rather than evaluated against a possibly-wrong interpreter; this limit is documented in code and tests.

Constraint-file lifecycle is a context manager: the file lives for the full subprocess invocation and is removed in `finally`, tolerating cleanup errors without masking the install result. A constraint-generation failure leaves the existing install untouched and returns actionable output rather than silently reverting to a global allow.

Audit of other receipt-aware/global-allow paths (scoped follow-ups, not fixed here to avoid broad refactoring and offline-install regressions):
- `install_extra` / `install_package` build commands unconditionally use `--prerelease allow`; they pin the current version, so converting them safely needs the same targeted-constraint plumbing plus offline-fallback handling.
- `dependency_refresh` only adds `--prerelease allow` when following the prerelease channel, so it does not exhibit the metadata-driven global-allow bug for stable installs (it fails safe instead).
- `scripts/install.sh` still defaults `DEEPAGENTS_CODE_PRERELEASE=allow` for fresh installs; porting the targeted strategy to bash is a larger installer change with its own tests.

Made by [Open SWE](https://openswe.vercel.app/agents/90a3f170-5a1a-ed8b-3c37-d97d6021c97d)