### PR TITLE
test(code): isolate conversation history artifacts

### DIFF
--- a/libs/code/tests/unit_tests/test_end_to_end.py
+++ b/libs/code/tests/unit_tests/test_end_to_end.py
@@ -81,7 +81,13 @@ def mock_settings(
     skills_dir.mkdir(parents=True)
 
     # Patch settings
-    with patch("deepagents_code.agent.settings") as mock_settings_obj:
+    with (
+        patch("deepagents_code.agent.settings") as mock_settings_obj,
+        patch(
+            "deepagents_code.agent._offload_fallback_root",
+            return_value=tmp_path / ".deepagents",
+        ),
+    ):
         mock_settings_obj.user_deepagents_dir = tmp_path / "agents"
         mock_settings_obj.ensure_agent_dir.return_value = agent_dir
         mock_settings_obj.ensure_user_skills_dir.return_value = skills_dir
@@ -235,6 +241,9 @@ class TestDeepAgentsCLIEndToEnd:
             # mode the history prefix lives under the backend's `artifacts_root`
             # (a per-session temp dir), routed to persistent storage.
             assert backend.ls(f"{backend.artifacts_root}/conversation_history/").entries
+            assert (
+                tmp_path / ".deepagents" / "conversation_history" / f"{thread_id}.md"
+            ).exists()
 
     def test_cli_agent_with_fake_llm_with_tools(self, tmp_path: Path) -> None:
         """Test CLI agent with tools using a fake LLM model.


### PR DESCRIPTION
`test_cli_agent_summarizes` exercises the production local conversation-history backend, whose fallback location is the user's `~/.deepagents` directory. The test's generated 720 KB payload therefore survived each run and polluted real user state.

Patch the test helper's offload root to a directory under `tmp_path` and assert that the archive is created there. Pytest now removes the artifact with the rest of the test directory without changing production persistence behavior.

Verified with the full `test_end_to_end.py` unit test file, Ruff, and a before/after comparison confirming the real conversation-history directory remains unchanged.
