### PR TITLE
fix(code): keep chat input responsive during MCP viewer `Ctrl+R` reconnect

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -17233,10 +17233,11 @@ class DeepAgentsApp(App):
                 # would stall the pump — key events stop being forwarded and the
                 # chat input is frozen ("blocked") for the whole reconnect.
                 # `asyncio.create_task` keeps the pump free (mirrors the
-                # force-reconnect confirm path), so input stays responsive;
-                # typing during `_connecting` is queued and drained once
-                # `ServerReady` fires. `_reconnect_from_viewer_safe` handles its
-                # own errors; `_log_task_exception` surfaces anything unexpected.
+                # force-reconnect confirm path), so input stays responsive:
+                # keystrokes stay live, and any message the user submits while
+                # `_connecting` is queued and drained once `ServerReady` fires.
+                # `_reconnect_from_viewer_safe` handles its own errors;
+                # `_log_task_exception` surfaces anything unexpected.
                 # `action_reconnect` gates dismiss on pending state, so the
                 # implicit `force=False` reconnect is correct.
                 task = asyncio.create_task(self._reconnect_from_viewer_safe())
@@ -17253,10 +17254,13 @@ class DeepAgentsApp(App):
     async def _reconnect_from_viewer_safe(self) -> None:
         """Run the post-viewer reconnect and surface unexpected failures.
 
-        `call_later` schedules this on Textual's message pump, which
-        logs but does not display exceptions. Re-checks pending state
-        so a flip between dismiss and the pump tick silently no-ops
-        instead of degrading to the CLI no-op notice.
+        Scheduled via `asyncio.create_task` from `_show_mcp_viewer`'s
+        dismiss callback so the reconnect runs detached from the message
+        pump; `_log_task_exception` logs any escaped error, and this
+        wrapper additionally catches failures to display an `ErrorMessage`.
+        Re-checks pending state so a flip between the viewer dismiss and
+        this task starting silently no-ops instead of degrading to the
+        CLI no-op notice.
         """
         if not self._pending_mcp_reconnect:
             return

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -17227,9 +17227,20 @@ class DeepAgentsApp(App):
         def handle_result(result: str | None) -> None:
             self._active_mcp_viewer = None
             if result == MCP_VIEWER_RECONNECT_REQUEST:
-                # `action_reconnect` gates dismiss on pending state, so
-                # `force=False` is correct.
-                self.call_later(self._reconnect_from_viewer_safe)
+                # Run the reconnect as a detached task, NOT via `call_later`.
+                # `call_later` awaits the coroutine inside the app's message
+                # pump, so `_respawn_server`'s multi-second `server_proc.restart()`
+                # would stall the pump — key events stop being forwarded and the
+                # chat input is frozen ("blocked") for the whole reconnect.
+                # `asyncio.create_task` keeps the pump free (mirrors the
+                # force-reconnect confirm path), so input stays responsive;
+                # typing during `_connecting` is queued and drained once
+                # `ServerReady` fires. `_reconnect_from_viewer_safe` handles its
+                # own errors; `_log_task_exception` surfaces anything unexpected.
+                # `action_reconnect` gates dismiss on pending state, so the
+                # implicit `force=False` reconnect is correct.
+                task = asyncio.create_task(self._reconnect_from_viewer_safe())
+                task.add_done_callback(_log_task_exception)
                 return
             if result:
                 # User picked an unauthenticated server — start login.

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -22325,6 +22325,48 @@ class TestMCPLoginCommand:
                 await pilot.pause()
             restart.assert_awaited_once_with("pending login")
 
+    @pytest.mark.timeout(15)
+    async def test_viewer_ctrl_r_keeps_chat_input_responsive(self) -> None:
+        """Ctrl+R reconnect must not freeze the chat input.
+
+        Regression guard: the reconnect was scheduled with `call_later`, which
+        awaits the coroutine inside the app message pump. While
+        `_reconnect_from_viewer_safe` (i.e. the multi-second server restart) ran,
+        the pump could not forward key events and the chat input was blocked
+        until reconnection completed. Running the reconnect as a detached task
+        keeps the pump free, so typing lands even while the reconnect is
+        in-flight. Without the fix this test times out (pump stalled on the
+        gated coroutine).
+        """
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._chat_input is not None
+            app._chat_input.focus_input()
+            await pilot.pause()
+
+            gate = asyncio.Event()
+
+            async def _blocked_reconnect() -> None:
+                await gate.wait()
+
+            app._pending_mcp_reconnect = True
+            with patch.object(
+                app, "_reconnect_from_viewer_safe", new=_blocked_reconnect
+            ):
+                await app._show_mcp_viewer()
+                await pilot.pause()
+                await pilot.press("ctrl+r")
+                await pilot.pause()
+                # The reconnect is now in-flight and gated open; the pump must
+                # still deliver keystrokes to the chat input.
+                await pilot.press("h", "i")
+                await pilot.pause()
+                typed = app._chat_input.value
+                gate.set()
+                await pilot.pause()
+            assert typed == "hi"
+
     async def test_prompt_mcp_reconnect_pilot_driven_happy_path(self) -> None:
         """End-to-end: real modal mounts, `enter` keypress, restart fires.
 


### PR DESCRIPTION
Fixed the `/mcp` viewer Ctrl+R reconnect blocking keyboard input until the server finished reconnecting.

---

Pressing Ctrl+R inside the `/mcp` viewer to reconnect froze the chat input until the reconnect finished. The handler scheduled `_reconnect_from_viewer_safe` with `call_later`, which awaits the coroutine inside the Textual app message pump; the multi-second `server_proc.restart()` then stalled the pump so key events were no longer forwarded. Running the reconnect as a detached `asyncio.create_task` (mirroring the force-reconnect confirm path) keeps the pump free, so input stays responsive and typed messages queue and drain once the server is ready.

Made by [Open SWE](https://openswe.vercel.app/agents/b1d98f23-e279-dc41-4f4f-ce0818900274)