### PR TITLE
fix(code): keep paste placeholder when backspacing newline below it

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/_paste_textarea.py
+++ b/libs/code/deepagents_code/tui/widgets/_paste_textarea.py
@@ -506,14 +506,14 @@ class CollapsingPasteTextArea(PasteBurstTextArea):
                     return start, end
                 if cursor_offset > 0:
                     previous_index = cursor_offset - 1
-                    # Only a literal space (the separator auto-inserted after a
-                    # token) is swallowed with it. A newline must not be — that
-                    # would delete the whole placeholder when the user is only
-                    # backspacing the line break to rejoin the lines.
+                    # Swallow trailing whitespace with the token, except for a
+                    # newline: backspacing a line break should rejoin the lines
+                    # without deleting the placeholder.
                     if (
                         previous_index < len(text)
                         and previous_index == end
-                        and text[previous_index] == " "
+                        and text[previous_index].isspace()
+                        and text[previous_index] != "\n"
                     ):
                         return start, cursor_offset
             elif start <= cursor_offset < end:

--- a/libs/code/deepagents_code/tui/widgets/_paste_textarea.py
+++ b/libs/code/deepagents_code/tui/widgets/_paste_textarea.py
@@ -506,10 +506,14 @@ class CollapsingPasteTextArea(PasteBurstTextArea):
                     return start, end
                 if cursor_offset > 0:
                     previous_index = cursor_offset - 1
+                    # Only a literal space (the separator auto-inserted after a
+                    # token) is swallowed with it. A newline must not be — that
+                    # would delete the whole placeholder when the user is only
+                    # backspacing the line break to rejoin the lines.
                     if (
                         previous_index < len(text)
                         and previous_index == end
-                        and text[previous_index].isspace()
+                        and text[previous_index] == " "
                     ):
                         return start, cursor_offset
             elif start <= cursor_offset < end:

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -1224,10 +1224,15 @@ class ChatTextArea(PasteBurstTextArea):
                         return start, end
                     if cursor_offset > 0:
                         previous_index = cursor_offset - 1
+                        # Only a literal space (the separator auto-inserted with
+                        # media placeholders) is swallowed with the token. A
+                        # newline must not be — otherwise backspacing the line
+                        # break after a placeholder deletes the placeholder
+                        # itself instead of just rejoining the lines.
                         if (
                             previous_index < len(text)
                             and previous_index == end
-                            and text[previous_index].isspace()
+                            and text[previous_index] == " "
                         ):
                             return start, cursor_offset
                 elif start <= cursor_offset < end:

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -1224,15 +1224,14 @@ class ChatTextArea(PasteBurstTextArea):
                         return start, end
                     if cursor_offset > 0:
                         previous_index = cursor_offset - 1
-                        # Only a literal space (the separator auto-inserted with
-                        # media placeholders) is swallowed with the token. A
-                        # newline must not be — otherwise backspacing the line
-                        # break after a placeholder deletes the placeholder
-                        # itself instead of just rejoining the lines.
+                        # Swallow trailing whitespace with the token, except for
+                        # a newline: backspacing a line break should rejoin the
+                        # lines without deleting the placeholder.
                         if (
                             previous_index < len(text)
                             and previous_index == end
-                            and text[previous_index] == " "
+                            and text[previous_index].isspace()
+                            and text[previous_index] != "\n"
                         ):
                             return start, cursor_offset
                 elif start <= cursor_offset < end:

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -2815,6 +2815,37 @@ class TestDroppedImagePaste:
             assert app.tracker.get_images() == []
             assert app.tracker.next_image_id == 1
 
+    async def test_backspace_from_line_below_image_keeps_placeholder(
+        self, tmp_path
+    ) -> None:
+        """Backspace on the line below `[image N]` rejoins lines, keeps token."""
+        img_path = tmp_path / "newline.png"
+        from PIL import Image
+
+        image = Image.new("RGB", (4, 4), color="cyan")
+        image.save(img_path, format="PNG")
+
+        app = _ImagePasteApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat.handle_external_paste(str(img_path))
+            await pilot.pause()
+            assert chat._text_area.text == "[image 1] "
+
+            chat._text_area.insert("\n")
+            await pilot.pause()
+            assert chat._text_area.cursor_location == (1, 0)
+
+            await pilot.press("backspace")
+            await pilot.pause()
+
+            # The line break is removed and the placeholder (with its trailing
+            # space) is preserved rather than being deleted atomically.
+            assert chat._text_area.text == "[image 1] "
+            assert len(app.tracker.get_images()) == 1
+
     async def test_readding_after_delete_restarts_image_counter(self, tmp_path) -> None:
         """Re-adding after deleting all placeholders should restart at `[image 1]`."""
         img_path = tmp_path / "readd.png"
@@ -5197,6 +5228,36 @@ class TestPasteCollapseIntegration:
             await pilot.pause()
 
             assert chat._text_area.text == ""
+            assert 1 in chat._pasted_contents
+
+    async def test_backspace_from_line_below_placeholder_keeps_it(self) -> None:
+        """Backspace on a line below a placeholder rejoins lines, keeps token.
+
+        Regression: a newline immediately after a `[Pasted text #N]` placeholder
+        was treated as an auto-inserted trailing separator, so backspacing from
+        the start of the next line deleted the whole placeholder instead of just
+        removing the line break. The cursor should land at the end of the
+        placeholder line with the placeholder intact.
+        """
+        big_text = "p" * 900
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat.handle_external_paste(big_text)
+            await pilot.pause()
+            assert chat._text_area.text == "[Pasted text #1]"
+
+            chat._text_area.insert("\n")
+            await pilot.pause()
+            assert chat._text_area.cursor_location == (1, 0)
+
+            await pilot.press("backspace")
+            await pilot.pause()
+
+            assert chat._text_area.text == "[Pasted text #1]"
+            assert chat._text_area.cursor_location == (0, len("[Pasted text #1]"))
             assert 1 in chat._pasted_contents
 
     async def test_identical_multiline_repaste_expands_placeholder(self) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -2818,33 +2818,41 @@ class TestDroppedImagePaste:
     async def test_backspace_from_line_below_image_keeps_placeholder(
         self, tmp_path
     ) -> None:
-        """Backspace on the line below `[image N]` rejoins lines, keeps token."""
-        img_path = tmp_path / "newline.png"
+        """Backspace on the line below `[image N]` rejoins lines, keeps token.
+
+        Two images dropped on separate lines render as `[image 1]`, a newline,
+        and then `[image 2]`, with no trailing space after the first token. The
+        newline sits immediately after the first
+        token's closing bracket. Backspacing from the start of the second line
+        must remove only the line break, not delete `[image 1]` atomically with
+        it (the regression this fix addresses for the media code path).
+        """
         from PIL import Image
 
-        image = Image.new("RGB", (4, 4), color="cyan")
-        image.save(img_path, format="PNG")
+        img1 = tmp_path / "one.png"
+        img2 = tmp_path / "two.png"
+        Image.new("RGB", (4, 4), color="cyan").save(img1, format="PNG")
+        Image.new("RGB", (4, 4), color="magenta").save(img2, format="PNG")
 
         app = _ImagePasteApp()
         async with app.run_test() as pilot:
             chat = app.query_one(ChatInput)
             assert chat._text_area is not None
 
-            chat.handle_external_paste(str(img_path))
+            chat.handle_external_paste(f"{img1}\n{img2}")
             await pilot.pause()
-            assert chat._text_area.text == "[image 1] "
+            assert chat._text_area.text == "[image 1]\n[image 2]"
 
-            chat._text_area.insert("\n")
+            chat._text_area.move_cursor((1, 0))
             await pilot.pause()
-            assert chat._text_area.cursor_location == (1, 0)
 
             await pilot.press("backspace")
             await pilot.pause()
 
-            # The line break is removed and the placeholder (with its trailing
-            # space) is preserved rather than being deleted atomically.
-            assert chat._text_area.text == "[image 1] "
-            assert len(app.tracker.get_images()) == 1
+            # The line break is removed and both placeholders survive rather
+            # than `[image 1]` being deleted atomically with the newline.
+            assert chat._text_area.text == "[image 1][image 2]"
+            assert len(app.tracker.get_images()) == 2
 
     async def test_readding_after_delete_restarts_image_counter(self, tmp_path) -> None:
         """Re-adding after deleting all placeholders should restart at `[image 1]`."""
@@ -3986,6 +3994,27 @@ class TestModifiedBackspaceDeleteWordLeft:
             chat.handle_external_paste("p" * 900)
             await pilot.pause()
             assert chat._text_area.text == "[Pasted text #1]"
+
+            await pilot.press(key)
+            await pilot.pause()
+
+            assert chat._text_area.text == ""
+            assert 1 in chat._pasted_contents
+
+    @pytest.mark.parametrize("key", ["ctrl+backspace", "alt+backspace"])
+    async def test_modified_backspace_after_tab_deletes_placeholder_atomically(
+        self, key: str
+    ) -> None:
+        """Modified Backspace preserves token integrity after a tab."""
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            assert chat._text_area is not None
+
+            chat.handle_external_paste("p" * 900)
+            chat._text_area.insert("\t")
+            await pilot.pause()
+            assert chat._text_area.text == "[Pasted text #1]\t"
 
             await pilot.press(key)
             await pilot.pause()

--- a/libs/code/tests/unit_tests/tui/widgets/test_inline_prompt.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_inline_prompt.py
@@ -137,6 +137,31 @@ class TestInlinePromptPaste:
 
                 assert ta.text == ""
 
+    async def test_modified_backspace_after_tab_deletes_placeholder_atomically(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Modified Backspace preserves token integrity after a tab."""
+        monkeypatch.setattr(
+            paste_textarea_module, "_collapse_pastes_enabled", lambda: True
+        )
+
+        for key in ("ctrl+backspace", "alt+backspace"):
+            app = _PromptApp()
+            async with app.run_test() as pilot:
+                ta = app.query_one(InlinePromptTextArea)
+                ta.focus()
+                await pilot.pause()
+
+                await ta._on_paste(Paste("a\nb\nc\nd"))
+                ta.insert("\t")
+                await pilot.pause()
+                assert ta.text == "[Pasted text #1 +3 lines]\t"
+
+                await pilot.press(key)
+                await pilot.pause()
+
+                assert ta.text == ""
+
     async def test_key_burst_with_newline_does_not_submit(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_inline_prompt.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_inline_prompt.py
@@ -230,6 +230,39 @@ class TestInlinePromptPaste:
 
             assert ta.text == ""
 
+    async def test_backspace_from_line_below_placeholder_keeps_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Backspace on the line below a placeholder rejoins lines, keeps token.
+
+        Regression: a newline right after a `[Pasted text #N]` placeholder was
+        treated as an auto-inserted trailing separator, so backspacing from the
+        start of the next line deleted the whole placeholder instead of only the
+        line break.
+        """
+        monkeypatch.setattr(
+            paste_textarea_module, "_collapse_pastes_enabled", lambda: True
+        )
+        app = _PromptApp()
+        async with app.run_test() as pilot:
+            ta = app.query_one(InlinePromptTextArea)
+            ta.focus()
+            await pilot.pause()
+
+            await ta._on_paste(Paste("a\nb\nc\nd"))
+            await pilot.pause()
+            assert ta.text == "[Pasted text #1 +3 lines]"
+
+            ta.insert("\n")
+            await pilot.pause()
+            assert ta.cursor_location == (1, 0)
+
+            await pilot.press("backspace")
+            await pilot.pause()
+
+            assert ta.text == "[Pasted text #1 +3 lines]"
+            assert ta.cursor_location == (0, len("[Pasted text #1 +3 lines]"))
+
     async def test_typed_placeholder_shape_is_not_atomic(self) -> None:
         """Hand-typed placeholder-shaped text deletes one char, not the token."""
         app = _PromptApp()


### PR DESCRIPTION
Fixed the `dcode` chat input deleting a collapsed `[Pasted text #N]` (or `[image N]`) placeholder when backspacing the line break on the line below it; the line break is now removed while the placeholder is preserved.

---

In the `dcode` chat input, pasting large text collapses it into a `[Pasted text #N]` placeholder. Pressing Enter to add a newline and then backspacing from the start of that new line deleted the entire placeholder instead of just rejoining the lines.

The cause is in `_find_placeholder_span`: its backwards-delete branch treats any whitespace immediately after a placeholder as an auto-inserted trailing separator and swallows the whole token with it. Since `str.isspace()` also matches a newline, backspacing a line break below a placeholder removed the placeholder. Restricting that branch to a literal space (the separator actually auto-inserted after media placeholders) lets a newline fall through to the default backspace, which removes only the line break and leaves the cursor at the end of the placeholder line. The same fix is applied to the shared base text area used by the inline prompts.

Made by [Open SWE](https://openswe.vercel.app/agents/79b11ee1-f326-668a-e659-c990811f4e29)