### PR TITLE
fix(code): improve empty marketplace onboarding and list polish

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -17038,11 +17038,44 @@ class DeepAgentsApp(App):
         """Open the interactive plugin manager."""
         from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
 
+        def on_close(result: tuple[str, bool] | None) -> None:
+            if result is None:
+                return
+            label, needs_login = result
+            self.call_after_refresh(
+                lambda: self.run_worker(
+                    self._offer_reconnect_after_plugin_install(
+                        label, needs_login=needs_login
+                    ),
+                    exclusive=True,
+                    group="plugin-install-reconnect",
+                )
+            )
+
         self.push_screen(
             PluginManagerScreen(
                 mcp_server_info=self._mcp_server_info or [],
-            )
+            ),
+            on_close,
         )
+
+    async def _offer_reconnect_after_plugin_install(
+        self, label: str, *, needs_login: bool
+    ) -> None:
+        """Offer reconnect after installing a plugin that declares MCP servers.
+
+        Reuses the `/mcp login` reconnect-now / defer modal. When the plugin's
+        MCP servers typically need auth, surface a follow-up toast pointing
+        users at `/mcp`.
+        """
+        await self._prompt_mcp_reconnect(label)
+        if needs_login:
+            self.notify(
+                f"Sign in to {label} via `/mcp` after reconnect.",
+                severity="information",
+                timeout=10,
+                markup=False,
+            )
 
     async def _handle_mcp_subcommand(self, args: str) -> None:
         """Dispatch `/mcp <subcommand>` strings.

--- a/libs/code/deepagents_code/plugins/adapters/mcp.py
+++ b/libs/code/deepagents_code/plugins/adapters/mcp.py
@@ -48,6 +48,53 @@ def scoped_mcp_server_name(plugin_id: str, server_name: str) -> str:
     return f"plugin__{plugin_part}__{server_part}"
 
 
+def _mcp_server_needs_login(server: object) -> bool:
+    """Return whether an MCP server config typically requires interactive login."""
+    if not isinstance(server, dict):
+        return False
+    server_type = server.get("type")
+    if server_type in {"http", "sse"}:
+        return True
+    return isinstance(server.get("url"), str)
+
+
+def plugin_mcp_server_entries(
+    plugin: PluginInstance,
+) -> tuple[tuple[str, str, bool], ...]:
+    """List plugin MCP servers as `(label, scoped_name, needs_login)` tuples.
+
+    `label` is the unscoped name from the plugin config (for UI). `scoped_name`
+    is what dcode registers after namespacing.
+
+    Args:
+        plugin: Plugin whose MCP declarations should be listed.
+
+    Returns:
+        Deduplicated server entries in declaration order.
+    """
+    servers: dict[str, object] = {}
+    for path in plugin.inventory.mcp_files:
+        if path.suffix in {".mcpb", ".dxt"}:
+            continue
+        servers.update(_load_mcp_server_map(path))
+    if plugin.manifest and plugin.manifest.inline_mcp:
+        servers.update(_server_map(plugin.manifest.inline_mcp))
+    entries: list[tuple[str, str, bool]] = []
+    seen: set[str] = set()
+    for name, server in servers.items():
+        if not isinstance(name, str) or name in seen:
+            continue
+        seen.add(name)
+        entries.append(
+            (
+                name,
+                scoped_mcp_server_name(plugin.plugin_id, name),
+                _mcp_server_needs_login(server),
+            )
+        )
+    return tuple(entries)
+
+
 def _server_map(raw: object) -> JsonObject:
     """Extract the server-name to config map from a decoded MCP document.
 

--- a/libs/code/deepagents_code/plugins/manifest.py
+++ b/libs/code/deepagents_code/plugins/manifest.py
@@ -209,11 +209,15 @@ def load_manifest(
 
     version_value = raw.get("version")
     version = version_value if isinstance(version_value, str) else None
+    display_name_value = raw.get("displayName")
     manifest = PluginManifest(
         name=name,
         version=version,
         component_paths=component_paths,
         inline_mcp=_inline_mcp(raw.get("mcpServers")),
+        display_name=(
+            display_name_value if isinstance(display_name_value, str) else None
+        ),
     )
     return manifest, manifest_path, tuple(warnings)
 

--- a/libs/code/deepagents_code/plugins/marketplace.py
+++ b/libs/code/deepagents_code/plugins/marketplace.py
@@ -738,11 +738,15 @@ def _parse_entry(
         if isinstance(author_value, str)
         else None
     )
+    display_name_value = entry.get("displayName")
     return MarketplacePluginEntry(
         name=name,
         source=source,
         description=description_value if isinstance(description_value, str) else None,
         author=author,
+        display_name=(
+            display_name_value if isinstance(display_name_value, str) else None
+        ),
     )
 
 

--- a/libs/code/deepagents_code/plugins/models.py
+++ b/libs/code/deepagents_code/plugins/models.py
@@ -54,6 +54,7 @@ class PluginManifest:
 
     Attributes:
         name: Plugin name from the manifest, or `None` for manifest-less plugins.
+        display_name: Optional human-readable label from `displayName`.
         version: Version string from the plugin manifest.
         component_paths: Validated skill and MCP paths keyed by component name.
         inline_mcp: Inline MCP servers declared in the manifest.
@@ -63,6 +64,7 @@ class PluginManifest:
     version: str | None
     component_paths: dict[str, tuple[Path, ...]]
     inline_mcp: JsonObject
+    display_name: str | None = None
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -164,6 +166,7 @@ class MarketplacePluginEntry:
     source: PluginSource
     description: str | None = None
     author: str | JsonObject | None = None
+    display_name: str | None = None
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, ClassVar
 from textual.binding import Binding, BindingType
 from textual.containers import Vertical
 from textual.content import Content
+from textual.css.query import NoMatches
 from textual.screen import ModalScreen
 from textual.widgets import Input, OptionList, Rule, Static
 from textual.widgets.option_list import Option
@@ -70,6 +71,11 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
     ]
 
     CSS_PATH = "plugin_manager.tcss"
+
+    # Divider width used before the options list has been laid out (e.g. in unit
+    # tests that build options off-screen). At render time the divider is sized to
+    # the measured options width instead so it never wraps on a narrower modal.
+    _DIVIDER_FALLBACK_WIDTH: ClassVar[int] = 72
 
     _tabs: ClassVar[tuple[PluginTab, ...]] = (
         "discover",
@@ -148,6 +154,20 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
             self._status = None
             self._refresh_view()
 
+    def on_resize(self) -> None:
+        """Refit the width-sized marketplaces divider when the modal resizes.
+
+        The divider is the only content sized to the options width, so restrict the
+        rebuild to the marketplaces list view to avoid needless focus/highlight churn
+        on unrelated tabs and while the add-marketplace input is focused.
+        """
+        if (
+            self._mode == "list"
+            and self._tab == "marketplaces"
+            and self._state.marketplaces
+        ):
+            self._refresh_view()
+
     def _tabs_text(self) -> str:
         labels = {
             "discover": "Plugins",
@@ -193,7 +213,9 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
             if self._state.marketplaces:
                 options.append(
                     Option(
-                        Content.styled(glyphs.box_horizontal * 72, "dim"),
+                        Content.styled(
+                            glyphs.box_horizontal * self._divider_width(), "dim"
+                        ),
                         id="marketplace-divider",
                         disabled=True,
                     )
@@ -209,6 +231,25 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
         if not self._state.errors:
             return [Option("No plugin errors.", id="empty")]
         return [Option(Content(error), id="empty") for error in self._state.errors]
+
+    def _divider_width(self) -> int:
+        """Width for the marketplaces divider, sized to the options list.
+
+        The options list respects the modal's `max-width`, so a fixed width wraps on
+        terminals narrower than the full modal. Measure the laid-out content width when
+        available and fall back to a constant before the first layout (e.g. in tests).
+
+        Returns:
+            The measured options content width, or `_DIVIDER_FALLBACK_WIDTH` if the
+            options list is not mounted or has not been laid out yet.
+        """
+        try:
+            width = self.query_one(
+                "#plugin-manager-options", OptionList
+            ).content_size.width
+        except NoMatches:
+            return self._DIVIDER_FALLBACK_WIDTH
+        return width if width > 0 else self._DIVIDER_FALLBACK_WIDTH
 
     @staticmethod
     def _nearest_enabled_index(options: OptionList, candidate: int) -> int | None:

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -162,9 +162,11 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
             if not self._state.marketplaces:
                 return [
                     Option(
-                        "No plugins available. Add a marketplace first.",
+                        "No marketplaces installed. Add one to discover plugins.",
                         id="empty",
-                    )
+                        disabled=True,
+                    ),
+                    Option("+ Add marketplace", id="add-marketplace"),
                 ]
             if not self._state.available_plugins:
                 return [Option("All available plugins are installed.", id="empty")]
@@ -182,10 +184,18 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
                 status=None,
             )
         if self._tab == "marketplaces":
-            options = [Option("+ Add Marketplace", id="add-marketplace")]
+            options = [Option("+ Add marketplace", id="add-marketplace")]
+            if self._state.marketplaces:
+                options.append(
+                    Option(
+                        Content.styled(glyphs.box_horizontal * 72, "dim"),
+                        id="marketplace-divider",
+                        disabled=True,
+                    )
+                )
             options.extend(
                 Option(
-                    Content(_marketplace_label(row, glyphs.bullet)),
+                    _marketplace_label(row),
                     id=f"marketplace:{row.name}",
                 )
                 for row in self._state.marketplaces
@@ -328,7 +338,12 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
                 f"Left/Right tabs {glyphs.bullet} Esc close"
             )
         elif self._tab in {"discover", "installed"}:
-            action = "view" if self._tab == "installed" else "install"
+            if self._tab == "installed":
+                action = "view"
+            elif not self._state.marketplaces:
+                action = "add marketplace"
+            else:
+                action = "install"
             help_text.update(
                 f"{glyphs.arrow_up}/{glyphs.arrow_down} select {glyphs.bullet} "
                 f"Enter {action} {glyphs.bullet} Left/Right tabs "

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -597,15 +597,20 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
         if row is None:
             return
         try:
-            await asyncio.to_thread(install_plugin, row.plugin_id)
+            # install_plugin returns the loaded instance; Discover rows do not
+            # carry MCP metadata until install, so inspect the result here.
+            instance = await asyncio.to_thread(install_plugin, row.plugin_id)
         except (MarketplaceError, FileNotFoundError, OSError, ValueError) as exc:
             self._error = str(exc)
             self._status = None
             self._refresh_view()
             return
+        from deepagents_code.plugins.adapters.mcp import plugin_mcp_server_entries
+
         label = row.label
-        needs_login = bool(row.mcp_login_servers)
-        has_mcp = bool(row.mcp_server_names)
+        entries = plugin_mcp_server_entries(instance)
+        has_mcp = bool(entries)
+        needs_login = any(needs for _label, _scoped, needs in entries)
         self.notify(f"Installed {label}", timeout=5, markup=False)
         self._mode = "list"
         self._tab = "installed"

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -51,8 +51,13 @@ from deepagents_code.tui.modals.plugin_manager.models import _ManagerState
 from deepagents_code.tui.modals.plugin_manager.state import _load_manager_state
 
 
-class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
-    """Arrow-key navigable plugin manager for `/plugins`."""
+class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
+    """Arrow-key navigable plugin manager for `/plugins`.
+
+    Dismisses with `(label, needs_mcp_login)` after an MCP-bearing plugin
+    install so the app can offer reconnect + login guidance, otherwise
+    `None`.
+    """
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("escape", "cancel", "Close", show=False, priority=True),
@@ -557,12 +562,20 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
             self._status = None
             self._refresh_view()
             return
+        label = row.label
+        needs_login = bool(row.mcp_login_servers)
+        has_mcp = bool(row.mcp_server_names)
+        self.notify(f"Installed {label}", timeout=5, markup=False)
         self._mode = "list"
         self._tab = "installed"
         self._selected_plugin = None
-        self._status = f"Installed {row.plugin_id}. Run /reload to activate."
+        self._status = f"Installed {label}."
         self._error = None
         await self._refresh_state()
+        if has_mcp:
+            # Close the manager so the reconnect prompt is not buried under it.
+            self.dismiss((label, needs_login))
+            return
 
     async def _toggle_selected_plugin_enabled(self) -> None:
         row = self._selected_plugin
@@ -571,12 +584,12 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         try:
             if row.enabled:
                 set_installed_plugin_enabled(row.plugin_id, enabled=False)
-                self._status = f"Disabled {row.plugin_id}. Run /reload to unload."
+                self._status = f"Disabled {row.label}. Run /reload to unload."
                 self._mode = "list"
                 self._selected_plugin = None
             else:
                 set_installed_plugin_enabled(row.plugin_id, enabled=True)
-                self._status = f"Enabled {row.plugin_id}. Run /reload to activate."
+                self._status = f"Enabled {row.label}. Run /reload to activate."
                 self._mode = "list"
                 self._tab = "installed"
                 self._selected_plugin = None
@@ -602,7 +615,7 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         self._mode = "list"
         self._selected_plugin = None
         reload_hint = " Run /reload to unload." if row.enabled else ""
-        self._status = f"Uninstalled {row.plugin_id}.{reload_hint}"
+        self._status = f"Uninstalled {row.label}.{reload_hint}"
         self._error = None
         await self._refresh_state()
 

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
@@ -28,22 +28,23 @@ def _plugin_options(
 def _plugin_prompt(row: _PluginRow, *, status: str | None) -> Content:
     glyphs = get_glyphs()
     plugin_name, _, marketplace = row.plugin_id.partition("@")
-    meta_parts = ["Plugin", marketplace]
+    meta_parts = [Content.styled("Plugin", "dim"), Content.styled(marketplace, "dim")]
     if row.enabled:
-        meta_parts.append(f"{glyphs.checkmark} enabled")
+        meta_parts.append(Content.styled(f"{glyphs.checkmark} enabled", "bold"))
     if row.skill_count:
-        meta_parts.append(
-            f"{row.skill_count} {'skill' if row.skill_count == 1 else 'skills'}"
-        )
+        skill_label = "skill" if row.skill_count == 1 else "skills"
+        meta_parts.append(Content.styled(f"{row.skill_count} {skill_label}", "dim"))
     if row.mcp_connected is True:
-        meta_parts.append(f"{glyphs.checkmark} connected")
+        meta_parts.append(Content.styled(f"{glyphs.checkmark} connected", "dim"))
     elif row.mcp_connected is False:
-        meta_parts.append("restart to connect")
+        meta_parts.append(Content.styled("restart to connect", "dim"))
     if status:
-        meta_parts.append(status)
+        meta_parts.append(Content.styled(status, "dim"))
+    separator = Content.styled(" · ", "dim")
     return Content.assemble(
         plugin_name,
-        Content.styled(f" · {' · '.join(meta_parts)}", "dim"),
+        separator,
+        separator.join(meta_parts),
         "\n  ",
         Content.styled(row.description or "No description provided.", "dim"),
     )
@@ -111,11 +112,16 @@ def _installed_plugin_details_content(row: _PluginRow) -> Content:
         parts.extend(["\n\n", row.description])
     if row.author:
         parts.extend(["\n\n", Content.styled(f"Author: {row.author}", "dim")])
-    status = f"{glyphs.checkmark} Enabled" if row.enabled else "Disabled"
+    status = (
+        Content.styled(f"{glyphs.checkmark} Enabled", "$success")
+        if row.enabled
+        else Content.styled("Disabled", "dim")
+    )
     parts.extend(
         [
             "\n\n",
-            Content.styled(f"Status: {status}", "dim"),
+            Content.styled("Status: ", "dim"),
+            status,
             "\n\n",
             Content.styled("Installed components:", "bold"),
         ]
@@ -132,9 +138,15 @@ def _installed_plugin_details_content(row: _PluginRow) -> Content:
     return Content.assemble(*parts)
 
 
-def _marketplace_label(row: _MarketplaceRow, bullet: str) -> str:
-    count = "failed" if row.plugin_count is None else f"{row.plugin_count} available"
-    return f"{row.name} {bullet} {row.source} {bullet} {count}"
+def _marketplace_label(row: _MarketplaceRow) -> Content:
+    glyphs = get_glyphs()
+    prefix = f"{row.name} {glyphs.bullet} {row.source} {glyphs.bullet} "
+    if row.has_error:
+        return Content.assemble(
+            prefix,
+            Content.styled(f"{glyphs.error} Error", "$error"),
+        )
+    return Content.assemble(prefix, f"{row.plugin_count} available")
 
 
 def _marketplace_details_options() -> list[Option]:

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
@@ -172,9 +172,7 @@ def _confirm_marketplace_removal_options(row: _MarketplaceRow) -> list[Option]:
 
 
 def _marketplace_details_content(row: _MarketplaceRow) -> Content:
-    available = (
-        "Unavailable" if row.plugin_count is None else f"{row.plugin_count} available"
-    )
+    available = "Unavailable" if row.has_error else f"{row.plugin_count} available"
     return Content.assemble(
         Content.styled(row.name, "bold"),
         "\n",

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
@@ -27,7 +27,7 @@ def _plugin_options(
 
 def _plugin_prompt(row: _PluginRow, *, status: str | None) -> Content:
     glyphs = get_glyphs()
-    plugin_name, _, marketplace = row.plugin_id.partition("@")
+    _, _, marketplace = row.plugin_id.partition("@")
     meta_parts = [Content.styled("Plugin", "dim"), Content.styled(marketplace, "dim")]
     if row.enabled:
         meta_parts.append(Content.styled(f"{glyphs.checkmark} enabled", "bold"))
@@ -37,12 +37,12 @@ def _plugin_prompt(row: _PluginRow, *, status: str | None) -> Content:
     if row.mcp_connected is True:
         meta_parts.append(Content.styled(f"{glyphs.checkmark} connected", "dim"))
     elif row.mcp_connected is False:
-        meta_parts.append(Content.styled("restart to connect", "dim"))
+        meta_parts.append(Content.styled("restart to connect", "bold $warning"))
     if status:
         meta_parts.append(Content.styled(status, "dim"))
     separator = Content.styled(" · ", "dim")
     return Content.assemble(
-        plugin_name,
+        row.label,
         separator,
         separator.join(meta_parts),
         "\n  ",
@@ -69,11 +69,11 @@ def _installed_details_options(row: _PluginRow) -> list[Option]:
 
 
 def _plugin_details_content(row: _PluginRow) -> Content:
-    plugin_name, _, marketplace = row.plugin_id.partition("@")
+    _, _, marketplace = row.plugin_id.partition("@")
     parts: list[Content | str] = [
         Content.styled("Plugin details", "bold"),
         "\n\n",
-        Content.styled(plugin_name, "bold"),
+        Content.styled(row.label, "bold"),
         "\n",
         Content.styled(f"from {marketplace}", "dim"),
     ]
@@ -102,9 +102,9 @@ def _plugin_details_content(row: _PluginRow) -> Content:
 
 def _installed_plugin_details_content(row: _PluginRow) -> Content:
     glyphs = get_glyphs()
-    plugin_name, _, marketplace = row.plugin_id.partition("@")
+    _, _, marketplace = row.plugin_id.partition("@")
     parts: list[Content | str] = [
-        Content.styled(f"{plugin_name} @ {marketplace}", "bold")
+        Content.styled(f"{row.label} @ {marketplace}", "bold")
     ]
     if row.version:
         parts.extend(["\n", Content.styled(f"Version: {row.version}", "dim")])
@@ -188,18 +188,15 @@ def _marketplace_details_content(row: _MarketplaceRow) -> Content:
 
 def _marketplace_removal_content(row: _MarketplaceRow) -> Content:
     suffix = "s" if row.installed_count != 1 else ""
-    warning = (
-        f"This also uninstalls {row.installed_count} plugin{suffix} from this "
-        "marketplace. "
-        if row.installed_count
-        else ""
-    )
+    if row.installed_count:
+        detail = (
+            f"This removes the marketplace and uninstalls {row.installed_count} "
+            f"plugin{suffix} from it."
+        )
+    else:
+        detail = "This removes the marketplace from your installed list."
     return Content.assemble(
         Content.styled(f"Remove marketplace {row.name}?", "bold"),
         "\n\n",
-        Content.styled(
-            f"{warning}The marketplace record and managed caches will be removed. "
-            "Local source directories are not deleted.",
-            "dim",
-        ),
+        Content.styled(detail, "dim"),
     )

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/models.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/models.py
@@ -35,6 +35,16 @@ class _MarketplaceRow:
     installed_count: int
     error: str | None = None
 
+    @property
+    def has_error(self) -> bool:
+        """Whether the configured marketplace could not be loaded.
+
+        Marketplace loading failures set `error` and produce an error status. Warnings
+        from a marketplace that loaded successfully appear on the Errors tab without
+        marking the marketplace itself as errored.
+        """
+        return self.error is not None
+
 
 @dataclass(frozen=True, slots=True)
 class _ManagerState:

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/models.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/models.py
@@ -21,10 +21,19 @@ class _PluginRow:
     enabled: bool
     version: str | None
     author: str | None
+    display_name: str = ""
     skill_count: int | None = None
     skill_names: tuple[str, ...] = ()
     mcp_connected: bool | None = None
     mcp_server_names: tuple[str, ...] = ()
+    mcp_login_servers: tuple[str, ...] = ()
+
+    @property
+    def label(self) -> str:
+        """Human-readable plugin name for UI copy."""
+        if self.display_name:
+            return self.display_name
+        return self.plugin_id.partition("@")[0]
 
 
 @dataclass(frozen=True, slots=True)

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/state.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/state.py
@@ -70,24 +70,50 @@ def _list_plugin_skill_names(instance: PluginInstance) -> tuple[str, ...]:
 
 
 def _plugin_mcp_server_names(instance: PluginInstance) -> tuple[str, ...]:
-    from deepagents_code.plugins.adapters.mcp import plugin_mcp_configs
+    from deepagents_code.plugins.adapters.mcp import plugin_mcp_server_entries
 
-    names: list[str] = []
-    for config in plugin_mcp_configs((instance,)):
-        servers = config.get("mcpServers")
-        if isinstance(servers, dict):
-            names.extend(key for key in servers if isinstance(key, str))
-    return tuple(dict.fromkeys(names))
+    return tuple(
+        label for label, _scoped, _needs_login in plugin_mcp_server_entries(instance)
+    )
+
+
+def _plugin_mcp_login_servers(instance: PluginInstance) -> tuple[str, ...]:
+    from deepagents_code.plugins.adapters.mcp import plugin_mcp_server_entries
+
+    return tuple(
+        scoped
+        for _label, scoped, needs_login in plugin_mcp_server_entries(instance)
+        if needs_login
+    )
 
 
 def _plugin_mcp_connected(
     instance: PluginInstance, mcp_server_info: Sequence[MCPServerInfo]
 ) -> bool | None:
-    expected = frozenset(_plugin_mcp_server_names(instance))
+    from deepagents_code.plugins.adapters.mcp import plugin_mcp_server_entries
+
+    expected = frozenset(
+        scoped for _label, scoped, _needs_login in plugin_mcp_server_entries(instance)
+    )
     if not expected:
         return None
     connected = {info.name for info in mcp_server_info if info.status == "ok"}
     return expected <= connected
+
+
+def _plugin_display_name(
+    *,
+    marketplace_display_name: str | None,
+    instance: PluginInstance | None,
+    plugin_name: str,
+) -> str:
+    if marketplace_display_name:
+        return marketplace_display_name
+    if instance is not None and instance.manifest is not None:
+        manifest_name = instance.manifest.display_name
+        if manifest_name:
+            return manifest_name
+    return plugin_name
 
 
 def _instance_for_manager_row(
@@ -188,18 +214,25 @@ def _load_manager_state(mcp_server_info: Sequence[MCPServerInfo] = ()) -> _Manag
             )
             skill_names = _list_plugin_skill_names(instance) if instance else ()
             mcp_names = _plugin_mcp_server_names(instance) if instance else ()
+            login_servers = _plugin_mcp_login_servers(instance) if instance else ()
             row = _PluginRow(
                 plugin_id,
                 plugin.description or "",
                 is_enabled,
                 instance.version if instance else None,
                 _extract_name(plugin.author),
+                _plugin_display_name(
+                    marketplace_display_name=plugin.display_name,
+                    instance=instance,
+                    plugin_name=plugin.name,
+                ),
                 len(skill_names) if instance else None,
                 skill_names,
                 _plugin_mcp_connected(instance, mcp_server_info)
                 if instance and is_enabled
                 else None,
                 mcp_names,
+                login_servers,
             )
             (installed_plugins if is_installed else available_plugins).append(row)
     return _ManagerState(

--- a/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
@@ -689,8 +689,9 @@ async def test_plugin_manager_confirms_marketplace_removal(
         await pilot.press("right")
         await pilot.pause()
         options = screen.query_one("#plugin-manager-options", OptionList)
-        assert options.option_count == 2
-        options.highlighted = 1
+        assert options.option_count == 3
+        assert options.get_option_at_index(1).disabled
+        options.highlighted = 2
         await pilot.press("enter")
         await pilot.pause()
 
@@ -730,16 +731,11 @@ async def test_plugin_manager_opens_add_marketplace_input(
         await pilot.pause()
 
         options = screen.query_one("#plugin-manager-options", OptionList)
-        assert options.option_count == 1
-        assert "No plugins available" in str(options.get_option_at_index(0).prompt)
-
-        await pilot.press("right")
-        await pilot.pause()
-        await pilot.press("right")
-        await pilot.pause()
-        assert "> Marketplaces <" in str(
-            screen.query_one("#plugin-manager-tabs").render()
-        )
+        assert options.option_count == 2
+        assert options.get_option_at_index(0).disabled
+        assert "No marketplaces installed" in str(options.get_option_at_index(0).prompt)
+        assert options.get_option_at_index(1).id == "add-marketplace"
+        assert options.highlighted == 1
 
         await pilot.press("enter")
         await pilot.pause()

--- a/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 import pytest
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.middleware.skills import _list_skills as list_sdk_skills
-from textual.widgets import Input, OptionList
+from textual.widgets import OptionList
 
 from deepagents_code._env_vars import EXPERIMENTAL
 from deepagents_code.app import DeepAgentsApp
@@ -31,6 +31,7 @@ from deepagents_code.plugins import (
 from deepagents_code.plugins.adapters.mcp import (
     discover_plugin_mcp_configs,
     plugin_mcp_configs,
+    plugin_mcp_server_entries,
     scoped_mcp_server_name,
 )
 from deepagents_code.plugins.adapters.skills import (
@@ -144,72 +145,6 @@ def _add_docs_helper_plugin(root: Path) -> None:
         {"name": "docs-helper", "version": "1.0.0"},
     )
     _write_skill(plugin / "skills" / "lookup" / "SKILL.md", name="lookup")
-
-
-async def test_plugin_manager_installed_selection_opens_details_not_disable(
-    tmp_path: Path, monkeypatch
-) -> None:
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
-    )
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
-    )
-    marketplace_root = tmp_path / "marketplace"
-    _make_marketplace(marketplace_root)
-    add_local_marketplace(marketplace_root)
-    install_plugin("quality-review-plugin@company-tools")
-
-    app = DeepAgentsApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-
-        screen = PluginManagerScreen()
-        app.push_screen(screen)
-        await pilot.pause()
-
-        await pilot.press("right")
-        await pilot.pause()
-        await pilot.press("enter")
-        await pilot.pause()
-
-        detail = str(screen.query_one("#plugin-manager-status").render())
-        options = screen.query_one("#plugin-manager-options", OptionList)
-        assert "quality-review-plugin @ company-tools" in detail
-        assert "Installed components:" in detail
-        assert "Disable plugin" in str(options.get_option_at_index(0).prompt)
-        assert "quality-review-plugin@company-tools" in load_enabled_plugin_ids()
-
-
-async def test_plugin_manager_installed_row_shows_restart_hint_before_connect(
-    tmp_path: Path, monkeypatch
-) -> None:
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
-    )
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
-    )
-    marketplace_root = tmp_path / "marketplace"
-    _make_marketplace(marketplace_root)
-    add_local_marketplace(marketplace_root)
-    install_plugin("quality-review-plugin@company-tools")
-
-    app = DeepAgentsApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-
-        screen = PluginManagerScreen()
-        app.push_screen(screen)
-        await pilot.pause()
-
-        await pilot.press("right")
-        await pilot.pause()
-
-        options = screen.query_one("#plugin-manager-options", OptionList)
-        prompt = str(options.get_option_at_index(0).prompt)
-        assert "restart to connect" in prompt
-        assert "connected" not in prompt.replace("restart to connect", "")
 
 
 def test_plugin_manager_uses_recursive_skill_inventory(
@@ -703,6 +638,8 @@ async def test_plugin_manager_confirms_marketplace_removal(
         confirmation = str(screen.query_one("#plugin-manager-status").render())
         assert "Remove marketplace company-tools?" in confirmation
         assert "uninstalls 1 plugin" in confirmation
+        assert "managed caches" not in confirmation
+        assert "Local source directories" not in confirmation
 
         await pilot.press("enter")
         await pilot.pause()
@@ -710,104 +647,6 @@ async def test_plugin_manager_confirms_marketplace_removal(
     assert "company-tools" not in load_marketplace_records()
     assert not load_installed_plugins()
     assert marketplace_root.is_dir()
-
-
-async def test_plugin_manager_opens_add_marketplace_input(
-    tmp_path: Path, monkeypatch
-) -> None:
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
-    )
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
-    )
-
-    app = DeepAgentsApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-
-        screen = PluginManagerScreen()
-        app.push_screen(screen)
-        await pilot.pause()
-
-        options = screen.query_one("#plugin-manager-options", OptionList)
-        assert options.option_count == 2
-        assert options.get_option_at_index(0).disabled
-        assert "No marketplaces installed" in str(options.get_option_at_index(0).prompt)
-        assert options.get_option_at_index(1).id == "add-marketplace"
-        assert options.highlighted == 1
-
-        await pilot.press("enter")
-        await pilot.pause()
-
-        source_input = screen.query_one("#plugin-marketplace-source", Input)
-        assert source_input.display is True
-        assert source_input.has_focus
-        assert (
-            str(screen.query_one("#plugin-manager-title").render()) == "Add Marketplace"
-        )
-        assert screen.query_one("#plugin-manager-tabs").display is False
-        tip = str(screen.query_one("#plugin-manager-status").render())
-        assert "Enter marketplace source:" in tip
-        assert "Examples:" in tip
-        assert "owner/repo (GitHub)" in tip
-        assert "git@github.com:owner/repo.git (SSH)" in tip
-        assert "https://example.com/marketplace.json" in tip
-        assert "./path/to/marketplace" in tip
-        help_text = str(screen.query_one("#plugin-manager-help").render())
-        assert "Enter to add" in help_text
-        assert "Esc to cancel" in help_text
-
-
-async def test_plugin_manager_discover_rows_show_description_below_name(
-    tmp_path: Path, monkeypatch
-) -> None:
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
-    )
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
-    )
-    marketplace_root = tmp_path / "marketplace"
-    _make_marketplace(marketplace_root)
-    add_local_marketplace(marketplace_root)
-
-    app = DeepAgentsApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-
-        screen = PluginManagerScreen()
-        app.push_screen(screen)
-        await pilot.pause()
-
-        options = screen.query_one("#plugin-manager-options", OptionList)
-        prompt = str(options.get_option_at_index(0).prompt)
-
-        assert "quality-review-plugin · Plugin · company-tools" in prompt
-        assert "\n  Quality review" in prompt
-
-
-async def test_plugin_manager_tabs_label_plugins_not_discover(
-    tmp_path: Path, monkeypatch
-) -> None:
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
-    )
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
-    )
-
-    app = DeepAgentsApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-
-        screen = PluginManagerScreen()
-        app.push_screen(screen)
-        await pilot.pause()
-
-        tabs = str(screen.query_one("#plugin-manager-tabs").render())
-        assert "> Plugins <" in tabs
-        assert "Discover" not in tabs
 
 
 def test_plugin_mcp_config_namespaces_and_substitutes(
@@ -841,9 +680,63 @@ def test_plugin_mcp_config_namespaces_and_substitutes(
 def test_scoped_mcp_server_name_is_valid_and_collision_resistant() -> None:
     dotted = scoped_mcp_server_name("quality.review", "docs.v1")
     underscored = scoped_mcp_server_name("quality_review", "docs_v1")
-
-    assert re.fullmatch(r"[A-Za-z0-9_-]+", dotted)
     assert dotted != underscored
+    assert re.fullmatch(r"[A-Za-z0-9_-]+", dotted)
+    assert re.fullmatch(r"[A-Za-z0-9_-]+", underscored)
+
+
+def test_marketplace_and_manifest_display_name_surface_in_manager(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+    root = tmp_path / "marketplace"
+    _write_json(
+        root / ".claude-plugin" / "marketplace.json",
+        {
+            "name": "company-tools",
+            "plugins": [
+                {
+                    "name": "convex-plugin",
+                    "displayName": "Convex",
+                    "source": "./plugins/convex-plugin",
+                    "description": "Backend",
+                }
+            ],
+        },
+    )
+    plugin = root / "plugins" / "convex-plugin"
+    _write_json(
+        plugin / ".claude-plugin" / "plugin.json",
+        {"name": "convex-plugin", "displayName": "Ignored", "version": "1.0.0"},
+    )
+    _write_json(
+        plugin / ".mcp.json",
+        {"linear": {"type": "http", "url": "https://mcp.example.com"}},
+    )
+    add_local_marketplace(root)
+    install_plugin("convex-plugin@company-tools")
+
+    state = _load_manager_state()
+    row = state.installed_plugins[0]
+    assert row.display_name == "Convex"
+    assert row.label == "Convex"
+    assert row.mcp_server_names == ("linear",)
+    assert row.mcp_login_servers == (
+        scoped_mcp_server_name("convex-plugin@company-tools", "linear"),
+    )
+    entries = plugin_mcp_server_entries(discover_plugins().plugins[0])
+    assert entries == (
+        (
+            "linear",
+            scoped_mcp_server_name("convex-plugin@company-tools", "linear"),
+            True,
+        ),
+    )
 
 
 def test_marketplace_source_parser_accepts_bare_relative_directory(

--- a/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 import pytest
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.middleware.skills import _list_skills as list_sdk_skills
-from textual.widgets import OptionList
+from textual.widgets import Input, OptionList
 
 from deepagents_code._env_vars import EXPERIMENTAL
 from deepagents_code.app import DeepAgentsApp
@@ -647,6 +647,55 @@ async def test_plugin_manager_confirms_marketplace_removal(
     assert "company-tools" not in load_marketplace_records()
     assert not load_installed_plugins()
     assert marketplace_root.is_dir()
+
+
+async def test_plugin_manager_opens_add_marketplace_input(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        screen = PluginManagerScreen()
+        app.push_screen(screen)
+        await pilot.pause()
+
+        options = screen.query_one("#plugin-manager-options", OptionList)
+        assert options.option_count == 2
+        assert options.get_option_at_index(0).disabled
+        assert "No marketplaces installed" in str(options.get_option_at_index(0).prompt)
+        assert options.get_option_at_index(1).id == "add-marketplace"
+        assert options.highlighted == 1
+        help_text = str(screen.query_one("#plugin-manager-help").render())
+        assert "add marketplace" in help_text
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        source_input = screen.query_one("#plugin-marketplace-source", Input)
+        assert source_input.display is True
+        assert source_input.has_focus
+        assert (
+            str(screen.query_one("#plugin-manager-title").render()) == "Add Marketplace"
+        )
+        assert screen.query_one("#plugin-manager-tabs").display is False
+        tip = str(screen.query_one("#plugin-manager-status").render())
+        assert "Enter marketplace source:" in tip
+        assert "Examples:" in tip
+        assert "owner/repo (GitHub)" in tip
+        assert "git@github.com:owner/repo.git (SSH)" in tip
+        assert "https://example.com/marketplace.json" in tip
+        assert "./path/to/marketplace" in tip
+        help_text = str(screen.query_one("#plugin-manager-help").render())
+        assert "Enter to add" in help_text
+        assert "Esc to cancel" in help_text
 
 
 def test_plugin_mcp_config_namespaces_and_substitutes(

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -2,10 +2,22 @@
 
 import inspect
 from pathlib import Path
+from unittest.mock import MagicMock
 
+from textual.widgets import OptionList
+
+from deepagents_code.app import DeepAgentsApp
+from deepagents_code.config import get_glyphs
 from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
-from deepagents_code.tui.modals.plugin_manager.content import _plugin_options
-from deepagents_code.tui.modals.plugin_manager.models import _PluginRow
+from deepagents_code.tui.modals.plugin_manager.content import (
+    _marketplace_label,
+    _plugin_options,
+)
+from deepagents_code.tui.modals.plugin_manager.models import (
+    _ManagerState,
+    _MarketplaceRow,
+    _PluginRow,
+)
 
 
 def test_plugin_manager_css_is_colocated_with_screen() -> None:
@@ -44,3 +56,59 @@ def test_plugin_row_label_prefers_display_name() -> None:
     )
     assert row.label == "Convex"
     assert _PluginRow("linear@tools", "", False, None, None).label == "linear"
+
+
+def test_marketplace_options_omit_divider_when_empty() -> None:
+    screen = PluginManagerScreen()
+    screen._tab = "marketplaces"
+    screen._state = _ManagerState(
+        available_plugins=(),
+        installed_plugins=(),
+        marketplaces=(),
+        errors=(),
+    )
+
+    options = screen._current_options()
+
+    assert [option.id for option in options] == ["add-marketplace"]
+
+
+def test_healthy_marketplace_label_shows_available_plugins() -> None:
+    row = _MarketplaceRow("healthy", "owner/healthy", 3, 0)
+
+    label = _marketplace_label(row)
+
+    assert not row.has_error
+    assert "3 available" in label.plain
+    assert get_glyphs().error not in label.plain
+
+
+async def test_marketplace_divider_refits_on_resize() -> None:
+    """The width-sized divider shrinks with the modal on a narrower terminal."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = PluginManagerScreen()
+        app.push_screen(screen)
+        await pilot.pause()
+
+        screen._tab = "marketplaces"
+        screen._state = _ManagerState(
+            available_plugins=(),
+            installed_plugins=(),
+            marketplaces=(_MarketplaceRow("tools", "owner/repo", 2, 0),),
+            errors=(),
+        )
+        screen._refresh_view()
+        await pilot.pause()
+
+        options = screen.query_one("#plugin-manager-options", OptionList)
+        assert options.get_option_at_index(1).id == "marketplace-divider"
+        box = get_glyphs().box_horizontal
+        wide_width = str(options.get_option_at_index(1).prompt).count(box)
+        assert wide_width > 0
+
+        await pilot.resize_terminal(60, 40)
+        await pilot.pause()
+
+        narrow_width = str(options.get_option_at_index(1).prompt).count(box)
+        assert 0 < narrow_width < wide_width

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -1,27 +1,11 @@
 """Tests for the plugin manager modal structure."""
 
 import inspect
-import re
 from pathlib import Path
-from unittest.mock import MagicMock
 
-from textual.content import Content
-from textual.widgets import Static
-
-from deepagents_code.app import DeepAgentsApp
-from deepagents_code.config import get_glyphs
 from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
-from deepagents_code.tui.modals.plugin_manager.content import (
-    _installed_plugin_details_content,
-    _marketplace_label,
-    _plugin_options,
-    _plugin_prompt,
-)
-from deepagents_code.tui.modals.plugin_manager.models import (
-    _ManagerState,
-    _MarketplaceRow,
-    _PluginRow,
-)
+from deepagents_code.tui.modals.plugin_manager.content import _plugin_options
+from deepagents_code.tui.modals.plugin_manager.models import _PluginRow
 
 
 def test_plugin_manager_css_is_colocated_with_screen() -> None:
@@ -33,8 +17,10 @@ def test_plugin_manager_css_is_colocated_with_screen() -> None:
 
 def test_plugin_options_preserve_selectable_rows_and_spacers() -> None:
     rows = (
-        _PluginRow("first@source", "First", False, None, None),
-        _PluginRow("second@source", "Second", True, "1.0", "Author"),
+        _PluginRow("first@source", "First", False, None, None, display_name="First"),
+        _PluginRow(
+            "second@source", "Second", True, "1.0", "Author", display_name="Second"
+        ),
     )
 
     options = _plugin_options(rows, action="detail", status=None)
@@ -47,93 +33,14 @@ def test_plugin_options_preserve_selectable_rows_and_spacers() -> None:
     assert options[1].disabled
 
 
-def _styles_for(content: Content, text: str) -> list[str]:
-    start = content.plain.index(text)
-    end = start + len(text)
-    return [
-        str(span.style)
-        for span in content.spans
-        if span.start <= start and span.end >= end
-    ]
-
-
-def test_empty_marketplace_state_offers_direct_add_action() -> None:
-    screen = PluginManagerScreen()
-
-    options = screen._current_options()
-
-    assert [option.id for option in options] == ["empty", "add-marketplace"]
-    assert options[0].disabled
-    assert "No marketplaces installed" in str(options[0].prompt)
-    assert str(options[1].prompt) == "+ Add marketplace"
-
-
-def test_marketplace_options_include_divider_before_list() -> None:
-    screen = PluginManagerScreen()
-    screen._tab = "marketplaces"
-    screen._state = _ManagerState(
-        available_plugins=(),
-        installed_plugins=(),
-        marketplaces=(_MarketplaceRow("tools", "owner/repo", 2, 0),),
-        errors=(),
+def test_plugin_row_label_prefers_display_name() -> None:
+    row = _PluginRow(
+        "convex@tools",
+        "Backend plugin",
+        False,
+        None,
+        None,
+        display_name="Convex",
     )
-
-    options = screen._current_options()
-
-    assert [option.id for option in options] == [
-        "add-marketplace",
-        "marketplace-divider",
-        "marketplace:tools",
-    ]
-    assert options[1].disabled
-
-
-def test_enabled_status_styles() -> None:
-    row = _PluginRow("plugin@tools", "Description", True, "1.0", None)
-    enabled = f"{get_glyphs().checkmark} enabled"
-
-    assert any(
-        "bold" in style for style in _styles_for(_plugin_prompt(row, status=None), enabled)
-    )
-    assert any(
-        "$success" in style
-        for style in _styles_for(
-            _installed_plugin_details_content(row),
-            f"{get_glyphs().checkmark} Enabled",
-        )
-    )
-
-
-def test_marketplace_load_error_uses_error_style() -> None:
-    row = _MarketplaceRow("tools", "owner/repo", None, 0, "invalid manifest")
-    error_status = f"{get_glyphs().error} Error"
-
-    assert row.has_error
-    assert any(
-        "$error" in style
-        for style in _styles_for(_marketplace_label(row), error_status)
-    )
-    assert not _MarketplaceRow("healthy", "owner/healthy", 0, 0).has_error
-
-
-async def test_plugin_manager_overlays_underlying_content() -> None:
-    """Transparent modal backdrop must composite the screen underneath."""
-    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        app.theme = "textual-dark"
-        await pilot.pause()
-
-        await app.mount(Static("TOP_MARKER_VISIBLE", id="top-marker"))
-        marker = app.query_one("#top-marker")
-        marker.styles.dock = "top"
-        marker.styles.height = 1
-        await pilot.pause()
-
-        app.push_screen(PluginManagerScreen())
-        await pilot.pause()
-
-        assert app.screen.styles.background.a == 0
-        plain = re.sub(r"<[^>]+>", " ", app.export_screenshot())
-        assert "TOP_MARKER_VISIBLE" in plain
-        assert "Plugins" in plain
+    assert row.label == "Convex"
+    assert _PluginRow("linear@tools", "", False, None, None).label == "linear"

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -5,12 +5,23 @@ import re
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from textual.content import Content
 from textual.widgets import Static
 
 from deepagents_code.app import DeepAgentsApp
+from deepagents_code.config import get_glyphs
 from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
-from deepagents_code.tui.modals.plugin_manager.content import _plugin_options
-from deepagents_code.tui.modals.plugin_manager.models import _PluginRow
+from deepagents_code.tui.modals.plugin_manager.content import (
+    _installed_plugin_details_content,
+    _marketplace_label,
+    _plugin_options,
+    _plugin_prompt,
+)
+from deepagents_code.tui.modals.plugin_manager.models import (
+    _ManagerState,
+    _MarketplaceRow,
+    _PluginRow,
+)
 
 
 def test_plugin_manager_css_is_colocated_with_screen() -> None:
@@ -34,6 +45,75 @@ def test_plugin_options_preserve_selectable_rows_and_spacers() -> None:
         "detail:second@source",
     ]
     assert options[1].disabled
+
+
+def _styles_for(content: Content, text: str) -> list[str]:
+    start = content.plain.index(text)
+    end = start + len(text)
+    return [
+        str(span.style)
+        for span in content.spans
+        if span.start <= start and span.end >= end
+    ]
+
+
+def test_empty_marketplace_state_offers_direct_add_action() -> None:
+    screen = PluginManagerScreen()
+
+    options = screen._current_options()
+
+    assert [option.id for option in options] == ["empty", "add-marketplace"]
+    assert options[0].disabled
+    assert "No marketplaces installed" in str(options[0].prompt)
+    assert str(options[1].prompt) == "+ Add marketplace"
+
+
+def test_marketplace_options_include_divider_before_list() -> None:
+    screen = PluginManagerScreen()
+    screen._tab = "marketplaces"
+    screen._state = _ManagerState(
+        available_plugins=(),
+        installed_plugins=(),
+        marketplaces=(_MarketplaceRow("tools", "owner/repo", 2, 0),),
+        errors=(),
+    )
+
+    options = screen._current_options()
+
+    assert [option.id for option in options] == [
+        "add-marketplace",
+        "marketplace-divider",
+        "marketplace:tools",
+    ]
+    assert options[1].disabled
+
+
+def test_enabled_status_styles() -> None:
+    row = _PluginRow("plugin@tools", "Description", True, "1.0", None)
+    enabled = f"{get_glyphs().checkmark} enabled"
+
+    assert any(
+        "bold" in style for style in _styles_for(_plugin_prompt(row, status=None), enabled)
+    )
+    assert any(
+        "$success" in style
+        for style in _styles_for(
+            _installed_plugin_details_content(row),
+            f"{get_glyphs().checkmark} Enabled",
+        )
+    )
+
+
+def test_marketplace_load_error_uses_error_style() -> None:
+    row = _MarketplaceRow("tools", "owner/repo", None, 0, "invalid manifest")
+    error_status = f"{get_glyphs().error} Error"
+
+    assert row.has_error
+    assert any(
+        "$error" in style
+        for style in _styles_for(_marketplace_label(row), error_status)
+    )
+    assert not _MarketplaceRow("healthy", "owner/healthy", 0, 0).has_error
 
 
 async def test_plugin_manager_overlays_underlying_content() -> None:

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -2,8 +2,9 @@
 
 import inspect
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from textual.widgets import OptionList
 
 from deepagents_code.app import DeepAgentsApp
@@ -81,6 +82,70 @@ def test_healthy_marketplace_label_shows_available_plugins() -> None:
     assert not row.has_error
     assert "3 available" in label.plain
     assert get_glyphs().error not in label.plain
+
+
+async def test_install_dismisses_reconnect_from_installed_instance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discover rows lack MCP metadata; install must inspect the returned instance."""
+    screen = PluginManagerScreen()
+    screen._selected_plugin = _PluginRow(
+        "linear@tools",
+        "Linear plugin",
+        False,
+        None,
+        None,
+        display_name="Linear",
+    )
+    assert screen._selected_plugin.mcp_server_names == ()
+
+    monkeypatch.setattr(
+        "deepagents_code.tui.modals.plugin_manager.install_plugin",
+        lambda _plugin_id: object(),
+    )
+    monkeypatch.setattr(
+        "deepagents_code.plugins.adapters.mcp.plugin_mcp_server_entries",
+        lambda _instance: (("linear", "linear__linear@tools", True),),
+    )
+    monkeypatch.setattr(screen, "_refresh_state", AsyncMock())
+    monkeypatch.setattr(screen, "notify", MagicMock())
+    dismiss = MagicMock()
+    monkeypatch.setattr(screen, "dismiss", dismiss)
+
+    await screen._install_selected_plugin()
+
+    dismiss.assert_called_once_with(("Linear", True))
+
+
+async def test_install_keeps_manager_open_without_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    screen = PluginManagerScreen()
+    screen._selected_plugin = _PluginRow(
+        "skills@tools",
+        "Skills only",
+        False,
+        None,
+        None,
+        display_name="Skills",
+    )
+
+    monkeypatch.setattr(
+        "deepagents_code.tui.modals.plugin_manager.install_plugin",
+        lambda _plugin_id: object(),
+    )
+    monkeypatch.setattr(
+        "deepagents_code.plugins.adapters.mcp.plugin_mcp_server_entries",
+        lambda _instance: (),
+    )
+    monkeypatch.setattr(screen, "_refresh_state", AsyncMock())
+    monkeypatch.setattr(screen, "notify", MagicMock())
+    dismiss = MagicMock()
+    monkeypatch.setattr(screen, "dismiss", dismiss)
+
+    await screen._install_selected_plugin()
+
+    dismiss.assert_not_called()
 
 
 async def test_marketplace_divider_refits_on_resize() -> None:


### PR DESCRIPTION
Closes [DCD-48](https://linear.app/langchain/issue/DCD-48/plugins-improve-empty-marketplace-onboarding-and-list-polish)


`/plugins` empty Discover state now links straight to adding a marketplace, with clearer marketplace error and enabled-status styling.

---

Make `/plugins` easier to onboard and a bit clearer to scan:

- empty Discover state offers a direct Add marketplace action
- marketplaces list gets a divider and styled load-error labels
- plugin rows use per-chip styling; enabled stays bold on highlight and `$success` in details