### PR TITLE
feat(code): Debug Console thread ID click-to-copy with LangSmith link

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -17018,7 +17018,7 @@ class DeepAgentsApp(App):
         because a diagnostic tool must still open when the app is misbehaving.
 
         Returns:
-            Ordered ``(label, value)`` fields for the console header.
+            Ordered `SnapshotField` rows for the console header.
         """
         from deepagents_code._debug import installed_debug_log_path
         from deepagents_code._env_vars import DEBUG, is_env_truthy
@@ -17056,7 +17056,7 @@ class DeepAgentsApp(App):
             # diagnostic overlay must open even when a subsystem misbehaves.
             try:
                 thread_id = self._lc_thread_id
-            except Exception as exc:  # a diagnostic must still open on a bad field
+            except Exception as exc:
                 logger.warning("Debug snapshot field 'Thread' failed", exc_info=True)
                 return SnapshotField(
                     label="Thread", value=f"(unavailable: {type(exc).__name__})"

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -16391,6 +16391,24 @@ class DeepAgentsApp(App):
                 f"/ {stats.request_count} req"
             )
 
+        def _thread_field() -> SnapshotField:
+            # Built directly (not via `_safe`) so the copyable/link metadata can
+            # ride along with the value; still degrades defensively because a
+            # diagnostic overlay must open even when a subsystem misbehaves.
+            try:
+                thread_id = self._lc_thread_id
+            except Exception as exc:  # a diagnostic must still open on a bad field
+                logger.warning("Debug snapshot field 'Thread' failed", exc_info=True)
+                return SnapshotField(
+                    label="Thread", value=f"(unavailable: {type(exc).__name__})"
+                )
+            return SnapshotField(
+                label="Thread",
+                value=thread_id or "(none)",
+                copyable=bool(thread_id),
+                thread_id=thread_id,
+            )
+
         def _log_path() -> str:
             path = installed_debug_log_path()
             if path:
@@ -16406,7 +16424,7 @@ class DeepAgentsApp(App):
         return [
             _safe("Version", lambda: __version__),
             _safe("Model", lambda: self._effective_model_spec() or "(not configured)"),
-            _safe("Thread", lambda: self._lc_thread_id or "(none)"),
+            _thread_field(),
             _safe("CWD", lambda: self._cwd),
             _safe("Auto-approve", lambda: "on" if self._auto_approve else "off"),
             _safe("Sandbox", lambda: self._sandbox_type or "local"),

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -3792,6 +3792,29 @@ def build_langsmith_thread_url(thread_id: str) -> str | None:
     return _assemble_langsmith_thread_url(project_url, thread_id)
 
 
+def get_cached_langsmith_thread_url(thread_id: str) -> str | None:
+    """Build a LangSmith thread URL only when its project URL is cached.
+
+    This non-blocking variant lets transient UI surfaces render a previously
+    resolved link immediately without repeating or scheduling another lookup.
+
+    Args:
+        thread_id: Thread identifier to build the URL for.
+
+    Returns:
+        Full thread URL string when the active project's URL is already cached,
+        otherwise `None`.
+    """
+    project_name = get_langsmith_project_name()
+    if not project_name or _langsmith_url_cache is None:
+        return None
+
+    cached_name, cached_url = _langsmith_url_cache
+    if cached_name != project_name:
+        return None
+    return _assemble_langsmith_thread_url(cached_url, thread_id)
+
+
 def reset_langsmith_url_cache() -> None:
     """Reset the LangSmith URL cache (for testing)."""
     global _langsmith_url_cache  # noqa: PLW0603  # Module-level cache requires global statement

--- a/libs/code/deepagents_code/tui/widgets/debug_console.py
+++ b/libs/code/deepagents_code/tui/widgets/debug_console.py
@@ -55,12 +55,11 @@ r"""Textual key name for the `Ctrl+\` chord that toggles the console."""
 
 
 class SnapshotField(NamedTuple):
-    """A single `label`/`value` row in the console's session snapshot.
+    """A single row in the console's session snapshot.
 
-    A named pair (rather than a bare ``tuple[str, str]``) so the two display-only
-    string slots cannot be silently transposed at the construction site. The
-    optional flags let a row opt into click-to-copy and, for the thread row, a
-    resolvable ``(langsmith)`` trace link.
+    The four named fields keep the display strings and their interaction metadata
+    explicit at construction sites. `copyable` opts a row into click-to-copy, and
+    `thread_id` enables a resolvable `(langsmith)` trace link for the thread row.
     """
 
     label: str
@@ -711,7 +710,7 @@ class DebugConsoleScreen(ModalScreen[None]):
         """Initialize with a captured *snapshot* of session/runtime fields.
 
         Args:
-            snapshot: Ordered `(label, value)` fields rendered in the header.
+            snapshot: Ordered `SnapshotField` rows rendered in the header.
         """
         super().__init__()
         self._snapshot = list(snapshot)
@@ -774,23 +773,37 @@ class DebugConsoleScreen(ModalScreen[None]):
     async def _fetch_langsmith_link(self, thread_id: str) -> None:
         """Resolve a thread's LangSmith URL and re-render the snapshot.
 
-        Mirrors the welcome banner: the lookup runs in a thread with a short
-        timeout so an unreachable LangSmith never blocks the console, and any
-        failure degrades to no link rather than surfacing an error in a
-        diagnostic overlay.
+        Follows the welcome banner's thread + short-timeout pattern so an
+        unreachable LangSmith never blocks the console, but splits error
+        handling by expectedness: an expected timeout/I/O failure degrades
+        quietly to no link, while an unexpected error is logged loudly so a
+        genuine resolution bug is not hidden inside the diagnostic overlay.
         """
         from deepagents_code.config import build_langsmith_thread_url
 
-        # A diagnostic overlay must not crash on a lookup failure, so every
-        # error degrades to no link.
         try:
             url = await asyncio.wait_for(
                 asyncio.to_thread(build_langsmith_thread_url, thread_id),
                 timeout=2.0,
             )
-        except (TimeoutError, Exception):
+        except (TimeoutError, OSError):
+            # Expected: the outer timeout fired or a network error escaped the
+            # helper. A passive convenience link merely fails to appear.
             logger.debug(
-                "LangSmith thread URL lookup failed for %r", thread_id, exc_info=True
+                "LangSmith thread URL lookup timed out/failed for %r",
+                thread_id,
+                exc_info=True,
+            )
+            return
+        except Exception:  # a diagnostic overlay must not crash on a lookup bug
+            # Unexpected: a real defect in URL resolution. WARNING (not DEBUG) so
+            # the traceback lands in the always-on in-memory buffer and is visible
+            # in the console itself; the package logger sits at INFO by default,
+            # which drops DEBUG.
+            logger.warning(
+                "LangSmith thread URL lookup errored unexpectedly for %r",
+                thread_id,
+                exc_info=True,
             )
             return
         if url:

--- a/libs/code/deepagents_code/tui/widgets/debug_console.py
+++ b/libs/code/deepagents_code/tui/widgets/debug_console.py
@@ -8,6 +8,7 @@ point-in-time session/runtime snapshot plus a live tail of recent
 
 from __future__ import annotations
 
+import asyncio
 import bisect
 import logging
 from typing import TYPE_CHECKING, ClassVar, Literal, NamedTuple, cast, get_args
@@ -22,6 +23,7 @@ from textual.geometry import Size
 from textual.screen import ModalScreen
 from textual.scroll_view import ScrollView
 from textual.strip import Strip
+from textual.style import Style as TStyle
 from textual.widgets import Select, Static
 from textual.widgets._select import (  # noqa: PLC2701  # needed to keep Tab navigation inside the open Select overlay
     SelectCurrent,
@@ -37,6 +39,7 @@ from deepagents_code._debug_buffer import (
     retention_bucket_for_level,
 )
 from deepagents_code.clipboard import copy_text_to_clipboard
+from deepagents_code.tui.widgets._links import open_style_link
 from deepagents_code.unicode_security import sanitize_control_chars
 
 if TYPE_CHECKING:
@@ -55,11 +58,22 @@ class SnapshotField(NamedTuple):
     """A single `label`/`value` row in the console's session snapshot.
 
     A named pair (rather than a bare ``tuple[str, str]``) so the two display-only
-    string slots cannot be silently transposed at the construction site.
+    string slots cannot be silently transposed at the construction site. The
+    optional flags let a row opt into click-to-copy and, for the thread row, a
+    resolvable ``(langsmith)`` trace link.
     """
 
     label: str
     value: str
+    copyable: bool = False
+    """Whether `value` can be clicked to copy it to the clipboard."""
+    thread_id: str | None = None
+    """A LangSmith thread id whose ``(langsmith)`` trace link is appended to the
+    row once the URL resolves. `None` disables the link."""
+
+
+_SNAPSHOT_COPY_META = "snapshot_copy"
+"""Meta key marking a snapshot span whose text is copied on click."""
 
 
 _REFRESH_INTERVAL = 0.5
@@ -554,6 +568,63 @@ class _DebugLogView(ScrollView, can_focus=True):
         self._on_copy_record(record)
 
 
+def _snapshot_copy_text(style: object) -> str | None:
+    """Return the copy payload from a snapshot span style, if any.
+
+    Args:
+        style: The Textual event style under the pointer/click.
+
+    Returns:
+        The text to copy when the span carries a copy marker, else `None`.
+    """
+    meta = getattr(style, "meta", None)
+    if not isinstance(meta, dict):
+        return None
+    text = meta.get(_SNAPSHOT_COPY_META)
+    return text if isinstance(text, str) and text else None
+
+
+class _SnapshotView(Static):
+    """Snapshot header that copies marked spans and opens link spans on click."""
+
+    # Match WelcomeBanner: disabling auto_links avoids a hover-refresh flicker
+    # loop caused by link styles getting a fresh random id on every render.
+    auto_links = False
+
+    def __init__(
+        self, on_copy: Callable[[str], None], *, classes: str | None = None
+    ) -> None:
+        """Initialize with a callback used to copy a clicked span's text.
+
+        Args:
+            on_copy: Called with the span text when a copyable span is clicked.
+            classes: Optional space-separated CSS classes.
+        """
+        super().__init__(classes=classes)
+        self._on_copy = on_copy
+
+    def on_click(self, event: events.Click) -> None:
+        """Copy a marked span or open a link span under the click."""
+        if getattr(event.style, "link", None):
+            open_style_link(event)
+            return
+        text = _snapshot_copy_text(event.style)
+        if text is not None:
+            event.stop()
+            self._on_copy(text)
+
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        """Show a hand pointer over clickable spans and reset it elsewhere."""
+        clickable = bool(getattr(event.style, "link", None)) or (
+            _snapshot_copy_text(event.style) is not None
+        )
+        self.styles.pointer = "pointer" if clickable else "default"
+
+    def on_leave(self) -> None:
+        """Reset the pointer shape when the mouse leaves the snapshot."""
+        self.styles.pointer = "default"
+
+
 class DebugConsoleScreen(ModalScreen[None]):
     """Modal showing a session snapshot and a live tail of recent log records."""
 
@@ -650,6 +721,9 @@ class DebugConsoleScreen(ModalScreen[None]):
         # One-shot guard so the "buffer unavailable" notice is written only once.
         self._missing_notice_shown = False
         self._level_filter: FilterValue = "all"
+        # Resolved LangSmith thread URLs keyed by thread id, filled in by a
+        # background worker after mount (network I/O must not block open).
+        self._langsmith_urls: dict[str, str] = {}
 
     def compose(self) -> ComposeResult:
         """Lay out the title, snapshot, filter, log tail, and key-hint footer.
@@ -659,7 +733,11 @@ class DebugConsoleScreen(ModalScreen[None]):
         """
         with Vertical():
             yield Static("Debug Console", classes="debug-console-title")
-            yield Static(self._render_snapshot(), classes="debug-console-snapshot")
+            snapshot_view = _SnapshotView(
+                self._copy_snapshot_value, classes="debug-console-snapshot"
+            )
+            snapshot_view.update(self._render_snapshot())
+            yield snapshot_view
             with Horizontal(classes="debug-console-toolbar"):
                 yield Static("Level", classes="debug-console-filter-label")
                 yield _LogLevelSelect(
@@ -680,7 +758,56 @@ class DebugConsoleScreen(ModalScreen[None]):
         """Start the refresh timer and render the current buffer contents."""
         self.set_interval(_REFRESH_INTERVAL, self._poll_logs)
         self._poll_logs()
+        self._resolve_langsmith_links()
         self.call_after_refresh(self.query_one("#debug-log", _DebugLogView).focus)
+
+    def _resolve_langsmith_links(self) -> None:
+        """Kick off background resolution of `(langsmith)` links for the snapshot."""
+        thread_ids = {field.thread_id for field in self._snapshot if field.thread_id}
+        for thread_id in thread_ids:
+            self.run_worker(
+                self._fetch_langsmith_link(thread_id),
+                exclusive=False,
+                group="debug-console-langsmith",
+            )
+
+    async def _fetch_langsmith_link(self, thread_id: str) -> None:
+        """Resolve a thread's LangSmith URL and re-render the snapshot.
+
+        Mirrors the welcome banner: the lookup runs in a thread with a short
+        timeout so an unreachable LangSmith never blocks the console, and any
+        failure degrades to no link rather than surfacing an error in a
+        diagnostic overlay.
+        """
+        from deepagents_code.config import build_langsmith_thread_url
+
+        # A diagnostic overlay must not crash on a lookup failure, so every
+        # error degrades to no link.
+        try:
+            url = await asyncio.wait_for(
+                asyncio.to_thread(build_langsmith_thread_url, thread_id),
+                timeout=2.0,
+            )
+        except (TimeoutError, Exception):
+            logger.debug(
+                "LangSmith thread URL lookup failed for %r", thread_id, exc_info=True
+            )
+            return
+        if url:
+            self._langsmith_urls[thread_id] = url
+            self._refresh_snapshot()
+
+    def _refresh_snapshot(self) -> None:
+        """Re-render the snapshot header in place (e.g. after a link resolves)."""
+        from textual.css.query import NoMatches
+
+        try:
+            self.query_one(".debug-console-snapshot", _SnapshotView).update(
+                self._render_snapshot()
+            )
+        except NoMatches:
+            # The console was dismissed before the worker returned.
+            logger.debug("Debug console snapshot refresh skipped (widget unavailable)")
 
     def key_tab(self, event: events.Key) -> None:
         """Cycle focus between the level filter and log lines."""
@@ -722,12 +849,33 @@ class DebugConsoleScreen(ModalScreen[None]):
         """
         if not self._snapshot:
             return Content.styled("(no session data)", "dim italic")
-        width = max(len(label) for label, _ in self._snapshot)
-        lines = [
-            Content.assemble((f"{label:>{width}}  ", "bold"), value)
-            for label, value in self._snapshot
-        ]
+        width = max(len(field.label) for field in self._snapshot)
+        lines = [self._render_snapshot_row(field, width) for field in self._snapshot]
         return Content("\n").join(lines)
+
+    def _render_snapshot_row(self, field: SnapshotField, width: int) -> Content:
+        """Render a single snapshot row, wiring up copy and link spans.
+
+        Args:
+            field: The snapshot field to render.
+            width: Column width the labels are right-aligned to.
+
+        Returns:
+            The formatted row content.
+        """
+        parts: list[str | tuple[str, str | TStyle]] = [
+            (f"{field.label:>{width}}  ", "bold")
+        ]
+        if field.copyable and field.value:
+            parts.append(
+                (field.value, TStyle.from_meta({_SNAPSHOT_COPY_META: field.value}))
+            )
+        else:
+            parts.append(field.value)
+        url = self._langsmith_urls.get(field.thread_id) if field.thread_id else None
+        if url:
+            parts.extend(("  ", ("(langsmith)", TStyle(link=url))))
+        return Content.assemble(*parts)
 
     @staticmethod
     def _render_help() -> Content:
@@ -737,7 +885,8 @@ class DebugConsoleScreen(ModalScreen[None]):
             The formatted key-hint line.
         """
         return Content.styled(
-            "Esc close · Ctrl+L clear view · c copy visible logs · click copy line",
+            "Esc close · Ctrl+L clear view · c copy visible logs · "
+            "click copy line/thread",
             "dim italic",
         )
 
@@ -855,13 +1004,27 @@ class DebugConsoleScreen(ModalScreen[None]):
         """Copy a clicked logical log record to the clipboard."""
         self._copy_lines([record.plain_line], empty_message="No log line to copy")
 
+    def _copy_snapshot_value(self, text: str) -> None:
+        """Copy a clicked snapshot value (e.g. the thread ID) to the clipboard."""
+        self._copy_lines(
+            [text],
+            empty_message="Nothing to copy",
+            success_message="Thread ID copied",
+        )
+
     def _level_select(self) -> Select[FilterValue]:
         """Return the level-filter dropdown."""
         return cast(
             "Select[FilterValue]", self.query_one("#debug-level-filter", Select)
         )
 
-    def _copy_lines(self, lines: Sequence[str], *, empty_message: str) -> None:
+    def _copy_lines(
+        self,
+        lines: Sequence[str],
+        *,
+        empty_message: str,
+        success_message: str = "Debug log copied",
+    ) -> None:
         """Copy lines to clipboard with user-visible feedback."""
         text = "\n".join(lines)
         if not text:
@@ -872,12 +1035,12 @@ class DebugConsoleScreen(ModalScreen[None]):
         success, error = copy_text_to_clipboard(self.app, text)
         if success:
             self.app.notify(
-                "Debug log copied", severity="information", timeout=2, markup=False
+                success_message, severity="information", timeout=2, markup=False
             )
             return
         suffix = f": {error}" if error else ""
         self.app.notify(
-            f"Failed to copy debug log{suffix}",
+            f"Failed to copy{suffix}",
             severity="warning",
             timeout=3,
             markup=False,

--- a/libs/code/deepagents_code/tui/widgets/debug_console.py
+++ b/libs/code/deepagents_code/tui/widgets/debug_console.py
@@ -720,9 +720,29 @@ class DebugConsoleScreen(ModalScreen[None]):
         # One-shot guard so the "buffer unavailable" notice is written only once.
         self._missing_notice_shown = False
         self._level_filter: FilterValue = "all"
-        # Resolved LangSmith thread URLs keyed by thread id, filled in by a
-        # background worker after mount (network I/O must not block open).
-        self._langsmith_urls: dict[str, str] = {}
+        # Seed links resolved elsewhere in this process (normally the welcome
+        # banner) so reopening the console does not briefly render without one.
+        self._langsmith_urls = self._cached_langsmith_urls()
+
+    def _cached_langsmith_urls(self) -> dict[str, str]:
+        """Return immediately available LangSmith URLs for snapshot threads."""
+        from deepagents_code.config import get_cached_langsmith_thread_url
+
+        urls: dict[str, str] = {}
+        thread_ids = {field.thread_id for field in self._snapshot if field.thread_id}
+        for thread_id in thread_ids:
+            try:
+                url = get_cached_langsmith_thread_url(thread_id)
+            except Exception:  # a diagnostic overlay must always be able to open
+                logger.warning(
+                    "Cached LangSmith thread URL lookup errored for %r",
+                    thread_id,
+                    exc_info=True,
+                )
+                continue
+            if url:
+                urls[thread_id] = url
+        return urls
 
     def compose(self) -> ComposeResult:
         """Lay out the title, snapshot, filter, log tail, and key-hint footer.
@@ -762,7 +782,11 @@ class DebugConsoleScreen(ModalScreen[None]):
 
     def _resolve_langsmith_links(self) -> None:
         """Kick off background resolution of `(langsmith)` links for the snapshot."""
-        thread_ids = {field.thread_id for field in self._snapshot if field.thread_id}
+        thread_ids = {
+            field.thread_id
+            for field in self._snapshot
+            if field.thread_id and field.thread_id not in self._langsmith_urls
+        }
         for thread_id in thread_ids:
             self.run_worker(
                 self._fetch_langsmith_link(thread_id),

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -42,6 +42,7 @@ from deepagents_code.config import (
     detect_provider,
     fetch_langsmith_project_url,
     fetch_langsmith_project_url_or_raise,
+    get_cached_langsmith_thread_url,
     get_langsmith_project_name,
     is_http_url,
     is_langsmith_redaction_enabled,
@@ -3443,6 +3444,43 @@ class TestBuildLangsmithThreadUrl:
             result
             == "https://smith.langchain.com/o/org/projects/p/proj/t/thread-123?utm_source=deepagents-code"
         )
+
+    def test_cached_url_is_available_without_another_lookup(self) -> None:
+        """A resolved project URL can build later thread links synchronously."""
+
+        class FakeProject:
+            url = "https://smith.langchain.com/o/org/projects/p/proj"
+
+        with (
+            patch(
+                "deepagents_code.config.get_langsmith_project_name",
+                return_value="my-project",
+            ),
+            patch("langsmith.Client") as mock_client_cls,
+        ):
+            mock_client_cls.return_value.read_project.return_value = FakeProject()
+            build_langsmith_thread_url("thread-123")
+            result = get_cached_langsmith_thread_url("thread-456")
+
+        assert (
+            result
+            == "https://smith.langchain.com/o/org/projects/p/proj/t/thread-456?utm_source=deepagents-code"
+        )
+        mock_client_cls.return_value.read_project.assert_called_once()
+
+    def test_cached_url_does_not_trigger_initial_lookup(self) -> None:
+        """A cache miss remains synchronous and never contacts LangSmith."""
+        with (
+            patch(
+                "deepagents_code.config.get_langsmith_project_name",
+                return_value="my-project",
+            ),
+            patch("langsmith.Client") as mock_client_cls,
+        ):
+            result = get_cached_langsmith_thread_url("thread-123")
+
+        assert result is None
+        mock_client_cls.assert_not_called()
 
     def test_strips_trailing_slash(self) -> None:
         """Should not produce double slashes when project URL has trailing slash."""

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -65,6 +65,12 @@ def _snapshot() -> list[SnapshotField]:
     ]
 
 
+def test_snapshot_field_tuple_contract_includes_interaction_metadata() -> None:
+    field = SnapshotField("Thread", "thread-abc", copyable=True, thread_id="thread-abc")
+
+    assert tuple(field) == ("Thread", "thread-abc", True, "thread-abc")
+
+
 class TestDebugConsoleScreen:
     async def test_renders_snapshot_fields(self) -> None:
         app = _Harness()
@@ -816,8 +822,9 @@ class TestDebugConsoleScreen:
             await pilot.pause()
 
             snapshot_widget = screen.query_one(".debug-console-snapshot", Static)
-            # Row renders as "Thread  thread-abc"; the value starts at column 8,
-            # so an x offset of 10 lands inside the copyable span.
+            # Single "Thread" field: label (6 chars) + 2-space gutter puts the
+            # value at column 8, so an x offset of 10 lands inside the copyable
+            # span. (Holds only while "Thread" is the widest label in this test.)
             await pilot.click(snapshot_widget, offset=(10, 0))
             await pilot.pause()
 
@@ -867,6 +874,149 @@ class TestDebugConsoleScreen:
             await pilot.pause()
 
         assert screen._langsmith_urls["thread-abc"] == url
+
+    async def test_fetch_langsmith_link_io_error_logs_debug_and_degrades(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import deepagents_code.config as config_mod
+
+        def boom(_thread_id: str) -> str:
+            msg = "network unavailable"
+            raise OSError(msg)
+
+        monkeypatch.setattr(config_mod, "build_langsmith_thread_url", boom)
+        caplog.set_level(logging.DEBUG, logger=debug_console_mod.__name__)
+        screen = DebugConsoleScreen(
+            [SnapshotField("Thread", "thread-abc", thread_id="thread-abc")]
+        )
+
+        await screen._fetch_langsmith_link("thread-abc")
+
+        assert screen._langsmith_urls == {}
+        records = [
+            record
+            for record in caplog.records
+            if record.name == debug_console_mod.__name__
+            and "timed out/failed" in record.getMessage()
+        ]
+        assert len(records) == 1
+        assert records[0].levelno == logging.DEBUG
+        assert records[0].exc_info is not None
+
+    async def test_fetch_langsmith_link_unexpected_error_logs_warning_and_degrades(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import deepagents_code.config as config_mod
+
+        def boom(_thread_id: str) -> str:
+            msg = "resolution bug"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(config_mod, "build_langsmith_thread_url", boom)
+        caplog.set_level(logging.WARNING, logger=debug_console_mod.__name__)
+        screen = DebugConsoleScreen(
+            [SnapshotField("Thread", "thread-abc", thread_id="thread-abc")]
+        )
+
+        await screen._fetch_langsmith_link("thread-abc")
+
+        assert screen._langsmith_urls == {}
+        records = [
+            record
+            for record in caplog.records
+            if record.name == debug_console_mod.__name__
+            and "errored unexpectedly" in record.getMessage()
+        ]
+        assert len(records) == 1
+        assert records[0].levelno == logging.WARNING
+        assert records[0].exc_info is not None
+
+    async def test_fetch_langsmith_link_none_result_stores_nothing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import deepagents_code.config as config_mod
+
+        monkeypatch.setattr(
+            config_mod, "build_langsmith_thread_url", lambda _thread_id: None
+        )
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            screen = DebugConsoleScreen(
+                [SnapshotField("Thread", "thread-abc", thread_id="thread-abc")]
+            )
+            app.push_screen(screen)
+            await pilot.pause()
+
+            refreshed: list[bool] = []
+            monkeypatch.setattr(
+                screen, "_refresh_snapshot", lambda: refreshed.append(True)
+            )
+            await screen._fetch_langsmith_link("thread-abc")
+            await pilot.pause()
+
+        # An unconfigured LangSmith (the common case) resolves to None: nothing
+        # is stored and no needless re-render is triggered.
+        assert screen._langsmith_urls == {}
+        assert refreshed == []
+
+    async def test_refresh_snapshot_without_widget_is_noop(self) -> None:
+        app = _Harness()
+        async with app.run_test():
+            screen = DebugConsoleScreen(
+                [SnapshotField("Thread", "thread-abc", thread_id="thread-abc")]
+            )
+            # Never pushed/composed, so the snapshot widget doesn't exist -- the
+            # same state as a worker resolving after the console was dismissed.
+            # The NoMatches guard must swallow this rather than raise.
+            screen._refresh_snapshot()
+
+    async def test_clicking_langsmith_link_opens_it_without_copying(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        opened: list[object] = []
+        monkeypatch.setattr(
+            debug_console_mod, "open_style_link", lambda event: opened.append(event)
+        )
+        copied: list[str] = []
+
+        def fake_copy(_app: App, text: str) -> tuple[bool, str | None]:
+            copied.append(text)
+            return True, None
+
+        monkeypatch.setattr(debug_console_mod, "copy_text_to_clipboard", fake_copy)
+
+        url = "https://smith.langchain.com/o/org/projects/p/proj/t/thread-abc"
+        app = _Harness()
+        async with app.run_test() as pilot:
+            screen = DebugConsoleScreen(
+                [
+                    SnapshotField(
+                        "Thread", "thread-abc", copyable=True, thread_id="thread-abc"
+                    )
+                ]
+            )
+            app.push_screen(screen)
+            await pilot.pause()
+
+            screen._langsmith_urls["thread-abc"] = url
+            screen._refresh_snapshot()
+            await pilot.pause()
+
+            snapshot_widget = screen.query_one(".debug-console-snapshot", Static)
+            # Row renders "Thread  thread-abc  (langsmith)": label (6) + 2-space
+            # gutter = col 8, value (10 chars) spans 8-17, 2-space gap, then
+            # "(langsmith)" starts at col 20. An x offset of 22 is inside it.
+            await pilot.click(snapshot_widget, offset=(22, 0))
+            await pilot.pause()
+
+        # The link branch wins and returns early: the trace opens, no copy fires.
+        assert len(opened) == 1
+        assert copied == []
 
     async def test_copy_failure_notifies_warning(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1060,6 +1210,32 @@ class TestDebugConsoleToggle:
             assert thread_field.value == "thread-xyz"
             assert thread_field.copyable is True
             assert thread_field.thread_id == "thread-xyz"
+
+    async def test_build_snapshot_thread_field_degrades_when_lookup_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        async with app.run_test():
+
+            def boom(_self: object) -> str:
+                msg = "bad thread"
+                raise RuntimeError(msg)
+
+            # A class-level data descriptor shadows the instance attribute, so
+            # reading `self._lc_thread_id` inside `_thread_field` raises.
+            # (`raising=False`: it's normally only an instance attribute.)
+            monkeypatch.setattr(
+                type(app), "_lc_thread_id", property(boom), raising=False
+            )
+            thread_field = next(
+                field
+                for field in app._build_debug_snapshot()
+                if field.label == "Thread"
+            )
+            # The Thread row degrades to a safe, non-interactive placeholder.
+            assert thread_field.value.startswith("(unavailable:")
+            assert thread_field.copyable is False
+            assert thread_field.thread_id is None
 
     async def test_build_snapshot_formats_mcp_servers(self) -> None:
         app = DeepAgentsApp(agent=MagicMock(), thread_id="t")

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -34,6 +34,10 @@ def _widget_text(widget: Static) -> str:
     return str(widget.render())
 
 
+def _snapshot_dict(fields: list[SnapshotField]) -> dict[str, str]:
+    return {field.label: field.value for field in fields}
+
+
 def _log_record(
     message: str, *, level: str = "INFO", levelno: int = logging.INFO
 ) -> InMemoryLogRecord:
@@ -745,6 +749,125 @@ class TestDebugConsoleScreen:
 
         assert "debug-console-click-copy-marker" in captured["text"]
 
+    async def test_thread_field_click_copies_thread_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, str] = {}
+
+        def fake_copy(_app: App, text: str) -> tuple[bool, str | None]:
+            captured["text"] = text
+            return True, None
+
+        monkeypatch.setattr(debug_console_mod, "copy_text_to_clipboard", fake_copy)
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            screen = DebugConsoleScreen(
+                [SnapshotField("Thread", "thread-abc", copyable=True)]
+            )
+            app.push_screen(screen)
+            await pilot.pause()
+
+            screen._copy_snapshot_value("thread-abc")
+            await pilot.pause()
+
+        assert captured["text"] == "thread-abc"
+        latest = list(app._notifications)[-1]
+        assert latest.severity == "information"
+        assert latest.message == "Thread ID copied"
+
+    async def test_langsmith_link_renders_after_resolution(self) -> None:
+        app = _Harness()
+        async with app.run_test() as pilot:
+            screen = DebugConsoleScreen(
+                [SnapshotField("Thread", "thread-abc", thread_id="thread-abc")]
+            )
+            app.push_screen(screen)
+            await pilot.pause()
+
+            snapshot_widget = screen.query_one(".debug-console-snapshot", Static)
+            assert "(langsmith)" not in _widget_text(snapshot_widget)
+
+            screen._langsmith_urls["thread-abc"] = (
+                "https://smith.langchain.com/o/org/projects/p/proj/t/thread-abc"
+            )
+            screen._refresh_snapshot()
+            await pilot.pause()
+
+            assert "(langsmith)" in _widget_text(snapshot_widget)
+
+    async def test_clicking_thread_value_copies_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, str] = {}
+
+        def fake_copy(_app: App, text: str) -> tuple[bool, str | None]:
+            captured["text"] = text
+            return True, None
+
+        monkeypatch.setattr(debug_console_mod, "copy_text_to_clipboard", fake_copy)
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            screen = DebugConsoleScreen(
+                [SnapshotField("Thread", "thread-abc", copyable=True)]
+            )
+            app.push_screen(screen)
+            await pilot.pause()
+
+            snapshot_widget = screen.query_one(".debug-console-snapshot", Static)
+            # Row renders as "Thread  thread-abc"; the value starts at column 8,
+            # so an x offset of 10 lands inside the copyable span.
+            await pilot.click(snapshot_widget, offset=(10, 0))
+            await pilot.pause()
+
+        assert captured["text"] == "thread-abc"
+
+    async def test_copyable_value_carries_copy_meta_span(self) -> None:
+        app = _Harness()
+        async with app.run_test() as pilot:
+            screen = DebugConsoleScreen(
+                [SnapshotField("Thread", "thread-abc", copyable=True)]
+            )
+            app.push_screen(screen)
+            await pilot.pause()
+
+            content = screen._render_snapshot()
+            copy_spans = [
+                span
+                for span in content.spans
+                if isinstance(span.style, debug_console_mod.TStyle)
+                and span.style.meta.get(debug_console_mod._SNAPSHOT_COPY_META)
+                == "thread-abc"
+            ]
+            assert any(
+                content.plain[span.start : span.end] == "thread-abc"
+                for span in copy_spans
+            )
+
+    async def test_fetch_langsmith_link_stores_resolved_url(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import deepagents_code.config as config_mod
+
+        url = "https://smith.langchain.com/o/org/projects/p/proj/t/thread-abc"
+        monkeypatch.setattr(
+            config_mod, "build_langsmith_thread_url", lambda _thread_id: url
+        )
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            screen = DebugConsoleScreen(
+                [SnapshotField("Thread", "thread-abc", thread_id="thread-abc")]
+            )
+            app.push_screen(screen)
+            await pilot.pause()
+
+            await screen._fetch_langsmith_link("thread-abc")
+            await pilot.pause()
+
+        assert screen._langsmith_urls["thread-abc"] == url
+
     async def test_copy_failure_notifies_warning(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -919,12 +1042,24 @@ class TestDebugConsoleToggle:
     async def test_build_snapshot_contains_core_fields(self) -> None:
         app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-xyz", cwd="/tmp/work")
         async with app.run_test():
-            snapshot = dict(app._build_debug_snapshot())
+            snapshot = _snapshot_dict(app._build_debug_snapshot())
             assert snapshot["Thread"] == "thread-xyz"
             assert snapshot["CWD"] == "/tmp/work"
             assert "Version" in snapshot
             assert "Auto-approve" in snapshot
             assert snapshot["MCP servers"] == "none"
+
+    async def test_build_snapshot_thread_field_is_copyable_and_linkable(self) -> None:
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-xyz")
+        async with app.run_test():
+            thread_field = next(
+                field
+                for field in app._build_debug_snapshot()
+                if field.label == "Thread"
+            )
+            assert thread_field.value == "thread-xyz"
+            assert thread_field.copyable is True
+            assert thread_field.thread_id == "thread-xyz"
 
     async def test_build_snapshot_formats_mcp_servers(self) -> None:
         app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
@@ -934,7 +1069,7 @@ class TestDebugConsoleToggle:
                 SimpleNamespace(name="web", status="error"),
             ]
             app._mcp_server_info = servers  # ty: ignore[invalid-assignment]  # stub servers expose .name/.status
-            snapshot = dict(app._build_debug_snapshot())
+            snapshot = _snapshot_dict(app._build_debug_snapshot())
             assert snapshot["MCP servers"] == "fs (connected), web (error)"
 
     async def test_build_snapshot_degrades_on_field_error(
@@ -948,7 +1083,7 @@ class TestDebugConsoleToggle:
                 raise RuntimeError(msg)
 
             monkeypatch.setattr(app, "_effective_model_spec", boom)
-            snapshot = dict(app._build_debug_snapshot())
+            snapshot = _snapshot_dict(app._build_debug_snapshot())
             # The failing field degrades; the rest of the snapshot still builds.
             assert snapshot["Model"].startswith("(unavailable")
             assert "Version" in snapshot

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -802,6 +802,31 @@ class TestDebugConsoleScreen:
 
             assert "(langsmith)" in _widget_text(snapshot_widget)
 
+    async def test_cached_langsmith_link_renders_on_first_frame_without_lookup(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import deepagents_code.config as config_mod
+
+        url = "https://smith.langchain.com/o/org/projects/p/proj/t/thread-abc"
+        monkeypatch.setattr(
+            config_mod, "get_cached_langsmith_thread_url", lambda _thread_id: url
+        )
+        lookup = MagicMock()
+        monkeypatch.setattr(config_mod, "build_langsmith_thread_url", lookup)
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            screen = DebugConsoleScreen(
+                [SnapshotField("Thread", "thread-abc", thread_id="thread-abc")]
+            )
+            app.push_screen(screen)
+            await pilot.pause()
+
+            snapshot_widget = screen.query_one(".debug-console-snapshot", Static)
+            assert "(langsmith)" in _widget_text(snapshot_widget)
+
+        lookup.assert_not_called()
+
     async def test_clicking_thread_value_copies_it(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Debug Console (`Ctrl+\`) thread ID is now click-to-copy and shows a clickable `(langsmith)` trace link.

---

The in-app Debug Console (`Ctrl+\`) now lets you click the Thread ID snapshot row to copy it to the clipboard, and appends a clickable inline `(langsmith)` trace link next to it once the thread's LangSmith URL resolves. The URL lookup runs in a background worker with a short timeout (mirroring the welcome banner), so it never blocks opening the overlay and degrades to no link on failure.

Made by [Open SWE](https://openswe.vercel.app/agents/7f7451e4-5850-04d6-b76e-ef6dea6300a4)