### PR TITLE
style(code): drop hardcoded indent from `ls` and `write_todos` output

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -1798,7 +1798,7 @@ class ToolCallMessage(Vertical):
             return FormattedOutput(content=Content(output))
 
         if not items:
-            return FormattedOutput(content=Content.styled("    No todos", "dim"))
+            return FormattedOutput(content=Content.styled("No todos", "dim"))
 
         lines: list[Content] = []
         max_items = 4 if is_preview else len(items)
@@ -1806,7 +1806,7 @@ class ToolCallMessage(Vertical):
         # Build stats header
         stats = self._build_todo_stats(items)
         if stats:
-            lines.extend([Content.assemble("    ", stats), Content("")])
+            lines.extend([stats, Content("")])
 
         # Format each item
         lines.extend(
@@ -1972,19 +1972,19 @@ class ToolCallMessage(Vertical):
         glyphs = get_glyphs()
         if status == "completed":
             return self._format_todo_line(
-                Content.styled(f"    {glyphs.checkmark} done   ", colors.success),
+                Content.styled(f"{glyphs.checkmark} done   ", colors.success),
                 text,
                 is_preview=is_preview,
                 text_style="dim",
             )
         if status == "in_progress":
             return self._format_todo_line(
-                Content.styled(f"    {glyphs.circle_filled} active ", colors.warning),
+                Content.styled(f"{glyphs.circle_filled} active ", colors.warning),
                 text,
                 is_preview=is_preview,
             )
         return self._format_todo_line(
-            Content.styled(f"    {glyphs.circle_empty} todo   ", "dim"),
+            Content.styled(f"{glyphs.circle_empty} todo   ", "dim"),
             text,
             is_preview=is_preview,
         )
@@ -2007,13 +2007,13 @@ class ToolCallMessage(Vertical):
                     path = Path(str(item))
                     name = path.name
                     if path.suffix in {".py", ".pyx"}:
-                        lines.append(Content.styled(f"    {name}", theme.FILE_PYTHON))
+                        lines.append(Content.styled(name, theme.FILE_PYTHON))
                     elif path.suffix in {".json", ".yaml", ".yml", ".toml"}:
-                        lines.append(Content.styled(f"    {name}", theme.FILE_CONFIG))
+                        lines.append(Content.styled(name, theme.FILE_CONFIG))
                     elif not path.suffix:
-                        lines.append(Content.styled(f"    {name}/", theme.FILE_DIR))
+                        lines.append(Content.styled(f"{name}/", theme.FILE_DIR))
                     else:
-                        lines.append(Content(f"    {name}"))
+                        lines.append(Content(name))
 
                 truncation = None
                 if is_preview and len(items) > max_items:

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -1023,7 +1023,7 @@ class TestToolCallMessageTodos:
         plain = result.content.plain
 
         # Continuation lines hang-indent to the width of the status label, which
-        # now starts flush at the gutter (no leading pad).
+        # starts flush at the gutter (the formatter emits no leading pad).
         from deepagents_code.config import get_glyphs
 
         indent = "\n" + " " * len(f"{get_glyphs().circle_filled} active ")
@@ -1035,7 +1035,11 @@ class TestToolCallMessageTodos:
         assert indent in plain
 
     def test_todo_rows_start_flush_at_gutter(self) -> None:
-        """Todo rows begin with the status glyph, not a hardcoded leading pad."""
+        """No formatted todo line carries a hardcoded leading pad.
+
+        Covers the status rows (which begin with the status glyph) as well as
+        the stats header, which is emitted flush at the gutter too.
+        """
         msg = ToolCallMessage("write_todos")
 
         result = msg._format_todos_output(
@@ -1053,6 +1057,14 @@ class TestToolCallMessageTodos:
         assert lines
         assert all(not line.startswith(" ") for line in lines)
 
+    def test_todo_empty_state_is_flush(self) -> None:
+        """The empty-list placeholder sits flush at the gutter, no leading pad."""
+        msg = ToolCallMessage("write_todos")
+
+        result = msg._format_todos_output(repr([]), is_preview=False)
+
+        assert result.content.plain == "No todos"
+
     def test_todo_expanded_continuation_aligns_content_column(self) -> None:
         """Wrapped continuation lines should align under the todo text."""
         long = "Write integration tests for " + "token refresh revocation " * 4
@@ -1068,11 +1080,14 @@ class TestToolCallMessageTodos:
         )
 
         # Continuation aligns under the todo text, i.e. the status-label width.
+        # Assert the exact leading-whitespace width, not just a prefix, so a pad
+        # reintroduced only on wrapped lines (wider than the label) is caught.
         from deepagents_code.config import get_glyphs
 
         indent = " " * len(f"{get_glyphs().circle_empty} todo   ")
         assert len(lines) > todo_start + 1
-        assert lines[todo_start + 1].startswith(indent)
+        continuation = lines[todo_start + 1]
+        assert len(continuation) - len(continuation.lstrip(" ")) == len(indent)
 
 
 class _ToolMsgApp(App[None]):
@@ -1296,14 +1311,16 @@ class TestToolCallMessageLsOutput:
 
         Alignment is owned by the output gutter layout; the formatter emits
         bare names so results aren't double-indented under the output marker.
-        Directories keep their trailing slash.
+        Directories keep their trailing slash. Every styled file-type branch
+        (python, config, dir, plain) is exercised so none reintroduces a pad.
         """
         msg = ToolCallMessage("ls", {"path": "/tmp"})
         result = msg._format_ls_output(
-            "['/tmp/SKILL.md', '/tmp/scripts', '/tmp/init.py']", is_preview=False
+            "['/tmp/SKILL.md', '/tmp/scripts', '/tmp/init.py', '/tmp/config.json']",
+            is_preview=False,
         )
         lines = result.content.plain.split("\n")
-        assert lines == ["SKILL.md", "scripts/", "init.py"]
+        assert lines == ["SKILL.md", "scripts/", "init.py", "config.json"]
         assert all(not line.startswith(" ") for line in lines)
 
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -1022,12 +1022,36 @@ class TestToolCallMessageTodos:
         )
         plain = result.content.plain
 
+        # Continuation lines hang-indent to the width of the status label, which
+        # now starts flush at the gutter (no leading pad).
+        from deepagents_code.config import get_glyphs
+
+        indent = "\n" + " " * len(f"{get_glyphs().circle_filled} active ")
         assert "..." not in plain
         assert long.replace(" ", "") == plain.split("active ", 1)[1].replace(
-            "\n             ",
+            indent,
             "",
         ).replace(" ", "")
-        assert "\n             " in plain
+        assert indent in plain
+
+    def test_todo_rows_start_flush_at_gutter(self) -> None:
+        """Todo rows begin with the status glyph, not a hardcoded leading pad."""
+        msg = ToolCallMessage("write_todos")
+
+        result = msg._format_todos_output(
+            repr(
+                [
+                    {"content": "a", "status": "completed"},
+                    {"content": "b", "status": "in_progress"},
+                    {"content": "c", "status": "pending"},
+                ]
+            ),
+            is_preview=False,
+        )
+        lines = result.content.plain.split("\n")
+
+        assert lines
+        assert all(not line.startswith(" ") for line in lines)
 
     def test_todo_expanded_continuation_aligns_content_column(self) -> None:
         """Wrapped continuation lines should align under the todo text."""
@@ -1043,8 +1067,12 @@ class TestToolCallMessageTodos:
             index for index, line in enumerate(lines) if "todo   " in line
         )
 
+        # Continuation aligns under the todo text, i.e. the status-label width.
+        from deepagents_code.config import get_glyphs
+
+        indent = " " * len(f"{get_glyphs().circle_empty} todo   ")
         assert len(lines) > todo_start + 1
-        assert lines[todo_start + 1].startswith("             ")
+        assert lines[todo_start + 1].startswith(indent)
 
 
 class _ToolMsgApp(App[None]):
@@ -1258,6 +1286,25 @@ class TestToolCallMessageSearchOutput:
 
         assert result.truncation is None
         assert result.content.plain.split("\n") == lines
+
+
+class TestToolCallMessageLsOutput:
+    """Tests for `ls` directory-listing formatting in `_format_ls_output`."""
+
+    def test_ls_output_has_no_hardcoded_indent(self) -> None:
+        """Ls entries sit flush under the output gutter, like grep/glob.
+
+        Alignment is owned by the output gutter layout; the formatter emits
+        bare names so results aren't double-indented under the output marker.
+        Directories keep their trailing slash.
+        """
+        msg = ToolCallMessage("ls", {"path": "/tmp"})
+        result = msg._format_ls_output(
+            "['/tmp/SKILL.md', '/tmp/scripts', '/tmp/init.py']", is_preview=False
+        )
+        lines = result.content.plain.split("\n")
+        assert lines == ["SKILL.md", "scripts/", "init.py"]
+        assert all(not line.startswith(" ") for line in lines)
 
 
 class TestToolCallMessageEditFileOutput:


### PR DESCRIPTION
`ls` and `write_todos` results in the `deepagents-code` TUI now align flush under the output-gutter glyph, matching other tools, instead of being indented an extra four spaces.

---

The `ls` and `write_todos` renderers in the terminal UI prefixed every row with four hardcoded spaces, so their entries rendered at a 4-space hanging indent under the `⎿` output-gutter glyph. Every other tool formatter (`grep`, `glob`, `read_file`, `execute`) sits flush after that gutter, and the gutter layout already owns alignment for soft-wrapped lines — so the extra pad just produced an inconsistent gap between the glyph and the first item. This emits bare rows for both formatters and also drops the matching indent from the todo stats header and empty-state, so the whole block stays flush and consistent. The todo continuation-line hang-indent auto-adjusts since it derives from the status-label width.

Made by [Open SWE](https://openswe.vercel.app/agents/c5dec078-214f-79a6-2417-4b0014e0944e)