### PR TITLE
fix(code): restore marketplace details keyboard focus [closes DCD-50]

### DIFF
--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -390,8 +390,25 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
             return
         self.dismiss(None)
 
+    def _cycle_details_option(self, step: int) -> None:
+        options = self.query_one("#plugin-manager-options", OptionList)
+        enabled = [
+            index
+            for index in range(options.option_count)
+            if not options.get_option_at_index(index).disabled
+        ]
+        if not enabled:
+            return
+        current = options.highlighted
+        position = enabled.index(current) if current in enabled else 0
+        options.highlighted = enabled[(position + step) % len(enabled)]
+        options.focus()
+
     def action_next_tab(self) -> None:
-        """Switch to the next tab."""
+        """Switch tabs or focus the next details option."""
+        if self._details_mode_active():
+            self._cycle_details_option(1)
+            return
         if self._mode != "list":
             return
         index = self._tabs.index(self._tab)
@@ -400,7 +417,10 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         self._refresh_view()
 
     def action_previous_tab(self) -> None:
-        """Switch to the previous tab."""
+        """Switch tabs or focus the previous details option."""
+        if self._details_mode_active():
+            self._cycle_details_option(-1)
+            return
         if self._mode != "list":
             return
         index = self._tabs.index(self._tab)

--- a/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
@@ -711,6 +711,47 @@ async def test_plugin_manager_confirms_marketplace_removal(
     assert marketplace_root.is_dir()
 
 
+async def test_plugin_manager_marketplace_details_keyboard_navigation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+    marketplace_root = tmp_path / "marketplace"
+    _make_marketplace(marketplace_root)
+    add_local_marketplace(marketplace_root)
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        screen = PluginManagerScreen()
+        app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("right", "right", "down", "enter")
+        await pilot.pause()
+
+        options = screen.query_one("#plugin-manager-options", OptionList)
+        assert screen._mode == "marketplace_details"
+        assert options.has_focus
+        assert options.highlighted == 0
+
+        await pilot.press("tab")
+        assert options.highlighted == 1
+        await pilot.press("tab")
+        assert options.highlighted == 0
+        await pilot.press("shift+tab")
+        assert options.highlighted == 1
+        await pilot.press("shift+tab")
+        assert options.highlighted == 0
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen._mode == "list"
+        assert screen._tab == "marketplaces"
+
+
 async def test_plugin_manager_opens_add_marketplace_input(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
Marketplace detail controls now support visible, predictable Tab and Shift+Tab keyboard navigation.

---

Marketplace detail controls ignored Tab and Shift+Tab because those bindings only attempted to switch tabs. Cycle enabled detail options with wraparound while preserving existing list-tab and Escape behavior.

Made by [Open SWE](https://openswe.vercel.app/agents/019f6783-f3db-727b-ad05-65934c0a9505)