### PR TITLE
feat(code): trace auto-approve (YOLO) mode in trace metadata

### DIFF
--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -1555,19 +1555,6 @@ async def run_non_interactive(
 
     thread_id = generate_thread_id()
 
-    # One user turn per process: fresh turn id, turn_number 1.
-    from uuid import uuid4
-
-    from deepagents_code.config import build_stream_config
-
-    config: RunnableConfig = build_stream_config(
-        thread_id,
-        assistant_id,
-        sandbox_type=sandbox_type,
-        turn_id=str(uuid4()),
-        turn_number=1,
-    )
-
     thread_url_lookup: ThreadUrlLookupState | None = None
     if not quiet:
         thread_url_lookup = _start_langsmith_thread_url_lookup(thread_id)
@@ -1613,6 +1600,23 @@ async def run_non_interactive(
             list(settings.shell_allow_list)
             if use_interrupt_shell_only and settings.shell_allow_list
             else None
+        )
+
+        # One user turn per process: fresh turn id, turn_number 1. Built here so
+        # the resolved `use_auto_approve` is stamped into the trace metadata
+        # (headless auto-approve means tools run without HITL because shell is
+        # unrestricted or disabled).
+        from uuid import uuid4
+
+        from deepagents_code.config import build_stream_config
+
+        config: RunnableConfig = build_stream_config(
+            thread_id,
+            assistant_id,
+            sandbox_type=sandbox_type,
+            turn_id=str(uuid4()),
+            turn_number=1,
+            auto_approve=use_auto_approve,
         )
 
         if not quiet:

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -1647,6 +1647,7 @@ def build_stream_config(
     sandbox_type: str | None = None,
     turn_id: str | None = None,
     turn_number: int | None = None,
+    auto_approve: bool = False,
 ) -> RunnableConfig:
     """Build the LangGraph stream config dict.
 
@@ -1679,6 +1680,11 @@ def build_stream_config(
     Also records `dcode_experimental=True` when `DEEPAGENTS_CODE_EXPERIMENTAL`
     is enabled, so experimental runs are filterable in trace metadata.
 
+    Also records `dcode_auto_approve=True` when auto-approve ("YOLO") mode is
+    active, so runs that ran tools without HITL approval are filterable in trace
+    metadata. This is a diagnostic key, not the contract-scoped `approval_policy`
+    key (see below), so it is safe to stamp trace-wide.
+
     Args:
         thread_id: The app session thread identifier. Set both on
             `configurable.thread_id` and as the top-level `metadata.thread_id`
@@ -1690,6 +1696,8 @@ def build_stream_config(
             sandbox is active.
         turn_id: Stable per-turn id for the current user prompt, or `None`.
         turn_number: 1-based per-thread turn index, or `None`.
+        auto_approve: Whether auto-approve ("YOLO") mode is active for this turn.
+            When `True`, `dcode_auto_approve=True` is recorded in trace metadata.
 
     Returns:
         Config dict with `configurable` and `metadata` keys.
@@ -1717,6 +1725,10 @@ def build_stream_config(
     # Mark experimental runs so they are filterable in trace metadata.
     if is_env_truthy(EXPERIMENTAL):
         metadata["dcode_experimental"] = True
+
+    # Mark auto-approve ("YOLO") runs so they are filterable in trace metadata.
+    if auto_approve:
+        metadata["dcode_auto_approve"] = True
 
     # Legacy / diagnostic keys preserved for backward-compatibility during the
     # coding-agent-v1 rollout (not part of the contract).

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -1683,7 +1683,7 @@ def build_stream_config(
     Also records `dcode_auto_approve=True` when auto-approve ("YOLO") mode is
     active, so runs that ran tools without HITL approval are filterable in trace
     metadata. This is a diagnostic key, not the contract-scoped `approval_policy`
-    key (see below), so it is safe to stamp trace-wide.
+    key (see above), so it is safe to stamp trace-wide.
 
     Args:
         thread_id: The app session thread identifier. Set both on

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -665,6 +665,10 @@ async def execute_task_textual(
     # `build_stream_config` does blocking git filesystem reads and may shell out
     # to `git`; offload it so the Textual event loop stays responsive. Advancing
     # the turn markers above is pure/cheap and stays on the loop.
+    #
+    # `auto_approve` is sampled once here, at turn start, so it labels the trace
+    # with the mode the turn began in. A mid-turn Shift+Tab toggle still changes
+    # execution behavior (via `context`) but does not relabel this turn's trace.
     config = await asyncio.to_thread(
         build_stream_config,
         thread_id,
@@ -672,6 +676,7 @@ async def execute_task_textual(
         sandbox_type=sandbox_type,
         turn_id=turn_id,
         turn_number=turn_number,
+        auto_approve=bool(session_state.auto_approve),
     )
 
     await dispatch_hook("session.start", {"thread_id": thread_id})

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -988,6 +988,16 @@ class TestShellAllowListDecisionLogic:
         assert kwargs["interrupt_shell_only"] is expected_shell_only
         assert kwargs["shell_allow_list"] == expected_allow_list
 
+        # The resolved auto-approve value must also reach the trace metadata
+        # (dcode_auto_approve), not only the server session — guards against the
+        # trace label silently diverging from the server's approval mode.
+        _, astream_kwargs = mock_agent.astream.call_args
+        stream_metadata = astream_kwargs["config"]["metadata"]
+        if expected_auto:
+            assert stream_metadata["dcode_auto_approve"] is True
+        else:
+            assert "dcode_auto_approve" not in stream_metadata
+
 
 class TestNonInteractivePrompt:
     """Tests that run_non_interactive passes interactive=False."""

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -1730,8 +1730,43 @@ class TestExecuteTaskTextualTurnMarkers:
         assert first_meta["turn_id"]
         assert second_meta["turn_id"]
         assert first_meta["turn_id"] != second_meta["turn_id"]
+        # The session's auto-approve mode is labeled onto every turn's trace.
+        assert first_meta["dcode_auto_approve"] is True
+        assert second_meta["dcode_auto_approve"] is True
         # The session state itself reflects the latest turn.
         assert session_state.turn_number == 2
+
+    async def test_auto_approve_absent_from_stream_config_when_disabled(self) -> None:
+        """A manual-approval session must not label its trace as auto-approve.
+
+        Complements the positive case above: guards the TUI call site
+        (`bool(session_state.auto_approve)` -> `build_stream_config`) against
+        wiring that would stamp `dcode_auto_approve` regardless of the mode.
+        """
+        from deepagents_code.app import TextualSessionState
+
+        session_state = TextualSessionState(thread_id="thread-1", auto_approve=False)
+        agent = _SequencedAgent([[]])
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+
+        # Stub git lookups so the captured metadata is deterministic.
+        with (
+            patch.object(config_module, "_get_repository_metadata", return_value=None),
+            patch.object(config_module, "_get_git_commit_sha", return_value=None),
+        ):
+            await execute_task_textual(
+                user_input="first",
+                agent=agent,
+                assistant_id="assistant",
+                session_state=session_state,
+                adapter=adapter,
+            )
+
+        assert "dcode_auto_approve" not in agent.configs[0]["metadata"]
 
 
 class TestExecuteTaskTextualAutoApproveInput:

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -1114,6 +1114,21 @@ class TestBuildStreamConfig:
         config = build_stream_config("t-default", assistant_id=None)
         assert "dcode_experimental" not in config["metadata"]
 
+    def test_auto_approve_included_when_active(self) -> None:
+        """YOLO (auto-approve) runs should be identifiable in trace metadata."""
+        config = build_stream_config("t-yolo", assistant_id=None, auto_approve=True)
+        assert config["metadata"]["dcode_auto_approve"] is True
+
+    def test_auto_approve_absent_when_inactive(self) -> None:
+        """Manual-approval runs should not carry the auto-approve label."""
+        config = build_stream_config("t-manual", assistant_id=None, auto_approve=False)
+        assert "dcode_auto_approve" not in config["metadata"]
+
+    def test_auto_approve_absent_by_default(self) -> None:
+        """The default (param omitted) is not labeled auto-approve."""
+        config = build_stream_config("t-default-approve", assistant_id=None)
+        assert "dcode_auto_approve" not in config["metadata"]
+
 
 class TestGetGitBranch:
     """Tests for `_get_git_branch` caching."""


### PR DESCRIPTION
Auto-approve ("YOLO") runs are now labeled with `dcode_auto_approve=True` in LangSmith trace metadata, making them filterable.

---

Auto-approve ("YOLO") mode — the `Shift+Tab` toggle / `--auto-approve` — sets `interrupt_on = {}` so tools run with no HITL gate, but nothing recorded that state in LangSmith traces, so YOLO runs weren't filterable. The `coding-agent-v1` contract's `approval_policy` key can't help here: it's scoped to root/interrupted runs and would leak onto every descendant run (and fail contract validation) if stamped trace-wide.

This adds a non-contract diagnostic `dcode_auto_approve=True` metadata key in `build_stream_config`, mirroring the existing `dcode_experimental` pattern (only stamped when active). Interactive turns pass `session_state.auto_approve`; headless turns pass the resolved `use_auto_approve` (which reflects "tools run without HITL because shell is unrestricted or disabled" — the same `auto_approve` flag the graph consumes). Metadata is sampled once at turn start, so a mid-turn toggle doesn't relabel that turn's trace.

New keyword-only `auto_approve` param defaults to `False`, so the change is additive and backward-compatible.

Made by [Open SWE](https://openswe.vercel.app/agents/31881cb9-2c33-7505-1b1a-fd453e84ea5a)

## References
- Plan: https://openswe.vercel.app/agents/31881cb9-2c33-7505-1b1a-fd453e84ea5a/plan