### PR TITLE
feat(code): add plugin list search

### DIFF
--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -9,9 +9,6 @@ from textual.binding import Binding, BindingType
 from textual.containers import Horizontal, Vertical
 from textual.content import Content
 from textual.css.query import NoMatches
-from textual.events import (
-    MouseMove,  # noqa: TC002 - needed at runtime for Textual event dispatch
-)
 from textual.screen import ModalScreen
 from textual.widgets import Input, OptionList, Rule, Static
 from textual.widgets.option_list import Option
@@ -20,6 +17,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence, Set as AbstractSet
 
     from textual.app import ComposeResult
+    from textual.events import MouseMove
 
     from deepagents_code.mcp_tools import MCPServerInfo
     from deepagents_code.tui.modals.plugin_manager.models import (
@@ -218,6 +216,9 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
             self._mode = "list"
             self._selected_plugin = None
             self._selected_marketplace = None
+        if tab != self._tab:
+            # A query typed on one tab should not silently filter another.
+            self._search_query = ""
         self._tab = tab
         self._error = None
         self._refresh_view()
@@ -496,6 +497,10 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
         return [Option("Back to plugin list", id="details-back")]
 
     async def _refresh_state(self) -> None:
+        # A mutating action (install/toggle/uninstall/marketplace change) reloads
+        # state and shows a fresh list, so a leftover query would hide results.
+        # Details round-trips use `_refresh_view` instead and keep the query.
+        self._search_query = ""
         self._state = await asyncio.to_thread(
             _load_manager_state,
             self._mcp_server_info,

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -72,6 +72,9 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
     ]
 
     CSS_PATH = "plugin_manager.tcss"
+    # Prefer the option list over the search Input so Enter activates rows on
+    # open; `/` still focuses search explicitly.
+    AUTO_FOCUS = "#plugin-manager-options"
 
     # Divider width used before the options list has been laid out (e.g. in unit
     # tests that build options off-screen). At render time the divider is sized to
@@ -390,7 +393,7 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
         source_input.display = False
         options.display = True
         search_input.display = self._tab in {"discover", "installed"}
-        if search_input.display:
+        if search_input.display and search_input.value != self._search_query:
             search_input.value = self._search_query
         highlighted = options.highlighted
         options.clear_options()
@@ -746,10 +749,12 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
         self._refresh_view()
 
     async def on_input_submitted(self, event: Input.Submitted) -> None:
-        """Leave search or add a marketplace from its source input."""
+        """Activate the highlighted row from search, or add a marketplace."""
         if event.input.id == "plugin-manager-search":
             event.stop()
-            self.query_one("#plugin-manager-options", OptionList).focus()
+            options = self.query_one("#plugin-manager-options", OptionList)
+            options.focus()
+            options.action_select()
             return
         if event.input.id != "plugin-marketplace-source":
             return

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence, Set as AbstractSet
 
     from textual.app import ComposeResult
-    from textual.events import MouseMove
 
     from deepagents_code.mcp_tools import MCPServerInfo
     from deepagents_code.tui.modals.plugin_manager.models import (
@@ -471,9 +470,12 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
                 action = "add marketplace"
             else:
                 action = "install"
+            search_hint = (
+                f"/ search {glyphs.bullet} " if self._search_available() else ""
+            )
             help_text.update(
                 f"{glyphs.arrow_up}/{glyphs.arrow_down} select {glyphs.bullet} "
-                f"Enter {action} {glyphs.bullet} Left/Right tabs "
+                f"Enter {action} {glyphs.bullet} {search_hint}Left/Right tabs "
                 f"{glyphs.bullet} Esc close"
             )
         else:
@@ -557,20 +559,6 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
             event: Tab selection message from `PluginTabLabel`.
         """
         self._select_tab(event.tab)
-
-    def on_mouse_move(self, event: MouseMove) -> None:
-        """Show a pointer cursor over clickable tab labels.
-
-        Args:
-            event: Mouse move event.
-        """
-        self.styles.pointer = (
-            "pointer" if isinstance(event.widget, PluginTabLabel) else "default"
-        )
-
-    def on_leave(self) -> None:
-        """Reset the pointer shape when the mouse leaves the manager."""
-        self.styles.pointer = "default"
 
     def action_cancel(self) -> None:
         """Clear a query, return an empty search to the list, close, or go back."""

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -250,14 +250,22 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
                 return [Option("All available plugins are installed.", id="empty")]
             rows = self._filtered_plugins(self._state.available_plugins)
             if not rows:
-                return [Option("No plugins match your search.", id="empty")]
+                return [
+                    Option("No plugins match your search.", id="empty", disabled=True)
+                ]
             return _plugin_options(rows, action="detail", status=None)
         if self._tab == "installed":
             if not self._state.installed_plugins:
                 return [Option("No plugins installed.", id="empty")]
             rows = self._filtered_plugins(self._state.installed_plugins)
             if not rows:
-                return [Option("No installed plugins match your search.", id="empty")]
+                return [
+                    Option(
+                        "No installed plugins match your search.",
+                        id="empty",
+                        disabled=True,
+                    )
+                ]
             return _plugin_options(rows, action="installed", status=None)
         if self._tab == "marketplaces":
             options = [Option("+ Add marketplace", id="add-marketplace")]
@@ -420,7 +428,10 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
 
         source_input.display = False
         options.display = True
-        search_input.display = self._tab in {"discover", "installed"}
+        search_input.display = (
+            self._tab == "discover"
+            and bool(self._state.marketplaces and self._state.available_plugins)
+        ) or (self._tab == "installed" and bool(self._state.installed_plugins))
         if search_input.display and search_input.value != self._search_query:
             search_input.value = self._search_query
         highlighted = options.highlighted
@@ -497,10 +508,14 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
     ) -> bool | None:
         """Gate priority bindings that would otherwise steal Input keystrokes.
 
-        `/` is only enabled on searchable list views so it stays typeable in the
-        Add Marketplace source field. Left/right release to a focused Input once
-        it has at least one character, so caret movement works while empty-field
-        arrows keep switching tabs.
+        `/` is enabled only on searchable list views whose filter is not focused,
+        so it remains typeable in the filter and Add Marketplace source field.
+        Left/right release to a focused Input once it has at least one character,
+        so caret movement works while empty-field arrows keep switching tabs.
+
+        Args:
+            action: Textual action name being considered for dispatch.
+            parameters: Parameters associated with the action.
 
         Returns:
             `False` to step a binding aside so the focused widget receives the
@@ -510,7 +525,12 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
             focused = self.focused
             return not (isinstance(focused, Input) and bool(focused.value))
         if action == "focus_search":
-            return self._mode == "list" and self._tab in {"discover", "installed"}
+            if self._mode != "list" or self._tab not in {"discover", "installed"}:
+                return False
+            try:
+                return not self.query_one("#plugin-manager-search", Input).has_focus
+            except NoMatches:
+                return True
         return True
 
     def on_plugin_tab_selected(self, event: PluginTabSelected) -> None:
@@ -536,7 +556,7 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
         self.styles.pointer = "default"
 
     def action_cancel(self) -> None:
-        """Clear search, close, or leave the active prompt."""
+        """Clear a query, return an empty search to the list, close, or go back."""
         search_input = self.query_one("#plugin-manager-search", Input)
         if search_input.has_focus:
             if self._search_query:
@@ -850,6 +870,12 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
         if event.input.id == "plugin-manager-search":
             event.stop()
             options = self.query_one("#plugin-manager-options", OptionList)
+            highlighted = options.highlighted
+            if highlighted is None:
+                return
+            option_id = options.get_option_at_index(highlighted).id
+            if option_id is None or not option_id.startswith(("detail:", "installed:")):
+                return
             options.focus()
             options.action_select()
             return

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -6,9 +6,11 @@ import asyncio
 from typing import TYPE_CHECKING, ClassVar
 
 from textual.binding import Binding, BindingType
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.content import Content
 from textual.css.query import NoMatches
+from textual.events import Click, MouseMove
+from textual.message import Message
 from textual.screen import ModalScreen
 from textual.widgets import Input, OptionList, Rule, Static
 from textual.widgets.option_list import Option
@@ -21,7 +23,6 @@ if TYPE_CHECKING:
     from deepagents_code.mcp_tools import MCPServerInfo
     from deepagents_code.tui.modals.plugin_manager.models import (
         PluginManagerView,
-        PluginTab,
         _MarketplaceRow,
         _PluginRow,
     )
@@ -48,8 +49,70 @@ from deepagents_code.tui.modals.plugin_manager.content import (
     _plugin_details_content,
     _plugin_options,
 )
-from deepagents_code.tui.modals.plugin_manager.models import _ManagerState
+from deepagents_code.tui.modals.plugin_manager.models import (
+    PluginTab,
+    _ManagerState,
+)
 from deepagents_code.tui.modals.plugin_manager.state import _load_manager_state
+
+_TAB_LABELS: dict[PluginTab, str] = {
+    "discover": "Plugins",
+    "installed": "Installed",
+    "marketplaces": "Marketplaces",
+    "errors": "Errors",
+}
+
+
+class PluginTabSelected(Message):
+    """Posted when a plugin manager tab label is clicked."""
+
+    def __init__(self, tab: PluginTab) -> None:
+        """Initialize with the selected tab id.
+
+        Args:
+            tab: Tab to activate.
+        """
+        super().__init__()
+        self.tab = tab
+
+
+class PluginTabLabel(Static):
+    """Mouse-clickable tab label in the plugin manager header."""
+
+    def __init__(self, tab: PluginTab, label: str) -> None:
+        """Create a tab label.
+
+        Args:
+            tab: Tab id this label activates.
+            label: Display text for the tab.
+        """
+        super().__init__(
+            f"  {label}  ",
+            id=f"plugin-tab-{tab}",
+            classes="plugin-manager-tab",
+            markup=False,
+        )
+        self._tab = tab
+        self._label = label
+        self.can_focus = False
+
+    def set_active(self, active: bool) -> None:
+        """Update the active marker and style.
+
+        Args:
+            active: Whether this tab is the current tab.
+        """
+        self.update(f"> {self._label} <" if active else f"  {self._label}  ")
+        self.set_class(active, "active")
+
+    def on_click(self, event: Click) -> None:
+        """Select this tab on click.
+
+        Args:
+            event: The click event.
+        """
+        event.stop()
+        self.post_message(PluginTabSelected(self._tab))
 
 
 class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
@@ -62,8 +125,12 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("escape", "cancel", "Close", show=False, priority=True),
-        Binding("left", "previous_tab", "Previous tab", show=False, priority=True),
-        Binding("right", "next_tab", "Next tab", show=False, priority=True),
+        # Separate from tab/shift+tab so check_action can release arrows to a
+        # non-empty Input for caret movement while keeping Tab as tab cycling.
+        Binding(
+            "left", "arrow_previous_tab", "Previous tab", show=False, priority=True
+        ),
+        Binding("right", "arrow_next_tab", "Next tab", show=False, priority=True),
         Binding("tab", "next_tab", "Next tab", show=False, priority=True),
         Binding("shift+tab", "previous_tab", "Previous tab", show=False, priority=True),
         Binding("up", "cursor_up", "Up", show=False, priority=True),
@@ -127,7 +194,9 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
             yield Static(
                 "Plugins", id="plugin-manager-title", classes="plugin-manager-title"
             )
-            yield Static(self._tabs_text(), id="plugin-manager-tabs")
+            with Horizontal(id="plugin-manager-tabs", classes="plugin-manager-tabs"):
+                for tab in self._tabs:
+                    yield PluginTabLabel(tab, _TAB_LABELS[tab])
             yield Rule(
                 line_style="heavy" if not is_ascii_mode() else "ascii",
                 id="plugin-manager-divider",
@@ -183,18 +252,28 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
         ):
             self._refresh_view()
 
-    def _tabs_text(self) -> str:
-        labels = {
-            "discover": "Plugins",
-            "installed": "Installed",
-            "marketplaces": "Marketplaces",
-            "errors": "Errors",
-        }
-        parts = []
+    def _update_tab_labels(self) -> None:
+        """Refresh active styling on each clickable tab label."""
         for tab in self._tabs:
-            label = labels[tab]
-            parts.append(f"> {label} <" if tab == self._tab else f"  {label}  ")
-        return " ".join(parts)
+            self.query_one(f"#plugin-tab-{tab}", PluginTabLabel).set_active(
+                tab == self._tab
+            )
+
+    def _select_tab(self, tab: PluginTab) -> None:
+        """Activate `tab`, exiting details into list mode when needed.
+
+        Args:
+            tab: Tab to show.
+        """
+        if self._mode == "add_marketplace":
+            return
+        if self._details_mode_active():
+            self._mode = "list"
+            self._selected_plugin = None
+            self._selected_marketplace = None
+        self._tab = tab
+        self._error = None
+        self._refresh_view()
 
     def _filtered_plugins(self, rows: Sequence[_PluginRow]) -> tuple[_PluginRow, ...]:
         query = self._search_query.strip().casefold()
@@ -315,9 +394,9 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
 
     def _refresh_view(self) -> None:
         title = self.query_one("#plugin-manager-title", Static)
-        tabs = self.query_one("#plugin-manager-tabs", Static)
+        tabs = self.query_one("#plugin-manager-tabs", Horizontal)
         divider = self.query_one("#plugin-manager-divider", Rule)
-        tabs.update(self._tabs_text())
+        self._update_tab_labels()
         status_widget = self.query_one("#plugin-manager-status", Static)
         if self._mode == "plugin_details" and self._selected_plugin is not None:
             status_widget.update(_plugin_details_content(self._selected_plugin))
@@ -469,20 +548,45 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
         action: str,
         parameters: tuple[object, ...],  # noqa: ARG002  # required by Textual's DOMNode.check_action override signature
     ) -> bool | None:
-        """Enable `/` search only on searchable list views.
+        """Gate priority bindings that would otherwise steal Input keystrokes.
 
-        The priority `/` binding would otherwise consume the key before the Add
-        Marketplace source input (and other non-list modes) can receive it, even
-        though `action_focus_search` no-ops there. Returning `False` disables the
-        binding for this dispatch so `/` falls through to the focused Input.
+        `/` is only enabled on searchable list views so it stays typeable in the
+        Add Marketplace source field. Left/right release to a focused Input once
+        it has at least one character, so caret movement works while empty-field
+        arrows keep switching tabs.
 
         Returns:
-            `True` when `focus_search` should run (list mode on discover/installed);
-                `False` to step the binding aside; `True` for every other action.
+            `False` to step a binding aside so the focused widget receives the
+                key; `True` to allow the action.
         """
+        if action in {"arrow_previous_tab", "arrow_next_tab"}:
+            focused = self.focused
+            return not (isinstance(focused, Input) and bool(focused.value))
         if action == "focus_search":
             return self._mode == "list" and self._tab in {"discover", "installed"}
         return True
+
+    def on_plugin_tab_selected(self, event: PluginTabSelected) -> None:
+        """Switch tabs from a mouse click on a tab label.
+
+        Args:
+            event: Tab selection message from `PluginTabLabel`.
+        """
+        self._select_tab(event.tab)
+
+    def on_mouse_move(self, event: MouseMove) -> None:
+        """Show a pointer cursor over clickable tab labels.
+
+        Args:
+            event: Mouse move event.
+        """
+        self.styles.pointer = (
+            "pointer" if isinstance(event.widget, PluginTabLabel) else "default"
+        )
+
+    def on_leave(self) -> None:
+        """Reset the pointer shape when the mouse leaves the manager."""
+        self.styles.pointer = "default"
 
     def action_cancel(self) -> None:
         """Clear search, close, or leave the active prompt."""
@@ -534,6 +638,14 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
         options.highlighted = enabled[(position + step) % len(enabled)]
         options.focus()
 
+    def action_arrow_next_tab(self) -> None:
+        """Switch tabs via right arrow when the caret is not editing text."""
+        self.action_next_tab()
+
+    def action_arrow_previous_tab(self) -> None:
+        """Switch tabs via left arrow when the caret is not editing text."""
+        self.action_previous_tab()
+
     def action_next_tab(self) -> None:
         """Switch tabs or focus the next details option."""
         if self._details_mode_active():
@@ -542,9 +654,7 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
         if self._mode != "list":
             return
         index = self._tabs.index(self._tab)
-        self._tab = self._tabs[(index + 1) % len(self._tabs)]
-        self._error = None
-        self._refresh_view()
+        self._select_tab(self._tabs[(index + 1) % len(self._tabs)])
 
     def action_previous_tab(self) -> None:
         """Switch tabs or focus the previous details option."""
@@ -554,9 +664,7 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
         if self._mode != "list":
             return
         index = self._tabs.index(self._tab)
-        self._tab = self._tabs[(index - 1) % len(self._tabs)]
-        self._error = None
-        self._refresh_view()
+        self._select_tab(self._tabs[(index - 1) % len(self._tabs)])
 
     def action_cursor_down(self) -> None:
         """Move the option-list cursor down."""

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -62,6 +62,7 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         Binding("shift+tab", "previous_tab", "Previous tab", show=False, priority=True),
         Binding("up", "cursor_up", "Up", show=False, priority=True),
         Binding("down", "cursor_down", "Down", show=False, priority=True),
+        Binding("/", "focus_search", "Search", show=False, priority=True),
     ]
 
     CSS_PATH = "plugin_manager.tcss"
@@ -94,6 +95,7 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         self._error: str | None = None
         self._selected_plugin: _PluginRow | None = None
         self._selected_marketplace: _MarketplaceRow | None = None
+        self._search_query = ""
 
     def compose(self) -> ComposeResult:
         """Compose the manager screen.
@@ -122,6 +124,10 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
                 id="plugin-manager-error",
                 classes="plugin-manager-error",
                 markup=False,
+            )
+            yield Input(
+                placeholder="Search plugins...",
+                id="plugin-manager-search",
             )
             yield OptionList(id="plugin-manager-options")
             yield Input(
@@ -156,6 +162,16 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
             parts.append(f"> {label} <" if tab == self._tab else f"  {label}  ")
         return " ".join(parts)
 
+    def _filtered_plugins(self, rows: Sequence[_PluginRow]) -> tuple[_PluginRow, ...]:
+        query = self._search_query.strip().casefold()
+        if not query:
+            return tuple(rows)
+        return tuple(
+            row
+            for row in rows
+            if query in row.plugin_id.casefold() or query in row.description.casefold()
+        )
+
     def _current_options(self) -> list[Option]:
         glyphs = get_glyphs()
         if self._tab == "discover":
@@ -168,19 +184,17 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
                 ]
             if not self._state.available_plugins:
                 return [Option("All available plugins are installed.", id="empty")]
-            return _plugin_options(
-                self._state.available_plugins,
-                action="detail",
-                status=None,
-            )
+            rows = self._filtered_plugins(self._state.available_plugins)
+            if not rows:
+                return [Option("No plugins match your search.", id="empty")]
+            return _plugin_options(rows, action="detail", status=None)
         if self._tab == "installed":
             if not self._state.installed_plugins:
                 return [Option("No plugins installed.", id="empty")]
-            return _plugin_options(
-                self._state.installed_plugins,
-                action="installed",
-                status=None,
-            )
+            rows = self._filtered_plugins(self._state.installed_plugins)
+            if not rows:
+                return [Option("No installed plugins match your search.", id="empty")]
+            return _plugin_options(rows, action="installed", status=None)
         if self._tab == "marketplaces":
             options = [Option("+ Add Marketplace", id="add-marketplace")]
             options.extend(
@@ -264,6 +278,7 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         self.query_one("#plugin-manager-error", Static).update(error)
 
         options = self.query_one("#plugin-manager-options", OptionList)
+        search_input = self.query_one("#plugin-manager-search", Input)
         source_input = self.query_one("#plugin-marketplace-source", Input)
         help_text = self.query_one("#plugin-manager-help", Static)
         glyphs = get_glyphs()
@@ -283,6 +298,7 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
                     f"  {glyphs.bullet} ./path/to/marketplace"
                 )
             options.display = False
+            search_input.display = False
             source_input.display = True
             source_input.focus()
             help_text.update(f"Enter to add {glyphs.bullet} Esc to cancel")
@@ -293,6 +309,7 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         divider.display = True
 
         if self._details_mode_active():
+            search_input.display = False
             source_input.display = False
             options.display = True
             options.clear_options()
@@ -310,6 +327,9 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
 
         source_input.display = False
         options.display = True
+        search_input.display = self._tab in {"discover", "installed"}
+        if search_input.display:
+            search_input.value = self._search_query
         highlighted = options.highlighted
         options.clear_options()
         for option in self._current_options():
@@ -319,7 +339,8 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
                 0 if highlighted is None else min(highlighted, options.option_count - 1)
             )
             options.highlighted = self._nearest_enabled_index(options, candidate)
-        options.focus()
+        if not search_input.has_focus:
+            options.focus()
 
         if self._tab == "marketplaces":
             help_text.update(
@@ -370,7 +391,17 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         self._refresh_view()
 
     def action_cancel(self) -> None:
-        """Close or leave the add-marketplace / details prompt."""
+        """Clear search, close, or leave the active prompt."""
+        search_input = self.query_one("#plugin-manager-search", Input)
+        if search_input.has_focus:
+            if self._search_query:
+                self._search_query = ""
+                search_input.value = ""
+                self._refresh_view()
+                search_input.focus()
+            else:
+                self.query_one("#plugin-manager-options", OptionList).focus()
+            return
         if self._mode == "add_marketplace":
             self._mode = "list"
             self._error = None
@@ -389,6 +420,11 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
             self._refresh_view()
             return
         self.dismiss(None)
+
+    def action_focus_search(self) -> None:
+        """Focus the plugin filter on searchable tabs."""
+        if self._mode == "list" and self._tab in {"discover", "installed"}:
+            self.query_one("#plugin-manager-search", Input).focus()
 
     def action_next_tab(self) -> None:
         """Switch to the next tab."""
@@ -620,8 +656,19 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         self._error = None
         await self._refresh_state()
 
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Filter the current plugin list as the search query changes."""
+        if event.input.id != "plugin-manager-search":
+            return
+        self._search_query = event.value
+        self._refresh_view()
+
     async def on_input_submitted(self, event: Input.Submitted) -> None:
-        """Add a marketplace from the source input."""
+        """Leave search or add a marketplace from its source input."""
+        if event.input.id == "plugin-manager-search":
+            event.stop()
+            self.query_one("#plugin-manager-options", OptionList).focus()
+            return
         if event.input.id != "plugin-marketplace-source":
             return
         source = event.value.strip()

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -464,6 +464,26 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
             )
         self._refresh_view()
 
+    def check_action(
+        self,
+        action: str,
+        parameters: tuple[object, ...],  # noqa: ARG002  # required by Textual's DOMNode.check_action override signature
+    ) -> bool | None:
+        """Enable `/` search only on searchable list views.
+
+        The priority `/` binding would otherwise consume the key before the Add
+        Marketplace source input (and other non-list modes) can receive it, even
+        though `action_focus_search` no-ops there. Returning `False` disables the
+        binding for this dispatch so `/` falls through to the focused Input.
+
+        Returns:
+            `True` when `focus_search` should run (list mode on discover/installed);
+                `False` to step the binding aside; `True` for every other action.
+        """
+        if action == "focus_search":
+            return self._mode == "list" and self._tab in {"discover", "installed"}
+        return True
+
     def action_cancel(self) -> None:
         """Clear search, close, or leave the active prompt."""
         search_input = self.query_one("#plugin-manager-search", Input)

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -222,6 +222,20 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
         self._error = None
         self._refresh_view()
 
+    def _search_available(self) -> bool:
+        """Whether the plugin filter should be shown and focusable.
+
+        Returns:
+            `True` when list mode has plugins that can be filtered.
+        """
+        if self._mode != "list":
+            return False
+        if self._tab == "discover":
+            return bool(self._state.marketplaces and self._state.available_plugins)
+        if self._tab == "installed":
+            return bool(self._state.installed_plugins)
+        return False
+
     def _filtered_plugins(self, rows: Sequence[_PluginRow]) -> tuple[_PluginRow, ...]:
         query = self._search_query.strip().casefold()
         if not query:
@@ -428,10 +442,7 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
 
         source_input.display = False
         options.display = True
-        search_input.display = (
-            self._tab == "discover"
-            and bool(self._state.marketplaces and self._state.available_plugins)
-        ) or (self._tab == "installed" and bool(self._state.installed_plugins))
+        search_input.display = self._search_available()
         if search_input.display and search_input.value != self._search_query:
             search_input.value = self._search_query
         highlighted = options.highlighted
@@ -508,8 +519,9 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
     ) -> bool | None:
         """Gate priority bindings that would otherwise steal Input keystrokes.
 
-        `/` is enabled only on searchable list views whose filter is not focused,
-        so it remains typeable in the filter and Add Marketplace source field.
+        `/` is enabled only when the plugin filter is visible and not focused,
+        so it remains typeable in the filter and Add Marketplace source field,
+        and cannot steal focus while the filter is hidden.
         Left/right release to a focused Input once it has at least one character,
         so caret movement works while empty-field arrows keep switching tabs.
 
@@ -525,7 +537,7 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
             focused = self.focused
             return not (isinstance(focused, Input) and bool(focused.value))
         if action == "focus_search":
-            if self._mode != "list" or self._tab not in {"discover", "installed"}:
+            if not self._search_available():
                 return False
             try:
                 return not self.query_one("#plugin-manager-search", Input).has_focus
@@ -587,8 +599,8 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
         self.dismiss(None)
 
     def action_focus_search(self) -> None:
-        """Focus the plugin filter on searchable tabs."""
-        if self._mode == "list" and self._tab in {"discover", "installed"}:
+        """Focus the plugin filter when it is visible."""
+        if self._search_available():
             self.query_one("#plugin-manager-search", Input).focus()
 
     def _cycle_details_option(self, step: int) -> None:

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -9,8 +9,9 @@ from textual.binding import Binding, BindingType
 from textual.containers import Horizontal, Vertical
 from textual.content import Content
 from textual.css.query import NoMatches
-from textual.events import Click, MouseMove
-from textual.message import Message
+from textual.events import (
+    MouseMove,  # noqa: TC002 - needed at runtime for Textual event dispatch
+)
 from textual.screen import ModalScreen
 from textual.widgets import Input, OptionList, Rule, Static
 from textual.widgets.option_list import Option
@@ -54,65 +55,11 @@ from deepagents_code.tui.modals.plugin_manager.models import (
     _ManagerState,
 )
 from deepagents_code.tui.modals.plugin_manager.state import _load_manager_state
-
-_TAB_LABELS: dict[PluginTab, str] = {
-    "discover": "Plugins",
-    "installed": "Installed",
-    "marketplaces": "Marketplaces",
-    "errors": "Errors",
-}
-
-
-class PluginTabSelected(Message):
-    """Posted when a plugin manager tab label is clicked."""
-
-    def __init__(self, tab: PluginTab) -> None:
-        """Initialize with the selected tab id.
-
-        Args:
-            tab: Tab to activate.
-        """
-        super().__init__()
-        self.tab = tab
-
-
-class PluginTabLabel(Static):
-    """Mouse-clickable tab label in the plugin manager header."""
-
-    def __init__(self, tab: PluginTab, label: str) -> None:
-        """Create a tab label.
-
-        Args:
-            tab: Tab id this label activates.
-            label: Display text for the tab.
-        """
-        super().__init__(
-            f"  {label}  ",
-            id=f"plugin-tab-{tab}",
-            classes="plugin-manager-tab",
-            markup=False,
-        )
-        self._tab = tab
-        self._label = label
-        self.can_focus = False
-
-    def set_active(self, active: bool) -> None:
-        """Update the active marker and style.
-
-        Args:
-            active: Whether this tab is the current tab.
-        """
-        self.update(f"> {self._label} <" if active else f"  {self._label}  ")
-        self.set_class(active, "active")
-
-    def on_click(self, event: Click) -> None:
-        """Select this tab on click.
-
-        Args:
-            event: The click event.
-        """
-        event.stop()
-        self.post_message(PluginTabSelected(self._tab))
+from deepagents_code.tui.modals.plugin_manager.tabs import (
+    TAB_LABELS,
+    PluginTabLabel,
+    PluginTabSelected,
+)
 
 
 class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
@@ -196,7 +143,7 @@ class PluginManagerScreen(ModalScreen[tuple[str, bool] | None]):  # noqa: RUF067
             )
             with Horizontal(id="plugin-manager-tabs", classes="plugin-manager-tabs"):
                 for tab in self._tabs:
-                    yield PluginTabLabel(tab, _TAB_LABELS[tab])
+                    yield PluginTabLabel(tab, TAB_LABELS[tab])
             yield Rule(
                 line_style="heavy" if not is_ascii_mode() else "ascii",
                 id="plugin-manager-divider",

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/plugin_manager.tcss
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/plugin_manager.tcss
@@ -20,8 +20,20 @@ PluginManagerScreen .plugin-manager-title {
 }
 
 PluginManagerScreen .plugin-manager-tabs {
-    color: $text-muted;
+    height: 1;
+    width: auto;
     margin-bottom: 0;
+}
+
+PluginManagerScreen .plugin-manager-tab {
+    width: auto;
+    height: 1;
+    color: $text-muted;
+    margin-right: 1;
+}
+
+PluginManagerScreen .plugin-manager-tab.active {
+    color: $text;
 }
 
 PluginManagerScreen .plugin-manager-divider {

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/plugin_manager.tcss
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/plugin_manager.tcss
@@ -6,7 +6,10 @@ PluginManagerScreen {
 PluginManagerScreen > Vertical {
     width: 88;
     max-width: 94%;
-    height: 80%;
+    /* The bordered search field adds four rows to list views. */
+    height: 90%;
+    min-height: 24;
+    max-height: 100%;
     background: $surface;
     border: solid $primary;
     padding: 1 2;
@@ -31,6 +34,11 @@ PluginManagerScreen .plugin-manager-tab {
     color: $text-muted;
     text-align: center;
     margin-right: 1;
+    pointer: pointer;
+}
+
+PluginManagerScreen .plugin-manager-tab:last-of-type {
+    margin-right: 0;
 }
 
 PluginManagerScreen .plugin-manager-tab.active {

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/plugin_manager.tcss
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/plugin_manager.tcss
@@ -42,6 +42,15 @@ PluginManagerScreen .plugin-manager-error {
     margin-bottom: 1;
 }
 
+PluginManagerScreen #plugin-manager-search {
+    margin-bottom: 1;
+    border: solid $primary-lighten-2;
+}
+
+PluginManagerScreen #plugin-manager-search:focus {
+    border: solid $primary;
+}
+
 PluginManagerScreen #plugin-manager-options {
     height: 1fr;
     min-height: 5;

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/plugin_manager.tcss
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/plugin_manager.tcss
@@ -21,14 +21,15 @@ PluginManagerScreen .plugin-manager-title {
 
 PluginManagerScreen .plugin-manager-tabs {
     height: 1;
-    width: auto;
+    width: 100%;
     margin-bottom: 0;
 }
 
 PluginManagerScreen .plugin-manager-tab {
-    width: auto;
+    width: 1fr;
     height: 1;
     color: $text-muted;
+    text-align: center;
     margin-right: 1;
 }
 

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/tabs.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/tabs.py
@@ -1,0 +1,73 @@
+"""Clickable tab labels for the plugin manager header."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from textual.events import (
+    Click,  # noqa: TC002 - needed at runtime for Textual event dispatch
+)
+from textual.message import Message
+from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from deepagents_code.tui.modals.plugin_manager.models import PluginTab
+
+TAB_LABELS: dict[PluginTab, str] = {
+    "discover": "Plugins",
+    "installed": "Installed",
+    "marketplaces": "Marketplaces",
+    "errors": "Errors",
+}
+
+
+class PluginTabSelected(Message):
+    """Posted when a plugin manager tab label is clicked."""
+
+    def __init__(self, tab: PluginTab) -> None:
+        """Initialize with the selected tab id.
+
+        Args:
+            tab: Tab to activate.
+        """
+        super().__init__()
+        self.tab = tab
+
+
+class PluginTabLabel(Static):
+    """Mouse-clickable tab label in the plugin manager header."""
+
+    def __init__(self, tab: PluginTab, label: str) -> None:
+        """Create a tab label.
+
+        Args:
+            tab: Tab id this label activates.
+            label: Display text for the tab.
+        """
+        super().__init__(
+            f"  {label}  ",
+            id=f"plugin-tab-{tab}",
+            classes="plugin-manager-tab",
+            markup=False,
+        )
+        self._tab = tab
+        self._label = label
+        self.can_focus = False
+
+    def set_active(self, active: bool) -> None:
+        """Update the active marker and style.
+
+        Args:
+            active: Whether this tab is the current tab.
+        """
+        self.update(f"> {self._label} <" if active else f"  {self._label}  ")
+        self.set_class(active, "active")
+
+    def on_click(self, event: Click) -> None:
+        """Select this tab on click.
+
+        Args:
+            event: The click event.
+        """
+        event.stop()
+        self.post_message(PluginTabSelected(self._tab))

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/tabs.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/tabs.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from textual.events import (
-    Click,  # noqa: TC002 - needed at runtime for Textual event dispatch
-)
 from textual.message import Message
 from textual.widgets import Static
 
 if TYPE_CHECKING:
+    from textual.events import Click
+
     from deepagents_code.tui.modals.plugin_manager.models import PluginTab
 
 TAB_LABELS: dict[PluginTab, str] = {

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/tabs.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/tabs.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from textual.message import Message
 from textual.widgets import Static
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
     from deepagents_code.tui.modals.plugin_manager.models import PluginTab
 
-TAB_LABELS: dict[PluginTab, str] = {
+TAB_LABELS: Final[dict[PluginTab, str]] = {
     "discover": "Plugins",
     "installed": "Installed",
     "marketplaces": "Marketplaces",
@@ -51,7 +51,6 @@ class PluginTabLabel(Static):
         )
         self._tab = tab
         self._label = label
-        self.can_focus = False
 
     def set_active(self, active: bool) -> None:
         """Update the active marker and style.

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -7,6 +7,7 @@ from typing import get_args
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from textual.containers import Vertical
 from textual.widgets import Input, OptionList, Static
 
 from deepagents_code.app import DeepAgentsApp
@@ -118,6 +119,46 @@ async def test_plugin_search_filters_and_clears() -> None:
         assert options.option_count == 3
         await pilot.press("escape")
         assert options.has_focus
+
+
+async def test_plugin_search_and_footer_fit_standard_terminal() -> None:
+    """Search must not push the plugin list or footer outside an 80x24 modal."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+    state = _ManagerState(
+        available_plugins=(
+            _PluginRow(
+                plugin_id="docs@official",
+                description="Search documentation",
+                enabled=False,
+                version=None,
+                author=None,
+            ),
+        ),
+        installed_plugins=(),
+        marketplaces=(_MarketplaceRow("official", "owner/official", 1, 0),),
+        errors=(),
+    )
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._state = state
+        screen._refresh_view()
+        await pilot.pause()
+
+        container = screen.query_one(Vertical)
+        search = screen.query_one("#plugin-manager-search", Input)
+        options = screen.query_one("#plugin-manager-options", OptionList)
+        help_text = screen.query_one("#plugin-manager-help", Static)
+
+        assert container.region.y >= 0
+        assert container.region.bottom <= app.size.height
+        assert search.display is True
+        assert options.region.height >= 5
+        assert options.region.bottom <= container.content_region.bottom
+        assert help_text.region.height >= 1
+        assert help_text.region.bottom <= container.content_region.bottom
 
 
 async def test_search_arrows_move_cursor_only_when_nonempty() -> None:
@@ -498,6 +539,86 @@ def test_tab_labels_cover_every_plugin_tab() -> None:
     assert set(TAB_LABELS) == set(get_args(PluginTab))
 
 
+def test_rendered_tabs_cover_every_plugin_tab() -> None:
+    """`_tabs` must stay in sync with the PluginTab literal.
+
+    The tab set is duplicated across PluginTab, TAB_LABELS, and `_tabs`. A tab
+    missing from `_tabs` would silently never render (compose iterates `_tabs`),
+    and one absent from TAB_LABELS would KeyError at compose time.
+    """
+    assert set(PluginManagerScreen._tabs) == set(get_args(PluginTab))
+
+
+async def test_refresh_state_clears_search_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mutating reload drops the query so reloaded results are not filtered."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+    fresh = _ManagerState(
+        available_plugins=(
+            _PluginRow(
+                plugin_id="docs@official",
+                description="Read/write documentation",
+                enabled=False,
+                version=None,
+                author=None,
+            ),
+            _PluginRow(
+                plugin_id="tests@official",
+                description="Run the test suite",
+                enabled=False,
+                version=None,
+                author=None,
+            ),
+        ),
+        installed_plugins=(),
+        marketplaces=(_MarketplaceRow("official", "owner/official", 2, 0),),
+        errors=(),
+    )
+    monkeypatch.setattr(
+        "deepagents_code.tui.modals.plugin_manager._load_manager_state",
+        lambda _info, **_kwargs: fresh,
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        options = screen.query_one("#plugin-manager-options", OptionList)
+        search = screen.query_one("#plugin-manager-search", Input)
+
+        await pilot.press("/", "d", "o", "c", "s")
+        await pilot.pause()
+        assert screen._search_query == "docs"
+        assert options.option_count == 1
+
+        await screen._refresh_state()
+        await pilot.pause()
+
+        assert screen._search_query == ""
+        assert search.value == ""
+        # The cleared query restores every plugin, not just the "docs" match.
+        ids = {options.get_option_at_index(i).id for i in range(options.option_count)}
+        assert {"detail:docs@official", "detail:tests@official"} <= ids
+
+
+async def test_tab_switch_ignored_during_add_marketplace() -> None:
+    """Switching tabs must not discard an in-progress marketplace source entry."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._mode = "add_marketplace"
+        screen._refresh_view()
+        await pilot.pause()
+
+        screen._select_tab("installed")
+        assert screen._mode == "add_marketplace"
+        assert screen._tab == "discover"
+
+
 async def test_search_hidden_without_filterable_plugins() -> None:
     app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
     screen = PluginManagerScreen()
@@ -520,6 +641,23 @@ async def test_search_hidden_without_filterable_plugins() -> None:
         screen._tab = "installed"
         screen._refresh_view()
         assert search.display is False
+
+        # Marketplaces and errors tabs never filter, even when populated.
+        screen._state = _ManagerState(
+            available_plugins=(),
+            installed_plugins=(),
+            marketplaces=(_MarketplaceRow("official", "owner/official", 2, 0),),
+            errors=("boom",),
+        )
+        screen._tab = "marketplaces"
+        screen._refresh_view()
+        assert search.display is False
+        assert screen.check_action("focus_search", ()) is False
+
+        screen._tab = "errors"
+        screen._refresh_view()
+        assert search.display is False
+        assert screen.check_action("focus_search", ()) is False
 
 
 def test_focus_search_binding_enabled_only_when_filter_visible() -> None:

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -320,10 +320,26 @@ async def test_search_hidden_without_filterable_plugins() -> None:
         assert search.display is False
 
 
-def test_focus_search_binding_enabled_only_on_searchable_list() -> None:
-    """`check_action` gates `/` so it stays typeable outside searchable lists."""
+def test_focus_search_binding_enabled_only_when_filter_visible() -> None:
+    """`check_action` enables `/` only when the search filter is shown."""
     screen = PluginManagerScreen()
 
+    assert screen.check_action("focus_search", ()) is False
+
+    screen._state = _ManagerState(
+        available_plugins=(
+            _PluginRow(
+                plugin_id="docs@official",
+                description="Search documentation",
+                enabled=False,
+                version=None,
+                author=None,
+            ),
+        ),
+        installed_plugins=(),
+        marketplaces=(_MarketplaceRow("official", "owner/official", 1, 0),),
+        errors=(),
+    )
     assert screen.check_action("focus_search", ()) is True
 
     screen._tab = "marketplaces"
@@ -334,7 +350,33 @@ def test_focus_search_binding_enabled_only_on_searchable_list() -> None:
     assert screen.check_action("focus_search", ()) is False
 
     screen._mode = "list"
+    screen._state = _ManagerState((), (), (), ())
+    assert screen.check_action("focus_search", ()) is False
     assert screen.check_action("cancel", ()) is True
+
+
+async def test_slash_does_not_focus_hidden_search() -> None:
+    """`/` must not steal focus when the filter is hidden (empty discover)."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._state = _ManagerState((), (), (), ())
+        screen._refresh_view()
+        search = screen.query_one("#plugin-manager-search", Input)
+        options = screen.query_one("#plugin-manager-options", OptionList)
+        assert search.display is False
+        assert options.has_focus
+
+        await pilot.press("/")
+        assert options.has_focus
+        assert not search.has_focus
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert screen._mode == "add_marketplace"
 
 
 async def test_slash_remains_typeable_in_add_marketplace_source() -> None:

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -114,6 +114,42 @@ async def test_plugin_search_filters_and_clears() -> None:
         assert options.has_focus
 
 
+def test_focus_search_binding_enabled_only_on_searchable_list() -> None:
+    """`check_action` gates `/` so it stays typeable outside searchable lists."""
+    screen = PluginManagerScreen()
+
+    assert screen.check_action("focus_search", ()) is True
+
+    screen._tab = "marketplaces"
+    assert screen.check_action("focus_search", ()) is False
+
+    screen._tab = "discover"
+    screen._mode = "add_marketplace"
+    assert screen.check_action("focus_search", ()) is False
+
+    screen._mode = "list"
+    assert screen.check_action("cancel", ()) is True
+
+
+async def test_slash_remains_typeable_in_add_marketplace_source() -> None:
+    """`/` must reach the marketplace source field (owner/repo, urls, paths)."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._mode = "add_marketplace"
+        screen._refresh_view()
+        await pilot.pause()
+
+        source = screen.query_one("#plugin-marketplace-source", Input)
+        assert source.has_focus
+
+        await pilot.press("o", "w", "n", "e", "r", "/", "r", "e", "p", "o")
+        assert source.value == "owner/repo"
+
+
 def test_filtered_plugins_matches_display_label() -> None:
     screen = PluginManagerScreen()
     screen._search_query = "convex"

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -3,6 +3,7 @@
 import inspect
 import re
 from pathlib import Path
+from typing import get_args
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -20,10 +21,12 @@ from deepagents_code.tui.modals.plugin_manager.content import (
     _plugin_prompt,
 )
 from deepagents_code.tui.modals.plugin_manager.models import (
+    PluginTab,
     _ManagerState,
     _MarketplaceRow,
     _PluginRow,
 )
+from deepagents_code.tui.modals.plugin_manager.tabs import TAB_LABELS
 
 
 def test_plugin_manager_css_is_colocated_with_screen() -> None:
@@ -214,6 +217,32 @@ async def test_plugin_tabs_are_mouse_clickable() -> None:
         assert not screen.query_one("#plugin-tab-discover", Static).has_class("active")
 
 
+async def test_plugin_tabs_fit_and_are_clickable_in_narrow_terminal() -> None:
+    """Every tab remains inside the modal when horizontal space is limited."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+
+    async with app.run_test(size=(50, 30)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        tabs = screen.query_one("#plugin-manager-tabs")
+        tab_labels = list(tabs.query(".plugin-manager-tab"))
+
+        assert tab_labels
+        assert all(
+            label.region.x >= tabs.region.x and label.region.right <= tabs.region.right
+            for label in tab_labels
+        )
+
+        await pilot.click("#plugin-tab-marketplaces")
+        await pilot.pause()
+        assert screen._tab == "marketplaces"
+
+        await pilot.click("#plugin-tab-errors")
+        await pilot.pause()
+        assert screen._tab == "errors"
+
+
 async def test_installed_plugin_search_filters_and_handles_no_match() -> None:
     app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
     screen = PluginManagerScreen()
@@ -294,6 +323,179 @@ async def test_enter_from_search_opens_highlighted_plugin_details() -> None:
         await pilot.pause()
 
         assert screen._mode == "plugin_details"
+
+
+async def test_enter_from_search_activates_installed_row() -> None:
+    """Enter on a matched installed row opens its details, not just `detail:`."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+    screen._tab = "installed"
+    state = _ManagerState(
+        available_plugins=(),
+        installed_plugins=(
+            _PluginRow(
+                plugin_id="docs@official",
+                description="Search documentation",
+                enabled=True,
+                version="1.0.0",
+                author=None,
+            ),
+        ),
+        marketplaces=(_MarketplaceRow("official", "owner/official", 1, 1),),
+        errors=(),
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._state = state
+        screen._refresh_view()
+
+        await pilot.press("/", "d", "o", "c", "s", "enter")
+        await pilot.pause()
+
+        assert screen._mode == "installed_details"
+
+
+async def test_search_query_resets_when_switching_tabs() -> None:
+    """A query typed on one tab does not silently filter another tab."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+    state = _ManagerState(
+        available_plugins=(
+            _PluginRow(
+                plugin_id="docs@official",
+                description="Search documentation",
+                enabled=False,
+                version=None,
+                author=None,
+            ),
+        ),
+        installed_plugins=(
+            _PluginRow(
+                plugin_id="tests@official",
+                description="Run the test suite",
+                enabled=True,
+                version="1.0.0",
+                author=None,
+            ),
+        ),
+        marketplaces=(_MarketplaceRow("official", "owner/official", 1, 1),),
+        errors=(),
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._state = state
+        screen._refresh_view()
+        search = screen.query_one("#plugin-manager-search", Input)
+        options = screen.query_one("#plugin-manager-options", OptionList)
+
+        await pilot.press("/", "d", "o", "c", "s")
+        assert screen._search_query == "docs"
+
+        # Click switches tabs regardless of focus; the installed list must not
+        # inherit the "docs" query (which would hide "tests@official").
+        await pilot.click("#plugin-tab-installed")
+        await pilot.pause()
+        assert screen._tab == "installed"
+        assert screen._search_query == ""
+        assert search.value == ""
+        assert options.option_count == 1
+        assert options.get_option_at_index(0).id == "installed:tests@official"
+
+
+async def test_search_query_persists_through_details_roundtrip() -> None:
+    """Opening a filtered row and returning keeps the query (uses _refresh_view)."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+    state = _ManagerState(
+        available_plugins=(
+            _PluginRow(
+                plugin_id="docs@official",
+                description="Search documentation",
+                enabled=False,
+                version=None,
+                author=None,
+            ),
+            _PluginRow(
+                plugin_id="tests@official",
+                description="Run the test suite",
+                enabled=False,
+                version=None,
+                author=None,
+            ),
+        ),
+        installed_plugins=(),
+        marketplaces=(_MarketplaceRow("official", "owner/official", 2, 0),),
+        errors=(),
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._state = state
+        screen._refresh_view()
+        options = screen.query_one("#plugin-manager-options", OptionList)
+
+        await pilot.press("/", "d", "o", "c", "s", "enter")
+        await pilot.pause()
+        assert screen._mode == "plugin_details"
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen._mode == "list"
+        assert screen._search_query == "docs"
+        assert options.option_count == 1
+        assert options.get_option_at_index(0).id == "detail:docs@official"
+
+
+async def test_tab_click_from_details_returns_to_list() -> None:
+    """Clicking another tab while in a details view drops back to list mode."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+    state = _ManagerState(
+        available_plugins=(
+            _PluginRow(
+                plugin_id="docs@official",
+                description="Search documentation",
+                enabled=False,
+                version=None,
+                author=None,
+            ),
+        ),
+        installed_plugins=(),
+        marketplaces=(_MarketplaceRow("official", "owner/official", 1, 0),),
+        errors=(),
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._state = state
+        screen._refresh_view()
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert screen._mode == "plugin_details"
+        assert screen._selected_plugin is not None
+
+        await pilot.click("#plugin-tab-marketplaces")
+        await pilot.pause()
+        assert screen._mode == "list"
+        assert screen._tab == "marketplaces"
+        assert screen._selected_plugin is None
+        assert screen._selected_marketplace is None
+
+
+def test_tab_labels_cover_every_plugin_tab() -> None:
+    """TAB_LABELS must stay in sync with the PluginTab literal.
+
+    `dict[PluginTab, str]` only constrains keys, not completeness, so a new tab
+    could otherwise KeyError at compose time.
+    """
+    assert set(TAB_LABELS) == set(get_args(PluginTab))
 
 
 async def test_search_hidden_without_filterable_plugins() -> None:

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -114,6 +114,96 @@ async def test_plugin_search_filters_and_clears() -> None:
         assert options.has_focus
 
 
+async def test_search_arrows_move_cursor_only_when_nonempty() -> None:
+    """Left/right move the caret only once the search box has text."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+    state = _ManagerState(
+        available_plugins=(
+            _PluginRow(
+                plugin_id="docs@official",
+                description="Search documentation",
+                enabled=False,
+                version=None,
+                author=None,
+            ),
+        ),
+        installed_plugins=(),
+        marketplaces=(),
+        errors=(),
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._state = state
+        screen._refresh_view()
+        search = screen.query_one("#plugin-manager-search", Input)
+        options = screen.query_one("#plugin-manager-options", OptionList)
+
+        await pilot.press("/")
+        assert search.has_focus
+        assert search.value == ""
+        await pilot.press("right")
+        assert screen._tab == "installed"
+        assert search.display is True
+
+        screen._select_tab("discover")
+        await pilot.press("/")
+        assert search.has_focus
+        await pilot.press("d", "o", "c", "s")
+        assert search.value == "docs"
+        assert search.cursor_position == 4
+        assert screen._tab == "discover"
+
+        await pilot.press("left")
+        assert screen._tab == "discover"
+        assert search.cursor_position == 3
+        assert search.has_focus
+
+        await pilot.press("right")
+        assert screen._tab == "discover"
+        assert search.cursor_position == 4
+
+        await pilot.press("escape", "escape")
+        assert options.has_focus
+        await pilot.press("right")
+        assert screen._tab == "installed"
+
+
+async def test_plugin_tabs_are_mouse_clickable() -> None:
+    """Clicking a tab label switches to that tab."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+    state = _ManagerState(
+        available_plugins=(),
+        installed_plugins=(
+            _PluginRow(
+                plugin_id="docs@official",
+                description="Search documentation",
+                enabled=True,
+                version=None,
+                author=None,
+            ),
+        ),
+        marketplaces=(),
+        errors=(),
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._state = state
+        screen._refresh_view()
+        assert screen._tab == "discover"
+
+        await pilot.click("#plugin-tab-installed")
+        await pilot.pause()
+        assert screen._tab == "installed"
+        assert screen.query_one("#plugin-tab-installed", Static).has_class("active")
+        assert not screen.query_one("#plugin-tab-discover", Static).has_class("active")
+
+
 def test_focus_search_binding_enabled_only_on_searchable_list() -> None:
     """`check_action` gates `/` so it stays typeable outside searchable lists."""
     screen = PluginManagerScreen()

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -70,7 +70,7 @@ async def test_plugin_search_filters_and_clears() -> None:
         available_plugins=(
             _PluginRow(
                 plugin_id="docs@official",
-                description="Search documentation",
+                description="Read/write documentation",
                 enabled=False,
                 version=None,
                 author=None,
@@ -98,13 +98,16 @@ async def test_plugin_search_filters_and_clears() -> None:
 
         await pilot.press("/")
         assert search.has_focus
-        await pilot.press("d", "o", "c", "s")
+        await pilot.press("r", "e", "a", "d", "/", "w", "r", "i", "t", "e")
+        assert search.value == "read/write"
         assert options.option_count == 1
         assert options.get_option_at_index(0).id == "detail:docs@official"
 
         await pilot.press("ctrl+a", "x")
         assert options.option_count == 1
         assert options.get_option_at_index(0).prompt == "No plugins match your search."
+        assert options.get_option_at_index(0).disabled
+        assert options.highlighted is None
 
         await pilot.press("escape")
         assert search.value == ""
@@ -128,8 +131,16 @@ async def test_search_arrows_move_cursor_only_when_nonempty() -> None:
                 author=None,
             ),
         ),
-        installed_plugins=(),
-        marketplaces=(),
+        installed_plugins=(
+            _PluginRow(
+                plugin_id="tests@official",
+                description="Run the test suite",
+                enabled=True,
+                version="1.0.0",
+                author=None,
+            ),
+        ),
+        marketplaces=(_MarketplaceRow("official", "owner/official", 2, 1),),
         errors=(),
     )
 
@@ -149,7 +160,6 @@ async def test_search_arrows_move_cursor_only_when_nonempty() -> None:
         assert search.display is True
 
         screen._select_tab("discover")
-        await pilot.press("/")
         assert search.has_focus
         await pilot.press("d", "o", "c", "s")
         assert search.value == "docs"
@@ -202,6 +212,112 @@ async def test_plugin_tabs_are_mouse_clickable() -> None:
         assert screen._tab == "installed"
         assert screen.query_one("#plugin-tab-installed", Static).has_class("active")
         assert not screen.query_one("#plugin-tab-discover", Static).has_class("active")
+
+
+async def test_installed_plugin_search_filters_and_handles_no_match() -> None:
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+    screen._tab = "installed"
+    state = _ManagerState(
+        available_plugins=(),
+        installed_plugins=(
+            _PluginRow(
+                plugin_id="docs@official",
+                description="Search documentation",
+                enabled=True,
+                version="1.0.0",
+                author=None,
+            ),
+            _PluginRow(
+                plugin_id="tests@official",
+                description="Run the test suite",
+                enabled=True,
+                version="1.0.0",
+                author=None,
+            ),
+        ),
+        marketplaces=(_MarketplaceRow("official", "owner/official", 2, 2),),
+        errors=(),
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._state = state
+        screen._refresh_view()
+        search = screen.query_one("#plugin-manager-search", Input)
+        options = screen.query_one("#plugin-manager-options", OptionList)
+
+        await pilot.press("/")
+        assert search.has_focus
+        await pilot.press("d", "o", "c", "s")
+        assert options.option_count == 1
+        assert options.get_option_at_index(0).id == "installed:docs@official"
+
+        await pilot.press("ctrl+a", "x")
+        assert options.option_count == 1
+        placeholder = options.get_option_at_index(0)
+        assert placeholder.prompt == "No installed plugins match your search."
+        assert placeholder.disabled
+        assert options.highlighted is None
+
+        await pilot.press("enter")
+        assert screen._mode == "list"
+        assert search.has_focus
+
+
+async def test_enter_from_search_opens_highlighted_plugin_details() -> None:
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+    state = _ManagerState(
+        available_plugins=(
+            _PluginRow(
+                plugin_id="docs@official",
+                description="Search documentation",
+                enabled=False,
+                version=None,
+                author=None,
+            ),
+        ),
+        installed_plugins=(),
+        marketplaces=(_MarketplaceRow("official", "owner/official", 1, 0),),
+        errors=(),
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._state = state
+        screen._refresh_view()
+
+        await pilot.press("/", "d", "o", "c", "s", "enter")
+        await pilot.pause()
+
+        assert screen._mode == "plugin_details"
+
+
+async def test_search_hidden_without_filterable_plugins() -> None:
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        search = screen.query_one("#plugin-manager-search", Input)
+
+        screen._state = _ManagerState((), (), (), ())
+        screen._refresh_view()
+        assert search.display is False
+
+        screen._state = _ManagerState(
+            (), (), (_MarketplaceRow("official", "owner/official", 0, 0),), ()
+        )
+        screen._refresh_view()
+        assert search.display is False
+
+        screen._tab = "installed"
+        screen._refresh_view()
+        assert search.display is False
 
 
 def test_focus_search_binding_enabled_only_on_searchable_list() -> None:
@@ -263,6 +379,32 @@ def test_filtered_plugins_matches_display_label() -> None:
 
     assert [row.plugin_id for row in screen._filtered_plugins(rows)] == [
         "cx-backend@tools"
+    ]
+
+
+def test_filtered_plugins_matches_description_case_insensitively() -> None:
+    screen = PluginManagerScreen()
+    screen._search_query = "DATA WAREHOUSE"
+    rows = (
+        _PluginRow(
+            plugin_id="analytics@tools",
+            description="Query the data warehouse",
+            enabled=False,
+            version=None,
+            author=None,
+            display_name="Analytics",
+        ),
+        _PluginRow(
+            plugin_id="linear@tools",
+            description="Issue tracker",
+            enabled=False,
+            version=None,
+            author=None,
+        ),
+    )
+
+    assert [row.plugin_id for row in screen._filtered_plugins(rows)] == [
+        "analytics@tools"
     ]
 
 

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -5,12 +5,12 @@ import re
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from textual.widgets import Static
+from textual.widgets import Input, OptionList, Static
 
 from deepagents_code.app import DeepAgentsApp
 from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
 from deepagents_code.tui.modals.plugin_manager.content import _plugin_options
-from deepagents_code.tui.modals.plugin_manager.models import _PluginRow
+from deepagents_code.tui.modals.plugin_manager.models import _ManagerState, _PluginRow
 
 
 def test_plugin_manager_css_is_colocated_with_screen() -> None:
@@ -34,6 +34,45 @@ def test_plugin_options_preserve_selectable_rows_and_spacers() -> None:
         "detail:second@source",
     ]
     assert options[1].disabled
+
+
+async def test_plugin_search_filters_and_clears() -> None:
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+    state = _ManagerState(
+        (
+            _PluginRow("docs@official", "Search documentation", False, None, None),
+            _PluginRow("tests@official", "Run the test suite", False, None, None),
+        ),
+        (),
+        (MagicMock(),),
+        (),
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._state = state
+        screen._refresh_view()
+        search = screen.query_one("#plugin-manager-search", Input)
+        options = screen.query_one("#plugin-manager-options", OptionList)
+
+        await pilot.press("/")
+        assert search.has_focus
+        await pilot.press("d", "o", "c", "s")
+        assert options.option_count == 1
+        assert options.get_option_at_index(0).id == "detail:docs@official"
+
+        await pilot.press("ctrl+a", "x")
+        assert options.option_count == 1
+        assert options.get_option_at_index(0).prompt == "No plugins match your search."
+
+        await pilot.press("escape")
+        assert search.value == ""
+        assert search.has_focus
+        assert options.option_count == 3
+        await pilot.press("escape")
+        assert options.has_focus
 
 
 async def test_plugin_manager_overlays_underlying_content() -> None:


### PR DESCRIPTION
Plugin screens now support filtering available and installed plugins by name or description.

---

Add keyboard-accessible search to available and installed plugin lists so users can filter by plugin name or description, clear searches with Escape, and see explicit no-results states.

## Screenshots
<img width="860" height="987" alt="Screenshot 2026-07-16 at 11 27 22 AM" src="https://github.com/user-attachments/assets/523be30d-c3cd-4aae-bb36-5441c3454d6b" />


Made by [Open SWE](https://openswe.vercel.app/agents/019f6784-b613-735d-bb42-f6e0c69c3956)