### PR TITLE
fix(code): add marketplaces asynchronously

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -620,22 +620,24 @@ _MODAL_WATCHDOG_TIMEOUT_SECONDS = 600.0
 Bounds command/worker handling against a modal that never resolves (compose
 crash, programmatic teardown that skips the dismiss callback). 10 minutes is
 well past any human latency but stops a genuinely broken modal from wedging
-the caller. Shared by the install-confirm, MCP-reconnect, restart-prompt, and
-plugin-reload watchdogs so they stay in lockstep.
+the caller. Shared by every modal watchdog so their timeouts stay in lockstep.
 """
 
 _PLUGIN_RELOAD_REMINDER = "Plugin changes are pending. Run /reload when ready."
 _PLUGIN_RELOAD_CHECK_FAILED = "Couldn't check plugin state. Run /reload to be safe."
 _MAX_PLUGIN_FINGERPRINT_ENTRIES = 10_000
+_UNREADABLE_PLUGIN_FINGERPRINT_STAT = -1
 _TRUNCATED_PLUGIN_FINGERPRINT_STAT = -2
 
 
 class _PathStat(NamedTuple):
     """Filesystem fingerprint entry for one component file.
 
-    `mtime_ns`/`size` are `-1` when a path cannot be inspected and `-2` when
-    the bounded scan is truncated. These sentinels keep incomplete scans from
-    being mistaken for complete, unchanged state.
+    `mtime_ns`/`size` are `_UNREADABLE_PLUGIN_FINGERPRINT_STAT` (-1) when a path
+    cannot be inspected and `_TRUNCATED_PLUGIN_FINGERPRINT_STAT` (-2) when the
+    bounded scan is truncated. These negative sentinels never collide with real
+    (non-negative) stat values and keep incomplete scans from being mistaken
+    for complete, unchanged state.
     """
 
     path: str
@@ -646,14 +648,20 @@ class _PathStat(NamedTuple):
 class _PluginFingerprint(NamedTuple):
     """Reload-comparison fingerprint for a single plugin.
 
-    Only ever compared with `==`/`!=` (never hashed), so `manifest` is held
-    directly — `PluginManifest` is a frozen dataclass that compares by value,
-    which avoids the key-order fragility of comparing `repr(manifest)`.
+    Only ever compared with `==`/`!=`, so `manifest` is held directly —
+    `PluginManifest` is a frozen dataclass that compares by value, which avoids
+    the key-order fragility of comparing `repr(manifest)`. `__hash__` is
+    disabled so hashing fails deterministically: without it a fingerprint is
+    only conditionally hashable (fine when `manifest is None`, `TypeError` via
+    the manifest's `dict` field otherwise), which would hide accidental
+    set/dict-key use behind whichever plugins happen to lack a manifest.
     """
 
     version: str | None
     manifest: PluginManifest | None
     components: tuple[_PathStat, ...]
+
+    __hash__ = None  # type: ignore[assignment]
 
 
 def _resolve_theme_name(value: object) -> str | None:
@@ -3333,12 +3341,13 @@ class DeepAgentsApp(App):
         self._plugin_fingerprints: dict[str, _PluginFingerprint] | None = None
         """Rolling plugin-fingerprint baseline keyed by plugin id.
 
-        Captured when the plugin manager first opens (see
-        `_show_plugin_manager`) and preserved across manager reopens, then read
-        as the `old` baseline for the `/reload` change summary and refreshed
-        there. `None` until first captured. The manager-close check
-        (`_check_plugin_manager_changes`) compares a fresh read against its own
-        open-time snapshot, not this attribute.
+        First populated by whichever of `_show_plugin_manager` (on open) or
+        `/reload` runs first, and preserved across manager reopens. Read as the
+        `old` baseline for the `/reload` change summary, which always refreshes
+        it (so `/reload` before the manager is ever opened is the first writer,
+        with no summary since `old` is `None`). `None` until first captured. The
+        manager-close check (`_check_plugin_manager_changes`) compares a fresh
+        read against its own open-time snapshot, not this attribute.
         """
 
         self._skill_allowed_roots: list[Path] = []
@@ -17839,20 +17848,37 @@ class DeepAgentsApp(App):
         Every directory is rechecked against the plugin root immediately before
         traversal, and the scan stops after `_MAX_PLUGIN_FINGERPRINT_ENTRIES`.
 
+        Because symlinks are never followed, a symlink is fingerprinted by its
+        own `lstat` only: edits to the contents of a symlinked directory (or a
+        symlink's target file) do not change the fingerprint and so are not
+        surfaced as a plugin change. The fingerprint is also stat-based, so
+        mode-only changes (e.g. `chmod +x`) and edits that preserve both size
+        and mtime are likewise invisible. This is a deliberate trade-off for
+        root containment and cheap comparison, not authoritative change
+        detection.
+
         Args:
             plugin_root: Root that every traversed component must remain within.
             paths: Component files or directories to fingerprint.
 
         Returns:
-            Deterministic fingerprint entries. Inaccessible paths use `-1` stats;
-            a `-2` entry marks a scan truncated by the entry limit.
+            Deterministic fingerprint entries. Inaccessible or out-of-root paths
+            use `_UNREADABLE_PLUGIN_FINGERPRINT_STAT` (-1) stats; a
+            `_TRUNCATED_PLUGIN_FINGERPRINT_STAT` (-2) entry marks a scan
+            truncated by the entry limit.
         """
         entries: list[_PathStat] = []
         visited_entries = 0
 
-        def _record_unreadable(target: Path) -> None:
-            logger.warning("Unreadable component path %s", target)
-            entries.append(_PathStat(str(target), -1, -1))
+        def _record_unreadable(target: Path, exc: OSError) -> None:
+            logger.warning("Unreadable component path %s: %s", target, exc)
+            entries.append(
+                _PathStat(
+                    str(target),
+                    _UNREADABLE_PLUGIN_FINGERPRINT_STAT,
+                    _UNREADABLE_PLUGIN_FINGERPRINT_STAT,
+                )
+            )
 
         def _consume_entry(target: Path) -> bool:
             nonlocal visited_entries
@@ -17875,8 +17901,8 @@ class DeepAgentsApp(App):
 
         try:
             resolved_root = plugin_root.resolve(strict=True)
-        except OSError:
-            _record_unreadable(plugin_root)
+        except OSError as exc:
+            _record_unreadable(plugin_root, exc)
             return tuple(entries)
 
         def _scan_directory(directory: Path) -> bool:
@@ -17888,8 +17914,8 @@ class DeepAgentsApp(App):
                     resolved = current.resolve(strict=True)
                 except FileNotFoundError:
                     continue
-                except OSError:
-                    _record_unreadable(current)
+                except OSError as exc:
+                    _record_unreadable(current, exc)
                     continue
                 if stat_module.S_ISLNK(current_stat.st_mode):
                     entries.append(
@@ -17902,7 +17928,13 @@ class DeepAgentsApp(App):
                     logger.warning(
                         "Ignoring plugin component outside plugin root: %s", current
                     )
-                    entries.append(_PathStat(str(current), -1, -1))
+                    entries.append(
+                        _PathStat(
+                            str(current),
+                            _UNREADABLE_PLUGIN_FINGERPRINT_STAT,
+                            _UNREADABLE_PLUGIN_FINGERPRINT_STAT,
+                        )
+                    )
                     continue
 
                 children: list[tuple[str, Path, os.stat_result]] = []
@@ -17916,14 +17948,14 @@ class DeepAgentsApp(App):
                                 child_stat = child.stat(follow_symlinks=False)
                             except FileNotFoundError:
                                 continue
-                            except OSError:
-                                _record_unreadable(target)
+                            except OSError as exc:
+                                _record_unreadable(target, exc)
                                 continue
                             children.append((child.name, target, child_stat))
                 except FileNotFoundError:
                     continue
-                except OSError:
-                    _record_unreadable(current)
+                except OSError as exc:
+                    _record_unreadable(current, exc)
                     continue
 
                 directories: list[Path] = []
@@ -17948,21 +17980,27 @@ class DeepAgentsApp(App):
                 resolved = path.resolve(strict=True)
             except FileNotFoundError:
                 continue
-            except OSError:
-                _record_unreadable(path)
+            except OSError as exc:
+                _record_unreadable(path, exc)
                 continue
             if not resolved.is_relative_to(resolved_root):
                 logger.warning(
                     "Ignoring plugin component outside plugin root: %s", path
                 )
-                entries.append(_PathStat(str(path), -1, -1))
+                entries.append(
+                    _PathStat(
+                        str(path),
+                        _UNREADABLE_PLUGIN_FINGERPRINT_STAT,
+                        _UNREADABLE_PLUGIN_FINGERPRINT_STAT,
+                    )
+                )
                 continue
             try:
                 path_stat = path.lstat()
             except FileNotFoundError:
                 continue
-            except OSError:
-                _record_unreadable(path)
+            except OSError as exc:
+                _record_unreadable(path, exc)
                 continue
             if stat_module.S_ISDIR(path_stat.st_mode):
                 if not _scan_directory(path):
@@ -17977,7 +18015,12 @@ class DeepAgentsApp(App):
     def _plugin_fingerprint_changed(
         before: _PluginFingerprint, after: _PluginFingerprint
     ) -> bool:
-        """Return whether a plugin changed or either scan was truncated."""
+        """Return whether the plugin changed, or either fingerprint is incomplete.
+
+        A negative stat sentinel means a component was inaccessible/out-of-root
+        (-1) or the scan was truncated (-2); either forces "changed" so an
+        incomplete scan is never mistaken for an unchanged plugin.
+        """
         return (
             before != after
             or any(entry.mtime_ns < 0 for entry in before.components)
@@ -18120,7 +18163,8 @@ class DeepAgentsApp(App):
             baseline = await asyncio.to_thread(self._snapshot_plugin_state)
         except Exception:
             # Still open the manager if the pre-open snapshot fails. Without a
-            # baseline, its close handler leaves a manual reload reminder.
+            # baseline, its close handler surfaces the check-failed notice
+            # (_PLUGIN_RELOAD_CHECK_FAILED) rather than the pending reminder.
             logger.exception("Failed to snapshot plugin state before opening manager")
             baseline = None
         else:

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING, ClassVar
 
 from textual import work
@@ -63,12 +64,15 @@ from deepagents_code.tui.modals.plugin_manager.tabs import (
     PluginTabSelected,
 )
 
+logger = logging.getLogger(__name__)  # noqa: RUF067  # module-level logger
+
 
 class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
     """Arrow-key navigable plugin manager for `/plugins`.
 
-    A reload prompt shown after this screen closes offers to apply plugin
-    changes via `/reload`.
+    When plugin state changed while the manager was open, a reload prompt is
+    shown after this screen closes offering to apply the changes via `/reload`;
+    an unchanged close shows nothing.
     """
 
     BINDINGS: ClassVar[list[BindingType]] = [
@@ -924,24 +928,41 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         except (MarketplaceError, OSError, RuntimeError) as exc:
             self.app.call_from_thread(self._finish_marketplace_add, None, str(exc))
             return
+        except Exception as exc:
+            # Any exception outside the expected set must still route through
+            # _finish_marketplace_add: with exit_on_error=False the worker
+            # crash is otherwise swallowed, leaving _adding_marketplace latched
+            # (spinner running, input disabled, Escape blocked by action_cancel)
+            # and the manager permanently unrecoverable.
+            logger.exception("Unexpected error adding marketplace source")
+            self.app.call_from_thread(
+                self._finish_marketplace_add, None, f"Unexpected error: {exc}"
+            )
+            return
         self.app.call_from_thread(self._finish_marketplace_add, marketplace, None)
 
     async def _finish_marketplace_add(
         self, marketplace: PluginMarketplace | None, error: str | None
     ) -> None:
-        self._adding_marketplace = False
         if self._marketplace_spinner_timer is not None:
             self._marketplace_spinner_timer.stop()
             self._marketplace_spinner_timer = None
         source_input = self.query_one("#plugin-marketplace-source", Input)
-        source_input.disabled = False
+
+        def release_guard() -> None:
+            """Re-enable the input and unblock Escape now the add has settled."""
+            self._adding_marketplace = False
+            source_input.disabled = False
+
         if error is not None:
+            release_guard()
             self._status = None
             self._error = f"Could not add marketplace: {error}"
             self._refresh_view()
             source_input.focus()
             return
         if marketplace is None:
+            release_guard()
             return
         self._mode = "list"
         self._tab = "discover"
@@ -950,4 +971,9 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
             f"({len(marketplace.plugins)} plugin(s))."
         )
         self._error = None
-        await self._refresh_state()
+        # Keep the guard set until the refresh finishes so Escape stays blocked
+        # while _refresh_state() runs.
+        try:
+            await self._refresh_state()
+        finally:
+            release_guard()

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, ClassVar
 
+from textual import work
 from textual.binding import Binding, BindingType
 from textual.containers import Vertical
 from textual.content import Content
@@ -12,12 +13,16 @@ from textual.screen import ModalScreen
 from textual.widgets import Input, OptionList, Rule, Static
 from textual.widgets.option_list import Option
 
+from deepagents_code.tui.widgets.loading import Spinner
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from textual.app import ComposeResult
+    from textual.timer import Timer
 
     from deepagents_code.mcp_tools import MCPServerInfo
+    from deepagents_code.plugins.models import PluginMarketplace
     from deepagents_code.tui.modals.plugin_manager.models import (
         PluginManagerView,
         PluginTab,
@@ -94,6 +99,9 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         self._error: str | None = None
         self._selected_plugin: _PluginRow | None = None
         self._selected_marketplace: _MarketplaceRow | None = None
+        self._adding_marketplace = False
+        self._marketplace_spinner = Spinner()
+        self._marketplace_spinner_timer: Timer | None = None
 
     def compose(self) -> ComposeResult:
         """Compose the manager screen.
@@ -371,6 +379,8 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
 
     def action_cancel(self) -> None:
         """Close or leave the add-marketplace / details prompt."""
+        if self._adding_marketplace:
+            return
         if self._mode == "add_marketplace":
             self._mode = "list"
             self._error = None
@@ -620,24 +630,53 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         self._error = None
         await self._refresh_state()
 
-    async def on_input_submitted(self, event: Input.Submitted) -> None:
+    def on_input_submitted(self, event: Input.Submitted) -> None:
         """Add a marketplace from the source input."""
-        if event.input.id != "plugin-marketplace-source":
+        if event.input.id != "plugin-marketplace-source" or self._adding_marketplace:
             return
         source = event.value.strip()
         if not source:
             self._error = "Please enter a marketplace source."
             self._refresh_view()
             return
-        self._status = "Adding marketplace..."
+        self._adding_marketplace = True
+        event.input.disabled = True
         self._error = None
+        self._marketplace_spinner_timer = self.set_interval(
+            0.1, self._tick_marketplace_spinner
+        )
+        self._tick_marketplace_spinner()
+        self._add_marketplace(source)
+
+    def _tick_marketplace_spinner(self) -> None:
+        self._status = f"{self._marketplace_spinner.next_frame()} Adding marketplace..."
         self._refresh_view()
+
+    @work(thread=True, exclusive=True, exit_on_error=False)
+    def _add_marketplace(self, source: str) -> None:
         try:
-            marketplace = await asyncio.to_thread(add_marketplace_source, source)
+            marketplace = add_marketplace_source(source)
         except (MarketplaceError, OSError, RuntimeError) as exc:
+            self.app.call_from_thread(self._finish_marketplace_add, None, str(exc))
+            return
+        self.app.call_from_thread(self._finish_marketplace_add, marketplace, None)
+
+    async def _finish_marketplace_add(
+        self, marketplace: PluginMarketplace | None, error: str | None
+    ) -> None:
+        self._adding_marketplace = False
+        if self._marketplace_spinner_timer is not None:
+            self._marketplace_spinner_timer.stop()
+            self._marketplace_spinner_timer = None
+        source_input = self.query_one("#plugin-marketplace-source", Input)
+        source_input.disabled = False
+        if error is not None:
             self._status = None
-            self._error = f"Could not add marketplace: {exc}"
+            self._error = f"Could not add marketplace: {error}"
             self._refresh_view()
+            source_input.focus()
+            return
+        if marketplace is None:
             return
         self._mode = "list"
         self._tab = "discover"

--- a/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
@@ -6,6 +6,7 @@ import io
 import json
 import re
 import shutil
+import threading
 from pathlib import Path
 from typing import Any, cast
 
@@ -51,6 +52,7 @@ from deepagents_code.plugins.models import (
     GithubPluginSource,
     LocalMarketplaceSource,
     MarketplaceRecord,
+    PluginMarketplace,
     RepositoryMarketplaceSource,
     UrlMarketplaceSource,
 )
@@ -761,6 +763,113 @@ async def test_plugin_manager_opens_add_marketplace_input(
         help_text = str(screen.query_one("#plugin-manager-help").render())
         assert "Enter to add" in help_text
         assert "Esc to cancel" in help_text
+
+
+async def test_plugin_manager_add_marketplace_runs_in_background(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def add_marketplace(source: str) -> None:
+        nonlocal calls
+        assert source == "owner/repo"
+        calls += 1
+        started.set()
+        assert release.wait(timeout=5)
+        msg = "marketplace failed"
+        raise MarketplaceError(msg)
+
+    monkeypatch.setattr(
+        "deepagents_code.tui.modals.plugin_manager.add_marketplace_source",
+        add_marketplace,
+    )
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        screen = PluginManagerScreen()
+        app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("right", "right", "enter")
+        await pilot.pause()
+
+        source_input = screen.query_one("#plugin-marketplace-source", Input)
+        source_input.value = "owner/repo"
+        await pilot.press("enter")
+        await asyncio.to_thread(started.wait, 5)
+        await pilot.pause()
+
+        assert screen._adding_marketplace is True
+        assert source_input.disabled is True
+        assert "Adding marketplace..." in str(
+            screen.query_one("#plugin-manager-status").render()
+        )
+        screen.on_input_submitted(Input.Submitted(source_input, source_input.value))
+        assert calls == 1
+        screen.action_cancel()
+        assert screen._mode == "add_marketplace"
+
+        release.set()
+        while screen._adding_marketplace:
+            await pilot.pause()
+
+        assert calls == 1
+        assert source_input.disabled is False
+        assert source_input.has_focus
+        assert "Could not add marketplace: marketplace failed" in str(
+            screen.query_one("#plugin-manager-error").render()
+        )
+
+
+async def test_plugin_manager_add_marketplace_success_refreshes_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+    marketplace_root = tmp_path / "marketplace"
+    _make_marketplace(marketplace_root)
+    marketplace = load_marketplace(marketplace_root)
+
+    def add_marketplace(source: str) -> PluginMarketplace:
+        assert source == "owner/repo"
+        add_local_marketplace(marketplace_root)
+        return marketplace
+
+    monkeypatch.setattr(
+        "deepagents_code.tui.modals.plugin_manager.add_marketplace_source",
+        add_marketplace,
+    )
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        screen = PluginManagerScreen()
+        app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("right", "right", "enter")
+        source_input = screen.query_one("#plugin-marketplace-source", Input)
+        source_input.value = "owner/repo"
+        await pilot.press("enter")
+
+        while screen._adding_marketplace:
+            await pilot.pause()
+
+        assert screen._mode == "list"
+        assert screen._tab == "discover"
+        assert len(screen._state.marketplaces) == 1
+        assert "Added marketplace company-tools (1 plugin(s))." in str(
+            screen.query_one("#plugin-manager-status").render()
+        )
 
 
 async def test_plugin_manager_discover_rows_show_description_below_name(

--- a/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
@@ -921,6 +921,59 @@ async def test_plugin_manager_add_marketplace_success_refreshes_state(
         )
 
 
+async def test_plugin_manager_add_marketplace_recovers_from_unexpected_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An exception outside the expected set must still release the modal.
+
+    Without the worker's catch-all, an unexpected error would leave
+    `exit_on_error=False` to swallow the crash, so `_finish_marketplace_add`
+    never runs: the spinner would spin forever, the input stay disabled, and
+    Escape stay blocked, wedging the manager permanently.
+    """
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+
+    def add_marketplace(source: str) -> PluginMarketplace:
+        assert source == "owner/repo"
+        # ValueError is not in the worker's (MarketplaceError, OSError,
+        # RuntimeError) tuple, so it exercises the catch-all path.
+        msg = "boom"
+        raise ValueError(msg)
+
+    monkeypatch.setattr(
+        "deepagents_code.tui.modals.plugin_manager.add_marketplace_source",
+        add_marketplace,
+    )
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        screen = PluginManagerScreen()
+        app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press("enter")
+        source_input = screen.query_one("#plugin-marketplace-source", Input)
+        source_input.value = "owner/repo"
+        await pilot.press("enter")
+
+        while screen._adding_marketplace:
+            await pilot.pause()
+
+        # Modal is recoverable: guard cleared, input re-enabled and focused,
+        # and the failure is surfaced rather than silently swallowed.
+        assert screen._adding_marketplace is False
+        assert screen._marketplace_spinner_timer is None
+        assert source_input.disabled is False
+        assert source_input.has_focus
+        assert "Could not add marketplace: Unexpected error: boom" in str(
+            screen.query_one("#plugin-manager-error").render()
+        )
+
+
 def test_plugin_mcp_config_namespaces_and_substitutes(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/libs/code/tests/unit_tests/test_reload.py
+++ b/libs/code/tests/unit_tests/test_reload.py
@@ -1416,7 +1416,9 @@ class TestReloadPluginsViaReload:
 
         assert labels == ("Login", "nameless")
 
-    @pytest.mark.parametrize("change", ["none", "fingerprint", "enabled"])
+    @pytest.mark.parametrize(
+        "change", ["none", "fingerprint", "fingerprint_key_added", "enabled"]
+    )
     async def test_plugin_manager_reminder_compares_actual_state(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1427,16 +1429,20 @@ class TestReloadPluginsViaReload:
         from deepagents_code.app import DeepAgentsApp
         from deepagents_code.plugins.models import PluginDiscoveryResult
 
-        before = (
-            {"demo@tools": _test_plugin_fingerprint("before")}
-            if change == "fingerprint"
-            else {}
-        )
-        after = (
-            {"demo@tools": _test_plugin_fingerprint("after")}
-            if change == "fingerprint"
-            else {}
-        )
+        if change == "fingerprint":
+            # Same plugin id, different fingerprint: exercises the intersection
+            # branch of _plugin_fingerprints_changed.
+            before = {"demo@tools": _test_plugin_fingerprint("before")}
+            after = {"demo@tools": _test_plugin_fingerprint("after")}
+        elif change == "fingerprint_key_added":
+            # A plugin appears (e.g. a marketplace added while the manager was
+            # open) with enabled ids unchanged: exercises the keys-differ branch,
+            # which is this PR's headline async-marketplace-add scenario.
+            before = {}
+            after = {"demo@tools": _test_plugin_fingerprint("after")}
+        else:
+            before = {}
+            after = {}
         fingerprints = iter((before, after))
         enabled_before = frozenset[str]()
         enabled_after = (

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -1,5 +1,6 @@
 """Tests for the plugin manager modal structure."""
 
+import asyncio
 import inspect
 import re
 from pathlib import Path
@@ -12,6 +13,7 @@ from textual.widgets import Input, OptionList, Static
 
 from deepagents_code.app import DeepAgentsApp
 from deepagents_code.config import get_glyphs
+from deepagents_code.plugins.models import PluginMarketplace
 from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
 from deepagents_code.tui.modals.plugin_manager.content import (
     _installed_plugin_details_content,
@@ -631,6 +633,53 @@ async def test_tab_switch_ignored_during_add_marketplace() -> None:
         screen._select_tab("installed")
         assert screen._mode == "add_marketplace"
         assert screen._tab == "discover"
+
+
+async def test_marketplace_add_stays_locked_during_state_refresh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A successful add cannot be submitted again while state is reloading."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    screen = PluginManagerScreen()
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+
+    async def refresh_state() -> None:
+        refresh_started.set()
+        await release_refresh.wait()
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        app.push_screen(screen)
+        await pilot.pause()
+        screen._mode = "add_marketplace"
+        screen._adding_marketplace = True
+        screen._refresh_view()
+        source = screen.query_one("#plugin-marketplace-source", Input)
+        source.value = "owner/repo"
+        source.disabled = True
+        add_marketplace = MagicMock()
+        monkeypatch.setattr(screen, "_add_marketplace", add_marketplace)
+        monkeypatch.setattr(screen, "_refresh_state", refresh_state)
+        marketplace = PluginMarketplace(
+            name="official",
+            root=tmp_path,
+            manifest_path=tmp_path / "marketplace.json",
+            metadata={},
+            plugins=(),
+        )
+
+        finish = asyncio.create_task(screen._finish_marketplace_add(marketplace, None))
+        await refresh_started.wait()
+
+        assert screen._adding_marketplace is True
+        assert source.disabled is True
+        screen.on_input_submitted(Input.Submitted(source, source.value))
+        add_marketplace.assert_not_called()
+
+        release_refresh.set()
+        await finish
+        assert screen._adding_marketplace is False
+        assert source.disabled is False
 
 
 async def test_search_hidden_without_filterable_plugins() -> None:


### PR DESCRIPTION
Plugin marketplaces are now added asynchronously with visible progress and recoverable errors.

---

Marketplace additions now run in a Textual thread worker so repository and network work cannot block the UI. The modal displays an animated spinner, prevents duplicate submissions and cancellation while busy, and restores the source field with an actionable error after failure.

## Screenshots
<img width="867" height="1004" alt="Screenshot 2026-07-16 at 11 44 16 AM" src="https://github.com/user-attachments/assets/031831a0-aa97-4d43-ac9b-e7cbcd7ce13f" />


Made by [Open SWE](https://openswe.vercel.app/agents/019f6785-019d-75b7-86c1-c35cc55cdf5d)