### PR TITLE
feat(code): summarize plugin changes on reload

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -550,6 +550,7 @@ if TYPE_CHECKING:
     from deepagents_code.event_bus import EventSource, ExternalEvent
     from deepagents_code.mcp_tools import MCPServerInfo
     from deepagents_code.model_config import MissingProviderPackageError
+    from deepagents_code.plugins.models import PluginInstance
     from deepagents_code.resume_state import GoalProposalKind, GoalStatus
     from deepagents_code.skills.load import ExtendedSkillMetadata
     from deepagents_code.tool_catalog import ToolCatalog, UnavailableServer
@@ -3198,6 +3199,9 @@ class DeepAgentsApp(App):
         Used by `_invoke_skill` to skip re-walking all skill directories on
         every invocation.
         """
+
+        self._plugin_fingerprints: dict[str, tuple[object, ...]] | None = None
+        """Plugin state before manager changes, consumed by `/reload`."""
 
         self._skill_allowed_roots: list[Path] = []
         """Pre-resolved skill root directories for containment checks in
@@ -11263,6 +11267,11 @@ class DeepAgentsApp(App):
                 from deepagents_code.plugins.adapters.mcp import plugin_mcp_configs
 
                 plugin_result = discover_plugins()
+                new_plugin_fingerprints = self._fingerprint_plugins(
+                    plugin_result.plugins
+                )
+                old_plugin_fingerprints = self._plugin_fingerprints
+                self._plugin_fingerprints = new_plugin_fingerprints
                 plugin_count = len(plugin_result.plugins)
                 mcp_configs = plugin_mcp_configs(plugin_result.plugins)
                 mcp_count = sum(
@@ -11279,6 +11288,29 @@ class DeepAgentsApp(App):
                     f"{mcp_count} plugin MCP server"
                     f"{'s' if mcp_count != 1 else ''}"
                 )
+                if old_plugin_fingerprints is not None:
+                    old_ids = set(old_plugin_fingerprints)
+                    new_ids = set(new_plugin_fingerprints)
+                    added_count = len(new_ids - old_ids)
+                    removed_count = len(old_ids - new_ids)
+                    changed_count = sum(
+                        old_plugin_fingerprints[plugin_id]
+                        != new_plugin_fingerprints[plugin_id]
+                        for plugin_id in old_ids & new_ids
+                    )
+                    change_parts = []
+                    for count, label in (
+                        (added_count, "added"),
+                        (removed_count, "removed"),
+                        (changed_count, "changed"),
+                    ):
+                        if count:
+                            noun = "plugin" if count == 1 else "plugins"
+                            change_parts.append(f"{count} {noun} {label}")
+                    if change_parts:
+                        report += "\nPlugin changes: " + ", ".join(change_parts) + "."
+                    else:
+                        report += "\nPlugin changes: no changes detected."
                 if plugin_result.warnings:
                     report += (
                         f"\n{len(plugin_result.warnings)} plugin warning(s) "
@@ -17034,14 +17066,53 @@ class DeepAgentsApp(App):
                 markup=False,
             )
 
+    @staticmethod
+    def _fingerprint_plugins(
+        plugins: tuple[PluginInstance, ...],
+    ) -> dict[str, tuple[object, ...]]:
+        """Build reload-comparison fingerprints for discovered plugins.
+
+        Returns:
+            Plugin fingerprints keyed by plugin id.
+        """
+        fingerprints: dict[str, tuple[object, ...]] = {}
+        for plugin in plugins:
+            paths = (*plugin.inventory.skills, *plugin.inventory.mcp_files)
+            file_state = tuple(
+                (str(path), path.stat().st_mtime_ns, path.stat().st_size)
+                for path in paths
+                if path.exists()
+            )
+            fingerprints[plugin.plugin_id] = (
+                plugin.version,
+                repr(plugin.manifest),
+                file_state,
+            )
+        return fingerprints
+
     async def _show_plugin_manager(self) -> None:
         """Open the interactive plugin manager."""
+        from deepagents_code.plugins import discover_plugins
         from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
+
+        self._plugin_fingerprints = self._fingerprint_plugins(
+            discover_plugins().plugins
+        )
+
+        def on_close(changed: bool | None) -> None:
+            if changed is None:
+                return
+            if changed:
+                self.call_after_refresh(
+                    self._mount_message,
+                    AppMessage("Plugin changes require /reload to take effect."),
+                )
 
         self.push_screen(
             PluginManagerScreen(
                 mcp_server_info=self._mcp_server_info or [],
-            )
+            ),
+            on_close,
         )
 
     async def _handle_mcp_subcommand(self, args: str) -> None:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -17734,6 +17734,9 @@ class DeepAgentsApp(App):
         Directory components (e.g. `skills/`) are walked recursively so edits to
         nested files like `SKILL.md` change the fingerprint even when the
         directory's own mtime/size stay the same.
+
+        Returns:
+            Sorted fingerprint entries of `(path, mtime_ns, size)`.
         """
         entries: list[tuple[str, int, int]] = []
         for path in paths:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -610,6 +610,8 @@ the caller. Shared by the install-confirm, MCP-reconnect, and restart-prompt
 watchdogs so the three stay in lockstep.
 """
 
+_PLUGIN_RELOAD_REMINDER = "Plugin changes are pending. Run /reload when ready."
+
 
 def _resolve_theme_name(value: object) -> str | None:
     """Resolve a user-supplied theme name to a canonical registry key.
@@ -17792,14 +17794,28 @@ class DeepAgentsApp(App):
         )
 
         def on_close(_result: None) -> None:
-            current_fingerprints = self._fingerprint_plugins(discover_plugins().plugins)
-            if (
-                load_enabled_plugin_ids() != enabled_plugin_ids
-                or current_fingerprints != self._plugin_fingerprints
-            ):
+            try:
+                current_fingerprints = self._fingerprint_plugins(
+                    discover_plugins().plugins
+                )
+                if (
+                    load_enabled_plugin_ids() != enabled_plugin_ids
+                    or current_fingerprints != self._plugin_fingerprints
+                ):
+                    self.call_after_refresh(
+                        lambda: self.run_worker(
+                            self._offer_plugin_reload(),
+                            exclusive=True,
+                            group="plugin-reload-prompt",
+                        )
+                    )
+            except Exception:
+                # State discovery may fail while the modal unwinds; preserve a
+                # manual reload path instead of raising from its dismiss callback.
+                logger.exception("Failed to check plugin state after manager close")
                 self.call_after_refresh(
                     lambda: self.run_worker(
-                        self._offer_plugin_reload(),
+                        self._mount_message(AppMessage(_PLUGIN_RELOAD_REMINDER)),
                         exclusive=True,
                         group="plugin-reload-prompt",
                     )
@@ -17826,23 +17842,18 @@ class DeepAgentsApp(App):
             )
         except TimeoutError:
             logger.warning("Plugin reload prompt timed out")
-            await self._mount_message(
-                AppMessage("Plugin changes are pending. Run /reload when ready.")
-            )
+            await self._mount_message(AppMessage(_PLUGIN_RELOAD_REMINDER))
             return
         except Exception:
+            # Modal could not be mounted; fall back to a pending reload reminder.
             logger.exception("Failed to mount plugin reload prompt")
-            await self._mount_message(
-                AppMessage("Plugin changes are pending. Run /reload when ready.")
-            )
+            await self._mount_message(AppMessage(_PLUGIN_RELOAD_REMINDER))
             return
 
         if choice == "reload":
             await self._submit_input("/reload", "command")
-        elif choice == "later":
-            await self._mount_message(
-                AppMessage("Plugin changes are pending. Run /reload when ready.")
-            )
+        else:
+            await self._mount_message(AppMessage(_PLUGIN_RELOAD_REMINDER))
 
     async def _handle_mcp_subcommand(self, args: str) -> None:
         """Dispatch `/mcp <subcommand>` strings.

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -559,7 +559,7 @@ if TYPE_CHECKING:
     from deepagents_code.goal_rubric import GoalCreateRequest, GoalCriteriaRequest
     from deepagents_code.mcp_tools import MCPServerInfo
     from deepagents_code.model_config import MissingProviderPackageError
-    from deepagents_code.plugins.models import PluginInstance
+    from deepagents_code.plugins.models import PluginDiscoveryResult, PluginInstance
     from deepagents_code.resume_state import GoalProposalKind, GoalStatus
     from deepagents_code.skills.load import ExtendedSkillMetadata
     from deepagents_code.tool_catalog import ToolCatalog, UnavailableServer
@@ -611,6 +611,7 @@ watchdogs so the three stay in lockstep.
 """
 
 _PLUGIN_RELOAD_REMINDER = "Plugin changes are pending. Run /reload when ready."
+_PLUGIN_RELOAD_CHECK_FAILED = "Couldn't check plugin state. Run /reload to be safe."
 
 
 def _resolve_theme_name(value: object) -> str | None:
@@ -3288,7 +3289,12 @@ class DeepAgentsApp(App):
         """
 
         self._plugin_fingerprints: dict[str, tuple[object, ...]] | None = None
-        """Plugin state before manager changes, consumed by `/reload`."""
+        """Rolling plugin-fingerprint baseline keyed by plugin id.
+
+        Captured when the plugin manager opens (see `_show_plugin_manager`),
+        compared against on manager close (`_check_plugin_manager_changes`), and
+        refreshed after each `/reload`. `None` until first captured.
+        """
 
         self._skill_allowed_roots: list[Path] = []
         """Pre-resolved skill root directories for containment checks in
@@ -11712,12 +11718,10 @@ class DeepAgentsApp(App):
             from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
 
             if is_env_truthy(EXPERIMENTAL):
-                from deepagents_code.plugins import discover_plugins
                 from deepagents_code.plugins.adapters.mcp import plugin_mcp_configs
 
-                plugin_result = discover_plugins()
-                new_plugin_fingerprints = self._fingerprint_plugins(
-                    plugin_result.plugins
+                plugin_result, new_plugin_fingerprints = await asyncio.to_thread(
+                    self._discover_plugins_with_fingerprints
                 )
                 old_plugin_fingerprints = self._plugin_fingerprints
                 self._plugin_fingerprints = new_plugin_fingerprints
@@ -11763,6 +11767,10 @@ class DeepAgentsApp(App):
                         report += "\nPlugin changes: " + ", ".join(change_parts) + "."
                     else:
                         report += "\nPlugin changes: no changes detected."
+                    for label in self._plugin_login_labels(
+                        plugin_result.plugins, new_ids - old_ids
+                    ):
+                        report += f"\nSign in to {label} via `/mcp`."
                 if plugin_result.warnings:
                     report += (
                         f"\n{len(plugin_result.warnings)} plugin warning(s) "
@@ -17738,7 +17746,8 @@ class DeepAgentsApp(App):
         directory's own mtime/size stay the same.
 
         Returns:
-            Sorted fingerprint entries of `(path, mtime_ns, size)`.
+            Deterministic fingerprint entries of `(path, mtime_ns, size)` (each
+            directory walked in sorted order).
         """
         entries: list[tuple[str, int, int]] = []
         for path in paths:
@@ -17748,6 +17757,9 @@ class DeepAgentsApp(App):
                 try:
                     stat = path.stat()
                 except OSError:
+                    logger.debug(
+                        "Skipping unreadable component path %s", path, exc_info=True
+                    )
                     continue
                 entries.append((str(path), stat.st_mtime_ns, stat.st_size))
                 continue
@@ -17759,6 +17771,9 @@ class DeepAgentsApp(App):
                 try:
                     stat = child.stat()
                 except OSError:
+                    logger.debug(
+                        "Skipping unreadable component path %s", child, exc_info=True
+                    )
                     continue
                 entries.append((str(child), stat.st_mtime_ns, stat.st_size))
         return tuple(entries)
@@ -17782,44 +17797,117 @@ class DeepAgentsApp(App):
             )
         return fingerprints
 
-    async def _show_plugin_manager(self) -> None:
-        """Open the interactive plugin manager."""
+    def _discover_plugins_with_fingerprints(
+        self,
+    ) -> tuple[PluginDiscoveryResult, dict[str, tuple[object, ...]]]:
+        """Discover plugins and fingerprint their reload-relevant files.
+
+        This performs recursive filesystem scans and must be called off the UI
+        thread.
+
+        Returns:
+            Plugin discovery output and fingerprints keyed by plugin id.
+        """
         from deepagents_code.plugins import discover_plugins
+
+        result = discover_plugins()
+        return result, self._fingerprint_plugins(result.plugins)
+
+    @staticmethod
+    def _plugin_login_labels(
+        plugins: tuple[PluginInstance, ...], plugin_ids: set[str]
+    ) -> tuple[str, ...]:
+        """List newly added plugins whose MCP servers require sign-in.
+
+        Args:
+            plugins: Plugins discovered by `/reload`.
+            plugin_ids: Newly added plugin ids to inspect.
+
+        Returns:
+            Deduplicated display labels in plugin discovery order.
+        """
+        from deepagents_code.plugins.adapters.mcp import plugin_mcp_server_entries
+
+        labels: list[str] = []
+        for plugin in plugins:
+            if plugin.plugin_id not in plugin_ids:
+                continue
+            entries = plugin_mcp_server_entries(plugin)
+            if not any(needs_login for _label, _scoped, needs_login in entries):
+                continue
+            manifest = plugin.manifest
+            labels.append(
+                manifest.display_name
+                if manifest is not None and manifest.display_name
+                else plugin.name
+            )
+        return tuple(dict.fromkeys(labels))
+
+    def _snapshot_plugin_state(
+        self,
+    ) -> tuple[frozenset[str], dict[str, tuple[object, ...]]]:
+        """Read enabled plugin ids and filesystem fingerprints.
+
+        This performs recursive filesystem scans and must be called off the UI
+        thread.
+
+        Returns:
+            Enabled plugin ids and fingerprints for all discovered plugins.
+        """
         from deepagents_code.plugins.store import load_enabled_plugin_ids
-        from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
 
         enabled_plugin_ids = load_enabled_plugin_ids()
-        self._plugin_fingerprints = self._fingerprint_plugins(
-            discover_plugins().plugins
+        _, fingerprints = self._discover_plugins_with_fingerprints()
+        return enabled_plugin_ids, fingerprints
+
+    async def _check_plugin_manager_changes(
+        self,
+        enabled_plugin_ids: frozenset[str],
+        plugin_fingerprints: dict[str, tuple[object, ...]],
+    ) -> None:
+        """Offer a reload when plugin state changed while the manager was open.
+
+        Args:
+            enabled_plugin_ids: Enabled plugin ids from before the manager opened.
+            plugin_fingerprints: Plugin fingerprints from before the manager opened.
+        """
+        try:
+            current_enabled_ids, current_fingerprints = await asyncio.to_thread(
+                self._snapshot_plugin_state
+            )
+        except Exception:
+            # Preserve a manual reload path if state discovery fails after the
+            # modal has closed. Pending state is unknown here, so point the user
+            # at /reload without asserting that changes are pending.
+            logger.exception("Failed to check plugin state after manager close")
+            await self._mount_message(AppMessage(_PLUGIN_RELOAD_CHECK_FAILED))
+            return
+
+        if (
+            current_enabled_ids != enabled_plugin_ids
+            or current_fingerprints != plugin_fingerprints
+        ):
+            await self._offer_plugin_reload()
+
+    async def _show_plugin_manager(self) -> None:
+        """Open the interactive plugin manager."""
+        from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
+
+        enabled_plugin_ids, plugin_fingerprints = await asyncio.to_thread(
+            self._snapshot_plugin_state
         )
+        self._plugin_fingerprints = plugin_fingerprints
 
         def on_close(_result: None) -> None:
-            try:
-                current_fingerprints = self._fingerprint_plugins(
-                    discover_plugins().plugins
+            self.call_after_refresh(
+                lambda: self.run_worker(
+                    self._check_plugin_manager_changes(
+                        enabled_plugin_ids, plugin_fingerprints
+                    ),
+                    exclusive=True,
+                    group="plugin-reload-prompt",
                 )
-                if (
-                    load_enabled_plugin_ids() != enabled_plugin_ids
-                    or current_fingerprints != self._plugin_fingerprints
-                ):
-                    self.call_after_refresh(
-                        lambda: self.run_worker(
-                            self._offer_plugin_reload(),
-                            exclusive=True,
-                            group="plugin-reload-prompt",
-                        )
-                    )
-            except Exception:
-                # State discovery may fail while the modal unwinds; preserve a
-                # manual reload path instead of raising from its dismiss callback.
-                logger.exception("Failed to check plugin state after manager close")
-                self.call_after_refresh(
-                    lambda: self.run_worker(
-                        self._mount_message(AppMessage(_PLUGIN_RELOAD_REMINDER)),
-                        exclusive=True,
-                        group="plugin-reload-prompt",
-                    )
-                )
+            )
 
         self.push_screen(
             PluginManagerScreen(

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -17783,32 +17783,25 @@ class DeepAgentsApp(App):
     async def _show_plugin_manager(self) -> None:
         """Open the interactive plugin manager."""
         from deepagents_code.plugins import discover_plugins
+        from deepagents_code.plugins.store import load_enabled_plugin_ids
         from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
 
+        enabled_plugin_ids = load_enabled_plugin_ids()
         self._plugin_fingerprints = self._fingerprint_plugins(
             discover_plugins().plugins
         )
 
-        def on_close(
-            result: tuple[bool, tuple[str, bool] | None] | None,
-        ) -> None:
-            if result is None:
-                return
-            changed, mcp_reconnect = result
-            if changed:
-                self.call_after_refresh(
-                    self._mount_message,
-                    AppMessage("Plugin changes require /reload to take effect."),
-                )
-            if mcp_reconnect is not None:
-                label, needs_login = mcp_reconnect
+        def on_close(_result: None) -> None:
+            current_fingerprints = self._fingerprint_plugins(discover_plugins().plugins)
+            if (
+                load_enabled_plugin_ids() != enabled_plugin_ids
+                or current_fingerprints != self._plugin_fingerprints
+            ):
                 self.call_after_refresh(
                     lambda: self.run_worker(
-                        self._offer_reconnect_after_plugin_install(
-                            label, needs_login=needs_login
-                        ),
+                        self._offer_plugin_reload(),
                         exclusive=True,
-                        group="plugin-install-reconnect",
+                        group="plugin-reload-prompt",
                     )
                 )
 
@@ -17820,22 +17813,35 @@ class DeepAgentsApp(App):
             on_close,
         )
 
-    async def _offer_reconnect_after_plugin_install(
-        self, label: str, *, needs_login: bool
-    ) -> None:
-        """Offer reconnect after installing a plugin that declares MCP servers.
+    async def _offer_plugin_reload(self) -> None:
+        """Offer to apply plugin changes after the manager closes."""
+        from deepagents_code.tui.widgets.plugin_reload import (
+            PluginReloadPromptScreen,
+        )
 
-        Reuses the `/mcp login` reconnect-now / defer modal. When the plugin's
-        MCP servers typically need auth, surface a follow-up toast pointing
-        users at `/mcp`.
-        """
-        await self._prompt_mcp_reconnect(label)
-        if needs_login:
-            self.notify(
-                f"Sign in to {label} via `/mcp` after reconnect.",
-                severity="information",
-                timeout=10,
-                markup=False,
+        try:
+            choice = await asyncio.wait_for(
+                self._push_screen_wait(PluginReloadPromptScreen()),
+                timeout=_MODAL_WATCHDOG_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning("Plugin reload prompt timed out")
+            await self._mount_message(
+                AppMessage("Plugin changes are pending. Run /reload when ready.")
+            )
+            return
+        except Exception:
+            logger.exception("Failed to mount plugin reload prompt")
+            await self._mount_message(
+                AppMessage("Plugin changes are pending. Run /reload when ready.")
+            )
+            return
+
+        if choice == "reload":
+            await self._submit_input("/reload", "command")
+        elif choice == "later":
+            await self._mount_message(
+                AppMessage("Plugin changes are pending. Run /reload when ready.")
             )
 
     async def _handle_mcp_subcommand(self, args: str) -> None:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -17726,6 +17726,39 @@ class DeepAgentsApp(App):
             )
 
     @staticmethod
+    def _fingerprint_component_paths(
+        paths: tuple[Path, ...],
+    ) -> tuple[tuple[str, int, int], ...]:
+        """Collect path/mtime/size entries for files under component paths.
+
+        Directory components (e.g. `skills/`) are walked recursively so edits to
+        nested files like `SKILL.md` change the fingerprint even when the
+        directory's own mtime/size stay the same.
+        """
+        entries: list[tuple[str, int, int]] = []
+        for path in paths:
+            if not path.exists():
+                continue
+            if path.is_file():
+                try:
+                    stat = path.stat()
+                except OSError:
+                    continue
+                entries.append((str(path), stat.st_mtime_ns, stat.st_size))
+                continue
+            if not path.is_dir():
+                continue
+            for child in sorted(path.rglob("*")):
+                if not child.is_file():
+                    continue
+                try:
+                    stat = child.stat()
+                except OSError:
+                    continue
+                entries.append((str(child), stat.st_mtime_ns, stat.st_size))
+        return tuple(entries)
+
+    @staticmethod
     def _fingerprint_plugins(
         plugins: tuple[PluginInstance, ...],
     ) -> dict[str, tuple[object, ...]]:
@@ -17737,15 +17770,10 @@ class DeepAgentsApp(App):
         fingerprints: dict[str, tuple[object, ...]] = {}
         for plugin in plugins:
             paths = (*plugin.inventory.skills, *plugin.inventory.mcp_files)
-            file_state = tuple(
-                (str(path), path.stat().st_mtime_ns, path.stat().st_size)
-                for path in paths
-                if path.exists()
-            )
             fingerprints[plugin.plugin_id] = (
                 plugin.version,
                 repr(plugin.manifest),
-                file_state,
+                DeepAgentsApp._fingerprint_component_paths(paths),
             )
         return fingerprints
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -9,6 +9,7 @@ import logging
 import os
 import shlex
 import signal
+import stat as stat_module
 import sys
 import threading
 import time
@@ -18,7 +19,16 @@ from collections import deque
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, assert_never, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Literal,
+    NamedTuple,
+    TypeVar,
+    assert_never,
+    cast,
+)
 
 from textual import on
 from textual.app import App, ScreenStackError
@@ -559,7 +569,11 @@ if TYPE_CHECKING:
     from deepagents_code.goal_rubric import GoalCreateRequest, GoalCriteriaRequest
     from deepagents_code.mcp_tools import MCPServerInfo
     from deepagents_code.model_config import MissingProviderPackageError
-    from deepagents_code.plugins.models import PluginDiscoveryResult, PluginInstance
+    from deepagents_code.plugins.models import (
+        PluginDiscoveryResult,
+        PluginInstance,
+        PluginManifest,
+    )
     from deepagents_code.resume_state import GoalProposalKind, GoalStatus
     from deepagents_code.skills.load import ExtendedSkillMetadata
     from deepagents_code.tool_catalog import ToolCatalog, UnavailableServer
@@ -606,12 +620,40 @@ _MODAL_WATCHDOG_TIMEOUT_SECONDS = 600.0
 Bounds command/worker handling against a modal that never resolves (compose
 crash, programmatic teardown that skips the dismiss callback). 10 minutes is
 well past any human latency but stops a genuinely broken modal from wedging
-the caller. Shared by the install-confirm, MCP-reconnect, and restart-prompt
-watchdogs so the three stay in lockstep.
+the caller. Shared by the install-confirm, MCP-reconnect, restart-prompt, and
+plugin-reload watchdogs so they stay in lockstep.
 """
 
 _PLUGIN_RELOAD_REMINDER = "Plugin changes are pending. Run /reload when ready."
 _PLUGIN_RELOAD_CHECK_FAILED = "Couldn't check plugin state. Run /reload to be safe."
+_MAX_PLUGIN_FINGERPRINT_ENTRIES = 10_000
+_TRUNCATED_PLUGIN_FINGERPRINT_STAT = -2
+
+
+class _PathStat(NamedTuple):
+    """Filesystem fingerprint entry for one component file.
+
+    `mtime_ns`/`size` are `-1` when a path cannot be inspected and `-2` when
+    the bounded scan is truncated. These sentinels keep incomplete scans from
+    being mistaken for complete, unchanged state.
+    """
+
+    path: str
+    mtime_ns: int
+    size: int
+
+
+class _PluginFingerprint(NamedTuple):
+    """Reload-comparison fingerprint for a single plugin.
+
+    Only ever compared with `==`/`!=` (never hashed), so `manifest` is held
+    directly — `PluginManifest` is a frozen dataclass that compares by value,
+    which avoids the key-order fragility of comparing `repr(manifest)`.
+    """
+
+    version: str | None
+    manifest: PluginManifest | None
+    components: tuple[_PathStat, ...]
 
 
 def _resolve_theme_name(value: object) -> str | None:
@@ -3288,12 +3330,15 @@ class DeepAgentsApp(App):
         every invocation.
         """
 
-        self._plugin_fingerprints: dict[str, tuple[object, ...]] | None = None
+        self._plugin_fingerprints: dict[str, _PluginFingerprint] | None = None
         """Rolling plugin-fingerprint baseline keyed by plugin id.
 
-        Captured when the plugin manager opens (see `_show_plugin_manager`),
-        compared against on manager close (`_check_plugin_manager_changes`), and
-        refreshed after each `/reload`. `None` until first captured.
+        Captured when the plugin manager first opens (see
+        `_show_plugin_manager`) and preserved across manager reopens, then read
+        as the `old` baseline for the `/reload` change summary and refreshed
+        there. `None` until first captured. The manager-close check
+        (`_check_plugin_manager_changes`) compares a fresh read against its own
+        open-time snapshot, not this attribute.
         """
 
         self._skill_allowed_roots: list[Path] = []
@@ -11727,78 +11772,101 @@ class DeepAgentsApp(App):
             if is_env_truthy(EXPERIMENTAL):
                 from deepagents_code.plugins.adapters.mcp import plugin_mcp_configs
 
-                plugin_result, new_plugin_fingerprints = await asyncio.to_thread(
-                    self._discover_plugins_with_fingerprints
-                )
-                old_plugin_fingerprints = self._plugin_fingerprints
-                self._plugin_fingerprints = new_plugin_fingerprints
-                discovered_plugin_ids = frozenset(
-                    plugin.plugin_id for plugin in plugin_result.plugins
-                )
-                plugin_count = len(plugin_result.plugins)
-                mcp_configs = plugin_mcp_configs(plugin_result.plugins)
-                mcp_count = sum(
-                    len(servers)
-                    for config in mcp_configs
-                    if isinstance((servers := config.get("mcpServers")), dict)
-                )
-                plugin_skill_count = sum(1 for name in new_skill_names if ":" in name)
-                report += (
-                    f"\nPlugins: {plugin_count} plugin"
-                    f"{'s' if plugin_count != 1 else ''} · "
-                    f"{plugin_skill_count} skill"
-                    f"{'s' if plugin_skill_count != 1 else ''} · "
-                    f"{mcp_count} plugin MCP server"
-                    f"{'s' if mcp_count != 1 else ''}"
-                )
-                if old_plugin_fingerprints is not None:
-                    old_ids = set(old_plugin_fingerprints)
-                    new_ids = set(new_plugin_fingerprints)
-                    added_count = len(new_ids - old_ids)
-                    removed_count = len(old_ids - new_ids)
-                    changed_count = sum(
-                        old_plugin_fingerprints[plugin_id]
-                        != new_plugin_fingerprints[plugin_id]
-                        for plugin_id in old_ids & new_ids
+                try:
+                    plugin_result, new_plugin_fingerprints = await asyncio.to_thread(
+                        self._discover_plugins_with_fingerprints
                     )
-                    change_parts = []
-                    for count, label in (
-                        (added_count, "added"),
-                        (removed_count, "removed"),
-                        (changed_count, "changed"),
-                    ):
-                        if count:
-                            noun = "plugin" if count == 1 else "plugins"
-                            change_parts.append(f"{count} {noun} {label}")
-                    if change_parts:
-                        report += "\nPlugin changes: " + ", ".join(change_parts) + "."
-                    else:
-                        report += "\nPlugin changes: no changes detected."
-                    for label in self._plugin_login_labels(
-                        plugin_result.plugins, new_ids - old_ids
-                    ):
-                        report += f"\nSign in to {label} via `/mcp`."
-                if plugin_result.warnings:
+                except Exception:
+                    # Discovery reads marketplace/plugin config from disk; if it
+                    # fails, keep the rest of the reload intact and point the
+                    # user at a manual retry rather than aborting the report.
+                    logger.exception("Failed to discover plugins during /reload")
+                    report += "\nCouldn't read plugin state; run /reload to be safe."
+                else:
+                    old_plugin_fingerprints = self._plugin_fingerprints
+                    self._plugin_fingerprints = new_plugin_fingerprints
+                    discovered_plugin_ids = frozenset(
+                        plugin.plugin_id for plugin in plugin_result.plugins
+                    )
+                    plugin_count = len(plugin_result.plugins)
+                    mcp_configs = plugin_mcp_configs(plugin_result.plugins)
+                    mcp_count = sum(
+                        len(servers)
+                        for config in mcp_configs
+                        if isinstance((servers := config.get("mcpServers")), dict)
+                    )
+                    plugin_skill_count = sum(
+                        1 for name in new_skill_names if ":" in name
+                    )
                     report += (
-                        f"\n{len(plugin_result.warnings)} plugin warning(s) "
-                        "during load."
+                        f"\nPlugins: {plugin_count} plugin"
+                        f"{'s' if plugin_count != 1 else ''} · "
+                        f"{plugin_skill_count} skill"
+                        f"{'s' if plugin_skill_count != 1 else ''} · "
+                        f"{mcp_count} plugin MCP server"
+                        f"{'s' if mcp_count != 1 else ''}"
                     )
-
-                restarted = False
-                if self._server_proc is not None and self._server_kwargs is not None:
-                    if self._agent_running and self._agent_worker:
-                        self._cancel_worker(self._agent_worker)
-                        self._agent_running = False
-                    else:
-                        self._discard_queue()
-                    restarted = await self._restart_server_manual()
-                    if restarted:
-                        self._session_plugin_ids = discovered_plugin_ids
-                        report += "\nAgent server restarted for plugin MCP."
-                    else:
-                        report += (
-                            "\nAgent server was not restarted; plugin MCP may be stale."
+                    if old_plugin_fingerprints is not None:
+                        old_ids = set(old_plugin_fingerprints)
+                        new_ids = set(new_plugin_fingerprints)
+                        added_count = len(new_ids - old_ids)
+                        removed_count = len(old_ids - new_ids)
+                        changed_count = sum(
+                            self._plugin_fingerprint_changed(
+                                old_plugin_fingerprints[plugin_id],
+                                new_plugin_fingerprints[plugin_id],
+                            )
+                            for plugin_id in old_ids & new_ids
                         )
+                        change_parts = []
+                        for count, label in (
+                            (added_count, "added"),
+                            (removed_count, "removed"),
+                            (changed_count, "changed"),
+                        ):
+                            if count:
+                                noun = "plugin" if count == 1 else "plugins"
+                                change_parts.append(f"{count} {noun} {label}")
+                        if change_parts:
+                            report += (
+                                "\nPlugin changes: " + ", ".join(change_parts) + "."
+                            )
+                        else:
+                            report += "\nPlugin changes: no changes detected."
+                        # Reads each added plugin's MCP config from disk; keep it
+                        # off the UI thread like the discovery scan above.
+                        login_labels = await asyncio.to_thread(
+                            self._plugin_login_labels,
+                            plugin_result.plugins,
+                            new_ids - old_ids,
+                        )
+                        for label in login_labels:
+                            report += f"\nSign in to {label} via `/mcp`."
+                    if plugin_result.warnings:
+                        report += (
+                            f"\n{len(plugin_result.warnings)} plugin warning(s) "
+                            "during load."
+                        )
+
+                    restarted = False
+                    if (
+                        self._server_proc is not None
+                        and self._server_kwargs is not None
+                    ):
+                        if self._agent_running and self._agent_worker:
+                            self._cancel_worker(self._agent_worker)
+                            self._agent_running = False
+                        else:
+                            self._discard_queue()
+                        restarted = await self._restart_server_manual()
+                        if restarted:
+                            self._session_plugin_ids = discovered_plugin_ids
+                            report += "\nAgent server restarted for plugin MCP."
+                        else:
+                            report += (
+                                "\nAgent server was not restarted; plugin MCP may "
+                                "be stale."
+                            )
 
             await self._mount_message(AppMessage(report))
             await self._maybe_start_deferred_server_from_default()
@@ -17762,69 +17830,197 @@ class DeepAgentsApp(App):
 
     @staticmethod
     def _fingerprint_component_paths(
+        plugin_root: Path,
         paths: tuple[Path, ...],
-    ) -> tuple[tuple[str, int, int], ...]:
-        """Collect path/mtime/size entries for files under component paths.
+    ) -> tuple[_PathStat, ...]:
+        """Collect bounded path/mtime/size entries under plugin component paths.
 
-        Directory components (e.g. `skills/`) are walked recursively so edits to
-        nested files like `SKILL.md` change the fingerprint even when the
-        directory's own mtime/size stay the same.
+        Directory components are scanned recursively without following symlinks.
+        Every directory is rechecked against the plugin root immediately before
+        traversal, and the scan stops after `_MAX_PLUGIN_FINGERPRINT_ENTRIES`.
+
+        Args:
+            plugin_root: Root that every traversed component must remain within.
+            paths: Component files or directories to fingerprint.
 
         Returns:
-            Deterministic fingerprint entries of `(path, mtime_ns, size)` (each
-            directory walked in sorted order).
+            Deterministic fingerprint entries. Inaccessible paths use `-1` stats;
+            a `-2` entry marks a scan truncated by the entry limit.
         """
-        entries: list[tuple[str, int, int]] = []
+        entries: list[_PathStat] = []
+        visited_entries = 0
+
+        def _record_unreadable(target: Path) -> None:
+            logger.warning("Unreadable component path %s", target)
+            entries.append(_PathStat(str(target), -1, -1))
+
+        def _consume_entry(target: Path) -> bool:
+            nonlocal visited_entries
+            if visited_entries >= _MAX_PLUGIN_FINGERPRINT_ENTRIES:
+                logger.warning(
+                    "Plugin component fingerprint exceeded %d entries at %s",
+                    _MAX_PLUGIN_FINGERPRINT_ENTRIES,
+                    target,
+                )
+                entries.append(
+                    _PathStat(
+                        str(target),
+                        _TRUNCATED_PLUGIN_FINGERPRINT_STAT,
+                        _TRUNCATED_PLUGIN_FINGERPRINT_STAT,
+                    )
+                )
+                return False
+            visited_entries += 1
+            return True
+
+        try:
+            resolved_root = plugin_root.resolve(strict=True)
+        except OSError:
+            _record_unreadable(plugin_root)
+            return tuple(entries)
+
+        def _scan_directory(directory: Path) -> bool:
+            stack = [directory]
+            while stack:
+                current = stack.pop()
+                try:
+                    current_stat = current.lstat()
+                    resolved = current.resolve(strict=True)
+                except FileNotFoundError:
+                    continue
+                except OSError:
+                    _record_unreadable(current)
+                    continue
+                if stat_module.S_ISLNK(current_stat.st_mode):
+                    entries.append(
+                        _PathStat(
+                            str(current), current_stat.st_mtime_ns, current_stat.st_size
+                        )
+                    )
+                    continue
+                if not resolved.is_relative_to(resolved_root):
+                    logger.warning(
+                        "Ignoring plugin component outside plugin root: %s", current
+                    )
+                    entries.append(_PathStat(str(current), -1, -1))
+                    continue
+
+                children: list[tuple[str, Path, os.stat_result]] = []
+                try:
+                    with os.scandir(current) as iterator:
+                        for child in iterator:
+                            target = Path(child.path)
+                            if not _consume_entry(target):
+                                return False
+                            try:
+                                child_stat = child.stat(follow_symlinks=False)
+                            except FileNotFoundError:
+                                continue
+                            except OSError:
+                                _record_unreadable(target)
+                                continue
+                            children.append((child.name, target, child_stat))
+                except FileNotFoundError:
+                    continue
+                except OSError:
+                    _record_unreadable(current)
+                    continue
+
+                directories: list[Path] = []
+                for _name, target, child_stat in sorted(children):
+                    if stat_module.S_ISDIR(child_stat.st_mode):
+                        directories.append(target)
+                    else:
+                        entries.append(
+                            _PathStat(
+                                str(target),
+                                child_stat.st_mtime_ns,
+                                child_stat.st_size,
+                            )
+                        )
+                stack.extend(reversed(directories))
+            return True
+
         for path in paths:
-            if not path.exists():
+            if not _consume_entry(path):
+                break
+            try:
+                resolved = path.resolve(strict=True)
+            except FileNotFoundError:
                 continue
-            if path.is_file():
-                try:
-                    stat = path.stat()
-                except OSError:
-                    logger.debug(
-                        "Skipping unreadable component path %s", path, exc_info=True
-                    )
-                    continue
-                entries.append((str(path), stat.st_mtime_ns, stat.st_size))
+            except OSError:
+                _record_unreadable(path)
                 continue
-            if not path.is_dir():
+            if not resolved.is_relative_to(resolved_root):
+                logger.warning(
+                    "Ignoring plugin component outside plugin root: %s", path
+                )
+                entries.append(_PathStat(str(path), -1, -1))
                 continue
-            for child in sorted(path.rglob("*")):
-                if not child.is_file():
-                    continue
-                try:
-                    stat = child.stat()
-                except OSError:
-                    logger.debug(
-                        "Skipping unreadable component path %s", child, exc_info=True
-                    )
-                    continue
-                entries.append((str(child), stat.st_mtime_ns, stat.st_size))
+            try:
+                path_stat = path.lstat()
+            except FileNotFoundError:
+                continue
+            except OSError:
+                _record_unreadable(path)
+                continue
+            if stat_module.S_ISDIR(path_stat.st_mode):
+                if not _scan_directory(path):
+                    break
+            else:
+                entries.append(
+                    _PathStat(str(path), path_stat.st_mtime_ns, path_stat.st_size)
+                )
         return tuple(entries)
+
+    @staticmethod
+    def _plugin_fingerprint_changed(
+        before: _PluginFingerprint, after: _PluginFingerprint
+    ) -> bool:
+        """Return whether a plugin changed or either scan was truncated."""
+        return (
+            before != after
+            or any(entry.mtime_ns < 0 for entry in before.components)
+            or any(entry.mtime_ns < 0 for entry in after.components)
+        )
+
+    @staticmethod
+    def _plugin_fingerprints_changed(
+        before: dict[str, _PluginFingerprint],
+        after: dict[str, _PluginFingerprint],
+    ) -> bool:
+        """Return whether plugin identities or any fingerprint changed."""
+        return before.keys() != after.keys() or any(
+            DeepAgentsApp._plugin_fingerprint_changed(
+                before[plugin_id], after[plugin_id]
+            )
+            for plugin_id in before.keys() & after.keys()
+        )
 
     @staticmethod
     def _fingerprint_plugins(
         plugins: tuple[PluginInstance, ...],
-    ) -> dict[str, tuple[object, ...]]:
+    ) -> dict[str, _PluginFingerprint]:
         """Build reload-comparison fingerprints for discovered plugins.
 
         Returns:
             Plugin fingerprints keyed by plugin id.
         """
-        fingerprints: dict[str, tuple[object, ...]] = {}
+        fingerprints: dict[str, _PluginFingerprint] = {}
         for plugin in plugins:
             paths = (*plugin.inventory.skills, *plugin.inventory.mcp_files)
-            fingerprints[plugin.plugin_id] = (
-                plugin.version,
-                repr(plugin.manifest),
-                DeepAgentsApp._fingerprint_component_paths(paths),
+            fingerprints[plugin.plugin_id] = _PluginFingerprint(
+                version=plugin.version,
+                manifest=plugin.manifest,
+                components=DeepAgentsApp._fingerprint_component_paths(
+                    plugin.root, paths
+                ),
             )
         return fingerprints
 
     def _discover_plugins_with_fingerprints(
         self,
-    ) -> tuple[PluginDiscoveryResult, dict[str, tuple[object, ...]]]:
+    ) -> tuple[PluginDiscoveryResult, dict[str, _PluginFingerprint]]:
         """Discover plugins and fingerprint their reload-relevant files.
 
         This performs recursive filesystem scans and must be called off the UI
@@ -17870,7 +18066,7 @@ class DeepAgentsApp(App):
 
     def _snapshot_plugin_state(
         self,
-    ) -> tuple[frozenset[str], dict[str, tuple[object, ...]]]:
+    ) -> tuple[frozenset[str], dict[str, _PluginFingerprint]]:
         """Read enabled plugin ids and filesystem fingerprints.
 
         This performs recursive filesystem scans and must be called off the UI
@@ -17888,7 +18084,7 @@ class DeepAgentsApp(App):
     async def _check_plugin_manager_changes(
         self,
         enabled_plugin_ids: frozenset[str],
-        plugin_fingerprints: dict[str, tuple[object, ...]],
+        plugin_fingerprints: dict[str, _PluginFingerprint],
     ) -> None:
         """Offer a reload when plugin state changed while the manager was open.
 
@@ -17910,7 +18106,9 @@ class DeepAgentsApp(App):
 
         if (
             current_enabled_ids != enabled_plugin_ids
-            or current_fingerprints != plugin_fingerprints
+            or self._plugin_fingerprints_changed(
+                plugin_fingerprints, current_fingerprints
+            )
         ):
             await self._offer_plugin_reload()
 
@@ -17918,17 +18116,30 @@ class DeepAgentsApp(App):
         """Open the interactive plugin manager."""
         from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
 
-        enabled_plugin_ids, plugin_fingerprints = await asyncio.to_thread(
-            self._snapshot_plugin_state
-        )
-        self._plugin_fingerprints = plugin_fingerprints
+        try:
+            baseline = await asyncio.to_thread(self._snapshot_plugin_state)
+        except Exception:
+            # Still open the manager if the pre-open snapshot fails. Without a
+            # baseline, its close handler leaves a manual reload reminder.
+            logger.exception("Failed to snapshot plugin state before opening manager")
+            baseline = None
+        else:
+            if self._plugin_fingerprints is None:
+                self._plugin_fingerprints = baseline[1]
+
+        async def check_changes() -> None:
+            if baseline is None:
+                await self._mount_message(AppMessage(_PLUGIN_RELOAD_CHECK_FAILED))
+                return
+            enabled_plugin_ids, plugin_fingerprints = baseline
+            await self._check_plugin_manager_changes(
+                enabled_plugin_ids, plugin_fingerprints
+            )
 
         def on_close(_result: None) -> None:
             self.call_after_refresh(
                 lambda: self.run_worker(
-                    self._check_plugin_manager_changes(
-                        enabled_plugin_ids, plugin_fingerprints
-                    ),
+                    check_changes(),
                     exclusive=True,
                     group="plugin-reload-prompt",
                 )

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -51,7 +51,7 @@ from deepagents_code.tui.modals.plugin_manager.models import _ManagerState
 from deepagents_code.tui.modals.plugin_manager.state import _load_manager_state
 
 
-class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
+class PluginManagerScreen(ModalScreen[bool]):  # noqa: RUF067
     """Arrow-key navigable plugin manager for `/plugins`."""
 
     BINDINGS: ClassVar[list[BindingType]] = [
@@ -94,6 +94,7 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         self._error: str | None = None
         self._selected_plugin: _PluginRow | None = None
         self._selected_marketplace: _MarketplaceRow | None = None
+        self._plugins_changed = False
 
     def compose(self) -> ComposeResult:
         """Compose the manager screen.
@@ -388,7 +389,7 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
             self._error = None
             self._refresh_view()
             return
-        self.dismiss(None)
+        self.dismiss(self._plugins_changed)
 
     def action_next_tab(self) -> None:
         """Switch to the next tab."""
@@ -545,6 +546,7 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         self._mode = "list"
         self._tab = "installed"
         self._selected_plugin = None
+        self._plugins_changed = True
         self._status = f"Installed {row.plugin_id}. Run /reload to activate."
         self._error = None
         await self._refresh_state()
@@ -570,6 +572,7 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
             self._status = None
             self._refresh_view()
             return
+        self._plugins_changed = True
         self._error = None
         await self._refresh_state()
 
@@ -586,6 +589,7 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
             return
         self._mode = "list"
         self._selected_plugin = None
+        self._plugins_changed = self._plugins_changed or row.enabled
         reload_hint = " Run /reload to unload." if row.enabled else ""
         self._status = f"Uninstalled {row.plugin_id}.{reload_hint}"
         self._error = None
@@ -610,6 +614,7 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
             await self._refresh_state()
             return
         plugin_label = "plugin" if row.installed_count == 1 else "plugins"
+        self._plugins_changed = self._plugins_changed or row.installed_count > 0
         self._mode = "list"
         self._tab = "marketplaces"
         self._selected_marketplace = None

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -52,15 +52,11 @@ from deepagents_code.tui.modals.plugin_manager.models import _ManagerState
 from deepagents_code.tui.modals.plugin_manager.state import _load_manager_state
 
 
-class PluginManagerScreen(  # noqa: RUF067
-    ModalScreen[tuple[bool, tuple[str, bool] | None] | None]
-):
+class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
     """Arrow-key navigable plugin manager for `/plugins`.
 
-    Dismisses with `(changed, mcp_reconnect)` where `changed` is whether
-    plugins/marketplaces were mutated (so the app can remind about
-    `/reload`), and `mcp_reconnect` is `(label, needs_mcp_login)` after an
-    MCP-bearing install so the app can offer reconnect + login guidance.
+    Plugin changes are applied by the reload prompt shown after this screen
+    closes.
     """
 
     BINDINGS: ClassVar[list[BindingType]] = [
@@ -114,7 +110,6 @@ class PluginManagerScreen(  # noqa: RUF067
         self._error: str | None = None
         self._selected_plugin: _PluginRow | None = None
         self._selected_marketplace: _MarketplaceRow | None = None
-        self._plugins_changed = False
 
     def compose(self) -> ComposeResult:
         """Compose the manager screen.
@@ -461,7 +456,7 @@ class PluginManagerScreen(  # noqa: RUF067
             self._error = None
             self._refresh_view()
             return
-        self.dismiss((self._plugins_changed, None))
+        self.dismiss(None)
 
     def _cycle_details_option(self, step: int) -> None:
         options = self.query_one("#plugin-manager-options", OptionList)
@@ -629,32 +624,20 @@ class PluginManagerScreen(  # noqa: RUF067
         if row is None:
             return
         try:
-            # install_plugin returns the loaded instance; Discover rows do not
-            # carry MCP metadata until install, so inspect the result here.
-            instance = await asyncio.to_thread(install_plugin, row.plugin_id)
+            await asyncio.to_thread(install_plugin, row.plugin_id)
         except (MarketplaceError, FileNotFoundError, OSError, ValueError) as exc:
             self._error = str(exc)
             self._status = None
             self._refresh_view()
             return
-        from deepagents_code.plugins.adapters.mcp import plugin_mcp_server_entries
-
         label = row.label
-        entries = plugin_mcp_server_entries(instance)
-        has_mcp = bool(entries)
-        needs_login = any(needs for _label, _scoped, needs in entries)
         self.notify(f"Installed {label}", timeout=5, markup=False)
         self._mode = "list"
         self._tab = "installed"
         self._selected_plugin = None
-        self._plugins_changed = True
         self._status = f"Installed {label}. Run /reload to activate."
         self._error = None
         await self._refresh_state()
-        if has_mcp:
-            # Close the manager so the reconnect prompt is not buried under it.
-            self.dismiss((True, (label, needs_login)))
-            return
 
     async def _toggle_selected_plugin_enabled(self) -> None:
         row = self._selected_plugin
@@ -677,7 +660,6 @@ class PluginManagerScreen(  # noqa: RUF067
             self._status = None
             self._refresh_view()
             return
-        self._plugins_changed = True
         self._error = None
         await self._refresh_state()
 
@@ -694,7 +676,6 @@ class PluginManagerScreen(  # noqa: RUF067
             return
         self._mode = "list"
         self._selected_plugin = None
-        self._plugins_changed = self._plugins_changed or row.enabled
         reload_hint = " Run /reload to unload." if row.enabled else ""
         self._status = f"Uninstalled {row.label}.{reload_hint}"
         self._error = None
@@ -719,7 +700,6 @@ class PluginManagerScreen(  # noqa: RUF067
             await self._refresh_state()
             return
         plugin_label = "plugin" if row.installed_count == 1 else "plugins"
-        self._plugins_changed = self._plugins_changed or row.installed_count > 0
         self._mode = "list"
         self._tab = "marketplaces"
         self._selected_marketplace = None

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -468,8 +468,13 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         if not enabled:
             return
         current = options.highlighted
-        position = enabled.index(current) if current in enabled else 0
-        options.highlighted = enabled[(position + step) % len(enabled)]
+        if current in enabled:
+            position = enabled.index(current)
+            options.highlighted = enabled[(position + step) % len(enabled)]
+        else:
+            # Nothing highlighted yet: step forward to the first option, back to
+            # the last.
+            options.highlighted = enabled[0] if step > 0 else enabled[-1]
         options.focus()
 
     def action_next_tab(self) -> None:
@@ -624,18 +629,28 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         if row is None:
             return
         try:
-            await asyncio.to_thread(install_plugin, row.plugin_id)
+            instance = await asyncio.to_thread(install_plugin, row.plugin_id)
         except (MarketplaceError, FileNotFoundError, OSError, ValueError) as exc:
             self._error = str(exc)
             self._status = None
             self._refresh_view()
             return
+        from deepagents_code.plugins.adapters.mcp import plugin_mcp_server_entries
+
         label = row.label
+        needs_login = any(
+            needs_login
+            for _server_label, _scoped, needs_login in plugin_mcp_server_entries(
+                instance
+            )
+        )
         self.notify(f"Installed {label}", timeout=5, markup=False)
         self._mode = "list"
         self._tab = "installed"
         self._selected_plugin = None
         self._status = f"Installed {label}. Run /reload to activate."
+        if needs_login:
+            self._status += f" After reload, sign in to {label} via /mcp."
         self._error = None
         await self._refresh_state()
 

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -55,8 +55,8 @@ from deepagents_code.tui.modals.plugin_manager.state import _load_manager_state
 class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
     """Arrow-key navigable plugin manager for `/plugins`.
 
-    Plugin changes are applied by the reload prompt shown after this screen
-    closes.
+    A reload prompt shown after this screen closes offers to apply plugin
+    changes via `/reload`.
     """
 
     BINDINGS: ClassVar[list[BindingType]] = [

--- a/libs/code/deepagents_code/tui/widgets/plugin_reload.py
+++ b/libs/code/deepagents_code/tui/widgets/plugin_reload.py
@@ -1,0 +1,96 @@
+"""Confirmation modal offered after reload-relevant plugin changes."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, Literal
+
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+
+PluginReloadChoice = Literal["reload", "later"]
+"""Outcome of the prompt: apply plugin changes now or defer."""
+
+
+class PluginReloadPromptScreen(ModalScreen[PluginReloadChoice]):
+    """Ask whether to reload after leaving the plugin manager."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("enter", "reload", "Reload", show=False, priority=True),
+        Binding("escape", "later", "Later", show=False, priority=True),
+    ]
+
+    CSS = """
+    PluginReloadPromptScreen {
+        align: center middle;
+    }
+
+    PluginReloadPromptScreen > Vertical {
+        width: 64;
+        max-width: 90%;
+        height: auto;
+        background: $surface;
+        border: solid $primary;
+        padding: 1 2;
+    }
+
+    PluginReloadPromptScreen .plugin-reload-title {
+        text-style: bold;
+        color: $primary;
+        text-align: center;
+        margin-bottom: 1;
+    }
+
+    PluginReloadPromptScreen .plugin-reload-body {
+        height: auto;
+        color: $text;
+        margin-bottom: 1;
+    }
+
+    PluginReloadPromptScreen .plugin-reload-help {
+        height: 1;
+        color: $text-muted;
+        text-style: italic;
+        text-align: center;
+    }
+    """
+
+    def compose(self) -> ComposeResult:  # noqa: PLR6301  # Textual requires an instance method
+        """Compose the title, explanation, and keyboard help.
+
+        Yields:
+            Widgets for the plugin reload prompt.
+        """
+        with Vertical():
+            yield Static(
+                "Reload plugins?",
+                classes="plugin-reload-title",
+                markup=False,
+            )
+            yield Static(
+                "Reload to apply changes to plugin skills and MCP tools.",
+                classes="plugin-reload-body",
+                markup=False,
+            )
+            yield Static(
+                "Enter to reload, Esc for later",
+                classes="plugin-reload-help",
+                markup=False,
+            )
+
+    def action_reload(self) -> None:
+        """Choose to apply plugin changes now."""
+        self.dismiss("reload")
+
+    def action_later(self) -> None:
+        """Defer the reload."""
+        self.dismiss("later")
+
+    def action_cancel(self) -> None:
+        """Treat the app-level Esc action as an explicit deferral."""
+        self.action_later()

--- a/libs/code/tests/unit_tests/test_reload.py
+++ b/libs/code/tests/unit_tests/test_reload.py
@@ -1124,12 +1124,45 @@ class TestReloadPluginsViaReload:
         else:
             call_after_refresh.assert_not_called()
 
-    @pytest.mark.parametrize("choice", ["reload", "later"])
+    async def test_plugin_manager_state_error_schedules_reminder(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A state read failure should not escape the modal dismiss callback."""
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.plugins.models import PluginDiscoveryResult
+
+        discovery = MagicMock(
+            side_effect=[
+                PluginDiscoveryResult(plugins=()),
+                PermissionError("plugin directory is unreadable"),
+            ]
+        )
+        app = DeepAgentsApp()
+        call_after_refresh = MagicMock()
+
+        monkeypatch.setattr("deepagents_code.plugins.discover_plugins", discovery)
+        monkeypatch.setattr(
+            "deepagents_code.plugins.store.load_enabled_plugin_ids",
+            lambda: frozenset[str](),
+        )
+        monkeypatch.setattr(
+            app,
+            "push_screen",
+            lambda _screen, callback: callback(None),
+        )
+        monkeypatch.setattr(app, "call_after_refresh", call_after_refresh)
+
+        await app._show_plugin_manager()
+
+        call_after_refresh.assert_called_once()
+        assert callable(call_after_refresh.call_args.args[0])
+
+    @pytest.mark.parametrize("choice", ["reload", "later", None])
     async def test_plugin_reload_prompt_choice(
         self,
         monkeypatch: pytest.MonkeyPatch,
         *,
-        choice: str,
+        choice: str | None,
     ) -> None:
         """Reload runs the command; deferral leaves one transcript reminder."""
         from deepagents_code.app import DeepAgentsApp
@@ -1159,6 +1192,42 @@ class TestReloadPluginsViaReload:
             message = mount_call.args[0]
             assert isinstance(message, AppMessage)
             assert "/reload" in str(message._content)
+
+    @pytest.mark.parametrize(
+        "error",
+        [TimeoutError(), RuntimeError("prompt mount failed")],
+        ids=["timeout", "unexpected-error"],
+    )
+    async def test_plugin_reload_prompt_error_leaves_reminder(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        error: Exception,
+    ) -> None:
+        """Prompt failures should retain a manual `/reload` recovery path."""
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.tui.widgets.messages import AppMessage
+
+        app = DeepAgentsApp()
+        submit = AsyncMock()
+        mount = AsyncMock()
+        monkeypatch.setattr(
+            app,
+            "_push_screen_wait",
+            AsyncMock(side_effect=error),
+        )
+        monkeypatch.setattr(app, "_submit_input", submit)
+        monkeypatch.setattr(app, "_mount_message", mount)
+
+        await app._offer_plugin_reload()
+
+        submit.assert_not_awaited()
+        mount.assert_awaited_once()
+        mount_call = mount.await_args
+        assert mount_call is not None
+        message = mount_call.args[0]
+        assert isinstance(message, AppMessage)
+        assert "/reload" in str(message._content)
 
     async def test_reports_plugin_summary_when_experimental(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_reload.py
+++ b/libs/code/tests/unit_tests/test_reload.py
@@ -1,8 +1,11 @@
 """Tests for runtime config reload behavior."""
 
+from __future__ import annotations
+
 import logging
 import os
-from pathlib import Path
+import threading
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import dotenv as _dotenv_module
@@ -12,6 +15,12 @@ from deepagents_code import _env_vars
 from deepagents_code.command_registry import get_slash_commands
 from deepagents_code.config import Settings
 from deepagents_code.skills.load import ExtendedSkillMetadata
+
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+    from pathlib import Path
+
+    from deepagents_code.plugins.models import PluginInstance
 
 # Capture before any monkeypatching replaces it on the module.
 _real_load_dotenv = _dotenv_module.load_dotenv
@@ -1073,6 +1082,86 @@ class TestReloadPluginsViaReload:
 
         assert before != after
 
+    def test_fingerprint_detects_version_change(self, tmp_path: Path) -> None:
+        """A version bump must change the fingerprint even with identical files."""
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.plugins.models import ComponentInventory, PluginInstance
+
+        def _plugin(version: str) -> PluginInstance:
+            return PluginInstance(
+                plugin_id="demo@tools",
+                name="demo",
+                marketplace="tools",
+                version=version,
+                root=tmp_path,
+                data_dir=tmp_path / "data",
+                manifest=None,
+                inventory=ComponentInventory(),
+            )
+
+        before = DeepAgentsApp._fingerprint_plugins((_plugin("1.0"),))
+        after = DeepAgentsApp._fingerprint_plugins((_plugin("2.0"),))
+
+        assert before != after
+
+    def test_fingerprint_detects_manifest_change(self, tmp_path: Path) -> None:
+        """A manifest change must flip the fingerprint even when files match."""
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.plugins.models import (
+            ComponentInventory,
+            PluginInstance,
+            PluginManifest,
+        )
+
+        def _plugin(manifest_version: str) -> PluginInstance:
+            manifest = PluginManifest(
+                name="demo",
+                version=manifest_version,
+                component_paths={},
+                inline_mcp={},
+            )
+            return PluginInstance(
+                plugin_id="demo@tools",
+                name="demo",
+                marketplace="tools",
+                # Hold the instance version fixed to isolate the manifest dimension.
+                version="1.0",
+                root=tmp_path,
+                data_dir=tmp_path / "data",
+                manifest=manifest,
+                inventory=ComponentInventory(),
+            )
+
+        before = DeepAgentsApp._fingerprint_plugins((_plugin("1.0"),))
+        after = DeepAgentsApp._fingerprint_plugins((_plugin("2.0"),))
+
+        assert before != after
+
+    def test_fingerprint_detects_mcp_file_edits(self, tmp_path: Path) -> None:
+        """Editing an `mcp_files` entry (a file path) must change the fingerprint."""
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.plugins.models import ComponentInventory, PluginInstance
+
+        mcp_file = tmp_path / ".mcp.json"
+        mcp_file.write_text('{"mcpServers": {}}', encoding="utf-8")
+
+        plugin = PluginInstance(
+            plugin_id="demo@tools",
+            name="demo",
+            marketplace="tools",
+            version="1.0",
+            root=tmp_path,
+            data_dir=tmp_path / "data",
+            manifest=None,
+            inventory=ComponentInventory(mcp_files=(mcp_file,)),
+        )
+
+        before = DeepAgentsApp._fingerprint_plugins((plugin,))
+        mcp_file.write_text('{"mcpServers": {"x": {}}}', encoding="utf-8")
+        after = DeepAgentsApp._fingerprint_plugins((plugin,))
+
+        assert before != after
+
     @pytest.mark.parametrize("change", ["none", "fingerprint", "enabled"])
     async def test_plugin_manager_reminder_compares_actual_state(
         self,
@@ -1093,7 +1182,14 @@ class TestReloadPluginsViaReload:
         )
         enabled_ids = iter((enabled_before, enabled_after))
         app = DeepAgentsApp()
-        call_after_refresh = MagicMock()
+        offer_reload = AsyncMock()
+        scheduled: list[Coroutine[object, object, None]] = []
+        ui_thread = threading.get_ident()
+        fingerprint_threads: list[int] = []
+
+        def fingerprint_plugins(_plugins: object) -> dict[str, tuple[str, ...]]:
+            fingerprint_threads.append(threading.get_ident())
+            return next(fingerprints)
 
         monkeypatch.setattr(
             "deepagents_code.plugins.discover_plugins",
@@ -1106,23 +1202,31 @@ class TestReloadPluginsViaReload:
         monkeypatch.setattr(
             app,
             "_fingerprint_plugins",
-            lambda _plugins: next(fingerprints),
+            fingerprint_plugins,
         )
         monkeypatch.setattr(
             app,
             "push_screen",
             lambda _screen, callback: callback(None),
         )
-        monkeypatch.setattr(app, "call_after_refresh", call_after_refresh)
+        monkeypatch.setattr(app, "call_after_refresh", lambda callback: callback())
+        monkeypatch.setattr(
+            app,
+            "run_worker",
+            lambda coroutine, **_kwargs: scheduled.append(coroutine),
+        )
+        monkeypatch.setattr(app, "_offer_plugin_reload", offer_reload)
 
         await app._show_plugin_manager()
+        await scheduled[0]
 
         assert app._plugin_fingerprints == before
+        assert len(fingerprint_threads) == 2
+        assert all(thread != ui_thread for thread in fingerprint_threads)
         if change != "none":
-            call_after_refresh.assert_called_once()
-            assert callable(call_after_refresh.call_args.args[0])
+            offer_reload.assert_awaited_once()
         else:
-            call_after_refresh.assert_not_called()
+            offer_reload.assert_not_awaited()
 
     async def test_plugin_manager_state_error_schedules_reminder(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1138,7 +1242,8 @@ class TestReloadPluginsViaReload:
             ]
         )
         app = DeepAgentsApp()
-        call_after_refresh = MagicMock()
+        mount = AsyncMock()
+        scheduled: list[Coroutine[object, object, None]] = []
 
         monkeypatch.setattr("deepagents_code.plugins.discover_plugins", discovery)
         monkeypatch.setattr(
@@ -1150,12 +1255,23 @@ class TestReloadPluginsViaReload:
             "push_screen",
             lambda _screen, callback: callback(None),
         )
-        monkeypatch.setattr(app, "call_after_refresh", call_after_refresh)
+        monkeypatch.setattr(app, "call_after_refresh", lambda callback: callback())
+        monkeypatch.setattr(
+            app,
+            "run_worker",
+            lambda coroutine, **_kwargs: scheduled.append(coroutine),
+        )
+        monkeypatch.setattr(app, "_mount_message", mount)
 
         await app._show_plugin_manager()
+        await scheduled[0]
 
-        call_after_refresh.assert_called_once()
-        assert callable(call_after_refresh.call_args.args[0])
+        mount.assert_awaited_once()
+        mount_call = mount.await_args
+        assert mount_call is not None
+        message = mount_call.args[0]
+        assert "Couldn't check plugin state" in str(message._content)
+        assert "/reload" in str(message._content)
 
     @pytest.mark.parametrize("choice", ["reload", "later", None])
     async def test_plugin_reload_prompt_choice(
@@ -1262,6 +1378,184 @@ class TestReloadPluginsViaReload:
 
             text = "\n".join(str(w._content) for w in app.query(AppMessage))
             assert "Plugins: 0 plugins · 0 skills · 0 plugin MCP servers" in text
+
+    async def _reload_transcript_with_fingerprints(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        old: dict[str, tuple[object, ...]] | None,
+        new: dict[str, tuple[object, ...]],
+        plugins: tuple[PluginInstance, ...] = (),
+        fingerprint_threads: list[int] | None = None,
+    ) -> str:
+        """Drive `/reload` with seeded before/after fingerprints.
+
+        Returns:
+            The joined transcript text of all rendered app messages.
+        """
+        from deepagents_code._env_vars import EXPERIMENTAL
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.plugins.models import PluginDiscoveryResult
+        from deepagents_code.tui.widgets.messages import AppMessage
+
+        monkeypatch.setenv(EXPERIMENTAL, "1")
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            async def _fake_discover() -> bool:  # noqa: RUF029
+                return True
+
+            def fingerprint_plugins(
+                _plugins: object,
+            ) -> dict[str, tuple[object, ...]]:
+                if fingerprint_threads is not None:
+                    fingerprint_threads.append(threading.get_ident())
+                return new
+
+            monkeypatch.setattr(app, "_discover_skills", _fake_discover)
+            monkeypatch.setattr(
+                "deepagents_code.plugins.discover_plugins",
+                lambda: PluginDiscoveryResult(plugins=plugins),
+            )
+            monkeypatch.setattr(
+                "deepagents_code.plugins.adapters.mcp.plugin_mcp_configs",
+                lambda _plugins: (),
+            )
+            monkeypatch.setattr(app, "_fingerprint_plugins", fingerprint_plugins)
+            app._plugin_fingerprints = old
+
+            await app._handle_command("/reload")
+            await pilot.pause()
+
+            return "\n".join(str(w._content) for w in app.query(AppMessage))
+
+    @pytest.mark.parametrize(
+        ("old", "new", "expected"),
+        [
+            pytest.param(
+                {"demo@tools": ("v1",)},
+                {"demo@tools": ("v1",)},
+                "Plugin changes: no changes detected.",
+                id="no-changes",
+            ),
+            pytest.param(
+                {},
+                {"demo@tools": ("v1",)},
+                "Plugin changes: 1 plugin added.",
+                id="added-singular",
+            ),
+            pytest.param(
+                {},
+                {"demo@tools": ("v1",), "extra@tools": ("v1",)},
+                "Plugin changes: 2 plugins added.",
+                id="added-plural",
+            ),
+            pytest.param(
+                {"demo@tools": ("v1",)},
+                {},
+                "Plugin changes: 1 plugin removed.",
+                id="removed",
+            ),
+            pytest.param(
+                {"demo@tools": ("v1",)},
+                {"demo@tools": ("v2",)},
+                "Plugin changes: 1 plugin changed.",
+                id="changed",
+            ),
+            pytest.param(
+                {"demo@tools": ("v1",), "gone@tools": ("v1",)},
+                {"demo@tools": ("v2",), "new@tools": ("v1",)},
+                "Plugin changes: 1 plugin added, 1 plugin removed, 1 plugin changed.",
+                id="added-removed-changed",
+            ),
+        ],
+    )
+    async def test_reload_report_summarizes_plugin_changes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        old: dict[str, tuple[object, ...]],
+        new: dict[str, tuple[object, ...]],
+        expected: str,
+    ) -> None:
+        """`/reload` summarizes added/removed/changed plugins against the baseline."""
+        text = await self._reload_transcript_with_fingerprints(
+            monkeypatch, old=old, new=new
+        )
+
+        assert expected in text
+
+    async def test_reload_report_omits_changes_on_first_reload(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The first `/reload` has no baseline, so it omits the changes line."""
+        text = await self._reload_transcript_with_fingerprints(
+            monkeypatch, old=None, new={"demo@tools": ("v1",)}
+        )
+
+        assert "Plugin changes:" not in text
+
+    async def test_reload_fingerprints_plugins_off_ui_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`/reload` must not recursively scan plugin files on the UI thread."""
+        ui_thread = threading.get_ident()
+        fingerprint_threads: list[int] = []
+
+        await self._reload_transcript_with_fingerprints(
+            monkeypatch,
+            old={},
+            new={},
+            fingerprint_threads=fingerprint_threads,
+        )
+
+        assert len(fingerprint_threads) == 1
+        assert fingerprint_threads[0] != ui_thread
+
+    async def test_reload_reports_mcp_login_for_new_plugin(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """New HTTP MCP plugins retain their post-reload sign-in guidance."""
+        from deepagents_code.plugins.models import (
+            ComponentInventory,
+            PluginInstance,
+            PluginManifest,
+        )
+
+        plugin = PluginInstance(
+            plugin_id="linear@tools",
+            name="linear",
+            marketplace="tools",
+            version="1.0",
+            root=tmp_path,
+            data_dir=tmp_path / "data",
+            manifest=PluginManifest(
+                name="linear",
+                display_name="Linear",
+                version="1.0",
+                component_paths={},
+                inline_mcp={
+                    "mcpServers": {
+                        "linear": {
+                            "type": "http",
+                            "url": "https://mcp.example.com",
+                        }
+                    }
+                },
+            ),
+            inventory=ComponentInventory(),
+        )
+
+        text = await self._reload_transcript_with_fingerprints(
+            monkeypatch,
+            old={},
+            new={plugin.plugin_id: ("v1",)},
+            plugins=(plugin,),
+        )
+
+        assert "Sign in to Linear via `/mcp`." in text
 
     async def test_skips_plugin_summary_when_experimental_off(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_reload.py
+++ b/libs/code/tests/unit_tests/test_reload.py
@@ -20,10 +20,18 @@ if TYPE_CHECKING:
     from collections.abc import Coroutine
     from pathlib import Path
 
+    from deepagents_code.app import _PluginFingerprint
     from deepagents_code.plugins.models import PluginInstance
 
 # Capture before any monkeypatching replaces it on the module.
 _real_load_dotenv = _dotenv_module.load_dotenv
+
+
+def _test_plugin_fingerprint(version: str) -> _PluginFingerprint:
+    from deepagents_code.app import _PluginFingerprint
+
+    return _PluginFingerprint(version=version, manifest=None, components=())
+
 
 _RELOAD_ENV_KEYS = (
     "OPENAI_API_KEY",
@@ -1082,6 +1090,184 @@ class TestReloadPluginsViaReload:
 
         assert before != after
 
+    def test_fingerprint_detects_added_and_removed_nested_files(
+        self, tmp_path: Path
+    ) -> None:
+        """Adding then removing a nested file must each change the fingerprint.
+
+        Directory stat alone can stay put across a child add/remove on some
+        filesystems, so the recursive walk is what has to notice.
+        """
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.plugins.models import ComponentInventory, PluginInstance
+
+        skills_root = tmp_path / "skills" / "demo"
+        skills_root.mkdir(parents=True)
+        (skills_root / "SKILL.md").write_text("---\nname: demo\n---\n", "utf-8")
+
+        plugin = PluginInstance(
+            plugin_id="demo@tools",
+            name="demo",
+            marketplace="tools",
+            version="1.0",
+            root=tmp_path,
+            data_dir=tmp_path / "data",
+            manifest=None,
+            inventory=ComponentInventory(skills=(tmp_path / "skills",)),
+        )
+
+        base = DeepAgentsApp._fingerprint_plugins((plugin,))
+        extra = skills_root / "helper.py"
+        extra.write_text("x = 1\n", encoding="utf-8")
+        with_extra = DeepAgentsApp._fingerprint_plugins((plugin,))
+        extra.unlink()
+        removed = DeepAgentsApp._fingerprint_plugins((plugin,))
+
+        assert base != with_extra
+        assert with_extra != removed
+        assert base == removed
+
+    def test_fingerprint_records_sentinel_for_unreadable_subdir(
+        self, tmp_path: Path
+    ) -> None:
+        """An unreadable subdirectory must perturb the fingerprint, not vanish.
+
+        Recursive scanners can skip subtrees they cannot descend into, which
+        would otherwise let an edit hidden beneath one read as "no change".
+        """
+        import sys
+
+        if sys.platform == "win32" or os.geteuid() == 0:
+            pytest.skip("chmod-based unreadability is not enforced here")
+
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.plugins.models import ComponentInventory, PluginInstance
+
+        skills_root = tmp_path / "skills"
+        locked = skills_root / "locked"
+        locked.mkdir(parents=True)
+        (locked / "SKILL.md").write_text("---\nname: demo\n---\n", "utf-8")
+        plugin = PluginInstance(
+            plugin_id="demo@tools",
+            name="demo",
+            marketplace="tools",
+            version="1.0",
+            root=tmp_path,
+            data_dir=tmp_path / "data",
+            manifest=None,
+            inventory=ComponentInventory(skills=(skills_root,)),
+        )
+
+        readable = DeepAgentsApp._fingerprint_plugins((plugin,))
+        locked.chmod(0o000)
+        try:
+            unreadable = DeepAgentsApp._fingerprint_plugins((plugin,))
+        finally:
+            locked.chmod(0o755)
+
+        # The locked directory is recorded as a -1/-1 sentinel rather than
+        # dropped, so the change is visible instead of silently swallowed.
+        assert readable != unreadable
+        fingerprint = unreadable["demo@tools"]
+        assert any(
+            entry.path == str(locked) and entry.mtime_ns == -1
+            for entry in fingerprint.components
+        )
+        assert DeepAgentsApp._plugin_fingerprint_changed(fingerprint, fingerprint)
+
+    def test_fingerprint_caps_recursive_scan(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Oversized component trees stop at the hard entry limit."""
+        from deepagents_code import app as app_module
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.plugins.models import ComponentInventory, PluginInstance
+
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        for index in range(5):
+            (skills_root / f"skill-{index}.md").write_text(str(index), encoding="utf-8")
+        monkeypatch.setattr(app_module, "_MAX_PLUGIN_FINGERPRINT_ENTRIES", 3)
+        plugin = PluginInstance(
+            plugin_id="demo@tools",
+            name="demo",
+            marketplace="tools",
+            version="1.0",
+            root=tmp_path,
+            data_dir=tmp_path / "data",
+            manifest=None,
+            inventory=ComponentInventory(skills=(skills_root,)),
+        )
+
+        first = DeepAgentsApp._fingerprint_plugins((plugin,))[plugin.plugin_id]
+        second = DeepAgentsApp._fingerprint_plugins((plugin,))[plugin.plugin_id]
+
+        assert any(
+            entry.mtime_ns == app_module._TRUNCATED_PLUGIN_FINGERPRINT_STAT
+            for entry in first.components
+        )
+        assert DeepAgentsApp._plugin_fingerprint_changed(first, second)
+
+    def test_fingerprint_does_not_follow_symlinks(self, tmp_path: Path) -> None:
+        """A nested directory symlink is recorded without scanning its target."""
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.plugins.models import ComponentInventory, PluginInstance
+
+        plugin_root = tmp_path / "plugin"
+        skills_root = plugin_root / "skills"
+        outside = tmp_path / "outside"
+        skills_root.mkdir(parents=True)
+        outside.mkdir()
+        outside_file = outside / "external.md"
+        outside_file.write_text("external", encoding="utf-8")
+        link = skills_root / "linked"
+        try:
+            link.symlink_to(outside, target_is_directory=True)
+        except (NotImplementedError, OSError):
+            pytest.skip("directory symlinks are unavailable")
+        plugin = PluginInstance(
+            plugin_id="demo@tools",
+            name="demo",
+            marketplace="tools",
+            version="1.0",
+            root=plugin_root,
+            data_dir=tmp_path / "data",
+            manifest=None,
+            inventory=ComponentInventory(skills=(skills_root,)),
+        )
+
+        fingerprint = DeepAgentsApp._fingerprint_plugins((plugin,))[plugin.plugin_id]
+        paths = {entry.path for entry in fingerprint.components}
+
+        assert str(link) in paths
+        assert str(outside_file) not in paths
+
+    def test_fingerprint_rejects_component_outside_plugin_root(
+        self, tmp_path: Path
+    ) -> None:
+        """A malformed inventory cannot make fingerprinting inspect another tree."""
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.plugins.models import ComponentInventory, PluginInstance
+
+        plugin_root = tmp_path / "plugin"
+        plugin_root.mkdir()
+        outside = tmp_path / "outside.json"
+        outside.write_text('{"mcpServers": {}}', encoding="utf-8")
+        plugin = PluginInstance(
+            plugin_id="demo@tools",
+            name="demo",
+            marketplace="tools",
+            version="1.0",
+            root=plugin_root,
+            data_dir=tmp_path / "data",
+            manifest=None,
+            inventory=ComponentInventory(mcp_files=(outside,)),
+        )
+
+        fingerprint = DeepAgentsApp._fingerprint_plugins((plugin,))[plugin.plugin_id]
+
+        assert fingerprint.components == ((str(outside), -1, -1),)
+
     def test_fingerprint_detects_version_change(self, tmp_path: Path) -> None:
         """A version bump must change the fingerprint even with identical files."""
         from deepagents_code.app import DeepAgentsApp
@@ -1162,6 +1348,74 @@ class TestReloadPluginsViaReload:
 
         assert before != after
 
+    def test_plugin_login_labels_filters_dedupes_and_falls_back(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Only added, login-needing plugins are listed, deduped, with name fallback."""
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.plugins.models import (
+            ComponentInventory,
+            PluginInstance,
+            PluginManifest,
+        )
+
+        def _plugin(name: str, *, display_name: str | None) -> PluginInstance:
+            manifest = (
+                None
+                if display_name is None
+                else PluginManifest(
+                    name=name,
+                    display_name=display_name,
+                    version="1.0",
+                    component_paths={},
+                    inline_mcp={},
+                )
+            )
+            return PluginInstance(
+                plugin_id=f"{name}@tools",
+                name=name,
+                marketplace="tools",
+                version="1.0",
+                root=tmp_path,
+                data_dir=tmp_path / "data",
+                manifest=manifest,
+                inventory=ComponentInventory(),
+            )
+
+        # login_needed twice -> should dedupe to one "Login" label; no_login has
+        # no login-requiring server; nameless falls back to plugin.name;
+        # not_added is excluded because it is not in the added set.
+        entries_by_id = {
+            "login_needed@tools": (("s", "scoped", True),),
+            "no_login@tools": (("s", "scoped", False),),
+            "nameless@tools": (("s", "scoped", True),),
+            "not_added@tools": (("s", "scoped", True),),
+        }
+        monkeypatch.setattr(
+            "deepagents_code.plugins.adapters.mcp.plugin_mcp_server_entries",
+            lambda plugin: entries_by_id[plugin.plugin_id],
+        )
+
+        plugins = (
+            _plugin("login_needed", display_name="Login"),
+            _plugin("dupe", display_name="Login"),
+            _plugin("no_login", display_name="Silent"),
+            _plugin("nameless", display_name=None),
+            _plugin("not_added", display_name="Skipped"),
+        )
+        # "dupe" shares the "Login" display name to exercise deduplication.
+        entries_by_id["dupe@tools"] = (("s", "scoped", True),)
+        added = {
+            "login_needed@tools",
+            "dupe@tools",
+            "no_login@tools",
+            "nameless@tools",
+        }
+
+        labels = DeepAgentsApp._plugin_login_labels(plugins, added)
+
+        assert labels == ("Login", "nameless")
+
     @pytest.mark.parametrize("change", ["none", "fingerprint", "enabled"])
     async def test_plugin_manager_reminder_compares_actual_state(
         self,
@@ -1173,8 +1427,16 @@ class TestReloadPluginsViaReload:
         from deepagents_code.app import DeepAgentsApp
         from deepagents_code.plugins.models import PluginDiscoveryResult
 
-        before = {"demo@tools": ("before",)} if change == "fingerprint" else {}
-        after = {"demo@tools": ("after",)} if change == "fingerprint" else {}
+        before = (
+            {"demo@tools": _test_plugin_fingerprint("before")}
+            if change == "fingerprint"
+            else {}
+        )
+        after = (
+            {"demo@tools": _test_plugin_fingerprint("after")}
+            if change == "fingerprint"
+            else {}
+        )
         fingerprints = iter((before, after))
         enabled_before = frozenset[str]()
         enabled_after = (
@@ -1187,7 +1449,7 @@ class TestReloadPluginsViaReload:
         ui_thread = threading.get_ident()
         fingerprint_threads: list[int] = []
 
-        def fingerprint_plugins(_plugins: object) -> dict[str, tuple[str, ...]]:
+        def fingerprint_plugins(_plugins: object) -> dict[str, _PluginFingerprint]:
             fingerprint_threads.append(threading.get_ident())
             return next(fingerprints)
 
@@ -1272,6 +1534,88 @@ class TestReloadPluginsViaReload:
         message = mount_call.args[0]
         assert "Couldn't check plugin state" in str(message._content)
         assert "/reload" in str(message._content)
+
+    async def test_plugin_manager_reopen_preserves_deferred_reload_baseline(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reopening after deferral must retain the state from before changes."""
+        from deepagents_code.app import DeepAgentsApp
+
+        before: dict[str, _PluginFingerprint] = {}
+        after = {"linear@tools": _test_plugin_fingerprint("v1")}
+        snapshots = iter(
+            (
+                (frozenset[str](), before),
+                (frozenset({"linear@tools"}), after),
+                (frozenset({"linear@tools"}), after),
+                (frozenset({"linear@tools"}), after),
+            )
+        )
+        app = DeepAgentsApp()
+        offer_reload = AsyncMock()
+        scheduled: list[Coroutine[object, object, None]] = []
+
+        monkeypatch.setattr(app, "_snapshot_plugin_state", lambda: next(snapshots))
+        monkeypatch.setattr(
+            app,
+            "push_screen",
+            lambda _screen, callback: callback(None),
+        )
+        monkeypatch.setattr(app, "call_after_refresh", lambda callback: callback())
+        monkeypatch.setattr(
+            app,
+            "run_worker",
+            lambda coroutine, **_kwargs: scheduled.append(coroutine),
+        )
+        monkeypatch.setattr(app, "_offer_plugin_reload", offer_reload)
+
+        await app._show_plugin_manager()
+        await scheduled[0]
+        await app._show_plugin_manager()
+        await scheduled[1]
+
+        assert app._plugin_fingerprints == before
+        offer_reload.assert_awaited_once()
+
+    async def test_plugin_manager_warns_when_snapshot_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A pre-open snapshot failure still opens the manager and warns on close."""
+        from deepagents_code.app import DeepAgentsApp
+
+        app = DeepAgentsApp()
+        pushed: list[object] = []
+        scheduled: list[Coroutine[object, object, None]] = []
+        mount = AsyncMock()
+
+        monkeypatch.setattr(
+            app,
+            "_snapshot_plugin_state",
+            MagicMock(side_effect=PermissionError("plugin directory is unreadable")),
+        )
+        monkeypatch.setattr(
+            app,
+            "push_screen",
+            lambda screen, callback: (pushed.append(screen), callback(None)),
+        )
+        monkeypatch.setattr(app, "call_after_refresh", lambda callback: callback())
+        monkeypatch.setattr(
+            app,
+            "run_worker",
+            lambda coroutine, **_kwargs: scheduled.append(coroutine),
+        )
+        monkeypatch.setattr(app, "_mount_message", mount)
+
+        await app._show_plugin_manager()
+        await scheduled[0]
+
+        assert len(pushed) == 1
+        assert len(scheduled) == 1
+        mount.assert_awaited_once()
+        mount_call = mount.await_args
+        assert mount_call is not None
+        assert "Couldn't check plugin state" in str(mount_call.args[0]._content)
+        assert app._plugin_fingerprints is None
 
     @pytest.mark.parametrize("choice", ["reload", "later", None])
     async def test_plugin_reload_prompt_choice(
@@ -1383,8 +1727,8 @@ class TestReloadPluginsViaReload:
         self,
         monkeypatch: pytest.MonkeyPatch,
         *,
-        old: dict[str, tuple[object, ...]] | None,
-        new: dict[str, tuple[object, ...]],
+        old: dict[str, _PluginFingerprint] | None,
+        new: dict[str, _PluginFingerprint],
         plugins: tuple[PluginInstance, ...] = (),
         fingerprint_threads: list[int] | None = None,
     ) -> str:
@@ -1409,7 +1753,7 @@ class TestReloadPluginsViaReload:
 
             def fingerprint_plugins(
                 _plugins: object,
-            ) -> dict[str, tuple[object, ...]]:
+            ) -> dict[str, _PluginFingerprint]:
                 if fingerprint_threads is not None:
                     fingerprint_threads.append(threading.get_ident())
                 return new
@@ -1432,41 +1776,41 @@ class TestReloadPluginsViaReload:
             return "\n".join(str(w._content) for w in app.query(AppMessage))
 
     @pytest.mark.parametrize(
-        ("old", "new", "expected"),
+        ("old_versions", "new_versions", "expected"),
         [
             pytest.param(
-                {"demo@tools": ("v1",)},
-                {"demo@tools": ("v1",)},
+                {"demo@tools": "v1"},
+                {"demo@tools": "v1"},
                 "Plugin changes: no changes detected.",
                 id="no-changes",
             ),
             pytest.param(
                 {},
-                {"demo@tools": ("v1",)},
+                {"demo@tools": "v1"},
                 "Plugin changes: 1 plugin added.",
                 id="added-singular",
             ),
             pytest.param(
                 {},
-                {"demo@tools": ("v1",), "extra@tools": ("v1",)},
+                {"demo@tools": "v1", "extra@tools": "v1"},
                 "Plugin changes: 2 plugins added.",
                 id="added-plural",
             ),
             pytest.param(
-                {"demo@tools": ("v1",)},
+                {"demo@tools": "v1"},
                 {},
                 "Plugin changes: 1 plugin removed.",
                 id="removed",
             ),
             pytest.param(
-                {"demo@tools": ("v1",)},
-                {"demo@tools": ("v2",)},
+                {"demo@tools": "v1"},
+                {"demo@tools": "v2"},
                 "Plugin changes: 1 plugin changed.",
                 id="changed",
             ),
             pytest.param(
-                {"demo@tools": ("v1",), "gone@tools": ("v1",)},
-                {"demo@tools": ("v2",), "new@tools": ("v1",)},
+                {"demo@tools": "v1", "gone@tools": "v1"},
+                {"demo@tools": "v2", "new@tools": "v1"},
                 "Plugin changes: 1 plugin added, 1 plugin removed, 1 plugin changed.",
                 id="added-removed-changed",
             ),
@@ -1476,11 +1820,19 @@ class TestReloadPluginsViaReload:
         self,
         monkeypatch: pytest.MonkeyPatch,
         *,
-        old: dict[str, tuple[object, ...]],
-        new: dict[str, tuple[object, ...]],
+        old_versions: dict[str, str],
+        new_versions: dict[str, str],
         expected: str,
     ) -> None:
         """`/reload` summarizes added/removed/changed plugins against the baseline."""
+        old = {
+            plugin_id: _test_plugin_fingerprint(version)
+            for plugin_id, version in old_versions.items()
+        }
+        new = {
+            plugin_id: _test_plugin_fingerprint(version)
+            for plugin_id, version in new_versions.items()
+        }
         text = await self._reload_transcript_with_fingerprints(
             monkeypatch, old=old, new=new
         )
@@ -1492,7 +1844,9 @@ class TestReloadPluginsViaReload:
     ) -> None:
         """The first `/reload` has no baseline, so it omits the changes line."""
         text = await self._reload_transcript_with_fingerprints(
-            monkeypatch, old=None, new={"demo@tools": ("v1",)}
+            monkeypatch,
+            old=None,
+            new={"demo@tools": _test_plugin_fingerprint("v1")},
         )
 
         assert "Plugin changes:" not in text
@@ -1551,11 +1905,84 @@ class TestReloadPluginsViaReload:
         text = await self._reload_transcript_with_fingerprints(
             monkeypatch,
             old={},
-            new={plugin.plugin_id: ("v1",)},
+            new={plugin.plugin_id: _test_plugin_fingerprint("v1")},
             plugins=(plugin,),
         )
 
         assert "Sign in to Linear via `/mcp`." in text
+
+    async def test_reload_omits_sign_in_on_first_reload(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """First `/reload` has no baseline, so sign-in guidance is suppressed too."""
+        from deepagents_code.plugins.models import (
+            ComponentInventory,
+            PluginInstance,
+            PluginManifest,
+        )
+
+        plugin = PluginInstance(
+            plugin_id="linear@tools",
+            name="linear",
+            marketplace="tools",
+            version="1.0",
+            root=tmp_path,
+            data_dir=tmp_path / "data",
+            manifest=PluginManifest(
+                name="linear",
+                display_name="Linear",
+                version="1.0",
+                component_paths={},
+                inline_mcp={
+                    "mcpServers": {
+                        "linear": {"type": "http", "url": "https://mcp.example.com"}
+                    }
+                },
+            ),
+            inventory=ComponentInventory(),
+        )
+
+        text = await self._reload_transcript_with_fingerprints(
+            monkeypatch,
+            old=None,
+            new={plugin.plugin_id: _test_plugin_fingerprint("v1")},
+            plugins=(plugin,),
+        )
+
+        assert "Sign in to" not in text
+
+    async def test_reload_reports_plugin_discovery_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A discovery failure degrades to a manual-retry note, not a crash."""
+        from deepagents_code._env_vars import EXPERIMENTAL
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.tui.widgets.messages import AppMessage
+
+        monkeypatch.setenv(EXPERIMENTAL, "1")
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            async def _fake_discover() -> bool:  # noqa: RUF029
+                return True
+
+            monkeypatch.setattr(app, "_discover_skills", _fake_discover)
+            monkeypatch.setattr(
+                "deepagents_code.plugins.discover_plugins",
+                MagicMock(side_effect=PermissionError("unreadable plugin dir")),
+            )
+
+            await app._handle_command("/reload")
+            await pilot.pause()
+
+            text = "\n".join(str(w._content) for w in app.query(AppMessage))
+            assert "Couldn't read plugin state; run /reload to be safe." in text
+            # The reload still completed: the config-reload header is present and
+            # no plugin summary line was emitted.
+            assert "Configuration reloaded." in text
+            assert "Plugins:" not in text
 
     async def test_skips_plugin_summary_when_experimental_off(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_reload.py
+++ b/libs/code/tests/unit_tests/test_reload.py
@@ -1045,6 +1045,34 @@ class TestReloadThemeReapply:
 class TestReloadPluginsViaReload:
     """Experimental plugins should reload through `/reload`."""
 
+    def test_fingerprint_detects_nested_skill_edits(self, tmp_path: Path) -> None:
+        """Editing `SKILL.md` under a skills directory must change the fingerprint."""
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.plugins.models import ComponentInventory, PluginInstance
+
+        skills_root = tmp_path / "skills"
+        skill_dir = skills_root / "demo"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("---\nname: demo\n---\noriginal\n", encoding="utf-8")
+
+        plugin = PluginInstance(
+            plugin_id="demo@tools",
+            name="demo",
+            marketplace="tools",
+            version="1.0",
+            root=tmp_path,
+            data_dir=tmp_path / "data",
+            manifest=None,
+            inventory=ComponentInventory(skills=(skills_root,)),
+        )
+
+        before = DeepAgentsApp._fingerprint_plugins((plugin,))
+        skill_md.write_text("---\nname: demo\n---\nedited\n", encoding="utf-8")
+        after = DeepAgentsApp._fingerprint_plugins((plugin,))
+
+        assert before != after
+
     async def test_reports_plugin_summary_when_experimental(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/test_reload.py
+++ b/libs/code/tests/unit_tests/test_reload.py
@@ -3,7 +3,7 @@
 import logging
 import os
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import dotenv as _dotenv_module
 import pytest
@@ -1072,6 +1072,93 @@ class TestReloadPluginsViaReload:
         after = DeepAgentsApp._fingerprint_plugins((plugin,))
 
         assert before != after
+
+    @pytest.mark.parametrize("change", ["none", "fingerprint", "enabled"])
+    async def test_plugin_manager_reminder_compares_actual_state(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        change: str,
+    ) -> None:
+        """Closing compares persisted state even when the modal reports no result."""
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.plugins.models import PluginDiscoveryResult
+
+        before = {"demo@tools": ("before",)} if change == "fingerprint" else {}
+        after = {"demo@tools": ("after",)} if change == "fingerprint" else {}
+        fingerprints = iter((before, after))
+        enabled_before = frozenset[str]()
+        enabled_after = (
+            frozenset({"demo@tools"}) if change == "enabled" else enabled_before
+        )
+        enabled_ids = iter((enabled_before, enabled_after))
+        app = DeepAgentsApp()
+        call_after_refresh = MagicMock()
+
+        monkeypatch.setattr(
+            "deepagents_code.plugins.discover_plugins",
+            lambda: PluginDiscoveryResult(plugins=()),
+        )
+        monkeypatch.setattr(
+            "deepagents_code.plugins.store.load_enabled_plugin_ids",
+            lambda: next(enabled_ids),
+        )
+        monkeypatch.setattr(
+            app,
+            "_fingerprint_plugins",
+            lambda _plugins: next(fingerprints),
+        )
+        monkeypatch.setattr(
+            app,
+            "push_screen",
+            lambda _screen, callback: callback(None),
+        )
+        monkeypatch.setattr(app, "call_after_refresh", call_after_refresh)
+
+        await app._show_plugin_manager()
+
+        assert app._plugin_fingerprints == before
+        if change != "none":
+            call_after_refresh.assert_called_once()
+            assert callable(call_after_refresh.call_args.args[0])
+        else:
+            call_after_refresh.assert_not_called()
+
+    @pytest.mark.parametrize("choice", ["reload", "later"])
+    async def test_plugin_reload_prompt_choice(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        choice: str,
+    ) -> None:
+        """Reload runs the command; deferral leaves one transcript reminder."""
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.tui.widgets.messages import AppMessage
+
+        app = DeepAgentsApp()
+        submit = AsyncMock()
+        mount = AsyncMock()
+        monkeypatch.setattr(
+            app,
+            "_push_screen_wait",
+            AsyncMock(return_value=choice),
+        )
+        monkeypatch.setattr(app, "_submit_input", submit)
+        monkeypatch.setattr(app, "_mount_message", mount)
+
+        await app._offer_plugin_reload()
+
+        if choice == "reload":
+            submit.assert_awaited_once_with("/reload", "command")
+            mount.assert_not_awaited()
+        else:
+            submit.assert_not_awaited()
+            mount.assert_awaited_once()
+            mount_call = mount.await_args
+            assert mount_call is not None
+            message = mount_call.args[0]
+            assert isinstance(message, AppMessage)
+            assert "/reload" in str(message._content)
 
     async def test_reports_plugin_summary_when_experimental(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -36,6 +36,19 @@ def test_plugin_options_preserve_selectable_rows_and_spacers() -> None:
     assert options[1].disabled
 
 
+def test_plugin_manager_reports_only_relevant_changes_on_close() -> None:
+    screen = PluginManagerScreen()
+    screen.dismiss = MagicMock()
+
+    screen.action_cancel()
+    screen.dismiss.assert_called_once_with(False)
+
+    screen.dismiss.reset_mock()
+    screen._plugins_changed = True
+    screen.action_cancel()
+    screen.dismiss.assert_called_once_with(True)
+
+
 async def test_plugin_manager_overlays_underlying_content() -> None:
     """Transparent modal backdrop must composite the screen underneath."""
     app = DeepAgentsApp(agent=MagicMock(), thread_id="t")

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -63,17 +63,12 @@ def test_plugin_options_preserve_selectable_rows_and_spacers() -> None:
     assert options[1].disabled
 
 
-def test_plugin_manager_reports_only_relevant_changes_on_close() -> None:
+def test_plugin_manager_closes_without_mcp_reconnect() -> None:
     screen = PluginManagerScreen()
     screen.dismiss = MagicMock()
 
     screen.action_cancel()
-    screen.dismiss.assert_called_once_with((False, None))
-
-    screen.dismiss.reset_mock()
-    screen._plugins_changed = True
-    screen.action_cancel()
-    screen.dismiss.assert_called_once_with((True, None))
+    screen.dismiss.assert_called_once_with(None)
 
 
 def test_plugin_row_label_prefers_display_name() -> None:
@@ -338,10 +333,9 @@ def test_plugin_prompt_pending_reload_keeps_connected_when_still_loaded() -> Non
     assert f"{checkmark} connected" in prompt
 
 
-async def test_install_dismisses_reconnect_from_installed_instance(
+async def test_install_keeps_manager_open(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Discover rows lack MCP metadata; install must inspect the returned instance."""
     screen = PluginManagerScreen()
     screen._selected_plugin = _PluginRow(
         plugin_id="linear@tools",
@@ -351,46 +345,9 @@ async def test_install_dismisses_reconnect_from_installed_instance(
         author=None,
         display_name="Linear",
     )
-    assert screen._selected_plugin.mcp_server_names == ()
-
     monkeypatch.setattr(
         "deepagents_code.tui.modals.plugin_manager.install_plugin",
         lambda _plugin_id: object(),
-    )
-    monkeypatch.setattr(
-        "deepagents_code.plugins.adapters.mcp.plugin_mcp_server_entries",
-        lambda _instance: (("linear", "linear__linear@tools", True),),
-    )
-    monkeypatch.setattr(screen, "_refresh_state", AsyncMock())
-    monkeypatch.setattr(screen, "notify", MagicMock())
-    dismiss = MagicMock()
-    monkeypatch.setattr(screen, "dismiss", dismiss)
-
-    await screen._install_selected_plugin()
-
-    dismiss.assert_called_once_with((True, ("Linear", True)))
-
-
-async def test_install_keeps_manager_open_without_mcp(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    screen = PluginManagerScreen()
-    screen._selected_plugin = _PluginRow(
-        plugin_id="skills@tools",
-        description="Skills only",
-        enabled=False,
-        version=None,
-        author=None,
-        display_name="Skills",
-    )
-
-    monkeypatch.setattr(
-        "deepagents_code.tui.modals.plugin_manager.install_plugin",
-        lambda _plugin_id: object(),
-    )
-    monkeypatch.setattr(
-        "deepagents_code.plugins.adapters.mcp.plugin_mcp_server_entries",
-        lambda _instance: (),
     )
     monkeypatch.setattr(screen, "_refresh_state", AsyncMock())
     monkeypatch.setattr(screen, "notify", MagicMock())

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -349,6 +349,10 @@ async def test_install_keeps_manager_open(
         "deepagents_code.tui.modals.plugin_manager.install_plugin",
         lambda _plugin_id: object(),
     )
+    monkeypatch.setattr(
+        "deepagents_code.plugins.adapters.mcp.plugin_mcp_server_entries",
+        lambda _instance: (),
+    )
     monkeypatch.setattr(screen, "_refresh_state", AsyncMock())
     monkeypatch.setattr(screen, "notify", MagicMock())
     dismiss = MagicMock()
@@ -357,6 +361,67 @@ async def test_install_keeps_manager_open(
     await screen._install_selected_plugin()
 
     dismiss.assert_not_called()
+
+
+async def test_install_preserves_mcp_login_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    screen = PluginManagerScreen()
+    screen._selected_plugin = _PluginRow(
+        plugin_id="linear@tools",
+        description="Linear plugin",
+        enabled=False,
+        version=None,
+        author=None,
+        display_name="Linear",
+    )
+    monkeypatch.setattr(
+        "deepagents_code.tui.modals.plugin_manager.install_plugin",
+        lambda _plugin_id: object(),
+    )
+    monkeypatch.setattr(
+        "deepagents_code.plugins.adapters.mcp.plugin_mcp_server_entries",
+        lambda _instance: (("linear", "plugin__linear_tools__linear", True),),
+    )
+    monkeypatch.setattr(screen, "_refresh_state", AsyncMock())
+    monkeypatch.setattr(screen, "notify", MagicMock())
+
+    await screen._install_selected_plugin()
+
+    assert screen._status is not None
+    assert "After reload, sign in to Linear via /mcp." in screen._status
+
+
+@pytest.mark.parametrize(
+    ("key", "expected_option_id"),
+    [("right", "action:install"), ("left", "details-back")],
+)
+async def test_details_navigation_starts_at_matching_edge(
+    key: str, expected_option_id: str
+) -> None:
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    async with app.run_test() as pilot:
+        screen = PluginManagerScreen()
+        app.push_screen(screen)
+        await pilot.pause()
+
+        screen._selected_plugin = _PluginRow(
+            plugin_id="linear@tools",
+            description="Linear plugin",
+            enabled=False,
+            version=None,
+            author=None,
+        )
+        screen._mode = "plugin_details"
+        screen._refresh_view()
+        options = screen.query_one("#plugin-manager-options", OptionList)
+        options.highlighted = None
+
+        await pilot.press(key)
+
+        highlighted = options.highlighted
+        assert highlighted is not None
+        assert options.get_option_at_index(highlighted).id == expected_option_id
 
 
 async def test_marketplace_divider_refits_on_resize() -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_plugin_reload.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_plugin_reload.py
@@ -1,0 +1,61 @@
+"""Tests for the plugin reload confirmation modal."""
+
+from __future__ import annotations
+
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from deepagents_code.tui.widgets.plugin_reload import PluginReloadPromptScreen
+
+
+class _PluginReloadTestApp(App[None]):
+    def compose(self) -> ComposeResult:
+        yield Static("base")
+
+
+class TestPluginReloadPromptScreen:
+    async def test_enter_chooses_reload(self) -> None:
+        app = _PluginReloadTestApp()
+        async with app.run_test() as pilot:
+            outcomes: list[str | None] = []
+            app.push_screen(PluginReloadPromptScreen(), outcomes.append)
+            await pilot.pause()
+
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert outcomes == ["reload"]
+
+    async def test_escape_chooses_later(self) -> None:
+        app = _PluginReloadTestApp()
+        async with app.run_test() as pilot:
+            outcomes: list[str | None] = []
+            app.push_screen(PluginReloadPromptScreen(), outcomes.append)
+            await pilot.pause()
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert outcomes == ["later"]
+
+    async def test_action_cancel_chooses_later(self) -> None:
+        app = _PluginReloadTestApp()
+        async with app.run_test() as pilot:
+            outcomes: list[str | None] = []
+            screen = PluginReloadPromptScreen()
+            app.push_screen(screen, outcomes.append)
+            await pilot.pause()
+
+            screen.action_cancel()
+            await pilot.pause()
+
+            assert outcomes == ["later"]
+
+    async def test_explains_reload_scope(self) -> None:
+        app = _PluginReloadTestApp()
+        async with app.run_test() as pilot:
+            app.push_screen(PluginReloadPromptScreen())
+            await pilot.pause()
+
+            body = str(app.screen.query_one(".plugin-reload-body").render())
+            assert "plugin skills and MCP tools" in body


### PR DESCRIPTION
Plugin management now reminds users to reload and `/reload` summarizes plugin changes.

---

Surfaces a `/reload` reminder after relevant plugin-manager changes and compares the pre-change plugin state with reload discovery. The reload report now summarizes added, removed, and changed plugins.

## Screenshots
<img width="862" height="447" alt="Screenshot 2026-07-16 at 11 19 51 AM" src="https://github.com/user-attachments/assets/1900856b-7ddb-47a1-8bc2-d5dbfb8701cc" />

Made by [Open SWE](https://openswe.vercel.app/agents/019f6784-519d-73cc-9f67-9a46c88d1de9)