### PR TITLE
fix(code): avoid blocking MCP OAuth token refresh

### DIFF
--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -284,6 +284,9 @@ class FileTokenStorage(TokenStorage):
 
     async def get_tokens(self) -> OAuthToken | None:
         """Return the stored `OAuthToken`, or `None` if none is persisted."""
+        return await asyncio.to_thread(self._get_tokens_sync)
+
+    def _get_tokens_sync(self) -> OAuthToken | None:
         data = self._read()
         if data is None:
             return None
@@ -300,6 +303,9 @@ class FileTokenStorage(TokenStorage):
         the SDK's `refresh_token` grant instead of a full browser re-auth.
         Cleared when `expires_in` is absent so the sidecar can't go stale.
         """
+        await asyncio.to_thread(self._set_tokens_sync, tokens)
+
+    def _set_tokens_sync(self, tokens: OAuthToken) -> None:
         data = self._read() or {}
         data["version"] = _STORAGE_VERSION
         data["tokens"] = json.loads(tokens.model_dump_json(exclude_none=True))
@@ -311,6 +317,9 @@ class FileTokenStorage(TokenStorage):
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         """Return the stored client registration, or `None` if none is persisted."""
+        return await asyncio.to_thread(self._get_client_info_sync)
+
+    def _get_client_info_sync(self) -> OAuthClientInformationFull | None:
         data = self._read()
         if data is None:
             return None
@@ -321,6 +330,9 @@ class FileTokenStorage(TokenStorage):
 
     async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
         """Persist `client_info` to disk, preserving any stored tokens."""
+        await asyncio.to_thread(self._set_client_info_sync, client_info)
+
+    def _set_client_info_sync(self, client_info: OAuthClientInformationFull) -> None:
         data = self._read() or {}
         data["version"] = _STORAGE_VERSION
         data["client_info"] = json.loads(client_info.model_dump_json(exclude_none=True))
@@ -328,6 +340,9 @@ class FileTokenStorage(TokenStorage):
 
     async def get_oauth_metadata(self) -> OAuthMetadata | None:
         """Return stored public OAuth authorization metadata, if available."""
+        return await asyncio.to_thread(self._get_oauth_metadata_sync)
+
+    def _get_oauth_metadata_sync(self) -> OAuthMetadata | None:
         data = self._read()
         if data is None:
             return None
@@ -338,6 +353,9 @@ class FileTokenStorage(TokenStorage):
 
     async def set_oauth_metadata(self, metadata: OAuthMetadata) -> None:
         """Persist public OAuth authorization metadata beside the token state."""
+        await asyncio.to_thread(self._set_oauth_metadata_sync, metadata)
+
+    def _set_oauth_metadata_sync(self, metadata: OAuthMetadata) -> None:
         data = self._read() or {}
         data["version"] = _STORAGE_VERSION
         data["oauth_metadata"] = json.loads(metadata.model_dump_json(exclude_none=True))
@@ -353,6 +371,15 @@ class FileTokenStorage(TokenStorage):
         Prevents the state where one call succeeds and the other fails,
         leaving an orphan on disk.
         """
+        await asyncio.to_thread(
+            self._set_tokens_and_client_info_sync, tokens, client_info
+        )
+
+    def _set_tokens_and_client_info_sync(
+        self,
+        tokens: OAuthToken,
+        client_info: OAuthClientInformationFull,
+    ) -> None:
         data = self._read() or {}
         data["version"] = _STORAGE_VERSION
         data["tokens"] = json.loads(tokens.model_dump_json(exclude_none=True))
@@ -371,6 +398,9 @@ class FileTokenStorage(TokenStorage):
         value fails to coerce to `float`. Callers should treat `None` as
         "expiry unknown" and decide policy (skip, assume-expired, etc.).
         """
+        return await asyncio.to_thread(self._get_expires_at_sync)
+
+    def _get_expires_at_sync(self) -> float | None:
         data = self._read()
         if data is None:
             return None

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -234,6 +234,11 @@ def _token_file_lock(path: Path) -> LockType:
     whole new file and has no modify step to lose. The reads are already
     offloaded via `asyncio.to_thread`, so guarding them would only add needless
     worker-thread contention without preventing any lost update.
+
+    The cache is never pruned, but it is not a leak: it holds one lock per
+    distinct token-file path — effectively the set of configured MCP servers —
+    so it is bounded by config, not by request volume. Pruning would also race a
+    thread mid-`with` on an entry, so entries are kept for the process lifetime.
     """
     with _TOKEN_FILE_LOCKS_GUARD:
         lock = _TOKEN_FILE_LOCKS.get(path)
@@ -284,7 +289,8 @@ async def _join_task_deferring_cancellation(
     cancellation: asyncio.CancelledError | None = None
     try:
         # Unlike awaiting the task directly, cancelling `asyncio.wait` does not
-        # cancel the member task. It also avoids Python 3.14's shield-failure log.
+        # cancel the member task. It also sidesteps the spurious shield-failure
+        # log that awaiting a shielded task emits on newer CPython.
         await asyncio.wait((task,))
     except asyncio.CancelledError as exc:
         cancellation = exc
@@ -394,7 +400,19 @@ class FileTokenStorage(TokenStorage):
         # A refresh may rotate the refresh token. Observe persistence before
         # propagating cancellation so the refresh lock cannot be released while
         # a new token is still queued, and so a write failure is not discarded.
-        write_task.result()
+        try:
+            write_task.result()
+        except Exception:
+            # The write failure takes precedence and is re-raised, but log that
+            # it supersedes a deferred cancellation so the dropped edge is not
+            # silent (parity with `_refresh_lock_guard`).
+            if cancellation is not None:
+                logger.warning(
+                    "MCP token write for %s failed; a deferred cancellation is "
+                    "superseded by the write error.",
+                    self._server_name,
+                )
+            raise
         if cancellation is not None:
             raise cancellation
 
@@ -1440,8 +1458,11 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
         """Hold the cross-process refresh lock across the serialized refresh.
 
         Acquires the lock (waiting up to `_REFRESH_LOCK_TIMEOUT_SECONDS`; on
-        timeout it yields `False` so the caller can avoid the refresh grant) and
-        always releases it on exit. Acquisition and release are joined before
+        timeout it yields `False` so the caller can avoid the refresh grant).
+        Release is gated on `lock.is_locked` rather than the acquire result, so
+        a cancellation that lands *after* the worker thread took the lock still
+        frees it instead of orphaning it, while a timed-out/failed acquisition
+        skips the release. Acquisition and release are each joined before
         cancellation escapes, so neither worker can acquire or retain the lock
         after the guard has returned.
 
@@ -1497,8 +1518,21 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
                         type(pending_exception).__name__,
                         exc_info=True,
                     )
-                if cancellation is not None and pending_exception is None:
-                    raise cancellation
+                else:
+                    # Release succeeded. Re-raise a deferred cancellation unless
+                    # a guarded error is already propagating, in which case the
+                    # guarded error wins; log the superseded cancellation so the
+                    # dropped edge is not silent (parity with the failure path).
+                    if cancellation is not None:
+                        if pending_exception is None:
+                            raise cancellation
+                        logger.warning(
+                            "MCP token refresh lock for %s released cleanly, but "
+                            "a deferred cancellation is superseded by the "
+                            "in-flight %s.",
+                            self.context.server_url,
+                            type(pending_exception).__name__,
+                        )
 
     async def _persist_oauth_metadata(self) -> None:
         """Persist discovered public OAuth metadata when storage supports it."""

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -26,10 +26,11 @@ import stat
 import threading
 import time
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, TypeVar
 from urllib.parse import parse_qs, urlparse
 
 import httpx
+from anyio import CancelScope
 from filelock import FileLock, Timeout
 from mcp.client.auth import OAuthClientProvider, TokenStorage
 from mcp.client.auth.utils import (
@@ -224,7 +225,15 @@ _TOKEN_FILE_LOCKS_GUARD = threading.Lock()
 
 
 def _token_file_lock(path: Path) -> LockType:
-    """Return the process-wide mutation lock for `path`."""
+    """Return the process-wide mutation lock for `path`.
+
+    Only read-modify-write *mutations* (the `_set_*_sync` methods and the
+    loopback self-heal) take this lock, to serialize their overlapping updates
+    to the shared envelope. Reads deliberately do **not**: `_write` publishes
+    via an atomic `tmp.replace(path)`, so a reader always sees a whole old or
+    whole new file and has no modify step to lose. Guarding reads would only add
+    needless contention and re-introduce event-loop blocking risk.
+    """
     with _TOKEN_FILE_LOCKS_GUARD:
         lock = _TOKEN_FILE_LOCKS.get(path)
         if lock is None:
@@ -255,6 +264,38 @@ def _token_file_stem(server_name: str, server_url: str | None) -> str:
         return server_name
     digest = hashlib.sha256(server_url.encode("utf-8")).hexdigest()[:16]
     return f"{server_name}-{digest}"
+
+
+_T = TypeVar("_T")
+
+
+async def _join_task_deferring_cancellation(
+    task: asyncio.Task[_T],
+) -> asyncio.CancelledError | None:
+    """Join `task` without letting caller cancellation cancel the task.
+
+    The caller must inspect `task.result()` before re-raising the returned
+    cancellation so the task's failure can take precedence.
+
+    Returns:
+        The first cancellation deferred while waiting, if any.
+    """
+    cancellation: asyncio.CancelledError | None = None
+    try:
+        # Unlike awaiting the task directly, cancelling `asyncio.wait` does not
+        # cancel the member task. It also avoids Python 3.14's shield-failure log.
+        await asyncio.wait((task,))
+    except asyncio.CancelledError as exc:
+        cancellation = exc
+        # Block repeated cancellation from the same AnyIO scope. Direct
+        # `Task.cancel()` calls are separate edges, so keep joining after each.
+        with CancelScope(shield=True):
+            while not task.done():
+                try:
+                    await asyncio.wait((task,))
+                except asyncio.CancelledError:
+                    continue
+    return cancellation
 
 
 class FileTokenStorage(TokenStorage):
@@ -316,8 +357,22 @@ class FileTokenStorage(TokenStorage):
         cold-started provider can detect a stale access token and trigger
         the SDK's `refresh_token` grant instead of a full browser re-auth.
         Cleared when `expires_in` is absent so the sidecar can't go stale.
+
+        Once persistence starts, cancellation is delayed until the write is
+        terminal. If persistence fails while cancellation is pending, the
+        persistence error takes precedence so it is not silently discarded.
         """
-        await asyncio.to_thread(self._set_tokens_sync, tokens)
+        write_task = asyncio.create_task(
+            asyncio.to_thread(self._set_tokens_sync, tokens)
+        )
+        cancellation = await _join_task_deferring_cancellation(write_task)
+
+        # A refresh may rotate the refresh token. Observe persistence before
+        # propagating cancellation so the refresh lock cannot be released while
+        # a new token is still queued, and so a write failure is not discarded.
+        write_task.result()
+        if cancellation is not None:
+            raise cancellation
 
     def _set_tokens_sync(self, tokens: OAuthToken) -> None:
         with _token_file_lock(self.path):
@@ -1295,12 +1350,18 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
             or the lock could not be created, signalling the caller to avoid
             using the possibly in-flight refresh token after reloading.
         """
-        try:
-            await asyncio.to_thread(
+        acquire_task = asyncio.create_task(
+            asyncio.to_thread(
                 lock.acquire,
                 timeout=_REFRESH_LOCK_TIMEOUT_SECONDS,
             )
+        )
+        cancellation = await _join_task_deferring_cancellation(acquire_task)
+        try:
+            acquire_task.result()
         except Timeout:
+            if cancellation is not None:
+                raise cancellation from None
             # A timeout means a peer may still be mid-refresh with this same
             # token. Do not refresh unlocked: rotating-token servers can treat
             # the second grant as reuse and revoke the whole token family.
@@ -1312,6 +1373,8 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
             )
             return False
         except OSError as exc:
+            if cancellation is not None:
+                raise cancellation from None
             # Creating/locking the sidecar can fail (read-only or missing
             # tokens dir, permission denial on a hardened host). Avoid an
             # unlocked refresh so we do not replay a rotating refresh token if a
@@ -1323,6 +1386,8 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
                 type(exc).__name__,
             )
             return False
+        if cancellation is not None:
+            raise cancellation
         return True
 
     @contextlib.asynccontextmanager
@@ -1331,9 +1396,9 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
 
         Acquires the lock (waiting up to `_REFRESH_LOCK_TIMEOUT_SECONDS`; on
         timeout it yields `False` so the caller can avoid the refresh grant) and
-        always releases it on exit. Release is gated on `lock.is_locked` rather
-        than the acquire result, so a cancellation that lands *after* the worker
-        thread took the lock still frees it instead of orphaning it until GC.
+        always releases it on exit. Acquisition and release are joined before
+        cancellation escapes, so neither worker can acquire or retain the lock
+        after the guard has returned.
 
         Args:
             lock_path: Sibling `.lock` path from `FileTokenStorage`.
@@ -1345,11 +1410,37 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
         # `asyncio.to_thread` worker threads; the default would refuse the
         # cross-thread release and leak the OS lock until process exit.
         lock = FileLock(str(lock_path), thread_local=False)
+        pending_exception: BaseException | None = None
         try:
             yield await self._acquire_refresh_lock(lock)
+        except BaseException as exc:
+            # Preserve the guarded operation's exception while joining cleanup.
+            pending_exception = exc
+            raise
         finally:
             if lock.is_locked:
-                await asyncio.to_thread(lock.release)
+                release_task = asyncio.create_task(asyncio.to_thread(lock.release))
+                cancellation = await _join_task_deferring_cancellation(release_task)
+                try:
+                    release_task.result()
+                except Exception as exc:
+                    if pending_exception is None or isinstance(
+                        pending_exception, asyncio.CancelledError
+                    ):
+                        raise
+                    pending_exception.add_note(
+                        "MCP refresh lock release also failed with "
+                        f"{type(exc).__name__}."
+                    )
+                    logger.warning(
+                        "Failed to release the MCP token refresh lock for %s "
+                        "while propagating %s",
+                        self.context.server_url,
+                        type(pending_exception).__name__,
+                        exc_info=True,
+                    )
+                if cancellation is not None and pending_exception is None:
+                    raise cancellation
 
     async def _persist_oauth_metadata(self) -> None:
         """Persist discovered public OAuth metadata when storage supports it."""

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -51,6 +51,7 @@ from typing_extensions import override
 from deepagents_code.mcp_config import resolve_mcp_server_env
 
 if TYPE_CHECKING:
+    from _thread import LockType
     from pathlib import Path
 
     from mcp.client.auth.oauth2 import OAuthContext
@@ -218,6 +219,19 @@ timeout the provider reloads tokens from disk and avoids using any still-stale
 refresh token (see `_acquire_refresh_lock`).
 """
 
+_TOKEN_FILE_LOCKS: dict[Path, LockType] = {}
+_TOKEN_FILE_LOCKS_GUARD = threading.Lock()
+
+
+def _token_file_lock(path: Path) -> LockType:
+    """Return the process-wide mutation lock for `path`."""
+    with _TOKEN_FILE_LOCKS_GUARD:
+        lock = _TOKEN_FILE_LOCKS.get(path)
+        if lock is None:
+            lock = threading.Lock()
+            _TOKEN_FILE_LOCKS[path] = lock
+        return lock
+
 
 def _tokens_dir() -> Path:
     """Return `~/.deepagents/.state/mcp-tokens/`.
@@ -306,14 +320,15 @@ class FileTokenStorage(TokenStorage):
         await asyncio.to_thread(self._set_tokens_sync, tokens)
 
     def _set_tokens_sync(self, tokens: OAuthToken) -> None:
-        data = self._read() or {}
-        data["version"] = _STORAGE_VERSION
-        data["tokens"] = json.loads(tokens.model_dump_json(exclude_none=True))
-        if tokens.expires_in is not None:
-            data["expires_at"] = time.time() + tokens.expires_in
-        else:
-            data.pop("expires_at", None)
-        self._write(data)
+        with _token_file_lock(self.path):
+            data = self._read() or {}
+            data["version"] = _STORAGE_VERSION
+            data["tokens"] = json.loads(tokens.model_dump_json(exclude_none=True))
+            if tokens.expires_in is not None:
+                data["expires_at"] = time.time() + tokens.expires_in
+            else:
+                data.pop("expires_at", None)
+            self._write(data)
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         """Return the stored client registration, or `None` if none is persisted."""
@@ -333,10 +348,13 @@ class FileTokenStorage(TokenStorage):
         await asyncio.to_thread(self._set_client_info_sync, client_info)
 
     def _set_client_info_sync(self, client_info: OAuthClientInformationFull) -> None:
-        data = self._read() or {}
-        data["version"] = _STORAGE_VERSION
-        data["client_info"] = json.loads(client_info.model_dump_json(exclude_none=True))
-        self._write(data)
+        with _token_file_lock(self.path):
+            data = self._read() or {}
+            data["version"] = _STORAGE_VERSION
+            data["client_info"] = json.loads(
+                client_info.model_dump_json(exclude_none=True)
+            )
+            self._write(data)
 
     async def get_oauth_metadata(self) -> OAuthMetadata | None:
         """Return stored public OAuth authorization metadata, if available."""
@@ -356,10 +374,13 @@ class FileTokenStorage(TokenStorage):
         await asyncio.to_thread(self._set_oauth_metadata_sync, metadata)
 
     def _set_oauth_metadata_sync(self, metadata: OAuthMetadata) -> None:
-        data = self._read() or {}
-        data["version"] = _STORAGE_VERSION
-        data["oauth_metadata"] = json.loads(metadata.model_dump_json(exclude_none=True))
-        self._write(data)
+        with _token_file_lock(self.path):
+            data = self._read() or {}
+            data["version"] = _STORAGE_VERSION
+            data["oauth_metadata"] = json.loads(
+                metadata.model_dump_json(exclude_none=True)
+            )
+            self._write(data)
 
     async def set_tokens_and_client_info(
         self,
@@ -380,15 +401,18 @@ class FileTokenStorage(TokenStorage):
         tokens: OAuthToken,
         client_info: OAuthClientInformationFull,
     ) -> None:
-        data = self._read() or {}
-        data["version"] = _STORAGE_VERSION
-        data["tokens"] = json.loads(tokens.model_dump_json(exclude_none=True))
-        data["client_info"] = json.loads(client_info.model_dump_json(exclude_none=True))
-        if tokens.expires_in is not None:
-            data["expires_at"] = time.time() + tokens.expires_in
-        else:
-            data.pop("expires_at", None)
-        self._write(data)
+        with _token_file_lock(self.path):
+            data = self._read() or {}
+            data["version"] = _STORAGE_VERSION
+            data["tokens"] = json.loads(tokens.model_dump_json(exclude_none=True))
+            data["client_info"] = json.loads(
+                client_info.model_dump_json(exclude_none=True)
+            )
+            if tokens.expires_in is not None:
+                data["expires_at"] = time.time() + tokens.expires_in
+            else:
+                data.pop("expires_at", None)
+            self._write(data)
 
     async def get_expires_at(self) -> float | None:
         """Return the stored absolute token expiry (Unix epoch), or `None`.
@@ -514,6 +538,10 @@ class FileTokenStorage(TokenStorage):
                 both "nothing to discard" and "could not discard" (an
                 unreadable or unwritable token file, logged where it happens).
         """
+        with _token_file_lock(self.path):
+            return self._discard_client_info_if_loopback_unusable_sync()
+
+    def _discard_client_info_if_loopback_unusable_sync(self) -> bool:
         try:
             data = self._read()
         except RuntimeError as exc:

--- a/libs/code/deepagents_code/mcp_auth.py
+++ b/libs/code/deepagents_code/mcp_auth.py
@@ -231,8 +231,9 @@ def _token_file_lock(path: Path) -> LockType:
     loopback self-heal) take this lock, to serialize their overlapping updates
     to the shared envelope. Reads deliberately do **not**: `_write` publishes
     via an atomic `tmp.replace(path)`, so a reader always sees a whole old or
-    whole new file and has no modify step to lose. Guarding reads would only add
-    needless contention and re-introduce event-loop blocking risk.
+    whole new file and has no modify step to lose. The reads are already
+    offloaded via `asyncio.to_thread`, so guarding them would only add needless
+    worker-thread contention without preventing any lost update.
     """
     with _TOKEN_FILE_LOCKS_GUARD:
         lock = _TOKEN_FILE_LOCKS.get(path)
@@ -343,12 +344,32 @@ class FileTokenStorage(TokenStorage):
 
     def _get_tokens_sync(self) -> OAuthToken | None:
         data = self._read()
+        return self._tokens_from_data(data)
+
+    @staticmethod
+    def _tokens_from_data(data: dict[str, Any] | None) -> OAuthToken | None:
         if data is None:
             return None
         raw = data.get("tokens")
         if raw is None:
             return None
         return OAuthToken.model_validate(raw)
+
+    async def get_tokens_with_expiry(
+        self,
+    ) -> tuple[OAuthToken | None, float | None]:
+        """Return tokens and their absolute expiry from one file snapshot.
+
+        Reading both fields together prevents a concurrent token rotation from
+        pairing one token generation with another generation's expiry.
+        """
+        return await asyncio.to_thread(self._get_tokens_with_expiry_sync)
+
+    def _get_tokens_with_expiry_sync(
+        self,
+    ) -> tuple[OAuthToken | None, float | None]:
+        data = self._read()
+        return self._tokens_from_data(data), self._expires_at_from_data(data)
 
     async def set_tokens(self, tokens: OAuthToken) -> None:
         """Persist `tokens` to disk, preserving any stored client info.
@@ -362,8 +383,11 @@ class FileTokenStorage(TokenStorage):
         terminal. If persistence fails while cancellation is pending, the
         persistence error takes precedence so it is not silently discarded.
         """
+        expires_at = (
+            time.time() + tokens.expires_in if tokens.expires_in is not None else None
+        )
         write_task = asyncio.create_task(
-            asyncio.to_thread(self._set_tokens_sync, tokens)
+            asyncio.to_thread(self._set_tokens_sync, tokens, expires_at)
         )
         cancellation = await _join_task_deferring_cancellation(write_task)
 
@@ -374,13 +398,13 @@ class FileTokenStorage(TokenStorage):
         if cancellation is not None:
             raise cancellation
 
-    def _set_tokens_sync(self, tokens: OAuthToken) -> None:
+    def _set_tokens_sync(self, tokens: OAuthToken, expires_at: float | None) -> None:
         with _token_file_lock(self.path):
             data = self._read() or {}
             data["version"] = _STORAGE_VERSION
             data["tokens"] = json.loads(tokens.model_dump_json(exclude_none=True))
-            if tokens.expires_in is not None:
-                data["expires_at"] = time.time() + tokens.expires_in
+            if expires_at is not None:
+                data["expires_at"] = expires_at
             else:
                 data.pop("expires_at", None)
             self._write(data)
@@ -447,14 +471,21 @@ class FileTokenStorage(TokenStorage):
         Prevents the state where one call succeeds and the other fails,
         leaving an orphan on disk.
         """
+        expires_at = (
+            time.time() + tokens.expires_in if tokens.expires_in is not None else None
+        )
         await asyncio.to_thread(
-            self._set_tokens_and_client_info_sync, tokens, client_info
+            self._set_tokens_and_client_info_sync,
+            tokens,
+            client_info,
+            expires_at,
         )
 
     def _set_tokens_and_client_info_sync(
         self,
         tokens: OAuthToken,
         client_info: OAuthClientInformationFull,
+        expires_at: float | None,
     ) -> None:
         with _token_file_lock(self.path):
             data = self._read() or {}
@@ -463,8 +494,8 @@ class FileTokenStorage(TokenStorage):
             data["client_info"] = json.loads(
                 client_info.model_dump_json(exclude_none=True)
             )
-            if tokens.expires_in is not None:
-                data["expires_at"] = time.time() + tokens.expires_in
+            if expires_at is not None:
+                data["expires_at"] = expires_at
             else:
                 data.pop("expires_at", None)
             self._write(data)
@@ -481,6 +512,9 @@ class FileTokenStorage(TokenStorage):
 
     def _get_expires_at_sync(self) -> float | None:
         data = self._read()
+        return self._expires_at_from_data(data)
+
+    def _expires_at_from_data(self, data: dict[str, Any] | None) -> float | None:
         if data is None:
             return None
         raw = data.get("expires_at")
@@ -1283,11 +1317,22 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
             )
             if get_oauth_metadata is not None:
                 self.context.oauth_metadata = await get_oauth_metadata()
-        get_expires_at = getattr(self.context.storage, "get_expires_at", None)
-        if get_expires_at is None:
-            return
-        expires_at = await get_expires_at()
-        tokens = self.context.current_tokens
+        get_tokens_with_expiry = getattr(
+            self.context.storage,
+            "get_tokens_with_expiry",
+            None,
+        )
+        if get_tokens_with_expiry is not None:
+            tokens, expires_at = await get_tokens_with_expiry()
+            # Keep the token and expiry paired from the same file snapshot. A
+            # peer may rotate both while the upstream initializer is yielding.
+            self.context.current_tokens = tokens
+        else:
+            get_expires_at = getattr(self.context.storage, "get_expires_at", None)
+            if get_expires_at is None:
+                return
+            expires_at = await get_expires_at()
+            tokens = self.context.current_tokens
         if expires_at is None:
             # Use 1.0 (one second after the Unix epoch) rather than 0.0 so the
             # SDK's `not self.token_expiry_time` falsy-zero check doesn't treat
@@ -1424,10 +1469,23 @@ class _ExpiryAwareOAuthClientProvider(OAuthClientProvider):
                 try:
                     release_task.result()
                 except Exception as exc:
-                    if pending_exception is None or isinstance(
-                        pending_exception, asyncio.CancelledError
-                    ):
+                    if pending_exception is None:
+                        # No guarded error to preserve, so the release failure
+                        # is the primary error to surface. It supersedes any
+                        # deferred cancellation; log that loss so it is not
+                        # silent.
+                        if cancellation is not None:
+                            logger.warning(
+                                "MCP token refresh lock release for %s failed; "
+                                "a deferred cancellation is superseded by the "
+                                "release error.",
+                                self.context.server_url,
+                            )
                         raise
+                    # Preserve the guarded operation's exception — including a
+                    # `CancelledError`, whose propagation structured
+                    # cancellation depends on — and record the release failure
+                    # as a note rather than masking the original with it.
                     pending_exception.add_note(
                         "MCP refresh lock release also failed with "
                         f"{type(exc).__name__}."

--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -457,8 +457,11 @@ class MCPSessionManager:
             try:
                 await exit_stack.aclose()
             except Exception:
-                # A cleanup failure must not mask the original error; the
-                # session is being discarded regardless.
+                # An ordinary cleanup failure must not mask the original error;
+                # the session is being discarded regardless. A `CancelledError`
+                # raised *by* `aclose()` is intentionally not caught here — it
+                # supersedes the original error, matching structured-cancellation
+                # semantics where an in-flight cancellation wins.
                 logger.warning(
                     "Failed to close a partially initialized MCP session for %r",
                     server_name,

--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -448,10 +448,12 @@ class MCPSessionManager:
             # "Attempted to exit cancel scope in a different task than it was
             # entered in". Catch `BaseException` (not just `Exception`) so a
             # `CancelledError` — e.g. from a crashed Streamable HTTP transport
-            # task group cancelling `session.initialize()` — triggers the same
-            # in-task teardown instead of abandoning the session, and so genuine
-            # user/app cancellation still propagates rather than surfacing as an
-            # ordinary tool error.
+            # task group cancelling `session.initialize()` — also triggers the
+            # in-task teardown below instead of abandoning the session. The bare
+            # `raise` re-raises the original exception unchanged, so cancellation
+            # (and any other error) always propagates regardless; widening the
+            # catch only controls whether teardown runs, not whether the error
+            # propagates.
             try:
                 await exit_stack.aclose()
             except Exception:

--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -440,8 +440,28 @@ class MCPSessionManager:
         try:
             session = await exit_stack.enter_async_context(create_session(connection))
             await session.initialize()
-        except Exception:
-            await exit_stack.aclose()
+        except BaseException:
+            # Close the partially entered stack in *this* task before
+            # propagating. `create_session` enters an AnyIO task group whose
+            # cancel scope must be exited by the task that entered it; deferring
+            # teardown to async-generator finalization on another task raises
+            # "Attempted to exit cancel scope in a different task than it was
+            # entered in". Catch `BaseException` (not just `Exception`) so a
+            # `CancelledError` — e.g. from a crashed Streamable HTTP transport
+            # task group cancelling `session.initialize()` — triggers the same
+            # in-task teardown instead of abandoning the session, and so genuine
+            # user/app cancellation still propagates rather than surfacing as an
+            # ordinary tool error.
+            try:
+                await exit_stack.aclose()
+            except Exception:
+                # A cleanup failure must not mask the original error; the
+                # session is being discarded regardless.
+                logger.warning(
+                    "Failed to close a partially initialized MCP session for %r",
+                    server_name,
+                    exc_info=True,
+                )
             raise
 
         return _MCPSessionEntry(session=session, exit_stack=exit_stack)

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -82,6 +82,10 @@ dependencies = [
     # (_probe_link_follow_symlinks), which trips Blockbuster's os.getcwd guard
     # on the async server graph startup path.
     "filelock>=3.12,<3.30",
+    # `CancelScope` shields MCP token writes/lock ops from cancellation in
+    # mcp_auth.py. Always installed transitively via mcp/httpx; declared here
+    # because we import it directly.
+    "anyio>=4.0.0,<5.0.0",
 
     # ACP
     "deepagents-acp>=0.0.8,<1.0.0",

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -581,7 +581,9 @@ class TestFileTokenStorage:
             await asyncio.gather(task, return_exceptions=True)
 
     async def test_set_tokens_reports_write_failure_while_cancelled(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """A persistence failure takes precedence without leaking to the loop."""
         storage = FileTokenStorage("notion")
@@ -601,6 +603,7 @@ class TestFileTokenStorage:
             raise OSError(msg)
 
         monkeypatch.setattr(storage, "_write", _failing_write)
+        caplog.set_level(logging.WARNING, logger="deepagents_code.mcp_auth")
         task = asyncio.create_task(storage.set_tokens(_make_tokens()))
         try:
             assert await asyncio.to_thread(write_started.wait, 5)
@@ -620,6 +623,13 @@ class TestFileTokenStorage:
             loop.set_exception_handler(previous_handler)
 
         assert not loop_contexts
+        # The write error supersedes the deferred cancellation; that loss must
+        # be logged rather than dropped silently.
+        assert any(
+            "a deferred cancellation is superseded by the write error"
+            in record.getMessage()
+            for record in caplog.records
+        )
 
     async def test_reads_run_off_event_loop_thread(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1798,6 +1808,204 @@ class TestRefreshTokenSerialization:
             "Failed to release the MCP token refresh lock" in record.getMessage()
             for record in caplog.records
         )
+
+    async def test_refresh_lock_clean_body_release_failure_propagates(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A release failure on a clean refresh surfaces instead of vanishing.
+
+        With no guarded error and no cancellation, the release `OSError` is the
+        only failure in play, so it must propagate rather than be swallowed.
+        """
+        from filelock import FileLock
+
+        from deepagents_code.mcp_auth import (
+            _ExpiryAwareOAuthClientProvider,
+            build_oauth_provider,
+        )
+
+        storage = FileTokenStorage("notion")
+        storage.path.parent.mkdir(parents=True)
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+            interactive=False,
+        )
+        assert isinstance(provider, _ExpiryAwareOAuthClientProvider)
+        real_release = FileLock.release
+
+        def _release_then_fail(lock: FileLock, *, force: bool = False) -> None:
+            real_release(lock, force=force)
+            if not force:
+                msg = "refresh lock release failed"
+                raise OSError(msg)
+
+        async def _clean_guard() -> None:
+            async with provider._refresh_lock_guard(
+                storage.refresh_lock_path
+            ) as acquired:
+                assert acquired
+
+        monkeypatch.setattr(FileLock, "release", _release_then_fail)
+        with pytest.raises(OSError, match="refresh lock release failed"):
+            await _clean_guard()
+
+    async def test_refresh_lock_clean_body_release_failure_supersedes_cancellation(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A clean-body release failure supersedes a deferred cancellation.
+
+        When the guarded body succeeds but the lock release then fails, the
+        release error is the primary failure. A cancellation deferred during the
+        release join is dropped in its favor — but that loss must be logged, not
+        silent.
+        """
+        from filelock import FileLock
+
+        from deepagents_code.mcp_auth import (
+            _ExpiryAwareOAuthClientProvider,
+            build_oauth_provider,
+        )
+
+        storage = FileTokenStorage("notion")
+        storage.path.parent.mkdir(parents=True)
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+            interactive=False,
+        )
+        assert isinstance(provider, _ExpiryAwareOAuthClientProvider)
+        real_release = FileLock.release
+        release_started = threading.Event()
+        allow_release = threading.Event()
+
+        def _blocking_release_then_fail(lock: FileLock, *, force: bool = False) -> None:
+            if force:
+                # Best-effort GC-time release must not block or raise.
+                real_release(lock, force=force)
+                return
+            release_started.set()
+            if not allow_release.wait(timeout=5):
+                pytest.fail("timed out waiting to fail the lock release")
+            real_release(lock)
+            msg = "refresh lock release failed"
+            raise OSError(msg)
+
+        async def _clean_guard() -> None:
+            async with provider._refresh_lock_guard(
+                storage.refresh_lock_path
+            ) as acquired:
+                assert acquired
+
+        monkeypatch.setattr(FileLock, "release", _blocking_release_then_fail)
+        caplog.set_level(logging.WARNING, logger="deepagents_code.mcp_auth")
+        task = asyncio.create_task(_clean_guard())
+        try:
+            # The guarded body has exited; cancel while the release worker is
+            # parked so the cancellation is deferred through the release join.
+            assert await asyncio.to_thread(release_started.wait, 5)
+            task.cancel()
+            await asyncio.sleep(0)
+            assert not task.done()
+
+            allow_release.set()
+            with pytest.raises(OSError, match="refresh lock release failed"):
+                await task
+        finally:
+            allow_release.set()
+            await asyncio.gather(task, return_exceptions=True)
+
+        assert any(
+            "a deferred cancellation is superseded by the release error"
+            in record.getMessage()
+            for record in caplog.records
+        )
+
+    async def test_acquire_refresh_lock_oserror_skips_refresh(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An un-creatable sidecar lock skips the refresh rather than racing it.
+
+        On a hardened host the `.lock` file may be un-openable (read-only or
+        missing tokens dir). `_acquire_refresh_lock` must return `False` — never
+        refresh unlocked — and say why, so an operator can see the refresh was
+        skipped to avoid refresh-token reuse.
+        """
+        from filelock import FileLock
+
+        provider, storage = await self._build_stale_refreshable_provider()
+        lock = FileLock(str(storage.refresh_lock_path), thread_local=False)
+
+        def _raise_oserror(*_args: Any, **_kwargs: Any) -> None:
+            msg = "cannot open lock file"
+            raise OSError(msg)
+
+        monkeypatch.setattr(FileLock, "acquire", _raise_oserror)
+        caplog.set_level(logging.WARNING, logger="deepagents_code.mcp_auth")
+
+        assert await provider._acquire_refresh_lock(lock) is False
+        assert any(
+            "skipping refresh to avoid refresh-token reuse" in record.getMessage()
+            for record in caplog.records
+        )
+
+
+@pytest.mark.usefixtures("fake_home")
+class TestJoinTaskDeferringCancellation:
+    """Tests for the cancellation-deferring task join primitive."""
+
+    async def test_defers_caller_cancellation_without_cancelling_task(self) -> None:
+        """A cancelled caller neither cancels the wrapped task nor loses its result.
+
+        The join must let the wrapped task run to completion and hand the
+        deferred `CancelledError` back to the caller to re-raise, so an
+        in-flight write/lock operation is never abandoned mid-flight.
+        """
+        from deepagents_code.mcp_auth import _join_task_deferring_cancellation
+
+        started = threading.Event()
+        allow_finish = threading.Event()
+        captured: dict[str, Any] = {}
+
+        def _blocking() -> str:
+            started.set()
+            if not allow_finish.wait(timeout=5):
+                pytest.fail("timed out waiting to finish the wrapped task")
+            return "done"
+
+        async def _caller() -> None:
+            task = asyncio.create_task(asyncio.to_thread(_blocking))
+            deferred = await _join_task_deferring_cancellation(task)
+            captured["deferred"] = deferred
+            captured["value"] = task.result()
+            if deferred is not None:
+                raise deferred
+
+        caller = asyncio.create_task(_caller())
+        try:
+            assert await asyncio.to_thread(started.wait, 5)
+            caller.cancel()
+            await asyncio.sleep(0)
+            assert not caller.done(), "the join must defer the caller's cancellation"
+
+            allow_finish.set()
+            with pytest.raises(asyncio.CancelledError):
+                await caller
+        finally:
+            allow_finish.set()
+            await asyncio.gather(caller, return_exceptions=True)
+
+        # The wrapped task ran to completion despite the caller being cancelled,
+        # and the deferred cancellation was returned (not swallowed) for re-raise.
+        assert captured["value"] == "done"
+        assert isinstance(captured["deferred"], asyncio.CancelledError)
 
 
 @pytest.mark.usefixtures("fake_home")

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -360,6 +360,41 @@ class TestFileTokenStorage:
         assert got is not None
         assert before + 3600 <= got <= after + 3600 + 1.0
 
+    @pytest.mark.parametrize("include_client_info", [False, True])
+    async def test_expiry_is_captured_before_worker_delay(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        include_client_info: bool,
+    ) -> None:
+        """Executor delays do not extend the persisted token lifetime."""
+        storage = FileTokenStorage("notion")
+        clock = {"now": 1_000.0}
+        real_read = storage._read
+
+        def _delayed_read() -> dict[str, Any] | None:
+            # Model time spent waiting for an executor worker or the mutation
+            # lock before the worker begins its read-modify-write operation.
+            clock["now"] = 2_000.0
+            return real_read()
+
+        monkeypatch.setattr(time, "time", lambda: clock["now"])
+        monkeypatch.setattr(storage, "_read", _delayed_read)
+        tokens = OAuthToken(
+            access_token="at",
+            token_type="Bearer",
+            refresh_token="rt",
+            expires_in=60,
+        )
+
+        if include_client_info:
+            await storage.set_tokens_and_client_info(tokens, _make_client_info())
+        else:
+            await storage.set_tokens(tokens)
+
+        data = json.loads(storage.path.read_text())
+        assert data["expires_at"] == pytest.approx(1_060.0)
+
     async def test_get_expires_at_returns_none_for_legacy_file(
         self, fake_home: Path
     ) -> None:
@@ -589,9 +624,16 @@ class TestFileTokenStorage:
     async def test_reads_run_off_event_loop_thread(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Async reads must offload their blocking `_read` off the loop thread."""
+        """Every async read offloads its blocking `_read` off the loop thread.
+
+        `BlockBuster` under `langgraph dev` trips on any synchronous file read
+        left on the loop, so this pins all of the read accessors — not just
+        `get_tokens` — including `get_expires_at`, which sits on the hot
+        refresh-decision path.
+        """
         storage = FileTokenStorage("notion")
-        await storage.set_tokens(_make_tokens())
+        await storage.set_tokens_and_client_info(_make_tokens(), _make_client_info())
+        await storage.set_oauth_metadata(_make_oauth_metadata())
 
         loop_thread = threading.get_ident()
         read_threads: list[int] = []
@@ -604,8 +646,12 @@ class TestFileTokenStorage:
         monkeypatch.setattr(storage, "_read", _spy_read)
 
         assert await storage.get_tokens() is not None
+        assert await storage.get_client_info() is not None
+        assert await storage.get_oauth_metadata() is not None
+        assert await storage.get_expires_at() is not None
+        assert await storage.get_tokens_with_expiry() != (None, None)
 
-        assert read_threads, "_read should have run"
+        assert len(read_threads) == 5, "each read accessor should have run once"
         assert all(thread_id != loop_thread for thread_id in read_threads), (
             "token reads must run off the event-loop thread"
         )
@@ -615,9 +661,9 @@ class TestFileTokenStorage:
     ) -> None:
         """Every setter offloads its blocking `_write` off the loop thread.
 
-        `set_tokens`/`get_tokens` are covered above; this pins the remaining
-        setters — notably `set_tokens_and_client_info`, the atomic combined
-        write on the primary OAuth-completion path this PR targets.
+        `set_tokens` is covered above; this pins the remaining setters —
+        notably `set_tokens_and_client_info`, the atomic combined write on the
+        primary OAuth-completion path this PR targets.
         """
         storage = FileTokenStorage("notion")
         loop_thread = threading.get_ident()
@@ -631,9 +677,10 @@ class TestFileTokenStorage:
         monkeypatch.setattr(storage, "_write", _spy_write)
 
         await storage.set_tokens_and_client_info(_make_tokens(), _make_client_info())
+        await storage.set_client_info(_make_client_info())
         await storage.set_oauth_metadata(_make_oauth_metadata())
 
-        assert len(write_threads) == 2, "both setters should have written once"
+        assert len(write_threads) == 3, "each setter should have written once"
         assert all(thread_id != loop_thread for thread_id in write_threads), (
             "token persistence must run off the event-loop thread"
         )
@@ -702,6 +749,46 @@ class TestExpiryAwareOAuthClientProvider:
         )
         assert provider.context.is_token_valid() is True
         assert provider.context.can_refresh_token() is True
+
+    async def test_initialize_loads_token_and_expiry_from_same_snapshot(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A concurrent rotation cannot pair an old token with a new expiry."""
+        from deepagents_code.mcp_auth import (
+            _REFRESH_SAFETY_MARGIN_SECONDS,
+            build_oauth_provider,
+        )
+
+        storage = FileTokenStorage("notion")
+        await storage.set_client_info(_make_client_info())
+        await storage.set_tokens(_make_tokens("old"))
+        data = json.loads(storage.path.read_text())
+        data["expires_at"] = time.time() - 60
+        storage.path.write_text(json.dumps(data))
+        original_get_tokens = storage.get_tokens
+
+        async def _get_old_tokens_then_rotate() -> OAuthToken | None:
+            tokens = await original_get_tokens()
+            await storage.set_tokens(_make_tokens("new"))
+            return tokens
+
+        monkeypatch.setattr(storage, "get_tokens", _get_old_tokens_then_rotate)
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+        )
+
+        await provider._initialize()
+
+        expected_expires_at = await storage.get_expires_at()
+        assert expected_expires_at is not None
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.access_token == "new"
+        assert provider.context.token_expiry_time == (
+            expected_expires_at - _REFRESH_SAFETY_MARGIN_SECONDS
+        )
 
     async def test_initialize_treats_expired_token_as_invalid(self) -> None:
         """A past `expires_at` makes the loaded token report as invalid."""
@@ -1526,6 +1613,75 @@ class TestRefreshTokenSerialization:
             if probe.is_locked:
                 probe.release()
 
+    async def test_refresh_lock_acquire_timeout_yields_to_cancellation(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Cancellation deferred through an acquire wins over the acquire timeout.
+
+        When a cancel lands while the acquire worker is still waiting on a
+        peer-held lock that ultimately times out, the guard must surface the
+        `CancelledError` — not swallow it into the "skip refresh" (`False`)
+        path the timeout takes on its own.
+        """
+        from filelock import FileLock
+
+        from deepagents_code import mcp_auth
+        from deepagents_code.mcp_auth import (
+            _ExpiryAwareOAuthClientProvider,
+            build_oauth_provider,
+        )
+
+        storage = FileTokenStorage("notion")
+        storage.path.parent.mkdir(parents=True)
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+            interactive=False,
+        )
+        assert isinstance(provider, _ExpiryAwareOAuthClientProvider)
+        monkeypatch.setattr(mcp_auth, "_REFRESH_LOCK_TIMEOUT_SECONDS", 0.3)
+        acquire_started = asyncio.Event()
+        real_acquire = provider._acquire_refresh_lock
+
+        async def _tracked_acquire(lock: FileLock) -> bool:
+            acquire_started.set()
+            return await real_acquire(lock)
+
+        monkeypatch.setattr(provider, "_acquire_refresh_lock", _tracked_acquire)
+        # A peer holds the lock for the whole flow, so the provider's acquire
+        # can only ever time out.
+        peer = FileLock(str(storage.refresh_lock_path), thread_local=False)
+        peer.acquire()
+
+        async def _enter_guard() -> None:
+            async with provider._refresh_lock_guard(storage.refresh_lock_path):
+                pass
+
+        task = asyncio.create_task(_enter_guard())
+        try:
+            caplog.set_level(logging.WARNING, logger="deepagents_code.mcp_auth")
+            await acquire_started.wait()
+            task.cancel()
+            await asyncio.sleep(0)
+            assert not task.done()
+
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            # The timeout's "skip refresh" warning must not fire: cancellation
+            # took precedence over the timed-out acquire.
+            assert not any(
+                "skipping refresh to avoid refresh-token reuse" in record.getMessage()
+                for record in caplog.records
+            )
+        finally:
+            if peer.is_locked:
+                peer.release()
+            await asyncio.gather(task, return_exceptions=True)
+
     async def test_refresh_lock_release_failure_preserves_body_error(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1571,9 +1727,69 @@ class TestRefreshTokenSerialization:
         ):
             await _raise_in_guard()
 
-        assert exc_info.value.__notes__ == [
-            "MCP refresh lock release also failed with OSError."
-        ]
+        assert any(
+            "release also failed with OSError" in note
+            for note in exc_info.value.__notes__
+        )
+        assert any(
+            "Failed to release the MCP token refresh lock" in record.getMessage()
+            for record in caplog.records
+        )
+
+    async def test_refresh_lock_release_failure_preserves_cancellation(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A release failure must not mask a cancelled guarded body.
+
+        This is the counterpart to the ``ValueError`` body above: when the
+        guarded operation is cancelled and the lock release then fails, the
+        ``CancelledError`` must still propagate (structured cancellation
+        depends on it) with the release failure attached as a note.
+        """
+        from filelock import FileLock
+
+        from deepagents_code.mcp_auth import (
+            _ExpiryAwareOAuthClientProvider,
+            build_oauth_provider,
+        )
+
+        storage = FileTokenStorage("notion")
+        storage.path.parent.mkdir(parents=True)
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+            interactive=False,
+        )
+        assert isinstance(provider, _ExpiryAwareOAuthClientProvider)
+        real_release = FileLock.release
+
+        def _release_then_fail(lock: FileLock, *, force: bool = False) -> None:
+            real_release(lock, force=force)
+            if not force:
+                msg = "refresh lock release failed"
+                raise OSError(msg)
+
+        async def _cancel_in_guard() -> None:
+            async with provider._refresh_lock_guard(
+                storage.refresh_lock_path
+            ) as acquired:
+                assert acquired
+                raise asyncio.CancelledError
+
+        monkeypatch.setattr(FileLock, "release", _release_then_fail)
+        with (
+            caplog.at_level(logging.WARNING, logger="deepagents_code.mcp_auth"),
+            pytest.raises(asyncio.CancelledError) as exc_info,
+        ):
+            await _cancel_in_guard()
+
+        assert any(
+            "release also failed with OSError" in note
+            for note in getattr(exc_info.value, "__notes__", [])
+        )
         assert any(
             "Failed to release the MCP token refresh lock" in record.getMessage()
             for record in caplog.records

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import re
@@ -171,6 +172,92 @@ class TestFileTokenStorage:
         assert got_tok is not None
         assert got_ci.client_id == "client-id"
         assert got_tok.access_token == "at"
+
+    async def test_concurrent_instances_preserve_distinct_updates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same-file read-modify-write operations retain both updates."""
+        token_storage = FileTokenStorage("notion")
+        client_storage = FileTokenStorage("notion")
+        write_barrier = threading.Barrier(2)
+        physical_write_lock = threading.Lock()
+        loop_thread = threading.get_ident()
+        filesystem_threads: list[int] = []
+        real_write = FileTokenStorage._write
+
+        def _coordinated_write(storage: FileTokenStorage, data: dict[str, Any]) -> None:
+            filesystem_threads.append(threading.get_ident())
+            with contextlib.suppress(threading.BrokenBarrierError):
+                write_barrier.wait(timeout=1)
+            # Isolate lost-update behavior from the fixed-name temporary file:
+            # both stale snapshots are written successfully, in sequence.
+            with physical_write_lock:
+                real_write(storage, data)
+
+        monkeypatch.setattr(FileTokenStorage, "_write", _coordinated_write)
+
+        await asyncio.gather(
+            token_storage.set_tokens(_make_tokens()),
+            client_storage.set_client_info(_make_client_info()),
+        )
+
+        stored_tokens = await token_storage.get_tokens()
+        stored_client = await client_storage.get_client_info()
+        assert stored_tokens is not None
+        assert stored_client is not None
+        assert filesystem_threads
+        assert all(thread_id != loop_thread for thread_id in filesystem_threads)
+
+    async def test_concurrent_instances_do_not_overlap_tmp_writes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same-file mutations cannot collide while writing the shared `.tmp`."""
+        first = FileTokenStorage("notion")
+        second = FileTokenStorage("notion")
+        write_barrier = threading.Barrier(2)
+        real_write = FileTokenStorage._write
+
+        def _collision_detecting_write(
+            storage: FileTokenStorage, data: dict[str, Any]
+        ) -> None:
+            try:
+                write_barrier.wait(timeout=1)
+            except threading.BrokenBarrierError:
+                real_write(storage, data)
+                return
+            msg = "concurrent writers collided on the shared temporary file"
+            raise FileExistsError(msg)
+
+        monkeypatch.setattr(
+            FileTokenStorage,
+            "_write",
+            _collision_detecting_write,
+        )
+
+        await asyncio.gather(
+            first.set_tokens(_make_tokens("first")),
+            second.set_tokens(_make_tokens("second")),
+        )
+
+    async def test_different_token_files_can_write_concurrently(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Per-file synchronization does not serialize unrelated servers."""
+        write_barrier = threading.Barrier(2)
+        real_write = FileTokenStorage._write
+
+        def _coordinated_write(storage: FileTokenStorage, data: dict[str, Any]) -> None:
+            write_barrier.wait(timeout=1)
+            real_write(storage, data)
+
+        monkeypatch.setattr(FileTokenStorage, "_write", _coordinated_write)
+
+        await asyncio.gather(
+            FileTokenStorage("alpha").set_tokens(_make_tokens("alpha")),
+            FileTokenStorage("beta").set_tokens(_make_tokens("beta")),
+        )
+
+        assert not write_barrier.broken
 
     async def test_sets_file_permissions_on_posix(self, fake_home: Path) -> None:
         """Token files are created with private user-only permissions."""
@@ -2322,6 +2409,42 @@ class TestFileTokenStorageExtras:
 
         assert storage.discard_client_info_if_loopback_unusable() is False
         assert await storage.get_client_info() is not None
+
+    async def test_discard_and_token_write_are_serialized_across_instances(
+        self, fake_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The synchronous self-heal cannot race an async token update."""
+        del fake_home
+        token_storage = FileTokenStorage("notion")
+        heal_storage = FileTokenStorage("notion")
+        await token_storage.set_client_info(_make_client_info())
+
+        write_barrier = threading.Barrier(2)
+        real_write = FileTokenStorage._write
+
+        def _collision_detecting_write(
+            storage: FileTokenStorage, data: dict[str, Any]
+        ) -> None:
+            try:
+                write_barrier.wait(timeout=1)
+            except threading.BrokenBarrierError:
+                real_write(storage, data)
+                return
+            msg = "self-heal overlapped another shared-envelope mutation"
+            raise FileExistsError(msg)
+
+        monkeypatch.setattr(
+            FileTokenStorage,
+            "_write",
+            _collision_detecting_write,
+        )
+
+        await asyncio.gather(
+            token_storage.set_tokens(_make_tokens()),
+            asyncio.to_thread(heal_storage.discard_client_info_if_loopback_unusable),
+        )
+
+        assert await token_storage.get_tokens() is not None
 
     async def test_discard_noop_without_client_info(self, fake_home: Path) -> None:
         """No persisted registration means nothing to discard."""

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Literal, cast
 from unittest.mock import patch
 
+import anyio
 import httpx
 import pytest
 from mcp.client.auth import TokenStorage
@@ -189,8 +190,9 @@ class TestFileTokenStorage:
             filesystem_threads.append(threading.get_ident())
             with contextlib.suppress(threading.BrokenBarrierError):
                 write_barrier.wait(timeout=1)
-            # Isolate lost-update behavior from the fixed-name temporary file:
-            # both stale snapshots are written successfully, in sequence.
+            # If the per-file lock regressed and both writers ran concurrently,
+            # serialize the physical writes so the test observes a clean
+            # last-writer-wins lost update rather than a shared-`.tmp` collision.
             with physical_write_lock:
                 real_write(storage, data)
 
@@ -238,6 +240,9 @@ class TestFileTokenStorage:
             first.set_tokens(_make_tokens("first")),
             second.set_tokens(_make_tokens("second")),
         )
+
+        # Both serialized writes landed rather than colliding on the `.tmp`.
+        assert await first.get_tokens() is not None
 
     async def test_different_token_files_can_write_concurrently(
         self, monkeypatch: pytest.MonkeyPatch
@@ -445,6 +450,142 @@ class TestFileTokenStorage:
         assert got.access_token == "at"
         assert await storage.get_expires_at() is not None
 
+    async def test_set_tokens_joins_write_despite_repeated_cancellation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Repeated cancellation waits for a rotated refresh token to reach disk."""
+        storage = FileTokenStorage("notion")
+        write_started = threading.Event()
+        write_finished = threading.Event()
+        allow_write = threading.Event()
+        real_write = storage._write
+
+        def _blocking_write(data: dict[str, Any]) -> None:
+            write_started.set()
+            if not allow_write.wait(timeout=5):
+                pytest.fail("timed out waiting to finish the token write")
+            try:
+                real_write(data)
+            finally:
+                write_finished.set()
+
+        monkeypatch.setattr(storage, "_write", _blocking_write)
+        task = asyncio.create_task(storage.set_tokens(_make_tokens()))
+
+        try:
+            assert await asyncio.to_thread(write_started.wait, 5)
+            task.cancel()
+            await asyncio.sleep(0)
+            assert not task.done(), (
+                "cancellation must stay joined to the in-flight token write"
+            )
+
+            for _ in range(2):
+                task.cancel()
+                await asyncio.sleep(0)
+                assert not task.done(), (
+                    "repeated cancellation must not detach the token write"
+                )
+
+            allow_write.set()
+
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            assert write_finished.is_set()
+            got = await storage.get_tokens()
+            assert got is not None
+            assert got.access_token == "at"
+        finally:
+            allow_write.set()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    async def test_set_tokens_joins_write_under_anyio_level_cancellation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An AnyIO cancelled scope cannot detach in-flight token persistence."""
+        storage = FileTokenStorage("notion")
+        write_started = threading.Event()
+        allow_write = threading.Event()
+        scopes: list[anyio.CancelScope] = []
+
+        real_write = storage._write
+
+        def _patched_write(data: dict[str, Any]) -> None:
+            write_started.set()
+            if not allow_write.wait(timeout=5):
+                pytest.fail("timed out waiting to finish the token write")
+            real_write(data)
+
+        monkeypatch.setattr(storage, "_write", _patched_write)
+
+        async def _persist_in_cancel_scope() -> bool:
+            with anyio.CancelScope() as scope:
+                scopes.append(scope)
+                await storage.set_tokens(_make_tokens())
+            return scope.cancelled_caught
+
+        task = asyncio.create_task(_persist_in_cancel_scope())
+        try:
+            assert await asyncio.to_thread(write_started.wait, 5)
+            scopes[0].cancel()
+            await asyncio.sleep(0)
+
+            assert not task.done(), (
+                "level cancellation must stay joined to the in-flight write"
+            )
+            allow_write.set()
+
+            assert await task is True
+            got = await storage.get_tokens()
+            assert got is not None
+            assert got.access_token == "at"
+        finally:
+            allow_write.set()
+            await asyncio.gather(task, return_exceptions=True)
+
+    async def test_set_tokens_reports_write_failure_while_cancelled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A persistence failure takes precedence without leaking to the loop."""
+        storage = FileTokenStorage("notion")
+        write_started = threading.Event()
+        allow_write = threading.Event()
+        loop = asyncio.get_running_loop()
+        loop_contexts: list[dict[str, Any]] = []
+        previous_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: loop_contexts.append(context))
+
+        def _failing_write(data: dict[str, Any]) -> None:
+            del data
+            write_started.set()
+            if not allow_write.wait(timeout=5):
+                pytest.fail("timed out waiting to fail the token write")
+            msg = "token persistence failed"
+            raise OSError(msg)
+
+        monkeypatch.setattr(storage, "_write", _failing_write)
+        task = asyncio.create_task(storage.set_tokens(_make_tokens()))
+        try:
+            assert await asyncio.to_thread(write_started.wait, 5)
+            task.cancel()
+            await asyncio.sleep(0)
+            task.cancel()
+            await asyncio.sleep(0)
+            assert not task.done()
+
+            allow_write.set()
+            with pytest.raises(OSError, match="token persistence failed"):
+                await task
+            await asyncio.sleep(0)
+        finally:
+            allow_write.set()
+            await asyncio.gather(task, return_exceptions=True)
+            loop.set_exception_handler(previous_handler)
+
+        assert not loop_contexts
+
     async def test_reads_run_off_event_loop_thread(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -468,6 +609,68 @@ class TestFileTokenStorage:
         assert all(thread_id != loop_thread for thread_id in read_threads), (
             "token reads must run off the event-loop thread"
         )
+
+    async def test_all_setters_persist_off_event_loop_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Every setter offloads its blocking `_write` off the loop thread.
+
+        `set_tokens`/`get_tokens` are covered above; this pins the remaining
+        setters — notably `set_tokens_and_client_info`, the atomic combined
+        write on the primary OAuth-completion path this PR targets.
+        """
+        storage = FileTokenStorage("notion")
+        loop_thread = threading.get_ident()
+        write_threads: list[int] = []
+        real_write = storage._write
+
+        def _spy_write(data: dict) -> None:
+            write_threads.append(threading.get_ident())
+            real_write(data)
+
+        monkeypatch.setattr(storage, "_write", _spy_write)
+
+        await storage.set_tokens_and_client_info(_make_tokens(), _make_client_info())
+        await storage.set_oauth_metadata(_make_oauth_metadata())
+
+        assert len(write_threads) == 2, "both setters should have written once"
+        assert all(thread_id != loop_thread for thread_id in write_threads), (
+            "token persistence must run off the event-loop thread"
+        )
+
+    async def test_read_not_blocked_by_in_flight_mutation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A read runs lock-free instead of serializing behind a live mutation.
+
+        A mutation holding the per-file lock during its blocking write must not
+        stall a concurrent read, which never takes that lock.
+        """
+        storage = FileTokenStorage("notion")
+        await storage.set_tokens(_make_tokens())
+
+        write_holding_lock = threading.Event()
+        release_write = threading.Event()
+        real_write = storage._write
+
+        def _blocking_write(data: dict) -> None:
+            # Called while `_set_tokens_sync` holds the per-file lock.
+            write_holding_lock.set()
+            if not release_write.wait(timeout=5):
+                pytest.fail("timed out holding the per-file mutation lock")
+            real_write(data)
+
+        monkeypatch.setattr(storage, "_write", _blocking_write)
+        write_task = asyncio.create_task(storage.set_tokens(_make_tokens("new")))
+        try:
+            assert await asyncio.to_thread(write_holding_lock.wait, 5)
+            # The mutation is parked inside `_write` still holding the lock; a
+            # read must complete instead of serializing behind it.
+            got = await asyncio.wait_for(storage.get_tokens(), timeout=1)
+            assert got is not None
+        finally:
+            release_write.set()
+            await write_task
 
 
 @pytest.mark.usefixtures("fake_home")
@@ -1118,6 +1321,263 @@ class TestRefreshTokenSerialization:
             pytest.fail("refresh lock was not released after a successful refresh")
         else:
             probe.release()
+
+    async def test_refresh_lock_held_until_cancelled_write_finishes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cancellation cannot release the refresh lock ahead of persistence."""
+        from filelock import FileLock, Timeout
+
+        from deepagents_code.mcp_auth import (
+            _ExpiryAwareOAuthClientProvider,
+            build_oauth_provider,
+        )
+
+        storage = FileTokenStorage("notion")
+        storage.path.parent.mkdir(parents=True)
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+            interactive=False,
+        )
+        assert isinstance(provider, _ExpiryAwareOAuthClientProvider)
+        write_started = threading.Event()
+        allow_write = threading.Event()
+        real_write = storage._write
+
+        def _blocking_write(data: dict[str, Any]) -> None:
+            write_started.set()
+            if not allow_write.wait(timeout=5):
+                pytest.fail("timed out waiting to finish the token write")
+            real_write(data)
+
+        monkeypatch.setattr(storage, "_write", _blocking_write)
+
+        async def _persist_under_refresh_lock() -> None:
+            async with provider._refresh_lock_guard(
+                storage.refresh_lock_path
+            ) as acquired:
+                assert acquired
+                await storage.set_tokens(_make_tokens())
+
+        task = asyncio.create_task(_persist_under_refresh_lock())
+        probe = FileLock(str(storage.refresh_lock_path), thread_local=False)
+        try:
+            assert await asyncio.to_thread(write_started.wait, 5)
+            task.cancel()
+            await asyncio.sleep(0)
+            task.cancel()
+            await asyncio.sleep(0)
+            assert not task.done()
+
+            with pytest.raises(Timeout):
+                await asyncio.to_thread(probe.acquire, timeout=0)
+
+            allow_write.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            await asyncio.to_thread(probe.acquire, timeout=1)
+        finally:
+            allow_write.set()
+            await asyncio.gather(task, return_exceptions=True)
+            if probe.is_locked:
+                probe.release()
+
+    async def test_refresh_lock_write_failure_wins_over_level_cancellation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cancelled refresh reports persistence failure after releasing its lock."""
+        from filelock import FileLock
+
+        from deepagents_code.mcp_auth import (
+            _ExpiryAwareOAuthClientProvider,
+            build_oauth_provider,
+        )
+
+        storage = FileTokenStorage("notion")
+        storage.path.parent.mkdir(parents=True)
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+            interactive=False,
+        )
+        assert isinstance(provider, _ExpiryAwareOAuthClientProvider)
+        write_started = threading.Event()
+        allow_write = threading.Event()
+        release_started = threading.Event()
+        allow_release = threading.Event()
+        scopes: list[anyio.CancelScope] = []
+        real_release = FileLock.release
+
+        def _failing_write(data: dict[str, Any]) -> None:
+            del data
+            write_started.set()
+            if not allow_write.wait(timeout=5):
+                pytest.fail("timed out waiting to fail the token write")
+            msg = "token persistence failed"
+            raise OSError(msg)
+
+        def _blocking_release(lock: FileLock, *, force: bool = False) -> None:
+            release_started.set()
+            if not allow_release.wait(timeout=5):
+                pytest.fail("timed out waiting to release the refresh lock")
+            real_release(lock, force=force)
+
+        monkeypatch.setattr(storage, "_write", _failing_write)
+        monkeypatch.setattr(FileLock, "release", _blocking_release)
+
+        async def _persist_in_cancel_scope() -> bool:
+            with anyio.CancelScope() as scope:
+                scopes.append(scope)
+                async with provider._refresh_lock_guard(
+                    storage.refresh_lock_path
+                ) as acquired:
+                    assert acquired
+                    await storage.set_tokens(_make_tokens())
+            return scope.cancelled_caught
+
+        task = asyncio.create_task(_persist_in_cancel_scope())
+        probe = FileLock(str(storage.refresh_lock_path), thread_local=False)
+        try:
+            assert await asyncio.to_thread(write_started.wait, 5)
+            scopes[0].cancel()
+            await asyncio.sleep(0)
+            assert not task.done()
+
+            allow_write.set()
+            assert await asyncio.to_thread(release_started.wait, 5)
+            assert not task.done()
+
+            task.cancel()
+            await asyncio.sleep(0)
+            assert not task.done()
+
+            allow_release.set()
+            with pytest.raises(OSError, match="token persistence failed"):
+                await task
+
+            await asyncio.to_thread(probe.acquire, timeout=1)
+        finally:
+            allow_write.set()
+            allow_release.set()
+            await asyncio.gather(task, return_exceptions=True)
+            if probe.is_locked:
+                probe.release()
+
+    async def test_refresh_lock_acquisition_joins_cancellation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cancellation waits for a lock-acquire worker and releases its result."""
+        from filelock import FileLock
+
+        from deepagents_code.mcp_auth import (
+            _ExpiryAwareOAuthClientProvider,
+            build_oauth_provider,
+        )
+
+        storage = FileTokenStorage("notion")
+        storage.path.parent.mkdir(parents=True)
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+            interactive=False,
+        )
+        assert isinstance(provider, _ExpiryAwareOAuthClientProvider)
+        acquire_started = asyncio.Event()
+        real_acquire = provider._acquire_refresh_lock
+
+        async def _tracked_acquire(lock: FileLock) -> bool:
+            acquire_started.set()
+            return await real_acquire(lock)
+
+        monkeypatch.setattr(provider, "_acquire_refresh_lock", _tracked_acquire)
+        peer = FileLock(str(storage.refresh_lock_path), thread_local=False)
+        peer.acquire()
+
+        async def _enter_guard() -> None:
+            async with provider._refresh_lock_guard(
+                storage.refresh_lock_path
+            ) as acquired:
+                assert acquired
+
+        task = asyncio.create_task(_enter_guard())
+        probe = FileLock(str(storage.refresh_lock_path), thread_local=False)
+        try:
+            await acquire_started.wait()
+            task.cancel()
+            await asyncio.sleep(0)
+            task.cancel()
+            await asyncio.sleep(0)
+            assert not task.done()
+
+            peer.release()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            await asyncio.to_thread(probe.acquire, timeout=1)
+        finally:
+            if peer.is_locked:
+                peer.release()
+            await asyncio.gather(task, return_exceptions=True)
+            if probe.is_locked:
+                probe.release()
+
+    async def test_refresh_lock_release_failure_preserves_body_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A cleanup failure is reported without replacing the guarded error."""
+        from filelock import FileLock
+
+        from deepagents_code.mcp_auth import (
+            _ExpiryAwareOAuthClientProvider,
+            build_oauth_provider,
+        )
+
+        storage = FileTokenStorage("notion")
+        storage.path.parent.mkdir(parents=True)
+        provider = build_oauth_provider(
+            server_name="notion",
+            server_url="https://mcp.notion.com/mcp",
+            storage=storage,
+            interactive=False,
+        )
+        assert isinstance(provider, _ExpiryAwareOAuthClientProvider)
+        real_release = FileLock.release
+
+        def _release_then_fail(lock: FileLock, *, force: bool = False) -> None:
+            real_release(lock, force=force)
+            if not force:
+                msg = "refresh lock release failed"
+                raise OSError(msg)
+
+        async def _raise_in_guard() -> None:
+            async with provider._refresh_lock_guard(
+                storage.refresh_lock_path
+            ) as acquired:
+                assert acquired
+                msg = "guarded operation failed"
+                raise ValueError(msg)
+
+        monkeypatch.setattr(FileLock, "release", _release_then_fail)
+        with (
+            caplog.at_level(logging.WARNING, logger="deepagents_code.mcp_auth"),
+            pytest.raises(ValueError, match="guarded operation failed") as exc_info,
+        ):
+            await _raise_in_guard()
+
+        assert exc_info.value.__notes__ == [
+            "MCP refresh lock release also failed with OSError."
+        ]
+        assert any(
+            "Failed to release the MCP token refresh lock" in record.getMessage()
+            for record in caplog.records
+        )
 
 
 @pytest.mark.usefixtures("fake_home")

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import re
+import threading
 import time
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -320,6 +321,66 @@ class TestFileTokenStorage:
         stored = await storage.get_oauth_metadata()
         assert stored is not None
         assert str(stored.token_endpoint) == "https://auth.example/token"
+
+    async def test_set_tokens_persists_off_event_loop_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Refreshed-token persistence must not block the event-loop thread.
+
+        `set_tokens` is awaited from the MCP SDK's async OAuth refresh flow.
+        Its synchronous read-modify-write (including `path.parent.mkdir`)
+        must run in a worker thread; otherwise BlockBuster under
+        `langgraph dev` raises `BlockingError`, which cancels the transport
+        task group and crashes the tool node. Regression for the MCP OAuth
+        refresh failure.
+        """
+        storage = FileTokenStorage("notion")
+        loop_thread = threading.get_ident()
+        write_threads: list[int] = []
+
+        real_write = storage._write
+
+        def _spy_write(data: dict) -> None:
+            write_threads.append(threading.get_ident())
+            real_write(data)
+
+        monkeypatch.setattr(storage, "_write", _spy_write)
+
+        await storage.set_tokens(_make_tokens())
+
+        assert write_threads, "_write should have run"
+        assert all(thread_id != loop_thread for thread_id in write_threads), (
+            "token persistence must run off the event-loop thread"
+        )
+        # The expected state is still written despite the offload.
+        got = await storage.get_tokens()
+        assert got is not None
+        assert got.access_token == "at"
+        assert await storage.get_expires_at() is not None
+
+    async def test_reads_run_off_event_loop_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Async reads must offload their blocking `_read` off the loop thread."""
+        storage = FileTokenStorage("notion")
+        await storage.set_tokens(_make_tokens())
+
+        loop_thread = threading.get_ident()
+        read_threads: list[int] = []
+        real_read = storage._read
+
+        def _spy_read() -> dict | None:
+            read_threads.append(threading.get_ident())
+            return real_read()
+
+        monkeypatch.setattr(storage, "_read", _spy_read)
+
+        assert await storage.get_tokens() is not None
+
+        assert read_threads, "_read should have run"
+        assert all(thread_id != loop_thread for thread_id in read_threads), (
+            "token reads must run off the event-loop thread"
+        )
 
 
 @pytest.mark.usefixtures("fake_home")

--- a/libs/code/tests/unit_tests/test_mcp_auth.py
+++ b/libs/code/tests/unit_tests/test_mcp_auth.py
@@ -1492,26 +1492,30 @@ class TestRefreshTokenSerialization:
             interactive=False,
         )
         assert isinstance(provider, _ExpiryAwareOAuthClientProvider)
-        write_started = threading.Event()
+        loop = asyncio.get_running_loop()
+        write_started = asyncio.Event()
         allow_write = threading.Event()
-        release_started = threading.Event()
+        release_started = asyncio.Event()
         allow_release = threading.Event()
         scopes: list[anyio.CancelScope] = []
         real_release = FileLock.release
 
         def _failing_write(data: dict[str, Any]) -> None:
             del data
-            write_started.set()
+            loop.call_soon_threadsafe(write_started.set)
             if not allow_write.wait(timeout=5):
                 pytest.fail("timed out waiting to fail the token write")
             msg = "token persistence failed"
             raise OSError(msg)
 
         def _blocking_release(lock: FileLock, *, force: bool = False) -> None:
-            release_started.set()
+            if force:
+                real_release(lock, force=True)
+                return
+            loop.call_soon_threadsafe(release_started.set)
             if not allow_release.wait(timeout=5):
                 pytest.fail("timed out waiting to release the refresh lock")
-            real_release(lock, force=force)
+            real_release(lock)
 
         monkeypatch.setattr(storage, "_write", _failing_write)
         monkeypatch.setattr(FileLock, "release", _blocking_release)
@@ -1529,13 +1533,13 @@ class TestRefreshTokenSerialization:
         task = asyncio.create_task(_persist_in_cancel_scope())
         probe = FileLock(str(storage.refresh_lock_path), thread_local=False)
         try:
-            assert await asyncio.to_thread(write_started.wait, 5)
+            await asyncio.wait_for(write_started.wait(), timeout=5)
             scopes[0].cancel()
             await asyncio.sleep(0)
             assert not task.done()
 
             allow_write.set()
-            assert await asyncio.to_thread(release_started.wait, 5)
+            await asyncio.wait_for(release_started.wait(), timeout=5)
             assert not task.done()
 
             task.cancel()

--- a/libs/code/tests/unit_tests/test_mcp_tools.py
+++ b/libs/code/tests/unit_tests/test_mcp_tools.py
@@ -1034,6 +1034,131 @@ class TestMCPSessionManager:
         exit_mock.assert_not_awaited()
         await manager.cleanup()
 
+    async def test_cancelled_initialize_closes_session_in_creating_task(self) -> None:
+        """`CancelledError` during init closes the session in the creating task.
+
+        Regression for the MCP OAuth refresh failure: a blocking-IO
+        `BlockingError` in the auth flow crashed the Streamable HTTP transport
+        task group, cancelling the task awaiting `session.initialize()`. Because
+        `_create_entry` caught only `Exception`, the partially entered
+        `AsyncExitStack` was abandoned and later finalized by async-generator GC
+        on a different task, raising "Attempted to exit cancel scope in a
+        different task than it was entered in". The entered context must be
+        closed in the creating task before the cancellation propagates.
+        """
+        enter_task: list[Any] = []
+        exit_task: list[Any] = []
+
+        session = AsyncMock()
+        session.initialize = AsyncMock(side_effect=asyncio.CancelledError)
+
+        @asynccontextmanager
+        async def _fake(
+            _connection: dict[str, Any],
+            *,
+            _mcp_callbacks: object | None = None,
+        ) -> AsyncIterator[AsyncMock]:
+            enter_task.append(asyncio.current_task())
+            try:
+                yield session
+            finally:
+                exit_task.append(asyncio.current_task())
+
+        manager = MCPSessionManager(
+            connections={
+                "filesystem": {"transport": "stdio", "command": "x", "args": []}
+            }
+        )
+
+        with (
+            patch("langchain_mcp_adapters.sessions.create_session", _fake),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await manager.get_session("filesystem")
+
+        assert enter_task, "the session context should have been entered"
+        assert exit_task, (
+            "the entered session context must be closed synchronously, not left "
+            "for async-generator garbage collection"
+        )
+        assert exit_task[0] is enter_task[0], (
+            "the session context must be closed in the creating task"
+        )
+        assert not manager._entries, "a cancelled session must not be cached"
+
+    async def test_base_exception_during_init_closes_session_in_creating_task(
+        self,
+    ) -> None:
+        """Any `BaseException` (not just `Exception`) triggers in-task teardown."""
+
+        class _Boom(BaseException):
+            pass
+
+        enter_task: list[Any] = []
+        exit_task: list[Any] = []
+
+        session = AsyncMock()
+        session.initialize = AsyncMock(side_effect=_Boom)
+
+        @asynccontextmanager
+        async def _fake(
+            _connection: dict[str, Any],
+            *,
+            _mcp_callbacks: object | None = None,
+        ) -> AsyncIterator[AsyncMock]:
+            enter_task.append(asyncio.current_task())
+            try:
+                yield session
+            finally:
+                exit_task.append(asyncio.current_task())
+
+        manager = MCPSessionManager(
+            connections={
+                "filesystem": {"transport": "stdio", "command": "x", "args": []}
+            }
+        )
+
+        with (
+            patch("langchain_mcp_adapters.sessions.create_session", _fake),
+            pytest.raises(_Boom),
+        ):
+            await manager.get_session("filesystem")
+
+        assert exit_task
+        assert exit_task[0] is enter_task[0]
+        assert not manager._entries
+
+    async def test_cleanup_failure_does_not_mask_original_cancellation(self) -> None:
+        """A teardown error must not mask the original cancellation."""
+        session = AsyncMock()
+        session.initialize = AsyncMock(side_effect=asyncio.CancelledError)
+
+        @asynccontextmanager
+        async def _fake(
+            _connection: dict[str, Any],
+            *,
+            _mcp_callbacks: object | None = None,
+        ) -> AsyncIterator[AsyncMock]:
+            try:
+                yield session
+            finally:
+                msg = "teardown boom"
+                raise RuntimeError(msg)
+
+        manager = MCPSessionManager(
+            connections={
+                "filesystem": {"transport": "stdio", "command": "x", "args": []}
+            }
+        )
+
+        with (
+            patch("langchain_mcp_adapters.sessions.create_session", _fake),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await manager.get_session("filesystem")
+
+        assert not manager._entries
+
 
 class TestTransientErrorDetection:
     """Tests for `_is_transient_session_error` classification."""

--- a/libs/code/tests/unit_tests/test_mcp_tools.py
+++ b/libs/code/tests/unit_tests/test_mcp_tools.py
@@ -1177,6 +1177,55 @@ class TestMCPSessionManager:
             "the cleanup failure must be logged with its traceback"
         )
 
+    async def test_cancelled_teardown_supersedes_original_init_error(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A `CancelledError` from teardown supersedes an ordinary init error.
+
+        The inner `except Exception` around `aclose()` deliberately does not
+        catch a `CancelledError` raised *by* teardown: an in-flight cancellation
+        must win over the original error, matching structured-cancellation
+        semantics. So a plain init `Exception` is replaced by the teardown
+        `CancelledError`, and the swallowed-cleanup warning must not fire because
+        the cancellation was not swallowed.
+        """
+
+        class _InitError(Exception):
+            pass
+
+        session = AsyncMock()
+        session.initialize = AsyncMock(side_effect=_InitError)
+
+        @asynccontextmanager
+        async def _fake(
+            _connection: dict[str, Any],
+            *,
+            _mcp_callbacks: object | None = None,
+        ) -> AsyncIterator[AsyncMock]:
+            try:
+                yield session
+            finally:
+                raise asyncio.CancelledError
+
+        manager = MCPSessionManager(
+            connections={
+                "filesystem": {"transport": "stdio", "command": "x", "args": []}
+            }
+        )
+
+        with (
+            patch("langchain_mcp_adapters.sessions.create_session", _fake),
+            caplog.at_level(logging.WARNING, logger="deepagents_code.mcp_tools"),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await manager.get_session("filesystem")
+
+        assert not manager._entries
+        assert not any(
+            "Failed to close a partially initialized MCP session" in record.getMessage()
+            for record in caplog.records
+        ), "a teardown cancellation supersedes rather than being swallowed+logged"
+
 
 class TestTransientErrorDetection:
     """Tests for `_is_transient_session_error` classification."""

--- a/libs/code/tests/unit_tests/test_mcp_tools.py
+++ b/libs/code/tests/unit_tests/test_mcp_tools.py
@@ -1128,8 +1128,14 @@ class TestMCPSessionManager:
         assert exit_task[0] is enter_task[0]
         assert not manager._entries
 
-    async def test_cleanup_failure_does_not_mask_original_cancellation(self) -> None:
-        """A teardown error must not mask the original cancellation."""
+    async def test_cleanup_failure_does_not_mask_original_cancellation(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A teardown error is logged and does not mask the original cancellation.
+
+        The swallowed cleanup failure must still be surfaced via a warning
+        rather than dropped silently.
+        """
         session = AsyncMock()
         session.initialize = AsyncMock(side_effect=asyncio.CancelledError)
 
@@ -1153,11 +1159,23 @@ class TestMCPSessionManager:
 
         with (
             patch("langchain_mcp_adapters.sessions.create_session", _fake),
+            caplog.at_level(logging.WARNING, logger="deepagents_code.mcp_tools"),
             pytest.raises(asyncio.CancelledError),
         ):
             await manager.get_session("filesystem")
 
         assert not manager._entries
+        cleanup_logs = [
+            record
+            for record in caplog.records
+            if "Failed to close a partially initialized MCP session"
+            in record.getMessage()
+        ]
+        assert cleanup_logs, "the swallowed cleanup failure must be logged"
+        assert "filesystem" in cleanup_logs[0].getMessage()
+        assert cleanup_logs[0].exc_info is not None, (
+            "the cleanup failure must be logged with its traceback"
+        )
 
 
 class TestTransientErrorDetection:

--- a/libs/code/uv.lock
+++ b/libs/code/uv.lock
@@ -1115,6 +1115,7 @@ version = "0.1.41"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "anyio" },
     { name = "deepagents" },
     { name = "deepagents-acp" },
     { name = "filelock" },
@@ -1290,6 +1291,7 @@ test = [
 requires-dist = [
     { name = "aiohttp", marker = "extra == 'nvidia'", specifier = ">=3.14.1,<3.15.0" },
     { name = "aiosqlite", specifier = ">=0.22.1,<1.0.0" },
+    { name = "anyio", specifier = ">=4.0.0,<5.0.0" },
     { name = "av", marker = "extra == 'media'", specifier = ">=17.0.0,<18.0.0" },
     { name = "deepagents", editable = "../deepagents" },
     { name = "deepagents-acp", specifier = ">=0.0.8,<1.0.0" },


### PR DESCRIPTION
Fixes MCP OAuth token refresh crashing tool calls under `langgraph dev` with a `NodeCancelledError`.

---

OAuth refresh previously performed token-file work synchronously. BlockBuster could interrupt that work, cancel session initialization, and leave its `AsyncExitStack` to be finalized from another task. Users then saw errors such as:

    Attempted to exit cancel scope in a different task than it was entered in

Token-file I/O now runs in worker threads. Writes are serialized, token and expiry values are read from one snapshot, and cancellation waits for token writes and refresh-lock acquisition or release to finish before propagating. Partial MCP sessions are closed by the task that created them without hiding the original failure.
