### PR TITLE
fix(code): keep `task` timers monotonic across nested subagent HITL

### DIFF
--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -519,22 +519,34 @@ def _interrupt_owned_tool_rows(
     action_requests: Iterable[Mapping[str, Any]],
     current_tool_messages: Mapping[str, ToolCallMessage],
 ) -> list[ToolCallMessage]:
-    """Return the tracked tool rows a HITL interrupt's action requests own.
+    """Return the tracked tool rows a nested interrupt's action requests own.
 
-    An interrupt concerns only the specific tool calls it carries, so the
-    pause/resume bracketing a HITL checkpoint must touch only those rows.
-    Because a `HITLRequest`'s `ActionRequest` has no tool-call id, ownership is
-    matched by tool name plus arguments — the human-in-the-loop middleware
-    copies the tool call's ``args`` verbatim into the action request — and each
-    candidate row is claimed at most once so two identical calls map to two
+    Used by `_interrupt_tool_rows` for a nested (non-main-agent) checkpoint,
+    whose pause/resume must touch only the specific tool calls it carries so
+    unrelated outer ``task`` rows keep running. Because a `HITLRequest`'s
+    `ActionRequest` carries no tool-call id, ownership is matched by tool name
+    plus argument value-equality (order-independent ``dict`` comparison). Each
+    candidate row is claimed at most once, so two identical calls map to two
     distinct rows.
 
-    Rows that no action request owns are left untouched. Only the main agent's
-    tool rows are tracked in ``current_tool_messages``; a nested subagent's
-    child tool call is never tracked here, so its interrupt matches nothing and
-    the still-running outer ``task`` rows — including a sibling subagent's
-    ``task`` row whose own child did not interrupt — keep their elapsed timers
-    monotonic instead of being reset by an unrelated approval.
+    Two caveats follow from matching on args value rather than an id:
+
+    - It relies on the human-in-the-loop middleware surfacing the tool call's
+      ``args`` unchanged in the action request (true as of the pinned
+      ``langchain`` middleware). If that ever diverges — normalization, a JSON
+      round-trip, redaction — the match degrades silently to returning fewer
+      rows; ``test_matches_row_by_name_and_args`` guards the current contract.
+    - A nested action request that happens to share a name and args with a
+      concurrently tracked row (e.g. an identical ``execute`` call at another
+      nesting level) can misattribute that row. This is strictly rarer than
+      pausing every row and self-corrects, since the same helper drives both
+      pause and resume.
+
+    A nested subagent's own child tool call is not tracked in
+    ``current_tool_messages`` — message-stream tool rows are gated to the main
+    agent (see the ``is_main_agent`` check) — so a purely nested interrupt
+    normally matches nothing and leaves every outer row untouched, keeping the
+    still-running ``task`` timers monotonic across the checkpoint.
 
     Args:
         action_requests: The interrupt's action requests (``name`` + ``args``).
@@ -558,6 +570,32 @@ def _interrupt_owned_tool_rows(
                 claimed_ids.add(id(tool_msg))
                 break
     return owned
+
+
+def _interrupt_tool_rows(
+    namespace: tuple[Any, ...],
+    action_requests: Iterable[Mapping[str, Any]],
+    current_tool_messages: Mapping[str, ToolCallMessage],
+) -> list[ToolCallMessage]:
+    """Return rows blocked by an interrupt at `namespace`.
+
+    A main-agent checkpoint prevents its entire parallel tool batch from
+    reaching the tool node, including ungated siblings omitted from the HITL
+    action requests. Nested checkpoints must remain scoped to their own action
+    requests so unrelated outer `task` rows keep running.
+
+    Args:
+        namespace: Stream namespace that emitted the interrupt.
+        action_requests: The interrupt's reviewed tool calls.
+        current_tool_messages: Live map of tool-call id to tracked tool row.
+
+    Returns:
+        Every tracked row for a main-agent interrupt, otherwise only rows owned
+        by the nested interrupt's action requests.
+    """
+    if not namespace:
+        return list(current_tool_messages.values())
+    return _interrupt_owned_tool_rows(action_requests, current_tool_messages)
 
 
 def _read_mentioned_file(file_path: Path, max_embed_bytes: int) -> str:
@@ -839,7 +877,7 @@ async def execute_task_textual(
         while True:
             interrupt_occurred = False
             suppress_resumed_output = False
-            pending_interrupts: dict[str, HITLRequest] = {}
+            pending_interrupts: dict[str, tuple[tuple[Any, ...], HITLRequest]] = {}
             pending_ask_user: dict[str, AskUserRequest] = {}
 
             # Carry the current approval mode into run context so the
@@ -1079,7 +1117,8 @@ async def execute_task_textual(
                                             hitl_request_adapter.validate_python(iv)
                                         )
                                         pending_interrupts[interrupt_obj.id] = (
-                                            validated_request
+                                            ns_key,
+                                            validated_request,
                                         )
                                         interrupt_occurred = True
                                         await dispatch_hook("input.required", {})
@@ -1551,23 +1590,23 @@ async def execute_task_textual(
                 resume_payload: dict[str, Any] = {}
 
                 # Tools mounted above start their spinner immediately, but a
-                # tool blocked on its own HITL approval or `ask_user` input is
-                # not actually running. Pause only the rows this interrupt owns
-                # so none shows a misleading "Running..."; the approve branches
-                # below call `set_running` on the same owned rows to resume them.
+                # tool blocked on HITL approval or `ask_user` input is not
+                # actually running. A main-agent checkpoint blocks its complete
+                # parallel batch, including ungated siblings absent from the
+                # action requests. Nested interrupts remain scoped so unrelated
+                # outer or sibling `task` rows keep running. The approve branches
+                # below call `set_running` on the same rows to resume them.
                 # Crucially, an unrelated in-flight row — a still-running outer
                 # `task`, or a sibling subagent's `task` whose child did not
                 # interrupt — is left running so its elapsed timer stays
-                # monotonic across the nested checkpoint. Ownership comes from
-                # the interrupts' action requests (HITL) and tool-call ids
-                # (ask_user); a nested subagent child tool is never tracked here,
-                # so its interrupt owns no row. Guard each row individually so a
-                # single bad widget can't abort the whole interrupt handler
-                # (mirrors `clear_awaiting_approval` below).
+                # monotonic across the nested checkpoint. Guard each row
+                # individually so a single bad widget can't abort the whole
+                # interrupt handler (mirrors `clear_awaiting_approval` below).
                 paused_tool_msgs: list[ToolCallMessage] = []
                 paused_ids: set[int] = set()
-                for hitl_request in pending_interrupts.values():
-                    for tool_msg in _interrupt_owned_tool_rows(
+                for namespace, hitl_request in pending_interrupts.values():
+                    for tool_msg in _interrupt_tool_rows(
+                        namespace,
                         hitl_request["action_requests"],
                         adapter._current_tool_messages,
                     ):
@@ -1786,7 +1825,9 @@ async def execute_task_textual(
                                     "Failed to update ask_user row for %s", tool_id
                                 )
 
-                for interrupt_id, hitl_request in list(pending_interrupts.items()):
+                for interrupt_id, (namespace, hitl_request) in list(
+                    pending_interrupts.items()
+                ):
                     action_requests = hitl_request["action_requests"]
 
                     if session_state.auto_approve:
@@ -1794,8 +1835,10 @@ async def execute_task_textual(
                             ApproveDecision(type="approve") for _ in action_requests
                         ]
                         resume_payload[interrupt_id] = {"decisions": decisions}
-                        for tool_msg in _interrupt_owned_tool_rows(
-                            action_requests, adapter._current_tool_messages
+                        for tool_msg in _interrupt_tool_rows(
+                            namespace,
+                            action_requests,
+                            adapter._current_tool_messages,
                         ):
                             tool_msg.set_running()
                             adapter._sync_tool_widget(tool_msg)
@@ -1864,7 +1907,8 @@ async def execute_task_textual(
                                     ApproveDecision(type="approve")
                                     for _ in action_requests
                                 ]
-                                tool_msgs = _interrupt_owned_tool_rows(
+                                tool_msgs = _interrupt_tool_rows(
+                                    namespace,
                                     action_requests,
                                     adapter._current_tool_messages,
                                 )
@@ -1889,7 +1933,8 @@ async def execute_task_textual(
                                     ApproveDecision(type="approve")
                                     for _ in action_requests
                                 ]
-                                tool_msgs = _interrupt_owned_tool_rows(
+                                tool_msgs = _interrupt_tool_rows(
+                                    namespace,
                                     action_requests,
                                     adapter._current_tool_messages,
                                 )
@@ -1925,12 +1970,6 @@ async def execute_task_textual(
                                     else RejectDecision(type="reject")
                                 )
                                 decisions = [reject_decision for _ in action_requests]
-                                tool_msgs = list(
-                                    adapter._current_tool_messages.values()
-                                )
-                                for tool_msg in tool_msgs:
-                                    tool_msg.set_rejected(reason=reject_message)
-                                    adapter._sync_tool_widget(tool_msg)
                                 # Bare reject aborts an ordinary conversation
                                 # turn and shows the canned "Command rejected"
                                 # banner. Server operations must receive every
@@ -1938,6 +1977,14 @@ async def execute_task_textual(
                                 # without the rejected context. A supplied
                                 # reason likewise resumes either kind of run.
                                 if reject_message is None and graph_input is None:
+                                    # The whole turn aborts: give every tracked
+                                    # row a terminal state before teardown so
+                                    # none is left frozen on a stale "Running...".
+                                    for tool_msg in list(
+                                        adapter._current_tool_messages.values()
+                                    ):
+                                        tool_msg.set_rejected(reason=reject_message)
+                                        adapter._sync_tool_widget(tool_msg)
                                     completed_tool_result_ids.update(
                                         _dispatch_terminal_tool_result_hooks(
                                             adapter._current_tool_messages,
@@ -1946,6 +1993,22 @@ async def execute_task_textual(
                                     )
                                     adapter._current_tool_messages.clear()
                                     any_rejected = True
+                                else:
+                                    # The run resumes, so reject only the rows
+                                    # this interrupt owns — every row for a
+                                    # main-agent checkpoint, otherwise just the
+                                    # nested interrupt's action requests. An
+                                    # unrelated in-flight `task` row keeps running
+                                    # instead of being frozen as rejected (and
+                                    # then stuck there, since `set_success`
+                                    # ignores an already-rejected row).
+                                    for tool_msg in _interrupt_tool_rows(
+                                        namespace,
+                                        action_requests,
+                                        adapter._current_tool_messages,
+                                    ):
+                                        tool_msg.set_rejected(reason=reject_message)
+                                        adapter._sync_tool_widget(tool_msg)
                             else:
                                 logger.warning(
                                     "Unexpected HITL decision type: %s",

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -1994,21 +1994,29 @@ async def execute_task_textual(
                                     adapter._current_tool_messages.clear()
                                     any_rejected = True
                                 else:
-                                    # The run resumes, so reject only the rows
-                                    # this interrupt owns — every row for a
-                                    # main-agent checkpoint, otherwise just the
-                                    # nested interrupt's action requests. An
-                                    # unrelated in-flight `task` row keeps running
-                                    # instead of being frozen as rejected (and
-                                    # then stuck there, since `set_success`
-                                    # ignores an already-rejected row).
-                                    for tool_msg in _interrupt_tool_rows(
-                                        namespace,
+                                    # The run resumes, so only reviewed calls are
+                                    # terminally rejected. A main-agent checkpoint
+                                    # also paused ungated siblings in the parallel
+                                    # batch; resume those because they can still run
+                                    # after the rejected calls are replaced with
+                                    # synthetic ToolMessages.
+                                    tracked_tool_msgs = adapter._current_tool_messages
+                                    rejected_tool_msgs = _interrupt_owned_tool_rows(
                                         action_requests,
-                                        adapter._current_tool_messages,
-                                    ):
+                                        tracked_tool_msgs,
+                                    )
+                                    rejected_ids = {
+                                        id(tool_msg) for tool_msg in rejected_tool_msgs
+                                    }
+                                    for tool_msg in rejected_tool_msgs:
                                         tool_msg.set_rejected(reason=reject_message)
                                         adapter._sync_tool_widget(tool_msg)
+                                    if not namespace:
+                                        for tool_msg in tracked_tool_msgs.values():
+                                            if id(tool_msg) in rejected_ids:
+                                                continue
+                                            tool_msg.set_running()
+                                            adapter._sync_tool_widget(tool_msg)
                             else:
                                 logger.warning(
                                     "Unexpected HITL decision type: %s",

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Iterable, Mapping
     from pathlib import Path
     from typing import Protocol
 
@@ -497,6 +497,51 @@ def _build_interrupted_ai_message(
         content=accumulated_text,
         tool_calls=tool_calls or [],
     )
+
+
+def _interrupt_owned_tool_rows(
+    action_requests: Iterable[Mapping[str, Any]],
+    current_tool_messages: Mapping[str, ToolCallMessage],
+) -> list[ToolCallMessage]:
+    """Return the tracked tool rows a HITL interrupt's action requests own.
+
+    An interrupt concerns only the specific tool calls it carries, so the
+    pause/resume bracketing a HITL checkpoint must touch only those rows.
+    Because a `HITLRequest`'s `ActionRequest` has no tool-call id, ownership is
+    matched by tool name plus arguments — the human-in-the-loop middleware
+    copies the tool call's ``args`` verbatim into the action request — and each
+    candidate row is claimed at most once so two identical calls map to two
+    distinct rows.
+
+    Rows that no action request owns are left untouched. Only the main agent's
+    tool rows are tracked in ``current_tool_messages``; a nested subagent's
+    child tool call is never tracked here, so its interrupt matches nothing and
+    the still-running outer ``task`` rows — including a sibling subagent's
+    ``task`` row whose own child did not interrupt — keep their elapsed timers
+    monotonic instead of being reset by an unrelated approval.
+
+    Args:
+        action_requests: The interrupt's action requests (``name`` + ``args``).
+        current_tool_messages: Live map of tool-call id to tracked tool row.
+
+    Returns:
+        The subset of tracked rows owned by these action requests, in request
+        order.
+    """
+    candidates = list(current_tool_messages.values())
+    claimed_ids: set[int] = set()
+    owned: list[ToolCallMessage] = []
+    for request in action_requests:
+        name = request.get("name")
+        args = request.get("args", {})
+        for tool_msg in candidates:
+            if id(tool_msg) in claimed_ids:
+                continue
+            if tool_msg.tool_name == name and tool_msg.args == args:
+                owned.append(tool_msg)
+                claimed_ids.add(id(tool_msg))
+                break
+    return owned
 
 
 def _read_mentioned_file(file_path: Path, max_embed_bytes: int) -> str:
@@ -1455,13 +1500,37 @@ async def execute_task_textual(
                 resume_payload: dict[str, Any] = {}
 
                 # Tools mounted above start their spinner immediately, but a
-                # tool blocked on HITL approval or `ask_user` input is not
-                # actually running. Pause every in-flight row so none shows a
-                # misleading "Running..."; the approve branches below call
-                # `set_running` again to resume those that proceed. Guard each
-                # row individually so a single bad widget can't abort the whole
-                # interrupt handler (mirrors `clear_awaiting_approval` below).
-                for tool_msg in adapter._current_tool_messages.values():
+                # tool blocked on its own HITL approval or `ask_user` input is
+                # not actually running. Pause only the rows this interrupt owns
+                # so none shows a misleading "Running..."; the approve branches
+                # below call `set_running` on the same owned rows to resume them.
+                # Crucially, an unrelated in-flight row — a still-running outer
+                # `task`, or a sibling subagent's `task` whose child did not
+                # interrupt — is left running so its elapsed timer stays
+                # monotonic across the nested checkpoint. Ownership comes from
+                # the interrupts' action requests (HITL) and tool-call ids
+                # (ask_user); a nested subagent child tool is never tracked here,
+                # so its interrupt owns no row. Guard each row individually so a
+                # single bad widget can't abort the whole interrupt handler
+                # (mirrors `clear_awaiting_approval` below).
+                paused_tool_msgs: list[ToolCallMessage] = []
+                paused_ids: set[int] = set()
+                for hitl_request in pending_interrupts.values():
+                    for tool_msg in _interrupt_owned_tool_rows(
+                        hitl_request["action_requests"],
+                        adapter._current_tool_messages,
+                    ):
+                        if id(tool_msg) not in paused_ids:
+                            paused_ids.add(id(tool_msg))
+                            paused_tool_msgs.append(tool_msg)
+                for ask_req in pending_ask_user.values():
+                    ask_tool_msg = adapter._current_tool_messages.get(
+                        ask_req["tool_call_id"]
+                    )
+                    if ask_tool_msg is not None and id(ask_tool_msg) not in paused_ids:
+                        paused_ids.add(id(ask_tool_msg))
+                        paused_tool_msgs.append(ask_tool_msg)
+                for tool_msg in paused_tool_msgs:
                     try:
                         tool_msg.pause_running()
                         adapter._sync_tool_widget(tool_msg)
@@ -1674,7 +1743,9 @@ async def execute_task_textual(
                             ApproveDecision(type="approve") for _ in action_requests
                         ]
                         resume_payload[interrupt_id] = {"decisions": decisions}
-                        for tool_msg in list(adapter._current_tool_messages.values()):
+                        for tool_msg in _interrupt_owned_tool_rows(
+                            action_requests, adapter._current_tool_messages
+                        ):
                             tool_msg.set_running()
                             adapter._sync_tool_widget(tool_msg)
                     else:
@@ -1697,7 +1768,9 @@ async def execute_task_textual(
                         suppressed_tool_msgs = (
                             [
                                 tool_msg
-                                for tool_msg in adapter._current_tool_messages.values()
+                                for tool_msg in _interrupt_owned_tool_rows(
+                                    action_requests, adapter._current_tool_messages
+                                )
                                 if tool_msg.tool_name == "execute"
                             ]
                             if len(action_requests) == 1
@@ -1740,8 +1813,9 @@ async def execute_task_textual(
                                     ApproveDecision(type="approve")
                                     for _ in action_requests
                                 ]
-                                tool_msgs = list(
-                                    adapter._current_tool_messages.values()
+                                tool_msgs = _interrupt_owned_tool_rows(
+                                    action_requests,
+                                    adapter._current_tool_messages,
                                 )
                                 for tool_msg in tool_msgs:
                                     tool_msg.set_running()
@@ -1764,8 +1838,9 @@ async def execute_task_textual(
                                     ApproveDecision(type="approve")
                                     for _ in action_requests
                                 ]
-                                tool_msgs = list(
-                                    adapter._current_tool_messages.values()
+                                tool_msgs = _interrupt_owned_tool_rows(
+                                    action_requests,
+                                    adapter._current_tool_messages,
                                 )
                                 for tool_msg in tool_msgs:
                                     tool_msg.set_running()

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -4006,6 +4006,108 @@ class TestExecuteTaskTextualTaskTimerAcrossInterrupts:
         assert rows["execute"]._status == "running"
         assert rows["read_file"]._status == "running"
 
+    async def test_main_reasoned_reject_resumes_ungated_sibling_task(self) -> None:
+        """A resumed rejection does not poison an ungated sibling task row."""
+        snapshot: dict[str, tuple[str, float | None]] = {}
+        rows: dict[str, ToolCallMessage] = {}
+
+        async def mount_message(widget: object) -> None:
+            await asyncio.sleep(0)
+            if isinstance(widget, ToolCallMessage):
+                rows[widget.tool_name] = widget
+
+        async def request_approval(
+            _action_requests: list[dict[str, Any]],
+            _assistant_id: str | None,
+        ) -> asyncio.Future[object]:
+            await asyncio.sleep(0)
+            for tool_id in ("exec-1", "task-1"):
+                row = adapter._current_tool_messages[tool_id]
+                snapshot[tool_id] = (row._status, row._start_time)
+            future: asyncio.Future[object] = asyncio.Future()
+            future.set_result({"type": "reject", "message": "use another command"})
+            return future
+
+        agent = _SequencedAgent(
+            streams_by_call=[
+                [
+                    (
+                        (),
+                        "messages",
+                        (
+                            _tool_call_message(
+                                "execute", {"command": "echo hi"}, "exec-1"
+                            ),
+                            {},
+                        ),
+                    ),
+                    self._task_chunk("task-1", "research the repo"),
+                    _hitl_interrupt_chunk(
+                        {
+                            "action_requests": [
+                                {"name": "execute", "args": {"command": "echo hi"}}
+                            ],
+                            "review_configs": [
+                                {
+                                    "action_name": "execute",
+                                    "allowed_decisions": ["approve", "reject"],
+                                }
+                            ],
+                        }
+                    ),
+                ],
+                [
+                    (
+                        (),
+                        "messages",
+                        (
+                            ToolMessage(
+                                content="Tool approval rejected",
+                                name="execute",
+                                tool_call_id="exec-1",
+                                status="error",
+                            ),
+                            {},
+                        ),
+                    ),
+                    (
+                        (),
+                        "messages",
+                        (
+                            ToolMessage(
+                                content="research complete",
+                                name="task",
+                                tool_call_id="task-1",
+                                status="success",
+                            ),
+                            {},
+                        ),
+                    ),
+                ],
+            ]
+        )
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=request_approval,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        assert snapshot == {
+            "exec-1": ("pending", None),
+            "task-1": ("pending", None),
+        }
+        assert rows["execute"]._status == "rejected"
+        assert rows["task"]._status == "success"
+        assert rows["task"]._duration is not None
+
     async def test_completed_task_duration_spans_full_execution(self) -> None:
         """A task's `Took …` covers full run time, not just post-approval.
 

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -6,6 +6,7 @@ from asyncio import Future
 from collections.abc import AsyncIterator, Awaitable, Callable, Generator
 from datetime import datetime
 from pathlib import Path
+from time import time
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -36,6 +37,7 @@ from deepagents_code.tui.textual_adapter import (
     _format_rubric_details,
     _format_rubric_event,
     _handle_interrupt_cleanup,
+    _interrupt_owned_tool_rows,
     _is_summarization_chunk,
     _read_mentioned_file,
     execute_task_textual,
@@ -3571,6 +3573,383 @@ class TestExecuteTaskTextualHITLShellSuppression:
         assert len(tool_rows) == 1
         assert tool_rows[0].display is True
         assert tool_rows[0]._awaiting_approval is False
+
+
+class TestInterruptOwnedToolRows:
+    """`_interrupt_owned_tool_rows` scopes pause/resume to the right rows."""
+
+    def test_matches_row_by_name_and_args(self) -> None:
+        """An action request owns the tracked row with the same name and args."""
+        execute_row = ToolCallMessage("execute", {"command": "echo hi"})
+        task_row = ToolCallMessage("task", {"description": "research"})
+        current = {"exec-1": execute_row, "task-1": task_row}
+
+        owned = _interrupt_owned_tool_rows(
+            [{"name": "execute", "args": {"command": "echo hi"}}], current
+        )
+
+        assert owned == [execute_row]
+
+    def test_nested_child_request_owns_no_outer_task_row(self) -> None:
+        """A subagent child tool (untracked) matches no outer `task` row.
+
+        The child `fetch_url`/`execute` calls that interrupt live inside the
+        subagent and are never tracked in `_current_tool_messages`; only the
+        outer `task` rows are. So the child's action request must own nothing,
+        leaving both task timers untouched.
+        """
+        task_one = ToolCallMessage("task", {"description": "a"})
+        task_two = ToolCallMessage("task", {"description": "b"})
+        current = {"task-1": task_one, "task-2": task_two}
+
+        owned = _interrupt_owned_tool_rows(
+            [{"name": "fetch_url", "args": {"url": "http://example.com"}}], current
+        )
+
+        assert owned == []
+
+    def test_duplicate_calls_map_to_distinct_rows(self) -> None:
+        """Two identical calls claim two distinct rows, not the same one twice."""
+        first = ToolCallMessage("execute", {"command": "echo hi"})
+        second = ToolCallMessage("execute", {"command": "echo hi"})
+        current = {"exec-1": first, "exec-2": second}
+
+        owned = _interrupt_owned_tool_rows(
+            [
+                {"name": "execute", "args": {"command": "echo hi"}},
+                {"name": "execute", "args": {"command": "echo hi"}},
+            ],
+            current,
+        )
+
+        assert len(owned) == 2
+        assert {id(row) for row in owned} == {id(first), id(second)}
+
+    def test_mismatched_args_are_not_owned(self) -> None:
+        """A same-named call with different args does not own the row."""
+        execute_row = ToolCallMessage("execute", {"command": "echo hi"})
+        current = {"exec-1": execute_row}
+
+        owned = _interrupt_owned_tool_rows(
+            [{"name": "execute", "args": {"command": "echo bye"}}], current
+        )
+
+        assert owned == []
+
+
+class TestExecuteTaskTextualTaskTimerAcrossInterrupts:
+    """A running `task` timer stays monotonic across nested subagent HITL.
+
+    Regression guard for the bug where any interrupt paused *every* tracked
+    tool row and each approval reset *every* row's start time — so an unrelated
+    nested child approval restarted the outer `task` elapsed timer from zero.
+    """
+
+    @staticmethod
+    def _task_chunk(tool_id: str, description: str) -> tuple[Any, ...]:
+        """A main-agent `task` tool call that mounts and starts running."""
+        return (
+            (),
+            "messages",
+            (
+                _tool_call_message(
+                    "task",
+                    {"description": description, "subagent_type": "general-purpose"},
+                    tool_id,
+                ),
+                {},
+            ),
+        )
+
+    @staticmethod
+    def _child_interrupt_chunk(
+        namespace: tuple[str, ...], tool_name: str, args: dict[str, Any]
+    ) -> tuple[Any, ...]:
+        """A HITL interrupt raised by a nested subagent's child tool call."""
+        interrupt = SimpleNamespace(
+            id=f"int-{tool_name}",
+            value={
+                "action_requests": [{"name": tool_name, "args": args}],
+                "review_configs": [
+                    {
+                        "action_name": tool_name,
+                        "allowed_decisions": ["approve", "reject"],
+                    }
+                ],
+            },
+        )
+        return (namespace, "updates", {"__interrupt__": [interrupt]})
+
+    async def test_outer_task_keeps_running_across_child_interrupt(self) -> None:
+        """The outer `task` row is not paused when its child interrupts.
+
+        The child `fetch_url` approval is unrelated to the `task` row, so at
+        approval time (after the pause step) the task must still be `running`
+        with an intact `_start_time`; before the fix the task was paused to
+        `pending` with `_start_time` cleared.
+        """
+        snapshot: dict[str, Any] = {}
+
+        async def request_approval(
+            _action_requests: list[dict[str, Any]],
+            _assistant_id: str | None,
+        ) -> asyncio.Future[object]:
+            await asyncio.sleep(0)
+            task_row = adapter._current_tool_messages["task-1"]
+            snapshot["status"] = task_row._status
+            snapshot["start_time"] = task_row._start_time
+            future: asyncio.Future[object] = asyncio.Future()
+            future.set_result({"type": "approve"})
+            return future
+
+        agent = _SequencedAgent(
+            streams_by_call=[
+                [
+                    self._task_chunk("task-1", "research the repo"),
+                    self._child_interrupt_chunk(
+                        ("task:task-1:0",),
+                        "fetch_url",
+                        {"url": "http://example.com"},
+                    ),
+                ],
+                [],
+            ]
+        )
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=request_approval,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        assert snapshot["status"] == "running"
+        assert snapshot["start_time"] is not None
+
+    async def test_only_interrupting_sibling_task_is_unaffected(self) -> None:
+        """Two concurrent tasks: a child interrupt leaves *both* timers running.
+
+        The interrupt belongs to `task-1`'s subagent, but its child tool call
+        is untracked, so neither the interrupting task nor the quiet sibling
+        `task-2` may be paused.
+        """
+        snapshot: dict[str, Any] = {}
+
+        async def request_approval(
+            _action_requests: list[dict[str, Any]],
+            _assistant_id: str | None,
+        ) -> asyncio.Future[object]:
+            await asyncio.sleep(0)
+            snapshot["task-1"] = (
+                adapter._current_tool_messages["task-1"]._status,
+                adapter._current_tool_messages["task-1"]._start_time,
+            )
+            snapshot["task-2"] = (
+                adapter._current_tool_messages["task-2"]._status,
+                adapter._current_tool_messages["task-2"]._start_time,
+            )
+            future: asyncio.Future[object] = asyncio.Future()
+            future.set_result({"type": "approve"})
+            return future
+
+        agent = _SequencedAgent(
+            streams_by_call=[
+                [
+                    self._task_chunk("task-1", "task one"),
+                    self._task_chunk("task-2", "task two"),
+                    self._child_interrupt_chunk(
+                        ("task:task-1:0",),
+                        "execute",
+                        {"command": "ls"},
+                    ),
+                ],
+                [],
+            ]
+        )
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=request_approval,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        assert snapshot["task-1"][0] == "running"
+        assert snapshot["task-1"][1] is not None
+        assert snapshot["task-2"][0] == "running"
+        assert snapshot["task-2"][1] is not None
+
+    async def test_tool_awaiting_own_approval_is_paused_then_resumed(self) -> None:
+        """A main-agent tool blocked on its own approval still pauses.
+
+        Requirement 4: a tool waiting for its *own* initial approval must not
+        misleadingly show "Running...". Its action request owns its row, so it
+        is paused to `pending` (start time cleared) during the await, then
+        resumed to `running` on approval.
+        """
+        snapshot: dict[str, Any] = {}
+
+        async def request_approval(
+            _action_requests: list[dict[str, Any]],
+            _assistant_id: str | None,
+        ) -> asyncio.Future[object]:
+            await asyncio.sleep(0)
+            row = adapter._current_tool_messages["exec-1"]
+            snapshot["status"] = row._status
+            snapshot["start_time"] = row._start_time
+            future: asyncio.Future[object] = asyncio.Future()
+            future.set_result({"type": "approve"})
+            return future
+
+        execute_row_holder: list[ToolCallMessage] = []
+
+        async def mount_message(widget: object) -> None:
+            await asyncio.sleep(0)
+            if isinstance(widget, ToolCallMessage):
+                execute_row_holder.append(widget)
+
+        agent = _SequencedAgent(
+            streams_by_call=[
+                [
+                    (
+                        (),
+                        "messages",
+                        (
+                            _tool_call_message(
+                                "execute", {"command": "echo hi"}, "exec-1"
+                            ),
+                            {},
+                        ),
+                    ),
+                    _hitl_interrupt_chunk(
+                        {
+                            "action_requests": [
+                                {"name": "execute", "args": {"command": "echo hi"}}
+                            ],
+                            "review_configs": [
+                                {
+                                    "action_name": "execute",
+                                    "allowed_decisions": ["approve", "reject"],
+                                }
+                            ],
+                        }
+                    ),
+                ],
+                [],
+            ]
+        )
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=request_approval,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        # Paused (not misleadingly "running") while awaiting its own approval.
+        assert snapshot["status"] == "pending"
+        assert snapshot["start_time"] is None
+        # Resumed to running on approval; the empty resume stream leaves it there.
+        assert execute_row_holder
+        assert execute_row_holder[0]._status == "running"
+        assert execute_row_holder[0]._start_time is not None
+
+    async def test_completed_task_duration_spans_full_execution(self) -> None:
+        """A task's `Took …` covers full run time, not just post-approval.
+
+        The nested interrupt+approval must not reset the task's `_start_time`;
+        otherwise the completed duration would only measure the sliver since the
+        last approval. A far-past start time injected at approval time survives
+        to completion and yields a large duration — before the fix, the approval
+        reset it and the duration collapsed to ~0.
+        """
+        task_row_holder: list[ToolCallMessage] = []
+
+        async def mount_message(widget: object) -> None:
+            await asyncio.sleep(0)
+            if isinstance(widget, ToolCallMessage):
+                task_row_holder.append(widget)
+
+        async def request_approval(
+            _action_requests: list[dict[str, Any]],
+            _assistant_id: str | None,
+        ) -> asyncio.Future[object]:
+            await asyncio.sleep(0)
+            task_row = adapter._current_tool_messages["task-1"]
+            # The task must still be running (not paused) here; pin a far-past
+            # start so a preserved timer produces a large, checkable duration.
+            assert task_row._status == "running"
+            assert task_row._start_time is not None
+            task_row._start_time = time() - 100.0
+            future: asyncio.Future[object] = asyncio.Future()
+            future.set_result({"type": "approve"})
+            return future
+
+        agent = _SequencedAgent(
+            streams_by_call=[
+                [
+                    self._task_chunk("task-1", "long research"),
+                    self._child_interrupt_chunk(
+                        ("task:task-1:0",),
+                        "fetch_url",
+                        {"url": "http://example.com"},
+                    ),
+                ],
+                [
+                    (
+                        (),
+                        "messages",
+                        (
+                            ToolMessage(
+                                content="subagent finished",
+                                name="task",
+                                tool_call_id="task-1",
+                                status="success",
+                            ),
+                            {},
+                        ),
+                    ),
+                ],
+            ]
+        )
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=request_approval,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        assert task_row_holder
+        task_row = task_row_holder[0]
+        assert task_row._status == "success"
+        assert task_row._duration is not None
+        # Full span (~100s), not the near-zero interval since the approval.
+        assert task_row._duration >= 99.0
 
 
 class TestExecuteTaskTextualAskUser:

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -3923,6 +3923,89 @@ class TestExecuteTaskTextualTaskTimerAcrossInterrupts:
         assert execute_row_holder[0]._status == "running"
         assert execute_row_holder[0]._start_time is not None
 
+    async def test_main_checkpoint_pauses_and_resumes_ungated_sibling(self) -> None:
+        """A main-agent checkpoint blocks every tool in its parallel batch."""
+        snapshot: dict[str, tuple[str, float | None]] = {}
+        rows: dict[str, ToolCallMessage] = {}
+
+        async def mount_message(widget: object) -> None:
+            await asyncio.sleep(0)
+            if isinstance(widget, ToolCallMessage):
+                rows[widget.tool_name] = widget
+
+        async def request_approval(
+            _action_requests: list[dict[str, Any]],
+            _assistant_id: str | None,
+        ) -> asyncio.Future[object]:
+            await asyncio.sleep(0)
+            for tool_id in ("exec-1", "read-1"):
+                row = adapter._current_tool_messages[tool_id]
+                snapshot[tool_id] = (row._status, row._start_time)
+            future: asyncio.Future[object] = asyncio.Future()
+            future.set_result({"type": "approve"})
+            return future
+
+        agent = _SequencedAgent(
+            streams_by_call=[
+                [
+                    (
+                        (),
+                        "messages",
+                        (
+                            _tool_call_message(
+                                "execute", {"command": "echo hi"}, "exec-1"
+                            ),
+                            {},
+                        ),
+                    ),
+                    (
+                        (),
+                        "messages",
+                        (
+                            _tool_call_message(
+                                "read_file", {"path": "notes.txt"}, "read-1"
+                            ),
+                            {},
+                        ),
+                    ),
+                    _hitl_interrupt_chunk(
+                        {
+                            "action_requests": [
+                                {"name": "execute", "args": {"command": "echo hi"}}
+                            ],
+                            "review_configs": [
+                                {
+                                    "action_name": "execute",
+                                    "allowed_decisions": ["approve", "reject"],
+                                }
+                            ],
+                        }
+                    ),
+                ],
+                [],
+            ]
+        )
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=request_approval,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        assert snapshot == {
+            "exec-1": ("pending", None),
+            "read-1": ("pending", None),
+        }
+        assert rows["execute"]._status == "running"
+        assert rows["read_file"]._status == "running"
+
     async def test_completed_task_duration_spans_full_execution(self) -> None:
         """A task's `Took …` covers full run time, not just post-approval.
 
@@ -4001,6 +4084,65 @@ class TestExecuteTaskTextualTaskTimerAcrossInterrupts:
         assert task_row._duration is not None
         # Full span (~100s), not the near-zero interval since the approval.
         assert task_row._duration >= 99.0
+
+    async def test_child_reasoned_reject_leaves_outer_task_running(self) -> None:
+        """A reasoned reject of a nested child does not reject the outer task.
+
+        A reject *with a reason* resumes the run rather than aborting it (the
+        bare-reject abort path is the only one that marks every row rejected and
+        clears the turn). The rejected child tool is untracked, so the
+        still-running outer `task` row must stay `running` — before the reject
+        path was scoped it was marked `rejected` on the resuming turn and, since
+        `set_success` ignores an already-rejected row, stuck there permanently
+        even after the task later completed.
+        """
+        task_row_holder: list[ToolCallMessage] = []
+
+        async def mount_message(widget: object) -> None:
+            await asyncio.sleep(0)
+            if isinstance(widget, ToolCallMessage):
+                task_row_holder.append(widget)
+
+        async def request_approval(
+            _action_requests: list[dict[str, Any]],
+            _assistant_id: str | None,
+        ) -> asyncio.Future[object]:
+            await asyncio.sleep(0)
+            future: asyncio.Future[object] = asyncio.Future()
+            future.set_result({"type": "reject", "message": "try a different url"})
+            return future
+
+        agent = _SequencedAgent(
+            streams_by_call=[
+                [
+                    self._task_chunk("task-1", "research the repo"),
+                    self._child_interrupt_chunk(
+                        ("task:task-1:0",),
+                        "fetch_url",
+                        {"url": "http://example.com"},
+                    ),
+                ],
+                [],
+            ]
+        )
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=request_approval,
+        )
+
+        await execute_task_textual(
+            user_input="hello",
+            agent=agent,
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+        )
+
+        assert task_row_holder
+        task_row = task_row_holder[0]
+        assert task_row._status == "running"
+        assert task_row._start_time is not None
 
 
 class TestExecuteTaskTextualAskUser:


### PR DESCRIPTION
Fixed dcode TUI `task` elapsed timers resetting when a nested subagent reached a human-in-the-loop approval checkpoint.

---

A long-running `task [general-purpose]` row's elapsed timer reset to zero whenever a nested subagent hit a HITL approval checkpoint. The interrupt handler paused/resumed *every* tracked tool row, and `ToolCallMessage.pause_running()`/`set_running()` clear and reassign `_start_time` — so an unrelated nested child's (or sibling subagent's) approval restarted the outer `task` timers. This scopes pause/resume to only the rows an interrupt actually owns (matched by tool name + args via the new `_interrupt_owned_tool_rows` helper). Untracked nested-child interrupts now own no outer row, so outer and sibling `task` timers stay monotonic and completed `Took …` durations reflect full execution time. A tool awaiting its own initial approval still pauses then resumes as before.

Made by [Open SWE](https://openswe.vercel.app/agents/5c0ae962-c16b-6e04-ada4-d4d76826adb9)