### PR TITLE
feat(code): debug-log skill-name override collisions

### DIFF
--- a/libs/code/deepagents_code/plugins/adapters/skills_middleware.py
+++ b/libs/code/deepagents_code/plugins/adapters/skills_middleware.py
@@ -301,9 +301,9 @@ class PluginSkillsMiddleware(SkillsMiddleware):
 
         # `self.sources`, `self.source_labels`, and `self._namespaces` are all
         # built from the same source sequence at the same indices (see
-        # `__init__` and the SDK base), so this zip is aligned by construction;
-        # `strict=True` turns any future drift into a loud error rather than a
-        # silent mispairing.
+        # `__init__` and the SDK base), so this zip is aligned by construction.
+        # `strict=True` turns future *length* drift into a loud error; it does
+        # not catch a same-length reorder, which would still mispair silently.
         for source_path, source_label, namespace in zip(
             self.sources, self.source_labels, self._namespaces, strict=True
         ):
@@ -346,7 +346,7 @@ class PluginSkillsMiddleware(SkillsMiddleware):
         errors: list[str] = []
 
         # See `before_agent`: the three sequences are index-aligned by
-        # construction, and `strict=True` guards against future drift.
+        # construction, and `strict=True` guards against future length drift.
         for source_path, source_label, namespace in zip(
             self.sources, self.source_labels, self._namespaces, strict=True
         ):

--- a/libs/code/deepagents_code/plugins/adapters/skills_middleware.py
+++ b/libs/code/deepagents_code/plugins/adapters/skills_middleware.py
@@ -296,9 +296,14 @@ class PluginSkillsMiddleware(SkillsMiddleware):
 
         backend = self._get_backend(state, runtime, config)
         all_skills: dict[str, sdk_skills.SkillMetadata] = {}
-        source_labels: dict[str, str | None] = {}
+        merged_source_labels: dict[str, str | None] = {}
         errors: list[str] = []
 
+        # `self.sources`, `self.source_labels`, and `self._namespaces` are all
+        # built from the same source sequence at the same indices (see
+        # `__init__` and the SDK base), so this zip is aligned by construction;
+        # `strict=True` turns any future drift into a loud error rather than a
+        # silent mispairing.
         for source_path, source_label, namespace in zip(
             self.sources, self.source_labels, self._namespaces, strict=True
         ):
@@ -311,7 +316,12 @@ class PluginSkillsMiddleware(SkillsMiddleware):
             else:
                 source_skills = load_namespaced_skills(backend, source_path, namespace)
             for skill in source_skills:
-                merge_skill(all_skills, source_labels, skill, source_label=source_label)
+                merge_skill(
+                    all_skills,
+                    merged_source_labels,
+                    skill,
+                    source_label=source_label,
+                )
 
         return self._state_update(all_skills, errors)
 
@@ -332,9 +342,11 @@ class PluginSkillsMiddleware(SkillsMiddleware):
 
         backend = self._get_backend(state, runtime, config)
         all_skills: dict[str, sdk_skills.SkillMetadata] = {}
-        source_labels: dict[str, str | None] = {}
+        merged_source_labels: dict[str, str | None] = {}
         errors: list[str] = []
 
+        # See `before_agent`: the three sequences are index-aligned by
+        # construction, and `strict=True` guards against future drift.
         for source_path, source_label, namespace in zip(
             self.sources, self.source_labels, self._namespaces, strict=True
         ):
@@ -350,6 +362,11 @@ class PluginSkillsMiddleware(SkillsMiddleware):
                     backend, source_path, namespace
                 )
             for skill in source_skills:
-                merge_skill(all_skills, source_labels, skill, source_label=source_label)
+                merge_skill(
+                    all_skills,
+                    merged_source_labels,
+                    skill,
+                    source_label=source_label,
+                )
 
         return self._state_update(all_skills, errors)

--- a/libs/code/deepagents_code/plugins/adapters/skills_middleware.py
+++ b/libs/code/deepagents_code/plugins/adapters/skills_middleware.py
@@ -17,6 +17,7 @@ from deepagents_code.plugins.adapters.skills import (
     SkillNamespace,
     namespaced_skill_name,
 )
+from deepagents_code.skills.merge import merge_skill
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -295,9 +296,12 @@ class PluginSkillsMiddleware(SkillsMiddleware):
 
         backend = self._get_backend(state, runtime, config)
         all_skills: dict[str, sdk_skills.SkillMetadata] = {}
+        source_labels: dict[str, str | None] = {}
         errors: list[str] = []
 
-        for source_path, namespace in zip(self.sources, self._namespaces, strict=True):
+        for source_path, source_label, namespace in zip(
+            self.sources, self.source_labels, self._namespaces, strict=True
+        ):
             if namespace is None:
                 source_skills, source_error = sdk_skills._list_skills_with_errors(
                     backend, source_path
@@ -307,7 +311,7 @@ class PluginSkillsMiddleware(SkillsMiddleware):
             else:
                 source_skills = load_namespaced_skills(backend, source_path, namespace)
             for skill in source_skills:
-                all_skills[skill["name"]] = skill
+                merge_skill(all_skills, source_labels, skill, source_label=source_label)
 
         return self._state_update(all_skills, errors)
 
@@ -328,9 +332,12 @@ class PluginSkillsMiddleware(SkillsMiddleware):
 
         backend = self._get_backend(state, runtime, config)
         all_skills: dict[str, sdk_skills.SkillMetadata] = {}
+        source_labels: dict[str, str | None] = {}
         errors: list[str] = []
 
-        for source_path, namespace in zip(self.sources, self._namespaces, strict=True):
+        for source_path, source_label, namespace in zip(
+            self.sources, self.source_labels, self._namespaces, strict=True
+        ):
             if namespace is None:
                 (
                     source_skills,
@@ -343,6 +350,6 @@ class PluginSkillsMiddleware(SkillsMiddleware):
                     backend, source_path, namespace
                 )
             for skill in source_skills:
-                all_skills[skill["name"]] = skill
+                merge_skill(all_skills, source_labels, skill, source_label=source_label)
 
         return self._state_update(all_skills, errors)

--- a/libs/code/deepagents_code/skills/load.py
+++ b/libs/code/deepagents_code/skills/load.py
@@ -25,6 +25,7 @@ from deepagents.middleware.skills import (
 )
 
 from deepagents_code._version import __version__ as _cli_version
+from deepagents_code.skills.merge import merge_skill
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,7 @@ def list_skills(
             directories taking priority when names conflict.
     """
     all_skills: dict[str, ExtendedSkillMetadata] = {}
+    merged_source_labels: dict[str, str | None] = {}
 
     sources: list[tuple[Path | None, str, bool, str]] = [
         (built_in_skills_dir, "built-in", False, ""),
@@ -141,7 +143,12 @@ def list_skills(
                         "deepagents-code-version": _cli_version,
                     }
                 extended = cast("ExtendedSkillMetadata", {**skill, **extra})
-                all_skills[skill["name"]] = extended
+                merge_skill(
+                    all_skills,
+                    merged_source_labels,
+                    extended,
+                    source_label=source_label,
+                )
         except Exception:
             # Degrade gracefully — one malformed/inaccessible source must not
             # block discovery of others, so catch broadly and log instead.

--- a/libs/code/deepagents_code/skills/merge.py
+++ b/libs/code/deepagents_code/skills/merge.py
@@ -4,9 +4,9 @@ Both skill discovery paths — the CLI `skills list` loader
 (`deepagents_code.skills.load`) and the runtime agent loader
 (`deepagents_code.plugins.adapters.skills_middleware.PluginSkillsMiddleware`) —
 merge skills from multiple sources by precedence, last-one-wins, keyed on skill
-name. A higher-precedence skill silently replaces a lower-precedence skill with
-the same name. That override behavior is intentional; this helper leaves it
-unchanged and only makes each effective replacement diagnosable in debug logs.
+name. A higher-precedence skill replaces a lower-precedence skill with the same
+name. That override behavior is intentional; this helper leaves it unchanged and
+makes each replacement observable in debug logs.
 """
 
 from __future__ import annotations
@@ -31,10 +31,10 @@ def merge_skill(
 ) -> None:
     """Merge one skill into `merged` by name, last-one-wins.
 
-    Emits a single `DEBUG` log when this skill replaces an already-merged skill
-    with the same name, recording the skill name plus the previous and
-    replacement source paths (and labels when available) so the winning
-    definition is unambiguous. Nothing is logged when there is no collision.
+    Emits one `DEBUG` log whenever a skill replaces an already-merged skill with
+    the same name, recording the skill name plus the previous and replacement
+    source paths and labels so the winning definition is unambiguous. Nothing is
+    logged when there is no collision.
 
     Callers must iterate sources in ascending precedence order so the replacing
     skill is always the higher-precedence one.
@@ -45,9 +45,10 @@ def merge_skill(
         source_labels: Parallel accumulator mapping skill name to the label of
             the source that last supplied it; mutated in place so the previous
             label is available on the next collision.
-        skill: Skill metadata to merge. Must expose `name` and (ideally) `path`.
+        skill: Skill metadata to merge. Must expose `name`; `path`, when present,
+            is included in the override log to identify the colliding files.
         source_label: Human-readable label for the source supplying `skill`,
-            when known.
+            when known. A missing label renders as `"unknown"` in the log.
     """
     name = str(skill["name"])
     previous = merged.get(name)

--- a/libs/code/deepagents_code/skills/merge.py
+++ b/libs/code/deepagents_code/skills/merge.py
@@ -48,7 +48,8 @@ def merge_skill(
         skill: Skill metadata to merge. Must expose `name`; `path`, when present,
             is included in the override log to identify the colliding files.
         source_label: Human-readable label for the source supplying `skill`,
-            when known. A missing label renders as `"unknown"` in the log.
+            when known. A missing or empty label renders as `"unknown"` in the
+            log.
     """
     name = str(skill["name"])
     previous = merged.get(name)

--- a/libs/code/deepagents_code/skills/merge.py
+++ b/libs/code/deepagents_code/skills/merge.py
@@ -1,0 +1,64 @@
+"""Shared skill-merge helper with override (name-collision) debug logging.
+
+Both skill discovery paths — the CLI `skills list` loader
+(`deepagents_code.skills.load`) and the runtime agent loader
+(`deepagents_code.plugins.adapters.skills_middleware.PluginSkillsMiddleware`) —
+merge skills from multiple sources by precedence, last-one-wins, keyed on skill
+name. A higher-precedence skill silently replaces a lower-precedence skill with
+the same name. That override behavior is intentional; this helper leaves it
+unchanged and only makes each effective replacement diagnosable in debug logs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, MutableMapping
+
+logger = logging.getLogger(__name__)
+
+_SkillT = TypeVar("_SkillT", bound="Mapping[str, object]")
+
+
+def merge_skill(
+    merged: MutableMapping[str, _SkillT],
+    source_labels: MutableMapping[str, str | None],
+    skill: _SkillT,
+    *,
+    source_label: str | None = None,
+) -> None:
+    """Merge one skill into `merged` by name, last-one-wins.
+
+    Emits a single `DEBUG` log when this skill replaces an already-merged skill
+    with the same name, recording the skill name plus the previous and
+    replacement source paths (and labels when available) so the winning
+    definition is unambiguous. Nothing is logged when there is no collision.
+
+    Callers must iterate sources in ascending precedence order so the replacing
+    skill is always the higher-precedence one.
+
+    Args:
+        merged: Accumulator mapping skill name to merged metadata; mutated in
+            place.
+        source_labels: Parallel accumulator mapping skill name to the label of
+            the source that last supplied it; mutated in place so the previous
+            label is available on the next collision.
+        skill: Skill metadata to merge. Must expose `name` and (ideally) `path`.
+        source_label: Human-readable label for the source supplying `skill`,
+            when known.
+    """
+    name = str(skill["name"])
+    previous = merged.get(name)
+    if previous is not None:
+        logger.debug(
+            "Skill %r override: %s (source: %s) replaced by %s (source: %s)",
+            name,
+            previous.get("path"),
+            source_labels.get(name) or "unknown",
+            skill.get("path"),
+            source_label or "unknown",
+        )
+    merged[name] = skill
+    source_labels[name] = source_label

--- a/libs/code/tests/unit_tests/skills/test_merge.py
+++ b/libs/code/tests/unit_tests/skills/test_merge.py
@@ -1,0 +1,162 @@
+"""Unit tests for skill-name collision (override) debug logging."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from deepagents_code.skills.load import list_skills
+from deepagents_code.skills.merge import merge_skill
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+_MERGE_LOGGER = "deepagents_code.skills.merge"
+
+
+def _create_skill(skill_dir: Path, name: str, description: str) -> None:
+    """Create a minimal skill directory with a valid `SKILL.md`."""
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(f"""---
+name: {name}
+description: {description}
+---
+Content
+""")
+
+
+def _override_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """Return only the DEBUG override records emitted by the merge helper."""
+    return [
+        record
+        for record in caplog.records
+        if record.name == _MERGE_LOGGER and record.levelno == logging.DEBUG
+    ]
+
+
+class TestMergeSkillHelper:
+    """Directly exercise `merge_skill`."""
+
+    def test_collision_logs_debug_with_useful_fields(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A same-name replacement emits one DEBUG log with name and paths."""
+        merged: dict[str, dict[str, str]] = {}
+        labels: dict[str, str | None] = {}
+
+        with caplog.at_level(logging.DEBUG, logger=_MERGE_LOGGER):
+            merge_skill(
+                merged,
+                labels,
+                {"name": "shared", "path": "/user/shared/SKILL.md"},
+                source_label="user",
+            )
+            merge_skill(
+                merged,
+                labels,
+                {"name": "shared", "path": "/project/shared/SKILL.md"},
+                source_label="project",
+            )
+
+        records = _override_records(caplog)
+        assert len(records) == 1
+        message = records[0].getMessage()
+        assert "shared" in message
+        assert "/user/shared/SKILL.md" in message
+        assert "/project/shared/SKILL.md" in message
+        assert "user" in message
+        assert "project" in message
+
+        # Override behavior is unchanged: the higher-precedence skill wins.
+        assert merged["shared"]["path"] == "/project/shared/SKILL.md"
+        assert labels["shared"] == "project"
+
+    def test_no_collision_does_not_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Distinct skill names produce no override DEBUG log."""
+        merged: dict[str, dict[str, str]] = {}
+        labels: dict[str, str | None] = {}
+
+        with caplog.at_level(logging.DEBUG, logger=_MERGE_LOGGER):
+            merge_skill(
+                merged,
+                labels,
+                {"name": "alpha", "path": "/user/alpha/SKILL.md"},
+                source_label="user",
+            )
+            merge_skill(
+                merged,
+                labels,
+                {"name": "beta", "path": "/project/beta/SKILL.md"},
+                source_label="project",
+            )
+
+        assert _override_records(caplog) == []
+        assert set(merged) == {"alpha", "beta"}
+
+    def test_repeated_replacement_logs_once_per_event(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Each effective replacement is logged once, not the final winner only."""
+        merged: dict[str, dict[str, str]] = {}
+        labels: dict[str, str | None] = {}
+
+        with caplog.at_level(logging.DEBUG, logger=_MERGE_LOGGER):
+            for label in ("built-in", "user", "project"):
+                merge_skill(
+                    merged,
+                    labels,
+                    {"name": "shared", "path": f"/{label}/shared/SKILL.md"},
+                    source_label=label,
+                )
+
+        # built-in -> user, then user -> project == two replacement events.
+        assert len(_override_records(caplog)) == 2
+        assert merged["shared"]["path"] == "/project/shared/SKILL.md"
+
+
+class TestListSkillsCollisionLogging:
+    """Exercise collision logging through the CLI `list_skills` discovery path."""
+
+    def test_project_overrides_user_logs_debug(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A project skill overriding a user skill logs a DEBUG override."""
+        user_dir = tmp_path / "user_skills"
+        project_dir = tmp_path / "project_skills"
+        _create_skill(user_dir / "shared-skill", "shared-skill", "User version")
+        _create_skill(project_dir / "shared-skill", "shared-skill", "Project version")
+
+        with caplog.at_level(logging.DEBUG, logger=_MERGE_LOGGER):
+            skills = list_skills(
+                user_skills_dir=user_dir, project_skills_dir=project_dir
+            )
+
+        # Override behavior preserved: project wins, single merged entry.
+        assert len(skills) == 1
+        assert skills[0]["description"] == "Project version"
+
+        records = _override_records(caplog)
+        assert len(records) == 1
+        message = records[0].getMessage()
+        assert "shared-skill" in message
+        assert "user" in message
+        assert "project" in message
+
+    def test_distinct_skills_do_not_log(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Distinct skill names across sources produce no override DEBUG log."""
+        user_dir = tmp_path / "user_skills"
+        project_dir = tmp_path / "project_skills"
+        _create_skill(user_dir / "user-skill", "user-skill", "User skill")
+        _create_skill(project_dir / "project-skill", "project-skill", "Project skill")
+
+        with caplog.at_level(logging.DEBUG, logger=_MERGE_LOGGER):
+            skills = list_skills(
+                user_skills_dir=user_dir, project_skills_dir=project_dir
+            )
+
+        assert len(skills) == 2
+        assert _override_records(caplog) == []

--- a/libs/code/tests/unit_tests/skills/test_merge.py
+++ b/libs/code/tests/unit_tests/skills/test_merge.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
+from deepagents.backends.filesystem import FilesystemBackend
+
+from deepagents_code.plugins.adapters.skills_middleware import PluginSkillsMiddleware
 from deepagents_code.skills.load import list_skills
 from deepagents_code.skills.merge import merge_skill
 
@@ -27,13 +30,22 @@ Content
 """)
 
 
-def _override_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
-    """Return only the DEBUG override records emitted by the merge helper."""
+def _override_records(
+    caplog: pytest.LogCaptureFixture, level: int = logging.DEBUG
+) -> list[logging.LogRecord]:
+    """Return the merge-helper override records emitted at exactly `level`."""
     return [
         record
         for record in caplog.records
-        if record.name == _MERGE_LOGGER and record.levelno == logging.DEBUG
+        if record.name == _MERGE_LOGGER and record.levelno == level
     ]
+
+
+def _args(record: logging.LogRecord) -> tuple[object, ...]:
+    """Return a record's positional log args, asserting they form a tuple."""
+    args = record.args
+    assert isinstance(args, tuple)
+    return args
 
 
 class TestMergeSkillHelper:
@@ -42,7 +54,7 @@ class TestMergeSkillHelper:
     def test_collision_logs_debug_with_useful_fields(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A same-name replacement emits one DEBUG log with name and paths."""
+        """A replacement emits one DEBUG log with all identifying fields."""
         merged: dict[str, dict[str, str]] = {}
         labels: dict[str, str | None] = {}
 
@@ -50,31 +62,130 @@ class TestMergeSkillHelper:
             merge_skill(
                 merged,
                 labels,
-                {"name": "shared", "path": "/user/shared/SKILL.md"},
+                {"name": "shared", "path": "/a/shared/SKILL.md"},
                 source_label="user",
             )
             merge_skill(
                 merged,
                 labels,
-                {"name": "shared", "path": "/project/shared/SKILL.md"},
+                {"name": "shared", "path": "/b/shared/SKILL.md"},
                 source_label="project",
             )
 
         records = _override_records(caplog)
         assert len(records) == 1
-        message = records[0].getMessage()
-        assert "shared" in message
-        assert "/user/shared/SKILL.md" in message
-        assert "/project/shared/SKILL.md" in message
-        assert "user" in message
-        assert "project" in message
-
-        # Override behavior is unchanged: the higher-precedence skill wins.
-        assert merged["shared"]["path"] == "/project/shared/SKILL.md"
+        assert records[0].args == (
+            "shared",
+            "/a/shared/SKILL.md",
+            "user",
+            "/b/shared/SKILL.md",
+            "project",
+        )
+        assert _override_records(caplog, logging.WARNING) == []
+        assert merged["shared"]["path"] == "/b/shared/SKILL.md"
         assert labels["shared"] == "project"
 
+    def test_same_label_collision_logs_debug(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Labels do not change the DEBUG level used for collision diagnostics."""
+        merged: dict[str, dict[str, str]] = {}
+        labels: dict[str, str | None] = {}
+
+        with caplog.at_level(logging.DEBUG, logger=_MERGE_LOGGER):
+            merge_skill(
+                merged,
+                labels,
+                {"name": "shared", "path": "/deepagents/shared/SKILL.md"},
+                source_label="user",
+            )
+            merge_skill(
+                merged,
+                labels,
+                {"name": "shared", "path": "/agents/shared/SKILL.md"},
+                source_label="user",
+            )
+
+        records = _override_records(caplog)
+        assert len(records) == 1
+        assert records[0].args == (
+            "shared",
+            "/deepagents/shared/SKILL.md",
+            "user",
+            "/agents/shared/SKILL.md",
+            "user",
+        )
+        assert _override_records(caplog, logging.WARNING) == []
+
+    def test_same_path_replacement_logs_debug(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Every replacement logs even when both metadata paths are equal."""
+        merged: dict[str, dict[str, str]] = {}
+        labels: dict[str, str | None] = {}
+
+        with caplog.at_level(logging.DEBUG, logger=_MERGE_LOGGER):
+            merge_skill(
+                merged,
+                labels,
+                {"name": "shared", "path": "/shared/SKILL.md"},
+                source_label="user",
+            )
+            merge_skill(
+                merged,
+                labels,
+                {"name": "shared", "path": "/shared/SKILL.md"},
+                source_label="project",
+            )
+
+        records = _override_records(caplog)
+        assert len(records) == 1
+        assert records[0].args == (
+            "shared",
+            "/shared/SKILL.md",
+            "user",
+            "/shared/SKILL.md",
+            "project",
+        )
+        assert _override_records(caplog, logging.WARNING) == []
+
+    def test_missing_path_logs_none(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A skill without a `path` key logs `None` rather than raising."""
+        merged: dict[str, dict[str, str]] = {}
+        labels: dict[str, str | None] = {}
+
+        with caplog.at_level(logging.DEBUG, logger=_MERGE_LOGGER):
+            merge_skill(merged, labels, {"name": "shared"}, source_label="user")
+            merge_skill(merged, labels, {"name": "shared"}, source_label="project")
+
+        records = _override_records(caplog)
+        assert len(records) == 1
+        name, prev_path, _prev_label, new_path, _new_label = _args(records[0])
+        assert name == "shared"
+        assert prev_path is None
+        assert new_path is None
+
+    def test_unknown_label_falls_back(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A `None` source label renders as the literal `"unknown"`."""
+        merged: dict[str, dict[str, str]] = {}
+        labels: dict[str, str | None] = {}
+
+        with caplog.at_level(logging.DEBUG, logger=_MERGE_LOGGER):
+            merge_skill(merged, labels, {"name": "shared", "path": "/a/SKILL.md"})
+            merge_skill(merged, labels, {"name": "shared", "path": "/b/SKILL.md"})
+
+        records = _override_records(caplog)
+        assert len(records) == 1
+        assert records[0].args == (
+            "shared",
+            "/a/SKILL.md",
+            "unknown",
+            "/b/SKILL.md",
+            "unknown",
+        )
+
     def test_no_collision_does_not_log(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Distinct skill names produce no override DEBUG log."""
+        """Distinct skill names produce no override log."""
         merged: dict[str, dict[str, str]] = {}
         labels: dict[str, str | None] = {}
 
@@ -92,13 +203,14 @@ class TestMergeSkillHelper:
                 source_label="project",
             )
 
-        assert _override_records(caplog) == []
+        assert _override_records(caplog, logging.DEBUG) == []
+        assert _override_records(caplog, logging.WARNING) == []
         assert set(merged) == {"alpha", "beta"}
 
     def test_repeated_replacement_logs_once_per_event(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Each effective replacement is logged once, not the final winner only."""
+        """Each replacement is logged once, not only the final winner."""
         merged: dict[str, dict[str, str]] = {}
         labels: dict[str, str | None] = {}
 
@@ -111,7 +223,6 @@ class TestMergeSkillHelper:
                     source_label=label,
                 )
 
-        # built-in -> user, then user -> project == two replacement events.
         assert len(_override_records(caplog)) == 2
         assert merged["shared"]["path"] == "/project/shared/SKILL.md"
 
@@ -133,21 +244,22 @@ class TestListSkillsCollisionLogging:
                 user_skills_dir=user_dir, project_skills_dir=project_dir
             )
 
-        # Override behavior preserved: project wins, single merged entry.
         assert len(skills) == 1
         assert skills[0]["description"] == "Project version"
 
         records = _override_records(caplog)
         assert len(records) == 1
-        message = records[0].getMessage()
-        assert "shared-skill" in message
-        assert "user" in message
-        assert "project" in message
+        name, prev_path, prev_label, new_path, new_label = _args(records[0])
+        assert name == "shared-skill"
+        assert prev_label == "user"
+        assert new_label == "project"
+        assert str(user_dir) in str(prev_path)
+        assert str(project_dir) in str(new_path)
 
     def test_distinct_skills_do_not_log(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Distinct skill names across sources produce no override DEBUG log."""
+        """Distinct skill names across sources produce no override log."""
         user_dir = tmp_path / "user_skills"
         project_dir = tmp_path / "project_skills"
         _create_skill(user_dir / "user-skill", "user-skill", "User skill")
@@ -159,4 +271,72 @@ class TestListSkillsCollisionLogging:
             )
 
         assert len(skills) == 2
-        assert _override_records(caplog) == []
+        assert _override_records(caplog, logging.DEBUG) == []
+        assert _override_records(caplog, logging.WARNING) == []
+
+
+class TestMiddlewareCollisionLogging:
+    """Exercise collision logging through `PluginSkillsMiddleware` (sync + async).
+
+    These lock in the new three-way `zip(self.sources, self.source_labels,
+    self._namespaces, ...)` wiring: both entry points must merge through
+    `merge_skill` and log overrides identically.
+    """
+
+    @staticmethod
+    def _middleware(user_dir: Path, project_dir: Path) -> PluginSkillsMiddleware:
+        """Build a middleware over two colliding, non-namespaced sources."""
+        _create_skill(user_dir / "review", "review", "User review")
+        _create_skill(project_dir / "review", "review", "Project review")
+        return PluginSkillsMiddleware(
+            backend=FilesystemBackend(virtual_mode=False),
+            sources=[(str(user_dir), "User"), (str(project_dir), "Project")],
+            system_prompt=None,
+        )
+
+    def test_before_agent_collision_logs_override(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The sync path merges through `merge_skill` and logs the override."""
+        middleware = self._middleware(tmp_path / "user", tmp_path / "project")
+
+        with caplog.at_level(logging.DEBUG, logger=_MERGE_LOGGER):
+            update = middleware.before_agent(
+                cast("Any", {"messages": []}), runtime=cast("Any", None), config={}
+            )
+
+        assert update is not None
+        # Precedence preserved: the later (project) source wins the collision.
+        metadata = update["skills_metadata"]
+        assert [skill["name"] for skill in metadata] == ["review"]
+        assert metadata[0]["description"] == "Project review"
+
+        records = _override_records(caplog)
+        assert len(records) == 1
+        name, _prev_path, prev_label, _new_path, new_label = _args(records[0])
+        assert name == "review"
+        assert prev_label == "User"
+        assert new_label == "Project"
+
+    async def test_abefore_agent_collision_logs_override(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The async path logs the override identically to the sync path."""
+        middleware = self._middleware(tmp_path / "user", tmp_path / "project")
+
+        with caplog.at_level(logging.DEBUG, logger=_MERGE_LOGGER):
+            update = await middleware.abefore_agent(
+                cast("Any", {"messages": []}), runtime=cast("Any", None), config={}
+            )
+
+        assert update is not None
+        metadata = update["skills_metadata"]
+        assert [skill["name"] for skill in metadata] == ["review"]
+        assert metadata[0]["description"] == "Project review"
+
+        records = _override_records(caplog)
+        assert len(records) == 1
+        name, _prev_path, prev_label, _new_path, new_label = _args(records[0])
+        assert name == "review"
+        assert prev_label == "User"
+        assert new_label == "Project"

--- a/libs/code/tests/unit_tests/skills/test_merge.py
+++ b/libs/code/tests/unit_tests/skills/test_merge.py
@@ -81,6 +81,13 @@ class TestMergeSkillHelper:
             "/b/shared/SKILL.md",
             "project",
         )
+        # Lock the human-facing rendered line: format string, placeholder order,
+        # and args must stay in sync (args-only assertions can't catch a
+        # reordered or reworded format string).
+        assert records[0].getMessage() == (
+            "Skill 'shared' override: /a/shared/SKILL.md (source: user) "
+            "replaced by /b/shared/SKILL.md (source: project)"
+        )
         assert _override_records(caplog, logging.WARNING) == []
         assert merged["shared"]["path"] == "/b/shared/SKILL.md"
         assert labels["shared"] == "project"
@@ -294,6 +301,26 @@ class TestMiddlewareCollisionLogging:
             system_prompt=None,
         )
 
+    @staticmethod
+    def _namespaced_middleware(dir_a: Path, dir_b: Path) -> PluginSkillsMiddleware:
+        """Build a middleware over two colliding plugin (namespaced) sources.
+
+        Both sources share the `myplugin` namespace and a `review` skill, so
+        both qualify to `myplugin:review` and drive the namespaced (`else`)
+        loop branch through `load_namespaced_skills` — the branch a plain-source
+        collision never reaches.
+        """
+        _create_skill(dir_a / "review", "review", "Plugin A review")
+        _create_skill(dir_b / "review", "review", "Plugin B review")
+        return PluginSkillsMiddleware(
+            backend=FilesystemBackend(virtual_mode=False),
+            sources=[
+                (str(dir_a), "Plugin A", "myplugin"),
+                (str(dir_b), "Plugin B", "myplugin"),
+            ],
+            system_prompt=None,
+        )
+
     def test_before_agent_collision_logs_override(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -340,3 +367,54 @@ class TestMiddlewareCollisionLogging:
         assert name == "review"
         assert prev_label == "User"
         assert new_label == "Project"
+
+    def test_before_agent_namespaced_collision_logs_override(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The namespaced (plugin) branch also merges through `merge_skill`."""
+        middleware = self._namespaced_middleware(
+            tmp_path / "plugin_a", tmp_path / "plugin_b"
+        )
+
+        with caplog.at_level(logging.DEBUG, logger=_MERGE_LOGGER):
+            update = middleware.before_agent(
+                cast("Any", {"messages": []}), runtime=cast("Any", None), config={}
+            )
+
+        assert update is not None
+        # Names are namespace-qualified; the later plugin source wins.
+        metadata = update["skills_metadata"]
+        assert [skill["name"] for skill in metadata] == ["myplugin:review"]
+        assert metadata[0]["description"] == "Plugin B review"
+
+        records = _override_records(caplog)
+        assert len(records) == 1
+        name, _prev_path, prev_label, _new_path, new_label = _args(records[0])
+        assert name == "myplugin:review"
+        assert prev_label == "Plugin A"
+        assert new_label == "Plugin B"
+
+    async def test_abefore_agent_namespaced_collision_logs_override(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The async namespaced branch logs the override identically."""
+        middleware = self._namespaced_middleware(
+            tmp_path / "plugin_a", tmp_path / "plugin_b"
+        )
+
+        with caplog.at_level(logging.DEBUG, logger=_MERGE_LOGGER):
+            update = await middleware.abefore_agent(
+                cast("Any", {"messages": []}), runtime=cast("Any", None), config={}
+            )
+
+        assert update is not None
+        metadata = update["skills_metadata"]
+        assert [skill["name"] for skill in metadata] == ["myplugin:review"]
+        assert metadata[0]["description"] == "Plugin B review"
+
+        records = _override_records(caplog)
+        assert len(records) == 1
+        name, _prev_path, prev_label, _new_path, new_label = _args(records[0])
+        assert name == "myplugin:review"
+        assert prev_label == "Plugin A"
+        assert new_label == "Plugin B"


### PR DESCRIPTION
Deep Agents Code now emits a `DEBUG` log when a higher-precedence skill overrides another skill with the same name, aiding skill-resolution debugging.

---

Skill sources (built-in, plugin, global, project) are merged by precedence and a higher-precedence skill silently replaces a lower-precedence one with the same name. This override is intentional and unchanged; this PR makes it diagnosable by routing both skill-discovery merge points — the CLI `skills list` loader (`skills/load.py`) and the runtime `PluginSkillsMiddleware` — through a shared `merge_skill` helper that emits a `DEBUG` log on each effective replacement, recording the skill name plus the previous and replacement source paths and labels.

Made by [Open SWE](https://openswe.vercel.app/agents/5f97f80c-bed1-0fa5-d0b1-ce67060df37c)