### PR TITLE
fix(code): clarify plugin component discovery and reload status

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2598,6 +2598,9 @@ class DeepAgentsApp(App):
         self._mcp_server_info = mcp_server_info
         """MCP server metadata surfaced in the `/mcp` viewer."""
 
+        self._session_plugin_ids: frozenset[str] = self._snapshot_session_plugin_ids()
+        """Plugin ids loaded into the current session (startup or last `/reload`)."""
+
         self._mcp_optimistic_original_server_info: dict[str, MCPServerInfo] = {}
         """Pre-disable server metadata for optimistic viewer toggles."""
 
@@ -11263,6 +11266,9 @@ class DeepAgentsApp(App):
                 from deepagents_code.plugins.adapters.mcp import plugin_mcp_configs
 
                 plugin_result = discover_plugins()
+                self._session_plugin_ids = frozenset(
+                    plugin.plugin_id for plugin in plugin_result.plugins
+                )
                 plugin_count = len(plugin_result.plugins)
                 mcp_configs = plugin_mcp_configs(plugin_result.plugins)
                 mcp_count = sum(
@@ -17041,8 +17047,23 @@ class DeepAgentsApp(App):
         self.push_screen(
             PluginManagerScreen(
                 mcp_server_info=self._mcp_server_info or [],
+                loaded_plugin_ids=self._session_plugin_ids,
             )
         )
+
+    @staticmethod
+    def _snapshot_session_plugin_ids() -> frozenset[str]:
+        """Return enabled plugin ids that should count as loaded for this session."""
+        from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
+
+        if not is_env_truthy(EXPERIMENTAL):
+            return frozenset()
+        try:
+            from deepagents_code.plugins import discover_plugins
+
+            return frozenset(plugin.plugin_id for plugin in discover_plugins().plugins)
+        except (OSError, RuntimeError, ValueError):
+            return frozenset()
 
     async def _handle_mcp_subcommand(self, args: str) -> None:
         """Dispatch `/mcp <subcommand>` strings.

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2598,8 +2598,11 @@ class DeepAgentsApp(App):
         self._mcp_server_info = mcp_server_info
         """MCP server metadata surfaced in the `/mcp` viewer."""
 
-        self._session_plugin_ids: frozenset[str] = self._snapshot_session_plugin_ids()
+        self._session_plugin_ids: frozenset[str] = frozenset()
         """Plugin ids loaded into the current session (startup or last `/reload`)."""
+
+        self._discovered_plugin_ids: frozenset[str] = frozenset()
+        """Plugin ids found by the latest background skill discovery."""
 
         self._mcp_optimistic_original_server_info: dict[str, MCPServerInfo] = {}
         """Pre-disable server metadata for optimistic viewer toggles."""
@@ -3719,7 +3722,7 @@ class DeepAgentsApp(App):
         # Discover skills first so /skill: autocomplete is ready as early
         # as possible. The heavy filesystem scan runs in a thread.
         self.run_worker(
-            self._discover_skills(),
+            self._discover_startup_skills(),
             exclusive=True,
             group="startup-skill-discovery",
         )
@@ -4067,6 +4070,17 @@ class DeepAgentsApp(App):
                 )
         return True
 
+    async def _discover_startup_skills(self) -> bool:
+        """Discover skills and record plugins loaded by initial startup.
+
+        Returns:
+            Whether skill and plugin discovery succeeded.
+        """
+        discovered = await self._discover_skills()
+        if discovered:
+            self._session_plugin_ids = self._discovered_plugin_ids
+        return discovered
+
     def _discover_skills_and_roots(
         self,
     ) -> tuple[list[ExtendedSkillMetadata], list[Path]]:
@@ -4079,14 +4093,12 @@ class DeepAgentsApp(App):
         Returns:
             Tuple of `(skill metadata list, pre-resolved containment roots)`.
         """
-        from deepagents_code.plugins.adapters.skills import (
-            discover_plugin_skill_sources_and_roots,
-        )
+        from deepagents_code.plugins.adapters.skills import discover_plugin_skill_state
         from deepagents_code.skills.invocation import discover_skills_and_roots
 
         assistant_id = self._assistant_id or DEFAULT_ASSISTANT_ID
-        plugin_skill_sources, plugin_skill_roots = (
-            discover_plugin_skill_sources_and_roots()
+        plugin_skill_sources, plugin_skill_roots, self._discovered_plugin_ids = (
+            discover_plugin_skill_state()
         )
         return discover_skills_and_roots(
             assistant_id,
@@ -11266,7 +11278,7 @@ class DeepAgentsApp(App):
                 from deepagents_code.plugins.adapters.mcp import plugin_mcp_configs
 
                 plugin_result = discover_plugins()
-                self._session_plugin_ids = frozenset(
+                discovered_plugin_ids = frozenset(
                     plugin.plugin_id for plugin in plugin_result.plugins
                 )
                 plugin_count = len(plugin_result.plugins)
@@ -11300,6 +11312,7 @@ class DeepAgentsApp(App):
                         self._discard_queue()
                     restarted = await self._restart_server_manual()
                     if restarted:
+                        self._session_plugin_ids = discovered_plugin_ids
                         report += "\nAgent server restarted for plugin MCP."
                     else:
                         report += (
@@ -17050,20 +17063,6 @@ class DeepAgentsApp(App):
                 loaded_plugin_ids=self._session_plugin_ids,
             )
         )
-
-    @staticmethod
-    def _snapshot_session_plugin_ids() -> frozenset[str]:
-        """Return enabled plugin ids that should count as loaded for this session."""
-        from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
-
-        if not is_env_truthy(EXPERIMENTAL):
-            return frozenset()
-        try:
-            from deepagents_code.plugins import discover_plugins
-
-            return frozenset(plugin.plugin_id for plugin in discover_plugins().plugins)
-        except (OSError, RuntimeError, ValueError):
-            return frozenset()
 
     async def _handle_mcp_subcommand(self, args: str) -> None:
         """Dispatch `/mcp <subcommand>` strings.

--- a/libs/code/deepagents_code/plugins/adapters/mcp.py
+++ b/libs/code/deepagents_code/plugins/adapters/mcp.py
@@ -82,6 +82,43 @@ def _load_mcp_server_map(path: Path) -> JsonObject:
     return _server_map(raw)
 
 
+def _plugin_mcp_server_map(plugin: PluginInstance) -> JsonObject:
+    """Load a plugin's declared MCP servers without creating runtime state.
+
+    Returns:
+        The unscoped server configuration keyed by declared server name.
+    """
+    servers: JsonObject = {}
+    for path in plugin.inventory.mcp_files:
+        if path.suffix in {".mcpb", ".dxt"}:
+            logger.warning(
+                "Skipping unsupported MCP bundle for plugin %s: %s",
+                plugin.plugin_id,
+                path,
+            )
+            continue
+        servers.update(_load_mcp_server_map(path))
+    if plugin.manifest and plugin.manifest.inline_mcp:
+        servers.update(_server_map(plugin.manifest.inline_mcp))
+    return servers
+
+
+def plugin_mcp_server_names(plugin: PluginInstance) -> tuple[str, ...]:
+    """Return scoped MCP server names without preparing plugin runtime state.
+
+    Args:
+        plugin: Plugin instance whose declarations should be inspected.
+
+    Returns:
+        Scoped MCP server names in declaration order.
+    """
+    return tuple(
+        scoped_mcp_server_name(plugin.plugin_id, name)
+        for name in _plugin_mcp_server_map(plugin)
+        if isinstance(name, str)
+    )
+
+
 def _normalize_server(
     server: object, *, plugin: PluginInstance, project_dir: Path | None
 ) -> JsonValue:
@@ -167,18 +204,7 @@ def plugin_mcp_configs(
                 plugin.data_dir,
                 exc_info=True,
             )
-        servers: JsonObject = {}
-        for path in plugin.inventory.mcp_files:
-            if path.suffix in {".mcpb", ".dxt"}:
-                logger.warning(
-                    "Skipping unsupported MCP bundle for plugin %s: %s",
-                    plugin.plugin_id,
-                    path,
-                )
-                continue
-            servers.update(_load_mcp_server_map(path))
-        if plugin.manifest and plugin.manifest.inline_mcp:
-            servers.update(_server_map(plugin.manifest.inline_mcp))
+        servers = _plugin_mcp_server_map(plugin)
         scoped: JsonObject = {}
         for name, server in servers.items():
             if not isinstance(name, str):

--- a/libs/code/deepagents_code/plugins/adapters/skills.py
+++ b/libs/code/deepagents_code/plugins/adapters/skills.py
@@ -93,17 +93,18 @@ def plugin_skill_roots(plugins: tuple[PluginInstance, ...]) -> list[Path]:
     return roots
 
 
-def discover_plugin_skill_sources_and_roots() -> tuple[
-    tuple[tuple[Path, str], ...], tuple[Path, ...]
+def discover_plugin_skill_state() -> tuple[
+    tuple[tuple[Path, str], ...], tuple[Path, ...], frozenset[str]
 ]:
-    """Discover plugin skill sources and containment roots.
+    """Discover plugin skill sources, containment roots, and loaded ids.
 
     Returns:
-        Plugin skill sources and roots, or empty tuples when plugins are disabled
-        or discovery fails.
+        Plugin skill sources, roots, and ids, or empty values when plugins are
+        disabled or discovery fails.
     """
     plugin_sources: tuple[tuple[Path, str], ...] = ()
     plugin_roots: tuple[Path, ...] = ()
+    plugin_ids: frozenset[str] = frozenset()
     try:
         if is_env_truthy(EXPERIMENTAL):
             from deepagents_code.plugins import discover_plugins
@@ -114,8 +115,23 @@ def discover_plugin_skill_sources_and_roots() -> tuple[
                 for path, _label, namespace in plugin_skill_sources(plugins)
             )
             plugin_roots = tuple(plugin_skill_roots(plugins))
+            plugin_ids = frozenset(plugin.plugin_id for plugin in plugins)
     except (OSError, RuntimeError):
         logger.warning("Could not discover plugin skills", exc_info=True)
-        return (), ()
+        return (), (), frozenset()
+
+    return plugin_sources, plugin_roots, plugin_ids
+
+
+def discover_plugin_skill_sources_and_roots() -> tuple[
+    tuple[tuple[Path, str], ...], tuple[Path, ...]
+]:
+    """Discover plugin skill sources and containment roots.
+
+    Returns:
+        Plugin skill sources and roots, or empty tuples when plugins are disabled
+        or discovery fails.
+    """
+    plugin_sources, plugin_roots, _plugin_ids = discover_plugin_skill_state()
 
     return plugin_sources, plugin_roots

--- a/libs/code/deepagents_code/plugins/manifest.py
+++ b/libs/code/deepagents_code/plugins/manifest.py
@@ -21,6 +21,7 @@ _MANIFEST_RELATIVE_PATHS = (
     Path(".codex-plugin") / "plugin.json",
 )
 _PATH_COMPONENT_FIELDS = {"skills", "mcpServers"}
+_UNSUPPORTED_COMPONENT_DIRS = ("agents", "commands", "hooks")
 _NAME_RE = re.compile(r"^[^\s]+$")
 
 
@@ -233,6 +234,19 @@ def _existing_component_path(path: Path, plugin_root: Path) -> tuple[Path, ...]:
         return (resolved,)
 
 
+def _unsupported_component_dirs(plugin_root: Path) -> tuple[str, ...]:
+    """Return present component dirs that deepagents-code does not load."""
+    found: list[str] = []
+    for name in _UNSUPPORTED_COMPONENT_DIRS:
+        path = plugin_root / name
+        try:
+            if path.is_dir():
+                found.append(name)
+        except OSError:
+            logger.warning("Could not inspect plugin component path %s", path)
+    return tuple(found)
+
+
 def build_inventory(
     plugin_root: Path,
     manifest: PluginManifest | None,
@@ -265,8 +279,11 @@ def build_inventory(
         *metadata_paths.get("mcpServers", ()),
     )
 
+    unsupported = _unsupported_component_dirs(plugin_root)
+
     return ComponentInventory(
         skills=tuple(dict.fromkeys(skills)),
         mcp_files=tuple(dict.fromkeys(mcp_files)),
+        unsupported=unsupported,
         warnings=tuple(warnings),
     )

--- a/libs/code/deepagents_code/plugins/manifest.py
+++ b/libs/code/deepagents_code/plugins/manifest.py
@@ -12,6 +12,7 @@ from deepagents_code.plugins.models import (
     ComponentInventory,
     JsonObject,
     PluginManifest,
+    UnsupportedComponent,
 )
 
 logger = logging.getLogger(__name__)
@@ -21,7 +22,11 @@ _MANIFEST_RELATIVE_PATHS = (
     Path(".codex-plugin") / "plugin.json",
 )
 _PATH_COMPONENT_FIELDS = {"skills", "mcpServers"}
-_UNSUPPORTED_COMPONENT_DIRS = ("agents", "commands", "hooks")
+_UNSUPPORTED_COMPONENT_DIRS: tuple[UnsupportedComponent, ...] = (
+    "agents",
+    "commands",
+    "hooks",
+)
 _NAME_RE = re.compile(r"^[^\s]+$")
 
 
@@ -234,9 +239,11 @@ def _existing_component_path(path: Path, plugin_root: Path) -> tuple[Path, ...]:
         return (resolved,)
 
 
-def _unsupported_component_dirs(plugin_root: Path) -> tuple[str, ...]:
+def _unsupported_component_dirs(
+    plugin_root: Path,
+) -> tuple[UnsupportedComponent, ...]:
     """Return present component dirs that deepagents-code does not load."""
-    found: list[str] = []
+    found: list[UnsupportedComponent] = []
     for name in _UNSUPPORTED_COMPONENT_DIRS:
         path = plugin_root / name
         try:

--- a/libs/code/deepagents_code/plugins/models.py
+++ b/libs/code/deepagents_code/plugins/models.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
 
 MarketplaceSourceType = Literal["directory", "file", "github", "git", "url"]
 ExternalPluginRepositorySourceType = Literal["github", "git-subdir", "url"]
+UnsupportedComponent = Literal["agents", "commands", "hooks"]
+"""Plugin component directory that `deepagents-code` does not load."""
 JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
 JsonObject = dict[str, JsonValue]
 
@@ -69,12 +71,13 @@ class PluginManifest:
 class ComponentInventory:
     """Inventory of supported plugin components.
 
-    `unsupported` lists plugin component directories that are not loaded by dcode`
+    `unsupported` lists plugin component directories that `deepagents-code` does
+    not load (e.g. `agents/`, `commands/`, `hooks/`).
     """
 
     skills: tuple[Path, ...] = ()
     mcp_files: tuple[Path, ...] = ()
-    unsupported: tuple[str, ...] = ()
+    unsupported: tuple[UnsupportedComponent, ...] = ()
     warnings: tuple[str, ...] = ()
 
 

--- a/libs/code/deepagents_code/plugins/models.py
+++ b/libs/code/deepagents_code/plugins/models.py
@@ -67,10 +67,14 @@ class PluginManifest:
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class ComponentInventory:
-    """Inventory of supported plugin components."""
+    """Inventory of supported plugin components.
+
+    `unsupported` lists plugin component directories that are not loaded by dcode`
+    """
 
     skills: tuple[Path, ...] = ()
     mcp_files: tuple[Path, ...] = ()
+    unsupported: tuple[str, ...] = ()
     warnings: tuple[str, ...] = ()
 
 

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -13,7 +13,7 @@ from textual.widgets import Input, OptionList, Rule, Static
 from textual.widgets.option_list import Option
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Sequence, Set
 
     from textual.app import ComposeResult
 
@@ -77,6 +77,7 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         self,
         *,
         mcp_server_info: Sequence[MCPServerInfo] = (),
+        loaded_plugin_ids: Set[str] | None = None,
     ) -> None:
         """Initialize the plugin manager.
 
@@ -84,11 +85,14 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
             mcp_server_info: Live MCP server metadata from the running session,
                 used to show connection status for plugins that declare MCP
                 servers.
+            loaded_plugin_ids: Plugin ids loaded into the current session
+                Enabled plugins missing from this set are shown as pending reload.
         """
         super().__init__()
         self._tab: PluginTab = "discover"
         self._mode: PluginManagerView = "list"
         self._mcp_server_info = mcp_server_info
+        self._loaded_plugin_ids: frozenset[str] = frozenset(loaded_plugin_ids or ())
         self._state = _ManagerState((), (), (), ())
         self._status: str | None = None
         self._error: str | None = None
@@ -356,7 +360,9 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
 
     async def _refresh_state(self) -> None:
         self._state = await asyncio.to_thread(
-            _load_manager_state, self._mcp_server_info
+            _load_manager_state,
+            self._mcp_server_info,
+            loaded_plugin_ids=self._loaded_plugin_ids,
         )
         if self._selected_plugin is not None:
             refreshed = self._find_installed_plugin(self._selected_plugin.plugin_id)

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -85,8 +85,10 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
             mcp_server_info: Live MCP server metadata from the running session,
                 used to show connection status for plugins that declare MCP
                 servers.
-            loaded_plugin_ids: Plugin ids loaded into the current session
-                Enabled plugins missing from this set are shown as pending reload.
+            loaded_plugin_ids: Plugin ids loaded into the current session.
+                Plugins whose enabled state differs from this set (enabled but
+                not loaded, or disabled but still loaded) are shown as pending
+                reload.
         """
         super().__init__()
         self._tab: PluginTab = "discover"

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -13,7 +13,7 @@ from textual.widgets import Input, OptionList, Rule, Static
 from textual.widgets.option_list import Option
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence, Set
+    from collections.abc import Sequence, Set as AbstractSet
 
     from textual.app import ComposeResult
 
@@ -77,7 +77,7 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
         self,
         *,
         mcp_server_info: Sequence[MCPServerInfo] = (),
-        loaded_plugin_ids: Set[str] | None = None,
+        loaded_plugin_ids: AbstractSet[str] | None = None,
     ) -> None:
         """Initialize the plugin manager.
 

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
@@ -25,20 +25,33 @@ def _plugin_options(
     return options
 
 
+def _load_state_label(row: _PluginRow) -> str | None:
+    glyphs = get_glyphs()
+    if row.load_state == "error":
+        return "error"
+    if row.load_state == "pending_reload":
+        return "pending /reload"
+    if row.load_state == "enabled":
+        return f"{glyphs.checkmark} enabled"
+    return None
+
+
 def _plugin_prompt(row: _PluginRow, *, status: str | None) -> Content:
     glyphs = get_glyphs()
     plugin_name, _, marketplace = row.plugin_id.partition("@")
     meta_parts = ["Plugin", marketplace]
-    if row.enabled:
-        meta_parts.append(f"{glyphs.checkmark} enabled")
+    load_label = _load_state_label(row)
+    if load_label:
+        meta_parts.append(load_label)
     if row.skill_count:
         meta_parts.append(
             f"{row.skill_count} {'skill' if row.skill_count == 1 else 'skills'}"
         )
-    if row.mcp_connected is True:
-        meta_parts.append(f"{glyphs.checkmark} connected")
-    elif row.mcp_connected is False:
-        meta_parts.append("restart to connect")
+    if row.load_state == "enabled":
+        if row.mcp_connected is True:
+            meta_parts.append(f"{glyphs.checkmark} connected")
+        elif row.mcp_connected is False:
+            meta_parts.append("restart to connect")
     if status:
         meta_parts.append(status)
     return Content.assemble(
@@ -67,6 +80,74 @@ def _installed_details_options(row: _PluginRow) -> list[Option]:
     ]
 
 
+def _component_summary_lines(row: _PluginRow) -> list[str]:
+    lines: list[str] = []
+    if row.skill_names:
+        lines.append(f"Skills: {', '.join(row.skill_names)}")
+    elif row.skill_count:
+        lines.append(f"Skills: {row.skill_count}")
+    if row.mcp_server_names:
+        lines.append(f"MCP: {', '.join(row.mcp_server_names)}")
+    if row.unsupported_components:
+        names = ", ".join(f"{name}/" for name in row.unsupported_components)
+        lines.append(f"Unsupported (not loaded): {names}")
+    return lines
+
+
+def _unsupported_summary(components: tuple[str, ...]) -> str:
+    return f"Found unsupported: {', '.join(f'{name}/' for name in components)}."
+
+
+def _will_install_lines(row: _PluginRow) -> list[str]:
+    lines = _component_summary_lines(row)
+    if row.skill_names or row.mcp_server_names or row.skill_count:
+        return lines
+    if row.unsupported_components:
+        return [
+            "No supported components (skills/MCP).",
+            _unsupported_summary(row.unsupported_components),
+        ]
+    if row.skill_count is None:
+        return [
+            "Skills and MCP servers if present (agents/, commands/, and hooks/ are not loaded)."
+        ]
+    return [
+        "No supported components (skills/MCP).",
+        "agents/, commands/, and hooks/ are not loaded by deepagents-code.",
+    ]
+
+
+def _installed_component_lines(row: _PluginRow) -> list[str]:
+    lines = _component_summary_lines(row)
+    if lines:
+        has_supported = bool(row.skill_names or row.mcp_server_names)
+        if not has_supported and row.unsupported_components:
+            return [
+                "No supported components (skills/MCP).",
+                _unsupported_summary(row.unsupported_components),
+            ]
+        return lines
+    return ["No components found."]
+
+
+def _status_lines(row: _PluginRow) -> list[str]:
+    glyphs = get_glyphs()
+    if row.load_state == "error":
+        detail = row.load_error or "Plugin failed to load."
+        return [f"Status: Error — {detail}", "Fix the error, then run /reload."]
+    if row.load_state == "disabled":
+        return ["Status: Disabled", "Enable the plugin, then run /reload to load it."]
+    if row.load_state == "pending_reload":
+        return [
+            "Status: Installed · pending /reload",
+            "Run /reload to load this plugin into the current session.",
+        ]
+    lines = [f"Status: {glyphs.checkmark} Enabled"]
+    if row.mcp_connected is False:
+        lines.append("MCP servers need a server restart (/reload) to connect.")
+    return lines
+
+
 def _plugin_details_content(row: _PluginRow) -> Content:
     plugin_name, _, marketplace = row.plugin_id.partition("@")
     parts: list[Content | str] = [
@@ -82,12 +163,11 @@ def _plugin_details_content(row: _PluginRow) -> Content:
         parts.extend(["\n\n", row.description])
     if row.author:
         parts.extend(["\n\n", Content.styled(f"By: {row.author}", "dim")])
+    parts.extend(["\n\n", Content.styled("Will install:", "bold")])
+    for line in _will_install_lines(row):
+        parts.extend(["\n  ", Content.styled(line, "dim")])
     parts.extend(
         [
-            "\n\n",
-            Content.styled("Will install:", "bold"),
-            "\n  ",
-            Content.styled("Components will be discovered at installation.", "dim"),
             "\n\n",
             Content.styled(
                 "Make sure you trust a plugin before installing, updating, "
@@ -100,7 +180,6 @@ def _plugin_details_content(row: _PluginRow) -> Content:
 
 
 def _installed_plugin_details_content(row: _PluginRow) -> Content:
-    glyphs = get_glyphs()
     plugin_name, _, marketplace = row.plugin_id.partition("@")
     parts: list[Content | str] = [
         Content.styled(f"{plugin_name} @ {marketplace}", "bold")
@@ -111,23 +190,13 @@ def _installed_plugin_details_content(row: _PluginRow) -> Content:
         parts.extend(["\n\n", row.description])
     if row.author:
         parts.extend(["\n\n", Content.styled(f"Author: {row.author}", "dim")])
-    status = f"{glyphs.checkmark} Enabled" if row.enabled else "Disabled"
-    parts.extend(
-        [
-            "\n\n",
-            Content.styled(f"Status: {status}", "dim"),
-            "\n\n",
-            Content.styled("Installed components:", "bold"),
-        ]
-    )
-    lines = (
-        [f"Skills: {', '.join(row.skill_names)}"]
-        if row.skill_names
-        else ([f"Skills: {row.skill_count}"] if row.skill_count else [])
-    )
-    if row.mcp_server_names:
-        lines.append(f"MCP: {', '.join(row.mcp_server_names)}")
-    for line in lines or ["No components discovered."]:
+    parts.extend(["\n\n"])
+    for index, line in enumerate(_status_lines(row)):
+        if index:
+            parts.append("\n")
+        parts.append(Content.styled(line, "dim"))
+    parts.extend(["\n\n", Content.styled("Installed components:", "bold")])
+    for line in _installed_component_lines(row):
         parts.extend(["\n  ", Content.styled(line, "dim")])
     return Content.assemble(*parts)
 

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
@@ -109,7 +109,10 @@ def _will_install_lines(row: _PluginRow) -> list[str]:
         ]
     if row.skill_count is None:
         return [
-            "Skills and MCP servers if present (agents/, commands/, and hooks/ are not loaded)."
+            (
+                "Skills and MCP servers if present "
+                "(agents/, commands/, and hooks/ are not loaded)."
+            )
         ]
     return [
         "No supported components (skills/MCP).",

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
@@ -52,6 +52,12 @@ def _plugin_prompt(row: _PluginRow, *, status: str | None) -> Content:
             meta_parts.append(f"{glyphs.checkmark} connected")
         elif row.mcp_connected is False:
             meta_parts.append("restart to connect")
+    elif (
+        row.load_state == "pending_reload"
+        and row.session_loaded
+        and row.mcp_connected is True
+    ):
+        meta_parts.append(f"{glyphs.checkmark} connected")
     if status:
         meta_parts.append(status)
     return Content.assemble(
@@ -141,9 +147,14 @@ def _status_lines(row: _PluginRow) -> list[str]:
     if row.load_state == "disabled":
         return ["Status: Disabled", "Enable the plugin, then run /reload to load it."]
     if row.load_state == "pending_reload":
+        if row.enabled:
+            return [
+                "Status: Installed · pending /reload",
+                "Run /reload to load this plugin into the current session.",
+            ]
         return [
-            "Status: Installed · pending /reload",
-            "Run /reload to load this plugin into the current session.",
+            "Status: Disabled · pending /reload",
+            "Run /reload to unload this plugin from the current session.",
         ]
     lines = [f"Status: {glyphs.checkmark} Enabled"]
     if row.mcp_connected is False:

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/models.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/models.py
@@ -35,11 +35,11 @@ class _PluginRow:
         """Session-aware plugin status for list and detail copy."""
         if self.load_error:
             return "error"
-        if not self.enabled:
-            return "disabled"
-        if not self.session_loaded:
+        if self.enabled != self.session_loaded:
             return "pending_reload"
-        return "enabled"
+        if self.enabled:
+            return "enabled"
+        return "disabled"
 
 
 @dataclass(frozen=True, slots=True)

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/models.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/models.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass
 from typing import Literal
 
+from deepagents_code.plugins.models import UnsupportedComponent
+
 PluginTab = Literal["discover", "installed", "marketplaces", "errors"]
 PluginManagerView = Literal[
     "list",
@@ -15,7 +17,7 @@ PluginManagerView = Literal[
 PluginLoadState = Literal["disabled", "pending_reload", "enabled", "error"]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, kw_only=True)
 class _PluginRow:
     plugin_id: str
     description: str
@@ -26,7 +28,7 @@ class _PluginRow:
     skill_names: tuple[str, ...] = ()
     mcp_connected: bool | None = None
     mcp_server_names: tuple[str, ...] = ()
-    unsupported_components: tuple[str, ...] = ()
+    unsupported_components: tuple[UnsupportedComponent, ...] = ()
     session_loaded: bool = False
     load_error: str | None = None
 

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/models.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/models.py
@@ -12,6 +12,7 @@ PluginManagerView = Literal[
     "marketplace_details",
     "confirm_remove_marketplace",
 ]
+PluginLoadState = Literal["disabled", "pending_reload", "enabled", "error"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,6 +26,20 @@ class _PluginRow:
     skill_names: tuple[str, ...] = ()
     mcp_connected: bool | None = None
     mcp_server_names: tuple[str, ...] = ()
+    unsupported_components: tuple[str, ...] = ()
+    session_loaded: bool = False
+    load_error: str | None = None
+
+    @property
+    def load_state(self) -> PluginLoadState:
+        """Session-aware plugin status for list and detail copy."""
+        if self.load_error:
+            return "error"
+        if not self.enabled:
+            return "disabled"
+        if not self.session_loaded:
+            return "pending_reload"
+        return "enabled"
 
 
 @dataclass(frozen=True, slots=True)

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/state.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/state.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence, Set
+    from collections.abc import Sequence, Set as AbstractSet
 
     from deepagents_code.mcp_tools import MCPServerInfo
     from deepagents_code.plugins.models import (
@@ -191,7 +191,7 @@ def _row_from_instance(
     is_enabled: bool,
     instance: PluginInstance | None,
     mcp_server_info: Sequence[MCPServerInfo],
-    loaded_plugin_ids: Set[str],
+    loaded_plugin_ids: AbstractSet[str],
     load_error: str | None = None,
 ) -> _PluginRow:
     skill_names = _list_plugin_skill_names(instance) if instance else ()
@@ -218,7 +218,7 @@ def _row_from_instance(
 def _load_manager_state(
     mcp_server_info: Sequence[MCPServerInfo] = (),
     *,
-    loaded_plugin_ids: Set[str] = frozenset(),
+    loaded_plugin_ids: AbstractSet[str] = frozenset(),
 ) -> _ManagerState:
     records = load_marketplace_records()
     enabled = load_enabled_plugin_ids()

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/state.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/state.py
@@ -75,14 +75,9 @@ def _list_plugin_skill_names(instance: PluginInstance) -> tuple[str, ...]:
 
 
 def _plugin_mcp_server_names(instance: PluginInstance) -> tuple[str, ...]:
-    from deepagents_code.plugins.adapters.mcp import plugin_mcp_configs
+    from deepagents_code.plugins.adapters.mcp import plugin_mcp_server_names
 
-    names: list[str] = []
-    for config in plugin_mcp_configs((instance,)):
-        servers = config.get("mcpServers")
-        if isinstance(servers, dict):
-            names.extend(key for key in servers if isinstance(key, str))
-    return tuple(dict.fromkeys(names))
+    return plugin_mcp_server_names(instance)
 
 
 def _plugin_mcp_connected(
@@ -109,6 +104,7 @@ def _instance_for_manager_row(
         return None
     entry = get_primary_install_entry(plugin_id)
     if entry is None:
+        errors.append(f"{plugin_id}: no install entry found; re-run install")
         return None
     root = Path(entry.install_path)
     try:
@@ -117,13 +113,12 @@ def _instance_for_manager_row(
         errors.append(f"{plugin_id}: could not inspect install path: {exc}")
         return None
     if not installed:
+        errors.append(f"{plugin_id}: install cache missing at {root}; re-run install")
         return None
     from deepagents_code.plugins.discovery import _plugin_from_install_path
 
-    try:
-        plugin_name, marketplace_name = split_plugin_id(plugin_id)
-    except ValueError:
-        return None
+    # plugin_id is built as `{name}@{marketplace}`, so split_plugin_id cannot fail.
+    plugin_name, marketplace_name = split_plugin_id(plugin_id)
     try:
         loaded, warnings = _plugin_from_install_path(
             plugin_id=plugin_id,
@@ -164,10 +159,8 @@ def _preview_local_plugin_instance(
         return None
     from deepagents_code.plugins.discovery import _plugin_from_install_path
 
-    try:
-        plugin_name, marketplace_name = split_plugin_id(plugin_id)
-    except ValueError:
-        return None
+    # plugin_id is built as `{name}@{marketplace}`, so split_plugin_id cannot fail.
+    plugin_name, marketplace_name = split_plugin_id(plugin_id)
     try:
         loaded, warnings = _plugin_from_install_path(
             plugin_id=plugin_id,
@@ -178,7 +171,8 @@ def _preview_local_plugin_instance(
     except (OSError, RuntimeError) as exc:
         errors.append(f"{plugin_id}: {exc}")
         return None
-    # Preview warnings stay on the instance inventory; avoid flooding Errors.
+    # Preview is best-effort: inventory warnings are intentionally not surfaced
+    # for un-installed plugins (they reach Errors once the plugin is installed).
     _ = warnings
     return loaded
 
@@ -197,20 +191,21 @@ def _row_from_instance(
     skill_names = _list_plugin_skill_names(instance) if instance else ()
     mcp_names = _plugin_mcp_server_names(instance) if instance else ()
     unsupported = instance.inventory.unsupported if instance else ()
+    session_loaded = plugin_id in loaded_plugin_ids
     return _PluginRow(
-        plugin_id,
-        description,
-        is_enabled,
-        instance.version if instance else None,
-        author,
-        len(skill_names) if instance else None,
-        skill_names,
-        _plugin_mcp_connected(instance, mcp_server_info)
-        if instance and plugin_id in loaded_plugin_ids
+        plugin_id=plugin_id,
+        description=description,
+        enabled=is_enabled,
+        version=instance.version if instance else None,
+        author=author,
+        skill_count=len(skill_names) if instance else None,
+        skill_names=skill_names,
+        mcp_connected=_plugin_mcp_connected(instance, mcp_server_info)
+        if instance and session_loaded
         else None,
-        mcp_names,
-        unsupported,
-        session_loaded=plugin_id in loaded_plugin_ids,
+        mcp_server_names=mcp_names,
+        unsupported_components=unsupported,
+        session_loaded=session_loaded,
         load_error=load_error,
     )
 

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/state.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/state.py
@@ -206,11 +206,11 @@ def _row_from_instance(
         len(skill_names) if instance else None,
         skill_names,
         _plugin_mcp_connected(instance, mcp_server_info)
-        if instance and is_enabled and plugin_id in loaded_plugin_ids
+        if instance and plugin_id in loaded_plugin_ids
         else None,
         mcp_names,
         unsupported,
-        session_loaded=is_enabled and plugin_id in loaded_plugin_ids,
+        session_loaded=plugin_id in loaded_plugin_ids,
         load_error=load_error,
     )
 

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/state.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/state.py
@@ -7,19 +7,24 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Sequence, Set
 
     from deepagents_code.mcp_tools import MCPServerInfo
-    from deepagents_code.plugins.models import PluginInstance
+    from deepagents_code.plugins.models import (
+        MarketplacePluginEntry,
+        PluginInstance,
+        PluginMarketplace,
+    )
 
 from deepagents_code.plugins import discover_plugins
 from deepagents_code.plugins.marketplace import (
     MarketplaceError,
     load_marketplace_location,
+    materialize_plugin_source,
     redact_marketplace_source,
     redact_urls_in_text,
 )
-from deepagents_code.plugins.models import split_plugin_id
+from deepagents_code.plugins.models import LocalPluginSource, split_plugin_id
 from deepagents_code.plugins.store import (
     get_primary_install_entry,
     load_enabled_plugin_ids,
@@ -133,7 +138,88 @@ def _instance_for_manager_row(
     return loaded
 
 
-def _load_manager_state(mcp_server_info: Sequence[MCPServerInfo] = ()) -> _ManagerState:
+def _preview_local_plugin_instance(
+    marketplace: PluginMarketplace,
+    plugin: MarketplacePluginEntry,
+    *,
+    plugin_id: str,
+    errors: list[str],
+) -> PluginInstance | None:
+    """Build a preview instance from a local marketplace source (no network).
+
+    Returns:
+        A plugin instance when the local source resolves, otherwise `None`.
+    """
+    if not isinstance(plugin.source, LocalPluginSource):
+        return None
+    root = materialize_plugin_source(marketplace, plugin)
+    if root is None:
+        return None
+    try:
+        exists = root.is_dir()
+    except (OSError, RuntimeError) as exc:
+        errors.append(f"{plugin_id}: could not inspect source path: {exc}")
+        return None
+    if not exists:
+        return None
+    from deepagents_code.plugins.discovery import _plugin_from_install_path
+
+    try:
+        plugin_name, marketplace_name = split_plugin_id(plugin_id)
+    except ValueError:
+        return None
+    try:
+        loaded, warnings = _plugin_from_install_path(
+            plugin_id=plugin_id,
+            root=root,
+            marketplace_name=marketplace_name,
+            fallback_name=plugin_name,
+        )
+    except (OSError, RuntimeError) as exc:
+        errors.append(f"{plugin_id}: {exc}")
+        return None
+    # Preview warnings stay on the instance inventory; avoid flooding Errors.
+    _ = warnings
+    return loaded
+
+
+def _row_from_instance(
+    *,
+    plugin_id: str,
+    description: str,
+    author: str | None,
+    is_enabled: bool,
+    instance: PluginInstance | None,
+    mcp_server_info: Sequence[MCPServerInfo],
+    loaded_plugin_ids: Set[str],
+    load_error: str | None = None,
+) -> _PluginRow:
+    skill_names = _list_plugin_skill_names(instance) if instance else ()
+    mcp_names = _plugin_mcp_server_names(instance) if instance else ()
+    unsupported = instance.inventory.unsupported if instance else ()
+    return _PluginRow(
+        plugin_id,
+        description,
+        is_enabled,
+        instance.version if instance else None,
+        author,
+        len(skill_names) if instance else None,
+        skill_names,
+        _plugin_mcp_connected(instance, mcp_server_info)
+        if instance and is_enabled and plugin_id in loaded_plugin_ids
+        else None,
+        mcp_names,
+        unsupported,
+        session_loaded=is_enabled and plugin_id in loaded_plugin_ids,
+        load_error=load_error,
+    )
+
+
+def _load_manager_state(
+    mcp_server_info: Sequence[MCPServerInfo] = (),
+    *,
+    loaded_plugin_ids: Set[str] = frozenset(),
+) -> _ManagerState:
     records = load_marketplace_records()
     enabled = load_enabled_plugin_ids()
     installed = load_installed_plugins()
@@ -180,26 +266,37 @@ def _load_manager_state(mcp_server_info: Sequence[MCPServerInfo] = ()) -> _Manag
             plugin_id = f"{plugin.name}@{marketplace.name}"
             is_enabled = plugin_id in enabled
             is_installed = plugin_id in installed
+            row_errors: list[str] = []
             instance = _instance_for_manager_row(
                 plugin_id,
                 discovered=discovered,
                 is_installed=is_installed,
-                errors=errors,
+                errors=row_errors,
             )
-            skill_names = _list_plugin_skill_names(instance) if instance else ()
-            mcp_names = _plugin_mcp_server_names(instance) if instance else ()
-            row = _PluginRow(
-                plugin_id,
-                plugin.description or "",
-                is_enabled,
-                instance.version if instance else None,
-                _extract_name(plugin.author),
-                len(skill_names) if instance else None,
-                skill_names,
-                _plugin_mcp_connected(instance, mcp_server_info)
-                if instance and is_enabled
-                else None,
-                mcp_names,
+            if instance is None and not is_installed:
+                instance = _preview_local_plugin_instance(
+                    marketplace,
+                    plugin,
+                    plugin_id=plugin_id,
+                    errors=row_errors,
+                )
+            errors.extend(row_errors)
+            load_error: str | None = None
+            if is_installed and instance is None:
+                load_error = (
+                    row_errors[0]
+                    if row_errors
+                    else "installed plugin could not be loaded"
+                )
+            row = _row_from_instance(
+                plugin_id=plugin_id,
+                description=plugin.description or "",
+                author=_extract_name(plugin.author),
+                is_enabled=is_enabled,
+                instance=instance,
+                mcp_server_info=mcp_server_info,
+                loaded_plugin_ids=loaded_plugin_ids,
+                load_error=load_error,
             )
             (installed_plugins if is_installed else available_plugins).append(row)
     return _ManagerState(

--- a/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
@@ -1381,6 +1381,30 @@ def test_manager_state_surfaces_unsupported_components_for_agents_plugin(
     assert row.load_state == "pending_reload"
 
 
+def test_manager_state_keeps_pending_reload_after_disable_while_loaded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+    marketplace_root = tmp_path / "marketplace"
+    _make_marketplace(marketplace_root)
+    add_local_marketplace(marketplace_root)
+    plugin_id = "quality-review-plugin@company-tools"
+    install_plugin(plugin_id)
+    set_installed_plugin_enabled(plugin_id, enabled=False)
+
+    state = _load_manager_state(loaded_plugin_ids=frozenset({plugin_id}))
+    row = next(r for r in state.installed_plugins if r.plugin_id == plugin_id)
+
+    assert row.enabled is False
+    assert row.session_loaded is True
+    assert row.load_state == "pending_reload"
+
+
 def test_manager_state_previews_local_discover_components(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
@@ -60,6 +60,7 @@ from deepagents_code.plugins.store import (
     load_enabled_plugin_ids,
     load_installed_plugins,
     load_marketplace_records,
+    plugin_data_dir,
     sanitize_plugin_id,
     save_marketplace_record,
     set_plugin_enabled,
@@ -1257,3 +1258,55 @@ def test_manager_state_previews_local_discover_components(
     assert any(
         name.endswith("__docs") or name == "docs" for name in row.mcp_server_names
     )
+
+
+def test_manager_preview_does_not_create_plugin_data_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+    marketplace_root = tmp_path / "marketplace"
+    _make_marketplace(marketplace_root)
+    add_local_marketplace(marketplace_root)
+    plugin_id = "quality-review-plugin@company-tools"
+    data_dir = plugin_data_dir(plugin_id)
+
+    assert not data_dir.exists()
+
+    state = _load_manager_state()
+
+    assert any(row.plugin_id == plugin_id for row in state.available_plugins)
+    assert not data_dir.exists()
+
+
+def test_manager_state_marks_installed_plugin_with_missing_cache_as_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+    marketplace_root = tmp_path / "marketplace"
+    _make_marketplace(marketplace_root)
+    add_local_marketplace(marketplace_root)
+    plugin_id = "quality-review-plugin@company-tools"
+    install_plugin(plugin_id)
+
+    entry = get_primary_install_entry(plugin_id)
+    assert entry is not None
+    shutil.rmtree(entry.install_path)
+
+    state = _load_manager_state(loaded_plugin_ids=frozenset())
+    row = next(r for r in state.installed_plugins if r.plugin_id == plugin_id)
+
+    assert row.load_state == "error"
+    assert row.load_error is not None
+    assert "re-run install" in row.load_error
+    # The actionable reason also reaches the Errors tab, not just the row.
+    assert any("re-run install" in err for err in state.errors)

--- a/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 import pytest
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.middleware.skills import _list_skills as list_sdk_skills
-from textual.widgets import OptionList
+from textual.widgets import Input, OptionList
 
 from deepagents_code._env_vars import EXPERIMENTAL
 from deepagents_code.app import DeepAgentsApp
@@ -145,6 +145,78 @@ def _add_docs_helper_plugin(root: Path) -> None:
         {"name": "docs-helper", "version": "1.0.0"},
     )
     _write_skill(plugin / "skills" / "lookup" / "SKILL.md", name="lookup")
+
+
+async def test_plugin_manager_installed_selection_opens_details_not_disable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+    marketplace_root = tmp_path / "marketplace"
+    _make_marketplace(marketplace_root)
+    add_local_marketplace(marketplace_root)
+    install_plugin("quality-review-plugin@company-tools")
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        screen = PluginManagerScreen(
+            loaded_plugin_ids=frozenset({"quality-review-plugin@company-tools"})
+        )
+        app.push_screen(screen)
+        await pilot.pause()
+
+        await pilot.press("right")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        detail = str(screen.query_one("#plugin-manager-status").render())
+        options = screen.query_one("#plugin-manager-options", OptionList)
+        assert "quality-review-plugin @ company-tools" in detail
+        assert "Installed components:" in detail
+        assert "Status:" in detail
+        assert "Enabled" in detail
+        assert "pending /reload" not in detail
+        assert "Disable plugin" in str(options.get_option_at_index(0).prompt)
+        assert "quality-review-plugin@company-tools" in load_enabled_plugin_ids()
+
+
+async def test_plugin_manager_installed_row_shows_restart_hint_before_connect(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+    marketplace_root = tmp_path / "marketplace"
+    _make_marketplace(marketplace_root)
+    add_local_marketplace(marketplace_root)
+    plugin_id = "quality-review-plugin@company-tools"
+    install_plugin(plugin_id)
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        screen = PluginManagerScreen(loaded_plugin_ids=frozenset({plugin_id}))
+        app.push_screen(screen)
+        await pilot.pause()
+
+        await pilot.press("right")
+        await pilot.pause()
+
+        options = screen.query_one("#plugin-manager-options", OptionList)
+        prompt = str(options.get_option_at_index(0).prompt)
+        assert "restart to connect" in prompt
+        assert "connected" not in prompt.replace("restart to connect", "")
 
 
 def test_plugin_manager_uses_recursive_skill_inventory(
@@ -644,6 +716,109 @@ async def test_plugin_manager_confirms_marketplace_removal(
     assert "company-tools" not in load_marketplace_records()
     assert not load_installed_plugins()
     assert marketplace_root.is_dir()
+
+
+async def test_plugin_manager_opens_add_marketplace_input(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        screen = PluginManagerScreen()
+        app.push_screen(screen)
+        await pilot.pause()
+
+        options = screen.query_one("#plugin-manager-options", OptionList)
+        assert options.option_count == 1
+        assert "No plugins available" in str(options.get_option_at_index(0).prompt)
+
+        await pilot.press("right")
+        await pilot.pause()
+        await pilot.press("right")
+        await pilot.pause()
+        assert "> Marketplaces <" in str(
+            screen.query_one("#plugin-manager-tabs").render()
+        )
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        source_input = screen.query_one("#plugin-marketplace-source", Input)
+        assert source_input.display is True
+        assert source_input.has_focus
+        assert (
+            str(screen.query_one("#plugin-manager-title").render()) == "Add Marketplace"
+        )
+        assert screen.query_one("#plugin-manager-tabs").display is False
+        tip = str(screen.query_one("#plugin-manager-status").render())
+        assert "Enter marketplace source:" in tip
+        assert "Examples:" in tip
+        assert "owner/repo (GitHub)" in tip
+        assert "git@github.com:owner/repo.git (SSH)" in tip
+        assert "https://example.com/marketplace.json" in tip
+        assert "./path/to/marketplace" in tip
+        help_text = str(screen.query_one("#plugin-manager-help").render())
+        assert "Enter to add" in help_text
+        assert "Esc to cancel" in help_text
+
+
+async def test_plugin_manager_discover_rows_show_description_below_name(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+    marketplace_root = tmp_path / "marketplace"
+    _make_marketplace(marketplace_root)
+    add_local_marketplace(marketplace_root)
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        screen = PluginManagerScreen()
+        app.push_screen(screen)
+        await pilot.pause()
+
+        options = screen.query_one("#plugin-manager-options", OptionList)
+        prompt = str(options.get_option_at_index(0).prompt)
+
+        assert "quality-review-plugin · Plugin · company-tools" in prompt
+        assert "\n  Quality review" in prompt
+
+
+async def test_plugin_manager_tabs_label_plugins_not_discover(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        screen = PluginManagerScreen()
+        app.push_screen(screen)
+        await pilot.pause()
+
+        tabs = str(screen.query_one("#plugin-manager-tabs").render())
+        assert "> Plugins <" in tabs
+        assert "Discover" not in tabs
 
 
 def test_plugin_mcp_config_namespaces_and_substitutes(

--- a/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 import pytest
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.middleware.skills import _list_skills as list_sdk_skills
-from textual.widgets import Input, OptionList
+from textual.widgets import OptionList
 
 from deepagents_code._env_vars import EXPERIMENTAL
 from deepagents_code.app import DeepAgentsApp
@@ -144,76 +144,6 @@ def _add_docs_helper_plugin(root: Path) -> None:
         {"name": "docs-helper", "version": "1.0.0"},
     )
     _write_skill(plugin / "skills" / "lookup" / "SKILL.md", name="lookup")
-
-
-async def test_plugin_manager_installed_selection_opens_details_not_disable(
-    tmp_path: Path, monkeypatch
-) -> None:
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
-    )
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
-    )
-    marketplace_root = tmp_path / "marketplace"
-    _make_marketplace(marketplace_root)
-    add_local_marketplace(marketplace_root)
-    install_plugin("quality-review-plugin@company-tools")
-
-    app = DeepAgentsApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-
-        screen = PluginManagerScreen(loaded_plugin_ids=app._session_plugin_ids)
-        app.push_screen(screen)
-        await pilot.pause()
-
-        await pilot.press("right")
-        await pilot.pause()
-        await pilot.press("enter")
-        await pilot.pause()
-
-        detail = str(screen.query_one("#plugin-manager-status").render())
-        options = screen.query_one("#plugin-manager-options", OptionList)
-        assert "quality-review-plugin @ company-tools" in detail
-        assert "Installed components:" in detail
-        assert "Status:" in detail
-        assert "Enabled" in detail
-        assert "pending /reload" not in detail
-        assert "Disable plugin" in str(options.get_option_at_index(0).prompt)
-        assert "quality-review-plugin@company-tools" in load_enabled_plugin_ids()
-
-
-async def test_plugin_manager_installed_row_shows_restart_hint_before_connect(
-    tmp_path: Path, monkeypatch
-) -> None:
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
-    )
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
-    )
-    marketplace_root = tmp_path / "marketplace"
-    _make_marketplace(marketplace_root)
-    add_local_marketplace(marketplace_root)
-    plugin_id = "quality-review-plugin@company-tools"
-    install_plugin(plugin_id)
-
-    app = DeepAgentsApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-
-        screen = PluginManagerScreen(loaded_plugin_ids=frozenset({plugin_id}))
-        app.push_screen(screen)
-        await pilot.pause()
-
-        await pilot.press("right")
-        await pilot.pause()
-
-        options = screen.query_one("#plugin-manager-options", OptionList)
-        prompt = str(options.get_option_at_index(0).prompt)
-        assert "restart to connect" in prompt
-        assert "connected" not in prompt.replace("restart to connect", "")
 
 
 def test_plugin_manager_uses_recursive_skill_inventory(
@@ -713,109 +643,6 @@ async def test_plugin_manager_confirms_marketplace_removal(
     assert "company-tools" not in load_marketplace_records()
     assert not load_installed_plugins()
     assert marketplace_root.is_dir()
-
-
-async def test_plugin_manager_opens_add_marketplace_input(
-    tmp_path: Path, monkeypatch
-) -> None:
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
-    )
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
-    )
-
-    app = DeepAgentsApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-
-        screen = PluginManagerScreen()
-        app.push_screen(screen)
-        await pilot.pause()
-
-        options = screen.query_one("#plugin-manager-options", OptionList)
-        assert options.option_count == 1
-        assert "No plugins available" in str(options.get_option_at_index(0).prompt)
-
-        await pilot.press("right")
-        await pilot.pause()
-        await pilot.press("right")
-        await pilot.pause()
-        assert "> Marketplaces <" in str(
-            screen.query_one("#plugin-manager-tabs").render()
-        )
-
-        await pilot.press("enter")
-        await pilot.pause()
-
-        source_input = screen.query_one("#plugin-marketplace-source", Input)
-        assert source_input.display is True
-        assert source_input.has_focus
-        assert (
-            str(screen.query_one("#plugin-manager-title").render()) == "Add Marketplace"
-        )
-        assert screen.query_one("#plugin-manager-tabs").display is False
-        tip = str(screen.query_one("#plugin-manager-status").render())
-        assert "Enter marketplace source:" in tip
-        assert "Examples:" in tip
-        assert "owner/repo (GitHub)" in tip
-        assert "git@github.com:owner/repo.git (SSH)" in tip
-        assert "https://example.com/marketplace.json" in tip
-        assert "./path/to/marketplace" in tip
-        help_text = str(screen.query_one("#plugin-manager-help").render())
-        assert "Enter to add" in help_text
-        assert "Esc to cancel" in help_text
-
-
-async def test_plugin_manager_discover_rows_show_description_below_name(
-    tmp_path: Path, monkeypatch
-) -> None:
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
-    )
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
-    )
-    marketplace_root = tmp_path / "marketplace"
-    _make_marketplace(marketplace_root)
-    add_local_marketplace(marketplace_root)
-
-    app = DeepAgentsApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-
-        screen = PluginManagerScreen()
-        app.push_screen(screen)
-        await pilot.pause()
-
-        options = screen.query_one("#plugin-manager-options", OptionList)
-        prompt = str(options.get_option_at_index(0).prompt)
-
-        assert "quality-review-plugin · Plugin · company-tools" in prompt
-        assert "\n  Quality review" in prompt
-
-
-async def test_plugin_manager_tabs_label_plugins_not_discover(
-    tmp_path: Path, monkeypatch
-) -> None:
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
-    )
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
-    )
-
-    app = DeepAgentsApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-
-        screen = PluginManagerScreen()
-        app.push_screen(screen)
-        await pilot.pause()
-
-        tabs = str(screen.query_one("#plugin-manager-tabs").render())
-        assert "> Plugins <" in tabs
-        assert "Discover" not in tabs
 
 
 def test_plugin_mcp_config_namespaces_and_substitutes(
@@ -1430,37 +1257,3 @@ def test_manager_state_previews_local_discover_components(
     assert any(
         name.endswith("__docs") or name == "docs" for name in row.mcp_server_names
     )
-
-
-async def test_plugin_manager_shows_pending_reload_until_session_loaded(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
-    )
-    monkeypatch.setattr(
-        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
-    )
-    marketplace_root = tmp_path / "marketplace"
-    _make_marketplace(marketplace_root)
-    add_local_marketplace(marketplace_root)
-    plugin_id = "quality-review-plugin@company-tools"
-    install_plugin(plugin_id)
-
-    app = DeepAgentsApp()
-    async with app.run_test() as pilot:
-        await pilot.pause()
-
-        screen = PluginManagerScreen(loaded_plugin_ids=frozenset())
-        app.push_screen(screen)
-        await pilot.pause()
-
-        await pilot.press("right")
-        await pilot.pause()
-        await pilot.press("enter")
-        await pilot.pause()
-
-        detail = str(screen.query_one("#plugin-manager-status").render())
-        assert "pending /reload" in detail
-        assert f"{get_glyphs().checkmark} Enabled" not in detail
-        assert "Run /reload" in detail

--- a/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
@@ -164,7 +164,7 @@ async def test_plugin_manager_installed_selection_opens_details_not_disable(
     async with app.run_test() as pilot:
         await pilot.pause()
 
-        screen = PluginManagerScreen()
+        screen = PluginManagerScreen(loaded_plugin_ids=app._session_plugin_ids)
         app.push_screen(screen)
         await pilot.pause()
 
@@ -177,6 +177,9 @@ async def test_plugin_manager_installed_selection_opens_details_not_disable(
         options = screen.query_one("#plugin-manager-options", OptionList)
         assert "quality-review-plugin @ company-tools" in detail
         assert "Installed components:" in detail
+        assert "Status:" in detail
+        assert "Enabled" in detail
+        assert "pending /reload" not in detail
         assert "Disable plugin" in str(options.get_option_at_index(0).prompt)
         assert "quality-review-plugin@company-tools" in load_enabled_plugin_ids()
 
@@ -193,13 +196,14 @@ async def test_plugin_manager_installed_row_shows_restart_hint_before_connect(
     marketplace_root = tmp_path / "marketplace"
     _make_marketplace(marketplace_root)
     add_local_marketplace(marketplace_root)
-    install_plugin("quality-review-plugin@company-tools")
+    plugin_id = "quality-review-plugin@company-tools"
+    install_plugin(plugin_id)
 
     app = DeepAgentsApp()
     async with app.run_test() as pilot:
         await pilot.pause()
 
-        screen = PluginManagerScreen()
+        screen = PluginManagerScreen(loaded_plugin_ids=frozenset({plugin_id}))
         app.push_screen(screen)
         await pilot.pause()
 
@@ -1301,3 +1305,138 @@ async def test_plugin_manager_renders_bracketed_errors_as_plain_text(
 
         options = screen.query_one("#plugin-manager-options", OptionList)
         assert "failure [plugin]" in str(options.get_option_at_index(0).prompt)
+
+
+def _make_agents_only_plugin(root: Path) -> None:
+    """Marketplace plugin shaped like Claude's `pr-review-toolkit`."""
+    _write_json(
+        root / ".claude-plugin" / "marketplace.json",
+        {
+            "name": "claude-plugins-official",
+            "owner": {"name": "Anthropic"},
+            "plugins": [
+                {
+                    "name": "pr-review-toolkit",
+                    "source": "./plugins/pr-review-toolkit",
+                    "description": "PR review agents",
+                }
+            ],
+        },
+    )
+    plugin = root / "plugins" / "pr-review-toolkit"
+    _write_json(
+        plugin / ".claude-plugin" / "plugin.json",
+        {
+            "name": "pr-review-toolkit",
+            "version": "1.0.0",
+            "description": "PR review agents",
+        },
+    )
+    (plugin / "agents").mkdir(parents=True)
+    (plugin / "agents" / "reviewer.md").write_text("# Reviewer\n", encoding="utf-8")
+    (plugin / "commands").mkdir(parents=True)
+    (plugin / "commands" / "review-pr.md").write_text("# Review\n", encoding="utf-8")
+
+
+def test_inventory_reports_unsupported_agents_and_commands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+    marketplace_root = tmp_path / "marketplace"
+    _make_agents_only_plugin(marketplace_root)
+    add_local_marketplace(marketplace_root)
+    instance = install_plugin("pr-review-toolkit@claude-plugins-official")
+
+    assert instance.inventory.skills == ()
+    assert instance.inventory.mcp_files == ()
+    assert instance.inventory.unsupported == ("agents", "commands")
+
+
+def test_manager_state_surfaces_unsupported_components_for_agents_plugin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+    marketplace_root = tmp_path / "marketplace"
+    _make_agents_only_plugin(marketplace_root)
+    add_local_marketplace(marketplace_root)
+    plugin_id = "pr-review-toolkit@claude-plugins-official"
+    install_plugin(plugin_id)
+
+    state = _load_manager_state(loaded_plugin_ids=frozenset())
+    row = next(r for r in state.installed_plugins if r.plugin_id == plugin_id)
+
+    assert row.unsupported_components == ("agents", "commands")
+    assert row.skill_names == ()
+    assert row.mcp_server_names == ()
+    assert row.load_state == "pending_reload"
+
+
+def test_manager_state_previews_local_discover_components(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+    marketplace_root = tmp_path / "marketplace"
+    _make_marketplace(marketplace_root)
+    add_local_marketplace(marketplace_root)
+
+    state = _load_manager_state()
+    row = next(
+        r
+        for r in state.available_plugins
+        if r.plugin_id == "quality-review-plugin@company-tools"
+    )
+
+    assert row.skill_count == 1
+    assert any(name.endswith(":review") for name in row.skill_names)
+    assert any(
+        name.endswith("__docs") or name == "docs" for name in row.mcp_server_names
+    )
+
+
+async def test_plugin_manager_shows_pending_reload_until_session_loaded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / "state"
+    )
+    monkeypatch.setattr(
+        "deepagents_code.model_config.DEFAULT_CONFIG_DIR", tmp_path / "config"
+    )
+    marketplace_root = tmp_path / "marketplace"
+    _make_marketplace(marketplace_root)
+    add_local_marketplace(marketplace_root)
+    plugin_id = "quality-review-plugin@company-tools"
+    install_plugin(plugin_id)
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        screen = PluginManagerScreen(loaded_plugin_ids=frozenset())
+        app.push_screen(screen)
+        await pilot.pause()
+
+        await pilot.press("right")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        detail = str(screen.query_one("#plugin-manager-status").render())
+        assert "pending /reload" in detail
+        assert f"{get_glyphs().checkmark} Enabled" not in detail
+        assert "Run /reload" in detail

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -20042,6 +20042,30 @@ class TestPrewarmAwait:
             f"prewarm must precede skill discovery thread; got {call_order}"
         )
 
+    def test_constructor_does_not_discover_plugins(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Plugin filesystem discovery must stay off the pre-paint hot path."""
+        from deepagents_code._env_vars import EXPERIMENTAL
+
+        monkeypatch.setenv(EXPERIMENTAL, "1")
+        with patch("deepagents_code.plugins.discover_plugins") as discover_mock:
+            app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+
+        discover_mock.assert_not_called()
+        assert app._session_plugin_ids == frozenset()
+
+    async def test_startup_skill_discovery_records_loaded_plugin_ids(self) -> None:
+        """The post-paint discovery result initializes running session state."""
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        app._discovered_plugin_ids = frozenset({"quality@tools"})
+
+        with patch.object(app, "_discover_skills", AsyncMock(return_value=True)):
+            discovered = await app._discover_startup_skills()
+
+        assert discovered is True
+        assert app._session_plugin_ids == frozenset({"quality@tools"})
+
     async def test_discover_skills_prewarm_failure_warns_with_debug_hint(
         self,
     ) -> None:

--- a/libs/code/tests/unit_tests/test_reload.py
+++ b/libs/code/tests/unit_tests/test_reload.py
@@ -1087,7 +1087,7 @@ class TestReloadPluginsViaReload:
         from deepagents_code.app import DeepAgentsApp
         from deepagents_code.tui.widgets.messages import AppMessage
 
-        monkeypatch.delenv(EXPERIMENTAL, raising=False)
+        monkeypatch.setenv(EXPERIMENTAL, "0")
 
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
@@ -1103,3 +1103,53 @@ class TestReloadPluginsViaReload:
 
             text = "\n".join(str(w._content) for w in app.query(AppMessage))
             assert "Plugins:" not in text
+
+    @pytest.mark.parametrize(
+        ("restarted", "expected_ids"),
+        [
+            (False, frozenset({"old@tools"})),
+            (True, frozenset({"new@tools"})),
+        ],
+    )
+    async def test_updates_loaded_ids_only_after_successful_restart(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        restarted: bool,
+        expected_ids: frozenset[str],
+    ) -> None:
+        """A failed restart leaves the prior server's plugin status intact."""
+        from deepagents_code._env_vars import EXPERIMENTAL
+        from deepagents_code.app import DeepAgentsApp
+        from deepagents_code.plugins.models import PluginDiscoveryResult
+
+        monkeypatch.setenv(EXPERIMENTAL, "1")
+        plugin = MagicMock(plugin_id="new@tools")
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._session_plugin_ids = frozenset({"old@tools"})
+            app._server_proc = MagicMock()
+            app._server_kwargs = {}
+
+            async def _fake_discover() -> bool:  # noqa: RUF029
+                return True
+
+            async def _fake_restart() -> bool:  # noqa: RUF029
+                return restarted
+
+            monkeypatch.setattr(app, "_discover_skills", _fake_discover)
+            monkeypatch.setattr(app, "_restart_server_manual", _fake_restart)
+            monkeypatch.setattr(app, "_discard_queue", lambda: None)
+            monkeypatch.setattr(
+                "deepagents_code.plugins.discover_plugins",
+                lambda: PluginDiscoveryResult(plugins=(plugin,)),
+            )
+            monkeypatch.setattr(
+                "deepagents_code.plugins.adapters.mcp.plugin_mcp_configs",
+                lambda _plugins: (),
+            )
+
+            await app._handle_command("/reload")
+            await pilot.pause()
+
+            assert app._session_plugin_ids == expected_ids

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -1,8 +1,13 @@
 """Tests for the plugin manager modal structure."""
 
 import inspect
+import re
 from pathlib import Path
+from unittest.mock import MagicMock
 
+from textual.widgets import Static
+
+from deepagents_code.app import DeepAgentsApp
 from deepagents_code.config import get_glyphs
 from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
 from deepagents_code.tui.modals.plugin_manager.content import (
@@ -263,3 +268,26 @@ def test_plugin_prompt_pending_reload_keeps_connected_when_still_loaded() -> Non
 
     assert "pending /reload" in prompt
     assert f"{checkmark} connected" in prompt
+
+
+async def test_plugin_manager_overlays_underlying_content() -> None:
+    """Transparent modal backdrop must composite the screen underneath."""
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.theme = "textual-dark"
+        await pilot.pause()
+
+        await app.mount(Static("TOP_MARKER_VISIBLE", id="top-marker"))
+        marker = app.query_one("#top-marker")
+        marker.styles.dock = "top"
+        marker.styles.height = 1
+        await pilot.pause()
+
+        app.push_screen(PluginManagerScreen())
+        await pilot.pause()
+
+        assert app.screen.styles.background.a == 0
+        plain = re.sub(r"<[^>]+>", " ", app.export_screenshot())
+        assert "TOP_MARKER_VISIBLE" in plain
+        assert "Plugins" in plain

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -7,8 +7,10 @@ from deepagents_code.config import get_glyphs
 from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
 from deepagents_code.tui.modals.plugin_manager.content import (
     _installed_plugin_details_content,
+    _load_state_label,
     _plugin_details_content,
     _plugin_options,
+    _plugin_prompt,
 )
 from deepagents_code.tui.modals.plugin_manager.models import _PluginRow
 
@@ -22,8 +24,20 @@ def test_plugin_manager_css_is_colocated_with_screen() -> None:
 
 def test_plugin_options_preserve_selectable_rows_and_spacers() -> None:
     rows = (
-        _PluginRow("first@source", "First", False, None, None),
-        _PluginRow("second@source", "Second", True, "1.0", "Author"),
+        _PluginRow(
+            plugin_id="first@source",
+            description="First",
+            enabled=False,
+            version=None,
+            author=None,
+        ),
+        _PluginRow(
+            plugin_id="second@source",
+            description="Second",
+            enabled=True,
+            version="1.0",
+            author="Author",
+        ),
     )
 
     options = _plugin_options(rows, action="detail", status=None)
@@ -38,11 +52,11 @@ def test_plugin_options_preserve_selectable_rows_and_spacers() -> None:
 
 def test_plugin_details_content_lists_preview_components() -> None:
     row = _PluginRow(
-        "quality@tools",
-        "Quality review",
-        False,
-        "1.0.0",
-        "Team",
+        plugin_id="quality@tools",
+        description="Quality review",
+        enabled=False,
+        version="1.0.0",
+        author="Team",
         skill_count=1,
         skill_names=("quality@tools:review",),
         mcp_server_names=("docs",),
@@ -58,11 +72,11 @@ def test_plugin_details_content_lists_preview_components() -> None:
 
 def test_installed_details_explain_unsupported_components() -> None:
     row = _PluginRow(
-        "pr-review-toolkit@official",
-        "PR review",
-        True,
-        "1.0.0",
-        None,
+        plugin_id="pr-review-toolkit@official",
+        description="PR review",
+        enabled=True,
+        version="1.0.0",
+        author=None,
         skill_count=0,
         unsupported_components=("agents", "commands"),
         session_loaded=True,
@@ -79,11 +93,11 @@ def test_installed_details_explain_unsupported_components() -> None:
 
 def test_installed_details_pending_reload_not_enabled() -> None:
     row = _PluginRow(
-        "quality@tools",
-        "Quality",
-        True,
-        "1.0.0",
-        None,
+        plugin_id="quality@tools",
+        description="Quality",
+        enabled=True,
+        version="1.0.0",
+        author=None,
         skill_count=1,
         skill_names=("quality@tools:review",),
         session_loaded=False,
@@ -98,11 +112,11 @@ def test_installed_details_pending_reload_not_enabled() -> None:
 
 def test_installed_details_pending_reload_after_disable() -> None:
     row = _PluginRow(
-        "quality@tools",
-        "Quality",
-        False,
-        "1.0.0",
-        None,
+        plugin_id="quality@tools",
+        description="Quality",
+        enabled=False,
+        version="1.0.0",
+        author=None,
         skill_count=1,
         skill_names=("quality@tools:review",),
         session_loaded=True,
@@ -114,3 +128,138 @@ def test_installed_details_pending_reload_after_disable() -> None:
     assert "Status: Disabled · pending /reload" in content
     assert "unload this plugin" in content
     assert "Status: Disabled\n" not in content
+
+
+def test_installed_details_error_state_shows_reason_and_fix() -> None:
+    row = _PluginRow(
+        plugin_id="broken@tools",
+        description="Broken",
+        enabled=True,
+        version=None,
+        author=None,
+        session_loaded=False,
+        load_error="install cache missing at /x; re-run install",
+    )
+
+    assert row.load_state == "error"
+    content = str(_installed_plugin_details_content(row))
+
+    assert "Status: Error — install cache missing at /x; re-run install" in content
+    assert "Fix the error, then run /reload." in content
+
+
+def test_installed_details_disabled_state_copy() -> None:
+    row = _PluginRow(
+        plugin_id="quality@tools",
+        description="Quality",
+        enabled=False,
+        version="1.0.0",
+        author=None,
+        skill_count=1,
+        skill_names=("quality@tools:review",),
+        session_loaded=False,
+    )
+
+    assert row.load_state == "disabled"
+    content = str(_installed_plugin_details_content(row))
+
+    assert "Status: Disabled" in content
+    assert "Enable the plugin, then run /reload to load it." in content
+
+
+def test_installed_details_enabled_flags_mcp_restart() -> None:
+    row = _PluginRow(
+        plugin_id="quality@tools",
+        description="Quality",
+        enabled=True,
+        version="1.0.0",
+        author=None,
+        skill_count=1,
+        skill_names=("quality@tools:review",),
+        mcp_connected=False,
+        session_loaded=True,
+    )
+
+    content = str(_installed_plugin_details_content(row))
+
+    assert f"Status: {get_glyphs().checkmark} Enabled" in content
+    assert "MCP servers need a server restart (/reload) to connect." in content
+
+
+def test_load_state_label_matches_state() -> None:
+    def _row(
+        *, enabled: bool, session_loaded: bool, load_error: str | None = None
+    ) -> _PluginRow:
+        return _PluginRow(
+            plugin_id="p@m",
+            description="",
+            enabled=enabled,
+            version=None,
+            author=None,
+            session_loaded=session_loaded,
+            load_error=load_error,
+        )
+
+    checkmark = get_glyphs().checkmark
+    assert _load_state_label(_row(enabled=True, session_loaded=True)) == (
+        f"{checkmark} enabled"
+    )
+    assert (
+        _load_state_label(_row(enabled=True, session_loaded=False)) == "pending /reload"
+    )
+    assert _load_state_label(_row(enabled=False, session_loaded=False)) is None
+    assert (
+        _load_state_label(_row(enabled=True, session_loaded=True, load_error="boom"))
+        == "error"
+    )
+
+
+def test_plugin_prompt_enabled_connection_hints() -> None:
+    checkmark = get_glyphs().checkmark
+
+    connected = _PluginRow(
+        plugin_id="quality@tools",
+        description="Quality",
+        enabled=True,
+        version="1.0.0",
+        author=None,
+        mcp_connected=True,
+        session_loaded=True,
+    )
+    prompt = str(_plugin_prompt(connected, status=None))
+    assert f"{checkmark} enabled" in prompt
+    assert f"{checkmark} connected" in prompt
+    assert "restart to connect" not in prompt
+
+    needs_restart = _PluginRow(
+        plugin_id="quality@tools",
+        description="Quality",
+        enabled=True,
+        version="1.0.0",
+        author=None,
+        mcp_connected=False,
+        session_loaded=True,
+    )
+    prompt = str(_plugin_prompt(needs_restart, status=None))
+    assert "restart to connect" in prompt
+    assert f"{checkmark} connected" not in prompt
+
+
+def test_plugin_prompt_pending_reload_keeps_connected_when_still_loaded() -> None:
+    """A disabled-but-still-loaded plugin keeps its live connection hint."""
+    checkmark = get_glyphs().checkmark
+    row = _PluginRow(
+        plugin_id="quality@tools",
+        description="Quality",
+        enabled=False,
+        version="1.0.0",
+        author=None,
+        mcp_connected=True,
+        session_loaded=True,
+    )
+
+    assert row.load_state == "pending_reload"
+    prompt = str(_plugin_prompt(row, status=None))
+
+    assert "pending /reload" in prompt
+    assert f"{checkmark} connected" in prompt

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -42,6 +42,23 @@ def test_plugin_options_preserve_selectable_rows_and_spacers() -> None:
     assert "pending /reload" in str(options[2].prompt)
 
 
+def test_plugin_options_show_pending_reload_when_disabled_but_loaded() -> None:
+    rows = (
+        _PluginRow(
+            "loaded@source",
+            "Still loaded",
+            False,
+            "1.0",
+            None,
+            session_loaded=True,
+        ),
+    )
+
+    options = _plugin_options(rows, action="installed", status=None)
+
+    assert "pending /reload" in str(options[0].prompt)
+
+
 def test_plugin_details_content_lists_preview_components() -> None:
     row = _PluginRow(
         "quality@tools",
@@ -111,6 +128,26 @@ def test_installed_details_pending_reload_not_enabled() -> None:
     assert "Status: Installed · pending /reload" in content
     assert "Run /reload" in content
     assert f"{get_glyphs().checkmark} Enabled" not in content
+
+
+def test_installed_details_pending_reload_after_disable() -> None:
+    row = _PluginRow(
+        "quality@tools",
+        "Quality",
+        False,
+        "1.0.0",
+        None,
+        skill_count=1,
+        skill_names=("quality@tools:review",),
+        session_loaded=True,
+    )
+
+    assert row.load_state == "pending_reload"
+    content = str(_installed_plugin_details_content(row))
+
+    assert "Status: Disabled · pending /reload" in content
+    assert "unload this plugin" in content
+    assert "Status: Disabled\n" not in content
 
 
 async def test_plugin_manager_overlays_underlying_content() -> None:

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -8,8 +8,13 @@ from unittest.mock import MagicMock
 from textual.widgets import Static
 
 from deepagents_code.app import DeepAgentsApp
+from deepagents_code.config import get_glyphs
 from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
-from deepagents_code.tui.modals.plugin_manager.content import _plugin_options
+from deepagents_code.tui.modals.plugin_manager.content import (
+    _installed_plugin_details_content,
+    _plugin_details_content,
+    _plugin_options,
+)
 from deepagents_code.tui.modals.plugin_manager.models import _PluginRow
 
 
@@ -34,6 +39,78 @@ def test_plugin_options_preserve_selectable_rows_and_spacers() -> None:
         "detail:second@source",
     ]
     assert options[1].disabled
+    assert "pending /reload" in str(options[2].prompt)
+
+
+def test_plugin_details_content_lists_preview_components() -> None:
+    row = _PluginRow(
+        "quality@tools",
+        "Quality review",
+        False,
+        "1.0.0",
+        "Team",
+        skill_count=1,
+        skill_names=("quality@tools:review",),
+        mcp_server_names=("docs",),
+    )
+
+    content = str(_plugin_details_content(row))
+
+    assert "Will install:" in content
+    assert "Skills: quality@tools:review" in content
+    assert "MCP: docs" in content
+    assert "Components will be discovered at installation." not in content
+
+
+def test_plugin_details_content_explains_remote_or_unknown_preview() -> None:
+    row = _PluginRow("remote@tools", "Remote", False, None, None)
+
+    content = str(_plugin_details_content(row))
+
+    assert "Will install:" in content
+    assert "Skills and MCP servers if present" in content
+    assert "agents/" in content
+    assert "Components will be discovered at installation." not in content
+
+
+def test_installed_details_explain_unsupported_components() -> None:
+    row = _PluginRow(
+        "pr-review-toolkit@official",
+        "PR review",
+        True,
+        "1.0.0",
+        None,
+        skill_count=0,
+        unsupported_components=("agents", "commands"),
+        session_loaded=True,
+    )
+
+    content = str(_installed_plugin_details_content(row))
+
+    assert f"Status: {get_glyphs().checkmark} Enabled" in content
+    assert "No supported components (skills/MCP)." in content
+    assert "agents/" in content
+    assert "commands/" in content
+    assert "No components discovered." not in content
+
+
+def test_installed_details_pending_reload_not_enabled() -> None:
+    row = _PluginRow(
+        "quality@tools",
+        "Quality",
+        True,
+        "1.0.0",
+        None,
+        skill_count=1,
+        skill_names=("quality@tools:review",),
+        session_loaded=False,
+    )
+
+    content = str(_installed_plugin_details_content(row))
+
+    assert "Status: Installed · pending /reload" in content
+    assert "Run /reload" in content
+    assert f"{get_glyphs().checkmark} Enabled" not in content
 
 
 async def test_plugin_manager_overlays_underlying_content() -> None:

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -1,13 +1,8 @@
 """Tests for the plugin manager modal structure."""
 
 import inspect
-import re
 from pathlib import Path
-from unittest.mock import MagicMock
 
-from textual.widgets import Static
-
-from deepagents_code.app import DeepAgentsApp
 from deepagents_code.config import get_glyphs
 from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
 from deepagents_code.tui.modals.plugin_manager.content import (
@@ -39,24 +34,6 @@ def test_plugin_options_preserve_selectable_rows_and_spacers() -> None:
         "detail:second@source",
     ]
     assert options[1].disabled
-    assert "pending /reload" in str(options[2].prompt)
-
-
-def test_plugin_options_show_pending_reload_when_disabled_but_loaded() -> None:
-    rows = (
-        _PluginRow(
-            "loaded@source",
-            "Still loaded",
-            False,
-            "1.0",
-            None,
-            session_loaded=True,
-        ),
-    )
-
-    options = _plugin_options(rows, action="installed", status=None)
-
-    assert "pending /reload" in str(options[0].prompt)
 
 
 def test_plugin_details_content_lists_preview_components() -> None:
@@ -76,17 +53,6 @@ def test_plugin_details_content_lists_preview_components() -> None:
     assert "Will install:" in content
     assert "Skills: quality@tools:review" in content
     assert "MCP: docs" in content
-    assert "Components will be discovered at installation." not in content
-
-
-def test_plugin_details_content_explains_remote_or_unknown_preview() -> None:
-    row = _PluginRow("remote@tools", "Remote", False, None, None)
-
-    content = str(_plugin_details_content(row))
-
-    assert "Will install:" in content
-    assert "Skills and MCP servers if present" in content
-    assert "agents/" in content
     assert "Components will be discovered at installation." not in content
 
 
@@ -148,26 +114,3 @@ def test_installed_details_pending_reload_after_disable() -> None:
     assert "Status: Disabled · pending /reload" in content
     assert "unload this plugin" in content
     assert "Status: Disabled\n" not in content
-
-
-async def test_plugin_manager_overlays_underlying_content() -> None:
-    """Transparent modal backdrop must composite the screen underneath."""
-    app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
-        app.theme = "textual-dark"
-        await pilot.pause()
-
-        await app.mount(Static("TOP_MARKER_VISIBLE", id="top-marker"))
-        marker = app.query_one("#top-marker")
-        marker.styles.dock = "top"
-        marker.styles.height = 1
-        await pilot.pause()
-
-        app.push_screen(PluginManagerScreen())
-        await pilot.pause()
-
-        assert app.screen.styles.background.a == 0
-        plain = re.sub(r"<[^>]+>", " ", app.export_screenshot())
-        assert "TOP_MARKER_VISIBLE" in plain
-        assert "Plugins" in plain


### PR DESCRIPTION
Closes [DCD-49](https://linear.app/langchain/issue/DCD-49/plugins-fix-installed-component-discovery-and-status-messaging)

Plugin manager status and component messaging now reflect what deepagents-code actually loads, and Enabled only appears after `/reload`.

---

Plugins that only ship `agents/`/`commands/`/`hooks` (e.g. `pr-review-toolkit`) now report those as unsupported instead of “no components discovered.” Discover preview and installed status distinguish pending `/reload`, enabled, and error.
