### PR TITLE
fix(code): honor live auto-approve on the async server store

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -10,7 +10,7 @@ import shutil
 import tomllib
 import warnings
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Annotated, Any, NotRequired, cast
 
 from deepagents import create_deep_agent
 from deepagents.backends import CompositeBackend, LocalShellBackend
@@ -31,7 +31,6 @@ if TYPE_CHECKING:
     from deepagents.middleware.async_subagents import AsyncSubAgent
     from deepagents.middleware.subagents import CompiledSubAgent, SubAgent
     from langchain.agents.middleware import InterruptOnConfig
-    from langchain.agents.middleware.types import AgentState
     from langchain.messages import ToolCall
     from langchain.tools import BaseTool
     from langchain_core.language_models import BaseChatModel
@@ -47,7 +46,11 @@ if TYPE_CHECKING:
     from deepagents_code.plugins.adapters.skills import CodeSkillSource
 
 from langchain.agents.middleware import TodoListMiddleware
-from langchain.agents.middleware.types import AgentMiddleware
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    PrivateStateAttr,
+)
 from langchain.tools import (
     ToolRuntime,  # noqa: TC002  # LangChain inspects this annotation for runtime injection.
 )
@@ -1241,6 +1244,110 @@ def _is_auto_approve_enabled(value: object) -> bool:
     return isinstance(value, bool) and value
 
 
+def _approval_mode_key_from_context(ctx: object) -> str | None:
+    """Return the live approval-mode store key carried in run context.
+
+    Accepts both context shapes: the `CLIContextSchema` dataclass (in-process)
+    and the plain dict delivered over the JSON/RemoteGraph boundary.
+    """
+    if isinstance(ctx, CLIContextSchema):
+        return ctx.approval_mode_key
+    if isinstance(ctx, dict):
+        raw_key = ctx.get("approval_mode_key")
+        return raw_key if isinstance(raw_key, str) else None
+    return None
+
+
+class _LiveApprovalModeState(AgentState):
+    """Private state channel carrying the prefetched live approval decision."""
+
+    _live_auto_approve: Annotated[NotRequired[bool | None], PrivateStateAttr]
+    """Resolved live approval mode for the current turn.
+
+    `True`/`False` are authoritative (a live Store read succeeded, or the read
+    failed with a configured key and fails closed to `False`). `None` means no
+    live key is configured, so the interrupt predicate falls back to the static
+    `auto_approve` context snapshot.
+    """
+
+
+class ApprovalModePrefetchMiddleware(AgentMiddleware[_LiveApprovalModeState, Any]):
+    """Threads the live approval mode into state before each model turn.
+
+    The `interrupt_on` `when` predicate is synchronous, but the LangGraph API
+    server's runtime Store is an `AsyncBatchedBaseStore` whose synchronous
+    `get()` raises on the running event loop. Reading the live mode here
+    (asynchronously, before the model turn) and stashing the resolved decision
+    in private state lets the sync predicate honor a live toggle without a
+    forbidden sync Store read. In-process runs configure no live key, so this
+    resolves to `None` and the predicate uses the static context snapshot.
+    """
+
+    state_schema = _LiveApprovalModeState
+
+    @staticmethod
+    def _resolved_update(key: str | None, value: bool | None) -> dict[str, Any]:
+        """Fail-closed state update for a resolved live mode.
+
+        A configured key whose Store item is unreadable (`value is None`) fails
+        closed to `False` (interrupt); a missing key resolves to `None` so the
+        predicate falls back to the static context snapshot.
+
+        Returns:
+            State update for the `_live_auto_approve` private channel.
+        """
+        if key is None:
+            return {"_live_auto_approve": None}
+        return {"_live_auto_approve": value if value is not None else False}
+
+    async def abefore_model(
+        self,
+        state: _LiveApprovalModeState,  # noqa: ARG002
+        runtime: Runtime[Any],
+    ) -> dict[str, Any]:
+        """Read the live mode via the async Store interface (server path).
+
+        Returns:
+            State update carrying the resolved live approval decision.
+        """
+        from deepagents_code.approval_mode import aread_approval_mode_from_store
+
+        key = _approval_mode_key_from_context(getattr(runtime, "context", None))
+        store = getattr(runtime, "store", None)
+        value = (
+            await aread_approval_mode_from_store(store, key)
+            if key is not None
+            else None
+        )
+        return self._resolved_update(key, value)
+
+    def before_model(
+        self,
+        state: _LiveApprovalModeState,  # noqa: ARG002
+        runtime: Runtime[Any],
+    ) -> dict[str, Any]:
+        """Read the live mode synchronously (in-process / sync execution).
+
+        Returns:
+            State update carrying the resolved live approval decision.
+        """
+        key = _approval_mode_key_from_context(getattr(runtime, "context", None))
+        store = getattr(runtime, "store", None)
+        value = _read_live_store_value(store, key) if key is not None else None
+        return self._resolved_update(key, value)
+
+
+def _read_live_store_value(store: object, key: str | None) -> bool | None:
+    """Sync live-Store read used by the prefetch middleware's sync path.
+
+    Returns:
+        The live `auto_approve` bool, or `None` when unreadable/unconfigured.
+    """
+    from deepagents_code.approval_mode import read_approval_mode_from_store
+
+    return read_approval_mode_from_store(store, key)
+
+
 def _read_live_auto_approve(store: object, key: str | None) -> bool | None:
     """Return live approval mode from the LangGraph Store when configured.
 
@@ -1287,12 +1394,24 @@ def _should_interrupt_tool_call(request: ToolCallRequest) -> bool:
     with `goto=None` — crashing `_control_branch` on a fresh thread. Context
     is also safer: the model cannot self-approve by writing state.
 
+    The live approval mode is prefetched by `ApprovalModePrefetchMiddleware`
+    (which can read the async server Store off the sync predicate path) and
+    threaded into private state; a prefetched boolean is authoritative here.
+    When no prefetched value is present (in-process paths, or unit requests
+    without state), the logic falls back to a synchronous Store read and then
+    the static `auto_approve` context snapshot.
+
     Args:
         request: The pending tool call under review.
 
     Returns:
         `True` to interrupt for approval, `False` to auto-approve.
     """
+    state = getattr(request, "state", None)
+    prefetched = state.get("_live_auto_approve") if isinstance(state, dict) else None
+    if isinstance(prefetched, bool):
+        return not prefetched
+
     runtime = getattr(request, "runtime", None)
     ctx = getattr(runtime, "context", None)
     store = getattr(runtime, "store", None)
@@ -1639,6 +1758,13 @@ def create_cli_agent(
                 "available; falling back to standard HITL interrupts"
             )
 
+    # Whether the main agent (and, by inheritance, subagents) will run HITL
+    # approval interrupts. Mirrors the `interrupt_on` decision made below:
+    # auto-approve and the restrictive shell-allow-list path both disable HITL.
+    # Computed here so the live approval-mode prefetch middleware can be added
+    # to subagent stacks, which are built before `interrupt_on` is resolved.
+    hitl_active = not auto_approve and restrictive_shell_allow_list is None
+
     user_agents_dir = settings.get_user_agents_dir(assistant_id)
     project_agents_dir = (
         project_context.project_agents_dir()
@@ -1646,11 +1772,18 @@ def create_cli_agent(
         else settings.get_project_agents_dir()
     )
 
-    def _subagent_cli_middleware(*, has_explicit_model: bool) -> list[AgentMiddleware]:
-        middleware: list[AgentMiddleware] = []
+    def _subagent_cli_middleware(
+        *, has_explicit_model: bool
+    ) -> list[AgentMiddleware[Any, Any]]:
+        middleware: list[AgentMiddleware[Any, Any]] = []
         # Experimental: mirror the main agent and drop TodoListMiddleware /
         # write_todos from subagent stacks too. No-op unless the flag is set.
         middleware.extend(_todo_list_middleware_override())
+        # Subagents inherit the main agent's `interrupt_on`, so they need the
+        # same live approval-mode prefetch to honor auto-approve without a
+        # forbidden sync Store read on the server event loop.
+        if hitl_active:
+            middleware.append(ApprovalModePrefetchMiddleware())
         if not has_explicit_model:
             middleware.append(ConfigurableModelMiddleware(persist_model_state=False))
         if restrictive_shell_allow_list is not None:
@@ -1727,6 +1860,13 @@ def create_cli_agent(
     from deepagents_code.resume_state import ResumeStateMiddleware
 
     agent_middleware.extend([ResumeStateMiddleware(), GoalToolsMiddleware()])
+
+    # Prefetch the live approval mode into private state before each model turn
+    # so the sync `interrupt_on` `when` predicate can honor auto-approve without
+    # reading the async server Store synchronously (which raises on the event
+    # loop). Only needed when HITL interrupts are active.
+    if hitl_active:
+        agent_middleware.append(ApprovalModePrefetchMiddleware())
 
     # Add ask_user middleware (must be early so its tool is available)
     if enable_ask_user:

--- a/libs/code/deepagents_code/approval_mode.py
+++ b/libs/code/deepagents_code/approval_mode.py
@@ -54,24 +54,58 @@ def _item_value(item: object) -> object:
     return getattr(item, "value", None)
 
 
+def _coerce_store_item(item: object) -> bool | None:
+    """Return the `auto_approve` bool from a store item, else `None`.
+
+    Shared by the sync and async readers so both apply the same fail-closed
+    parsing: a missing item, unrecognized shape, or non-bool `auto_approve`
+    yields `None`.
+    """
+    if item is None:
+        logger.debug("Approval-mode store item is missing")
+        return None
+
+    value = _item_value(item)
+    auto_approve = value.get("auto_approve") if isinstance(value, Mapping) else None
+    if isinstance(auto_approve, bool):
+        return auto_approve
+
+    logger.debug("Approval-mode store item has invalid contents")
+    return None
+
+
+def _validate_store_key(store: object, key: str | None) -> bool:
+    """Return whether `store`/`key` are usable, logging why when they are not.
+
+    The `isinstance` guard still rejects non-string keys as defense-in-depth,
+    since the value crosses the JSON/RemoteGraph boundary before reaching here.
+    """
+    if store is None:
+        logger.debug("Approval-mode store is unavailable")
+        return False
+    if not isinstance(key, str) or not key:
+        logger.debug("Approval-mode store key is missing or invalid")
+        return False
+    return True
+
+
 def read_approval_mode_from_store(store: object, key: str | None) -> bool | None:
     """Read a live approval mode from the server-side LangGraph Store.
 
+    Synchronous variant. On the LangGraph API server the runtime Store is an
+    `AsyncBatchedBaseStore` whose synchronous `get()` raises on the running
+    event loop, so prefer `aread_approval_mode_from_store` on async paths; this
+    remains for in-process stores whose sync `get()` is safe.
+
     Args:
         store: `request.runtime.store` from the graph server.
-        key: Store key produced by `approval_mode_key`. The `isinstance` guard
-            below still rejects non-string keys as defense-in-depth, since the
-            value crosses the JSON/RemoteGraph boundary before reaching here.
+        key: Store key produced by `approval_mode_key`.
 
     Returns:
         `True` or `False` when the store contains a valid mode, otherwise
         `None`. Callers should treat `None` as fail-closed.
     """
-    if store is None:
-        logger.debug("Approval-mode store is unavailable")
-        return None
-    if not isinstance(key, str) or not key:
-        logger.debug("Approval-mode store key is missing or invalid")
+    if not _validate_store_key(store, key):
         return None
 
     get = getattr(store, "get", None)
@@ -84,17 +118,44 @@ def read_approval_mode_from_store(store: object, key: str | None) -> bool | None
     except Exception:
         logger.warning("Could not read approval-mode store item", exc_info=True)
         return None
-    if item is None:
-        logger.debug("Approval-mode store item is missing")
+    return _coerce_store_item(item)
+
+
+async def aread_approval_mode_from_store(store: object, key: str | None) -> bool | None:
+    """Read a live approval mode from the LangGraph Store asynchronously.
+
+    The `when` interrupt predicate is synchronous, but the LangGraph API
+    server's runtime Store is an `AsyncBatchedBaseStore` whose synchronous
+    `get()` raises `asyncio.InvalidStateError` when called on the server's
+    running event loop. This awaits `aget()` (the supported interface) so the
+    live mode is actually read there; a prefetch middleware calls this before
+    the model turn and threads the result into state for the sync predicate.
+
+    Args:
+        store: `runtime.store` from the graph server.
+        key: Store key produced by `approval_mode_key`.
+
+    Returns:
+        `True` or `False` when the store contains a valid mode, otherwise
+        `None`. Callers should treat `None` as fail-closed.
+    """
+    if not _validate_store_key(store, key):
         return None
 
-    value = _item_value(item)
-    auto_approve = value.get("auto_approve") if isinstance(value, Mapping) else None
-    if isinstance(auto_approve, bool):
-        return auto_approve
-
-    logger.debug("Approval-mode store item has invalid contents")
-    return None
+    aget = getattr(store, "aget", None)
+    get = getattr(store, "get", None)
+    try:
+        if aget is not None:
+            item = await aget(APPROVAL_MODE_NAMESPACE, key)
+        elif get is not None:
+            item = get(APPROVAL_MODE_NAMESPACE, key)
+        else:
+            logger.debug("Approval-mode store exposes neither aget() nor get()")
+            return None
+    except Exception:
+        logger.warning("Could not read approval-mode store item", exc_info=True)
+        return None
+    return _coerce_store_item(item)
 
 
 async def awrite_approval_mode(

--- a/libs/code/deepagents_code/goal_rubric.py
+++ b/libs/code/deepagents_code/goal_rubric.py
@@ -1454,6 +1454,7 @@ def create_goal_criteria_agent(
     from langchain_core.tools import BaseTool, StructuredTool
 
     from deepagents_code._cli_context import CLIContextSchema
+    from deepagents_code.agent import ApprovalModePrefetchMiddleware
     from deepagents_code.configurable_model import ConfigurableModelMiddleware
 
     normalized_context_tools: list[BaseTool] = []
@@ -1479,6 +1480,9 @@ def create_goal_criteria_agent(
         raise ValueError(msg)
     middleware: list[AgentMiddleware[Any, Any]] = [
         ConfigurableModelMiddleware(persist_model_state=False),
+        # Honor live auto-approve for the criteria agent's gated context tools
+        # (`fetch_url`, `web_search`, MCP) without a sync Store read on the loop.
+        ApprovalModePrefetchMiddleware(),
         _GoalContextFallbackMiddleware(),
         _WebSearchBudgetMiddleware(),
         _CriteriaContextBudgetMiddleware(),

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -512,6 +512,200 @@ def test_should_interrupt_tool_call_warns_on_unexpected_context_shape(
     assert "unexpected context type" not in caplog.text
 
 
+def _request_with_state(
+    state: object,
+    *,
+    context: object = None,
+    store: object | None = None,
+) -> "ToolCallRequest":
+    return cast(
+        "ToolCallRequest",
+        SimpleNamespace(
+            state=state,
+            runtime=SimpleNamespace(context=context, store=store),
+        ),
+    )
+
+
+def test_should_interrupt_tool_call_uses_prefetched_state() -> None:
+    """A prefetched live decision in state is authoritative for the predicate."""
+    # Auto-approve prefetched -> suppress the interrupt.
+    assert not _should_interrupt_tool_call(
+        _request_with_state({"_live_auto_approve": True})
+    )
+    # Manual prefetched -> interrupt.
+    assert _should_interrupt_tool_call(
+        _request_with_state({"_live_auto_approve": False})
+    )
+
+
+def test_should_interrupt_tool_call_prefetched_state_overrides_context() -> None:
+    """A prefetched manual decision overrides a stale auto-approve context."""
+    assert _should_interrupt_tool_call(
+        _request_with_state(
+            {"_live_auto_approve": False},
+            context=CLIContextSchema(auto_approve=True),
+        )
+    )
+    assert not _should_interrupt_tool_call(
+        _request_with_state(
+            {"_live_auto_approve": True},
+            context=CLIContextSchema(auto_approve=False),
+        )
+    )
+
+
+def test_should_interrupt_tool_call_falls_back_without_prefetched_state() -> None:
+    """Absent or non-bool prefetched state falls back to the context snapshot."""
+    assert not _should_interrupt_tool_call(
+        _request_with_state(
+            {"_live_auto_approve": None},
+            context=CLIContextSchema(auto_approve=True),
+        )
+    )
+    assert _should_interrupt_tool_call(
+        _request_with_state({}, context=CLIContextSchema(auto_approve=False))
+    )
+    # A non-bool prefetched value must not bypass approval on mere truthiness.
+    assert _should_interrupt_tool_call(
+        _request_with_state(
+            {"_live_auto_approve": "yes"},
+            context=CLIContextSchema(auto_approve=False),
+        )
+    )
+
+
+async def test_prefetch_middleware_resolves_live_store_true() -> None:
+    """`abefore_model` threads a live auto-approve decision into state."""
+    from deepagents_code.agent import ApprovalModePrefetchMiddleware
+    from deepagents_code.approval_mode import (
+        APPROVAL_MODE_NAMESPACE,
+        approval_mode_key,
+        approval_mode_payload,
+    )
+
+    store = _FakeStore()
+    key = approval_mode_key("thread-1")
+    store.put(APPROVAL_MODE_NAMESPACE, key, approval_mode_payload(auto_approve=True))
+    runtime = SimpleNamespace(
+        context=CLIContextSchema(auto_approve=False, approval_mode_key=key),
+        store=store,
+    )
+
+    update = await ApprovalModePrefetchMiddleware().abefore_model(
+        cast("Any", {}), cast("Any", runtime)
+    )
+    assert update == {"_live_auto_approve": True}
+
+
+async def test_prefetch_middleware_resolves_live_store_false() -> None:
+    """A live manual mode is threaded into state as `False`."""
+    from deepagents_code.agent import ApprovalModePrefetchMiddleware
+    from deepagents_code.approval_mode import (
+        APPROVAL_MODE_NAMESPACE,
+        approval_mode_key,
+        approval_mode_payload,
+    )
+
+    store = _FakeStore()
+    key = approval_mode_key("thread-1")
+    store.put(APPROVAL_MODE_NAMESPACE, key, approval_mode_payload(auto_approve=False))
+    runtime = SimpleNamespace(
+        context=CLIContextSchema(auto_approve=True, approval_mode_key=key),
+        store=store,
+    )
+
+    update = await ApprovalModePrefetchMiddleware().abefore_model(
+        cast("Any", {}), cast("Any", runtime)
+    )
+    assert update == {"_live_auto_approve": False}
+
+
+async def test_prefetch_middleware_fails_closed_on_unreadable_store() -> None:
+    """A configured key with a missing store item fails closed to interrupt."""
+    from deepagents_code.agent import ApprovalModePrefetchMiddleware
+    from deepagents_code.approval_mode import approval_mode_key
+
+    key = approval_mode_key("thread-1")
+    runtime = SimpleNamespace(
+        context=CLIContextSchema(auto_approve=True, approval_mode_key=key),
+        store=_FakeStore(),
+    )
+
+    update = await ApprovalModePrefetchMiddleware().abefore_model(
+        cast("Any", {}), cast("Any", runtime)
+    )
+    # `False` -> the predicate will interrupt, never silently auto-approve.
+    assert update == {"_live_auto_approve": False}
+
+
+async def test_prefetch_middleware_no_key_defers_to_context() -> None:
+    """With no live key the prefetch yields `None` so context wins."""
+    from deepagents_code.agent import ApprovalModePrefetchMiddleware
+
+    runtime = SimpleNamespace(
+        context=CLIContextSchema(auto_approve=True, approval_mode_key=None),
+        store=_FakeStore(),
+    )
+
+    update = await ApprovalModePrefetchMiddleware().abefore_model(
+        cast("Any", {}), cast("Any", runtime)
+    )
+    assert update == {"_live_auto_approve": None}
+
+
+async def test_prefetch_middleware_switch_auto_to_manual() -> None:
+    """A mid-session flip from auto to manual is picked up on the next turn."""
+    from deepagents_code.agent import ApprovalModePrefetchMiddleware
+    from deepagents_code.approval_mode import (
+        APPROVAL_MODE_NAMESPACE,
+        approval_mode_key,
+        approval_mode_payload,
+    )
+
+    store = _FakeStore()
+    key = approval_mode_key("thread-1")
+    mw = ApprovalModePrefetchMiddleware()
+    runtime = SimpleNamespace(
+        context=CLIContextSchema(auto_approve=True, approval_mode_key=key),
+        store=store,
+    )
+
+    store.put(APPROVAL_MODE_NAMESPACE, key, approval_mode_payload(auto_approve=True))
+    first = await mw.abefore_model(cast("Any", {}), cast("Any", runtime))
+    assert first == {"_live_auto_approve": True}
+    assert not _should_interrupt_tool_call(_request_with_state(first))
+
+    # User toggles to manual mid-session; the store item flips.
+    store.put(APPROVAL_MODE_NAMESPACE, key, approval_mode_payload(auto_approve=False))
+    second = await mw.abefore_model(cast("Any", {}), cast("Any", runtime))
+    assert second == {"_live_auto_approve": False}
+    assert _should_interrupt_tool_call(_request_with_state(second))
+
+
+def test_prefetch_middleware_sync_path_resolves_from_dict_context() -> None:
+    """The sync `before_model` path resolves a dict (RemoteGraph) context."""
+    from deepagents_code.agent import ApprovalModePrefetchMiddleware
+    from deepagents_code.approval_mode import (
+        APPROVAL_MODE_NAMESPACE,
+        approval_mode_key,
+        approval_mode_payload,
+    )
+
+    store = _FakeStore()
+    key = approval_mode_key("thread-1")
+    store.put(APPROVAL_MODE_NAMESPACE, key, approval_mode_payload(auto_approve=True))
+    runtime = SimpleNamespace(
+        context={"auto_approve": False, "approval_mode_key": key},
+        store=store,
+    )
+
+    update = ApprovalModePrefetchMiddleware().before_model(
+        cast("Any", {}), cast("Any", runtime)
+    )
+    assert update == {"_live_auto_approve": True}
+
+
 def test_cli_context_field_parity() -> None:
     """`CLIContext` and `CLIContextSchema` must declare the same field set.
 
@@ -3535,6 +3729,101 @@ class TestExperimentalTodoMiddlewareWiring:
         assert not self._has_todo_standin(kwargs["middleware"])
         for spec in kwargs["subagents"]:
             assert not self._has_todo_standin(spec.get("middleware", []))
+
+
+class TestApprovalModePrefetchWiring:
+    """`create_cli_agent` wires the prefetch middleware into every HITL stack.
+
+    The live approval-mode prefetch must reach both the main agent and every
+    subagent (which inherit the main `interrupt_on`) so auto-approve is honored
+    without a forbidden sync Store read on the server event loop. It must be
+    absent when HITL is disabled (auto-approve / restrictive shell allow-list).
+    """
+
+    @staticmethod
+    def _build_mock_settings(tmp_path: Path) -> Mock:
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        mock_settings = Mock()
+        mock_settings.ensure_agent_dir.return_value = agent_dir
+        mock_settings.ensure_user_skills_dir.return_value = skills_dir
+        mock_settings.get_project_skills_dir.return_value = None
+        mock_settings.get_built_in_skills_dir.return_value = (
+            Settings.get_built_in_skills_dir()
+        )
+        mock_settings.get_user_agent_md_path.return_value = agent_dir / "AGENTS.md"
+        mock_settings.get_project_agent_md_path.return_value = []
+        mock_settings.get_user_agents_dir.return_value = tmp_path / "agents"
+        mock_settings.get_project_agents_dir.return_value = None
+        mock_settings.model_name = None
+        mock_settings.model_provider = None
+        mock_settings.model_unsupported_modalities = frozenset()
+        mock_settings.model_context_limit = None
+        mock_settings.project_root = None
+        mock_settings.shell_allow_list = ["ls", "cat"]
+        return mock_settings
+
+    def _capture_kwargs(self, tmp_path: Path, **create_kwargs: Any) -> dict[str, Any]:
+        mock_settings = self._build_mock_settings(tmp_path)
+        mock_agent = Mock()
+        mock_agent.with_config.return_value = mock_agent
+        subagent_meta = {
+            "name": "researcher",
+            "description": "Researches things",
+            "system_prompt": "Investigate the task thoroughly.",
+            "model": None,
+        }
+        with (
+            patch("deepagents_code.agent.settings", mock_settings),
+            patch("deepagents_code.agent.PluginSkillsMiddleware"),
+            patch("deepagents_code.agent.MemoryMiddleware"),
+            patch("deepagents_code.agent.list_subagents", return_value=[subagent_meta]),
+            patch(
+                "deepagents_code.agent.create_deep_agent", return_value=mock_agent
+            ) as mock_create,
+            patch(
+                "deepagents._models.init_chat_model",
+                return_value=_make_fake_chat_model(),
+            ),
+        ):
+            create_cli_agent(
+                model="fake-model",
+                assistant_id="test",
+                enable_memory=False,
+                enable_skills=False,
+                enable_shell=True,
+                **create_kwargs,
+            )
+        _, kwargs = mock_create.call_args
+        return kwargs
+
+    @staticmethod
+    def _has_prefetch(middleware: list[Any]) -> bool:
+        from deepagents_code.agent import ApprovalModePrefetchMiddleware
+
+        return any(isinstance(mw, ApprovalModePrefetchMiddleware) for mw in middleware)
+
+    def test_present_on_main_and_subagents_when_hitl_active(
+        self, tmp_path: Path
+    ) -> None:
+        kwargs = self._capture_kwargs(tmp_path, auto_approve=False)
+
+        assert self._has_prefetch(kwargs["middleware"])
+        subagents_by_name = {sa["name"]: sa for sa in kwargs["subagents"]}
+        assert {"researcher", "general-purpose"} <= set(subagents_by_name)
+        for name, spec in subagents_by_name.items():
+            assert self._has_prefetch(spec.get("middleware", [])), (
+                f"Expected prefetch middleware on subagent {name!r}"
+            )
+
+    def test_absent_from_all_stacks_when_auto_approve(self, tmp_path: Path) -> None:
+        kwargs = self._capture_kwargs(tmp_path, auto_approve=True)
+
+        assert not self._has_prefetch(kwargs["middleware"])
+        for spec in kwargs["subagents"]:
+            assert not self._has_prefetch(spec.get("middleware", []))
 
 
 def _mock_agents_dir(agents_dir: Path) -> Mock:

--- a/libs/code/tests/unit_tests/test_approval_mode.py
+++ b/libs/code/tests/unit_tests/test_approval_mode.py
@@ -11,6 +11,7 @@ from deepagents_code.approval_mode import (
     APPROVAL_MODE_NAMESPACE,
     approval_mode_key,
     approval_mode_payload,
+    aread_approval_mode_from_store,
     awrite_approval_mode,
     read_approval_mode_from_store,
 )
@@ -107,6 +108,89 @@ def test_read_approval_mode_from_store_exception_fails_closed(
         assert (
             read_approval_mode_from_store(
                 _FailingStore(),
+                approval_mode_key("thread-1"),
+            )
+            is None
+        )
+
+    assert "Could not read approval-mode store item" in caplog.text
+
+
+class _AsyncStore:
+    """Store double exposing only `aget`, like the server's async Store."""
+
+    def __init__(self, item: object = None) -> None:
+        self.item = item
+        self.get_calls = 0
+
+    async def aget(self, namespace: tuple[str, ...], key: str) -> object:
+        assert namespace == APPROVAL_MODE_NAMESPACE
+        assert key
+        self.get_calls += 1
+        return self.item
+
+    def get(self, namespace: tuple[str, ...], key: str) -> object:
+        _ = (namespace, key)
+        msg = "sync get is unsafe on the server event loop"
+        raise AssertionError(msg)
+
+
+class _AsyncFailingStore:
+    async def aget(self, namespace: tuple[str, ...], key: str) -> object:
+        _ = (namespace, key)
+        msg = "store unavailable"
+        raise RuntimeError(msg)
+
+
+async def test_aread_approval_mode_prefers_aget() -> None:
+    key = approval_mode_key("thread-1")
+    store = _AsyncStore(_StoreItem({"auto_approve": True}))
+
+    assert await aread_approval_mode_from_store(store, key) is True
+    assert store.get_calls == 1
+
+
+async def test_aread_approval_mode_accepts_mapping_item() -> None:
+    key = approval_mode_key("thread-1")
+    store = _AsyncStore({"value": {"auto_approve": False}})
+
+    assert await aread_approval_mode_from_store(store, key) is False
+
+
+async def test_aread_approval_mode_falls_back_to_sync_get() -> None:
+    """Stores without `aget` (in-process/test doubles) still resolve."""
+    key = approval_mode_key("thread-1")
+    store = _Store(_StoreItem({"auto_approve": True}))
+
+    assert await aread_approval_mode_from_store(store, key) is True
+
+
+@pytest.mark.parametrize(
+    ("store", "key"),
+    [
+        (None, approval_mode_key("thread-1")),
+        (_AsyncStore(None), approval_mode_key("thread-1")),
+        (_AsyncStore(_StoreItem(["not", "a", "mapping"])), approval_mode_key("t")),
+        (_AsyncStore(_StoreItem({"auto_approve": "yes"})), approval_mode_key("t")),
+        (_AsyncStore(_StoreItem({"auto_approve": 1})), approval_mode_key("t")),
+        (_AsyncStore(_StoreItem({"auto_approve": True})), ""),
+        (_AsyncStore(_StoreItem({"auto_approve": True})), None),
+    ],
+)
+async def test_aread_approval_mode_fails_closed(
+    store: object,
+    key: str | None,
+) -> None:
+    assert await aread_approval_mode_from_store(store, key) is None
+
+
+async def test_aread_approval_mode_exception_fails_closed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("WARNING", logger="deepagents_code.approval_mode"):
+        assert (
+            await aread_approval_mode_from_store(
+                _AsyncFailingStore(),
                 approval_mode_key("thread-1"),
             )
             is None

--- a/libs/code/tests/unit_tests/test_approval_mode_interrupt.py
+++ b/libs/code/tests/unit_tests/test_approval_mode_interrupt.py
@@ -1,0 +1,232 @@
+"""End-to-end regression tests for live approval-mode interrupt suppression.
+
+These reproduce the original bug: with `auto_approve=true` and a configured
+`approval_mode_key`, gated tools still produced LangGraph `GraphInterrupt`
+approval checkpoints on the LangGraph API server path, because the runtime
+Store there is an `AsyncBatchedBaseStore` whose synchronous `get()` raises on
+the running event loop. The synchronous `when` predicate caught that, failed
+closed, and interrupted despite the live store saying auto-approve.
+
+The tests run a real agent graph against an `AsyncBatchedBaseStore` — the store
+shape used by the server — so a regression to a synchronous store read in the
+interrupt path resurfaces as an unexpected interrupt.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+from deepagents import create_deep_agent
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.store.base.batch import AsyncBatchedBaseStore
+from langgraph.store.memory import InMemoryStore
+
+from deepagents_code._cli_context import CLIContextSchema
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
+
+    from langchain.agents.middleware import InterruptOnConfig
+    from langchain.agents.middleware.types import AgentMiddleware
+    from langchain_core.language_models import LanguageModelInput
+    from langchain_core.runnables import Runnable
+    from langchain_core.tools import BaseTool
+    from langgraph.pregel import Pregel
+    from langgraph.store.base import Op, Result
+
+
+class _ToolCallingFakeModel(GenericFakeChatModel):
+    """Fake chat model that tolerates `bind_tools` for agent graphs."""
+
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Callable | BaseTool],  # noqa: ARG002
+        *,
+        tool_choice: str | None = None,  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002
+    ) -> Runnable[LanguageModelInput, AIMessage]:
+        return self
+
+
+class _LoopBoundStore(AsyncBatchedBaseStore):
+    """`AsyncBatchedBaseStore` backed by an `InMemoryStore`.
+
+    Mirrors the server runtime store: created on the running event loop, so its
+    synchronous `get()` raises `asyncio.InvalidStateError` when called there.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._base = InMemoryStore()
+
+    async def abatch(self, ops: Iterable[Op]) -> list[Result]:
+        return await self._base.abatch(ops)
+
+    def batch(self, ops: Iterable[Op]) -> list[Result]:
+        return self._base.batch(ops)
+
+
+@tool
+def touch_network(url: str) -> str:
+    """A gated tool that would touch the network."""
+    return f"fetched {url}"
+
+
+def _make_agent(
+    model: _ToolCallingFakeModel, store: AsyncBatchedBaseStore
+) -> Pregel[Any, Any, Any, Any]:
+    from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT, SubAgent
+
+    from deepagents_code.agent import (
+        ApprovalModePrefetchMiddleware,
+        _should_interrupt_tool_call,
+    )
+
+    interrupt_on: dict[str, bool | InterruptOnConfig] = {
+        "touch_network": {
+            "allowed_decisions": ["approve", "reject"],
+            "when": _should_interrupt_tool_call,
+        }
+    }
+    prefetch_main = cast(
+        "list[AgentMiddleware[Any, Any]]", [ApprovalModePrefetchMiddleware()]
+    )
+    general_purpose: SubAgent = {
+        "name": GENERAL_PURPOSE_SUBAGENT["name"],
+        "description": GENERAL_PURPOSE_SUBAGENT["description"],
+        "system_prompt": GENERAL_PURPOSE_SUBAGENT["system_prompt"],
+        "middleware": cast(
+            "list[AgentMiddleware[Any, Any]]", [ApprovalModePrefetchMiddleware()]
+        ),
+    }
+    return create_deep_agent(
+        model=model,
+        tools=[touch_network],
+        middleware=prefetch_main,
+        interrupt_on=interrupt_on,
+        context_schema=CLIContextSchema,
+        subagents=[general_purpose],
+        checkpointer=InMemorySaver(),
+        store=store,
+    )
+
+
+async def _seed_mode(
+    store: AsyncBatchedBaseStore, thread_id: str, *, auto: bool
+) -> str:
+    from deepagents_code.approval_mode import (
+        APPROVAL_MODE_NAMESPACE,
+        approval_mode_key,
+        approval_mode_payload,
+    )
+
+    key = approval_mode_key(thread_id)
+    await store.aput(
+        APPROVAL_MODE_NAMESPACE, key, dict(approval_mode_payload(auto_approve=auto))
+    )
+    return key
+
+
+@pytest.mark.parametrize(
+    ("auto", "expect_interrupt"),
+    [(True, False), (False, True)],
+)
+async def test_top_level_gated_tool_honors_live_store(
+    auto: bool, expect_interrupt: bool
+) -> None:
+    """A top-level gated tool honors the live store on the async-batched path."""
+    store = _LoopBoundStore()
+    thread_id = "thread-top"
+    key = await _seed_mode(store, thread_id, auto=auto)
+
+    model = _ToolCallingFakeModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "touch_network",
+                            "args": {"url": "https://example.com"},
+                            "id": "c1",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(content="done"),
+            ]
+        )
+    )
+    agent = _make_agent(model, store)
+    ctx = CLIContextSchema(
+        auto_approve=auto, approval_mode_key=key, thread_id=thread_id
+    )
+    result = await agent.ainvoke(
+        {"messages": [{"role": "user", "content": "go"}]},
+        {"configurable": {"thread_id": thread_id}},
+        context=ctx,
+    )
+    assert bool(result.get("__interrupt__")) is expect_interrupt
+
+
+@pytest.mark.parametrize(
+    ("auto", "expect_interrupt"),
+    [(True, False), (False, True)],
+)
+async def test_subagent_gated_tool_honors_live_store(
+    auto: bool, expect_interrupt: bool
+) -> None:
+    """A gated tool inside a general-purpose subagent honors the live store."""
+    store = _LoopBoundStore()
+    thread_id = "thread-sub"
+    key = await _seed_mode(store, thread_id, auto=auto)
+
+    model = _ToolCallingFakeModel(
+        messages=iter(
+            [
+                # Main agent delegates to the general-purpose subagent.
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "task",
+                            "args": {
+                                "description": "fetch a page",
+                                "subagent_type": "general-purpose",
+                            },
+                            "id": "t1",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                # Subagent turn: call the gated tool.
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "touch_network",
+                            "args": {"url": "https://example.com"},
+                            "id": "c1",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(content="subagent done"),
+                AIMessage(content="all done"),
+            ]
+        )
+    )
+    agent = _make_agent(model, store)
+    ctx = CLIContextSchema(
+        auto_approve=auto, approval_mode_key=key, thread_id=thread_id
+    )
+    result = await agent.ainvoke(
+        {"messages": [{"role": "user", "content": "go"}]},
+        {"configurable": {"thread_id": thread_id}},
+        context=ctx,
+    )
+    assert bool(result.get("__interrupt__")) is expect_interrupt

--- a/libs/code/tests/unit_tests/test_goal_rubric.py
+++ b/libs/code/tests/unit_tests/test_goal_rubric.py
@@ -973,6 +973,14 @@ class TestCreateGoalCriteriaAgent:
             isinstance(item, _CriteriaContextBudgetMiddleware)
             for item in kwargs["middleware"]
         )
+        # The criteria agent's gated context tools must honor live auto-approve
+        # without a sync Store read on the server event loop.
+        from deepagents_code.agent import ApprovalModePrefetchMiddleware
+
+        assert any(
+            isinstance(item, ApprovalModePrefetchMiddleware)
+            for item in kwargs["middleware"]
+        )
 
     def test_client_generation_symbols_are_removed(self) -> None:
         import deepagents_code.goal_rubric as module


### PR DESCRIPTION
Fix dcode auto-approve so gated tools (including inside subagents) no longer produce unnecessary approval interrupts/resume cycles on the LangGraph server path.

---

With `auto_approve=true` and a configured `approval_mode_key`, gated tools still produced `GraphInterrupt` approval checkpoints on the LangGraph API server path (top-level tools and subagents). The interrupt `when` predicate is synchronous, but on the server `runtime.store` is an `AsyncBatchedBaseStore` whose synchronous `get()` raises `asyncio.InvalidStateError` on the running event loop; the predicate caught that, failed closed, and interrupted despite the live store saying auto-approve.

The live mode is now read asynchronously in a new `ApprovalModePrefetchMiddleware` (`before_model`/`abefore_model`) via `aget()` and threaded into a private state channel; the sync predicate reads that first and falls back to the existing runtime/context logic otherwise. Wired into the main agent, subagent stacks, and the server-side goal-criteria agent (the `fetch_url`/`web_search` path). Fail-closed safety, live auto→manual switching, and the static-context fallback are preserved.

Made by [Open SWE](https://openswe.vercel.app/agents/f2718164-a780-da1f-da82-b6ebffdf4433)
