### PR TITLE
fix(code): stop dimming the interrupted prompt

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -14102,8 +14102,8 @@ class DeepAgentsApp(App):
         submission) only when the input holds no draft, so typed text is never
         clobbered. Unlike the queued-message pop, this path does not consume
         the message — the interrupted `UserMessage` stays visible in the
-        transcript, dimmed via `set_cancelled()` — so when it does not restore
-        it stays silent rather than reporting a "discarded" outcome.
+        transcript — so when it does not restore it stays silent rather than
+        reporting a "discarded" outcome.
 
         Restore is also skipped once model text or a tool call is visible for
         the turn (`_active_turn_visible_output_started`). Returning the prompt
@@ -14370,8 +14370,6 @@ class DeepAgentsApp(App):
         # whereas prompt-restore belongs to Esc's edit/retract flow. Do not
         # add a restore call here without reconciling both interrupt paths.
         if self._agent_running and self._agent_worker:
-            if self._active_user_message is not None:
-                self._active_user_message.set_cancelled()
             self._cancel_worker(self._agent_worker)
             self._quit_pending = False
             return
@@ -14560,7 +14558,6 @@ class DeepAgentsApp(App):
         # If agent is running, interrupt it and discard queued messages
         if self._agent_running and self._agent_worker:
             if self._active_user_message is not None:
-                self._active_user_message.set_cancelled()
                 self._restore_interrupted_message_to_input(self._active_user_message)
             self._cancel_worker(self._agent_worker)
             return

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3035,7 +3035,8 @@ class DeepAgentsApp(App):
 
         self._active_user_message: UserMessage | None = None
         """The `UserMessage` widget that started the in-flight turn, tracked so
-        it can be dimmed if the turn is interrupted."""
+        its prompt can be restored to the input if the turn is interrupted
+        (Esc)."""
 
         self._active_turn_visible_output_started = False
         """True once the current turn has displayed model text or a tool call.
@@ -12804,7 +12805,8 @@ class DeepAgentsApp(App):
         Args:
             message: The user's message
         """
-        # Mount the user message, tracking it so it can be dimmed on interrupt.
+        # Mount the user message, tracking it so its prompt can be restored to
+        # the input if the turn is interrupted (Esc).
         media_snapshot = self._image_tracker.snapshot()
         user_message = UserMessage(message, media_snapshot=media_snapshot)
         await self._mount_message(user_message)

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -276,12 +276,7 @@ class UserMessage(Static):
         border-left: wide $primary;
         pointer: text;
     }
-
-    UserMessage.-cancelled {
-        opacity: 0.6;
-    }
     """
-    """`-cancelled` dims a prompt whose turn was interrupted by the user."""
 
     def __init__(
         self,
@@ -315,10 +310,6 @@ class UserMessage(Static):
     def media_snapshot(self) -> MediaTracker | None:
         """Media tracker state captured when the message was submitted."""
         return self._media_snapshot
-
-    def set_cancelled(self) -> None:
-        """Dim the message to mark its turn as interrupted by the user."""
-        self.add_class("-cancelled")
 
     def get_selection(self, selection: Selection) -> tuple[str, str] | None:
         """Return selected text, preferring the full content over the render.

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -2784,8 +2784,8 @@ class TestCtrlCCopySelection:
             exit_mock.assert_not_called()
             assert app._quit_pending is False
 
-    async def test_ctrl_c_interrupt_marks_active_user_message_cancelled(self) -> None:
-        """Ctrl+C dims the prompt but, unlike Esc, does not restore it."""
+    async def test_ctrl_c_interrupt_does_not_restore_prompt(self) -> None:
+        """Ctrl+C interrupts but, unlike Esc, does not restore the prompt."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -2807,7 +2807,6 @@ class TestCtrlCCopySelection:
                 app.action_quit_or_interrupt()
             await pilot.pause()
 
-            assert user_message.has_class("-cancelled")
             mock_worker.cancel.assert_called_once()
             assert app._quit_pending is False
             # Ctrl+C is the quit/copy flow: the prompt must NOT be restored to
@@ -3966,7 +3965,6 @@ class TestMessageQueue:
 
             assert chat.value == "do the thing"
             worker.cancel.assert_called_once()
-            assert active.has_class("-cancelled")
             mock_notify.assert_called_once_with("Message restored to input", timeout=2)
 
     async def test_escape_restores_interrupted_message_media(self) -> None:
@@ -4006,7 +4004,6 @@ class TestMessageQueue:
             assert images[0].base64_data == "abc123"
             assert images[0].placeholder == "[image 1]"
             worker.cancel.assert_called_once()
-            assert active.has_class("-cancelled")
             mock_notify.assert_called_once_with("Message restored to input", timeout=2)
 
     async def test_escape_interrupt_keeps_existing_input_draft(self) -> None:
@@ -4092,7 +4089,6 @@ class TestMessageQueue:
 
             assert chat.value == ""
             worker.cancel.assert_called_once()
-            assert active.has_class("-cancelled")
             mock_notify.assert_not_called()
 
     async def test_ui_adapter_wires_visible_output_started_callback(self) -> None:
@@ -4215,7 +4211,6 @@ class TestMessageQueue:
             assert chat.value == "queued"
             assert len(app._pending_messages) == 0
             worker.cancel.assert_not_called()
-            assert not active.has_class("-cancelled")
 
             # Second ESC: queue drained and the input now holds the queued
             # text, so the agent is interrupted but the active prompt is NOT
@@ -4223,7 +4218,6 @@ class TestMessageQueue:
             app.action_interrupt()
             assert chat.value == "queued"
             worker.cancel.assert_called_once()
-            assert active.has_class("-cancelled")
 
     async def test_escape_pop_single_then_interrupt(self) -> None:
         """Single queued message is popped, then next ESC interrupts agent."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -3895,25 +3895,6 @@ class TestStripSuccessExitLine:
         assert msg._output == "hi"
 
 
-class TestUserMessageCancelled:
-    """`set_cancelled` dims a prompt whose turn was interrupted."""
-
-    async def test_set_cancelled_adds_dim_class(self) -> None:
-        """`set_cancelled` adds the `-cancelled` class that dims the prompt."""
-
-        class _Harness(App[None]):
-            def compose(self) -> ComposeResult:
-                yield UserMessage("hello")
-
-        app = _Harness()
-        async with app.run_test() as pilot:
-            msg = app.query_one(UserMessage)
-            assert not msg.has_class("-cancelled")
-            msg.set_cancelled()
-            await pilot.pause()
-            assert msg.has_class("-cancelled")
-
-
 class TestSummarizeToolGroup:
     """Tests for the tool-group summary phrasing."""
 


### PR DESCRIPTION
Interrupting an agent turn no longer dims the prompt that started it; the inline "Interrupted by user" message remains the sole indicator.

---

Interrupting an agent turn (Esc or Ctrl+C) dimmed the initiating prompt to `opacity: 0.6` via `UserMessage.set_cancelled()` / the `-cancelled` CSS class. That dim is redundant: every interrupted turn already mounts an inline `AppMessage("Interrupted by user")` into the transcript (whenever `recover_interrupted_turn` is true, i.e. all normal turns), which is the authoritative "this turn was cut short" signal. The dim also diverged between the two interrupt paths — Ctrl+C dimmed without restoring, while Esc dimmed *and* restored the prompt to the chat input.

This removes `set_cancelled()`, its CSS, and both call sites, so the prompt keeps full opacity on interrupt and the inline message carries the meaning on its own.

## Open question for reviewers
There's one case where the dim carried information the inline message doesn't: an Esc interrupt *before* any visible output restores the prompt to the chat input, and dimming the transcript copy signaled "this one is stale, the live copy is in your input now" (also covered today by the "Message restored to input" toast). We opted to drop the dim entirely rather than gate it on `_active_turn_visible_output_started`, on the view that the inline message + toast are sufficient. If we'd rather keep de-emphasizing that superseded transcript copy in the retract-to-input case, the alternative is to re-add a gated dim there instead — happy to switch approaches.

Made by [Open SWE](https://openswe.vercel.app/agents/348699a2-a68e-92e6-8b65-4914fe2edfc0)