### PR TITLE
test(code): isolate ambient env and global dotenv in unit tests

### DIFF
--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -89,10 +89,13 @@ def _restore_os_environ() -> Generator[None, None, None]:
 def _clear_langsmith_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent LangSmith env vars loaded from .env from leaking into tests.
 
-    `dotenv.load_dotenv()` runs at `deepagents_code.config` import time and
-    may inject `LANGSMITH_*` variables from a local `.env` file.  These
-    cause spurious failures in unit tests that run with `--disable-socket`
-    because the LangSmith client attempts real HTTP requests.
+    `deepagents_code.config` loads dotenv lazily on first `settings` access
+    (via `_ensure_bootstrap()` / `_load_dotenv()`, which reads values with
+    `dotenv.dotenv_values()`) and may inject `LANGSMITH_*` variables from a
+    local `.env` file. Because those mutations persist in `os.environ`, they
+    can be present before this fixture runs, causing spurious failures in unit
+    tests that run with `--disable-socket` because the LangSmith client
+    attempts real HTTP requests.
 
     Each test that *needs* LangSmith variables should set them explicitly via
     `monkeypatch.setenv` or `patch.dict("os.environ", ...)`.
@@ -133,8 +136,9 @@ def _disable_langsmith_batching(monkeypatch: pytest.MonkeyPatch) -> None:
 def _clear_tavily_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent a Tavily key loaded from .env from leaking into tests.
 
-    Like `LANGSMITH_*`, `dotenv.load_dotenv()` at `deepagents_code.config`
-    import time may inject `TAVILY_API_KEY` from a developer's local `.env`.
+    Like `LANGSMITH_*`, the lazy dotenv load on first `settings` access (see
+    `_clear_langsmith_env`) may inject `TAVILY_API_KEY` from a developer's
+    local `.env`.
     A leaked key flips `settings.has_tavily` to `True`, which silently changes
     onboarding behavior: the launch sequence short-circuits the Tavily step on
     a dev machine but runs it on CI, so a test that reaches the step passes
@@ -152,8 +156,9 @@ def _clear_project_mcp_trust_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent developer MCP trust decisions from changing unit-test behavior.
 
     These may already be present in `os.environ` before any fixture runs:
-    `dotenv.load_dotenv()` at `deepagents_code.config` import time injects them
-    from the developer's global `~/.deepagents/.env`. The dangerous allowlist
+    `deepagents_code.config` loads dotenv lazily on first `settings` access
+    (via `_ensure_bootstrap()` / `_load_dotenv()`) and injects them from the
+    developer's global `~/.deepagents/.env`. The dangerous allowlist
     intentionally replaces the scoped TOML approvals used by trust-list and
     selective-project-trust tests, so leaving it set breaks those assertions.
     Removing them here (rather than relying on each test) keeps the MCP,
@@ -173,11 +178,12 @@ def _clear_debug_notifications_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent the debug-notifications override from changing suppression tests.
 
     `DEEPAGENTS_CODE_DEBUG_NOTIFICATIONS` may be loaded from the developer's
-    global `~/.deepagents/.env` at `deepagents_code.config` import time, before
-    fixtures run. When set, the notification suppression path skips persistence
-    and drops the entry instead of keeping the row, which breaks the
-    notification-center integration tests. Tests that exercise the debug path
-    set it explicitly.
+    global `~/.deepagents/.env` when `deepagents_code.config` loads dotenv
+    lazily on first `settings` access, before fixtures run. When set, the
+    notification suppression path skips persistence -- it removes the entry
+    without calling `suppress_warning` -- so tests asserting that a suppression
+    is persisted (or that a failed suppression keeps the row) break. Tests that
+    exercise the debug path set it explicitly.
     """
     monkeypatch.delenv("DEEPAGENTS_CODE_DEBUG_NOTIFICATIONS", raising=False)
 
@@ -376,6 +382,11 @@ def _isolate_global_dotenv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     guaranteed-absent path under `tmp_path` makes dotenv rereads inert without
     touching production behavior. Tests that exercise global dotenv loading set
     this attribute explicitly after this fixture runs.
+
+    This only stops a reread from *restoring* cleared vars; a var already
+    loaded into `os.environ` before this fixture runs is removed only if it is
+    on one of the `_clear_*` denylists above. New config vars that must not
+    leak from the developer's environment need to be added there.
     """
     monkeypatch.setattr(
         "deepagents_code.config._GLOBAL_DOTENV_PATH",

--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -149,13 +149,37 @@ def _clear_tavily_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture(autouse=True)
 def _clear_project_mcp_trust_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Prevent developer MCP trust decisions from changing unit-test behavior."""
+    """Prevent developer MCP trust decisions from changing unit-test behavior.
+
+    These may already be present in `os.environ` before any fixture runs:
+    `dotenv.load_dotenv()` at `deepagents_code.config` import time injects them
+    from the developer's global `~/.deepagents/.env`. The dangerous allowlist
+    intentionally replaces the scoped TOML approvals used by trust-list and
+    selective-project-trust tests, so leaving it set breaks those assertions.
+    Removing them here (rather than relying on each test) keeps the MCP,
+    model-config, and main suites hermetic. `_isolate_global_dotenv` below
+    prevents a later dotenv reread (e.g. via `/reload`) from restoring them.
+    """
     for key in (
         "DEEPAGENTS_CODE_DANGEROUSLY_ENABLE_PROJECT_MCP_SERVERS",
         "DEEPAGENTS_CODE_DISABLED_PROJECT_MCP_SERVERS",
         "DEEPAGENTS_CODE_ENABLED_PROJECT_MCP_SERVERS",
     ):
         monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _clear_debug_notifications_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent the debug-notifications override from changing suppression tests.
+
+    `DEEPAGENTS_CODE_DEBUG_NOTIFICATIONS` may be loaded from the developer's
+    global `~/.deepagents/.env` at `deepagents_code.config` import time, before
+    fixtures run. When set, the notification suppression path skips persistence
+    and drops the entry instead of keeping the row, which breaks the
+    notification-center integration tests. Tests that exercise the debug path
+    set it explicitly.
+    """
+    monkeypatch.delenv("DEEPAGENTS_CODE_DEBUG_NOTIFICATIONS", raising=False)
 
 
 @pytest.fixture(autouse=True)
@@ -338,6 +362,25 @@ def _provide_app_context() -> Generator[None]:
         yield
     finally:
         active_app.reset(token)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_dotenv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the global dotenv path at a nonexistent temp file.
+
+    `deepagents_code.config._GLOBAL_DOTENV_PATH` defaults to the developer's
+    real `~/.deepagents/.env`. Code paths like `/reload` call
+    `_load_dotenv(refresh_loaded=True)`, which rereads that file and can restore
+    ambient variables the isolation fixtures cleared (e.g.
+    `DEEPAGENTS_CODE_EXPERIMENTAL` or the MCP trust vars). Redirecting it to a
+    guaranteed-absent path under `tmp_path` makes dotenv rereads inert without
+    touching production behavior. Tests that exercise global dotenv loading set
+    this attribute explicitly after this fixture runs.
+    """
+    monkeypatch.setattr(
+        "deepagents_code.config._GLOBAL_DOTENV_PATH",
+        tmp_path / "nonexistent-global.env",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -206,8 +206,17 @@ class TestBranchDisplay:
             assert visible.rstrip().endswith("\u2026")
             assert "feature/" in visible
 
-    async def test_short_branch_name_not_truncated(self) -> None:
-        """A branch that fits should render in full with no ellipsis."""
+    async def test_short_branch_name_not_truncated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A branch that fits should render in full with no ellipsis.
+
+        `HIDE_CWD` removes the cwd from the layout (as in
+        `test_branch_display_shows_branch_name`) so a deep real checkout path
+        cannot starve the branch region to zero width -- otherwise this flakes
+        on the run directory's length rather than any real behavior.
+        """
+        monkeypatch.setenv(HIDE_CWD, "1")
         async with StatusBarApp().run_test(size=(150, 24)) as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.branch = "main"


### PR DESCRIPTION
Make the Deep Agents Code unit tests hermetic so they no longer depend on the developer's real environment, `~/.deepagents/.env`, or the checkout-path length.

Ambient MCP trust vars (`DEEPAGENTS_CODE_DANGEROUSLY_ENABLE_PROJECT_MCP_SERVERS` and friends), `DEEPAGENTS_CODE_DEBUG_NOTIFICATIONS`, and `DEEPAGENTS_CODE_EXPERIMENTAL` can be loaded from the developer's global dotenv at `deepagents_code.config` import time — before fixtures run — and `/reload` rereads that global dotenv and restores them. The dangerous MCP allowlist intentionally replaces scoped TOML approvals (breaking trust-list/selective-project-trust assertions), the debug var changes notification suppression, and a restored experimental flag breaks the `/reload` plugin-summary test. Separately, `TestBranchDisplay::test_short_branch_name_not_truncated` let a long real CWD consume the status bar, leaving the branch widget zero width.

Approach (test-only; no production behavior changes):
- New autouse fixture redirects `config._GLOBAL_DOTENV_PATH` to a nonexistent `tmp_path` file so dotenv rereads (e.g. `/reload`) are inert.
- New autouse fixture clears `DEEPAGENTS_CODE_DEBUG_NOTIFICATIONS`; the existing MCP-trust fixture already removes the trust vars (docstring expanded to explain why).
- The short-branch test now hides the CWD via `HIDE_CWD`, consistent with neighboring branch-display tests, so path length can't starve the widget.

Tests that intentionally exercise dotenv loading already set `_GLOBAL_DOTENV_PATH` and their inputs explicitly in the test body (after the isolation fixtures), so they are unaffected.

Made by [Open SWE](https://openswe.vercel.app/agents/234e9ee9-f18a-e812-4187-aae8190e4711)