### PR TITLE
fix(code): dismiss startup tip on `-m` initial submission

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -8293,9 +8293,12 @@ class DeepAgentsApp(App):
     async def _dismiss_startup_tip(self) -> None:
         """Remove the startup tip once the first prompt is submitted.
 
-        Called from `_submit_input`, so every submission path (interactive
-        and external) dismisses the tip. Subsequent calls are no-ops: the
-        widget is already gone and `query_one` raises `NoMatches`.
+        Called from both submission entry points: `_submit_input` (the shared
+        interactive/external path) and `_submit_initial_submission` (the
+        `-m`/`--skill`/`--goal` startup path, which submits without going
+        through `_submit_input`). Every submission path therefore dismisses
+        the tip. Subsequent calls are no-ops: the widget is already gone and
+        `query_one` raises `NoMatches`.
         """
         with suppress(NoMatches):
             await self.query_one("#startup-tip", StartupTip).remove()

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7553,6 +7553,10 @@ class DeepAgentsApp(App):
 
     async def _submit_initial_submission(self) -> None:
         """Submit the startup prompt or skill after the UI is ready."""
+        # These startup paths (`-m`, `--skill`, `--goal`) submit outside
+        # `_submit_input`, so dismiss the startup tip here to match the
+        # interactive submission behavior.
+        await self._dismiss_startup_tip()
         try:
             if self._initial_skill is not None:
                 await self._invoke_skill(

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -3691,23 +3691,47 @@ class TestMessageQueue:
             assert not app.query(StartupTip)
             assert app._pending_messages[0].text == "task"
 
-    async def test_startup_tip_removed_by_initial_submission(self) -> None:
-        """A `-m` initial prompt dismisses the tip via initial submission."""
+    @pytest.mark.parametrize(
+        ("attr", "value", "method", "expected_args"),
+        [
+            (
+                "_initial_prompt",
+                "hello world",
+                "_handle_user_message",
+                ("hello world",),
+            ),
+            ("_initial_skill", "review", "_invoke_skill", ("review", "")),
+            ("_initial_goal", "ship it", "_handle_goal_command", ("/goal ship it",)),
+        ],
+    )
+    async def test_startup_tip_removed_by_initial_submission(
+        self,
+        attr: str,
+        value: str,
+        method: str,
+        expected_args: tuple[str, ...],
+    ) -> None:
+        """Every startup path (`-m`/`--skill`/`--goal`) dismisses the tip.
+
+        The dismissal is a single shared call at the top of
+        `_submit_initial_submission`, so all three paths exercise it.
+        """
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
             assert len(app.query(StartupTip)) == 1
-            # Simulate the `-m` startup path without kicking off agent work:
-            # `_submit_initial_submission` should dismiss the tip before
-            # dispatching the prompt.
-            app._initial_prompt = "hello world"
-            app._handle_user_message = AsyncMock()  # ty: ignore
+            # Simulate the startup path without kicking off agent work:
+            # `_submit_initial_submission` should dismiss the tip when
+            # handling the prompt.
+            setattr(app, attr, value)
+            dispatch = AsyncMock()
+            setattr(app, method, dispatch)
 
             await app._submit_initial_submission()
             await pilot.pause()
 
             assert not app.query(StartupTip)
-            app._handle_user_message.assert_awaited_once_with("hello world")
+            dispatch.assert_awaited_once_with(*expected_args)
 
     async def test_message_queued_when_agent_running(self) -> None:
         """Messages should be queued when agent is running."""

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -3671,6 +3671,24 @@ class TestMessageQueue:
             assert not app.query(StartupTip)
             assert app._pending_messages[0].text == "task"
 
+    async def test_startup_tip_removed_by_initial_submission(self) -> None:
+        """A `-m` initial prompt dismisses the tip via initial submission."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert len(app.query(StartupTip)) == 1
+            # Simulate the `-m` startup path without kicking off agent work:
+            # `_submit_initial_submission` should dismiss the tip before
+            # dispatching the prompt.
+            app._initial_prompt = "hello world"
+            app._handle_user_message = AsyncMock()  # ty: ignore
+
+            await app._submit_initial_submission()
+            await pilot.pause()
+
+            assert not app.query(StartupTip)
+            app._handle_user_message.assert_awaited_once_with("hello world")
+
     async def test_message_queued_when_agent_running(self) -> None:
         """Messages should be queued when agent is running."""
         app = DeepAgentsApp()


### PR DESCRIPTION
The splash tip above the chat input is now dismissed when the TUI is launched with an initial prompt (`-m`), skill (`--skill`), or goal (`--goal`), matching interactive submissions.

---

When launching the TUI with `dcode -m "msg"`, the splash tip above the chat input stayed visible, unlike a normal interactive prompt which clears it.

The tip was only dismissed inside `_submit_input`, the shared path for interactive and external prompts. Startup submissions from `-m` (as well as `--skill` and `--goal`) run through `_submit_initial_submission` instead, which dispatches directly to `_handle_user_message` / `_invoke_skill` / `_handle_goal_command` and never dismissed the tip. This adds a `_dismiss_startup_tip()` call at the top of `_submit_initial_submission` so all startup submission paths match interactive behavior.

Made by [Open SWE](https://openswe.vercel.app/agents/2d2a8fdc-c71c-58c6-287a-6d4109d24bbb)