### PR TITLE
feat(code): add `Ctrl+X` to goal review editing

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -568,7 +568,11 @@ if TYPE_CHECKING:
     from deepagents_code.tui.widgets.auth import AuthManagerScreen
     from deepagents_code.tui.widgets.cwd_switch import CwdSwitchAbortMode
     from deepagents_code.tui.widgets.debug_console import SnapshotField
-    from deepagents_code.tui.widgets.goal_review import GoalReviewMenu, GoalReviewResult
+    from deepagents_code.tui.widgets.goal_review import (
+        GoalReviewMenu,
+        GoalReviewResult,
+        GoalReviewTextArea,
+    )
     from deepagents_code.tui.widgets.model_selector import ModelSelectorScreen
     from deepagents_code.tui.widgets.notification_center import (
         NotificationActionRequested,
@@ -15099,20 +15103,61 @@ class DeepAgentsApp(App):
         if self._pending_approval_widget:
             self._pending_approval_widget.action_select_reject()
 
-    async def action_open_editor(self) -> None:
-        """Open the current prompt text in an external editor ($VISUAL/$EDITOR)."""
+    def _focused_goal_review_editor(self) -> GoalReviewTextArea | None:
+        """Return the active focused goal-review editor, if any."""
+        menu = self._pending_goal_review_widget
+        if (
+            menu is None
+            or menu._input_mode is None
+            or not menu.is_attached
+            or not menu.display
+            or not menu.visible
+        ):
+            return None
+
+        from deepagents_code.tui.widgets.goal_review import GoalReviewTextArea
+
+        focused = self.focused
+        if (
+            not isinstance(focused, GoalReviewTextArea)
+            or focused is not menu._edit_input
+            or not focused.is_attached
+            or not focused.display
+            or not focused.visible
+        ):
+            return None
+        return focused
+
+    async def _open_text_area_in_editor(
+        self,
+        text_area: TextArea,
+        current_text: str,
+        *,
+        allow_empty: bool,
+        raise_editor_errors: bool,
+        restore_focus: Callable[[], object],
+        reset_after_edit: Callable[[], None] | None = None,
+    ) -> None:
+        """Edit text externally, then restore the originating field's focus.
+
+        Args:
+            text_area: Field to replace when the editor returns a result.
+            current_text: Complete value to pre-populate in the editor.
+            allow_empty: Whether a blank edited result should replace the field.
+            raise_editor_errors: Whether launch and file errors should reach the
+                notification handler instead of looking like cancellation.
+            restore_focus: Callback that restores the originating editable surface.
+            reset_after_edit: Optional state reset after replacing the field text.
+        """
         from deepagents_code.editor import open_in_editor
 
-        chat_input = self._chat_input
-        if not chat_input or not chat_input._text_area:
-            return
-
-        current_text = chat_input._text_area.text or ""
-
-        edited: str | None = None
         try:
             with self.suspend():
-                edited = open_in_editor(current_text)
+                edited = open_in_editor(
+                    current_text,
+                    allow_empty=allow_empty,
+                    raise_on_error=raise_editor_errors,
+                )
         except Exception:
             logger.warning("External editor failed", exc_info=True)
             self.notify(
@@ -15120,14 +15165,41 @@ class DeepAgentsApp(App):
                 severity="error",
                 timeout=5,
             )
-            chat_input.focus_input()
+        else:
+            if edited is not None:
+                text_area.text = edited
+                if reset_after_edit is not None:
+                    reset_after_edit()
+                lines = edited.split("\n")
+                text_area.move_cursor((len(lines) - 1, len(lines[-1])))
+        finally:
+            restore_focus()
+
+    async def action_open_editor(self) -> None:
+        """Open the focused editable surface in $VISUAL/$EDITOR."""
+        goal_editor = self._focused_goal_review_editor()
+        if goal_editor is not None:
+            await self._open_text_area_in_editor(
+                goal_editor,
+                goal_editor.submitted_value,
+                allow_empty=True,
+                raise_editor_errors=True,
+                restore_focus=goal_editor.focus,
+                reset_after_edit=goal_editor.reset_paste_state,
+            )
             return
 
-        if edited is not None:
-            chat_input._text_area.text = edited
-            lines = edited.split("\n")
-            chat_input._text_area.move_cursor((len(lines) - 1, len(lines[-1])))
-        chat_input.focus_input()
+        chat_input = self._chat_input
+        if not chat_input or not chat_input._text_area:
+            return
+
+        await self._open_text_area_in_editor(
+            chat_input._text_area,
+            chat_input._text_area.text or "",
+            allow_empty=False,
+            raise_editor_errors=False,
+            restore_focus=chat_input.focus_input,
+        )
 
     def on_paste(self, event: Paste) -> None:
         """Route unfocused paste events to chat input for drag/drop reliability."""

--- a/libs/code/deepagents_code/editor.py
+++ b/libs/code/deepagents_code/editor.py
@@ -27,6 +27,10 @@ VIM_EDITORS = {"vi", "vim", "nvim"}
 """Set of vim-family editor base names that receive the `-i NONE` flag."""
 
 
+class ExternalEditorError(RuntimeError):
+    """Raised when an external editor cannot be opened or read."""
+
+
 def resolve_editor() -> list[str] | None:
     """Resolve editor command from environment.
 
@@ -70,21 +74,37 @@ def _prepare_command(cmd: list[str], filepath: str) -> list[str]:
     return cmd
 
 
-def open_in_editor(current_text: str) -> str | None:
+def open_in_editor(
+    current_text: str,
+    *,
+    allow_empty: bool = False,
+    raise_on_error: bool = False,
+) -> str | None:
     """Open current_text in an external editor.
 
     Creates a temp .md file, launches the editor, and reads back the result.
 
     Args:
         current_text: The text to pre-populate in the editor.
+        allow_empty: Return an empty or whitespace-only edited result instead of
+            treating it as cancellation.
+        raise_on_error: Re-raise editor launch and file errors instead of treating
+            them as cancellation.
 
     Returns:
         The edited text with normalized line endings, or `None` if the editor
-            exited with a non-zero status, was not found, or the result was
-            empty/whitespace-only.
+            exited with a non-zero status, returned blank text while `allow_empty`
+            is false, or failed while `raise_on_error` is false.
+
+    Raises:
+        ExternalEditorError: If opening or reading the editor file fails while
+            `raise_on_error` is true.
     """
     cmd = resolve_editor()
     if cmd is None:
+        if raise_on_error:
+            msg = "Editor command resolved to no arguments"
+            raise ExternalEditorError(msg)
         return None
 
     tmp_path: str | None = None
@@ -125,14 +145,21 @@ def open_in_editor(current_text: str) -> str | None:
         # while preserving any intentional trailing newlines the user added.
         edited = edited.removesuffix("\n")
 
-        # Treat empty result as cancellation
-        if not edited.strip():
+        # Chat composition historically treats a blank result as cancellation;
+        # callers with their own submit-time validation may opt in to preserving it.
+        if not allow_empty and not edited.strip():
             return None
 
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
+        if raise_on_error:
+            msg = "External editor executable or temporary file was not found"
+            raise ExternalEditorError(msg) from exc
         return None
-    except Exception:
+    except Exception as exc:
         logger.warning("Editor failed", exc_info=True)
+        if raise_on_error:
+            msg = "External editor failed"
+            raise ExternalEditorError(msg) from exc
         return None
     else:
         return edited

--- a/libs/code/deepagents_code/tui/widgets/goal_review.py
+++ b/libs/code/deepagents_code/tui/widgets/goal_review.py
@@ -363,7 +363,7 @@ class GoalReviewMenu(Container):
         glyphs = get_glyphs()
         self._help_widget.update(
             f"Enter some {what}, or press Esc to go back {glyphs.bullet} "
-            "Shift+Enter newline"
+            f"Shift+Enter newline {glyphs.bullet} Ctrl+X external editor"
         )
 
     def _submit(self, result: GoalReviewResult) -> None:
@@ -388,13 +388,15 @@ class GoalReviewMenu(Container):
         if self._input_mode == "edit":
             self._help_widget.update(
                 f"Enter save edits {glyphs.bullet} "
-                f"Shift+Enter newline {glyphs.bullet} Esc back"
+                f"Shift+Enter newline {glyphs.bullet} "
+                f"Ctrl+X external editor {glyphs.bullet} Esc back"
             )
             return
         if self._input_mode == "reject":
             self._help_widget.update(
                 f"Enter regenerate {glyphs.bullet} "
-                f"Shift+Enter newline {glyphs.bullet} Esc back"
+                f"Shift+Enter newline {glyphs.bullet} "
+                f"Ctrl+X external editor {glyphs.bullet} Esc back"
             )
             return
         self._help_widget.update(

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -12491,6 +12491,31 @@ class TestOnApprovalMenuDecidedCleanup:
 class TestActionOpenEditor:
     """Tests for the external editor action."""
 
+    @staticmethod
+    async def _open_goal_editor(
+        app: DeepAgentsApp,
+        pilot: Pilot[DeepAgentsApp],
+        *,
+        reject: bool = False,
+    ) -> tuple[GoalReviewMenu, GoalReviewTextArea, asyncio.Future[GoalReviewResult]]:
+        """Mount a goal review and enter one of its text-editing modes."""
+        messages = app.query_one("#messages", Container)
+        menu = GoalReviewMenu("goal", "- original criterion")
+        future: asyncio.Future[GoalReviewResult] = (
+            asyncio.get_running_loop().create_future()
+        )
+        menu.set_future(future)
+        await messages.mount(menu)
+        app._pending_goal_review_widget = menu
+        await pilot.pause()
+        menu.focus()
+        await pilot.pause()
+        await pilot.press("r" if reject else "e")
+        await pilot.pause()
+        text_area = menu.query_one(".goal-review-edit-input", GoalReviewTextArea)
+        assert app.focused is text_area
+        return menu, text_area, future
+
     async def test_updates_text_on_successful_edit(self) -> None:
         app = DeepAgentsApp(agent=MagicMock())
         text_area = MagicMock()
@@ -12561,6 +12586,238 @@ class TestActionOpenEditor:
         mock_notify.assert_called_once()
         assert "failed" in mock_notify.call_args[0][0].lower()
         chat_input.focus_input.assert_called_once()
+
+    async def test_ctrl_x_edits_focused_goal_criteria_without_submitting(self) -> None:
+        """Ctrl+X should round-trip criteria through the focused goal editor."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            menu, text_area, future = await self._open_goal_editor(app, pilot)
+
+            with (
+                patch.object(app, "suspend"),
+                patch(
+                    "deepagents_code.editor.open_in_editor",
+                    return_value="- revised criterion",
+                ) as open_editor,
+            ):
+                await pilot.press("ctrl+x")
+                await pilot.pause()
+
+            open_editor.assert_called_once_with(
+                "- original criterion", allow_empty=True, raise_on_error=True
+            )
+            assert text_area.text == "- revised criterion"
+            assert text_area.cursor_location == text_area.document.end
+            assert app.focused is text_area
+            assert menu._input_mode == "edit"
+            assert future.done() is False
+
+    async def test_ctrl_x_edits_rejection_feedback_without_submitting(self) -> None:
+        """Ctrl+X should round-trip feedback without leaving rejection mode."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            menu, text_area, future = await self._open_goal_editor(
+                app, pilot, reject=True
+            )
+            text_area.text = "add coverage"
+            text_area.move_cursor(text_area.document.end)
+
+            with (
+                patch.object(app, "suspend"),
+                patch(
+                    "deepagents_code.editor.open_in_editor",
+                    return_value="add coverage and docs",
+                ) as open_editor,
+            ):
+                await pilot.press("ctrl+x")
+                await pilot.pause()
+
+            open_editor.assert_called_once_with(
+                "add coverage", allow_empty=True, raise_on_error=True
+            )
+            assert text_area.text == "add coverage and docs"
+            assert text_area.cursor_location == text_area.document.end
+            assert app.focused is text_area
+            assert menu._input_mode == "reject"
+            assert future.done() is False
+
+    async def test_ctrl_x_preserves_empty_goal_editor_result(self) -> None:
+        """An empty external edit should remain for normal goal validation."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            menu, text_area, future = await self._open_goal_editor(app, pilot)
+
+            with (
+                patch.object(app, "suspend"),
+                patch(
+                    "deepagents_code.editor.open_in_editor", return_value=""
+                ) as open_editor,
+            ):
+                await pilot.press("ctrl+x")
+                await pilot.pause()
+
+            open_editor.assert_called_once_with(
+                "- original criterion", allow_empty=True, raise_on_error=True
+            )
+            assert text_area.text == ""
+            assert text_area.cursor_location == (0, 0)
+            assert app.focused is text_area
+            assert menu._input_mode == "edit"
+            assert future.done() is False
+
+    async def test_ctrl_x_expands_and_resets_goal_editor_paste_state(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """External edits should use logical paste text and discard stale backing."""
+        from deepagents_code.tui.widgets import _paste_textarea as paste_textarea_module
+
+        monkeypatch.setattr(
+            paste_textarea_module, "_collapse_pastes_enabled", lambda: True
+        )
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            _, text_area, future = await self._open_goal_editor(app, pilot)
+            text_area.text = ""
+            big = "- criterion\n" * 5
+            await text_area._on_paste(events.Paste(big))
+            await pilot.pause()
+            assert text_area.text == "[Pasted text #1 +5 lines]"
+            assert text_area._pasted_contents
+
+            with (
+                patch.object(app, "suspend"),
+                patch(
+                    "deepagents_code.editor.open_in_editor",
+                    return_value="replacement",
+                ) as open_editor,
+            ):
+                await pilot.press("ctrl+x")
+                await pilot.pause()
+
+            open_editor.assert_called_once_with(
+                big, allow_empty=True, raise_on_error=True
+            )
+            assert text_area.text == "replacement"
+            assert text_area.submitted_value == "replacement"
+            assert text_area._pasted_contents == {}
+            assert text_area._next_paste_id == 1
+            assert app.focused is text_area
+            assert future.done() is False
+
+    async def test_ctrl_x_cancel_preserves_goal_editor_and_paste_state(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cancelling the editor should preserve visible and stored paste text."""
+        from deepagents_code.tui.widgets import _paste_textarea as paste_textarea_module
+
+        monkeypatch.setattr(
+            paste_textarea_module, "_collapse_pastes_enabled", lambda: True
+        )
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            _, text_area, future = await self._open_goal_editor(app, pilot)
+            text_area.text = ""
+            big = "- criterion\n" * 5
+            await text_area._on_paste(events.Paste(big))
+            await pilot.pause()
+            visible = text_area.text
+            pasted = dict(text_area._pasted_contents)
+            next_paste_id = text_area._next_paste_id
+
+            with (
+                patch.object(app, "suspend"),
+                patch(
+                    "deepagents_code.editor.open_in_editor", return_value=None
+                ) as open_editor,
+            ):
+                await pilot.press("ctrl+x")
+                await pilot.pause()
+
+            open_editor.assert_called_once_with(
+                big, allow_empty=True, raise_on_error=True
+            )
+            assert text_area.text == visible
+            assert text_area._pasted_contents == pasted
+            assert text_area._next_paste_id == next_paste_id
+            assert app.focused is text_area
+            assert future.done() is False
+
+    async def test_ctrl_x_goal_editor_failure_preserves_text_and_focus(self) -> None:
+        """Editor errors should notify without moving focus to the chat input."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            _, text_area, future = await self._open_goal_editor(app, pilot)
+            original = text_area.text
+
+            with (
+                patch.object(app, "suspend"),
+                patch(
+                    "deepagents_code.editor.resolve_editor",
+                    return_value=["missing-editor"],
+                ),
+                patch(
+                    "deepagents_code.editor.subprocess.run",
+                    side_effect=FileNotFoundError("missing-editor"),
+                ),
+                patch.object(app, "notify") as notify,
+            ):
+                await pilot.press("ctrl+x")
+                await pilot.pause()
+
+            notify.assert_called_once_with(
+                "External editor failed. Check $VISUAL/$EDITOR.",
+                severity="error",
+                timeout=5,
+            )
+            assert text_area.text == original
+            assert app.focused is text_area
+            assert future.done() is False
+
+    @pytest.mark.parametrize("state", ["hidden", "unfocused", "detached"])
+    async def test_inactive_goal_editor_does_not_intercept_chat_ctrl_x(
+        self, state: str
+    ) -> None:
+        """Only the visible, attached, focused goal editor should capture Ctrl+X."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            menu, text_area, future = await self._open_goal_editor(app, pilot)
+            if state == "hidden":
+                menu.action_cancel()
+                assert text_area.display is False
+            elif state == "unfocused":
+                menu.focus()
+                assert text_area.display is True
+            else:
+                await menu.remove()
+                assert menu.is_attached is False
+            await pilot.pause()
+            assert app.focused is not text_area
+
+            chat_input = app.query_one(ChatInput)
+            chat_input.set_value_at_end("chat draft")
+            with (
+                patch.object(app, "suspend"),
+                patch(
+                    "deepagents_code.editor.open_in_editor",
+                    return_value="edited chat draft",
+                ) as open_editor,
+            ):
+                await pilot.press("ctrl+x")
+                await pilot.pause()
+
+            open_editor.assert_called_once_with(
+                "chat draft", allow_empty=False, raise_on_error=False
+            )
+            assert chat_input.value == "edited chat draft"
+            assert app.focused is chat_input.input_widget
+            assert future.done() is False
 
 
 class TestEditorSlashCommand:

--- a/libs/code/tests/unit_tests/test_editor.py
+++ b/libs/code/tests/unit_tests/test_editor.py
@@ -141,6 +141,19 @@ class TestOpenInEditor:
             result = open_in_editor("original")
         assert result is None
 
+    @patch("deepagents_code.editor.subprocess.run")
+    def test_returns_empty_edit_when_allowed(self, mock_run: MagicMock) -> None:
+        """Callers with submit-time validation may preserve an empty edit."""
+
+        def fake_run(cmd: list[str], **_: object) -> MagicMock:
+            pathlib.Path(cmd[-1]).write_text("", encoding="utf-8")
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = fake_run
+        with patch("deepagents_code.editor.resolve_editor", return_value=["nano"]):
+            result = open_in_editor("original", allow_empty=True)
+        assert result == ""
+
     def test_returns_none_on_editor_not_found(self) -> None:
         with (
             patch(

--- a/libs/code/tests/unit_tests/tui/widgets/test_goal_review.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_goal_review.py
@@ -195,6 +195,22 @@ class TestGoalReviewMenu:
                 "message": "include docs and migration notes",
             }
 
+    async def test_text_editor_help_advertises_external_editor(self) -> None:
+        """Both goal-review text modes should advertise the Ctrl+X editor."""
+        app = _GoalReviewTestApp()
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            menu = app.query_one("#goal-review", GoalReviewMenu)
+            help_widget = menu.query_one(".goal-review-help", Static)
+
+            menu.action_edit()
+            assert "Ctrl+X external editor" in str(help_widget.content)
+
+            menu.action_cancel()
+            menu.action_reject_with_message()
+            assert "Ctrl+X external editor" in str(help_widget.content)
+
     async def test_edit_expands_collapsed_paste_on_submit(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
`Ctrl+X` now opens the active `/goal` criteria or rejection-feedback field in the configured external editor.

---

When a user was editing proposed goal criteria or entering regeneration feedback, `Ctrl+X` still opened the unrelated chat draft because the priority app binding always targeted the composer. This moved focus out of the review and made external-editor composition unusable in both goal-review modes.

`Ctrl+X` now detects the active goal-review field and opens its complete logical value, including expanded collapsed-paste content, in `$VISUAL` or `$EDITOR`. Saved text returns to the same field without submitting; cancellation or failure preserves the existing value and focus. Hidden, stale, detached, or unfocused goal editors fall through to the unchanged chat-input behavior.