### PR TITLE
fix(code): complete goals after satisfied grading

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1646,10 +1646,13 @@ class _ThreadHistoryPayload:
     """Persisted evidence or blocker note, if any."""
 
     pending_goal_completion_note: str | None = None
-    """Persisted completion evidence awaiting rubric/user approval."""
+    """Persisted agent-provided completion evidence awaiting final grading."""
 
     rubric_status: str | None = None
     """Latest rubric grading status from `RubricMiddleware`, if any."""
+
+    rubric_grading_run_id: str | None = None
+    """Persisted identifier for the rubric grading run, if any."""
 
     pending_goal_objective: str | None = None
     """Persisted pending goal objective, if any."""
@@ -2236,6 +2239,7 @@ class _MainScreen(Screen[None]):
 # failure would otherwise strand it. Retry the read a few times before giving up.
 _GOAL_SYNC_READ_ATTEMPTS = 3
 _GOAL_SYNC_READ_RETRY_SECONDS = 0.4
+_DEFAULT_GOAL_COMPLETION_NOTE = "Acceptance criteria satisfied."
 
 
 class DeepAgentsApp(App):
@@ -2826,10 +2830,10 @@ class DeepAgentsApp(App):
         `complete`)."""
 
         self._goal_status_note: str | None = None
-        """Evidence or blocker note recorded by the model's goal tool."""
+        """Persisted completion evidence or blocker note for the goal."""
 
         self._pending_goal_completion_note: str | None = None
-        """Agent-requested completion awaiting rubric and user approval."""
+        """Optional agent-provided completion evidence awaiting final grading."""
 
         self._pending_goal_objective: str | None = None
         """Goal objective awaiting user acceptance of proposed criteria."""
@@ -9280,6 +9284,9 @@ class DeepAgentsApp(App):
                 state_values.get("_pending_goal_completion_note")
             ),
             rubric_status=_as_str(state_values.get("_rubric_status")),
+            rubric_grading_run_id=_as_nonblank_str(
+                state_values.get("_current_grading_run_id")
+            ),
             pending_goal_objective=_as_str(state_values.get("_pending_goal_objective")),
             pending_goal_rubric=_as_str(state_values.get("_pending_goal_rubric")),
             pending_goal_kind=coerce_goal_proposal_kind(
@@ -9358,56 +9365,45 @@ class DeepAgentsApp(App):
         *,
         previous_status: str | None,
     ) -> bool:
-        """Clear a rubric-approved goal after its completion is saved.
+        """Persist a completed goal without discarding its objective or criteria.
 
         Returns:
-            `True` when the cleared state was persisted, or `False` when the active
-                goal was restored for retry.
+            `True` when the completed state was persisted, or `False` when the
+                active state was restored for retry.
         """
-        active_goal = self._active_goal
         goal_status = self._goal_status
         goal_status_note = self._goal_status_note
-        active_rubric = self._active_rubric
         pending_goal_completion_note = self._pending_goal_completion_note
         pending_goal_objective = self._pending_goal_objective
         pending_goal_rubric = self._pending_goal_rubric
         pending_goal_kind = self._pending_goal_kind
         pending_goal_request_id = self._pending_goal_request_id
-        next_rubric = self._next_rubric
-        last_consumed_next_rubric = self._last_consumed_next_rubric
-        last_consumed_next_previous_rubric = self._last_consumed_next_previous_rubric
 
-        self._clear_all_goal_rubric_state()
+        self._goal_status = "complete"
+        self._goal_status_note = note
+        self._pending_goal_completion_note = None
+        self._clear_pending_goal_rubric()
         self._sync_status_rubric()
         persisted = await self._persist_goal_rubric_state()
         if persisted:
             if previous_status != "complete":
-                text = "Goal marked complete by the agent."
-                if note:
-                    text = f"{text}\n\n{note}"
-                await self._mount_message(AppMessage(text))
+                await self._mount_message(
+                    AppMessage(f"Goal marked complete.\n\n{note}")
+                )
             return True
 
-        # The checkpoint still contains the active goal and pending completion
-        # request. Restore that exact local state so the UI and next grading
-        # turn cannot diverge from it, and so a later sync can safely retry.
-        self._active_goal = active_goal
         self._goal_status = goal_status
         self._goal_status_note = goal_status_note
-        self._active_rubric = active_rubric
-        self._pending_goal_completion_note = pending_goal_completion_note or note
+        self._pending_goal_completion_note = pending_goal_completion_note
         self._pending_goal_objective = pending_goal_objective
         self._pending_goal_rubric = pending_goal_rubric
         self._pending_goal_kind = pending_goal_kind
         self._pending_goal_request_id = pending_goal_request_id
-        self._next_rubric = next_rubric
-        self._last_consumed_next_rubric = last_consumed_next_rubric
-        self._last_consumed_next_previous_rubric = last_consumed_next_previous_rubric
         self._sync_status_rubric()
         await self._mount_message(
             ErrorMessage(
                 "Goal completion could not be saved, so the goal remains active "
-                "and its completion request is still pending for retry."
+                "and can be retried after another satisfied grading turn."
             )
         )
         return False
@@ -9422,99 +9418,70 @@ class DeepAgentsApp(App):
         self,
         *,
         rubric_status: str | None,
+        rubric_grading_run_id: str | None,
+        goal_grading_run_id: str | None,
         previous_status: str | None,
     ) -> bool:
-        """Resolve a staged completion request after rubric grading.
+        """Resolve completion from a correlated goal-backed grading turn.
 
         Returns:
-            `True` when the request committed the goal as complete.
+            `True` when the current grading turn completed the goal.
         """
-        note = self._pending_goal_completion_note
-        if not self._active_goal or not note or self._goal_status == "complete":
+        if (
+            goal_grading_run_id is None
+            or rubric_grading_run_id != goal_grading_run_id
+            or not self._active_goal
+            or self._goal_status != "active"
+            or self._queued_goal_application is not None
+        ):
             return False
 
+        note = self._pending_goal_completion_note
         if rubric_status == "grader_error":
-            await self._mount_message(
-                ErrorMessage(
-                    "Acceptance-criteria grading failed because of a grader or "
-                    "infrastructure error. The goal remains active, and its completion "
-                    "request is still pending; it will be re-graded on your next turn."
+            if note:
+                await self._mount_message(
+                    ErrorMessage(
+                        "Acceptance-criteria grading failed because of a grader or "
+                        "infrastructure error. The goal remains active, and its "
+                        "completion request is still pending; it will be re-graded on "
+                        "your next turn."
+                    )
                 )
-            )
             return False
         if rubric_status == "max_iterations_reached":
-            await self._clear_pending_goal_completion(
-                "Goal completion was not recorded: the iteration limit was reached "
-                "with unmet criteria. The goal remains active for resume, amendment, "
-                "retry, or clearing."
-            )
+            if note:
+                await self._clear_pending_goal_completion(
+                    "Goal completion was not recorded: the iteration limit was reached "
+                    "with unmet criteria. The goal remains active for resume, "
+                    "amendment, retry, or clearing."
+                )
             return False
         if rubric_status == "failed":
-            await self._clear_pending_goal_completion(
-                "Goal completion was not recorded because the grader could not "
-                "evaluate the rubric. The goal remains active."
-            )
+            if note:
+                await self._clear_pending_goal_completion(
+                    "Goal completion was not recorded because the grader could not "
+                    "evaluate the rubric. The goal remains active."
+                )
             return False
         if rubric_status != "satisfied":
-            await self._clear_pending_goal_completion(
-                "Goal completion was not recorded because the rubric was not satisfied."
-            )
+            if note:
+                await self._clear_pending_goal_completion(
+                    "Goal completion was not recorded because the rubric was not "
+                    "satisfied."
+                )
             return False
 
-        if self._session_state is not None and self._session_state.auto_approve:
-            return await self._commit_pending_goal_completion(
-                note,
-                previous_status=previous_status,
-            )
-
-        action_requests = [
-            {
-                "name": "update_goal",
-                "args": {"status": "complete", "note": note},
-                "description": (
-                    "The agent believes the current goal is complete. "
-                    "Approve to mark it complete."
-                ),
-            }
-        ]
-        try:
-            future = await self._request_approval(action_requests, self._assistant_id)
-            decision = await future
-        except Exception:
-            logger.warning("Failed to request goal completion approval", exc_info=True)
-            self.notify(
-                "Could not request approval to mark the goal complete.",
-                severity="warning",
-                markup=False,
-            )
-            return False
-
-        decision_type = decision.get("type") if isinstance(decision, dict) else None
-        if decision_type == "auto_approve_all":
-            await self._on_auto_approve_enabled()
-            return await self._commit_pending_goal_completion(
-                note,
-                previous_status=previous_status,
-            )
-        if decision_type == "approve":
-            return await self._commit_pending_goal_completion(
-                note,
-                previous_status=previous_status,
-            )
-
-        reject_message = decision.get("message") if isinstance(decision, dict) else None
-        if isinstance(reject_message, str) and reject_message.strip():
-            message = f"Goal completion rejected: {reject_message.strip()}"
-        else:
-            message = "Goal completion rejected."
-        await self._clear_pending_goal_completion(message)
-        return False
+        return await self._commit_pending_goal_completion(
+            note or _DEFAULT_GOAL_COMPLETION_NOTE,
+            previous_status=previous_status,
+        )
 
     async def _sync_goal_rubric_state_from_thread(
         self,
         *,
         force: bool = False,
         proposal_request_id: str | None = None,
+        goal_grading_run_id: str | None = None,
     ) -> None:
         """Refresh goal/rubric metadata from the active checkpoint.
 
@@ -9523,18 +9490,20 @@ class DeepAgentsApp(App):
             proposal_request_id: When set, restore a pending proposal only if it
                 originated from this criteria request. Resume callers omit it so
                 persisted proposals remain reviewable across clients.
+            goal_grading_run_id: Grading run observed during the current
+                goal-backed work turn. Omit outside that exact turn.
         """
         if not self._lc_thread_id:
             self._last_consumed_next_rubric = None
             self._last_consumed_next_previous_rubric = None
             return
-        # The fetched checkpoint is only needed to reflect the agent's
-        # `update_goal` tool, which can only run while a goal is active. When no
-        # goal/rubric state is engaged locally (and no one-shot rubric reconcile
-        # is pending), nothing server-side could have changed these channels, so
-        # skip the per-turn `aget_state` round-trip (and full message-history
-        # deserialization). Resume populates these locals before any turn runs,
-        # so a thread with persisted state never reaches this fast path empty.
+        # The fetched checkpoint reflects agent-side goal updates, generated
+        # proposals, and the current turn's rubric result. When no goal/rubric state
+        # is engaged locally (and no one-shot rubric reconcile is pending), none of
+        # those channels can affect the TUI, so skip the per-turn `aget_state`
+        # round-trip and full message-history deserialization. Resume populates
+        # these locals before any turn runs, so a thread with persisted state never
+        # reaches this fast path empty.
         if not force and not (
             self._active_goal
             or self._active_rubric
@@ -9564,12 +9533,11 @@ class DeepAgentsApp(App):
                 if attempt + 1 < attempts:
                     await asyncio.sleep(_GOAL_SYNC_READ_RETRY_SECONDS)
         if state_values is None:
-            # This refresh is the only path that reflects the agent's
-            # `update_goal` completion/block into the transcript and status bar,
-            # so a swallowed failure would silently lose that signal. Surface it
-            # (once) rather than dropping to DEBUG. Leave the consumed one-shot
-            # rubric bookkeeping intact so a later successful sync can still
-            # reconcile it.
+            # This refresh is the only path that reflects agent-side goal updates
+            # and the current grading result into the TUI, so a swallowed failure
+            # could silently miss a completion or blocker. Surface it once rather
+            # than dropping to DEBUG. Leave consumed one-shot bookkeeping intact so
+            # a later successful sync can still reconcile it.
             logger.warning("Failed to refresh goal/rubric state", exc_info=read_error)
             if not self._goal_rubric_sync_warned:
                 self._goal_rubric_sync_warned = True
@@ -9660,6 +9628,8 @@ class DeepAgentsApp(App):
         )
         completion_committed = await self._resolve_pending_goal_completion(
             rubric_status=payload.rubric_status,
+            rubric_grading_run_id=payload.rubric_grading_run_id,
+            goal_grading_run_id=goal_grading_run_id,
             previous_status=previous_status,
         )
         if not completion_committed:
@@ -12731,20 +12701,39 @@ class DeepAgentsApp(App):
 
         # A paused or completed goal withholds its rubric so the grader does not
         # run this turn (mirrors the persisted-state suppression in
-        # `_goal_state_update`). A one-shot `_next_rubric` still applies.
+        # `_goal_state_update`). A one-shot `_next_rubric` still applies, but is
+        # deliberately not treated as a goal-backed grade even when its text matches.
         rubric = None
+        goal_backed_grading = False
         if graph_input is None:
             rubric = self._next_rubric
             if rubric is None and not (
                 self._active_goal and self._goal_status in {"paused", "complete"}
             ):
                 rubric = self._active_rubric
+                goal_backed_grading = bool(
+                    rubric and self._active_goal and self._goal_status == "active"
+                )
             if self._next_rubric is not None:
                 self._last_consumed_next_rubric = self._next_rubric
                 self._last_consumed_next_previous_rubric = self._active_rubric
                 await self._persist_goal_rubric_state()
                 self._next_rubric = None
                 self._sync_status_rubric()
+
+        goal_grading_run_id: str | None = None
+        turn_completed = False
+
+        def _record_goal_grading_run(grading_run_id: str, result: str) -> None:
+            nonlocal goal_grading_run_id
+            if result in {
+                "satisfied",
+                "needs_revision",
+                "max_iterations_reached",
+                "failed",
+                "grader_error",
+            }:
+                goal_grading_run_id = grading_run_id
 
         try:
             await execute_task_textual(
@@ -12759,8 +12748,11 @@ class DeepAgentsApp(App):
                 message_kwargs=message_kwargs,
                 graph_input=graph_input,
                 rubric=rubric,
-                goal_active=bool(self._active_goal) and graph_input is None,
+                goal_active=goal_backed_grading,
                 blocked_goal_retry_context=blocked_goal_retry_context,
+                on_rubric_evaluation_end=(
+                    _record_goal_grading_run if goal_backed_grading else None
+                ),
                 # `auto_approve` is intentionally omitted here: execute_task_textual
                 # writes it into this context from `session_state.auto_approve` at
                 # the top of every stream iteration, so seeding it would be dead.
@@ -12772,6 +12764,7 @@ class DeepAgentsApp(App):
                 ),
                 turn_stats=turn_stats,
             )
+            turn_completed = True
             # Close the final step's group once the turn ends with no trailing
             # assistant text to trigger the boundary path. Grouping is cosmetic,
             # so a failure here must not abort the turn — but log it, since
@@ -12845,6 +12838,7 @@ class DeepAgentsApp(App):
             await self._cleanup_agent_task(
                 force_goal_sync=graph_input is not None,
                 goal_criteria_request_id=criteria_request_id,
+                goal_grading_run_id=(goal_grading_run_id if turn_completed else None),
             )
 
     async def _process_next_from_queue(self) -> None:
@@ -12901,6 +12895,7 @@ class DeepAgentsApp(App):
         *,
         force_goal_sync: bool = False,
         goal_criteria_request_id: str | None = None,
+        goal_grading_run_id: str | None = None,
     ) -> None:
         """Tear down after a turn completes or is cancelled.
 
@@ -12915,6 +12910,8 @@ class DeepAgentsApp(App):
             force_goal_sync: Read goal state even when no local goal fields are set.
             goal_criteria_request_id: Terminal criteria request to clear and use
                 when correlating a newly generated proposal.
+            goal_grading_run_id: Grading run observed during the completed
+                goal-backed work turn, or `None` for every other cleanup path.
         """
         self._agent_quiescent.clear()
         self._agent_reconciling = True
@@ -12938,6 +12935,7 @@ class DeepAgentsApp(App):
                 await self._sync_goal_rubric_state_from_thread(
                     force=force_goal_sync,
                     proposal_request_id=goal_criteria_request_id,
+                    goal_grading_run_id=goal_grading_run_id,
                 )
 
                 try:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1647,7 +1647,7 @@ class _ThreadHistoryPayload:
     """Persisted accepted goal criteria, if any."""
 
     goal_status_note: str | None = None
-    """Persisted evidence or blocker note, if any."""
+    """Persisted completion evidence or blocker note for the goal, if any."""
 
     pending_goal_completion_note: str | None = None
     """Persisted agent-provided completion evidence awaiting final grading."""
@@ -1656,7 +1656,13 @@ class _ThreadHistoryPayload:
     """Latest rubric grading status from `RubricMiddleware`, if any."""
 
     rubric_grading_run_id: str | None = None
-    """Persisted identifier for the rubric grading run, if any."""
+    """Persisted `_current_grading_run_id` for the latest rubric grade, if any.
+
+    Correlation only, never authority: the resolve path compares it against the
+    *current* turn's observed grading run so that only a grade produced this turn
+    can complete the goal. It is intentionally not consumed on restore (see
+    `_restore_goal_rubric_state`), where a persisted status is display data.
+    """
 
     pending_goal_objective: str | None = None
     """Persisted pending goal objective, if any."""
@@ -2243,7 +2249,25 @@ class _MainScreen(Screen[None]):
 # failure would otherwise strand it. Retry the read a few times before giving up.
 _GOAL_SYNC_READ_ATTEMPTS = 3
 _GOAL_SYNC_READ_RETRY_SECONDS = 0.4
+
+# Recorded as the completion note when a goal auto-completes on a satisfied
+# grade without the agent having staged any `update_goal(complete)` evidence.
 _DEFAULT_GOAL_COMPLETION_NOTE = "Acceptance criteria satisfied."
+
+
+@dataclass(frozen=True)
+class _GoalGradeObservation:
+    """A goal-backed grading run observed on a work turn that completed.
+
+    Threaded (as `| None`) from the turn to `_resolve_pending_goal_completion`,
+    where its `grading_run_id` is compared against the persisted
+    `rubric_grading_run_id`. Its *presence* encodes the whole precondition — a
+    goal-backed grade was observed on a turn that did not abort — so callers no
+    longer juggle a bare run-id plus a separate "did the turn finish" flag.
+    """
+
+    grading_run_id: str
+    """Correlation ID minted by `RubricMiddleware` for the observed grade."""
 
 
 class DeepAgentsApp(App):
@@ -9314,6 +9338,12 @@ class DeepAgentsApp(App):
             preserve_queued_application: Keep an accepted in-flight goal update
                 that must be applied after turn-end reconciliation.
         """
+        # `payload.rubric_status`/`rubric_grading_run_id` are intentionally NOT
+        # consumed here. Restore treats a persisted grade as display data, never
+        # as authority to complete a goal: completion is resolved only for the
+        # *current* turn's grading run in `_resolve_pending_goal_completion`.
+        # Wiring a persisted "satisfied" status into restore would reintroduce
+        # stale auto-completion on resume/thread-switch.
         self._active_goal = payload.goal_objective
         self._goal_status = payload.goal_status
         self._goal_status_note = payload.goal_status_note
@@ -9423,17 +9453,25 @@ class DeepAgentsApp(App):
         *,
         rubric_status: str | None,
         rubric_grading_run_id: str | None,
-        goal_grading_run_id: str | None,
+        goal_grade: _GoalGradeObservation | None,
         previous_status: str | None,
     ) -> bool:
         """Resolve completion from a correlated goal-backed grading turn.
+
+        Args:
+            rubric_status: Persisted verdict read from the checkpoint.
+            rubric_grading_run_id: Persisted grading-run ID for that verdict.
+            goal_grade: Grade observed live on the current goal-backed turn, or
+                `None` when this cleanup is not that turn. Completion requires it
+                to correlate with `rubric_grading_run_id`.
+            previous_status: Goal status before this resolution, for messaging.
 
         Returns:
             `True` when the current grading turn completed the goal.
         """
         if (
-            goal_grading_run_id is None
-            or rubric_grading_run_id != goal_grading_run_id
+            goal_grade is None
+            or rubric_grading_run_id != goal_grade.grading_run_id
             or not self._active_goal
             or self._goal_status != "active"
             or self._queued_goal_application is not None
@@ -9485,7 +9523,7 @@ class DeepAgentsApp(App):
         *,
         force: bool = False,
         proposal_request_id: str | None = None,
-        goal_grading_run_id: str | None = None,
+        goal_grade: _GoalGradeObservation | None = None,
     ) -> None:
         """Refresh goal/rubric metadata from the active checkpoint.
 
@@ -9494,8 +9532,9 @@ class DeepAgentsApp(App):
             proposal_request_id: When set, restore a pending proposal only if it
                 originated from this criteria request. Resume callers omit it so
                 persisted proposals remain reviewable across clients.
-            goal_grading_run_id: Grading run observed during the current
-                goal-backed work turn. Omit outside that exact turn.
+            goal_grade: Grade observed during the current goal-backed work turn.
+                Omit outside that exact turn; only a correlated grade completes
+                the goal.
         """
         if not self._lc_thread_id:
             self._last_consumed_next_rubric = None
@@ -9633,7 +9672,7 @@ class DeepAgentsApp(App):
         completion_committed = await self._resolve_pending_goal_completion(
             rubric_status=payload.rubric_status,
             rubric_grading_run_id=payload.rubric_grading_run_id,
-            goal_grading_run_id=goal_grading_run_id,
+            goal_grade=goal_grade,
             previous_status=previous_status,
         )
         if not completion_committed:
@@ -12677,7 +12716,11 @@ class DeepAgentsApp(App):
         if self._ui_adapter is None:
             return
         from deepagents_code.config import settings
-        from deepagents_code.tui.textual_adapter import execute_task_textual
+        from deepagents_code.resume_state import RUBRIC_RESULT_VALUES
+        from deepagents_code.tui.textual_adapter import (
+            RubricEvaluationEnd,
+            execute_task_textual,
+        )
 
         criteria_request_id: str | None = None
         if graph_input is not None:
@@ -12725,19 +12768,23 @@ class DeepAgentsApp(App):
                 self._next_rubric = None
                 self._sync_status_rubric()
 
-        goal_grading_run_id: str | None = None
+        latest_goal_grade: RubricEvaluationEnd | None = None
         turn_completed = False
 
-        def _record_goal_grading_run(grading_run_id: str, result: str) -> None:
-            nonlocal goal_grading_run_id
-            if result in {
-                "satisfied",
-                "needs_revision",
-                "max_iterations_reached",
-                "failed",
-                "grader_error",
-            }:
-                goal_grading_run_id = grading_run_id
+        def _record_goal_grading_run(event: RubricEvaluationEnd) -> None:
+            nonlocal latest_goal_grade
+            if event.result in RUBRIC_RESULT_VALUES:
+                latest_goal_grade = event
+            else:
+                # A verdict outside the SDK's `RubricResult` vocabulary means the
+                # grader contract drifted. Auto-completion keys on `satisfied`, so
+                # a renamed/added verdict would silently disable it — make it loud
+                # rather than mute.
+                logger.warning(
+                    "Unrecognized rubric result %r; goal auto-completion skipped "
+                    "for this grade",
+                    event.result,
+                )
 
         try:
             await execute_task_textual(
@@ -12820,6 +12867,27 @@ class DeepAgentsApp(App):
                     "Could not mount error message (app closing?)",
                     exc_info=True,
                 )
+            # A satisfied grade may have arrived just before the turn aborted.
+            # That completion is deliberately dropped (the checkpoint write may
+            # be incomplete, so `turn_completed` gates it off below), but the
+            # rendered "satisfied" verdict and a still-active goal would then
+            # diverge with nothing to reconcile them — say so explicitly.
+            if latest_goal_grade is not None and latest_goal_grade.result == (
+                "satisfied"
+            ):
+                try:
+                    await self._mount_message(
+                        AppMessage(
+                            "The turn ended before the goal could be marked "
+                            "complete. The goal remains active and will be "
+                            "re-checked on your next turn."
+                        )
+                    )
+                except Exception:
+                    logger.debug(
+                        "Could not mount goal reconciliation message",
+                        exc_info=True,
+                    )
         finally:
             # Merge turn stats before cleanup — _cleanup_agent_task may raise
             # during teardown (widget removal on a torn-down DOM), and stats
@@ -12839,10 +12907,18 @@ class DeepAgentsApp(App):
             # Collapse the open tool group so an interrupted turn doesn't leave a
             # summary spinning "Running…" forever (synchronous, cancel-safe).
             self._close_active_tool_group()
+            # Only a turn that finished streaming can authorize completion: an
+            # abort may have left the checkpoint's grade write incomplete, so a
+            # grade observed on such a turn is dropped by yielding `None` here.
+            goal_grade = (
+                _GoalGradeObservation(latest_goal_grade.grading_run_id)
+                if turn_completed and latest_goal_grade is not None
+                else None
+            )
             await self._cleanup_agent_task(
                 force_goal_sync=graph_input is not None,
                 goal_criteria_request_id=criteria_request_id,
-                goal_grading_run_id=(goal_grading_run_id if turn_completed else None),
+                goal_grade=goal_grade,
             )
 
     async def _process_next_from_queue(self) -> None:
@@ -12899,7 +12975,7 @@ class DeepAgentsApp(App):
         *,
         force_goal_sync: bool = False,
         goal_criteria_request_id: str | None = None,
-        goal_grading_run_id: str | None = None,
+        goal_grade: _GoalGradeObservation | None = None,
     ) -> None:
         """Tear down after a turn completes or is cancelled.
 
@@ -12914,8 +12990,8 @@ class DeepAgentsApp(App):
             force_goal_sync: Read goal state even when no local goal fields are set.
             goal_criteria_request_id: Terminal criteria request to clear and use
                 when correlating a newly generated proposal.
-            goal_grading_run_id: Grading run observed during the completed
-                goal-backed work turn, or `None` for every other cleanup path.
+            goal_grade: Grade observed during the completed goal-backed work
+                turn, or `None` for every other cleanup path.
         """
         self._agent_quiescent.clear()
         self._agent_reconciling = True
@@ -12939,7 +13015,7 @@ class DeepAgentsApp(App):
                 await self._sync_goal_rubric_state_from_thread(
                     force=force_goal_sync,
                     proposal_request_id=goal_criteria_request_id,
-                    goal_grading_run_id=goal_grading_run_id,
+                    goal_grade=goal_grade,
                 )
 
                 try:

--- a/libs/code/deepagents_code/goal_tools.py
+++ b/libs/code/deepagents_code/goal_tools.py
@@ -47,7 +47,9 @@ Use `get_rubric` to inspect active acceptance criteria before deciding whether w
 complete.
 When a goal is active, use `get_goal` to inspect the objective and current status.
 A paused goal is persisted for later but must not drive work until the user resumes it.
-Use `update_goal` only when you have evidence that the goal is complete or blocked."""
+A goal is marked complete automatically when its current grading turn satisfies the
+accepted criteria. Use `update_goal` to report a blocker; `status="complete"` remains
+available for optional completion evidence but is not required."""
 """Model-visible guidance injected before each request by `GoalToolsMiddleware`."""
 
 ResponseT = TypeVar("ResponseT")
@@ -115,7 +117,7 @@ class GoalSnapshot(TypedDict):
     """Persisted goal criteria, or shared rubric criteria when no goal rubric exists."""
 
     note: str | None
-    """Latest evidence or blocker note recorded by `update_goal`."""
+    """Persisted completion evidence or blocker note for the goal."""
 
 
 class GoalToolState(GoalRubricChannels):
@@ -375,18 +377,18 @@ class GoalToolsMiddleware(AgentMiddleware[GoalToolState, ContextT]):
             tool_call_id: Annotated[str, InjectedToolCallId],
             state: Annotated[dict[str, Any], InjectedState],
         ) -> Command[Any]:
-            """Mark the current goal complete or blocked with evidence.
+            """Report a blocked goal or attach optional completion evidence.
 
-            Use `complete` only when the accepted criteria are satisfied; use
-            `blocked` when you cannot proceed without user input. Completion is
-            rejected unless the latest rubric result is satisfied. Do not create,
+            Use `blocked` when you cannot proceed without user input. Goals complete
+            automatically after a satisfied goal-backed grading turn, so `complete`
+            is optional and only stages its evidence for that result. Do not create,
             pause, resume, clear, or replace goals — those are user-controlled.
 
             Args:
-                status: `complete` when the criteria are met, `blocked` when you
-                    are stuck and need the user.
+                status: `complete` to attach completion evidence, or `blocked` when
+                    you are stuck and need the user.
                 note: Evidence the criteria are satisfied, or the specific
-                    blocker. Required — the status is not recorded without it.
+                    blocker. Required when calling this tool.
                 tool_call_id: Injected tool call ID for the tool response.
                 state: Injected graph state holding the current goal.
 

--- a/libs/code/deepagents_code/resume_state.py
+++ b/libs/code/deepagents_code/resume_state.py
@@ -21,8 +21,8 @@ write sites are called out below:
     the accepted goal and its lifecycle status. `_goal_objective`/`_goal_rubric`
     are client-only, but `_goal_status`/`_goal_status_note` are *also* written
     from inside the graph by the agent's `update_goal` tool.
-- `_pending_goal_completion_note` — an agent-requested completion awaiting the
-    post-turn rubric result and, when needed, user approval.
+- `_pending_goal_completion_note` — optional agent-provided completion evidence
+    awaiting the post-turn rubric result.
 - `_sticky_rubric` — the TUI-owned persistent rubric. This is separate from
     the public `rubric` graph input so one-shot rubric turns can be checkpointed
     without being restored as sticky state.
@@ -143,10 +143,10 @@ class GoalRubricChannels(AgentState):
     """Accepted rubric associated with `_goal_objective`."""
 
     _goal_status_note: Annotated[NotRequired[str | None], PrivateStateAttr]
-    """Evidence or blocker note recorded by `update_goal`."""
+    """Persisted completion evidence or blocker note for the goal."""
 
     _pending_goal_completion_note: Annotated[NotRequired[str | None], PrivateStateAttr]
-    """Completion evidence awaiting rubric and user approval."""
+    """Optional agent-provided completion evidence awaiting final grading."""
 
     _sticky_rubric: Annotated[NotRequired[str | None], PrivateStateAttr]
     """Persistent rubric owned by the TUI, distinct from graph input `rubric`."""

--- a/libs/code/deepagents_code/resume_state.py
+++ b/libs/code/deepagents_code/resume_state.py
@@ -57,6 +57,7 @@ from typing import (
     get_args,
 )
 
+from deepagents.middleware.rubric import RubricResult
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,
@@ -82,6 +83,36 @@ GoalProposalKind = Literal["create", "amend"]
 
 _GOAL_STATUS_VALUES: frozenset[str] = frozenset(get_args(GoalStatus))
 _GOAL_PROPOSAL_KIND_VALUES: frozenset[str] = frozenset(get_args(GoalProposalKind))
+
+
+def _flatten_literal_values(tp: object) -> frozenset[str]:
+    """Collect every string value from a (possibly unioned) `Literal` type.
+
+    Args:
+        tp: A `Literal` type, or a union of `Literal`s, to inspect.
+
+    Returns:
+        Every string member across the (possibly nested) `Literal` args.
+    """
+    values: set[str] = set()
+    for arg in get_args(tp):
+        if isinstance(arg, str):
+            values.add(arg)
+        else:
+            values |= _flatten_literal_values(arg)
+    return frozenset(values)
+
+
+RUBRIC_RESULT_VALUES: frozenset[str] = _flatten_literal_values(RubricResult)
+"""Every verdict `RubricMiddleware` can emit for a completed grading run.
+
+Derived from the SDK's `RubricResult` `Literal` so it cannot drift out of sync
+with the grader vocabulary: if the SDK renames or adds a verdict, this set
+follows automatically. Consumers that branch on a rubric result (goal
+auto-completion in `app.py`, the rubric-event formatters in `textual_adapter`)
+treat any value outside this set as an unrecognized grade rather than silently
+mishandling it.
+"""
 
 
 def coerce_goal_proposal_kind(value: object) -> GoalProposalKind | None:

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -7,7 +7,7 @@ import contextlib
 import logging
 import time
 import uuid
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 import httpx
 
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from pydantic import TypeAdapter
 
     from deepagents_code._ask_user_types import AskUserWidgetResult, Question
+    from deepagents_code.resume_state import RubricResult
 
     # Type alias matching HITLResponse["decisions"] element type
     HITLDecision = ApproveDecision | EditDecision | RejectDecision
@@ -222,6 +223,21 @@ def _is_summarization_chunk(metadata: dict | None) -> bool:
     if metadata is None:
         return False
     return metadata.get("lc_source") == "summarization"
+
+
+class RubricEvaluationEnd(NamedTuple):
+    """A validated `rubric_evaluation_end` event forwarded to the caller.
+
+    Bundling the two fields as named attributes (rather than two positional
+    strings) makes the grading-run correlation self-documenting and removes the
+    risk of transposing the run ID and the verdict at a call site.
+    """
+
+    grading_run_id: str
+    """Correlation ID minted by `RubricMiddleware` for this grading run."""
+
+    result: RubricResult
+    """Terminal/loop verdict carried by the event."""
 
 
 def _format_rubric_event(data: dict[str, Any]) -> str | None:
@@ -555,7 +571,7 @@ async def execute_task_textual(
     rubric: str | None = None,
     goal_active: bool = False,
     blocked_goal_retry_context: str | None = None,
-    on_rubric_evaluation_end: Callable[[str, str], None] | None = None,
+    on_rubric_evaluation_end: Callable[[RubricEvaluationEnd], None] | None = None,
     turn_stats: SessionStats | None = None,
 ) -> SessionStats:
     """Execute a task with output directed to Textual UI.
@@ -589,8 +605,9 @@ async def execute_task_textual(
         blocked_goal_retry_context: One-turn model context for retrying a
             previously blocked goal. This is carried via runtime context so it
             is not parsed for file mentions or checkpointed as human input.
-        on_rubric_evaluation_end: Optional callback receiving the grading run ID
-            and result for validated main-agent rubric completion events.
+        on_rubric_evaluation_end: Optional callback receiving a validated
+            `RubricEvaluationEnd` (grading run ID and verdict) for each
+            main-agent `rubric_evaluation_end` event.
         turn_stats: Pre-created `SessionStats` to accumulate into.
 
             When the caller holds a reference to the same object, stats are
@@ -882,9 +899,15 @@ async def execute_task_textual(
                                 and grading_run_id.strip()
                                 and isinstance(result, str)
                             ):
+                                # Structurally validated here; the verdict is
+                                # cast to `RubricResult` at this boundary and the
+                                # consumer re-checks it against the known set.
                                 try:
                                     on_rubric_evaluation_end(
-                                        grading_run_id.strip(), result
+                                        RubricEvaluationEnd(
+                                            grading_run_id=grading_run_id.strip(),
+                                            result=cast("RubricResult", result),
+                                        )
                                     )
                                 except Exception:
                                     logger.warning(

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -555,6 +555,7 @@ async def execute_task_textual(
     rubric: str | None = None,
     goal_active: bool = False,
     blocked_goal_retry_context: str | None = None,
+    on_rubric_evaluation_end: Callable[[str, str], None] | None = None,
     turn_stats: SessionStats | None = None,
 ) -> SessionStats:
     """Execute a task with output directed to Textual UI.
@@ -588,6 +589,8 @@ async def execute_task_textual(
         blocked_goal_retry_context: One-turn model context for retrying a
             previously blocked goal. This is carried via runtime context so it
             is not parsed for file mentions or checkpointed as human input.
+        on_rubric_evaluation_end: Optional callback receiving the grading run ID
+            and result for validated main-agent rubric completion events.
         turn_stats: Pre-created `SessionStats` to accumulate into.
 
             When the caller holds a reference to the same object, stats are
@@ -868,6 +871,26 @@ async def execute_task_textual(
                             else AppMessage(formatted_rubric_event)
                         )
                         await adapter._mount_message(message)
+                        if (
+                            on_rubric_evaluation_end is not None
+                            and rubric_message.get("type") == "rubric_evaluation_end"
+                        ):
+                            grading_run_id = rubric_message.get("grading_run_id")
+                            result = rubric_message.get("result")
+                            if (
+                                isinstance(grading_run_id, str)
+                                and grading_run_id.strip()
+                                and isinstance(result, str)
+                            ):
+                                try:
+                                    on_rubric_evaluation_end(
+                                        grading_run_id.strip(), result
+                                    )
+                                except Exception:
+                                    logger.warning(
+                                        "on_rubric_evaluation_end callback failed",
+                                        exc_info=True,
+                                    )
                         continue
                     if formatted_rubric_event is not None:
                         # Rubric events come from the main agent today; a

--- a/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
+++ b/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
@@ -358,7 +358,9 @@ Use `get_rubric` to inspect active acceptance criteria before deciding whether w
 complete.
 When a goal is active, use `get_goal` to inspect the objective and current status.
 A paused goal is persisted for later but must not drive work until the user resumes it.
-Use `update_goal` only when you have evidence that the goal is complete or blocked.
+A goal is marked complete automatically when its current grading turn satisfies the
+accepted criteria. Use `update_goal` to report a blocker; `status="complete"` remains
+available for optional completion evidence but is not required.
 
 ## `ask_user`
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -6904,10 +6904,14 @@ class TestGoalCommand:
             assert not any(app.query(GoalReviewMenu))
 
     async def test_goal_accept_sets_sticky_rubric(self) -> None:
-        """Accepting a proposed goal should set the rubric and start work."""
+        """Accepting a proposed goal should replace a completed goal and start work."""
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
+            app._active_goal = "previous goal"
+            app._goal_status = "complete"
+            app._goal_status_note = "previous goal passed"
+            app._active_rubric = "- previous criteria"
             app._pending_goal_completion_note = "evidence for the previous goal"
             app._pending_goal_objective = "add refresh tokens"
             app._pending_goal_rubric = "- tests pass"
@@ -6926,6 +6930,7 @@ class TestGoalCommand:
 
             assert app._active_goal == "add refresh tokens"
             assert app._goal_status == "active"
+            assert app._goal_status_note is None
             assert app._active_rubric == "- tests pass"
             assert app._pending_goal_completion_note is None
             assert app._pending_goal_objective is None
@@ -7240,12 +7245,14 @@ class TestGoalCommand:
             assert app._goal_status_note == "waiting for credentials"
             assert app._active_rubric == "- tests pass"
 
-    async def test_sync_goal_completion_auto_commits_after_rubric_satisfied(
+    @pytest.mark.parametrize("auto_approve", [False, True])
+    async def test_current_goal_grade_completes_without_approval(
         self,
+        auto_approve: bool,
     ) -> None:
-        """Auto mode should commit a staged completion after rubric approval."""
+        """Manual and YOLO modes persist the same automatic completion state."""
         updater = SimpleNamespace(aupdate_state=AsyncMock())
-        app = DeepAgentsApp(agent=MagicMock(), auto_approve=True)
+        app = DeepAgentsApp(agent=MagicMock(), auto_approve=auto_approve)
         async with app.run_test() as pilot:
             await pilot.pause()
             app._agent = updater
@@ -7253,35 +7260,40 @@ class TestGoalCommand:
             app._active_goal = "add refresh tokens"
             app._goal_status = "active"
             app._active_rubric = "- tests pass"
-            assert app._session_state is not None
-            app._session_state.auto_approve = True
 
             fetch = AsyncMock(
                 return_value={
                     "_goal_objective": "add refresh tokens",
                     "_goal_status": "active",
                     "_goal_rubric": "- tests pass",
-                    "_pending_goal_completion_note": "tests pass",
                     "_rubric_status": "satisfied",
+                    "_current_grading_run_id": "grade-current",
                 }
             )
-            with patch.object(app, "_get_thread_state_values", fetch):
-                await app._sync_goal_rubric_state_from_thread()
+            request_approval = AsyncMock()
+            with (
+                patch.object(app, "_get_thread_state_values", fetch),
+                patch.object(app, "_request_approval", request_approval),
+            ):
+                await app._sync_goal_rubric_state_from_thread(
+                    goal_grading_run_id="grade-current"
+                )
 
-            assert app._active_goal is None
-            assert app._goal_status is None
-            assert app._goal_status_note is None
-            assert app._active_rubric is None
+            request_approval.assert_not_awaited()
+            assert app._active_goal == "add refresh tokens"
+            assert app._goal_status == "complete"
+            assert app._goal_status_note == "Acceptance criteria satisfied."
+            assert app._active_rubric == "- tests pass"
             assert app._pending_goal_completion_note is None
             assert updater.aupdate_state.await_args is not None
             state_update = updater.aupdate_state.await_args.args[1]
             assert state_update == {
                 "rubric": None,
-                "_sticky_rubric": None,
-                "_goal_objective": None,
-                "_goal_status": None,
-                "_goal_rubric": None,
-                "_goal_status_note": None,
+                "_sticky_rubric": "- tests pass",
+                "_goal_objective": "add refresh tokens",
+                "_goal_status": "complete",
+                "_goal_rubric": "- tests pass",
+                "_goal_status_note": "Acceptance criteria satisfied.",
                 "_pending_goal_completion_note": None,
                 "_pending_goal_objective": None,
                 "_pending_goal_rubric": None,
@@ -7289,7 +7301,17 @@ class TestGoalCommand:
                 "_pending_goal_request_id": None,
             }
 
-    async def test_completed_goal_is_cleared_before_next_turn(self) -> None:
+            await app._show_goal_state()
+            await pilot.pause()
+            rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
+            assert "Goal:\nadd refresh tokens" in rendered
+            assert "Status:\ncomplete" in rendered
+            assert "Criteria:\n- tests pass" in rendered
+            assert "Status note:\nAcceptance criteria satisfied." in rendered
+
+    async def test_completed_goal_remains_visible_but_does_not_grade_next_turn(
+        self,
+    ) -> None:
         app = DeepAgentsApp(agent=MagicMock(), auto_approve=True)
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -7302,10 +7324,14 @@ class TestGoalCommand:
                 previous_status="active",
             )
 
-            assert app._active_goal is None
-            assert app._active_rubric is None
+            assert app._active_goal == "add refresh tokens"
+            assert app._goal_status == "complete"
+            assert app._goal_status_note == "all acceptance tests pass"
+            assert app._active_rubric == "- tests pass"
             assert app._status_bar is not None
-            assert app._status_bar.rubric_label == ""
+            assert app._status_bar.rubric_label == _rubric_status_label(
+                "checkmark", "Goal complete"
+            )
 
             with (
                 patch(
@@ -7323,15 +7349,18 @@ class TestGoalCommand:
             assert execute.await_args is not None
             assert execute.await_args.kwargs["rubric"] is None
             assert execute.await_args.kwargs["goal_active"] is False
+            assert execute.await_args.kwargs["on_rubric_evaluation_end"] is None
 
             await app._show_goal_state()
             await pilot.pause()
             rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
-            assert "No goal set." in rendered
-            assert "Last completed goal:" not in rendered
+            assert "Goal:\nadd refresh tokens" in rendered
+            assert "Status:\ncomplete" in rendered
+            assert "Criteria:\n- tests pass" in rendered
+            assert "Status note:\nall acceptance tests pass" in rendered
 
     async def test_failed_completion_persistence_restores_retryable_goal(self) -> None:
-        """A failed clear write must leave local state aligned for retry."""
+        """A failed completion write must restore the active goal and proposal."""
         app = DeepAgentsApp(agent=MagicMock(), auto_approve=True)
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -7349,6 +7378,8 @@ class TestGoalCommand:
 
             committed = await app._resolve_pending_goal_completion(
                 rubric_status="satisfied",
+                rubric_grading_run_id="grade-current",
+                goal_grading_run_id="grade-current",
                 previous_status="active",
             )
             await pilot.pause()
@@ -7362,10 +7393,10 @@ class TestGoalCommand:
             assert app._pending_goal_rubric == "- security tests pass"
             assert app._pending_goal_kind == "amend"
             rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
-            assert "Goal marked complete by the agent." not in rendered
+            assert "Goal marked complete." not in rendered
             errors = "\n".join(str(w._content) for w in app.query(ErrorMessage))
             assert "goal remains active" in errors
-            assert "completion request is still pending" in errors
+            assert "another satisfied grading turn" in errors
 
     async def test_grader_error_keeps_goal_and_completion_request_active(self) -> None:
         app = DeepAgentsApp(agent=MagicMock(), auto_approve=True)
@@ -7378,6 +7409,8 @@ class TestGoalCommand:
 
             committed = await app._resolve_pending_goal_completion(
                 rubric_status="grader_error",
+                rubric_grading_run_id="grade-current",
+                goal_grading_run_id="grade-current",
                 previous_status="active",
             )
             await pilot.pause()
@@ -7403,6 +7436,8 @@ class TestGoalCommand:
 
             committed = await app._resolve_pending_goal_completion(
                 rubric_status="max_iterations_reached",
+                rubric_grading_run_id="grade-current",
+                goal_grading_run_id="grade-current",
                 previous_status="active",
             )
             await app._show_goal_state()
@@ -7438,6 +7473,8 @@ class TestGoalCommand:
 
             committed = await app._resolve_pending_goal_completion(
                 rubric_status="failed",
+                rubric_grading_run_id="grade-current",
+                goal_grading_run_id="grade-current",
                 previous_status="active",
             )
             await pilot.pause()
@@ -7476,10 +7513,13 @@ class TestGoalCommand:
                     "_goal_rubric": "- tests pass",
                     "_pending_goal_completion_note": "tests pass",
                     "_rubric_status": "needs_revision",
+                    "_current_grading_run_id": "grade-current",
                 }
             )
             with patch.object(app, "_get_thread_state_values", fetch):
-                await app._sync_goal_rubric_state_from_thread()
+                await app._sync_goal_rubric_state_from_thread(
+                    goal_grading_run_id="grade-current"
+                )
                 await pilot.pause()
 
             assert app._goal_status == "active"
@@ -7487,14 +7527,10 @@ class TestGoalCommand:
             rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
             assert "rubric was not satisfied" in rendered
 
-    async def test_sync_goal_completion_requests_manual_approval(
-        self,
-    ) -> None:
-        """Manual mode should ask before committing a rubric-approved completion."""
+    async def test_explicit_completion_note_remains_compatible(self) -> None:
+        """An optional `update_goal(complete)` note is kept without approval."""
         updater = SimpleNamespace(aupdate_state=AsyncMock())
         app = DeepAgentsApp(agent=MagicMock(), auto_approve=False)
-        approval = asyncio.get_running_loop().create_future()
-        approval.set_result({"type": "approve"})
         async with app.run_test() as pilot:
             await pilot.pause()
             app._agent = updater
@@ -7502,34 +7538,186 @@ class TestGoalCommand:
             app._active_goal = "add refresh tokens"
             app._goal_status = "active"
             app._active_rubric = "- tests pass"
-            assert app._session_state is not None
-            app._session_state.auto_approve = False
 
             fetch = AsyncMock(
                 return_value={
                     "_goal_objective": "add refresh tokens",
                     "_goal_status": "active",
                     "_goal_rubric": "- tests pass",
-                    "_pending_goal_completion_note": "tests pass",
+                    "_pending_goal_completion_note": "all refresh tests pass",
                     "_rubric_status": "satisfied",
+                    "_current_grading_run_id": "grade-current",
                 }
             )
-            request_approval = AsyncMock(return_value=approval)
+            request_approval = AsyncMock()
             with (
                 patch.object(app, "_get_thread_state_values", fetch),
                 patch.object(app, "_request_approval", request_approval),
             ):
-                await app._sync_goal_rubric_state_from_thread()
+                await app._sync_goal_rubric_state_from_thread(
+                    goal_grading_run_id="grade-current"
+                )
 
-            request_approval.assert_awaited_once()
-            assert request_approval.await_args is not None
-            action_requests = request_approval.await_args.args[0]
-            assert action_requests[0]["name"] == "update_goal"
-            assert action_requests[0]["args"]["status"] == "complete"
-            assert app._active_goal is None
-            assert app._goal_status is None
-            assert app._active_rubric is None
+            request_approval.assert_not_awaited()
+            assert app._active_goal == "add refresh tokens"
+            assert app._goal_status == "complete"
+            assert app._goal_status_note == "all refresh tests pass"
+            assert app._active_rubric == "- tests pass"
             assert app._pending_goal_completion_note is None
+
+    async def test_goal_turn_event_completes_through_cleanup(self) -> None:
+        """A satisfied event from the selected goal rubric completes without a tool."""
+        updater = SimpleNamespace(aupdate_state=AsyncMock())
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = updater
+            app._lc_thread_id = "thread-1"
+            app._active_goal = "add refresh tokens"
+            app._goal_status = "active"
+            app._active_rubric = "- tests pass"
+
+            async def execute(**kwargs: object) -> SessionStats:
+                await asyncio.sleep(0)
+                callback = cast(
+                    "Callable[[str, str], None]",
+                    kwargs["on_rubric_evaluation_end"],
+                )
+                callback("grade-current", "satisfied")
+                return SessionStats()
+
+            fetch = AsyncMock(
+                return_value={
+                    "_goal_objective": "add refresh tokens",
+                    "_goal_status": "active",
+                    "_goal_rubric": "- tests pass",
+                    "_rubric_status": "satisfied",
+                    "_current_grading_run_id": "grade-current",
+                }
+            )
+            with (
+                patch(
+                    "deepagents_code.tui.textual_adapter.execute_task_textual",
+                    side_effect=execute,
+                ),
+                patch.object(app, "_get_thread_state_values", fetch),
+            ):
+                await app._run_agent_task("finish the goal")
+
+            assert app._active_goal == "add refresh tokens"
+            assert app._goal_status == "complete"
+            assert app._goal_status_note == "Acceptance criteria satisfied."
+
+    @pytest.mark.parametrize("mode", ["unrelated", "mismatched", "criteria"])
+    async def test_stale_satisfied_status_cannot_complete_goal(
+        self,
+        mode: str,
+    ) -> None:
+        """Only the matching current goal-backed grading run can complete a goal."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._lc_thread_id = "thread-1"
+            app._active_goal = "add refresh tokens"
+            app._goal_status = "active"
+            app._active_rubric = "- tests pass"
+
+            state_values = {
+                "_goal_objective": "add refresh tokens",
+                "_goal_status": "active",
+                "_goal_rubric": "- tests pass",
+                "_rubric_status": "satisfied",
+                "_current_grading_run_id": "grade-stale",
+                "_pending_goal_objective": "add audit logs",
+                "_pending_goal_rubric": "- audit tests pass",
+                "_pending_goal_kind": "create",
+                "_pending_goal_request_id": "criteria-request",
+            }
+            with (
+                patch.object(
+                    app,
+                    "_get_thread_state_values",
+                    AsyncMock(return_value=state_values),
+                ),
+                patch.object(app, "_remount_pending_goal_rubric_review", AsyncMock()),
+            ):
+                if mode == "mismatched":
+                    await app._sync_goal_rubric_state_from_thread(
+                        goal_grading_run_id="grade-current"
+                    )
+                elif mode == "criteria":
+                    await app._sync_goal_rubric_state_from_thread(
+                        force=True,
+                        proposal_request_id="criteria-request",
+                    )
+                else:
+                    await app._sync_goal_rubric_state_from_thread()
+
+            assert app._active_goal == "add refresh tokens"
+            assert app._goal_status == "active"
+            assert app._active_rubric == "- tests pass"
+            assert app._pending_goal_objective == "add audit logs"
+
+    async def test_restore_does_not_complete_from_stale_satisfied_status(self) -> None:
+        """Thread restoration treats rubric status as display data, not authority."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            payload = _ThreadHistoryPayload(
+                [],
+                0,
+                "",
+                goal_objective="add refresh tokens",
+                goal_status="active",
+                goal_rubric="- tests pass",
+                rubric_status="satisfied",
+                rubric_grading_run_id="grade-stale",
+            )
+
+            app._restore_goal_rubric_state(payload)
+
+            assert app._active_goal == "add refresh tokens"
+            assert app._goal_status == "active"
+            assert app._active_rubric == "- tests pass"
+
+    @pytest.mark.parametrize(
+        "rubric_status",
+        [None, "needs_revision", "max_iterations_reached", "failed", "grader_error"],
+    )
+    async def test_non_satisfied_current_goal_grade_stays_unfinished(
+        self,
+        rubric_status: str | None,
+    ) -> None:
+        """Every non-satisfied or missing final status leaves the goal active."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._lc_thread_id = "thread-1"
+            app._active_goal = "add refresh tokens"
+            app._goal_status = "active"
+            app._active_rubric = "- tests pass"
+
+            state_values: dict[str, object] = {
+                "_goal_objective": "add refresh tokens",
+                "_goal_status": "active",
+                "_goal_rubric": "- tests pass",
+                "_current_grading_run_id": "grade-current",
+            }
+            if rubric_status is not None:
+                state_values["_rubric_status"] = rubric_status
+            with patch.object(
+                app,
+                "_get_thread_state_values",
+                AsyncMock(return_value=state_values),
+            ):
+                await app._sync_goal_rubric_state_from_thread(
+                    goal_grading_run_id="grade-current"
+                )
+
+            assert app._active_goal == "add refresh tokens"
+            assert app._goal_status == "active"
+            assert app._goal_status_note is None
+            assert app._active_rubric == "- tests pass"
 
     async def test_sync_goal_rubric_state_drops_unknown_status(self) -> None:
         """An unrecognized persisted goal status normalizes to None."""
@@ -7862,6 +8050,8 @@ class TestGoalCommand:
         async with app.run_test() as pilot:
             await pilot.pause()
             app._active_goal = "add refresh tokens"
+            app._goal_status = "complete"
+            app._goal_status_note = "Acceptance criteria satisfied."
             app._active_rubric = "- tests pass"
             app._pending_goal_objective = "other goal"
             app._pending_goal_rubric = "- draft"
@@ -7871,6 +8061,8 @@ class TestGoalCommand:
             await pilot.pause()
 
             assert app._active_goal is None
+            assert app._goal_status is None
+            assert app._goal_status_note is None
             assert app._active_rubric is None
             assert app._pending_goal_objective is None
             assert app._pending_goal_rubric is None
@@ -8500,6 +8692,50 @@ class TestRubricCommand:
             assert mock_execute.await_args.kwargs["rubric"] == "update docs"
             assert app._next_rubric is None
             assert app._status_bar.rubric_label == ""
+
+    async def test_standalone_next_rubric_cannot_complete_active_goal(self) -> None:
+        """A satisfied one-shot rubric cannot complete a goal with identical text."""
+        updater = SimpleNamespace(aupdate_state=AsyncMock())
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = updater
+            app._lc_thread_id = "thread-1"
+            app._active_goal = "add refresh tokens"
+            app._goal_status = "active"
+            app._active_rubric = "- tests pass"
+            app._next_rubric = "- tests pass"
+
+            async def execute(**kwargs: object) -> SessionStats:
+                await asyncio.sleep(0)
+                assert kwargs["rubric"] == "- tests pass"
+                assert kwargs["goal_active"] is False
+                assert kwargs["on_rubric_evaluation_end"] is None
+                return SessionStats()
+
+            fetch = AsyncMock(
+                return_value={
+                    "rubric": "- tests pass",
+                    "_sticky_rubric": "- tests pass",
+                    "_goal_objective": "add refresh tokens",
+                    "_goal_status": "active",
+                    "_goal_rubric": "- tests pass",
+                    "_rubric_status": "satisfied",
+                    "_current_grading_run_id": "grade-one-shot",
+                }
+            )
+            with (
+                patch(
+                    "deepagents_code.tui.textual_adapter.execute_task_textual",
+                    side_effect=execute,
+                ),
+                patch.object(app, "_get_thread_state_values", fetch),
+            ):
+                await app._run_agent_task("check this turn")
+
+            assert app._active_goal == "add refresh tokens"
+            assert app._goal_status == "active"
+            assert app._goal_status_note is None
 
     async def test_rubric_next_sync_does_not_restore_as_sticky(self) -> None:
         """A checkpointed one-shot rubric should not become sticky on cleanup."""

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -25,7 +25,11 @@ if TYPE_CHECKING:
 
     from deepagents_code.mcp_auth import McpServerSpec
     from deepagents_code.notifications import PendingNotification
-    from deepagents_code.resume_state import GoalProposalKind, GoalStatus
+    from deepagents_code.resume_state import (
+        GoalProposalKind,
+        GoalStatus,
+        RubricResult,
+    )
     from deepagents_code.sessions import ThreadInfo
     from deepagents_code.tui.widgets.messages import ToolCallMessage
 
@@ -56,12 +60,14 @@ from deepagents_code.app import (
     _display_model_label,
     _extra_is_ready,
     _GoalApplication,
+    _GoalGradeObservation,
     _parse_rubric_max_iterations,
     _ThreadHistoryPayload,
     _warn_discarded_goal_channels,
 )
 from deepagents_code.event_bus import ExternalEvent
 from deepagents_code.media_utils import ImageData, VideoData
+from deepagents_code.tui.textual_adapter import RubricEvaluationEnd
 from deepagents_code.tui.widgets.ask_user import AskUserMenu, AskUserTextArea
 from deepagents_code.tui.widgets.chat_input import ChatInput
 from deepagents_code.tui.widgets.goal_review import (
@@ -7276,7 +7282,7 @@ class TestGoalCommand:
                 patch.object(app, "_request_approval", request_approval),
             ):
                 await app._sync_goal_rubric_state_from_thread(
-                    goal_grading_run_id="grade-current"
+                    goal_grade=_GoalGradeObservation("grade-current")
                 )
 
             request_approval.assert_not_awaited()
@@ -7379,7 +7385,7 @@ class TestGoalCommand:
             committed = await app._resolve_pending_goal_completion(
                 rubric_status="satisfied",
                 rubric_grading_run_id="grade-current",
-                goal_grading_run_id="grade-current",
+                goal_grade=_GoalGradeObservation("grade-current"),
                 previous_status="active",
             )
             await pilot.pause()
@@ -7388,6 +7394,10 @@ class TestGoalCommand:
             assert app._active_goal == "add refresh tokens"
             assert app._goal_status == "active"
             assert app._active_rubric == "- tests pass"
+            # `_commit_pending_goal_completion` no longer clears the active goal
+            # or rubric, so those two are sanity checks; the load-bearing
+            # assertions are the restored `_pending_goal_*` fields below, which a
+            # failed persistence must roll back for a later retry.
             assert app._pending_goal_completion_note == "all acceptance tests pass"
             assert app._pending_goal_objective == "add refresh tokens safely"
             assert app._pending_goal_rubric == "- security tests pass"
@@ -7410,7 +7420,7 @@ class TestGoalCommand:
             committed = await app._resolve_pending_goal_completion(
                 rubric_status="grader_error",
                 rubric_grading_run_id="grade-current",
-                goal_grading_run_id="grade-current",
+                goal_grade=_GoalGradeObservation("grade-current"),
                 previous_status="active",
             )
             await pilot.pause()
@@ -7437,7 +7447,7 @@ class TestGoalCommand:
             committed = await app._resolve_pending_goal_completion(
                 rubric_status="max_iterations_reached",
                 rubric_grading_run_id="grade-current",
-                goal_grading_run_id="grade-current",
+                goal_grade=_GoalGradeObservation("grade-current"),
                 previous_status="active",
             )
             await app._show_goal_state()
@@ -7474,7 +7484,7 @@ class TestGoalCommand:
             committed = await app._resolve_pending_goal_completion(
                 rubric_status="failed",
                 rubric_grading_run_id="grade-current",
-                goal_grading_run_id="grade-current",
+                goal_grade=_GoalGradeObservation("grade-current"),
                 previous_status="active",
             )
             await pilot.pause()
@@ -7518,7 +7528,7 @@ class TestGoalCommand:
             )
             with patch.object(app, "_get_thread_state_values", fetch):
                 await app._sync_goal_rubric_state_from_thread(
-                    goal_grading_run_id="grade-current"
+                    goal_grade=_GoalGradeObservation("grade-current")
                 )
                 await pilot.pause()
 
@@ -7555,7 +7565,7 @@ class TestGoalCommand:
                 patch.object(app, "_request_approval", request_approval),
             ):
                 await app._sync_goal_rubric_state_from_thread(
-                    goal_grading_run_id="grade-current"
+                    goal_grade=_GoalGradeObservation("grade-current")
                 )
 
             request_approval.assert_not_awaited()
@@ -7580,10 +7590,10 @@ class TestGoalCommand:
             async def execute(**kwargs: object) -> SessionStats:
                 await asyncio.sleep(0)
                 callback = cast(
-                    "Callable[[str, str], None]",
+                    "Callable[[RubricEvaluationEnd], None]",
                     kwargs["on_rubric_evaluation_end"],
                 )
-                callback("grade-current", "satisfied")
+                callback(RubricEvaluationEnd("grade-current", "satisfied"))
                 return SessionStats()
 
             fetch = AsyncMock(
@@ -7607,6 +7617,131 @@ class TestGoalCommand:
             assert app._active_goal == "add refresh tokens"
             assert app._goal_status == "complete"
             assert app._goal_status_note == "Acceptance criteria satisfied."
+
+    async def test_satisfied_grade_before_turn_error_keeps_goal_active(self) -> None:
+        """A satisfied grade seen before the turn aborts must not complete a goal.
+
+        The checkpoint write may be incomplete when the stream raises, so the
+        grade is withheld (via the `turn_completed` gate) and the divergence
+        between the rendered verdict and the still-active goal is reconciled with
+        an explicit message.
+        """
+        updater = SimpleNamespace(aupdate_state=AsyncMock())
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = updater
+            app._lc_thread_id = "thread-1"
+            app._active_goal = "add refresh tokens"
+            app._goal_status = "active"
+            app._active_rubric = "- tests pass"
+
+            async def execute(**kwargs: object) -> SessionStats:
+                await asyncio.sleep(0)
+                callback = cast(
+                    "Callable[[RubricEvaluationEnd], None]",
+                    kwargs["on_rubric_evaluation_end"],
+                )
+                callback(RubricEvaluationEnd("grade-current", "satisfied"))
+                msg = "stream aborted after grading"
+                raise RuntimeError(msg)
+
+            fetch = AsyncMock(
+                return_value={
+                    "_goal_objective": "add refresh tokens",
+                    "_goal_status": "active",
+                    "_goal_rubric": "- tests pass",
+                    "_rubric_status": "satisfied",
+                    "_current_grading_run_id": "grade-current",
+                }
+            )
+            with (
+                patch(
+                    "deepagents_code.tui.textual_adapter.execute_task_textual",
+                    side_effect=execute,
+                ),
+                patch.object(app, "_get_thread_state_values", fetch),
+            ):
+                await app._run_agent_task("finish the goal")
+            await pilot.pause()
+
+            assert app._active_goal == "add refresh tokens"
+            assert app._goal_status == "active"
+            assert app._goal_status_note is None
+            rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
+            assert "re-checked on your next turn" in rendered
+
+    async def test_unrecognized_grade_does_not_complete_goal(self) -> None:
+        """A verdict outside the known set is skipped and cannot complete a goal."""
+        updater = SimpleNamespace(aupdate_state=AsyncMock())
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = updater
+            app._lc_thread_id = "thread-1"
+            app._active_goal = "add refresh tokens"
+            app._goal_status = "active"
+            app._active_rubric = "- tests pass"
+
+            async def execute(**kwargs: object) -> SessionStats:
+                await asyncio.sleep(0)
+                callback = cast(
+                    "Callable[[RubricEvaluationEnd], None]",
+                    kwargs["on_rubric_evaluation_end"],
+                )
+                # A verdict the SDK vocabulary does not contain — the callback
+                # must skip it rather than record the run for completion.
+                callback(
+                    RubricEvaluationEnd(
+                        "grade-current", cast("RubricResult", "brand_new_verdict")
+                    )
+                )
+                return SessionStats()
+
+            fetch = AsyncMock(
+                return_value={
+                    "_goal_objective": "add refresh tokens",
+                    "_goal_status": "active",
+                    "_goal_rubric": "- tests pass",
+                    "_rubric_status": "satisfied",
+                    "_current_grading_run_id": "grade-current",
+                }
+            )
+            with (
+                patch(
+                    "deepagents_code.tui.textual_adapter.execute_task_textual",
+                    side_effect=execute,
+                ),
+                patch.object(app, "_get_thread_state_values", fetch),
+            ):
+                await app._run_agent_task("finish the goal")
+
+            assert app._active_goal == "add refresh tokens"
+            assert app._goal_status == "active"
+            assert app._goal_status_note is None
+
+    async def test_queued_goal_application_blocks_completion(self) -> None:
+        """A satisfied, correlated grade cannot complete a goal pending replacement."""
+        app = DeepAgentsApp(agent=MagicMock(), auto_approve=True)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._active_goal = "add refresh tokens"
+            app._goal_status = "active"
+            app._active_rubric = "- tests pass"
+            app._queued_goal_application = _GoalApplication(
+                "replace with audit logs", "- audit tests pass", "amend"
+            )
+
+            committed = await app._resolve_pending_goal_completion(
+                rubric_status="satisfied",
+                rubric_grading_run_id="grade-current",
+                goal_grade=_GoalGradeObservation("grade-current"),
+                previous_status="active",
+            )
+
+            assert committed is False
+            assert app._goal_status == "active"
+            assert app._goal_status_note is None
 
     @pytest.mark.parametrize("mode", ["unrelated", "mismatched", "criteria"])
     async def test_stale_satisfied_status_cannot_complete_goal(
@@ -7643,7 +7778,7 @@ class TestGoalCommand:
             ):
                 if mode == "mismatched":
                     await app._sync_goal_rubric_state_from_thread(
-                        goal_grading_run_id="grade-current"
+                        goal_grade=_GoalGradeObservation("grade-current")
                     )
                 elif mode == "criteria":
                     await app._sync_goal_rubric_state_from_thread(
@@ -7711,13 +7846,21 @@ class TestGoalCommand:
                 AsyncMock(return_value=state_values),
             ):
                 await app._sync_goal_rubric_state_from_thread(
-                    goal_grading_run_id="grade-current"
+                    goal_grade=_GoalGradeObservation("grade-current")
                 )
 
             assert app._active_goal == "add refresh tokens"
             assert app._goal_status == "active"
             assert app._goal_status_note is None
             assert app._active_rubric == "- tests pass"
+            # No completion was staged, so a non-satisfied grade during ordinary
+            # automatic grading must stay quiet: the `if note:` guards suppress
+            # any "completion not recorded"/grader-error message (the raw verdict
+            # panel is rendered separately upstream, not here).
+            assert not app.query(ErrorMessage)
+            rendered = "\n".join(str(w._content) for w in app.query(AppMessage)).lower()
+            assert "completion was not recorded" not in rendered
+            assert "grading failed" not in rendered
 
     async def test_sync_goal_rubric_state_drops_unknown_status(self) -> None:
         """An unrecognized persisted goal status normalizes to None."""

--- a/libs/code/tests/unit_tests/test_goal_criteria_client.py
+++ b/libs/code/tests/unit_tests/test_goal_criteria_client.py
@@ -233,7 +233,7 @@ async def test_failed_criteria_turn_shows_actionable_message() -> None:
     cleanup.assert_awaited_once_with(
         force_goal_sync=True,
         goal_criteria_request_id="request-fail",
-        goal_grading_run_id=None,
+        goal_grade=None,
     )
 
 
@@ -404,7 +404,7 @@ async def test_cancelled_criteria_turn_still_runs_request_cleanup() -> None:
     cleanup.assert_awaited_once_with(
         force_goal_sync=True,
         goal_criteria_request_id="request-cancel",
-        goal_grading_run_id=None,
+        goal_grade=None,
     )
 
 

--- a/libs/code/tests/unit_tests/test_goal_criteria_client.py
+++ b/libs/code/tests/unit_tests/test_goal_criteria_client.py
@@ -233,6 +233,7 @@ async def test_failed_criteria_turn_shows_actionable_message() -> None:
     cleanup.assert_awaited_once_with(
         force_goal_sync=True,
         goal_criteria_request_id="request-fail",
+        goal_grading_run_id=None,
     )
 
 
@@ -403,6 +404,7 @@ async def test_cancelled_criteria_turn_still_runs_request_cleanup() -> None:
     cleanup.assert_awaited_once_with(
         force_goal_sync=True,
         goal_criteria_request_id="request-cancel",
+        goal_grading_run_id=None,
     )
 
 

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -7092,8 +7092,9 @@ class TestExecuteTaskTextualRubricEvents:
     """Rubric custom-stream events surface only for the main agent."""
 
     async def test_main_agent_rubric_event_mounts_message(self) -> None:
-        """A main-agent rubric verdict is rendered in the transcript."""
+        """A main-agent rubric verdict is rendered and forwarded with its run ID."""
         mounted: list[object] = []
+        evaluations: list[tuple[str, str]] = []
 
         async def mount_message(widget: object) -> None:
             await asyncio.sleep(0)
@@ -7101,44 +7102,14 @@ class TestExecuteTaskTextualRubricEvents:
 
         # (namespace, stream_mode, data); empty namespace == main agent.
         chunks = [
-            ((), "custom", {"type": "rubric_evaluation_end", "result": "satisfied"}),
-        ]
-        adapter = TextualUIAdapter(
-            mount_message=mount_message,
-            update_status=_noop_status,
-            request_approval=_mock_approval,
-        )
-
-        await execute_task_textual(
-            user_input="hi",
-            agent=_FakeAgent(chunks),
-            assistant_id="assistant",
-            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
-            adapter=adapter,
-        )
-
-        rubric_msgs = [
-            m
-            for m in mounted
-            if isinstance(m, AppMessage)
-            and "Acceptance criteria satisfied" in str(m._content)
-        ]
-        assert len(rubric_msgs) == 1
-
-    async def test_subagent_rubric_event_is_not_mounted(self) -> None:
-        """A rubric event from a subagent namespace must not reach the transcript."""
-        mounted: list[object] = []
-
-        async def mount_message(widget: object) -> None:
-            await asyncio.sleep(0)
-            mounted.append(widget)
-
-        # Non-empty namespace == subagent; the is_main_agent gate suppresses it.
-        chunks = [
             (
-                ("subagent",),
+                (),
                 "custom",
-                {"type": "rubric_evaluation_end", "result": "satisfied"},
+                {
+                    "type": "rubric_evaluation_end",
+                    "result": "satisfied",
+                    "grading_run_id": "grade-current",
+                },
             ),
         ]
         adapter = TextualUIAdapter(
@@ -7153,10 +7124,121 @@ class TestExecuteTaskTextualRubricEvents:
             assistant_id="assistant",
             session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
             adapter=adapter,
+            on_rubric_evaluation_end=lambda run_id, result: evaluations.append(
+                (run_id, result)
+            ),
         )
 
+        rubric_msgs = [
+            m
+            for m in mounted
+            if isinstance(m, AppMessage)
+            and "Acceptance criteria satisfied" in str(m._content)
+        ]
+        assert len(rubric_msgs) == 1
+        assert evaluations == [("grade-current", "satisfied")]
+
+    async def test_subagent_rubric_event_is_not_mounted(self) -> None:
+        """A rubric event from a subagent namespace must not reach the transcript."""
+        mounted: list[object] = []
+        evaluations: list[tuple[str, str]] = []
+
+        async def mount_message(widget: object) -> None:
+            await asyncio.sleep(0)
+            mounted.append(widget)
+
+        # Non-empty namespace == subagent; the is_main_agent gate suppresses it.
+        chunks = [
+            (
+                ("subagent",),
+                "custom",
+                {
+                    "type": "rubric_evaluation_end",
+                    "result": "satisfied",
+                    "grading_run_id": "grade-subagent",
+                },
+            ),
+        ]
+        adapter = TextualUIAdapter(
+            mount_message=mount_message,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+
+        await execute_task_textual(
+            user_input="hi",
+            agent=_FakeAgent(chunks),
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+            on_rubric_evaluation_end=lambda run_id, result: evaluations.append(
+                (run_id, result)
+            ),
+        )
+
+        assert evaluations == []
         assert not [
             m
             for m in mounted
             if isinstance(m, AppMessage) and "Rubric" in str(m._content)
         ]
+
+    async def test_rubric_event_without_run_id_is_not_forwarded(self) -> None:
+        """A verdict without correlation metadata cannot authorize completion."""
+        callback = MagicMock()
+        adapter = TextualUIAdapter(
+            mount_message=AsyncMock(),
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+
+        await execute_task_textual(
+            user_input="hi",
+            agent=_FakeAgent(
+                [
+                    (
+                        (),
+                        "custom",
+                        {"type": "rubric_evaluation_end", "result": "satisfied"},
+                    )
+                ]
+            ),
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+            on_rubric_evaluation_end=callback,
+        )
+
+        callback.assert_not_called()
+
+    async def test_rubric_callback_failure_does_not_abort_stream(self) -> None:
+        """Completion bookkeeping cannot break an otherwise successful turn."""
+        callback = MagicMock(side_effect=RuntimeError("boom"))
+        adapter = TextualUIAdapter(
+            mount_message=AsyncMock(),
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+
+        await execute_task_textual(
+            user_input="hi",
+            agent=_FakeAgent(
+                [
+                    (
+                        (),
+                        "custom",
+                        {
+                            "type": "rubric_evaluation_end",
+                            "result": "satisfied",
+                            "grading_run_id": "grade-current",
+                        },
+                    )
+                ]
+            ),
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+            on_rubric_evaluation_end=callback,
+        )
+
+        callback.assert_called_once_with("grade-current", "satisfied")

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -30,6 +30,7 @@ from deepagents_code.client.non_interactive import (
 )
 from deepagents_code.config import ASCII_GLYPHS, UNICODE_GLYPHS, build_stream_config
 from deepagents_code.tui.textual_adapter import (
+    RubricEvaluationEnd,
     SessionStats,
     TextualUIAdapter,
     _build_interrupted_ai_message,
@@ -7124,8 +7125,8 @@ class TestExecuteTaskTextualRubricEvents:
             assistant_id="assistant",
             session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
             adapter=adapter,
-            on_rubric_evaluation_end=lambda run_id, result: evaluations.append(
-                (run_id, result)
+            on_rubric_evaluation_end=lambda event: evaluations.append(
+                (event.grading_run_id, event.result)
             ),
         )
 
@@ -7171,8 +7172,8 @@ class TestExecuteTaskTextualRubricEvents:
             assistant_id="assistant",
             session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
             adapter=adapter,
-            on_rubric_evaluation_end=lambda run_id, result: evaluations.append(
-                (run_id, result)
+            on_rubric_evaluation_end=lambda event: evaluations.append(
+                (event.grading_run_id, event.result)
             ),
         )
 
@@ -7200,6 +7201,38 @@ class TestExecuteTaskTextualRubricEvents:
                         (),
                         "custom",
                         {"type": "rubric_evaluation_end", "result": "satisfied"},
+                    )
+                ]
+            ),
+            assistant_id="assistant",
+            session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
+            adapter=adapter,
+            on_rubric_evaluation_end=callback,
+        )
+
+        callback.assert_not_called()
+
+    async def test_rubric_event_with_blank_run_id_is_not_forwarded(self) -> None:
+        """A whitespace-only run ID is treated as missing correlation metadata."""
+        callback = MagicMock()
+        adapter = TextualUIAdapter(
+            mount_message=AsyncMock(),
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+        )
+
+        await execute_task_textual(
+            user_input="hi",
+            agent=_FakeAgent(
+                [
+                    (
+                        (),
+                        "custom",
+                        {
+                            "type": "rubric_evaluation_end",
+                            "result": "satisfied",
+                            "grading_run_id": "   ",
+                        },
                     )
                 ]
             ),
@@ -7241,4 +7274,6 @@ class TestExecuteTaskTextualRubricEvents:
             on_rubric_evaluation_end=callback,
         )
 
-        callback.assert_called_once_with("grade-current", "satisfied")
+        callback.assert_called_once_with(
+            RubricEvaluationEnd("grade-current", "satisfied")
+        )


### PR DESCRIPTION
Accepted `/goal` objectives now automatically transition to `complete` when their current goal-backed work turn finishes with a satisfied acceptance-criteria grade. Completed goals remain visible through `/goal show` but no longer affect later ordinary turns.

---

An accepted `/goal` should finish when its own final rubric grade says every criterion is satisfied. Previously the agent also had to call `update_goal(status="complete", ...)`, manual mode requested another approval, and successful completion removed the goal record entirely. That made completion depend on approval mode and left `/goal show` with nothing to report.

Completion now requires a validated grading event observed live during the current goal-backed work turn, a matching grading-run identifier in the checkpoint, and a turn that finishes without aborting. Criteria generation, thread restoration, standalone `/rubric` grading, unrelated or ungraded turns, stale persisted grader state, and unknown grader verdicts cannot complete a goal. If a satisfied grade arrives before an interrupted turn, the goal remains active and the UI explains that it will be checked again on the next turn.

Completion is persisted transactionally; if that write fails, the active goal and any agent-provided note remain available for a later retry. Completed goals retain their objective, acceptance criteria, status, and completion note while no longer driving subsequent work or grading. Agents may still call `update_goal(status="complete", ...)` to provide a completion note, but the call is optional. Manual and YOLO modes use the same completion path without a completion approval prompt.