### PR TITLE
docs(repo): clarify PR title and body guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,12 @@
 Fixes #
 
+<!-- Update the relationship and number above, or remove the line when none applies. Only `Closes`, `Fixes`, and `Resolves` auto-close the referenced GitHub issue on merge. -->
+
+<!-- For a net new feature or behavior-changing bugfix, replace this comment with a high-level, plain-English summary of the user-visible change. Do not add a heading or label. Remove this comment for chores, refactors, or test-only changes. -->
+
 ---
 
-<!-- Keep the `Fixes #xx` keyword at the very top and update the issue number — this auto-closes the issue on merge. Replace this comment with a 1-2 sentence description of your change. No `# Summary` header; the description is the summary. -->
+<!-- Explain the motivation and why this solution is the right one. Do not add a `# Summary` or `## Release note` heading. -->
 
 Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview
 
@@ -18,23 +22,31 @@ Thank you for contributing to Deep Agents! Follow these steps to have your pull 
     - fix(sdk): resolve flag parsing error
     - feat(cli): add multi-tenant support
     - test(acp): update API usage tests
+  - Do not include Linear issue-closing markers such as `[closes DCD-52]` in the title. Put issue references and closing metadata in the PR description instead.
   - Allowed TYPE and SCOPE values: https://github.com/langchain-ai/deepagents/blob/main/.github/workflows/pr_lint.yml
 
 2. PR description:
 
-  - Write 1-2 sentences summarizing the change.
-  - If this PR addresses a specific issue, please include "Fixes #ISSUE_NUMBER" in the description to automatically close the issue when the PR is merged.
+  - Keep an optional issue or PR relationship and, when required, the user-facing summary above the `---`; put the rest of the body below it.
+  - For net new features or behavior-changing bugfixes, write a high-level, plain-English summary of the user-visible change without a heading or label.
+  - If this PR addresses a specific issue, use `Fixes #ISSUE_NUMBER`, `Closes #ISSUE_NUMBER`, or `Resolves #ISSUE_NUMBER` to automatically close it when the PR is merged.
   - If there are any breaking changes, please clearly describe them.
-  - If this PR depends on another PR being merged first, please include "Depends on #PR_NUMBER" in the description.
+  - If this PR depends on another PR being merged first, please include `Depends on #PR_NUMBER` in the description.
 
-## Release note
-<!-- Required for net new features or behavior-changing bugfixes. State the user-visible change in release-note-ready language. Omit this section for chores, refactors, or test-only changes. -->
+<!--
+Do not add a dedicated "Test plan" or "Testing" section unless this PR is large or the changes are highly consequential. When one is warranted, keep it collapsed:
+
+<details>
+<summary>Test plan</summary>
+
+- Describe the verification performed.
+
+</details>
+-->
 
 3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.
 
   - We will not consider a PR unless these three are passing in CI.
-
-4. How did you verify your code works?
 
 Additional guidelines:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Follow Conventional Commits. See `.github/workflows/pr_lint.yml` for allowed typ
 - Start the text after `type(scope):` with a lowercase letter, unless the first word is a proper noun (e.g. `Azure`, `GitHub`, `OpenAI`) or a named entity (class, function, method, parameter, or variable name).
 - Wrap named entities in backticks so they render as code. Proper nouns are left unadorned.
 - Keep titles short and descriptive — save detail for the body.
+- Do not include Linear issue-closing markers such as `[closes DCD-52]` in PR titles. Put issue references and closing metadata in the PR description instead.
 - For version-branch sync PRs, use a title like `chore(repo): sync main into vX.Y`. Do not use `release` as the scope; PR title lint reserves `release` for the type and disallows it as a scope.
 
 Examples:
@@ -118,27 +119,35 @@ mdrxy/cli/startup-cmd-flag
 
 #### PR descriptions
 
-The description *is* the summary — do not add a `# Summary` header.
+Do not add a `# Summary` or `## Release note` heading. Use an opening block ("frontmatter") in this order:
 
-- When the PR closes an issue, lead with the closing keyword on its own line at the very top, followed by a horizontal rule and then the body:
+```md
+Closes #123
 
-  ```txt
-  Closes #123
+A high-level, plain-English summary of the user-visible change.
 
-  ---
+---
 
-  <rest of description>
-  ```
+<rest of PR body>
+```
 
-  Only `Closes`, `Fixes`, and `Resolves` auto-close the referenced issue on merge. `Related:` or similar labels are informational and do not close anything.
-
-- Explain the *why*: the motivation and why this solution is the right one. Limit prose.
+- The issue or PR relationship line is optional. Use the appropriate keyword, such as `Fixes`, `Closes`, `Resolves`, `Supersedes`, `Depends on`, or `Related`. Only `Closes`, `Fixes`, and `Resolves` auto-close the referenced GitHub issue on merge.
+- For net new features or behavior-changing bugfixes, include the high-level user-facing summary in this opening block. Write it in release-note-ready plain English without a label or heading. Omit it for chores, refactors, or test-only changes.
+- Explain the *why* in the rest of the body: the motivation and why this solution is the right one. Limit prose.
 - Write for readers who may be unfamiliar with this area of the codebase. Avoid insider shorthand and prefer language that is friendly to public viewers — this aids interpretability.
 - Do **not** cite line numbers; they go stale as soon as the file changes.
 - Rarely include full file paths or filenames. Reference the affected symbol, class, or subsystem by name instead.
 - Wrap class, function, method, parameter, and variable names in backticks.
-- For net new features or behavior-changing bugfixes, PR descriptions should include a `## Release note` section that states the user-visible change in release-note-ready language. Otherwise, omit the header.
-- Skip dedicated "Test plan" or "Testing" sections in most cases. Mention tests only when coverage is non-obvious, risky, or otherwise notable.
+- Do not include a dedicated "Test plan" or "Testing" section unless the PR is large or the changes are highly consequential. When one is warranted, keep it collapsed with GitHub's `<details>` and `<summary>` elements:
+
+  ```html
+  <details>
+  <summary>Test plan</summary>
+
+  - Describe the verification performed.
+
+  </details>
+  ```
 - Call out areas of the change that require careful review.
 
 ## Core development principles


### PR DESCRIPTION
PR authors and agents now follow concise, consistent title and body conventions.

---

Routine PRs should omit dedicated test plans; large or highly consequential changes keep them in collapsed details. User-facing release-note text now appears as plain-English frontmatter, and Linear-style issue-closing markers belong in the body rather than the title.
