### PR TITLE
feat(code): make plugins generally available

### DIFF
--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -30,7 +30,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/model` |  | Switch models or edit model settings |
 | `/notifications` |  | Configure startup warnings |
 | `/offload` | `/compact` | Summarize and offload older messages to free context |
-| `/plugins` |  | Manage plugins (experimental) |
+| `/plugins` |  | Manage plugins |
 | `/quit` | `/q` | Exit app |
 | `/reload` |  | Reload environment and config |
 | `/remember` |  | Save useful context to memory or skills |

--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -401,6 +401,3 @@ def is_env_truthy(name: str, *, default: bool = False) -> bool:
         return default
     classified = classify_env_bool(raw)
     return default if classified is None else classified
-
-
-EXPERIMENTAL_HINT = f"This feature is experimental. Set {EXPERIMENTAL}=1 to enable."

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1783,18 +1783,13 @@ def create_cli_agent(
             (str(settings.get_built_in_skills_dir()), "Built-in"),
         ]
         try:
-            if is_env_truthy(EXPERIMENTAL):
-                from deepagents_code.plugins import discover_plugins
-                from deepagents_code.plugins.adapters.skills import (
-                    plugin_skill_sources,
-                )
+            from deepagents_code.plugins import discover_plugins
+            from deepagents_code.plugins.adapters.skills import plugin_skill_sources
 
-                plugin_result = discover_plugins()
-                if plugin_result.warnings:
-                    logger.warning(
-                        "Plugin discovery warnings: %s", plugin_result.warnings
-                    )
-                sources.extend(plugin_skill_sources(plugin_result.plugins))
+            plugin_result = discover_plugins()
+            if plugin_result.warnings:
+                logger.warning("Plugin discovery warnings: %s", plugin_result.warnings)
+            sources.extend(plugin_skill_sources(plugin_result.plugins))
         except Exception:
             logger.warning("Could not discover plugin skills", exc_info=True)
         sources.extend(

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -11543,15 +11543,6 @@ class DeepAgentsApp(App):
             await self._handle_mcp_subcommand(args)
         elif cmd == "/plugins":
             await self._mount_message(UserMessage(command))
-            from deepagents_code._env_vars import (
-                EXPERIMENTAL,
-                EXPERIMENTAL_HINT,
-                is_env_truthy,
-            )
-
-            if not is_env_truthy(EXPERIMENTAL):
-                await self._mount_message(AppMessage(EXPERIMENTAL_HINT))
-                return
             await self._show_plugin_manager()
         elif cmd in {"/auth", "/connect"}:
             await self._show_auth_manager()
@@ -11708,56 +11699,51 @@ class DeepAgentsApp(App):
                     skill_lines.append(f"  - Removed: {', '.join(removed_skills)}")
                 report += "\nSkills updated:\n" + "\n".join(skill_lines)
 
-            # Experimental plugins: rediscover and restart the owned server so
-            # plugin MCP config is picked up without a separate slash command.
-            from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
+            # Rediscover plugins and restart the owned server so plugin MCP config
+            # is picked up without a separate slash command.
+            from deepagents_code.plugins import discover_plugins
+            from deepagents_code.plugins.adapters.mcp import plugin_mcp_configs
 
-            if is_env_truthy(EXPERIMENTAL):
-                from deepagents_code.plugins import discover_plugins
-                from deepagents_code.plugins.adapters.mcp import plugin_mcp_configs
-
-                plugin_result = discover_plugins()
-                discovered_plugin_ids = frozenset(
-                    plugin.plugin_id for plugin in plugin_result.plugins
-                )
-                plugin_count = len(plugin_result.plugins)
-                mcp_configs = plugin_mcp_configs(plugin_result.plugins)
-                mcp_count = sum(
-                    len(servers)
-                    for config in mcp_configs
-                    if isinstance((servers := config.get("mcpServers")), dict)
-                )
-                plugin_skill_count = sum(1 for name in new_skill_names if ":" in name)
+            plugin_result = discover_plugins()
+            discovered_plugin_ids = frozenset(
+                plugin.plugin_id for plugin in plugin_result.plugins
+            )
+            plugin_count = len(plugin_result.plugins)
+            mcp_configs = plugin_mcp_configs(plugin_result.plugins)
+            mcp_count = sum(
+                len(servers)
+                for config in mcp_configs
+                if isinstance((servers := config.get("mcpServers")), dict)
+            )
+            plugin_skill_count = sum(1 for name in new_skill_names if ":" in name)
+            report += (
+                f"\nPlugins: {plugin_count} plugin"
+                f"{'s' if plugin_count != 1 else ''} · "
+                f"{plugin_skill_count} skill"
+                f"{'s' if plugin_skill_count != 1 else ''} · "
+                f"{mcp_count} plugin MCP server"
+                f"{'s' if mcp_count != 1 else ''}"
+            )
+            if plugin_result.warnings:
                 report += (
-                    f"\nPlugins: {plugin_count} plugin"
-                    f"{'s' if plugin_count != 1 else ''} · "
-                    f"{plugin_skill_count} skill"
-                    f"{'s' if plugin_skill_count != 1 else ''} · "
-                    f"{mcp_count} plugin MCP server"
-                    f"{'s' if mcp_count != 1 else ''}"
+                    f"\n{len(plugin_result.warnings)} plugin warning(s) during load."
                 )
-                if plugin_result.warnings:
+
+            restarted = False
+            if self._server_proc is not None and self._server_kwargs is not None:
+                if self._agent_running and self._agent_worker:
+                    self._cancel_worker(self._agent_worker)
+                    self._agent_running = False
+                else:
+                    self._discard_queue()
+                restarted = await self._restart_server_manual()
+                if restarted:
+                    self._session_plugin_ids = discovered_plugin_ids
+                    report += "\nAgent server restarted for plugin MCP."
+                else:
                     report += (
-                        f"\n{len(plugin_result.warnings)} plugin warning(s) "
-                        "during load."
+                        "\nAgent server was not restarted; plugin MCP may be stale."
                     )
-
-                restarted = False
-                if self._server_proc is not None and self._server_kwargs is not None:
-                    if self._agent_running and self._agent_worker:
-                        self._cancel_worker(self._agent_worker)
-                        self._agent_running = False
-                    else:
-                        self._discard_queue()
-                    restarted = await self._restart_server_manual()
-                    if restarted:
-                        self._session_plugin_ids = discovered_plugin_ids
-                        report += "\nAgent server restarted for plugin MCP."
-                    else:
-                        report += (
-                            "\nAgent server was not restarted; plugin MCP may be stale."
-                        )
-
             await self._mount_message(AppMessage(report))
             await self._maybe_start_deferred_server_from_default()
         elif cmd.startswith("/skill:"):

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -138,7 +138,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
     ),
     SlashCommand(
         name="/plugins",
-        description="Manage plugins (experimental)",
+        description="Manage plugins",
         bypass_tier=BypassTier.IMMEDIATE_UI,
         hidden_keywords="plugin marketplace skills mcp enable disable install",
     ),
@@ -401,29 +401,13 @@ class CommandEntry(NamedTuple):
         return self.display_name or self.name
 
 
-_EXPERIMENTAL_PLUGIN_COMMANDS: frozenset[str] = frozenset({"/plugins"})
-"""Slash commands gated behind `DEEPAGENTS_CODE_EXPERIMENTAL`."""
-
-
 def get_slash_commands() -> list[CommandEntry]:
-    """Return autocomplete entries for currently enabled slash commands.
-
-    This function is the public autocomplete API. It derives entries directly
-    from `COMMANDS` so callers always observe the current experimental-feature
-    environment instead of a stale import-time snapshot.
+    """Return autocomplete entries for slash commands.
 
     Returns:
-        Autocomplete entries derived from `COMMANDS`, excluding experimental
-        plugin commands unless `DEEPAGENTS_CODE_EXPERIMENTAL` is set.
+        Autocomplete entries derived from `COMMANDS`.
     """
-    from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
-
-    include_experimental = is_env_truthy(EXPERIMENTAL)
-    return [
-        command.to_entry()
-        for command in COMMANDS
-        if include_experimental or command.name not in _EXPERIMENTAL_PLUGIN_COMMANDS
-    ]
+    return [command.to_entry() for command in COMMANDS]
 
 
 def parse_skill_command(command: str) -> tuple[str, str]:

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1419,25 +1419,13 @@ def parse_args() -> argparse.Namespace:
         make_help_action=_make_help_action,
     )
 
-    from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
+    from deepagents_code.plugins.commands_cli import setup_plugin_parser
 
-    if is_env_truthy(EXPERIMENTAL):
-        from deepagents_code.plugins.commands_cli import setup_plugin_parser
-
-        setup_plugin_parser(
-            subparsers,
-            make_help_action=_make_help_action,
-            add_output_args=add_json_output_arg,
-        )
-    else:
-        plugin_parser = subparsers.add_parser(
-            "plugin",
-            aliases=["plugins"],
-            add_help=False,
-            help=argparse.SUPPRESS,
-        )
-        plugin_parser.add_argument("plugin_command", nargs="?")
-        plugin_parser.add_argument("plugin_args", nargs=argparse.REMAINDER)
+    setup_plugin_parser(
+        subparsers,
+        make_help_action=_make_help_action,
+        add_output_args=add_json_output_arg,
+    )
 
     setup_config_parser(
         subparsers,
@@ -4081,15 +4069,6 @@ def cli_main() -> None:
 
             execute_skills_command(args)
         elif args.command in {"plugin", "plugins"}:
-            from deepagents_code._env_vars import (
-                EXPERIMENTAL,
-                EXPERIMENTAL_HINT,
-                is_env_truthy,
-            )
-
-            if not is_env_truthy(EXPERIMENTAL):
-                print(EXPERIMENTAL_HINT)  # noqa: T201
-                sys.exit(2)
             from deepagents_code.plugins.commands_cli import execute_plugin_command
 
             execute_plugin_command(args)

--- a/libs/code/deepagents_code/plugins/adapters/mcp.py
+++ b/libs/code/deepagents_code/plugins/adapters/mcp.py
@@ -202,13 +202,8 @@ def discover_plugin_mcp_configs(
         project_dir: Project directory for variable substitution.
 
     Returns:
-        Plugin MCP config layers, or an empty tuple when plugins are disabled or
-        discovery fails.
+        Plugin MCP config layers, or an empty tuple when discovery fails.
     """
-    from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
-
-    if not is_env_truthy(EXPERIMENTAL):
-        return ()
     try:
         from deepagents_code.plugins import discover_plugins
 

--- a/libs/code/deepagents_code/plugins/adapters/skills.py
+++ b/libs/code/deepagents_code/plugins/adapters/skills.py
@@ -126,8 +126,7 @@ def discover_plugin_skill_sources_and_roots() -> tuple[
     """Discover plugin skill sources and containment roots.
 
     Returns:
-        Plugin skill sources and roots, or empty tuples when plugins are disabled
-        or discovery fails.
+        Plugin skill sources and roots, or empty tuples when discovery fails.
     """
     plugin_sources, plugin_roots, _plugin_ids = discover_plugin_skill_state()
 

--- a/libs/code/deepagents_code/plugins/adapters/skills.py
+++ b/libs/code/deepagents_code/plugins/adapters/skills.py
@@ -6,8 +6,6 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeAlias
 
-from deepagents_code._env_vars import EXPERIMENTAL, is_env_truthy
-
 if TYPE_CHECKING:
     from deepagents_code.plugins.models import PluginInstance
 
@@ -99,23 +97,22 @@ def discover_plugin_skill_state() -> tuple[
     """Discover plugin skill sources, containment roots, and loaded ids.
 
     Returns:
-        Plugin skill sources, roots, and ids, or empty values when plugins are
-        disabled or discovery fails.
+        Plugin skill sources, roots, and ids, or empty values when discovery
+        fails.
     """
     plugin_sources: tuple[tuple[Path, str], ...] = ()
     plugin_roots: tuple[Path, ...] = ()
     plugin_ids: frozenset[str] = frozenset()
     try:
-        if is_env_truthy(EXPERIMENTAL):
-            from deepagents_code.plugins import discover_plugins
+        from deepagents_code.plugins import discover_plugins
 
-            plugins = discover_plugins().plugins
-            plugin_sources = tuple(
-                (Path(path), namespace)
-                for path, _label, namespace in plugin_skill_sources(plugins)
-            )
-            plugin_roots = tuple(plugin_skill_roots(plugins))
-            plugin_ids = frozenset(plugin.plugin_id for plugin in plugins)
+        plugins = discover_plugins().plugins
+        plugin_sources = tuple(
+            (Path(path), namespace)
+            for path, _label, namespace in plugin_skill_sources(plugins)
+        )
+        plugin_roots = tuple(plugin_skill_roots(plugins))
+        plugin_ids = frozenset(plugin.plugin_id for plugin in plugins)
     except (OSError, RuntimeError):
         logger.warning("Could not discover plugin skills", exc_info=True)
         return (), (), frozenset()

--- a/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
@@ -14,7 +14,6 @@ from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.middleware.skills import _list_skills as list_sdk_skills
 from textual.widgets import Input, OptionList
 
-from deepagents_code._env_vars import EXPERIMENTAL
 from deepagents_code.app import DeepAgentsApp
 from deepagents_code.config import get_glyphs
 from deepagents_code.mcp_tools import MCPServerInfo
@@ -73,11 +72,6 @@ from deepagents_code.tui.modals.plugin_manager.state import (
     _list_plugin_skill_names,
     _load_manager_state,
 )
-
-
-@pytest.fixture(autouse=True)
-def _enable_experimental(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv(EXPERIMENTAL, "1")
 
 
 def _write_json(path: Path, data: dict[str, object]) -> None:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -5331,6 +5331,27 @@ class TestTraceCommand:
             await pilot.pause()
             assert isinstance(app.screen, AuthManagerScreen)
 
+    async def test_plugins_routed_from_handle_command(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """'/plugins' should push the PluginManagerScreen modal without a gate.
+
+        Plugins are generally available, so dispatch must open the manager
+        directly rather than emitting an experimental hint.
+        """
+        from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
+
+        monkeypatch.setattr(
+            "deepagents_code.model_config.DEFAULT_STATE_DIR", tmp_path / ".state"
+        )
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            await app._handle_command("/plugins")
+            await pilot.pause()
+            assert isinstance(app.screen, PluginManagerScreen)
+
 
 class TestClearCommand:
     """Test /clear slash command."""
@@ -21461,13 +21482,8 @@ class TestPrewarmAwait:
             f"prewarm must precede skill discovery thread; got {call_order}"
         )
 
-    def test_constructor_does_not_discover_plugins(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_constructor_does_not_discover_plugins(self) -> None:
         """Plugin filesystem discovery must stay off the pre-paint hot path."""
-        from deepagents_code._env_vars import EXPERIMENTAL
-
-        monkeypatch.setenv(EXPERIMENTAL, "1")
         with patch("deepagents_code.plugins.discover_plugins") as discover_mock:
             app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
 

--- a/libs/code/tests/unit_tests/test_args.py
+++ b/libs/code/tests/unit_tests/test_args.py
@@ -8,7 +8,6 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from rich.console import Console
 
-from deepagents_code._env_vars import EXPERIMENTAL
 from deepagents_code.main import parse_args
 from deepagents_code.ui import show_help, show_threads_list_help
 
@@ -50,21 +49,15 @@ class TestInitialPromptArg:
         assert args.initial_prompt == ""
 
 
-def test_plugin_subcommand_parses_without_experimental_flag(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Argparse accepts `plugin` without the experimental flag."""
-    monkeypatch.delenv(EXPERIMENTAL, raising=False)
+def test_plugin_subcommand_parses() -> None:
+    """Argparse accepts the `plugin` subcommand."""
     with patch.object(sys, "argv", ["deepagents", "plugin", "list"]):
         args = parse_args()
     assert args.command == "plugin"
     assert args.plugin_command == "list"
 
 
-def test_plugin_marketplace_remove_parses(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv(EXPERIMENTAL, "1")
+def test_plugin_marketplace_remove_parses() -> None:
     with patch.object(
         sys,
         "argv",

--- a/libs/code/tests/unit_tests/test_args.py
+++ b/libs/code/tests/unit_tests/test_args.py
@@ -53,11 +53,7 @@ class TestInitialPromptArg:
 def test_plugin_subcommand_parses_without_experimental_flag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Argparse still accepts `plugin` when experimental is off.
-
-    The experimental gate lives at execution time in `main` (exit 2 + hint),
-    not in argparse, so disabled users get a clear message instead of a usage error.
-    """
+    """Argparse accepts `plugin` without the experimental flag."""
     monkeypatch.delenv(EXPERIMENTAL, raising=False)
     with patch.object(sys, "argv", ["deepagents", "plugin", "list"]):
         args = parse_args()

--- a/libs/code/tests/unit_tests/test_command_registry.py
+++ b/libs/code/tests/unit_tests/test_command_registry.py
@@ -129,16 +129,7 @@ class TestSlashCommands:
         command_entries = {command.to_entry() for command in COMMANDS}
         assert set(get_slash_commands()) <= command_entries
 
-    def test_experimental_plugin_commands_hidden_by_default(self) -> None:
-        names = {entry.name for entry in get_slash_commands()}
-        assert "/plugins" not in names
-
-    def test_experimental_plugin_commands_visible_when_enabled(
-        self, monkeypatch
-    ) -> None:
-        from deepagents_code._env_vars import EXPERIMENTAL
-
-        monkeypatch.setenv(EXPERIMENTAL, "1")
+    def test_plugin_commands_visible_by_default(self) -> None:
         names = {entry.name for entry in get_slash_commands()}
         assert "/plugins" in names
 

--- a/libs/code/tests/unit_tests/test_reload.py
+++ b/libs/code/tests/unit_tests/test_reload.py
@@ -1043,18 +1043,15 @@ class TestReloadThemeReapply:
 
 
 class TestReloadPluginsViaReload:
-    """Experimental plugins should reload through `/reload`."""
+    """Plugins should reload through `/reload`."""
 
-    async def test_reports_plugin_summary_when_experimental(
+    async def test_reports_plugin_summary(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """`/reload` includes a plugin summary when experimental mode is on."""
-        from deepagents_code._env_vars import EXPERIMENTAL
+        """`/reload` includes a plugin summary."""
         from deepagents_code.app import DeepAgentsApp
         from deepagents_code.plugins.models import PluginDiscoveryResult
         from deepagents_code.tui.widgets.messages import AppMessage
-
-        monkeypatch.setenv(EXPERIMENTAL, "1")
 
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
@@ -1078,31 +1075,6 @@ class TestReloadPluginsViaReload:
 
             text = "\n".join(str(w._content) for w in app.query(AppMessage))
             assert "Plugins: 0 plugins · 0 skills · 0 plugin MCP servers" in text
-
-    async def test_skips_plugin_summary_when_experimental_off(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """`/reload` omits plugin summary when experimental mode is off."""
-        from deepagents_code._env_vars import EXPERIMENTAL
-        from deepagents_code.app import DeepAgentsApp
-        from deepagents_code.tui.widgets.messages import AppMessage
-
-        monkeypatch.setenv(EXPERIMENTAL, "0")
-
-        app = DeepAgentsApp()
-        async with app.run_test() as pilot:
-            await pilot.pause()
-
-            async def _fake_discover() -> bool:  # noqa: RUF029
-                return True
-
-            monkeypatch.setattr(app, "_discover_skills", _fake_discover)
-
-            await app._handle_command("/reload")
-            await pilot.pause()
-
-            text = "\n".join(str(w._content) for w in app.query(AppMessage))
-            assert "Plugins:" not in text
 
     @pytest.mark.parametrize(
         ("restarted", "expected_ids"),


### PR DESCRIPTION
Plugins are now available by default in deepagents-code without setting `DEEPAGENTS_CODE_EXPERIMENTAL`.

This removes the flag gates from CLI and slash-command discovery, plugin skills and MCP loading, and reload behavior while preserving the flag for unrelated experimental features.

Made by [Open SWE](https://openswe.vercel.app/agents/019f6c79-6211-734f-b05c-a5a3401c8a6b)