### PR TITLE
feat(code): add Kimi K3 to model selector under OpenRouter

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -112,6 +112,7 @@ _RECOMMENDED_MODELS: dict[str, str] = {
     "openrouter:google/gemini-3.5-flash": "Gemini 3.5 Flash",
     "openrouter:google/gemini-3.1-pro-preview": "Gemini 3.1 Pro Preview",
     "openrouter:moonshotai/kimi-k2.7-code": "Kimi K2.7 Code",
+    "openrouter:moonshotai/kimi-k3": "Kimi K3",
     "openrouter:nvidia/nemotron-3-ultra-550b-a55b": "Nemotron 3 Ultra 550B A55B",
     "openrouter:openai/gpt-5.4": "GPT-5.4",
     "openrouter:openai/gpt-5.4-mini": "GPT-5.4 mini",


### PR DESCRIPTION
Add Kimi K3 to the model selector under the OpenRouter provider.

Made by [Open SWE](https://openswe.vercel.app/agents/74c5c230-fc6c-57ce-320b-3379bae51abd)