### PR TITLE
fix(code): quiet MCP auth-skip debug logging for known patterns

### DIFF
--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -2084,6 +2084,7 @@ async def _load_tools_from_config(
             from deepagents_code.mcp_auth import (
                 find_oauth_challenge,
                 find_reauth_required,
+                format_login_failure,
             )
 
             status: MCPServerStatus
@@ -2114,7 +2115,11 @@ async def _load_tools_from_config(
                 # re-login. This is an expected, already-classified outcome, so
                 # the actionable WARNING says everything useful; the full
                 # traceback adds no diagnostic value, so keep the DEBUG log to a
-                # concise line (just the exception type as a breadcrumb).
+                # concise, token-safe breadcrumb. Use `format_login_failure`
+                # rather than `exc.__class__.__name__`: these failures usually
+                # arrive wrapped in an anyio `ExceptionGroup`, so the bare root
+                # class name would just read "ExceptionGroup"; the helper walks
+                # the group/cause chain to name the nested culprit instead.
                 status = "unauthenticated"
                 error = f"{reauth} (token refresh failed)"
                 logger.warning(
@@ -2125,7 +2130,7 @@ async def _load_tools_from_config(
                 logger.debug(
                     "MCP server '%s' skipped: token refresh failed (%s)",
                     server_name,
-                    exc.__class__.__name__,
+                    format_login_failure(exc),
                 )
             elif challenge_url is not None:
                 # A remote server answered with a 401 OAuth challenge
@@ -2133,7 +2138,9 @@ async def _load_tools_from_config(
                 # typically a server not opted into OAuth in config. Surface it
                 # as unauthenticated so the user can log in, rather than as an
                 # opaque connection error. Like the reauth case, this is a
-                # recognized outcome: keep the DEBUG log to a concise line
+                # recognized outcome: keep the DEBUG log to a concise,
+                # token-safe breadcrumb (via `format_login_failure`, which
+                # names the nested culprit inside the anyio `ExceptionGroup`)
                 # rather than dumping the full challenge traceback.
                 status = "unauthenticated"
                 error = (
@@ -2148,7 +2155,7 @@ async def _load_tools_from_config(
                 logger.debug(
                     "MCP server '%s' skipped: 401 OAuth challenge detected (%s)",
                     server_name,
-                    exc.__class__.__name__,
+                    format_login_failure(exc),
                 )
             else:
                 status = "error"

--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -2086,31 +2086,30 @@ async def _load_tools_from_config(
                 # Tokens existed (we checked above) but the OAuth provider
                 # fell back to interactive reauth — the refresh attempt
                 # failed. Flag unauthenticated so the user is prompted to
-                # re-login, and keep the original exception only in debug logs
-                # so expected re-auth skips don't flood non-interactive output.
+                # re-login. This is an expected, already-classified outcome, so
+                # the actionable WARNING says everything useful; the full
+                # traceback adds no diagnostic value, so keep the DEBUG log to a
+                # concise line (just the exception type as a breadcrumb).
                 status = "unauthenticated"
-                detail = (
-                    "details redacted because config uses environment interpolation"
-                    if redact_failure_details
-                    else "the original error is in debug logs"
-                )
-                error = f"{reauth} (token refresh failed; {detail})"
+                error = f"{reauth} (token refresh failed)"
                 logger.warning(
                     "MCP server '%s' skipped: %s",
                     server_name,
                     error,
                 )
-                _log_caught_exception(
-                    logging.DEBUG,
-                    "MCP server '%s' skipped: tool discovery failed",
-                    exc,
+                logger.debug(
+                    "MCP server '%s' skipped: token refresh failed (%s)",
+                    server_name,
+                    exc.__class__.__name__,
                 )
             elif challenge_url is not None:
                 # A remote server answered with a 401 OAuth challenge
                 # (RFC 9728) that wasn't already handled as a token refresh —
                 # typically a server not opted into OAuth in config. Surface it
                 # as unauthenticated so the user can log in, rather than as an
-                # opaque connection error.
+                # opaque connection error. Like the reauth case, this is a
+                # recognized outcome: keep the DEBUG log to a concise line
+                # rather than dumping the full challenge traceback.
                 status = "unauthenticated"
                 error = (
                     f"MCP server {server_name!r} requires authentication; "
@@ -2121,10 +2120,10 @@ async def _load_tools_from_config(
                     server_name,
                     error,
                 )
-                _log_caught_exception(
-                    logging.DEBUG,
-                    "MCP server '%s' skipped: 401 OAuth challenge detected",
-                    exc,
+                logger.debug(
+                    "MCP server '%s' skipped: 401 OAuth challenge detected (%s)",
+                    server_name,
+                    exc.__class__.__name__,
                 )
             else:
                 status = "error"

--- a/libs/code/tests/unit_tests/test_mcp_tools.py
+++ b/libs/code/tests/unit_tests/test_mcp_tools.py
@@ -1332,6 +1332,7 @@ class TestGetMCPTools:
     async def test_discovery_failure_marks_server_error(
         self,
         write_config: Callable[..., str],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Discovery failures are reported per-server instead of aborting load."""
         path = write_config(
@@ -1349,6 +1350,8 @@ class TestGetMCPTools:
             raise RuntimeError(msg)
             yield
 
+        caplog.set_level(logging.DEBUG, logger="deepagents_code.mcp_tools")
+
         with patch("langchain_mcp_adapters.sessions.create_session", _fake):
             tools, manager, server_infos = await get_mcp_tools(path)
 
@@ -1356,6 +1359,14 @@ class TestGetMCPTools:
         assert isinstance(manager, MCPSessionManager)
         assert server_infos[0].status == "error"
         assert "boom" in (server_infos[0].error or "")
+        # Unlike the recognized auth-skip branches, a genuinely unknown
+        # discovery error keeps its full traceback so real anomalies stay
+        # debuggable — guard against a future change silently suppressing it.
+        assert any(
+            record.exc_info is not None
+            for record in caplog.records
+            if record.name == "deepagents_code.mcp_tools"
+        )
         await manager.cleanup()
 
     async def test_stdio_health_check_failure_is_non_fatal(
@@ -1771,7 +1782,14 @@ class TestLoadToolsFromConfigOAuth:
         assert tools == []
         assert isinstance(manager, MCPSessionManager)
         assert server_infos[0].status == "unauthenticated"
-        assert "re-authentication" in (server_infos[0].error or "")
+        error = server_infos[0].error or ""
+        assert "re-authentication" in error
+        # The reauth error carries only the concise, classified suffix — no
+        # "debug logs" / "redacted" note, since the breadcrumb now holds the
+        # (token-safe) detail instead.
+        assert "(token refresh failed)" in error
+        assert "debug logs" not in error
+        assert "redacted" not in error
         mcp_records = [
             record
             for record in caplog.records
@@ -1785,6 +1803,23 @@ class TestLoadToolsFromConfigOAuth:
         # the actionable WARNING already says everything useful.
         assert all(record.exc_info is None for record in mcp_records)
         assert "Exception Group Traceback" not in caplog.text
+        # The concise DEBUG breadcrumb must be emitted and must name the nested
+        # culprit (via `format_login_failure`), not the bare `ExceptionGroup`
+        # wrapper the failure arrives in — deleting the breadcrumb or reverting
+        # to `exc.__class__.__name__` should fail here.
+        debug_breadcrumbs = [
+            record
+            for record in mcp_records
+            if record.levelno == logging.DEBUG
+            and "token refresh failed" in record.getMessage()
+        ]
+        assert debug_breadcrumbs
+        assert all(
+            "ExceptionGroup" not in record.getMessage() for record in debug_breadcrumbs
+        )
+        assert any(
+            "re-authentication" in record.getMessage() for record in debug_breadcrumbs
+        )
         await manager.cleanup()
 
     async def test_stored_tokens_attach_provider_without_explicit_oauth(
@@ -1924,8 +1959,11 @@ class TestLoadToolsFromConfigOAuth:
             for record in caplog.records
             if record.name == "deepagents_code.mcp_tools"
         ]
+        # The breadcrumb must be present AND carry its diagnostic payload — the
+        # classified exception's type name (via `format_login_failure`) — so
+        # dropping the `(%s)` argument would fail here, not just its absence.
         assert any(
-            "401 OAuth challenge detected" in record.getMessage()
+            "401 OAuth challenge detected (HTTPStatusError)" in record.getMessage()
             for record in mcp_records
         )
         assert all(record.exc_info is None for record in mcp_records)

--- a/libs/code/tests/unit_tests/test_mcp_tools.py
+++ b/libs/code/tests/unit_tests/test_mcp_tools.py
@@ -1562,7 +1562,7 @@ class TestLoadToolsFromConfigOAuth:
             raise ExceptionGroup(msg, [MCPReauthRequiredError("notion")])
             yield
 
-        caplog.set_level(logging.WARNING, logger="deepagents_code.mcp_tools")
+        caplog.set_level(logging.DEBUG, logger="deepagents_code.mcp_tools")
 
         with patch("langchain_mcp_adapters.sessions.create_session", _fake):
             config = {
@@ -1580,14 +1580,18 @@ class TestLoadToolsFromConfigOAuth:
         assert isinstance(manager, MCPSessionManager)
         assert server_infos[0].status == "unauthenticated"
         assert "re-authentication" in (server_infos[0].error or "")
-        warning_records = [
+        mcp_records = [
             record
             for record in caplog.records
             if record.name == "deepagents_code.mcp_tools"
-            and record.levelno == logging.WARNING
+        ]
+        warning_records = [
+            record for record in mcp_records if record.levelno == logging.WARNING
         ]
         assert warning_records
-        assert all(record.exc_info is None for record in warning_records)
+        # A recognized re-auth skip must not dump a traceback at any level —
+        # the actionable WARNING already says everything useful.
+        assert all(record.exc_info is None for record in mcp_records)
         assert "Exception Group Traceback" not in caplog.text
         await manager.cleanup()
 
@@ -1676,7 +1680,10 @@ class TestLoadToolsFromConfigOAuth:
         assert "auth" not in recorded[0]
         await manager.cleanup()
 
-    async def test_discovery_401_challenge_marks_unauthenticated(self) -> None:
+    async def test_discovery_401_challenge_marks_unauthenticated(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         """A 401 OAuth challenge during discovery is surfaced as unauthenticated."""
         request = httpx.Request("GET", "https://mcp.notion.com/mcp")
         response = httpx.Response(
@@ -1701,6 +1708,8 @@ class TestLoadToolsFromConfigOAuth:
             raise challenge
             yield
 
+        caplog.set_level(logging.DEBUG, logger="deepagents_code.mcp_tools")
+
         with patch("langchain_mcp_adapters.sessions.create_session", _fake):
             config = {
                 "mcpServers": {
@@ -1716,6 +1725,19 @@ class TestLoadToolsFromConfigOAuth:
         assert isinstance(manager, MCPSessionManager)
         assert server_infos[0].status == "unauthenticated"
         assert "mcp login notion" in (server_infos[0].error or "")
+        # A recognized 401 challenge is expected: no branch should dump the full
+        # challenge traceback (at DEBUG or WARNING), only concise lines.
+        mcp_records = [
+            record
+            for record in caplog.records
+            if record.name == "deepagents_code.mcp_tools"
+        ]
+        assert any(
+            "401 OAuth challenge detected" in record.getMessage()
+            for record in mcp_records
+        )
+        assert all(record.exc_info is None for record in mcp_records)
+        assert "Traceback (most recent call last)" not in caplog.text
         await manager.cleanup()
 
     async def test_discovery_401_without_challenge_stays_error(self) -> None:


### PR DESCRIPTION
Reduce noisy full-traceback DEBUG logs when an MCP server is skipped because it requires authentication; the actionable warning and a concise debug line remain.

---

When an MCP server is skipped during discovery because it needs authentication — either a token-refresh (`reauth`) failure or an RFC 9728 `401` OAuth challenge — `deepagents-code` logged the entire anyio `ExceptionGroup` / httpx traceback at DEBUG via `exc_info`, on top of the actionable WARNING. For these already-classified, expected outcomes the traceback adds no diagnostic value and just floods debug output.

These two recognized branches now emit a concise single-line DEBUG breadcrumb (the exception class name only). The full traceback is still logged for genuinely unknown discovery errors (the `else` branch) and for classifier failures, so real anomalies stay debuggable. The user-facing WARNING is unchanged apart from dropping the now-inaccurate "the original error is in debug logs" note from the reauth message.

Made by [Open SWE](https://openswe.vercel.app/agents/a5ab799b-1747-0d65-16b6-ee0ccccee0c4)