### PR TITLE
fix(code): probe unreachable Ollama daemon once per reload

### DIFF
--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -817,12 +817,16 @@ self-deadlock. Cross-process races are out of scope (mirrors the existing
 helpers)."""
 _ollama_installed_models_cache: dict[str, list[str]] = {}
 _ollama_unreachable_endpoints: set[str] = set()
-"""Normalized endpoints whose daemon failed the TCP presence preflight.
+"""Local endpoints (trailing slash stripped) whose daemon refused the TCP
+presence preflight.
 
-Lets `_get_ollama_installed_models` negatively-cache the empty result for an
-*unreachable* daemon so it probes and logs "not detected" once per reload,
-while a *reachable* daemon that merely has no models pulled yet is still
-re-probed (its empty result is not cached). Cleared by `clear_caches()`."""
+Lets `_get_ollama_installed_models` negatively-cache the empty result for a
+daemon that is definitively absent (connection refused) so it probes and logs
+"not detected" once per reload. A *reachable* daemon that merely has no models
+pulled yet -- and a daemon whose preflight is only ambiguous (a connect
+timeout, which defers to the HTTP probe) -- is still re-probed (its empty
+result is not cached), so a later `ollama pull` is discovered without
+`/reload`. Cleared by `clear_caches()`."""
 _ollama_model_profiles_cache: dict[tuple[str, str], dict[str, Any]] = {}
 _profiles_cache: Mapping[str, ModelProfileEntry] | None = None
 _profiles_override_cache: tuple[int, Mapping[str, ModelProfileEntry]] | None = None
@@ -1455,11 +1459,13 @@ def _ollama_discovery_enabled() -> bool:
 def _get_ollama_installed_models(endpoint: str | None) -> list[str]:
     """Return cached Ollama model names for `endpoint`.
 
-    The result is cached when the daemon returns models, and also when the
-    daemon is unreachable so the two startup callers (`get_available_models`
-    and `get_model_profiles`) share a single probe and a single "not detected"
-    log line per reload. A reachable daemon that reports no models is left
-    uncached so a later pull can still be discovered without `/reload`.
+    The result is cached when the daemon returns models, and also when a local
+    daemon definitively refuses the TCP presence preflight, so the two startup
+    callers (`get_available_models` and `get_model_profiles`) share a single
+    probe and a single "not detected" log line per reload. A reachable daemon
+    that reports no models -- and one whose preflight is merely ambiguous (a
+    connect timeout) -- is left uncached so a later pull can still be discovered
+    without `/reload`.
 
     Args:
         endpoint: Base URL of the Ollama daemon. When `None`, defaults to
@@ -1486,10 +1492,14 @@ def _ollama_host_reachable(
     A lightweight presence preflight so Ollama discovery can skip the HTTP
     probe entirely when no daemon is running (e.g. Ollama is not installed).
     The check opens and immediately closes a TCP connection to the endpoint's
-    host and port. Any failure -- connection refused, DNS error, timeout, or
-    sockets blocked under `pytest-socket` -- is treated as "not reachable" so
-    discovery falls back gracefully; an unexpected (non-`OSError`) failure is
-    additionally logged at warning so a real bug isn't misreported as absence.
+    host and port. A *definitive* failure -- connection refused, DNS error, or
+    sockets blocked under `pytest-socket` -- reports "not reachable" so
+    discovery falls back gracefully (and the caller may negatively cache it). A
+    *connect timeout* is ambiguous -- a present-but-slow or still-booting daemon
+    times out just like an absent one -- so it defers to the HTTP probe
+    (reports "reachable") rather than being cached as absent. An unexpected
+    (non-`OSError`) failure is additionally logged at warning so a real bug
+    isn't misreported as absence.
 
     Args:
         base: Base URL of the Ollama daemon, e.g. `http://localhost:11434`.
@@ -1497,8 +1507,9 @@ def _ollama_host_reachable(
 
     Returns:
         `True` when a connection is established (a daemon appears present) or
-            when the target cannot be determined (deferring to the HTTP probe);
-            `False` when the connection cannot be made.
+            when presence cannot be determined -- unparseable target or a
+            connect timeout -- so the caller defers to the HTTP probe; `False`
+            when the connection is definitively refused.
     """
     import socket
 
@@ -1514,15 +1525,22 @@ def _ollama_host_reachable(
         return True
     if port is None:
         port = 443 if parsed.scheme == "https" else 80
-    # Mirror the discovery probe below: expected transport failures (refused,
-    # DNS, timeout) just mean the daemon is absent and stay silent; anything
-    # else is surfaced at warning so a real bug isn't misreported as "not
-    # detected". `pytest-socket`'s `SocketBlockedError` inherits from
+    # Expected transport failures split by how definitive they are. A refusal
+    # (`ECONNREFUSED` and friends -- an `OSError`) is a fast, certain "nothing
+    # is listening", so it reports absent and lets the caller negatively cache
+    # it. A connect *timeout* is ambiguous (present-but-slow vs. absent-and-
+    # firewalled), so it defers to the HTTP probe rather than being cached as
+    # absent and stuck until the next reload. `TimeoutError` is an `OSError`
+    # subclass, so its branch must precede the broad `OSError` one. Anything
+    # non-`OSError` is surfaced at warning so a real bug isn't misreported as
+    # "not detected"; `pytest-socket`'s `SocketBlockedError` inherits from
     # `Exception` (not `OSError`), so the broad branch catches it. The socket
     # is its own context manager, so `with` closes the probe connection.
     try:
         with socket.create_connection((host, port), timeout=timeout):
             return True
+    except TimeoutError:
+        return True
     except OSError:
         return False
     except Exception as exc:  # noqa: BLE001  # see comment above

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -816,6 +816,13 @@ It is reentrant so a caller can hold it across several of these helpers without
 self-deadlock. Cross-process races are out of scope (mirrors the existing
 helpers)."""
 _ollama_installed_models_cache: dict[str, list[str]] = {}
+_ollama_unreachable_endpoints: set[str] = set()
+"""Normalized endpoints whose daemon failed the TCP presence preflight.
+
+Lets `_get_ollama_installed_models` negatively-cache the empty result for an
+*unreachable* daemon so it probes and logs "not detected" once per reload,
+while a *reachable* daemon that merely has no models pulled yet is still
+re-probed (its empty result is not cached). Cleared by `clear_caches()`."""
 _ollama_model_profiles_cache: dict[tuple[str, str], dict[str, Any]] = {}
 _profiles_cache: Mapping[str, ModelProfileEntry] | None = None
 _profiles_override_cache: tuple[int, Mapping[str, ModelProfileEntry]] | None = None
@@ -832,6 +839,7 @@ def clear_caches() -> None:
     _default_config_cache = None
     _provider_profiles_cache.clear()
     _ollama_installed_models_cache.clear()
+    _ollama_unreachable_endpoints.clear()
     _ollama_model_profiles_cache.clear()
     _profiles_cache = None
     _profiles_override_cache = None
@@ -1447,6 +1455,12 @@ def _ollama_discovery_enabled() -> bool:
 def _get_ollama_installed_models(endpoint: str | None) -> list[str]:
     """Return cached Ollama model names for `endpoint`.
 
+    The result is cached when the daemon returns models, and also when the
+    daemon is unreachable so the two startup callers (`get_available_models`
+    and `get_model_profiles`) share a single probe and a single "not detected"
+    log line per reload. A reachable daemon that reports no models is left
+    uncached so a later pull can still be discovered without `/reload`.
+
     Args:
         endpoint: Base URL of the Ollama daemon. When `None`, defaults to
             `OLLAMA_DEFAULT_BASE_URL`.
@@ -1459,7 +1473,7 @@ def _get_ollama_installed_models(endpoint: str | None) -> list[str]:
     if cached is not None:
         return list(cached)
     models = _fetch_ollama_installed_models(endpoint)
-    if models:
+    if models or key in _ollama_unreachable_endpoints:
         _ollama_installed_models_cache[key] = models
     return list(models)
 
@@ -1567,6 +1581,7 @@ def _fetch_ollama_installed_models(
     # "discovery failed ... Connection refused" debug line.
     if _is_local_endpoint(base) and not _ollama_host_reachable(base, timeout=timeout):
         logger.debug("Ollama daemon not detected at %s; skipping discovery", base)
+        _ollama_unreachable_endpoints.add(base)
         return []
 
     url = f"{base}/api/tags"

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -2771,6 +2771,8 @@ enabled = false
             assert model_config._get_ollama_installed_models(None) == ["qwen3:4b"]
 
         assert fetch.call_count == 2
+        # A reachable-but-empty daemon is never marked unreachable.
+        assert model_config._ollama_unreachable_endpoints == set()
 
     def test_unreachable_daemon_probed_and_logged_once(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
@@ -2798,6 +2800,69 @@ enabled = false
         reachable.assert_called_once()
         urlopen.assert_not_called()
         assert caplog.text.count("Ollama daemon not detected") == 1
+
+    def test_unreachable_daemon_logged_once_across_callers(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The two startup callers share one probe and one "not detected" log.
+
+        Regression: an unreachable daemon was probed -- and logged "not
+        detected" -- once by `get_available_models` and again by
+        `get_model_profiles`, so the line appeared twice per reload. Drives the
+        real callers rather than `_get_ollama_installed_models` directly.
+        """
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("")
+        monkeypatch.delenv("DEEPAGENTS_CODE_OLLAMA_DISCOVERY", raising=False)
+        monkeypatch.setattr(
+            "deepagents_code.model_config._ollama_host_reachable",
+            MagicMock(return_value=False),
+        )
+
+        with (
+            self._patch_registry(),
+            patch(
+                "deepagents_code.model_config._load_provider_profiles",
+                side_effect=self._empty_profiles_loader,
+            ),
+            patch(
+                "deepagents_code.model_config.importlib.util.find_spec",
+                return_value=object(),
+            ),
+            patch("urllib.request.urlopen") as urlopen,
+            patch.object(model_config, "DEFAULT_CONFIG_PATH", config_path),
+            caplog.at_level(logging.DEBUG, logger="deepagents_code.model_config"),
+        ):
+            get_available_models()
+            get_model_profiles()
+
+        urlopen.assert_not_called()
+        assert caplog.text.count("Ollama daemon not detected") == 1
+
+    @pytest.mark.parametrize("endpoint", [None, "http://localhost:11434/"])
+    def test_unreachable_cache_key_matches_across_normalization(
+        self, endpoint: str | None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`None` and a trailing slash resolve to the same negative-cache key.
+
+        The add-site (`_fetch_ollama_installed_models`) and check-site
+        (`_get_ollama_installed_models`) must normalize identically, else the
+        empty result is keyed differently from the lookup and the daemon is
+        re-probed every call instead of once per reload.
+        """
+        reachable = MagicMock(return_value=False)
+        monkeypatch.setattr(
+            "deepagents_code.model_config._ollama_host_reachable", reachable
+        )
+
+        with patch("urllib.request.urlopen"):
+            assert model_config._get_ollama_installed_models(endpoint) == []
+            assert model_config._get_ollama_installed_models(endpoint) == []
+
+        reachable.assert_called_once()
 
     def test_model_profiles_include_discovered_context_length(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -3244,6 +3309,29 @@ class TestOllamaHostReachable:
             assert (
                 model_config._ollama_host_reachable("http://localhost:11434") is False
             )
+
+        assert caplog.records == []
+
+    def test_defers_to_probe_on_connect_timeout(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A connect timeout is ambiguous, so it defers to the HTTP probe.
+
+        A present-but-slow or still-booting daemon times out just like an
+        absent one; reporting it absent here would negatively cache the empty
+        result and hide a working daemon until the next reload. Returning
+        "reachable" lets the HTTP probe -- which may now succeed -- decide, and
+        leaves the empty result uncached. Silent, since a timeout is expected.
+        """
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise TimeoutError
+
+        with (
+            caplog.at_level(logging.WARNING, logger="deepagents_code.model_config"),
+            patch("socket.create_connection", side_effect=boom),
+        ):
+            assert model_config._ollama_host_reachable("http://localhost:11434") is True
 
         assert caplog.records == []
 
@@ -6678,12 +6766,14 @@ max_input_tokens = 4096
         model_config._ollama_installed_models_cache["http://localhost:11434"] = [
             "qwen3:4b"
         ]
+        model_config._ollama_unreachable_endpoints.add("http://localhost:11434")
         model_config._ollama_model_profiles_cache[
             "http://localhost:11434", "qwen3:4b"
         ] = {"max_input_tokens": 262144}
         clear_caches()
         assert model_config._profiles_cache is None
         assert model_config._ollama_installed_models_cache == {}
+        assert model_config._ollama_unreachable_endpoints == set()
         assert model_config._ollama_model_profiles_cache == {}
 
     def test_overridden_keys_subset_of_profile(self, tmp_path: Path) -> None:

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -2762,7 +2762,7 @@ enabled = false
         fetch.assert_called_once_with(None)
 
     def test_empty_installed_model_discovery_not_cached(self) -> None:
-        """Empty `/api/tags` results do not block later recovery."""
+        """Empty `/api/tags` results from a reachable daemon are not cached."""
         with patch(
             "deepagents_code.model_config._fetch_ollama_installed_models",
             side_effect=[[], ["qwen3:4b"]],
@@ -2771,6 +2771,33 @@ enabled = false
             assert model_config._get_ollama_installed_models(None) == ["qwen3:4b"]
 
         assert fetch.call_count == 2
+
+    def test_unreachable_daemon_probed_and_logged_once(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An unreachable daemon is probed and logged once per reload."""
+        reachable = MagicMock(return_value=False)
+        monkeypatch.setattr(
+            "deepagents_code.model_config._ollama_host_reachable", reachable
+        )
+
+        with (
+            patch("urllib.request.urlopen") as urlopen,
+            caplog.at_level(logging.DEBUG, logger="deepagents_code.model_config"),
+        ):
+            assert (
+                model_config._get_ollama_installed_models("http://localhost:11434")
+                == []
+            )
+            assert (
+                model_config._get_ollama_installed_models("http://localhost:11434")
+                == []
+            )
+
+        # Preflight ran once; the negative result was cached for the second call.
+        reachable.assert_called_once()
+        urlopen.assert_not_called()
+        assert caplog.text.count("Ollama daemon not detected") == 1
 
     def test_model_profiles_include_discovered_context_length(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
When an Ollama daemon is down, discovery no longer probes it twice or emits duplicate, out-of-order debug logs at startup — it probes and logs "not detected" once per reload.

---

Ollama discovery runs from two startup callers — `get_available_models` and `get_model_profiles` — that both call `_get_ollama_installed_models`. Empty results were never cached, so an unreachable daemon was probed twice per reload and logged `Ollama daemon not detected ...` twice. Because the second `not detected` (from `get_model_profiles`) landed right after the first pass's `discovery returned no models` line, the two appeared out of order even though each individual pass logs in the correct order.

This tracks endpoints that fail the TCP presence preflight in `_ollama_unreachable_endpoints` and negatively-caches their empty result, so the probe and log happen once. A *reachable* daemon that simply reports no models is still left uncached, preserving recovery of a later `ollama pull` without `/reload` (covered by the existing `test_empty_installed_model_discovery_not_cached`).

Made by [Open SWE](https://openswe.vercel.app/agents/7b64e449-2a7e-f258-17a1-5ffe933608a3)