### PR TITLE
feat(code): add `reconnect`/`connect` hidden keywords for `/restart`

### DIFF
--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -216,7 +216,7 @@ COMMANDS: tuple[SlashCommand, ...] = (
         name="/restart",
         description="Restart the agent server",
         bypass_tier=BypassTier.ALWAYS,
-        hidden_keywords="respawn server",
+        hidden_keywords="respawn server reconnect connect",
     ),
     SlashCommand(
         name="/theme",


### PR DESCRIPTION
Typing "reconnect" or "connect" in the slash-command autocomplete now surfaces the `/restart` command, which respawns the agent server.

Adds `reconnect` and `connect` to the `hidden_keywords` for the `/restart` `SlashCommand` entry so fuzzy matching finds it under those common terms. These keywords are never displayed and don't appear in the commands catalog, so no regeneration is needed.

Made by [Open SWE](https://openswe.vercel.app/agents/05f60126-f5ea-25a4-3b3b-84127a4a529b)