### PR TITLE
fix(code): count only running tools in live tool-group line

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -2993,8 +2993,10 @@ class ToolGroupSummary(Static):
 
     Tools are hidden from the moment they start; this single line shows live
     progress ("Running 1 shell command…") and flips to the past tense
-    ("Ran 1 shell command") once every tool finishes. Clicking the line or
-    pressing Ctrl+O expands the underlying tool rows (and their diffs).
+    ("Ran 1 shell command") once every tool finishes. The live line counts only
+    the tools still in progress, so finished calls drop out of it as they
+    complete; the past-tense line summarizes every tool that ran. Clicking the
+    line or pressing Ctrl+O expands the underlying tool rows (and their diffs).
 
     Two modes:
 
@@ -3055,6 +3057,10 @@ class ToolGroupSummary(Static):
         # every spinner tick). None means "recompute on next render".
         self._present_text: str | None = None
         self._past_text: str | None = None
+        # The set of in-progress tool names the cached present line was built
+        # from. The live line counts only running tools, so it must be rebuilt
+        # whenever a member finishes, not just when membership grows.
+        self._present_key: tuple[str, ...] | None = None
 
     def on_mount(self) -> None:
         """Apply initial visibility, render, and arm the spinner if live."""
@@ -3244,10 +3250,11 @@ class ToolGroupSummary(Static):
         if in_progress is None:
             in_progress = self._in_progress()
         if not self._finalized and in_progress:
-            if self._present_text is None:
-                self._present_text = summarize_tool_group(
-                    [tool.tool_name for tool in self._tools], tense="present"
-                )
+            pending = [tool.tool_name for tool in self._tools if tool.is_pending]
+            key = tuple(pending)
+            if self._present_text is None or key != self._present_key:
+                self._present_text = summarize_tool_group(pending, tense="present")
+                self._present_key = key
             frames = glyphs.spinner_frames
             spinner = frames[self._spinner_pos % len(frames)]
             self.update(

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -2995,8 +2995,10 @@ class ToolGroupSummary(Static):
     progress ("Running 1 shell command…") and flips to the past tense
     ("Ran 1 shell command") once every tool finishes. The live line counts only
     the tools still in progress, so finished calls drop out of it as they
-    complete; the past-tense line summarizes every tool that ran. Clicking the
-    line or pressing Ctrl+O expands the underlying tool rows (and their diffs).
+    complete; the past-tense line summarizes the tools that succeeded — failed,
+    rejected, and skipped tools are evicted to standalone rows (see
+    `_evict_failed`) so errors stay visible. Clicking the line or pressing
+    Ctrl+O expands the underlying tool rows (and their diffs).
 
     Two modes:
 
@@ -3057,9 +3059,9 @@ class ToolGroupSummary(Static):
         # every spinner tick). None means "recompute on next render".
         self._present_text: str | None = None
         self._past_text: str | None = None
-        # The set of in-progress tool names the cached present line was built
-        # from. The live line counts only running tools, so it must be rebuilt
-        # whenever a member finishes, not just when membership grows.
+        # The tuple of in-progress tool names the cached present line was built
+        # from. The live line counts only in-progress tools, so it must be
+        # rebuilt whenever a member finishes, not just when membership grows.
         self._present_key: tuple[str, ...] | None = None
 
     def on_mount(self) -> None:
@@ -3076,7 +3078,7 @@ class ToolGroupSummary(Static):
         for widget in extra:
             widget.add_class("-grouped")
             self._collapsible.append(widget)
-        self._present_text = self._past_text = None
+        self._present_text = self._past_text = self._present_key = None
         self._apply_visibility()
         self._render_line()
         self._sync_timer()
@@ -3113,7 +3115,7 @@ class ToolGroupSummary(Static):
             tool.remove_class("-grouped")
             if tool.is_attached and not tool._awaiting_approval:
                 tool.display = True
-        self._present_text = self._past_text = None
+        self._present_text = self._past_text = self._present_key = None
         if self._tools:
             self._render_line()
             self._sync_timer()
@@ -3175,7 +3177,7 @@ class ToolGroupSummary(Static):
             tool.remove_class("-grouped")
             if tool.is_attached:
                 tool.display = True
-        self._present_text = self._past_text = None
+        self._present_text = self._past_text = self._present_key = None
 
     def _sync_timer(self) -> None:
         """Run the spinner timer only while live members are in progress."""
@@ -3209,8 +3211,8 @@ class ToolGroupSummary(Static):
             in_progress = self._in_progress()
             if not in_progress:
                 self._stop_timer()
-            # A bare spinner advance keeps the line height; only relayout when
-            # membership changed (eviction) or the line flips to past tense.
+            # A bare spinner advance keeps the line height. `_render_line`
+            # promotes this to a layout update if the pending summary changed.
             self._render_line(
                 in_progress=in_progress, layout=evicted or not in_progress
             )
@@ -3237,9 +3239,9 @@ class ToolGroupSummary(Static):
         Args:
             in_progress: Pre-computed progress state to avoid re-scanning members
                 on the spinner hot path; recomputed when omitted.
-            layout: Whether the update may change the line's height. The spinner
-                hot path passes False so a bare glyph swap doesn't relayout the
-                whole transcript 10x/second.
+            layout: Whether to force a layout update. A changed summary always
+                triggers layout; the spinner hot path passes False so a bare
+                glyph swap doesn't relayout the whole transcript 10x/second.
         """
         if not self.is_attached:
             return
@@ -3252,14 +3254,15 @@ class ToolGroupSummary(Static):
         if not self._finalized and in_progress:
             pending = [tool.tool_name for tool in self._tools if tool.is_pending]
             key = tuple(pending)
-            if self._present_text is None or key != self._present_key:
+            summary_changed = self._present_text is None or key != self._present_key
+            if summary_changed:
                 self._present_text = summarize_tool_group(pending, tense="present")
                 self._present_key = key
             frames = glyphs.spinner_frames
             spinner = frames[self._spinner_pos % len(frames)]
             self.update(
                 Content(f"{spinner} {self._present_text}{glyphs.ellipsis}"),
-                layout=layout,
+                layout=layout or summary_changed,
             )
         else:
             mark = (

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -4056,6 +4056,23 @@ class _LiveToolGroupApp(App[None]):
         yield t2
 
 
+class _LiveToolGroupSameCategoryApp(App[None]):
+    """Live group with two tools of the same category (both shell commands)."""
+
+    def compose(self) -> ComposeResult:
+        from deepagents_code.tui.widgets.messages import ToolGroupSummary
+
+        summary = ToolGroupSummary(live=True)
+        summary.id = "summary"
+        t1 = ToolCallMessage("execute", {"command": "ls"})
+        t1.id = "t1"
+        t2 = ToolCallMessage("execute", {"command": "pwd"})
+        t2.id = "t2"
+        yield summary
+        yield t1
+        yield t2
+
+
 class TestLiveToolGroupSummary:
     """Eager/live group: collapsed from the start, running -> ran transition."""
 
@@ -4111,6 +4128,53 @@ class TestLiveToolGroupSummary:
             assert isinstance(rendered, Content)
             assert "Reading 1 file" in rendered.plain
             assert "shell command" not in rendered.plain
+
+    async def test_live_line_decrements_same_category_count(self) -> None:
+        """One of two shell commands finishing drops the live count 2 -> 1."""
+        from deepagents_code.tui.widgets.messages import ToolGroupSummary
+
+        async with _LiveToolGroupSameCategoryApp().run_test() as pilot:
+            summary = pilot.app.query_one("#summary", ToolGroupSummary)
+            done = pilot.app.query_one("#t1", ToolCallMessage)
+            running = pilot.app.query_one("#t2", ToolCallMessage)
+
+            summary.add_member(done)
+            summary.add_member(running)
+            rendered = summary.render()
+            assert isinstance(rendered, Content)
+            assert "Running 2 shell commands" in rendered.plain
+
+            # One command finishes; the surviving pending tuple shrinks from
+            # ("execute", "execute") to ("execute",), which must invalidate the
+            # cached line even though the category (and membership) is unchanged.
+            done.set_success("done")
+            summary._render_line()
+            rendered = summary.render()
+            assert isinstance(rendered, Content)
+            assert "Running 1 shell command" in rendered.plain
+            assert "2 shell commands" not in rendered.plain
+
+    async def test_live_line_relayouts_only_when_summary_changes(self) -> None:
+        """A shorter pending summary recalculates height on the next tick."""
+        from deepagents_code.tui.widgets.messages import ToolGroupSummary
+
+        async with _LiveToolGroupApp().run_test() as pilot:
+            summary = pilot.app.query_one("#summary", ToolGroupSummary)
+            done = pilot.app.query_one("#t1", ToolCallMessage)
+            running = pilot.app.query_one("#t2", ToolCallMessage)
+
+            summary.add_member(done)
+            summary.add_member(running)
+            summary._stop_timer()
+            done.set_success("done")
+
+            with patch.object(summary, "update", wraps=summary.update) as update:
+                summary._tick()
+                assert update.call_args.kwargs["layout"] is True
+
+                update.reset_mock()
+                summary._tick()
+                assert update.call_args.kwargs["layout"] is False
 
     async def test_pending_member_is_revealed_for_approval(self) -> None:
         """Only unfinished calls leave the collapsed group before approval."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -4088,6 +4088,30 @@ class TestLiveToolGroupSummary:
             assert summary.is_attached
             assert bool(pilot.app.query(ToolGroupSummary))
 
+    async def test_live_line_counts_only_running_members(self) -> None:
+        """Finished tools drop out of the live line while others still run."""
+        from deepagents_code.tui.widgets.messages import ToolGroupSummary
+
+        async with _LiveToolGroupApp().run_test() as pilot:
+            summary = pilot.app.query_one("#summary", ToolGroupSummary)
+            done = pilot.app.query_one("#t1", ToolCallMessage)  # execute
+            running = pilot.app.query_one("#t2", ToolCallMessage)  # read_file
+
+            summary.add_member(done)
+            summary.add_member(running)
+            rendered = summary.render()
+            assert isinstance(rendered, Content)
+            assert "Running 1 shell command, reading 1 file" in rendered.plain
+
+            # The shell command finishes but the read is still in flight: the
+            # live line must stop advertising the completed command.
+            done.set_success("done")
+            summary._render_line()
+            rendered = summary.render()
+            assert isinstance(rendered, Content)
+            assert "Reading 1 file" in rendered.plain
+            assert "shell command" not in rendered.plain
+
     async def test_pending_member_is_revealed_for_approval(self) -> None:
         """Only unfinished calls leave the collapsed group before approval."""
         from deepagents_code.tui.widgets.messages import ToolGroupSummary


### PR DESCRIPTION
Fix the live tool-group progress line in `dcode` so it counts only the tools still running instead of every tool in the step.

---

The collapsed tool-group summary's live progress line summarizes the whole assistant step instead of what is actually still running. Because it aggregates every tool in the group, finished calls keep being reported as in progress — e.g. it shows `Running 1 shell command, running 2 agents…` even after the shell command and one of the agents have completed.

This builds the present-tense line from only the still-pending members, so finished calls drop out as they complete. The past-tense line (shown once everything finishes) continues to summarize every tool that ran. The cached present phrasing now rebuilds whenever the set of running members changes, not just when the group grows.

Made by [Open SWE](https://openswe.vercel.app/agents/25ed04be-b8ed-97c9-a600-d24d80c02162)