### PR TITLE
feat(code): persist Debug Console `Ctrl+L` clear across reopen

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2638,7 +2638,7 @@ class DeepAgentsApp(App):
         """
 
         self._debug_console_cleared_upto = 0
-        """Absolute log-buffer index the Debug Console was last cleared up to.
+        """Absolute emission index the Debug Console was last cleared up to.
 
         Persists a `Ctrl+L` clear across close/reopen of the console for the
         process lifetime; each newly opened `DebugConsoleScreen` is seeded from

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2583,6 +2583,14 @@ class DeepAgentsApp(App):
         completion in the chat input.
         """
 
+        self._debug_console_cleared_upto = 0
+        """Absolute log-buffer index the Debug Console was last cleared up to.
+
+        Persists a `Ctrl+L` clear across close/reopen of the console for the
+        process lifetime; each newly opened `DebugConsoleScreen` is seeded from
+        it and reports a fresh clear back through its `on_clear` callback.
+        """
+
         self._lc_thread_id = thread_id
         """LangChain thread identifier.
 
@@ -17013,8 +17021,16 @@ class DeepAgentsApp(App):
             if self._chat_input:
                 self._chat_input.focus_input()
 
+        def persist_clear(cursor: int) -> None:
+            self._debug_console_cleared_upto = cursor
+
         self.push_screen(
-            DebugConsoleScreen(self._build_debug_snapshot()), handle_result
+            DebugConsoleScreen(
+                self._build_debug_snapshot(),
+                cleared_upto=self._debug_console_cleared_upto,
+                on_clear=persist_clear,
+            ),
+            handle_result,
         )
 
     def _build_debug_snapshot(self) -> list[SnapshotField]:

--- a/libs/code/deepagents_code/tui/widgets/debug_console.py
+++ b/libs/code/deepagents_code/tui/widgets/debug_console.py
@@ -706,17 +706,30 @@ class DebugConsoleScreen(ModalScreen[None]):
     }
     """
 
-    def __init__(self, snapshot: Sequence[SnapshotField]) -> None:
+    def __init__(
+        self,
+        snapshot: Sequence[SnapshotField],
+        *,
+        cleared_upto: int = 0,
+        on_clear: Callable[[int], None] | None = None,
+    ) -> None:
         """Initialize with a captured *snapshot* of session/runtime fields.
 
         Args:
             snapshot: Ordered `SnapshotField` rows rendered in the header.
+            cleared_upto: Absolute buffer index a prior `Ctrl+L` cleared up to.
+                The console starts rendering from here so a clear persists across
+                close/reopen; records emitted after it still appear.
+            on_clear: Invoked with the new clear cursor whenever `Ctrl+L` clears
+                the view, letting the owner persist it for the next open.
         """
         super().__init__()
         self._snapshot = list(snapshot)
         self._records: list[InMemoryLogRecord] = []
-        # Absolute index of the next unrendered log record (incremental writes).
-        self._rendered_upto = 0
+        # Absolute index of the next unrendered log record (incremental writes),
+        # seeded from any persisted clear so reopening honors the last Ctrl+L.
+        self._rendered_upto = cleared_upto
+        self._on_clear = on_clear
         # One-shot guard so the "buffer unavailable" notice is written only once.
         self._missing_notice_shown = False
         self._level_filter: FilterValue = "all"
@@ -1025,12 +1038,18 @@ class DebugConsoleScreen(ModalScreen[None]):
         )
 
     def action_clear_view(self) -> None:
-        """Clear the on-screen log view; the in-memory buffer keeps accruing."""
+        """Clear the on-screen log view; the in-memory buffer keeps accruing.
+
+        Advances the render cursor past everything emitted so far and reports it
+        via `on_clear` so the owner can persist the clear across close/reopen.
+        """
         self.query_one("#debug-log", _DebugLogView).clear_records()
         self._records.clear()
         buffer = get_log_buffer()
         if buffer is not None:
             self._rendered_upto = buffer.total_emitted
+        if self._on_clear is not None:
+            self._on_clear(self._rendered_upto)
 
     def action_copy(self) -> None:
         """Copy visible retained log records since the last clear to the clipboard."""

--- a/libs/code/deepagents_code/tui/widgets/debug_console.py
+++ b/libs/code/deepagents_code/tui/widgets/debug_console.py
@@ -717,7 +717,7 @@ class DebugConsoleScreen(ModalScreen[None]):
 
         Args:
             snapshot: Ordered `SnapshotField` rows rendered in the header.
-            cleared_upto: Absolute buffer index a prior `Ctrl+L` cleared up to.
+            cleared_upto: Absolute emission index a prior `Ctrl+L` cleared up to.
                 The console starts rendering from here so a clear persists across
                 close/reopen; records emitted after it still appear.
             on_clear: Invoked with the new clear cursor whenever `Ctrl+L` clears

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -453,6 +453,45 @@ class TestDebugConsoleScreen:
             assert log.line_count == 0
             assert screen._rendered_upto == buffer.total_emitted
 
+    async def test_clear_view_reports_cursor_via_on_clear(self) -> None:
+        logger.info("debug-console-on-clear-marker")
+        cleared: list[int] = []
+        app = _Harness()
+        async with app.run_test() as pilot:
+            screen = DebugConsoleScreen(_snapshot(), on_clear=cleared.append)
+            app.push_screen(screen)
+            await pilot.pause()
+            buffer = get_log_buffer()
+            assert buffer is not None
+
+            await pilot.press("ctrl+l")
+            await pilot.pause()
+            assert cleared == [buffer.total_emitted]
+
+    async def test_cleared_upto_seeds_render_cursor(self) -> None:
+        logger.info("debug-console-pre-clear-marker")
+        app = _Harness()
+        async with app.run_test() as pilot:
+            buffer = get_log_buffer()
+            assert buffer is not None
+            # Simulate a prior clear by seeding past everything emitted so far.
+            screen = DebugConsoleScreen(_snapshot(), cleared_upto=buffer.total_emitted)
+            app.push_screen(screen)
+            await pilot.pause()
+            log = screen.query_one("#debug-log", _DebugLogView)
+            assert not any(
+                "debug-console-pre-clear-marker" in record.message
+                for record in log.records
+            )
+
+            logger.info("debug-console-post-clear-marker")
+            screen._poll_logs()
+            await pilot.pause()
+            assert any(
+                "debug-console-post-clear-marker" in record.message
+                for record in log.records
+            )
+
     async def test_copy_key_invokes_clipboard_with_retained_lines(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1185,6 +1224,36 @@ class TestDebugConsoleToggle:
             app.action_toggle_debug_console()
             await pilot.pause()
             assert not isinstance(app.screen, DebugConsoleScreen)
+
+    async def test_clear_persists_across_reopen(self) -> None:
+        logger.info("debug-console-persist-marker")
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+backslash")
+            await pilot.pause()
+            screen = cast("DebugConsoleScreen", app.screen)
+            log = screen.query_one("#debug-log", _DebugLogView)
+            assert any(
+                "debug-console-persist-marker" in record.message
+                for record in log.records
+            )
+
+            await pilot.press("ctrl+l")
+            await pilot.pause()
+            assert app._debug_console_cleared_upto > 0
+
+            # Close and reopen: the cleared records must not come back.
+            await pilot.press("ctrl+backslash")
+            await pilot.pause()
+            await pilot.press("ctrl+backslash")
+            await pilot.pause()
+            reopened = cast("DebugConsoleScreen", app.screen)
+            reopened_log = reopened.query_one("#debug-log", _DebugLogView)
+            assert not any(
+                "debug-console-persist-marker" in record.message
+                for record in reopened_log.records
+            )
 
     async def test_debug_command_opens_console(self) -> None:
         app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-123")

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -464,9 +464,12 @@ class TestDebugConsoleScreen:
             buffer = get_log_buffer()
             assert buffer is not None
 
+            # Capture the cursor at clear time; the shared process-wide buffer
+            # may accrue records between the clear and a later re-read.
+            expected = buffer.total_emitted
             await pilot.press("ctrl+l")
             await pilot.pause()
-            assert cleared == [buffer.total_emitted]
+            assert cleared == [expected]
 
     async def test_cleared_upto_seeds_render_cursor(self) -> None:
         logger.info("debug-console-pre-clear-marker")
@@ -1239,11 +1242,19 @@ class TestDebugConsoleToggle:
                 for record in log.records
             )
 
+            buffer = get_log_buffer()
+            assert buffer is not None
+            expected = buffer.total_emitted
             await pilot.press("ctrl+l")
             await pilot.pause()
-            assert app._debug_console_cleared_upto > 0
+            assert app._debug_console_cleared_upto == expected
 
-            # Close and reopen: the cleared records must not come back.
+            # A record emitted after the clear must survive the reopen; only the
+            # pre-clear tail is suppressed.
+            logger.info("debug-console-post-clear-marker")
+
+            # Close and reopen: the cleared records must not come back, but the
+            # post-clear record must appear.
             await pilot.press("ctrl+backslash")
             await pilot.pause()
             await pilot.press("ctrl+backslash")
@@ -1252,6 +1263,10 @@ class TestDebugConsoleToggle:
             reopened_log = reopened.query_one("#debug-log", _DebugLogView)
             assert not any(
                 "debug-console-persist-marker" in record.message
+                for record in reopened_log.records
+            )
+            assert any(
+                "debug-console-post-clear-marker" in record.message
                 for record in reopened_log.records
             )
 


### PR DESCRIPTION
Clearing the Debug Console (`Ctrl+\`) traceback/log tail with `Ctrl+L` now persists across closing and reopening the console for the process lifetime, instead of re-populating from the in-memory buffer on the next open.

---

The console modal is recreated fresh on every open and, on mount, replays everything still retained in the always-on in-memory ring buffer. `Ctrl+L` (`action_clear_view`) was deliberately a view-only clear that advanced only the current instance's render cursor, so closing and reopening replayed the buffer and the "cleared" records came back.

This adds a process-lifetime "cleared upto" cursor owned by the app. `DebugConsoleScreen` gains keyword-only `cleared_upto` (seeds its render cursor so a prior clear is honored on open) and `on_clear` (reports the new cursor when `Ctrl+L` fires). `DeepAgentsApp` stores the cursor in `_debug_console_cleared_upto`, seeds each new console from it, and persists updates via the callback.

The change stays strictly view-only: the shared ring buffer is never mutated, other diagnostics are unaffected, and records logged *after* a clear still appear. Clearing is by emission time, matching the existing in-session semantics.

Made by [Open SWE](https://openswe.vercel.app/agents/58c9cc66-afbe-b468-729d-375b731bbf71)