### PR TITLE
fix(code): surface `langchain-quickjs` in `/version` core deps

### DIFF
--- a/libs/code/deepagents_code/extras_info.py
+++ b/libs/code/deepagents_code/extras_info.py
@@ -548,6 +548,7 @@ def format_extras_status_plain(status: ExtrasStatus) -> str:
 CORE_DEPENDENCIES: tuple[str, ...] = (
     "langchain",
     "langchain-core",
+    "langchain-quickjs",
     "langgraph",
     "langgraph-checkpoint",
     "langgraph-prebuilt",
@@ -559,6 +560,9 @@ CORE_DEPENDENCIES: tuple[str, ...] = (
 The deepagents SDK is reported separately by `/version`, so it is omitted
 here. These are the packages a local checkout is most likely to pin or
 override, so their resolved versions help diagnose editable environments.
+`langchain-quickjs` powers the built-in interpreter and is a core dependency
+(not an optional extra), so it belongs here rather than under the optional
+dependencies section.
 """
 
 


### PR DESCRIPTION
`/version` now lists `langchain-quickjs` under its "Core dependencies" section for editable installs.

---

`langchain-quickjs` powers the built-in interpreter and is a core runtime dependency (declared directly in `dependencies`, not as an optional extra). It was previously invisible in `/version`: the "Installed optional dependencies" table only reads packages gated by `extra == "..."` markers (and the `quickjs` extra is intentionally empty), while the curated `CORE_DEPENDENCIES` list that drives the "Core dependencies" section did not include it.

Adding it to `CORE_DEPENDENCIES` surfaces its resolved version alongside the other LangChain-ecosystem packages, which helps diagnose editable environments where a local checkout of the partner package may be overriding the released one. The section is only rendered for editable installs, matching existing behavior.

The `CORE_DEPENDENCIES`-driven tests iterate the tuple generically, so they cover the new entry without modification.

Made by [Open SWE](https://openswe.vercel.app/agents/e258f95b-7cc4-33f3-52f0-32d4aa4c13fd)