### PR TITLE
fix(code): make markdown `AppMessage` output selectable

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -3617,6 +3617,12 @@ class _MutedRichMarkdown:
 # readable table instead of collapsing to a single column.
 _MARKDOWN_MIN_RENDER_WIDTH = 20
 
+# One-shot flag (mutable holder to avoid a `global` statement) set once the first
+# markdown style conversion fails, so a systematic breakage (e.g. a Rich/Textual
+# version drift) surfaces at `warning` once instead of staying invisible at
+# `debug`, without spamming a line per unconvertible span.
+_markdown_style_conversion_warned = [False]
+
 
 def _markdown_to_content(
     markup: str, width: int, console: RichConsole | None = None
@@ -3668,7 +3674,18 @@ def _markdown_to_content(
                 try:
                     style = Style.from_rich_style(segment.style)
                 except Exception:  # style conversion is best-effort
-                    logger.debug("Skipping unconvertible markdown style", exc_info=True)
+                    if not _markdown_style_conversion_warned[0]:
+                        _markdown_style_conversion_warned[0] = True
+                        logger.warning(
+                            "Failed to convert a markdown style; markdown will "
+                            "render without some styling (later occurrences log "
+                            "at debug)",
+                            exc_info=True,
+                        )
+                    else:
+                        logger.debug(
+                            "Skipping unconvertible markdown style", exc_info=True
+                        )
                 else:
                     spans.append(Span(start, end, style))
         content_lines.append(Content(stripped, spans))
@@ -3740,12 +3757,16 @@ class AppMessage(Static):
 
         Returns:
             The message `Content`. Markdown is rendered to selectable `Content`
-                sized to the widget's content width so it can be highlighted and
-                copied.
+                sized to the widget's current render width so it can be
+                highlighted and copied.
         """
         if not self._is_markdown:
             return super().render()  # ty: ignore[invalid-return-type]
         width = self._markdown_render_width()
+        # The cache is keyed on width only: captured spans are late-bound styles
+        # (`dim`, `bold`, ANSI colors) that Textual resolves against the active
+        # theme at display time, so cached `Content` still recolors on a theme
+        # switch and does not need re-rendering.
         if self._markdown_cache is None or self._markdown_cache[0] != width:
             try:
                 console = self.app.console
@@ -3762,12 +3783,19 @@ class AppMessage(Static):
             The widget's content width, falling back to the container or app
                 width, and never below `_MARKDOWN_MIN_RENDER_WIDTH`.
         """
-        width = self.content_size.width or self.container_size.width
+        width = self.content_size.width
         if width <= 0:
-            try:
-                width = self.app.size.width
-            except NoActiveAppError:
-                width = 0
+            # `content_size` is not known yet; fall back to the container (then
+            # app) width and subtract this widget's own horizontal padding,
+            # which those outer widths — unlike `content_size` — don't exclude.
+            outer = self.container_size.width
+            if outer <= 0:
+                try:
+                    outer = self.app.size.width
+                except NoActiveAppError:
+                    outer = 0
+            padding = self.styles.padding
+            width = outer - padding.left - padding.right
         return max(width, _MARKDOWN_MIN_RENDER_WIDTH)
 
     def on_click(self, event: Click) -> None:  # noqa: PLR6301  # Textual event handler

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -3613,6 +3613,70 @@ class _MutedRichMarkdown:
             )
 
 
+# Floor for markdown layout width so a not-yet-sized widget still renders a
+# readable table instead of collapsing to a single column.
+_MARKDOWN_MIN_RENDER_WIDTH = 20
+
+
+def _markdown_to_content(
+    markup: str, width: int, console: RichConsole | None = None
+) -> Content:
+    """Render muted markdown to selectable `Content` at a fixed width.
+
+    Textual's mouse text-selection only works over widgets whose rendered
+    visual is `Content` or Rich `Text`; a raw Rich renderable (such as
+    `_MutedRichMarkdown`) renders as a `RichVisual`, which carries none of the
+    per-cell offset metadata selection relies on, so its text can be neither
+    highlighted nor copied. Rendering the markdown to segments and rebuilding
+    them as `Content` preserves the visual (tables, rules, emphasis) while
+    making the text selectable.
+
+    Args:
+        markup: The markdown source to render.
+        width: Target render width in cells; the markdown is laid out to fit.
+        console: Console used to render segments; a default is created when
+            `None`.
+
+    Returns:
+        `Content` visually equivalent to the rendered markdown, with trailing
+            whitespace trimmed from each line so copies stay clean.
+    """
+    from rich.console import Console
+    from rich.segment import Segment
+    from textual.content import Span
+    from textual.style import Style
+
+    render_width = max(width, 1)
+    if console is None:
+        console = Console(width=render_width)
+    segments = console.render(
+        _MutedRichMarkdown(markup), console.options.update_width(render_width)
+    )
+    content_lines: list[Content] = []
+    for line in Segment.split_lines(segments):
+        text = "".join(segment.text for segment in line)
+        stripped = text.rstrip()
+        spans: list[Span] = []
+        position = 0
+        for segment in line:
+            start = position
+            position += len(segment.text)
+            if start >= len(stripped):
+                break
+            end = min(position, len(stripped))
+            if segment.style is not None and end > start:
+                try:
+                    style = Style.from_rich_style(segment.style)
+                except Exception:  # style conversion is best-effort
+                    logger.debug("Skipping unconvertible markdown style", exc_info=True)
+                else:
+                    spans.append(Span(start, end, style))
+        content_lines.append(Content(stripped, spans))
+    while content_lines and not content_lines[-1].plain:
+        content_lines.pop()
+    return Content("\n").join(content_lines)
+
+
 class AppMessage(Static):
     """Widget displaying an app message."""
 
@@ -3644,8 +3708,8 @@ class AppMessage(Static):
 
         Args:
             message: The system message as a string or pre-styled `Content`.
-            markdown: When `True`, render `message` as markdown via Rich's
-                markdown renderer (tables, headings, bold, etc.).
+            markdown: When `True`, render `message` as markdown (tables,
+                headings, bold, etc.).
 
                 Requires a string message — `Content` objects already carry
                 their own structure.
@@ -3657,16 +3721,54 @@ class AppMessage(Static):
         """
         self._content = message
         self._is_markdown = markdown
+        # Markdown is rendered lazily in `render()` so it can be laid out to the
+        # widget's current width and rebuilt as selectable `Content`.
+        self._markdown_cache: tuple[int, Content] | None = None
         if markdown:
             if not isinstance(message, str):
                 msg = "AppMessage(markdown=True) requires a string message"
                 raise TypeError(msg)
-            rendered = _MutedRichMarkdown(message)
+            rendered: Content = Content("")
         elif isinstance(message, Content):
             rendered = message
         else:
             rendered = Content.styled(message, "dim italic")
         super().__init__(rendered, **kwargs)
+
+    def render(self) -> Content:
+        """Render the message, laying out markdown to the current width.
+
+        Returns:
+            The message `Content`. Markdown is rendered to selectable `Content`
+                sized to the widget's content width so it can be highlighted and
+                copied.
+        """
+        if not self._is_markdown:
+            return super().render()  # ty: ignore[invalid-return-type]
+        width = self._markdown_render_width()
+        if self._markdown_cache is None or self._markdown_cache[0] != width:
+            try:
+                console = self.app.console
+            except NoActiveAppError:
+                console = None
+            content = _markdown_to_content(str(self._content), width, console)
+            self._markdown_cache = (width, content)
+        return self._markdown_cache[1]
+
+    def _markdown_render_width(self) -> int:
+        """Best-known content width for laying out markdown, with fallbacks.
+
+        Returns:
+            The widget's content width, falling back to the container or app
+                width, and never below `_MARKDOWN_MIN_RENDER_WIDTH`.
+        """
+        width = self.content_size.width or self.container_size.width
+        if width <= 0:
+            try:
+                width = self.app.size.width
+            except NoActiveAppError:
+                width = 0
+        return max(width, _MARKDOWN_MIN_RENDER_WIDTH)
 
     def on_click(self, event: Click) -> None:  # noqa: PLR6301  # Textual event handler
         """Open style-embedded hyperlinks on single click."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_message_store.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_message_store.py
@@ -176,7 +176,7 @@ class TestMessageData:
         or `to_widget` would silently downgrade rehydrated `/version` extras
         tables to plain-text rendering.
         """
-        from deepagents_code.tui.widgets.messages import _MutedRichMarkdown
+        from textual.content import Content
 
         markdown_source = (
             "### Installed optional dependencies\n"
@@ -195,8 +195,11 @@ class TestMessageData:
         restored = data.to_widget()
         assert isinstance(restored, AppMessage)
         assert restored._is_markdown is True
-        rendered = restored._Static__content  # ty: ignore
-        assert isinstance(rendered, _MutedRichMarkdown)
+        # Markdown renders to selectable `Content` (not a raw Rich renderable)
+        # so the rehydrated extras table stays copyable.
+        rendered = restored.render()
+        assert isinstance(rendered, Content)
+        assert "langchain-anthropic" in rendered.plain
 
     def test_diff_message_roundtrip(self):
         """Test DiffMessage serialization and deserialization."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -3677,6 +3677,100 @@ class TestAppMessageMarkdownSelectable:
             assert result is not None
             assert not any(line != line.rstrip() for line in result[0].splitlines())
 
+    async def test_markdown_caches_content_at_same_width(self) -> None:
+        """A second render at an unchanged width reuses the cached `Content`."""
+        async with _MarkdownAppMessageApp().run_test(size=(80, 24)) as pilot:
+            widget = pilot.app.query_one("#md", AppMessage)
+            first = widget.render()
+            second = widget.render()
+            assert first is second
+
+    async def test_markdown_reflows_on_resize(self) -> None:
+        """Shrinking the terminal re-lays-out markdown to the new width.
+
+        Guards the width-keyed cache invalidation (`_markdown_cache[0] != width`):
+        a regression that dropped the width key would keep serving the stale,
+        wider `Content`.
+        """
+        markdown = "This is a fairly long paragraph of prose " * 6
+        app = _MarkdownAppMessageApp()
+        app._MARKDOWN = markdown
+        async with app.run_test(size=(80, 24)) as pilot:
+            widget = pilot.app.query_one("#md", AppMessage)
+            wide = widget.render()
+            wide_cache = widget._markdown_cache
+            assert wide_cache is not None
+            wide_key = wide_cache[0]
+
+            await pilot.resize_terminal(40, 24)
+            await pilot.pause()
+            narrow = widget.render()
+            narrow_cache = widget._markdown_cache
+            assert narrow_cache is not None
+            narrow_key = narrow_cache[0]
+
+            assert narrow is not wide
+            assert narrow_key < wide_key
+            wide_max = max(len(line) for line in wide.plain.splitlines())
+            narrow_max = max(len(line) for line in narrow.plain.splitlines())
+            assert narrow_max < wide_max
+            assert narrow_max <= narrow_key
+
+    async def test_markdown_content_has_style_spans(self) -> None:
+        """Styled markdown keeps its spans so emphasis survives to selection."""
+        async with _MarkdownAppMessageApp().run_test(size=(80, 24)) as pilot:
+            widget = pilot.app.query_one("#md", AppMessage)
+            assert widget.render().spans
+
+
+class TestMarkdownToContent:
+    """Direct unit tests for `_markdown_to_content` edge cases."""
+
+    def test_empty_markdown_yields_empty_content(self) -> None:
+        from deepagents_code.tui.widgets.messages import _markdown_to_content
+
+        assert not _markdown_to_content("", 40).plain
+
+    def test_whitespace_only_markdown_yields_empty_content(self) -> None:
+        from deepagents_code.tui.widgets.messages import _markdown_to_content
+
+        assert not _markdown_to_content("   \n   \n", 40).plain
+
+    def test_trailing_blank_lines_are_trimmed(self) -> None:
+        from deepagents_code.tui.widgets.messages import _markdown_to_content
+
+        content = _markdown_to_content("# Title\n\n\n", 40)
+        assert "Title" in content.plain
+        # Block-level trim: no empty trailing lines left in the joined content.
+        assert content.plain == content.plain.rstrip("\n ")
+
+    def test_style_conversion_failure_keeps_text(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A failing style conversion drops the span but keeps text, warns once."""
+        import logging
+
+        from textual.style import Style
+
+        from deepagents_code.tui.widgets import messages as messages_module
+        from deepagents_code.tui.widgets.messages import _markdown_to_content
+
+        def _boom(_style: object) -> Style:
+            msg = "unconvertible"
+            raise ValueError(msg)
+
+        monkeypatch.setattr(Style, "from_rich_style", staticmethod(_boom))
+        monkeypatch.setattr(
+            messages_module, "_markdown_style_conversion_warned", [False]
+        )
+
+        with caplog.at_level(logging.WARNING, logger=messages_module.__name__):
+            content = _markdown_to_content("### heading", 40)
+
+        assert "heading" in content.plain
+        assert not content.spans
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
+
 
 class TestAppMessageAutoLinksDisabled:
     """Tests that `auto_links` is disabled to prevent hover flicker."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -175,11 +175,16 @@ class TestAppMessageMarkupSafety:
         rendered = msg._Static__content  # ty: ignore
         assert rendered is pre
 
-    def test_app_message_markdown_uses_muted_wrapper(self) -> None:
-        """`markdown=True` should route through `_MutedRichMarkdown`."""
+    def test_app_message_markdown_renders_selectable_content(self) -> None:
+        """`markdown=True` should render selectable `Content`, not a `RichVisual`.
+
+        Textual text-selection only works over `Content`/`Text` visuals, so
+        markdown must resolve to `Content` for its text to be copyable.
+        """
         msg = AppMessage("### heading", markdown=True)
-        rendered = msg._Static__content  # ty: ignore
-        assert isinstance(rendered, _MutedRichMarkdown)
+        rendered = msg.render()
+        assert isinstance(rendered, Content)
+        assert "heading" in rendered.plain
 
     def test_app_message_markdown_requires_string(self) -> None:
         """`markdown=True` with non-string input should raise `TypeError`."""
@@ -3618,6 +3623,59 @@ class TestUserMessageGetSelection:
             result = widget.get_selection(pilot.app.screen.selections[widget])
             assert result is not None
             assert result[0] == "pwd"
+
+
+class _MarkdownAppMessageApp(App[None]):
+    """Mount a markdown `AppMessage` so selection has an active app + layout."""
+
+    _MARKDOWN = (
+        "### Core dependencies\n"
+        "\n"
+        "| Package | Version |\n"
+        "| --- | --- |\n"
+        "| langchain | 1.2.3 |\n"
+        "| langgraph | not installed |\n"
+    )
+
+    def compose(self) -> ComposeResult:
+        yield AppMessage(self._MARKDOWN, markdown=True, id="md")
+
+
+class TestAppMessageMarkdownSelectable:
+    """Markdown `AppMessage` output must be selectable and copyable.
+
+    Regression guard: rendering markdown as a raw Rich renderable produces a
+    `RichVisual`, which Textual cannot select or copy. The text must resolve to
+    `Content` so `/version` tables and incognito shell output stay copyable.
+    """
+
+    async def test_markdown_renders_content_visual(self) -> None:
+        from textual.content import Content
+
+        async with _MarkdownAppMessageApp().run_test(size=(80, 24)) as pilot:
+            widget = pilot.app.query_one("#md", AppMessage)
+            assert isinstance(widget._render(), Content)
+
+    async def test_markdown_select_all_copies_table_text(self) -> None:
+        from textual.selection import SELECT_ALL
+
+        async with _MarkdownAppMessageApp().run_test(size=(80, 24)) as pilot:
+            widget = pilot.app.query_one("#md", AppMessage)
+            result = widget.get_selection(SELECT_ALL)
+            assert result is not None
+            selected = result[0]
+            assert "Core dependencies" in selected
+            assert "langchain" in selected
+            assert "not installed" in selected
+
+    async def test_markdown_selection_has_no_trailing_padding(self) -> None:
+        from textual.selection import SELECT_ALL
+
+        async with _MarkdownAppMessageApp().run_test(size=(80, 24)) as pilot:
+            widget = pilot.app.query_one("#md", AppMessage)
+            result = widget.get_selection(SELECT_ALL)
+            assert result is not None
+            assert not any(line != line.rstrip() for line in result[0].splitlines())
 
 
 class TestAppMessageAutoLinksDisabled:


### PR DESCRIPTION
`/version` output (and incognito shell output) is now selectable and copyable.

---

The output from the `/version` command could not be selected or copied. Those tables — and incognito shell output — render through `AppMessage(markdown=True)`, which produced a raw Rich renderable. Textual only supports text selection over `Content`/`Text` visuals, so a `RichVisual` carries none of the per-cell offset metadata selection relies on and its text is neither highlightable nor copyable.

This renders the muted markdown to segments and rebuilds it as `Content`, laid out to the widget's current width, so the tables/rules/emphasis look the same but the text is now selectable and copyable. Trailing padding is trimmed per line so copies stay clean.

Made by [Open SWE](https://openswe.vercel.app/agents/f705adb2-3ebb-25a2-7ebd-ddce94887917)