### PR TITLE
fix(code): disentangle version diagnostics for editable installs

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -5987,13 +5987,24 @@ class DeepAgentsApp(App):
         resolved versions of the core LangChain-ecosystem dependencies, which
         helps diagnose local checkouts.
         """
+        from deepagents_code.extras_info import (
+            collect_version_report,
+            format_cli_version_annotation,
+            format_sdk_version_annotation,
+        )
+
+        report = await asyncio.to_thread(collect_version_report)
+
         lines: list[str] = []
         try:
             from deepagents_code._version import __version__ as cli_version
             from deepagents_code.update_check import format_age_suffix
 
             age_suffix = await asyncio.to_thread(format_age_suffix, cli_version)
-            lines.append(f"deepagents-code version: {cli_version}{age_suffix}")
+            cli_annotation = format_cli_version_annotation(report.cli)
+            lines.append(
+                f"deepagents-code version: {cli_version}{age_suffix}{cli_annotation}"
+            )
         except ImportError:
             logger.debug("deepagents_code._version module not found")
             lines.append("deepagents-code version: unknown")
@@ -6001,14 +6012,16 @@ class DeepAgentsApp(App):
             logger.warning("Unexpected error looking up app version", exc_info=True)
             lines.append("deepagents-code version: unknown")
 
-        from deepagents_code.extras_info import resolve_sdk_version
-
-        sdk_version, sdk_status = resolve_sdk_version()
-        if sdk_status == "resolved":
+        if report.sdk.status == "resolved":
             from deepagents_code.update_check import format_sdk_age_suffix
 
+            sdk_version = report.sdk.primary_version
             sdk_age_suffix = await asyncio.to_thread(format_sdk_age_suffix, sdk_version)
-            lines.append(f"deepagents (SDK) version: {sdk_version}{sdk_age_suffix}")
+            sdk_annotation = format_sdk_version_annotation(report)
+            lines.append(
+                f"deepagents (SDK) version: {sdk_version}{sdk_age_suffix}"
+                f"{sdk_annotation}"
+            )
         else:
             lines.append("deepagents (SDK) version: unknown")
 

--- a/libs/code/deepagents_code/doctor.py
+++ b/libs/code/deepagents_code/doctor.py
@@ -160,19 +160,20 @@ def _collect_diagnostics() -> DiagnosticSection:
         _get_editable_install_path,
         _is_editable_install,
     )
-    from deepagents_code.extras_info import collect_version_report
+    from deepagents_code.extras_info import (
+        collect_version_report,
+        format_cli_version_annotation,
+    )
     from deepagents_code.update_check import detect_install_method
 
     report = collect_version_report()
     sdk_version, sdk_ok = _sdk_diagnostic(report)
 
     # Source/metadata drift is informational (normal while editing source), so
-    # it annotates the value without flagging the CLI item unhealthy.
-    cli = report.cli
-    if cli.has_drift and cli.metadata_version is not None:
-        cli_value = f"{__version__} (installed metadata: {cli.metadata_version})"
-    else:
-        cli_value = __version__
+    # it annotates the value without flagging the CLI item unhealthy. Reuse the
+    # shared annotation helper so the phrasing stays in lockstep with
+    # `--version`/`/version` (editable status is shown via `Install method`).
+    cli_value = f"{__version__}{format_cli_version_annotation(report.cli)}"
 
     editable = _is_editable_install()
     if editable:

--- a/libs/code/deepagents_code/doctor.py
+++ b/libs/code/deepagents_code/doctor.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     import argparse
 
     from deepagents_code.config import TracingStatus
+    from deepagents_code.extras_info import VersionReport
 
 logger = logging.getLogger(__name__)
 
@@ -59,22 +60,24 @@ def _platform_tag() -> str:
     return f"{platform.system()}-{platform.machine()}".lower()
 
 
-def _sdk_version() -> tuple[str, bool]:
-    """Return the installed `deepagents` SDK version and whether it resolved.
+def _sdk_diagnostic(report: VersionReport) -> tuple[str, bool]:
+    """Return the doctor SDK version value and whether it is healthy.
 
-    Maps the shared `resolve_sdk_version` outcome onto doctor's display: a
-    genuinely missing package reads as `not installed`, an unexpected lookup
-    failure as `unknown`, and only a resolved version is marked healthy.
+    A genuinely missing package reads as `not installed`, an unexpected lookup
+    failure as `unknown`, and a resolved version carries its editable/drift/
+    mismatch annotation. A dependency-requirement mismatch is unhealthy; drift
+    between the source and installed metadata alone is informational, since it
+    is normal while editing SDK source.
     """
-    from deepagents_code.extras_info import resolve_sdk_version
+    from deepagents_code.extras_info import format_sdk_version_annotation
 
-    sdk_version, status = resolve_sdk_version()
-    if status == "resolved":
-        # `sdk_version` is a real string when the status is "resolved".
-        return sdk_version or "unknown", True
-    if status == "not_installed":
+    sdk = report.sdk
+    if sdk.status == "not_installed":
         return "not installed", False
-    return "unknown", False
+    if sdk.status != "resolved":
+        return "unknown", False
+    value = f"{sdk.primary_version}{format_sdk_version_annotation(report)}"
+    return value, not report.sdk_requirement_mismatch
 
 
 def _build_commit() -> str | None:
@@ -157,9 +160,20 @@ def _collect_diagnostics() -> DiagnosticSection:
         _get_editable_install_path,
         _is_editable_install,
     )
+    from deepagents_code.extras_info import collect_version_report
     from deepagents_code.update_check import detect_install_method
 
-    sdk_version, sdk_ok = _sdk_version()
+    report = collect_version_report()
+    sdk_version, sdk_ok = _sdk_diagnostic(report)
+
+    # Source/metadata drift is informational (normal while editing source), so
+    # it annotates the value without flagging the CLI item unhealthy.
+    cli = report.cli
+    if cli.has_drift and cli.metadata_version is not None:
+        cli_value = f"{__version__} (installed metadata: {cli.metadata_version})"
+    else:
+        cli_value = __version__
+
     editable = _is_editable_install()
     if editable:
         method = "editable"
@@ -171,7 +185,7 @@ def _collect_diagnostics() -> DiagnosticSection:
     return DiagnosticSection(
         title="Diagnostics",
         items=[
-            DiagnosticItem("deepagents-code", __version__),
+            DiagnosticItem("deepagents-code", cli_value),
             DiagnosticItem("deepagents (SDK)", sdk_version, ok=sdk_ok),
             DiagnosticItem("Commit hash", _commit_hash(path)),
             DiagnosticItem("Python", platform.python_version()),

--- a/libs/code/deepagents_code/extras_info.py
+++ b/libs/code/deepagents_code/extras_info.py
@@ -29,10 +29,11 @@ from packaging.version import InvalidVersion, Version
 
 logger = logging.getLogger(__name__)
 
-SdkVersionStatus = Literal["resolved", "not_installed", "error"]
-"""Outcome of an SDK version lookup.
+DistributionMetadataStatus = Literal["resolved", "not_installed", "error"]
+"""Outcome of a distribution version lookup.
 
-`"not_installed"` means the package metadata is genuinely absent;
+Used for any distribution (the `deepagents` SDK and the `deepagents-code`
+CLI alike). `"not_installed"` means the package metadata is genuinely absent;
 `"error"` means an unexpected failure occurred while reading it. Callers
 that don't care which kind of failure happened can treat both the same.
 """
@@ -149,12 +150,12 @@ def _contract_home(path: Path) -> str:
 class DistributionVersion:
     """Structured version facts for a single installed distribution.
 
-    Separates three facts that are easily conflated: the live version declared
-    by the imported source (`source_version`), the version recorded in the
-    installed distribution metadata (`metadata_version`), and whether the
-    install is editable (with its `source_path`). `status` records whether the
-    metadata lookup succeeded so diagnostic callers can distinguish a genuinely
-    absent package from an unexpected lookup failure.
+    Separates three facts that are easily conflated: the live version read from
+    the running source, whether imported or parsed (`source_version`), the
+    version recorded in the installed distribution metadata (`metadata_version`),
+    and whether the install is editable (with its `source_path`). `status`
+    records whether the metadata lookup succeeded so diagnostic callers can
+    distinguish a genuinely absent package from an unexpected lookup failure.
     """
 
     name: str
@@ -170,9 +171,14 @@ class DistributionVersion:
     """Whether the distribution is installed in editable mode."""
 
     source_path: str | None
-    """`~`-contracted editable source root, when known."""
+    """`~`-contracted editable source root, when known.
 
-    status: SdkVersionStatus
+    Available for callers that want to display the editable root; the
+    `--version`/`/version` surfaces render the CLI path from `config` instead,
+    so this is not rendered on every surface today.
+    """
+
+    status: DistributionMetadataStatus
     """Outcome of the metadata lookup."""
 
     @property
@@ -181,11 +187,14 @@ class DistributionVersion:
 
         Editable installs prefer the live source version because their metadata
         can lag the working tree after a local version change; every other
-        install uses the metadata version.
+        install uses the metadata version, falling back to the source version
+        when metadata is absent. This keeps the "a resolved lookup yields a
+        non-`None` version" contract intact even when a source version is the
+        only fact available.
         """
         if self.editable and self.source_version:
             return self.source_version
-        return self.metadata_version
+        return self.metadata_version or self.source_version
 
     @property
     def has_drift(self) -> bool:
@@ -225,6 +234,9 @@ class VersionReport:
     @property
     def sdk_requirement_mismatch(self) -> bool:
         """Whether the installed SDK metadata violates the declared requirement."""
+        # `is False`, not `not`: an inconclusive comparison (`None`) is *not* a
+        # mismatch. Collapsing this to `not self.sdk_requirement_satisfied` would
+        # silently report every unknown as a mismatch and flag doctor unhealthy.
         return self.sdk_requirement_satisfied is False
 
 
@@ -238,7 +250,11 @@ def _read_cli_source_version() -> str | None:
     try:
         from deepagents_code._version import __version__
     except Exception:
-        logger.debug("Could not read deepagents-code source version", exc_info=True)
+        # `_version` is generated and always present for the running package, so
+        # a failure here means a broken checkout that masks the source version
+        # and forces a fall back to potentially stale metadata. Warn for parity
+        # with `_sdk_version_from_source`, which handles the same failure shape.
+        logger.warning("Could not read deepagents-code source version", exc_info=True)
         return None
     return __version__ if isinstance(__version__, str) and __version__ else None
 
@@ -268,14 +284,15 @@ def collect_cli_version_info() -> DistributionVersion:
 
     Returns:
         The structured CLI version facts. The status is `"resolved"` whenever a
-            source or metadata version is available, `"not_installed"` when both
-            are absent, and `"error"` on an unexpected metadata failure with no
-            source fallback.
+            source or metadata version is available, `"not_installed"` when the
+            metadata is genuinely missing (`PackageNotFoundError`) and no source
+            version is available, and `"error"` on an unexpected metadata failure
+            with no source fallback.
     """
     source = _read_cli_source_version()
     try:
         metadata: str | None = pkg_version("deepagents-code")
-        status: SdkVersionStatus = "resolved"
+        status: DistributionMetadataStatus = "resolved"
     except PackageNotFoundError:
         logger.debug("deepagents-code package metadata not found in environment")
         metadata = None
@@ -353,9 +370,9 @@ def sdk_requirement_from_cli(
     """Return the base `deepagents` requirement declared by `deepagents-code`.
 
     Reads the installed distribution's `Requires-Dist` metadata and parses each
-    entry with `packaging.Requirement`, returning the unconditional `deepagents`
-    dependency. Extras-gated or environment-conditional variants whose marker
-    does not apply to the current environment are skipped.
+    entry with `packaging.Requirement`, returning the applicable base
+    `deepagents` dependency. Extras-gated or environment-conditional variants
+    whose marker does not apply to the current environment are skipped.
 
     Args:
         distribution_name: Name of the installed distribution to inspect.
@@ -378,8 +395,16 @@ def sdk_requirement_from_cli(
         )
         return None
 
+    try:
+        requirements = dist.requires or []
+    except Exception:  # Best-effort lookup; malformed metadata must not be fatal
+        logger.warning(
+            "Unexpected error reading %s requirements", distribution_name, exc_info=True
+        )
+        return None
+
     target = canonicalize_name("deepagents")
-    for raw in dist.requires or []:
+    for raw in requirements:
         try:
             req = Requirement(raw)
         except InvalidRequirement:
@@ -392,15 +417,21 @@ def sdk_requirement_from_cli(
             # variants that do not apply; only the base runtime dependency is
             # meaningful for a straight installed-version comparison.
             try:
-                if not req.marker.evaluate():
-                    continue
+                applicable = req.marker.evaluate()
             except Exception:
-                logger.debug(
-                    "Could not evaluate marker for Requires-Dist entry: %s",
+                # An unexpected marker-evaluation failure must not silently drop
+                # the base requirement — that would hide the very SDK mismatch
+                # this check exists to surface. Warn and treat it as applicable
+                # so a genuine mismatch is still flagged rather than masked.
+                logger.warning(
+                    "Could not evaluate marker for Requires-Dist entry %s; "
+                    "treating the requirement as applicable",
                     raw,
                     exc_info=True,
                 )
-                continue
+            else:
+                if not applicable:
+                    continue
         return req
     return None
 
@@ -445,6 +476,9 @@ def collect_version_report() -> VersionReport:
     cli = collect_cli_version_info()
     sdk = collect_sdk_version_info()
     requirement = sdk_requirement_from_cli()
+    # Compare against the metadata version — what the environment actually
+    # installed — rather than the (possibly ahead) editable source version, so
+    # the mismatch reflects the real dependency resolution.
     satisfied = _requirement_satisfied(requirement, sdk.metadata_version)
     return VersionReport(
         cli=cli,
@@ -479,19 +513,22 @@ def _join_annotation_parts(parts: list[str]) -> str:
 
 
 def format_cli_version_annotation(info: DistributionVersion) -> str:
-    """Return the editable/drift annotation for the CLI version line.
+    """Return the source/metadata drift annotation for the CLI version line.
+
+    Editable status is surfaced separately by every caller (the dedicated
+    `Editable install:` line on `--version`/`/version`, and the `Install method`
+    item in `doctor`), so it is intentionally *not* repeated inline here — that
+    kept the CLI reading "editable" twice on those surfaces.
 
     Args:
         info: The CLI version facts.
 
     Returns:
-        A trailing ` (...)` suffix flagging an editable install and any drift
-            between the source and installed metadata versions, or an empty
-            string when neither applies (so normal installs stay unchanged).
+        A trailing ` (...)` suffix flagging any drift between the source and
+            installed metadata versions, or an empty string when they agree (so
+            normal installs stay unchanged).
     """
     parts: list[str] = []
-    if info.editable:
-        parts.append("editable")
     if info.has_drift and info.metadata_version is not None:
         parts.append(f"installed metadata: {info.metadata_version}")
     return _join_annotation_parts(parts)
@@ -509,6 +546,12 @@ def format_sdk_version_annotation(report: VersionReport) -> str:
             actionable requirement mismatch when the installed SDK metadata does
             not satisfy the requirement declared by `deepagents-code`. Empty
             when none applies.
+
+    The mismatch is judged against the installed SDK *metadata* version (what
+    the environment actually resolved), not the source version shown as primary
+    for editable installs. When the two differ, the accompanying
+    `installed metadata:` note makes that basis explicit, so an editable source
+    version that appears to match the requirement can still read as a mismatch.
     """
     info = report.sdk
     parts: list[str] = []
@@ -517,12 +560,14 @@ def format_sdk_version_annotation(report: VersionReport) -> str:
     if info.has_drift and info.metadata_version is not None:
         parts.append(f"installed metadata: {info.metadata_version}")
     if report.sdk_requirement_mismatch and report.sdk_requirement is not None:
+        # Compared against `metadata_version` (see docstring), which is why the
+        # drift note above is emitted alongside so the basis is visible.
         required = _format_requirement_display(report.sdk_requirement)
         parts.append(f"required by deepagents-code: {required} — mismatch")
     return _join_annotation_parts(parts)
 
 
-def resolve_sdk_version() -> tuple[str | None, SdkVersionStatus]:
+def resolve_sdk_version() -> tuple[str | None, DistributionMetadataStatus]:
     """Resolve the installed `deepagents` SDK version.
 
     Compatibility wrapper over `collect_sdk_version_info` for callers that only

--- a/libs/code/deepagents_code/extras_info.py
+++ b/libs/code/deepagents_code/extras_info.py
@@ -25,6 +25,7 @@ from urllib.request import url2pathname
 
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
 
 logger = logging.getLogger(__name__)
 
@@ -120,13 +121,414 @@ def _sdk_version_from_source(root: Path) -> str | None:
     return None
 
 
+def _contract_home(path: Path) -> str:
+    """Return `path` as text with a home-directory prefix contracted to `~`.
+
+    Args:
+        path: Filesystem path to render.
+
+    Returns:
+        The stringified path, with a leading home directory replaced by `~`
+            when applicable. The raw path is returned when the home directory
+            cannot be determined.
+    """
+    text = str(path)
+    try:
+        home = str(Path.home())
+    except (OSError, RuntimeError):
+        return text
+    if text == home:
+        return "~"
+    prefix = home if home.endswith("/") else f"{home}/"
+    if text.startswith(prefix):
+        return f"~/{text[len(prefix) :]}"
+    return text
+
+
+@dataclass(frozen=True)
+class DistributionVersion:
+    """Structured version facts for a single installed distribution.
+
+    Separates three facts that are easily conflated: the live version declared
+    by the imported source (`source_version`), the version recorded in the
+    installed distribution metadata (`metadata_version`), and whether the
+    install is editable (with its `source_path`). `status` records whether the
+    metadata lookup succeeded so diagnostic callers can distinguish a genuinely
+    absent package from an unexpected lookup failure.
+    """
+
+    name: str
+    """Distribution name, such as `deepagents` or `deepagents-code`."""
+
+    source_version: str | None
+    """Version read from the imported/source `_version.py`, when available."""
+
+    metadata_version: str | None
+    """Version from `importlib.metadata`, when the distribution is installed."""
+
+    editable: bool
+    """Whether the distribution is installed in editable mode."""
+
+    source_path: str | None
+    """`~`-contracted editable source root, when known."""
+
+    status: SdkVersionStatus
+    """Outcome of the metadata lookup."""
+
+    @property
+    def primary_version(self) -> str | None:
+        """Version to report as authoritative.
+
+        Editable installs prefer the live source version because their metadata
+        can lag the working tree after a local version change; every other
+        install uses the metadata version.
+        """
+        if self.editable and self.source_version:
+            return self.source_version
+        return self.metadata_version
+
+    @property
+    def has_drift(self) -> bool:
+        """Whether the source and metadata versions are both known and differ."""
+        return (
+            self.source_version is not None
+            and self.metadata_version is not None
+            and self.source_version != self.metadata_version
+        )
+
+
+@dataclass(frozen=True)
+class VersionReport:
+    """Network-free snapshot of the version facts diagnostics need.
+
+    Bundles the running CLI and installed SDK version facts with the result of
+    comparing the `deepagents` requirement that `deepagents-code` declares
+    against the installed SDK metadata version.
+    """
+
+    cli: DistributionVersion
+    """Version facts for the running `deepagents-code` distribution."""
+
+    sdk: DistributionVersion
+    """Version facts for the installed `deepagents` SDK distribution."""
+
+    sdk_requirement: Requirement | None
+    """The `deepagents` requirement declared by `deepagents-code`, if found."""
+
+    sdk_requirement_satisfied: bool | None
+    """Whether the installed SDK metadata satisfies `sdk_requirement`.
+
+    `None` when the comparison cannot be made (no declared requirement, the SDK
+    is not installed, or an unparseable version).
+    """
+
+    @property
+    def sdk_requirement_mismatch(self) -> bool:
+        """Whether the installed SDK metadata violates the declared requirement."""
+        return self.sdk_requirement_satisfied is False
+
+
+def _read_cli_source_version() -> str | None:
+    """Return the running `deepagents-code` source version, or `None`.
+
+    Reads `deepagents_code._version.__version__`, which is always present for
+    the running package but is imported defensively so best-effort diagnostics
+    never crash on a broken checkout.
+    """
+    try:
+        from deepagents_code._version import __version__
+    except Exception:
+        logger.debug("Could not read deepagents-code source version", exc_info=True)
+        return None
+    return __version__ if isinstance(__version__, str) and __version__ else None
+
+
+def _cli_editable_info() -> tuple[bool, str | None]:
+    """Return the editable status and source path for `deepagents-code`.
+
+    Reuses the cached PEP 610 detection in `config` rather than reimplementing
+    it, so both surfaces agree and stay patchable in tests.
+    """
+    try:
+        from deepagents_code.config import (
+            _get_editable_install_path,
+            _is_editable_install,
+        )
+
+        return _is_editable_install(), _get_editable_install_path()
+    except Exception:
+        logger.debug(
+            "Could not determine deepagents-code editable status", exc_info=True
+        )
+        return False, None
+
+
+def collect_cli_version_info() -> DistributionVersion:
+    """Collect version facts for the running `deepagents-code` distribution.
+
+    Returns:
+        The structured CLI version facts. The status is `"resolved"` whenever a
+            source or metadata version is available, `"not_installed"` when both
+            are absent, and `"error"` on an unexpected metadata failure with no
+            source fallback.
+    """
+    source = _read_cli_source_version()
+    try:
+        metadata: str | None = pkg_version("deepagents-code")
+        status: SdkVersionStatus = "resolved"
+    except PackageNotFoundError:
+        logger.debug("deepagents-code package metadata not found in environment")
+        metadata = None
+        status = "resolved" if source else "not_installed"
+    except Exception:  # Best-effort lookup; never propagate to the caller
+        logger.warning(
+            "Unexpected error looking up deepagents-code metadata version",
+            exc_info=True,
+        )
+        metadata = None
+        status = "resolved" if source else "error"
+    editable, path = _cli_editable_info()
+    return DistributionVersion(
+        name="deepagents-code",
+        source_version=source,
+        metadata_version=metadata,
+        editable=editable,
+        source_path=path,
+        status=status,
+    )
+
+
+def collect_sdk_version_info() -> DistributionVersion:
+    """Collect version facts for the installed `deepagents` SDK distribution.
+
+    Editable SDK installs prefer the source tree's `_version.py`; everything
+    else reports the installed metadata version. Distinguishes a genuinely
+    missing package from an unexpected metadata error.
+
+    Returns:
+        The structured SDK version facts.
+    """
+    try:
+        metadata = pkg_version("deepagents")
+    except PackageNotFoundError:
+        logger.debug("deepagents SDK package not found in environment")
+        return DistributionVersion(
+            name="deepagents",
+            source_version=None,
+            metadata_version=None,
+            editable=False,
+            source_path=None,
+            status="not_installed",
+        )
+    except Exception:  # Best-effort lookup; never propagate to the caller
+        logger.warning(
+            "Unexpected error looking up deepagents SDK version", exc_info=True
+        )
+        return DistributionVersion(
+            name="deepagents",
+            source_version=None,
+            metadata_version=None,
+            editable=False,
+            source_path=None,
+            status="error",
+        )
+
+    source_root = _editable_sdk_source_root()
+    editable = source_root is not None
+    source_version = _sdk_version_from_source(source_root) if source_root else None
+    source_path = _contract_home(source_root) if source_root else None
+    return DistributionVersion(
+        name="deepagents",
+        source_version=source_version,
+        metadata_version=metadata,
+        editable=editable,
+        source_path=source_path,
+        status="resolved",
+    )
+
+
+def sdk_requirement_from_cli(
+    distribution_name: str = "deepagents-code",
+) -> Requirement | None:
+    """Return the base `deepagents` requirement declared by `deepagents-code`.
+
+    Reads the installed distribution's `Requires-Dist` metadata and parses each
+    entry with `packaging.Requirement`, returning the unconditional `deepagents`
+    dependency. Extras-gated or environment-conditional variants whose marker
+    does not apply to the current environment are skipped.
+
+    Args:
+        distribution_name: Name of the installed distribution to inspect.
+
+    Returns:
+        The parsed `deepagents` requirement, or `None` when the distribution or
+            requirement cannot be read.
+    """
+    try:
+        dist = distribution(distribution_name)
+    except PackageNotFoundError:
+        logger.debug(
+            "Distribution %s not found; cannot read deepagents requirement",
+            distribution_name,
+        )
+        return None
+    except Exception:  # Best-effort lookup; never propagate to the caller
+        logger.warning(
+            "Unexpected error reading %s requirements", distribution_name, exc_info=True
+        )
+        return None
+
+    target = canonicalize_name("deepagents")
+    for raw in dist.requires or []:
+        try:
+            req = Requirement(raw)
+        except InvalidRequirement:
+            logger.warning("Could not parse Requires-Dist entry: %s", raw)
+            continue
+        if canonicalize_name(req.name) != target:
+            continue
+        if req.marker is not None:
+            # Skip extras-gated (`extra == "..."`) or environment-conditional
+            # variants that do not apply; only the base runtime dependency is
+            # meaningful for a straight installed-version comparison.
+            try:
+                if not req.marker.evaluate():
+                    continue
+            except Exception:
+                logger.debug(
+                    "Could not evaluate marker for Requires-Dist entry: %s",
+                    raw,
+                    exc_info=True,
+                )
+                continue
+        return req
+    return None
+
+
+def _requirement_satisfied(
+    requirement: Requirement | None, metadata_version: str | None
+) -> bool | None:
+    """Return whether `metadata_version` satisfies `requirement`.
+
+    Args:
+        requirement: The declared requirement, or `None`.
+        metadata_version: The installed SDK metadata version, or `None`.
+
+    Returns:
+        `True`/`False` when the comparison can be made, or `None` when either
+            input is absent or the version cannot be parsed. Prereleases are
+            allowed so a prerelease pin (e.g. `==0.7.0a7`) is evaluated
+            correctly.
+    """
+    if requirement is None or metadata_version is None:
+        return None
+    try:
+        parsed = Version(metadata_version)
+    except InvalidVersion:
+        logger.debug(
+            "Could not parse SDK metadata version %r for requirement comparison",
+            metadata_version,
+            exc_info=True,
+        )
+        return None
+    return requirement.specifier.contains(parsed, prereleases=True)
+
+
+def collect_version_report() -> VersionReport:
+    """Collect the offline version report used by `--version`, `/version`, and doctor.
+
+    Returns:
+        A `VersionReport` bundling CLI and SDK version facts with the declared
+            `deepagents` requirement and whether the installed SDK metadata
+            satisfies it. Performs no network or subprocess calls.
+    """
+    cli = collect_cli_version_info()
+    sdk = collect_sdk_version_info()
+    requirement = sdk_requirement_from_cli()
+    satisfied = _requirement_satisfied(requirement, sdk.metadata_version)
+    return VersionReport(
+        cli=cli,
+        sdk=sdk,
+        sdk_requirement=requirement,
+        sdk_requirement_satisfied=satisfied,
+    )
+
+
+def _format_requirement_display(requirement: Requirement) -> str:
+    """Render a requirement's version constraint for display.
+
+    A single exact pin (`==X`) is shown as the bare version for readability;
+    any other constraint keeps its full specifier form.
+
+    Returns:
+        The display form of the requirement's version constraint.
+    """
+    specs = list(requirement.specifier)
+    if len(specs) == 1 and specs[0].operator == "==":
+        return specs[0].version
+    return str(requirement.specifier) or "any"
+
+
+def _join_annotation_parts(parts: list[str]) -> str:
+    """Join annotation parts into a trailing ` (...)` suffix.
+
+    Returns:
+        The parts joined as ` (a; b)`, or an empty string when `parts` is empty.
+    """
+    return f" ({'; '.join(parts)})" if parts else ""
+
+
+def format_cli_version_annotation(info: DistributionVersion) -> str:
+    """Return the editable/drift annotation for the CLI version line.
+
+    Args:
+        info: The CLI version facts.
+
+    Returns:
+        A trailing ` (...)` suffix flagging an editable install and any drift
+            between the source and installed metadata versions, or an empty
+            string when neither applies (so normal installs stay unchanged).
+    """
+    parts: list[str] = []
+    if info.editable:
+        parts.append("editable")
+    if info.has_drift and info.metadata_version is not None:
+        parts.append(f"installed metadata: {info.metadata_version}")
+    return _join_annotation_parts(parts)
+
+
+def format_sdk_version_annotation(report: VersionReport) -> str:
+    """Return the editable/drift/mismatch annotation for the SDK version line.
+
+    Args:
+        report: The collected version report.
+
+    Returns:
+        A trailing ` (...)` suffix flagging an editable SDK install, any drift
+            between the source and installed metadata versions, and an
+            actionable requirement mismatch when the installed SDK metadata does
+            not satisfy the requirement declared by `deepagents-code`. Empty
+            when none applies.
+    """
+    info = report.sdk
+    parts: list[str] = []
+    if info.editable:
+        parts.append("editable")
+    if info.has_drift and info.metadata_version is not None:
+        parts.append(f"installed metadata: {info.metadata_version}")
+    if report.sdk_requirement_mismatch and report.sdk_requirement is not None:
+        required = _format_requirement_display(report.sdk_requirement)
+        parts.append(f"required by deepagents-code: {required} — mismatch")
+    return _join_annotation_parts(parts)
+
+
 def resolve_sdk_version() -> tuple[str | None, SdkVersionStatus]:
     """Resolve the installed `deepagents` SDK version.
 
-    Single source of truth for the lookup that `--version`, `/version`, and
-    `doctor` each used to reimplement. Editable installs can have stale package
-    metadata after local version files change, so they prefer the source tree's
-    `_version.py` and fall back to metadata when the source version is
+    Compatibility wrapper over `collect_sdk_version_info` for callers that only
+    need the primary version and lookup status. Editable installs can have stale
+    package metadata after local version files change, so they prefer the source
+    tree's `_version.py` and fall back to metadata when the source version is
     unavailable. Distinguishes a genuinely missing package from an unexpected
     metadata error so diagnostic callers can report the two differently, while
     collapse-friendly callers can ignore the split.
@@ -135,24 +537,10 @@ def resolve_sdk_version() -> tuple[str | None, SdkVersionStatus]:
         `(version, status)`. `version` is the resolved version string when
             `status` is `"resolved"`, otherwise `None`.
     """
-    try:
-        metadata_version = pkg_version("deepagents")
-    except PackageNotFoundError:
-        logger.debug("deepagents SDK package not found in environment")
-        return None, "not_installed"
-    except Exception:  # Best-effort lookup; never propagate to the caller
-        logger.warning(
-            "Unexpected error looking up deepagents SDK version", exc_info=True
-        )
-        return None, "error"
-
-    source_root = _editable_sdk_source_root()
-    if source_root:
-        source_version = _sdk_version_from_source(source_root)
-        if source_version:
-            return source_version, "resolved"
-
-    return metadata_version, "resolved"
+    info = collect_sdk_version_info()
+    if info.status != "resolved":
+        return None, info.status
+    return info.primary_version, "resolved"
 
 
 _EXTRA_MARKER_RE = re.compile(r"""extra\s*==\s*["']([^"']+)["']""")

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -118,12 +118,25 @@ def build_version_text() -> str:
     Returns:
         Multi-line version string suitable for stdout.
     """
-    from deepagents_code.extras_info import resolve_sdk_version
+    from deepagents_code.extras_info import (
+        collect_version_report,
+        format_cli_version_annotation,
+        format_sdk_version_annotation,
+    )
 
-    sdk_version_value, status = resolve_sdk_version()
-    sdk_version = sdk_version_value if status == "resolved" else "unknown"
+    report = collect_version_report()
+    cli_annotation = format_cli_version_annotation(report.cli)
+    if report.sdk.status == "resolved":
+        sdk_version = report.sdk.primary_version
+        sdk_annotation = format_sdk_version_annotation(report)
+    else:
+        sdk_version = "unknown"
+        sdk_annotation = ""
 
-    text = f"deepagents-code {__version__}\ndeepagents (SDK) {sdk_version}"
+    text = (
+        f"deepagents-code {__version__}{cli_annotation}\n"
+        f"deepagents (SDK) {sdk_version}{sdk_annotation}"
+    )
 
     editable = False
     try:

--- a/libs/code/tests/unit_tests/test_doctor.py
+++ b/libs/code/tests/unit_tests/test_doctor.py
@@ -77,13 +77,103 @@ class TestCollectSections:
         """The Diagnostics section reports the running CLI version."""
         from deepagents_code._version import __version__
 
-        diagnostics = collect_sections()[0]
+        # Isolate the SDK requirement check so the workspace pin cannot inject a
+        # mismatch annotation into the CLI value under test.
+        with patch(
+            "deepagents_code.extras_info.sdk_requirement_from_cli",
+            return_value=None,
+        ):
+            diagnostics = collect_sections()[0]
         labels = {item.label: item.value for item in diagnostics.items}
         assert labels["deepagents-code"] == __version__
         assert "Commit hash" in labels
         assert labels["Commit hash"]
         assert "Platform" in labels
         assert "Install method" in labels
+
+
+class TestDiagnosticsVersionReport:
+    """Tests for how the Diagnostics section renders version-report facts."""
+
+    def _diagnostics(self, report: object) -> dict[str, DiagnosticItem]:
+        from deepagents_code.doctor import _collect_diagnostics
+
+        with (
+            patch(
+                "deepagents_code.extras_info.collect_version_report",
+                return_value=report,
+            ),
+            patch("deepagents_code.doctor._commit_hash", return_value="abc1234"),
+        ):
+            section = _collect_diagnostics()
+        return {item.label: item for item in section.items}
+
+    def test_sdk_requirement_mismatch_is_unhealthy(self) -> None:
+        """An unsatisfied declared SDK requirement makes the SDK item unhealthy."""
+        from packaging.requirements import Requirement
+
+        from deepagents_code._version import __version__
+        from deepagents_code.extras_info import DistributionVersion, VersionReport
+
+        report = VersionReport(
+            cli=DistributionVersion(
+                "deepagents-code", __version__, __version__, True, "~/src", "resolved"
+            ),
+            sdk=DistributionVersion(
+                "deepagents", "0.6.12", "0.6.12", True, "~/src/sdk", "resolved"
+            ),
+            sdk_requirement=Requirement("deepagents==0.7.0a7"),
+            sdk_requirement_satisfied=False,
+        )
+        items = self._diagnostics(report)
+        sdk = items["deepagents (SDK)"]
+        assert sdk.ok is False
+        assert "required by deepagents-code: 0.7.0a7 — mismatch" in sdk.value
+
+    def test_source_metadata_drift_is_informational(self) -> None:
+        """Source/metadata drift annotates the values but stays healthy."""
+        from packaging.requirements import Requirement
+
+        from deepagents_code._version import __version__
+        from deepagents_code.extras_info import DistributionVersion, VersionReport
+
+        report = VersionReport(
+            cli=DistributionVersion(
+                "deepagents-code", __version__, "0.1.40", True, "~/src", "resolved"
+            ),
+            sdk=DistributionVersion(
+                "deepagents", "0.6.13", "0.6.12", True, "~/src/sdk", "resolved"
+            ),
+            sdk_requirement=Requirement("deepagents>=0.6"),
+            sdk_requirement_satisfied=True,
+        )
+        items = self._diagnostics(report)
+        cli = items["deepagents-code"]
+        sdk = items["deepagents (SDK)"]
+        assert cli.ok is True
+        assert cli.value == f"{__version__} (installed metadata: 0.1.40)"
+        assert sdk.ok is True
+        assert "installed metadata: 0.6.12" in sdk.value
+
+    def test_sdk_not_installed_is_unhealthy(self) -> None:
+        """A missing SDK is reported as not installed and unhealthy."""
+        from deepagents_code._version import __version__
+        from deepagents_code.extras_info import DistributionVersion, VersionReport
+
+        report = VersionReport(
+            cli=DistributionVersion(
+                "deepagents-code", __version__, __version__, False, None, "resolved"
+            ),
+            sdk=DistributionVersion(
+                "deepagents", None, None, False, None, "not_installed"
+            ),
+            sdk_requirement=None,
+            sdk_requirement_satisfied=None,
+        )
+        items = self._diagnostics(report)
+        sdk = items["deepagents (SDK)"]
+        assert sdk.ok is False
+        assert sdk.value == "not installed"
 
 
 class TestCollectTracing:
@@ -475,7 +565,14 @@ class TestRunDoctorCommand:
 
     def test_text_output_contains_sections(self) -> None:
         """Text output renders each section title and key facts."""
-        code, output = self._run_text()
+        # Isolate the SDK requirement check so a workspace where the declared
+        # `deepagents` pin intentionally leads the installed SDK does not make
+        # the section unhealthy; the mismatch path has dedicated coverage.
+        with patch(
+            "deepagents_code.extras_info.sdk_requirement_from_cli",
+            return_value=None,
+        ):
+            code, output = self._run_text()
         assert code == 0
         assert "Diagnostics" in output
         assert "Updates" in output
@@ -490,7 +587,13 @@ class TestRunDoctorCommand:
     def test_json_output_envelope(self, capsys) -> None:
         """JSON output is a stable envelope with section data."""
         args = argparse.Namespace(output_format="json")
-        code = run_doctor_command(args)
+        # Isolate the SDK requirement check (see text-output test) so the
+        # envelope reports the healthy shape regardless of the workspace pin.
+        with patch(
+            "deepagents_code.extras_info.sdk_requirement_from_cli",
+            return_value=None,
+        ):
+            code = run_doctor_command(args)
         assert code == 0
 
         captured = capsys.readouterr()

--- a/libs/code/tests/unit_tests/test_extras_info.py
+++ b/libs/code/tests/unit_tests/test_extras_info.py
@@ -3,7 +3,7 @@
 import tomllib
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from packaging.requirements import Requirement
@@ -14,8 +14,8 @@ from deepagents_code.extras_info import (
     MODEL_PROVIDER_EXTRAS,
     SANDBOX_EXTRAS,
     STANDALONE_EXTRAS,
+    DistributionMetadataStatus,
     DistributionVersion,
-    SdkVersionStatus,
     VersionReport,
     _editable_sdk_source_root,
     _requirement_satisfied,
@@ -627,7 +627,7 @@ def _distribution_version(
     metadata_version: str | None = None,
     editable: bool = False,
     source_path: str | None = None,
-    status: SdkVersionStatus = "resolved",
+    status: DistributionMetadataStatus = "resolved",
 ) -> DistributionVersion:
     """Build a `DistributionVersion` with sensible defaults for tests."""
     return DistributionVersion(
@@ -638,6 +638,44 @@ def _distribution_version(
         source_path=source_path,
         status=status,
     )
+
+
+class TestContractHome:
+    """Tests for `~`-contraction of displayed editable source paths."""
+
+    def test_contracts_home_prefix(self) -> None:
+        """A path under the home directory is shown with a `~` prefix."""
+        from deepagents_code.extras_info import _contract_home
+
+        with patch(
+            "deepagents_code.extras_info.Path.home", return_value=Path("/home/dev")
+        ):
+            assert _contract_home(Path("/home/dev/src/proj")) == "~/src/proj"
+
+    def test_exact_home_becomes_tilde(self) -> None:
+        """The home directory itself contracts to a bare `~`."""
+        from deepagents_code.extras_info import _contract_home
+
+        with patch(
+            "deepagents_code.extras_info.Path.home", return_value=Path("/home/dev")
+        ):
+            assert _contract_home(Path("/home/dev")) == "~"
+
+    def test_non_home_path_is_unchanged(self) -> None:
+        """A path outside the home directory is returned verbatim."""
+        from deepagents_code.extras_info import _contract_home
+
+        with patch(
+            "deepagents_code.extras_info.Path.home", return_value=Path("/home/dev")
+        ):
+            assert _contract_home(Path("/opt/other")) == "/opt/other"
+
+    def test_unresolvable_home_returns_raw_path(self) -> None:
+        """When the home directory cannot be determined, the raw path is kept."""
+        from deepagents_code.extras_info import _contract_home
+
+        with patch("deepagents_code.extras_info.Path.home", side_effect=RuntimeError):
+            assert _contract_home(Path("/home/dev/x")) == "/home/dev/x"
 
 
 class TestDistributionVersion:
@@ -710,28 +748,30 @@ class TestVersionAnnotations:
         )
         assert format_cli_version_annotation(info) == ""
 
-    def test_cli_annotation_marks_editable(self) -> None:
-        """An editable install with agreeing versions is marked editable only."""
+    def test_cli_annotation_omits_editable_when_versions_agree(self) -> None:
+        """Editable status is shown separately, so an in-sync editable CLI is bare.
+
+        The CLI editable state is rendered by the dedicated `Editable install:`
+        line (and doctor's `Install method`), so the inline annotation carries
+        only drift — here there is none.
+        """
         info = _distribution_version(
             name="deepagents-code",
             source_version="0.1.41",
             metadata_version="0.1.41",
             editable=True,
         )
-        assert format_cli_version_annotation(info) == " (editable)"
+        assert format_cli_version_annotation(info) == ""
 
     def test_cli_annotation_shows_stale_metadata(self) -> None:
-        """An editable CLI with stale metadata shows both versions."""
+        """An editable CLI with stale metadata shows the drift, not `editable`."""
         info = _distribution_version(
             name="deepagents-code",
             source_version="0.1.41",
             metadata_version="0.1.40",
             editable=True,
         )
-        assert (
-            format_cli_version_annotation(info)
-            == " (editable; installed metadata: 0.1.40)"
-        )
+        assert format_cli_version_annotation(info) == " (installed metadata: 0.1.40)"
 
     def test_sdk_annotation_empty_for_normal_install(self) -> None:
         """A non-editable SDK whose requirement is satisfied gets no annotation."""
@@ -777,6 +817,24 @@ class TestVersionAnnotations:
         )
         annotation = format_sdk_version_annotation(report)
         assert "required by deepagents-code: <0.8,>=0.7 — mismatch" in annotation
+
+    def test_sdk_annotation_combines_editable_drift_and_mismatch(self) -> None:
+        """Editable, drift, and mismatch parts join in order when they co-occur.
+
+        This is the case where the displayed primary (source) version happens to
+        equal the requirement yet the (stale) installed metadata does not — the
+        drift note reconciles the apparent contradiction.
+        """
+        sdk = _distribution_version(
+            source_version="0.7.0a7", metadata_version="0.6.12", editable=True
+        )
+        report = self._report(
+            sdk=sdk, requirement=Requirement("deepagents==0.7.0a7"), satisfied=False
+        )
+        assert format_sdk_version_annotation(report) == (
+            " (editable; installed metadata: 0.6.12; "
+            "required by deepagents-code: 0.7.0a7 — mismatch)"
+        )
 
 
 class TestRequirementSatisfied:
@@ -865,6 +923,48 @@ class TestSdkRequirementFromCli:
         ):
             assert sdk_requirement_from_cli() is None
 
+    @pytest.mark.parametrize(
+        "error",
+        [
+            UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"),
+            TypeError("malformed metadata"),
+        ],
+    )
+    def test_unreadable_requirements_return_none(self, error: Exception) -> None:
+        """Unreadable requirement metadata is inconclusive rather than fatal."""
+        dist = MagicMock()
+        type(dist).requires = PropertyMock(side_effect=error)
+        with patch("deepagents_code.extras_info.distribution", return_value=dist):
+            assert sdk_requirement_from_cli() is None
+
+    def test_returns_applicable_marked_requirement(self) -> None:
+        """A base `deepagents` dep whose marker applies is still returned."""
+        dist = self._dist(['deepagents==0.7.0a7; python_version >= "3.0"'])
+        with patch("deepagents_code.extras_info.distribution", return_value=dist):
+            req = sdk_requirement_from_cli()
+        assert req is not None
+        assert str(req.specifier) == "==0.7.0a7"
+
+    def test_unevaluable_marker_is_treated_as_applicable(self) -> None:
+        """A marker that fails to evaluate must not silently drop the pin.
+
+        Dropping it would hide the SDK requirement mismatch this check exists to
+        surface, so an unexpected evaluation error is treated as applicable.
+        """
+        dist = self._dist(['deepagents==0.7.0a7; python_version >= "3.0"'])
+
+        def boom(_self: object, *_a: object, **_k: object) -> bool:
+            msg = "marker blew up"
+            raise ValueError(msg)
+
+        with (
+            patch("deepagents_code.extras_info.distribution", return_value=dist),
+            patch("packaging.markers.Marker.evaluate", boom),
+        ):
+            req = sdk_requirement_from_cli()
+        assert req is not None
+        assert str(req.specifier) == "==0.7.0a7"
+
 
 class TestCollectVersionInfo:
     """Tests for the version collectors that read the live environment."""
@@ -908,6 +1008,87 @@ class TestCollectVersionInfo:
         assert info.editable is True
         assert info.source_path == "~/src/deepagents/libs/code"
         assert info.has_drift is True
+
+    def test_collect_cli_metadata_missing_resolves_from_source(self) -> None:
+        """Absent CLI metadata still resolves via the source version."""
+        with (
+            patch(
+                "deepagents_code.extras_info._read_cli_source_version",
+                return_value="0.1.41",
+            ),
+            patch(
+                "deepagents_code.extras_info.pkg_version",
+                side_effect=PackageNotFoundError("deepagents-code"),
+            ),
+            patch(
+                "deepagents_code.extras_info._cli_editable_info",
+                return_value=(False, None),
+            ),
+        ):
+            info = collect_cli_version_info()
+        assert info.status == "resolved"
+        assert info.metadata_version is None
+        assert info.primary_version == "0.1.41"
+
+    def test_collect_cli_metadata_and_source_missing_is_not_installed(self) -> None:
+        """No source and no metadata reports `not_installed`."""
+        with (
+            patch(
+                "deepagents_code.extras_info._read_cli_source_version",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_code.extras_info.pkg_version",
+                side_effect=PackageNotFoundError("deepagents-code"),
+            ),
+            patch(
+                "deepagents_code.extras_info._cli_editable_info",
+                return_value=(False, None),
+            ),
+        ):
+            info = collect_cli_version_info()
+        assert info.status == "not_installed"
+        assert info.primary_version is None
+
+    def test_collect_cli_unexpected_error_with_source_resolves(self) -> None:
+        """An unexpected metadata failure still resolves when source is present."""
+        with (
+            patch(
+                "deepagents_code.extras_info._read_cli_source_version",
+                return_value="0.1.41",
+            ),
+            patch(
+                "deepagents_code.extras_info.pkg_version",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch(
+                "deepagents_code.extras_info._cli_editable_info",
+                return_value=(False, None),
+            ),
+        ):
+            info = collect_cli_version_info()
+        assert info.status == "resolved"
+        assert info.primary_version == "0.1.41"
+
+    def test_collect_cli_unexpected_error_without_source_is_error(self) -> None:
+        """An unexpected metadata failure with no source reports `error`."""
+        with (
+            patch(
+                "deepagents_code.extras_info._read_cli_source_version",
+                return_value=None,
+            ),
+            patch(
+                "deepagents_code.extras_info.pkg_version",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch(
+                "deepagents_code.extras_info._cli_editable_info",
+                return_value=(False, None),
+            ),
+        ):
+            info = collect_cli_version_info()
+        assert info.status == "error"
+        assert info.primary_version is None
 
     def test_collect_sdk_normal_install(self) -> None:
         """A non-editable SDK reports metadata and no editable source."""

--- a/libs/code/tests/unit_tests/test_extras_info.py
+++ b/libs/code/tests/unit_tests/test_extras_info.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from packaging.requirements import Requirement
 
 from deepagents_code.extras_info import (
     _COMPOSITE_EXTRAS,
@@ -13,14 +14,24 @@ from deepagents_code.extras_info import (
     MODEL_PROVIDER_EXTRAS,
     SANDBOX_EXTRAS,
     STANDALONE_EXTRAS,
+    DistributionVersion,
+    SdkVersionStatus,
+    VersionReport,
     _editable_sdk_source_root,
+    _requirement_satisfied,
+    collect_cli_version_info,
+    collect_sdk_version_info,
+    collect_version_report,
     extra_for_package,
+    format_cli_version_annotation,
     format_extras_status,
     format_extras_status_plain,
     format_known_extras,
+    format_sdk_version_annotation,
     get_extras_status,
     get_optional_dependency_status,
     resolve_sdk_version,
+    sdk_requirement_from_cli,
     verify_interpreter_deps,
 )
 
@@ -607,3 +618,378 @@ class TestResolveSdkVersion:
         ):
             version, status = resolve_sdk_version()
         assert (version, status) == (None, "error")
+
+
+def _distribution_version(
+    *,
+    name: str = "deepagents",
+    source_version: str | None = None,
+    metadata_version: str | None = None,
+    editable: bool = False,
+    source_path: str | None = None,
+    status: SdkVersionStatus = "resolved",
+) -> DistributionVersion:
+    """Build a `DistributionVersion` with sensible defaults for tests."""
+    return DistributionVersion(
+        name=name,
+        source_version=source_version,
+        metadata_version=metadata_version,
+        editable=editable,
+        source_path=source_path,
+        status=status,
+    )
+
+
+class TestDistributionVersion:
+    """Tests for the structured single-distribution version representation."""
+
+    def test_primary_prefers_source_for_editable(self) -> None:
+        """Editable installs report the live source version as primary."""
+        info = _distribution_version(
+            source_version="1.2.4", metadata_version="1.2.3", editable=True
+        )
+        assert info.primary_version == "1.2.4"
+
+    def test_primary_uses_metadata_for_non_editable(self) -> None:
+        """Non-editable installs report the metadata version as primary."""
+        info = _distribution_version(
+            source_version="9.9.9", metadata_version="1.2.3", editable=False
+        )
+        assert info.primary_version == "1.2.3"
+
+    def test_primary_falls_back_to_metadata_without_source(self) -> None:
+        """An editable install with no readable source version uses metadata."""
+        info = _distribution_version(
+            source_version=None, metadata_version="1.2.3", editable=True
+        )
+        assert info.primary_version == "1.2.3"
+
+    def test_has_drift_true_when_versions_differ(self) -> None:
+        """Drift is reported when both versions are known and differ."""
+        info = _distribution_version(source_version="1.2.4", metadata_version="1.2.3")
+        assert info.has_drift is True
+
+    def test_has_drift_false_when_versions_agree(self) -> None:
+        """No drift is reported when the versions agree."""
+        info = _distribution_version(source_version="1.2.3", metadata_version="1.2.3")
+        assert info.has_drift is False
+
+    @pytest.mark.parametrize(
+        ("source", "metadata"),
+        [(None, "1.2.3"), ("1.2.3", None), (None, None)],
+    )
+    def test_has_drift_false_when_a_version_is_unknown(
+        self, source: str | None, metadata: str | None
+    ) -> None:
+        """Drift requires both versions; a missing one is never drift."""
+        info = _distribution_version(source_version=source, metadata_version=metadata)
+        assert info.has_drift is False
+
+
+class TestVersionAnnotations:
+    """Tests for the rendered editable/drift/mismatch annotations."""
+
+    def _report(
+        self,
+        *,
+        sdk: DistributionVersion | None = None,
+        requirement: Requirement | None = None,
+        satisfied: bool | None = None,
+    ) -> VersionReport:
+        return VersionReport(
+            cli=_distribution_version(name="deepagents-code"),
+            sdk=sdk or _distribution_version(),
+            sdk_requirement=requirement,
+            sdk_requirement_satisfied=satisfied,
+        )
+
+    def test_cli_annotation_empty_for_normal_install(self) -> None:
+        """A non-editable install with agreeing versions gets no annotation."""
+        info = _distribution_version(
+            name="deepagents-code", source_version="0.1.41", metadata_version="0.1.41"
+        )
+        assert format_cli_version_annotation(info) == ""
+
+    def test_cli_annotation_marks_editable(self) -> None:
+        """An editable install with agreeing versions is marked editable only."""
+        info = _distribution_version(
+            name="deepagents-code",
+            source_version="0.1.41",
+            metadata_version="0.1.41",
+            editable=True,
+        )
+        assert format_cli_version_annotation(info) == " (editable)"
+
+    def test_cli_annotation_shows_stale_metadata(self) -> None:
+        """An editable CLI with stale metadata shows both versions."""
+        info = _distribution_version(
+            name="deepagents-code",
+            source_version="0.1.41",
+            metadata_version="0.1.40",
+            editable=True,
+        )
+        assert (
+            format_cli_version_annotation(info)
+            == " (editable; installed metadata: 0.1.40)"
+        )
+
+    def test_sdk_annotation_empty_for_normal_install(self) -> None:
+        """A non-editable SDK whose requirement is satisfied gets no annotation."""
+        sdk = _distribution_version(source_version="0.7.0", metadata_version="0.7.0")
+        report = self._report(
+            sdk=sdk, requirement=Requirement("deepagents==0.7.0"), satisfied=True
+        )
+        assert format_sdk_version_annotation(report) == ""
+
+    def test_sdk_annotation_shows_stale_metadata_without_mismatch(self) -> None:
+        """An editable SDK with stale metadata but a satisfied pin shows drift."""
+        sdk = _distribution_version(
+            source_version="0.7.1", metadata_version="0.7.0", editable=True
+        )
+        report = self._report(
+            sdk=sdk, requirement=Requirement("deepagents>=0.7.0"), satisfied=True
+        )
+        assert (
+            format_sdk_version_annotation(report)
+            == " (editable; installed metadata: 0.7.0)"
+        )
+
+    def test_sdk_annotation_surfaces_exact_pin_mismatch(self) -> None:
+        """An unsatisfied exact pin surfaces an actionable mismatch."""
+        sdk = _distribution_version(
+            source_version="0.6.12", metadata_version="0.6.12", editable=True
+        )
+        report = self._report(
+            sdk=sdk, requirement=Requirement("deepagents==0.7.0a7"), satisfied=False
+        )
+        assert (
+            format_sdk_version_annotation(report)
+            == " (editable; required by deepagents-code: 0.7.0a7 — mismatch)"
+        )
+
+    def test_sdk_annotation_shows_ranged_requirement_mismatch(self) -> None:
+        """A ranged requirement keeps its full specifier in the mismatch note."""
+        sdk = _distribution_version(source_version="0.6.12", metadata_version="0.6.12")
+        report = self._report(
+            sdk=sdk,
+            requirement=Requirement("deepagents>=0.7,<0.8"),
+            satisfied=False,
+        )
+        annotation = format_sdk_version_annotation(report)
+        assert "required by deepagents-code: <0.8,>=0.7 — mismatch" in annotation
+
+
+class TestRequirementSatisfied:
+    """Tests for comparing a declared requirement against installed metadata."""
+
+    def test_exact_pin_satisfied(self) -> None:
+        assert _requirement_satisfied(Requirement("deepagents==0.7.0"), "0.7.0") is True
+
+    def test_exact_pin_unsatisfied(self) -> None:
+        assert (
+            _requirement_satisfied(Requirement("deepagents==0.7.0a7"), "0.6.12")
+            is False
+        )
+
+    def test_ranged_requirement_satisfied(self) -> None:
+        assert (
+            _requirement_satisfied(Requirement("deepagents>=0.7,<0.8"), "0.7.3") is True
+        )
+
+    def test_ranged_requirement_unsatisfied(self) -> None:
+        assert (
+            _requirement_satisfied(Requirement("deepagents>=0.7,<0.8"), "0.6.12")
+            is False
+        )
+
+    def test_prerelease_metadata_is_evaluated(self) -> None:
+        """A prerelease installed version is compared, not silently dropped."""
+        assert (
+            _requirement_satisfied(Requirement("deepagents==0.7.0a7"), "0.7.0a7")
+            is True
+        )
+
+    @pytest.mark.parametrize(
+        ("requirement", "metadata"),
+        [(None, "0.7.0"), (Requirement("deepagents==0.7.0"), None), (None, None)],
+    )
+    def test_missing_inputs_are_inconclusive(
+        self, requirement: Requirement | None, metadata: str | None
+    ) -> None:
+        """A missing requirement or version yields `None`, not a boolean."""
+        assert _requirement_satisfied(requirement, metadata) is None
+
+    def test_unparseable_version_is_inconclusive(self) -> None:
+        """An unparseable installed version degrades to `None` rather than raising."""
+        assert (
+            _requirement_satisfied(Requirement("deepagents==0.7.0"), "not-a-version")
+            is None
+        )
+
+
+class TestSdkRequirementFromCli:
+    """Tests for reading the declared `deepagents` requirement from metadata."""
+
+    def _dist(self, requires: list[str]) -> MagicMock:
+        dist = MagicMock()
+        dist.requires = requires
+        return dist
+
+    def test_returns_base_requirement(self) -> None:
+        """The unconditional `deepagents` dependency is returned."""
+        dist = self._dist(["deepagents==0.7.0a7", "rich>=13"])
+        with patch("deepagents_code.extras_info.distribution", return_value=dist):
+            req = sdk_requirement_from_cli()
+        assert req is not None
+        assert str(req) == "deepagents==0.7.0a7"
+
+    def test_skips_extras_gated_requirement(self) -> None:
+        """An `extra`-gated `deepagents` entry is not treated as the base pin."""
+        dist = self._dist(['deepagents[extra]==9.9.9; extra == "foo"'])
+        with patch("deepagents_code.extras_info.distribution", return_value=dist):
+            assert sdk_requirement_from_cli() is None
+
+    def test_skips_unparseable_entries(self) -> None:
+        """A malformed `Requires-Dist` entry is skipped, not fatal."""
+        dist = self._dist(["=not a requirement=", "deepagents>=0.7,<0.8"])
+        with patch("deepagents_code.extras_info.distribution", return_value=dist):
+            req = sdk_requirement_from_cli()
+        assert req is not None
+        assert str(req.specifier) == "<0.8,>=0.7"
+
+    def test_missing_distribution_returns_none(self) -> None:
+        """A missing distribution yields `None` rather than raising."""
+        with patch(
+            "deepagents_code.extras_info.distribution",
+            side_effect=PackageNotFoundError("deepagents-code"),
+        ):
+            assert sdk_requirement_from_cli() is None
+
+
+class TestCollectVersionInfo:
+    """Tests for the version collectors that read the live environment."""
+
+    def test_collect_cli_normal_install(self) -> None:
+        """A non-editable CLI reports source and metadata with no editable flag."""
+        with (
+            patch(
+                "deepagents_code.extras_info._read_cli_source_version",
+                return_value="0.1.41",
+            ),
+            patch("deepagents_code.extras_info.pkg_version", return_value="0.1.41"),
+            patch(
+                "deepagents_code.extras_info._cli_editable_info",
+                return_value=(False, None),
+            ),
+        ):
+            info = collect_cli_version_info()
+        assert info.source_version == "0.1.41"
+        assert info.metadata_version == "0.1.41"
+        assert info.editable is False
+        assert info.status == "resolved"
+        assert info.has_drift is False
+
+    def test_collect_cli_editable_stale_metadata(self) -> None:
+        """An editable CLI surfaces the stale-metadata drift."""
+        with (
+            patch(
+                "deepagents_code.extras_info._read_cli_source_version",
+                return_value="0.1.41",
+            ),
+            patch("deepagents_code.extras_info.pkg_version", return_value="0.1.40"),
+            patch(
+                "deepagents_code.extras_info._cli_editable_info",
+                return_value=(True, "~/src/deepagents/libs/code"),
+            ),
+        ):
+            info = collect_cli_version_info()
+        assert info.primary_version == "0.1.41"
+        assert info.metadata_version == "0.1.40"
+        assert info.editable is True
+        assert info.source_path == "~/src/deepagents/libs/code"
+        assert info.has_drift is True
+
+    def test_collect_sdk_normal_install(self) -> None:
+        """A non-editable SDK reports metadata and no editable source."""
+        dist = MagicMock()
+        dist.read_text.return_value = None
+        with (
+            patch("deepagents_code.extras_info.pkg_version", return_value="0.7.0"),
+            patch("deepagents_code.extras_info.distribution", return_value=dist),
+        ):
+            info = collect_sdk_version_info()
+        assert info.metadata_version == "0.7.0"
+        assert info.editable is False
+        assert info.source_version is None
+        assert info.primary_version == "0.7.0"
+        assert info.status == "resolved"
+
+    def test_collect_sdk_editable_stale_metadata(self, tmp_path: Path) -> None:
+        """An editable SDK prefers source over stale metadata and reports drift."""
+        version_file = tmp_path / "deepagents" / "_version.py"
+        version_file.parent.mkdir()
+        version_file.write_text('__version__ = "0.6.13"\n', encoding="utf-8")
+        dist = MagicMock()
+        dist.read_text.return_value = (
+            f'{{"url":"{tmp_path.as_uri()}","dir_info":{{"editable":true}}}}'
+        )
+        with (
+            patch("deepagents_code.extras_info.pkg_version", return_value="0.6.12"),
+            patch("deepagents_code.extras_info.distribution", return_value=dist),
+        ):
+            info = collect_sdk_version_info()
+        assert info.editable is True
+        assert info.source_version == "0.6.13"
+        assert info.metadata_version == "0.6.12"
+        assert info.primary_version == "0.6.13"
+        assert info.has_drift is True
+
+    def test_collect_sdk_not_installed(self) -> None:
+        """A missing SDK reports `not_installed` with no versions."""
+        with patch(
+            "deepagents_code.extras_info.pkg_version",
+            side_effect=PackageNotFoundError("deepagents"),
+        ):
+            info = collect_sdk_version_info()
+        assert info.status == "not_installed"
+        assert info.metadata_version is None
+        assert info.primary_version is None
+
+    def test_collect_version_report_flags_requirement_mismatch(self) -> None:
+        """The aggregated report flags an unsatisfied declared SDK requirement."""
+        dist = MagicMock()
+        dist.read_text.return_value = None
+        dist.requires = ["deepagents==0.7.0a7"]
+
+        def fake_version(name: str) -> str:
+            return {"deepagents": "0.6.12", "deepagents-code": "0.1.41"}[name]
+
+        with (
+            patch("deepagents_code.extras_info.pkg_version", side_effect=fake_version),
+            patch("deepagents_code.extras_info.distribution", return_value=dist),
+            patch(
+                "deepagents_code.extras_info._cli_editable_info",
+                return_value=(False, None),
+            ),
+        ):
+            report = collect_version_report()
+        assert report.sdk_requirement is not None
+        assert report.sdk_requirement_mismatch is True
+
+    def test_collect_version_report_uses_no_network_or_subprocess(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Collecting the report must not open sockets or spawn subprocesses."""
+        import socket
+        import subprocess
+
+        def _forbidden(*_args: object, **_kwargs: object) -> None:
+            msg = "version collection must stay offline and process-free"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr(socket, "socket", _forbidden)
+        monkeypatch.setattr(subprocess, "run", _forbidden)
+        monkeypatch.setattr(subprocess, "Popen", _forbidden)
+
+        report = collect_version_report()
+        assert isinstance(report, VersionReport)

--- a/libs/code/tests/unit_tests/test_startup_fast_paths.py
+++ b/libs/code/tests/unit_tests/test_startup_fast_paths.py
@@ -41,15 +41,27 @@ def _run_cli_main(argv: list[str]) -> subprocess.CompletedProcess[str]:
     code = """
         import json
         import sys
+        from contextlib import nullcontext
         from unittest.mock import patch
 
         from deepagents_code.main import cli_main
 
         argv = ["deepagents", *json.loads(sys.argv[1])]
+        # An intentional prerelease SDK pin can make `doctor` exit unhealthy;
+        # omit that environment-specific check while testing startup bootstrap.
+        requirement_patch = (
+            patch(
+                "deepagents_code.extras_info.sdk_requirement_from_cli",
+                return_value=None,
+            )
+            if argv[1:] == ["doctor", "--json"]
+            else nullcontext()
+        )
         try:
             with (
                 patch.object(sys, "argv", argv),
                 patch("deepagents_code.main.check_cli_dependencies"),
+                requirement_patch,
             ):
                 cli_main()
         finally:

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -18,6 +18,8 @@ from deepagents_code._version import __version__
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from deepagents_code.extras_info import VersionReport
+
 
 @pytest.fixture(autouse=True)
 def _block_sdk_pypi_fetch(tmp_path: Path) -> Iterator[None]:
@@ -372,6 +374,81 @@ def test_build_version_text_omits_core_deps_when_not_editable() -> None:
 
     assert "Editable install" not in text
     assert "Core dependencies:" not in text
+
+
+def _mismatch_version_report(cli_metadata: str = "0.1.40") -> VersionReport:
+    """Build a report with editable installs, CLI drift, and an SDK mismatch."""
+    from packaging.requirements import Requirement
+
+    from deepagents_code.extras_info import DistributionVersion, VersionReport
+
+    return VersionReport(
+        cli=DistributionVersion(
+            name="deepagents-code",
+            source_version=__version__,
+            metadata_version=cli_metadata,
+            editable=True,
+            source_path="~/src/deepagents/libs/code",
+            status="resolved",
+        ),
+        sdk=DistributionVersion(
+            name="deepagents",
+            source_version="0.6.12",
+            metadata_version="0.6.12",
+            editable=True,
+            source_path="~/src/deepagents/libs/deepagents",
+            status="resolved",
+        ),
+        sdk_requirement=Requirement("deepagents==0.7.0a7"),
+        sdk_requirement_satisfied=False,
+    )
+
+
+def test_build_version_text_reports_editable_drift_and_sdk_mismatch() -> None:
+    """`--version` surfaces CLI stale metadata and an SDK requirement mismatch."""
+    from deepagents_code.main import build_version_text
+
+    with patch(
+        "deepagents_code.extras_info.collect_version_report",
+        return_value=_mismatch_version_report(),
+    ):
+        text = build_version_text()
+
+    assert (
+        f"deepagents-code {__version__} (editable; installed metadata: 0.1.40)" in text
+    )
+    assert (
+        "deepagents (SDK) 0.6.12 "
+        "(editable; required by deepagents-code: 0.7.0a7 — mismatch)" in text
+    )
+
+
+async def test_version_slash_command_reports_editable_drift_and_sdk_mismatch() -> None:
+    """`/version` renders the same drift/mismatch facts as `--version`."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.tui.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with patch(
+            "deepagents_code.extras_info.collect_version_report",
+            return_value=_mismatch_version_report(),
+        ):
+            await app._handle_command("/version")
+        await pilot.pause()
+
+        content = str(
+            [m for m in app.query(AppMessage) if not m._is_markdown][-1]._content
+        )
+        assert (
+            f"deepagents-code version: {__version__} "
+            "(editable; installed metadata: 0.1.40)" in content
+        )
+        assert (
+            "deepagents (SDK) version: 0.6.12 "
+            "(editable; required by deepagents-code: 0.7.0a7 — mismatch)" in content
+        )
 
 
 def test_format_core_dependencies_lists_known_packages() -> None:

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -414,9 +414,9 @@ def test_build_version_text_reports_editable_drift_and_sdk_mismatch() -> None:
     ):
         text = build_version_text()
 
-    assert (
-        f"deepagents-code {__version__} (editable; installed metadata: 0.1.40)" in text
-    )
+    # Editable status is shown on its own `Editable install:` line, so the CLI
+    # version line carries only the source/metadata drift, not `editable`.
+    assert f"deepagents-code {__version__} (installed metadata: 0.1.40)" in text
     assert (
         "deepagents (SDK) 0.6.12 "
         "(editable; required by deepagents-code: 0.7.0a7 — mismatch)" in text
@@ -443,7 +443,7 @@ async def test_version_slash_command_reports_editable_drift_and_sdk_mismatch() -
         )
         assert (
             f"deepagents-code version: {__version__} "
-            "(editable; installed metadata: 0.1.40)" in content
+            "(installed metadata: 0.1.40)" in content
         )
         assert (
             "deepagents (SDK) version: 0.6.12 "


### PR DESCRIPTION
Editable installs conflated three distinct version facts, so `/version`, `--version`, and `doctor` could silently report a single number that hid stale metadata or a broken SDK dependency pin. Version diagnostics now separate the live source version, the installed distribution metadata version, and the `deepagents` requirement that `deepagents-code` declares — reporting the source version as primary for editable installs, showing the installed metadata alongside it when they drift, and flagging an actionable mismatch when the installed SDK metadata does not satisfy the declared requirement.

---

A new structured `DistributionVersion`/`VersionReport` representation in `extras_info` is the single source of truth these surfaces render. `resolve_sdk_version()` is preserved as a thin compatibility wrapper so existing callers are untouched.

- `/version`, `--version`, and `doctor` render the same facts: an editable SDK is now clearly identified (not just editable `deepagents-code`), source/metadata drift shows both versions, and an unsatisfied requirement (compared via `packaging.Requirement`) is surfaced as `required by deepagents-code: <version> — mismatch`.
- `doctor` marks a dependency-requirement mismatch unhealthy, while treating source/metadata drift as informational since it is normal while editing SDK source.
- Normal non-editable output is unchanged when all versions agree, and version collection stays fully offline and best-effort (no `uv`/`pip`/PyPI, no subprocess).
- No package versions or dependency pins were changed.

Two existing `doctor` integration tests now isolate the SDK requirement check so they stay deterministic regardless of the workspace's intentional prerelease pin; the mismatch and drift paths have dedicated new coverage.

Made by [Open SWE](https://openswe.vercel.app/agents/1145d1a5-ba8a-abbb-e5b7-039e9c2a5b04)