### PR TITLE
fix(sdk): set status='error' on synthetic ToolMessage for invalid_tool_calls

### DIFF
--- a/libs/deepagents/deepagents/middleware/patch_tool_calls.py
+++ b/libs/deepagents/deepagents/middleware/patch_tool_calls.py
@@ -39,8 +39,11 @@ class PatchToolCallsMiddleware(AgentMiddleware):
                 name = tool_call["name"] or "unknown"
                 if tool_call.get("type") == "invalid_tool_call":
                     content = f"Tool call {name} with id {tool_call_id} could not be executed - arguments were malformed or truncated."
+                    patched_messages.append(
+                        ToolMessage(content=content, name=name, tool_call_id=tool_call_id, status="error")
+                    )
                 else:
                     content = f"Tool call {name} with id {tool_call_id} was cancelled - another message came in before it could be completed."
-                patched_messages.append(ToolMessage(content=content, name=name, tool_call_id=tool_call_id))
+                    patched_messages.append(ToolMessage(content=content, name=name, tool_call_id=tool_call_id))
 
         return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *patched_messages]}

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -9,6 +9,7 @@ from langchain.tools import ToolRuntime
 from langchain_core.messages import (
     AIMessage,
     HumanMessage,
+    InvalidToolCall,
     RemoveMessage,
     SystemMessage,
     ToolCall,
@@ -3201,6 +3202,63 @@ class TestPatchToolCallsMiddleware:
         assert patched_messages[6].tool_call_id == "456"
         assert patched_messages[7].type == "human"
         assert patched_messages[7].content == "What is the weather in Tokyo?"
+
+    def test_invalid_tool_call_synthetic_message_has_error_status(self) -> None:
+        """Invalid tool calls must produce ToolMessage with status='error' (not default 'success')."""
+        input_messages = [
+            HumanMessage(content="Call echo.", id="1"),
+            AIMessage(
+                content="",
+                invalid_tool_calls=[
+                    InvalidToolCall(
+                        id="call_malformed",
+                        name="echo",
+                        args='{"value":',
+                        error="Invalid JSON",
+                        type="invalid_tool_call",
+                    )
+                ],
+                id="2",
+            ),
+            HumanMessage(content="What happened?", id="3"),
+        ]
+        middleware = PatchToolCallsMiddleware()
+        state_update = middleware.before_agent({"messages": input_messages}, None)
+        assert state_update is not None
+        messages = state_update["messages"]
+        assert isinstance(messages, list)
+        # Skip RemoveMessage sentinel
+        patched_messages = messages[1:]
+        # Find the synthetic ToolMessage
+        tool_messages = [m for m in patched_messages if m.type == "tool"]
+        assert len(tool_messages) == 1
+        synthetic = tool_messages[0]
+        assert synthetic.tool_call_id == "call_malformed"
+        assert synthetic.name == "echo"
+        assert synthetic.status == "error"
+        assert "malformed or truncated" in synthetic.content
+
+    def test_cancelled_tool_call_synthetic_message_has_default_status(self) -> None:
+        """Cancelled (not malformed) tool calls keep the default 'success' status."""
+        input_messages = [
+            HumanMessage(content="Do something.", id="1"),
+            AIMessage(
+                content="",
+                tool_calls=[ToolCall(id="call_ok", name="echo", args={"value": "hi"})],
+                id="2",
+            ),
+            HumanMessage(content="Interrupt!", id="3"),
+        ]
+        middleware = PatchToolCallsMiddleware()
+        state_update = middleware.before_agent({"messages": input_messages}, None)
+        assert state_update is not None
+        patched_messages = state_update["messages"][1:]
+        tool_messages = [m for m in patched_messages if m.type == "tool"]
+        assert len(tool_messages) == 1
+        synthetic = tool_messages[0]
+        assert synthetic.tool_call_id == "call_ok"
+        assert synthetic.status == "success"
+        assert "cancelled" in synthetic.content
 
 
 class TestTruncation:


### PR DESCRIPTION
Fixes #4662

`PatchToolCallsMiddleware` injects a synthetic `ToolMessage` when it detects a dangling `invalid_tool_call` at the start of a new invocation. The injected message described an execution failure but used the default `status` (`"success"`), which misled models and tooling into treating the repair as a successful tool run.

---

This sets `status="error"` on the synthetic `ToolMessage` for `invalid_tool_call` entries (malformed/truncated arguments). Cancelled-but-valid `tool_calls` that are patched with a `"was cancelled"` message retain the default status — the call itself was not erroneous, it simply did not run.

> [!NOTE]
> This addresses the simpler of the two behaviors described in #4662 (correct status on the deferred repair message). The in-run retry — routing back to the model within the same invocation — is a separate graph-level concern and is better handled as a follow-up.

> I used AI assistance for this contribution.

Twitter: @
LinkedIn: https://linkedin.com/in/