### PR TITLE
style(code): show enabled plugin status in green

### DIFF
--- a/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
@@ -145,26 +145,40 @@ def _installed_component_lines(row: _PluginRow) -> list[str]:
     return ["No components found."]
 
 
-def _status_lines(row: _PluginRow) -> list[str]:
+def _status_lines(row: _PluginRow) -> list[Content]:
     glyphs = get_glyphs()
     if row.load_state == "error":
         detail = row.load_error or "Plugin failed to load."
-        return [f"Status: Error — {detail}", "Fix the error, then run /reload."]
+        return [
+            Content.styled(f"Status: Error — {detail}", "dim"),
+            Content.styled("Fix the error, then run /reload.", "dim"),
+        ]
     if row.load_state == "disabled":
-        return ["Status: Disabled", "Enable the plugin, then run /reload to load it."]
+        return [
+            Content.styled("Status: Disabled", "dim"),
+            Content.styled("Enable the plugin, then run /reload to load it.", "dim"),
+        ]
     if row.load_state == "pending_reload":
         if row.enabled:
             return [
-                "Status: Installed · pending /reload",
-                "Run /reload to load this plugin into the current session.",
+                Content.styled("Status: Installed · pending /reload", "dim"),
+                Content.styled(
+                    "Run /reload to load this plugin into the current session.", "dim"
+                ),
             ]
         return [
-            "Status: Disabled · pending /reload",
-            "Run /reload to unload this plugin from the current session.",
+            Content.styled("Status: Disabled · pending /reload", "dim"),
+            Content.styled(
+                "Run /reload to unload this plugin from the current session.", "dim"
+            ),
         ]
-    lines = [f"Status: {glyphs.checkmark} Enabled"]
+    lines = [Content.styled(f"Status: {glyphs.checkmark} Enabled", "$success")]
     if row.mcp_connected is False:
-        lines.append("MCP servers need a server restart (/reload) to connect.")
+        lines.append(
+            Content.styled(
+                "MCP servers need a server restart (/reload) to connect.", "dim"
+            )
+        )
     return lines
 
 
@@ -214,7 +228,7 @@ def _installed_plugin_details_content(row: _PluginRow) -> Content:
     for index, line in enumerate(_status_lines(row)):
         if index:
             parts.append("\n")
-        parts.append(Content.styled(line, "dim"))
+        parts.append(line)
     parts.extend(["\n\n", Content.styled("Installed components:", "bold")])
     for line in _installed_component_lines(row):
         parts.extend(["\n  ", Content.styled(line, "dim")])

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -22,6 +22,7 @@ from deepagents_code.tui.modals.plugin_manager.content import (
     _plugin_details_content,
     _plugin_options,
     _plugin_prompt,
+    _status_lines,
 )
 from deepagents_code.tui.modals.plugin_manager.models import (
     PluginTab,
@@ -1034,6 +1035,47 @@ def test_installed_details_enabled_flags_mcp_restart() -> None:
 
     assert f"Status: {get_glyphs().checkmark} Enabled" in content
     assert "MCP servers need a server restart (/reload) to connect." in content
+
+
+def test_status_lines_enabled_is_success_and_companions_stay_dim() -> None:
+    """The enabled status renders green ($success); companion lines stay dim."""
+    row = _PluginRow(
+        plugin_id="quality@tools",
+        description="Quality",
+        enabled=True,
+        version="1.0.0",
+        author=None,
+        skill_count=1,
+        skill_names=("quality@tools:review",),
+        mcp_connected=False,  # forces the second (dim) status line
+        session_loaded=True,
+    )
+
+    lines = _status_lines(row)
+
+    assert lines[0].plain == f"Status: {get_glyphs().checkmark} Enabled"
+    assert [span.style for span in lines[0].spans] == ["$success"]
+    # The MCP-restart companion line must NOT inherit the success color.
+    assert lines[1].plain.startswith("MCP servers need a server restart")
+    assert [span.style for span in lines[1].spans] == ["dim"]
+
+
+def test_status_lines_non_enabled_states_stay_dim() -> None:
+    """Every line of a non-enabled status keeps the plain dim styling."""
+    row = _PluginRow(
+        plugin_id="broken@tools",
+        description="Broken",
+        enabled=True,
+        version=None,
+        author=None,
+        session_loaded=False,
+        load_error="boom",  # load_state == "error"
+    )
+
+    assert row.load_state == "error"
+    assert all(
+        span.style == "dim" for line in _status_lines(row) for span in line.spans
+    )
 
 
 def test_load_state_label_matches_state() -> None:


### PR DESCRIPTION
In the installed plugin details view, the `Status: ✓ Enabled` line was rendered `dim` like every other status line. This styles it with the `$success` theme color so a successful load reads as green, matching the semantic coloring used elsewhere in the TUI. Other status lines (error/disabled/pending, and the secondary MCP restart note) stay `dim`.

Made by [Open SWE](https://openswe.vercel.app/agents/d3174852-cfc9-43f5-f431-56993468deaf)