### PR TITLE
fix(code): drop `uv install` tip from `/version` update hint

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6096,12 +6096,34 @@ class DeepAgentsApp(App):
 
         available, latest = self._update_available
         if available and latest:
-            from deepagents_code.update_check import is_auto_update_enabled
+            manual_hint = "Run /update or `dcode update` to install it."
+            hint = "Update it using the method that installed this copy of dcode."
+            upgrade_supported = False
+            try:
+                # Imported function-locally on purpose: tests patch these on the
+                # `update_check` module, which only takes effect because the names
+                # are resolved here at call time. Hoisting this to module scope
+                # would silently defeat those patches.
+                from deepagents_code.update_check import (
+                    detect_install_method,
+                    is_auto_update_enabled,
+                )
 
-            if await asyncio.to_thread(is_auto_update_enabled):
-                hint = "Quit and relaunch dcode to install it automatically."
-            else:
-                hint = "Run /update or `dcode update` to install it."
+                method = await asyncio.to_thread(detect_install_method)
+                upgrade_supported = method in {"uv", "brew"}
+                if upgrade_supported:
+                    if await asyncio.to_thread(is_auto_update_enabled):
+                        hint = "Quit and relaunch dcode to install it automatically."
+                    else:
+                        hint = manual_hint
+            except Exception:
+                logger.warning(
+                    "Could not resolve update preference for /version; "
+                    "falling back to a manual update hint",
+                    exc_info=True,
+                )
+                if upgrade_supported:
+                    hint = manual_hint
             lines.extend(("", f"Update available: v{latest}. {hint}"))
 
         await self._mount_message(AppMessage("\n".join(lines)))

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6096,20 +6096,13 @@ class DeepAgentsApp(App):
 
         available, latest = self._update_available
         if available and latest:
-            try:
-                from deepagents_code.update_check import upgrade_command
+            from deepagents_code.update_check import is_auto_update_enabled
 
-                cmd = upgrade_command()
-            except Exception:
-                logger.warning(
-                    "Could not resolve upgrade command for /version; "
-                    "falling back to generic upgrade hint",
-                    exc_info=True,
-                )
-                from deepagents_code.update_check import FALLBACK_UPGRADE_COMMAND
-
-                cmd = FALLBACK_UPGRADE_COMMAND
-            lines.extend(("", f"Update available: v{latest}. Run: {cmd}"))
+            if await asyncio.to_thread(is_auto_update_enabled):
+                hint = "Quit and relaunch dcode to install it automatically."
+            else:
+                hint = "Run /update or `dcode update` to install it."
+            lines.extend(("", f"Update available: v{latest}. {hint}"))
 
         await self._mount_message(AppMessage("\n".join(lines)))
 

--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -3313,6 +3313,9 @@ def _read_update_config_strict() -> dict[str, bool]:
     except (OSError, tomllib.TOMLDecodeError) as exc:
         raise _ConfigReadError from exc
     section = data.get("update", {})
+    if not isinstance(section, dict):
+        msg = "[update] config must be a table"
+        raise _ConfigReadError(msg)
     return {k: v for k, v in section.items() if isinstance(v, bool)}
 
 

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -4840,6 +4840,19 @@ class TestIsAutoUpdateEnabled:
             assert is_auto_update_enabled() is False
         assert "disabling auto-update" in caplog.text
 
+    def test_malformed_update_section_fails_closed(
+        self, config_path, monkeypatch, caplog
+    ) -> None:
+        """A non-table `update` value disables auto-update without raising."""
+        config_path.write_text("update = false\n", encoding="utf-8")
+        monkeypatch.delenv("DEEPAGENTS_CODE_AUTO_UPDATE", raising=False)
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            caplog.at_level(logging.WARNING, logger="deepagents_code.update_check"),
+        ):
+            assert is_auto_update_enabled() is False
+        assert "disabling auto-update" in caplog.text
+
 
 class TestAutoUpdateDefaultMigration:
     @pytest.fixture

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -255,13 +255,42 @@ async def test_version_slash_command_mentions_update_available() -> None:
     async with app.run_test() as pilot:
         await pilot.pause()
         app._update_available = (True, "99.99.99")
-        await app._handle_command("/version")
+        with patch(
+            "deepagents_code.update_check.is_auto_update_enabled",
+            return_value=True,
+        ):
+            await app._handle_command("/version")
         await pilot.pause()
 
         app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
         content = str(app_msgs[-1]._content)
         assert "Update available: v99.99.99" in content
-        assert "Run: " in content
+        assert "relaunch dcode to install it automatically" in content
+        assert "uv tool install" not in content
+
+
+async def test_version_slash_command_update_hint_when_auto_update_disabled() -> None:
+    """Verify `/version` points to `/update` when auto-update is disabled."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.tui.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._update_available = (True, "99.99.99")
+        with patch(
+            "deepagents_code.update_check.is_auto_update_enabled",
+            return_value=False,
+        ):
+            await app._handle_command("/version")
+        await pilot.pause()
+
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        content = str(app_msgs[-1]._content)
+        assert "Update available: v99.99.99" in content
+        assert "/update" in content
+        assert "dcode update" in content
+        assert "uv tool install" not in content
 
 
 async def test_version_slash_command_omits_update_hint_when_up_to_date() -> None:

--- a/libs/code/tests/unit_tests/test_version.py
+++ b/libs/code/tests/unit_tests/test_version.py
@@ -255,9 +255,15 @@ async def test_version_slash_command_mentions_update_available() -> None:
     async with app.run_test() as pilot:
         await pilot.pause()
         app._update_available = (True, "99.99.99")
-        with patch(
-            "deepagents_code.update_check.is_auto_update_enabled",
-            return_value=True,
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=True,
+            ),
         ):
             await app._handle_command("/version")
         await pilot.pause()
@@ -266,6 +272,8 @@ async def test_version_slash_command_mentions_update_available() -> None:
         content = str(app_msgs[-1]._content)
         assert "Update available: v99.99.99" in content
         assert "relaunch dcode to install it automatically" in content
+        # The auto-update hint must not also carry the manual fallback.
+        assert "/update" not in content
         assert "uv tool install" not in content
 
 
@@ -278,9 +286,15 @@ async def test_version_slash_command_update_hint_when_auto_update_disabled() -> 
     async with app.run_test() as pilot:
         await pilot.pause()
         app._update_available = (True, "99.99.99")
-        with patch(
-            "deepagents_code.update_check.is_auto_update_enabled",
-            return_value=False,
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=False,
+            ),
         ):
             await app._handle_command("/version")
         await pilot.pause()
@@ -290,7 +304,68 @@ async def test_version_slash_command_update_hint_when_auto_update_disabled() -> 
         assert "Update available: v99.99.99" in content
         assert "/update" in content
         assert "dcode update" in content
+        # The manual hint must not falsely promise an automatic install.
+        assert "automatically" not in content
         assert "uv tool install" not in content
+
+
+async def test_version_slash_command_does_not_promise_unsupported_update() -> None:
+    """Verify `/version` does not promise auto-update for unknown installers."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.tui.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._update_available = (True, "99.99.99")
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="other",
+            ),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                return_value=True,
+            ) as auto_update_enabled,
+        ):
+            await app._handle_command("/version")
+        await pilot.pause()
+
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        content = str(app_msgs[-1]._content)
+        assert "Update available: v99.99.99" in content
+        assert "method that installed this copy of dcode" in content
+        assert "automatically" not in content
+        auto_update_enabled.assert_not_called()
+
+
+async def test_version_slash_command_falls_back_when_preference_lookup_fails() -> None:
+    """Verify `/version` survives an unreadable auto-update preference."""
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.tui.widgets.messages import AppMessage
+
+    app = DeepAgentsApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._update_available = (True, "99.99.99")
+        with (
+            patch(
+                "deepagents_code.update_check.detect_install_method",
+                return_value="uv",
+            ),
+            patch(
+                "deepagents_code.update_check.is_auto_update_enabled",
+                side_effect=AttributeError("malformed update config"),
+            ),
+        ):
+            await app._handle_command("/version")
+        await pilot.pause()
+
+        app_msgs = [m for m in app.query(AppMessage) if not m._is_markdown]
+        content = str(app_msgs[-1]._content)
+        assert "Update available: v99.99.99" in content
+        assert "/update" in content
+        assert "automatically" not in content
 
 
 async def test_version_slash_command_omits_update_hint_when_up_to_date() -> None:


### PR DESCRIPTION
The `/version` command's update-available line hard-coded `uv tool install -U deepagents-code`, which is stale guidance now that dcode auto-updates on relaunch and offers `/update` and `dcode update`. It now points at the relaunch/auto-update path when auto-update is enabled, and at `/update` or `dcode update` otherwise.

---

Made by [Open SWE](https://openswe.vercel.app/agents/a8b54b7c-cc2f-e6cc-a034-61a8578b8a04)