### PR TITLE
ci(infra): flag stale dependency minimums on release PRs

### DIFF
--- a/.github/scripts/check_dep_freshness.py
+++ b/.github/scripts/check_dep_freshness.py
@@ -71,19 +71,59 @@ class HTTPResponse(Protocol):
         """Read the response body."""
 
 
-OpenUrl = Callable[..., HTTPResponse]
+class OpenUrl(Protocol):
+    """A urllib-compatible opener that accepts a per-request timeout."""
+
+    def __call__(self, request: Request, *, timeout: float) -> HTTPResponse:
+        """Open a request and return a context-managed response."""
+
+
 FetchPyPI = Callable[[str], Mapping[str, object]]
 Sleep = Callable[[float], None]
 
 
 @dataclass(frozen=True)
 class DependencyDeclaration:
-    """A bounded dependency declared by one release package."""
+    """A bounded dependency declared by one release package.
+
+    Construct via `from_requirement`, which guarantees `minimum` is the concrete
+    lower bound derived from `requirement`.
+    """
 
     manifest_path: str
     package_name: str
     requirement: Requirement
     minimum: Version
+
+    @classmethod
+    def from_requirement(
+        cls, manifest_path: str, package_name: str, requirement: Requirement
+    ) -> Self | None:
+        """Build a declaration when the requirement has a concrete minimum.
+
+        Args:
+            manifest_path: Repository-relative release manifest path.
+            package_name: Name of the package being released.
+            requirement: Parsed dependency requirement.
+
+        Returns:
+            A declaration, or `None` when no concrete lower bound is declared.
+
+        """
+        minimum = extract_minimum(requirement.specifier)
+        if minimum is None:
+            return None
+        return cls(
+            manifest_path=manifest_path,
+            package_name=package_name,
+            requirement=requirement,
+            minimum=minimum,
+        )
+
+    @property
+    def canonical_name(self) -> str:
+        """Return the canonicalized distribution name."""
+        return canonicalize_name(self.requirement.name)
 
 
 @dataclass(frozen=True)
@@ -96,6 +136,20 @@ class StaleDependency:
     minimum: Version
     latest: Version
     within_upper_bound: bool
+
+    def __post_init__(self) -> None:
+        """Reject findings that are not actually stale.
+
+        Raises:
+            ValueError: If `latest` does not exceed `minimum`.
+
+        """
+        if self.latest <= self.minimum:
+            msg = (
+                f"StaleDependency requires latest > minimum, "
+                f"got {self.latest} <= {self.minimum}"
+            )
+            raise ValueError(msg)
 
 
 class PyPIRequestError(RuntimeError):
@@ -223,7 +277,7 @@ def latest_pypi_version(
         The greatest eligible PEP 440 version, or `None` when none is available.
 
     Raises:
-        TypeError: If the payload has no releases mapping.
+        TypeError: If the payload's `releases` value is missing or not a mapping.
 
     """
     releases = payload.get("releases")
@@ -342,7 +396,10 @@ def fetch_pypi_json(
 
 def _source_is_local(source: object) -> bool:
     if isinstance(source, Mapping):
-        return isinstance(source.get("path"), str) or source.get("workspace") is True
+        local = isinstance(source.get("path"), str) or source.get("workspace") is True
+        # A marker-guarded local source only applies on some platforms; the
+        # dependency can still resolve from PyPI elsewhere, so keep checking it.
+        return local and "marker" not in source
     if isinstance(source, list) and source:
         return all(_source_is_local(item) for item in source)
     return False
@@ -350,6 +407,9 @@ def _source_is_local(source: object) -> bool:
 
 def local_dependency_names(manifest: Mapping[str, object]) -> frozenset[str]:
     """Return dependency names backed only by local path/workspace uv sources.
+
+    Marker-guarded sources are excluded: because the marker can be false on some
+    platforms, the dependency may still resolve from PyPI and remains in scope.
 
     Args:
         manifest: Parsed `pyproject.toml` data.
@@ -432,21 +492,16 @@ def load_declarations(
             or canonical_name == self_name
         ):
             continue
-        minimum = extract_minimum(requirement.specifier)
-        if minimum is None:
+        declaration = DependencyDeclaration.from_requirement(
+            manifest_path, package_name, requirement
+        )
+        if declaration is None:
             continue
         key = (canonical_name, str(requirement.specifier))
         if key in seen:
             continue
         seen.add(key)
-        declarations.append(
-            DependencyDeclaration(
-                manifest_path=manifest_path,
-                package_name=package_name,
-                requirement=requirement,
-                minimum=minimum,
-            )
-        )
+        declarations.append(declaration)
     return declarations
 
 
@@ -573,7 +628,9 @@ def check_dependency_freshness(
         fetcher: Injectable PyPI fetcher for tests.
 
     Returns:
-        Zero. Lagging bounds and known PyPI failures are advisory.
+        Zero on normal completion; lagging bounds and known PyPI failures are
+        advisory. Unexpected errors (e.g. a malformed manifest or git failure)
+        propagate; `main` fail-closes on those with exit code 2.
 
     """
     packages = load_release_packages()
@@ -594,9 +651,7 @@ def check_dependency_freshness(
             packages[manifest_path.removesuffix("/pyproject.toml")],
         )
     ]
-    canonical_names = {
-        canonicalize_name(declaration.requirement.name) for declaration in declarations
-    }
+    canonical_names = {declaration.canonical_name for declaration in declarations}
     payloads, failures = _fetch_payloads(
         canonical_names,
         fetcher or fetch_pypi_json,
@@ -609,7 +664,7 @@ def check_dependency_freshness(
         _warning(f"Skipping {name} after a {kind}PyPI query failure: {failure}")
 
     for declaration in declarations:
-        canonical_name = canonicalize_name(declaration.requirement.name)
+        canonical_name = declaration.canonical_name
         payload = payloads.get(canonical_name)
         if payload is None:
             continue
@@ -681,7 +736,7 @@ def main() -> int:
     try:
         policy = PrereleasePolicy(raw_policy)
     except ValueError:
-        choices = ", ".join(policy.value for policy in PrereleasePolicy)
+        choices = ", ".join(option.value for option in PrereleasePolicy)
         _error(f"{PRERELEASE_POLICY_ENV} must be one of: {choices}")
         return 2
 

--- a/.github/scripts/check_dep_freshness.py
+++ b/.github/scripts/check_dep_freshness.py
@@ -1,0 +1,696 @@
+"""Report release-package dependency minimums that trail published PyPI versions."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import tomllib
+from collections.abc import Callable, Mapping
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from enum import StrEnum
+from http.client import HTTPException
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol, Self
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from check_release_deps import (
+    _write_output,
+    _write_step_summary,
+    changed_manifests,
+    load_release_packages,
+)
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
+
+if TYPE_CHECKING:
+    from packaging.specifiers import SpecifierSet
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BYPASS_LABEL = "release-deps: acknowledged"
+COMMENT_MARKER = "<!-- dep-freshness-check -->"
+PRERELEASE_POLICY_ENV = "DEP_FRESHNESS_PRERELEASE_POLICY"
+DEFAULT_REQUEST_TIMEOUT = 5.0
+DEFAULT_REQUEST_ATTEMPTS = 3
+MAX_FETCH_WORKERS = 8
+MAX_RETRY_DELAY = 5.0
+SERVER_ERROR_MIN = 500
+SERVER_ERROR_MAX = 600
+TRANSIENT_HTTP_STATUSES = frozenset({408, 425, 429})
+LOWER_BOUND_OPERATORS = frozenset({">=", "~=", "=="})
+UPPER_BOUND_OPERATORS = frozenset({"<", "<=", "~=", "=="})
+
+
+class PrereleasePolicy(StrEnum):
+    """Control when published pre-releases participate in comparisons."""
+
+    BOUND = "bound"
+    ALWAYS = "always"
+    NEVER = "never"
+
+
+class HTTPResponse(Protocol):
+    """Subset of an urllib response used by the PyPI client."""
+
+    def __enter__(self) -> Self:
+        """Enter the response context."""
+
+    def __exit__(
+        self,
+        exc_type: object,
+        exc_value: object,
+        traceback: object,
+    ) -> bool | None:
+        """Exit the response context."""
+
+    def read(self) -> bytes:
+        """Read the response body."""
+
+
+OpenUrl = Callable[..., HTTPResponse]
+FetchPyPI = Callable[[str], Mapping[str, object]]
+Sleep = Callable[[float], None]
+
+
+@dataclass(frozen=True)
+class DependencyDeclaration:
+    """A bounded dependency declared by one release package."""
+
+    manifest_path: str
+    package_name: str
+    requirement: Requirement
+    minimum: Version
+
+
+@dataclass(frozen=True)
+class StaleDependency:
+    """A dependency whose published version is newer than its declared minimum."""
+
+    manifest_path: str
+    package_name: str
+    dependency_name: str
+    minimum: Version
+    latest: Version
+    within_upper_bound: bool
+
+
+class PyPIRequestError(RuntimeError):
+    """A known failure while querying or decoding a PyPI response."""
+
+    def __init__(self, message: str, *, transient: bool) -> None:
+        """Initialize a PyPI request failure.
+
+        Args:
+            message: Human-readable failure detail.
+            transient: Whether retrying later could reasonably succeed.
+
+        """
+        super().__init__(message)
+        self.transient = transient
+
+
+class _InvalidPyPIResponseError(ValueError):
+    """Raised when PyPI returns a response that cannot be decoded safely."""
+
+
+def _notice(message: str) -> None:
+    print(f"::notice::{message}")
+
+
+def _warning(message: str) -> None:
+    print(f"::warning::{message}")
+
+
+def _file_warning(path: str, message: str) -> None:
+    print(f"::warning file={path}::{message}")
+
+
+def _error(message: str) -> None:
+    print(f"::error::{message}")
+
+
+def extract_minimum(specifiers: SpecifierSet) -> Version | None:
+    """Return the strongest concrete `>=`, `~=`, or `==` lower bound.
+
+    Wildcard equality constraints such as `==1.2.*` do not identify one concrete
+    minimum and are ignored. If another supported concrete lower bound is present,
+    it can still establish the minimum.
+
+    Args:
+        specifiers: Parsed requirement specifiers.
+
+    Returns:
+        The greatest concrete lower-bound version, or `None` when none is declared.
+
+    """
+    candidates: list[Version] = []
+    for specifier in specifiers:
+        if specifier.operator not in LOWER_BOUND_OPERATORS:
+            continue
+        if specifier.operator == "==" and "*" in specifier.version:
+            continue
+        try:
+            candidates.append(Version(specifier.version))
+        except InvalidVersion:
+            continue
+    return max(candidates, default=None)
+
+
+def includes_prereleases(policy: PrereleasePolicy, minimum: Version) -> bool:
+    """Return whether pre-releases should be considered for one dependency.
+
+    Args:
+        policy: Configured pre-release comparison policy.
+        minimum: Declared concrete minimum version.
+
+    Returns:
+        Whether eligible published pre-releases should participate.
+
+    """
+    if policy is PrereleasePolicy.ALWAYS:
+        return True
+    if policy is PrereleasePolicy.NEVER:
+        return False
+    return minimum.is_prerelease
+
+
+def within_upper_bound(requirement: Requirement, version: Version) -> bool:
+    """Return whether a version satisfies every upper-bound-like specifier.
+
+    Args:
+        requirement: Parsed dependency requirement.
+        version: Published version being compared.
+
+    Returns:
+        `True` when no upper bound exists or the version remains below it.
+
+    """
+    upper_bounds = [
+        specifier
+        for specifier in requirement.specifier
+        if specifier.operator in UPPER_BOUND_OPERATORS
+    ]
+    return all(
+        specifier.contains(version, prereleases=True) for specifier in upper_bounds
+    )
+
+
+def _release_is_available(files: object) -> bool:
+    if not isinstance(files, list) or not files:
+        return False
+    valid_files = [item for item in files if isinstance(item, Mapping)]
+    return bool(valid_files) and any(
+        item.get("yanked") is not True for item in valid_files
+    )
+
+
+def latest_pypi_version(
+    payload: Mapping[str, object], *, include_prereleases: bool
+) -> Version | None:
+    """Select the newest usable PyPI release from a project JSON response.
+
+    Empty releases and releases whose every file is yanked are ignored.
+
+    Args:
+        payload: Decoded PyPI project JSON.
+        include_prereleases: Whether pre/dev releases are eligible.
+
+    Returns:
+        The greatest eligible PEP 440 version, or `None` when none is available.
+
+    Raises:
+        TypeError: If the payload has no releases mapping.
+
+    """
+    releases = payload.get("releases")
+    if not isinstance(releases, Mapping):
+        msg = "PyPI response has no releases mapping"
+        raise TypeError(msg)
+
+    candidates: list[Version] = []
+    for raw_version, files in releases.items():
+        if not isinstance(raw_version, str) or not _release_is_available(files):
+            continue
+        try:
+            version = Version(raw_version)
+        except InvalidVersion:
+            continue
+        if version.is_prerelease and not include_prereleases:
+            continue
+        candidates.append(version)
+    return max(candidates, default=None)
+
+
+def _decode_pypi_response(raw: bytes) -> Mapping[str, object]:
+    try:
+        payload: object = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as err:
+        msg = f"invalid JSON response: {err}"
+        raise _InvalidPyPIResponseError(msg) from err
+    if not isinstance(payload, dict) or not isinstance(payload.get("releases"), dict):
+        msg = "JSON response does not contain a releases object"
+        raise _InvalidPyPIResponseError(msg)
+    return payload
+
+
+def _retry_delay(error: HTTPError | None, attempt: int) -> float:
+    retry_after = error.headers.get("Retry-After") if error and error.headers else None
+    if retry_after:
+        try:
+            return min(MAX_RETRY_DELAY, max(0.0, float(retry_after)))
+        except ValueError:
+            pass
+    return min(MAX_RETRY_DELAY, 0.25 * (2**attempt))
+
+
+def _is_transient_status(status: int) -> bool:
+    return (
+        status in TRANSIENT_HTTP_STATUSES
+        or SERVER_ERROR_MIN <= status < SERVER_ERROR_MAX
+    )
+
+
+def fetch_pypi_json(
+    name: str,
+    *,
+    attempts: int = DEFAULT_REQUEST_ATTEMPTS,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT,
+    opener: OpenUrl | None = None,
+    sleep: Sleep = time.sleep,
+) -> Mapping[str, object]:
+    """Fetch one project's PyPI JSON with bounded retries.
+
+    Args:
+        name: Distribution name, which is canonicalized before querying.
+        attempts: Maximum number of HTTP attempts.
+        timeout: Timeout in seconds for each attempt.
+        opener: Injectable urllib-compatible opener for tests.
+        sleep: Injectable delay function for tests.
+
+    Returns:
+        Decoded PyPI JSON response.
+
+    Raises:
+        ValueError: If `attempts` is less than one.
+        PyPIRequestError: If PyPI cannot provide a usable response.
+
+    """
+    if attempts < 1:
+        msg = "attempts must be at least 1"
+        raise ValueError(msg)
+
+    canonical_name = canonicalize_name(name)
+    url = f"https://pypi.org/pypi/{quote(canonical_name, safe='')}/json"
+    request = Request(  # noqa: S310  # URL is fixed to the HTTPS PyPI origin.
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "langchain-ai/deepagents-dependency-freshness-check",
+        },
+    )
+    open_url = opener or urlopen
+
+    for attempt in range(attempts):
+        try:
+            with open_url(request, timeout=timeout) as response:
+                return _decode_pypi_response(response.read())
+        except HTTPError as err:
+            transient = _is_transient_status(err.code)
+            if not transient or attempt == attempts - 1:
+                msg = f"PyPI returned HTTP {err.code} for {canonical_name}"
+                raise PyPIRequestError(msg, transient=transient) from err
+            sleep(_retry_delay(err, attempt))
+        except (
+            URLError,
+            TimeoutError,
+            OSError,
+            HTTPException,
+            _InvalidPyPIResponseError,
+        ) as err:
+            if attempt == attempts - 1:
+                msg = f"PyPI request failed for {canonical_name}: {err}"
+                raise PyPIRequestError(msg, transient=True) from err
+            sleep(_retry_delay(None, attempt))
+
+    msg = f"PyPI request exhausted retries for {canonical_name}"
+    raise PyPIRequestError(msg, transient=True)
+
+
+def _source_is_local(source: object) -> bool:
+    if isinstance(source, Mapping):
+        return isinstance(source.get("path"), str) or source.get("workspace") is True
+    if isinstance(source, list) and source:
+        return all(_source_is_local(item) for item in source)
+    return False
+
+
+def local_dependency_names(manifest: Mapping[str, object]) -> frozenset[str]:
+    """Return dependency names backed only by local path/workspace uv sources.
+
+    Args:
+        manifest: Parsed `pyproject.toml` data.
+
+    Returns:
+        Canonicalized local distribution names.
+
+    """
+    tool = manifest.get("tool")
+    if not isinstance(tool, Mapping):
+        return frozenset()
+    uv = tool.get("uv")
+    if not isinstance(uv, Mapping):
+        return frozenset()
+    sources = uv.get("sources")
+    if not isinstance(sources, Mapping):
+        return frozenset()
+    return frozenset(
+        canonicalize_name(name)
+        for name, source in sources.items()
+        if isinstance(name, str) and _source_is_local(source)
+    )
+
+
+def _declared_requirement_strings(project: Mapping[str, object]) -> list[str]:
+    requirements: list[str] = []
+    dependencies = project.get("dependencies", [])
+    if isinstance(dependencies, list):
+        requirements.extend(item for item in dependencies if isinstance(item, str))
+
+    optional = project.get("optional-dependencies", {})
+    if isinstance(optional, Mapping):
+        for values in optional.values():
+            if isinstance(values, list):
+                requirements.extend(item for item in values if isinstance(item, str))
+    return requirements
+
+
+def load_declarations(
+    manifest_path: str, package_name: str
+) -> list[DependencyDeclaration]:
+    """Load bounded, non-local runtime dependency declarations from a manifest.
+
+    Args:
+        manifest_path: Repository-relative release manifest path.
+        package_name: Name of the package being released.
+
+    Returns:
+        De-duplicated dependency declarations with concrete minimums.
+
+    Raises:
+        TypeError: If the manifest has no valid project table.
+
+    """
+    manifest = tomllib.loads((REPO_ROOT / manifest_path).read_text(encoding="utf-8"))
+    project = manifest.get("project")
+    if not isinstance(project, Mapping):
+        msg = f"{manifest_path} has no [project] table"
+        raise TypeError(msg)
+
+    local_names = local_dependency_names(manifest)
+    project_name = project.get("name")
+    self_name = (
+        canonicalize_name(project_name) if isinstance(project_name, str) else None
+    )
+    declarations: list[DependencyDeclaration] = []
+    seen: set[tuple[str, str]] = set()
+
+    for raw_requirement in _declared_requirement_strings(project):
+        try:
+            requirement = Requirement(raw_requirement)
+        except InvalidRequirement as err:
+            _warning(f"Skipping invalid requirement in {manifest_path}: {err}")
+            continue
+
+        canonical_name = canonicalize_name(requirement.name)
+        if (
+            requirement.url
+            or canonical_name in local_names
+            or canonical_name == self_name
+        ):
+            continue
+        minimum = extract_minimum(requirement.specifier)
+        if minimum is None:
+            continue
+        key = (canonical_name, str(requirement.specifier))
+        if key in seen:
+            continue
+        seen.add(key)
+        declarations.append(
+            DependencyDeclaration(
+                manifest_path=manifest_path,
+                package_name=package_name,
+                requirement=requirement,
+                minimum=minimum,
+            )
+        )
+    return declarations
+
+
+def _fetch_payloads(
+    names: set[str], fetcher: FetchPyPI
+) -> tuple[dict[str, Mapping[str, object]], dict[str, PyPIRequestError]]:
+    payloads: dict[str, Mapping[str, object]] = {}
+    failures: dict[str, PyPIRequestError] = {}
+    if not names:
+        return payloads, failures
+
+    workers = min(MAX_FETCH_WORKERS, len(names))
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(fetcher, name): name for name in sorted(names)}
+        for future in as_completed(futures):
+            name = futures[future]
+            try:
+                payloads[name] = future.result()
+            except PyPIRequestError as err:
+                failures[name] = err
+    return payloads, failures
+
+
+def _policy_description(policy: PrereleasePolicy) -> str:
+    if policy is PrereleasePolicy.ALWAYS:
+        return "Pre-releases are included for every dependency."
+    if policy is PrereleasePolicy.NEVER:
+        return "Pre-releases are ignored for every dependency."
+    return (
+        "Pre-releases are included only when the declared minimum is itself a "
+        "pre-release."
+    )
+
+
+def freshness_markdown(
+    findings: list[StaleDependency],
+    *,
+    policy: PrereleasePolicy,
+    unavailable: tuple[str, ...] = (),
+    include_marker: bool,
+) -> str:
+    """Render dependency freshness findings as Markdown.
+
+    Args:
+        findings: Lagging dependency minimums.
+        policy: Pre-release comparison policy used by the check.
+        unavailable: Dependencies that could not be queried completely.
+        include_marker: Whether to prefix the PR-comment marker.
+
+    Returns:
+        A Markdown report suitable for a step summary or PR comment.
+
+    """
+    lines: list[str] = []
+    if include_marker:
+        lines.append(COMMENT_MARKER)
+    lines.extend(
+        [
+            "## Dependency minimums trail PyPI",
+            "",
+            (
+                "The following release-package dependencies have a newer published "
+                "version than their declared minimum:"
+            ),
+            "",
+            (
+                "| Package | Dependency | Current min | Latest on PyPI | "
+                "Within current upper bound? |"
+            ),
+            "|---|---|---:|---:|:---:|",
+        ]
+    )
+    for finding in sorted(
+        findings,
+        key=lambda item: (item.package_name, canonicalize_name(item.dependency_name)),
+    ):
+        within = "Yes" if finding.within_upper_bound else "**No**"
+        lines.append(
+            f"| `{finding.package_name}` | `{finding.dependency_name}` | "
+            f"`{finding.minimum}` | `{finding.latest}` | {within} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            _policy_description(policy),
+            "Local path/workspace dependencies from `[tool.uv.sources]` are excluded.",
+            "",
+            (
+                "This check is advisory. Bump dependency bounds where appropriate, "
+                f"or apply the `{BYPASS_LABEL}` label to record that the release "
+                "dependencies were reviewed."
+            ),
+        ]
+    )
+    if unavailable:
+        names = ", ".join(f"`{name}`" for name in unavailable)
+        lines.extend(
+            [
+                "",
+                (
+                    "> [!WARNING]\n> PyPI could not be queried completely for: "
+                    f"{names}. Re-run the check before relying on this report as "
+                    "exhaustive."
+                ),
+            ]
+        )
+    return "\n".join(lines)
+
+
+def check_dependency_freshness(
+    base_sha: str,
+    head_sha: str,
+    *,
+    policy: PrereleasePolicy = PrereleasePolicy.BOUND,
+    fetcher: FetchPyPI | None = None,
+) -> int:
+    """Check changed release manifests and emit advisory GitHub Actions outputs.
+
+    Args:
+        base_sha: Pull request base commit.
+        head_sha: Pull request head commit.
+        policy: Pre-release comparison policy.
+        fetcher: Injectable PyPI fetcher for tests.
+
+    Returns:
+        Zero. Lagging bounds and known PyPI failures are advisory.
+
+    """
+    packages = load_release_packages()
+    manifests = changed_manifests(base_sha, head_sha, list(packages))
+    if not manifests:
+        _notice("No release-package pyproject.toml files changed; nothing to check.")
+        _write_output("stale", "false")
+        _write_output("indeterminate", "false")
+        _write_output("comment_body", "")
+        return 0
+
+    _notice(f"Changed package manifests: {', '.join(manifests)}")
+    declarations = [
+        declaration
+        for manifest_path in manifests
+        for declaration in load_declarations(
+            manifest_path,
+            packages[manifest_path.removesuffix("/pyproject.toml")],
+        )
+    ]
+    canonical_names = {
+        canonicalize_name(declaration.requirement.name) for declaration in declarations
+    }
+    payloads, failures = _fetch_payloads(
+        canonical_names,
+        fetcher or fetch_pypi_json,
+    )
+
+    findings: list[StaleDependency] = []
+    unavailable = set(failures)
+    for name, failure in sorted(failures.items()):
+        kind = "transient " if failure.transient else ""
+        _warning(f"Skipping {name} after a {kind}PyPI query failure: {failure}")
+
+    for declaration in declarations:
+        canonical_name = canonicalize_name(declaration.requirement.name)
+        payload = payloads.get(canonical_name)
+        if payload is None:
+            continue
+        try:
+            latest = latest_pypi_version(
+                payload,
+                include_prereleases=includes_prereleases(policy, declaration.minimum),
+            )
+        except TypeError as err:
+            unavailable.add(canonical_name)
+            _warning(f"Skipping malformed PyPI data for {canonical_name}: {err}")
+            continue
+        if latest is None:
+            _notice(
+                f"No eligible published release found for {canonical_name}; skipping."
+            )
+            continue
+        if latest <= declaration.minimum:
+            continue
+        finding = StaleDependency(
+            manifest_path=declaration.manifest_path,
+            package_name=declaration.package_name,
+            dependency_name=declaration.requirement.name,
+            minimum=declaration.minimum,
+            latest=latest,
+            within_upper_bound=within_upper_bound(declaration.requirement, latest),
+        )
+        findings.append(finding)
+        _file_warning(
+            finding.manifest_path,
+            f"{finding.dependency_name} minimum {finding.minimum} trails PyPI "
+            f"{finding.latest}",
+        )
+
+    unavailable_names = tuple(sorted(unavailable))
+    _write_output("stale", "true" if findings else "false")
+    _write_output("indeterminate", "true" if unavailable_names else "false")
+    if findings:
+        summary = freshness_markdown(
+            findings,
+            policy=policy,
+            unavailable=unavailable_names,
+            include_marker=False,
+        )
+        _write_step_summary(summary)
+        _write_output(
+            "comment_body",
+            freshness_markdown(
+                findings,
+                policy=policy,
+                unavailable=unavailable_names,
+                include_marker=True,
+            ),
+        )
+    else:
+        _write_output("comment_body", "")
+    return 0
+
+
+def main() -> int:
+    """Run the dependency freshness check for a pull request diff."""
+    base_sha = os.environ.get("BASE_SHA")
+    head_sha = os.environ.get("HEAD_SHA")
+    if not base_sha or not head_sha:
+        _error("BASE_SHA and HEAD_SHA must be set")
+        return 2
+
+    raw_policy = os.environ.get(PRERELEASE_POLICY_ENV, PrereleasePolicy.BOUND.value)
+    try:
+        policy = PrereleasePolicy(raw_policy)
+    except ValueError:
+        choices = ", ".join(policy.value for policy in PrereleasePolicy)
+        _error(f"{PRERELEASE_POLICY_ENV} must be one of: {choices}")
+        return 2
+
+    try:
+        return check_dependency_freshness(base_sha, head_sha, policy=policy)
+    except Exception as err:  # noqa: BLE001  # fail closed on script defects
+        _error(f"Dependency freshness check failed unexpectedly: {err}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_check_dep_freshness.py
+++ b/.github/scripts/test_check_dep_freshness.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import json
 from email.message import Message
+from pathlib import Path
 from typing import TYPE_CHECKING, Self
 from urllib.error import HTTPError, URLError
 
 import pytest
 
 if TYPE_CHECKING:
-    from pathlib import Path
     from urllib.request import Request
 from check_dep_freshness import (
     BYPASS_LABEL,
@@ -426,6 +426,20 @@ def test_check_dependency_freshness_warns_without_failing_on_transient_error(
     assert written.count("\ntrue\n") == 1
     assert COMMENT_MARKER not in written
     assert "transient PyPI query failure" in capsys.readouterr().out
+
+
+def test_comment_workflow_preserves_existing_report_on_partial_pypi_failure() -> None:
+    workflow = (
+        Path(__file__).parents[1] / "workflows/check_dep_freshness.yml"
+    ).read_text(encoding="utf-8")
+    preserve = "if (indeterminate && existing) {"
+    update = "await github.rest.issues.updateComment"
+
+    assert preserve in workflow
+    preserve_start = workflow.index(preserve)
+    update_start = workflow.index(update)
+    assert preserve_start < update_start
+    assert "return;" in workflow[preserve_start:update_start]
 
 
 def test_check_dependency_freshness_noops_without_changed_manifests(

--- a/.github/scripts/test_check_dep_freshness.py
+++ b/.github/scripts/test_check_dep_freshness.py
@@ -1,0 +1,477 @@
+"""Tests for the release dependency freshness helper."""
+
+from __future__ import annotations
+
+import json
+from email.message import Message
+from typing import TYPE_CHECKING, Self
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from urllib.request import Request
+from check_dep_freshness import (
+    BYPASS_LABEL,
+    COMMENT_MARKER,
+    PRERELEASE_POLICY_ENV,
+    DependencyDeclaration,
+    PrereleasePolicy,
+    PyPIRequestError,
+    StaleDependency,
+    check_dependency_freshness,
+    extract_minimum,
+    fetch_pypi_json,
+    freshness_markdown,
+    includes_prereleases,
+    latest_pypi_version,
+    load_declarations,
+    local_dependency_names,
+    main,
+    within_upper_bound,
+)
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+
+class FakeResponse:
+    """Minimal context-managed HTTP response for urllib client tests."""
+
+    def __init__(self, payload: object, *, raw: bool = False) -> None:
+        """Store a JSON payload or pre-encoded response body."""
+        self.body = payload if raw else json.dumps(payload).encode()
+
+    def __enter__(self) -> Self:
+        """Return this fake response."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: object,
+        exc_value: object,
+        traceback: object,
+    ) -> None:
+        """Leave the fake response context."""
+
+    def read(self) -> bytes:
+        """Return the configured response body."""
+        assert isinstance(self.body, bytes)
+        return self.body
+
+
+class SequenceOpener:
+    """Return or raise configured outcomes in order."""
+
+    def __init__(self, outcomes: list[FakeResponse | Exception]) -> None:
+        """Initialize response outcomes."""
+        self.outcomes = outcomes
+        self.requests: list[tuple[Request, float]] = []
+
+    def __call__(self, request: Request, *, timeout: float) -> FakeResponse:
+        """Record a request and consume the next outcome."""
+        self.requests.append((request, timeout))
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def pypi_payload(**releases: list[dict[str, object]]) -> dict[str, object]:
+    """Build a minimal PyPI JSON payload."""
+    return {"releases": releases}
+
+
+@pytest.mark.parametrize(
+    ("requirement", "expected"),
+    [
+        ("demo>=1.2,<2", Version("1.2")),
+        ("demo~=1.4.5", Version("1.4.5")),
+        ("demo==2.0.1", Version("2.0.1")),
+        ("demo>=1,>=2,<3", Version("2")),
+        ("demo==1.2.*,>=1", Version("1")),
+        ("demo==1.2.*", None),
+        ("demo<3", None),
+        ("demo", None),
+    ],
+)
+def test_extract_minimum(requirement: str, expected: Version | None) -> None:
+    assert extract_minimum(Requirement(requirement).specifier) == expected
+
+
+def test_prerelease_policy_defaults_to_bound_type() -> None:
+    stable = Version("1.0")
+    prerelease = Version("1.0a1")
+
+    assert not includes_prereleases(PrereleasePolicy.BOUND, stable)
+    assert includes_prereleases(PrereleasePolicy.BOUND, prerelease)
+    assert includes_prereleases(PrereleasePolicy.ALWAYS, stable)
+    assert not includes_prereleases(PrereleasePolicy.NEVER, prerelease)
+
+
+def test_latest_pypi_version_ignores_prereleases_for_stable_bound() -> None:
+    payload = pypi_payload(
+        **{
+            "1.0": [{"yanked": False}],
+            "1.1rc1": [{"yanked": False}],
+            "2.0.dev1": [{"yanked": False}],
+        }
+    )
+
+    assert latest_pypi_version(payload, include_prereleases=False) == Version("1.0")
+    assert latest_pypi_version(payload, include_prereleases=True) == Version("2.0.dev1")
+
+
+def test_latest_pypi_version_ignores_invalid_empty_and_fully_yanked_releases() -> None:
+    payload = pypi_payload(
+        **{
+            "not-a-version": [{"yanked": False}],
+            "1.0": [],
+            "1.1": [{"yanked": True}],
+            "1.2": [{"yanked": True}, {"yanked": False}],
+        }
+    )
+
+    assert latest_pypi_version(payload, include_prereleases=False) == Version("1.2")
+
+
+def test_latest_pypi_version_rejects_missing_releases() -> None:
+    with pytest.raises(TypeError, match="releases mapping"):
+        latest_pypi_version({}, include_prereleases=False)
+
+
+@pytest.mark.parametrize(
+    ("requirement", "version", "expected"),
+    [
+        ("demo>=1", "9", True),
+        ("demo>=1,<3", "2.9", True),
+        ("demo>=1,<3", "3", False),
+        ("demo~=1.4", "1.9", True),
+        ("demo~=1.4", "2.0", False),
+        ("demo==1.4", "2.0", False),
+    ],
+)
+def test_within_upper_bound(requirement: str, version: str, expected: bool) -> None:
+    assert within_upper_bound(Requirement(requirement), Version(version)) is expected
+
+
+def test_local_dependency_names_only_includes_exclusively_local_sources() -> None:
+    manifest = {
+        "tool": {
+            "uv": {
+                "sources": {
+                    "DeepAgents": {"path": "../deepagents", "editable": True},
+                    "workspace-package": {"workspace": True},
+                    "conditional-local": [
+                        {"path": "../one", "marker": "sys_platform == 'darwin'"},
+                        {"path": "../two", "marker": "sys_platform != 'darwin'"},
+                    ],
+                    "mixed": [
+                        {"path": "../local"},
+                        {"git": "https://example.test/repo"},
+                    ],
+                    "remote": {"git": "https://example.test/repo"},
+                }
+            }
+        }
+    }
+
+    assert local_dependency_names(manifest) == frozenset(
+        {"deepagents", "workspace-package", "conditional-local"}
+    )
+
+
+def test_load_declarations_reads_required_and_optional_and_skips_local(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    path = tmp_path / manifest_path
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        """
+[project]
+name = "example"
+dependencies = [
+    "deepagents>=1",
+    "requests>=2,<3",
+    "bare-package",
+    "remote @ https://example.test/remote.whl",
+]
+
+[project.optional-dependencies]
+extra = ["requests>=2,<3", "httpx~=0.28"]
+
+[tool.uv.sources]
+deepagents = { path = "../deepagents", editable = true }
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("check_dep_freshness.REPO_ROOT", tmp_path)
+
+    declarations = load_declarations(manifest_path, "example")
+
+    assert [(item.requirement.name, item.minimum) for item in declarations] == [
+        ("requests", Version("2")),
+        ("httpx", Version("0.28")),
+    ]
+
+
+def test_fetch_pypi_json_builds_canonical_request() -> None:
+    opener = SequenceOpener([FakeResponse(pypi_payload(**{"1.0": [{}]}))])
+
+    payload = fetch_pypi_json("Demo_Package", opener=opener, sleep=lambda _delay: None)
+
+    assert latest_pypi_version(payload, include_prereleases=False) == Version("1.0")
+    request, timeout = opener.requests[0]
+    assert request.full_url == "https://pypi.org/pypi/demo-package/json"
+    assert request.get_header("Accept") == "application/json"
+    assert "deepagents" in request.get_header("User-agent")
+    assert timeout == 5.0
+
+
+def test_fetch_pypi_json_retries_transient_http_error() -> None:
+    headers = Message()
+    headers["Retry-After"] = "999"
+    error = HTTPError("https://pypi.org", 503, "unavailable", headers, None)
+    opener = SequenceOpener(
+        [error, FakeResponse(pypi_payload(**{"1.0": [{"yanked": False}]}))]
+    )
+    delays: list[float] = []
+
+    payload = fetch_pypi_json("demo", opener=opener, sleep=delays.append)
+
+    assert latest_pypi_version(payload, include_prereleases=False) == Version("1.0")
+    assert len(opener.requests) == 2
+    assert delays == [5.0]
+
+
+def test_fetch_pypi_json_retries_malformed_response() -> None:
+    opener = SequenceOpener(
+        [
+            FakeResponse(b"not json", raw=True),
+            FakeResponse(pypi_payload(**{"1.0": [{}]})),
+        ]
+    )
+
+    payload = fetch_pypi_json("demo", opener=opener, sleep=lambda _delay: None)
+
+    assert latest_pypi_version(payload, include_prereleases=False) == Version("1.0")
+    assert len(opener.requests) == 2
+
+
+def test_fetch_pypi_json_marks_exhausted_network_error_transient() -> None:
+    opener = SequenceOpener([URLError("offline"), URLError("offline")])
+
+    with pytest.raises(PyPIRequestError, match="offline") as exc_info:
+        fetch_pypi_json(
+            "demo",
+            attempts=2,
+            opener=opener,
+            sleep=lambda _delay: None,
+        )
+
+    assert exc_info.value.transient
+    assert len(opener.requests) == 2
+
+
+def test_fetch_pypi_json_does_not_retry_not_found() -> None:
+    error = HTTPError("https://pypi.org", 404, "not found", Message(), None)
+    opener = SequenceOpener([error])
+
+    with pytest.raises(PyPIRequestError, match="HTTP 404") as exc_info:
+        fetch_pypi_json("demo", opener=opener, sleep=lambda _delay: None)
+
+    assert not exc_info.value.transient
+    assert len(opener.requests) == 1
+
+
+def finding(*, within: bool = True) -> StaleDependency:
+    """Build one dependency freshness finding."""
+    return StaleDependency(
+        manifest_path="libs/deepagents/pyproject.toml",
+        package_name="deepagents",
+        dependency_name="langchain",
+        minimum=Version("1.0"),
+        latest=Version("1.1"),
+        within_upper_bound=within,
+    )
+
+
+def test_freshness_markdown_formats_table_policy_and_marker() -> None:
+    markdown = freshness_markdown(
+        [finding(within=False)],
+        policy=PrereleasePolicy.BOUND,
+        unavailable=("langsmith",),
+        include_marker=True,
+    )
+
+    assert markdown.startswith(COMMENT_MARKER)
+    assert "| `deepagents` | `langchain` | `1.0` | `1.1` | **No** |" in markdown
+    assert "only when the declared minimum is itself a pre-release" in markdown
+    assert "`langsmith`" in markdown
+    assert BYPASS_LABEL in markdown
+
+
+def _write_manifest(tmp_path: Path, manifest_path: str, dependency: str) -> None:
+    path = tmp_path / manifest_path
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        f"""
+[project]
+name = "example"
+version = "0.1.0"
+dependencies = ["{dependency}"]
+""".strip(),
+        encoding="utf-8",
+    )
+
+
+def _configure_check(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    manifest_path: str,
+) -> Path:
+    output = tmp_path / "github_output"
+    summary = tmp_path / "github_summary"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.setattr("check_dep_freshness.REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        "check_dep_freshness.load_release_packages",
+        lambda: {"libs/example": "example"},
+    )
+    monkeypatch.setattr(
+        "check_dep_freshness.changed_manifests",
+        lambda _base, _head, _packages: [manifest_path],
+    )
+    return output
+
+
+def test_check_dependency_freshness_emits_advisory_stale_outputs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    _write_manifest(tmp_path, manifest_path, "demo>=1,<3")
+    output = _configure_check(monkeypatch, tmp_path, manifest_path)
+    calls: list[str] = []
+
+    def fetcher(name: str) -> dict[str, object]:
+        calls.append(name)
+        return pypi_payload(**{"2.0": [{"yanked": False}]})
+
+    assert check_dependency_freshness("base", "head", fetcher=fetcher) == 0
+
+    written = output.read_text(encoding="utf-8")
+    assert "stale<<" in written
+    assert "\ntrue\n" in written
+    assert "indeterminate<<" in written
+    assert COMMENT_MARKER in written
+    assert calls == ["demo"]
+    assert (
+        (tmp_path / "github_summary")
+        .read_text(encoding="utf-8")
+        .startswith("## Dependency minimums trail PyPI")
+    )
+
+
+def test_check_dependency_freshness_fetches_each_canonical_project_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    path = tmp_path / manifest_path
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        """
+[project]
+name = "example"
+dependencies = ["demo>=1", "Demo>=0.9,<3"]
+
+[project.optional-dependencies]
+extra = ["demo~=1.0"]
+""".strip(),
+        encoding="utf-8",
+    )
+    _configure_check(monkeypatch, tmp_path, manifest_path)
+    calls: list[str] = []
+
+    def fetcher(name: str) -> dict[str, object]:
+        calls.append(name)
+        return pypi_payload(**{"2.0": [{"yanked": False}]})
+
+    assert check_dependency_freshness("base", "head", fetcher=fetcher) == 0
+    assert calls == ["demo"]
+
+
+def test_check_dependency_freshness_warns_without_failing_on_transient_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    _write_manifest(tmp_path, manifest_path, "demo>=1")
+    output = _configure_check(monkeypatch, tmp_path, manifest_path)
+
+    def fetcher(_name: str) -> dict[str, object]:
+        msg = "PyPI is unavailable"
+        raise PyPIRequestError(msg, transient=True)
+
+    assert check_dependency_freshness("base", "head", fetcher=fetcher) == 0
+
+    written = output.read_text(encoding="utf-8")
+    assert "stale<<" in written
+    assert "indeterminate<<" in written
+    assert written.count("\ntrue\n") == 1
+    assert COMMENT_MARKER not in written
+    assert "transient PyPI query failure" in capsys.readouterr().out
+
+
+def test_check_dependency_freshness_noops_without_changed_manifests(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "github_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    monkeypatch.setattr(
+        "check_dep_freshness.load_release_packages",
+        lambda: {"libs/example": "example"},
+    )
+    monkeypatch.setattr(
+        "check_dep_freshness.changed_manifests",
+        lambda _base, _head, _packages: [],
+    )
+
+    assert check_dependency_freshness("base", "head") == 0
+    written = output.read_text(encoding="utf-8")
+    assert written.count("\nfalse\n") == 2
+    assert COMMENT_MARKER not in written
+
+
+def test_main_rejects_invalid_prerelease_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BASE_SHA", "base")
+    monkeypatch.setenv("HEAD_SHA", "head")
+    monkeypatch.setenv(PRERELEASE_POLICY_ENV, "sometimes")
+
+    assert main() == 2
+
+
+def test_main_requires_pull_request_shas(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BASE_SHA", raising=False)
+    monkeypatch.delenv("HEAD_SHA", raising=False)
+
+    assert main() == 2
+
+
+def test_declaration_dataclass_keeps_parsed_requirement() -> None:
+    declaration = DependencyDeclaration(
+        manifest_path="libs/example/pyproject.toml",
+        package_name="example",
+        requirement=Requirement("demo>=1"),
+        minimum=Version("1"),
+    )
+
+    assert declaration.requirement.name == "demo"

--- a/.github/scripts/test_check_dep_freshness.py
+++ b/.github/scripts/test_check_dep_freshness.py
@@ -162,9 +162,12 @@ def test_local_dependency_names_only_includes_exclusively_local_sources() -> Non
                 "sources": {
                     "DeepAgents": {"path": "../deepagents", "editable": True},
                     "workspace-package": {"workspace": True},
-                    "conditional-local": [
+                    "conditional-alternatives": [
                         {"path": "../one", "marker": "sys_platform == 'darwin'"},
                         {"path": "../two", "marker": "sys_platform != 'darwin'"},
+                    ],
+                    "conditional-fallback": [
+                        {"path": "../local", "marker": "sys_platform == 'darwin'"}
                     ],
                     "mixed": [
                         {"path": "../local"},
@@ -177,8 +180,35 @@ def test_local_dependency_names_only_includes_exclusively_local_sources() -> Non
     }
 
     assert local_dependency_names(manifest) == frozenset(
-        {"deepagents", "workspace-package", "conditional-local"}
+        {"deepagents", "workspace-package"}
     )
+
+
+def test_load_declarations_keeps_conditionally_local_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    path = tmp_path / manifest_path
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        """
+[project]
+name = "example"
+dependencies = ["demo>=1"]
+
+[tool.uv.sources]
+demo = [{ path = "../demo", marker = "sys_platform == 'darwin'" }]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("check_dep_freshness.REPO_ROOT", tmp_path)
+
+    declarations = load_declarations(manifest_path, "example")
+
+    assert [(item.requirement.name, item.minimum) for item in declarations] == [
+        ("demo", Version("1"))
+    ]
 
 
 def test_load_declarations_reads_required_and_optional_and_skips_local(
@@ -489,3 +519,350 @@ def test_declaration_dataclass_keeps_parsed_requirement() -> None:
     )
 
     assert declaration.requirement.name == "demo"
+
+
+def test_declaration_from_requirement_derives_minimum_and_canonical_name() -> None:
+    declaration = DependencyDeclaration.from_requirement(
+        "libs/example/pyproject.toml", "example", Requirement("Demo_Package>=1,<3")
+    )
+
+    assert declaration is not None
+    assert declaration.minimum == Version("1")
+    assert declaration.canonical_name == "demo-package"
+
+
+def test_declaration_from_requirement_returns_none_without_lower_bound() -> None:
+    assert (
+        DependencyDeclaration.from_requirement(
+            "libs/example/pyproject.toml", "example", Requirement("demo<3")
+        )
+        is None
+    )
+
+
+def test_stale_dependency_rejects_non_stale_versions() -> None:
+    with pytest.raises(ValueError, match="latest > minimum"):
+        StaleDependency(
+            manifest_path="libs/example/pyproject.toml",
+            package_name="example",
+            dependency_name="demo",
+            minimum=Version("2.0"),
+            latest=Version("1.0"),
+            within_upper_bound=True,
+        )
+
+
+def test_freshness_markdown_renders_within_bound_as_yes() -> None:
+    markdown = freshness_markdown(
+        [finding(within=True)],
+        policy=PrereleasePolicy.BOUND,
+        include_marker=False,
+    )
+
+    assert "| `deepagents` | `langchain` | `1.0` | `1.1` | Yes |" in markdown
+
+
+def test_check_dependency_freshness_reports_current_dependency_as_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    _write_manifest(tmp_path, manifest_path, "demo>=2,<3")
+    output = _configure_check(monkeypatch, tmp_path, manifest_path)
+
+    def fetcher(_name: str) -> dict[str, object]:
+        return pypi_payload(**{"2.0": [{"yanked": False}]})
+
+    assert check_dependency_freshness("base", "head", fetcher=fetcher) == 0
+
+    written = output.read_text(encoding="utf-8")
+    assert written.count("\nfalse\n") == 2
+    assert COMMENT_MARKER not in written
+    assert not (tmp_path / "github_summary").exists()
+
+
+def test_check_dependency_freshness_always_policy_flags_prerelease(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    _write_manifest(tmp_path, manifest_path, "demo>=1")
+    output = _configure_check(monkeypatch, tmp_path, manifest_path)
+
+    def fetcher(_name: str) -> dict[str, object]:
+        return pypi_payload(
+            **{"1.0": [{"yanked": False}], "2.0rc1": [{"yanked": False}]}
+        )
+
+    assert (
+        check_dependency_freshness(
+            "base", "head", policy=PrereleasePolicy.ALWAYS, fetcher=fetcher
+        )
+        == 0
+    )
+
+    written = output.read_text(encoding="utf-8")
+    assert "`2.0rc1`" in written
+    # No upper bound is declared, so the newer version stays within bounds.
+    assert "| Yes |" in written
+
+
+def test_check_dependency_freshness_never_policy_ignores_prerelease(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    _write_manifest(tmp_path, manifest_path, "demo>=1")
+    output = _configure_check(monkeypatch, tmp_path, manifest_path)
+
+    def fetcher(_name: str) -> dict[str, object]:
+        return pypi_payload(
+            **{"1.0": [{"yanked": False}], "2.0rc1": [{"yanked": False}]}
+        )
+
+    assert (
+        check_dependency_freshness(
+            "base", "head", policy=PrereleasePolicy.NEVER, fetcher=fetcher
+        )
+        == 0
+    )
+
+    written = output.read_text(encoding="utf-8")
+    assert COMMENT_MARKER not in written
+
+
+def test_check_dependency_freshness_flags_version_over_upper_bound(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    _write_manifest(tmp_path, manifest_path, "demo>=1,<2")
+    output = _configure_check(monkeypatch, tmp_path, manifest_path)
+
+    def fetcher(_name: str) -> dict[str, object]:
+        return pypi_payload(**{"2.0": [{"yanked": False}]})
+
+    assert check_dependency_freshness("base", "head", fetcher=fetcher) == 0
+
+    written = output.read_text(encoding="utf-8")
+    assert "| `2.0` | **No** |" in written
+
+
+def test_check_dependency_freshness_skips_dependency_without_eligible_release(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    _write_manifest(tmp_path, manifest_path, "demo>=1")
+    output = _configure_check(monkeypatch, tmp_path, manifest_path)
+
+    def fetcher(_name: str) -> dict[str, object]:
+        return pypi_payload()
+
+    assert check_dependency_freshness("base", "head", fetcher=fetcher) == 0
+
+    written = output.read_text(encoding="utf-8")
+    assert written.count("\nfalse\n") == 2
+    assert COMMENT_MARKER not in written
+
+
+def test_check_dependency_freshness_reports_findings_with_partial_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    path = tmp_path / manifest_path
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        """
+[project]
+name = "example"
+dependencies = ["demo>=1", "other>=1"]
+""".strip(),
+        encoding="utf-8",
+    )
+    output = _configure_check(monkeypatch, tmp_path, manifest_path)
+
+    def fetcher(name: str) -> dict[str, object]:
+        if name == "demo":
+            return pypi_payload(**{"2.0": [{"yanked": False}]})
+        msg = "PyPI is unavailable"
+        raise PyPIRequestError(msg, transient=True)
+
+    assert check_dependency_freshness("base", "head", fetcher=fetcher) == 0
+
+    written = output.read_text(encoding="utf-8")
+    assert written.count("\ntrue\n") == 2  # stale and indeterminate
+    assert "`2.0`" in written
+    assert "could not be queried completely" in written
+    assert "`other`" in written
+
+
+def test_check_dependency_freshness_marks_malformed_payload_indeterminate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    _write_manifest(tmp_path, manifest_path, "demo>=1")
+    output = _configure_check(monkeypatch, tmp_path, manifest_path)
+
+    def fetcher(_name: str) -> dict[str, object]:
+        return {"releases": "not-a-mapping"}
+
+    assert check_dependency_freshness("base", "head", fetcher=fetcher) == 0
+
+    written = output.read_text(encoding="utf-8")
+    assert "stale<<" in written
+    assert "indeterminate<<" in written
+    assert written.count("\ntrue\n") == 1  # indeterminate only; nothing stale
+    assert COMMENT_MARKER not in written
+
+
+def test_load_declarations_requires_project_table(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    path = tmp_path / manifest_path
+    path.parent.mkdir(parents=True)
+    path.write_text("[build-system]\nrequires = []\n", encoding="utf-8")
+    monkeypatch.setattr("check_dep_freshness.REPO_ROOT", tmp_path)
+
+    with pytest.raises(TypeError, match=r"no \[project\] table"):
+        load_declarations(manifest_path, "example")
+
+
+def test_load_declarations_warns_and_skips_invalid_requirement(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    path = tmp_path / manifest_path
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        """
+[project]
+name = "example"
+dependencies = ["valid>=1", "@@bad@@"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("check_dep_freshness.REPO_ROOT", tmp_path)
+
+    declarations = load_declarations(manifest_path, "example")
+
+    assert [item.requirement.name for item in declarations] == ["valid"]
+    assert "Skipping invalid requirement" in capsys.readouterr().out
+
+
+def test_load_declarations_excludes_self_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    path = tmp_path / manifest_path
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        """
+[project]
+name = "example"
+dependencies = ["Example>=1", "demo>=1"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("check_dep_freshness.REPO_ROOT", tmp_path)
+
+    declarations = load_declarations(manifest_path, "example")
+
+    assert [item.requirement.name for item in declarations] == ["demo"]
+
+
+def test_load_declarations_deduplicates_identical_requirements(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    path = tmp_path / manifest_path
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        """
+[project]
+name = "example"
+dependencies = ["demo>=1,<3"]
+
+[project.optional-dependencies]
+extra = ["demo>=1,<3"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("check_dep_freshness.REPO_ROOT", tmp_path)
+
+    declarations = load_declarations(manifest_path, "example")
+
+    assert len(declarations) == 1
+
+
+def test_fetch_pypi_json_rejects_non_positive_attempts() -> None:
+    with pytest.raises(ValueError, match="at least 1"):
+        fetch_pypi_json("demo", attempts=0)
+
+
+def test_fetch_pypi_json_retries_rate_limit_status() -> None:
+    error = HTTPError("https://pypi.org", 429, "too many", Message(), None)
+    opener = SequenceOpener(
+        [error, FakeResponse(pypi_payload(**{"1.0": [{"yanked": False}]}))]
+    )
+
+    payload = fetch_pypi_json("demo", opener=opener, sleep=lambda _delay: None)
+
+    assert latest_pypi_version(payload, include_prereleases=False) == Version("1.0")
+    assert len(opener.requests) == 2
+
+
+def test_fetch_pypi_json_uses_exponential_backoff_on_invalid_retry_after() -> None:
+    headers = Message()
+    headers["Retry-After"] = "soon"
+    error = HTTPError("https://pypi.org", 503, "unavailable", headers, None)
+    opener = SequenceOpener(
+        [error, FakeResponse(pypi_payload(**{"1.0": [{"yanked": False}]}))]
+    )
+    delays: list[float] = []
+
+    fetch_pypi_json("demo", opener=opener, sleep=delays.append)
+
+    assert delays == [0.25]
+
+
+def test_main_runs_check_and_returns_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    manifest_path = "libs/example/pyproject.toml"
+    _write_manifest(tmp_path, manifest_path, "demo>=1")
+    _configure_check(monkeypatch, tmp_path, manifest_path)
+    monkeypatch.setattr(
+        "check_dep_freshness.fetch_pypi_json",
+        lambda _name: pypi_payload(**{"1.0": [{"yanked": False}]}),
+    )
+    monkeypatch.setenv("BASE_SHA", "base")
+    monkeypatch.setenv("HEAD_SHA", "head")
+    monkeypatch.delenv(PRERELEASE_POLICY_ENV, raising=False)
+
+    assert main() == 0
+
+
+def test_main_fail_closes_on_unexpected_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BASE_SHA", "base")
+    monkeypatch.setenv("HEAD_SHA", "head")
+    monkeypatch.delenv(PRERELEASE_POLICY_ENV, raising=False)
+
+    def boom() -> dict[str, str]:
+        msg = "config exploded"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr("check_dep_freshness.load_release_packages", boom)
+
+    assert main() == 2

--- a/.github/workflows/check_dep_freshness.yml
+++ b/.github/workflows/check_dep_freshness.yml
@@ -1,0 +1,136 @@
+# Advisory check: reports release-package dependency minimums that trail PyPI.
+# Does not block merge; updates or removes one marker-tagged PR comment.
+
+name: "📦 Check Dependency Freshness"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - "libs/**/pyproject.toml"
+      - "release-please-config.json"
+      - ".github/scripts/check_dep_freshness.py"
+      - ".github/scripts/check_release_deps.py"
+      - ".github/workflows/check_dep_freshness.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-dependency-freshness:
+    name: "compare dependency minimums with PyPI"
+    if: >-
+      startsWith(github.event.pull_request.title, 'release(') &&
+      !contains(github.event.pull_request.labels.*.name, 'release-deps: acknowledged')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      stale: ${{ steps.check.outputs.stale }}
+      indeterminate: ${{ steps.check.outputs.indeterminate }}
+      comment_body: ${{ steps.check.outputs.comment_body }}
+    steps:
+      - name: "📋 Checkout Code"
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: "🐍 Set up Python and uv"
+        uses: "./.github/actions/uv_setup"
+        with:
+          python-version: "3.14"
+          enable-cache: "false"
+
+      - name: "🔍 Compare dependency minimums with PyPI"
+        id: check
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # "bound" includes pre-releases only for pre-release minimums. The
+          # script also accepts "always" and "never" for future policy changes.
+          DEP_FRESHNESS_PRERELEASE_POLICY: "bound"
+        run: uv run --no-project --with packaging python .github/scripts/check_dep_freshness.py
+
+  manage-dependency-freshness-comment:
+    name: "manage dependency freshness PR comment"
+    needs: check-dependency-freshness
+    # Run for bypassed and renamed PRs too, so an obsolete comment is removed.
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: "💬 Manage PR comment"
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COMMENT_BODY: ${{ needs.check-dependency-freshness.outputs.comment_body }}
+          INDETERMINATE: ${{ needs.check-dependency-freshness.outputs.indeterminate }}
+          RESULT: ${{ needs.check-dependency-freshness.result }}
+          STALE: ${{ needs.check-dependency-freshness.outputs.stale }}
+        with:
+          script: |
+            const marker = '<!-- dep-freshness-check -->';
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const body = process.env.COMMENT_BODY || '';
+            const staleRaw = process.env.STALE || '';
+            const result = process.env.RESULT || '';
+            const stale = staleRaw === 'true';
+            const indeterminate = process.env.INDETERMINATE === 'true';
+
+            // Empty outputs mean the check was skipped (bypass/non-release) or
+            // crashed. Skips resolve the advisory; crashes preserve its last
+            // known result while the failed job explains that no result exists.
+            const crashed = staleRaw === '' && result !== 'skipped';
+
+            try {
+              if (crashed) {
+                core.info('Dependency freshness check produced no result; leaving any existing comment in place.');
+                return;
+              }
+
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number: prNumber, per_page: 100 },
+              );
+              const existing = comments.find(
+                c => c.user?.login === 'github-actions[bot]' &&
+                  (c.body ?? '').startsWith(marker),
+              );
+
+              if (stale) {
+                if (!body.trim()) {
+                  core.warning('Dependency freshness check found stale bounds but produced no comment body; keeping any existing comment.');
+                  return;
+                }
+                if (existing) {
+                  await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+                  core.info('Updated dependency freshness warning comment.');
+                } else {
+                  await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+                  core.info('Created dependency freshness warning comment.');
+                }
+                return;
+              }
+
+              if (indeterminate) {
+                core.warning('Some PyPI queries were indeterminate; leaving any existing dependency freshness comment in place.');
+                return;
+              }
+
+              if (existing) {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+                core.info('Dependency minimums are current or acknowledged — removed stale warning comment.');
+              } else {
+                core.info('No dependency freshness warning comment needed.');
+              }
+            } catch (err) {
+              if (err.status === 403) {
+                core.warning(`Skipping dependency freshness PR comment (token cannot write comments): ${err.message}`);
+                return;
+              }
+              throw err;
+            }

--- a/.github/workflows/check_dep_freshness.yml
+++ b/.github/workflows/check_dep_freshness.yml
@@ -50,7 +50,8 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           # "bound" includes pre-releases only for pre-release minimums. The
-          # script also accepts "always" and "never" for future policy changes.
+          # script also accepts "always" and "never" today if the policy needs
+          # to change.
           DEP_FRESHNESS_PRERELEASE_POLICY: "bound"
         run: uv run --no-project --with packaging python .github/scripts/check_dep_freshness.py
 
@@ -133,8 +134,11 @@ jobs:
                 core.info('No dependency freshness warning comment needed.');
               }
             } catch (err) {
+              // 403 covers both missing comment permissions and rate/abuse
+              // limits. Commenting is advisory, so degrade to a warning (with
+              // the original message for diagnosis) instead of failing the job.
               if (err.status === 403) {
-                core.warning(`Skipping dependency freshness PR comment (token cannot write comments): ${err.message}`);
+                core.warning(`Skipping dependency freshness PR comment (403 — token lacks comment permission or is rate limited): ${err.message}`);
                 return;
               }
               throw err;

--- a/.github/workflows/check_dep_freshness.yml
+++ b/.github/workflows/check_dep_freshness.yml
@@ -101,6 +101,11 @@ jobs:
                   (c.body ?? '').startsWith(marker),
               );
 
+              if (indeterminate && existing) {
+                core.warning('Some PyPI queries were indeterminate; leaving the existing dependency freshness comment in place.');
+                return;
+              }
+
               if (stale) {
                 if (!body.trim()) {
                   core.warning('Dependency freshness check found stale bounds but produced no comment body; keeping any existing comment.');


### PR DESCRIPTION
Release PRs currently verify that dependencies resolve against PyPI, but they do not show when a declared minimum has fallen behind the newest published version. That makes dependency reconciliation easy to miss at the point maintainers are preparing a release.

This adds an advisory release-PR check for the changed package manifests. It compares required and optional dependency minimums with PyPI, reports whether the newest version still fits the current ceiling, and maintains one non-blocking PR comment. The existing `release-deps: acknowledged` label records that maintainers reviewed the result without requiring a metadata change.

Stable releases are compared by default. Pre-releases participate only when the declared minimum is itself a pre-release, while an environment setting keeps that policy explicit and adjustable. Local path and workspace sources are excluded, so sibling development installs do not create noise while external LangChain dependencies remain covered.

PyPI requests use bounded concurrency, timeouts, and retries. Query failures remain advisory and preserve any previous finding rather than incorrectly declaring the dependency set current. Unit coverage exercises requirement parsing, release selection, upper bounds, source exclusions, retries, output formatting, and canonical-name request deduplication.
