### PR TITLE
fix(infra): preserve merge base in Dependabot lockfile fixer

### DIFF
--- a/.github/workflows/dependabot_lockfile_fix.yml
+++ b/.github/workflows/dependabot_lockfile_fix.yml
@@ -74,7 +74,10 @@ jobs:
         working-directory: pr-preflight
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          # Fetch the exact event-time base without making it a shallow boundary.
+          # A depth-limited fetch hides its parents and breaks the three-dot diff
+          # whenever the base branch has advanced past the PR's merge base.
+          git fetch --no-tags origin "$BASE_SHA"
           # Three-dot diff = changes introduced on the PR head relative to the
           # merge base, i.e. exactly what this PR changed. Under `set -e` a
           # failure to compute it (e.g. an unreachable merge base) aborts the


### PR DESCRIPTION
Related #4827

The Dependabot lockfile fixer now keeps enough Git history to inspect dependency PRs that have fallen behind `main`.

---

The preflight checkout already retrieves complete history, but its explicit fetch of the event-time base used `--depth=1`. That marked the base commit as a shallow boundary, so the three-dot diff could not walk back to the common ancestor when `main` had advanced after Dependabot created its branch.

Fetch the exact base SHA without limiting its depth. This retains the event snapshot while preserving the ancestry needed by the path-scope guard. The fix was validated against the base and head SHAs from #4827, where the diff now resolves to the two expected `libs/talon` files.
