### PR TITLE
feat(code): shutdown toast for deferred exits

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -15449,6 +15449,14 @@ class DeepAgentsApp(App):
         should_drain_hooks = has_pending_hooks()
 
         if should_wait_for_agent or should_drain_hooks:
+            # Surface a single toast so the user knows shutdown is intentionally
+            # waiting rather than hung. Scheduling `_graceful_exit` below defers
+            # `super().exit()` behind at least one `await`, so returning here
+            # lets Textual's message pump render this toast before teardown.
+            # Immediate/idle exits skip this branch and stay toast-free, and a
+            # repeated exit hits the force-quit guard above before reaching here,
+            # so the toast is never duplicated.
+            self.notify("Finishing pending work before exit…", markup=False)
 
             async def _graceful_exit() -> None:
                 from textual.worker import WorkerCancelled, WorkerFailed

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -15449,19 +15449,30 @@ class DeepAgentsApp(App):
         should_drain_hooks = has_pending_hooks()
 
         if should_wait_for_agent or should_drain_hooks:
+            from deepagents_code.config import get_glyphs
+
             # Surface a single toast so the user knows shutdown is intentionally
-            # waiting rather than hung. Scheduling `_graceful_exit` below defers
-            # `super().exit()` behind at least one `await`, so returning here
-            # lets Textual's message pump render this toast before teardown.
+            # waiting rather than hung. Gate `_graceful_exit` on an explicit
+            # refresh so even an already-finished worker or hook drain can't tear
+            # down Textual before the queued notification has been rendered.
             # Immediate/idle exits skip this branch and stay toast-free, and a
-            # repeated exit hits the force-quit guard above before reaching here,
-            # so the toast is never duplicated.
-            self.notify("Finishing pending work before exit…", markup=False)
+            # repeated exit while shutdown is still pending hits the force-quit
+            # guard above before reaching here, so it stays toast-free too.
+            self.notify(
+                f"Finishing pending work before exit{get_glyphs().ellipsis}",
+                markup=False,
+            )
+            refreshed = asyncio.Event()
+            if not self.call_after_refresh(refreshed.set):
+                # A closing message pump can't render the toast, but it must not
+                # strand shutdown waiting on a refresh that will never happen.
+                refreshed.set()
 
             async def _graceful_exit() -> None:
                 from textual.worker import WorkerCancelled, WorkerFailed
 
                 try:
+                    await refreshed.wait()
                     worker = agent_worker
                     if should_wait_for_agent and worker is not None:
                         try:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -15193,6 +15193,119 @@ class TestExitGracefulWorkerHandoff:
                 assert app._graceful_exit_task is pending
             pending.cancel()
 
+    _SHUTDOWN_TOAST = "Finishing pending work before exit…"
+
+    async def test_toast_shown_when_agent_worker_unfinished(self) -> None:
+        """A deferred exit for an unfinished worker shows the shutdown toast."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+            worker = MagicMock()
+            worker.is_finished = False
+            worker.wait = AsyncMock()
+            app._agent_worker = worker
+
+            with (
+                patch.object(App, "exit"),
+                patch.object(app, "notify") as notify,
+            ):
+                app.exit()
+                assert app._graceful_exit_task is not None
+                await app._graceful_exit_task
+
+            notify.assert_called_once_with(self._SHUTDOWN_TOAST, markup=False)
+
+    async def test_toast_shown_when_hooks_pending(self) -> None:
+        """A deferred exit that only drains hooks still shows the toast."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            with (
+                patch("deepagents_code.hooks.has_pending_hooks", return_value=True),
+                patch(
+                    "deepagents_code.hooks.drain_pending_hooks",
+                    new_callable=AsyncMock,
+                ),
+                patch.object(App, "exit"),
+                patch.object(app, "notify") as notify,
+            ):
+                app.exit()
+                assert app._graceful_exit_task is not None
+                await app._graceful_exit_task
+
+            notify.assert_called_once_with(self._SHUTDOWN_TOAST, markup=False)
+
+    async def test_toast_shown_once_when_worker_and_hooks_pending(self) -> None:
+        """Both wait conditions being true still yields a single toast."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+            worker = MagicMock()
+            worker.is_finished = False
+            worker.wait = AsyncMock()
+            app._agent_worker = worker
+
+            with (
+                patch("deepagents_code.hooks.has_pending_hooks", return_value=True),
+                patch(
+                    "deepagents_code.hooks.drain_pending_hooks",
+                    new_callable=AsyncMock,
+                ),
+                patch.object(App, "exit"),
+                patch.object(app, "notify") as notify,
+            ):
+                app.exit()
+                assert app._graceful_exit_task is not None
+                await app._graceful_exit_task
+
+            notify.assert_called_once_with(self._SHUTDOWN_TOAST, markup=False)
+
+    async def test_no_toast_for_immediate_idle_exit(self) -> None:
+        """An idle, synchronous exit shows no shutdown toast."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = False
+
+            with (
+                patch.object(App, "exit") as super_exit,
+                patch.object(app, "notify") as notify,
+            ):
+                app.exit()
+                super_exit.assert_called_once()
+
+            assert app._graceful_exit_task is None
+            notify.assert_not_called()
+
+    async def test_no_duplicate_toast_on_repeated_exit(self) -> None:
+        """A forced second exit does not emit a second shutdown toast."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+            worker = MagicMock()
+            worker.is_finished = False
+            worker.wait = AsyncMock()
+            app._agent_worker = worker
+
+            with (
+                patch.object(App, "exit"),
+                patch.object(app, "notify") as notify,
+            ):
+                app.exit()
+                pending = app._graceful_exit_task
+                assert pending is not None
+
+                # Second press before the deferred task runs force-quits and
+                # must not arm another toast.
+                app.exit()
+                notify.assert_called_once_with(self._SHUTDOWN_TOAST, markup=False)
+
+                await pending
+
 
 class TestSlashCommandBypass:
     """Test that certain slash commands bypass the queue gate."""

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -15193,7 +15193,45 @@ class TestExitGracefulWorkerHandoff:
                 assert app._graceful_exit_task is pending
             pending.cancel()
 
-    _SHUTDOWN_TOAST = "Finishing pending work before exit…"
+    @staticmethod
+    def _shutdown_toast() -> str:
+        """Return the shutdown toast for the active terminal charset."""
+        from deepagents_code.config import get_glyphs
+
+        return f"Finishing pending work before exit{get_glyphs().ellipsis}"
+
+    async def test_cleanup_starts_only_after_toast_refresh(self) -> None:
+        """Deferred cleanup waits until Textual has rendered the queued toast."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+            worker = MagicMock()
+            worker.is_finished = False
+            worker.wait = AsyncMock()
+            app._agent_worker = worker
+
+            with (
+                patch("deepagents_code.hooks.has_pending_hooks", return_value=False),
+                patch.object(App, "exit") as super_exit,
+                patch.object(app, "notify"),
+                patch.object(app, "call_after_refresh") as after_refresh,
+            ):
+                app.exit()
+                assert app._graceful_exit_task is not None
+
+                # Let the task reach the render barrier. Fast cleanup must not
+                # start until Textual invokes the after-refresh callback.
+                await asyncio.sleep(0)
+                worker.wait.assert_not_awaited()
+                super_exit.assert_not_called()
+
+                refresh_callback = after_refresh.call_args.args[0]
+                refresh_callback()
+                await app._graceful_exit_task
+
+            worker.wait.assert_awaited_once()
+            super_exit.assert_called_once()
 
     async def test_toast_shown_when_agent_worker_unfinished(self) -> None:
         """A deferred exit for an unfinished worker shows the shutdown toast."""
@@ -15207,6 +15245,7 @@ class TestExitGracefulWorkerHandoff:
             app._agent_worker = worker
 
             with (
+                patch("deepagents_code.hooks.has_pending_hooks", return_value=False),
                 patch.object(App, "exit"),
                 patch.object(app, "notify") as notify,
             ):
@@ -15214,7 +15253,7 @@ class TestExitGracefulWorkerHandoff:
                 assert app._graceful_exit_task is not None
                 await app._graceful_exit_task
 
-            notify.assert_called_once_with(self._SHUTDOWN_TOAST, markup=False)
+            notify.assert_called_once_with(self._shutdown_toast(), markup=False)
 
     async def test_toast_shown_when_hooks_pending(self) -> None:
         """A deferred exit that only drains hooks still shows the toast."""
@@ -15235,7 +15274,7 @@ class TestExitGracefulWorkerHandoff:
                 assert app._graceful_exit_task is not None
                 await app._graceful_exit_task
 
-            notify.assert_called_once_with(self._SHUTDOWN_TOAST, markup=False)
+            notify.assert_called_once_with(self._shutdown_toast(), markup=False)
 
     async def test_toast_shown_once_when_worker_and_hooks_pending(self) -> None:
         """Both wait conditions being true still yields a single toast."""
@@ -15261,7 +15300,37 @@ class TestExitGracefulWorkerHandoff:
                 assert app._graceful_exit_task is not None
                 await app._graceful_exit_task
 
-            notify.assert_called_once_with(self._SHUTDOWN_TOAST, markup=False)
+            notify.assert_called_once_with(self._shutdown_toast(), markup=False)
+
+    async def test_toast_uses_ascii_ellipsis_in_ascii_mode(self) -> None:
+        """The shutdown toast honors the configured ASCII glyph set."""
+        from deepagents_code.config import ASCII_GLYPHS
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            with (
+                patch("deepagents_code.hooks.has_pending_hooks", return_value=True),
+                patch(
+                    "deepagents_code.hooks.drain_pending_hooks",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "deepagents_code.config.get_glyphs",
+                    return_value=ASCII_GLYPHS,
+                ),
+                patch.object(App, "exit"),
+                patch.object(app, "notify") as notify,
+            ):
+                app.exit()
+                assert app._graceful_exit_task is not None
+                await app._graceful_exit_task
+
+            notify.assert_called_once_with(
+                "Finishing pending work before exit...",
+                markup=False,
+            )
 
     async def test_no_toast_for_immediate_idle_exit(self) -> None:
         """An idle, synchronous exit shows no shutdown toast."""
@@ -15271,6 +15340,29 @@ class TestExitGracefulWorkerHandoff:
             app._agent_running = False
 
             with (
+                patch("deepagents_code.hooks.has_pending_hooks", return_value=False),
+                patch.object(App, "exit") as super_exit,
+                patch.object(app, "notify") as notify,
+            ):
+                app.exit()
+                super_exit.assert_called_once()
+
+            assert app._graceful_exit_task is None
+            notify.assert_not_called()
+
+    async def test_no_toast_when_worker_present_but_finished(self) -> None:
+        """A present-but-finished worker with no hooks defers nothing."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+            worker = MagicMock()
+            worker.is_finished = True
+            worker.wait = AsyncMock()
+            app._agent_worker = worker
+
+            with (
+                patch("deepagents_code.hooks.has_pending_hooks", return_value=False),
                 patch.object(App, "exit") as super_exit,
                 patch.object(app, "notify") as notify,
             ):
@@ -15292,6 +15384,7 @@ class TestExitGracefulWorkerHandoff:
             app._agent_worker = worker
 
             with (
+                patch("deepagents_code.hooks.has_pending_hooks", return_value=False),
                 patch.object(App, "exit"),
                 patch.object(app, "notify") as notify,
             ):
@@ -15302,7 +15395,7 @@ class TestExitGracefulWorkerHandoff:
                 # Second press before the deferred task runs force-quits and
                 # must not arm another toast.
                 app.exit()
-                notify.assert_called_once_with(self._SHUTDOWN_TOAST, markup=False)
+                notify.assert_called_once_with(self._shutdown_toast(), markup=False)
 
                 await pending
 


### PR DESCRIPTION
When quitting waits for unfinished work, `deepagents-code` now shows a brief "Finishing pending work before exit…" toast so the pause reads as intentional rather than a hang.

---

`DeepAgentsApp.exit()` only defers teardown when it must wait for an in-flight agent worker or pending fire-and-forget hooks. That wait was previously silent, so a user pressing quit could think the app had frozen. This adds a single toast on exactly that deferred path.

The notification is emitted before scheduling the `_graceful_exit` coroutine. Because scheduling returns control to the event loop and teardown is deferred behind at least one `await`, Textual's message pump gets an opportunity to render the toast before `super().exit()` runs. Immediate/idle exits skip this branch entirely, no delay is introduced, and the existing two-second grace period is untouched. A repeated/forced exit hits the existing force-quit guard before reaching the notify, so the toast is never duplicated (including when both wait conditions apply).

Made by [Open SWE](https://openswe.vercel.app/agents/26e6d24a-3180-4334-b655-4075767ae45b)