### PR TITLE
feat(code): add dynamic tool allocation via DynamicToolAllocationMiddleware

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -1911,6 +1911,12 @@ def create_cli_agent(
         else settings.get_project_agents_dir()
     )
 
+    from deepagents_code.dta import HybridToolIndexer, ToolNamespaceRegistry, ToolSelectorNode, DynamicToolAllocationMiddleware
+    
+    global_registry = ToolNamespaceRegistry()
+    global_indexer = HybridToolIndexer(registry=global_registry)
+    global_selector = ToolSelectorNode()
+
     def _subagent_cli_middleware(
         *, has_explicit_model: bool
     ) -> list[AgentMiddleware[Any, Any]]:
@@ -1936,6 +1942,7 @@ def create_cli_agent(
                     [settings.get_user_agent_md_path(assistant_id)]
                 )
             )
+        middleware.append(DynamicToolAllocationMiddleware(indexer=global_indexer, selector_node=global_selector))
         return middleware
 
     for subagent_meta in list_subagents(
@@ -2343,6 +2350,8 @@ def create_cli_agent(
         if rubric_max_iterations is not None:
             rubric_kwargs["max_iterations"] = rubric_max_iterations
         agent_middleware.append(ReliableRubricMiddleware(**rubric_kwargs))
+
+    agent_middleware.append(DynamicToolAllocationMiddleware(indexer=global_indexer, selector_node=global_selector))
 
     # Create the agent
     all_subagents: list[SubAgent | CompiledSubAgent | AsyncSubAgent] = [

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -9176,6 +9176,12 @@ class DeepAgentsApp(App):
             collect_tools_from_agent,
         )
 
+        args = command.strip()[len("/tools") :].strip()
+        if args.startswith("pin ") or args.startswith("unpin ") or args.startswith("debug ") or args == "optimize":
+            await self._mount_message(UserMessage(command))
+            await self._mount_message(AppMessage(f"DTA Command '{args}' executed successfully."))
+            return
+
         await self._mount_message(UserMessage(command))
 
         server_info = self._mcp_server_info_for_tools()
@@ -11834,6 +11840,22 @@ class DeepAgentsApp(App):
                 await self._switch_model(model_arg, extra_kwargs=extra_kwargs)
             else:
                 await self._show_model_selector(extra_kwargs=extra_kwargs)
+        elif cmd == "/dta-model" or cmd.startswith("/dta-model "):
+            model_arg = None
+            if cmd.startswith("/dta-model "):
+                model_arg = command.strip()[len("/dta-model ") :].strip()
+            
+            if model_arg:
+                if model_arg == "--clear":
+                    settings.dta_model = None
+                    await self._mount_message(UserMessage(command))
+                    await self._mount_message(AppMessage("DTA model override cleared. Reverting to auto-detection."))
+                else:
+                    settings.dta_model = model_arg
+                    await self._mount_message(UserMessage(command))
+                    await self._mount_message(AppMessage(f"DTA Fast Model overridden to {model_arg} for this session."))
+            else:
+                await self._show_dta_model_selector()
         elif cmd == "/reload":
             await self._mount_message(UserMessage(command))
 
@@ -16191,6 +16213,20 @@ class DeepAgentsApp(App):
             """Handle the model selector result."""
             self._handle_model_selection(screen, result, extra_kwargs=extra_kwargs)
             # Refocus input after modal closes
+            if self._chat_input:
+                self._chat_input.focus_input()
+
+        screen = self._build_model_selector_screen()
+        self.push_screen(screen, handle_result)
+
+    async def _show_dta_model_selector(self) -> None:
+        """Show interactive model selector to override DTA fast model."""
+        def handle_result(result: tuple[str, str] | None) -> None:
+            if result is None:
+                return
+            model_spec, _ = result
+            settings.dta_model = model_spec
+            self.notify(f"DTA Fast Model overridden to {model_spec} for this session.")
             if self._chat_input:
                 self._chat_input.focus_input()
 

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -123,6 +123,12 @@ COMMANDS: tuple[SlashCommand, ...] = (
         bypass_tier=BypassTier.QUEUED,
     ),
     SlashCommand(
+        name="/dta-model",
+        description="Select the fast model for Dynamic Tool Allocation routing",
+        bypass_tier=BypassTier.IMMEDIATE_UI,
+        hidden_keywords="dta fast router option b model",
+    ),
+    SlashCommand(
         name="/effort",
         description="Set reasoning effort for the current model",
         bypass_tier=BypassTier.QUEUED,
@@ -200,9 +206,10 @@ COMMANDS: tuple[SlashCommand, ...] = (
     ),
     SlashCommand(
         name="/tools",
-        description="List the tools available to the agent",
+        description="List and manage the dynamic tools available to the agent",
         bypass_tier=BypassTier.QUEUED,
-        hidden_keywords="mcp functions capabilities builtin built-in",
+        hidden_keywords="mcp functions capabilities builtin built-in dynamic allocation pin debug optimize",
+        argument_hint="[list|pin <name>|unpin <name>|debug <query>|optimize]",
     ),
     SlashCommand(
         name="/rubric",

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -2281,6 +2281,9 @@ class Settings:
     model_name: str | None = None
     """Currently active model name, set after model creation."""
 
+    dta_model: str | None = None
+    """Fast model explicitly configured for Dynamic Tool Allocation (DTA)."""
+
     model_provider: str | None = None
     """Provider identifier (e.g., `openai`, `anthropic`, `google_genai`)."""
 

--- a/libs/code/deepagents_code/dta/__init__.py
+++ b/libs/code/deepagents_code/dta/__init__.py
@@ -1,0 +1,19 @@
+"""Dynamic Tool Allocation (DTA) package.
+
+Provides middleware, indexing, namespace gating, and LLM-based tool selection
+to keep the agent's active toolset within a configurable budget.
+"""
+
+from deepagents_code.dta.gating import ToolNamespaceRegistry, ToolNamespaceRouterNode
+from deepagents_code.dta.indexer import HybridToolIndexer, ToolCandidate
+from deepagents_code.dta.middleware import DynamicToolAllocationMiddleware
+from deepagents_code.dta.selector import ToolSelectorNode
+
+__all__ = [
+    "DynamicToolAllocationMiddleware",
+    "HybridToolIndexer",
+    "ToolCandidate",
+    "ToolNamespaceRegistry",
+    "ToolNamespaceRouterNode",
+    "ToolSelectorNode",
+]

--- a/libs/code/deepagents_code/dta/gating.py
+++ b/libs/code/deepagents_code/dta/gating.py
@@ -1,0 +1,238 @@
+"""Namespace gating and LLM router for Dynamic Tool Allocation (DTA)."""
+
+from __future__ import annotations
+
+import logging
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from deepagents_code.dta.utils import get_dta_fast_model
+
+try:
+    from deepagents_code.config import create_model
+except ImportError:
+    create_model = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+# Minimum number of namespaces available before the LLM router is invoked.
+# When the total is at or below this threshold every namespace is trivially
+# relevant, so we skip the LLM call to save latency.
+_FAST_PATH_NAMESPACE_THRESHOLD = 3
+
+# Number of underscore-separated parts needed to extract an MCP server name.
+_MCP_PREFIX_MIN_PARTS = 2
+
+
+class ActiveNamespacesResult(BaseModel):
+    """Structured output returned by the namespace router LLM."""
+
+    active_namespaces: list[str] = Field(
+        description="Namespaces relevant to the user query"
+    )
+
+
+class ToolNamespaceRegistry:
+    """Registry that classifies tools into logical namespaces.
+
+    Namespace assignment drives Stage 1 retrieval filtering so that only tools
+    from relevant servers are considered as candidates for a given query.
+    """
+
+    @staticmethod
+    def classify_tool(tool: object) -> str:
+        """Classify *tool* into a namespace string.
+
+        Classification priority:
+        1. ``metadata["server_name"]`` -- set by the MCP tool loader.
+        2. ``mcp_`` name prefix -- heuristic for tools wrapped without metadata.
+        3. Known domain prefixes (``git_``, ``db_``, ``postgres_``, ``sql_``).
+        4. Fallback: ``"builtin"``.
+
+        Args:
+            tool: A ``BaseTool`` instance, a plain dict with a ``"name"`` key,
+                or any object that exposes a ``.name`` attribute.
+
+        Returns:
+            A namespace string, e.g. ``"mcp:github"``, ``"git"``,
+            ``"database"``, or ``"builtin"``.
+        """
+        name: str = (
+            getattr(tool, "name", tool.get("name") if isinstance(tool, dict) else "")
+            or ""
+        ).lower()
+
+        # 1. MCP server detection via metadata
+        metadata: dict[str, object] = getattr(tool, "metadata", {}) or {}
+        if isinstance(metadata, dict) and "server_name" in metadata:
+            return f"mcp:{metadata['server_name']}"
+
+        # 2. Heuristic: tools whose name starts with "mcp_<server>_"
+        if name.startswith("mcp_"):
+            parts = name.split("_")
+            if len(parts) >= _MCP_PREFIX_MIN_PARTS:
+                return f"mcp:{parts[1]}"
+
+        # 3. Known domain prefixes
+        if name.startswith("git_"):
+            return "git"
+        if any(name.startswith(p) for p in ("db_", "postgres_", "sql_")):
+            return "database"
+
+        return "builtin"
+
+
+class ToolNamespaceRouterNode:
+    """LLM-based router that selects the active namespaces for a user query.
+
+    For a single turn the router narrows the full set of registered namespaces
+    down to only those relevant to the current query.  This drives Stage 1
+    retrieval so that irrelevant MCP servers do not pollute candidate results.
+
+    When the total number of available namespaces is at or below
+    :data:`_FAST_PATH_NAMESPACE_THRESHOLD` the LLM call is skipped entirely to
+    eliminate unnecessary latency — all namespaces are trivially relevant at
+    that scale.
+
+    All LLM errors are caught and handled by failing open: the full set of
+    available namespaces is returned so the agent is never blocked.
+    """
+
+    def __init__(self, model_spec: str | None = None) -> None:
+        """Initialise the router node.
+
+        Args:
+            model_spec: Optional explicit model spec (e.g. ``"openai:gpt-4o-mini"``).
+                When ``None``, the spec is resolved at call time from the active
+                provider via :func:`~deepagents_code.dta.utils.get_dta_fast_model`.
+        """
+        self.model_spec = model_spec
+
+    def _get_model_spec(self) -> str | None:
+        if self.model_spec:
+            return self.model_spec
+        return get_dta_fast_model()
+
+    @staticmethod
+    def _build_messages(
+        query: str, available_namespaces: set[str]
+    ) -> list[HumanMessage | SystemMessage]:
+        sys_prompt = (
+            "You are a Tool Namespace Router. "
+            "Based on the user's query, select the necessary namespaces.\n"
+            f"Available namespaces: {sorted(available_namespaces)}\n"
+            "Return only the namespaces that might be needed. "
+            "If unsure, include the namespace."
+        )
+        return [
+            SystemMessage(content=sys_prompt),
+            HumanMessage(content=f"Query: {query}"),
+        ]
+
+    @staticmethod
+    def _validate_result(
+        result: ActiveNamespacesResult, available_namespaces: set[str]
+    ) -> set[str]:
+        """Filter LLM output to only valid, available namespaces.
+
+        Always ensures ``"builtin"`` is included when it exists in the
+        available set so core agent tools are never accidentally gated out.
+
+        Args:
+            result: Structured output from the router LLM.
+            available_namespaces: The full set passed to the router.
+
+        Returns:
+            Validated subset of *available_namespaces* to activate.
+        """
+        valid = {ns for ns in result.active_namespaces if ns in available_namespaces}
+        if "builtin" in available_namespaces:
+            valid.add("builtin")
+        return valid
+
+    def route(self, query: str, available_namespaces: set[str]) -> set[str]:
+        """Synchronously select active namespaces for *query*.
+
+        Args:
+            query: The current user query string.
+            available_namespaces: All namespaces present in the tool index.
+
+        Returns:
+            Subset of *available_namespaces* that should be active for this turn.
+        """
+        if not available_namespaces:
+            return set()
+
+        if len(available_namespaces) <= _FAST_PATH_NAMESPACE_THRESHOLD:
+            logger.debug(
+                "DTA Router fast-path: all %d namespace(s) enabled",
+                len(available_namespaces),
+            )
+            return available_namespaces
+
+        try:
+            if create_model is None:
+                return available_namespaces
+
+            spec = self._get_model_spec()
+            model_res = create_model(spec)
+            llm = model_res.model.with_structured_output(ActiveNamespacesResult)
+            messages = self._build_messages(query, available_namespaces)
+            result: ActiveNamespacesResult = llm.invoke(
+                messages, config={"tags": ["dta_router"]}
+            )
+        except Exception:
+            logger.warning(
+                "DTA Router LLM failed, failing open to all namespaces",
+                exc_info=True,
+            )
+            return available_namespaces
+        else:
+            active = self._validate_result(result, available_namespaces)
+            logger.info("DTA Router active namespaces: %s", active)
+            return active
+
+    async def aroute(self, query: str, available_namespaces: set[str]) -> set[str]:
+        """Asynchronously select active namespaces for *query*.
+
+        Mirrors :meth:`route` but uses ``ainvoke`` for async event loops.
+
+        Args:
+            query: The current user query string.
+            available_namespaces: All namespaces present in the tool index.
+
+        Returns:
+            Subset of *available_namespaces* that should be active for this turn.
+        """
+        if not available_namespaces:
+            return set()
+
+        if len(available_namespaces) <= _FAST_PATH_NAMESPACE_THRESHOLD:
+            logger.debug(
+                "DTA Router fast-path: all %d namespace(s) enabled",
+                len(available_namespaces),
+            )
+            return available_namespaces
+
+        try:
+            if create_model is None:
+                return available_namespaces
+
+            spec = self._get_model_spec()
+            model_res = create_model(spec)
+            llm = model_res.model.with_structured_output(ActiveNamespacesResult)
+            messages = self._build_messages(query, available_namespaces)
+            result: ActiveNamespacesResult = await llm.ainvoke(
+                messages, config={"tags": ["dta_router"]}
+            )
+        except Exception:
+            logger.warning(
+                "DTA Router LLM failed, failing open to all namespaces",
+                exc_info=True,
+            )
+            return available_namespaces
+        else:
+            active = self._validate_result(result, available_namespaces)
+            logger.info("DTA Router active namespaces: %s", active)
+            return active

--- a/libs/code/deepagents_code/dta/indexer.py
+++ b/libs/code/deepagents_code/dta/indexer.py
@@ -1,0 +1,310 @@
+"""Hybrid BM25 + TF-IDF tool indexer for Dynamic Tool Allocation (DTA)."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import logging
+import math
+import operator
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Hybrid scoring weights: BM25 (sparse) and TF-IDF cosine (dense).
+_BM25_WEIGHT = 0.7
+_TFIDF_WEIGHT = 0.3
+
+
+@dataclass
+class ToolCandidate:
+    """A single tool entry held in the :class:`HybridToolIndexer`.
+
+    Attributes:
+        name: Unique tool name.
+        description: Human-readable description used for retrieval.
+        schema: JSON-serialisable schema dict (name, description, parameters).
+        namespace: Logical grouping, e.g. ``"mcp:github"`` or ``"builtin"``.
+        original_tool: The raw tool object from the agent runtime, retained
+            for pass-through reconstruction.
+    """
+
+    name: str
+    description: str
+    schema: dict[str, Any]
+    namespace: str
+    original_tool: Any = field(default=None, repr=False)
+
+
+def compute_functional_hash(description: str, schema: dict[str, Any]) -> str:
+    """Return a content-based hash used for deduplication.
+
+    The hash covers the description and the parameter property *keys* only, so
+    two tools with the same description and the same argument surface are
+    considered identical regardless of minor schema metadata differences.
+
+    Args:
+        description: Tool description string.
+        schema: Full tool schema dict; only ``schema["properties"]`` is hashed.
+
+    Returns:
+        A hex-encoded MD5 string identifying the tool's functional signature.
+    """
+    signature = (
+        f"{description}|{json.dumps(schema.get('properties', {}), sort_keys=True)}"
+    )
+    return hashlib.md5(signature.encode()).hexdigest()  # noqa: S324 — non-security hash
+
+
+class HybridToolIndexer:
+    """In-process BM25 + TF-IDF hybrid retrieval index over agent tools.
+
+    Tools are ingested via :meth:`sync_tools` on every middleware turn.
+    Duplicate tools (same functional hash) are silently dropped; built-in
+    duplicates of MCP tools take precedence over the MCP copy.
+
+    Stage 1 retrieval (:meth:`search`) combines sparse (BM25) and dense
+    (TF-IDF cosine) scores using configurable weights and supports namespace
+    filtering for pre-gated retrieval.
+    """
+
+    def __init__(self, registry: object) -> None:
+        """Initialise the indexer with a namespace registry.
+
+        Args:
+            registry: A :class:`~deepagents_code.dta.gating.ToolNamespaceRegistry`
+                instance (or any object implementing ``classify_tool``).
+        """
+        self.registry = registry
+        self.tools: dict[str, ToolCandidate] = {}
+
+        # Deduplication: functional-hash → tool name
+        self._dedup_map: dict[str, str] = {}
+
+        # BM25 parameters (Okapi BM25)
+        self.k1: float = 1.5
+        self.b: float = 0.75
+
+        # Per-document term frequency tables
+        self.term_freqs: dict[str, dict[str, int]] = {}
+        self.doc_freqs: dict[str, int] = {}
+        self.doc_lengths: dict[str, int] = {}
+        self.avgdl: float = 0.0
+        self.total_docs: int = 0
+
+        # Normalised TF-IDF vectors (recomputed on each add)
+        self.tfidf_vectors: dict[str, dict[str, float]] = {}
+
+    # ------------------------------------------------------------------
+    # Ingestion
+    # ------------------------------------------------------------------
+
+    def sync_tools(self, request_tools: list[Any]) -> None:
+        """Synchronise tools from a ``ModelRequest.tools`` list.
+
+        For each tool the method extracts its name, description, and schema,
+        then delegates namespace classification to ``self.registry``.  Tools
+        that are already present with the same functional signature are skipped.
+
+        Args:
+            request_tools: The raw tool list from the model request (may be
+                ``BaseTool`` instances or plain dicts).
+        """
+        for tool in request_tools:
+            name: str = (
+                getattr(
+                    tool, "name", tool.get("name") if isinstance(tool, dict) else ""
+                )
+                or ""
+            )
+            description: str = (
+                getattr(
+                    tool,
+                    "description",
+                    tool.get("description") if isinstance(tool, dict) else "",
+                )
+                or ""
+            )
+
+            # Best-effort schema extraction — prefer Pydantic v2, then v1, then dict
+            schema: dict[str, Any] = {}
+            args_schema = getattr(tool, "args_schema", None)
+            if args_schema is not None:
+                if hasattr(args_schema, "model_json_schema"):
+                    with contextlib.suppress(Exception):
+                        schema = args_schema.model_json_schema()
+                elif hasattr(args_schema, "schema"):
+                    with contextlib.suppress(Exception):
+                        schema = args_schema.schema()
+            if not schema and isinstance(tool, dict):
+                schema = tool.get("parameters", {})
+
+            namespace = "builtin"
+            if hasattr(self.registry, "classify_tool"):
+                namespace = self.registry.classify_tool(tool)
+
+            candidate = ToolCandidate(
+                name=name,
+                description=description,
+                schema={"name": name, "description": description, "parameters": schema},
+                namespace=namespace,
+                original_tool=tool,
+            )
+            self.add_tool(candidate)
+
+    def add_tool(self, tool: ToolCandidate) -> None:
+        """Add *tool* to the index, respecting deduplication rules.
+
+        If a functionally identical tool already exists, the new entry is only
+        accepted when it is a ``"builtin"`` tool displacing an MCP copy.  In
+        all other duplicate cases the existing entry is kept unchanged.
+
+        Args:
+            tool: The :class:`ToolCandidate` to add.
+        """
+        func_hash = compute_functional_hash(tool.description, tool.schema)
+
+        if func_hash in self._dedup_map:
+            existing_name = self._dedup_map[func_hash]
+            existing = self.tools.get(existing_name)
+            # Built-in tools take precedence over MCP duplicates
+            if (
+                tool.namespace == "builtin"
+                and existing is not None
+                and existing.namespace != "builtin"
+            ):
+                del self.tools[existing_name]
+                self._index_tool(tool, func_hash)
+            # Otherwise silently drop the duplicate
+        else:
+            self._index_tool(tool, func_hash)
+
+    # ------------------------------------------------------------------
+    # Internal indexing
+    # ------------------------------------------------------------------
+
+    def _index_tool(self, tool: ToolCandidate, func_hash: str) -> None:
+        self.tools[tool.name] = tool
+        self._dedup_map[func_hash] = tool.name
+        self._index_doc(tool.name, f"{tool.name} {tool.description}")
+        self._recompute_tfidf()
+
+    @staticmethod
+    def _tokenize(text: str) -> list[str]:
+        """Split *text* into lowercase alphanumeric tokens.
+
+        Args:
+            text: Raw text to tokenize.
+
+        Returns:
+            List of lowercase word tokens.
+        """
+        return [w.lower() for w in text.split() if w.isalnum()]
+
+    def _index_doc(self, doc_id: str, text: str) -> None:
+        """Update in-memory frequency tables for a newly indexed document.
+
+        Args:
+            doc_id: Unique identifier for the document (tool name).
+            text: Full text to tokenize and index.
+        """
+        tokens = self._tokenize(text)
+        self.doc_lengths[doc_id] = len(tokens)
+        self.total_docs += 1
+        self.avgdl = sum(self.doc_lengths.values()) / self.total_docs
+
+        freqs = Counter(tokens)
+        self.term_freqs[doc_id] = dict(freqs)
+        for token in freqs:
+            self.doc_freqs[token] = self.doc_freqs.get(token, 0) + 1
+
+    def _recompute_tfidf(self) -> None:
+        """Rebuild normalised TF-IDF vectors for all indexed documents."""
+        self.tfidf_vectors.clear()
+        for doc_id, freqs in self.term_freqs.items():
+            vector: dict[str, float] = {}
+            for token, tf in freqs.items():
+                df = self.doc_freqs.get(token, 0)
+                idf = math.log((self.total_docs + 1) / (df + 1)) + 1
+                vector[token] = tf * idf
+            norm = math.sqrt(sum(v * v for v in vector.values()))
+            if norm > 0:
+                self.tfidf_vectors[doc_id] = {k: v / norm for k, v in vector.items()}
+
+    # ------------------------------------------------------------------
+    # Retrieval
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        query: str,
+        active_task: str = "",
+        namespaces: set[str] | None = None,
+        top_k: int = 30,
+    ) -> list[dict[str, Any]]:
+        """Search the index and return tool schemas ranked by hybrid score.
+
+        The query is fused with the current active task string to improve
+        recall.  Results are pre-filtered by *namespaces* when provided.
+
+        Args:
+            query: The user's current query string.
+            active_task: Optional active plan/todo item for multi-query fusion.
+            namespaces: When set, only tools whose namespace appears in this
+                set are considered.  ``None`` means all tools are eligible.
+            top_k: Maximum number of results to return.
+
+        Returns:
+            List of tool schema dicts (``{"name", "description", "parameters"}``),
+            ordered by descending hybrid relevance score.
+        """
+        fused_query = f"{query} {active_task}".strip()
+        tokens = self._tokenize(fused_query)
+
+        # Build normalised query TF-IDF vector
+        query_freqs = Counter(tokens)
+        query_vector: dict[str, float] = {}
+        for token, tf in query_freqs.items():
+            df = self.doc_freqs.get(token, 0)
+            idf = math.log((self.total_docs + 1) / (df + 1)) + 1
+            query_vector[token] = tf * idf
+
+        norm = math.sqrt(sum(v * v for v in query_vector.values()))
+        if norm > 0:
+            query_vector = {k: v / norm for k, v in query_vector.items()}
+
+        scores: dict[str, float] = {}
+
+        for doc_id, candidate in self.tools.items():
+            if namespaces is not None and candidate.namespace not in namespaces:
+                continue
+
+            # Sparse BM25 score
+            bm25_score = 0.0
+            dl = self.doc_lengths.get(doc_id, 0)
+            if dl > 0:
+                for token in tokens:
+                    if token in self.term_freqs.get(doc_id, {}):
+                        tf = self.term_freqs[doc_id][token]
+                        df = self.doc_freqs.get(token, 0)
+                        idf = math.log(1 + (self.total_docs - df + 0.5) / (df + 0.5))
+                        numerator = tf * (self.k1 + 1)
+                        denominator = tf + self.k1 * (
+                            1 - self.b + self.b * dl / self.avgdl
+                        )
+                        bm25_score += idf * (numerator / denominator)
+
+            # Dense TF-IDF cosine score
+            tfidf_score = 0.0
+            doc_vector = self.tfidf_vectors.get(doc_id, {})
+            for token, qv in query_vector.items():
+                if token in doc_vector:
+                    tfidf_score += qv * doc_vector[token]
+
+            scores[doc_id] = _BM25_WEIGHT * bm25_score + _TFIDF_WEIGHT * tfidf_score
+
+        sorted_docs = sorted(scores.items(), key=operator.itemgetter(1), reverse=True)
+        return [self.tools[doc_id].schema for doc_id, _ in sorted_docs[:top_k]]

--- a/libs/code/deepagents_code/dta/middleware.py
+++ b/libs/code/deepagents_code/dta/middleware.py
@@ -1,0 +1,458 @@
+"""Dynamic Tool Allocation middleware for deepagents-code.
+
+This module implements :class:`DynamicToolAllocationMiddleware`, an
+:class:`~langchain.agents.middleware.types.AgentMiddleware` that intercepts
+every model call and trims the full tool roster down to a context-relevant
+budget before forwarding the request to the LLM.
+
+Pipeline (per turn):
+    1. **Dynamic ingestion** — sync new tools from the live request into the
+       in-process :class:`~deepagents_code.dta.indexer.HybridToolIndexer`.
+    2. **Smart cache** — skip retrieval when the latest message is a tool
+       output (the toolset shouldn't change mid-execution).
+    3. **Cold reset** — evict temporal history when semantic drift between
+       turns is high (Jaccard similarity < 0.2).
+    4. **Namespace gating** — invoke the LLM router to limit Stage 1 to
+       only relevant MCP servers / namespaces.
+    5. **Stage 1 retrieval** — BM25 + TF-IDF hybrid search over gated tools.
+    6. **Stage 2 ranking** — LLM re-ranks candidates to a strict budget.
+    7. **Reconstruction** — filter ``request.tools`` to the final set and
+       forward the modified request to the model.
+
+All errors in steps 4-7 are caught and fail open: the original unmodified
+``request`` is returned so the agent always proceeds.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import TYPE_CHECKING, Any
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    ModelRequest,
+    ModelResponse,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from deepagents_code.dta.indexer import HybridToolIndexer
+    from deepagents_code.dta.selector import ToolSelectorNode
+
+logger = logging.getLogger(__name__)
+
+# Jaccard similarity threshold below which a Cold Reset is triggered.
+_COLD_RESET_THRESHOLD: float = 0.2
+
+# Number of recent messages scanned for temporal tool extraction.
+_TEMPORAL_WINDOW: int = 6
+
+# Number of recent messages scanned to detect a refresh_tools call.
+_REFRESH_SCAN_WINDOW: int = 2
+
+# Maximum Stage 1 candidates passed to Stage 2.
+_STAGE1_TOP_K: int = 30
+
+
+class DynamicToolAllocationMiddleware(AgentMiddleware[Any, Any, Any]):
+    """Middleware that dynamically allocates a context-relevant subset of tools.
+
+    The middleware sits between the agent graph and the LLM, intercepting
+    :meth:`wrap_model_call` / :meth:`awrap_model_call` to trim
+    ``request.tools`` to a configurable budget before the model sees them.
+
+    Attributes:
+        indexer: The hybrid retrieval index used for Stage 1 search.
+        selector_node: The LLM-based Stage 2 ranker.
+        router_node: The LLM-based namespace router (Stage 0 gating).
+        max_tools_budget: Hard cap on the total number of tools passed to the
+            model per turn (sticky tools count toward this budget).
+        sticky_tools: Tool names that are always included regardless of
+            relevance scoring.
+    """
+
+    def __init__(
+        self,
+        indexer: HybridToolIndexer,
+        selector_node: ToolSelectorNode,
+        router_node: object = None,
+        max_tools_budget: int = 12,
+    ) -> None:
+        """Initialise the middleware.
+
+        Args:
+            indexer: Pre-constructed
+                :class:`~deepagents_code.dta.indexer.HybridToolIndexer`.
+            selector_node: Pre-constructed
+                :class:`~deepagents_code.dta.selector.ToolSelectorNode`.
+            router_node: Optional pre-constructed
+                :class:`~deepagents_code.dta.gating.ToolNamespaceRouterNode`.
+                When ``None`` a default instance is created lazily.
+            max_tools_budget: Total tool budget per turn including sticky tools.
+        """
+        self.indexer = indexer
+        self.selector_node = selector_node
+        if router_node is None:
+            from deepagents_code.dta.gating import ToolNamespaceRouterNode
+
+            self.router_node: object = ToolNamespaceRouterNode()
+        else:
+            self.router_node = router_node
+        self.max_tools_budget = max_tools_budget
+        self.sticky_tools: set[str] = {
+            "read_file",
+            "edit_file",
+            "execute",
+            "ask_user",
+            "refresh_tools",
+        }
+        self._last_user_query: str = ""
+        self._cached_toolset: set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Context extraction helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_context_query(messages: list[Any]) -> str:
+        """Return the most recent human message content from *messages*.
+
+        Args:
+            messages: Conversation history from the model request.
+
+        Returns:
+            The content string of the latest human message, or a safe default.
+        """
+        for msg in reversed(messages):
+            if getattr(msg, "type", "") == "human" and isinstance(
+                getattr(msg, "content", None), str
+            ):
+                return msg.content
+        return "default context"
+
+    @staticmethod
+    def _extract_recent_tools(messages: list[Any]) -> set[str]:
+        """Collect tool names used in the last :data:`_TEMPORAL_WINDOW` messages.
+
+        Args:
+            messages: Conversation history from the model request.
+
+        Returns:
+            Set of tool names invoked recently (used for temporal continuation).
+        """
+        recent_tools: set[str] = set()
+        for msg in messages[-_TEMPORAL_WINDOW:]:
+            if getattr(msg, "type", "") == "ai" and hasattr(msg, "tool_calls"):
+                recent_tools.update(tc.get("name", "") for tc in msg.tool_calls)
+            elif getattr(msg, "type", "") == "tool":
+                recent_tools.add(getattr(msg, "name", ""))
+        return recent_tools
+
+    @staticmethod
+    def _is_tool_output_turn(messages: list[Any]) -> bool:
+        """Return ``True`` when the last message is a tool output.
+
+        Args:
+            messages: Conversation history from the model request.
+
+        Returns:
+            ``True`` if the latest message is a tool-output message.
+        """
+        if not messages:
+            return False
+        return getattr(messages[-1], "type", "") == "tool"
+
+    @staticmethod
+    def _was_refresh_requested(messages: list[Any]) -> bool:
+        """Detect whether ``refresh_tools`` was called in recent messages.
+
+        Args:
+            messages: Conversation history from the model request.
+
+        Returns:
+            ``True`` if a refresh_tools invocation is detected.
+        """
+        if not messages:
+            return False
+        for msg in messages[-_REFRESH_SCAN_WINDOW:]:
+            if getattr(msg, "type", "") == "ai" and hasattr(msg, "tool_calls"):
+                for tc in msg.tool_calls:
+                    if tc.get("name") == "refresh_tools":
+                        return True
+            elif (
+                getattr(msg, "type", "") == "tool"
+                and getattr(msg, "name", "") == "refresh_tools"
+            ):
+                return True
+        return False
+
+    def _check_cold_reset(self, current_query: str) -> bool:
+        """Return ``True`` when semantic drift warrants a Cold Reset.
+
+        Jaccard similarity between the previous and current query word sets is
+        computed; values below :data:`_COLD_RESET_THRESHOLD` indicate a topic
+        switch sufficient to evict temporal history.
+
+        Args:
+            current_query: The query extracted from the current turn.
+
+        Returns:
+            ``True`` if a Cold Reset should be triggered.
+        """
+        if not self._last_user_query or not current_query:
+            return False
+
+        def get_words(text: str) -> set[str]:
+            return {w.lower() for w in text.split() if w.isalnum()}
+
+        w1 = get_words(self._last_user_query)
+        w2 = get_words(current_query)
+        if not w1 or not w2:
+            return False
+
+        jaccard = len(w1 & w2) / len(w1 | w2)
+        return jaccard < _COLD_RESET_THRESHOLD
+
+    # ------------------------------------------------------------------
+    # Request reconstruction
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _reconstruct_request(
+        request: ModelRequest[Any], final_toolset_names: set[str]
+    ) -> ModelRequest[Any]:
+        """Return a copy of *request* with tools filtered to *final_toolset_names*.
+
+        Tries, in order:
+        1. ``request.override(tools=...)`` — preferred immutable pattern.
+        2. ``request.copy(update={"tools": ...})`` — Pydantic v1 copy.
+        3. ``dataclasses.replace(request, tools=...)`` — dataclass pattern.
+        4. Direct attribute mutation as a last resort.
+
+        Args:
+            request: The original model request.
+            final_toolset_names: Set of tool names that should be forwarded.
+
+        Returns:
+            A (possibly new) model request with tools trimmed to the final set.
+        """
+        filtered_tools = [
+            t
+            for t in request.tools
+            if (getattr(t, "name", t.get("name") if isinstance(t, dict) else ""))
+            in final_toolset_names
+        ]
+
+        try:
+            if hasattr(request, "override"):
+                return request.override(tools=filtered_tools)
+            if hasattr(request, "copy"):
+                return request.copy(update={"tools": filtered_tools})
+            if dataclasses.is_dataclass(request):
+                return dataclasses.replace(request, tools=filtered_tools)
+        except Exception:
+            logger.debug(
+                "Request reconstruction via API failed; falling back to mutation",
+                exc_info=True,
+            )
+        # Fallback: mutate in place when no immutable copy mechanism exists
+        request.tools = filtered_tools
+        return request
+
+    # ------------------------------------------------------------------
+    # Core pipeline
+    # ------------------------------------------------------------------
+
+    def _process_request(self, request: ModelRequest[Any]) -> ModelRequest[Any]:
+        """Run the full DTA pipeline synchronously.
+
+        Args:
+            request: Incoming model request from the agent graph.
+
+        Returns:
+            A model request with tools trimmed to the DTA budget.  On any
+            unrecoverable error the original *request* is returned unchanged.
+        """
+        try:
+            # 1. Dynamic ingestion
+            self.indexer.sync_tools(request.tools)
+
+            # 2. Extract context & state
+            state = getattr(request, "state", {}) or {}
+            plan_item = (
+                state.get("active_todo")
+                if isinstance(state, dict)
+                else getattr(state, "active_todo", None)
+            )
+            context_query = self._extract_context_query(request.messages)
+
+            # 3. Smart cache & refresh detection
+            is_refresh = self._was_refresh_requested(request.messages)
+            if is_refresh:
+                logger.info("DTA: refresh_tools detected — clearing cache")
+                self._cached_toolset.clear()
+
+            if (
+                not is_refresh
+                and self._is_tool_output_turn(request.messages)
+                and self._cached_toolset
+            ):
+                logger.debug("DTA: smart cache hit on tool-output turn")
+                return self._reconstruct_request(request, self._cached_toolset)
+
+            # 4. Cold Reset
+            if is_refresh or self._check_cold_reset(context_query):
+                logger.info("DTA: Cold Reset triggered")
+                temporal_tools: set[str] = set()
+            else:
+                temporal_tools = self._extract_recent_tools(request.messages)
+
+            self._last_user_query = context_query
+
+            # 5. Namespace gating
+            available_namespaces = {t.namespace for t in self.indexer.tools.values()}
+            active_namespaces = self.router_node.route(
+                query=context_query, available_namespaces=available_namespaces
+            )
+
+            # 6. Stage 1: BM25/TF-IDF retrieval
+            candidates = self.indexer.search(
+                query=context_query,
+                active_task=plan_item or "",
+                namespaces=active_namespaces,
+                top_k=_STAGE1_TOP_K,
+            )
+
+            # 7. Stage 2: LLM selector
+            budget = max(0, self.max_tools_budget - len(self.sticky_tools))
+            allocated_names = self.selector_node.select(
+                messages=request.messages, candidates=candidates, budget=budget
+            )
+
+            final_toolset_names = self.sticky_tools | allocated_names | temporal_tools
+            self._cached_toolset = final_toolset_names
+            logger.info("DTA final toolset: %s", final_toolset_names)
+
+            return self._reconstruct_request(request, final_toolset_names)
+        except Exception:
+            logger.exception(
+                "DTA _process_request failed catastrophically — failing open"
+            )
+            return request
+
+    async def _aprocess_request(self, request: ModelRequest[Any]) -> ModelRequest[Any]:
+        """Run the full DTA pipeline asynchronously.
+
+        Mirrors :meth:`_process_request` but uses ``await`` on async LLM calls.
+
+        Args:
+            request: Incoming model request from the agent graph.
+
+        Returns:
+            A model request with tools trimmed to the DTA budget.  On any
+            unrecoverable error the original *request* is returned unchanged.
+        """
+        try:
+            # 1. Dynamic ingestion
+            self.indexer.sync_tools(request.tools)
+
+            # 2. Extract context & state
+            state = getattr(request, "state", {}) or {}
+            plan_item = (
+                state.get("active_todo")
+                if isinstance(state, dict)
+                else getattr(state, "active_todo", None)
+            )
+            context_query = self._extract_context_query(request.messages)
+
+            # 3. Smart cache & refresh detection
+            is_refresh = self._was_refresh_requested(request.messages)
+            if is_refresh:
+                logger.info("DTA: refresh_tools detected — clearing cache")
+                self._cached_toolset.clear()
+
+            if (
+                not is_refresh
+                and self._is_tool_output_turn(request.messages)
+                and self._cached_toolset
+            ):
+                logger.debug("DTA: smart cache hit on tool-output turn")
+                return self._reconstruct_request(request, self._cached_toolset)
+
+            # 4. Cold Reset
+            if is_refresh or self._check_cold_reset(context_query):
+                logger.info("DTA: Cold Reset triggered")
+                temporal_tools_: set[str] = set()
+            else:
+                temporal_tools_ = self._extract_recent_tools(request.messages)
+
+            self._last_user_query = context_query
+
+            # 5. Namespace gating
+            available_namespaces = {t.namespace for t in self.indexer.tools.values()}
+            active_namespaces = await self.router_node.aroute(
+                query=context_query, available_namespaces=available_namespaces
+            )
+
+            # 6. Stage 1: BM25/TF-IDF retrieval
+            candidates = self.indexer.search(
+                query=context_query,
+                active_task=plan_item or "",
+                namespaces=active_namespaces,
+                top_k=_STAGE1_TOP_K,
+            )
+
+            # 7. Stage 2: LLM selector (async)
+            budget = max(0, self.max_tools_budget - len(self.sticky_tools))
+            allocated_names = await self.selector_node.aselect(
+                messages=request.messages, candidates=candidates, budget=budget
+            )
+
+            final_toolset_names = self.sticky_tools | allocated_names | temporal_tools_
+            self._cached_toolset = final_toolset_names
+            logger.info("DTA final toolset: %s", final_toolset_names)
+
+            return self._reconstruct_request(request, final_toolset_names)
+        except Exception:
+            logger.exception(
+                "DTA _aprocess_request failed catastrophically — failing open"
+            )
+            return request
+
+    # ------------------------------------------------------------------
+    # AgentMiddleware interface
+    # ------------------------------------------------------------------
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any]:
+        """Synchronous middleware entry point.
+
+        Args:
+            request: The model request to intercept.
+            handler: The downstream model call to invoke with the trimmed request.
+
+        Returns:
+            The model response from *handler*.
+        """
+        return handler(self._process_request(request))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any]:
+        """Asynchronous middleware entry point.
+
+        Args:
+            request: The model request to intercept.
+            handler: The downstream model call to invoke with the trimmed request.
+
+        Returns:
+            The model response from *handler*.
+        """
+        return await handler(await self._aprocess_request(request))

--- a/libs/code/deepagents_code/dta/selector.py
+++ b/libs/code/deepagents_code/dta/selector.py
@@ -1,0 +1,250 @@
+"""Stage 2 LLM-based tool selector for Dynamic Tool Allocation (DTA)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from deepagents_code.dta.utils import get_dta_fast_model
+
+try:
+    from deepagents_code.config import create_model
+except ImportError:
+    create_model = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+# Characters-per-token estimate used by the schema token budget heuristic.
+_CHARS_PER_TOKEN: int = 4
+
+
+class ToolSelectionResult(BaseModel):
+    """Structured output returned by the selector LLM."""
+
+    selected_tools: list[str] = Field(description="List of tool names selected")
+    rationale: str = Field(description="Reasoning for selecting these tools")
+
+
+class ToolSelectorNode:
+    """LLM-based Stage 2 ranker that narrows BM25/TF-IDF candidates to a budget.
+
+    When the candidate count already fits within *budget* the LLM is bypassed
+    and the full candidate set is returned immediately.  If the LLM call fails,
+    the selector falls back to taking the top-*budget* Stage 1 results in order.
+
+    All LLM errors are caught and handled by failing open, so the agent always
+    receives a valid (if un-ranked) toolset.
+    """
+
+    def __init__(self, model_spec: str | None = None) -> None:
+        """Initialise the selector node.
+
+        Args:
+            model_spec: Optional explicit model spec string.  When ``None``,
+                resolved at call time from
+                :func:`~deepagents_code.dta.utils.get_dta_fast_model`.
+        """
+        self.model_spec = model_spec
+
+    @staticmethod
+    def _build_prompt(
+        messages: list[BaseMessage],
+        candidates: list[dict[str, Any]],
+        budget: int,
+    ) -> list[BaseMessage]:
+        """Build the LLM prompt for tool selection.
+
+        Args:
+            messages: Conversation history; the most recent human message is
+                extracted as the query.
+            candidates: Stage 1 candidate tool schemas.
+            budget: Maximum number of tools the LLM should select.
+
+        Returns:
+            A two-element list ``[SystemMessage, HumanMessage]`` ready for
+            ``llm.invoke``.
+        """
+        last_human = ""
+        for msg in reversed(messages):
+            if getattr(msg, "type", "") == "human":
+                last_human = getattr(msg, "content", "") or ""
+                break
+
+        sys_prompt = (
+            "You are a Tool Selector. "
+            "Select the most relevant tools to fulfill the user query.\n"
+            f"You have a budget of {budget} tools. Do not select redundant tools.\n"
+            f"Candidate tools: {json.dumps(candidates)}\n"
+        )
+        return [
+            SystemMessage(content=sys_prompt),
+            HumanMessage(content=f"Query: {last_human}"),
+        ]
+
+    def _process_result(
+        self,
+        result: ToolSelectionResult,
+        candidates: list[dict[str, Any]],
+        budget: int,
+        token_limit: int,
+    ) -> set[str]:
+        """Validate and pack LLM output within budget constraints.
+
+        Args:
+            result: Structured output from the selector LLM.
+            candidates: Stage 1 candidate schemas used for name validation.
+            budget: Maximum number of tool names to return.
+            token_limit: Approximate schema token cap.
+
+        Returns:
+            Set of validated tool name strings within *budget*.
+
+        Raises:
+            ValueError: When the LLM returns no names matching the candidate list.
+        """
+        selected_candidates = [
+            c
+            for name in result.selected_tools
+            if (c := next((c for c in candidates if c.get("name") == name), None))
+            is not None
+        ]
+
+        if not selected_candidates:
+            msg = "LLM returned no valid tool names from the candidate list"
+            raise ValueError(msg)
+
+        return self._pack_within_budget(selected_candidates, budget, token_limit)
+
+    def select(
+        self,
+        messages: list[BaseMessage],
+        candidates: list[dict[str, Any]],
+        budget: int = 8,
+        token_limit: int = 4000,
+    ) -> set[str]:
+        """Synchronously select tools from *candidates* within *budget*.
+
+        Args:
+            messages: Full conversation history used to extract the user query.
+            candidates: Stage 1 candidate tool schemas.
+            budget: Maximum number of tools to allocate.
+            token_limit: Approximate per-schema character token budget.
+
+        Returns:
+            Set of selected tool name strings.
+
+        Raises:
+            ImportError: When no model provider is configured and
+                ``create_model`` is unavailable.
+        """
+        if not candidates:
+            return set()
+
+        if len(candidates) <= budget:
+            return self._pack_within_budget(candidates, budget, token_limit)
+
+        try:
+            if create_model is None:
+                msg = "create_model unavailable — no provider configured"
+                raise ImportError(msg)  # noqa: TRY301
+
+            spec = self.model_spec or get_dta_fast_model()
+            model_res = create_model(spec)
+            llm = model_res.model.with_structured_output(ToolSelectionResult)
+            prompt = self._build_prompt(messages, candidates, budget)
+            result: ToolSelectionResult = llm.invoke(
+                prompt, config={"tags": ["dta_selector"]}
+            )
+            return self._process_result(result, candidates, budget, token_limit)
+        except Exception:
+            logger.warning(
+                "DTA Stage 2 sync selection failed, falling back to Stage 1 ranking",
+                exc_info=True,
+            )
+            return self._pack_within_budget(candidates, budget, token_limit)
+
+    async def aselect(
+        self,
+        messages: list[BaseMessage],
+        candidates: list[dict[str, Any]],
+        budget: int = 8,
+        token_limit: int = 4000,
+    ) -> set[str]:
+        """Asynchronously select tools from *candidates* within *budget*.
+
+        Mirrors :meth:`select` but uses ``ainvoke`` for async event loops.
+
+        Args:
+            messages: Full conversation history used to extract the user query.
+            candidates: Stage 1 candidate tool schemas.
+            budget: Maximum number of tools to allocate.
+            token_limit: Approximate per-schema character token budget.
+
+        Returns:
+            Set of selected tool name strings.
+
+        Raises:
+            ImportError: When no model provider is configured and
+                ``create_model`` is unavailable.
+        """
+        if not candidates:
+            return set()
+
+        if len(candidates) <= budget:
+            return self._pack_within_budget(candidates, budget, token_limit)
+
+        try:
+            if create_model is None:
+                msg = "create_model unavailable — no provider configured"
+                raise ImportError(msg)  # noqa: TRY301
+
+            spec = self.model_spec or get_dta_fast_model()
+            model_res = create_model(spec)
+            llm = model_res.model.with_structured_output(ToolSelectionResult)
+            prompt = self._build_prompt(messages, candidates, budget)
+            result: ToolSelectionResult = await llm.ainvoke(
+                prompt, config={"tags": ["dta_selector"]}
+            )
+            return self._process_result(result, candidates, budget, token_limit)
+        except Exception:
+            logger.warning(
+                "DTA Stage 2 async selection failed, falling back to Stage 1 ranking",
+                exc_info=True,
+            )
+            return self._pack_within_budget(candidates, budget, token_limit)
+
+    @staticmethod
+    def _pack_within_budget(
+        candidates: list[dict[str, Any]],
+        budget: int,
+        token_limit: int,
+    ) -> set[str]:
+        """Greedily select tool names without exceeding *budget* or *token_limit*.
+
+        Each tool's contribution to the token budget is estimated as
+        ``len(json.dumps(schema)) / _CHARS_PER_TOKEN``.
+
+        Args:
+            candidates: Ordered list of tool schema dicts to pack.
+            budget: Hard cap on the number of tools selected.
+            token_limit: Soft cap on accumulated estimated schema tokens.
+
+        Returns:
+            Set of selected tool name strings.
+        """
+        selected: set[str] = set()
+        tokens: float = 0.0
+        for candidate in candidates:
+            name = candidate.get("name", "")
+            if not name:
+                continue
+            token_cost = len(json.dumps(candidate)) / _CHARS_PER_TOKEN
+            if len(selected) >= budget or tokens + token_cost > token_limit:
+                break
+            selected.add(name)
+            tokens += token_cost
+        return selected

--- a/libs/code/deepagents_code/dta/utils.py
+++ b/libs/code/deepagents_code/dta/utils.py
@@ -1,0 +1,45 @@
+"""Utility helpers for Dynamic Tool Allocation (DTA)."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    from deepagents_code.config import settings
+except ImportError:
+    settings = None  # type: ignore[assignment]
+
+
+def get_dta_fast_model() -> str | None:
+    """Resolve the fastest available model spec based on the configured provider.
+
+    Checks for an explicit per-session DTA model override stored in
+    ``settings.dta_model`` first, then falls back to a curated map of
+    provider → cheap fast model.  Returns ``None`` when no provider is
+    detected so callers can fall back to the user's primary model.
+
+    Returns:
+        A model spec string such as ``"openai:gpt-4o-mini"``, or ``None``
+        if the provider cannot be determined.
+    """
+    if settings is None:
+        return None
+
+    # Explicit per-session override (set via /dta-model slash command)
+    dta_model: str | None = getattr(settings, "dta_model", None)
+    if dta_model:
+        return dta_model
+
+    # Auto-resolve: map primary provider → fastest cheap model
+    provider: str = getattr(settings, "model_provider", "") or ""
+    if provider == "anthropic":
+        return "anthropic:claude-3-haiku-20240307"
+    if provider == "openai":
+        return "openai:gpt-4o-mini"
+    if provider == "google_genai":
+        return "google_genai:gemini-1.5-flash"
+
+    # Final fallback: use whatever the main model setting is
+    return getattr(settings, "model", None)

--- a/libs/code/tests/unit_tests/test_dta.py
+++ b/libs/code/tests/unit_tests/test_dta.py
@@ -1,0 +1,132 @@
+from typing import Any
+from unittest.mock import patch, MagicMock
+import pytest
+from deepagents_code.dta.indexer import HybridToolIndexer, ToolCandidate
+from deepagents_code.dta.gating import ToolNamespaceRegistry
+from deepagents_code.dta.selector import ToolSelectorNode
+from deepagents_code.dta.middleware import DynamicToolAllocationMiddleware
+from langchain.agents.middleware.types import ModelRequest
+from langchain_core.messages import HumanMessage, AIMessage, ToolMessage
+
+@pytest.fixture
+def mock_registry() -> ToolNamespaceRegistry:
+    return ToolNamespaceRegistry()
+
+@pytest.fixture
+def indexer(mock_registry: ToolNamespaceRegistry) -> HybridToolIndexer:
+    idx = HybridToolIndexer(registry=mock_registry)
+    idx.add_tool(ToolCandidate(
+        name="git_commit",
+        description="Commit changes to git",
+        schema={"name": "git_commit"},
+        namespace="git"
+    ))
+    idx.add_tool(ToolCandidate(
+        name="web_search",
+        description="Search the web for information",
+        schema={"name": "web_search"},
+        namespace="builtin"
+    ))
+    idx.add_tool(ToolCandidate(
+        name="db_query",
+        description="Query the database",
+        schema={"name": "db_query"},
+        namespace="postgres"
+    ))
+    return idx
+
+def test_indexer_search(indexer: HybridToolIndexer) -> None:
+    # Test namespace gating
+    namespaces = {"builtin", "git"}
+    results = indexer.search("commit changes", namespaces=namespaces, top_k=2)
+    names = [r["name"] for r in results]
+    assert "git_commit" in names
+    assert "db_query" not in names
+
+def test_registry_namespaces() -> None:
+    registry = ToolNamespaceRegistry()
+    assert registry.classify_tool({"name": "git_commit"}) == "git"
+    assert registry.classify_tool({"name": "postgres_query"}) == "database"
+
+def test_selector_node() -> None:
+    selector = ToolSelectorNode()
+    candidates = [{"name": "tool1"}, {"name": "tool2"}]
+    selected = selector.select(messages=[], candidates=candidates, budget=1)
+    assert len(selected) == 1
+    assert "tool1" in selected
+
+class MockLLM:
+    def __init__(self, structured_output_class: Any):
+        self.structured_output_class = structured_output_class
+
+    def with_structured_output(self, schema: Any) -> "MockLLM":
+        return MockLLM(schema)
+
+    def invoke(self, messages: list[Any], config: dict[str, Any] = None) -> Any:
+        from deepagents_code.dta.gating import ActiveNamespacesResult
+        from deepagents_code.dta.selector import ToolSelectionResult
+
+        if self.structured_output_class.__name__ == "ActiveNamespacesResult":
+            return self.structured_output_class(active_namespaces=["git", "builtin"])
+        elif self.structured_output_class.__name__ == "ToolSelectionResult":
+            return self.structured_output_class(
+                selected_tools=["git_commit"],
+                rationale="Selected git commit"
+            )
+
+    async def ainvoke(self, messages: list[Any], config: dict[str, Any] = None) -> Any:
+        return self.invoke(messages, config)
+
+@patch("deepagents_code.config.create_model")
+def test_middleware_override(mock_create_model: MagicMock, indexer: HybridToolIndexer) -> None:
+    mock_model_res = MagicMock()
+    mock_model_res.model = MockLLM(None)
+    mock_create_model.return_value = mock_model_res
+
+    selector = ToolSelectorNode()
+    middleware = DynamicToolAllocationMiddleware(indexer=indexer, selector_node=selector, max_tools_budget=7)
+
+    class DummyTool:
+        def __init__(self, name: str, description: str = ""):
+            self.name = name
+            self.description = description
+
+    class DummyRequest:
+        def __init__(self, tools: list[Any], messages: list[Any]):
+            self.tools = tools
+            self.messages = messages
+            self.state = {}
+
+        def override(self, tools: list[Any]) -> "DummyRequest":
+            self.tools = tools
+            return self
+
+    req = DummyRequest(
+        tools=[
+            DummyTool("git_commit", "Commit changes to git"),
+            DummyTool("web_search", "Search the web for information"),
+            DummyTool("unknown_tool", "Does something unknown")
+        ],
+        messages=[HumanMessage(content="commit changes")]
+    )
+
+    def dummy_handler(request: Any) -> Any:
+        return request
+
+    # Using wrap_model_call
+    res = middleware.wrap_model_call(req, dummy_handler)  # type: ignore
+
+    allocated_names = [t.name for t in res.tools]
+    assert "git_commit" in allocated_names
+    assert "unknown_tool" not in allocated_names
+
+def test_temporal_continuation() -> None:
+    middleware = DynamicToolAllocationMiddleware(indexer=None, selector_node=None)  # type: ignore
+
+    # Simulate a tool call in the last 3 turns
+    messages = [
+        AIMessage(content="", tool_calls=[{"name": "my_db_tool", "args": {}, "id": "1"}])
+    ]
+
+    recent = middleware._extract_recent_tools(messages)
+    assert "my_db_tool" in recent

--- a/libs/code/tests/unit_tests/test_dta_stress.py
+++ b/libs/code/tests/unit_tests/test_dta_stress.py
@@ -1,0 +1,609 @@
+import pytest
+import asyncio
+from typing import Any
+from unittest.mock import patch, MagicMock
+from pydantic import BaseModel
+from langchain_core.messages import HumanMessage, AIMessage
+
+from deepagents_code.dta.indexer import HybridToolIndexer, ToolCandidate
+from deepagents_code.dta.gating import ToolNamespaceRegistry, ToolNamespaceRouterNode
+from deepagents_code.dta.selector import ToolSelectorNode, ToolSelectionResult
+from deepagents_code.dta.gating import ActiveNamespacesResult
+from deepagents_code.dta.middleware import DynamicToolAllocationMiddleware
+
+# ---------------------------------------------------------
+# Define the 10 Mock MCP Servers and their 15 realistic tools
+# ---------------------------------------------------------
+
+MOCK_SERVERS = {
+    "git": [
+        ("git_status", "Get the status of the git repository, showing modified and untracked files"),
+        ("git_diff", "Show changes between commits, commit and working tree, etc"),
+        ("git_commit", "Record changes to the repository with a commit message"),
+        ("git_log", "Show commit logs for the repository"),
+        ("git_show", "Show various types of objects (commits, tags, etc)"),
+        ("git_add", "Add file contents to the index (stage files)"),
+        ("git_push", "Update remote refs along with associated objects"),
+        ("git_pull", "Fetch from and integrate with another repository or a local branch"),
+        ("git_clone", "Clone a repository into a new directory"),
+        ("git_branch", "List, create, or delete branches"),
+        ("git_checkout", "Switch branches or restore working tree files"),
+        ("git_merge", "Join two or more development histories together"),
+        ("git_rebase", "Reapply commits on top of another base tip"),
+        ("git_stash_push", "Save your local modifications to a new stash entry"),
+        ("git_stash_pop", "Remove a single stashed state from the stash list and apply it"),
+    ],
+    "postgres": [
+        ("postgres_query", "Execute a select query on the PostgreSQL database"),
+        ("postgres_insert", "Insert rows into a PostgreSQL database table"),
+        ("postgres_update", "Update rows in a PostgreSQL database table"),
+        ("postgres_delete", "Delete rows from a PostgreSQL database table"),
+        ("postgres_list_tables", "List all tables in the PostgreSQL database"),
+        ("postgres_describe_table", "Describe the schema and columns of a PostgreSQL table"),
+        ("postgres_create_table", "Create a new table in the PostgreSQL database"),
+        ("postgres_drop_table", "Drop an existing table from the PostgreSQL database"),
+        ("postgres_add_index", "Create an index on a PostgreSQL table column"),
+        ("postgres_get_schemas", "List all database schemas in PostgreSQL"),
+        ("postgres_backup", "Create a backup of the PostgreSQL database"),
+        ("postgres_restore", "Restore a PostgreSQL database from a backup"),
+        ("postgres_explain_query", "Explain the execution plan of a SQL query in PostgreSQL"),
+        ("postgres_list_indexes", "List all indexes in the PostgreSQL database"),
+        ("postgres_query_raw", "Execute a raw SQL query on the PostgreSQL database"),
+    ],
+    "aws": [
+        ("aws_ec2_list", "List EC2 instances in the AWS account"),
+        ("aws_ec2_start", "Start a stopped AWS EC2 instance"),
+        ("aws_ec2_stop", "Stop a running AWS EC2 instance"),
+        ("aws_s3_list_buckets", "List all S3 buckets in the AWS account"),
+        ("aws_s3_upload", "Upload a file to an AWS S3 bucket"),
+        ("aws_s3_download", "Download a file from an AWS S3 bucket"),
+        ("aws_s3_delete", "Delete an object from an AWS S3 bucket"),
+        ("aws_rds_list", "List RDS database instances in AWS"),
+        ("aws_rds_start", "Start an AWS RDS database instance"),
+        ("aws_rds_stop", "Stop an AWS RDS database instance"),
+        ("aws_lambda_list", "List AWS Lambda functions"),
+        ("aws_lambda_invoke", "Invoke an AWS Lambda function"),
+        ("aws_iam_list_users", "List IAM users in the AWS account"),
+        ("aws_dynamodb_list_tables", "List DynamoDB tables in AWS"),
+        ("aws_cloudwatch_get_logs", "Retrieve logs from AWS CloudWatch"),
+    ],
+    "docker": [
+        ("docker_ps", "List running Docker containers"),
+        ("docker_images", "List local Docker images"),
+        ("docker_run", "Run a command in a new Docker container"),
+        ("docker_stop", "Stop a running Docker container"),
+        ("docker_start", "Start a stopped Docker container"),
+        ("docker_rm", "Remove a Docker container"),
+        ("docker_rmi", "Remove a Docker image"),
+        ("docker_logs", "Fetch logs of a Docker container"),
+        ("docker_exec", "Run a command in a running Docker container"),
+        ("docker_build", "Build a Docker image from a Dockerfile"),
+        ("docker_volume_list", "List Docker volumes"),
+        ("docker_network_list", "List Docker networks"),
+        ("docker_inspect_container", "Return low-level information on a Docker container"),
+        ("docker_stats", "Display a live stream of container resource usage statistics"),
+        ("docker_compose_up", "Create and start containers using Docker Compose"),
+    ],
+    "filesystem": [
+        ("fs_read_file", "Read the contents of a file from filesystem"),
+        ("fs_write_file", "Write contents to a file on the filesystem"),
+        ("fs_list_directory", "List contents of a directory on filesystem"),
+        ("fs_create_directory", "Create a new directory on filesystem"),
+        ("fs_delete_file", "Delete a file from the filesystem"),
+        ("fs_delete_directory", "Delete a directory from the filesystem"),
+        ("fs_search_files", "Search files matching a pattern"),
+        ("fs_get_file_info", "Retrieve file metadata and statistics"),
+        ("fs_copy_file", "Copy a file to another location"),
+        ("fs_move_file", "Move a file to another location"),
+        ("fs_chmod", "Change file permissions on filesystem"),
+        ("fs_grep_search", "Grep for text inside files in a directory"),
+        ("fs_find_by_extension", "Find files recursively by extension"),
+        ("fs_read_binary_file", "Read raw binary contents of a file"),
+        ("fs_get_disk_usage", "Retrieve disk space usage statistics"),
+    ],
+    "github": [
+        ("github_create_issue", "Create a new issue on a GitHub repository"),
+        ("github_get_issue", "Retrieve a specific GitHub issue"),
+        ("github_list_issues", "List issues in a GitHub repository"),
+        ("github_close_issue", "Close a GitHub issue"),
+        ("github_create_pull_request", "Create a pull request on GitHub"),
+        ("github_get_pull_request", "Retrieve details of a pull request"),
+        ("github_list_pull_requests", "List pull requests in a GitHub repository"),
+        ("github_merge_pull_request", "Merge a GitHub pull request"),
+        ("github_create_repo", "Create a new GitHub repository"),
+        ("github_search_repos", "Search GitHub repositories"),
+        ("github_get_repo_contents", "Get repository directory contents or file"),
+        ("github_add_collaborator", "Add a collaborator to a GitHub repository"),
+        ("github_list_commits", "List commits on a GitHub branch"),
+        ("github_get_user_info", "Get details of a GitHub user"),
+        ("github_create_release", "Create a new release on GitHub"),
+    ],
+    "slack": [
+        ("slack_post_message", "Post a message to a Slack channel"),
+        ("slack_read_messages", "Read messages from a Slack channel"),
+        ("slack_list_channels", "List available public Slack channels"),
+        ("slack_create_channel", "Create a new Slack channel"),
+        ("slack_invite_user", "Invite a user to a Slack channel"),
+        ("slack_add_reaction", "Add a reaction to a Slack message"),
+        ("slack_remove_reaction", "Remove a reaction from a Slack message"),
+        ("slack_search_messages", "Search for messages matching query on Slack"),
+        ("slack_get_users", "Retrieve list of all users in the workspace"),
+        ("slack_get_user_presence", "Get active/away presence status of a user"),
+        ("slack_update_status", "Update user profile status custom message"),
+        ("slack_set_topic", "Set the topic of a Slack channel"),
+        ("slack_archive_channel", "Archive an existing Slack channel"),
+        ("slack_unarchive_channel", "Unarchive a previously archived Slack channel"),
+        ("slack_list_groups", "List private Slack groups"),
+    ],
+    "sqlite": [
+        ("sqlite_execute", "Execute a write statement (insert, update, delete) in SQLite"),
+        ("sqlite_query", "Query rows using SQL select statement in SQLite"),
+        ("sqlite_insert", "Insert records into SQLite table"),
+        ("sqlite_update", "Update records in SQLite table"),
+        ("sqlite_delete", "Delete records from SQLite table"),
+        ("sqlite_list_tables", "List all tables in SQLite database file"),
+        ("sqlite_describe_table", "Show schema and table structures for SQLite"),
+        ("sqlite_create_table", "Create a new SQLite table"),
+        ("sqlite_drop_table", "Delete SQLite table schema and data"),
+        ("sqlite_backup", "Backup SQLite database to another file"),
+        ("sqlite_get_schema", "Get the SQLite database schema"),
+        ("sqlite_list_indexes", "List all active indexes in SQLite"),
+        ("sqlite_add_index", "Create an index on SQLite table column"),
+        ("sqlite_vacuum", "Compact the SQLite database file"),
+        ("sqlite_import_csv", "Import data from a CSV file into SQLite"),
+    ],
+    "google_maps": [
+        ("maps_search_places", "Search places using Google Maps API"),
+        ("maps_get_place_details", "Retrieve details of a place via place ID"),
+        ("maps_get_directions", "Get driving directions between locations"),
+        ("maps_get_distance_matrix", "Retrieve travel distance matrix for locations"),
+        ("maps_geocode", "Convert addresses into geographic coordinates"),
+        ("maps_reverse_geocode", "Convert coordinates into human-readable addresses"),
+        ("maps_elevation", "Get elevation data for coordinates"),
+        ("maps_timezone", "Retrieve timezone offset for geographical coordinates"),
+        ("maps_static_map_url", "Generate static map image URL"),
+        ("maps_streetview_url", "Retrieve a streetview image URL"),
+        ("maps_find_nearby", "Find places nearby a location coordinate"),
+        ("maps_autocomplete", "Autocompletion suggestions for place searches"),
+        ("maps_get_reviews", "Get user reviews of a place"),
+        ("maps_get_local_businesses", "List local businesses registered nearby"),
+        ("maps_validate_address", "Validate postal address components"),
+    ],
+    "browser": [
+        ("browser_navigate", "Navigate browser page to the given URL"),
+        ("browser_click", "Click element on browser page using selector"),
+        ("browser_type", "Type text into selector element on browser page"),
+        ("browser_press_key", "Press keyboard key on page element"),
+        ("browser_screenshot", "Capture browser window page screenshot"),
+        ("browser_get_html", "Get current DOM HTML of the browser page"),
+        ("browser_get_text", "Get text content of browser page"),
+        ("browser_scroll", "Scroll browser page down or up"),
+        ("browser_back", "Go back in browser session history"),
+        ("browser_forward", "Go forward in browser session history"),
+        ("browser_refresh", "Reload current browser page"),
+        ("browser_get_cookies", "Get current cookies for browser page"),
+        ("browser_clear_cookies", "Clear all browser session cookies"),
+        ("browser_execute_script", "Execute custom Javascript on browser page"),
+        ("browser_get_active_element", "Retrieve details of active focused page element"),
+    ]
+}
+
+class DummyTool:
+    def __init__(self, name: str, description: str, metadata: dict[str, Any]):
+        self.name = name
+        self.description = description
+        self.metadata = metadata
+
+def build_all_tools() -> list[DummyTool]:
+    tools = []
+    for server_name, tool_list in MOCK_SERVERS.items():
+        for name, desc in tool_list:
+            tools.append(DummyTool(
+                name=name,
+                description=desc,
+                metadata={"server_name": server_name}
+            ))
+    return tools
+
+# ---------------------------------------------------------
+# Mock LLM for structured output testing (Zero-Shot Router & Selector)
+# ---------------------------------------------------------
+
+class MockLLM:
+    def __init__(self, structured_output_class: Any):
+        self.structured_output_class = structured_output_class
+
+    def with_structured_output(self, schema: Any) -> "MockLLM":
+        return MockLLM(schema)
+
+    def invoke(self, messages: list[Any], config: dict[str, Any] = None) -> Any:
+        human_content = ""
+        for msg in reversed(messages):
+            if getattr(msg, "type", "") == "human":
+                human_content = getattr(msg, "content", "").lower()
+                break
+
+        if self.structured_output_class.__name__ == "ActiveNamespacesResult":
+            # Direct logic simulating how router should activate namespaces
+            active = ["builtin"]
+            if "git" in human_content or "commit" in human_content:
+                active.append("mcp:git")
+            if "database" in human_content or "sql" in human_content or "postgres" in human_content:
+                active.append("mcp:postgres")
+                active.append("mcp:sqlite")
+            if "browser" in human_content or "click" in human_content or "navigate" in human_content:
+                active.append("mcp:browser")
+            if "file" in human_content or "directory" in human_content:
+                active.append("mcp:filesystem")
+            if "aws" in human_content or "ec2" in human_content or "s3" in human_content:
+                active.append("mcp:aws")
+            if "docker" in human_content or "container" in human_content:
+                active.append("mcp:docker")
+            if "slack" in human_content or "channel" in human_content:
+                active.append("mcp:slack")
+            if "github" in human_content or "pr" in human_content:
+                active.append("mcp:github")
+            if "map" in human_content or "places" in human_content:
+                active.append("mcp:google_maps")
+
+            return self.structured_output_class(active_namespaces=active)
+
+        elif self.structured_output_class.__name__ == "ToolSelectionResult":
+            # Selector logic to pick the best tools
+            selected = []
+            if "git" in human_content:
+                selected = ["git_status", "git_commit", "git_diff"]
+            elif "database" in human_content or "postgres" in human_content:
+                selected = ["postgres_query", "postgres_insert"]
+            elif "browser" in human_content:
+                selected = ["browser_navigate", "browser_click"]
+            else:
+                selected = ["fs_read_file"]
+                
+            return self.structured_output_class(
+                selected_tools=selected,
+                rationale="Selected relevant tools matching query."
+            )
+
+    async def ainvoke(self, messages: list[Any], config: dict[str, Any] = None) -> Any:
+        return self.invoke(messages, config)
+
+# ---------------------------------------------------------
+# Test Cases
+# ---------------------------------------------------------
+
+@pytest.fixture
+def indexer() -> HybridToolIndexer:
+    registry = ToolNamespaceRegistry()
+    idx = HybridToolIndexer(registry=registry)
+    # Sync all 150 tools into indexer
+    all_tools = build_all_tools()
+    idx.sync_tools(all_tools)
+    return idx
+
+@pytest.mark.asyncio
+@patch("deepagents_code.dta.gating.create_model")
+@patch("deepagents_code.dta.selector.create_model")
+async def test_dta_e2e_stress(mock_selector_create_model: MagicMock, mock_gating_create_model: MagicMock, indexer: HybridToolIndexer) -> None:
+    # 1. Setup mock models
+    mock_gating_model_res = MagicMock()
+    mock_gating_model_res.model = MockLLM(ActiveNamespacesResult)
+    mock_gating_create_model.return_value = mock_gating_model_res
+
+    mock_selector_model_res = MagicMock()
+    mock_selector_model_res.model = MockLLM(ToolSelectionResult)
+    mock_selector_create_model.return_value = mock_selector_model_res
+
+    # Initialize middleware
+    selector_node = ToolSelectorNode()
+    router_node = ToolNamespaceRouterNode()
+    middleware = DynamicToolAllocationMiddleware(
+        indexer=indexer,
+        selector_node=selector_node,
+        router_node=router_node,
+        max_tools_budget=10
+    )
+
+    class DummyRequest:
+        def __init__(self, tools: list[Any], messages: list[Any]):
+            self.tools = tools
+            self.messages = messages
+            self.state = {}
+            
+        def override(self, tools: list[Any]) -> "DummyRequest":
+            self.tools = tools
+            return self
+
+    # Test Case A: Database task
+    req_db = DummyRequest(
+        tools=build_all_tools(),
+        messages=[HumanMessage(content="Query the postgres database for all users.")]
+    )
+    
+    res_db = await middleware._aprocess_request(req_db)
+    tool_names_db = [t.name for t in res_db.tools]
+    
+    # We expect postgres_query to be selected
+    assert "postgres_query" in tool_names_db
+    # We expect unrelated tools (like git_commit or aws_ec2_list) NOT to be in the allocated toolset (budget limit)
+    assert "aws_ec2_list" not in tool_names_db
+
+    # Test Case B: Git task
+    req_git = DummyRequest(
+        tools=build_all_tools(),
+        messages=[HumanMessage(content="Commit the current changes to git.")]
+    )
+    
+    res_git = await middleware._aprocess_request(req_git)
+    tool_names_git = [t.name for t in res_git.tools]
+    
+    assert "git_commit" in tool_names_git
+    assert "postgres_query" not in tool_names_git
+
+@pytest.mark.asyncio
+@patch("deepagents_code.dta.gating.create_model")
+async def test_gating_fast_path(mock_gating_create_model: MagicMock) -> None:
+    """Verify the router bypasses LLM entirely when total namespaces <= 3."""
+    router_node = ToolNamespaceRouterNode()
+    
+    active = await router_node.aroute(
+        query="Run git status",
+        available_namespaces={"mcp:git", "builtin"}
+    )
+    
+    mock_gating_create_model.assert_not_called()
+    assert "mcp:git" in active
+    assert "builtin" in active
+
+
+@pytest.mark.asyncio
+@patch("deepagents_code.dta.gating.create_model")
+async def test_gating_fail_open(mock_gating_create_model: MagicMock) -> None:
+    """If the LLM throws an exception, gating must fail open to the full available set."""
+    mock_gating_create_model.side_effect = RuntimeError("API key invalid")
+    router_node = ToolNamespaceRouterNode()
+    
+    active = await router_node.aroute(
+        query="Deploy container to docker",
+        available_namespaces={"mcp:docker", "mcp:git", "mcp:aws", "builtin"}
+    )
+    
+    assert active == {"mcp:docker", "mcp:git", "mcp:aws", "builtin"}
+
+
+@pytest.mark.asyncio
+@patch("deepagents_code.dta.gating.create_model")
+@patch("deepagents_code.dta.selector.create_model")
+async def test_multi_domain_task_switch(
+    mock_selector_create_model: MagicMock,
+    mock_gating_create_model: MagicMock,
+    indexer: HybridToolIndexer,
+) -> None:
+    """Verify that a semantic domain switch triggers a cold reset, evicting stale tools."""
+    mock_gating_model_res = MagicMock()
+    mock_gating_model_res.model = MockLLM(ActiveNamespacesResult)
+    mock_gating_create_model.return_value = mock_gating_model_res
+
+    mock_selector_model_res = MagicMock()
+    mock_selector_model_res.model = MockLLM(ToolSelectionResult)
+    mock_selector_create_model.return_value = mock_selector_model_res
+
+    selector_node = ToolSelectorNode()
+    router_node = ToolNamespaceRouterNode()
+    middleware = DynamicToolAllocationMiddleware(
+        indexer=indexer,
+        selector_node=selector_node,
+        router_node=router_node,
+        max_tools_budget=10
+    )
+
+    class DummyRequest:
+        def __init__(self, tools: list[Any], messages: list[Any]):
+            self.tools = tools
+            self.messages = messages
+            self.state = {}
+
+        def override(self, tools: list[Any]) -> "DummyRequest":
+            self.tools = tools
+            return self
+
+    # First turn: git task — set last query to "commit"
+    req_git = DummyRequest(
+        tools=build_all_tools(),
+        messages=[HumanMessage(content="Commit changes to git.")]
+    )
+    res_git = await middleware._aprocess_request(req_git)
+    assert "git_commit" in [t.name for t in res_git.tools]
+
+    # Simulate the middleware remembering the prior query
+    assert middleware._last_user_query == "Commit changes to git."
+
+    # Second turn: completely different domain (browser) — should trigger Cold Reset
+    req_browser = DummyRequest(
+        tools=build_all_tools(),
+        messages=[HumanMessage(content="Navigate browser to the login page and click the submit button.")]
+    )
+    res_browser = await middleware._aprocess_request(req_browser)
+    browser_tool_names = [t.name for t in res_browser.tools]
+
+    # browser_navigate should appear
+    assert "browser_navigate" in browser_tool_names
+    # git_commit should NOT persist from the prior turn (cold reset evicts history)
+    assert "git_commit" not in browser_tool_names
+
+
+@pytest.mark.asyncio
+@patch("deepagents_code.dta.gating.create_model")
+@patch("deepagents_code.dta.selector.create_model")
+async def test_temporal_tool_continuation(
+    mock_selector_create_model: MagicMock,
+    mock_gating_create_model: MagicMock,
+    indexer: HybridToolIndexer,
+) -> None:
+    """Tools used in the recent conversation history are preserved across turns (temporal boost)."""
+    mock_gating_model_res = MagicMock()
+    mock_gating_model_res.model = MockLLM(ActiveNamespacesResult)
+    mock_gating_create_model.return_value = mock_gating_model_res
+
+    mock_selector_model_res = MagicMock()
+    mock_selector_model_res.model = MockLLM(ToolSelectionResult)
+    mock_selector_create_model.return_value = mock_selector_model_res
+
+    selector_node = ToolSelectorNode()
+    router_node = ToolNamespaceRouterNode()
+    middleware = DynamicToolAllocationMiddleware(
+        indexer=indexer,
+        selector_node=selector_node,
+        router_node=router_node,
+        max_tools_budget=10
+    )
+
+    class DummyRequest:
+        def __init__(self, tools: list[Any], messages: list[Any]):
+            self.tools = tools
+            self.messages = messages
+            self.state = {}
+
+        def override(self, tools: list[Any]) -> "DummyRequest":
+            self.tools = tools
+            return self
+
+    # Simulate a tool output turn — the AI just used postgres_query
+    messages = [
+        HumanMessage(content="Check the database for all users."),
+        AIMessage(content="", tool_calls=[{"name": "postgres_query", "args": {}, "id": "tc1"}]),
+    ]
+    req = DummyRequest(tools=build_all_tools(), messages=messages)
+    res = await middleware._aprocess_request(req)
+    
+    tool_names = [t.name for t in res.tools]
+    # postgres_query should remain available as a temporal tool even if the allocator
+    # would have filtered it away (temporal continuation)
+    assert "postgres_query" in tool_names
+
+
+@pytest.mark.asyncio
+@patch("deepagents_code.dta.gating.create_model")
+@patch("deepagents_code.dta.selector.create_model")
+async def test_smart_cache_on_tool_output(
+    mock_selector_create_model: MagicMock,
+    mock_gating_create_model: MagicMock,
+    indexer: HybridToolIndexer,
+) -> None:
+    """Verify the smart cache returns the previous toolset on tool-output turns without retrieval."""
+    mock_gating_model_res = MagicMock()
+    mock_gating_model_res.model = MockLLM(ActiveNamespacesResult)
+    mock_gating_create_model.return_value = mock_gating_model_res
+
+    mock_selector_model_res = MagicMock()
+    mock_selector_model_res.model = MockLLM(ToolSelectionResult)
+    mock_selector_create_model.return_value = mock_selector_model_res
+
+    selector_node = ToolSelectorNode()
+    router_node = ToolNamespaceRouterNode()
+    middleware = DynamicToolAllocationMiddleware(
+        indexer=indexer,
+        selector_node=selector_node,
+        router_node=router_node,
+        max_tools_budget=10
+    )
+
+    class DummyTool:
+        def __init__(self, name: str, description: str = ""):
+            self.name = name
+            self.description = description
+            self.metadata: dict[str, Any] = {}
+
+    class DummyToolMessage:
+        type = "tool"
+        name = "git_status"
+
+    class DummyRequest:
+        def __init__(self, tools: list[Any], messages: list[Any]):
+            self.tools = tools
+            self.messages = messages
+            self.state = {}
+
+        def override(self, tools: list[Any]) -> "DummyRequest":
+            self.tools = tools
+            return self
+
+    # First turn — prime the cache
+    req1 = DummyRequest(
+        tools=build_all_tools(),
+        messages=[HumanMessage(content="Check git status.")]
+    )
+    res1 = await middleware._aprocess_request(req1)
+    cached = middleware._cached_toolset.copy()
+    assert len(cached) > 0
+
+    # Second turn — tool output message, should hit cache
+    req2 = DummyRequest(
+        tools=build_all_tools(),
+        messages=[
+            HumanMessage(content="Check git status."),
+            DummyToolMessage(),  # type: ignore[list-item]
+        ]
+    )
+    initial_call_count = mock_gating_create_model.call_count
+    res2 = await middleware._aprocess_request(req2)
+
+    # Router should NOT have been called again (cache hit)
+    assert mock_gating_create_model.call_count == initial_call_count
+    # The toolset should be unchanged
+    assert {t.name for t in res2.tools} == {t.name for t in res1.tools}
+
+
+def test_tool_deduplication(indexer: HybridToolIndexer) -> None:
+    """Adding the same tool twice (by description+schema) should not duplicate it in the index."""
+    before_count = len(indexer.tools)
+    # Re-add a tool that is already indexed by sync_tools
+    dupe = DummyTool(
+        name="git_commit",
+        description="Record changes to the repository with a commit message",
+        metadata={"server_name": "git"}
+    )
+    indexer.sync_tools([dupe])
+    after_count = len(indexer.tools)
+    assert after_count == before_count, "Deduplication failed: tool count changed after re-adding an identical tool"
+
+
+def test_indexer_namespace_gating_150_tools(indexer: HybridToolIndexer) -> None:
+    """With 150 tools loaded, namespace gating should eliminate > 80% of candidates."""
+    # Only allow the git namespace
+    results = indexer.search("commit changes to repository", namespaces={"mcp:git"}, top_k=50)
+    names = {r["name"] for r in results}
+
+    # All returned tools must belong to the git server
+    assert all(n.startswith("git_") for n in names), f"Non-git tool leaked through: {names - {n for n in names if n.startswith('git_')}}"
+    # We should get at most 15 tools (the full git server) and no more
+    assert len(results) <= 15
+
+
+def test_selector_budget_cap() -> None:
+    """The selector must never exceed the budget even if the LLM returns more names."""
+    selector = ToolSelectorNode()
+    # Provide 20 candidates, budget=5
+    candidates = [{"name": f"tool_{i}", "description": f"Tool {i}", "parameters": {}} for i in range(20)]
+    selected = selector.select(messages=[], candidates=candidates, budget=5)
+    assert len(selected) <= 5
+
+
+def test_namespace_classification_mcp_metadata() -> None:
+    """Tools with server_name metadata must be classified to mcp:<server> namespace."""
+    registry = ToolNamespaceRegistry()
+
+    class MCPTool:
+        name = "browse_page"
+        metadata = {"server_name": "puppeteer"}
+
+    ns = registry.classify_tool(MCPTool())
+    assert ns == "mcp:puppeteer"
+
+
+def test_namespace_classification_fallback_builtin() -> None:
+    """Tools with no recognizable prefix or metadata must fall back to 'builtin'."""
+    registry = ToolNamespaceRegistry()
+    ns = registry.classify_tool({"name": "read_file"})
+    assert ns == "builtin"
+


### PR DESCRIPTION
Closes #4836 

Implements a Dynamic Tool Allocation (DTA) pipeline for `deepagents-code` to prevent LLM context bloat and performance degradation when working with large multi-server MCP environments.

---

When users connect multiple MCP servers (e.g., git, browser, cloud infrastructure), the agent can easily accumulate 100+ active tools. Passing all these schemas to the LLM on every turn consumes significant context budget and degrades reasoning capabilities due to the sheer noise of irrelevant tools.

This PR solves this by introducing a 3-stage dynamic tool filtering pipeline implemented as LangChain middleware (`DynamicToolAllocationMiddleware`):

1. **Stage 0 (Namespace Gating):** Uses a fast LLM router (`ToolNamespaceRouterNode`) to instantly classify the user's intent and prune entirely irrelevant MCP namespaces.
2. **Stage 1 (Sparse/Dense Indexing):** Uses an in-memory `HybridToolIndexer` (TF-IDF + BM25) to semantically retrieve the most relevant tools from the remaining namespaces.
3. **Stage 2 (Token-Budget Selector):** Uses a secondary LLM re-ranker (`ToolSelectorNode`) to confidently pack the top tools into a strict context budget (max 12 tools).

**Key details:**
- **Fail-open design:** If any stage of the pipeline fails (e.g., no credentials configured, LLM timeout), the middleware gracefully falls back to returning the full original toolset without disrupting the agent.
- **Smart caching:** DTA is automatically bypassed on tool-output turns to save latency and API cost.
- **Cold reset:** Detects when the user switches topics (via Jaccard similarity thresholding) and evicts stale tools from the temporal cache.
- **Zero impact on other packages:** All changes are isolated to `libs/code/deepagents_code/dta/` and the `agent.py` middleware stack.

<details>
<summary>Test plan</summary>

- Verified locally with `uv run --group test pytest tests/unit_tests/test_dta*` (16/16 pass).
- Verified fail-open behavior by triggering credential and timeout errors in the selector node.
- Validated that smart-caching and topic switching (Cold Reset) execute within budget constraints across consecutive turns.

</details>