### PR TITLE
fix(code): hide `Auto` option in approval widget when ineligible

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2447,10 +2447,10 @@ class DeepAgentsApp(App):
         Binding("j", "approval_down", "Down", show=False),
         Binding("enter", "approval_select", "Select", show=False),
         Binding("y", "approval_yes", "Yes", show=False),
-        Binding("1", "approval_yes", "Yes", show=False),
-        Binding("2", "approval_auto", "Auto", show=False),
+        Binding("1", "approval_position(0)", "Select first", show=False),
+        Binding("2", "approval_position(1)", "Select second", show=False),
+        Binding("3", "approval_position(2)", "Select third", show=False),
         Binding("a", "approval_auto", "Auto", show=False),
-        Binding("3", "approval_no", "No", show=False),
         Binding("n", "approval_no", "No", show=False),
     ]
     """App-level keybindings for interrupt, quit, toggles, and approval menu
@@ -15939,17 +15939,26 @@ class DeepAgentsApp(App):
         return focused.id == "chat-input" or focused in self._chat_input.walk_children()
 
     def action_approval_yes(self) -> None:
-        """Handle yes/1 in approval menu."""
+        """Handle the semantic approve key in the approval menu."""
         if self._pending_approval_widget:
             self._pending_approval_widget.action_select_approve()
 
+    def action_approval_position(self, position: int) -> None:
+        """Select an approval option by its visible position.
+
+        Args:
+            position: Zero-based position of the displayed option.
+        """
+        if self._pending_approval_widget:
+            self._pending_approval_widget.action_select_position(position)
+
     def action_approval_auto(self) -> None:
-        """Handle auto/2 in approval menu."""
+        """Handle the semantic Auto key in the approval menu."""
         if self._pending_approval_widget:
             self._pending_approval_widget.action_select_auto()
 
     def action_approval_no(self) -> None:
-        """Handle no/3 in approval menu."""
+        """Handle the semantic reject key in the approval menu."""
         if self._pending_approval_widget:
             self._pending_approval_widget.action_select_reject()
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -7073,7 +7073,12 @@ class DeepAgentsApp(App):
         from deepagents_code.tui.widgets.approval import ApprovalMenu
 
         unique_id = f"approval-menu-{uuid.uuid4().hex[:8]}"
-        menu = ApprovalMenu(action_requests, assistant_id, id=unique_id)
+        menu = ApprovalMenu(
+            action_requests,
+            assistant_id,
+            id=unique_id,
+            auto_mode_eligible=self._auto_mode_eligible,
+        )
         menu.set_future(result_future)
 
         self._pending_approval_widget = menu

--- a/libs/code/deepagents_code/tui/widgets/approval.py
+++ b/libs/code/deepagents_code/tui/widgets/approval.py
@@ -483,14 +483,15 @@ class ApprovalMenu(Container):
         """Submit the option at a display position (0-indexed).
 
         Backs the numeric quick keys, which map key `1`/`2`/`3` to position
-        `0`/`1`/`2`. Positions past the last visible option are ignored, so
+        `0`/`1`/`2`. Positions outside the visible options are ignored, so
         when the Auto option is hidden (only positions 0-1 exist) the `3` key
-        (position 2) is a no-op.
+        (position 2) is a no-op and key `2` (position 1) selects Reject rather
+        than Auto.
 
         Args:
             position: Zero-based index of the visible option to submit.
         """
-        if position >= self._num_options:
+        if not 0 <= position < self._num_options:
             return
         self._handle_selection(position)
 

--- a/libs/code/deepagents_code/tui/widgets/approval.py
+++ b/libs/code/deepagents_code/tui/widgets/approval.py
@@ -175,7 +175,11 @@ class ApprovalMenu(Container):
         # Auto fallback implies Auto is already active, so its "Switch to
         # Manual" affordance is always shown regardless of eligibility.
         self._show_auto_option = self._is_auto_fallback or auto_mode_eligible
-        self._num_options = len(self._build_options())
+        # Built once: every input to `_build_options` is fixed for the widget's
+        # lifetime, so caching keeps `_num_options`/`_reject_index` from ever
+        # disagreeing with the option list they describe.
+        self._options = self._build_options()
+        self._num_options = len(self._options)
         self._reject_index = self._num_options - 1
         self._selected = 0
         self._future: asyncio.Future[dict[str, str]] | None = None
@@ -423,8 +427,9 @@ class ApprovalMenu(Container):
         """Build the visible options as `(label, decision_type)` pairs.
 
         The Auto option is omitted unless Auto can actually be enabled
-        (`_show_auto_option`), so it is never suggested outside the beta.
-        Labels are unnumbered; `_update_options` prefixes the display number.
+        (`_show_auto_option`), so it is never suggested outside the
+        experimental opt-in. Labels are unnumbered; `_update_options`
+        prefixes the display number.
 
         Returns:
             Ordered `(label, decision_type)` pairs for the visible options.
@@ -443,9 +448,8 @@ class ApprovalMenu(Container):
 
     def _update_options(self) -> None:
         """Update option widgets based on selection."""
-        options = self._build_options()
         for i, ((text, _decision), widget) in enumerate(
-            zip(options, self._option_widgets, strict=True)
+            zip(self._options, self._option_widgets, strict=True)
         ):
             cursor = f"{get_glyphs().cursor} " if i == self._selected else "  "
             widget.update(f"{cursor}{i + 1}. {text}")
@@ -478,8 +482,10 @@ class ApprovalMenu(Container):
     def action_select_position(self, position: int) -> None:
         """Submit the option at a display position (0-indexed).
 
-        Backs the numeric quick keys. Positions past the last visible option
-        (e.g. `3` when the Auto option is hidden) are ignored.
+        Backs the numeric quick keys, which map key `1`/`2`/`3` to position
+        `0`/`1`/`2`. Positions past the last visible option are ignored, so
+        when the Auto option is hidden (only positions 0-1 exist) the `3` key
+        (position 2) is a no-op.
 
         Args:
             position: Zero-based index of the visible option to submit.
@@ -493,10 +499,11 @@ class ApprovalMenu(Container):
         self._handle_selection(0)
 
     def action_select_auto(self) -> None:
-        """Submit auto-approve option.
+        """Submit the middle option (Auto, or Switch to Manual in a fallback).
 
-        No-op when the Auto option is hidden, since Auto cannot be enabled.
-        Auto is always the second option (index 1) when shown.
+        No-op when the option is hidden, since Auto cannot be enabled. When
+        shown it is always the second option (index 1): "Enable Auto" normally,
+        or "Switch to Manual" during a live Auto fallback.
         """
         if not self._show_auto_option:
             return
@@ -531,10 +538,11 @@ class ApprovalMenu(Container):
         Args:
             option: Index of the chosen visible option. Maps to a decision type
                 via the current option layout (which omits Auto when hidden).
-            reject_message: Optional free-text reason. Only attached when the
-                user rejects with a non-empty message via `action_reject_with_reason`.
+            reject_message: Optional free-text reason. Only attached when a
+                non-empty reason is submitted via `on_input_submitted` (the
+                free-text reject flow opened by `action_reject_with_reason`).
         """
-        decision_type = self._build_options()[option][1]
+        decision_type = self._options[option][1]
         decision: dict[str, str] = {"type": decision_type}
         if decision_type == "reject" and reject_message:
             decision["message"] = reject_message

--- a/libs/code/deepagents_code/tui/widgets/approval.py
+++ b/libs/code/deepagents_code/tui/widgets/approval.py
@@ -598,7 +598,7 @@ class ApprovalMenu(Container):
             return
         reason = event.value.strip()
         self._reason_input_active = False
-        self._handle_selection(2, reject_message=reason or None)
+        self._handle_selection(self._reject_index, reject_message=reason or None)
 
     def _collect_security_warnings(self) -> list[str]:
         """Collect warning strings for suspicious Unicode and URL values.

--- a/libs/code/deepagents_code/tui/widgets/approval.py
+++ b/libs/code/deepagents_code/tui/widgets/approval.py
@@ -42,8 +42,6 @@ _SHELL_COMMAND_TRUNCATE_LENGTH: int = 120
 _SHELL_COMMAND_TRUNCATE_LINES: int = 5
 _WARNING_PREVIEW_LIMIT: int = 3
 _WARNING_TEXT_TRUNCATE_LENGTH: int = 220
-# Must match the "reject" entry in `_handle_selection`'s decision map.
-_REJECT_OPTION_INDEX: int = 2
 
 
 def _is_command_too_long(command: str) -> bool:
@@ -109,11 +107,11 @@ class ApprovalMenu(Container):
         Binding("down", "move_down", "Down", show=False),
         Binding("j", "move_down", "Down", show=False),
         Binding("enter", "select", "Select", show=False),
-        Binding("1", "select_approve", "Approve", show=False),
+        Binding("1", "select_position(0)", "Select first", show=False),
+        Binding("2", "select_position(1)", "Select second", show=False),
+        Binding("3", "select_position(2)", "Select third", show=False),
         Binding("y", "select_approve", "Approve", show=False),
-        Binding("2", "select_auto", "Auto-approve", show=False),
         Binding("a", "select_auto", "Auto-approve", show=False),
-        Binding("3", "select_reject", "Reject", show=False),
         Binding("n", "select_reject", "Reject", show=False),
         Binding("e", "toggle_expand", "Expand command", show=False),
         Binding("tab", "reject_with_reason", "Reject with reason", show=False),
@@ -140,6 +138,8 @@ class ApprovalMenu(Container):
         action_requests: list[dict[str, Any]] | dict[str, Any],
         assistant_id: str | None = None,
         id: str | None = None,  # noqa: A002  # Textual widget constructor uses `id` parameter
+        *,
+        auto_mode_eligible: bool = True,
         **kwargs: Any,
     ) -> None:
         """Initialize the ApprovalMenu widget.
@@ -151,6 +151,9 @@ class ApprovalMenu(Container):
             assistant_id: Optional assistant ID for resolving virtual paths in
                 file-operation previews.
             id: Optional widget ID. Defaults to 'approval-menu'.
+            auto_mode_eligible: Whether Auto mode can be enabled in this session.
+                When `False` (e.g. the experimental opt-in is off), the "Enable
+                Auto for this thread" option is not offered.
             **kwargs: Additional keyword arguments passed to the Container base class.
         """
         super().__init__(id=id or "approval-menu", classes="approval-menu", **kwargs)
@@ -168,6 +171,12 @@ class ApprovalMenu(Container):
             and request["description"].startswith("Auto human fallback ")
             for request in self._action_requests
         )
+        # Only offer the Auto option when it can actually be enabled. A live
+        # Auto fallback implies Auto is already active, so its "Switch to
+        # Manual" affordance is always shown regardless of eligibility.
+        self._show_auto_option = self._is_auto_fallback or auto_mode_eligible
+        self._num_options = len(self._build_options())
+        self._reject_index = self._num_options - 1
         self._selected = 0
         self._future: asyncio.Future[dict[str, str]] | None = None
         self._option_widgets: list[Static] = []
@@ -312,8 +321,8 @@ class ApprovalMenu(Container):
 
         # Options container at bottom
         with Container(classes="approval-options-container"):
-            # Options - create 3 Static widgets
-            for i in range(3):  # noqa: B007  # Loop variable unused - iterating for count only
+            # Options - one Static widget per visible option
+            for i in range(self._num_options):  # noqa: B007  # Loop variable unused - iterating for count only
                 widget = Static("", classes="approval-option")
                 self._option_widgets.append(widget)
                 yield widget
@@ -343,13 +352,14 @@ class ApprovalMenu(Container):
                 f"Enter submit {glyphs.bullet} Esc cancel {glyphs.bullet} "
                 "leave blank to reject without a reason"
             )
+        quick_keys = "y/a/n" if self._show_auto_option else "y/n"
         help_parts = [
             (
                 f"{glyphs.arrow_up}/{glyphs.arrow_down} navigate "
-                f"{glyphs.bullet} Enter select {glyphs.bullet} y/a/n quick keys"
+                f"{glyphs.bullet} Enter select {glyphs.bullet} {quick_keys} quick keys"
             ),
         ]
-        if self._selected == _REJECT_OPTION_INDEX:
+        if self._selected == self._reject_index:
             help_parts.append("Tab amend")
         help_parts.append("Esc reject")
         help_text = f" {glyphs.bullet} ".join(help_parts)
@@ -409,32 +419,36 @@ class ApprovalMenu(Container):
             approval_widget = widget_class(data)
             await self._tool_info_container.mount(approval_widget)
 
+    def _build_options(self) -> list[tuple[str, str]]:
+        """Build the visible options as `(label, decision_type)` pairs.
+
+        The Auto option is omitted unless Auto can actually be enabled
+        (`_show_auto_option`), so it is never suggested outside the beta.
+        Labels are unnumbered; `_update_options` prefixes the display number.
+
+        Returns:
+            Ordered `(label, decision_type)` pairs for the visible options.
+        """
+        count = len(self._action_requests)
+        approve = "Approve (y)" if count == 1 else f"Approve all {count} (y)"
+        reject = "Reject (n)" if count == 1 else f"Reject all {count} (n)"
+        options: list[tuple[str, str]] = [(approve, "approve")]
+        if self._show_auto_option:
+            if self._is_auto_fallback:
+                options.append(("Switch to Manual (a)", "switch_manual"))
+            else:
+                options.append(("Enable Auto for this thread (a)", "auto_approve_all"))
+        options.append((reject, "reject"))
+        return options
+
     def _update_options(self) -> None:
         """Update option widgets based on selection."""
-        count = len(self._action_requests)
-        middle = (
-            "2. Switch to Manual (a)"
-            if self._is_auto_fallback
-            else "2. Enable Auto for this thread (a)"
-        )
-        if count == 1:
-            options = [
-                "1. Approve (y)",
-                middle,
-                "3. Reject (n)",
-            ]
-        else:
-            options = [
-                f"1. Approve all {count} (y)",
-                middle,
-                f"3. Reject all {count} (n)",
-            ]
-
-        for i, (text, widget) in enumerate(
+        options = self._build_options()
+        for i, ((text, _decision), widget) in enumerate(
             zip(options, self._option_widgets, strict=True)
         ):
             cursor = f"{get_glyphs().cursor} " if i == self._selected else "  "
-            widget.update(f"{cursor}{text}")
+            widget.update(f"{cursor}{i + 1}. {text}")
 
             # Update classes
             widget.remove_class("approval-option-selected")
@@ -447,26 +461,45 @@ class ApprovalMenu(Container):
         """Move selection up."""
         if self._reason_input_active:
             return
-        self._selected = (self._selected - 1) % 3
+        self._selected = (self._selected - 1) % self._num_options
         self._update_options()
 
     def action_move_down(self) -> None:
         """Move selection down."""
         if self._reason_input_active:
             return
-        self._selected = (self._selected + 1) % 3
+        self._selected = (self._selected + 1) % self._num_options
         self._update_options()
 
     def action_select(self) -> None:
         """Select current option."""
         self._handle_selection(self._selected)
 
+    def action_select_position(self, position: int) -> None:
+        """Submit the option at a display position (0-indexed).
+
+        Backs the numeric quick keys. Positions past the last visible option
+        (e.g. `3` when the Auto option is hidden) are ignored.
+
+        Args:
+            position: Zero-based index of the visible option to submit.
+        """
+        if position >= self._num_options:
+            return
+        self._handle_selection(position)
+
     def action_select_approve(self) -> None:
         """Submit approve option."""
         self._handle_selection(0)
 
     def action_select_auto(self) -> None:
-        """Submit auto-approve option."""
+        """Submit auto-approve option.
+
+        No-op when the Auto option is hidden, since Auto cannot be enabled.
+        Auto is always the second option (index 1) when shown.
+        """
+        if not self._show_auto_option:
+            return
         self._handle_selection(1)
 
     def action_select_reject(self) -> None:
@@ -479,7 +512,7 @@ class ApprovalMenu(Container):
         if self._reason_input_active:
             self._exit_reason_input_mode()
             return
-        self._handle_selection(2)
+        self._handle_selection(self._reject_index)
 
     def action_toggle_expand(self) -> None:
         """Toggle shell command expansion."""
@@ -496,17 +529,14 @@ class ApprovalMenu(Container):
         """Handle the selected option.
 
         Args:
-            option: Index of the chosen option (0 approve, 1 auto-approve, 2 reject).
+            option: Index of the chosen visible option. Maps to a decision type
+                via the current option layout (which omits Auto when hidden).
             reject_message: Optional free-text reason. Only attached when the
                 user rejects with a non-empty message via `action_reject_with_reason`.
         """
-        decision_map = {
-            0: "approve",
-            1: "switch_manual" if self._is_auto_fallback else "auto_approve_all",
-            2: "reject",
-        }
-        decision: dict[str, str] = {"type": decision_map[option]}
-        if option == _REJECT_OPTION_INDEX and reject_message:
+        decision_type = self._build_options()[option][1]
+        decision: dict[str, str] = {"type": decision_type}
+        if decision_type == "reject" and reject_message:
             decision["message"] = reject_message
 
         self.display = False
@@ -526,7 +556,7 @@ class ApprovalMenu(Container):
         """
         if self._reason_input_active:
             return
-        if self._selected != _REJECT_OPTION_INDEX:
+        if self._selected != self._reject_index:
             return
         if self._reason_input is None:
             # Lifecycle bug: Tab fired before `compose()` populated the Input ref.

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -13458,8 +13458,12 @@ class TestApprovalPositionBindings:
     def test_numeric_position_is_no_op_without_pending_approval(self) -> None:
         """Fallback number actions do nothing outside an approval prompt."""
         app = DeepAgentsApp()
+        assert app._pending_approval_widget is None
 
+        # Must not raise despite there being no widget to delegate to.
         app.action_approval_position(1)
+
+        assert app._pending_approval_widget is None
 
 
 class TestIsUserTyping:
@@ -13621,6 +13625,45 @@ class TestRequestApprovalBranching:
         assert ApprovalMenu in mounted_types, (
             f"Expected ApprovalMenu to be mounted, got {mounted_types}"
         )
+
+    @pytest.mark.parametrize("eligible", [True, False])
+    async def test_menu_receives_auto_mode_eligibility(self, *, eligible: bool) -> None:
+        """The app forwards `_auto_mode_eligible` into the mounted ApprovalMenu.
+
+        Guards the load-bearing seam: if this kwarg were dropped or hardcoded,
+        the Auto option would (dis)appear regardless of session eligibility, and
+        the widget-level tests — which pass the flag themselves — would not catch
+        it.
+        """
+        app = DeepAgentsApp(agent=MagicMock())
+        app._last_typed_at = None
+        app._auto_mode_eligible = eligible
+
+        async def fake_mount_before_queued(  # noqa: RUF029
+            _container: object, _widget: object
+        ) -> None:
+            return None
+
+        app._mount_before_queued = fake_mount_before_queued  # ty: ignore
+        app.call_after_refresh = MagicMock()  # ty: ignore
+        app.query_one = MagicMock(return_value=MagicMock())  # ty: ignore
+
+        action_requests = [
+            {"name": "write_file", "args": {"path": "/tmp/e.txt", "content": "hi"}}
+        ]
+        future = asyncio.get_running_loop().create_future()
+
+        with (
+            patch.object(asyncio, "get_running_loop") as mock_loop,
+            patch.object(app, "_reveal_pending_tool_calls"),
+        ):
+            mock_loop.return_value.create_future.return_value = future
+            await app._request_approval(action_requests, None)
+
+        # For a non-fallback request `_show_auto_option` equals the eligibility
+        # flag, so this asserts the value actually crossed the app→widget seam.
+        assert app._pending_approval_widget is not None
+        assert app._pending_approval_widget._show_auto_option is eligible
 
 
 class TestDeferredShowApproval:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -13420,6 +13420,48 @@ class TestInterruptApprovalPriority:
         assert app._quit_pending is False
 
 
+class TestApprovalPositionBindings:
+    """Tests for app-level approval fallback shortcuts."""
+
+    @pytest.mark.parametrize(
+        ("key", "action"),
+        [
+            ("1", "approval_position(0)"),
+            ("2", "approval_position(1)"),
+            ("3", "approval_position(2)"),
+        ],
+    )
+    def test_numeric_bindings_route_by_visible_position(
+        self, key: str, action: str
+    ) -> None:
+        """Each app fallback number maps to the matching display position."""
+        bindings = [
+            binding
+            for binding in DeepAgentsApp.BINDINGS
+            if isinstance(binding, Binding) and binding.key == key
+        ]
+
+        assert len(bindings) == 1
+        assert bindings[0].action == action
+
+    @pytest.mark.parametrize("position", [0, 1, 2])
+    def test_numeric_position_delegates_to_visible_option(self, position: int) -> None:
+        """Fallback number actions use the widget's visible option positions."""
+        app = DeepAgentsApp()
+        approval = MagicMock()
+        app._pending_approval_widget = approval
+
+        app.action_approval_position(position)
+
+        approval.action_select_position.assert_called_once_with(position)
+
+    def test_numeric_position_is_no_op_without_pending_approval(self) -> None:
+        """Fallback number actions do nothing outside an approval prompt."""
+        app = DeepAgentsApp()
+
+        app.action_approval_position(1)
+
+
 class TestIsUserTyping:
     """Unit tests for `_is_user_typing()` threshold logic."""
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_approval.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_approval.py
@@ -394,6 +394,109 @@ class TestOptionOrdering:
         assert decision_received == {"type": expected_type}
 
 
+class TestAutoOptionEligibility:
+    """The Auto option is only offered when Auto can actually be enabled."""
+
+    def test_auto_option_hidden_when_not_eligible(self) -> None:
+        """With Auto ineligible, only Approve and Reject are offered."""
+        menu = ApprovalMenu(
+            {"name": "execute", "args": {"command": "echo hello"}},
+            auto_mode_eligible=False,
+        )
+        labels = [label for label, _ in menu._build_options()]
+        decisions = [decision for _, decision in menu._build_options()]
+        assert menu._num_options == 2
+        assert decisions == ["approve", "reject"]
+        assert all("Auto" not in label for label in labels)
+
+    def test_auto_option_shown_when_eligible(self) -> None:
+        """The default (eligible) layout still offers Auto in the middle."""
+        menu = ApprovalMenu(
+            {"name": "execute", "args": {"command": "echo hello"}},
+            auto_mode_eligible=True,
+        )
+        decisions = [decision for _, decision in menu._build_options()]
+        assert menu._num_options == 3
+        assert decisions == ["approve", "auto_approve_all", "reject"]
+
+    def test_reject_index_tracks_layout_when_auto_hidden(self) -> None:
+        """Reject is the second (last) option when Auto is hidden."""
+        menu = ApprovalMenu(
+            {"name": "execute", "args": {"command": "echo hello"}},
+            auto_mode_eligible=False,
+        )
+        assert menu._reject_index == 1
+
+    def test_reject_via_second_position_when_auto_hidden(self) -> None:
+        """The `2` quick key selects Reject once Auto is removed."""
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        future: asyncio.Future[dict[str, str]] = loop.create_future()
+        menu = ApprovalMenu(
+            {"name": "execute", "args": {"command": "echo hello"}},
+            auto_mode_eligible=False,
+        )
+        menu.set_future(future)
+        menu.action_select_position(1)
+        assert future.result() == {"type": "reject"}
+        loop.close()
+
+    def test_select_auto_is_no_op_when_hidden(self) -> None:
+        """Pressing `a` does nothing when Auto is not offered."""
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        future: asyncio.Future[dict[str, str]] = loop.create_future()
+        menu = ApprovalMenu(
+            {"name": "execute", "args": {"command": "echo hello"}},
+            auto_mode_eligible=False,
+        )
+        menu.set_future(future)
+        menu.action_select_auto()
+        assert not future.done()
+        assert menu.display is True
+        loop.close()
+
+    def test_third_position_is_no_op_when_auto_hidden(self) -> None:
+        """The `3` quick key has no target once Auto is removed."""
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        future: asyncio.Future[dict[str, str]] = loop.create_future()
+        menu = ApprovalMenu(
+            {"name": "execute", "args": {"command": "echo hello"}},
+            auto_mode_eligible=False,
+        )
+        menu.set_future(future)
+        menu.action_select_position(2)
+        assert not future.done()
+        loop.close()
+
+    def test_help_omits_auto_quick_key_when_hidden(self) -> None:
+        """The footer advertises `y/n` (not `y/a/n`) when Auto is hidden."""
+        menu = ApprovalMenu(
+            {"name": "execute", "args": {"command": "echo hello"}},
+            auto_mode_eligible=False,
+        )
+        help_text = menu._compose_help_text()
+        assert "y/n quick keys" in help_text
+        assert "y/a/n" not in help_text
+
+    def test_auto_fallback_shows_switch_even_when_not_eligible(self) -> None:
+        """A live Auto fallback keeps its Switch-to-Manual option."""
+        menu = ApprovalMenu(
+            {
+                "name": "delete",
+                "args": {"file_path": "old.py"},
+                "description": "Auto human fallback (consecutive denials: 3).",
+            },
+            auto_mode_eligible=False,
+        )
+        decisions = [decision for _, decision in menu._build_options()]
+        assert decisions == ["approve", "switch_manual", "reject"]
+
+
 class TestRejectWithReason:
     """Tests for the free-text reject mode (`action_reject_with_reason`)."""
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_approval.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_approval.py
@@ -602,8 +602,15 @@ class TestRejectWithReason:
         menu.action_select_reject()
         menu._handle_selection.assert_called_once_with(2)
 
-    async def test_tab_then_type_then_enter_submits_reason(self) -> None:
-        """End-to-end Tab → type → Enter sends a reject decision with the message."""
+    @pytest.mark.parametrize(
+        ("auto_mode_eligible", "down_presses"),
+        [(True, 2), (False, 1)],
+        ids=["auto-shown", "auto-hidden"],
+    )
+    async def test_tab_then_type_then_enter_submits_reason(
+        self, *, auto_mode_eligible: bool, down_presses: int
+    ) -> None:
+        """Tab → type → Enter sends a reason with either option layout."""
         from textual.app import App, ComposeResult
 
         decision_received: dict[str, str] | None = None
@@ -611,7 +618,8 @@ class TestRejectWithReason:
         class ApprovalTestApp(App[None]):
             def compose(self) -> ComposeResult:
                 yield ApprovalMenu(
-                    {"name": "execute", "args": {"command": "echo hello"}}
+                    {"name": "execute", "args": {"command": "echo hello"}},
+                    auto_mode_eligible=auto_mode_eligible,
                 )
 
             def on_approval_menu_decided(self, event: ApprovalMenu.Decided) -> None:
@@ -620,8 +628,7 @@ class TestRejectWithReason:
 
         async with ApprovalTestApp().run_test() as pilot:
             await pilot.pause()
-            # Move to Reject (option 3 of 3) — start at 0, so two downs.
-            await pilot.press("down", "down")
+            await pilot.press(*(["down"] * down_presses))
             await pilot.press("tab")
             await pilot.pause()
             for ch in "dry run first":

--- a/libs/code/tests/unit_tests/tui/widgets/test_approval.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_approval.py
@@ -495,6 +495,135 @@ class TestAutoOptionEligibility:
         )
         decisions = [decision for _, decision in menu._build_options()]
         assert decisions == ["approve", "switch_manual", "reject"]
+        assert menu._num_options == 3
+        # Ineligible session but Auto is live, so the footer still advertises `a`.
+        assert "y/a/n quick keys" in menu._compose_help_text()
+
+    def test_first_position_approves_when_auto_hidden(self) -> None:
+        """The `1` quick key still approves in the 2-option layout."""
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        future: asyncio.Future[dict[str, str]] = loop.create_future()
+        menu = ApprovalMenu(
+            {"name": "execute", "args": {"command": "echo hello"}},
+            auto_mode_eligible=False,
+        )
+        menu.set_future(future)
+        menu.action_select_position(0)
+        assert future.result() == {"type": "approve"}
+        loop.close()
+
+    def test_batch_labels_when_auto_hidden(self) -> None:
+        """Batch (count > 1) Approve/Reject labels stay pluralized with Auto hidden."""
+        menu = ApprovalMenu(
+            [
+                {"name": "execute", "args": {"command": "echo one"}},
+                {"name": "execute", "args": {"command": "echo two"}},
+            ],
+            auto_mode_eligible=False,
+        )
+        labels = [label for label, _ in menu._build_options()]
+        decisions = [decision for _, decision in menu._build_options()]
+        assert decisions == ["approve", "reject"]
+        assert labels == ["Approve all 2 (y)", "Reject all 2 (n)"]
+
+    def test_navigation_wraps_within_two_option_layout(self) -> None:
+        """Down/up wrap modulo the visible count, never landing on a phantom index."""
+        menu = ApprovalMenu(
+            {"name": "execute", "args": {"command": "echo hello"}},
+            auto_mode_eligible=False,
+        )
+        menu._option_widgets = [MagicMock(), MagicMock()]
+        assert menu._selected == 0
+        menu.action_move_up()
+        assert menu._selected == 1  # wrapped backwards to the last option
+        menu.action_move_down()
+        assert menu._selected == 0  # wrapped forward to the first option
+        menu.action_move_down()
+        assert menu._selected == 1
+
+    def test_select_after_wraparound_resolves_without_index_error(self) -> None:
+        """Selecting after wraparound in the 2-option layout resolves cleanly.
+
+        Guards against a regression to a hardcoded ``% 3`` modulus, which would
+        leave ``_selected == 2`` and raise ``IndexError`` on selection.
+        """
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        future: asyncio.Future[dict[str, str]] = loop.create_future()
+        menu = ApprovalMenu(
+            {"name": "execute", "args": {"command": "echo hello"}},
+            auto_mode_eligible=False,
+        )
+        menu.set_future(future)
+        menu._option_widgets = [MagicMock(), MagicMock()]
+        menu.action_move_down()  # 0 -> 1 (reject)
+        menu.action_move_down()  # 1 -> 0 (wrap to approve)
+        menu.action_select()
+        assert future.result() == {"type": "approve"}
+        loop.close()
+
+    @pytest.mark.parametrize(
+        ("key", "expected_type"),
+        [
+            ("1", "approve"),
+            ("y", "approve"),
+            ("2", "reject"),
+            ("n", "reject"),
+        ],
+    )
+    async def test_key_binding_resolves_decision_when_auto_hidden(
+        self, key: str, expected_type: str
+    ) -> None:
+        """With Auto hidden, keys route to the 2-option layout via real dispatch."""
+        from textual.app import App, ComposeResult
+
+        decision_received: dict[str, str] | None = None
+
+        class ApprovalTestApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield ApprovalMenu(
+                    {"name": "execute", "args": {"command": "echo hello"}},
+                    auto_mode_eligible=False,
+                )
+
+            def on_approval_menu_decided(self, event: ApprovalMenu.Decided) -> None:
+                nonlocal decision_received
+                decision_received = event.decision
+
+        async with ApprovalTestApp().run_test() as pilot:
+            await pilot.pause()
+            await pilot.press(key)
+            await pilot.pause()
+
+        assert decision_received == {"type": expected_type}
+
+    @pytest.mark.parametrize("key", ["a", "3"])
+    async def test_hidden_auto_keys_are_no_ops_via_dispatch(self, key: str) -> None:
+        """`a` and `3` do nothing through real key dispatch when Auto is hidden."""
+        from textual.app import App, ComposeResult
+
+        decision_received: dict[str, str] | None = None
+
+        class ApprovalTestApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield ApprovalMenu(
+                    {"name": "execute", "args": {"command": "echo hello"}},
+                    auto_mode_eligible=False,
+                )
+
+            def on_approval_menu_decided(self, event: ApprovalMenu.Decided) -> None:
+                nonlocal decision_received
+                decision_received = event.decision
+
+        async with ApprovalTestApp().run_test() as pilot:
+            await pilot.pause()
+            await pilot.press(key)
+            await pilot.pause()
+
+        assert decision_received is None
 
 
 class TestRejectWithReason:

--- a/libs/code/tests/unit_tests/tui/widgets/test_approval.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_approval.py
@@ -1,5 +1,8 @@
 """Unit tests for approval widget expandable command display."""
 
+import asyncio
+from collections.abc import Callable, Iterator
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,6 +13,32 @@ from deepagents_code.tui.widgets.approval import (
     _SHELL_COMMAND_TRUNCATE_LINES,
     ApprovalMenu,
 )
+
+MenuFactory = Callable[..., tuple[ApprovalMenu, "asyncio.Future[dict[str, str]]"]]
+
+
+@pytest.fixture
+def wired_menu() -> Iterator[MenuFactory]:
+    """Build an `ApprovalMenu` wired to a future on a throwaway event loop.
+
+    Yields a factory `(*args, **kwargs) -> (menu, future)` that forwards its
+    arguments to `ApprovalMenu` and attaches a fresh future. Every loop it opens
+    is closed at teardown, so tests can assert on `future.result()` without
+    hand-rolling (and remembering to close) an event loop.
+    """
+    loops: list[asyncio.AbstractEventLoop] = []
+
+    def _make(*args: Any, **kwargs: Any) -> tuple[ApprovalMenu, asyncio.Future]:
+        loop = asyncio.new_event_loop()
+        loops.append(loop)
+        future: asyncio.Future[dict[str, str]] = loop.create_future()
+        menu = ApprovalMenu(*args, **kwargs)
+        menu.set_future(future)
+        return menu, future
+
+    yield _make
+    for loop in loops:
+        loop.close()
 
 
 class TestCheckExpandableCommand:
@@ -427,51 +456,37 @@ class TestAutoOptionEligibility:
         )
         assert menu._reject_index == 1
 
-    def test_reject_via_second_position_when_auto_hidden(self) -> None:
+    def test_reject_via_second_position_when_auto_hidden(
+        self, wired_menu: MenuFactory
+    ) -> None:
         """The `2` quick key selects Reject once Auto is removed."""
-        import asyncio
-
-        loop = asyncio.new_event_loop()
-        future: asyncio.Future[dict[str, str]] = loop.create_future()
-        menu = ApprovalMenu(
+        menu, future = wired_menu(
             {"name": "execute", "args": {"command": "echo hello"}},
             auto_mode_eligible=False,
         )
-        menu.set_future(future)
         menu.action_select_position(1)
         assert future.result() == {"type": "reject"}
-        loop.close()
 
-    def test_select_auto_is_no_op_when_hidden(self) -> None:
+    def test_select_auto_is_no_op_when_hidden(self, wired_menu: MenuFactory) -> None:
         """Pressing `a` does nothing when Auto is not offered."""
-        import asyncio
-
-        loop = asyncio.new_event_loop()
-        future: asyncio.Future[dict[str, str]] = loop.create_future()
-        menu = ApprovalMenu(
+        menu, future = wired_menu(
             {"name": "execute", "args": {"command": "echo hello"}},
             auto_mode_eligible=False,
         )
-        menu.set_future(future)
         menu.action_select_auto()
         assert not future.done()
         assert menu.display is True
-        loop.close()
 
-    def test_third_position_is_no_op_when_auto_hidden(self) -> None:
+    def test_third_position_is_no_op_when_auto_hidden(
+        self, wired_menu: MenuFactory
+    ) -> None:
         """The `3` quick key has no target once Auto is removed."""
-        import asyncio
-
-        loop = asyncio.new_event_loop()
-        future: asyncio.Future[dict[str, str]] = loop.create_future()
-        menu = ApprovalMenu(
+        menu, future = wired_menu(
             {"name": "execute", "args": {"command": "echo hello"}},
             auto_mode_eligible=False,
         )
-        menu.set_future(future)
         menu.action_select_position(2)
         assert not future.done()
-        loop.close()
 
     def test_help_omits_auto_quick_key_when_hidden(self) -> None:
         """The footer advertises `y/n` (not `y/a/n`) when Auto is hidden."""
@@ -499,20 +514,16 @@ class TestAutoOptionEligibility:
         # Ineligible session but Auto is live, so the footer still advertises `a`.
         assert "y/a/n quick keys" in menu._compose_help_text()
 
-    def test_first_position_approves_when_auto_hidden(self) -> None:
+    def test_first_position_approves_when_auto_hidden(
+        self, wired_menu: MenuFactory
+    ) -> None:
         """The `1` quick key still approves in the 2-option layout."""
-        import asyncio
-
-        loop = asyncio.new_event_loop()
-        future: asyncio.Future[dict[str, str]] = loop.create_future()
-        menu = ApprovalMenu(
+        menu, future = wired_menu(
             {"name": "execute", "args": {"command": "echo hello"}},
             auto_mode_eligible=False,
         )
-        menu.set_future(future)
         menu.action_select_position(0)
         assert future.result() == {"type": "approve"}
-        loop.close()
 
     def test_batch_labels_when_auto_hidden(self) -> None:
         """Batch (count > 1) Approve/Reject labels stay pluralized with Auto hidden."""
@@ -527,6 +538,31 @@ class TestAutoOptionEligibility:
         decisions = [decision for _, decision in menu._build_options()]
         assert decisions == ["approve", "reject"]
         assert labels == ["Approve all 2 (y)", "Reject all 2 (n)"]
+
+    def test_update_options_renders_contiguous_numbers_when_auto_hidden(self) -> None:
+        """The hidden-Auto layout renders `1.`/`2.` rows, never skipping to `3.`.
+
+        The display number is prefixed in `_update_options`, not baked into the
+        labels, so a regression to hardcoded numbering would show `3. Reject` in
+        a 2-option menu.
+        """
+        menu = ApprovalMenu(
+            {"name": "execute", "args": {"command": "echo hello"}},
+            auto_mode_eligible=False,
+        )
+        menu._option_widgets = [MagicMock(), MagicMock()]
+        menu._selected = 0
+        menu._update_options()
+        rendered = [
+            widget.update.call_args.args[0]  # ty: ignore
+            for widget in menu._option_widgets
+        ]
+        assert "1. Approve (y)" in rendered[0]
+        assert "2. Reject (n)" in rendered[1]
+        assert not any("3." in text for text in rendered)
+        # The cursor glyph marks the selected row only.
+        assert rendered[0].startswith(f"{get_glyphs().cursor} ")
+        assert rendered[1].startswith("  ")
 
     def test_navigation_wraps_within_two_option_layout(self) -> None:
         """Down/up wrap modulo the visible count, never landing on a phantom index."""
@@ -543,27 +579,23 @@ class TestAutoOptionEligibility:
         menu.action_move_down()
         assert menu._selected == 1
 
-    def test_select_after_wraparound_resolves_without_index_error(self) -> None:
+    def test_select_after_wraparound_resolves_without_index_error(
+        self, wired_menu: MenuFactory
+    ) -> None:
         """Selecting after wraparound in the 2-option layout resolves cleanly.
 
         Guards against a regression to a hardcoded ``% 3`` modulus, which would
         leave ``_selected == 2`` and raise ``IndexError`` on selection.
         """
-        import asyncio
-
-        loop = asyncio.new_event_loop()
-        future: asyncio.Future[dict[str, str]] = loop.create_future()
-        menu = ApprovalMenu(
+        menu, future = wired_menu(
             {"name": "execute", "args": {"command": "echo hello"}},
             auto_mode_eligible=False,
         )
-        menu.set_future(future)
         menu._option_widgets = [MagicMock(), MagicMock()]
         menu.action_move_down()  # 0 -> 1 (reject)
         menu.action_move_down()  # 1 -> 0 (wrap to approve)
         menu.action_select()
         assert future.result() == {"type": "approve"}
-        loop.close()
 
     @pytest.mark.parametrize(
         ("key", "expected_type"),


### PR DESCRIPTION
Approval prompts no longer suggest enabling Auto mode when it is unavailable (experimental opt-in off).

---

The HITL approval widget always offered "Enable Auto for this thread (a)" even when Auto mode is ineligible (e.g. `DEEPAGENTS_CODE_EXPERIMENTAL` is off or a sandbox is active), where choosing it only surfaced the "Auto is available only in the opt-in local TUI beta" warning and did nothing. `ApprovalMenu` now takes `auto_mode_eligible` (passed from `App._auto_mode_eligible`) and omits the Auto option when it can't be enabled, dynamically renumbering options and quick keys. A live Auto fallback still shows its Switch-to-Manual affordance.

Made by [Open SWE](https://openswe.vercel.app/agents/6c5eb368-e615-f9d7-b8d0-bbce9ebaa3ff)