### PR TITLE
ci: restrict Harbor package overrides

### DIFF
--- a/.github/workflows/_harbor_run.yml
+++ b/.github/workflows/_harbor_run.yml
@@ -384,10 +384,28 @@ jobs:
           # so newline is the only safe delimiter. Collect into an array and pass
           # as separate args — never re-split or eval'd, preserving injection
           # safety — so a single install covers e.g. harbor + harbor-langsmith.
+          #
+          # This step runs before Harbor receives model/LangSmith secrets. Keep
+          # the override narrowly scoped to the trusted Harbor repository and an
+          # immutable commit SHA; arbitrary package specs would execute attacker
+          # code in the following secret-bearing `uv run harbor run` step.
+          harbor_ref_re='^harbor(\[langsmith\])? @ git\+https://github\.com/harbor-framework/harbor\.git@[0-9a-fA-F]{40}$'
+          harbor_langsmith_ref_re='^harbor-langsmith @ git\+https://github\.com/harbor-framework/harbor\.git@[0-9a-fA-F]{40}#subdirectory=packages/harbor-langsmith$'
           specs=()
           while IFS= read -r line; do
-            [ -n "$line" ] && specs+=("$line")
+            [ -z "$line" ] && continue
+            if [[ "$line" =~ $harbor_ref_re || "$line" =~ $harbor_langsmith_ref_re ]]; then
+              specs+=("$line")
+              continue
+            fi
+            echo "::error::Invalid harbor_package_override line: $line"
+            echo "::error::Allowed overrides are harbor or harbor[langsmith] from github.com/harbor-framework/harbor.git pinned to a 40-character commit SHA. harbor-langsmith must use #subdirectory=packages/harbor-langsmith."
+            exit 1
           done <<< "$HARBOR_PACKAGE_OVERRIDE"
+          if [ "${#specs[@]}" -eq 0 ]; then
+            echo "::error::harbor_package_override was provided but contained no package specs"
+            exit 1
+          fi
           uv pip install --reinstall --refresh "${specs[@]}"
 
       - name: "🔇 Suppress Harbor first-run tips"

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -189,7 +189,7 @@ on:
         default: "10"
         type: string
       harbor_package_override:
-        description: "Optional: install Harbor from an arbitrary package spec instead of the locked version, to test an unreleased Harbor build. One spec per line — e.g. `harbor @ git+…@<sha>` on the first line and `harbor-langsmith @ git+…@<sha>#subdirectory=packages/harbor-langsmith` on the second. Use a trusted package source. Prefer an immutable commit SHA, and never embed credentials in the package spec. Leave empty to use the pinned Harbor."
+        description: "Optional: install Harbor from the trusted harbor-framework/harbor repository instead of the locked version. One spec per line. Only `harbor`, `harbor[langsmith]`, and `harbor-langsmith` refs from `git+https://github.com/harbor-framework/harbor.git@<40-char-sha>` are accepted; `harbor-langsmith` must include `#subdirectory=packages/harbor-langsmith`. Branches, tags, arbitrary hosts, and embedded credentials are rejected. Leave empty to use the pinned Harbor."
         required: false
         default: ""
         type: string

--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -189,7 +189,7 @@ on:
         default: "10"
         type: string
       harbor_package_override:
-        description: "Optional: install Harbor from the trusted harbor-framework/harbor repository instead of the locked version. One spec per line. Only `harbor`, `harbor[langsmith]`, and `harbor-langsmith` refs from `git+https://github.com/harbor-framework/harbor.git@<40-char-sha>` are accepted; `harbor-langsmith` must include `#subdirectory=packages/harbor-langsmith`. Branches, tags, arbitrary hosts, and embedded credentials are rejected. Leave empty to use the pinned Harbor."
+        description: "Optional: install Harbor from a trusted package source instead of the locked version. One spec per line. Only `harbor`, `harbor[langsmith]`, and `harbor-langsmith` refs from `git+https://github.com/harbor-framework/harbor.git@<40-char-sha>` are accepted; `harbor-langsmith` must include `#subdirectory=packages/harbor-langsmith`. Prefer an immutable commit SHA, and never embed credentials in the package spec. Branches, tags, and arbitrary hosts are rejected. Leave empty to use the pinned Harbor."
         required: false
         default: ""
         type: string

--- a/.github/workflows/unified_evals.yml
+++ b/.github/workflows/unified_evals.yml
@@ -40,7 +40,7 @@ on:
         type: boolean
         default: false
       harbor_package_override:
-        description: "Optional: install Harbor from an arbitrary package spec instead of the locked version, to test an unreleased Harbor build. One spec per line — e.g. `harbor @ git+…@<sha>` on the first line and `harbor-langsmith @ git+…@<sha>#subdirectory=packages/harbor-langsmith` on the second. Use a trusted package source. Prefer an immutable commit SHA, and never embed credentials in the package spec. Leave empty to use the pinned Harbor."
+        description: "Optional: install Harbor from a trusted package source instead of the locked version. One spec per line. Only `harbor`, `harbor[langsmith]`, and `harbor-langsmith` refs from `git+https://github.com/harbor-framework/harbor.git@<40-char-sha>` are accepted; `harbor-langsmith` must include `#subdirectory=packages/harbor-langsmith`. Prefer an immutable commit SHA, and never embed credentials in the package spec. Branches, tags, and arbitrary hosts are rejected. Leave empty to use the pinned Harbor."
         type: string
         default: ""
       judge_models:


### PR DESCRIPTION
## Summary

Fixes Corridor finding `32f652ef` by narrowing the `harbor_package_override` workflow escape hatch before the secret-bearing Harbor run step.

Changes:
- validate each override line before install
- allow only `harbor`, `harbor[langsmith]`, or `harbor-langsmith` from `git+https://github.com/harbor-framework/harbor.git@<40-char-sha>`
- require `harbor-langsmith` to use `#subdirectory=packages/harbor-langsmith`
- reject branches, tags, arbitrary hosts, unknown packages, and embedded credentials via fail-closed allowlist
- update the workflow dispatch input description to document the accepted format

## Validation

- `ruby -e 'require "yaml"; ...'` parsed both edited workflow files
- extracted the validation block and checked:
  - accepts `harbor[langsmith] @ git+https://github.com/harbor-framework/harbor.git@<40-char-sha>`
  - accepts `harbor-langsmith @ git+https://github.com/harbor-framework/harbor.git@<40-char-sha>#subdirectory=packages/harbor-langsmith`
  - rejects branch refs such as `@main`
  - rejects arbitrary package/host specs

## Security note

The override install still runs before `uv run harbor run`, but only after the package ref is proven to be a trusted Harbor repository ref pinned to an immutable commit SHA.