### PR TITLE
style(code): pad between marketplace entries in plugin manager

### DIFF
--- a/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/__init__.py
@@ -304,13 +304,17 @@ class PluginManagerScreen(ModalScreen[None]):  # noqa: RUF067
                         disabled=True,
                     )
                 )
-            options.extend(
-                Option(
-                    _marketplace_label(row),
-                    id=f"marketplace:{row.name}",
+            for index, row in enumerate(self._state.marketplaces):
+                if index > 0:
+                    options.append(
+                        Option(" ", id=f"marketplace-spacer:{index}", disabled=True)
+                    )
+                options.append(
+                    Option(
+                        _marketplace_label(row),
+                        id=f"marketplace:{row.name}",
+                    )
                 )
-                for row in self._state.marketplaces
-            )
             return options
         if not self._state.errors:
             return [Option("No plugin errors.", id="empty")]

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -891,6 +891,34 @@ def test_marketplace_options_omit_divider_when_empty() -> None:
     assert [option.id for option in options] == ["add-marketplace"]
 
 
+def test_marketplace_options_pad_between_entries() -> None:
+    """Marketplace entries are separated by disabled spacers, like the plugins list."""
+    screen = PluginManagerScreen()
+    screen._tab = "marketplaces"
+    screen._state = _ManagerState(
+        available_plugins=(),
+        installed_plugins=(),
+        marketplaces=(
+            _MarketplaceRow("first", "owner/first", 1, 0),
+            _MarketplaceRow("second", "owner/second", 1, 0),
+        ),
+        errors=(),
+    )
+
+    options = screen._current_options()
+
+    ids = [option.id for option in options]
+    assert ids == [
+        "add-marketplace",
+        "marketplace-divider",
+        "marketplace:first",
+        "marketplace-spacer:1",
+        "marketplace:second",
+    ]
+    spacer = next(option for option in options if option.id == "marketplace-spacer:1")
+    assert spacer.disabled is True
+
+
 def test_healthy_marketplace_label_shows_available_plugins() -> None:
     row = _MarketplaceRow("healthy", "owner/healthy", 3, 0)
 

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -901,6 +901,7 @@ def test_marketplace_options_pad_between_entries() -> None:
         marketplaces=(
             _MarketplaceRow("first", "owner/first", 1, 0),
             _MarketplaceRow("second", "owner/second", 1, 0),
+            _MarketplaceRow("third", "owner/third", 1, 0),
         ),
         errors=(),
     )
@@ -914,9 +915,15 @@ def test_marketplace_options_pad_between_entries() -> None:
         "marketplace:first",
         "marketplace-spacer:1",
         "marketplace:second",
+        "marketplace-spacer:2",
+        "marketplace:third",
     ]
-    spacer = next(option for option in options if option.id == "marketplace-spacer:1")
-    assert spacer.disabled is True
+    spacers = [
+        option
+        for option in options
+        if option.id is not None and option.id.startswith("marketplace-spacer:")
+    ]
+    assert all(spacer.disabled for spacer in spacers)
 
 
 def test_healthy_marketplace_label_shows_available_plugins() -> None:


### PR DESCRIPTION
Marketplace entries in the plugin manager now have spacing between them, matching the plugins list.

---

The marketplaces tab rendered entries back-to-back, while the plugins list (`_plugin_options`) inserts a disabled spacer `Option` between rows. This applies the same disabled-spacer pattern between marketplace rows so both surfaces are visually consistent. The spacers are disabled, so keyboard navigation still skips over them.

Made by [Open SWE](https://openswe.vercel.app/agents/045a43e2-f199-47e8-a7f0-ffb5dbff5762)