### PR TITLE
style(code): dim the `/plugins` modal backdrop

### DIFF
--- a/libs/code/AGENTS.md
+++ b/libs/code/AGENTS.md
@@ -62,7 +62,7 @@ Apply these rules to new UI; do not treat them as a mandate to refactor existing
 - Co-locate a screen's `.tcss` file with its root component and set `CSS_PATH` relative to that module. Its styles may target sibling and small nested components, but a large nested component should generally own its own stylesheet.
 - Widgets cannot use `CSS_PATH`; put intrinsic, auto-scoped defaults in `DEFAULT_CSS`. The mounting screen owns the widget's sizing and placement.
 - Children must not import parent components. They may import shared utilities and data models; send events up and pass state/data down.
-- Never set `background: transparent` on a `ModalScreen` root. That override removes Textual's default `background: $background 60%` dim backdrop and makes the modal fully see-through instead of dimming the content behind it. Leave the default in place so the modal matches the others (it already degrades to transparent under ansi themes via `&:ansi`).
+- Never set `background: transparent` on a `ModalScreen` root. That override removes Textual's default.
 
 ### Testing Textual apps
 

--- a/libs/code/AGENTS.md
+++ b/libs/code/AGENTS.md
@@ -62,6 +62,7 @@ Apply these rules to new UI; do not treat them as a mandate to refactor existing
 - Co-locate a screen's `.tcss` file with its root component and set `CSS_PATH` relative to that module. Its styles may target sibling and small nested components, but a large nested component should generally own its own stylesheet.
 - Widgets cannot use `CSS_PATH`; put intrinsic, auto-scoped defaults in `DEFAULT_CSS`. The mounting screen owns the widget's sizing and placement.
 - Children must not import parent components. They may import shared utilities and data models; send events up and pass state/data down.
+- Never set `background: transparent` on a `ModalScreen` root. That override removes Textual's default `background: $background 60%` dim backdrop and makes the modal fully see-through instead of dimming the content behind it. Leave the default in place so the modal matches the others (it already degrades to transparent under ansi themes via `&:ansi`).
 
 ### Testing Textual apps
 

--- a/libs/code/AGENTS.md
+++ b/libs/code/AGENTS.md
@@ -62,7 +62,7 @@ Apply these rules to new UI; do not treat them as a mandate to refactor existing
 - Co-locate a screen's `.tcss` file with its root component and set `CSS_PATH` relative to that module. Its styles may target sibling and small nested components, but a large nested component should generally own its own stylesheet.
 - Widgets cannot use `CSS_PATH`; put intrinsic, auto-scoped defaults in `DEFAULT_CSS`. The mounting screen owns the widget's sizing and placement.
 - Children must not import parent components. They may import shared utilities and data models; send events up and pass state/data down.
-- Never set `background: transparent` on a `ModalScreen` root. That override removes Textual's default.
+- A `ModalScreen` root inherits Textual's default translucent backdrop (`background: $background 60%`, which degrades to transparent under ansi themes) so it dims and composites the content underneath. Don't override it with `background: transparent` unless the modal is deliberately a non-dimming popover (as some selector overlays are); doing so by accident removes the dim.
 
 ### Testing Textual apps
 

--- a/libs/code/deepagents_code/tui/modals/plugin_manager/plugin_manager.tcss
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/plugin_manager.tcss
@@ -1,6 +1,5 @@
 PluginManagerScreen {
     align: center middle;
-    background: transparent;
 }
 
 PluginManagerScreen > Vertical {

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -1280,7 +1280,7 @@ async def test_marketplace_divider_refits_on_resize() -> None:
 
 
 async def test_plugin_manager_overlays_underlying_content() -> None:
-    """Transparent modal backdrop must composite the screen underneath."""
+    """Dimmed modal backdrop must composite the screen underneath."""
     app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
@@ -1296,7 +1296,9 @@ async def test_plugin_manager_overlays_underlying_content() -> None:
         app.push_screen(PluginManagerScreen())
         await pilot.pause()
 
-        assert app.screen.styles.background.a == 0
+        # Inherit the default ModalScreen dim backdrop instead of a fully
+        # transparent one, matching the other modals.
+        assert 0 < app.screen.styles.background.a < 1
         plain = re.sub(r"<[^>]+>", " ", app.export_screenshot())
         assert "TOP_MARKER_VISIBLE" in plain
         assert "Plugins" in plain

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -1297,7 +1297,9 @@ async def test_plugin_manager_overlays_underlying_content() -> None:
         await pilot.pause()
 
         # Inherit the default ModalScreen dim backdrop instead of a fully
-        # transparent one, matching the other modals.
+        # transparent one. The alpha is in (0, 1) only under a non-ansi theme
+        # (hence the "textual-dark" pin above); it degrades to transparent
+        # under ansi themes.
         assert 0 < app.screen.styles.background.a < 1
         plain = re.sub(r"<[^>]+>", " ", app.export_screenshot())
         assert "TOP_MARKER_VISIBLE" in plain


### PR DESCRIPTION
The `/plugins` modal now dims the background behind it, consistent with other modals.

---

The `/plugins` (`PluginManagerScreen`) modal overrode Textual's default `ModalScreen` backdrop with `background: transparent`, making it fully see-through instead of dimming the content behind it like every other modal. Removing the override lets it inherit the standard `background: $background 60%` dim backdrop (which still degrades to transparent under ansi themes).

Made by [Open SWE](https://openswe.vercel.app/agents/8d011f9e-b11e-7cc1-e8a6-6138c7381983)