### PR TITLE
refactor(code): share newline affordances across input surfaces

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/_inline_prompt.py
+++ b/libs/code/deepagents_code/tui/widgets/_inline_prompt.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-from textual.binding import Binding, BindingType
 from textual.content import Content
 from textual.message import Message
 from textual.widgets import Static
@@ -87,22 +86,6 @@ class InlinePromptTextArea(CollapsingPasteTextArea):
     back to the full text via `submitted_value`.
     """
 
-    BINDINGS: ClassVar[list[BindingType]] = [
-        Binding(
-            "shift+enter,alt+enter,ctrl+enter,ctrl+j",
-            "insert_newline",
-            "New Line",
-            show=False,
-            priority=True,
-        ),
-        Binding(
-            "ctrl+backspace,alt+backspace",
-            "delete_word_left",
-            "Delete left to start of word",
-            show=False,
-        ),
-    ]
-
     class Submitted(Message):
         """Posted when the user presses Enter to submit text.
 
@@ -159,6 +142,18 @@ class InlinePromptTextArea(CollapsingPasteTextArea):
         if event.key == "backspace" and self._delete_placeholder_token(backwards=True):
             event.prevent_default()
             event.stop()
+            return
+
+        # Some terminals (e.g. VSCode built-in) send a literal backslash followed
+        # by enter for shift+enter; treat that pair as a newline before the enter
+        # below would otherwise submit.
+        if self._consume_backslash_enter_newline(event, now):
+            return
+
+        self._track_backslash_pending(event, now)
+
+        # Modifier+Enter (and Ctrl+J) insert a newline rather than submitting.
+        if self._consume_modifier_newline(event):
             return
 
         if event.key == "enter":
@@ -236,6 +231,13 @@ class InlinePromptOption(Static):
         if self._selected_class is None:
             return
         self.set_class(self._highlighted, self._selected_class)
+
+
+def newline_hint() -> str:
+    """Return the newline-shortcut hint fragment (e.g. 'Ctrl+J newline')."""
+    from deepagents_code.config import newline_shortcut
+
+    return f"{newline_shortcut()} newline"
 
 
 def apply_inline_prompt_border(widget: Widget) -> None:

--- a/libs/code/deepagents_code/tui/widgets/_paste_textarea.py
+++ b/libs/code/deepagents_code/tui/widgets/_paste_textarea.py
@@ -17,8 +17,9 @@ on top, keeping the full content off-screen until submission.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
+from textual.binding import Binding
 from textual.widgets import TextArea
 
 from deepagents_code.paste_collapse import (
@@ -61,6 +62,16 @@ Keeps multi-line pastes grouped as one input even when newlines arrive as
 terminal read boundaries), instead of submitting mid-paste.
 """
 
+_BACKSLASH_ENTER_GAP_SECONDS = 0.15
+"""Maximum gap between a `\\` key and a following `enter` key to treat the
+pair as a terminal-emitted shift+enter sequence.
+
+Some terminals (e.g. VSCode's built-in terminal) send a literal backslash
+followed by enter when the user presses shift+enter.  The gap is
+generous (150 ms) because the terminal emits both characters nearly
+simultaneously; a human deliberately typing `\\` then pressing Enter would
+have a much larger gap."""
+
 
 class PasteBurstTextArea(TextArea):
     """`TextArea` that detects paste-like keystroke bursts.
@@ -72,6 +83,36 @@ class PasteBurstTextArea(TextArea):
     by `CollapsingPasteTextArea`.
     """
 
+    BINDINGS: ClassVar[list[Binding]] = [
+        Binding(
+            "shift+enter,alt+enter,ctrl+enter,ctrl+j",
+            "insert_newline",
+            "New Line",
+            show=False,
+            priority=True,
+        ),
+        Binding(
+            "ctrl+backspace,alt+backspace",
+            "delete_word_left",
+            "Delete left to start of word",
+            show=False,
+        ),
+    ]
+    """Shared key bindings for every paste-aware text area.
+
+    These are the single source of truth for shortcut keys, inherited by both
+    the chat input and inline prompts (Textual aggregates BINDINGS across the
+    MRO). `_NEWLINE_KEYS` is derived from this list so `_on_key` stays in sync.
+    """
+
+    _NEWLINE_KEYS: ClassVar[frozenset[str]] = frozenset(
+        key
+        for b in BINDINGS
+        if b.action == "insert_newline"
+        for key in b.key.split(",")
+    )
+    """Flattened set of keys that insert a newline, derived from `BINDINGS`."""
+
     _paste_burst_buffer: str
     _paste_burst_last_char_time: float | None
     _paste_burst_timer: Timer | None
@@ -80,6 +121,7 @@ class PasteBurstTextArea(TextArea):
     _paste_burst_last_key_time: float | None
     _paste_burst_last_suppressed_enter_time: float | None
     _paste_burst_window_until: float | None
+    _backslash_pending_time: float | None
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the text area and its paste-burst state."""
@@ -102,6 +144,9 @@ class PasteBurstTextArea(TextArea):
         # Deadline until which `enter` inserts a newline rather than submitting,
         # keeping multi-line pastes grouped across read boundaries.
         self._paste_burst_window_until = None
+        # Timestamp of a `\` keypress awaiting a fast `enter` to be treated as a
+        # terminal-emitted shift+enter. See `_BACKSLASH_ENTER_GAP_SECONDS`.
+        self._backslash_pending_time = None
 
     # -- Policy hooks (override in subclasses) --------------------------------
 
@@ -345,6 +390,65 @@ class PasteBurstTextArea(TextArea):
         self._paste_burst_last_suppressed_enter_time = now
         self.action_insert_newline()
         return True
+
+    # -- Newline affordances (shared by concrete text areas) ------------------
+
+    def _delete_preceding_backslash(self) -> bool:
+        """Delete the backslash character immediately before the cursor.
+
+        Caller must ensure a backslash is expected at this position. The
+        method verifies the character before deleting it.
+
+        Returns:
+            `True` if a backslash was found and deleted, `False` otherwise.
+        """
+        row, col = self.cursor_location
+        if col > 0:
+            start = (row, col - 1)
+            if self.document.get_text_range(start, self.cursor_location) == "\\":
+                self.delete(start, self.cursor_location)
+                return True
+        elif row > 0:
+            prev_line = self.document.get_line(row - 1)
+            start = (row - 1, len(prev_line) - 1)
+            end = (row - 1, len(prev_line))
+            if self.document.get_text_range(start, end) == "\\":
+                self.delete(start, self.cursor_location)
+                return True
+        return False
+
+    def _consume_backslash_enter_newline(
+        self, event: events.Key, now: float, *, enabled: bool = True
+    ) -> bool:
+        """Return whether a terminal-emitted backslash+Enter became a newline."""
+        if (
+            event.key == "enter"
+            and enabled
+            and self._backslash_pending_time is not None
+            and (now - self._backslash_pending_time) <= _BACKSLASH_ENTER_GAP_SECONDS
+        ):
+            self._backslash_pending_time = None
+            if self._delete_preceding_backslash():
+                event.prevent_default()
+                event.stop()
+                self.action_insert_newline()
+                return True
+        self._backslash_pending_time = None
+        return False
+
+    def _track_backslash_pending(self, event: events.Key, now: float) -> None:
+        """Record a backslash keypress so a fast following Enter becomes a newline."""
+        if event.key == "backslash" and event.character == "\\":
+            self._backslash_pending_time = now
+
+    def _consume_modifier_newline(self, event: events.Key) -> bool:
+        """Return whether a modifier-Enter key was consumed as an inserted newline."""
+        if event.key in self._NEWLINE_KEYS:
+            event.prevent_default()
+            event.stop()
+            self.action_insert_newline()
+            return True
+        return False
 
 
 class CollapsingPasteTextArea(PasteBurstTextArea):

--- a/libs/code/deepagents_code/tui/widgets/_paste_textarea.py
+++ b/libs/code/deepagents_code/tui/widgets/_paste_textarea.py
@@ -216,7 +216,7 @@ class PasteBurstTextArea(TextArea):
         self._paste_burst_last_suppressed_enter_time = None
 
     def _reset_paste_burst_state(self) -> None:
-        """Reset all paste-burst tracking to a clean slate.
+        """Reset all paste-burst and backslash tracking to a clean slate.
 
         Used by text-replacing entry points so a wholesale text swap never
         leaves stale burst timing that would misclassify the next keystroke.
@@ -224,6 +224,7 @@ class PasteBurstTextArea(TextArea):
         self._paste_burst_buffer = ""
         self._paste_burst_last_char_time = None
         self._paste_burst_window_until = None
+        self._backslash_pending_time = None
         self._reset_paste_burst_run()
         self._cancel_paste_burst_timer()
 
@@ -453,7 +454,7 @@ class PasteBurstTextArea(TextArea):
             self._backslash_pending_time = now
 
     def _consume_modifier_newline(self, event: events.Key) -> bool:
-        """Return whether a modifier-Enter key was consumed as an inserted newline."""
+        """Return whether a modifier-Enter (or Ctrl+J) key inserted a newline."""
         if event.key in self._NEWLINE_KEYS:
             event.prevent_default()
             event.stop()

--- a/libs/code/deepagents_code/tui/widgets/_paste_textarea.py
+++ b/libs/code/deepagents_code/tui/widgets/_paste_textarea.py
@@ -101,8 +101,10 @@ class PasteBurstTextArea(TextArea):
     """Shared key bindings for every paste-aware text area.
 
     These are the single source of truth for shortcut keys, inherited by both
-    the chat input and inline prompts (Textual aggregates BINDINGS across the
-    MRO). `_NEWLINE_KEYS` is derived from this list so `_on_key` stays in sync.
+    the chat input and inline prompts, which no longer define their own (were a
+    subclass to add its own BINDINGS, Textual would merge them across the MRO
+    rather than replace these). `_NEWLINE_KEYS` is derived from this list so
+    `_on_key` stays in sync.
     """
 
     _NEWLINE_KEYS: ClassVar[frozenset[str]] = frozenset(
@@ -420,7 +422,16 @@ class PasteBurstTextArea(TextArea):
     def _consume_backslash_enter_newline(
         self, event: events.Key, now: float, *, enabled: bool = True
     ) -> bool:
-        """Return whether a terminal-emitted backslash+Enter became a newline."""
+        """Return whether a terminal-emitted backslash+Enter became a newline.
+
+        Args:
+            event: The key event being handled.
+            now: Current monotonic timestamp, compared against the pending
+                backslash time via `_BACKSLASH_ENTER_GAP_SECONDS`.
+            enabled: When `False`, the fallback is skipped (still clearing any
+                pending backslash). Callers pass `False` to suppress it while a
+                competing affordance owns Enter (e.g. an open completion popup).
+        """
         if (
             event.key == "enter"
             and enabled

--- a/libs/code/deepagents_code/tui/widgets/ask_user.py
+++ b/libs/code/deepagents_code/tui/widgets/ask_user.py
@@ -29,6 +29,7 @@ from deepagents_code.tui.widgets._inline_prompt import (
     InlinePromptOption,
     InlinePromptTextArea,
     apply_inline_prompt_border,
+    newline_hint,
     stop_inline_prompt_blur,
 )
 
@@ -174,6 +175,7 @@ class AskUserMenu(Container):
         parts = [
             f"{glyphs.arrow_up}/{glyphs.arrow_down} Select",
             "Enter to continue",
+            newline_hint(),
         ]
         if len(self._questions) > 1:
             parts.append("Tab/Shift+Tab switch question")

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -850,16 +850,6 @@ class ChatTextArea(PasteBurstTextArea):
             return
         super().action_cursor_down(select)
 
-    def _reset_paste_burst_state(self) -> None:
-        """Reset all paste-burst and backslash tracking to a clean slate.
-
-        Shared by the text-replacing entry points (`set_text_from_history`,
-        `clear_text`, `discard_text`) so a wholesale text swap never leaves
-        stale burst/backslash timing that would misclassify the next keystroke.
-        """
-        super()._reset_paste_burst_state()
-        self._backslash_pending_time = None
-
     def _in_slash_command_context(self) -> bool:
         """Return whether the current input is composing a slash command."""
         owner = self._chat_input_owner

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -7,11 +7,10 @@ import contextlib
 import logging
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, assert_never
+from typing import TYPE_CHECKING, Any, Literal, assert_never
 
 from rich.cells import cell_len
 from rich.segment import Segment
-from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.content import Content
 from textual.css.query import NoMatches
@@ -81,16 +80,6 @@ protocol spec (functional key definitions) for background.
 
 _FILE_CACHE_WORKER_GROUP = "file-cache"
 """Textual worker group for all `@` file-completion cache warmers."""
-
-_BACKSLASH_ENTER_GAP_SECONDS = 0.15
-"""Maximum gap between a `\\` key and a following `enter` key to treat the
-pair as a terminal-emitted shift+enter sequence.
-
-Some terminals (e.g. VSCode's built-in terminal) send a literal backslash
-followed by enter when the user presses shift+enter.  The gap is
-generous (150 ms) because the terminal emits both characters nearly
-simultaneously; a human deliberately typing `\\` then pressing Enter would
-have a much larger gap."""
 
 _REFOCUS_CLICK_SUPPRESS_WINDOW_SECONDS = 0.3
 """Window after a terminal focus regain during which a click only refocuses.
@@ -456,36 +445,11 @@ class CompletionPopup(VerticalScroll):
 
 
 class ChatTextArea(PasteBurstTextArea):
-    """TextArea subclass with custom key handling for chat input."""
+    """TextArea subclass with custom key handling for chat input.
 
-    BINDINGS: ClassVar[list[Binding]] = [
-        Binding(
-            "shift+enter,alt+enter,ctrl+enter,ctrl+j",
-            "insert_newline",
-            "New Line",
-            show=False,
-            priority=True,
-        ),
-        Binding(
-            "ctrl+backspace,alt+backspace",
-            "delete_word_left",
-            "Delete left to start of word",
-            show=False,
-        ),
-    ]
-    """Key bindings for the chat text area.
-
-    These are the single source of truth for shortcut keys. `_NEWLINE_KEYS`
-    is derived from this list so that `_on_key` stays in sync automatically.
+    Modifier-Enter / Ctrl+J newline bindings and the VSCode backslash+enter
+    fallback are inherited from `PasteBurstTextArea`.
     """
-
-    _NEWLINE_KEYS: ClassVar[frozenset[str]] = frozenset(
-        key
-        for b in BINDINGS
-        if b.action == "insert_newline"
-        for key in b.key.split(",")
-    )
-    """Flattened set of keys that insert a newline, derived from `BINDINGS`."""
 
     _skip_history_change_events: int
     """Counter incremented before a history-driven text replacement so the
@@ -556,9 +520,8 @@ class ChatTextArea(PasteBurstTextArea):
         self._chat_input_owner: ChatInput | None = None
         self._skip_history_change_events = 0
         self._completion_active = False
-        # Paste-burst state is initialized by PasteBurstTextArea.__init__.
-        # See _BACKSLASH_ENTER_GAP_SECONDS for context.
-        self._backslash_pending_time: float | None = None
+        # Paste-burst and backslash-pending state is initialized by
+        # PasteBurstTextArea.__init__.
         # Tracks terminal focus so a click that re-focuses the window only
         # restores focus instead of also moving the cursor. See
         # `_REFOCUS_CLICK_SUPPRESS_WINDOW_SECONDS`.
@@ -944,30 +907,6 @@ class ChatTextArea(PasteBurstTextArea):
 
         self.insert(payload)
 
-    def _delete_preceding_backslash(self) -> bool:
-        """Delete the backslash character immediately before the cursor.
-
-        Caller must ensure a backslash is expected at this position. The
-        method verifies the character before deleting it.
-
-        Returns:
-            `True` if a backslash was found and deleted, `False` otherwise.
-        """
-        row, col = self.cursor_location
-        if col > 0:
-            start = (row, col - 1)
-            if self.document.get_text_range(start, self.cursor_location) == "\\":
-                self.delete(start, self.cursor_location)
-                return True
-        elif row > 0:
-            prev_line = self.document.get_line(row - 1)
-            start = (row - 1, len(prev_line) - 1)
-            end = (row - 1, len(prev_line))
-            if self.document.get_text_range(start, end) == "\\":
-                self.delete(start, self.cursor_location)
-                return True
-        return False
-
     async def _on_key(self, event: events.Key) -> None:
         """Handle key events."""
         # Lock keys (Caps Lock, Num Lock, Scroll Lock) must never type. The
@@ -1044,29 +983,17 @@ class ChatTextArea(PasteBurstTextArea):
 
         # Some terminals (e.g. VSCode built-in) send a literal backslash
         # followed by enter for shift+enter.  When enter arrives shortly
-        # after a backslash, delete the backslash and insert a newline.
-        if (
-            event.key == "enter"
-            and not self._completion_active
-            and self._backslash_pending_time is not None
-            and (now - self._backslash_pending_time) <= _BACKSLASH_ENTER_GAP_SECONDS
+        # after a backslash, delete the backslash and insert a newline.  The
+        # fallback is inactive while completion is active.
+        if self._consume_backslash_enter_newline(
+            event, now, enabled=not self._completion_active
         ):
-            self._backslash_pending_time = None
-            if self._delete_preceding_backslash():
-                event.prevent_default()
-                event.stop()
-                self.action_insert_newline()
-                return
-        self._backslash_pending_time = None
+            return
 
-        if event.key == "backslash" and event.character == "\\":
-            self._backslash_pending_time = now
+        self._track_backslash_pending(event, now)
 
         # Modifier+Enter inserts newline — keys derived from BINDINGS
-        if event.key in self._NEWLINE_KEYS:
-            event.prevent_default()
-            event.stop()
-            self.action_insert_newline()
+        if self._consume_modifier_newline(event):
             return
 
         if event.key == "backspace" and self._delete_placeholder_token(backwards=True):

--- a/libs/code/deepagents_code/tui/widgets/goal_review.py
+++ b/libs/code/deepagents_code/tui/widgets/goal_review.py
@@ -16,12 +16,13 @@ if TYPE_CHECKING:
     from textual import events
     from textual.app import ComposeResult
 
-from deepagents_code.config import get_glyphs, newline_shortcut
+from deepagents_code.config import get_glyphs
 from deepagents_code.tui.widgets._inline_prompt import (
     InlinePromptCompletion,
     InlinePromptOption,
     InlinePromptTextArea,
     apply_inline_prompt_border,
+    newline_hint,
     stop_inline_prompt_blur,
 )
 
@@ -363,7 +364,7 @@ class GoalReviewMenu(Container):
         glyphs = get_glyphs()
         self._help_widget.update(
             f"Enter some {what}, or press Esc to go back {glyphs.bullet} "
-            f"{newline_shortcut()} newline {glyphs.bullet} Ctrl+X external editor"
+            f"{newline_hint()} {glyphs.bullet} Ctrl+X external editor"
         )
 
     def _submit(self, result: GoalReviewResult) -> None:
@@ -388,14 +389,14 @@ class GoalReviewMenu(Container):
         if self._input_mode == "edit":
             self._help_widget.update(
                 f"Enter save edits {glyphs.bullet} "
-                f"{newline_shortcut()} newline {glyphs.bullet} "
+                f"{newline_hint()} {glyphs.bullet} "
                 f"Ctrl+X external editor {glyphs.bullet} Esc back"
             )
             return
         if self._input_mode == "reject":
             self._help_widget.update(
                 f"Enter regenerate {glyphs.bullet} "
-                f"{newline_shortcut()} newline {glyphs.bullet} "
+                f"{newline_hint()} {glyphs.bullet} "
                 f"Ctrl+X external editor {glyphs.bullet} Esc back"
             )
             return

--- a/libs/code/deepagents_code/tui/widgets/goal_review.py
+++ b/libs/code/deepagents_code/tui/widgets/goal_review.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from textual import events
     from textual.app import ComposeResult
 
-from deepagents_code.config import get_glyphs
+from deepagents_code.config import get_glyphs, newline_shortcut
 from deepagents_code.tui.widgets._inline_prompt import (
     InlinePromptCompletion,
     InlinePromptOption,
@@ -363,7 +363,7 @@ class GoalReviewMenu(Container):
         glyphs = get_glyphs()
         self._help_widget.update(
             f"Enter some {what}, or press Esc to go back {glyphs.bullet} "
-            f"Shift+Enter newline {glyphs.bullet} Ctrl+X external editor"
+            f"{newline_shortcut()} newline {glyphs.bullet} Ctrl+X external editor"
         )
 
     def _submit(self, result: GoalReviewResult) -> None:
@@ -388,14 +388,14 @@ class GoalReviewMenu(Container):
         if self._input_mode == "edit":
             self._help_widget.update(
                 f"Enter save edits {glyphs.bullet} "
-                f"Shift+Enter newline {glyphs.bullet} "
+                f"{newline_shortcut()} newline {glyphs.bullet} "
                 f"Ctrl+X external editor {glyphs.bullet} Esc back"
             )
             return
         if self._input_mode == "reject":
             self._help_widget.update(
                 f"Enter regenerate {glyphs.bullet} "
-                f"Shift+Enter newline {glyphs.bullet} "
+                f"{newline_shortcut()} newline {glyphs.bullet} "
                 f"Ctrl+X external editor {glyphs.bullet} Esc back"
             )
             return

--- a/libs/code/tests/unit_tests/tui/widgets/test_ask_user.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_ask_user.py
@@ -911,6 +911,23 @@ class TestAskUserMenu:
             help_text = menu.query_one(".ask-user-help").render()
             assert "Tab" not in str(help_text)
 
+    async def test_help_text_advertises_newline_shortcut(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Footer advertises the terminal-aware newline shortcut."""
+        from deepagents_code import config as config_module
+
+        # `newline_hint` resolves `newline_shortcut` via a call-time import from
+        # config, so patch the name on the config module it looks up.
+        monkeypatch.setattr(config_module, "newline_shortcut", lambda: "Ctrl+J")
+        app = _AskUserTestApp([{"question": "Q1?", "type": "text"}])
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            menu = app.query_one("#ask-user-menu", AskUserMenu)
+            help_text = menu.query_one(".ask-user-help").render()
+            assert "Ctrl+J newline" in str(help_text)
+
     async def test_required_label_shown_for_required_question(self) -> None:
         """Required questions display a (required) indicator."""
         app = _AskUserTestApp([{"question": "Name?", "type": "text", "required": True}])

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -3783,6 +3783,44 @@ class TestBackslashEnterNewline:
             # Should have submitted (backslash included in text)
             assert len(app.submitted) == 1
 
+    async def test_backslash_enter_suppressed_while_completion_active(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An open completion popup owns Enter, so the fallback must not fire.
+
+        `_on_key` passes `enabled=not self._completion_active` to the shared
+        `_consume_backslash_enter_newline`. While completion is active the
+        backslash+enter fallback must be suppressed (the popup consumes Enter to
+        accept a suggestion), yet the pending-backslash timestamp must still be
+        cleared so a *later* Enter can't retroactively trip the fallback.
+
+        Driving `_on_key` directly (as the sibling completion tests do) isolates
+        the text area's handling from the parent's completion bubbling, which is
+        what makes the assertions deterministic.
+        """
+        monkeypatch.setattr(paste_textarea_module, "_BACKSLASH_ENTER_GAP_SECONDS", 60.0)
+
+        app = _RecordingApp()
+        async with app.run_test() as pilot:
+            chat = app.query_one(ChatInput)
+            ta = chat._text_area
+            assert ta is not None
+
+            ta.insert("hello")
+            ta.set_completion_active(active=True)
+            await pilot.pause()
+
+            # Backslash arms the fallback; Enter arrives well within the gap.
+            await ta._on_key(events.Key("backslash", "\\"))
+            await ta._on_key(events.Key("enter", None))
+            await pilot.pause()
+
+            # Fallback suppressed: backslash untouched, no newline, no submit.
+            assert ta.text == "hello\\"
+            # Pending state cleared even though the fallback was disabled.
+            assert ta._backslash_pending_time is None
+            assert len(app.submitted) == 0
+
 
 class TestVSCodeSpaceWorkaround:
     """VS Code 1.110 sends space as CSI u (character=None, is_printable=False).

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -3647,7 +3647,7 @@ class TestBackslashEnterNewline:
         # Widen the gap so wall-clock timing between pilot.press calls on slow
         # CI runners cannot push the enter past the 150ms default and trip the
         # submit path.
-        monkeypatch.setattr(chat_input_module, "_BACKSLASH_ENTER_GAP_SECONDS", 60.0)
+        monkeypatch.setattr(paste_textarea_module, "_BACKSLASH_ENTER_GAP_SECONDS", 60.0)
 
         app = _RecordingApp()
         async with app.run_test() as pilot:
@@ -3685,7 +3685,7 @@ class TestBackslashEnterNewline:
         `call_after_refresh(scroll_cursor_visible)` keeps the cursor visible.
         """
         # Widen the backslash+enter gap so the fallback test isn't racy on CI.
-        monkeypatch.setattr(chat_input_module, "_BACKSLASH_ENTER_GAP_SECONDS", 60.0)
+        monkeypatch.setattr(paste_textarea_module, "_BACKSLASH_ENTER_GAP_SECONDS", 60.0)
 
         app = _ChatInputTestApp()
         async with app.run_test() as pilot:
@@ -3743,7 +3743,7 @@ class TestBackslashEnterNewline:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Backslash + enter on empty prompt should not submit."""
-        monkeypatch.setattr(chat_input_module, "_BACKSLASH_ENTER_GAP_SECONDS", 60.0)
+        monkeypatch.setattr(paste_textarea_module, "_BACKSLASH_ENTER_GAP_SECONDS", 60.0)
 
         app = _RecordingApp()
         async with app.run_test() as pilot:
@@ -3764,7 +3764,7 @@ class TestBackslashEnterNewline:
     ) -> None:
         """Backslash + enter beyond the timing gap should submit normally."""
         # Set gap to 0 so any real delay exceeds it.
-        monkeypatch.setattr(chat_input_module, "_BACKSLASH_ENTER_GAP_SECONDS", 0.0)
+        monkeypatch.setattr(paste_textarea_module, "_BACKSLASH_ENTER_GAP_SECONDS", 0.0)
 
         app = _RecordingApp()
         async with app.run_test() as pilot:

--- a/libs/code/tests/unit_tests/tui/widgets/test_goal_review.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_goal_review.py
@@ -220,9 +220,12 @@ class TestGoalReviewMenu:
         `newline_shortcut` returns `Ctrl+J`/`Option+Enter`; the goal editor must
         advertise that key rather than a Shift+Enter that would submit instead.
         """
-        from deepagents_code.tui.widgets import goal_review as goal_review_module
+        from deepagents_code import config as config_module
 
-        monkeypatch.setattr(goal_review_module, "newline_shortcut", lambda: "Ctrl+J")
+        # `newline_hint` resolves `newline_shortcut` via a call-time
+        # `from deepagents_code.config import newline_shortcut`, so patch the
+        # name on the config module it actually looks up.
+        monkeypatch.setattr(config_module, "newline_shortcut", lambda: "Ctrl+J")
         app = _GoalReviewTestApp()
 
         async with app.run_test() as pilot:

--- a/libs/code/tests/unit_tests/tui/widgets/test_goal_review.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_goal_review.py
@@ -211,6 +211,36 @@ class TestGoalReviewMenu:
             menu.action_reject_with_message()
             assert "Ctrl+X external editor" in str(help_widget.content)
 
+    async def test_newline_hint_uses_terminal_shortcut(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Newline hints use the terminal-aware shortcut, not a hardcoded key.
+
+        On terminals that cannot report Shift+Enter (e.g. macOS Terminal.app),
+        `newline_shortcut` returns `Ctrl+J`/`Option+Enter`; the goal editor must
+        advertise that key rather than a Shift+Enter that would submit instead.
+        """
+        from deepagents_code.tui.widgets import goal_review as goal_review_module
+
+        monkeypatch.setattr(goal_review_module, "newline_shortcut", lambda: "Ctrl+J")
+        app = _GoalReviewTestApp()
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            menu = app.query_one("#goal-review", GoalReviewMenu)
+            help_widget = menu.query_one(".goal-review-help", Static)
+
+            menu.action_edit()
+            assert "Ctrl+J newline" in str(help_widget.content)
+            assert "Shift+Enter" not in str(help_widget.content)
+
+            menu.action_cancel()
+            menu.action_reject_with_message()
+            assert "Ctrl+J newline" in str(help_widget.content)
+
+            menu._hint_empty_submission("criteria")
+            assert "Ctrl+J newline" in str(help_widget.content)
+
     async def test_edit_expands_collapsed_paste_on_submit(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_inline_prompt.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_inline_prompt.py
@@ -205,6 +205,35 @@ class TestInlinePromptPaste:
 
             assert app.submissions == ["hello"]
 
+    async def test_backslash_then_enter_inserts_newline(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rapid backslash + enter inserts a newline instead of submitting.
+
+        Some terminals (e.g. VSCode built-in) emit a literal backslash followed
+        by enter for shift+enter; the inline prompt must collapse that pair into
+        a newline like the chat input does.
+        """
+        # Widen the gap so wall-clock timing between pilot.press calls on slow
+        # CI runners cannot trip the submit path.
+        monkeypatch.setattr(paste_textarea_module, "_BACKSLASH_ENTER_GAP_SECONDS", 60.0)
+        app = _PromptApp()
+        async with app.run_test() as pilot:
+            ta = app.query_one(InlinePromptTextArea)
+            ta.focus()
+            await pilot.pause()
+
+            ta.insert("hello")
+            await pilot.pause()
+
+            await pilot.press("backslash")
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert "\n" in ta.text
+            assert "\\" not in ta.text
+            assert app.submissions == []
+
     async def test_identical_second_paste_expands_placeholder(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_inline_prompt.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_inline_prompt.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+import pytest
 from textual.app import App
 from textual.events import Key, Paste
 
@@ -13,9 +14,9 @@ from deepagents_code.tui.widgets._inline_prompt import (
     InlinePromptCompletion,
     InlinePromptTextArea,
 )
+from deepagents_code.tui.widgets._paste_textarea import PasteBurstTextArea
 
 if TYPE_CHECKING:
-    import pytest
     from textual.app import ComposeResult
 
 
@@ -234,6 +235,36 @@ class TestInlinePromptPaste:
             assert "\\" not in ta.text
             assert app.submissions == []
 
+    @pytest.mark.parametrize(
+        "key",
+        [
+            pytest.param("shift+enter", id="shift_enter"),
+            pytest.param("ctrl+j", id="ctrl_j"),
+        ],
+    )
+    async def test_modifier_enter_inserts_newline(self, key: str) -> None:
+        """Modifier+Enter (and Ctrl+J) insert a newline instead of submitting.
+
+        This is the headline affordance the inline prompt inherits from
+        `PasteBurstTextArea`; without it these keys would fall through to the
+        plain-enter branch and submit. Regression guard for the shared
+        `BINDINGS` / `_consume_modifier_newline` wiring.
+        """
+        app = _PromptApp()
+        async with app.run_test() as pilot:
+            ta = app.query_one(InlinePromptTextArea)
+            ta.focus()
+            await pilot.pause()
+
+            ta.insert("hello")
+            await pilot.pause()
+
+            await pilot.press(key)
+            await pilot.pause()
+
+            assert "\n" in ta.text
+            assert app.submissions == []
+
     async def test_identical_second_paste_expands_placeholder(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -406,6 +437,65 @@ class TestInlinePromptPaste:
             # content. The verbatim insert is Textual's base handler's job.
             assert "[Pasted text #1" not in ta.text
             assert ta._pasted_contents == {}
+
+
+class TestSharedBindings:
+    """The newline/word-delete bindings live on the base and reach subclasses."""
+
+    def test_base_bindings_are_the_single_source_of_truth(self) -> None:
+        """`PasteBurstTextArea` owns the shared newline and word-delete keys.
+
+        Introspecting the base protects every paste-aware subclass at once: a
+        regression in these bindings would surface here before it reached the
+        chat input or inline prompt.
+        """
+        newline_keys = {
+            key.strip()
+            for binding in PasteBurstTextArea.BINDINGS
+            if binding.action == "insert_newline"
+            for key in binding.key.split(",")
+        }
+        word_delete_keys = {
+            key.strip()
+            for binding in PasteBurstTextArea.BINDINGS
+            if binding.action == "delete_word_left"
+            for key in binding.key.split(",")
+        }
+
+        assert {"shift+enter", "alt+enter", "ctrl+enter", "ctrl+j"} <= newline_keys
+        # `ctrl+m` is carriage return in terminals, so it must remain plain Enter.
+        assert "ctrl+m" not in newline_keys
+        assert newline_keys == PasteBurstTextArea._NEWLINE_KEYS
+        assert {"ctrl+backspace", "alt+backspace"} <= word_delete_keys
+
+    def test_inline_prompt_inherits_bindings(self) -> None:
+        """`InlinePromptTextArea` defines no bindings of its own; it inherits them."""
+        assert "BINDINGS" not in InlinePromptTextArea.__dict__
+        assert InlinePromptTextArea._NEWLINE_KEYS == PasteBurstTextArea._NEWLINE_KEYS
+
+    @pytest.mark.parametrize("key", ["ctrl+backspace", "alt+backspace"])
+    async def test_modified_backspace_deletes_word_on_ordinary_text(
+        self, key: str
+    ) -> None:
+        """The inherited word-delete binding removes the previous word.
+
+        The other inline-prompt backspace tests only cover atomic deletion of a
+        collapsed-paste placeholder; this one exercises the inherited
+        `delete_word_left` binding on ordinary text.
+        """
+        app = _PromptApp()
+        async with app.run_test() as pilot:
+            ta = app.query_one(InlinePromptTextArea)
+            ta.focus()
+            await pilot.pause()
+
+            ta.insert("hello world")
+            await pilot.pause()
+
+            await pilot.press(key)
+            await pilot.pause()
+
+            assert ta.text == "hello "
 
 
 class TestInlinePromptCompletion:

--- a/libs/code/tests/unit_tests/tui/widgets/test_inline_prompt.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_inline_prompt.py
@@ -231,9 +231,32 @@ class TestInlinePromptPaste:
             await pilot.press("enter")
             await pilot.pause()
 
-            assert "\n" in ta.text
-            assert "\\" not in ta.text
+            # Exact match: the backslash is gone and exactly one newline was
+            # inserted (guards against a double-fire re-adding the char or a
+            # second newline).
+            assert ta.text == "hello\n"
             assert app.submissions == []
+
+    async def test_reset_clears_pending_backslash(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Replacing text cannot reuse a backslash timestamp from old text."""
+        monkeypatch.setattr(paste_textarea_module, "_BACKSLASH_ENTER_GAP_SECONDS", 60.0)
+        app = _PromptApp()
+        async with app.run_test() as pilot:
+            ta = app.query_one(InlinePromptTextArea)
+            ta.focus()
+            await pilot.pause()
+
+            await pilot.press("backslash")
+            ta.text = "replacement\\"
+            ta.move_cursor((0, len(ta.text)))
+            ta.reset_paste_state()
+
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert app.submissions == ["replacement\\"]
 
     @pytest.mark.parametrize(
         "key",
@@ -246,9 +269,9 @@ class TestInlinePromptPaste:
         """Modifier+Enter (and Ctrl+J) insert a newline instead of submitting.
 
         This is the headline affordance the inline prompt inherits from
-        `PasteBurstTextArea`; without it these keys would fall through to the
-        plain-enter branch and submit. Regression guard for the shared
-        `BINDINGS` / `_consume_modifier_newline` wiring.
+        `PasteBurstTextArea`; without it these keys would not insert a newline
+        (and a bare-`enter` variant would submit). Regression guard for the
+        shared `BINDINGS` / `_consume_modifier_newline` wiring.
         """
         app = _PromptApp()
         async with app.run_test() as pilot:
@@ -262,7 +285,9 @@ class TestInlinePromptPaste:
             await pilot.press(key)
             await pilot.pause()
 
-            assert "\n" in ta.text
+            # Exact match guards against both keys double-firing (inherited
+            # priority binding + explicit `_consume_modifier_newline` handler).
+            assert ta.text == "hello\n"
             assert app.submissions == []
 
     async def test_identical_second_paste_expands_placeholder(


### PR DESCRIPTION
Fixes the newline-entry inconsistencies across dcode's text-entry surfaces, and refactors so any future surface inherits the affordances.

Three gaps came out of a comparison with Codex and opencode:

- The goal-criteria editor advertised a hardcoded "Shift+Enter newline" in its footer. On terminals that cannot report Shift+Enter (e.g. macOS Terminal.app) that chord submits, so the hint pointed at the wrong key.
- The VSCode `backslash+enter`→newline fallback (for terminals that emulate Shift+Enter that way) lived only in the chat input, so Shift+Enter submitted with a stray backslash in the goal editor and the `ask_user` free-text prompt.
- The `ask_user` free-text prompt never told users how to insert a newline at all.

Rather than patch each surface, the shared newline affordances now live in the common `PasteBurstTextArea` base: the modifier-Enter / Ctrl+J bindings, the derived newline-key set, and the backslash+enter fallback (via small `_consume_backslash_enter_newline` / `_track_backslash_pending` / `_consume_modifier_newline` helpers). Both the chat input and the inline prompts inherit them, and any future `TextArea`-based input surface that extends the base gets them for free. A shared `newline_hint()` helper renders the terminal-aware shortcut (`Ctrl+J` / `Option+Enter` / `Shift+Enter`) consistently, now used by both the goal editor and the `ask_user` footer.

The chat input's existing behavior — including the completion-active gating on the backslash path and key ordering — is preserved.

Made by [Open SWE](https://openswe.vercel.app/agents/a7bdfa65-aba1-0246-373d-5a12d84a9860)