### PR TITLE
refactor(evals): make `langgraph.json` the single agent registry

### DIFF
--- a/.github/scripts/test_unified_prep.py
+++ b/.github/scripts/test_unified_prep.py
@@ -69,6 +69,17 @@ def test_main_rejects_invalid_agent_impl(tmp_path, monkeypatch):
         up.main()
 
 
+def test_category_map_guard_rejects_entry_missing_fan_out():
+    import pytest
+
+    malformed = {
+        "autonomous": {"agent_impl": "bare", "fan_out": True},
+        "broken": {"agent_impl": "bare"},  # missing "fan_out"
+    }
+    with pytest.raises(RuntimeError, match=r"'broken'.*agent_impl.*fan_out"):
+        up._validate_category_map_keys(malformed)
+
+
 def test_derive_impl_sets_new_graph_is_selectable():
     cats = {
         "autonomous": {"agent_impl": "bare", "fan_out": True},

--- a/.github/scripts/test_unified_prep.py
+++ b/.github/scripts/test_unified_prep.py
@@ -64,9 +64,26 @@ def test_main_rejects_invalid_agent_impl(tmp_path, monkeypatch):
     monkeypatch.setenv("UNIFIED_MODELS", "openai:gpt")
     monkeypatch.setenv("UNIFIED_CATEGORIES", "autonomous")
     monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "o"))
-    monkeypatch.setenv("UNIFIED_AGENT_IMPLS", "deepagent")
+    monkeypatch.setenv("UNIFIED_AGENT_IMPLS", "nonexistent-graph")
     with pytest.raises(SystemExit, match=r"UNIFIED_AGENT_IMPLS entries must be in"):
         up.main()
+
+
+def test_derive_impl_sets_new_graph_is_selectable():
+    cats = {
+        "autonomous": {"agent_impl": "bare", "fan_out": True},
+        "conversation": {"agent_impl": "tau3", "fan_out": False},
+        "context": {"agent_impl": "bare", "fan_out": True},
+    }
+    known, code = up.derive_impl_sets({"bare", "dcode", "tau3", "foo"}, cats)
+    assert known == {"bare", "dcode", "tau3", "foo"}
+    assert "foo" in code
+    assert "tau3" not in code
+
+
+def test_module_impl_sets_match_registry():
+    assert up.KNOWN_AGENT_IMPLS == {"bare", "dcode", "tau3"}
+    assert up.CODE_AGENT_IMPLS == {"bare", "dcode"}
 
 
 def test_main_rejects_invalid_profile(tmp_path, monkeypatch):

--- a/.github/scripts/test_validate_agent_graph.py
+++ b/.github/scripts/test_validate_agent_graph.py
@@ -1,0 +1,25 @@
+import importlib
+
+validate_agent_graph = importlib.import_module("validate_agent_graph")
+
+
+def _registry(tmp_path):
+    p = tmp_path / "langgraph.json"
+    p.write_text('{"graphs": {"bare": "x", "dcode": "y", "tau3": "z"}}')
+    return str(p)
+
+
+def test_valid_impl_returns_zero(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENT_IMPL", "bare")
+    assert validate_agent_graph.main([_registry(tmp_path)]) == 0
+
+
+def test_unknown_impl_returns_one(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("AGENT_IMPL", "nope")
+    assert validate_agent_graph.main([_registry(tmp_path)]) == 1
+    assert "::error::" in capsys.readouterr().out
+
+
+def test_missing_registry_returns_two(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENT_IMPL", "bare")
+    assert validate_agent_graph.main([str(tmp_path / "absent.json")]) == 2

--- a/.github/scripts/test_validate_agent_graph.py
+++ b/.github/scripts/test_validate_agent_graph.py
@@ -23,3 +23,14 @@ def test_unknown_impl_returns_one(tmp_path, monkeypatch, capsys):
 def test_missing_registry_returns_two(tmp_path, monkeypatch):
     monkeypatch.setenv("AGENT_IMPL", "bare")
     assert validate_agent_graph.main([str(tmp_path / "absent.json")]) == 2
+
+
+def test_missing_graphs_object_returns_two(tmp_path, monkeypatch, capsys):
+    # A registry with no (or an empty/non-dict) "graphs" object is a broken
+    # registry, not a bad impl choice; it must not degrade to the "unknown
+    # impl ... (have: [])" exit-1 path (see test_unknown_impl_returns_one).
+    p = tmp_path / "langgraph.json"
+    p.write_text('{"nograph": {}}')
+    monkeypatch.setenv("AGENT_IMPL", "bare")
+    assert validate_agent_graph.main([str(p)]) == 2
+    assert "has no 'graphs' object" in capsys.readouterr().out

--- a/.github/scripts/unified_prep.py
+++ b/.github/scripts/unified_prep.py
@@ -24,6 +24,7 @@ import os
 import re
 import subprocess
 import sys
+from pathlib import Path
 from typing import cast
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -53,36 +54,80 @@ CATEGORY_MAP: dict[str, dict] = {
         "dataset": "harbor-index/harbor-index-1.0",
         "dataset_path": "",
         "agent_impl": "bare",
+        "fan_out": True,
     },
     "conversation": {
         "dataset": "tau3-subset",
         "dataset_path": "",
         "agent_impl": "tau3",
+        "fan_out": False,
     },
     "context": {
         "dataset": "",
         "dataset_path": "datasets/context-retrieval-evals",
         "agent_impl": "bare",
+        "fan_out": True,
     },
 }
-
-# Harnesses selectable for the code categories (autonomous, context) via the
-# `agent_impls` input. Conversation is always tau3 and is never overridden.
-CODE_AGENT_IMPLS = {"dcode", "bare"}
 
 # Harness used when the `agent_impls` input (UNIFIED_AGENT_IMPLS) is unset or blank.
 DEFAULT_AGENT_IMPL = "bare"
 
-# Every harness a category may pin in CATEGORY_MAP (code harnesses plus tau3).
-KNOWN_AGENT_IMPLS = CODE_AGENT_IMPLS | {"tau3"}
+# langgraph.json is the single source of truth for which agent graphs exist. Its
+# path is resolved relative to this file so it holds regardless of the caller's
+# cwd (.github/scripts -> repo root is two parents up).
+_LANGGRAPH_JSON = (
+    Path(__file__).resolve().parents[2]
+    / "libs/evals/deepagents_harbor/langgraph_project/langgraph.json"
+)
 
-# A typo in a CATEGORY_MAP `agent_impl` (e.g. "bear") would silently make that
-# category ineligible for the override and route it to a nonexistent harness, so
-# validate at import. raise (not assert): asserts are stripped under `python -O`.
-if not all(cm["agent_impl"] in KNOWN_AGENT_IMPLS for cm in CATEGORY_MAP.values()):
-    raise RuntimeError(f"every CATEGORY_MAP agent_impl must be one of {sorted(KNOWN_AGENT_IMPLS)}")
+
+def _load_registry_graphs(path: Path) -> set[str]:
+    """Return the set of graph keys registered in a langgraph.json."""
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(f"cannot read agent registry {path}: {exc}") from exc
+    graphs = data.get("graphs")
+    if not isinstance(graphs, dict) or not graphs:
+        raise RuntimeError(f"agent registry {path} has no 'graphs' object")
+    return set(graphs)
+
+
+def derive_impl_sets(
+    all_graphs: set[str], category_map: dict[str, dict]
+) -> tuple[set[str], set[str]]:
+    """Derive (known, code) impl sets from the registry and category policy.
+
+    `known` is every registered graph. `code` is the graphs a user may select on
+    the code (fan-out) categories: every graph except one pinned by a non-fan-out
+    category (e.g. `tau3`, bound to conversation).
+    """
+    pinned_non_code = {
+        cm["agent_impl"] for cm in category_map.values() if not cm["fan_out"]
+    }
+    return all_graphs, all_graphs - pinned_non_code
+
+
+ALL_GRAPHS = _load_registry_graphs(_LANGGRAPH_JSON)
+KNOWN_AGENT_IMPLS, CODE_AGENT_IMPLS = derive_impl_sets(ALL_GRAPHS, CATEGORY_MAP)
+
+# A CATEGORY_MAP agent_impl that is not a registered graph would route a category
+# to a nonexistent harness. Validate at import; raise (not assert) so `python -O`
+# cannot strip it.
+_unknown = [
+    cm["agent_impl"] for cm in CATEGORY_MAP.values() if cm["agent_impl"] not in ALL_GRAPHS
+]
+if _unknown:
+    raise RuntimeError(
+        f"CATEGORY_MAP agent_impl(s) {_unknown} are not graphs in {_LANGGRAPH_JSON} "
+        f"(have {sorted(ALL_GRAPHS)})"
+    )
 if DEFAULT_AGENT_IMPL not in CODE_AGENT_IMPLS:
-    raise RuntimeError(f"DEFAULT_AGENT_IMPL must be one of {sorted(CODE_AGENT_IMPLS)}")
+    raise RuntimeError(
+        f"DEFAULT_AGENT_IMPL {DEFAULT_AGENT_IMPL!r} must be a selectable code "
+        f"harness, one of {sorted(CODE_AGENT_IMPLS)}"
+    )
 
 # Run profiles: "full" = every task in each category; "lite" = the frozen
 # high-signal subset from lite_tasks.py (fewer tasks, full rollouts).
@@ -246,7 +291,7 @@ def build_flat_matrix(
 ) -> list[dict]:
     """One flat matrix of single-`harbor run` shards spanning categories x configs.
 
-    Code categories (their CATEGORY_MAP agent_impl is in CODE_AGENT_IMPLS) emit one
+    Fan-out categories (`CATEGORY_MAP` `fan_out=True`) emit one
     shard group per (category, config) across `code_impls`. A non-code category
     (conversation / tau3) emits one group with its pinned agent_impl and is never
     multiplied by configs. The per-model entry count is bounded by
@@ -267,7 +312,7 @@ def build_flat_matrix(
         tasks = tasks_by_cat.get(cat, [])
         if not tasks:
             continue
-        if cm["agent_impl"] in CODE_AGENT_IMPLS:
+        if cm["fan_out"]:
             for impl in code_impls:
                 groups.append((cat, impl, tasks))
         else:

--- a/.github/scripts/unified_prep.py
+++ b/.github/scripts/unified_prep.py
@@ -106,9 +106,29 @@ def derive_impl_sets(
     pinned_non_code = {
         cm["agent_impl"] for cm in category_map.values() if not cm["fan_out"]
     }
+    # Subtractive, not additive: a graph pinned by a non-fan-out category is
+    # excluded from the selectable code set even if a fan-out category also uses
+    # it. Not reachable with the current CATEGORY_MAP, but it is the defined
+    # invariant.
     return all_graphs, all_graphs - pinned_non_code
 
 
+def _validate_category_map_keys(category_map: dict[str, dict]) -> None:
+    """Fail fast, naming the offending category, if a CATEGORY_MAP entry is
+    missing `agent_impl` or `fan_out`.
+
+    `derive_impl_sets` reads `cm["fan_out"]` for every entry unconditionally, so
+    a missing key would otherwise surface as a bare `KeyError('fan_out')`
+    instead of identifying which category is malformed.
+    """
+    for cat, cm in category_map.items():
+        if "agent_impl" not in cm or "fan_out" not in cm:
+            raise RuntimeError(
+                f"CATEGORY_MAP[{cat!r}] must define both 'agent_impl' and 'fan_out'"
+            )
+
+
+_validate_category_map_keys(CATEGORY_MAP)
 ALL_GRAPHS = _load_registry_graphs(_LANGGRAPH_JSON)
 KNOWN_AGENT_IMPLS, CODE_AGENT_IMPLS = derive_impl_sets(ALL_GRAPHS, CATEGORY_MAP)
 

--- a/.github/scripts/validate_agent_graph.py
+++ b/.github/scripts/validate_agent_graph.py
@@ -21,9 +21,16 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     impl = os.environ.get("AGENT_IMPL", "")
     try:
-        graphs = json.loads(Path(argv[0]).read_text()).get("graphs", {})
+        data = json.loads(Path(argv[0]).read_text())
     except (OSError, ValueError) as exc:
         print(f"::error::cannot read agent registry {argv[0]}: {exc}")
+        return 2
+    graphs = data.get("graphs")
+    if not isinstance(graphs, dict) or not graphs:
+        # A broken registry (no/empty/non-dict "graphs") is a distinct failure
+        # from a bad impl choice; keep it out of the exit-1 "unknown impl" path
+        # below, where it would otherwise misattribute as "have: []".
+        print(f"::error::agent registry {argv[0]} has no 'graphs' object")
         return 2
     if impl not in graphs:
         print(

--- a/.github/scripts/validate_agent_graph.py
+++ b/.github/scripts/validate_agent_graph.py
@@ -1,0 +1,38 @@
+"""Validate that an agent impl names a graph registered in langgraph.json.
+
+`_harbor_run.yml` calls this so an invalid `agent_impl` can never reach
+`harbor run --agent-kwarg graph=...`. langgraph.json's graph keys are
+repo-controlled, so membership is a strict allowlist. The impl is read from the
+`AGENT_IMPL` environment variable, never interpolated into this source.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if len(argv) != 1:
+        print("::error::usage: AGENT_IMPL=<impl> validate_agent_graph.py <langgraph.json>")
+        return 2
+    impl = os.environ.get("AGENT_IMPL", "")
+    try:
+        graphs = json.loads(Path(argv[0]).read_text()).get("graphs", {})
+    except (OSError, ValueError) as exc:
+        print(f"::error::cannot read agent registry {argv[0]}: {exc}")
+        return 2
+    if impl not in graphs:
+        print(
+            f"::error::Unknown agent implementation {impl!r}; not a graph in "
+            f"langgraph.json (have: {sorted(graphs)})"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/_harbor_run.yml
+++ b/.github/workflows/_harbor_run.yml
@@ -753,29 +753,14 @@ jobs:
           fi
 
           env_flag="--env $HARBOR_SANDBOX_ENV"
-          case "$HARBOR_AGENT_IMPL" in
-            dcode)
-              HARBOR_AGENT_GRAPH=deepagent
-              HARBOR_AGENT_LABEL="dcode harness"
-              ;;
-            bare)
-              HARBOR_AGENT_GRAPH=bare_deepagent
-              HARBOR_AGENT_LABEL="bare create_deep_agent"
-              ;;
-            tau3)
-              # Requires a Harbor build that forwards the task environment's MCP
-              # servers into the LangGraph graph configurable. The pinned Harbor
-              # does not yet, so set `harbor_package_override` to such a build
-              # until that support ships in a release; otherwise tau3_deepagent
-              # exits early with no MCP servers.
-              HARBOR_AGENT_GRAPH=tau3_deepagent
-              HARBOR_AGENT_LABEL="tau3 conversational deepagent"
-              ;;
-            *)
-              echo "::error::Unknown agent implementation: $HARBOR_AGENT_IMPL"
-              exit 1
-              ;;
-          esac
+          # agent_impl IS the graph key in langgraph.json (the single registry).
+          # Validate membership before it reaches `harbor run --agent-kwarg
+          # graph=...`. Callers already validate, so this is defense-in-depth;
+          # AGENT_IMPL is passed via env, never interpolated into the validator.
+          AGENT_IMPL="$HARBOR_AGENT_IMPL" python3 \
+            "$GITHUB_WORKSPACE/.github/scripts/validate_agent_graph.py" \
+            "$GITHUB_WORKSPACE/libs/evals/deepagents_harbor/langgraph_project/langgraph.json"
+          HARBOR_AGENT_GRAPH="$HARBOR_AGENT_IMPL"
           experiment_model=$(printf '%s' "$HARBOR_MODEL" | tr '/:' '--' | tr -c '[:alnum:]._-' '-')
           experiment_agent=$(printf '%s' "$HARBOR_AGENT_IMPL" | tr -c '[:alnum:]._-' '-')
           experiment_branch=$(printf '%s' "$HARBOR_BRANCH" | tr -c '[:alnum:]._-' '-')
@@ -795,7 +780,6 @@ jobs:
           # is already set (local-path-aware) in the dataset-resolution block above.
           HARBOR_LANGSMITH_EXPERIMENT="deepagents-harbor-${experiment_branch}-${experiment_agent}-${experiment_model}${experiment_category:+-$experiment_category}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "HARBOR_AGENT_GRAPH=$HARBOR_AGENT_GRAPH" >> "$GITHUB_ENV"
-          echo "HARBOR_AGENT_LABEL=$HARBOR_AGENT_LABEL" >> "$GITHUB_ENV"
           echo "HARBOR_LANGSMITH_DATASET=$HARBOR_LANGSMITH_DATASET" >> "$GITHUB_ENV"
           echo "HARBOR_LANGSMITH_EXPERIMENT=$HARBOR_LANGSMITH_EXPERIMENT" >> "$GITHUB_ENV"
 
@@ -840,7 +824,7 @@ jobs:
           esac
 
           echo "LangSmith plugin experiment: $HARBOR_LANGSMITH_EXPERIMENT"
-          echo "Agent implementation: $HARBOR_AGENT_LABEL ($HARBOR_AGENT_GRAPH)"
+          echo "Agent implementation: $HARBOR_AGENT_GRAPH"
           echo ""
 
           uv run harbor run \
@@ -891,7 +875,6 @@ jobs:
         env:
           HARBOR_JOB_DIR: ${{ steps.latest-job.outputs.job_dir }}
           HARBOR_AGENT_GRAPH: ${{ env.HARBOR_AGENT_GRAPH }}
-          HARBOR_AGENT_LABEL: ${{ env.HARBOR_AGENT_LABEL }}
           HARBOR_LANGSMITH_DATASET: ${{ env.HARBOR_LANGSMITH_DATASET }}
           HARBOR_LANGSMITH_EXPERIMENT: ${{ env.HARBOR_LANGSMITH_EXPERIMENT }}
           LATEST_JOB_OUTCOME: ${{ steps.latest-job.outcome }}
@@ -918,7 +901,7 @@ jobs:
               echo "- Included tasks: all"
             fi
             echo "- Rollouts per task: ${HARBOR_ROLLOUTS_PER_TASK}"
-            echo "- Agent: Harbor LangGraph ${HARBOR_AGENT_LABEL} (${HARBOR_AGENT_GRAPH})"
+            echo "- Agent: Harbor LangGraph ${HARBOR_AGENT_GRAPH}"
             echo "- LangSmith dataset: ${HARBOR_LANGSMITH_DATASET}"
             echo "- LangSmith experiment: ${HARBOR_LANGSMITH_EXPERIMENT}"
             if [ "$LATEST_JOB_OUTCOME" = "success" ]; then

--- a/libs/evals/CONTRIBUTING.md
+++ b/libs/evals/CONTRIBUTING.md
@@ -415,7 +415,7 @@ uv run harbor run \
   --agent langgraph \
   --agent-kwarg project_path=deepagents_harbor/langgraph_project \
   --agent-kwarg config=langgraph.json \
-  --agent-kwarg graph=deepagent \
+  --agent-kwarg graph=dcode \
   --agent-env 'ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}' \
   --dataset terminal-bench/terminal-bench-2 \
   --model "$MODEL" \
@@ -428,7 +428,7 @@ uv run harbor run \
   --agent langgraph \
   --agent-kwarg project_path=deepagents_harbor/langgraph_project \
   --agent-kwarg config=langgraph.json \
-  --agent-kwarg graph=deepagent \
+  --agent-kwarg graph=dcode \
   --agent-env 'ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}' \
   --agent-env 'LANGSMITH_API_KEY=${LANGSMITH_API_KEY}' \
   --agent-env 'LANGSMITH_TRACING=true' \
@@ -480,7 +480,7 @@ uv run harbor run \
   --agent langgraph \
   --agent-kwarg project_path=deepagents_harbor/langgraph_project \
   --agent-kwarg config=langgraph.json \
-  --agent-kwarg graph=deepagent \
+  --agent-kwarg graph=dcode \
   --agent-env 'ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}' \
   --agent-env 'LANGSMITH_API_KEY=${LANGSMITH_API_KEY}' \
   --agent-env 'LANGSMITH_TRACING=true' \

--- a/libs/evals/Makefile
+++ b/libs/evals/Makefile
@@ -42,7 +42,7 @@ test_watch: ## Run tests in watch mode
 # -n = concurrent trials (parallel sandbox slots), NOT task count
 # -l = max tasks to run (omit for all)
 HARBOR_AGENT_IMPL ?= dcode
-HARBOR_AGENT_GRAPH = $(if $(filter bare,$(HARBOR_AGENT_IMPL)),bare_deepagent,deepagent)
+HARBOR_AGENT_GRAPH = $(HARBOR_AGENT_IMPL)
 HARBOR_LANGGRAPH_PROJECT = deepagents_harbor/langgraph_project
 HARBOR_LOCAL_DEPS_DIR = $(HARBOR_LANGGRAPH_PROJECT)/.local_deps
 HARBOR_AGENT_ARGS = --agent langgraph --agent-kwarg project_path=$(HARBOR_LANGGRAPH_PROJECT) --agent-kwarg config=langgraph.json --agent-kwarg graph=$(HARBOR_AGENT_GRAPH)

--- a/libs/evals/deepagents_harbor/langgraph_project/langgraph.json
+++ b/libs/evals/deepagents_harbor/langgraph_project/langgraph.json
@@ -18,8 +18,8 @@
     "toml>=0.10.2,<1.0.0"
   ],
   "graphs": {
-    "deepagent": "./langgraph_agent.py:make_graph",
-    "bare_deepagent": "./langgraph_agent.py:make_bare_graph",
-    "tau3_deepagent": "./langgraph_agent.py:make_tau3_graph"
+    "dcode": "./langgraph_agent.py:make_graph",
+    "bare": "./langgraph_agent.py:make_bare_graph",
+    "tau3": "./langgraph_agent.py:make_tau3_graph"
   }
 }

--- a/libs/evals/tests/unit_tests/test_harbor_langgraph_agent.py
+++ b/libs/evals/tests/unit_tests/test_harbor_langgraph_agent.py
@@ -17,9 +17,9 @@ def test_langgraph_config_points_to_deepagent_factory() -> None:
     config = json.loads(config_path.read_text())
 
     assert config["graphs"] == {
-        "deepagent": "./langgraph_agent.py:make_graph",
-        "bare_deepagent": "./langgraph_agent.py:make_bare_graph",
-        "tau3_deepagent": "./langgraph_agent.py:make_tau3_graph",
+        "dcode": "./langgraph_agent.py:make_graph",
+        "bare": "./langgraph_agent.py:make_bare_graph",
+        "tau3": "./langgraph_agent.py:make_tau3_graph",
     }
     assert not (project_path / "langsmith.py").exists()
 

--- a/libs/evals/tests/unit_tests/test_harbor_langsmith_integration.py
+++ b/libs/evals/tests/unit_tests/test_harbor_langsmith_integration.py
@@ -24,10 +24,7 @@ def test_langsmith_make_target_uses_harbor_plugin_and_langgraph_agent() -> None:
     target = target.split("\n\n", maxsplit=1)[0]
 
     assert "HARBOR_AGENT_IMPL ?= dcode" in makefile
-    assert (
-        "HARBOR_AGENT_GRAPH = $(if $(filter bare,$(HARBOR_AGENT_IMPL)),bare_deepagent,deepagent)"
-        in makefile
-    )
+    assert "HARBOR_AGENT_GRAPH = $(HARBOR_AGENT_IMPL)" in makefile
     assert "HARBOR_AGENT_ARGS = --agent langgraph" in makefile
     assert "HARBOR_LANGGRAPH_PROJECT = deepagents_harbor/langgraph_project" in makefile
     assert "--agent-kwarg project_path=$(HARBOR_LANGGRAPH_PROJECT)" in makefile


### PR DESCRIPTION
Adding an eval agent is now `langgraph.json` + a factory: `agent_impl == graph key`, the workflow YAML and Makefile become passthroughs, and `unified_prep.py` derives its allowlists from the registry.