### PR TITLE
fix(code): warm MCP auth imports off event loop

### DIFF
--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -1770,17 +1770,35 @@ def _warm_mcp_adapter_imports() -> None:
     """Eagerly import MCP modules whose first import may block.
 
     Run via `asyncio.to_thread` before adapter/auth symbols are used, so any
-    blocking import side effect (package-resource scans, or a dependency that
-    does file I/O at import time — e.g. `filelock`, pulled in by `mcp_auth`)
-    happens off the server event loop where Blockbuster would otherwise reject
-    it. Runs only when at least one active MCP server exists.
+    blocking side effect of a first import happens off the server event loop
+    rather than where Blockbuster would reject it. Two known offenders:
+
+    - `langchain_mcp_adapters` runs a package-resource scan on first import.
+    - `mcp_auth` imports `httpx`, which transitively imports `rich`; `rich`
+      calls `os.getcwd()` in its module body (verified against the pinned
+      versions — the exact culprit may shift as dependencies change, but the
+      general risk of import-time I/O in this subtree does not).
+
+    Warming `mcp_auth` is best-effort: it is only *used* on per-server paths
+    (remote-server preflight and the per-tool call path), where an import
+    failure is captured and reported per server. A failure to warm it must not
+    abort loading for every server — notably stdio-only configs, which never
+    import `mcp_auth` otherwise — so it is swallowed here and left to re-raise
+    at the real use site. Runs only when at least one active MCP server exists.
     """
     from langchain_mcp_adapters import (
         sessions as _sessions,  # noqa: F401
         tools as _tools,  # noqa: F401
     )
 
-    from deepagents_code import mcp_auth as _mcp_auth  # noqa: F401
+    try:
+        from deepagents_code import mcp_auth as _mcp_auth  # noqa: F401
+    except Exception:  # warmup is a best-effort optimization; never abort load
+        logger.warning(
+            "Failed to warm mcp_auth import off the event loop; "
+            "deferring to per-server use",
+            exc_info=True,
+        )
 
 
 async def _gather_bounded(

--- a/libs/code/deepagents_code/mcp_tools.py
+++ b/libs/code/deepagents_code/mcp_tools.py
@@ -1767,18 +1767,20 @@ spawn an unbounded number of simultaneous socket/subprocess handshakes (or
 
 
 def _warm_mcp_adapter_imports() -> None:
-    """Eagerly import MCP adapter modules whose first import may block.
+    """Eagerly import MCP modules whose first import may block.
 
-    Run via `asyncio.to_thread` before adapter symbols are used, so the initial
-    (potentially blocking) package-resource scan stays off the server event
-    loop. Because this runs inside `_load_tools_from_config`, it happens only
-    when at least one active MCP server exists — a config with no MCP servers
-    never imports the adapters.
+    Run via `asyncio.to_thread` before adapter/auth symbols are used, so any
+    blocking import side effect (package-resource scans, or a dependency that
+    does file I/O at import time — e.g. `filelock`, pulled in by `mcp_auth`)
+    happens off the server event loop where Blockbuster would otherwise reject
+    it. Runs only when at least one active MCP server exists.
     """
     from langchain_mcp_adapters import (
         sessions as _sessions,  # noqa: F401
         tools as _tools,  # noqa: F401
     )
+
+    from deepagents_code import mcp_auth as _mcp_auth  # noqa: F401
 
 
 async def _gather_bounded(

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -172,6 +172,9 @@ test = [
     "pytest-xdist>=3.8.0,<4.0.0",
     "responses>=0.26.1,<1.0.0",
     "twine>=6.2.0,<7.0.0",
+    # Detect blocking calls on the event loop in startup smoke tests; mirrors the
+    # Blockbuster instance langgraph-runtime-inmem activates at runtime.
+    "blockbuster>=1.5.26,<1.6",
 ]
 
 [tool.hatch.build.hooks.custom]

--- a/libs/code/tests/unit_tests/test_mcp_tools.py
+++ b/libs/code/tests/unit_tests/test_mcp_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import sys
 import threading
 import time
 from contextlib import asynccontextmanager
@@ -34,6 +35,7 @@ from deepagents_code.mcp_tools import (
     _json_error_snippet,
     _load_tools_from_config,
     _normalize_mcp_arguments,
+    _warm_mcp_adapter_imports,
     classify_discovered_configs,
     discover_mcp_configs,
     extract_project_server_summaries,
@@ -3203,8 +3205,32 @@ class TestLoadToolsConcurrency:
         assert manager is not None
         await manager.cleanup()
 
+    def test_warmup_imports_adapter_and_auth_modules(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Warmup eagerly imports every module used later on the event loop."""
+        import langchain_mcp_adapters
+
+        import deepagents_code
+
+        module_names = {
+            "deepagents_code.mcp_auth",
+            "langchain_mcp_adapters.sessions",
+            "langchain_mcp_adapters.tools",
+        }
+        for module_name in module_names:
+            monkeypatch.delitem(sys.modules, module_name, raising=False)
+        monkeypatch.delattr(deepagents_code, "mcp_auth", raising=False)
+        monkeypatch.delattr(langchain_mcp_adapters, "sessions", raising=False)
+        monkeypatch.delattr(langchain_mcp_adapters, "tools", raising=False)
+
+        _warm_mcp_adapter_imports()
+
+        assert module_names <= sys.modules.keys()
+
     async def test_warmup_runs_off_loop_before_discovery(self) -> None:
-        """Adapter warmup runs, off the event loop, before any discovery."""
+        """MCP warmup runs, off the event loop, before any discovery."""
         loop_thread_id = threading.get_ident()
         events: list[tuple[str, int]] = []
 

--- a/libs/code/tests/unit_tests/test_mcp_tools.py
+++ b/libs/code/tests/unit_tests/test_mcp_tools.py
@@ -20,6 +20,7 @@ from deepagents_code import model_config
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Generator
+    from types import ModuleType
 
     from langchain_mcp_adapters.client import Connection
 
@@ -3228,6 +3229,54 @@ class TestLoadToolsConcurrency:
         _warm_mcp_adapter_imports()
 
         assert module_names <= sys.modules.keys()
+
+    def test_warmup_swallows_failing_auth_import(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A failing `mcp_auth` warmup logs and returns without propagating.
+
+        `mcp_auth` is only used on per-server paths, so a warmup failure must
+        not escape `_warm_mcp_adapter_imports` and abort loading for every
+        server (e.g. stdio-only configs that never import it); the real use
+        site re-raises and reports the failure per server.
+        """
+        import builtins
+
+        import deepagents_code
+
+        monkeypatch.delitem(sys.modules, "deepagents_code.mcp_auth", raising=False)
+        monkeypatch.delattr(deepagents_code, "mcp_auth", raising=False)
+
+        original_import = builtins.__import__
+
+        def _failing_auth_import(
+            name: str,
+            globals_: dict[str, object] | None = None,
+            locals_: dict[str, object] | None = None,
+            fromlist: tuple[str, ...] = (),
+            level: int = 0,
+        ) -> ModuleType:
+            cold_auth_import = "deepagents_code.mcp_auth" not in sys.modules and (
+                name == "deepagents_code.mcp_auth"
+                or (name == "deepagents_code" and "mcp_auth" in fromlist)
+            )
+            if cold_auth_import:
+                msg = "simulated broken mcp_auth import"
+                raise ImportError(msg)
+            return original_import(name, globals_, locals_, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", _failing_auth_import)
+
+        with caplog.at_level(logging.WARNING, logger="deepagents_code.mcp_tools"):
+            _warm_mcp_adapter_imports()  # must not raise
+
+        assert "deepagents_code.mcp_auth" not in sys.modules
+        assert any(
+            "Failed to warm mcp_auth import" in record.getMessage()
+            for record in caplog.records
+        )
 
     async def test_warmup_runs_off_loop_before_discovery(self) -> None:
         """MCP warmup runs, off the event loop, before any discovery."""

--- a/libs/code/tests/unit_tests/test_startup_blocking.py
+++ b/libs/code/tests/unit_tests/test_startup_blocking.py
@@ -1,0 +1,65 @@
+"""Smoke tests for blocking calls during server startup."""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import sys
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+from blockbuster import BlockingError, blockbuster_ctx
+
+import deepagents_code
+from deepagents_code.mcp_tools import _warm_mcp_adapter_imports
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+async def test_mcp_auth_import_is_warmed_off_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The MCP auth startup import remains safe on the server event loop."""
+    for module_name in tuple(sys.modules):
+        if module_name == "deepagents_code.mcp_auth" or module_name.startswith(
+            "filelock."
+        ):
+            monkeypatch.delitem(sys.modules, module_name)
+    monkeypatch.delitem(sys.modules, "filelock", raising=False)
+    monkeypatch.delattr(deepagents_code, "mcp_auth", raising=False)
+
+    original_import = builtins.__import__
+
+    def _blocking_first_auth_import(
+        name: str,
+        globals_: dict[str, object] | None = None,
+        locals_: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        cold_auth_import = "deepagents_code.mcp_auth" not in sys.modules and (
+            name == "deepagents_code.mcp_auth"
+            or (name == "deepagents_code" and "mcp_auth" in fromlist)
+        )
+        if cold_auth_import:
+            # Model a future transitive dependency that blocks when `mcp_auth`
+            # first imports it. The call is allowed only in the worker thread.
+            time.sleep(0)
+        return original_import(name, globals_, locals_, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _blocking_first_auth_import)
+
+    with blockbuster_ctx() as blockbuster:
+        try:
+            with pytest.raises(BlockingError):
+                time.sleep(0)  # noqa: ASYNC251  # verifies Blockbuster is active
+
+            await asyncio.to_thread(_warm_mcp_adapter_imports)
+
+            from deepagents_code.mcp_auth import build_oauth_provider
+
+            assert callable(build_oauth_provider)
+        finally:
+            blockbuster.deactivate()

--- a/libs/code/tests/unit_tests/test_startup_blocking.py
+++ b/libs/code/tests/unit_tests/test_startup_blocking.py
@@ -21,13 +21,19 @@ if TYPE_CHECKING:
 async def test_mcp_auth_import_is_warmed_off_loop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The MCP auth startup import remains safe on the server event loop."""
-    for module_name in tuple(sys.modules):
-        if module_name == "deepagents_code.mcp_auth" or module_name.startswith(
-            "filelock."
-        ):
-            monkeypatch.delitem(sys.modules, module_name)
-    monkeypatch.delitem(sys.modules, "filelock", raising=False)
+    """Warmup routes the `mcp_auth` first-import off the server event loop.
+
+    Importing `mcp_auth` today does block on the loop (its `httpx` -> `rich`
+    chain calls `os.getcwd()` at import time). Rather than couple to that exact
+    transitive culprit, this test injects a *synthetic* block via a first-import
+    hook, so it stays a stable regression guard for the routing — that
+    `_warm_mcp_adapter_imports` consumes the cold import in a worker thread —
+    even as dependencies shift. It does not itself prove the real chain blocks.
+    If warmup stopped importing `mcp_auth`, the on-loop import below would hit
+    the synthetic block and raise `BlockingError` outside `pytest.raises`,
+    failing the test.
+    """
+    monkeypatch.delitem(sys.modules, "deepagents_code.mcp_auth", raising=False)
     monkeypatch.delattr(deepagents_code, "mcp_auth", raising=False)
 
     original_import = builtins.__import__
@@ -44,8 +50,9 @@ async def test_mcp_auth_import_is_warmed_off_loop(
             or (name == "deepagents_code" and "mcp_auth" in fromlist)
         )
         if cold_auth_import:
-            # Model a future transitive dependency that blocks when `mcp_auth`
-            # first imports it. The call is allowed only in the worker thread.
+            # Synthetic stand-in for `mcp_auth`'s real import-time blocking: a
+            # call Blockbuster rejects on the loop but allows in a worker
+            # thread. Fires only on the first (cold) import.
             time.sleep(0)
         return original_import(name, globals_, locals_, fromlist, level)
 

--- a/libs/code/uv.lock
+++ b/libs/code/uv.lock
@@ -1268,6 +1268,7 @@ xai = [
 
 [package.dev-dependencies]
 test = [
+    { name = "blockbuster" },
     { name = "build" },
     { name = "hatchling" },
     { name = "pytest" },
@@ -1359,6 +1360,7 @@ provides-extras = ["anthropic", "baseten", "bedrock", "cohere", "deepseek", "fir
 
 [package.metadata.requires-dev]
 test = [
+    { name = "blockbuster", specifier = ">=1.5.26,<1.6" },
     { name = "build", specifier = ">=1.5.0,<2.0.0" },
     { name = "hatchling", specifier = ">=1.30.1,<2.0.0" },
     { name = "pytest", specifier = ">=9.1.1,<10.0.0" },


### PR DESCRIPTION
Related #4786

When `dcode` starts with MCP servers enabled, it loads the code used to connect to those servers. Loading the optional authentication support for the first time can perform filesystem work. Previously, that work happened on the async server's event loop, where blocking calls are rejected, so startup could fail with:

    BlockingError: Blocking call to os.getcwd

`dcode` now loads MCP authentication support in a worker thread before the server needs it. This keeps the potentially blocking work away from the event loop so the runtime no longer rejects it during startup.

---

#4786 addressed the immediate failure by limiting `filelock` to versions before 3.30. This follow-up hardens `dcode` against the broader problem instead of relying only on one dependency version. The version limit remains in place for now.

If the optional authentication support cannot be loaded, the failure is still reported only for an MCP server that needs it; it does not prevent unrelated or stdio MCP servers from loading.

A startup smoke test uses the same blocking-call detector as the runtime to verify that first-time authentication loading happens in a worker thread, so CI catches regressions.