### PR TITLE
fix(code): bust CDN cache on forced `dcode update` checks

### DIFF
--- a/libs/code/deepagents_code/update_check.py
+++ b/libs/code/deepagents_code/update_check.py
@@ -25,6 +25,7 @@ import sys
 import tempfile
 import time
 import tomllib
+import uuid
 from collections.abc import Awaitable, Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
@@ -497,6 +498,34 @@ def _write_release_prerelease_pins(version: str, pins: Sequence[str]) -> None:
         )
 
 
+def _pypi_request_kwargs(*, bypass_cache: bool) -> dict[str, Any]:
+    """Build `requests.get` keyword arguments for a PyPI metadata request.
+
+    PyPI's JSON API is served through a CDN (Fastly). Bypassing only the local
+    on-disk cache is not enough immediately after a release: an edge node can
+    keep serving a stale copy for a few seconds until the purge propagates, so
+    a forced check may still report "already on the latest version" until a
+    retry. When `bypass_cache` is set, send no-cache request headers and a
+    unique cache-busting query parameter so the CDN cache key misses and the
+    response is fetched fresh from origin.
+
+    Args:
+        bypass_cache: When `True`, defeat CDN edge caching as well as the local
+            cache.
+
+    Returns:
+        Keyword arguments to pass to `requests.get`. Callers still pass
+        `timeout` explicitly so the timeout lint rule can see it.
+    """
+    headers = {"User-Agent": USER_AGENT}
+    kwargs: dict[str, Any] = {"headers": headers}
+    if bypass_cache:
+        headers["Cache-Control"] = "no-cache"
+        headers["Pragma"] = "no-cache"
+        kwargs["params"] = {"_": uuid.uuid4().hex}
+    return kwargs
+
+
 def get_latest_version(
     *,
     bypass_cache: bool = False,
@@ -548,8 +577,8 @@ def get_latest_version(
     try:
         resp = requests.get(
             PYPI_URL,
-            headers={"User-Agent": USER_AGENT},
             timeout=3,
+            **_pypi_request_kwargs(bypass_cache=bypass_cache),
         )
         resp.raise_for_status()
         payload = resp.json()
@@ -690,8 +719,8 @@ def release_prerelease_pins(
         url = f"{PYPI_URL.removesuffix('/json')}/{version}/json"
         resp = requests.get(
             url,
-            headers={"User-Agent": USER_AGENT},
             timeout=3,
+            **_pypi_request_kwargs(bypass_cache=bypass_cache),
         )
         resp.raise_for_status()
         payload = resp.json()
@@ -955,8 +984,8 @@ def get_sdk_release_time(
     try:
         resp = requests.get(
             SDK_PYPI_URL,
-            headers={"User-Agent": USER_AGENT},
             timeout=3,
+            **_pypi_request_kwargs(bypass_cache=bypass_cache),
         )
         resp.raise_for_status()
         payload = resp.json()

--- a/libs/code/tests/unit_tests/test_update_check.py
+++ b/libs/code/tests/unit_tests/test_update_check.py
@@ -598,6 +598,46 @@ class TestGetLatestVersion:
         assert result is None
         assert not cache_file.exists()
 
+    def test_bypass_cache_busts_cdn_cache(self, cache_file) -> None:  # noqa: ARG002
+        """A forced check sends no-cache headers and a cache-busting param.
+
+        PyPI's JSON API is served through a CDN, so bypassing only the local
+        cache can still return a stale answer right after a release. The
+        request must defeat the edge cache too.
+        """
+        with patch(
+            "requests.get", return_value=_mock_pypi_response("2.0.0")
+        ) as mock_get:
+            get_latest_version(bypass_cache=True)
+
+        kwargs = mock_get.call_args.kwargs
+        assert kwargs["headers"]["Cache-Control"] == "no-cache"
+        assert kwargs["headers"]["Pragma"] == "no-cache"
+        assert kwargs["params"]["_"]
+
+    def test_cache_bust_params_are_unique_per_call(self, cache_file) -> None:  # noqa: ARG002
+        """Each forced check uses a distinct cache-busting token."""
+        with patch(
+            "requests.get", return_value=_mock_pypi_response("2.0.0")
+        ) as mock_get:
+            get_latest_version(bypass_cache=True)
+            get_latest_version(bypass_cache=True)
+
+        first, second = mock_get.call_args_list
+        assert first.kwargs["params"]["_"] != second.kwargs["params"]["_"]
+
+    def test_non_bypass_fetch_omits_cache_busting(self, cache_file) -> None:  # noqa: ARG002
+        """A routine (non-forced) refresh does not add cache-busting."""
+        with patch(
+            "requests.get", return_value=_mock_pypi_response("2.0.0")
+        ) as mock_get:
+            get_latest_version(bypass_cache=False)
+
+        kwargs = mock_get.call_args.kwargs
+        assert "Cache-Control" not in kwargs["headers"]
+        assert "Pragma" not in kwargs["headers"]
+        assert "params" not in kwargs
+
 
 class TestPrereleasePinRequirements:
     """Unit tests for the targeted `Requires-Dist` pre-release pin extractor.


### PR DESCRIPTION
`dcode update` now returns fresh results even in the seconds right after a new release lands on PyPI.

---

`dcode update` already calls `is_update_available(bypass_cache=True)`, which skips the local on-disk version cache. But PyPI's JSON API is served through a CDN (Fastly), so immediately after a release an edge node can keep serving a stale copy until the purge propagates. That's why a first `dcode update` reported "Already on the latest version (v0.1.43)" while a retry seconds later found v0.1.44.

When the local cache is bypassed, the PyPI requests now also defeat the CDN edge cache: they send `Cache-Control: no-cache` / `Pragma: no-cache` request headers and append a unique cache-busting query parameter so the CDN cache key misses and the response comes fresh from origin. A shared `_pypi_request_kwargs` helper applies this consistently to the version check, the per-release pre-release-pin lookup, and the SDK release-time lookup. Routine (non-forced) refreshes are unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/f2647aaa-94ac-f901-c39d-e081d0eb1f79)