### PR TITLE
feat(code): show experimental mode in splash and debug console

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -17408,7 +17408,7 @@ class DeepAgentsApp(App):
             Ordered `SnapshotField` rows for the console header.
         """
         from deepagents_code._debug import installed_debug_log_path
-        from deepagents_code._env_vars import DEBUG, is_env_truthy
+        from deepagents_code._env_vars import DEBUG, EXPERIMENTAL, is_env_truthy
         from deepagents_code._version import __version__
         from deepagents_code.tui.widgets.debug_console import SnapshotField
 
@@ -17473,6 +17473,10 @@ class DeepAgentsApp(App):
             _thread_field(),
             _safe("CWD", lambda: self._cwd),
             _safe("Approval mode", lambda: self._approval_mode.value),
+            _safe(
+                "Experimental",
+                lambda: "on" if is_env_truthy(EXPERIMENTAL) else "off",
+            ),
             _safe("Sandbox", lambda: self._sandbox_type or "local"),
             _safe("MCP servers", _mcp),
             _safe("Tokens", _tokens),

--- a/libs/code/deepagents_code/tui/widgets/welcome.py
+++ b/libs/code/deepagents_code/tui/widgets/welcome.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 from deepagents_code import theme
 from deepagents_code._env_vars import (
     DEBUG,
+    EXPERIMENTAL,
     HIDE_CWD,
     HIDE_LANGSMITH_TRACING,
     HIDE_SPLASH_VERSION,
@@ -115,6 +116,23 @@ def _debug_tag_style(*, ansi: bool, colors: theme.ThemeColors) -> str | TStyle:
     return TStyle(foreground=TColor.parse(colors.warning), bold=True)
 
 
+def _experimental_tag_style(*, ansi: bool, colors: theme.ThemeColors) -> str | TStyle:
+    """Build the style for the `(experimental mode)` tag.
+
+    Args:
+        ansi: Whether the active theme is an ANSI terminal theme.
+        colors: Active Deep Agents theme colors.
+
+    Returns:
+        A bold magenta markup style under ANSI themes (whose palette the terminal
+            owns, so a parsed color could be invisible) or a bold themed accent
+            color otherwise.
+    """
+    if ansi:
+        return "bold magenta"
+    return TStyle(foreground=TColor.parse(colors.accent), bold=True)
+
+
 def _home_prefixed(cwd: str) -> str:
     """Format a directory path, using `~` for the home directory when possible.
 
@@ -144,7 +162,9 @@ class WelcomeBanner(Static):
 
     Renders a bordered box with the product title and optional version. A
     `(debug enabled)` tag appears when `DEEPAGENTS_CODE_DEBUG` is enabled
-    (truthy), even when the version is hidden. A `(local)` tag appears for
+    (truthy), and an `(experimental mode)` tag appears when
+    `DEEPAGENTS_CODE_EXPERIMENTAL` is enabled (truthy), both even when the
+    version is hidden. A `(local)` tag appears for
     editable installs only when the version is shown. Rows follow that appear
     only when their data (and any env gate) is present. In render order: the
     active model
@@ -230,6 +250,7 @@ class WelcomeBanner(Static):
         )
         self._project_urls: dict[str, str] = {}
         self._debug_enabled = is_env_truthy(DEBUG)
+        self._experimental_enabled = is_env_truthy(EXPERIMENTAL)
         self._show_thread_id = self._debug_enabled
         super().__init__(self._build_banner(), **kwargs)
 
@@ -351,7 +372,8 @@ class WelcomeBanner(Static):
 
         Returns:
             Content with the title, optional version, and any applicable header
-            tags (`(debug enabled)` when debug is on; `(local)` for editable
+            tags (`(debug enabled)` when debug is on; `(experimental mode)` when
+            experimental mode is on; `(local)` for editable
             installs when the version is shown), followed by any applicable rows
             in order: model (when `SPLASH_SHOW_MODEL`), directory (when
             `SPLASH_SHOW_CWD`), tracing and replica (each clickable once its URL
@@ -379,6 +401,13 @@ class WelcomeBanner(Static):
                 (
                     " (debug enabled)",
                     _debug_tag_style(ansi=ansi, colors=colors),
+                )
+            )
+        if self._experimental_enabled:
+            parts.append(
+                (
+                    " (experimental mode)",
+                    _experimental_tag_style(ansi=ansi, colors=colors),
                 )
             )
         if not self._hide_version and _is_editable_install():

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -1308,6 +1308,24 @@ class TestDebugConsoleToggle:
             assert snapshot["Approval mode"] == "manual"
             assert snapshot["MCP servers"] == "none"
 
+    async def test_build_snapshot_experimental_off_by_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DEEPAGENTS_CODE_EXPERIMENTAL", raising=False)
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        async with app.run_test():
+            snapshot = _snapshot_dict(app._build_debug_snapshot())
+            assert snapshot["Experimental"] == "off"
+
+    async def test_build_snapshot_experimental_on_when_env_truthy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DEEPAGENTS_CODE_EXPERIMENTAL", "1")
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        async with app.run_test():
+            snapshot = _snapshot_dict(app._build_debug_snapshot())
+            assert snapshot["Experimental"] == "on"
+
     async def test_build_snapshot_thread_field_is_copyable_and_linkable(self) -> None:
         app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-xyz")
         async with app.run_test():

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -1317,6 +1317,21 @@ class TestDebugConsoleToggle:
             snapshot = _snapshot_dict(app._build_debug_snapshot())
             assert snapshot["Experimental"] == "off"
 
+    async def test_build_snapshot_experimental_off_when_env_falsy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A present-but-falsy `DEEPAGENTS_CODE_EXPERIMENTAL` reads as `off`.
+
+        Locks the truthy gate (`is_env_truthy`) against a regression to a bare
+        presence check (`EXPERIMENTAL in os.environ`), which the unset and
+        truthy cases would both pass.
+        """
+        monkeypatch.setenv("DEEPAGENTS_CODE_EXPERIMENTAL", "0")
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="t")
+        async with app.run_test():
+            snapshot = _snapshot_dict(app._build_debug_snapshot())
+            assert snapshot["Experimental"] == "off"
+
     async def test_build_snapshot_experimental_on_when_env_truthy(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
@@ -9,6 +9,7 @@ from textual.style import Style as TStyle
 
 from deepagents_code._env_vars import (
     DEBUG,
+    EXPERIMENTAL,
     HIDE_CWD,
     HIDE_LANGSMITH_TRACING,
     HIDE_SPLASH_VERSION,
@@ -20,6 +21,7 @@ from deepagents_code._version import __version__
 from deepagents_code.tui.widgets.welcome import (
     WelcomeBanner,
     _debug_tag_style,
+    _experimental_tag_style,
     _home_prefixed,
     _langsmith_project_link,
     _langsmith_project_link_style,
@@ -32,6 +34,7 @@ _PROJECT_NAME = "deepagents_code.tui.widgets.welcome.get_langsmith_project_name"
 _REPLICA_PROJECT = "deepagents_code.tui.widgets.welcome.get_langsmith_replica_project"
 _FETCH_URL = "deepagents_code.tui.widgets.welcome.fetch_langsmith_project_url"
 _DEBUG_STYLE = "deepagents_code.tui.widgets.welcome._debug_tag_style"
+_EXPERIMENTAL_STYLE = "deepagents_code.tui.widgets.welcome._experimental_tag_style"
 _LOCAL_STYLE = "deepagents_code.tui.widgets.welcome._local_tag_style"
 
 
@@ -251,6 +254,27 @@ class TestDebugTagStyle:
         assert style.foreground == TColor.parse(DARK_COLORS.warning)
 
 
+class TestExperimentalTagStyle:
+    """Tests for the `(experimental mode)` tag style."""
+
+    def test_ansi_uses_bold_magenta_markup(self) -> None:
+        """Under ANSI themes the tag stays visible via bold magenta terminal text."""
+        from deepagents_code.theme import DARK_COLORS
+
+        assert _experimental_tag_style(ansi=True, colors=DARK_COLORS) == "bold magenta"
+
+    def test_non_ansi_uses_themed_accent_color(self) -> None:
+        """Non-ANSI themes color the tag with the theme's accent color."""
+        from textual.color import Color as TColor
+
+        from deepagents_code.theme import DARK_COLORS
+
+        style = _experimental_tag_style(ansi=False, colors=DARK_COLORS)
+        assert isinstance(style, TStyle)
+        assert style.bold is True
+        assert style.foreground == TColor.parse(DARK_COLORS.accent)
+
+
 class TestTitle:
     """Tests for the banner title line."""
 
@@ -338,6 +362,85 @@ class TestTitle:
         assert f"v{__version__}" not in plain
         assert "(debug enabled)" in plain
         assert "(local)" not in plain
+
+    def test_no_experimental_tag_by_default(self) -> None:
+        """No `(experimental mode)` tag when `DEEPAGENTS_CODE_EXPERIMENTAL` is unset."""
+        with patch(_EDITABLE, return_value=False):
+            plain = _make_banner()._build_banner().plain
+        assert "(experimental mode)" not in plain
+
+    def test_no_experimental_tag_when_env_falsy(self) -> None:
+        """A present-but-falsy `DEEPAGENTS_CODE_EXPERIMENTAL` shows no tag.
+
+        Locks the truthy gate (`is_env_truthy`) against a regression to a bare
+        presence check (`EXPERIMENTAL in os.environ`), which every other test
+        would pass.
+        """
+        with patch(_EDITABLE, return_value=False):
+            plain = _make_banner(env={EXPERIMENTAL: "0"})._build_banner().plain
+        assert "(experimental mode)" not in plain
+
+    def test_marks_experimental_when_env_set(self) -> None:
+        """`DEEPAGENTS_CODE_EXPERIMENTAL` shows an `(experimental mode)` tag."""
+        with patch(_EDITABLE, return_value=False):
+            plain = _make_banner(env={EXPERIMENTAL: "1"})._build_banner().plain
+        assert f"v{__version__}" in plain
+        # Leading space guards the separator from the preceding segment.
+        assert " (experimental mode)" in plain
+        assert "(local)" not in plain
+        assert plain.index(f"v{__version__}") < plain.index("(experimental mode)")
+
+    def test_experimental_tag_follows_debug_precedes_local(self) -> None:
+        """`(experimental mode)` renders after `(debug enabled)`, before `(local)`."""
+        with patch(_EDITABLE, return_value=True):
+            plain = (
+                _make_banner(env={DEBUG: "1", EXPERIMENTAL: "1"})._build_banner().plain
+            )
+        assert (
+            plain.index("(debug enabled)")
+            < plain.index("(experimental mode)")
+            < plain.index("(local)")
+        )
+
+    def test_experimental_tag_when_version_hidden(self) -> None:
+        """The experimental tag stays visible without exposing local-install info."""
+        with patch(_EDITABLE, return_value=True):
+            plain = (
+                _make_banner(env={EXPERIMENTAL: "1", HIDE_SPLASH_VERSION: "1"})
+                ._build_banner()
+                .plain
+            )
+        assert f"v{__version__}" not in plain
+        assert "(experimental mode)" in plain
+        assert "(local)" not in plain
+
+    def test_experimental_tag_carries_its_own_style(self) -> None:
+        """The experimental span carries the experimental style helper's output."""
+        from textual.color import Color as TColor
+
+        experimental_style = TStyle(foreground=TColor.parse("#070809"), bold=True)
+        with (
+            patch(_EDITABLE, return_value=False),
+            patch(_EXPERIMENTAL_STYLE, return_value=experimental_style),
+        ):
+            content = _make_banner(env={EXPERIMENTAL: "1"})._build_banner()
+        assert _style_covering(
+            content, "(experimental mode)"
+        ).foreground == TColor.parse("#070809")
+
+    def test_experimental_tag_uses_ansi_markup_under_ansi_theme(self) -> None:
+        """Under an ANSI theme the experimental span carries bold-magenta markup."""
+        from textual._context import active_app
+
+        app = active_app.get()
+        previous_theme = app.theme
+        app.theme = "ansi-dark"
+        try:
+            with patch(_EDITABLE, return_value=False):
+                content = _make_banner(env={EXPERIMENTAL: "1"})._build_banner()
+        finally:
+            app.theme = previous_theme
+        assert _raw_style_covering(content, "(experimental mode)") == "bold magenta"
 
     def test_title_tags_carry_their_own_styles(self) -> None:
         """Each title tag's span carries its own style helper's output.


### PR DESCRIPTION
When `DEEPAGENTS_CODE_EXPERIMENTAL` is set, `dcode` now surfaces that unstable behavior is active — an `(experimental mode)` tag on the startup splash (alongside the existing `(debug enabled)` tag) and an `Experimental` on/off row in the Debug Console snapshot.

---

Experimental behavior was previously invisible, so users couldn't tell when the flag was in effect. The splash tag mirrors the `(debug enabled)` pattern (its own themed style helper, ANSI fallback, rendered even when the version is hidden, ordered debug → experimental → local). The Debug Console gains an always-present `Experimental` field so the diagnostic snapshot reports the flag state directly.

Made by [Open SWE](https://openswe.vercel.app/agents/6cb12589-9525-8da6-05db-a4134a7ea44a)