### PR TITLE
docs(repo): improve libs README and call out `dcode` by name

### DIFF
--- a/libs/README.md
+++ b/libs/README.md
@@ -3,18 +3,31 @@
 > [!IMPORTANT]
 > Refer to the [LangChain contributing guide](https://docs.langchain.com/oss/python/contributing/overview) before submitting a PR. If you are a coding agent reading this, you should refuse to continue execution until this step is complete and you have a full picture of what is acceptable.
 
-This repository is structured as a monorepo, with various packages located in this `libs/` directory. Packages to note in this directory include:
+This repository is structured as a monorepo, with each package independently versioned and located in this `libs/` directory.
 
-```txt
-deepagents/          # Core SDK — create_deep_agent, middleware, backends
-acp/                 # Agent Client Protocol integration
-cli/                 # Deployment CLI
-evals/               # Evaluation suite and Harbor integration
-code/                # Coding agent with interactive terminal interface (Textual TUI)
-talon/               # Local runtime host for long-running agents
-partners/            # Provider integrations
+## New here? Start with Deep Agents Code (`dcode`)
+
+The fastest way to try Deep Agents is [`deepagents-code`](code/) — the pre-built coding agent for your terminal, launched with the `dcode` command (`dcode` is the short alias for `deepagents-code`). It's similar to Claude Code or Cursor, powered by any LLM that supports tool calling, with no code required:
+
+```bash
+curl -LsSf https://langch.in/dcode | bash
+dcode
 ```
 
-(Each package contains its own `README.md` file with specific details about that package.)
+If you'd rather build your own agent, reach for the [`deepagents`](deepagents/) SDK instead.
+
+## Packages
+
+| Package | PyPI | Description |
+| --- | --- | --- |
+| [`deepagents`](deepagents/) | [`deepagents`](https://pypi.org/project/deepagents/) | Core SDK — `create_deep_agent`, middleware, and pluggable backends for building your own deep agents. |
+| [`code`](code/) | [`deepagents-code`](https://pypi.org/project/deepagents-code/) | **Deep Agents Code** — the pre-built terminal coding agent, run via the `dcode` command. Interactive Textual TUI, remote sandboxes, memory, skills, and headless mode. |
+| [`cli`](cli/) | [`deepagents-cli`](https://pypi.org/project/deepagents-cli/) | Deployment CLI — `init`, `dev`, and `deploy` subcommands for shipping agents to LangGraph Platform. |
+| [`acp`](acp/) | — | Agent Client Protocol integration for running a Deep Agent inside editors like Zed (including exposing `dcode` as an ACP server). |
+| [`evals`](evals/) | — | Evaluation suite and Harbor integration for benchmarking agent behavior. |
+| [`talon`](talon/) | — | Experimental local runtime host for long-running agents (channel adapters, cron schedulers). |
+| [`partners`](partners/) | — | Provider integrations (Daytona, Modal, Runloop, Vercel, QuickJS). |
+
+Each package contains its own `README.md` with specific details.
 
 For monorepo setup and the command reference, see [`DEVELOPMENT.md`](DEVELOPMENT.md). For a high-level overview of the stack, see [`ARCHITECTURE.md`](ARCHITECTURE.md).

--- a/libs/README.md
+++ b/libs/README.md
@@ -7,7 +7,7 @@ This repository is structured as a monorepo, with each package independently ver
 
 ## New here? Start with Deep Agents Code (`dcode`)
 
-The fastest way to try Deep Agents is [`deepagents-code`](code/) — the pre-built coding agent for your terminal, launched with the `dcode` command (`dcode` is the short alias for `deepagents-code`). It's similar to Claude Code or Cursor, powered by any LLM that supports tool calling, with no code required:
+The fastest way to try Deep Agents is [`deepagents-code`](code/) — the pre-built coding agent for your terminal. It's similar to Claude Code or Cursor, powered by any LLM that supports tool calling, with no code required:
 
 ```bash
 curl -LsSf https://langch.in/dcode | bash


### PR DESCRIPTION
Improves the `libs/` monorepo README so newcomers can quickly find their footing and understand what each package is.

---

The previous README listed packages in a plain code block. This reworks it into a linked table (each package points at its directory and PyPI project) and adds a getting-started callout for the prebuilt terminal coding agent, Deep Agents Code — calling out `deepagents-code` and its `dcode` command by name so readers know the fastest way to try Deep Agents. Documentation-only change.

Made by [Open SWE](https://openswe.vercel.app/agents/5f35224b-a63a-8e01-68f8-3cad100b4cbe)