### PR TITLE
refactor(code): centralize JSON type aliases

### DIFF
--- a/libs/code/deepagents_code/json_types.py
+++ b/libs/code/deepagents_code/json_types.py
@@ -1,0 +1,7 @@
+"""Shared recursive types for JSON-compatible data."""
+
+from typing import TypeAlias
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -28,16 +28,8 @@ from deepagents_code import _env_vars, auth_store
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
-    from typing import TypeAlias
 
-    # A parsed-JSON value. An MCP server definition is one of these (in practice
-    # a dict), but a malformed `.mcp.json` entry can be any JSON scalar/array, so
-    # the trust helpers accept the whole shape rather than lying with `Mapping`.
-    # String form keeps the recursive reference valid on Python 3.11 (no PEP 695
-    # `type` statement).
-    JSONValue: TypeAlias = (
-        "str | int | float | bool | list[JSONValue] | dict[str, JSONValue] | None"
-    )
+    from deepagents_code.json_types import JsonValue
 
 logger = logging.getLogger(__name__)
 
@@ -3434,7 +3426,7 @@ class McpProjectServerApproval:
 
     @classmethod
     def create(
-        cls, *, project_root: str | Path | None, name: str, server: JSONValue
+        cls, *, project_root: str | Path | None, name: str, server: JsonValue
     ) -> McpProjectServerApproval | None:
         """Build an approval, normalizing the root and fingerprinting `server`.
 
@@ -3553,7 +3545,7 @@ def normalize_mcp_project_root(project_root: str | Path | None) -> str | None:
         return None
 
 
-def fingerprint_mcp_server_config(server: JSONValue) -> str:
+def fingerprint_mcp_server_config(server: JsonValue) -> str:
     """Return a stable fingerprint for an MCP server definition.
 
     The contract is a JSON-serializable value (in practice the `dict` parsed
@@ -3678,7 +3670,7 @@ class McpServerTrustLists:
         name: str,
         *,
         project_root: str | Path | None,
-        server: JSONValue,
+        server: JsonValue,
     ) -> bool:
         """Return whether `server` is approved by name or scoped fingerprint.
 
@@ -4002,7 +3994,7 @@ def add_enabled_project_mcp_servers(
     config_path: Path | None = None,
     *,
     project_root: str | Path | None = None,
-    server_configs: Mapping[str, JSONValue] | None = None,
+    server_configs: Mapping[str, JsonValue] | None = None,
 ) -> bool:
     """Persist project-scoped MCP server approvals.
 

--- a/libs/code/deepagents_code/plugins/models.py
+++ b/libs/code/deepagents_code/plugins/models.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
+from deepagents_code.json_types import (  # noqa: TC001
+    JsonObject as JsonObject,
+    JsonValue as JsonValue,
+)
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -12,8 +17,6 @@ MarketplaceSourceType = Literal["directory", "file", "github", "git", "url"]
 ExternalPluginRepositorySourceType = Literal["github", "git-subdir", "url"]
 UnsupportedComponent = Literal["agents", "commands", "hooks"]
 """Plugin component directory that `deepagents-code` does not load."""
-JsonValue = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
-JsonObject = dict[str, JsonValue]
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/libs/code/deepagents_code/plugins/models.py
+++ b/libs/code/deepagents_code/plugins/models.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
-from deepagents_code.json_types import (  # noqa: TC001
-    JsonObject as JsonObject,
-    JsonValue as JsonValue,
-)
+from deepagents_code.json_types import JsonObject, JsonValue  # noqa: TC001, F401
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/libs/code/tests/unit_tests/test_json_types.py
+++ b/libs/code/tests/unit_tests/test_json_types.py
@@ -1,0 +1,13 @@
+"""Tests for shared JSON type aliases."""
+
+from deepagents_code.json_types import JsonObject, JsonValue
+from deepagents_code.plugins.models import (
+    JsonObject as PluginJsonObject,
+    JsonValue as PluginJsonValue,
+)
+
+
+def test_plugin_json_types_are_compatibility_reexports() -> None:
+    """Plugin imports resolve to the canonical shared aliases."""
+    assert PluginJsonValue is JsonValue
+    assert PluginJsonObject is JsonObject

--- a/libs/code/tests/unit_tests/test_mcp_login_service.py
+++ b/libs/code/tests/unit_tests/test_mcp_login_service.py
@@ -20,11 +20,13 @@ from deepagents_code.mcp_login_service import (
 if TYPE_CHECKING:
     import pytest
 
+    from deepagents_code.json_types import JsonValue
+
 
 def _project_approval_config(
     project_root: Path,
     name: str,
-    server: object,
+    server: JsonValue,
     *,
     disabled: list[str] | None = None,
 ) -> str:

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from deepagents_code import model_config
+from deepagents_code.json_types import JsonObject
 from deepagents_code.model_config import (
     DEFAULT_STARTUP_MODE,
     IMPLICIT_AUTH_PROVIDERS,
@@ -7012,7 +7013,7 @@ class TestAddEnabledProjectMcpServers:
     """Tests for persisting the approval prompt's "always allow" choice."""
 
     @staticmethod
-    def _server_configs() -> dict[str, object]:
+    def _server_configs() -> JsonObject:
         return {
             "docs": {"command": "echo", "args": ["docs"]},
             "reference": {"type": "http", "url": "https://example.test/mcp"},


### PR DESCRIPTION
Centralize recursive JSON aliases in a neutral module so config and plugin code share one definition while preserving plugin import compatibility.

The aliases remain static types only; existing runtime ingress validation is unchanged.

<details>
<summary>Test plan</summary>

- `make -C libs/code format`
- `make -C libs/code lint`
- Focused JSON, hooks, model config, and MCP login tests (546 passed; one unrelated root-permission assertion failed)

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/019f8107-bf8c-7545-9a37-299374653ddc)