### PR TITLE
perf(sdk): upload offloaded media concurrently

### DIFF
--- a/libs/deepagents/deepagents/middleware/summarization.py
+++ b/libs/deepagents/deepagents/middleware/summarization.py
@@ -1178,9 +1178,12 @@ A condensed summary follows:
 
         See `_offload_inline_media` for full documentation, including the
         `(messages, failed_block_count)` return contract.
+
+        Uploads run concurrently, as in `_aclip_overflow_tail`. Each keeps its
+        own `aupload_files` call, so a failing file still fails alone; only the
+        waiting overlaps, turning one round trip per image into one overall.
         """
-        path_map: dict[str, str] = {}
-        failed_keys: set[str] = set()
+        pending: dict[str, tuple[str, bytes]] = {}
         saw_inline_media = False
 
         for msg in messages:
@@ -1194,31 +1197,25 @@ A condensed summary follows:
                     continue  # undecodable; rewrite emits a failed-offload placeholder
                 raw, ext, _mime = decoded
                 key = hashlib.sha256(raw).hexdigest()[:16]
-                if key in path_map or key in failed_keys:
-                    continue
-                img_path = f"{self._media_prefix}/{key}.{ext}"
-                try:
-                    responses = await backend.aupload_files([(img_path, raw)])
-                    if error := _upload_response_error(responses):
-                        logger.warning(
-                            "Failed to upload media %s to backend: %s",
-                            img_path,
-                            error,
-                        )
-                        failed_keys.add(key)
-                        continue
-                    path_map[key] = img_path
-                except Exception as e:  # noqa: BLE001
-                    logger.warning(
-                        "Failed to upload media %s to backend: %s: %s",
-                        img_path,
-                        type(e).__name__,
-                        e,
-                    )
-                    failed_keys.add(key)
+                if key not in pending:
+                    pending[key] = (f"{self._media_prefix}/{key}.{ext}", raw)
 
         if not saw_inline_media:
             return messages, 0
+
+        async def _upload(key: str, img_path: str, raw: bytes) -> tuple[str, str | None]:
+            """Upload one media file, returning `(key, path)`, or `(key, None)` on failure."""
+            try:
+                error = _upload_response_error(await backend.aupload_files([(img_path, raw)]))
+            except Exception as e:  # noqa: BLE001
+                error = f"{type(e).__name__}: {e}"
+            if error:
+                logger.warning("Failed to upload media %s to backend: %s", img_path, error)
+                return key, None
+            return key, img_path
+
+        results = await asyncio.gather(*(_upload(key, *item) for key, item in pending.items()))
+        path_map: dict[str, str] = {key: path for key, path in results if path is not None}
 
         return _rewrite_data_url_blocks(messages, path_map)
 

--- a/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_summarization_middleware.py
@@ -3295,6 +3295,118 @@ class TestTokenCountingEfficiency:
         assert first_ai.tool_calls[0]["args"]["content"] == "x" * 20 + "...(argument truncated)"
 
 
+class TestAsyncInlineMediaOffload:
+    """Async media offload overlaps uploads without changing per-file outcomes."""
+
+    @staticmethod
+    def _media_message(payload: bytes, idx: int) -> BaseMessage:
+        b64 = _base64.b64encode(payload).decode()
+        return HumanMessage(
+            content=[{"type": "image", "base64": b64, "mime_type": "image/png"}],
+            id=f"img-{idx}",
+        )
+
+    @staticmethod
+    def _middleware(backend: MockBackend) -> SummarizationMiddleware:
+        return SummarizationMiddleware(
+            model=make_mock_model(),
+            backend=backend,
+            trigger=("messages", 5),
+            keep=("messages", 2),
+        )
+
+    @staticmethod
+    def _expected_path(payload: bytes) -> str:
+        return f"/conversation_history/media/{hashlib.sha256(payload).hexdigest()[:16]}.png"
+
+    async def test_uploads_are_concurrent(self) -> None:
+        """All uploads are in flight together, not one round trip per file."""
+        in_flight = 0
+        peak = 0
+
+        class _TrackingBackend(MockBackend):
+            async def aupload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+                nonlocal in_flight, peak
+                in_flight += 1
+                peak = max(peak, in_flight)
+                await asyncio.sleep(0)  # yield so siblings can start
+                in_flight -= 1
+                return [FileUploadResponse(path=path, error=None) for path, _ in files]
+
+        backend = _TrackingBackend()
+        middleware = self._middleware(backend)
+        messages = [self._media_message(f"png-{i}".encode(), i) for i in range(5)]
+
+        _, failed = await middleware._aoffload_inline_media(backend, messages)
+
+        assert failed == 0
+        assert peak == 5  # every upload overlapped; serialized offload peaks at 1
+
+    async def test_single_failure_does_not_affect_siblings(self) -> None:
+        """A per-file error still fails only that file, as in the serial path."""
+        bad = b"png-bad"
+
+        class _PartialFailureBackend(MockBackend):
+            async def aupload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+                return [FileUploadResponse(path=path, error="permission_denied" if content == bad else None) for path, content in files]
+
+        backend = _PartialFailureBackend()
+        middleware = self._middleware(backend)
+        payloads = [b"png-ok-1", bad, b"png-ok-2"]
+        messages = [self._media_message(p, i) for i, p in enumerate(payloads)]
+
+        result, failed = await middleware._aoffload_inline_media(backend, messages)
+
+        assert failed == 1  # only the rejected upload becomes a placeholder
+        rendered = repr([m.content for m in result])
+        assert self._expected_path(b"png-ok-1") in rendered
+        assert self._expected_path(b"png-ok-2") in rendered
+        assert self._expected_path(bad) not in rendered
+
+    async def test_raising_upload_does_not_cancel_siblings(self) -> None:
+        """One upload raising must not abort the others (no gather fail-fast)."""
+
+        class _RaisingBackend(MockBackend):
+            async def aupload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+                if any(content == b"png-boom" for _, content in files):
+                    msg = "backend exploded"
+                    raise RuntimeError(msg)
+                return [FileUploadResponse(path=path, error=None) for path, _ in files]
+
+        backend = _RaisingBackend()
+        middleware = self._middleware(backend)
+        payloads = [b"png-fine", b"png-boom"]
+        messages = [self._media_message(p, i) for i, p in enumerate(payloads)]
+
+        result, failed = await middleware._aoffload_inline_media(backend, messages)
+
+        assert failed == 1
+        assert self._expected_path(b"png-fine") in repr([m.content for m in result])
+
+    async def test_duplicate_media_uploads_once(self) -> None:
+        """Content-hash dedup survives the switch to concurrent uploads."""
+        backend = MockBackend()
+        middleware = self._middleware(backend)
+        payload = b"png-repeated"
+        messages = [self._media_message(payload, i) for i in range(4)]
+
+        await middleware._aoffload_inline_media(backend, messages)
+
+        media_writes = [p for p, _ in backend.write_calls if p.startswith("/conversation_history/media/")]
+        assert media_writes == [self._expected_path(payload)]
+
+    async def test_no_inline_media_returns_messages_unchanged(self) -> None:
+        """The `saw_inline_media` short-circuit still returns the original list."""
+        backend = MockBackend()
+        middleware = self._middleware(backend)
+        messages = make_conversation_messages(num_old=5, num_recent=2)
+
+        result, failed = await middleware._aoffload_inline_media(backend, messages)
+
+        assert result is messages
+        assert failed == 0
+
+
 class _OpaqueCounter:
     """Wraps a counter so its signature cannot be introspected.
 


### PR DESCRIPTION
Inline media offloaded during compaction is now uploaded concurrently instead of
one file at a time, so compacting a conversation containing images no longer
waits on a serial chain of round trips.

---

`_offload_media` awaited each upload in turn, making latency scale with the
number of media items. The uploads are independent, so they are now issued
together and awaited as a group.

With a simulated 30 ms round trip:

| images | before | after |
|---:|---:|---:|
| 5 | 156 ms | 31 ms |
| 20 | 627 ms | 33 ms |
| 50 | 1566 ms | 33 ms |

Round trips go from O(images) to O(1). Failure handling is unchanged: a file
that fails to upload still fails on its own and still renders the
`failed_to_offload` placeholder, with the same log output.

Generative AI was used to help write this change.