### PR TITLE
fix(code): abort project MCP approval on Esc

### DIFF
--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2779,8 +2779,9 @@ def _run_project_mcp_trust_action_picker(
         console: Console to print fallback notices to (stderr).
 
     Returns:
-        The chosen action, `INTERRUPTED` for Ctrl+C, or `None` when the inline
-        picker cannot run and the caller should use the text fallback.
+        The chosen action, `CANCELLED` for Esc, `INTERRUPTED` for Ctrl+C, or
+        `None` when the inline picker cannot run and the caller should use the
+        text fallback.
     """
     if not _project_mcp_picker_has_terminal():
         return None
@@ -2819,7 +2820,7 @@ def _run_project_mcp_trust_action_picker(
                 "class:prompt.help",
                 (
                     f"{glyphs.arrow_up}/{glyphs.arrow_down}/Tab move · "
-                    "Enter select · Esc deny\n"
+                    "Enter select · Esc abort\n"
                 ),
             ),
         ]
@@ -2852,8 +2853,8 @@ def _run_project_mcp_trust_action_picker(
         event.app.exit(result=actions[selected_index][0])
 
     @key_bindings.add("escape")
-    def _deny(event: KeyPressEvent) -> None:
-        event.app.exit(result=_ProjectMcpTrustAction.DENY)
+    def _abort(event: KeyPressEvent) -> None:
+        event.app.exit(result=_ProjectMcpTrustPromptOutcome.CANCELLED)
 
     @key_bindings.add("c-c")
     def _interrupt(event: KeyPressEvent) -> None:
@@ -2904,7 +2905,8 @@ def _select_project_mcp_trust_action(
         console: Console used by the text fallback.
 
     Returns:
-        The selected trust action, or `INTERRUPTED` when the user presses Ctrl+C.
+        The selected trust action, `CANCELLED` when the user presses Esc, or
+        `INTERRUPTED` when the user presses Ctrl+C.
     """
     selected = _run_project_mcp_trust_action_picker(console)
     if selected is not None:
@@ -3150,7 +3152,8 @@ def _select_project_servers_to_persist(
     Returns:
         The chosen server names. Empty when the user confirms no servers or
         makes no valid fallback selection. `CANCELLED` means the user backed out
-        and the caller should deny. `INTERRUPTED` means the user pressed Ctrl+C.
+        and the caller should abort the launch. `INTERRUPTED` means the user
+        pressed Ctrl+C.
     """
     names = [name for name, _kind, _summary in prompt_servers]
     if len(names) <= 1:
@@ -3184,8 +3187,8 @@ def _check_mcp_project_trust(
     returns `True`. Otherwise it shows an inline action selector for unresolved
     servers: allow once, remember selected servers, or deny. Remembered approvals
     are scoped to this project and each exact server definition. The remember
-    picker starts with nothing selected; Esc cancels the launch, and no server
-    loads without an explicit allow action.
+    picker starts with nothing selected; Esc in either picker aborts the launch,
+    and no server loads without an explicit allow action.
 
     Servers already resolved by the user's scoped approvals, the
     `DANGEROUSLY_ENABLE_PROJECT_MCP_SERVERS` env allowlist, or the
@@ -3203,8 +3206,8 @@ def _check_mcp_project_trust(
         `True` to allow project servers, `False` to deny (including when the
             user's trust policy could not be read), `None` when there are no
             project servers whose fate this prompt decides, `INTERRUPTED` when
-            the user presses Ctrl+C, or `CANCELLED` when the user backs out of
-            server selection.
+            the user presses Ctrl+C, or `CANCELLED` when the user presses Esc to
+            abort the launch.
     """
     from deepagents_code.mcp_tools import (
         ProjectServerSummary,
@@ -3317,6 +3320,8 @@ def _check_mcp_project_trust(
     action = _select_project_mcp_trust_action(prompt_console)
     if action is _ProjectMcpTrustPromptOutcome.INTERRUPTED:
         return _ProjectMcpTrustPromptOutcome.INTERRUPTED
+    if action is _ProjectMcpTrustPromptOutcome.CANCELLED:
+        return _ProjectMcpTrustPromptOutcome.CANCELLED
     if action is _ProjectMcpTrustAction.DENY:
         prompt_console.print(
             f"[dim]Denied {server_count} project MCP {noun}.[/dim]",
@@ -3337,10 +3342,6 @@ def _check_mcp_project_trust(
     if names is _ProjectMcpTrustPromptOutcome.INTERRUPTED:
         return _ProjectMcpTrustPromptOutcome.INTERRUPTED
     if names is _ProjectMcpTrustPromptOutcome.CANCELLED:
-        prompt_console.print(
-            f"[dim]Cancelled; denied {server_count} project MCP {noun}.[/dim]",
-            highlight=False,
-        )
         return _ProjectMcpTrustPromptOutcome.CANCELLED
     if not names:
         prompt_console.print(

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -65,7 +65,8 @@ class _ProjectMcpTrustPromptOutcome(Enum):
     """The user pressed Ctrl+C; the caller aborts the run (exit 130)."""
 
     CANCELLED = "cancelled"
-    """The user backed out of a nested prompt; the caller aborts the launch."""
+    """The user backed out of the trust prompt (Esc in the action or remember
+    picker, or blank/EOF in the text fallback); the caller aborts the launch."""
 
 
 _PROJECT_MCP_PICKER_VISIBLE_ROWS = 8
@@ -2938,7 +2939,7 @@ def _run_project_mcp_server_checkbox_picker(
 
     Returns:
         Selected server names. Empty means the user confirmed no selections;
-        `CANCELLED` means the user pressed Esc to abort the launch;
+        `CANCELLED` means the user backed out (Esc or Ctrl+D) to abort the launch;
         `INTERRUPTED` means the user pressed Ctrl+C; `None` means the checkbox UI
         could not run and the caller should fall back to a simpler prompt.
     """

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2938,7 +2938,7 @@ def _run_project_mcp_server_checkbox_picker(
 
     Returns:
         Selected server names. Empty means the user confirmed no selections;
-        `CANCELLED` means the user pressed Esc to cancel the approval;
+        `CANCELLED` means the user pressed Esc to abort the launch;
         `INTERRUPTED` means the user pressed Ctrl+C; `None` means the checkbox UI
         could not run and the caller should fall back to a simpler prompt.
     """
@@ -2987,7 +2987,7 @@ def _run_project_mcp_server_checkbox_picker(
                         f"{len(selected_names)} selected\n"
                         f"{glyphs.arrow_up}/{glyphs.arrow_down}/Tab move · "
                         "Space toggle · a select all · c clear · Enter confirm · "
-                        "Esc cancel\n"
+                        "Esc abort\n"
                     ),
                 ),
             ]
@@ -3123,7 +3123,7 @@ def _select_project_servers_with_numbers(
             highlight=False,
         )
     try:
-        raw = input("Enter numbers to remember (e.g. 1,3), 'all', or blank to cancel: ")
+        raw = input("Enter numbers to remember (e.g. 1,3), 'all', or blank to abort: ")
     except KeyboardInterrupt:
         return _ProjectMcpTrustPromptOutcome.INTERRUPTED
     except EOFError:
@@ -4506,6 +4506,12 @@ def cli_main() -> None:
             if mcp_trust_decision is _ProjectMcpTrustPromptOutcome.INTERRUPTED:
                 sys.exit(130)
             if mcp_trust_decision is _ProjectMcpTrustPromptOutcome.CANCELLED:
+                from rich.console import Console as _Console
+
+                _Console(stderr=True).print(
+                    "[dim]Aborted; no project MCP servers loaded.[/dim]",
+                    highlight=False,
+                )
                 return
 
             # Run Textual TUI

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -996,7 +996,9 @@ class TestStartupAutoUpdate:
         assert exc_info.value.code == 130
         launch.assert_not_called()
 
-    def test_project_mcp_server_selection_cancel_aborts_before_tui(self) -> None:
+    def test_project_mcp_server_selection_cancel_aborts_before_tui(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         """Esc in the server selector cancels launch before Textual starts."""
         from deepagents_code.main import _ProjectMcpTrustPromptOutcome
 
@@ -1018,6 +1020,7 @@ class TestStartupAutoUpdate:
             cli_main()
 
         launch.assert_not_called()
+        assert "aborted" in capsys.readouterr().err.lower()
 
 
 class TestAutoUpdateDefaultMigration:
@@ -3567,6 +3570,8 @@ class TestSelectProjectServersToPersist:
                 captured.update(kwargs)
 
             def run(self) -> _ProjectMcpTrustPromptOutcome:
+                from prompt_toolkit.keys import Keys
+
                 bindings = captured["key_bindings"].bindings
                 holder: dict[str, _ProjectMcpTrustPromptOutcome] = {}
                 event = SimpleNamespace(
@@ -3577,7 +3582,7 @@ class TestSelectProjectServersToPersist:
                 abort = next(
                     binding.handler
                     for binding in bindings
-                    if binding.handler.__name__ == "_abort"
+                    if Keys.Escape in binding.keys
                 )
                 abort(event)
                 return holder["value"]
@@ -3591,6 +3596,27 @@ class TestSelectProjectServersToPersist:
         )
         assert "Esc abort" in rendered
         assert "Esc deny" not in rendered
+
+    def test_select_action_forwards_picker_cancelled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A CANCELLED outcome from the inline picker passes straight through."""
+        from rich.console import Console
+
+        from deepagents_code.main import (
+            _ProjectMcpTrustPromptOutcome,
+            _select_project_mcp_trust_action,
+        )
+
+        monkeypatch.setattr(
+            "deepagents_code.main._run_project_mcp_trust_action_picker",
+            lambda _console: _ProjectMcpTrustPromptOutcome.CANCELLED,
+        )
+
+        result = _select_project_mcp_trust_action(Console(stderr=True))
+
+        assert result is _ProjectMcpTrustPromptOutcome.CANCELLED
 
     def test_action_picker_falls_back_when_stderr_is_redirected(
         self, monkeypatch: pytest.MonkeyPatch
@@ -3880,10 +3906,10 @@ class TestSelectProjectServersToPersist:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Esc cancels the approval, distinct from confirming an empty selection.
+        """Esc aborts the launch, distinct from confirming an empty selection.
 
-        Both paths deny rather than silently granting session trust, while Ctrl+C
-        remains a separate launch interruption.
+        Confirming an empty selection denies and continues; Esc aborts the launch
+        entirely, while Ctrl+C remains a separate launch interruption.
         """
         from rich.console import Console
 
@@ -3902,6 +3928,8 @@ class TestSelectProjectServersToPersist:
                 captured.update(kwargs)
 
             def run(self) -> list[str]:
+                from prompt_toolkit.keys import Keys
+
                 bindings = captured["key_bindings"].bindings
                 holder: dict[str, list[str]] = {}
                 event = SimpleNamespace(
@@ -3912,7 +3940,7 @@ class TestSelectProjectServersToPersist:
                 cancel = next(
                     binding.handler
                     for binding in bindings
-                    if binding.handler.__name__ == "_cancel"
+                    if Keys.Escape in binding.keys
                 )
                 cancel(event)
                 return holder["value"]

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -1020,7 +1020,7 @@ class TestStartupAutoUpdate:
             cli_main()
 
         launch.assert_not_called()
-        assert "aborted" in capsys.readouterr().err.lower()
+        assert "Aborted; no project MCP servers loaded" in capsys.readouterr().err
 
 
 class TestAutoUpdateDefaultMigration:
@@ -2517,6 +2517,7 @@ class TestCheckMcpProjectTrustPrompt:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Esc aborts the launch without recording a denial decision."""
+        from deepagents_code import model_config
         from deepagents_code._env_vars import DEBUG_MCP_PROJECT_TRUST
         from deepagents_code.main import (
             _check_mcp_project_trust,
@@ -2525,6 +2526,8 @@ class TestCheckMcpProjectTrustPrompt:
 
         project_context = SimpleNamespace(project_root=tmp_path, user_cwd=tmp_path)
         monkeypatch.setenv(DEBUG_MCP_PROJECT_TRUST, "1")
+        user_config = tmp_path / "config.toml"
+        monkeypatch.setattr(model_config, "DEFAULT_CONFIG_PATH", user_config)
 
         with (
             patch(
@@ -2548,6 +2551,50 @@ class TestCheckMcpProjectTrustPrompt:
 
         assert decision is _ProjectMcpTrustPromptOutcome.CANCELLED
         assert "denied" not in capsys.readouterr().err.lower()
+        assert not user_config.exists()
+
+    def test_explicit_deny_action_reports_denial(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The menu Deny action reports a denial and continues (distinct from Esc).
+
+        Positive companion to the abort tests: their `"denied" not in ...` guards
+        only mean something if the explicit-Deny path actually emits the wording.
+        """
+        from deepagents_code._env_vars import DEBUG_MCP_PROJECT_TRUST
+        from deepagents_code.main import (
+            _check_mcp_project_trust,
+            _ProjectMcpTrustAction,
+        )
+
+        project_context = SimpleNamespace(project_root=tmp_path, user_cwd=tmp_path)
+        monkeypatch.setenv(DEBUG_MCP_PROJECT_TRUST, "1")
+
+        with (
+            patch(
+                "deepagents_code.project_utils.ProjectContext.from_user_cwd",
+                return_value=project_context,
+            ),
+            patch(
+                "deepagents_code.mcp_tools.discover_mcp_configs",
+                return_value=[],
+            ),
+            patch(
+                "deepagents_code.mcp_tools.classify_discovered_configs",
+                return_value=([], []),
+            ),
+            patch(
+                "deepagents_code.main._select_project_mcp_trust_action",
+                return_value=_ProjectMcpTrustAction.DENY,
+            ),
+        ):
+            decision = _check_mcp_project_trust(trust_flag=False)
+
+        assert decision is False
+        assert "denied" in capsys.readouterr().err.lower()
 
     def test_prompt_is_concise(
         self, capsys: pytest.CaptureFixture[str], tmp_path: Path
@@ -3954,6 +4001,10 @@ class TestSelectProjectServersToPersist:
         result = _run_project_mcp_server_checkbox_picker(servers, Console(stderr=True))
 
         assert result is _ProjectMcpTrustPromptOutcome.CANCELLED
+        help_control = captured["layout"].container.children[0].content
+        rendered = "".join(text for _style, text in help_control.text())
+        assert "Esc abort" in rendered
+        assert "Esc cancel" not in rendered
 
     @pytest.mark.usefixtures("_interactive_picker_terminal")
     def test_checkbox_picker_ctrl_c_returns_interrupted(

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -2507,6 +2507,45 @@ class TestCheckMcpProjectTrustPrompt:
         captured = capsys.readouterr()
         assert "debug-project-mcp" in captured.err
 
+    def test_escape_aborts_without_denying(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Esc aborts the launch without recording a denial decision."""
+        from deepagents_code._env_vars import DEBUG_MCP_PROJECT_TRUST
+        from deepagents_code.main import (
+            _check_mcp_project_trust,
+            _ProjectMcpTrustPromptOutcome,
+        )
+
+        project_context = SimpleNamespace(project_root=tmp_path, user_cwd=tmp_path)
+        monkeypatch.setenv(DEBUG_MCP_PROJECT_TRUST, "1")
+
+        with (
+            patch(
+                "deepagents_code.project_utils.ProjectContext.from_user_cwd",
+                return_value=project_context,
+            ),
+            patch(
+                "deepagents_code.mcp_tools.discover_mcp_configs",
+                return_value=[],
+            ),
+            patch(
+                "deepagents_code.mcp_tools.classify_discovered_configs",
+                return_value=([], []),
+            ),
+            patch(
+                "deepagents_code.main._select_project_mcp_trust_action",
+                return_value=_ProjectMcpTrustPromptOutcome.CANCELLED,
+            ),
+        ):
+            decision = _check_mcp_project_trust(trust_flag=False)
+
+        assert decision is _ProjectMcpTrustPromptOutcome.CANCELLED
+        assert "denied" not in capsys.readouterr().err.lower()
+
     def test_prompt_is_concise(
         self, capsys: pytest.CaptureFixture[str], tmp_path: Path
     ) -> None:
@@ -3024,7 +3063,7 @@ class TestCheckMcpProjectTrustPrompt:
 
         assert decision is _ProjectMcpTrustPromptOutcome.CANCELLED
         assert not user_config.exists()
-        assert "Cancelled" in capsys.readouterr().err
+        assert "denied" not in capsys.readouterr().err.lower()
 
     def test_always_allow_all_excludes_disabled_server(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -3504,6 +3543,54 @@ class TestSelectProjectServersToPersist:
         assert "Allow for this project — until changed" in rendered
         assert "Deny" in rendered
         assert "Choose how to continue" not in rendered
+
+    @pytest.mark.usefixtures("_interactive_picker_terminal")
+    def test_action_picker_escape_aborts(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Esc aborts the launch instead of selecting the deny action."""
+        from rich.console import Console
+
+        from deepagents_code.main import (
+            _ProjectMcpTrustPromptOutcome,
+            _run_project_mcp_trust_action_picker,
+        )
+
+        captured: dict[str, Any] = {}
+
+        class _FakeApplication:
+            def __class_getitem__(cls, _item: object) -> type["_FakeApplication"]:
+                return cls
+
+            def __init__(self, **kwargs: Any) -> None:
+                captured.update(kwargs)
+
+            def run(self) -> _ProjectMcpTrustPromptOutcome:
+                bindings = captured["key_bindings"].bindings
+                holder: dict[str, _ProjectMcpTrustPromptOutcome] = {}
+                event = SimpleNamespace(
+                    app=SimpleNamespace(
+                        exit=lambda *, result: holder.update(value=result)
+                    )
+                )
+                abort = next(
+                    binding.handler
+                    for binding in bindings
+                    if binding.handler.__name__ == "_abort"
+                )
+                abort(event)
+                return holder["value"]
+
+        monkeypatch.setattr("prompt_toolkit.Application", _FakeApplication)
+        result = _run_project_mcp_trust_action_picker(Console(stderr=True))
+
+        assert result is _ProjectMcpTrustPromptOutcome.CANCELLED
+        rendered = "".join(
+            text for _style, text in captured["layout"].container.content.text()
+        )
+        assert "Esc abort" in rendered
+        assert "Esc deny" not in rendered
 
     def test_action_picker_falls_back_when_stderr_is_redirected(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Pressing Esc in the project MCP approval prompt now aborts startup and returns to the terminal instead of treating Esc as **Deny** and continuing into the TUI.

---

Esc now produces the same launch-cancellation outcome in both project MCP selectors. The explicit **Deny** option remains available and selected by default, so declining trust still requires choosing it and pressing Enter.
