### PR TITLE
fix(code): prevent failed exit setup from stranding the app

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -15648,16 +15648,15 @@ class DeepAgentsApp(App):
             message: Optional message to display on exit.
         """
         # A second exit() while shutdown is already underway means the user is
-        # forcing the issue (e.g. mashing Ctrl+D/Ctrl+C). `_exiting` is set at
-        # the top of the first exit() below, before it decides whether to defer,
-        # so this guard fires for both the deferred and immediate first paths.
-        # Tear down immediately rather than arming another bounded wait — the
-        # first call already ran cleanup and cancelled the worker, so re-running
-        # it would only make the force-quit wait out another window.
+        # forcing the issue (e.g. mashing Ctrl+D/Ctrl+C). `_exiting` is set by
+        # the first exit() below, before it decides whether to defer, so this
+        # guard fires for both the deferred and immediate first paths. Tear down
+        # immediately rather than arming another bounded wait — the first call
+        # already ran cleanup and cancelled the worker, so re-running it would
+        # only make the force-quit wait out another window.
         if self._exiting:
             super().exit(result=result, return_code=return_code, message=message)
             return
-        self._exiting = True
 
         # Merge in-flight turn stats before any cleanup that might raise.
         # When the agent worker is cancelled (e.g. Ctrl+D during a pending tool
@@ -15728,6 +15727,7 @@ class DeepAgentsApp(App):
                 exc_info=True,
             )
         restore_iterm_cursor_guide()
+        self._exiting = True
 
         # Defer super().exit() so teardown can overlap independent slow phases
         # instead of serializing them, while keeping the Textual event loop
@@ -20279,10 +20279,12 @@ class DeepAgentsApp(App):
             timeout: Optional outer timeout for the full restart.
 
         Raises:
-            asyncio.CancelledError: If app teardown has already begun.
+            asyncio.CancelledError: If app teardown has already begun, or if
+                `server_proc.restart()` is cancelled because a terminal `stop()`
+                bumped the stop generation mid-restart.
             RuntimeError: Propagated from `server_proc.restart()` on failure.
             TimeoutError: If `timeout` is set and the restart exceeds it.
-        """  # noqa: DOC502  # RuntimeError/TimeoutError propagate from restart()
+        """  # noqa: DOC502  # restart() raises RuntimeError; wait_for() times out.
         if self._exiting:
             raise asyncio.CancelledError
 
@@ -20347,12 +20349,9 @@ class DeepAgentsApp(App):
             # `asyncio.CancelledError` is intentionally NOT caught here (it is a
             # `BaseException`): `_restart_server_process` raises it only when app
             # teardown has begun or a terminal `stop()` bumped the server's stop
-            # generation mid-restart — i.e. only during shutdown. Letting it
-            # propagate means the `_connecting`/`_reconnecting` reset below is
-            # skipped, but that is safe because UI state no longer matters during
-            # shutdown and the `/restart` caller (`_run_restart_respawn`) resets
-            # those flags in its own `finally`. If a future edit ever lets this
-            # fire outside teardown, add a reset on the cancellation path.
+            # generation mid-restart — i.e. only during shutdown. Let it propagate
+            # to the outer `BaseException` handler below, which resets
+            # `_connecting`/`_reconnecting`, syncs connection status, and re-raises.
             except (Exception, TimeoutError) as exc:
                 self._connecting = False
                 self._reconnecting = False

--- a/libs/code/deepagents_code/client/launch/server.py
+++ b/libs/code/deepagents_code/client/launch/server.py
@@ -1018,7 +1018,9 @@ class ServerProcess:
                 first), or if a terminal `stop()` bumped the stop generation
                 during cleanup — in which case `_start` aborts rather than
                 resurrecting the subprocess the terminal stop just tore down.
-        """
+            RuntimeError: If workspace preparation, process startup, or the
+                server health check fails.
+        """  # noqa: DOC502  # RuntimeError propagates from _start().
         logger.info("Restarting langgraph dev server")
         async with self._lifecycle_lock:
             with self._state_lock:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -15852,6 +15852,51 @@ class TestExitGracefulWorkerHandoff:
             server_proc.stop.assert_called_once_with()
             super_exit.assert_called_once()
 
+    async def test_restart_timeout_still_stops_server(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A hung restart cleanup hits its timeout; server shutdown still runs."""
+        restart_started = asyncio.Event()
+        cleanup_started = asyncio.Event()
+        cleanup_blocker = asyncio.Event()
+
+        async def respawn() -> None:
+            restart_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cleanup_started.set()
+                await cleanup_blocker.wait()
+
+        server_proc = MagicMock()
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._server_proc = server_proc
+            restart = asyncio.create_task(respawn())
+            app._track_server_restart_task(restart)
+            await asyncio.wait_for(restart_started.wait(), timeout=2.0)
+
+            with (
+                caplog.at_level(logging.WARNING, logger="deepagents_code.app"),
+                patch("deepagents_code.app._GRACEFUL_EXIT_WAIT_SECONDS", 0.01),
+                patch.object(App, "exit") as super_exit,
+            ):
+                app.exit()
+                assert app._graceful_exit_task is not None
+                await asyncio.wait_for(cleanup_started.wait(), timeout=2.0)
+                await asyncio.wait_for(app._graceful_exit_task, timeout=2.0)
+
+            server_proc.stop.assert_called_once_with()
+            super_exit.assert_called_once()
+
+        assert any(
+            "Server restart cleanup did not finish within 0.01s before app exit"
+            in record.message
+            and record.levelno == logging.WARNING
+            for record in caplog.records
+        )
+
     async def test_submission_is_rejected_during_graceful_exit(self) -> None:
         """A responsive UI cannot start work after shutdown begins."""
         stop_started = threading.Event()


### PR DESCRIPTION
Deep Agents Code no longer becomes stuck rejecting input if shutdown setup fails before teardown is scheduled. Restart cleanup timeouts are now covered directly, and restart error documentation matches runtime behavior.

---

`exit()` now marks the app as exiting only after hook loading and iTerm cursor-guide restoration complete. The flag is still set before either the deferred teardown task or immediate `super().exit()` path, so a second exit during the graceful window continues to force quit.

The new teardown test holds a tracked restart task in cancellation cleanup until the graceful-exit deadline expires, then verifies the warning, server stop, and single Textual exit. Related docstrings and the `_respawn_server` cancellation comment now identify where cancellation, timeout, and restart errors are handled.

No timeout values or teardown phase ordering changed.