### PR TITLE
perf(code): speed up local context detection

### DIFF
--- a/libs/code/deepagents_code/local_context.py
+++ b/libs/code/deepagents_code/local_context.py
@@ -256,10 +256,10 @@ logger = logging.getLogger(__name__)
 
 
 def _section_header() -> str:
-    """CWD line and IN_GIT flag (used by other sections).
+    """CWD line and Git metadata used by other sections.
 
     Returns:
-        Bash snippet that prints the header and sets `CWD` / `IN_GIT`.
+        Bash snippet that prints the header and sets `CWD`, `IN_GIT`, and `ROOT`.
     """
     return r"""CWD="$(pwd)"
 echo "## Local Context"
@@ -267,19 +267,27 @@ echo ""
 echo "**Current Directory**: \`${CWD}\`"
 echo ""
 
-# --- Check git once ---
+# --- Check git and resolve its root once ---
 IN_GIT=false
-if command -v git >/dev/null 2>&1 \
-    && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  IN_GIT=true
+ROOT=""
+if command -v git >/dev/null 2>&1; then
+  GIT_INFO="$(git rev-parse --is-inside-work-tree --show-toplevel 2>/dev/null)"
+  GIT_MODE="${GIT_INFO%%$'\n'*}"
+  case "$GIT_MODE" in
+    true)
+      IN_GIT=true
+      ROOT="${GIT_INFO#*$'\n'}"
+      ;;
+    false) IN_GIT=true ;;  # Bare repository or the Git directory itself.
+  esac
 fi"""
 
 
 def _section_project() -> str:
-    """Language, monorepo, git root, virtual-env detection.
+    """Language, monorepo, project-root display, virtual-env detection.
 
     Returns:
-        Bash snippet (requires `CWD` / `IN_GIT` from header).
+        Bash snippet (requires `CWD` and `ROOT` from header).
     """
     return r"""# --- Project ---
 PROJ_LANG=""
@@ -293,9 +301,6 @@ MONOREPO=false
 { [ -f lerna.json ] || [ -f pnpm-workspace.yaml ] \
   || [ -d packages ] || { [ -d libs ] && [ -d apps ]; } \
   || [ -d workspaces ]; } && MONOREPO=true
-
-ROOT=""
-$IN_GIT && ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 
 ENVS=""
 { [ -d .venv ] || [ -d venv ]; } && ENVS=".venv"
@@ -352,15 +357,38 @@ def _section_runtimes() -> str:
         Bash snippet (standalone).
     """
     return r"""# --- Runtimes ---
-RT=""
+_RT_TMP="${_DCT:-}"
+_RT_CLEANUP=false
+if [ -z "$_RT_TMP" ]; then
+  _RT_TMP="$(mktemp -d)" || exit 1
+  _RT_CLEANUP=true
+fi
+
+HAS_PYTHON=false
 if command -v python3 >/dev/null 2>&1; then
-  PV="$(python3 --version 2>/dev/null | awk '{print $2}')"
+  python3 --version > "$_RT_TMP/runtime_python" 2>/dev/null &
+  HAS_PYTHON=true
+fi
+HAS_NODE=false
+if command -v node >/dev/null 2>&1; then
+  node --version > "$_RT_TMP/runtime_node" 2>/dev/null &
+  HAS_NODE=true
+fi
+wait
+
+RT=""
+if $HAS_PYTHON && [ -s "$_RT_TMP/runtime_python" ]; then
+  IFS= read -r PV < "$_RT_TMP/runtime_python"
+  PV="${PV#* }"
+  PV="${PV%% *}"
   [ -n "$PV" ] && RT="Python ${PV}"
 fi
-if command -v node >/dev/null 2>&1; then
-  NV="$(node --version 2>/dev/null | sed 's/^v//')"
+if $HAS_NODE && [ -s "$_RT_TMP/runtime_node" ]; then
+  IFS= read -r NV < "$_RT_TMP/runtime_node"
+  NV="${NV#v}"
   [ -n "$NV" ] && RT="${RT:+${RT}, }Node ${NV}"
 fi
+$_RT_CLEANUP && rm -rf "$_RT_TMP"
 [ -n "$RT" ] && echo "**Detected Runtimes**: ${RT}" && echo ""
 """
 
@@ -382,7 +410,8 @@ if $IN_GIT; then
   fi
 
   MAINS=""
-  for b in $(git branch 2>/dev/null | sed 's/^[* ]*//'); do
+  for b in $(git for-each-ref --format='%(refname:short)' \
+      refs/heads/main refs/heads/master 2>/dev/null); do
     case "$b" in
       main) MAINS="${MAINS:+${MAINS}, }\`main\`" ;;
       master) MAINS="${MAINS:+${MAINS}, }\`master\`" ;;
@@ -390,7 +419,7 @@ if $IN_GIT; then
   done
   [ -n "$MAINS" ] && GT="${GT}, ${MAINS} available"
 
-  DC=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+  DC=$(git status --porcelain 2>/dev/null | awk 'END { print NR }')
   if [ "$DC" -gt 0 ]; then
     if [ "$DC" -eq 1 ]; then GT="${GT}, 1 uncommitted change"
     else GT="${GT}, ${DC} uncommitted changes"
@@ -415,14 +444,36 @@ if command -v gh >/dev/null 2>&1; then
       | awk '
         /^JSON FIELDS/ { in_fields = 1; next }
         in_fields && /^$/ { exit }
-        in_fields { gsub(/^  /, ""); print }
-      ' \
-      | tr '\n' ' ' \
-      | sed 's/  */ /g; s/^ //; s/ $//'
+        in_fields {
+          sub(/^[[:space:]]+/, "")
+          gsub(/[[:space:]]+/, " ")
+          fields = fields (fields ? " " : "") $0
+        }
+        END {
+          sub(/^ /, "", fields)
+          sub(/ $/, "", fields)
+          if (fields != "") print fields
+        }
+      '
   }
 
-  GH_PRS_FIELDS="$(_gh_json_fields prs)"
-  GH_ISSUES_FIELDS="$(_gh_json_fields issues)"
+  _GH_TMP="${_DCT:-}"
+  _GH_CLEANUP=false
+  if [ -z "$_GH_TMP" ]; then
+    _GH_TMP="$(mktemp -d)" || exit 1
+    _GH_CLEANUP=true
+  fi
+  _gh_json_fields prs > "$_GH_TMP/gh_prs_fields" &
+  _gh_json_fields issues > "$_GH_TMP/gh_issues_fields" &
+  wait
+
+  GH_PRS_FIELDS=""
+  GH_ISSUES_FIELDS=""
+  [ -s "$_GH_TMP/gh_prs_fields" ] \
+    && IFS= read -r GH_PRS_FIELDS < "$_GH_TMP/gh_prs_fields"
+  [ -s "$_GH_TMP/gh_issues_fields" ] \
+    && IFS= read -r GH_ISSUES_FIELDS < "$_GH_TMP/gh_issues_fields"
+  $_GH_CLEANUP && rm -rf "$_GH_TMP"
   if [ -n "$GH_PRS_FIELDS" ] || [ -n "$GH_ISSUES_FIELDS" ]; then
     echo "**GitHub CLI**:"
     [ -n "$GH_PRS_FIELDS" ] \
@@ -468,30 +519,44 @@ def _section_files() -> str:
         Bash snippet (standalone).
     """
     return r"""# --- Files ---
-EXCL='node_modules|__pycache__|\.pytest_cache'
-EXCL="${EXCL}|\.mypy_cache|\.ruff_cache|\.tox"
-EXCL="${EXCL}|\.coverage|\.eggs|dist|build"
-FILES=$(
+FILE_SUMMARY=$(
   { ls -1 2>/dev/null; [ -e .deepagents ] && echo .deepagents; } |
-  grep -vE "^(${EXCL})$" |
-  sort -u
+  sort -u |
+  awk '
+    BEGIN {
+      excluded["node_modules"] = excluded["__pycache__"] = 1
+      excluded[".pytest_cache"] = excluded[".mypy_cache"] = 1
+      excluded[".ruff_cache"] = excluded[".tox"] = 1
+      excluded[".coverage"] = excluded[".eggs"] = 1
+      excluded["dist"] = excluded["build"] = 1
+    }
+    !($0 in excluded) {
+      total++
+      if (shown < 20) files[++shown] = $0
+    }
+    END {
+      print total + 0
+      print shown + 0
+      for (i = 1; i <= shown; i++) print files[i]
+    }
+  '
 )
-if [ -n "$FILES" ]; then
-  TOTAL=$(echo "$FILES" | wc -l | tr -d ' ')
-  SHOWN_FILES=$(echo "$FILES" | head -20)
-  SHOWN=$(echo "$SHOWN_FILES" | wc -l | tr -d ' ')
-  TOTAL=${TOTAL:-0}
-  SHOWN=${SHOWN:-0}
+TOTAL="${FILE_SUMMARY%%$'\n'*}"
+FILE_DETAILS="${FILE_SUMMARY#*$'\n'}"
+SHOWN="${FILE_DETAILS%%$'\n'*}"
+SHOWN_FILES="${FILE_DETAILS#*$'\n'}"
+
+if [ "$TOTAL" -gt 0 ]; then
   if [ "$SHOWN" -lt "$TOTAL" ]; then
     echo "**Files** (showing ${SHOWN} of ${TOTAL}):"
   else
     echo "**Files** (${TOTAL}):"
   fi
-  echo "$SHOWN_FILES" | while IFS= read -r f; do
+  while IFS= read -r f; do
     if [ -d "$f" ]; then echo "- ${f}/"
     else echo "- ${f}"
     fi
-  done
+  done <<< "$SHOWN_FILES"
   echo ""
 fi"""
 
@@ -510,12 +575,11 @@ if command -v tree >/dev/null 2>&1; then
   T_PREVIEW=$(tree -L 3 --noreport --dirsfirst \
     -I "$TREE_EXCL" 2>/dev/null | sed -n '1,22p;23{p;q;}')
   if [ -n "$T_PREVIEW" ]; then
-    PREVIEW_LINES=$(echo "$T_PREVIEW" | wc -l | tr -d ' ')
-    PREVIEW_LINES=${PREVIEW_LINES:-0}
+    PREVIEW_LINES=$(printf '%s\n' "$T_PREVIEW" | awk 'END { print NR }')
     T="$T_PREVIEW"
     TREE_TRUNCATED=false
     if [ "$PREVIEW_LINES" -gt 22 ]; then
-      T=$(echo "$T_PREVIEW" | head -22)
+      T=$(printf '%s\n' "$T_PREVIEW" | sed -n '1,22p')
       TREE_TRUNCATED=true
     fi
     echo "**Tree** (3 levels):"
@@ -532,7 +596,7 @@ def _section_makefile() -> str:
     """First 20 lines of Makefile (falls back to git root in monorepos).
 
     Returns:
-        Bash snippet (requires `ROOT` from `_section_project` and `CWD` from header).
+        Bash snippet (requires `ROOT` and `CWD` from `_section_header`).
     """
     return r"""# --- Makefile ---
 MK=""
@@ -544,9 +608,7 @@ fi
 if [ -n "$MK" ]; then
   echo "**Makefile** (\`${MK}\`, first 20 lines):"
   echo '```makefile'
-  head -20 "$MK"
-  TL=$(wc -l < "$MK" | tr -d ' ')
-  [ "$TL" -gt 20 ] && echo "... (truncated)"
+  awk 'NR <= 20 { print; next } { print "... (truncated)"; exit }' "$MK"
   echo '```'
 fi"""
 
@@ -556,13 +618,13 @@ def build_detect_script() -> str:
 
     Independent sections run as parallel background jobs writing to temp
     files, then results are concatenated in the original display order.
-    The header (CWD / IN_GIT) and project section (sets ROOT) run first
+    The header (sets `CWD`, `IN_GIT`, and `ROOT`) and project section run first
     because later sections depend on their variables.
 
     Returns:
         Complete bash heredoc ready for `backend.execute()`.
     """
-    # Header + project run synchronously (set CWD, IN_GIT, ROOT for others)
+    # Header (sets CWD, IN_GIT, ROOT) + project run synchronously for others
     serial_prefix = f"{_section_header()}\n{_section_project()}"
 
     # These sections are independent — run them in parallel.
@@ -581,10 +643,10 @@ def build_detect_script() -> str:
     ]
 
     # Build parallel wrapper: each section runs in a subshell writing to a
-    # temp file. Stderr is captured per-section to prevent noise leakage.
+    # temp file. Section stderr is discarded to prevent noise leakage.
     parallel_setup = "_DCT=$(mktemp -d) || exit 1\ntrap 'rm -rf \"$_DCT\"' EXIT"
     parallel_block = "\n".join(
-        f'(\n{body}\n) > "$_DCT/{name}" 2>"$_DCT/{name}.err" &'
+        f'(\n{body}\n) > "$_DCT/{name}" 2>/dev/null &'
         for name, body in parallel_sections
     )
     cat_line = "cat " + " ".join(f'"$_DCT/{name}"' for name, _ in parallel_sections)
@@ -658,9 +720,10 @@ class LocalContextMiddleware(AgentMiddleware):
                 shell commands the agent runs.
         """
         self.backend = backend
-        self._mcp_context = _build_mcp_context(mcp_server_info or [])
-        self._tracing_context = _build_tracing_context(
-            tracing_project, user_tracing_project
+        tracing_context = _build_tracing_context(tracing_project, user_tracing_project)
+        mcp_context = _build_mcp_context(mcp_server_info or [])
+        self._static_context = "\n\n".join(
+            context for context in (tracing_context, mcp_context) if context
         )
 
     @staticmethod
@@ -878,16 +941,19 @@ class LocalContextMiddleware(AgentMiddleware):
         """
         state = cast("LocalContextState", request.state)
         local_context = state.get("_local_context", "")
+        system_prompt = request.system_prompt or ""
 
-        parts = [
-            p for p in (local_context, self._tracing_context, self._mcp_context) if p
-        ]
-        if not parts:
+        if local_context:
+            if self._static_context:
+                prompt_parts = (system_prompt, local_context, self._static_context)
+            else:
+                prompt_parts = (system_prompt, local_context)
+        elif self._static_context:
+            prompt_parts = (system_prompt, self._static_context)
+        else:
             return None
 
-        system_prompt = request.system_prompt or ""
-        new_prompt = system_prompt + "\n\n" + "\n\n".join(parts)
-        return request.override(system_prompt=new_prompt)
+        return request.override(system_prompt="\n\n".join(prompt_parts))
 
     def wrap_model_call(
         self,

--- a/libs/code/tests/integration_tests/benchmarks/test_local_context_benchmarks.py
+++ b/libs/code/tests/integration_tests/benchmarks/test_local_context_benchmarks.py
@@ -1,0 +1,315 @@
+"""Wall-time benchmarks for `LocalContextMiddleware`.
+
+Run locally:  `make benchmark`
+Run with CodSpeed:  `make bench`
+
+The shell benchmarks exercise the environment-detection work that delays the first
+interaction and each post-summarization refresh. The middleware-bookkeeping benchmark
+isolates `before_agent`'s per-invocation overhead from shell execution (using a static
+backend). The request benchmark isolates the prompt composition performed before every
+model call.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+from deepagents.backends import LocalShellBackend
+from deepagents.backends.protocol import ExecuteResponse
+from langchain.agents.middleware.types import AgentState, ModelRequest
+
+from deepagents_code.local_context import (
+    _DETECT_SCRIPT_TIMEOUT,
+    DETECT_CONTEXT_SCRIPT,
+    LocalContextMiddleware,
+    LocalContextState,
+    _section_files,
+    _section_makefile,
+)
+from deepagents_code.mcp_tools import MCPServerInfo, MCPToolInfo
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from langchain_core.language_models import BaseChatModel
+    from langgraph.runtime import Runtime
+    from pytest_benchmark.fixture import BenchmarkFixture
+
+pytestmark = pytest.mark.benchmark
+
+
+class _StaticBackend:
+    """Return prebuilt detection output without shell or mock overhead."""
+
+    def __init__(self, output: str) -> None:
+        self._result = ExecuteResponse(output=output, exit_code=0)
+
+    def execute(
+        self,
+        command: str,  # noqa: ARG002
+        *,
+        timeout: int | None = None,  # noqa: ARG002
+    ) -> ExecuteResponse:
+        """Return the prebuilt result."""
+        return self._result
+
+
+def _git_env(home: Path) -> dict[str, str]:
+    """Build a deterministic environment for Git fixture setup."""
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "benchmark",
+        "GIT_AUTHOR_EMAIL": "benchmark@example.com",
+        "GIT_COMMITTER_NAME": "benchmark",
+        "GIT_COMMITTER_EMAIL": "benchmark@example.com",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "HOME": str(home),
+        "LC_ALL": "C",
+        "LANG": "C",
+    }
+
+
+def _shell_env(home: Path, tools: Path) -> dict[str, str]:
+    """Build an isolated environment with controlled optional executables."""
+    return {
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+        "HOME": str(home),
+        "LC_ALL": "C",
+        "LANG": "C",
+        "PATH": f"{tools}{os.pathsep}{os.environ['PATH']}",
+        "TMPDIR": str(home),
+    }
+
+
+def _install_benchmark_tools(directory: Path) -> None:
+    """Install deterministic stand-ins for optional detection commands."""
+    directory.mkdir()
+    scripts = {
+        "python3": "#!/bin/sh\necho 'Python 3.12.0'\n",
+        "node": "#!/bin/sh\necho 'v22.0.0'\n",
+        "gh": ("#!/bin/sh\ncat <<'EOF'\nJSON FIELDS\n  number, title, url\n\nEOF\n"),
+        "tree": ("#!/bin/sh\nprintf '.\\n|-- apps\\n|-- libs\\n`-- tests\\n'\n"),
+    }
+    for name, script in scripts.items():
+        executable = directory / name
+        executable.write_text(script)
+        executable.chmod(0o755)
+
+
+@pytest.fixture(scope="module")
+def realistic_backend(tmp_path_factory: pytest.TempPathFactory) -> LocalShellBackend:
+    """Create a dirty mixed-language monorepo for full-script measurements."""
+    root = tmp_path_factory.mktemp("local-context-repo")
+    home = tmp_path_factory.mktemp("local-context-home")
+    tools = home / "bin"
+    _install_benchmark_tools(tools)
+    (root / "libs" / "python_pkg").mkdir(parents=True)
+    (root / "apps" / "web" / "src").mkdir(parents=True)
+    (root / "tests").mkdir()
+    (root / ".deepagents").mkdir()
+    (root / ".venv").mkdir()
+    (root / "node_modules").mkdir()
+    (root / "pyproject.toml").write_text(
+        "[tool.uv]\n[tool.pytest.ini_options]\naddopts = '-q'\n"
+    )
+    (root / "uv.lock").write_text("")
+    (root / "package.json").write_text('{"scripts": {"test": "vitest"}}\n')
+    (root / "pnpm-lock.yaml").write_text("lockfileVersion: '9.0'\n")
+    (root / "Makefile").write_text(
+        "test:\n\tpytest\n" + "".join(f"target-{i}:\n\t@true\n" for i in range(24))
+    )
+    for index in range(120):
+        parent = root / ("libs/python_pkg" if index % 2 else "apps/web/src")
+        (parent / f"module_{index:03d}.py").write_text(f"VALUE = {index}\n")
+
+    env = _git_env(home)
+    subprocess.run(
+        ["git", "init", "-b", "main"],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "add", "Makefile", "apps", "libs", "package.json", "pyproject.toml"],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "benchmark fixture"],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        check=True,
+    )
+    (root / "apps" / "web" / "src" / "module_000.py").write_text("VALUE = -1\n")
+    (root / "untracked.txt").write_text("dirty\n")
+
+    return LocalShellBackend(
+        root_dir=root,
+        virtual_mode=False,
+        inherit_env=False,
+        env=_shell_env(home, tools),
+    )
+
+
+@pytest.fixture(scope="module")
+def large_makefile_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Create a large Makefile whose preview should require only 21 lines."""
+    root = tmp_path_factory.mktemp("local-context-large-makefile")
+    (root / "Makefile").write_text("test:\n\t@true\n" + "# filler\n" * 500_000)
+    return root
+
+
+@pytest.fixture(scope="module")
+def large_directory(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Create enough top-level entries to expose non-linear shell processing."""
+    root = tmp_path_factory.mktemp("local-context-large-directory")
+    for index in range(10_000):
+        (root / f"file-{index:05d}").touch()
+    return root
+
+
+def test_detect_context_script_realistic_monorepo(
+    benchmark: BenchmarkFixture,
+    realistic_backend: LocalShellBackend,
+) -> None:
+    """Measure production detection through `LocalShellBackend.execute`."""
+    result = benchmark.pedantic(
+        realistic_backend.execute,
+        args=(DETECT_CONTEXT_SCRIPT,),
+        kwargs={"timeout": _DETECT_SCRIPT_TIMEOUT},
+        rounds=10,
+        warmup_rounds=2,
+        iterations=1,
+    )
+
+    assert result.exit_code == 0
+    assert "## Local Context" in result.output
+    assert "Current branch `main`" in result.output
+    assert "uncommitted changes" in result.output
+
+
+def test_large_makefile_preview(
+    benchmark: BenchmarkFixture,
+    large_makefile_dir: Path,
+) -> None:
+    """Measure that Makefile preview work stays bounded by its 20-line output."""
+
+    def run_section() -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", "-c", _section_makefile()],
+            cwd=large_makefile_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    result = benchmark.pedantic(
+        run_section,
+        rounds=10,
+        warmup_rounds=2,
+        iterations=1,
+    )
+
+    assert result.returncode == 0
+    assert "... (truncated)" in result.stdout
+
+
+def test_large_directory_listing(
+    benchmark: BenchmarkFixture,
+    large_directory: Path,
+) -> None:
+    """Measure top-level filtering/counting without a per-entry Bash loop."""
+
+    def run_section() -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", "-c", _section_files()],
+            cwd=large_directory,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    result = benchmark.pedantic(
+        run_section,
+        rounds=10,
+        warmup_rounds=2,
+        iterations=1,
+    )
+
+    assert result.returncode == 0
+    assert "**Files** (showing 20 of 10000):" in result.stdout
+
+
+def test_initial_detection_python_overhead(benchmark: BenchmarkFixture) -> None:
+    """Measure middleware bookkeeping separately from shell execution."""
+    middleware = LocalContextMiddleware(_StaticBackend("local context\n" * 200))
+    state: LocalContextState = {"messages": []}
+    runtime = cast("Runtime[Any]", None)
+
+    def run_batch() -> dict[str, Any]:
+        result = None
+        for _ in range(10_000):
+            result = middleware.before_agent(state, runtime)
+        assert result is not None
+        return result
+
+    result = benchmark(run_batch)
+
+    assert result["_local_context"].startswith("local context")
+
+
+def test_compose_model_request(benchmark: BenchmarkFixture) -> None:
+    """Measure the prompt composition performed before every model call."""
+    servers = [
+        MCPServerInfo(
+            name=f"server-{server_index}",
+            transport="http",
+            tools=tuple(
+                MCPToolInfo(name=f"tool_{server_index}_{tool_index}", description="")
+                for tool_index in range(12)
+            ),
+        )
+        for server_index in range(3)
+    ]
+    middleware = LocalContextMiddleware(
+        _StaticBackend(""),
+        mcp_server_info=servers,
+        tracing_project="shared-deepagents-code",
+        user_tracing_project="user-project",
+    )
+    local_context = "## Local Context\n\n" + "context detail\n" * 600
+    state = cast(
+        "AgentState[Any]",
+        {"messages": [], "_local_context": local_context},
+    )
+    request = ModelRequest(
+        model=cast("BaseChatModel", None),
+        messages=[],
+        system_prompt="system instruction\n" * 800,
+        state=state,
+    )
+
+    def run_batch() -> ModelRequest:
+        result = None
+        for _ in range(1_000):
+            result = middleware._get_modified_request(request)
+        assert result is not None
+        return result
+
+    result = benchmark(run_batch)
+
+    assert result.system_prompt is not None
+    assert "## Local Context" in result.system_prompt
+    assert "**LangSmith Tracing**:" in result.system_prompt
+    assert "**MCP Servers**" in result.system_prompt

--- a/libs/code/tests/unit_tests/test_local_context.py
+++ b/libs/code/tests/unit_tests/test_local_context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, Mock
@@ -309,6 +310,27 @@ class TestLocalContextMiddleware:
 
         handler.assert_called_once_with(overridden_request)
         assert result == "response"
+
+    @pytest.mark.parametrize("base_prompt", ["", None])
+    def test_blank_base_prompt_composition(self, base_prompt: str | None) -> None:
+        """A blank/None base prompt composes to exactly the joined context.
+
+        Guards the blank-delimiter join composition against dropping the
+        leading separator or duplicating it for empty/None input.
+        """
+        backend = _make_backend()
+        middleware = LocalContextMiddleware(backend=backend)
+
+        request = Mock()
+        request.system_prompt = base_prompt
+        request.state = {"_local_context": SAMPLE_CONTEXT}
+        request.override.return_value = Mock()
+        handler = Mock(return_value="response")
+
+        middleware.wrap_model_call(request, handler)
+
+        prompt = request.override.call_args[1]["system_prompt"]
+        assert prompt == "\n\n" + SAMPLE_CONTEXT
 
     def test_wrap_model_call_without_local_context(self) -> None:
         """Test that wrap_model_call passes through when no local context."""
@@ -979,6 +1001,26 @@ class TestSectionHeader:
         )
         assert "IN_GIT=true" in result.stdout
 
+    def test_in_git_true_inside_bare_repo(self, tmp_path: Path) -> None:
+        bare_repo = tmp_path / "repo.git"
+        subprocess.run(
+            ["git", "init", "--bare", bare_repo],
+            capture_output=True,
+            check=True,
+        )
+        # Delimit ROOT so the assertion fails if it is wrongly populated
+        # (a bare substring `ROOT=` would pass even for `ROOT=/foo`).
+        script = _section_header() + '\necho "IN_GIT=$IN_GIT ROOT=[$ROOT]"'
+        result = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+            cwd=bare_repo,
+            check=False,
+        )
+
+        assert "IN_GIT=true ROOT=[]" in result.stdout
+
 
 class TestSectionProject:
     """Tests for _section_project."""
@@ -1068,6 +1110,110 @@ class TestSectionRuntimes:
         # python3 is available in CI and dev; just check format
         assert "**Detected Runtimes**:" in out
         assert "Python " in out
+
+    def test_python_runtime_version_remains_a_single_token(
+        self, tmp_path: Path
+    ) -> None:
+        """Extra implementation details in Python's banner are not surfaced."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        python = bin_dir / "python3"
+        python.write_text("#!/bin/sh\necho 'Python 3.11.9 (PyPy 7.3.15)'\n")
+        python.chmod(0o755)
+        node = bin_dir / "node"
+        node.write_text("#!/bin/sh\necho 'v22.4.0'\n")
+        node.chmod(0o755)
+
+        result = subprocess.run(
+            ["/bin/bash", "-c", _section_runtimes()],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env={"PATH": f"{bin_dir}:/usr/bin:/bin", "TMPDIR": str(tmp_path)},
+            check=False,
+        )
+
+        assert result.stderr == ""
+        assert "**Detected Runtimes**: Python 3.11.9, Node 22.4.0" in result.stdout
+        assert "PyPy" not in result.stdout
+
+    def test_node_only_has_no_leading_separator(self, tmp_path: Path) -> None:
+        """Node-only output must not start with the `, ` runtime separator."""
+        env = _runtime_stub_env(
+            tmp_path, python=None, node="#!/bin/sh\necho 'v20.11.1'\n"
+        )
+        result = subprocess.run(
+            ["/bin/bash", "-c", _section_runtimes()],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env=env,
+            check=False,
+        )
+
+        assert result.stderr == ""
+        assert "**Detected Runtimes**: Node 20.11.1" in result.stdout
+        assert "Python" not in result.stdout
+
+    def test_no_runtimes_line_when_neither_present(self, tmp_path: Path) -> None:
+        """No runtimes line is emitted when neither python3 nor node exists."""
+        env = _runtime_stub_env(tmp_path, python=None, node=None)
+        result = subprocess.run(
+            ["/bin/bash", "-c", _section_runtimes()],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env=env,
+            check=False,
+        )
+
+        assert result.stderr == ""
+        assert "**Detected Runtimes**" not in result.stdout
+
+    def test_empty_version_output_is_skipped(self, tmp_path: Path) -> None:
+        """A runtime that prints nothing is skipped, not surfaced as a bare label."""
+        env = _runtime_stub_env(
+            tmp_path,
+            python="#!/bin/sh\nexit 0\n",
+            node="#!/bin/sh\necho 'v18.20.0'\n",
+        )
+        result = subprocess.run(
+            ["/bin/bash", "-c", _section_runtimes()],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env=env,
+            check=False,
+        )
+
+        assert result.stderr == ""
+        assert "**Detected Runtimes**: Node 18.20.0" in result.stdout
+        assert "Python" not in result.stdout
+
+
+def _runtime_stub_env(
+    tmp_path: Path, *, python: str | None, node: str | None
+) -> dict[str, str]:
+    """Build an isolated PATH exposing only coreutils plus optional runtime stubs.
+
+    `_section_runtimes` needs `mktemp`/`rm` from the real environment, but the
+    system `python3`/`node` must not leak in when a test asserts an absent
+    runtime. Symlink just the required coreutils into a private bin dir and add
+    only the runtime stubs the test asks for.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for tool in ("mktemp", "rm"):
+        resolved = shutil.which(tool)
+        assert resolved, f"{tool} not found on PATH"
+        (bin_dir / tool).symlink_to(resolved)
+    for name, script in (("python3", python), ("node", node)):
+        if script is None:
+            continue
+        stub = bin_dir / name
+        stub.write_text(script)
+        stub.chmod(0o755)
+    return {"PATH": str(bin_dir), "TMPDIR": str(tmp_path)}
 
 
 def _git_env(tmp_path: Path) -> dict[str, str]:
@@ -1174,8 +1320,8 @@ class TestSectionGhCli:
             'if [ "$1" = search ] && [ "$3" = --help ]; then\n'
             "  cat <<'EOF'\n"
             "JSON FIELDS\n"
-            "  number, title, url,\n"
-            "  closedAt, updatedAt\n"
+            "    number, title, url,\n"
+            "    closedAt, updatedAt\n"
             "\n"
             "EXAMPLES\n"
             "EOF\n"
@@ -1203,6 +1349,41 @@ class TestSectionGhCli:
             in result.stdout
         )
         assert "does not expose `mergedAt`" in result.stdout
+
+    def test_mergedat_present_suppresses_fallback_note(self, tmp_path: Path) -> None:
+        """When `mergedAt` is already exposed, the fallback note is omitted."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        gh = bin_dir / "gh"
+        gh.write_text(
+            "#!/bin/sh\n"
+            'if [ "$1" = search ] && [ "$3" = --help ]; then\n'
+            "  cat <<'EOF'\n"
+            "JSON FIELDS\n"
+            "    number, title, url,\n"
+            "    mergedAt, updatedAt\n"
+            "\n"
+            "EXAMPLES\n"
+            "EOF\n"
+            "fi\n"
+        )
+        gh.chmod(0o755)
+
+        result = subprocess.run(
+            ["/bin/bash", "-c", _section_gh_cli()],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env={"PATH": f"{bin_dir}:/usr/bin:/bin"},
+            check=False,
+        )
+
+        assert result.stderr == ""
+        assert (
+            "`gh search prs --json` fields: number, title, url, mergedAt, updatedAt"
+            in result.stdout
+        )
+        assert "does not expose `mergedAt`" not in result.stdout
 
 
 class TestSectionTestCommand:
@@ -1252,6 +1433,20 @@ class TestSectionFiles:
             (tmp_path / f"file{i:02d}.txt").write_text("")
         out = _run_section(_section_files(), tmp_path)
         assert "(showing 20 of 25)" in out
+
+    def test_exactly_20_shows_total_not_range(self, tmp_path: Path) -> None:
+        """At the cap boundary the header shows the plain total, not a range."""
+        for i in range(20):
+            (tmp_path / f"file{i:02d}.txt").write_text("")
+        out = _run_section(_section_files(), tmp_path)
+        assert "**Files** (20):" in out
+        assert "showing" not in out
+
+    def test_empty_directory_emits_no_section(self, tmp_path: Path) -> None:
+        """An empty directory produces no Files section and no stray bullet."""
+        out = _run_section(_section_files(), tmp_path)
+        assert "**Files**" not in out
+        assert "- " not in out
 
     def test_excludes_pycache(self, tmp_path: Path) -> None:
         (tmp_path / "__pycache__").mkdir()
@@ -1342,6 +1537,13 @@ class TestSectionMakefile:
         out = _run_section(_section_makefile(), tmp_path, with_header=True)
         assert "... (truncated)" in out
 
+    def test_preview_does_not_count_the_entire_makefile(self) -> None:
+        """The preview command exits after seeing the twenty-first line."""
+        script = _section_makefile()
+        assert "wc -l" not in script
+        assert "NR <= 20" in script
+        assert "exit" in script
+
     def test_no_output_without_makefile(self, tmp_path: Path) -> None:
         """No Makefile section is emitted when no Makefile exists."""
         out = _run_section(_section_makefile(), tmp_path, with_header=True)
@@ -1364,9 +1566,7 @@ class TestSectionMakefile:
         (tmp_path / "Makefile").write_text("test:\n\tpytest\n")
         subdir = tmp_path / "packages" / "foo"
         subdir.mkdir(parents=True)
-        # Need _section_project() to set ROOT before _section_makefile()
-        script = _section_project() + "\n" + _section_makefile()
-        out = _run_section(script, subdir, with_header=True)
+        out = _run_section(_section_makefile(), subdir, with_header=True)
         assert f"`{tmp_path}/Makefile`" in out
         assert "pytest" in out
 


### PR DESCRIPTION
Speeds up Deep Agents Code's local-context collection, reducing the delay before the first interaction and after conversation summarization without changing the context shown to the agent.

---

Local-context collection previously ran several independent shell probes serially and fully scanned some inputs even though it displayed only a preview. This change runs independent work concurrently, reuses shared metadata, and stops preview-oriented reads once enough output is available.

Benchmark results:

- **Overall detection:** approximately 16–17% faster, reducing the median initial load or context refresh from 73 ms to 61 ms.
- **Large inputs:** approximately 50% faster for large Makefile previews and 35% faster for 10,000-entry directory listings.
- **Prompt composition:** approximately 8–12% faster per model call.

The benchmarks cover a realistic monorepo, large directories and Makefiles, initial middleware bookkeeping, and per-model-request prompt composition.
