### PR TITLE
fix(sdk): propagate root listing errors from `CompositeBackend`

### DIFF
--- a/libs/deepagents/deepagents/backends/composite.py
+++ b/libs/deepagents/deepagents/backends/composite.py
@@ -277,6 +277,8 @@ class CompositeBackend(BackendProtocol):
         if path == "/":
             results: list[FileInfo] = []
             default_result = self._coerce_ls_result(self.default.ls(path))
+            if default_result.error:
+                return default_result
             results.extend(default_result.entries or [])
             for route_prefix, _backend in self.sorted_routes:
                 # Add the route itself as a directory (e.g., /memories/)
@@ -312,6 +314,8 @@ class CompositeBackend(BackendProtocol):
         if path == "/":
             results: list[FileInfo] = []
             default_result = self._coerce_ls_result(await self.default.als(path))
+            if default_result.error:
+                return default_result
             results.extend(default_result.entries or [])
             for route_prefix, _backend in self.sorted_routes:
                 # Add the route itself as a directory (e.g., /memories/)

--- a/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_composite_backend.py
@@ -12,6 +12,7 @@ from deepagents.backends.protocol import (
     ExecuteResponse,
     GlobResult,
     GrepResult,
+    LsResult,
     SandboxBackendProtocol,
     WriteResult,
 )
@@ -418,6 +419,30 @@ async def test_composite_async_merge_propagates_truncated_and_error(monkeypatch:
     monkeypatch.setattr(routed, "aglob", _aglob_error)
     glob_result = await comp.aglob("*.txt", path="/")
     assert glob_result.error == "sandbox RPC failed"
+
+
+def test_composite_ls_root_propagates_default_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    comp, default, _routed = _merge_composite()
+    monkeypatch.setattr(default, "ls", lambda _path: LsResult(error="Error: connection to sandbox lost"))
+
+    result = comp.ls("/")
+
+    assert result.error == "Error: connection to sandbox lost"
+    assert result.entries is None
+
+
+async def test_composite_als_root_propagates_default_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    comp, default, _routed = _merge_composite()
+
+    async def _als_error(_path: str) -> LsResult:
+        return LsResult(error="Error: connection to sandbox lost")
+
+    monkeypatch.setattr(default, "als", _als_error)
+
+    result = await comp.als("/")
+
+    assert result.error == "Error: connection to sandbox lost"
+    assert result.entries is None
 
 
 def test_composite_backend_ls_nested_directories(tmp_path: Path):


### PR DESCRIPTION
Closes #4846

`CompositeBackend.ls("/")` and `als("/")` now report failures from the default backend instead of returning a successful route-only listing. This prevents agents from interpreting an unavailable root filesystem as healthy and nearly empty.

Credit to @Kushal9889 for reporting the issue and providing the reproduction.

---

Root listings combine the default backend's files with virtual route directories. Previously, that merge ignored an error from the default backend and constructed a successful result from routes alone. This change gives backend failures precedence over partial listings, matching routed listings and the existing grep and glob merge behavior.
