### PR TITLE
docs(code): clarify MCP plugin reload guidance

### DIFF
--- a/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
+++ b/libs/code/deepagents_code/tui/modals/plugin_manager/content.py
@@ -55,7 +55,7 @@ def _plugin_prompt(row: _PluginRow, *, status: str | None) -> Content:
         if row.mcp_connected is True:
             meta_parts.append(Content.styled(f"{glyphs.checkmark} connected", "dim"))
         elif row.mcp_connected is False:
-            meta_parts.append(Content.styled("restart to connect", "bold $warning"))
+            meta_parts.append(Content.styled("run /reload to connect", "bold $warning"))
     elif (
         row.load_state == "pending_reload"
         and row.session_loaded
@@ -176,7 +176,8 @@ def _status_lines(row: _PluginRow) -> list[Content]:
     if row.mcp_connected is False:
         lines.append(
             Content.styled(
-                "MCP servers need a server restart (/reload) to connect.", "dim"
+                "Run /reload to rebuild the agent with this plugin's MCP tools.",
+                "dim",
             )
         )
     return lines

--- a/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
+++ b/libs/code/tests/unit_tests/plugins/test_plugins_p0.py
@@ -184,7 +184,7 @@ async def test_plugin_manager_installed_selection_opens_details_not_disable(
         assert "quality-review-plugin@company-tools" in load_enabled_plugin_ids()
 
 
-async def test_plugin_manager_installed_row_shows_restart_hint_before_connect(
+async def test_plugin_manager_installed_row_shows_reload_hint_before_connect(
     tmp_path: Path, monkeypatch
 ) -> None:
     monkeypatch.setattr(
@@ -212,8 +212,8 @@ async def test_plugin_manager_installed_row_shows_restart_hint_before_connect(
 
         options = screen.query_one("#plugin-manager-options", OptionList)
         prompt = str(options.get_option_at_index(0).prompt)
-        assert "restart to connect" in prompt
-        assert "connected" not in prompt.replace("restart to connect", "")
+        assert "run /reload to connect" in prompt
+        assert "connected" not in prompt.replace("run /reload to connect", "")
 
 
 def test_plugin_manager_uses_recursive_skill_inventory(

--- a/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
+++ b/libs/code/tests/unit_tests/tui/modals/plugin_manager/test_structure.py
@@ -1053,7 +1053,7 @@ def test_installed_details_disabled_state_copy() -> None:
     assert "Enable the plugin, then run /reload to load it." in content
 
 
-def test_installed_details_enabled_flags_mcp_restart() -> None:
+def test_installed_details_enabled_flags_mcp_reload() -> None:
     row = _PluginRow(
         plugin_id="quality@tools",
         description="Quality",
@@ -1069,7 +1069,7 @@ def test_installed_details_enabled_flags_mcp_restart() -> None:
     content = str(_installed_plugin_details_content(row))
 
     assert f"Status: {get_glyphs().checkmark} Enabled" in content
-    assert "MCP servers need a server restart (/reload) to connect." in content
+    assert "Run /reload to rebuild the agent with this plugin's MCP tools." in content
 
 
 def test_status_lines_enabled_is_success_and_companions_stay_dim() -> None:
@@ -1090,8 +1090,10 @@ def test_status_lines_enabled_is_success_and_companions_stay_dim() -> None:
 
     assert lines[0].plain == f"Status: {get_glyphs().checkmark} Enabled"
     assert [span.style for span in lines[0].spans] == ["$success"]
-    # The MCP-restart companion line must NOT inherit the success color.
-    assert lines[1].plain.startswith("MCP servers need a server restart")
+    # The MCP /reload guidance must NOT inherit the success color.
+    assert lines[1].plain == (
+        "Run /reload to rebuild the agent with this plugin's MCP tools."
+    )
     assert [span.style for span in lines[1].spans] == ["dim"]
 
 
@@ -1156,9 +1158,9 @@ def test_plugin_prompt_enabled_connection_hints() -> None:
     prompt = str(_plugin_prompt(connected, status=None))
     assert f"{checkmark} enabled" in prompt
     assert f"{checkmark} connected" in prompt
-    assert "restart to connect" not in prompt
+    assert "run /reload to connect" not in prompt
 
-    needs_restart = _PluginRow(
+    needs_reload = _PluginRow(
         plugin_id="quality@tools",
         description="Quality",
         enabled=True,
@@ -1167,8 +1169,8 @@ def test_plugin_prompt_enabled_connection_hints() -> None:
         mcp_connected=False,
         session_loaded=True,
     )
-    prompt = str(_plugin_prompt(needs_restart, status=None))
-    assert "restart to connect" in prompt
+    prompt = str(_plugin_prompt(needs_reload, status=None))
+    assert "run /reload to connect" in prompt
     assert f"{checkmark} connected" not in prompt
 
 


### PR DESCRIPTION
Plugin manager guidance now tells users to run `/reload` to make newly added MCP tools available, without implying `/reload` and `/restart` are interchangeable.

---

`/reload` is the normal action after plugin changes: it rediscovers plugins and rebuilds the agent. `/restart` remains available as a separate recovery command. This changes only the plugin-manager wording and its assertions; command behavior is unchanged.
