### PR TITLE
chore(code): bump SDK pin to 0.7.0a8

### DIFF
--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     # Framework
-    "deepagents==0.7.0a7",
+    "deepagents==0.7.0a8",
     "langchain>=1.3.14,<2.0.0",
     "langgraph-checkpoint-sqlite>=3.1.0,<4.0.0",
 


### PR DESCRIPTION
Pins `deepagents-code` to `deepagents==0.7.0a8`, the latest published SDK alpha. This keeps dcode releases aligned with the prerelease SDK line.
