### PR TITLE
fix(code): thread id always copies on click in Debug Console

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/debug_console.py
+++ b/libs/code/deepagents_code/tui/widgets/debug_console.py
@@ -605,27 +605,25 @@ class _SnapshotView(Static):
         on_copy: Callable[[str], None],
         *,
         classes: str | None = None,
-        click_to_copy: bool = _CLICK_TO_COPY_DEFAULT,
     ) -> None:
         """Initialize with a callback used to copy a clicked span's text.
 
         Args:
             on_copy: Called with the span text when a copyable span is clicked.
             classes: Optional space-separated CSS classes.
-            click_to_copy: Whether copyable spans respond to clicks. Links
-                always open regardless of this setting.
         """
         super().__init__(classes=classes)
         self._on_copy = on_copy
-        self.click_to_copy = click_to_copy
-        """Whether clicking a copyable span copies its value."""
 
     def on_click(self, event: events.Click) -> None:
-        """Copy a marked span or open a link span under the click."""
+        """Copy a marked span or open a link span under the click.
+
+        Copyable snapshot spans (e.g. the thread id) always copy on click; the
+        console's "Click to copy" checkbox governs only the log lines, never the
+        snapshot.
+        """
         if getattr(event.style, "link", None):
             open_style_link(event)
-            return
-        if not self.click_to_copy:
             return
         text = _snapshot_copy_text(event.style)
         if text is not None:
@@ -635,7 +633,7 @@ class _SnapshotView(Static):
     def on_mouse_move(self, event: events.MouseMove) -> None:
         """Show a hand pointer over clickable spans and reset it elsewhere."""
         clickable = bool(getattr(event.style, "link", None)) or (
-            self.click_to_copy and _snapshot_copy_text(event.style) is not None
+            _snapshot_copy_text(event.style) is not None
         )
         self.styles.pointer = "pointer" if clickable else "default"
 
@@ -801,7 +799,6 @@ class DebugConsoleScreen(ModalScreen[None]):
             snapshot_view = _SnapshotView(
                 self._copy_snapshot_value,
                 classes="debug-console-snapshot",
-                click_to_copy=self._click_to_copy,
             )
             snapshot_view.update(self._render_snapshot())
             yield snapshot_view
@@ -967,14 +964,15 @@ class DebugConsoleScreen(ModalScreen[None]):
         self._refresh_log_view(scroll_end=True)
 
     def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
-        """Toggle click-to-copy for the log lines and snapshot spans."""
+        """Toggle click-to-copy for the log lines.
+
+        The checkbox governs only the log lines; copyable snapshot spans (e.g.
+        the thread id) always copy on click regardless of this setting.
+        """
         if event.checkbox.id != _CLICK_TO_COPY_ID:
             return
         self._click_to_copy = event.value
         self.query_one("#debug-log", _DebugLogView).click_to_copy = event.value
-        self.query_one(
-            ".debug-console-snapshot", _SnapshotView
-        ).click_to_copy = event.value
         if self._on_click_to_copy_change is not None:
             self._on_click_to_copy_change(event.value)
 

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -967,9 +967,6 @@ class TestDebugConsoleScreen:
             app.push_screen(screen)
             await pilot.pause()
 
-            screen.query_one("#debug-click-to-copy", Checkbox).value = True
-            await pilot.pause()
-
             snapshot_widget = screen.query_one(".debug-console-snapshot", Static)
             # Single "Thread" field: label (6 chars) + 2-space gutter puts the
             # value at column 8, so an x offset of 10 lands inside the copyable
@@ -979,9 +976,10 @@ class TestDebugConsoleScreen:
 
         assert captured["text"] == "thread-abc"
 
-    async def test_click_to_copy_defaults_off_and_ignores_snapshot_click(
+    async def test_snapshot_click_copies_regardless_of_checkbox(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """The thread id always copies on click, even with the checkbox off."""
         captured: dict[str, str] = {}
 
         def fake_copy(_app: App, text: str) -> tuple[bool, str | None]:
@@ -1004,7 +1002,7 @@ class TestDebugConsoleScreen:
             await pilot.click(snapshot_widget, offset=(10, 0))
             await pilot.pause()
 
-        assert "text" not in captured
+        assert captured["text"] == "thread-abc"
 
     async def test_click_line_ignored_when_click_to_copy_off_but_enter_copies(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1044,7 +1042,7 @@ class TestDebugConsoleScreen:
 
         assert "debug-console-click-off-marker" in captured["text"]
 
-    async def test_toggling_checkbox_propagates_to_child_widgets(self) -> None:
+    async def test_toggling_checkbox_propagates_to_log_view(self) -> None:
         app = _Harness()
         async with app.run_test() as pilot:
             screen = DebugConsoleScreen(
@@ -1054,22 +1052,16 @@ class TestDebugConsoleScreen:
             await pilot.pause()
 
             log = screen.query_one("#debug-log", _DebugLogView)
-            snapshot_view = screen.query_one(
-                ".debug-console-snapshot", debug_console_mod._SnapshotView
-            )
             assert log.click_to_copy is False
-            assert snapshot_view.click_to_copy is False
 
             screen.query_one("#debug-click-to-copy", Checkbox).value = True
             await pilot.pause()
             assert screen._click_to_copy is True
             assert log.click_to_copy is True
-            assert snapshot_view.click_to_copy is True
 
             screen.query_one("#debug-click-to-copy", Checkbox).value = False
             await pilot.pause()
             assert log.click_to_copy is False
-            assert snapshot_view.click_to_copy is False
 
     async def test_initial_click_to_copy_restores_checkbox_and_children(self) -> None:
         app = _Harness()


### PR DESCRIPTION
Clicking the thread id in the Debug Console now always copies it, and the "Click to copy" checkbox governs only the log lines.

---

Previously the checkbox gated both the log lines and the snapshot's copyable spans, so the thread id would not copy on click unless the checkbox was on. The checkbox now controls the log lines only; copyable snapshot spans (currently the thread id) always copy on click. LangSmith links still take priority and open first.

Made by [Open SWE](https://openswe.vercel.app/agents/4911c553-8a39-fcf7-1b15-de9f2eacca79)