### PR TITLE
fix(code): pair interrupted tool calls with synthetic tool results

### DIFF
--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
         HITLRequest,
         RejectDecision,
     )
-    from langchain_core.messages import AIMessage
+    from langchain_core.messages import AIMessage, ToolMessage
     from langchain_core.runnables import RunnableConfig
     from langgraph.types import Command, Interrupt
     from pydantic import TypeAdapter
@@ -538,6 +538,45 @@ def _build_interrupted_ai_message(
         content=accumulated_text,
         tool_calls=tool_calls or [],
     )
+
+
+def _build_interrupted_tool_messages(
+    interrupted_msg: AIMessage | None,
+) -> list[ToolMessage]:
+    """Build synthetic error `ToolMessage`s for an interrupted turn's tool calls.
+
+    Anthropic's Messages API requires every `tool_use` block to be immediately
+    followed by a matching `tool_result` block. When a turn is interrupted
+    mid-tool-execution, the partial `AIMessage` is persisted with its
+    `tool_calls` but no results, leaving the checkpoint in a state Anthropic
+    rejects on replay. One error `ToolMessage` per pending tool-call id
+    satisfies the pairing rule so the next turn resumes cleanly.
+
+    Args:
+        interrupted_msg: The partial `AIMessage` saved on interrupt, or `None`.
+
+    Returns:
+        One `ToolMessage` (with `status="error"`) per tool call on
+        `interrupted_msg`, in call order; empty when there are no tool calls.
+    """
+    from langchain_core.messages import ToolMessage
+
+    if interrupted_msg is None:
+        return []
+
+    tool_messages: list[ToolMessage] = []
+    for tool_call in interrupted_msg.tool_calls:
+        tool_call_id = tool_call.get("id")
+        if not tool_call_id:
+            continue
+        tool_messages.append(
+            ToolMessage(
+                content="Tool execution was interrupted by the user.",
+                tool_call_id=tool_call_id,
+                status="error",
+            )
+        )
+    return tool_messages
 
 
 def _interrupt_owned_tool_rows(
@@ -2490,6 +2529,22 @@ async def _handle_interrupt_cleanup(
     except Exception:
         logger.warning("Terminal tool.result dispatch failed on cancel", exc_info=True)
 
+    # Synthesize one error `ToolMessage` per pending tool-call id so the
+    # partial `AIMessage`'s `tool_use` blocks are each paired with a
+    # `tool_result` in the checkpoint. Without this, Anthropic rejects the
+    # replay on the next turn (OpenAI tolerates the gap). Built here — and
+    # written alongside `interrupted_msg` in the *same* `aupdate_state` call
+    # below — so the checkpointer never persists an `AIMessage` without its
+    # results. Guarded (best-effort) so a build failure can't skip the
+    # cancellation write or escape the cancel handler.
+    try:
+        interrupted_tool_messages = _build_interrupted_tool_messages(interrupted_msg)
+    except Exception:
+        logger.warning(
+            "Failed to build synthetic tool results on interrupt", exc_info=True
+        )
+        interrupted_tool_messages = []
+
     # Save accumulated state before marking tools as rejected (best-effort).
     # State update failures shouldn't prevent cleanup.
     from langsmith import tracing_context
@@ -2504,7 +2559,10 @@ async def _handle_interrupt_cleanup(
         with tracing_context(enabled=False):
             if recover_interrupted_turn:
                 if interrupted_msg:
-                    await agent.aupdate_state(config, {"messages": [interrupted_msg]})
+                    await agent.aupdate_state(
+                        config,
+                        {"messages": [interrupted_msg, *interrupted_tool_messages]},
+                    )
 
                 cancellation_msg = HumanMessage(
                     content=f"{SYSTEM_MESSAGE_PREFIX} Task interrupted by user. "

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -588,6 +588,67 @@ class TestInterruptCleanup:
             "Task interrupted by user" in str(message.content) for message in persisted
         )
 
+    async def test_interrupt_writes_synthetic_tool_results_to_checkpoint(self) -> None:
+        """Interrupted tool calls get paired error `ToolMessage`s in the checkpoint.
+
+        Anthropic rejects a replay where a `tool_use` block has no matching
+        `tool_result` immediately after. The first `aupdate_state` write must
+        therefore persist the partial `AIMessage` followed by one error
+        `ToolMessage` per pending tool-call id, before the `[SYSTEM]`
+        cancellation `HumanMessage`.
+        """
+        adapter = TextualUIAdapter(
+            mount_message=_mock_mount,
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            set_spinner=AsyncMock(),
+            set_active_message=MagicMock(),
+        )
+        first_tool = MagicMock()
+        first_tool._tool_name = "read_file"
+        first_tool._args = {"path": "notes.txt"}
+        second_tool = MagicMock()
+        second_tool._tool_name = "execute"
+        second_tool._args = {"command": "sleep 100"}
+        adapter._current_tool_messages = {
+            "call-1": first_tool,
+            "call-2": second_tool,
+        }
+        agent = SimpleNamespace(aupdate_state=AsyncMock())
+
+        await _handle_interrupt_cleanup(
+            adapter=adapter,
+            agent=agent,
+            config={"configurable": {"thread_id": "t-1"}},  # ty: ignore
+            pending_text_by_namespace={(): "partial answer"},
+            captured_input_tokens=0,
+            captured_output_tokens=0,
+            turn_stats=SessionStats(),
+            start_time=0.0,
+        )
+
+        first_write = agent.aupdate_state.await_args_list[0].args[1]["messages"]
+        ai_message = first_write[0]
+        assert isinstance(ai_message, AIMessage)
+        pending_ids = [call["id"] for call in ai_message.tool_calls]
+        assert pending_ids == ["call-1", "call-2"]
+
+        tool_messages = [m for m in first_write if isinstance(m, ToolMessage)]
+        assert [m.tool_call_id for m in tool_messages] == pending_ids
+        assert all(m.status == "error" for m in tool_messages)
+        # The AIMessage precedes its tool results within the first write.
+        assert first_write.index(ai_message) < min(
+            first_write.index(m) for m in tool_messages
+        )
+
+        # The tool results land before the [SYSTEM] cancellation HumanMessage,
+        # which is written in the second aupdate_state call.
+        second_write = agent.aupdate_state.await_args_list[1].args[1]["messages"]
+        assert any(
+            isinstance(m, HumanMessage) and "Task interrupted by user" in str(m.content)
+            for m in second_write
+        )
+
     async def test_remote_run_cancel_failure_does_not_skip_state_writes(self) -> None:
         """Interrupt cleanup remains best-effort when remote cancel fails."""
         agent = SimpleNamespace(


### PR DESCRIPTION
Interrupting a turn mid-tool-execution left the checkpoint in a state Anthropic rejects on the next turn: the partial `AIMessage` was persisted with its `tool_calls`, but no matching tool results. Anthropic's Messages API requires every `tool_use` block to be immediately followed by a `tool_result`, so replaying such a thread failed with a `400 tool_use ids were found without tool_result blocks`. OpenAI tolerates the gap, so the symptom was Anthropic-specific even though the checkpoint corruption affected all providers.

---

`_handle_interrupt_cleanup` now synthesizes one error `ToolMessage` (`status="error"`) per pending tool-call id from the saved `AIMessage.tool_calls` and writes them alongside the partial `AIMessage` in the **same** `aupdate_state` call, so the checkpointer never persists an `AIMessage` without its results. The `[SYSTEM]` cancellation `HumanMessage` still lands after. Construction is guarded (best-effort) so it can never skip the cancellation write or escape the cancel handler.

The headless path in `non_interactive.py` was checked: it drains UI hooks only and never writes a partial `AIMessage` to the checkpoint (`aupdate_state`), so no equivalent fix is needed there.

Made by [Open SWE](https://openswe.vercel.app/agents/80f025b0-594a-64ca-9f56-4f2ba62bdfc4)