### PR TITLE
style(code): hide terminal cursor in pre-TUI selectors

### DIFF
--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -909,7 +909,7 @@ def _prompt_yolo_acknowledgement(console: "Console") -> bool:
         app: Application[bool] = Application(
             layout=Layout(
                 Window(
-                    FormattedTextControl(rows),
+                    FormattedTextControl(rows, show_cursor=False),
                     height=len(choices) + 1,
                     dont_extend_height=True,
                 )
@@ -2968,7 +2968,7 @@ def _run_project_mcp_trust_action_picker(
         Application(
             layout=Layout(
                 Window(
-                    FormattedTextControl(_rows),
+                    FormattedTextControl(_rows, show_cursor=False),
                     height=len(actions) + 1,
                     dont_extend_height=True,
                 )
@@ -3161,12 +3161,12 @@ def _run_project_mcp_server_checkbox_picker(
             HSplit(
                 [
                     Window(
-                        FormattedTextControl(_help_text),
+                        FormattedTextControl(_help_text, show_cursor=False),
                         height=4,
                         dont_extend_height=True,
                     ),
                     Window(
-                        FormattedTextControl(_rows),
+                        FormattedTextControl(_rows, show_cursor=False),
                         height=visible_count,
                         dont_extend_height=True,
                     ),

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -9,11 +9,14 @@ from collections.abc import Callable, Iterator
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 from rich.console import Console
+
+if TYPE_CHECKING:
+    from prompt_toolkit.layout import Layout
 
 from deepagents_code.app import AppResult, DeepAgentsApp, run_textual_app
 from deepagents_code.config import build_langsmith_thread_url, reset_langsmith_url_cache
@@ -3614,6 +3617,23 @@ class TestCheckMcpProjectTrustPrompt:
         assert "require approval" not in err
 
 
+def _assert_all_controls_hide_cursor(layout: "Layout") -> None:
+    """Assert every text control in `layout` suppresses the terminal cursor.
+
+    Walks the layout instead of indexing into a fixed container/window shape so
+    the check stays valid if the selector's nesting changes.
+    """
+    from prompt_toolkit.layout.controls import FormattedTextControl
+
+    controls = [
+        control
+        for control in layout.find_all_controls()
+        if isinstance(control, FormattedTextControl)
+    ]
+    assert controls
+    assert all(control.show_cursor is False for control in controls)
+
+
 class TestPromptYoloAcknowledgement:
     """Tests for the inline YOLO acknowledgement selector."""
 
@@ -3650,7 +3670,7 @@ class TestPromptYoloAcknowledgement:
 
         _prompt_yolo_acknowledgement(Console(file=StringIO()))
 
-        assert captured["layout"].container.content.show_cursor is False
+        _assert_all_controls_hide_cursor(captured["layout"])
 
 
 class TestSelectProjectServersToPersist:
@@ -3805,7 +3825,7 @@ class TestSelectProjectServersToPersist:
         monkeypatch.setattr("prompt_toolkit.Application", _FakeApplication)
         _run_project_mcp_trust_action_picker(Console(stderr=True))
 
-        assert captured["layout"].container.content.show_cursor is False
+        _assert_all_controls_hide_cursor(captured["layout"])
 
     @pytest.mark.usefixtures("_interactive_picker_terminal")
     def test_action_picker_escape_aborts(
@@ -3982,8 +4002,7 @@ class TestSelectProjectServersToPersist:
         ]
         _run_project_mcp_server_checkbox_picker(servers, Console(stderr=True))
 
-        windows = captured["layout"].container.children
-        assert all(window.content.show_cursor is False for window in windows)
+        _assert_all_controls_hide_cursor(captured["layout"])
 
     @pytest.mark.usefixtures("_interactive_picker_terminal")
     def test_checkbox_picker_navigation_wraps(

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -3614,6 +3614,45 @@ class TestCheckMcpProjectTrustPrompt:
         assert "require approval" not in err
 
 
+class TestPromptYoloAcknowledgement:
+    """Tests for the inline YOLO acknowledgement selector."""
+
+    def test_yolo_selector_hides_terminal_cursor(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The selector suppresses the stray first-character terminal cursor."""
+        from deepagents_code.main import _prompt_yolo_acknowledgement
+
+        captured: dict[str, Any] = {}
+
+        class _FakeApplication:
+            def __class_getitem__(cls, _item: object) -> type["_FakeApplication"]:
+                return cls
+
+            def __init__(self, **kwargs: Any) -> None:
+                captured.update(kwargs)
+
+            def run(self) -> bool:
+                return False
+
+        monkeypatch.setattr(
+            "deepagents_code.main.sys.stdin", SimpleNamespace(isatty=lambda: True)
+        )
+        monkeypatch.setattr(
+            "deepagents_code.main.sys.stderr", SimpleNamespace(isatty=lambda: True)
+        )
+        monkeypatch.setattr(
+            "prompt_toolkit.output.defaults.create_output",
+            lambda **_kwargs: SimpleNamespace(),
+        )
+        monkeypatch.setattr("prompt_toolkit.Application", _FakeApplication)
+
+        _prompt_yolo_acknowledgement(Console(file=StringIO()))
+
+        assert captured["layout"].container.content.show_cursor is False
+
+
 class TestSelectProjectServersToPersist:
     """Tests for the "always allow" subset selection helpers."""
 
@@ -3737,6 +3776,36 @@ class TestSelectProjectServersToPersist:
         assert "Allow for this project — until changed" in rendered
         assert "Deny" in rendered
         assert "Choose how to continue" not in rendered
+
+    @pytest.mark.usefixtures("_interactive_picker_terminal")
+    def test_action_picker_hides_terminal_cursor(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The inline picker suppresses the stray first-character terminal cursor."""
+        from rich.console import Console
+
+        from deepagents_code.main import (
+            _ProjectMcpTrustAction,
+            _run_project_mcp_trust_action_picker,
+        )
+
+        captured: dict[str, Any] = {}
+
+        class _FakeApplication:
+            def __class_getitem__(cls, _item: object) -> type["_FakeApplication"]:
+                return cls
+
+            def __init__(self, **kwargs: Any) -> None:
+                captured.update(kwargs)
+
+            def run(self) -> _ProjectMcpTrustAction:
+                return _ProjectMcpTrustAction.DENY
+
+        monkeypatch.setattr("prompt_toolkit.Application", _FakeApplication)
+        _run_project_mcp_trust_action_picker(Console(stderr=True))
+
+        assert captured["layout"].container.content.show_cursor is False
 
     @pytest.mark.usefixtures("_interactive_picker_terminal")
     def test_action_picker_escape_aborts(
@@ -3882,6 +3951,39 @@ class TestSelectProjectServersToPersist:
 
         assert names == ["reference"]
         assert captured["full_screen"] is False
+
+    @pytest.mark.usefixtures("_interactive_picker_terminal")
+    def test_checkbox_picker_hides_terminal_cursor(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Both checkbox windows suppress the stray first-character cursor."""
+        from rich.console import Console
+
+        from deepagents_code.main import _run_project_mcp_server_checkbox_picker
+
+        captured: dict[str, Any] = {}
+
+        class _FakeApplication:
+            def __class_getitem__(cls, _item: object) -> type["_FakeApplication"]:
+                return cls
+
+            def __init__(self, **kwargs: Any) -> None:
+                captured.update(kwargs)
+
+            def run(self) -> list[str]:
+                return []
+
+        monkeypatch.setattr("prompt_toolkit.Application", _FakeApplication)
+
+        servers = [
+            ProjectServerSummary("docs", "stdio", "a"),
+            ProjectServerSummary("reference", "stdio", "b"),
+        ]
+        _run_project_mcp_server_checkbox_picker(servers, Console(stderr=True))
+
+        windows = captured["layout"].container.children
+        assert all(window.content.show_cursor is False for window in windows)
 
     @pytest.mark.usefixtures("_interactive_picker_terminal")
     def test_checkbox_picker_navigation_wraps(


### PR DESCRIPTION
The `dcode --yolo` acknowledgement selector and the project MCP trust prompts (shown before the Textual app starts) no longer leave the terminal cursor blinking on the first character while the selector is open.

---

These pre-TUI selectors render a `FormattedTextControl` inside a prompt_toolkit `Window`. Its `UIContent` defaults `cursor_position` to `Point(0, 0)` with `show_cursor=True`, so the focused window kept the terminal cursor visible on the first character. Passing `show_cursor=False` lets prompt_toolkit emit the hide-cursor sequence for the lifetime of each selector, which is the idiomatic fix rather than manually writing escape codes.

Applies to the YOLO acknowledgement selector, the project MCP trust action picker, and the server checkbox picker. Added unit tests asserting each control is built with `show_cursor=False`.

Made by [Open SWE](https://openswe.vercel.app/agents/03529f7d-97be-ece6-a6cc-bf661700873e)