### PR TITLE
fix(repo): remove obsolete frontend build target

### DIFF
--- a/libs/Makefile
+++ b/libs/Makefile
@@ -7,12 +7,10 @@ PACKAGE_DIRS := $(sort $(LIB_PACKAGE_DIRS) $(EXAMPLE_PACKAGE_DIRS))
 # acp requires 3.14, everything else uses 3.12
 python_version = $(if $(filter acp,$1),3.14,3.12)
 
-.PHONY: help lock no-cache lock-bump lock-check lint format build-frontends bench-all
+.PHONY: help lock no-cache lock-bump lock-check lint format bench-all
 
 LOCK_ARGS := $(if $(filter no-cache,$(MAKECMDGOALS)),--no-cache,)
 
-FRONTEND_SRC := cli/frontend
-FRONTEND_DEST := cli/deepagents_cli/deploy/frontend_dist
 BENCH_PACKAGES := deepagents code
 
 .DEFAULT_GOAL := help
@@ -69,16 +67,6 @@ format: ## Format all packages
 		$(MAKE) -C "$$dir" format; \
 	done
 	@echo "✅ All packages formatted!"
-
-build-frontends: ## Build the CLI frontend and copy into the deploy bundle
-	@set -e; \
-	echo "--> Building $(FRONTEND_SRC)"; \
-	( cd $(FRONTEND_SRC) && npm ci && npm run build ); \
-	echo "--> Copying dist into $(FRONTEND_DEST)"; \
-	rm -rf $(FRONTEND_DEST); \
-	mkdir -p $(FRONTEND_DEST); \
-	cp -R $(FRONTEND_SRC)/dist/. $(FRONTEND_DEST)/; \
-	echo "Frontend built: $(FRONTEND_DEST)"
 
 bench-all: ## Run benchmarks across all benched packages
 	@set -e; \


### PR DESCRIPTION
Closes #4959

The aggregate `libs` Makefile no longer advertises or invokes the deleted CLI frontend build.

---

PR #3609 removed `libs/cli/frontend` and its bundled deployment assets, but left the corresponding variables and `build-frontends` recipe in the aggregate Makefile. As a result, the advertised target always failed while changing into a directory that no longer exists.

This removes the stale variables, recipe, and `.PHONY` entry. Verified with `make -C libs help`, the expected absence of the removed target, and `git diff --check`.
