### PR TITLE
refactor(code): use concrete middleware backends

### DIFF
--- a/libs/code/deepagents_code/offload_middleware.py
+++ b/libs/code/deepagents_code/offload_middleware.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from deepagents.backends.protocol import (
-        BACKEND_TYPES,
         BackendProtocol,
         EditResult,
         FileDownloadResponse,
@@ -442,17 +441,13 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
             coroutine=async_compact,
         )
 
-    def _resolve_backend(self, runtime: ToolRuntime) -> BackendProtocol:
-        """Resolve the backend with fail-closed archive append behavior.
-
-        Args:
-            runtime: Runtime used to resolve backend factories.
+    def _guarded_backend(self) -> BackendProtocol:
+        """Wrap the configured backend with fail-closed archive append behavior.
 
         Returns:
             A backend adapter that refuses writes after raised archive reads.
         """
-        backend = super()._resolve_backend(runtime)
-        return cast("BackendProtocol", _ArchiveReadGuard(backend))
+        return cast("BackendProtocol", _ArchiveReadGuard(self._summarization._backend))
 
     def _summarization_for_runtime(
         self, runtime: ToolRuntime
@@ -464,7 +459,7 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
 
         Returns:
             The startup summarizer when no runtime model is selected, otherwise
-                a model-aware summarizer using the same resolved backend.
+                a model-aware summarizer using the same configured backend.
         """
         config = _runtime_model_config(runtime)
         if not config.model_spec:
@@ -498,7 +493,7 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
                         context_limit,
                         exc_info=True,
                     )
-        backend = self._resolve_backend(runtime)
+        backend = self._guarded_backend()
         return create_summarization_middleware(model, backend)
 
     def _run_forced_compact(self, runtime: ToolRuntime) -> Command:
@@ -536,7 +531,7 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
 
             to_summarize, _ = summarization._partition_messages(effective, cutoff)
             summary = summarization._create_summary(to_summarize)
-            backend = self._resolve_backend(runtime)
+            backend = self._guarded_backend()
             file_path = summarization._offload_to_backend(backend, to_summarize)
             # The inherited `_build_compact_result` produces the same event and
             # tool message as the SDK's gated path via model-independent helpers
@@ -571,7 +566,7 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
 
             to_summarize, _ = summarization._partition_messages(effective, cutoff)
             summary = await summarization._acreate_summary(to_summarize)
-            backend = self._resolve_backend(runtime)
+            backend = self._guarded_backend()
             file_path = await summarization._aoffload_to_backend(backend, to_summarize)
             # See `_run_forced_compact` for why the inherited builder is reused
             # and why it stays inside the `try`.
@@ -625,7 +620,7 @@ class CLICompactionMiddleware(SummarizationToolMiddleware):
 
 def _create_cli_compaction_middleware(
     model: str | BaseChatModel,
-    backend: BACKEND_TYPES,
+    backend: BackendProtocol,
 ) -> CLICompactionMiddleware:
     """Create the dcode compaction middleware from the SDK configuration.
 

--- a/libs/code/deepagents_code/plugins/adapters/skills_middleware.py
+++ b/libs/code/deepagents_code/plugins/adapters/skills_middleware.py
@@ -22,7 +22,7 @@ from deepagents_code.skills.merge import merge_skill
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from deepagents.backends.protocol import BACKEND_TYPES, BackendProtocol
+    from deepagents.backends.protocol import BackendProtocol
     from langchain_core.runnables import RunnableConfig
     from langgraph.runtime import Runtime
 
@@ -240,7 +240,7 @@ class PluginSkillsMiddleware(SkillsMiddleware):
     def __init__(
         self,
         *,
-        backend: BACKEND_TYPES,
+        backend: BackendProtocol,
         sources: Sequence[CodeSkillSource],
         system_prompt: str | None = sdk_skills.SKILLS_SYSTEM_PROMPT,
     ) -> None:
@@ -282,8 +282,8 @@ class PluginSkillsMiddleware(SkillsMiddleware):
     def before_agent(
         self,
         state: sdk_skills.SkillsState,
-        runtime: Runtime,
-        config: RunnableConfig,
+        runtime: Runtime,  # noqa: ARG002
+        config: RunnableConfig,  # noqa: ARG002
     ) -> sdk_skills.SkillsStateUpdate | None:
         """Load and namespace plugin skills before collision resolution.
 
@@ -294,7 +294,7 @@ class PluginSkillsMiddleware(SkillsMiddleware):
         if "skills_metadata" in state:
             return None
 
-        backend = self._get_backend(state, runtime, config)
+        backend = self._backend
         all_skills: dict[str, sdk_skills.SkillMetadata] = {}
         merged_source_labels: dict[str, str | None] = {}
         errors: list[str] = []
@@ -328,8 +328,8 @@ class PluginSkillsMiddleware(SkillsMiddleware):
     async def abefore_agent(
         self,
         state: sdk_skills.SkillsState,
-        runtime: Runtime,
-        config: RunnableConfig,
+        runtime: Runtime,  # noqa: ARG002
+        config: RunnableConfig,  # noqa: ARG002
     ) -> sdk_skills.SkillsStateUpdate | None:
         """Asynchronously load and namespace skills before collision resolution.
 
@@ -340,7 +340,7 @@ class PluginSkillsMiddleware(SkillsMiddleware):
         if "skills_metadata" in state:
             return None
 
-        backend = self._get_backend(state, runtime, config)
+        backend = self._backend
         all_skills: dict[str, sdk_skills.SkillMetadata] = {}
         merged_source_labels: dict[str, str | None] = {}
         errors: list[str] = []

--- a/libs/code/tests/unit_tests/test_compact_tool.py
+++ b/libs/code/tests/unit_tests/test_compact_tool.py
@@ -641,9 +641,8 @@ class TestSdkContractGuards:
         ):
             assert callable(getattr(SummarizationMiddleware, name, None)), name
 
-        # Called on the tool-middleware subclass itself.
+        # Inherited SDK helpers called on the tool-middleware subclass.
         for name in (
-            "_resolve_backend",
             "_build_compact_result",
             "_nothing_to_compact",
         ):


### PR DESCRIPTION
Related #4541

Deep Agents Code now uses concrete middleware backend instances directly, keeping plugin skill loading and forced conversation compaction compatible with the SDK after backend factory support was removed.

---

The SDK cleanup in #4541 removed `SkillsMiddleware._get_backend`, `SummarizationToolMiddleware._resolve_backend`, and `BACKEND_TYPES`. Deep Agents Code still depended on those compatibility paths, so plugin skill discovery raised `AttributeError` and forced `/offload` compaction failed.

Read each adapter's configured backend directly. The compaction adapter still wraps that backend in `_ArchiveReadGuard` to preserve fail-closed history writes. The SDK contract guard now tracks only the private parent helpers that remain inherited.
