### PR TITLE
ci(infra): collect `dcode` coverage on Python 3.14

### DIFF
--- a/.github/scripts/test_ci_workflow.py
+++ b/.github/scripts/test_ci_workflow.py
@@ -1,0 +1,21 @@
+"""Static contracts for the main CI workflow."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = ROOT / ".github/workflows/ci.yml"
+
+
+def test_deepagents_code_collects_coverage_on_python_3_14() -> None:
+    """Keep all supported runtimes while collecting coverage on Python 3.14."""
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+    config = workflow["jobs"]["test-code"]["with"]
+
+    assert json.loads(config["python-versions"]) == ["3.11", "3.12", "3.13", "3.14"]
+    assert config["coverage-python-version"] == "3.14"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
     with:
       working-directory: "libs/code"
       python-versions: '["3.11", "3.12", "3.13", "3.14"]'
-      coverage-python-version: "3.12"
+      coverage-python-version: "3.14"
 
   test-talon:
     name: "🧪 Test deepagents-talon"


### PR DESCRIPTION
Deep Agents Code currently collects coverage on Python 3.12, where coverage.py uses its C tracing core. Python 3.14 lets coverage.py 7.15.2 use CPython's `sys.monitoring` core by default, reducing instrumentation overhead on the coverage-enabled test leg.

This moves only coverage collection to the existing Python 3.14 leg. Tests continue to run on Python 3.11–3.14. A workflow contract keeps the supported matrix and coverage leg aligned.
