### PR TITLE
fix(code): show rubric grader defaults

### DIFF
--- a/libs/code/deepagents_code/_constants.py
+++ b/libs/code/deepagents_code/_constants.py
@@ -33,8 +33,8 @@ SDK_DEFAULT_RUBRIC_MAX_ITERATIONS: Final[int] = 3
 Hardcoded rather than read from `deepagents.middleware.rubric.RubricMiddleware`
 because this module is dependency-free and importing the SDK for a display
 string would violate the startup-performance rule (see AGENTS.md). This is a
-hand-maintained duplicate: if the SDK bumps its default, this value silently
-rots. `test_reliable_rubric.py::test_displayed_max_iterations_default_matches_sdk`
+hand-maintained duplicate that can rot if the SDK bumps its default, so
+`test_reliable_rubric.py::TestReliableRubricMiddleware::test_displayed_max_iterations_default_matches_sdk`
 is the drift guard that fails when the two diverge.
 """
 

--- a/libs/code/deepagents_code/_constants.py
+++ b/libs/code/deepagents_code/_constants.py
@@ -27,6 +27,17 @@ drift guards in `test_main_args` and `test_tool_catalog` pin it so a new or
 renamed SDK filesystem tool fails a test instead of silently diverging.
 """
 
+SDK_DEFAULT_RUBRIC_MAX_ITERATIONS: Final[int] = 3
+"""Default `RubricMiddleware.max_iterations`, shown without importing the SDK.
+
+Hardcoded rather than read from `deepagents.middleware.rubric.RubricMiddleware`
+because this module is dependency-free and importing the SDK for a display
+string would violate the startup-performance rule (see AGENTS.md). This is a
+hand-maintained duplicate: if the SDK bumps its default, this value silently
+rots. `test_reliable_rubric.py::test_displayed_max_iterations_default_matches_sdk`
+is the drift guard that fails when the two diverge.
+"""
+
 FIREWORKS_PROVIDER_ID_PREFIX: Final[str] = "accounts/fireworks/"
 """Prefix used to infer Fireworks from fully-qualified IDs."""
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -11580,7 +11580,7 @@ class DeepAgentsApp(App):
             title="Choose grader model for rubric",
             description=(
                 "Pick the model used to grade rubric criteria. Clear it with "
-                "`/rubric model clear` to reuse the current chat model."
+                "`/rubric model clear` to reuse the startup chat model."
             ),
         )
         self.push_screen(screen, handle_result)
@@ -11763,7 +11763,7 @@ class DeepAgentsApp(App):
             )
         else:
             await self._mount_message(
-                AppMessage("Rubric grader model cleared; using current chat model."),
+                AppMessage("Rubric grader model cleared; using startup chat model."),
             )
 
     async def _handle_command(self, command: str) -> None:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -58,6 +58,7 @@ from deepagents_code._cli_context import CLIContext
 from deepagents_code._constants import (
     DEFAULT_AGENT_NAME as DEFAULT_ASSISTANT_ID,
     MCP_REENABLED_PENDING_ERROR,
+    SDK_DEFAULT_RUBRIC_MAX_ITERATIONS,
     SYSTEM_MESSAGE_PREFIX,
 )
 from deepagents_code._git import (
@@ -3071,6 +3072,16 @@ class DeepAgentsApp(App):
         # Per-turn model overrides
         self._model_override: str | None = None
         """Per-turn model override set via `/model`; `None` uses session default."""
+
+        self._rubric_default_model: str | None = (server_kwargs or {}).get(
+            "model_name"
+        ) or (model_kwargs or {}).get("model_spec")
+        """Chat model captured when the rubric middleware is constructed.
+
+        Unlike `_effective_model_spec`, this does not follow per-turn `/model`
+        overrides because those only affect `ConfigurableModelMiddleware`; the
+        rubric middleware keeps using its construction-time model.
+        """
 
         self._model_params_override: dict[str, Any] | None = (
             model_kwargs.get("extra_kwargs") if model_kwargs is not None else None
@@ -10399,14 +10410,27 @@ class DeepAgentsApp(App):
     def _grader_display_values(self) -> tuple[str, str]:
         """Return display strings for the shared grader model and iteration cap.
 
-        Both fall back to human-readable defaults when unset. Shared by
-        `/goal show` and `/rubric show` so the default wording stays in sync.
+        When no explicit grader model is set, the model string reports the
+        rubric's construction-time chat model (`_rubric_default_model`, which
+        deliberately ignores per-turn `/model` overrides), falling back to a
+        bare "startup chat model" when that is unknown. An unset iteration cap
+        reports the concrete SDK default (`SDK_DEFAULT_RUBRIC_MAX_ITERATIONS`)
+        rather than the word "default". Shared by `/goal show` and
+        `/rubric show` so the default wording stays in sync.
         """
-        model = self._rubric_model or "current chat model"
+        if self._rubric_model:
+            model = self._rubric_model
+        else:
+            chat_model = self._rubric_default_model
+            model = (
+                f"startup chat model ({chat_model})"
+                if chat_model
+                else "startup chat model"
+            )
         iterations = (
             str(self._rubric_max_iterations)
             if self._rubric_max_iterations is not None
-            else "SDK default"
+            else f"{SDK_DEFAULT_RUBRIC_MAX_ITERATIONS} (SDK default)"
         )
         return model, iterations
 
@@ -21768,6 +21792,7 @@ class DeepAgentsApp(App):
         }
         self._model_kwargs = new_model_kwargs
         self._server_kwargs["model_name"] = display
+        self._rubric_default_model = display
         if extra_kwargs is not None:
             self._server_kwargs["model_params"] = extra_kwargs
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -7834,6 +7834,22 @@ class TestGoalCommand:
 
         assert model == "startup chat model"
 
+    def test_grader_display_falls_back_to_model_kwargs_spec(self) -> None:
+        """Without `server_kwargs`, the startup model comes from `model_kwargs`.
+
+        Guards the second arm of the `_rubric_default_model` `or` fallback,
+        which is the source when server startup was deferred with only a
+        `model_spec` supplied.
+        """
+        app = DeepAgentsApp(
+            agent=MagicMock(),
+            model_kwargs={"model_spec": "openai:gpt-5.5"},
+        )
+
+        model, _ = app._grader_display_values()
+
+        assert model == "startup chat model (openai:gpt-5.5)"
+
     @pytest.mark.parametrize("command", ["/goal", "/goal show"])
     async def test_goal_state_omits_redundant_commands(self, command: str) -> None:
         """Goal state should not repeat commands already shown in the input hint."""
@@ -9854,7 +9870,7 @@ class TestRubricCommand:
 
             rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
             assert "No rubric set." in rendered
-            assert "Rubric grader model: current chat model" not in rendered
+            assert "Rubric grader model:" not in rendered
 
     async def test_rubric_set_passes_sticky_rubric_to_turn(self) -> None:
         """`/rubric set` should apply to subsequent TUI agent turns."""
@@ -10884,7 +10900,7 @@ class TestRubricCommand:
             )
             assert respawn.await_count == 1
             rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
-            assert "Rubric grader model cleared; using current chat model." in rendered
+            assert "Rubric grader model cleared; using startup chat model." in rendered
 
     async def test_set_rubric_model_sets_before_owned_server_starts(self) -> None:
         """With owned server config, the grader model is staged and confirmed."""
@@ -19146,6 +19162,12 @@ class TestDeferredActions:
             assert app._server_startup_missing_provider_package is None
             assert app._server_startup_missing_credentials_provider is None
             assert app._server_startup_error is None
+
+            # The retry reconstructs the server with the new model, so the
+            # grader's construction-time model must follow it — otherwise
+            # `/goal show` / `/rubric show` would report the stale pre-retry
+            # model, the exact class of bug this display path exists to fix.
+            assert app._rubric_default_model == "anthropic:claude-opus-4-7"
 
             # A `/model` retry is a mid-session reconnect, not an initial
             # connect: both flags are set and the status bar reads

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -7789,7 +7789,11 @@ class TestGoalCommand:
 
     async def test_goal_show_grader_line_reports_defaults(self) -> None:
         """The grader line should spell out defaults when the grader is unset."""
-        app = DeepAgentsApp(agent=MagicMock())
+        app = DeepAgentsApp(
+            agent=MagicMock(),
+            server_kwargs={"model_name": "openai:gpt-5.5"},
+            defer_server_start=True,
+        )
         async with app.run_test() as pilot:
             await pilot.pause()
             app._active_goal = "ship the feature"
@@ -7800,8 +7804,35 @@ class TestGoalCommand:
 
             rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
             assert (
-                "Grader: current chat model · max iterations: SDK default" in rendered
+                "Grader: startup chat model (openai:gpt-5.5) · "
+                "max iterations: 3 (SDK default)" in rendered
             )
+
+    def test_grader_display_ignores_per_turn_model_override(self) -> None:
+        """A `/model` override should not be reported as the grader model."""
+        app = DeepAgentsApp(
+            agent=MagicMock(),
+            server_kwargs={"model_name": "anthropic:claude-sonnet-4-5"},
+        )
+        app._model_override = "openai:gpt-5.5"
+
+        model, _ = app._grader_display_values()
+
+        assert model == "startup chat model (anthropic:claude-sonnet-4-5)"
+
+    def test_grader_display_reports_bare_default_without_startup_model(self) -> None:
+        """With no startup model captured, the grader line omits the spec.
+
+        This is the state a fresh, unconfigured user sees on `/goal show` or
+        `/rubric show`, so guard against a regression rendering a stray
+        "startup chat model (None)".
+        """
+        app = DeepAgentsApp(agent=MagicMock())
+        assert app._rubric_default_model is None
+
+        model, _ = app._grader_display_values()
+
+        assert model == "startup chat model"
 
     @pytest.mark.parametrize("command", ["/goal", "/goal show"])
     async def test_goal_state_omits_redundant_commands(self, command: str) -> None:
@@ -10633,7 +10664,11 @@ class TestRubricCommand:
 
     async def test_rubric_state_reports_sdk_default_when_cap_unset(self) -> None:
         """`/rubric show` labels an unset cap as the SDK default."""
-        app = DeepAgentsApp(agent=MagicMock())
+        app = DeepAgentsApp(
+            agent=MagicMock(),
+            server_kwargs={"model_name": "openai:gpt-5.5"},
+            defer_server_start=True,
+        )
         async with app.run_test() as pilot:
             await pilot.pause()
             app._active_rubric = "tests pass"
@@ -10642,7 +10677,10 @@ class TestRubricCommand:
             await pilot.pause()
 
             rendered = "\n".join(str(w._content) for w in app.query(AppMessage))
-            assert "Rubric max iterations: SDK default" in rendered
+            assert (
+                "Rubric grader model: startup chat model (openai:gpt-5.5)" in rendered
+            )
+            assert "Rubric max iterations: 3 (SDK default)" in rendered
 
     async def test_set_rubric_max_iterations_rejects_without_owned_server(self) -> None:
         """External graph sessions cannot change construction-time rubric caps."""

--- a/libs/code/tests/unit_tests/test_reliable_rubric.py
+++ b/libs/code/tests/unit_tests/test_reliable_rubric.py
@@ -8,6 +8,7 @@ import pytest
 from deepagents.middleware.rubric import GraderResponse, RubricState
 from langchain_core.messages import AIMessage, HumanMessage
 
+from deepagents_code._constants import SDK_DEFAULT_RUBRIC_MAX_ITERATIONS
 from deepagents_code.reliable_rubric import (
     ReliableRubricMiddleware,
     _is_transient_grader_transport_error,
@@ -102,6 +103,16 @@ class TestTransientGraderTransportClassification:
 
 
 class TestReliableRubricMiddleware:
+    def test_displayed_max_iterations_default_matches_sdk(self) -> None:
+        """Drift guard for the TUI-display duplicate of the SDK default.
+
+        The constant must equal the `RubricMiddleware` default that the app
+        actually instantiates.
+        """
+        middleware = ReliableRubricMiddleware(model="fake-model")
+
+        assert middleware.max_iterations == SDK_DEFAULT_RUBRIC_MAX_ITERATIONS
+
     async def test_retries_only_grading_without_mutating_agent_transcript(self) -> None:
         middleware = ReliableRubricMiddleware(model="fake-model")
         error = httpx.ReadError(


### PR DESCRIPTION
`/goal show` and `/rubric show` now report the rubric grader's startup chat model and concrete default maximum iteration count, rather than implying that per-turn `/model` changes affect the grader or leaving the default unspecified.

---

The rubric middleware keeps the model chosen when the local server is constructed, while `/model` only changes the configurable chat model for later turns. Capturing that startup model keeps the displayed settings aligned with actual grading behavior.

The SDK's default iteration count remains duplicated in the dependency-light display path to preserve startup performance. A drift test compares it with the middleware default so the displayed value cannot silently become stale.

AI assistance was used to implement and prepare this contribution.
