### PR TITLE
fix(sdk): include HTTP status in rubric grader errors

### DIFF
--- a/libs/deepagents/deepagents/middleware/rubric.py
+++ b/libs/deepagents/deepagents/middleware/rubric.py
@@ -674,11 +674,13 @@ class RubricMiddleware(AgentMiddleware[RubricState, ContextT, ResponseT]):
         # `Exception`, so they propagate up the call stack and preserve
         # normal Python interrupt / asyncio cancellation semantics.
         logger.exception("RubricMiddleware grader failed")
+        status_code = getattr(exc, "status_code", None)
+        status_suffix = f" (HTTP {status_code})" if isinstance(status_code, int) and not isinstance(status_code, bool) else ""
         evaluation: RubricEvaluation = {
             "grading_run_id": grading_run_id,
             "iteration": iteration,
             "result": "grader_error",
-            "explanation": f"Grader raised {type(exc).__name__}: {exc}",
+            "explanation": f"Grader raised {type(exc).__name__}{status_suffix}: {exc}",
             "criteria": [],
         }
         self._emit(runtime, "rubric_evaluation_end", grading_run_id, iteration, evaluation)

--- a/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
@@ -278,7 +278,18 @@ class TestAfterAgentDirect:
         assert update["_rubric_status"] == "failed"
         assert "jump_to" not in update
 
-    def test_grader_exception_becomes_grader_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_grader_exception_includes_http_status_code(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class APIStatusError(RuntimeError):
+            status_code = 529
+
+        mw = RubricMiddleware(model=_STUB_MODEL, max_iterations=3)
+        _stub_grader(mw, monkeypatch, exc=APIStatusError("API overloaded"))
+        update = mw.after_agent(self._state(), _runtime())
+        assert update is not None
+        evals = update["_rubric_evaluations"]
+        assert evals[0]["explanation"] == "Grader raised APIStatusError (HTTP 529): API overloaded"
+
+    def test_grader_exception_without_status_preserves_explanation(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Infrastructure failures get the distinct `grader_error` status.
 
         Separate from `"failed"`, which the grader *itself* returns when
@@ -293,7 +304,7 @@ class TestAfterAgentDirect:
         evals = update["_rubric_evaluations"]
         assert len(evals) == 1
         assert evals[0]["result"] == "grader_error"
-        assert "grader exploded" in evals[0]["explanation"]
+        assert evals[0]["explanation"] == "Grader raised RuntimeError: grader exploded"
 
     def test_keyboard_interrupt_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # `KeyboardInterrupt` (and `asyncio.CancelledError`) are


### PR DESCRIPTION
Rubric grader failures now include a direct provider exception's integer HTTP status when available, while preserving the existing explanation for exceptions without one.

---

This makes overloaded and gateway failures distinguishable in acceptance-criteria grading without coupling `RubricMiddleware` to a provider SDK. Non-integer values are ignored, and grader retry and classification behavior is unchanged.
