### PR TITLE
fix(infra): remove invalid root interpreter path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,7 +67,6 @@
     "editor.insertSpaces": true
   },
   "python.terminal.activateEnvironment": false,
-  "python.defaultInterpreterPath": "./.venv/bin/python",
   "github.copilot.chat.commitMessageGeneration.instructions": [
     {
       "file": ".github/workflows/pr_lint.yml"


### PR DESCRIPTION
VS Code no longer warns that `./.venv/bin/python` cannot be resolved when opening the repository root or its worktrees.

---

This monorepo has no root Python project or root virtual environment. Each package owns its environment inside its package directory, so the repository-level interpreter setting pointed to a location that should not exist. Removing the default lets Python tooling discover the appropriate package environment instead.