### PR TITLE
style(code): render `-m` slash prompts as plain agent text

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -8096,7 +8096,10 @@ class DeepAgentsApp(App):
         # readiness before creating a placeholder that nobody will remove.
         if not self._connecting or self._initial_prompt_queued_widget is not None:
             return
-        queued_widget = QueuedUserMessage(self._initial_prompt)
+        # The `-m` prompt is always sent as literal agent text (never a slash
+        # or shell command), so a leading `/` (e.g. a file path) must render as
+        # a plain user message rather than a slash command.
+        queued_widget = QueuedUserMessage(self._initial_prompt, detect_mode=False)
         self._initial_prompt_queued_widget = queued_widget
         await self._mount_message(queued_widget)
         self._sync_status_queued()
@@ -13229,8 +13232,14 @@ class DeepAgentsApp(App):
             message: The user's message
         """
         # Mount the user message, tracking it so it can be dimmed on interrupt.
+        # Everything routed here is literal agent text (slash/shell commands go
+        # through `_handle_command`/`_handle_shell_command`), so disable mode
+        # detection: a leading `/` (e.g. a file path from `-m`) must render as a
+        # plain user message rather than a slash command.
         media_snapshot = self._image_tracker.snapshot()
-        user_message = UserMessage(message, media_snapshot=media_snapshot)
+        user_message = UserMessage(
+            message, media_snapshot=media_snapshot, detect_mode=False
+        )
         await self._mount_message(user_message)
         self._active_user_message = user_message
         await self._send_to_agent(message)

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -289,6 +289,7 @@ class UserMessage(Static):
         content: str,
         *,
         media_snapshot: MediaTracker | None = None,
+        detect_mode: bool = True,
         **kwargs: Any,
     ) -> None:
         """Initialize a user message.
@@ -296,11 +297,18 @@ class UserMessage(Static):
         Args:
             content: The message content
             media_snapshot: Optional media tracker state captured at submission.
+            detect_mode: When `True` (default), a leading mode trigger (`/`,
+                `!`, `!!`) is rendered with its shell/command glyph, border, and
+                highlight. Set to `False` for text submitted as literal agent
+                input (e.g. via `-m`/`--message`), which never triggers a
+                shell/command mode, so a leading slash (like a file path) must
+                render as a plain user message rather than a slash command.
             **kwargs: Additional arguments passed to parent
         """
         super().__init__(**kwargs)
         self._content = content
         self._media_snapshot = media_snapshot
+        self._detect_mode = detect_mode
 
     @property
     def raw_text(self) -> str:
@@ -350,7 +358,7 @@ class UserMessage(Static):
         """
         colors = theme.get_theme_colors(self)
         content = self._content
-        mode_match = detect_mode_prefix(content)
+        mode_match = detect_mode_prefix(content) if self._detect_mode else None
         if mode_match:
             prefix_text, mode = mode_match
             glyph = MODE_DISPLAY_GLYPHS.get(mode, prefix_text[0])
@@ -375,7 +383,7 @@ class UserMessage(Static):
 
     def on_mount(self) -> None:
         """Add CSS classes for mode-specific border and ASCII border type."""
-        mode_match = detect_mode_prefix(self._content)
+        mode_match = detect_mode_prefix(self._content) if self._detect_mode else None
         if mode_match:
             _prefix, mode = mode_match
             self.add_class(f"-mode-{mode.replace('_', '-')}")
@@ -418,8 +426,13 @@ class UserMessage(Static):
 
             # The regex only matches tokens starting with / or @
             if token.startswith("/") and start == 0:
-                # /command at start
-                parts.append((token, f"bold {colors.warning}"))
+                # A leading `/command` is only highlighted when mode detection
+                # is on; otherwise it is literal text (e.g. a file path passed
+                # via `-m`) and must render plain so the token is not dropped.
+                if self._detect_mode:
+                    parts.append((token, f"bold {colors.warning}"))
+                else:
+                    parts.append(token)
             elif token.startswith("@"):
                 # @file mention
                 parts.append((token, f"bold {colors.primary}"))
@@ -451,15 +464,23 @@ class QueuedUserMessage(Static):
     """
     """Dimmed border + reduced opacity to distinguish queued messages from sent ones."""
 
-    def __init__(self, content: str, **kwargs: Any) -> None:
+    def __init__(
+        self, content: str, *, detect_mode: bool = True, **kwargs: Any
+    ) -> None:
         """Initialize a queued user message.
 
         Args:
             content: The message content
+            detect_mode: When `True` (default), a leading mode trigger (`/`,
+                `!`, `!!`) is rendered with its shell/command glyph. Set to
+                `False` for text queued as literal agent input (e.g. via
+                `-m`/`--message`), so a leading slash (like a file path) renders
+                as a plain user message rather than a slash command.
             **kwargs: Additional arguments passed to parent
         """
         super().__init__(**kwargs)
         self._content = content
+        self._detect_mode = detect_mode
 
     def on_mount(self) -> None:
         """Add ASCII border class when in ASCII mode."""
@@ -492,7 +513,7 @@ class QueuedUserMessage(Static):
         """
         colors = theme.get_theme_colors(self)
         content = self._content
-        mode_match = detect_mode_prefix(content)
+        mode_match = detect_mode_prefix(content) if self._detect_mode else None
         if mode_match:
             prefix_text, mode = mode_match
             glyph = MODE_DISPLAY_GLYPHS.get(mode, prefix_text[0])

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -3754,6 +3754,33 @@ class TestMessageQueue:
             assert app._status_bar.queued_count == 1
             assert not app.query(StartupTip)
 
+    async def test_initial_prompt_slash_path_renders_as_plain_message(self) -> None:
+        """A `-m` prompt starting with `/` must not render as a slash command.
+
+        `-m`/`--message` text is always sent as literal agent text, so a leading
+        slash (like a file path) should render with the plain `'> '` prefix in
+        both the queued placeholder and the submitted `UserMessage`.
+        """
+        app = DeepAgentsApp(initial_prompt="/etc/hosts explain this")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._connecting = True
+
+            await app._show_initial_prompt_as_queued()
+            await pilot.pause()
+
+            placeholder = app.query(QueuedUserMessage).first()
+            assert placeholder._detect_mode is False
+            assert placeholder.render().plain == "> /etc/hosts explain this"
+
+            app._connecting = False
+            await app._handle_user_message(app._initial_prompt or "")
+            await pilot.pause()
+
+            submitted = app.query(UserMessage).first()
+            assert submitted._detect_mode is False
+            assert submitted.render().plain == "> /etc/hosts explain this"
+
     async def test_initial_prompt_placeholder_replaced_on_submission(self) -> None:
         """Submitting the `-m` prompt drops the placeholder and sends the message."""
         app = DeepAgentsApp(initial_prompt="hello world")

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -3657,6 +3657,24 @@ class TestUserMessageModeRendering:
         content = _render_content(UserMessage(""))
         assert content.plain == "> "
 
+    def test_detect_mode_false_renders_leading_slash_as_plain(self) -> None:
+        """A `-m` file-path prompt should render `'> '` plus the full path.
+
+        `-m`/`--message` text is always literal agent input, so a leading slash
+        (like a file path) must not be treated as a slash command.
+        """
+        content = _render_content(
+            UserMessage("/etc/hosts explain this", detect_mode=False)
+        )
+        assert content.plain == "> /etc/hosts explain this"
+        first_span = content._spans[0]
+        assert theme.DARK_COLORS.primary in str(first_span.style)
+
+    def test_detect_mode_false_renders_leading_bang_as_plain(self) -> None:
+        """A leading `!` in literal agent text should not render as shell mode."""
+        content = _render_content(UserMessage("!important note", detect_mode=False))
+        assert content.plain == "> !important note"
+
 
 class TestModeColorsDrift:
     """Ensure `_mode_color` handles every mode in `MODE_PREFIXES`."""
@@ -3700,6 +3718,13 @@ class TestQueuedUserMessageModeRendering:
         """`QueuedUserMessage('')` should not crash and should render `'> '`."""
         content = _render_content(QueuedUserMessage(""))
         assert content.plain == "> "
+
+    def test_detect_mode_false_renders_leading_slash_as_plain(self) -> None:
+        """A queued `-m` file-path prompt should render dimmed `'> '` plus path."""
+        content = _render_content(
+            QueuedUserMessage("/etc/hosts explain this", detect_mode=False)
+        )
+        assert content.plain == "> /etc/hosts explain this"
 
 
 class TestStripPromptPrefix:


### PR DESCRIPTION
A prompt passed via `-m`/`--message` that starts with a slash (like a file path) now renders as a normal user message in the TUI instead of a slash command.

---

Text supplied through `-m`/`--message` is always dispatched as literal agent input — it never triggers a slash or shell command. However, `UserMessage` and its queued placeholder unconditionally ran mode-prefix detection on the raw content, so a leading `/` (e.g. `-m /etc/hosts explain this`) was rendered with the command glyph, command border, and command highlight, misrepresenting what was actually sent.

This adds a `detect_mode` flag (default `True`, so all existing slash/shell command displays are unchanged) to `UserMessage` and `QueuedUserMessage`, and disables it on the `-m` startup paths. Those paths route exclusively through `_handle_user_message`, which only ever carries literal agent text, so mode detection is turned off there for both the connecting placeholder and the submitted message. When detection is off, a leading `/command` token is emitted as plain text rather than being dropped by the highlighter.

Made by [Open SWE](https://openswe.vercel.app/agents/4c6eb77f-8a71-8326-97b9-89c073251068)