### PR TITLE
refactor(sdk): correct prompt docs and harden rubric diagnostics

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -348,20 +348,25 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             To drop a built-in tool, register a
             [`HarnessProfile`][deepagents.HarnessProfile] with
             `excluded_tools`.
-        system_prompt: Custom system instructions placed at the front of
-            the system prompt sent to the model.
+        system_prompt: Caller-authored system instructions (`USER`) placed
+            first in the system prompt sent to the model.
 
-            Whatever you pass here always sits before the SDK's default
-            deep-agent prompt and any model-tuning suffix from a
-            registered `HarnessProfile`. With `system_prompt=None`, the
-            SDK default is used on its own (plus the profile suffix
-            when one applies). Sections are joined by a blank line.
+            The final authored prompt is assembled as `USER` -> `BASE` -> `SUFFIX`.
+            `BASE` is empty unless the active
+            [`HarnessProfile`][deepagents.HarnessProfile] defines
+            `base_system_prompt`, and `SUFFIX` is the profile's optional
+            `system_prompt_suffix`. Parts are separated by blank lines.
 
-            Passing a `SystemMessage` instead of a string preserves any
-            `cache_control` markers on the message's content blocks —
-            useful for placing explicit Anthropic prompt-cache
-            breakpoints. The same ordering applies (caller's blocks
-            first, SDK content appended as an additional text block).
+            With `system_prompt=None` and no matching profile prompt, the
+            model receives an empty authored system prompt. Pass
+            `system_prompt=BASE_AGENT_PROMPT` explicitly to opt into the
+            built-in persona and task guidance.
+
+            Passing a `SystemMessage` preserves any `cache_control` markers
+            on its existing content blocks — useful for explicit Anthropic
+            prompt-cache breakpoints. When profile content is present, its
+            assembled `BASE` and `SUFFIX` are appended as an additional text content block
+            after the caller's blocks.
 
             See [Prompt assembly](https://docs.langchain.com/oss/deepagents/customization#prompt-assembly)
             for the full case-by-case breakdown.

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -359,8 +359,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
 
             With `system_prompt=None` and no profile `base_system_prompt` or
             `system_prompt_suffix`, the model receives an empty authored system
-            prompt. Pass `system_prompt=BASE_AGENT_PROMPT` explicitly to opt
-            into the built-in persona and task guidance.
+            prompt.
 
             Passing a `SystemMessage` preserves any `cache_control` markers
             on its existing content blocks — useful for explicit Anthropic

--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -357,16 +357,16 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
             `base_system_prompt`, and `SUFFIX` is the profile's optional
             `system_prompt_suffix`. Parts are separated by blank lines.
 
-            With `system_prompt=None` and no matching profile prompt, the
-            model receives an empty authored system prompt. Pass
-            `system_prompt=BASE_AGENT_PROMPT` explicitly to opt into the
-            built-in persona and task guidance.
+            With `system_prompt=None` and no profile `base_system_prompt` or
+            `system_prompt_suffix`, the model receives an empty authored system
+            prompt. Pass `system_prompt=BASE_AGENT_PROMPT` explicitly to opt
+            into the built-in persona and task guidance.
 
             Passing a `SystemMessage` preserves any `cache_control` markers
             on its existing content blocks — useful for explicit Anthropic
             prompt-cache breakpoints. When profile content is present, its
-            assembled `BASE` and `SUFFIX` are appended as an additional text content block
-            after the caller's blocks.
+            assembled `BASE` and `SUFFIX` are appended as an additional text
+            content block after the caller's blocks.
 
             See [Prompt assembly](https://docs.langchain.com/oss/deepagents/customization#prompt-assembly)
             for the full case-by-case breakdown.

--- a/libs/deepagents/deepagents/middleware/rubric.py
+++ b/libs/deepagents/deepagents/middleware/rubric.py
@@ -384,11 +384,23 @@ def _fallback_structured_output_model_patterns() -> Sequence[str] | None:
     try:
         factory = import_module("langchain.agents.factory")
     except ImportError:
+        logger.debug(
+            "Could not import LangChain's fallback-model patterns for rubric grader diagnostics",
+            exc_info=True,
+        )
         return None
     patterns = getattr(factory, "FALLBACK_MODELS_WITH_STRUCTURED_OUTPUT", None)
+    if patterns is None:
+        logger.debug("LangChain's fallback-model patterns are unavailable for rubric grader diagnostics")
+        return None
     if isinstance(patterns, str) or not isinstance(patterns, Sequence):
+        logger.debug(
+            "LangChain's fallback-model patterns have unsupported type %s",
+            type(patterns).__name__,
+        )
         return None
     if not all(isinstance(pattern, str) for pattern in patterns):
+        logger.debug("LangChain's fallback-model patterns contain non-string values")
         return None
     return patterns
 

--- a/libs/deepagents/deepagents/middleware/rubric.py
+++ b/libs/deepagents/deepagents/middleware/rubric.py
@@ -16,7 +16,8 @@ import logging
 import re
 import secrets
 import uuid
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
+from importlib import import_module
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -26,7 +27,6 @@ from typing import (
 )
 
 from langchain.agents import create_agent
-from langchain.agents.factory import FALLBACK_MODELS_WITH_STRUCTURED_OUTPUT
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,
@@ -52,7 +52,7 @@ from pydantic import BaseModel, Discriminator, Field, model_validator
 from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable
 
     from langchain_core.language_models import BaseChatModel
     from langchain_core.tools import BaseTool
@@ -375,6 +375,24 @@ def _strategy_from_exception(exc: BaseException) -> _StructuredOutputStrategy | 
     return None
 
 
+def _fallback_structured_output_model_patterns() -> Sequence[str] | None:
+    """Load LangChain's private fallback-model patterns when available.
+
+    These patterns support trace diagnostics only. If LangChain relocates or
+    removes them, grading must continue without a model-based prediction.
+    """
+    try:
+        factory = import_module("langchain.agents.factory")
+    except ImportError:
+        return None
+    patterns = getattr(factory, "FALLBACK_MODELS_WITH_STRUCTURED_OUTPUT", None)
+    if isinstance(patterns, str) or not isinstance(patterns, Sequence):
+        return None
+    if not all(isinstance(pattern, str) for pattern in patterns):
+        return None
+    return patterns
+
+
 def _strategy_from_model(
     model: object,
     *,
@@ -384,8 +402,9 @@ def _strategy_from_model(
 
     This mirrors LangChain's model-profile and known-model fallbacks, including
     its tool-calling exception for Gemini models before Gemini 3. A configured
-    model string means resolution did not finish, so its strategy is unknown;
-    every resolved model ineligible for provider output uses `ToolStrategy`.
+    model string means resolution did not finish, so its strategy is unknown.
+    If LangChain's private fallback-model table is unavailable, predictions
+    that depend on it are also unknown.
     """
     if isinstance(model, str):
         return None
@@ -396,7 +415,10 @@ def _strategy_from_model(
         if has_tools and normalized is not None and "gemini" in normalized and "gemini-3" not in normalized:
             return "ToolStrategy"
         return "ProviderStrategy"
-    if normalized is not None and any(re.search(pattern, normalized) for pattern in FALLBACK_MODELS_WITH_STRUCTURED_OUTPUT):
+    fallback_patterns = _fallback_structured_output_model_patterns()
+    if fallback_patterns is None:
+        return None
+    if normalized is not None and any(re.search(pattern, normalized) for pattern in fallback_patterns):
         return "ProviderStrategy"
     return "ToolStrategy"
 

--- a/libs/deepagents/deepagents/profiles/harness/_openai_codex.py
+++ b/libs/deepagents/deepagents/profiles/harness/_openai_codex.py
@@ -6,9 +6,9 @@ runtime defaults with how Codex was trained to operate — autonomous
 senior engineer demeanor, bias to action, parallel tool use, and TODO
 hygiene.
 
-The suffix is appended to whatever `base_system_prompt` is ultimately
-assembled for the agent, so it layers cleanly on top of user- or
-SDK-provided base prompts without fighting them.
+The suffix is appended last to each assembled prompt, so it layers cleanly
+on top of caller and profile content for the main agent and each subagent's
+own authored base prompt.
 
 Per-model keys (not the `"openai"` prefix) keep the default behavior of
 non-Codex OpenAI models unchanged.

--- a/libs/deepagents/deepagents/profiles/harness/harness_profiles.py
+++ b/libs/deepagents/deepagents/profiles/harness/harness_profiles.py
@@ -254,27 +254,25 @@ class HarnessProfileConfig:
     """
 
     base_system_prompt: str | None = None
-    """`CUSTOM` slot in the prompt assembly order — replaces the base prompt
-    when set.
+    """`BASE` slot in the prompt assembly order.
 
-    `None` (the default) leaves the base prompt unchanged. The main agent has
-    no authored base prompt by default.
+    When applied to a stack, this replaces its authored base prompt. `None`
+    (the default) leaves that base unchanged; the main agent has no authored
+    base prompt by default.
 
-    If both `base_system_prompt` and `system_prompt_suffix` are set, the
-    suffix is appended to this custom base. A caller-supplied
-    `system_prompt=` is still placed before this base — see
+    For the main agent, a caller-supplied `system_prompt=` (`USER`) is placed
+    before this `BASE`, and `system_prompt_suffix` (`SUFFIX`) follows it. See
     `create_deep_agent`'s `system_prompt` parameter or
     [Prompt assembly](https://docs.langchain.com/oss/deepagents/customization#prompt-assembly)
     for the full assembly order.
     """
 
     system_prompt_suffix: str | None = None
-    """`SUFFIX` slot in the prompt assembly order — text appended to
-    the assembled base system prompt.
+    """`SUFFIX` slot in the prompt assembly order.
 
-    Always sits last (after `BASE` or `CUSTOM`) so model-tuning guidance
-    lands closest to the conversation history. `None` (the default)
-    means no suffix.
+    This text is appended last — after `USER` and `BASE` for the main agent —
+    so model-tuning guidance lands closest to the conversation history. `None`
+    (the default) means no suffix.
     """
 
     tool_description_overrides: Mapping[str, str] = field(default_factory=dict)
@@ -544,30 +542,28 @@ class HarnessProfile:
     """
 
     base_system_prompt: str | None = None
-    """`CUSTOM` slot in the prompt assembly order — replaces the base prompt
-    when set.
+    """`BASE` slot in the prompt assembly order.
 
-    `None` (the default) leaves the base prompt unchanged. The main agent has
-    no authored base prompt by default.
+    When applied to a stack, this replaces its authored base prompt. `None`
+    (the default) leaves that base unchanged; the main agent has no authored
+    base prompt by default.
 
-    If both `base_system_prompt` and `system_prompt_suffix` are set, the
-    suffix is appended to this custom base. A caller-supplied
-    `system_prompt=` is still placed before this base — see
+    For the main agent, a caller-supplied `system_prompt=` (`USER`) is placed
+    before this `BASE`, and `system_prompt_suffix` (`SUFFIX`) follows it. See
     `create_deep_agent`'s `system_prompt` parameter or
     [Prompt assembly](https://docs.langchain.com/oss/deepagents/customization#prompt-assembly)
     for the full assembly order.
 
-    Most profiles only set `system_prompt_suffix` to layer model-tuning
-    guidance on top of the SDK base.
+    Most profiles only set `system_prompt_suffix`, so each stack retains its
+    own base prompt and the main agent's authored base remains empty.
     """
 
     system_prompt_suffix: str | None = None
-    """`SUFFIX` slot in the prompt assembly order — text appended to
-    the assembled base system prompt.
+    """`SUFFIX` slot in the prompt assembly order.
 
-    Always sits last (after `BASE` or `CUSTOM`) so model-tuning guidance
-    lands closest to the conversation history. `None` (the default)
-    means no suffix.
+    This text is appended last — after `USER` and `BASE` for the main agent —
+    so model-tuning guidance lands closest to the conversation history. `None`
+    (the default) means no suffix.
 
     Applied uniformly to every assembled stack that consults this
     profile: the main agent, declarative subagents whose model resolves

--- a/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
@@ -592,6 +592,53 @@ class TestGraderPlumbing:
 
         assert mw._grader_trace_metadata()["rubric_grader_effective_strategy"] == "unknown"
 
+    @pytest.mark.parametrize(
+        "patterns",
+        [
+            "gpt-4.1",
+            [123],
+        ],
+    )
+    def test_grader_metadata_strategy_is_unknown_for_invalid_fallback_models(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        patterns: object,
+    ) -> None:
+        monkeypatch.setattr(
+            "deepagents.middleware.rubric.import_module",
+            lambda _name: SimpleNamespace(
+                FALLBACK_MODELS_WITH_STRUCTURED_OUTPUT=patterns,
+            ),
+        )
+        mw = RubricMiddleware(model="openai:gpt-4.1")
+        monkeypatch.setattr(
+            mw,
+            "_resolved_model",
+            SimpleNamespace(model_name="gpt-4.1", profile=None),
+        )
+
+        assert mw._grader_trace_metadata()["rubric_grader_effective_strategy"] == "unknown"
+
+    def test_grader_metadata_uses_model_profile_without_fallback_models(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "deepagents.middleware.rubric.import_module",
+            lambda _name: SimpleNamespace(),
+        )
+        mw = RubricMiddleware(model="provider:profiled-model")
+        monkeypatch.setattr(
+            mw,
+            "_resolved_model",
+            SimpleNamespace(
+                model_name="profiled-model",
+                profile={"structured_output": True},
+            ),
+        )
+
+        assert mw._grader_trace_metadata()["rubric_grader_effective_strategy"] == "ProviderStrategy"
+
     def test_grade_records_model_strategy_and_preserves_inherited_metadata(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_rubric_middleware.py
@@ -530,13 +530,22 @@ class TestGraderPlumbing:
             ("custom-model", None, "ToolStrategy"),
         ],
     )
-    def test_grader_metadata_matches_langchain_model_strategy(
+    def test_grader_metadata_uses_langchain_fallback_models(
         self,
         monkeypatch: pytest.MonkeyPatch,
         model_name: str,
         profile: dict[str, bool] | None,
         expected_strategy: str,
     ) -> None:
+        monkeypatch.setattr(
+            "deepagents.middleware.rubric.import_module",
+            lambda _name: SimpleNamespace(
+                FALLBACK_MODELS_WITH_STRUCTURED_OUTPUT=[
+                    r"gpt-4\.1",
+                    r"claude-sonnet-4-6",
+                ]
+            ),
+        )
         mw = RubricMiddleware(model=f"provider:{model_name}")
         monkeypatch.setattr(
             mw,
@@ -545,6 +554,43 @@ class TestGraderPlumbing:
         )
 
         assert mw._grader_trace_metadata()["rubric_grader_effective_strategy"] == expected_strategy
+
+    def test_grader_metadata_strategy_is_unknown_without_langchain_fallback_models(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "deepagents.middleware.rubric.import_module",
+            lambda _name: SimpleNamespace(),
+        )
+        mw = RubricMiddleware(model="openai:gpt-4.1")
+        monkeypatch.setattr(
+            mw,
+            "_resolved_model",
+            SimpleNamespace(model_name="gpt-4.1", profile=None),
+        )
+
+        assert mw._grader_trace_metadata()["rubric_grader_effective_strategy"] == "unknown"
+
+    def test_grader_metadata_strategy_is_unknown_without_langchain_factory(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def unavailable_factory(_name: str) -> None:
+            raise ImportError
+
+        monkeypatch.setattr(
+            "deepagents.middleware.rubric.import_module",
+            unavailable_factory,
+        )
+        mw = RubricMiddleware(model="openai:gpt-4.1")
+        monkeypatch.setattr(
+            mw,
+            "_resolved_model",
+            SimpleNamespace(model_name="gpt-4.1", profile=None),
+        )
+
+        assert mw._grader_trace_metadata()["rubric_grader_effective_strategy"] == "unknown"
 
     def test_grade_records_model_strategy_and_preserves_inherited_metadata(
         self,

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 import shutil
 import subprocess
@@ -534,6 +535,18 @@ class TestPromptCachingWiring:
 class TestSystemPromptAssembly:
     """Tests for system prompt assembly: profile base_system_prompt, suffix, and user prompt interaction."""
 
+    def test_public_docstring_describes_prompt_assembly(self) -> None:
+        docstring = inspect.getdoc(create_deep_agent)
+
+        assert docstring is not None
+        assert "`USER` -> `BASE` -> `SUFFIX`" in docstring
+        assert "`BASE` is empty unless" in docstring
+        assert "With `system_prompt=None` and no matching profile prompt" in docstring
+        assert "`system_prompt=BASE_AGENT_PROMPT` explicitly" in docstring
+        assert "appended as an additional text content block" in docstring
+        assert "`cache_control` markers" in docstring
+        assert "SDK's default deep-agent prompt" not in docstring
+
     def _build_and_capture_system_prompt(self, profile_key: str, profile: HarnessProfile, **kwargs: Any) -> str | SystemMessage:
         """Register a profile, call create_deep_agent, return the system_prompt passed to create_agent."""
         original = dict(_HARNESS_PROFILES)
@@ -614,18 +627,39 @@ class TestSystemPromptAssembly:
         assert prompt == "User instructions.\n\nCustom base.\n\nExtra."
         assert BASE_AGENT_PROMPT not in prompt
 
-    def test_system_message_with_profile_base(self) -> None:
-        msg = SystemMessage(content="User content.")
+    def test_system_message_preserves_caller_blocks_and_appends_profile_prompt(self) -> None:
+        caller_block = {
+            "type": "text",
+            "text": "User content.",
+            "cache_control": {"type": "ephemeral"},
+        }
+        msg = SystemMessage(content=[caller_block])
         result = self._build_and_capture_system_prompt(
             "custprov",
-            HarnessProfile(base_system_prompt="Custom base."),
+            HarnessProfile(
+                base_system_prompt="Custom base.",
+                system_prompt_suffix="Extra.",
+            ),
             system_prompt=msg,
         )
+
         assert isinstance(result, SystemMessage)
-        # Last content block should contain the custom base.
-        last_block = result.content_blocks[-1]
-        assert "Custom base." in last_block["text"]
-        assert BASE_AGENT_PROMPT not in last_block["text"]
+        assert result.content_blocks == [
+            caller_block,
+            {"type": "text", "text": "\n\nCustom base.\n\nExtra."},
+        ]
+        assert msg.content_blocks == [caller_block]
+
+    def test_system_message_without_profile_prompt_is_passed_through(self) -> None:
+        msg = SystemMessage(content="User content.")
+
+        result = self._build_and_capture_system_prompt(
+            "defprov",
+            HarnessProfile(),
+            system_prompt=msg,
+        )
+
+        assert result is msg
 
     def test_empty_string_base_system_prompt_replaces_with_empty(self) -> None:
         prompt = self._build_and_capture_system_prompt(

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 import logging
 import shutil
 import subprocess
@@ -25,7 +24,6 @@ from deepagents.backends import StateBackend
 from deepagents.graph import (
     _REQUIRED_MIDDLEWARE_CLASSES,
     _REQUIRED_MIDDLEWARE_NAMES,
-    BASE_AGENT_PROMPT,
     DeepAgentState,
     _apply_custom_middleware,
     create_deep_agent,
@@ -535,19 +533,6 @@ class TestPromptCachingWiring:
 class TestSystemPromptAssembly:
     """Tests for system prompt assembly: profile base_system_prompt, suffix, and user prompt interaction."""
 
-    def test_public_docstring_describes_prompt_assembly(self) -> None:
-        raw_docstring = inspect.getdoc(create_deep_agent)
-
-        assert raw_docstring is not None
-        docstring = " ".join(raw_docstring.split())
-        assert "`USER` -> `BASE` -> `SUFFIX`" in docstring
-        assert "`BASE` is empty unless" in docstring
-        assert "With `system_prompt=None` and no profile `base_system_prompt` or" in docstring
-        assert "`system_prompt=BASE_AGENT_PROMPT` explicitly" in docstring
-        assert "appended as an additional text content block" in docstring
-        assert "`cache_control` markers" in docstring
-        assert "SDK's default deep-agent prompt" not in docstring
-
     def _build_and_capture_system_prompt(self, profile_key: str, profile: HarnessProfile, **kwargs: Any) -> str | SystemMessage:
         """Register a profile, call create_deep_agent, return the system_prompt passed to create_agent."""
         original = dict(_HARNESS_PROFILES)
@@ -579,7 +564,6 @@ class TestSystemPromptAssembly:
             HarnessProfile(base_system_prompt="You are a custom agent."),
         )
         assert prompt == "You are a custom agent."
-        assert BASE_AGENT_PROMPT not in prompt
 
     def test_profile_base_system_prompt_with_suffix(self) -> None:
         prompt = self._build_and_capture_system_prompt(
@@ -590,7 +574,6 @@ class TestSystemPromptAssembly:
             ),
         )
         assert prompt == "You are a custom agent.\n\nBe concise."
-        assert BASE_AGENT_PROMPT not in prompt
 
     def test_suffix_without_base_system_prompt_omits_empty_base(self) -> None:
         prompt = self._build_and_capture_system_prompt(
@@ -606,7 +589,6 @@ class TestSystemPromptAssembly:
             system_prompt="User instructions.",
         )
         assert prompt == "User instructions.\n\nCustom base."
-        assert BASE_AGENT_PROMPT not in prompt
 
     def test_user_system_prompt_is_used_without_default_base(self) -> None:
         prompt = self._build_and_capture_system_prompt(
@@ -626,7 +608,6 @@ class TestSystemPromptAssembly:
             system_prompt="User instructions.",
         )
         assert prompt == "User instructions.\n\nCustom base.\n\nExtra."
-        assert BASE_AGENT_PROMPT not in prompt
 
     def test_system_message_preserves_caller_blocks_and_appends_profile_prompt(self) -> None:
         caller_block = {
@@ -668,7 +649,6 @@ class TestSystemPromptAssembly:
             HarnessProfile(base_system_prompt=""),
         )
         assert prompt == ""
-        assert BASE_AGENT_PROMPT not in prompt
 
     def test_empty_string_suffix_still_appended(self) -> None:
         prompt = self._build_and_capture_system_prompt(
@@ -684,21 +664,6 @@ class TestSystemPromptAssembly:
         """With no profile base and no caller base, the assembled base is empty."""
         prompt = self._build_and_capture_system_prompt("defprov", HarnessProfile())
         assert prompt == ""
-        assert BASE_AGENT_PROMPT not in prompt
-
-    def test_base_agent_prompt_restores_base(self) -> None:
-        """Callers opt the authored prose back in via `system_prompt=BASE_AGENT_PROMPT`."""
-        prompt = self._build_and_capture_system_prompt(
-            "defprov",
-            HarnessProfile(),
-            system_prompt=BASE_AGENT_PROMPT,
-        )
-        assert prompt == BASE_AGENT_PROMPT
-
-    def test_base_agent_prompt_holds_authored_prose(self) -> None:
-        """The authored prose is preserved (not deleted) so it can be restored."""
-        assert "You are a deep agent" in BASE_AGENT_PROMPT
-        assert "Professional Objectivity" in BASE_AGENT_PROMPT
 
 
 _ABSENT = object()

--- a/libs/deepagents/tests/unit_tests/test_graph.py
+++ b/libs/deepagents/tests/unit_tests/test_graph.py
@@ -536,12 +536,13 @@ class TestSystemPromptAssembly:
     """Tests for system prompt assembly: profile base_system_prompt, suffix, and user prompt interaction."""
 
     def test_public_docstring_describes_prompt_assembly(self) -> None:
-        docstring = inspect.getdoc(create_deep_agent)
+        raw_docstring = inspect.getdoc(create_deep_agent)
 
-        assert docstring is not None
+        assert raw_docstring is not None
+        docstring = " ".join(raw_docstring.split())
         assert "`USER` -> `BASE` -> `SUFFIX`" in docstring
         assert "`BASE` is empty unless" in docstring
-        assert "With `system_prompt=None` and no matching profile prompt" in docstring
+        assert "With `system_prompt=None` and no profile `base_system_prompt` or" in docstring
         assert "`system_prompt=BASE_AGENT_PROMPT` explicitly" in docstring
         assert "appended as an additional text content block" in docstring
         assert "`cache_control` markers" in docstring


### PR DESCRIPTION
Closes #4977

`create_deep_agent` now documents the system prompt it actually sends: caller instructions first, followed by an optional profile base and suffix. Rubric grading also continues if LangChain no longer exposes the private fallback model list used only for trace diagnostics; those diagnostics report `unknown` instead.

---

The SDK no longer suggests that `BASE_AGENT_PROMPT` is injected by default. The public harness-profile API uses the same `USER` → `BASE` → `SUFFIX` model and explains how profile content is appended to a `SystemMessage` without disturbing cache-control markers.

When LangChain’s fallback table is available, rubric trace inference retains its existing provider-versus-tool prediction. If the private module or symbol is unavailable, grading still runs and only that prediction is omitted.
