### PR TITLE
fix(code): consistent modal backdrop dimming for selectors

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/agent_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/agent_selector.py
@@ -51,7 +51,6 @@ class AgentSelectorScreen(ModalScreen[str | None]):
     CSS = """
     AgentSelectorScreen {
         align: center middle;
-        background: transparent;
     }
 
     AgentSelectorScreen > Vertical {

--- a/libs/code/deepagents_code/tui/widgets/effort_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/effort_selector.py
@@ -31,7 +31,6 @@ class EffortSelectorScreen(ModalScreen[str | None]):
     CSS = """
     EffortSelectorScreen {
         align: center middle;
-        background: transparent;
     }
 
     EffortSelectorScreen > Vertical {

--- a/libs/code/deepagents_code/tui/widgets/notification_settings.py
+++ b/libs/code/deepagents_code/tui/widgets/notification_settings.py
@@ -52,7 +52,6 @@ class NotificationSettingsScreen(ModalScreen[None]):
     CSS = """
     NotificationSettingsScreen {
         align: center middle;
-        background: transparent;
     }
 
     NotificationSettingsScreen > VerticalGroup {

--- a/libs/code/tests/unit_tests/test_reasoning_effort.py
+++ b/libs/code/tests/unit_tests/test_reasoning_effort.py
@@ -1381,3 +1381,25 @@ def test_effort_selector_format_label_combines_current_default() -> None:
         default_effort="high",
     )
     assert "(current, default)" in str(screen._format_label("high"))
+
+
+async def test_effort_selector_dims_underlying_content() -> None:
+    """The modal must inherit the translucent `ModalScreen` backdrop.
+
+    Like the other selector modals, `/effort` should dim the content
+    underneath rather than render a fully transparent overlay. The alpha is
+    in (0, 1) only under a non-ansi theme, so pin `textual-dark`.
+    """
+    app = _EffortSelectorHost()
+    async with app.run_test() as pilot:
+        app.theme = "textual-dark"
+        await pilot.pause()
+        await app.push_screen(
+            EffortSelectorScreen(
+                model_spec="openai:gpt-5.5",
+                efforts=("low", "high"),
+                current_effort="low",
+            )
+        )
+        await pilot.pause()
+        assert 0 < app.screen.styles.background.a < 1

--- a/libs/code/tests/unit_tests/tui/widgets/test_agent_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_agent_selector.py
@@ -464,3 +464,23 @@ class TestAgentSelectorSetDefaultErrorPaths:
                 prompt = str(option_list.get_option_at_index(i).prompt)
                 assert "(default)" not in prompt
                 assert "default)" not in prompt
+
+
+class TestAgentSelectorBackdrop:
+    """Tests for the modal's dimming backdrop."""
+
+    async def test_dims_underlying_content(self) -> None:
+        """The modal must inherit the translucent `ModalScreen` backdrop.
+
+        Like the model and thread selectors, `/agents` should composite and
+        dim the content underneath rather than render a fully transparent
+        (non-dimming) overlay. The alpha is in (0, 1) only under a non-ansi
+        theme, so pin `textual-dark`.
+        """
+        async with AgentSelectorTestApp().run_test() as pilot:
+            app = _app(pilot)
+            app.theme = "textual-dark"
+            await pilot.pause()
+            app.show_selector()
+            await pilot.pause()
+            assert 0 < app.screen.styles.background.a < 1

--- a/libs/code/tests/unit_tests/tui/widgets/test_notification_settings.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_notification_settings.py
@@ -1,0 +1,29 @@
+"""Tests for NotificationSettingsScreen."""
+
+from __future__ import annotations
+
+from textual.app import App
+
+from deepagents_code.tui.widgets.notification_settings import (
+    NotificationSettingsScreen,
+)
+
+
+class _NotificationSettingsHost(App[None]):
+    """Minimal host app for mounting `NotificationSettingsScreen` in tests."""
+
+
+async def test_notification_settings_dims_underlying_content() -> None:
+    """The modal must inherit the translucent `ModalScreen` backdrop.
+
+    Like the selector modals, the notification settings dialog should dim the
+    content underneath rather than render a fully transparent overlay. The
+    alpha is in (0, 1) only under a non-ansi theme, so pin `textual-dark`.
+    """
+    app = _NotificationSettingsHost()
+    async with app.run_test() as pilot:
+        app.theme = "textual-dark"
+        await pilot.pause()
+        await app.push_screen(NotificationSettingsScreen(suppressed=set()))
+        await pilot.pause()
+        assert 0 < app.screen.styles.background.a < 1


### PR DESCRIPTION
Some full-screen modals set `background: transparent` on the screen root, which strips Textual's default translucent `ModalScreen` backdrop (`background: $background 60%`) and leaves them without the background dimming that the model and thread selectors inherit. This restores consistent dimming across these modals.

Affected modals fixed: `/agents` (`AgentSelectorScreen`), `/effort` (`EffortSelectorScreen`), and the notification settings dialog (`NotificationSettingsScreen`). `ThemeSelectorScreen` intentionally keeps its transparent backdrop so its live theme preview isn't tinted by the dim overlay.

Each fix is covered by a test asserting the screen backdrop alpha is in (0, 1) under a non-ansi theme.

Made by [Open SWE](https://openswe.vercel.app/agents/e92ee808-0b56-174a-a975-f1caa58dcc59)