### PR TITLE
fix(code): omit `plugins/` and `conversation_history/` from `/agent` picker

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -98,6 +98,7 @@ from deepagents_code.local_context import (
 )
 from deepagents_code.offload import (
     _FALLBACK_ARTIFACTS_ROOT,
+    CONVERSATION_HISTORY_DIRNAME,
     _artifacts_root,
     _offload_fallback_root,
 )
@@ -1166,14 +1167,24 @@ def load_async_subagents(config_path: Path | None = None) -> list[AsyncSubAgent]
 def _reserved_agent_dir_names() -> frozenset[str]:
     """Return non-agent directory names reserved by the app under `~/.deepagents/`.
 
-    `bin/` holds the managed `rg` binary (`managed_tools.BIN_DIR`) and must
-    never appear in the agent picker. The name is derived from `BIN_DIR` so it
-    stays a single source of truth rather than being hardcoded here. The result
-    is cached since the reserved set is constant for the process.
+    These directories are created by the app for its own use and must never
+    appear in the agent picker:
+
+    - `bin/` holds the managed `rg` binary (`managed_tools.BIN_DIR`).
+    - `plugins/` holds installed plugin state (`plugins.store`).
+    - `conversation_history/` holds offloaded per-thread archives (`offload`).
+
+    Each name is derived from its owning module so it stays a single source of
+    truth rather than being hardcoded here. The result is cached since the
+    reserved set is constant for the process.
     """
     from deepagents_code.managed_tools import BIN_DIR
+    from deepagents_code.offload import CONVERSATION_HISTORY_DIRNAME
+    from deepagents_code.plugins.store import DEFAULT_PLUGIN_DIRNAME
 
-    return frozenset({BIN_DIR.name})
+    return frozenset(
+        {BIN_DIR.name, DEFAULT_PLUGIN_DIRNAME, CONVERSATION_HISTORY_DIRNAME},
+    )
 
 
 def _is_agent_dir_entry(entry: Path) -> bool:
@@ -1182,7 +1193,7 @@ def _is_agent_dir_entry(entry: Path) -> bool:
     Filters out symlinks (so dangling links don't masquerade as agents),
     dot-prefixed names — `.state/` (app internal state) plus any other
     hidden directory the user may have placed there — and reserved names
-    the app owns (e.g. `bin/`, the managed-binary install dir).
+    the app owns (`bin/`, `plugins/`, and `conversation_history/`).
 
     `OSError` from `is_dir`/`is_symlink` propagates so callers can log
     with the failing entry's name as context.
@@ -1198,8 +1209,9 @@ def get_available_agent_names() -> list[str]:
     Scans the user's `.deepagents` directory and returns each real
     subdirectory found there. Symlinks excluded so a dangling link does not
     masquerade as an agent. Dot-prefixed entries (e.g., `.state/`) and
-    reserved app-owned directories (e.g., `bin/`, the managed-binary install
-    dir) are skipped so internal state never appears as an agent.
+    reserved app-owned directories (`bin/`, `plugins/`, and
+    `conversation_history/`) are skipped so internal state never appears as an
+    agent.
 
     Filesystem errors (missing parent, permission denied, broken entries) are
     logged and surfaced as an empty list rather than raised — the caller shows
@@ -2834,12 +2846,16 @@ def create_cli_agent(
         artifacts_storage = _artifacts_root()
         artifacts_root = artifacts_storage.root
         conversation_history_backend = FilesystemBackend(
-            root_dir=_offload_fallback_root() / "conversation_history",
+            root_dir=_offload_fallback_root() / CONVERSATION_HISTORY_DIRNAME,
             virtual_mode=True,
         )
-        fallback_history_root = f"{_FALLBACK_ARTIFACTS_ROOT}/conversation_history/"
+        fallback_history_root = (
+            f"{_FALLBACK_ARTIFACTS_ROOT}/{CONVERSATION_HISTORY_DIRNAME}/"
+        )
         artifact_routes: dict[str, BackendProtocol] = {
-            f"{artifacts_root}/conversation_history/": conversation_history_backend,
+            f"{artifacts_root}/{CONVERSATION_HISTORY_DIRNAME}/": (
+                conversation_history_backend
+            ),
             fallback_history_root: conversation_history_backend,
         }
         if artifacts_storage.large_results_dir is not None:

--- a/libs/code/deepagents_code/offload.py
+++ b/libs/code/deepagents_code/offload.py
@@ -13,6 +13,13 @@ logger = logging.getLogger(__name__)
 
 _FALLBACK_ARTIFACTS_ROOT = "/dcode-artifacts-fallback"
 
+CONVERSATION_HISTORY_DIRNAME = "conversation_history"
+"""Subdirectory of the offload root that holds per-thread conversation archives.
+
+Lives directly under `~/.deepagents/` in local mode, so it is reserved and must
+never be listed as an agent by the `/agent` picker.
+"""
+
 
 @dataclass(frozen=True)
 class _ArtifactsStorage:
@@ -184,7 +191,7 @@ def _offload_fallback_root() -> Path:
         # Ensure the shared config root exists and is usable, but leave its
         # permissions untouched -- hardening belongs on the archive subdir only.
         base.mkdir(parents=True, exist_ok=True)
-        archive_dir = base / "conversation_history"
+        archive_dir = base / CONVERSATION_HISTORY_DIRNAME
         _harden_dir(archive_dir)
         _probe_writable(archive_dir)
         return base
@@ -264,7 +271,7 @@ def delete_offloaded_history(thread_id: str) -> bool:
     if not thread_id:
         return False
     try:
-        archive_dir = _offload_fallback_root() / "conversation_history"
+        archive_dir = _offload_fallback_root() / CONVERSATION_HISTORY_DIRNAME
     except (OSError, RuntimeError):
         logger.warning(
             "Could not resolve offload root to clean history for thread %s",

--- a/libs/code/deepagents_code/plugins/store.py
+++ b/libs/code/deepagents_code/plugins/store.py
@@ -32,6 +32,9 @@ SUPPORTED_MARKETPLACE_SOURCE_TYPES: frozenset[MarketplaceSourceType] = frozenset
     {"directory", "file", "github", "git", "url"}
 )
 
+DEFAULT_PLUGIN_DIRNAME = "plugins"
+"""Default directory name for plugin storage under `~/.deepagents/`."""
+
 
 class PluginStateError(OSError):
     """Raised when existing plugin state cannot be safely modified."""
@@ -45,7 +48,7 @@ def plugin_storage_root() -> Path:
     raw = os.environ.get(PLUGIN_CACHE_DIR)
     if raw:
         return Path(raw).expanduser()
-    return DEFAULT_CONFIG_DIR / "plugins"
+    return DEFAULT_CONFIG_DIR / DEFAULT_PLUGIN_DIRNAME
 
 
 def plugin_data_dir(plugin_id: str) -> Path:

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -56,9 +56,11 @@ from deepagents_code.config import Settings, get_glyphs
 from deepagents_code.managed_tools import BIN_DIR
 from deepagents_code.offload import (
     _FALLBACK_ARTIFACTS_ROOT,
+    CONVERSATION_HISTORY_DIRNAME,
     _ArtifactsStorage,
     _filesystem_tool_path,
 )
+from deepagents_code.plugins.store import DEFAULT_PLUGIN_DIRNAME
 from deepagents_code.project_utils import ProjectContext
 
 
@@ -4759,9 +4761,27 @@ class TestGetAvailableAgentNames:
         with patch("deepagents_code.agent.settings", _mock_agents_dir(agents_dir)):
             assert get_available_agent_names() == ["agent"]
 
-    def test_reserved_agent_dir_names_includes_bin_dir(self) -> None:
-        """The reserved-name set is sourced from `BIN_DIR.name` (single source)."""
-        assert _reserved_agent_dir_names() == frozenset({BIN_DIR.name})
+    def test_ignores_reserved_app_dirs(self, tmp_path: Path) -> None:
+        """App-owned `plugins/` and `conversation_history/` are not agents.
+
+        These directories are created by the app under `~/.deepagents/` for
+        plugin state and offloaded conversation archives, so they must never
+        surface in the `/agent` picker alongside real agents.
+        """
+        agents_dir = tmp_path / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "agent").mkdir()
+        for reserved in _reserved_agent_dir_names():
+            (agents_dir / reserved).mkdir()
+
+        with patch("deepagents_code.agent.settings", _mock_agents_dir(agents_dir)):
+            assert get_available_agent_names() == ["agent"]
+
+    def test_reserved_agent_dir_names_includes_app_dirs(self) -> None:
+        """The reserved-name set is sourced from each owning module."""
+        assert _reserved_agent_dir_names() == frozenset(
+            {BIN_DIR.name, DEFAULT_PLUGIN_DIRNAME, CONVERSATION_HISTORY_DIRNAME},
+        )
 
     def test_permission_error_returns_empty(self, tmp_path: Path) -> None:
         """PermissionError on iterdir → logged + empty list, not raised."""


### PR DESCRIPTION
Fixed the `/agent` picker listing the app-owned `plugins/` and `conversation_history/` directories as selectable agents.

---

The `/agent` switcher scanned `~/.deepagents/` and listed every non-hidden subdirectory as an agent. App-owned `plugins/` (installed plugin state) and `conversation_history/` (offloaded per-thread archives) are not agents and were incorrectly surfaced. This reserves both alongside `bin/`, deriving each name from its owning module (`plugins.store.DEFAULT_PLUGIN_DIRNAME`, `offload.CONVERSATION_HISTORY_DIRNAME`) so the reserved set stays a single source of truth.

Made by [Open SWE](https://openswe.vercel.app/agents/4d725141-181b-fa99-add4-a78056113b7a)