### PR TITLE
feat(code)!: remove default todos, matching SDK opt-in

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -159,10 +159,8 @@ EXPERIMENTAL = "DEEPAGENTS_CODE_EXPERIMENTAL"
 """Opt into experimental, unstable dcode behavior.
 
 Off by default; parsed by `is_env_truthy` (see there for the accepted truthy
-values). Currently gates dropping the SDK's `TodoListMiddleware` (and its
-`write_todos` tool) from the agent and its subagents, along with the matching
-todo-list prompt guidance. Behavior behind this flag may change or be removed
-without notice.
+values). Currently gates the beta classifier-backed Auto approval mode.
+Behavior behind this flag may change or be removed without notice.
 """
 
 EXTERNAL_EVENT_SOCKET = "DEEPAGENTS_CODE_EXTERNAL_EVENT_SOCKET"

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -48,7 +48,6 @@ if TYPE_CHECKING:
 from langchain.agents.middleware import (
     HumanInTheLoopMiddleware,
     InterruptOnConfig,
-    TodoListMiddleware,
 )
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain.tools import (
@@ -142,37 +141,6 @@ REQUIRE_COMPACT_TOOL_APPROVAL: bool = True
 """When `True`, `compact_conversation` requires HITL approval like other gated tools."""
 
 
-class _NoTodoListMiddleware(AgentMiddleware):
-    """No-op stand-in that drops the SDK's `TodoListMiddleware` by name.
-
-    `create_deep_agent` always injects `TodoListMiddleware` and exposes no
-    per-call parameter to disable it (only a globally registered
-    `HarnessProfile.excluded_middleware` can strip it, which dcode does not use
-    here). Its `_apply_custom_middleware` merge replaces a default middleware in
-    place when a caller-supplied middleware shares its `.name`, so threading
-    this tool-less stand-in into the agent and subagent middleware lists removes
-    the real middleware — and its `write_todos` tool — without touching the SDK.
-
-    Deriving `name` from `TodoListMiddleware.__name__` makes a *rename* or
-    removal of the SDK class fail loudly (`ImportError`) at the top-of-module
-    import. It does not, on its own, guard a `.name` *override* on an unrenamed
-    class: the merge keys on the instance `.name`, not `__name__`, so such an
-    override would slip past the import and silently turn this into a no-op.
-    That case is caught two ways — `_todo_list_middleware_override` re-checks the
-    match at build time and raises, and `test_agent.py` guards it in CI. Gated
-    behind `DEEPAGENTS_CODE_EXPERIMENTAL`; see `_todo_list_middleware_override`.
-    """
-
-    name: str = TodoListMiddleware.__name__
-    tools: Sequence[BaseTool] = ()
-    """No tools — replacing the real `TodoListMiddleware` drops its `write_todos`.
-
-    Declared explicitly (mirroring the base's `transformers = ()` default) so a
-    bare instance is self-contained rather than relying on the SDK's
-    `getattr(mw, "tools", [])` fallback.
-    """
-
-
 def _get_harness_tool_descriptions(
     model: str | BaseChatModel,
 ) -> dict[str, str]:
@@ -260,41 +228,6 @@ def _inject_fs_tools_into_subagents(
                 ),
             ],
         )
-
-
-def _todo_list_middleware_override() -> list[AgentMiddleware]:
-    """Return the middleware needed to strip `TodoListMiddleware`, if enabled.
-
-    Returns a single-element list with `_NoTodoListMiddleware` when the
-    experimental flag is set, else an empty list. Callers splice the result
-    into the middleware list they pass to `create_deep_agent` so the SDK's
-    name-based merge drops the real `TodoListMiddleware`.
-
-    Raises:
-        RuntimeError: If the stand-in's `.name` no longer matches the SDK
-            middleware's instance `.name`. The merge replaces by name, so a
-            mismatch would silently *append* the tool-less stand-in instead of
-            replacing the real middleware, leaving `write_todos` bound. Failing
-            fast here converts that silent no-op into a loud, actionable error
-            (only ever runs when the flag is on).
-    """
-    if not is_env_truthy(EXPERIMENTAL):
-        return []
-    stand_in = _NoTodoListMiddleware()
-    sdk_name = TodoListMiddleware().name
-    if stand_in.name != sdk_name:
-        msg = (
-            f"{EXPERIMENTAL} is set but the TodoListMiddleware override would be "
-            f"a silent no-op: stand-in name {stand_in.name!r} no longer matches "
-            f"the SDK middleware's instance name {sdk_name!r}. The SDK likely "
-            f"overrode TodoListMiddleware.name; update _NoTodoListMiddleware."
-        )
-        raise RuntimeError(msg)
-    logger.info(
-        "%s set: dropping TodoListMiddleware / write_todos from this stack",
-        EXPERIMENTAL,
-    )
-    return [stand_in]
 
 
 def _rubric_grader_read_file_prefix(backend: CompositeBackend) -> str:
@@ -534,7 +467,7 @@ def _resolve_ptc_option(
     """Resolve the configured PTC allowlist to a concrete list of tool names.
 
     Names are *not* validated against `tools`. The Deep Agents SDK injects the
-    filesystem, `task`, `write_todos`, and `execute` tools via middleware in
+    filesystem, `task`, and `execute` tools via middleware in
     `create_deep_agent` — *after* this point — so they are absent from `tools`
     here, and the SDK exposes no importable list of them. `CodeInterpreterMiddleware`
     matches the resolved names against the live runtime registry and silently
@@ -1056,8 +989,7 @@ def get_system_prompt(
 
     Loads the base system prompt template from `system_prompt.md` and
     interpolates dynamic sections (model identity, working directory,
-    skills path, execution mode, and todo-list guidance for
-    interactive vs headless).
+    skills path, and execution mode for interactive vs headless).
 
     Args:
         assistant_id: The agent identifier for path references
@@ -1085,9 +1017,6 @@ def get_system_prompt(
     """
     prompt_dir = Path(__file__).parent
     template = (prompt_dir / "system_prompt.md").read_text()
-    todo_list_section = ""
-    if not is_env_truthy(EXPERIMENTAL):
-        todo_list_section = (prompt_dir / "todo_list_prompt.md").read_text().rstrip()
 
     skills_path = f"~/.deepagents/{assistant_id}/skills"
 
@@ -1102,15 +1031,6 @@ def get_system_prompt(
         ambiguity_guidance = (
             "- If the request is ambiguous, ask questions before acting.\n"
             "- If asked how to approach something, explain first, then act."
-        )
-        todo_guidance = (
-            "6. When first creating a todo list for a task, ALWAYS ask the user if "
-            "the plan looks good before starting work\n"
-            '   - Create the todos, then ask: "Does this plan '
-            'look good?" or similar\n'
-            "   - Wait for the user's response before marking the first todo as "
-            "in_progress\n"
-            "7. Update todo status promptly as you complete each item"
         )
     else:
         mode_description = (
@@ -1133,15 +1053,6 @@ def get_system_prompt(
             "`npm init`, `apt-get install -y` not `apt-get install`, "
             "`yes |` or `--no-input`/`--non-interactive` flags where "
             "available. Never run commands that block waiting for stdin."
-        )
-        todo_guidance = (
-            "6. There is no human operator in this mode — do NOT ask the user to "
-            "approve your plan or wait for a reply.\n"
-            "   After you create todos for a multi-step task, mark the first item "
-            "`in_progress` immediately and start work.\n"
-            "   If the plan needs adjustment, revise the todo list yourself; do "
-            "not block on human confirmation.\n"
-            "7. Update todo status promptly as you complete each item"
         )
 
     model_identity_section = build_model_identity_section(
@@ -1200,8 +1111,6 @@ def get_system_prompt(
         template.replace("{mode_description}", mode_description)
         .replace("{interactive_preamble}", interactive_preamble)
         .replace("{ambiguity_guidance}", ambiguity_guidance)
-        .replace("{todo_list_section}", todo_list_section)
-        .replace("{todo_guidance}", todo_guidance)
         .replace("{model_identity_section}", model_identity_section)
         .replace("{working_dir_section}", working_dir_section)
         .replace("{skills_path}", skills_path)
@@ -2057,9 +1966,6 @@ def create_cli_agent(
         has_explicit_model: bool,
     ) -> list[AgentMiddleware[Any, Any]]:
         middleware: list[AgentMiddleware[Any, Any]] = []
-        # Experimental: mirror the main agent and drop TodoListMiddleware /
-        # write_todos from subagent stacks too. No-op unless the flag is set.
-        middleware.extend(_todo_list_middleware_override())
         if resolved_interrupt_on is not None:
             middleware.append(AsyncApprovalHITLMiddleware(resolved_interrupt_on))
         if not has_explicit_model:
@@ -2137,9 +2043,6 @@ def create_cli_agent(
     # Build middleware stack based on enabled features
     agent_middleware: list[AgentMiddleware[Any, Any]] = [
         ConfigurableModelMiddleware(),
-        # Experimental: drop the SDK's TodoListMiddleware / write_todos tool.
-        # No-op unless DEEPAGENTS_CODE_EXPERIMENTAL is truthy.
-        *_todo_list_middleware_override(),
     ]
     if not interactive:
         agent_middleware.append(_GlmTerminalStallRecovery())

--- a/libs/code/deepagents_code/system_prompt.md
+++ b/libs/code/deepagents_code/system_prompt.md
@@ -211,5 +211,3 @@ When you use the web_search tool:
 6. If the search doesn't find what you need, explain what you found and ask clarifying questions
 
 The user only sees your text responses - not tool results. Always provide a complete, natural language answer after using web_search.
-
-{todo_list_section}

--- a/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
+++ b/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
@@ -233,24 +233,6 @@ When you use the web_search tool:
 
 The user only sees your text responses - not tool results. Always provide a complete, natural language answer after using web_search.
 
-### Todo List Management
-
-When using the write_todos tool:
-
-1. Use todos for any task with 2+ steps — they give the user visibility
-2. Mark tasks `in_progress` before starting, `completed` immediately after
-3. Don't batch completions — mark each item done as you finish it
-4. If a task reveals sub-tasks, add them right away
-5. For simple 1-step tasks, just do them directly
-6. When first creating a todo list for a task, ALWAYS ask the user if the plan looks good before starting work
-   - Create the todos, then ask: "Does this plan look good?" or similar
-   - Wait for the user's response before marking the first todo as in_progress
-7. Update todo status promptly as you complete each item
-
-The todo list is a planning tool - use it judiciously to avoid overwhelming the user with excessive task tracking.
-
-
-
 
 ## Shell paths vs. virtual paths
 

--- a/libs/code/tests/unit_tests/test_agent.py
+++ b/libs/code/tests/unit_tests/test_agent.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import Mock, patch
 
 import pytest
-from langchain.agents.middleware import TodoListMiddleware
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage
 from langgraph.errors import GraphInterrupt
@@ -1552,66 +1551,23 @@ class TestGetSystemPromptNonInteractive:
 
         assert "interactive TUI" in prompt
 
-    def test_interactive_todo_section_asks_user_before_starting(self) -> None:
-        """Interactive mode should require plan approval before first in_progress."""
-        mock_settings = Mock()
-        mock_settings.model_name = None
+    def test_prompt_omits_todo_guidance(self) -> None:
+        """Todos are opt-in in the SDK, so dcode's prompt must not reference them.
 
-        with patch("deepagents_code.agent.settings", mock_settings):
-            prompt = get_system_prompt("test-agent", interactive=True)
-
-        assert "Wait for the user's response before marking the first todo" in prompt
-
-    def test_non_interactive_todo_section_does_not_wait_for_user(self) -> None:
-        """Headless mode must not contradict 'no human' guidance in todo rules."""
-        mock_settings = Mock()
-        mock_settings.model_name = None
-
-        with patch("deepagents_code.agent.settings", mock_settings):
-            prompt = get_system_prompt("test-agent", interactive=False)
-
-        wait_for_user = "Wait for the user's response before marking the first todo"
-        assert wait_for_user not in prompt
-        assert "do NOT ask the user to approve your plan" in prompt
-        assert "mark the first item `in_progress` immediately" in prompt
-
-    def test_experimental_prompt_omits_todo_section(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Experimental mode must not reference its removed todo tool."""
-        monkeypatch.setenv(EXPERIMENTAL, "1")
-        mock_settings = Mock()
-        mock_settings.model_name = None
-
-        with patch("deepagents_code.agent.settings", mock_settings):
-            prompt = get_system_prompt("test-agent")
-
-        assert "Todo List Management" not in prompt
-        assert "write_todos" not in prompt
-        # `{todo_guidance}` lives only inside the gated section, so dropping the
-        # section must not leave the placeholder unresolved.
-        assert "{todo_list_section}" not in prompt
-        assert "{todo_guidance}" not in prompt
-
-    def test_default_prompt_resolves_todo_placeholders(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Default mode keeps the todo section with no unresolved placeholders.
-
-        Guards the `.replace` ordering in `get_system_prompt`: `{todo_guidance}`
-        is nested inside the todo section, so the section must be substituted
-        before the guidance placeholder is filled.
+        Covers both modes and guards against leftover placeholders once the
+        `{todo_list_section}`/`{todo_guidance}` wiring is gone.
         """
-        monkeypatch.delenv(EXPERIMENTAL, raising=False)
         mock_settings = Mock()
         mock_settings.model_name = None
 
-        with patch("deepagents_code.agent.settings", mock_settings):
-            prompt = get_system_prompt("test-agent")
+        for interactive in (True, False):
+            with patch("deepagents_code.agent.settings", mock_settings):
+                prompt = get_system_prompt("test-agent", interactive=interactive)
 
-        assert "Todo List Management" in prompt
-        assert "{todo_list_section}" not in prompt
-        assert "{todo_guidance}" not in prompt
+            assert "Todo List Management" not in prompt
+            assert "write_todos" not in prompt
+            assert "{todo_list_section}" not in prompt
+            assert "{todo_guidance}" not in prompt
 
 
 class TestGetSystemPromptCwdOSError:
@@ -4445,14 +4401,13 @@ class TestCreateCliAgentFsToolsWiring:
         ]
 
 
-class TestExperimentalTodoMiddlewareWiring:
-    """`DEEPAGENTS_CODE_EXPERIMENTAL` drops TodoListMiddleware from every stack.
+class TestAutoModeSubagentHITLWiring:
+    """Auto-mode async HITL reaches every dcode subagent stack.
 
-    `collect_built_in_tools` (see `test_tool_catalog.py`) only inspects the main
-    agent's bound tools, so the subagent splice needs its own coverage: these
-    tests capture the `create_deep_agent` kwargs and assert the stand-in reaches
-    the main agent, custom subagents, and the general-purpose subagent that
-    dcode auto-adds.
+    These tests capture the `create_deep_agent` kwargs and assert that, in Auto
+    mode (gated behind `DEEPAGENTS_CODE_EXPERIMENTAL`), the async approval
+    middleware reaches both custom subagents and the general-purpose subagent
+    that dcode auto-adds.
     """
 
     @staticmethod
@@ -4535,71 +4490,6 @@ class TestExperimentalTodoMiddlewareWiring:
 
         _, kwargs = mock_create.call_args
         return kwargs
-
-    @staticmethod
-    def _has_todo_standin(middleware: list[Any]) -> bool:
-        return any(
-            getattr(mw, "name", None) == TodoListMiddleware.__name__
-            for mw in middleware
-        )
-
-    def test_standin_name_matches_sdk_middleware(self) -> None:
-        """The stand-in must impersonate the real middleware's `.name`.
-
-        The name-based merge keys on the instance `.name`, so this guards a
-        hypothetical SDK `.name` override that `__name__`-derivation would miss.
-        """
-        from deepagents_code.agent import _NoTodoListMiddleware
-
-        assert _NoTodoListMiddleware().name == TodoListMiddleware().name
-
-    def test_dropped_from_main_and_subagents_when_experimental(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv(EXPERIMENTAL, "1")
-        kwargs = self._capture_create_deep_agent_kwargs(tmp_path)
-
-        assert self._has_todo_standin(kwargs["middleware"])
-
-        subagents_by_name = {sa["name"]: sa for sa in kwargs["subagents"]}
-        assert {"researcher", "general-purpose"} <= set(subagents_by_name)
-        for name, spec in subagents_by_name.items():
-            assert self._has_todo_standin(spec.get("middleware", [])), (
-                f"Expected TodoListMiddleware stand-in on subagent {name!r}"
-            )
-
-    def test_dropped_from_explicit_model_subagent_when_experimental(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """The splice must survive the `has_explicit_model` branch.
-
-        `_subagent_cli_middleware` extends the stand-in in *before* the
-        `if not has_explicit_model:` model-middleware check, so a subagent with
-        an explicit `model:` in frontmatter must still receive it. The other
-        wiring cases only exercise the `model: None` branch, so without this a
-        regression that moved the splice inside that `if` would pass unnoticed.
-        """
-        monkeypatch.setenv(EXPERIMENTAL, "1")
-        kwargs = self._capture_create_deep_agent_kwargs(
-            tmp_path, subagent_model="fake-model"
-        )
-
-        subagents_by_name = {sa["name"]: sa for sa in kwargs["subagents"]}
-        researcher = subagents_by_name["researcher"]
-        # Guards the premise: an explicit model must reach the spec, else the
-        # subagent would take the `model: None` path and the test proves nothing.
-        assert researcher.get("model"), "explicit subagent model was not forwarded"
-        assert self._has_todo_standin(researcher.get("middleware", []))
-
-    def test_absent_from_all_stacks_by_default(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.delenv(EXPERIMENTAL, raising=False)
-        kwargs = self._capture_create_deep_agent_kwargs(tmp_path)
-
-        assert not self._has_todo_standin(kwargs["middleware"])
-        for spec in kwargs["subagents"]:
-            assert not self._has_todo_standin(spec.get("middleware", []))
 
     async def test_async_hitl_covers_declarative_and_general_subagents_in_auto(
         self,

--- a/libs/code/tests/unit_tests/test_end_to_end.py
+++ b/libs/code/tests/unit_tests/test_end_to_end.py
@@ -133,8 +133,8 @@ class TestDeepAgentsCLIEndToEnd:
                             content="I'll help you with that.",
                             tool_calls=[
                                 {
-                                    "name": "write_todos",
-                                    "args": {"todos": []},
+                                    "name": "ls",
+                                    "args": {},
                                     "id": "call_1",
                                     "type": "tool_call",
                                 }

--- a/libs/code/tests/unit_tests/test_tool_catalog.py
+++ b/libs/code/tests/unit_tests/test_tool_catalog.py
@@ -8,7 +8,6 @@ from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
 
-from deepagents_code._env_vars import EXPERIMENTAL
 from deepagents_code.config import Settings
 from deepagents_code.mcp_tools import MCPServerInfo, MCPToolInfo
 from deepagents_code.tool_catalog import (
@@ -29,7 +28,6 @@ from deepagents_code.tool_catalog import (
 
 # Core tools the agent always binds, independent of optional integrations.
 _CORE_BUILT_IN = {
-    "write_todos",
     "ls",
     "read_file",
     "write_file",
@@ -240,24 +238,14 @@ class TestCollectBuiltInTools:
             collect_built_in_tools()
 
 
-class TestExperimentalTodoRemoval:
-    """`DEEPAGENTS_CODE_EXPERIMENTAL` drops the SDK `write_todos` tool."""
+class TestTodoToolNotBound:
+    """Todos are opt-in in the SDK, so dcode binds no `write_todos` by default."""
 
-    def test_write_todos_bound_by_default(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.delenv(EXPERIMENTAL, raising=False)
-        names = {tool.name for tool in collect_built_in_tools()}
-        assert "write_todos" in names
-
-    def test_write_todos_removed_when_experimental(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv(EXPERIMENTAL, "1")
+    def test_write_todos_absent_by_default(self) -> None:
         names = {tool.name for tool in collect_built_in_tools()}
         assert "write_todos" not in names
-        # Only the todo tool is dropped; the rest of the core set stays bound.
-        assert names >= _CORE_BUILT_IN - {"write_todos"}
+        # The rest of the core set stays bound.
+        assert names >= _CORE_BUILT_IN
 
 
 class TestCollectToolsFromAgent:


### PR DESCRIPTION
Stacked on #4929. Now that the SDK makes `TodoListMiddleware` opt-in, this mirrors the change in `deepagents-code` so `dcode` no longer exposes `write_todos` by default.

## Breaking Change

`dcode` agents no longer bind the `write_todos` tool, the `todos` state channel, or the todo-planning prompt. This tracks the SDK default; there is no dcode-level opt-in flag.

## Why

`dcode` previously assumed the SDK *always* injected `TodoListMiddleware`, so it carried machinery to *strip* it behind `DEEPAGENTS_CODE_EXPERIMENTAL`. With the SDK default flipped, that machinery is dead code and the todo prompt guidance would instruct the model to call a tool that no longer exists.

## What This PR Does

- Removes the todo-drop machinery from `agent.py`: the `TodoListMiddleware` import, the `_NoTodoListMiddleware` stand-in, `_todo_list_middleware_override()`, and both splice call sites (main + subagent stacks).
- Stops injecting the todo prompt: drops the `todo_list_section` load, both `todo_guidance` blocks, and the `{todo_list_section}`/`{todo_guidance}` placeholders (removed from `system_prompt.md`).
- Keeps `DEEPAGENTS_CODE_EXPERIMENTAL` — it still gates the beta Auto approval mode (and its trace/UI markers). Only its todo usage is removed; the docstring is retargeted accordingly.
- Keeps the `write_todos` UI renderer (`messages.py`, `tool_display.py`, `app.py` grouping) and `todo_list_prompt.md` as dormant scaffolding, so re-enabling todos needs no display work.

## Tests

- Replaced the todo-prompt tests with one asserting todos are absent by default; renamed the todo-wiring test class to retain only its Auto-mode HITL cases.
- Dropped `write_todos` from the core-tools set in `test_tool_catalog.py`; swapped the fake-model `write_todos` call for `ls` in `test_end_to_end.py` (mirroring the SDK fix).
- Regenerated the one affected smoke snapshot (only the todo block removed).
- `make lint` clean; full unit suite passes (pre-existing `TestLangsmithSecretRedaction` env-dependent failures are unrelated and reproduce on the base branch).