### PR TITLE
ci(infra): apply `pending-deletion` when warning old PRs

### DIFF
--- a/.github/scripts/close-old-prs.js
+++ b/.github/scripts/close-old-prs.js
@@ -87,6 +87,23 @@ async function ensureIssueLabel({ github, owner, repo, issueNumber, name, existi
   existingLabels.push(name);
 }
 
+async function removeIssueLabel({ github, owner, repo, issueNumber, name, existingLabels }) {
+  if (!existingLabels.includes(name)) return;
+  try {
+    await github.rest.issues.removeLabel({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      name,
+    });
+  } catch (error) {
+    // Already gone (manual removal or a concurrent run) is fine.
+    if (error.status !== 404) throw error;
+  }
+  const index = existingLabels.indexOf(name);
+  if (index !== -1) existingLabels.splice(index, 1);
+}
+
 async function findMarkerComment({ github, owner, repo, issueNumber }) {
   const comments = await github.paginate(
     github.rest.issues.listComments,
@@ -205,15 +222,41 @@ async function processPr({
     throw error;
   }
 
+  // Drop pending-deletion once the PR is no longer a close candidate so label
+  // filters do not keep dead/exempt entries.
   if (live.state !== 'open') {
+    await removeIssueLabel({
+      github,
+      owner,
+      repo,
+      issueNumber: number,
+      name: pendingDeletionLabel,
+      existingLabels: live.labels,
+    });
     core.info(`PR #${number} is no longer open; skipping`);
     return 'skipped';
   }
   if (live.draft) {
+    await removeIssueLabel({
+      github,
+      owner,
+      repo,
+      issueNumber: number,
+      name: pendingDeletionLabel,
+      existingLabels: live.labels,
+    });
     core.info(`PR #${number} is a draft; skipping`);
     return 'skipped';
   }
   if (live.labels.includes(bypassLabel)) {
+    await removeIssueLabel({
+      github,
+      owner,
+      repo,
+      issueNumber: number,
+      name: pendingDeletionLabel,
+      existingLabels: live.labels,
+    });
     core.info(`PR #${number} has ${bypassLabel}; skipping`);
     return 'skipped';
   }
@@ -234,7 +277,7 @@ async function processPr({
       issue_number: number,
       body: warningBody({ warningDays, closeDays, bypassLabel }),
     });
-    // Apply at warning time so the PR is filterable until close or bypass.
+    // Apply at warning time so the PR is filterable until close, draft, or bypass.
     await ensureIssueLabel({
       github,
       owner,
@@ -246,17 +289,6 @@ async function processPr({
     core.info(`Warned PR #${number} after ${age} day(s)`);
     return 'warned';
   }
-
-  // Backfill the pending label for PRs warned before this label existed, or
-  // when a prior run posted the comment but failed before labeling.
-  await ensureIssueLabel({
-    github,
-    owner,
-    repo,
-    issueNumber: number,
-    name: pendingDeletionLabel,
-    existingLabels: live.labels,
-  });
 
   const noticeDays = closeDays - warningDays;
   const warningAge = ageInDays(existing.created_at, now);
@@ -278,14 +310,100 @@ async function processPr({
       pull_number: number,
       state: 'closed',
     });
+    await removeIssueLabel({
+      github,
+      owner,
+      repo,
+      issueNumber: number,
+      name: pendingDeletionLabel,
+      existingLabels: live.labels,
+    });
     core.info(`Closed PR #${number} after ${age} day(s)`);
     return 'closed';
   }
+
+  // Backfill the pending label for PRs warned before this label existed, or
+  // when a prior run posted the comment but failed before labeling.
+  await ensureIssueLabel({
+    github,
+    owner,
+    repo,
+    issueNumber: number,
+    name: pendingDeletionLabel,
+    existingLabels: live.labels,
+  });
 
   core.info(
     `PR #${number} is ${age} day(s) old and was warned ${warningAge} day(s) ago; no action`,
   );
   return 'skipped';
+}
+
+// The primary open-PR search omits drafts (`draft:false`) and closed PRs, so a
+// separate label query is needed to clear pending-deletion after those
+// transitions (or after a manual close).
+async function sweepStalePendingDeletionLabels({
+  github,
+  core,
+  owner,
+  repo,
+  pendingDeletionLabel,
+  bypassLabel,
+  maxItems,
+}) {
+  const query = `repo:${owner}/${repo} is:pr label:"${pendingDeletionLabel}"`;
+  let cleared = 0;
+  let seen = 0;
+  try {
+    for await (const response of github.paginate.iterator(
+      github.rest.search.issuesAndPullRequests,
+      { q: query, per_page: 100 },
+    )) {
+      for (const item of response.data) {
+        seen += 1;
+        if (seen > maxItems) {
+          core.warning(
+            `Reached maxItems cap (${maxItems}) while sweeping ` +
+            `${pendingDeletionLabel}; some labeled PRs were not checked.`,
+          );
+          return cleared;
+        }
+
+        let live;
+        try {
+          live = await getLivePr({ github, owner, repo, number: item.number });
+        } catch (error) {
+          if (error.status === 404) continue;
+          throw error;
+        }
+
+        const stale = live.state !== 'open'
+          || live.draft
+          || live.labels.includes(bypassLabel);
+        if (!stale) continue;
+
+        await removeIssueLabel({
+          github,
+          owner,
+          repo,
+          issueNumber: item.number,
+          name: pendingDeletionLabel,
+          existingLabels: live.labels,
+        });
+        cleared += 1;
+        core.info(
+          `Cleared ${pendingDeletionLabel} from PR #${item.number} ` +
+          `(no longer a close candidate)`,
+        );
+      }
+    }
+  } catch (error) {
+    core.warning(
+      `pending-deletion sweep failed after clearing ${cleared} label(s) ` +
+      `(HTTP ${error.status ?? 'unknown'}): ${error.message}`,
+    );
+  }
+  return cleared;
 }
 
 async function run({ github, context, core, options = {} }) {
@@ -337,7 +455,7 @@ async function run({ github, context, core, options = {} }) {
   const { items: prs, incomplete, truncated } = await searchOpenPrs({ github, owner, repo, maxItems, core });
   core.info(`Found ${prs.length} open PR(s)`);
 
-  const summary = { checked: 0, warned: 0, closed: 0, skipped: 0, incomplete, truncated, errors: [] };
+  const summary = { checked: 0, warned: 0, closed: 0, skipped: 0, staleCleared: 0, incomplete, truncated, errors: [] };
   for (const item of prs) {
     summary.checked += 1;
     try {
@@ -365,9 +483,22 @@ async function run({ github, context, core, options = {} }) {
     }
   }
 
+  const staleCleared = await sweepStalePendingDeletionLabels({
+    github,
+    core,
+    owner,
+    repo,
+    pendingDeletionLabel,
+    bypassLabel,
+    maxItems,
+  });
+  summary.staleCleared = staleCleared;
+
   core.info(
     `Checked ${summary.checked}; warned ${summary.warned}; ` +
-    `closed ${summary.closed}; skipped ${summary.skipped}; errors ${summary.errors.length}`,
+    `closed ${summary.closed}; skipped ${summary.skipped}; ` +
+    `cleared stale ${pendingDeletionLabel} ${summary.staleCleared}; ` +
+    `errors ${summary.errors.length}`,
   );
 
   // Continue processing after an individual API failure, but fail the run when

--- a/.github/scripts/close-old-prs.js
+++ b/.github/scripts/close-old-prs.js
@@ -1,6 +1,7 @@
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 const DEFAULT_BYPASS_LABEL = 'do-not-close';
+const DEFAULT_PENDING_DELETION_LABEL = 'pending-deletion';
 const DEFAULT_WARNING_DAYS = 14;
 const DEFAULT_CLOSE_DAYS = 30;
 const DEFAULT_MAX_ITEMS = 1000;
@@ -45,7 +46,7 @@ function labelNames(labels) {
   return labels.map(label => typeof label === 'string' ? label : label.name);
 }
 
-async function ensureLabel({ github, owner, repo, name }) {
+async function ensureLabel({ github, owner, repo, name, color, description }) {
   try {
     await github.rest.issues.getLabel({ owner, repo, name });
   } catch (error) {
@@ -55,8 +56,8 @@ async function ensureLabel({ github, owner, repo, name }) {
         owner,
         repo,
         name,
-        color: '0e8a16',
-        description: 'Bypass automatic closure of old PRs',
+        color,
+        description,
       });
     } catch (createError) {
       if (createError.status !== 422) throw createError;
@@ -73,6 +74,17 @@ async function ensureLabel({ github, owner, repo, name }) {
       }
     }
   }
+}
+
+async function ensureIssueLabel({ github, owner, repo, issueNumber, name, existingLabels }) {
+  if (existingLabels.includes(name)) return;
+  await github.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    labels: [name],
+  });
+  existingLabels.push(name);
 }
 
 async function findMarkerComment({ github, owner, repo, issueNumber }) {
@@ -165,6 +177,7 @@ async function processPr({
   item,
   now,
   bypassLabel,
+  pendingDeletionLabel,
   warningDays,
   closeDays,
 }) {
@@ -221,9 +234,29 @@ async function processPr({
       issue_number: number,
       body: warningBody({ warningDays, closeDays, bypassLabel }),
     });
+    // Apply at warning time so the PR is filterable until close or bypass.
+    await ensureIssueLabel({
+      github,
+      owner,
+      repo,
+      issueNumber: number,
+      name: pendingDeletionLabel,
+      existingLabels: live.labels,
+    });
     core.info(`Warned PR #${number} after ${age} day(s)`);
     return 'warned';
   }
+
+  // Backfill the pending label for PRs warned before this label existed, or
+  // when a prior run posted the comment but failed before labeling.
+  await ensureIssueLabel({
+    github,
+    owner,
+    repo,
+    issueNumber: number,
+    name: pendingDeletionLabel,
+    existingLabels: live.labels,
+  });
 
   const noticeDays = closeDays - warningDays;
   const warningAge = ageInDays(existing.created_at, now);
@@ -259,8 +292,11 @@ async function run({ github, context, core, options = {} }) {
   const { owner, repo } = context.repo;
   // `||` (not `??`) so an empty string falls back to the default: an
   // empty-named label can never be applied, which would silently disable the
-  // bypass mechanism.
+  // bypass or pending-deletion mechanisms.
   const bypassLabel = options.bypassLabel || process.env.BYPASS_LABEL || DEFAULT_BYPASS_LABEL;
+  const pendingDeletionLabel = options.pendingDeletionLabel
+    || process.env.PENDING_DELETION_LABEL
+    || DEFAULT_PENDING_DELETION_LABEL;
   const warningDays = parsePositiveInt(
     options.warningDays ?? process.env.WARNING_DAYS,
     DEFAULT_WARNING_DAYS,
@@ -282,7 +318,22 @@ async function run({ github, context, core, options = {} }) {
     throw new Error(`warningDays (${warningDays}) must be less than closeDays (${closeDays})`);
   }
 
-  await ensureLabel({ github, owner, repo, name: bypassLabel });
+  await ensureLabel({
+    github,
+    owner,
+    repo,
+    name: bypassLabel,
+    color: '0e8a16',
+    description: 'Bypass automatic closure of old PRs',
+  });
+  await ensureLabel({
+    github,
+    owner,
+    repo,
+    name: pendingDeletionLabel,
+    color: 'fbca04',
+    description: 'PR is past the auto-close warning threshold and will be closed unless exempted',
+  });
   const { items: prs, incomplete, truncated } = await searchOpenPrs({ github, owner, repo, maxItems, core });
   core.info(`Found ${prs.length} open PR(s)`);
 
@@ -298,6 +349,7 @@ async function run({ github, context, core, options = {} }) {
         item,
         now,
         bypassLabel,
+        pendingDeletionLabel,
         warningDays,
         closeDays,
       });

--- a/.github/scripts/close-old-prs.test.js
+++ b/.github/scripts/close-old-prs.test.js
@@ -22,6 +22,7 @@ function makeCore() {
 
 function makeGithub({
   items = [],
+  labeledItems = [],
   comments = new Map(),
   live = new Map(),
   labelExists = true,
@@ -34,6 +35,7 @@ function makeGithub({
   const calls = {
     createLabel: [],
     addLabels: [],
+    removeLabel: [],
     createComment: [],
     updateComment: [],
     close: [],
@@ -60,6 +62,9 @@ function makeGithub({
         },
         addLabels: async params => {
           calls.addLabels.push(params);
+        },
+        removeLabel: async params => {
+          calls.removeLabel.push(params);
         },
         listComments: async ({ issue_number }) => ({
           data: (comments.get(issue_number) ?? []).map(comment => ({
@@ -94,20 +99,23 @@ function makeGithub({
 
   github.paginate.iterator = async function* iterator(_method, params) {
     calls.queries.push(params);
+    // Primary open-PR scan vs pending-deletion sweep use different queries.
+    const labeledQuery = typeof params.q === 'string' && params.q.includes('label:"');
+    const source = labeledQuery ? labeledItems : items;
     const pages = [];
-    for (let index = 0; index < items.length; index += 100) {
-      pages.push(items.slice(index, index + 100));
+    for (let index = 0; index < source.length; index += 100) {
+      pages.push(source.slice(index, index + 100));
     }
     if (pages.length === 0) pages.push([]);
 
     for (const [index, page] of pages.entries()) {
-      if (maxPagesBeforeError !== null && index >= maxPagesBeforeError) {
+      if (!labeledQuery && maxPagesBeforeError !== null && index >= maxPagesBeforeError) {
         throw iteratorError;
       }
-      page.incomplete_results = incompleteResults;
+      page.incomplete_results = !labeledQuery && incompleteResults;
       yield { data: page };
     }
-    if (iteratorError && maxPagesBeforeError === null) throw iteratorError;
+    if (!labeledQuery && iteratorError && maxPagesBeforeError === null) throw iteratorError;
   };
 
   return { github, calls };
@@ -122,6 +130,7 @@ test('warns after 14 days and closes after 30 days from opening', async () => {
     [102, [{ id: 77, body: `${COMMENT_MARKER}\nwarning`, user: workflowBot }]],
   ]);
   const live = new Map([
+    [102, { labels: ['pending-deletion'] }],
     [103, { labels: ['do-not-close'] }],
     [104, { draft: true }],
   ]);
@@ -140,20 +149,25 @@ test('warns after 14 days and closes after 30 days from opening', async () => {
   const summary = await run({ github, context, core, options: { now } });
 
   assert.deepEqual(summary, {
-    checked: 4, warned: 1, closed: 1, skipped: 2, incomplete: false, truncated: false, errors: [],
+    checked: 4, warned: 1, closed: 1, skipped: 2, staleCleared: 0, incomplete: false, truncated: false, errors: [],
   });
   assert.equal(calls.createComment.length, 1);
   assert.equal(calls.createComment[0].issue_number, 101);
   assert.match(calls.createComment[0].body, /open for at least 14 days/);
-  assert.equal(calls.addLabels.length, 2);
   assert.deepEqual(
     calls.addLabels.map(call => [call.issue_number, call.labels]),
-    [[101, ['pending-deletion']], [102, ['pending-deletion']]],
+    [[101, ['pending-deletion']]],
   );
   assert.equal(calls.updateComment.length, 1);
   assert.equal(calls.updateComment[0].comment_id, 77);
   assert.match(calls.updateComment[0].body, /open for at least 30 days/);
   assert.deepEqual(calls.close, [102]);
+  assert.deepEqual(calls.removeLabel, [{
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    issue_number: 102,
+    name: 'pending-deletion',
+  }]);
   assert.equal(core.failed, null);
 });
 
@@ -452,6 +466,68 @@ test('fails the run when every processed PR errors, even transiently', async () 
   assert.ok(summary.errors.every(error => error.transient));
   assert.match(core.failed, /#720: outage/);
   assert.match(core.failed, /#721: outage/);
+});
+
+test('removes pending-deletion when a PR gains do-not-close', async () => {
+  const { github, calls } = makeGithub({
+    items: [{ number: 321, created_at: '2026-04-23T00:00:00Z' }],
+    live: new Map([[321, { labels: ['pending-deletion', 'do-not-close'] }]]),
+  });
+
+  const summary = await run({ github, context, core: makeCore(), options: { now } });
+
+  assert.equal(summary.skipped, 1);
+  assert.deepEqual(calls.removeLabel, [{
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    issue_number: 321,
+    name: 'pending-deletion',
+  }]);
+  assert.equal(calls.addLabels.length, 0);
+  assert.deepEqual(calls.close, []);
+});
+
+test('removes pending-deletion when a PR becomes a draft', async () => {
+  const { github, calls } = makeGithub({
+    items: [{ number: 322, created_at: '2026-04-23T00:00:00Z' }],
+    live: new Map([[322, { draft: true, labels: ['pending-deletion'] }]]),
+  });
+
+  const summary = await run({ github, context, core: makeCore(), options: { now } });
+
+  assert.equal(summary.skipped, 1);
+  assert.deepEqual(calls.removeLabel, [{
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    issue_number: 322,
+    name: 'pending-deletion',
+  }]);
+});
+
+test('sweep clears pending-deletion on closed or draft PRs missed by open search', async () => {
+  const { github, calls } = makeGithub({
+    items: [],
+    labeledItems: [
+      { number: 330, created_at: '2026-04-01T00:00:00Z' },
+      { number: 331, created_at: '2026-04-01T00:00:00Z' },
+      { number: 332, created_at: '2026-04-01T00:00:00Z' },
+    ],
+    live: new Map([
+      [330, { state: 'closed', labels: ['pending-deletion'] }],
+      [331, { draft: true, labels: ['pending-deletion'] }],
+      [332, { labels: ['pending-deletion'] }],
+    ]),
+  });
+
+  const summary = await run({ github, context, core: makeCore(), options: { now } });
+
+  assert.equal(summary.staleCleared, 2);
+  assert.deepEqual(
+    calls.removeLabel.map(call => call.issue_number).sort((a, b) => a - b),
+    [330, 331],
+  );
+  // Still-open non-exempt PRs keep the label.
+  assert.ok(!calls.removeLabel.some(call => call.issue_number === 332));
 });
 
 test('creates the bypass and pending-deletion labels when they do not exist', async () => {

--- a/.github/scripts/close-old-prs.test.js
+++ b/.github/scripts/close-old-prs.test.js
@@ -33,25 +33,33 @@ function makeGithub({
 } = {}) {
   const calls = {
     createLabel: [],
+    addLabels: [],
     createComment: [],
     updateComment: [],
     close: [],
     queries: [],
     get: [],
   };
-  let labelPresent = labelExists;
+  // When labels are presumed present, unknown names still succeed so tests do
+  // not have to seed every label the workflow may ensure.
+  const presentLabels = new Set(labelExists ? ['do-not-close', 'pending-deletion'] : []);
 
   const github = {
     rest: {
       issues: {
-        getLabel: async () => {
-          if (!labelPresent) throw httpError('missing label', 404);
-          return { data: { name: 'do-not-close' } };
+        getLabel: async ({ name }) => {
+          if (!labelExists && !presentLabels.has(name)) {
+            throw httpError('missing label', 404);
+          }
+          return { data: { name } };
         },
         createLabel: async params => {
           calls.createLabel.push(params);
           if (createLabelError) throw createLabelError;
-          labelPresent = true;
+          presentLabels.add(params.name);
+        },
+        addLabels: async params => {
+          calls.addLabels.push(params);
         },
         listComments: async ({ issue_number }) => ({
           data: (comments.get(issue_number) ?? []).map(comment => ({
@@ -137,6 +145,11 @@ test('warns after 14 days and closes after 30 days from opening', async () => {
   assert.equal(calls.createComment.length, 1);
   assert.equal(calls.createComment[0].issue_number, 101);
   assert.match(calls.createComment[0].body, /open for at least 14 days/);
+  assert.equal(calls.addLabels.length, 2);
+  assert.deepEqual(
+    calls.addLabels.map(call => [call.issue_number, call.labels]),
+    [[101, ['pending-deletion']], [102, ['pending-deletion']]],
+  );
   assert.equal(calls.updateComment.length, 1);
   assert.equal(calls.updateComment[0].comment_id, 77);
   assert.match(calls.updateComment[0].body, /open for at least 30 days/);
@@ -158,6 +171,12 @@ test('warns an old PR that was never warned instead of closing it', async () => 
   assert.equal(calls.createComment[0].issue_number, 201);
   assert.match(calls.createComment[0].body, /open for at least 14 days/);
   assert.match(calls.createComment[0].body, /warning is at least 16 days old/);
+  assert.deepEqual(calls.addLabels, [{
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    issue_number: 201,
+    labels: ['pending-deletion'],
+  }]);
   assert.deepEqual(calls.close, []);
 });
 
@@ -198,6 +217,7 @@ test('does not duplicate warning comments on daily runs', async () => {
   const { github, calls } = makeGithub({
     items: [{ number: 301, created_at: '2026-04-23T00:00:00Z' }],
     comments,
+    live: new Map([[301, { labels: ['pending-deletion'] }]]),
   });
 
   const summary = await run({ github, context, core: makeCore(), options: { now } });
@@ -205,7 +225,29 @@ test('does not duplicate warning comments on daily runs', async () => {
   assert.equal(summary.skipped, 1);
   assert.equal(calls.createComment.length, 0);
   assert.equal(calls.updateComment.length, 0);
+  assert.equal(calls.addLabels.length, 0);
   assert.deepEqual(calls.close, []);
+});
+
+test('backfills pending-deletion on already-warned PRs', async () => {
+  const comments = new Map([
+    [305, [{ id: 91, body: `${COMMENT_MARKER}\nwarning`, user: workflowBot }]],
+  ]);
+  const { github, calls } = makeGithub({
+    items: [{ number: 305, created_at: '2026-04-23T00:00:00Z' }],
+    comments,
+  });
+
+  const summary = await run({ github, context, core: makeCore(), options: { now } });
+
+  assert.equal(summary.skipped, 1);
+  assert.equal(calls.createComment.length, 0);
+  assert.deepEqual(calls.addLabels, [{
+    owner: 'langchain-ai',
+    repo: 'deepagents',
+    issue_number: 305,
+    labels: ['pending-deletion'],
+  }]);
 });
 
 test('ignores marker comments posted by PR participants when warning', async () => {
@@ -412,13 +454,19 @@ test('fails the run when every processed PR errors, even transiently', async () 
   assert.match(core.failed, /#721: outage/);
 });
 
-test('creates the bypass label when it does not exist', async () => {
+test('creates the bypass and pending-deletion labels when they do not exist', async () => {
   const { github, calls } = makeGithub({ items: [], labelExists: false });
 
   const summary = await run({ github, context, core: makeCore(), options: { now } });
 
-  assert.equal(calls.createLabel.length, 1);
-  assert.equal(calls.createLabel[0].name, 'do-not-close');
+  assert.equal(calls.createLabel.length, 2);
+  assert.deepEqual(
+    calls.createLabel.map(call => [call.name, call.color]),
+    [
+      ['do-not-close', '0e8a16'],
+      ['pending-deletion', 'fbca04'],
+    ],
+  );
   assert.equal(summary.checked, 0);
 });
 
@@ -429,19 +477,19 @@ test('confirms the label exists after a create-label 422 race', async () => {
     createLabelError: httpError('already exists', 422),
   });
   // Simulate a concurrent run that created the label between our getLabel (404)
-  // and createLabel (422): the confirming getLabel now succeeds.
-  let confirmed = false;
-  github.rest.issues.getLabel = async () => {
-    if (!confirmed) {
-      confirmed = true;
+  // and createLabel (422): the confirming getLabel now succeeds per name.
+  const seen = new Set();
+  github.rest.issues.getLabel = async ({ name }) => {
+    if (!seen.has(name)) {
+      seen.add(name);
       throw httpError('missing label', 404);
     }
-    return { data: { name: 'do-not-close' } };
+    return { data: { name } };
   };
 
   const summary = await run({ github, context, core: makeCore(), options: { now } });
 
-  assert.equal(calls.createLabel.length, 1);
+  assert.equal(calls.createLabel.length, 2);
   assert.equal(summary.checked, 0);
 });
 

--- a/.github/workflows/close_old_prs.yml
+++ b/.github/workflows/close_old_prs.yml
@@ -1,7 +1,8 @@
 # Warn on open PRs after 14 days and close them after 30 days, measured from
-# when the PR was opened (by age, not last activity). Draft PRs and PRs with
-# the "do-not-close" label are skipped. Thresholds and the bypass label are
-# defined in .github/scripts/close-old-prs.js.
+# when the PR was opened (by age, not last activity). The warning also applies
+# a "pending-deletion" label. Draft PRs and PRs with the "do-not-close" label
+# are skipped. Thresholds and labels are defined in
+# .github/scripts/close-old-prs.js.
 
 name: Close Old PRs
 


### PR DESCRIPTION
The old-PR cleanup workflow already comments when a PR reaches the warning threshold. It now also adds a `pending-deletion` label at that same point so those PRs are easy to find and filter before they auto-close.

Already-warned PRs that are missing the label get it on the next run. PRs with `do-not-close` are still skipped entirely.

---

Ensures the repo label exists (yellow) alongside `do-not-close`, applies it with the warning comment, and backfills it when a prior warning run never labeled.
