### PR TITLE
ci(infra): scope GitHub Actions credentials

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -67,7 +67,7 @@ For an exceptional release that must skip curation, add the `release: dangerousl
 
 #### One-time repository setup
 
-The draft and apply jobs reuse the repository's GitHub App credentials to mint short-lived installation tokens. Keep `ORG_MEMBERSHIP_APP_CLIENT_ID` and `ORG_MEMBERSHIP_APP_PRIVATE_KEY` as repository secrets, and ensure the installed App grants read/write access to contents, issues, and pull requests. `ORG_MEMBERSHIP_APP_ID` is not used by this workflow.
+The draft and apply jobs reuse the repository's GitHub App credentials to mint short-lived installation tokens. Keep `ORG_MEMBERSHIP_APP_CLIENT_ID` as a repository variable and `ORG_MEMBERSHIP_APP_PRIVATE_KEY` as a repository secret, and ensure the installed App grants read/write access to contents, issues, and pull requests. `ORG_MEMBERSHIP_APP_ID` is not used by this workflow.
 
 Configure these repository-level Actions variables, which are also needed by jobs that do not use the release environment:
 

--- a/.github/scripts/test_dcode_release_notes.py
+++ b/.github/scripts/test_dcode_release_notes.py
@@ -133,7 +133,7 @@ def test_mutation_workflow_commands_are_target_only() -> None:
             "bcd2ba49218906704ab6c1aa796996da409d3eb1"
         )
         assert app_token["with"] == {
-            "client-id": "${{ secrets.ORG_MEMBERSHIP_APP_CLIENT_ID }}",
+            "client-id": "${{ vars.ORG_MEMBERSHIP_APP_CLIENT_ID }}",
             "private-key": "${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}",
             "permission-contents": "write",
             "permission-issues": "write",

--- a/.github/scripts/test_workflow_secret_scoping.py
+++ b/.github/scripts/test_workflow_secret_scoping.py
@@ -1,0 +1,71 @@
+"""Static contracts for credential scoping in GitHub workflows."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+APP_TOKEN_WORKFLOWS = (
+    "close_unchecked_issues.yml",
+    "dcode_release_notes.yml",
+    "dependabot_lockfile_fix.yml",
+    "pr_labeler.yml",
+    "pr_labeler_backfill.yml",
+    "tag-external-issues.yml",
+)
+
+
+def test_github_app_client_id_uses_repository_variable() -> None:
+    for name in APP_TOKEN_WORKFLOWS:
+        workflow = (WORKFLOWS / name).read_text()
+        assert "secrets.ORG_MEMBERSHIP_APP_CLIENT_ID" not in workflow
+        assert "vars.ORG_MEMBERSHIP_APP_CLIENT_ID" in workflow
+
+
+def test_integration_credentials_are_scoped_by_package() -> None:
+    workflow = (WORKFLOWS / "integration_tests.yml").read_text()
+    run_step = workflow.split('- name: "🚀 Run Integration Tests"', maxsplit=1)[1]
+    run_step = run_step.split("      - name:", maxsplit=1)[0]
+
+    expected = {
+        "ANTHROPIC_API_KEY": "matrix.working-directory == 'libs/deepagents' || matrix.working-directory == 'libs/partners/quickjs'",
+        "DAYTONA_API_KEY": "matrix.working-directory == 'libs/partners/daytona' || matrix.working-directory == 'libs/code'",
+        "LANGSMITH_API_KEY": "matrix.working-directory == 'libs/deepagents' || matrix.working-directory == 'libs/code'",
+        "MODAL_TOKEN_ID": "matrix.working-directory == 'libs/partners/modal' || matrix.working-directory == 'libs/code'",
+        "MODAL_TOKEN_SECRET": "matrix.working-directory == 'libs/partners/modal' || matrix.working-directory == 'libs/code'",
+        "OPENAI_API_KEY": "matrix.working-directory == 'libs/deepagents'",
+        "RUNLOOP_API_KEY": "matrix.working-directory == 'libs/partners/runloop' || matrix.working-directory == 'libs/code'",
+    }
+    for secret, condition in expected.items():
+        assert f"{secret}: ${{{{" in run_step
+        assert condition in run_step
+        assert f"secrets.{secret}" in run_step
+
+
+def test_release_keeps_disabled_package_scoped_integration_wiring() -> None:
+    workflow = (WORKFLOWS / "release.yml").read_text()
+    run_step = workflow.split("      - name: Run integration tests", maxsplit=1)[1]
+    run_step = run_step.split("      working-directory:", maxsplit=1)[0]
+
+    assert "        if: false" in run_step
+    expected = {
+        "ANTHROPIC_API_KEY": "needs.setup.outputs.package == 'deepagents' || needs.setup.outputs.package == 'langchain-quickjs'",
+        "DAYTONA_API_KEY": "needs.setup.outputs.package == 'langchain-daytona'",
+        "LANGSMITH_API_KEY": "needs.setup.outputs.package == 'deepagents'",
+        "MODAL_TOKEN_ID": "needs.setup.outputs.package == 'langchain-modal'",
+        "MODAL_TOKEN_SECRET": "needs.setup.outputs.package == 'langchain-modal'",
+        "OPENAI_API_KEY": "needs.setup.outputs.package == 'deepagents'",
+        "RUNLOOP_API_KEY": "needs.setup.outputs.package == 'langchain-runloop'",
+        "VERCEL_TOKEN": "needs.setup.outputs.package == 'langchain-vercel-sandbox'",
+    }
+    for secret, condition in expected.items():
+        assert f"{secret}: ${{{{" in run_step
+        assert condition in run_step
+        assert f"secrets.{secret}" in run_step
+
+
+def test_openwiki_uses_dedicated_environment() -> None:
+    workflow = (WORKFLOWS / "openwiki-update.yml").read_text()
+    assert (
+        "  update:\n    runs-on: ubuntu-latest\n    environment: openwiki\n" in workflow
+    )

--- a/.github/workflows/close_unchecked_issues.yml
+++ b/.github/workflows/close_unchecked_issues.yml
@@ -41,7 +41,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.ORG_MEMBERSHIP_APP_CLIENT_ID }}
+          client-id: ${{ vars.ORG_MEMBERSHIP_APP_CLIENT_ID }}
           private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
 
       - name: Validate issue checkboxes

--- a/.github/workflows/dcode_release_notes.yml
+++ b/.github/workflows/dcode_release_notes.yml
@@ -116,7 +116,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.ORG_MEMBERSHIP_APP_CLIENT_ID }}
+          client-id: ${{ vars.ORG_MEMBERSHIP_APP_CLIENT_ID }}
           private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-issues: write
@@ -282,7 +282,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.ORG_MEMBERSHIP_APP_CLIENT_ID }}
+          client-id: ${{ vars.ORG_MEMBERSHIP_APP_CLIENT_ID }}
           private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-issues: write

--- a/.github/workflows/dependabot_lockfile_fix.yml
+++ b/.github/workflows/dependabot_lockfile_fix.yml
@@ -271,7 +271,7 @@ jobs:
         if: steps.commit_lockfiles.outputs.has_changes == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.ORG_MEMBERSHIP_APP_CLIENT_ID }}
+          client-id: ${{ vars.ORG_MEMBERSHIP_APP_CLIENT_ID }}
           private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
           permission-contents: write
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -113,12 +113,13 @@ jobs:
       - name: "🚀 Run Integration Tests"
         working-directory: ${{ matrix.working-directory }}
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }} # sandboxes
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          RUNLOOP_API_KEY: ${{ secrets.RUNLOOP_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ (matrix.working-directory == 'libs/deepagents' || matrix.working-directory == 'libs/partners/quickjs') && secrets.ANTHROPIC_API_KEY || '' }}
+          DAYTONA_API_KEY: ${{ (matrix.working-directory == 'libs/partners/daytona' || matrix.working-directory == 'libs/code') && secrets.DAYTONA_API_KEY || '' }}
+          LANGSMITH_API_KEY: ${{ (matrix.working-directory == 'libs/deepagents' || matrix.working-directory == 'libs/code') && secrets.LANGSMITH_API_KEY || '' }}
+          MODAL_TOKEN_ID: ${{ (matrix.working-directory == 'libs/partners/modal' || matrix.working-directory == 'libs/code') && secrets.MODAL_TOKEN_ID || '' }}
+          MODAL_TOKEN_SECRET: ${{ (matrix.working-directory == 'libs/partners/modal' || matrix.working-directory == 'libs/code') && secrets.MODAL_TOKEN_SECRET || '' }}
+          OPENAI_API_KEY: ${{ matrix.working-directory == 'libs/deepagents' && secrets.OPENAI_API_KEY || '' }}
+          RUNLOOP_API_KEY: ${{ (matrix.working-directory == 'libs/partners/runloop' || matrix.working-directory == 'libs/code') && secrets.RUNLOOP_API_KEY || '' }}
         run: make integration_tests
 
       - name: "🧹 Verify Clean Working Directory"

--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-latest
+    environment: openwiki
     steps:
       - name: Check out repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -16,9 +16,9 @@
 #    - Repository: Issues (write)
 #    - Organization: Members (read)
 # 2. Install the app on your organization and this repository
-# 3. Add these repository secrets:
-#    - ORG_MEMBERSHIP_APP_CLIENT_ID: Your app's Client ID
-#    - ORG_MEMBERSHIP_APP_PRIVATE_KEY: Your app's private key
+# 3. Add the repository credential:
+#    - Variable ORG_MEMBERSHIP_APP_CLIENT_ID: Your app's Client ID
+#    - Secret ORG_MEMBERSHIP_APP_PRIVATE_KEY: Your app's private key
 #
 # The GitHub App token is required to check private organization membership
 # and to propagate label events to downstream workflows.
@@ -58,7 +58,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.ORG_MEMBERSHIP_APP_CLIENT_ID }}
+          client-id: ${{ vars.ORG_MEMBERSHIP_APP_CLIENT_ID }}
           private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
 
       - name: Verify App token

--- a/.github/workflows/pr_labeler_backfill.yml
+++ b/.github/workflows/pr_labeler_backfill.yml
@@ -32,7 +32,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.ORG_MEMBERSHIP_APP_CLIENT_ID }}
+          client-id: ${{ vars.ORG_MEMBERSHIP_APP_CLIENT_ID }}
           private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
 
       - name: Backfill labels on open PRs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1342,28 +1342,20 @@ jobs:
       - name: Run integration tests
         if: false # Disabled: integration tests are not run during releases
         env:
-          # deepagents SDK: subagent middleware tests
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          # deepagents SDK: LangSmith sandbox tests
-          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          # langchain-daytona, CLI test_sandbox_operations.py
-          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-          # langchain-modal
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          # langchain-runloop
-          RUNLOOP_API_KEY: ${{ secrets.RUNLOOP_API_KEY }}
-          # langchain-vercel-sandbox
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ (needs.setup.outputs.package == 'deepagents' || needs.setup.outputs.package == 'langchain-quickjs') && secrets.ANTHROPIC_API_KEY || '' }}
+          DAYTONA_API_KEY: ${{ needs.setup.outputs.package == 'langchain-daytona' && secrets.DAYTONA_API_KEY || '' }}
+          LANGSMITH_API_KEY: ${{ needs.setup.outputs.package == 'deepagents' && secrets.LANGSMITH_API_KEY || '' }}
+          MODAL_TOKEN_ID: ${{ needs.setup.outputs.package == 'langchain-modal' && secrets.MODAL_TOKEN_ID || '' }}
+          MODAL_TOKEN_SECRET: ${{ needs.setup.outputs.package == 'langchain-modal' && secrets.MODAL_TOKEN_SECRET || '' }}
+          OPENAI_API_KEY: ${{ needs.setup.outputs.package == 'deepagents' && secrets.OPENAI_API_KEY || '' }}
+          RUNLOOP_API_KEY: ${{ needs.setup.outputs.package == 'langchain-runloop' && secrets.RUNLOOP_API_KEY || '' }}
+          VERCEL_TOKEN: ${{ needs.setup.outputs.package == 'langchain-vercel-sandbox' && secrets.VERCEL_TOKEN || '' }}
 
-        # We skip test_sandbox_factory.py and test_sandbox_operations.py in CLI
-        # releases — overlap with partner-level SandboxIntegrationTests.
-        # TODO: upstream unique batch/binary tests to langchain-tests, then
-        # remove files.
+        # The deepagents-code sandbox coverage overlaps with the partner-level
+        # SandboxIntegrationTests, so keep those files out of release checks.
         run: |
           if [ -f Makefile ] && grep -q "integration_test" Makefile; then
-            if [ "${{ needs.setup.outputs.package }}" = "deepagents-cli" ]; then
+            if [ "${{ needs.setup.outputs.package }}" = "deepagents-code" ]; then
               export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:-} --ignore=tests/integration_tests/test_sandbox_factory.py --ignore=tests/integration_tests/test_sandbox_operations.py"
             fi
             make integration_test

--- a/.github/workflows/tag-external-issues.yml
+++ b/.github/workflows/tag-external-issues.yml
@@ -11,9 +11,9 @@
 #    - Repository: Issues (write)
 #    - Organization: Members (read)
 # 2. Install the app on your organization and this repository
-# 3. Add these repository secrets:
-#    - ORG_MEMBERSHIP_APP_CLIENT_ID: Your app's Client ID
-#    - ORG_MEMBERSHIP_APP_PRIVATE_KEY: Your app's private key
+# 3. Add the repository credential:
+#    - Variable ORG_MEMBERSHIP_APP_CLIENT_ID: Your app's Client ID
+#    - Secret ORG_MEMBERSHIP_APP_PRIVATE_KEY: Your app's private key
 #
 # The GitHub App token is required to check private organization membership.
 # Without it, the workflow will fail.
@@ -55,7 +55,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.ORG_MEMBERSHIP_APP_CLIENT_ID }}
+          client-id: ${{ vars.ORG_MEMBERSHIP_APP_CLIENT_ID }}
           private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
 
       - name: Check if contributor is external
@@ -123,7 +123,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.ORG_MEMBERSHIP_APP_CLIENT_ID }}
+          client-id: ${{ vars.ORG_MEMBERSHIP_APP_CLIENT_ID }}
           private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
 
       - name: Backfill labels on open issues


### PR DESCRIPTION
GitHub Actions now exposes stored credentials only to the automation and package tests that need them, and OpenWiki is ready to read its API keys from a dedicated environment instead of repository scope.

---

The GitHub App Client ID is not sensitive, so token-minting workflows now read it from the repository variable while the private key remains a secret. Integration-test credentials are selected by matrix package, including wiring the previously unavailable Daytona key. The disabled release integration step keeps its future credential wiring but applies the same package-level isolation.

OpenWiki now targets an `openwiki` environment. Repository-level fallback keeps the workflow working during migration; after environment secrets are configured and a manual run succeeds, the repository copies can be removed.