### PR TITLE
test(infra): harden workflow credential contracts

### DIFF
--- a/.github/scripts/test_workflow_secret_scoping.py
+++ b/.github/scripts/test_workflow_secret_scoping.py
@@ -1,6 +1,10 @@
 """Static contracts for credential scoping in GitHub workflows."""
 
+import json
+import re
 from pathlib import Path
+
+import yaml
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -13,59 +17,107 @@ APP_TOKEN_WORKFLOWS = (
     "pr_labeler_backfill.yml",
     "tag-external-issues.yml",
 )
+INTEGRATION_ENV = {
+    "ANTHROPIC_API_KEY": "${{ (matrix.working-directory == 'libs/deepagents' || matrix.working-directory == 'libs/partners/quickjs') && secrets.ANTHROPIC_API_KEY || '' }}",
+    "DAYTONA_API_KEY": "${{ (matrix.working-directory == 'libs/partners/daytona' || matrix.working-directory == 'libs/code') && secrets.DAYTONA_API_KEY || '' }}",
+    "LANGSMITH_API_KEY": "${{ (matrix.working-directory == 'libs/deepagents' || matrix.working-directory == 'libs/code') && secrets.LANGSMITH_API_KEY || '' }}",
+    "MODAL_TOKEN_ID": "${{ (matrix.working-directory == 'libs/partners/modal' || matrix.working-directory == 'libs/code') && secrets.MODAL_TOKEN_ID || '' }}",
+    "MODAL_TOKEN_SECRET": "${{ (matrix.working-directory == 'libs/partners/modal' || matrix.working-directory == 'libs/code') && secrets.MODAL_TOKEN_SECRET || '' }}",
+    "OPENAI_API_KEY": "${{ matrix.working-directory == 'libs/deepagents' && secrets.OPENAI_API_KEY || '' }}",
+    "RUNLOOP_API_KEY": "${{ (matrix.working-directory == 'libs/partners/runloop' || matrix.working-directory == 'libs/code') && secrets.RUNLOOP_API_KEY || '' }}",
+}
+RELEASE_INTEGRATION_ENV = {
+    "ANTHROPIC_API_KEY": "${{ (needs.setup.outputs.package == 'deepagents' || needs.setup.outputs.package == 'langchain-quickjs') && secrets.ANTHROPIC_API_KEY || '' }}",
+    "DAYTONA_API_KEY": "${{ needs.setup.outputs.package == 'langchain-daytona' && secrets.DAYTONA_API_KEY || '' }}",
+    "LANGSMITH_API_KEY": "${{ needs.setup.outputs.package == 'deepagents' && secrets.LANGSMITH_API_KEY || '' }}",
+    "MODAL_TOKEN_ID": "${{ needs.setup.outputs.package == 'langchain-modal' && secrets.MODAL_TOKEN_ID || '' }}",
+    "MODAL_TOKEN_SECRET": "${{ needs.setup.outputs.package == 'langchain-modal' && secrets.MODAL_TOKEN_SECRET || '' }}",
+    "OPENAI_API_KEY": "${{ needs.setup.outputs.package == 'deepagents' && secrets.OPENAI_API_KEY || '' }}",
+    "RUNLOOP_API_KEY": "${{ needs.setup.outputs.package == 'langchain-runloop' && secrets.RUNLOOP_API_KEY || '' }}",
+    "VERCEL_TOKEN": "${{ needs.setup.outputs.package == 'langchain-vercel-sandbox' && secrets.VERCEL_TOKEN || '' }}",
+}
+OVERRIDE_ONLY_INTEGRATION_TARGETS = {
+    "libs/code",
+    "libs/partners/quickjs",
+}
+
+
+def _load_workflow(name: str) -> dict:
+    workflow = yaml.safe_load((WORKFLOWS / name).read_text())
+    workflow["on"] = workflow.pop(True, workflow.get("on"))
+    return workflow
+
+
+def _find_step(workflow: dict, *, job: str, name: str) -> dict:
+    matches = [
+        step for step in workflow["jobs"][job]["steps"] if step.get("name") == name
+    ]
+    assert len(matches) == 1, (
+        f"Expected one {name!r} step in {job!r}, got {len(matches)}"
+    )
+    return matches[0]
 
 
 def test_github_app_client_id_uses_repository_variable() -> None:
     for name in APP_TOKEN_WORKFLOWS:
-        workflow = (WORKFLOWS / name).read_text()
-        assert "secrets.ORG_MEMBERSHIP_APP_CLIENT_ID" not in workflow
-        assert "vars.ORG_MEMBERSHIP_APP_CLIENT_ID" in workflow
+        workflow = _load_workflow(name)
+        token_steps = [
+            step
+            for job in workflow["jobs"].values()
+            for step in job["steps"]
+            if str(step.get("uses", "")).startswith("actions/create-github-app-token@")
+        ]
+        assert token_steps, f"No GitHub App token step found in {name}"
+        for step in token_steps:
+            assert step["with"]["client-id"] == (
+                "${{ vars.ORG_MEMBERSHIP_APP_CLIENT_ID }}"
+            )
+            assert step["with"]["private-key"] == (
+                "${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}"
+            )
 
 
 def test_integration_credentials_are_scoped_by_package() -> None:
-    workflow = (WORKFLOWS / "integration_tests.yml").read_text()
-    run_step = workflow.split('- name: "🚀 Run Integration Tests"', maxsplit=1)[1]
-    run_step = run_step.split("      - name:", maxsplit=1)[0]
+    workflow = _load_workflow("integration_tests.yml")
+    run_step = _find_step(
+        workflow,
+        job="integration-tests",
+        name="🚀 Run Integration Tests",
+    )
+    assert run_step["env"] == INTEGRATION_ENV
 
-    expected = {
-        "ANTHROPIC_API_KEY": "matrix.working-directory == 'libs/deepagents' || matrix.working-directory == 'libs/partners/quickjs'",
-        "DAYTONA_API_KEY": "matrix.working-directory == 'libs/partners/daytona' || matrix.working-directory == 'libs/code'",
-        "LANGSMITH_API_KEY": "matrix.working-directory == 'libs/deepagents' || matrix.working-directory == 'libs/code'",
-        "MODAL_TOKEN_ID": "matrix.working-directory == 'libs/partners/modal' || matrix.working-directory == 'libs/code'",
-        "MODAL_TOKEN_SECRET": "matrix.working-directory == 'libs/partners/modal' || matrix.working-directory == 'libs/code'",
-        "OPENAI_API_KEY": "matrix.working-directory == 'libs/deepagents'",
-        "RUNLOOP_API_KEY": "matrix.working-directory == 'libs/partners/runloop' || matrix.working-directory == 'libs/code'",
+
+def test_integration_secret_targets_are_selectable_or_explicit_overrides() -> None:
+    workflow = _load_workflow("integration_tests.yml")
+    options = set(
+        workflow["on"]["workflow_dispatch"]["inputs"]["working-directory"]["options"]
+    )
+    selectable_targets = options - {"all"}
+    assert set(json.loads(workflow["env"]["DEFAULT_LIBS"])) == selectable_targets
+
+    condition_targets = {
+        target
+        for expression in INTEGRATION_ENV.values()
+        for target in re.findall(r"matrix\.working-directory == '([^']+)'", expression)
     }
-    for secret, condition in expected.items():
-        assert f"{secret}: ${{{{" in run_step
-        assert condition in run_step
-        assert f"secrets.{secret}" in run_step
+    assert condition_targets - selectable_targets == OVERRIDE_ONLY_INTEGRATION_TARGETS
+    for target in condition_targets:
+        assert (ROOT / target).is_dir(), (
+            f"Credential condition targets missing path: {target}"
+        )
 
 
 def test_release_keeps_disabled_package_scoped_integration_wiring() -> None:
-    workflow = (WORKFLOWS / "release.yml").read_text()
-    run_step = workflow.split("      - name: Run integration tests", maxsplit=1)[1]
-    run_step = run_step.split("      working-directory:", maxsplit=1)[0]
-
-    assert "        if: false" in run_step
-    expected = {
-        "ANTHROPIC_API_KEY": "needs.setup.outputs.package == 'deepagents' || needs.setup.outputs.package == 'langchain-quickjs'",
-        "DAYTONA_API_KEY": "needs.setup.outputs.package == 'langchain-daytona'",
-        "LANGSMITH_API_KEY": "needs.setup.outputs.package == 'deepagents'",
-        "MODAL_TOKEN_ID": "needs.setup.outputs.package == 'langchain-modal'",
-        "MODAL_TOKEN_SECRET": "needs.setup.outputs.package == 'langchain-modal'",
-        "OPENAI_API_KEY": "needs.setup.outputs.package == 'deepagents'",
-        "RUNLOOP_API_KEY": "needs.setup.outputs.package == 'langchain-runloop'",
-        "VERCEL_TOKEN": "needs.setup.outputs.package == 'langchain-vercel-sandbox'",
-    }
-    for secret, condition in expected.items():
-        assert f"{secret}: ${{{{" in run_step
-        assert condition in run_step
-        assert f"secrets.{secret}" in run_step
+    workflow = _load_workflow("release.yml")
+    run_step = _find_step(
+        workflow,
+        job="pre-release-checks",
+        name="Run integration tests",
+    )
+    assert run_step["if"] is False
+    assert run_step["env"] == RELEASE_INTEGRATION_ENV
 
 
 def test_openwiki_uses_dedicated_environment() -> None:
-    workflow = (WORKFLOWS / "openwiki-update.yml").read_text()
-    assert (
-        "  update:\n    runs-on: ubuntu-latest\n    environment: openwiki\n" in workflow
-    )
+    workflow = _load_workflow("openwiki-update.yml")
+    assert workflow["jobs"]["update"]["environment"] == "openwiki"

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -16,7 +16,7 @@
 #    - Repository: Issues (write)
 #    - Organization: Members (read)
 # 2. Install the app on your organization and this repository
-# 3. Add the repository credential:
+# 3. Add the repository credentials:
 #    - Variable ORG_MEMBERSHIP_APP_CLIENT_ID: Your app's Client ID
 #    - Secret ORG_MEMBERSHIP_APP_PRIVATE_KEY: Your app's private key
 #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1342,6 +1342,8 @@ jobs:
       - name: Run integration tests
         if: false # Disabled: integration tests are not run during releases
         env:
+          # The Code sandbox files are ignored below and its remaining integration
+          # tests use a fake model, so Code receives no provider credentials here.
           ANTHROPIC_API_KEY: ${{ (needs.setup.outputs.package == 'deepagents' || needs.setup.outputs.package == 'langchain-quickjs') && secrets.ANTHROPIC_API_KEY || '' }}
           DAYTONA_API_KEY: ${{ needs.setup.outputs.package == 'langchain-daytona' && secrets.DAYTONA_API_KEY || '' }}
           LANGSMITH_API_KEY: ${{ needs.setup.outputs.package == 'deepagents' && secrets.LANGSMITH_API_KEY || '' }}

--- a/.github/workflows/tag-external-issues.yml
+++ b/.github/workflows/tag-external-issues.yml
@@ -11,7 +11,7 @@
 #    - Repository: Issues (write)
 #    - Organization: Members (read)
 # 2. Install the app on your organization and this repository
-# 3. Add the repository credential:
+# 3. Add the repository credentials:
 #    - Variable ORG_MEMBERSHIP_APP_CLIENT_ID: Your app's Client ID
 #    - Secret ORG_MEMBERSHIP_APP_PRIVATE_KEY: Your app's private key
 #


### PR DESCRIPTION
Credential-scoping regressions now fail with precise assertions instead of passing when secret names, conditions, and references merely appear somewhere in the same workflow step.

---

The static contracts now parse workflow YAML and compare the complete integration and disabled-release `env` mappings. This binds each secret to its exact package condition and credential reference while rejecting unexpected additional entries, including an accidentally unconditional secret.

A separate reachability contract records `libs/code` and `libs/partners/quickjs` as deliberate free-text override targets and verifies every credential condition still points to an existing package path. The dormant integration workflow and its current matrix are otherwise unchanged.

The same parser-based approach replaces whitespace-sensitive extraction for the GitHub App, release, and OpenWiki contracts. A release comment explains why Deep Agents Code intentionally receives no provider credentials there, and two setup comments now refer to the plural credentials they list.