### PR TITLE
ci(infra): move OpenWiki gateway URL to environment variable

### DIFF
--- a/.github/workflows/openwiki-update.yml
+++ b/.github/workflows/openwiki-update.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           OPENWIKI_PROVIDER: openai
           OPENAI_API_KEY: ${{ secrets.LS_GATEWAY_OPENAI_API_KEY }}
-          OPENAI_BASE_URL: https://gateway.smith.langchain.com/openai/v1
+          OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
           OPENWIKI_MODEL_ID: gpt-5.6-terra
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
           LANGCHAIN_PROJECT: openwiki


### PR DESCRIPTION
Read the OpenWiki gateway base URL from the `openwiki` environment variable instead of hardcoding LangSmith's URL in the workflow.

---

The scheduled OpenWiki job already uses environment-scoped secrets for gateway auth. Pointing `OPENAI_BASE_URL` at `${{ vars.OPENAI_BASE_URL }}` keeps endpoint config alongside those credentials so the destination can change without a workflow edit.

Set `OPENAI_BASE_URL` on the `openwiki` GitHub Environment (previously hardcoded as `https://gateway.smith.langchain.com/openai/v1`).
