### PR TITLE
fix(evals): pin virtual_mode=False in the Harbor bare adapter

### DIFF
--- a/libs/evals/deepagents_harbor/langgraph_project/langgraph_agent.py
+++ b/libs/evals/deepagents_harbor/langgraph_project/langgraph_agent.py
@@ -344,7 +344,13 @@ def make_bare_graph(config: dict[str, object] | None = None) -> object:
     """
     configurable = _configurable(config)
     model = _build_model(configurable)
-    backend = LocalShellBackend(root_dir=_workdir(configurable), inherit_env=False)
+    # Harbor runs each task in its own isolated container rooted at the workdir,
+    # and tasks operate on the real sandbox paths, so path virtualization is
+    # unnecessary here (isolation is the container's job). Pin virtual_mode=False
+    # so the bare agent uses paths as-is rather than resolving against a virtual root.
+    backend = LocalShellBackend(
+        root_dir=_workdir(configurable), inherit_env=False, virtual_mode=False
+    )
     # No `system_prompt`: keep the bare agent on `create_deep_agent`'s
     # prompt-free default. The sandbox workdir is already enforced by the shell
     # backend's `root_dir`.

--- a/libs/evals/tests/unit_tests/test_harbor_langgraph_agent.py
+++ b/libs/evals/tests/unit_tests/test_harbor_langgraph_agent.py
@@ -622,7 +622,7 @@ def test_make_bare_graph_builds_sdk_deepagent_with_local_shell(
             "kwargs": {"temperature": 0.0},
         }
     ]
-    assert captured_backend == [{"root_dir": tmp_path, "inherit_env": False}]
+    assert captured_backend == [{"root_dir": tmp_path, "inherit_env": False, "virtual_mode": False}]
     assert captured_create
     assert captured_create[0]["model"] == "chat-model"
     assert captured_create[0]["backend"] is backend


### PR DESCRIPTION
## Problem

The SDK's `LocalShellBackend` `virtual_mode` default flipped from `False` to `True`. The Harbor bare adapter (`make_bare_graph`) constructs `LocalShellBackend(root_dir=..., inherit_env=False)` **without** pinning `virtual_mode`, so it silently began virtualizing sandbox paths.

That broke context-retrieval evals: the agent's filesystem tools resolve paths against a virtual root instead of the real sandbox paths the tasks use. On gpt-5.6-luna lite, context **avg@k dropped ~0.90 → ~0.09** (largely hidden by pass@k, which saturates with rollouts).

## Fix

Pin `virtual_mode=False` in the bare adapter. Harbor runs each task in its own isolated container rooted at the workdir, and the tasks operate on real sandbox paths — path virtualization is unnecessary (isolation comes from the container) and actively breaks file/retrieval tasks.

## Result

With the pin, gpt-5.6-luna lite context returns to canonical (**avg@k 0.967**, pass@k 1.00), matching the scorecard.

## Testing

Unified lite eval (gpt-5.6-luna, bare, docker) on this fix: context pass@k 1.00 / avg@k 0.967 vs 0.70 / 0.09 without it.