### PR TITLE
fix(code): log underlying Auto classifier failures

### DIFF
--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -2092,7 +2092,7 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
         except asyncio.CancelledError:
             raise
         # Providers expose heterogeneous error types; all failures block review.
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             latency_ms = int((time.monotonic() - started) * 1000)
             counters["consecutive_unavailable"] += 1
             counters["last_batch_id"] = batch_id
@@ -2101,6 +2101,11 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
             )
             if not counters_saved:
                 plan["fallback_reason"] = "control_state_unavailable"
+            # Keep the agent/UI reason type-only; put the concrete failure in logs.
+            error_detail = sanitize_auto_reason(
+                f"{type(exc).__name__}: {exc}",
+                known_secrets=self._known_secrets,
+            )
             reason = sanitize_auto_reason(
                 f"The authorization classifier was unavailable ({type(exc).__name__}).",
                 known_secrets=self._known_secrets,
@@ -2129,10 +2134,12 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
             plan["counters_applied"] = True
             logger.info(
                 "Auto decision mode=auto model=%s tools=%d path=classifier "
-                "decision=unavailable latency_ms=%d",
+                "decision=unavailable latency_ms=%d error=%s",
                 _extract_model_name(request.model),
                 len(review_calls),
                 latency_ms,
+                error_detail,
+                exc_info=True,
             )
             return ExtendedModelResponse(
                 model_response=response,

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -2697,6 +2697,43 @@ async def test_malformed_classifier_batch_blocks_call_and_increments_unavailable
     assert counters["total_denials"] == 0
 
 
+async def test_classifier_unavailable_logs_underlying_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    model = _StructuredModel(error=RuntimeError("provider overloaded"))
+    middleware = _middleware(tmp_path)
+    request, _store, _key = _request(
+        tmp_path,
+        model=model,
+        tool_name="delete",
+        args={"file_path": "old.py"},
+    )
+
+    with caplog.at_level("INFO", logger="deepagents_code.auto_mode"):
+        plan = await _plan(
+            middleware,
+            request,
+            tool_name="delete",
+            args={"file_path": "old.py"},
+        )
+
+    assert plan["decisions"][0]["disposition"] == "classifier_unavailable"
+    # Agent/UI stays type-only; logs include the concrete failure and traceback.
+    assert "RuntimeError" in plan["decisions"][0]["reason"]
+    assert "provider overloaded" not in plan["decisions"][0]["reason"]
+    records = [
+        record
+        for record in caplog.records
+        if record.name == "deepagents_code.auto_mode"
+        and "decision=unavailable" in record.getMessage()
+    ]
+    assert len(records) == 1
+    assert "error=RuntimeError: provider overloaded" in records[0].getMessage()
+    assert records[0].exc_info is not None
+    assert records[0].exc_info[0] is RuntimeError
+
+
 async def test_classifier_failure_with_counter_store_failure_routes_human(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
When Auto mode's authorization classifier can't run, application logs now include the redacted exception detail and traceback so you can see why the classifier was unavailable.

Previously the unavailable path only logged that a classifier failure occurred. The agent/UI reason stays type-only.

---

The unavailable logger path now includes a sanitized `Type: message` detail and attaches the exception via `exc_info=True`. Secrets still go through `sanitize_auto_reason` before logging.