### PR TITLE
feat(code): command palette

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2573,9 +2573,13 @@ class DeepAgentsApp(App):
     CSS_PATH = "app.tcss"
     """Path to the Textual CSS stylesheet for the app layout."""
 
-    ENABLE_COMMAND_PALETTE = False
-    """Disable Textual's built-in command palette in favor of the custom slash
-    command system."""
+    ENABLE_COMMAND_PALETTE = True
+    """Enable Textual's built-in command palette."""
+
+    COMMANDS = {
+        "deepagents_code.tui.command_palette:ModelProvider",
+    }
+    """Command palette providers for deepagents-code."""
 
     SCROLL_SENSITIVITY_Y = 1.0
     """Vertical scroll speed (reduced from Textual default for finer control)."""

--- a/libs/code/deepagents_code/tui/command_palette.py
+++ b/libs/code/deepagents_code/tui/command_palette.py
@@ -1,0 +1,121 @@
+"""Command palette providers for deepagents-code."""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import TYPE_CHECKING, AsyncIterator, Mapping, cast
+
+from textual.command import DiscoveryHit, Hit, Hits, Provider
+
+from deepagents_code.model_config import (
+    ModelProfileEntry,
+    ModelSpec,
+    get_available_models,
+    get_model_profiles,
+)
+from deepagents_code.tui.widgets.model_selector import _RECOMMENDED_MODELS
+
+if TYPE_CHECKING:
+    from deepagents_code.app import DeepAgentsApp
+
+
+def _get_display_name(model_spec: str, profiles: Mapping[str, ModelProfileEntry]) -> str:
+    """Resolve the friendly display name for a model spec.
+
+    Matches the logic in `ModelSelectorScreen._get_model_display_name`.
+    """
+    entry = profiles.get(model_spec)
+    if entry:
+        profile = entry.get("profile")
+        if isinstance(profile, dict):
+            name = profile.get("name")
+            if isinstance(name, str) and name:
+                return name
+
+    recommended = _RECOMMENDED_MODELS.get(model_spec)
+    if recommended:
+        return recommended
+
+    parsed = ModelSpec.try_parse(model_spec)
+    if parsed and parsed.model:
+        return parsed.model
+
+    return model_spec
+
+
+class ModelProvider(Provider):
+    """A command palette provider for switching models."""
+
+    async def search(self, query: str) -> Hits:
+        """Search for models matching the query.
+
+        Args:
+            query: The search query.
+
+        Yields:
+            Fuzzy-matched model hits.
+        """
+        matcher = self.matcher(query)
+        app = self.app
+
+        # We need these methods to function. If they are missing (e.g. in some
+        # test environments or if the provider is mounted on a different app),
+        # we degrade gracefully by yielding nothing.
+        switch_model = getattr(app, "_switch_model", None)
+        effective_model_spec = getattr(app, "_effective_model_spec", None)
+
+        if not (callable(switch_model) and callable(effective_model_spec)):
+            return
+
+        available = get_available_models()
+        profiles = get_model_profiles()
+        current_spec = effective_model_spec()
+
+        for provider, models in available.items():
+            for model in models:
+                model_spec = f"{provider}:{model}"
+                display_name = _get_display_name(model_spec, profiles)
+
+                if model_spec == current_spec:
+                    display_name = f"{display_name} (current)"
+
+                score = matcher.match(display_name)
+                if score > 0:
+                    yield Hit(
+                        score,
+                        matcher.highlight(display_name),
+                        partial(switch_model, model_spec),
+                        help=f"Switch to {display_name} ({provider})",
+                    )
+
+    async def discover(self) -> Hits:
+        """Yield all models for discovery (empty query).
+
+        Yields:
+            All available model discovery hits.
+        """
+        app = self.app
+
+        switch_model = getattr(app, "_switch_model", None)
+        effective_model_spec = getattr(app, "_effective_model_spec", None)
+
+        if not (callable(switch_model) and callable(effective_model_spec)):
+            return
+
+        available = get_available_models()
+        profiles = get_model_profiles()
+        current_spec = effective_model_spec()
+
+        for provider, models in available.items():
+            for model in models:
+                model_spec = f"{provider}:{model}"
+                display_name = _get_display_name(model_spec, profiles)
+
+                if model_spec == current_spec:
+                    display_name = f"{display_name} (current)"
+
+                yield DiscoveryHit(
+                    display_name,
+                    partial(switch_model, model_spec),
+                    help=f"Switch to {display_name} ({provider})",
+                )

--- a/libs/code/tests/unit_tests/tui/test_command_palette.py
+++ b/libs/code/tests/unit_tests/tui/test_command_palette.py
@@ -1,0 +1,95 @@
+"""Tests for ModelProvider and CommandPalette integration."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from textual.app import App
+from textual.command import DiscoveryHit, Hit
+
+from deepagents_code.app import DeepAgentsApp
+from deepagents_code.tui.command_palette import ModelProvider
+
+
+class CommandPaletteTestApp(App):
+    """Test app for CommandPalette registration and functionality."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.switched_model: str | None = None
+        self.current_spec: str | None = "openai:gpt-4"
+
+    def _effective_model_spec(self) -> str | None:
+        """Mock _effective_model_spec."""
+        return self.current_spec
+
+    async def _switch_model(
+        self,
+        model_spec: str,
+        *,
+        extra_kwargs: dict[str, Any] | None = None,
+        announce_unchanged: bool = True,
+        persist: bool = True,
+        from_resume: bool = False,
+    ) -> None:
+        """Mock _switch_model for testing."""
+        del extra_kwargs, announce_unchanged, persist, from_resume
+        self.switched_model = model_spec
+
+
+@pytest.mark.asyncio
+async def test_model_provider_logic() -> None:
+    """Test that ModelProvider correctly discovers and searches models."""
+
+    mock_available = {
+        "anthropic": ["claude-3-sonnet", "claude-3-opus"],
+        "openai": ["gpt-4"],
+    }
+    mock_profiles = {
+        "anthropic:claude-3-sonnet": {"profile": {"name": "Claude 3 Sonnet"}},
+        "anthropic:claude-3-opus": {"profile": {"name": "Claude 3 Opus"}},
+        "openai:gpt-4": {"profile": {"name": "GPT-4"}},
+    }
+
+    # Patch model_config functions that ModelProvider calls.
+    with patch(
+        "deepagents_code.tui.command_palette.get_available_models",
+        return_value=mock_available,
+    ), patch(
+        "deepagents_code.tui.command_palette.get_model_profiles",
+        return_value=mock_profiles,
+    ):
+        app = CommandPaletteTestApp()
+        from textual.app import active_app
+
+        active_app.set(app)
+        provider = ModelProvider(app)
+
+        # Test discover()
+        discovery_hits = [hit async for hit in provider.discover()]
+        assert len(discovery_hits) == 3
+        assert all(isinstance(hit, DiscoveryHit) for hit in discovery_hits)
+
+        # DiscoveryHit uses 'display' for the label
+        display_names = {str(hit.display) for hit in discovery_hits}
+        assert "Claude 3 Sonnet" in display_names
+        assert "Claude 3 Opus" in display_names
+        # Check that current model is indicated
+        assert "GPT-4 (current)" in display_names
+
+        # Test search() with a query
+        search_hits = [hit async for hit in provider.search("claude")]
+        assert len(search_hits) == 2
+        assert all(isinstance(hit, Hit) for hit in search_hits)
+
+        # Verify help text includes provider
+        assert any("anthropic" in hit.help.lower() for hit in search_hits)
+
+
+@pytest.mark.asyncio
+async def test_command_palette_registration() -> None:
+    """Test that the command palette is enabled and provider is registered."""
+    assert DeepAgentsApp.ENABLE_COMMAND_PALETTE is True
+    assert "deepagents_code.tui.command_palette:ModelProvider" in DeepAgentsApp.COMMANDS


### PR DESCRIPTION
Resolves #1418

Adds a command palette to the Textual UI, enabling model switching without losing in-progress prompt text.

### Changes
- Enabled Textual's built-in command palette in `DeepAgentsApp`.
- Implemented `ModelProvider` for fuzzy-searching and switching models.
- Added unit tests for the provider logic and app registration.

### Verification
- Added logic tests in `tests/unit_tests/tui/test_command_palette.py` (passing).
- Verified that current model is indicated with a `(current)` suffix.

---
*Created by Hermes Agent*
