### PR TITLE
fix(code): trim `web_search` and `fetch_url` tool descriptions

### DIFF
--- a/libs/code/deepagents_code/tools.py
+++ b/libs/code/deepagents_code/tools.py
@@ -324,32 +324,17 @@ def web_search(  # noqa: ANN201  # Return type depends on dynamic tool configura
     topic: Literal["general", "news", "finance"] = "general",
     include_raw_content: bool = False,
 ):
-    """Search the web using Tavily for current information and documentation.
-
-    This tool searches the web and returns relevant results. After receiving results,
-    you MUST synthesize the information into a natural, helpful response for the user.
+    """Search the web for current information.
 
     Args:
-        query: The search query (be specific and detailed)
-        max_results: Number of results to return (default: 5)
-        topic: Search topic type - "general" for most queries, "news" for current events
-        include_raw_content: Include full page content (warning: uses more tokens)
+        query: Specific search query.
+        max_results: Number of results to return.
+        topic: `"general"`, `"news"`, or `"finance"`.
+        include_raw_content: Include full page text (large; prefer `fetch_url` for a
+            single URL).
 
     Returns:
-        Dictionary containing:
-        - results: List of search results, each with:
-            - title: Page title
-            - url: Page URL
-            - content: Relevant excerpt from the page
-            - score: Relevance score (0-1)
-        - query: The original search query
-
-    IMPORTANT: After using this tool:
-    1. Read through the 'content' field of each result
-    2. Extract relevant information that answers the user's question
-    3. Synthesize this into a clear, natural language response
-    4. Cite sources by mentioning the page titles or URLs
-    5. NEVER show the raw JSON to the user - always provide a formatted response
+        Search hits with title, URL, snippet, and score.
     """
     try:
         import requests
@@ -394,29 +379,14 @@ def web_search(  # noqa: ANN201  # Return type depends on dynamic tool configura
 
 
 def fetch_url(url: str, timeout: int = 30) -> dict[str, Any]:
-    """Fetch content from a URL and convert HTML to markdown format.
-
-    This tool fetches web page content and converts it to clean markdown text,
-    making it easy to read and process HTML content. After receiving the markdown,
-    you MUST synthesize the information into a natural, helpful response for the user.
+    """Fetch a URL and return the page content as markdown.
 
     Args:
-        url: The URL to fetch (must be a valid HTTP/HTTPS URL)
-        timeout: Request timeout in seconds (default: 30)
+        url: HTTP or HTTPS URL to fetch.
+        timeout: Request timeout in seconds.
 
     Returns:
-        Dictionary containing:
-        - success: Whether the request succeeded
-        - url: The final URL after redirects
-        - markdown_content: The page content converted to markdown
-        - status_code: HTTP status code
-        - content_length: Length of the markdown content in characters
-
-    IMPORTANT: After using this tool:
-    1. Read through the markdown content
-    2. Extract relevant information that answers the user's question
-    3. Synthesize this into a clear, natural language response
-    4. NEVER show the raw markdown to the user unless specifically requested
+        Fetched page markdown plus status metadata.
     """
     try:
         import requests

--- a/libs/code/deepagents_code/tools.py
+++ b/libs/code/deepagents_code/tools.py
@@ -336,17 +336,15 @@ def web_search(  # noqa: ANN201  # Return type depends on dynamic tool configura
     ] = "general",
     include_raw_content: Annotated[
         bool,
-        Field(description="Include full page content (uses more tokens)."),
+        Field(
+            description=(
+                "Include full page content (uses more tokens). Prefer `fetch_url` "
+                "for a single URL."
+            )
+        ),
     ] = False,
 ):
     """Search the web for current information.
-
-    Args:
-        query: Specific search query.
-        max_results: Number of results to return.
-        topic: `"general"`, `"news"`, or `"finance"`.
-        include_raw_content: Include full page text (large; prefer `fetch_url` for a
-            single URL).
 
     Returns:
         Search hits with title, URL, snippet, and score.
@@ -404,10 +402,6 @@ def fetch_url(
     ] = 30,
 ) -> dict[str, Any]:
     """Fetch a URL and return the page content as markdown.
-
-    Args:
-        url: HTTP or HTTPS URL to fetch.
-        timeout: Request timeout in seconds.
 
     Returns:
         Fetched page markdown plus status metadata.


### PR DESCRIPTION
Shortens the model-facing `web_search` and `fetch_url` tool descriptions by dropping provider branding, response-field inventories, and generic "synthesize for the user" instructions that do not change tool behavior.

---

Tavily remains visible in user-facing setup and approval copy; only the LLM tool schema text was trimmed.
