### PR TITLE
fix(code): put field descriptions on first-party tool schemas

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -556,7 +556,10 @@ def _create_rubric_grader_tools(
             return active.bound_text(name, result)
         return _RUBRIC_GRADER_NON_TEXT_MESSAGE
 
-    @tool(description=artifact_read_file.description)
+    @tool(
+        description=artifact_read_file.description,
+        args_schema=artifact_read_file.args_schema,
+    )
     def read_file(
         file_path: str,
         runtime: ToolRuntime[None, Any],
@@ -632,7 +635,10 @@ def _create_rubric_grader_tools(
         fs_ls = cast("StructuredTool", repository_tools["ls"])
         fs_ls_func = _fs_func(repository_tools, "ls")
 
-        @tool(description=fs_ls.description)
+        @tool(
+            description=fs_ls.description,
+            args_schema=fs_ls.args_schema,
+        )
         def ls(path: str, runtime: ToolRuntime[None, Any]) -> object:
             """List a working-directory path to verify criteria against files.
 
@@ -657,7 +663,10 @@ def _create_rubric_grader_tools(
         fs_glob = cast("StructuredTool", repository_tools["glob"])
         fs_glob_func = _fs_func(repository_tools, "glob")
 
-        @tool(description=fs_glob.description)
+        @tool(
+            description=fs_glob.description,
+            args_schema=fs_glob.args_schema,
+        )
         def glob(
             pattern: str,
             runtime: ToolRuntime[None, Any],
@@ -695,7 +704,10 @@ def _create_rubric_grader_tools(
         fs_grep = cast("StructuredTool", repository_tools["grep"])
         fs_grep_func = _fs_func(repository_tools, "grep")
 
-        @tool(description=fs_grep.description)
+        @tool(
+            description=fs_grep.description,
+            args_schema=fs_grep.args_schema,
+        )
         def grep(
             pattern: str,
             runtime: ToolRuntime[None, Any],

--- a/libs/code/deepagents_code/ask_user.py
+++ b/libs/code/deepagents_code/ask_user.py
@@ -21,6 +21,7 @@ from langchain.tools import InjectedToolCallId, ToolRuntime
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.tools import tool
 from langgraph.types import Command, interrupt
+from pydantic import Field
 
 from deepagents_code._ask_user_types import (
     ASK_USER_AUTHORIZATION_METADATA_KEY,
@@ -306,16 +307,14 @@ class AskUserMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
 
         @tool(description=self.tool_description)
         def _ask_user(
-            questions: list[Question],
+            questions: Annotated[
+                list[Question],
+                Field(description="Questions to present to the user."),
+            ],
             tool_call_id: Annotated[str, InjectedToolCallId],
             runtime: ToolRuntime[Any, Any],
         ) -> Command[Any]:
             """Ask the user one or more questions.
-
-            Args:
-                questions: Questions to present to the user.
-                tool_call_id: Tool call identifier injected by LangChain.
-                runtime: Trusted graph runtime for thread and turn identity.
 
             Returns:
                 `Command` containing the parsed user answers as a `ToolMessage`.

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -48,7 +48,7 @@ from langchain_core.messages import (
 )
 from langchain_core.tools import BaseTool, tool
 from langgraph.types import Command, interrupt
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from typing_extensions import TypedDict
 
 from deepagents_code._ask_user_types import (
@@ -1582,20 +1582,21 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
 
         @tool
         def create_temp_artifact(
-            content: str,
+            content: Annotated[
+                str,
+                Field(description="UTF-8 text to write once to the scratch file."),
+            ],
             runtime: ToolRuntime[Any, AutoModeState],
-            suffix: str = "",
+            suffix: Annotated[
+                str,
+                Field(description="Optional short extension such as `.md`."),
+            ] = "",
         ) -> Command[Any]:
             """Create a private OS-temp text file for this request.
 
             Use this instead of `write_file` when a command needs a temporary input
             file, such as a pull-request body passed with `--body-file`. Dcode chooses
             and exclusively allocates the path; callers cannot select or overwrite one.
-
-            Args:
-                content: UTF-8 text to write once to the scratch file.
-                runtime: Trusted tool runtime injected by LangGraph.
-                suffix: Optional short extension such as `.md`.
 
             Returns:
                 A tool message containing the allocated absolute path.
@@ -1642,14 +1643,13 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
 
         @tool
         def delete_temp_artifact(
-            file_path: str,
+            file_path: Annotated[
+                str,
+                Field(description="Exact path returned by `create_temp_artifact`."),
+            ],
             runtime: ToolRuntime[Any, AutoModeState],
         ) -> Command[Any]:
             """Delete one exact OS-temp artifact created for this request.
-
-            Args:
-                file_path: Exact path returned by `create_temp_artifact`.
-                runtime: Trusted tool runtime injected by LangGraph.
 
             Returns:
                 A tool message reporting exact cleanup or a fail-closed denial.

--- a/libs/code/deepagents_code/goal_tools.py
+++ b/libs/code/deepagents_code/goal_tools.py
@@ -24,6 +24,7 @@ from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
 from langchain_core.tools import InjectedToolCallId, tool
 from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
+from pydantic import Field
 from typing_extensions import override
 
 # Runtime (not TYPE_CHECKING) imports. `GoalRubricChannels` supplies the shared
@@ -421,8 +422,24 @@ class GoalToolsMiddleware(AgentMiddleware[GoalToolState, ContextT]):
 
         @tool
         def update_goal(
-            status: Literal["complete", "blocked"],
-            note: str,
+            status: Annotated[
+                Literal["complete", "blocked"],
+                Field(
+                    description=(
+                        "`complete` to attach completion evidence, or `blocked` "
+                        "when you are stuck and need the user."
+                    )
+                ),
+            ],
+            note: Annotated[
+                str,
+                Field(
+                    description=(
+                        "Evidence the criteria are satisfied, or the specific "
+                        "blocker. Required when calling this tool."
+                    )
+                ),
+            ],
             tool_call_id: Annotated[str, InjectedToolCallId],
             state: Annotated[dict[str, Any], InjectedState],
         ) -> Command[Any]:
@@ -432,14 +449,6 @@ class GoalToolsMiddleware(AgentMiddleware[GoalToolState, ContextT]):
             automatically after a satisfied goal-backed grading turn, so `complete`
             is optional and only stages its evidence for that result. Do not create,
             pause, resume, clear, or replace goals — those are user-controlled.
-
-            Args:
-                status: `complete` to attach completion evidence, or `blocked` when
-                    you are stuck and need the user.
-                note: Evidence the criteria are satisfied, or the specific
-                    blocker. Required when calling this tool.
-                tool_call_id: Injected tool call ID for the tool response.
-                state: Injected graph state holding the current goal.
 
             Returns:
                 Command that updates goal status and returns a tool message.

--- a/libs/code/deepagents_code/tools.py
+++ b/libs/code/deepagents_code/tools.py
@@ -8,11 +8,12 @@ import logging
 import socket
 import threading
 from html.parser import HTMLParser
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 from urllib.parse import urljoin, urlparse
 
-from langchain_core.runnables import RunnableConfig  # noqa: TC002  # runtime hint
 from langchain_core.tools import tool
+from langgraph.config import get_config
+from pydantic import Field
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -303,37 +304,45 @@ def _get_tavily_client() -> TavilyClient | None:
 
 
 @tool
-def get_current_thread_id(config: RunnableConfig) -> str:
+def get_current_thread_id() -> str:
     """Get the current Deep Agents thread ID for LangSmith or MCP tooling.
-
-    Args:
-        config: Runtime config injected by LangChain.
 
     Returns:
         The current `configurable.thread_id`, or an explanatory message if missing.
     """
-    thread_id = config.get("configurable", {}).get("thread_id")
+    thread_id = get_config().get("configurable", {}).get("thread_id")
     if isinstance(thread_id, str) and thread_id:
         return thread_id
     return "No current thread ID is available."
 
 
 def web_search(  # noqa: ANN201  # Return type depends on dynamic tool configuration
-    query: str,
-    max_results: int = 5,
-    topic: Literal["general", "news", "finance"] = "general",
-    include_raw_content: bool = False,
+    query: Annotated[
+        str,
+        Field(description="The search query (be specific and detailed)."),
+    ],
+    max_results: Annotated[
+        int,
+        Field(description="Number of results to return."),
+    ] = 5,
+    topic: Annotated[
+        Literal["general", "news", "finance"],
+        Field(
+            description=(
+                'Search topic type: "general" for most queries, "news" for '
+                'current events, or "finance".'
+            )
+        ),
+    ] = "general",
+    include_raw_content: Annotated[
+        bool,
+        Field(description="Include full page content (uses more tokens)."),
+    ] = False,
 ):
     """Search the web using Tavily for current information and documentation.
 
     This tool searches the web and returns relevant results. After receiving results,
     you MUST synthesize the information into a natural, helpful response for the user.
-
-    Args:
-        query: The search query (be specific and detailed)
-        max_results: Number of results to return (default: 5)
-        topic: Search topic type - "general" for most queries, "news" for current events
-        include_raw_content: Include full page content (warning: uses more tokens)
 
     Returns:
         Dictionary containing:
@@ -393,16 +402,21 @@ def web_search(  # noqa: ANN201  # Return type depends on dynamic tool configura
         return {"error": f"Web search error: {e!s}", "query": query}
 
 
-def fetch_url(url: str, timeout: int = 30) -> dict[str, Any]:
+def fetch_url(
+    url: Annotated[
+        str,
+        Field(description="The URL to fetch (must be a valid HTTP/HTTPS URL)."),
+    ],
+    timeout: Annotated[
+        int,
+        Field(description="Request timeout in seconds."),
+    ] = 30,
+) -> dict[str, Any]:
     """Fetch content from a URL and convert HTML to markdown format.
 
     This tool fetches web page content and converts it to clean markdown text,
     making it easy to read and process HTML content. After receiving the markdown,
     you MUST synthesize the information into a natural, helpful response for the user.
-
-    Args:
-        url: The URL to fetch (must be a valid HTTP/HTTPS URL)
-        timeout: Request timeout in seconds (default: 30)
 
     Returns:
         Dictionary containing:

--- a/libs/code/tests/unit_tests/tools/test_tool_arg_schemas.py
+++ b/libs/code/tests/unit_tests/tools/test_tool_arg_schemas.py
@@ -1,0 +1,149 @@
+"""Ensure first-party tools expose per-argument schema descriptions."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Annotated
+from unittest.mock import Mock
+
+import pytest
+from langchain_core.tools import BaseTool, StructuredTool, tool
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from pydantic import Field
+
+from deepagents_code.ask_user import AskUserMiddleware
+from deepagents_code.auto_mode import AutoModeHITLMiddleware
+from deepagents_code.goal_tools import GoalToolsMiddleware
+from deepagents_code.offload_middleware import CLICompactionMiddleware
+from deepagents_code.tools import fetch_url, get_current_thread_id, web_search
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from langchain.agents.middleware.human_in_the_loop import InterruptOnConfig
+
+ToolLike = BaseTool | Callable[..., object]
+
+
+def _as_tool(candidate: ToolLike) -> BaseTool:
+    """Normalize bare callables the same way agent construction does."""
+    if isinstance(candidate, BaseTool):
+        return candidate
+    return StructuredTool.from_function(func=candidate)
+
+
+def _model_properties(candidate: ToolLike) -> dict[str, object]:
+    """Return OpenAI-style parameter properties for a tool."""
+    schema = convert_to_openai_tool(_as_tool(candidate))
+    params = schema["function"]["parameters"]
+    assert isinstance(params, dict)
+    props = params.get("properties") or {}
+    assert isinstance(props, dict)
+    return props
+
+
+def _assert_model_args_described(
+    candidate: ToolLike, *, expected: set[str] | None = None
+) -> None:
+    """Assert every model-visible property has a non-empty description."""
+    props = _model_properties(candidate)
+    if expected is not None:
+        assert set(props) == expected
+    missing = [
+        name
+        for name, spec in props.items()
+        if not isinstance(spec, dict) or not str(spec.get("description") or "").strip()
+    ]
+    tool_name = getattr(_as_tool(candidate), "name", type(candidate).__name__)
+    assert not missing, f"{tool_name} missing property descriptions: {missing}"
+
+
+@pytest.mark.parametrize(
+    ("candidate", "expected"),
+    [
+        (get_current_thread_id, set()),
+        (
+            web_search,
+            {"query", "max_results", "topic", "include_raw_content"},
+        ),
+        (fetch_url, {"url", "timeout"}),
+    ],
+)
+def test_core_custom_tools_have_described_args(
+    candidate: ToolLike, expected: set[str]
+) -> None:
+    """`tools.py` callables should expose Field descriptions in the model schema."""
+    _assert_model_args_described(candidate, expected=expected)
+
+
+def test_goal_tools_have_described_model_args() -> None:
+    """Goal tools keep injected state hidden and describe model-facing fields."""
+    middleware = GoalToolsMiddleware()
+    by_name = {item.name: item for item in middleware.tools}
+    _assert_model_args_described(by_name["get_rubric"], expected=set())
+    _assert_model_args_described(by_name["get_goal"], expected=set())
+    _assert_model_args_described(by_name["update_goal"], expected={"status", "note"})
+
+
+def test_ask_user_has_described_questions_arg() -> None:
+    """`ask_user` should describe its questions list at the property level."""
+    middleware = AskUserMiddleware()
+    _assert_model_args_described(middleware.tools[0], expected={"questions"})
+
+
+def test_compact_conversation_has_no_model_args() -> None:
+    """Forced-compaction injects handle model-facing args only via runtime."""
+    middleware = CLICompactionMiddleware(Mock())
+    compact = next(t for t in middleware.tools if t.name == "compact_conversation")
+    _assert_model_args_described(compact, expected=set())
+
+
+def test_auto_mode_temp_artifact_tools_have_described_args(
+    tmp_path: Path,
+) -> None:
+    """Auto mode scratch tools expose Field descriptions for model args."""
+    config: InterruptOnConfig = {"allowed_decisions": ["approve", "reject"]}
+    middleware = AutoModeHITLMiddleware(
+        {
+            "compact_conversation": config,
+            "delete": config,
+            "execute": config,
+            "write_file": config,
+            "edit_file": config,
+            "task": config,
+            "mcp_mutate": config,
+            "mcp_read": config,
+        },
+        worktree_root=tmp_path,
+        classifier_timeout_seconds=1,
+    )
+    by_name = {item.name: item for item in middleware.tools}
+    _assert_model_args_described(
+        by_name["create_temp_artifact"], expected={"content", "suffix"}
+    )
+    _assert_model_args_described(
+        by_name["delete_temp_artifact"], expected={"file_path"}
+    )
+
+
+def test_annotated_field_survives_from_function_wrapper() -> None:
+    """Regression: bare `from_function` keeps Annotated Field descriptions."""
+
+    def sample(value: str) -> str:
+        """Sample tool."""
+        return value
+
+    def sample_described(
+        value: Annotated[str, Field(description="A described value.")],
+    ) -> str:
+        """Sample tool."""
+        return value
+
+    plain = tool(sample)
+    described = StructuredTool.from_function(func=sample_described)
+    plain_props = convert_to_openai_tool(plain)["function"]["parameters"]["properties"]
+    described_props = convert_to_openai_tool(described)["function"]["parameters"][
+        "properties"
+    ]
+    assert "description" not in plain_props["value"]
+    assert described_props["value"]["description"] == "A described value."


### PR DESCRIPTION
First-party Deep Agents Code tools like `web_search` only put argument docs in the tool description string. LangSmith and model tool schemas therefore showed argument names/types without per-arg descriptions, unlike SDK filesystem tools and `js_eval`, which use `Field(description=...)`.

Put model-facing parameter documentation on the JSON schema properties for built-in dcode tools, and keep injected runtime parameters out of that schema.

---

- Annotate model-facing tool parameters with `Field(description=...)` (or reuse existing FS `args_schema`s when wrapping grader tools).
- Keep zero-arg / injected-only tools argument-free (`get_current_thread_id` via `get_config()`, goal state tools, compaction).