### PR TITLE
fix(code): ignore LangSmith default US endpoint as custom target

### DIFF
--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -714,6 +714,12 @@ def _disable_orphaned_tracing() -> None:
         return
 
     env = dict(os.environ)
+    # Match SDK endpoint precedence: a populated env var wins over the profile,
+    # even when it is the default US URL. Only consult the profile when no
+    # endpoint env var is set.
+    has_env_endpoint = any(
+        (env.get(var) or "").strip() for var in _TRACING_ENDPOINT_ENV_VARS
+    )
     has_custom_endpoint = any(
         (value := (env.get(var) or "").strip())
         and not _is_langsmith_sdk_default_endpoint(value)
@@ -721,7 +727,7 @@ def _disable_orphaned_tracing() -> None:
     )
     if (
         has_custom_endpoint
-        or _has_langsmith_profile_custom_endpoint()
+        or (not has_env_endpoint and _has_langsmith_profile_custom_endpoint())
         or _has_langsmith_runs_endpoints_from(env)
     ):
         return
@@ -3649,17 +3655,23 @@ def _tracing_endpoint_from(env: dict[str, str]) -> str | None:
     LangSmith SDK reads them canonically, so only the canonical names (plus the
     active profile's `api_url`) are consulted here.
 
-    The SDK default US SaaS URL is ignored whether it comes from env or profile:
-    it is not a custom ingest target, and forwarding it would make keyless
-    upload-target checks fire for ordinary cloud profiles.
+    Mirrors SDK resolution order (`env_api_url or profile_config.api_url`): a
+    populated env endpoint wins over the profile. The SDK default US SaaS URL is
+    not a custom ingest target — when env is that default, return `None` without
+    falling through to the profile. When env is unset, a non-default profile
+    `api_url` still counts.
 
     Args:
         env: Environment mapping to read.
     """
     for var in _TRACING_ENDPOINT_ENV_VARS:
         value = (env.get(var) or "").strip()
-        if value and not _is_langsmith_sdk_default_endpoint(value):
-            return value
+        if not value:
+            continue
+        if _is_langsmith_sdk_default_endpoint(value):
+            # Non-empty env wins over profile, even when it is the SDK default.
+            return None
+        return value
     config = _load_langsmith_profile_config(env)
     if config is not None:
         api_url = (config.api_url or "").strip()

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -461,6 +461,21 @@ def normalize_langsmith_endpoint(value: str) -> str:
     return cleaned
 
 
+def _is_langsmith_sdk_default_endpoint(value: str) -> bool:
+    """Return whether `value` is the LangSmith SDK's default US SaaS endpoint.
+
+    Profiles and configs often surface `LANGSMITH_US_ENDPOINT` even when the
+    user never chose a custom ingest target. That default is not a keyless
+    custom endpoint: the SDK treats it the same as leaving `api_url` unset, so
+    upload-target checks and client kwargs should ignore it.
+    """
+    cleaned = value.strip().rstrip("/")
+    if not cleaned:
+        return False
+    default = LANGSMITH_US_ENDPOINT.rstrip("/")
+    return cleaned.lower() == default.lower()
+
+
 def is_http_url(value: str) -> bool:
     """Return whether `value` is a non-empty `http`/`https` URL with a host.
 
@@ -575,12 +590,17 @@ def _has_langsmith_profile_credentials(env: dict[str, str] | None = None) -> boo
 
 
 def _has_langsmith_profile_custom_endpoint(env: dict[str, str] | None = None) -> bool:
-    """Return whether the LangSmith profile points at a custom endpoint."""
+    """Return whether the LangSmith profile points at a custom endpoint.
+
+    The SDK default US SaaS URL does not count: profiles often store it
+    even when the user never chose a custom ingest target.
+    """
     config = _load_langsmith_profile_config(env)
     if config is None:
         return False
 
-    return bool((config.api_url or "").strip())
+    api_url = (config.api_url or "").strip()
+    return bool(api_url) and not _is_langsmith_sdk_default_endpoint(api_url)
 
 
 def _build_orphaned_tracing_disabled_notice() -> str:
@@ -695,7 +715,9 @@ def _disable_orphaned_tracing() -> None:
 
     env = dict(os.environ)
     has_custom_endpoint = any(
-        (env.get(var) or "").strip() for var in _TRACING_ENDPOINT_ENV_VARS
+        (value := (env.get(var) or "").strip())
+        and not _is_langsmith_sdk_default_endpoint(value)
+        for var in _TRACING_ENDPOINT_ENV_VARS
     )
     if (
         has_custom_endpoint
@@ -3627,17 +3649,21 @@ def _tracing_endpoint_from(env: dict[str, str]) -> str | None:
     LangSmith SDK reads them canonically, so only the canonical names (plus the
     active profile's `api_url`) are consulted here.
 
+    The SDK default US SaaS URL is ignored whether it comes from env or profile:
+    it is not a custom ingest target, and forwarding it would make keyless
+    upload-target checks fire for ordinary cloud profiles.
+
     Args:
         env: Environment mapping to read.
     """
     for var in _TRACING_ENDPOINT_ENV_VARS:
         value = (env.get(var) or "").strip()
-        if value:
+        if value and not _is_langsmith_sdk_default_endpoint(value):
             return value
     config = _load_langsmith_profile_config(env)
     if config is not None:
         api_url = (config.api_url or "").strip()
-        if api_url:
+        if api_url and not _is_langsmith_sdk_default_endpoint(api_url):
             return api_url
     return None
 

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -2343,6 +2343,40 @@ class TestLangsmithSecretRedaction:
         _, kwargs = client_cls.call_args
         assert "api_url" not in kwargs
 
+    def test_default_us_env_does_not_forward_profile_custom_endpoint(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A populated default env endpoint wins over a profile custom `api_url`.
+
+        The SDK resolves `env_api_url or profile_config.api_url`, so an explicit
+        default US env value must not fall through to the profile when building
+        the redacting client.
+        """
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", "lsv2_test")
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_TRACING", "true")
+        monkeypatch.setenv("LANGSMITH_ENDPOINT", LANGSMITH_US_ENDPOINT)
+
+        profile = Mock()
+        profile.api_url = "https://eu.smith.example.com"
+        profile.api_key = None
+        profile.oauth_access_token = None
+        profile.oauth_refresh_token = None
+
+        with (
+            patch("deepagents_code.config_manifest.load_config_toml", return_value={}),
+            patch(
+                "deepagents_code.config._load_langsmith_profile_config",
+                return_value=profile,
+            ),
+            patch("langsmith.Client", return_value=object()) as client_cls,
+            patch("langsmith.configure"),
+        ):
+            assert configure_langsmith_secret_redaction() is True
+
+        _, kwargs = client_cls.call_args
+        assert "api_url" not in kwargs
+
     def test_skips_keyless_default_us_endpoint(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -2740,6 +2774,33 @@ class TestDisableOrphanedTracing:
         )
         env = self._clean_env()
         env["LANGCHAIN_TRACING_V2"] = "true"
+        env["LANGSMITH_CONFIG_FILE"] = str(config)
+        with patch.dict("os.environ", env, clear=False):
+            _disable_orphaned_tracing()
+            import os
+
+            assert os.environ["LANGCHAIN_TRACING_V2"] == "false"
+            assert consume_orphaned_tracing_disabled_notice() is not None
+
+    def test_disables_tracing_when_default_us_env_overrides_profile_custom(
+        self, tmp_path: Path
+    ) -> None:
+        """Populated default US env wins over profile custom for orphaned disable.
+
+        The SDK would still target keyless US in that case, so the profile's
+        custom api_url must not be trusted as a keyless upload target.
+        """
+        config = tmp_path / "config.json"
+        config.write_text(
+            "{"
+            '"current_profile":"default",'
+            '"profiles":{"default":{"api_url":"http://localhost:1984"}}'
+            "}",
+            encoding="utf-8",
+        )
+        env = self._clean_env()
+        env["LANGCHAIN_TRACING_V2"] = "true"
+        env["LANGSMITH_ENDPOINT"] = LANGSMITH_US_ENDPOINT
         env["LANGSMITH_CONFIG_FILE"] = str(config)
         with patch.dict("os.environ", env, clear=False):
             _disable_orphaned_tracing()

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -2324,6 +2324,47 @@ class TestLangsmithSecretRedaction:
         _, kwargs = client_cls.call_args
         assert kwargs["api_url"] == "https://eu.smith.example.com"
 
+    def test_does_not_forward_default_us_endpoint_as_api_url(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The SDK default US SaaS URL is not forwarded as a custom `api_url`."""
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_API_KEY", "lsv2_test")
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_TRACING", "true")
+        monkeypatch.setenv("LANGSMITH_ENDPOINT", LANGSMITH_US_ENDPOINT)
+
+        with (
+            patch("deepagents_code.config_manifest.load_config_toml", return_value={}),
+            patch("langsmith.Client", return_value=object()) as client_cls,
+            patch("langsmith.configure"),
+        ):
+            assert configure_langsmith_secret_redaction() is True
+
+        _, kwargs = client_cls.call_args
+        assert "api_url" not in kwargs
+
+    def test_skips_keyless_default_us_endpoint(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Keyless default US endpoint is not treated as an upload target."""
+        monkeypatch.setenv("DEEPAGENTS_CODE_LANGSMITH_TRACING", "true")
+        monkeypatch.setenv("LANGSMITH_ENDPOINT", f"{LANGSMITH_US_ENDPOINT}/")
+
+        with (
+            patch("deepagents_code.config_manifest.load_config_toml", return_value={}),
+            patch(
+                "deepagents_code.config._has_langsmith_profile_credentials",
+                return_value=False,
+            ),
+            patch("langsmith.Client") as client_cls,
+            patch("langsmith.configure") as configure,
+        ):
+            assert configure_langsmith_secret_redaction() is False
+
+        client_cls.assert_not_called()
+        configure.assert_not_called()
+
     def test_configures_client_for_keyless_custom_endpoint(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -2636,6 +2677,18 @@ class TestDisableOrphanedTracing:
             # Nothing was disabled, so no startup notice should be staged.
             assert consume_orphaned_tracing_disabled_notice() is None
 
+    def test_disables_tracing_when_only_default_us_endpoint_set(self) -> None:
+        """SDK default US endpoint alone is not a keyless custom upload target."""
+        env = self._clean_env()
+        env["LANGCHAIN_TRACING_V2"] = "true"
+        env["LANGSMITH_ENDPOINT"] = LANGSMITH_US_ENDPOINT
+        with patch.dict("os.environ", env, clear=False):
+            _disable_orphaned_tracing()
+            import os
+
+            assert os.environ["LANGCHAIN_TRACING_V2"] == "false"
+            assert consume_orphaned_tracing_disabled_notice() is not None
+
     def test_preserves_tracing_when_runs_endpoints_set(self) -> None:
         """Replica endpoints are trusted upload targets even without a top-level key."""
         env = self._clean_env()
@@ -2672,6 +2725,28 @@ class TestDisableOrphanedTracing:
             assert os.environ["LANGCHAIN_TRACING_V2"] == "true"
             # Nothing was disabled, so no startup notice should be staged.
             assert consume_orphaned_tracing_disabled_notice() is None
+
+    def test_disables_tracing_when_profile_only_has_default_us_endpoint(
+        self, tmp_path: Path
+    ) -> None:
+        """Profile default US api_url alone does not count as a custom endpoint."""
+        config = tmp_path / "config.json"
+        config.write_text(
+            "{"
+            '"current_profile":"default",'
+            f'"profiles":{{"default":{{"api_url":"{LANGSMITH_US_ENDPOINT}"}}}}'
+            "}",
+            encoding="utf-8",
+        )
+        env = self._clean_env()
+        env["LANGCHAIN_TRACING_V2"] = "true"
+        env["LANGSMITH_CONFIG_FILE"] = str(config)
+        with patch.dict("os.environ", env, clear=False):
+            _disable_orphaned_tracing()
+            import os
+
+            assert os.environ["LANGCHAIN_TRACING_V2"] == "false"
+            assert consume_orphaned_tracing_disabled_notice() is not None
 
     def test_preserves_tracing_when_key_present(self) -> None:
         """Tracing stays enabled when a usable API key is set."""


### PR DESCRIPTION
When LangSmith profiles or env vars include the default US SaaS URL (`https://api.smith.langchain.com`), dcode no longer treats that URL as a custom keyless upload target.

Previously, that default looked like a self-hosted/custom endpoint, so keyless redaction setup could still run, client kwargs could forward a redundant `api_url`, and orphaned-tracing disable could skip even though no real custom ingest target was configured.

---

Profiles and configs often surface the stock US endpoint even when the user never chose a custom target. The SDK treats that the same as leaving `api_url` unset, so upload-target checks and client construction now ignore it whether it comes from env vars or the active profile.
