### PR TITLE
refactor(code): drop redundant goal-tool system prompt injection

### DIFF
--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -2501,7 +2501,7 @@ def create_cli_agent(
     # is written by `ConfigurableModelMiddleware` from the actual completed model
     # request. The CLI reads them back from `state_values` on thread resume.
     # Goal tools: exposes the read-only `get_goal`/`get_rubric` tools and the
-    # constrained `update_goal` tool, and injects goal guidance into the prompt.
+    # constrained `update_goal` tool, and maintains goal-state notices.
     from deepagents_code.goal_tools import GoalToolsMiddleware
     from deepagents_code.resume_state import ResumeStateMiddleware
 

--- a/libs/code/deepagents_code/goal_tools.py
+++ b/libs/code/deepagents_code/goal_tools.py
@@ -398,7 +398,8 @@ class GoalToolsMiddleware(AgentMiddleware[GoalToolState, ContextT]):
 
             Use this only when the latest goal/rubric state notice reports an
             actionable goal. It returns the objective, criteria, lifecycle status,
-            and any prior note from authoritative checkpoint state.
+            and any prior note from authoritative checkpoint state. Paused and
+            completed goals report `active=False` and must not drive work.
 
             Returns:
                 Goal snapshot with `active`, `objective`, `status`, `criteria`,

--- a/libs/code/deepagents_code/goal_tools.py
+++ b/libs/code/deepagents_code/goal_tools.py
@@ -20,7 +20,7 @@ from langchain.agents.middleware.types import (
     ModelRequest,
     ModelResponse,
 )
-from langchain_core.messages import HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages import HumanMessage, ToolMessage
 from langchain_core.tools import InjectedToolCallId, tool
 from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
@@ -51,20 +51,6 @@ if TYPE_CHECKING:
 
 RubricSource = Literal["goal", "sticky", "invocation"]
 """Where the active rubric criteria came from, as reported to the model."""
-
-GOAL_TOOLS_SYSTEM_PROMPT = """## Goal and Rubric Tools
-
-Consult the latest goal/rubric state notice in conversation history before using
-these tools. Later notices supersede earlier notices. If no notice exists, assume
-there is no actionable goal or rubric and do not call these tools.
-
-When the latest notice says a rubric is active, use `get_rubric` when its exact
-acceptance criteria are needed. When it says a goal is actionable, use `get_goal`
-when its objective or current status is needed. Paused and completed goals must not
-drive work. Use `update_goal` only for an actionable goal: report a blocker with it;
-`status="complete"` remains available for optional completion evidence but is not
-required. Private checkpoint state and the tools remain authoritative for details."""
-"""Static model-visible guidance injected by `GoalToolsMiddleware`."""
 
 GOAL_TOOL_NAMES = frozenset({"get_goal", "get_rubric", "update_goal"})
 """Tool names used by behavioral absence gates and middleware contract tests."""
@@ -376,9 +362,9 @@ class GoalToolsMiddleware(AgentMiddleware[GoalToolState, ContextT]):
     Besides registering `get_goal`/`get_rubric`/`update_goal`, this middleware
     keeps the model oriented at each model boundary: `before_model` persists a
     fresh goal-state notice into checkpointed history when the latest one no
-    longer matches authoritative state, and `wrap_model_call` both appends the
-    static goal guidance to the system prompt and re-pins the notice into the
-    (post-summarization) request when the persisted one is out of view.
+    longer matches authoritative state, and `wrap_model_call` re-pins the
+    notice into the (post-summarization) request when the persisted one is out
+    of view. Tool usage guidance lives in the tool docstrings and notices.
     """
 
     state_schema = GoalToolState
@@ -502,38 +488,25 @@ class GoalToolsMiddleware(AgentMiddleware[GoalToolState, ContextT]):
         return self._notice_update(state)
 
     @staticmethod
-    def _request_with_goal_system_prompt(
+    def _request_with_goal_notice(
         request: ModelRequest[ContextT],
     ) -> ModelRequest[ContextT]:
-        """Append static goal guidance and re-pin the notice into a request.
+        """Re-pin the current goal-state notice into a model request when needed.
 
-        The system prompt gains the static goal-tool guidance, and — when
-        checkpointed history no longer surfaces a current notice — a transient
-        goal-state notice is appended to the request messages only (not
-        persisted; `before_model` owns the durable write).
+        When checkpointed history no longer surfaces a current notice, a
+        transient goal-state notice is appended to the request messages only
+        (not persisted; `before_model` owns the durable write). The system
+        prompt is left unchanged.
 
         Returns:
-            Model request with goal guidance in the system prompt and, when
-            needed, a current goal-state notice appended to its messages.
+            The original request when no notice is needed, otherwise a request
+            with a current goal-state notice appended to its messages.
         """
-        if request.system_message is not None:
-            content = [
-                *request.system_message.content_blocks,
-                {"type": "text", "text": f"\n\n{GOAL_TOOLS_SYSTEM_PROMPT}"},
-            ]
-        else:
-            content = [{"type": "text", "text": GOAL_TOOLS_SYSTEM_PROMPT}]
         values = cast("dict[str, Any]", request.state)
         notice = _goal_state_notice_for(values, request.messages)
-        messages = (
-            [*request.messages, notice] if notice is not None else request.messages
-        )
-        return request.override(
-            messages=messages,
-            system_message=SystemMessage(
-                content=cast("list[str | dict[str, str]]", content)
-            ),
-        )
+        if notice is None:
+            return request
+        return request.override(messages=[*request.messages, notice])
 
     @override
     def wrap_model_call(
@@ -541,12 +514,12 @@ class GoalToolsMiddleware(AgentMiddleware[GoalToolState, ContextT]):
         request: ModelRequest[ContextT],
         handler: Callable[[ModelRequest[ContextT]], ModelResponse[ResponseT]],
     ) -> ModelResponse[ResponseT]:
-        """Inject goal-tool guidance into each model request.
+        """Re-pin the goal-state notice into each model request when needed.
 
         Returns:
             Model response from the wrapped handler.
         """
-        return handler(self._request_with_goal_system_prompt(request))
+        return handler(self._request_with_goal_notice(request))
 
     @override
     async def awrap_model_call(
@@ -556,9 +529,9 @@ class GoalToolsMiddleware(AgentMiddleware[GoalToolState, ContextT]):
             [ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]
         ],
     ) -> ModelResponse[ResponseT]:
-        """Inject goal-tool guidance into each async model request.
+        """Re-pin the goal-state notice into each async model request when needed.
 
         Returns:
             Model response from the wrapped handler.
         """
-        return await handler(self._request_with_goal_system_prompt(request))
+        return await handler(self._request_with_goal_notice(request))

--- a/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
+++ b/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
@@ -249,19 +249,6 @@ Host path mappings:
 - `<tmp_path>/dcode-artifacts/conversation_history/` -> `<tmp_path>/.deepagents/conversation_history/` (e.g. `<tmp_path>/dcode-artifacts/conversation_history/dir/x.py` -> `<tmp_path>/.deepagents/conversation_history/dir/x.py`)
 - `/dcode-artifacts-fallback/conversation_history/` -> `<tmp_path>/.deepagents/conversation_history/` (e.g. `/dcode-artifacts-fallback/conversation_history/dir/x.py` -> `<tmp_path>/.deepagents/conversation_history/dir/x.py`)
 
-## Goal and Rubric Tools
-
-Consult the latest goal/rubric state notice in conversation history before using
-these tools. Later notices supersede earlier notices. If no notice exists, assume
-there is no actionable goal or rubric and do not call these tools.
-
-When the latest notice says a rubric is active, use `get_rubric` when its exact
-acceptance criteria are needed. When it says a goal is actionable, use `get_goal`
-when its objective or current status is needed. Paused and completed goals must not
-drive work. Use `update_goal` only for an actionable goal: report a blocker with it;
-`status="complete"` remains available for optional completion evidence but is not
-required. Private checkpoint state and the tools remain authoritative for details.
-
 ## `ask_user`
 
 You have access to the `ask_user` tool to ask the user questions when you need clarification or input.

--- a/libs/code/tests/unit_tests/test_goal_tools.py
+++ b/libs/code/tests/unit_tests/test_goal_tools.py
@@ -17,7 +17,6 @@ from deepagents_code.goal_state_notice import (
     goal_state_notice_info,
 )
 from deepagents_code.goal_tools import (
-    GOAL_TOOLS_SYSTEM_PROMPT,
     GoalToolsMiddleware,
     GoalToolState,
     _goal_snapshot,
@@ -370,13 +369,20 @@ def _fake_request(
     messages: list[object] | None = None,
 ) -> SimpleNamespace:
     """Build a `ModelRequest`-shaped double with an `override` that mirrors it."""
-    return SimpleNamespace(
+    request = SimpleNamespace(
         system_message=system_message,
         runtime=SimpleNamespace(context=context or {}),
         state=state or {},
         messages=messages or [],
-        override=lambda **kw: SimpleNamespace(**kw),
     )
+
+    def override(**kw: object) -> SimpleNamespace:
+        updated = SimpleNamespace(**vars(request))
+        updated.__dict__.update(kw)
+        return updated
+
+    request.override = override
+    return request
 
 
 def test_before_model_persists_public_rubric_notice() -> None:
@@ -526,10 +532,11 @@ def test_wrap_model_call_does_not_restore_stale_state_over_unsaved_fallback() ->
     assert captured["request"].messages == [fallback]
 
 
-def test_wrap_model_call_appends_guidance_to_existing_prompt() -> None:
-    """Guidance should append to an existing system message's blocks."""
+def test_wrap_model_call_leaves_system_message_unchanged() -> None:
+    """Request wrapping must not mutate the system prompt."""
+    system = SystemMessage(content="base instructions")
     captured: dict[str, SimpleNamespace] = {}
-    request = _fake_request(SystemMessage(content="base instructions"))
+    request = _fake_request(system)
 
     result = GoalToolsMiddleware().wrap_model_call(
         request,  # ty: ignore[invalid-argument-type]
@@ -537,15 +544,12 @@ def test_wrap_model_call_appends_guidance_to_existing_prompt() -> None:
     )
 
     assert result == "response"
-    new_system = captured["request"].system_message
-    assert isinstance(new_system, SystemMessage)
-    blocks = new_system.content
-    assert blocks[0]["text"] == "base instructions"
-    assert blocks[-1]["text"] == f"\n\n{GOAL_TOOLS_SYSTEM_PROMPT}"
+    assert captured["request"] is request
+    assert captured["request"].system_message is system
 
 
-def test_wrap_model_call_seeds_guidance_without_system_message() -> None:
-    """Guidance should seed a fresh system message when none exists."""
+def test_wrap_model_call_leaves_missing_system_message_none() -> None:
+    """Request wrapping must not invent a system message when none exists."""
     captured: dict[str, SimpleNamespace] = {}
     request = _fake_request(None)
 
@@ -554,13 +558,13 @@ def test_wrap_model_call_seeds_guidance_without_system_message() -> None:
         _capturing_handler(captured),  # ty: ignore[invalid-argument-type]
     )
 
-    new_system = captured["request"].system_message
-    text = new_system.content[0]["text"]
-    assert text == GOAL_TOOLS_SYSTEM_PROMPT
+    assert captured["request"] is request
+    assert captured["request"].system_message is None
 
 
 def test_system_prompt_and_tool_schemas_are_byte_stable_across_states() -> None:
     """Goal lifecycle state must not change cache-sensitive request prefixes."""
+    base_system = SystemMessage(content="base instructions")
     states: list[dict[str, object]] = [
         {},
         {
@@ -593,41 +597,39 @@ def test_system_prompt_and_tool_schemas_are_byte_stable_across_states() -> None:
             "_goal_status_note": None,
         },
     ]
-    system_bytes: list[bytes] = []
+    system_refs: list[object] = []
     schema_bytes: list[bytes] = []
 
     for state in states:
         captured: dict[str, SimpleNamespace] = {}
         middleware = GoalToolsMiddleware()
-        request = _fake_request(None, state=state)
+        request = _fake_request(base_system, state=state)
         middleware.wrap_model_call(
             request,  # ty: ignore[invalid-argument-type]
             _capturing_handler(captured),  # ty: ignore[invalid-argument-type]
         )
-        content = captured["request"].system_message.content
-        system_bytes.append(
-            json.dumps(content, sort_keys=True, separators=(",", ":")).encode()
-        )
+        system_refs.append(captured["request"].system_message)
         schemas = [convert_to_openai_tool(tool) for tool in middleware.tools]
         schema_bytes.append(
             json.dumps(schemas, sort_keys=True, separators=(",", ":")).encode()
         )
 
-    assert len(set(system_bytes)) == 1
+    assert all(system is base_system for system in system_refs)
     assert len(set(schema_bytes)) == 1
-    assert b"Current Persisted Goal/Rubric State" not in system_bytes[0]
-    assert b"blocked_goal_retry_context" not in system_bytes[0]
+    assert b"Current Persisted Goal/Rubric State" not in schema_bytes[0]
+    assert b"blocked_goal_retry_context" not in schema_bytes[0]
 
 
-async def test_awrap_model_call_appends_guidance_to_existing_prompt() -> None:
-    """The async path should mirror the sync guidance injection."""
+async def test_awrap_model_call_leaves_system_message_unchanged() -> None:
+    """The async path should also leave the system prompt alone."""
+    system = SystemMessage(content="base instructions")
     captured: dict[str, SimpleNamespace] = {}
 
     async def handler(request: SimpleNamespace) -> str:  # noqa: RUF029
         captured["request"] = request
         return "response"
 
-    request = _fake_request(SystemMessage(content="base instructions"))
+    request = _fake_request(system)
 
     result = await GoalToolsMiddleware().awrap_model_call(
         request,  # ty: ignore[invalid-argument-type]
@@ -635,9 +637,8 @@ async def test_awrap_model_call_appends_guidance_to_existing_prompt() -> None:
     )
 
     assert result == "response"
-    blocks = captured["request"].system_message.content
-    assert blocks[0]["text"] == "base instructions"
-    assert blocks[-1]["text"].strip().startswith(GOAL_TOOLS_SYSTEM_PROMPT)
+    assert captured["request"] is request
+    assert captured["request"].system_message is system
 
 
 def test_goal_tool_state_marks_goal_fields_private() -> None:

--- a/libs/code/tests/unit_tests/test_goal_tools.py
+++ b/libs/code/tests/unit_tests/test_goal_tools.py
@@ -599,6 +599,7 @@ def test_system_prompt_and_tool_schemas_are_byte_stable_across_states() -> None:
     ]
     system_refs: list[object] = []
     schema_bytes: list[bytes] = []
+    notice_texts: list[str] = []
 
     for state in states:
         captured: dict[str, SimpleNamespace] = {}
@@ -609,6 +610,13 @@ def test_system_prompt_and_tool_schemas_are_byte_stable_across_states() -> None:
             _capturing_handler(captured),  # ty: ignore[invalid-argument-type]
         )
         system_refs.append(captured["request"].system_message)
+        notice_texts.append(
+            "".join(
+                message.content
+                for message in captured["request"].messages
+                if isinstance(getattr(message, "content", None), str)
+            )
+        )
         schemas = [convert_to_openai_tool(tool) for tool in middleware.tools]
         schema_bytes.append(
             json.dumps(schemas, sort_keys=True, separators=(",", ":")).encode()
@@ -616,8 +624,16 @@ def test_system_prompt_and_tool_schemas_are_byte_stable_across_states() -> None:
 
     assert all(system is base_system for system in system_refs)
     assert len(set(schema_bytes)) == 1
-    assert b"Current Persisted Goal/Rubric State" not in schema_bytes[0]
-    assert b"blocked_goal_retry_context" not in schema_bytes[0]
+    # The appended goal-state notice is the only model-visible surface this
+    # middleware adds, so it must stay coarse: the private objective, status
+    # note, and rubric criteria must never leak into it, while an
+    # objective-bearing state still produces a notice.
+    for state, notice_text in zip(states, notice_texts, strict=True):
+        assert "ship it" not in notice_text
+        assert "tests pass" not in notice_text
+        assert "waiting" not in notice_text
+        if state.get("_goal_objective"):
+            assert "Goal status:" in notice_text
 
 
 async def test_awrap_model_call_leaves_system_message_unchanged() -> None:


### PR DESCRIPTION
Deep Agents Code no longer appends the static “Goal and Rubric Tools” block to every system prompt. Goal/rubric guidance still reaches the model through tool docstrings, durable state notices, and request-only notice pinning when history no longer has the current notice in view.

---

The static system-prompt block duplicated guidance already present on `get_goal` / `get_rubric` / `update_goal` and in the goal-state notice path. Dropping it keeps the durable notice write and the compaction-style request pin, without mutating the system prompt on each turn.

`GoalToolsMiddleware.wrap_model_call` now only re-pins a current goal-state notice into request messages when needed, and returns the original request otherwise.