### PR TITLE
refactor(code): remove `get_rubric` source metadata

### DIFF
--- a/libs/code/deepagents_code/goal_tools.py
+++ b/libs/code/deepagents_code/goal_tools.py
@@ -49,9 +49,6 @@ if TYPE_CHECKING:
 
     from langgraph.runtime import Runtime
 
-RubricSource = Literal["goal", "sticky", "invocation"]
-"""Where the active rubric criteria came from, as reported to the model."""
-
 GOAL_TOOLS_SYSTEM_PROMPT = """## Goal and Rubric Tools
 
 Consult the latest goal/rubric state notice in conversation history before using
@@ -110,9 +107,6 @@ class RubricSnapshot(TypedDict):
 
     criteria: str | None
     """Current acceptance criteria, or `None` when no rubric is set."""
-
-    source: RubricSource | None
-    """Where the criteria came from: `goal`, `sticky`, `invocation`, or `None`."""
 
     grading_status: str | None
     """Latest `RubricMiddleware` grading status for the in-progress or
@@ -187,6 +181,11 @@ def _clean_state_text(state: dict[str, Any], key: str) -> str | None:
 def _rubric_snapshot(state: dict[str, Any]) -> RubricSnapshot:
     """Build the `get_rubric` response from graph state.
 
+    Criteria resolve in precedence order: public `rubric` input, else an
+    actionable goal rubric, else a standalone sticky rubric. Goal lifecycle and
+    sticky ownership stay in app state logic; this tool only exposes the current
+    criteria and grading status.
+
     Args:
         state: Current graph state injected by LangGraph.
 
@@ -201,23 +200,13 @@ def _rubric_snapshot(state: dict[str, Any]) -> RubricSnapshot:
     goal_is_actionable = objective is not None and status in {"active", "blocked"}
     sticky_is_goal_rubric = objective is not None and sticky_rubric == goal_rubric
 
-    source: RubricSource | None = None
-    if criteria is not None:
-        if goal_is_actionable and goal_rubric == criteria:
-            source = "goal"
-        elif sticky_rubric == criteria and not sticky_is_goal_rubric:
-            source = "sticky"
-        else:
-            source = "invocation"
-    # Fallback branches below run only when there is no public `rubric` input,
-    # so `invocation` is unreachable here by construction — the criteria can
-    # only be attributed to an actionable `goal` or a standalone `sticky` rubric.
-    elif goal_is_actionable and goal_rubric is not None:
-        criteria = goal_rubric
-        source = "goal"
-    elif sticky_rubric is not None and not sticky_is_goal_rubric:
-        criteria = sticky_rubric
-        source = "sticky"
+    # Prefer the public `rubric` graph input when present; otherwise surface
+    # actionable goal criteria or a standalone sticky rubric.
+    if criteria is None:
+        if goal_is_actionable and goal_rubric is not None:
+            criteria = goal_rubric
+        elif sticky_rubric is not None and not sticky_is_goal_rubric:
+            criteria = sticky_rubric
 
     # `_rubric_status` is owned by the SDK's `RubricMiddleware`, co-composed into
     # this agent's graph; see the `grading_status` field docstring above.
@@ -225,7 +214,6 @@ def _rubric_snapshot(state: dict[str, Any]) -> RubricSnapshot:
     return {
         "active": criteria is not None,
         "criteria": criteria,
-        "source": source,
         "grading_status": grading_status,
     }
 
@@ -394,12 +382,11 @@ class GoalToolsMiddleware(AgentMiddleware[GoalToolState, ContextT]):
             """Read criteria when the latest state notice says a rubric is active.
 
             Use this only when the latest goal/rubric state notice reports an active
-            rubric. It returns whether the criteria came from a goal, a sticky
-            rubric, or the current invocation, plus the latest grading status.
+            rubric. Use `get_goal` when a goal is actionable; this tool only returns
+            current criteria and the latest grading status.
 
             Returns:
-                Rubric snapshot with `active`, `criteria`, `source`, and
-                `grading_status` keys.
+                Rubric snapshot with `active`, `criteria`, and `grading_status` keys.
             """
             return _rubric_snapshot(state)
 

--- a/libs/code/deepagents_code/goal_tools.py
+++ b/libs/code/deepagents_code/goal_tools.py
@@ -101,7 +101,10 @@ ResponseT = TypeVar("ResponseT")
 
 
 class RubricSnapshot(TypedDict):
-    """Read-only rubric view returned by the `get_rubric` tool to the model."""
+    """Read-only rubric view returned by the `get_rubric` tool to the model.
+
+    `active` is always `criteria is not None`; the two never disagree.
+    """
 
     active: bool
     """Whether acceptance criteria are currently available."""
@@ -383,8 +386,9 @@ class GoalToolsMiddleware(AgentMiddleware[GoalToolState, ContextT]):
             """Read criteria when the latest state notice says a rubric is active.
 
             Use this only when the latest goal/rubric state notice reports an active
-            rubric. Use `get_goal` when a goal is actionable; this tool only returns
-            current criteria and the latest grading status.
+            rubric. Use `get_goal` when a goal is actionable; this tool only reports
+            whether criteria are active, the current criteria, and the latest grading
+            status.
 
             Returns:
                 Rubric snapshot with `active`, `criteria`, and `grading_status` keys.

--- a/libs/code/tests/unit_tests/test_goal_tools.py
+++ b/libs/code/tests/unit_tests/test_goal_tools.py
@@ -31,7 +31,6 @@ def test_rubric_snapshot_without_rubric() -> None:
     assert _rubric_snapshot({}) == {
         "active": False,
         "criteria": None,
-        "source": None,
         "grading_status": None,
     }
 
@@ -49,13 +48,12 @@ def test_rubric_snapshot_prefers_current_invocation_rubric() -> None:
     ) == {
         "active": True,
         "criteria": "- one-shot criteria",
-        "source": "invocation",
         "grading_status": "needs_revision",
     }
 
 
 def test_rubric_snapshot_identifies_goal_rubric() -> None:
-    """A goal-backed rubric should be labeled as goal criteria."""
+    """A goal-backed rubric should surface the goal criteria."""
     assert _rubric_snapshot(
         {
             "rubric": "- tests pass",
@@ -65,7 +63,22 @@ def test_rubric_snapshot_identifies_goal_rubric() -> None:
     ) == {
         "active": True,
         "criteria": "- tests pass",
-        "source": "goal",
+        "grading_status": None,
+    }
+
+
+def test_rubric_snapshot_uses_actionable_goal_rubric_without_public_input() -> None:
+    """Actionable goal criteria are returned when no public rubric is set."""
+    assert _rubric_snapshot(
+        {
+            "_goal_objective": "ship it",
+            "_goal_status": "active",
+            "_goal_rubric": "- goal criteria",
+            "_sticky_rubric": "- sticky criteria",
+        }
+    ) == {
+        "active": True,
+        "criteria": "- goal criteria",
         "grading_status": None,
     }
 
@@ -83,7 +96,6 @@ def test_rubric_snapshot_suppresses_inactive_goal_rubric(status: str) -> None:
     ) == {
         "active": False,
         "criteria": None,
-        "source": None,
         "grading_status": None,
     }
 
@@ -100,7 +112,6 @@ def test_rubric_snapshot_keeps_standalone_sticky_rubric_for_paused_goal() -> Non
     ) == {
         "active": True,
         "criteria": "- standalone criteria",
-        "source": "sticky",
         "grading_status": None,
     }
 
@@ -110,7 +121,6 @@ def test_rubric_snapshot_restores_sticky_rubric_without_public_input() -> None:
     assert _rubric_snapshot({"_sticky_rubric": "- sticky criteria"}) == {
         "active": True,
         "criteria": "- sticky criteria",
-        "source": "sticky",
         "grading_status": None,
     }
 

--- a/libs/code/tests/unit_tests/test_goal_tools.py
+++ b/libs/code/tests/unit_tests/test_goal_tools.py
@@ -52,27 +52,15 @@ def test_rubric_snapshot_prefers_current_invocation_rubric() -> None:
     }
 
 
-def test_rubric_snapshot_identifies_goal_rubric() -> None:
-    """A goal-backed rubric should surface the goal criteria."""
-    assert _rubric_snapshot(
-        {
-            "rubric": "- tests pass",
-            "_goal_objective": "ship it",
-            "_goal_rubric": "- tests pass",
-        }
-    ) == {
-        "active": True,
-        "criteria": "- tests pass",
-        "grading_status": None,
-    }
-
-
-def test_rubric_snapshot_uses_actionable_goal_rubric_without_public_input() -> None:
+@pytest.mark.parametrize("status", ["active", "blocked"])
+def test_rubric_snapshot_uses_actionable_goal_rubric_without_public_input(
+    status: str,
+) -> None:
     """Actionable goal criteria are returned when no public rubric is set."""
     assert _rubric_snapshot(
         {
             "_goal_objective": "ship it",
-            "_goal_status": "active",
+            "_goal_status": status,
             "_goal_rubric": "- goal criteria",
             "_sticky_rubric": "- sticky criteria",
         }


### PR DESCRIPTION
`get_rubric` no longer returns source provenance. Models only see active criteria and grading status; goal-backed vs sticky lifecycle decisions stay in app state logic.

---

Provenance still exists internally for notice fingerprints and precedence (`rubric_source` in projected goal state). This change removes only the model-facing `source` field from `RubricSnapshot`/`get_rubric`, so the LLM is not asked to interpret sticky vs goal vs invocation labels.

Criteria resolution is unchanged:
- public `rubric` when present
- else actionable goal rubric
- else standalone sticky rubric

Completion, `update_goal` gating, and paused/complete goal withholding remain in app code.