### PR TITLE
fix(code): report Auto classifier timeout budget

### DIFF
--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -487,6 +487,25 @@ def sanitize_auto_reason(reason: object, *, known_secrets: Sequence[str] = ()) -
     return text[:_REASON_LIMIT] or "The action was not authorized by the user request."
 
 
+def classifier_unavailable_reason(exc: BaseException, *, timeout_seconds: float) -> str:
+    """Build a safe agent/UI reason for a failed auto classifier call.
+
+    Provider exception text stays out of the reason (it can carry secrets or
+    noisy HTML). Timeouts are our own deadline, so reporting the configured
+    limit is safe and actionable.
+
+    Args:
+        exc: Failure raised while invoking or validating the classifier.
+        timeout_seconds: Configured `asyncio.wait_for` limit for one batch.
+
+    Returns:
+        Compact single-line reason for tool messages and TUI events.
+    """
+    if isinstance(exc, TimeoutError):
+        return f"The authorization classifier timed out after {timeout_seconds:g}s."
+    return f"The authorization classifier was unavailable ({type(exc).__name__})."
+
+
 def _default_counters(mode: ApprovalMode) -> AutoModeCounters:
     return {
         "consecutive_denials": 0,
@@ -2159,13 +2178,16 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
             )
             if not counters_saved:
                 plan["fallback_reason"] = "control_state_unavailable"
-            # Keep the agent/UI reason type-only; put the concrete failure in logs.
+            # Agent/UI reasons stay non-provider text (type, or our timeout
+            # budget). Concrete provider failure text belongs in logs only.
             error_detail = sanitize_auto_reason(
                 f"{type(exc).__name__}: {exc}",
                 known_secrets=self._known_secrets,
             )
             reason = sanitize_auto_reason(
-                f"The authorization classifier was unavailable ({type(exc).__name__}).",
+                classifier_unavailable_reason(
+                    exc, timeout_seconds=self._classifier_timeout_seconds
+                ),
                 known_secrets=self._known_secrets,
             )
             for call in review_calls:

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -491,8 +491,8 @@ def classifier_unavailable_reason(exc: BaseException, *, timeout_seconds: float)
     """Build a safe agent/UI reason for a failed auto classifier call.
 
     Provider exception text stays out of the reason (it can carry secrets or
-    noisy HTML). Timeouts are our own deadline, so reporting the configured
-    limit is safe and actionable.
+    noisy HTML). Timeouts are dcode's local `asyncio.wait_for` deadline, so
+    reporting that app-imposed limit is safe and actionable.
 
     Args:
         exc: Failure raised while invoking or validating the classifier.
@@ -502,7 +502,10 @@ def classifier_unavailable_reason(exc: BaseException, *, timeout_seconds: float)
         Compact single-line reason for tool messages and TUI events.
     """
     if isinstance(exc, TimeoutError):
-        return f"The authorization classifier timed out after {timeout_seconds:g}s."
+        return (
+            "dcode cancelled the authorization classifier after its local "
+            f"{timeout_seconds:g}s timeout (app-imposed, not a provider timeout)."
+        )
     return f"The authorization classifier was unavailable ({type(exc).__name__})."
 
 

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -98,6 +98,20 @@ _TEMP_ARTIFACT_PREFIX = "dcode-scratch-"
 _TEMP_ARTIFACT_SUFFIX_RE = re.compile(r"(?:\.[A-Za-z0-9][A-Za-z0-9._-]{0,31})?")
 
 
+class _ClassifierDeadlineExceededError(TimeoutError):
+    """Raised when dcode's local classifier wait budget expires.
+
+    Distinct from a provider-raised `TimeoutError` so agent/UI text can name
+    the app-imposed deadline without mislabeling socket-level failures.
+    """
+
+    def __init__(self, timeout_seconds: float) -> None:
+        self.timeout_seconds = timeout_seconds
+        super().__init__(
+            f"local classifier deadline exceeded after {timeout_seconds:g}s"
+        )
+
+
 class AutoDecisionCategory(StrEnum):
     """Classifier denial categories exposed to the agent and TUI."""
 
@@ -491,17 +505,19 @@ def classifier_unavailable_reason(exc: BaseException, *, timeout_seconds: float)
     """Build a safe agent/UI reason for a failed auto classifier call.
 
     Provider exception text stays out of the reason (it can carry secrets or
-    noisy HTML). Timeouts are dcode's local `asyncio.wait_for` deadline, so
-    reporting that app-imposed limit is safe and actionable.
+    noisy HTML). Only real local deadline expiry
+    (`_ClassifierDeadlineExceededError`) gets app-timeout wording; a bare
+    provider `TimeoutError` stays type-only so we do not claim dcode
+    cancelled a call the model failed first.
 
     Args:
         exc: Failure raised while invoking or validating the classifier.
-        timeout_seconds: Configured `asyncio.wait_for` limit for one batch.
+        timeout_seconds: Configured local wait budget for one batch.
 
     Returns:
         Compact single-line reason for tool messages and TUI events.
     """
-    if isinstance(exc, TimeoutError):
+    if isinstance(exc, _ClassifierDeadlineExceededError):
         return (
             "dcode cancelled the authorization classifier after its local "
             f"{timeout_seconds:g}s timeout (app-imposed, not a provider timeout)."
@@ -1962,9 +1978,19 @@ class AutoModeHITLMiddleware(HumanInTheLoopMiddleware[AutoModeState, Any, Any]):
             },
             **request.model_settings,
         )
-        result = await asyncio.wait_for(
-            invoke, timeout=self._classifier_timeout_seconds
-        )
+        # `asyncio.timeout(...).expired()` distinguishes our wait budget from a
+        # provider that raises `TimeoutError` itself. `wait_for` cannot;
+        # both ends surface the same type.
+        timeout_cm = asyncio.timeout(self._classifier_timeout_seconds)
+        try:
+            async with timeout_cm:
+                result = await invoke
+        except TimeoutError:
+            if timeout_cm.expired():
+                raise _ClassifierDeadlineExceededError(
+                    self._classifier_timeout_seconds
+                ) from None
+            raise
         if isinstance(result, AutoDecisionBatch):
             return result
         return AutoDecisionBatch.model_validate(result)

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -2897,13 +2897,13 @@ async def test_malformed_classifier_batch_blocks_call_and_increments_unavailable
 
 
 def test_classifier_unavailable_reason_specializes_timeouts() -> None:
-    assert (
-        classifier_unavailable_reason(TimeoutError(), timeout_seconds=20.0)
-        == "The authorization classifier timed out after 20s."
+    assert classifier_unavailable_reason(TimeoutError(), timeout_seconds=20.0) == (
+        "dcode cancelled the authorization classifier after its local "
+        "20s timeout (app-imposed, not a provider timeout)."
     )
-    assert (
-        classifier_unavailable_reason(TimeoutError(), timeout_seconds=1.5)
-        == "The authorization classifier timed out after 1.5s."
+    assert classifier_unavailable_reason(TimeoutError(), timeout_seconds=1.5) == (
+        "dcode cancelled the authorization classifier after its local "
+        "1.5s timeout (app-imposed, not a provider timeout)."
     )
     assert (
         classifier_unavailable_reason(
@@ -2932,7 +2932,8 @@ async def test_classifier_timeout_reports_configured_limit(tmp_path: Path) -> No
 
     assert plan["decisions"][0]["disposition"] == "classifier_unavailable"
     assert plan["decisions"][0]["reason"] == (
-        "The authorization classifier timed out after 1s."
+        "dcode cancelled the authorization classifier after its local "
+        "1s timeout (app-imposed, not a provider timeout)."
     )
 
 
@@ -3449,7 +3450,10 @@ async def test_classifier_unavailable_emits_single_event_for_batch(
         store=store,
         stream_writer=events.append,
     )
-    reason = "The authorization classifier timed out after 1s."
+    reason = (
+        "dcode cancelled the authorization classifier after its local "
+        "1s timeout (app-imposed, not a provider timeout)."
+    )
     plan = {
         "batch_id": _batch_id(ai_message.tool_calls),
         "thread_key": key,

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -61,6 +61,7 @@ from deepagents_code.auto_mode import (
     HeadlessMCPGuardMiddleware,
     _active_user_directives,
     _batch_id,
+    _ClassifierDeadlineExceededError,
     _default_counters,
     _fixed_repo_command_allowed,
     _merge_temp_artifacts,
@@ -2897,13 +2898,22 @@ async def test_malformed_classifier_batch_blocks_call_and_increments_unavailable
 
 
 def test_classifier_unavailable_reason_specializes_timeouts() -> None:
-    assert classifier_unavailable_reason(TimeoutError(), timeout_seconds=20.0) == (
+    assert classifier_unavailable_reason(
+        _ClassifierDeadlineExceededError(20.0), timeout_seconds=20.0
+    ) == (
         "dcode cancelled the authorization classifier after its local "
         "20s timeout (app-imposed, not a provider timeout)."
     )
-    assert classifier_unavailable_reason(TimeoutError(), timeout_seconds=1.5) == (
+    assert classifier_unavailable_reason(
+        _ClassifierDeadlineExceededError(1.5), timeout_seconds=1.5
+    ) == (
         "dcode cancelled the authorization classifier after its local "
         "1.5s timeout (app-imposed, not a provider timeout)."
+    )
+    # Provider exception type alone must not claim dcode cancelled the call.
+    assert (
+        classifier_unavailable_reason(TimeoutError(), timeout_seconds=20.0)
+        == "The authorization classifier was unavailable (TimeoutError)."
     )
     assert (
         classifier_unavailable_reason(
@@ -2914,8 +2924,22 @@ def test_classifier_unavailable_reason_specializes_timeouts() -> None:
 
 
 async def test_classifier_timeout_reports_configured_limit(tmp_path: Path) -> None:
-    model = _StructuredModel(error=TimeoutError())
-    middleware = _middleware(tmp_path)
+    class _SlowModel(_StructuredModel):
+        async def ainvoke(self, messages: list[object], **kwargs: object) -> object:
+            self.calls.append(messages)
+            self.call_kwargs.append(kwargs)
+            await asyncio.sleep(5)
+            return self.result
+
+    model = _SlowModel()
+    config: InterruptOnConfig = {"allowed_decisions": ["approve", "reject"]}
+    middleware = AutoModeHITLMiddleware(
+        {
+            "delete": config,
+        },
+        worktree_root=tmp_path,
+        classifier_timeout_seconds=0.05,
+    )
     request, _store, _key = _request(
         tmp_path,
         model=model,
@@ -2933,7 +2957,30 @@ async def test_classifier_timeout_reports_configured_limit(tmp_path: Path) -> No
     assert plan["decisions"][0]["disposition"] == "classifier_unavailable"
     assert plan["decisions"][0]["reason"] == (
         "dcode cancelled the authorization classifier after its local "
-        "1s timeout (app-imposed, not a provider timeout)."
+        "0.05s timeout (app-imposed, not a provider timeout)."
+    )
+
+
+async def test_classifier_provider_timeout_stays_type_only(tmp_path: Path) -> None:
+    model = _StructuredModel(error=TimeoutError("socket timed out"))
+    middleware = _middleware(tmp_path)
+    request, _store, _key = _request(
+        tmp_path,
+        model=model,
+        tool_name="delete",
+        args={"file_path": "old.py"},
+    )
+
+    plan = await _plan(
+        middleware,
+        request,
+        tool_name="delete",
+        args={"file_path": "old.py"},
+    )
+
+    assert plan["decisions"][0]["disposition"] == "classifier_unavailable"
+    assert plan["decisions"][0]["reason"] == (
+        "The authorization classifier was unavailable (TimeoutError)."
     )
 
 

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -64,6 +64,7 @@ from deepagents_code.auto_mode import (
     _default_counters,
     _fixed_repo_command_allowed,
     _merge_temp_artifacts,
+    classifier_unavailable_reason,
     gated_mcp_tool_names,
     mcp_tool_is_coherently_read_only,
     sanitize_auto_reason,
@@ -2895,6 +2896,46 @@ async def test_malformed_classifier_batch_blocks_call_and_increments_unavailable
     assert counters["total_denials"] == 0
 
 
+def test_classifier_unavailable_reason_specializes_timeouts() -> None:
+    assert (
+        classifier_unavailable_reason(TimeoutError(), timeout_seconds=20.0)
+        == "The authorization classifier timed out after 20s."
+    )
+    assert (
+        classifier_unavailable_reason(TimeoutError(), timeout_seconds=1.5)
+        == "The authorization classifier timed out after 1.5s."
+    )
+    assert (
+        classifier_unavailable_reason(
+            RuntimeError("provider overloaded"), timeout_seconds=20.0
+        )
+        == "The authorization classifier was unavailable (RuntimeError)."
+    )
+
+
+async def test_classifier_timeout_reports_configured_limit(tmp_path: Path) -> None:
+    model = _StructuredModel(error=TimeoutError())
+    middleware = _middleware(tmp_path)
+    request, _store, _key = _request(
+        tmp_path,
+        model=model,
+        tool_name="delete",
+        args={"file_path": "old.py"},
+    )
+
+    plan = await _plan(
+        middleware,
+        request,
+        tool_name="delete",
+        args={"file_path": "old.py"},
+    )
+
+    assert plan["decisions"][0]["disposition"] == "classifier_unavailable"
+    assert plan["decisions"][0]["reason"] == (
+        "The authorization classifier timed out after 1s."
+    )
+
+
 async def test_classifier_unavailable_logs_underlying_error(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -2917,8 +2958,10 @@ async def test_classifier_unavailable_logs_underlying_error(
         )
 
     assert plan["decisions"][0]["disposition"] == "classifier_unavailable"
-    # Agent/UI stays type-only; logs include the concrete failure and traceback.
-    assert "RuntimeError" in plan["decisions"][0]["reason"]
+    # Provider exception text stays out of agent/UI; logs keep the detail.
+    assert plan["decisions"][0]["reason"] == (
+        "The authorization classifier was unavailable (RuntimeError)."
+    )
     assert "provider overloaded" not in plan["decisions"][0]["reason"]
     records = [
         record
@@ -3406,7 +3449,7 @@ async def test_classifier_unavailable_emits_single_event_for_batch(
         store=store,
         stream_writer=events.append,
     )
-    reason = "The authorization classifier was unavailable (TimeoutError)."
+    reason = "The authorization classifier timed out after 1s."
     plan = {
         "batch_id": _batch_id(ai_message.tool_calls),
         "thread_key": key,


### PR DESCRIPTION
When Auto mode's authorization classifier hits its 20s deadline, denials now say it timed out after that budget instead of only showing `TimeoutError`.

---

Other classifier failures stay type-only in the agent/UI so raw provider text does not leak into transcript reasons; timeout is special-cased because the limit is ours and useful for diagnosis.
