### PR TITLE
hotfix(infra): pin `deepagents-code` next release to `0.1.46`

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -104,6 +104,7 @@
       "release-type": "python",
       "package-name": "deepagents-code",
       "component": "deepagents-code",
+      "release-as": "0.1.46",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [


### PR DESCRIPTION
Pins the next `deepagents-code` release at `0.1.46` so release-please stops treating #4929's breaking `!` as a `0.2.0` cut for code.

---

`#4929` landed as `feat(sdk,code,quickjs)!…`, and pre-1.0 minor-on-break policy rewrote [release PR #4965](https://github.com/langchain-ai/deepagents/pull/4965) to `0.2.0`. This temporary `"release-as": "0.1.46"` override on the code package forces the next code release back onto the `0.1.x` line without changing the SDK bump path.

Remove this key in a follow-up immediately after release-please rewrites #4965 to `0.1.46`, or every later code release will stay pinned.
