### PR TITLE
hotfix(infra): remove deepagents-code release-as pin

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -104,7 +104,6 @@
       "release-type": "python",
       "package-name": "deepagents-code",
       "component": "deepagents-code",
-      "release-as": "0.1.46",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [


### PR DESCRIPTION
`deepagents-code` 0.1.46 is out. Remove the temporary `"release-as": "0.1.46"` pin so the next code release is computed normally again.

---

This undoes the standing override from #5028 after the forced `0.1.46` cut.
