### PR TITLE
ci(infra): clarify release PR bot and pin check copy

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -63,7 +63,7 @@ Run `@dcode-release-bot draft` to regenerate the draft if the automatic run fail
 
 The merged changelog is the source for the published GitHub release notes.
 
-For an exceptional release that must skip curation, add the `release: dangerously skip curated notes` label.
+To ship without curated notes, add the `release: dangerously skip curated notes` label. That is the only way to skip the curated-notes merge gate — use it only when you intentionally want the generated changelog as-is, without maintainer polish.
 
 #### One-time repository setup
 

--- a/.github/scripts/dcode-release-notes.js
+++ b/.github/scripts/dcode-release-notes.js
@@ -282,15 +282,31 @@ function overrideBody({ version, head, headingHash, fingerprint, section }) {
     '-->',
     'Review and edit the release notes between the content markers below. Keep the version heading intact.',
     '',
+    '---',
     CONTENT_START,
     canonical(section).trimEnd(),
     CONTENT_END,
+    '---',
     '',
-    `When the release changes are finalized, run \`${COMMAND_MENTION} apply\`. Merge only after the curated release-notes check passes.`,
+    'When the release changes are finalized, run:',
     '',
-    `If new relevant entries appear after applying, run \`${COMMAND_MENTION} draft\` and then \`${COMMAND_MENTION} apply\` again.`,
+    '```',
+    `${COMMAND_MENTION} apply`,
+    '```',
     '',
-    `The only bypass is the \`${BYPASS_LABEL}\` label.`,
+    'Merge only after the curated release-notes check passes.',
+    '',
+    'If new relevant entries appear after applying, draft again and then re-apply:',
+    '',
+    '```',
+    `${COMMAND_MENTION} draft`,
+    '```',
+    '',
+    '```',
+    `${COMMAND_MENTION} apply`,
+    '```',
+    '',
+    `To ship without curated notes, add the \`${BYPASS_LABEL}\` label. That is the only way to skip the curated-notes merge gate — use it only when you intentionally want the generated changelog as-is, without maintainer polish.`,
   ].join('\n');
 }
 
@@ -936,8 +952,10 @@ async function checkCuratedState({
       core.setFailed(`Run ${COMMAND_MENTION} draft and then ${COMMAND_MENTION} apply before merging`);
       return { status: 'missing' };
     }
-    core.setFailed(`Review the curated release-note draft, then run ${COMMAND_MENTION} apply before merging`);
-    return { status: 'unapplied' };
+    const draftCommentUrl = override.comment.html_url
+      ?? `https://github.com/${owner}/${repo}/pull/${number}#issuecomment-${override.comment.id}`;
+    core.setFailed(`Review the curated release-note draft (${draftCommentUrl}), then run ${COMMAND_MENTION} apply before merging`);
+    return { status: 'unapplied', draftCommentUrl };
   }
 
   const appliedMetadata = applied.metadata;

--- a/.github/scripts/dcode-release-notes.test.js
+++ b/.github/scripts/dcode-release-notes.test.js
@@ -387,7 +387,11 @@ test('posts a bot-authored draft and refuses stale agent output', async t => {
   assert.deepEqual(calls.getByUsername, [{ username: BOT.login }]);
   assert.equal(calls.createComment.length, 1);
   assert.match(calls.createComment[0].body, /changelog-fingerprint:/);
-  assert.match(calls.createComment[0].body, /@dcode-release-bot apply/);
+  assert.match(calls.createComment[0].body, /---\n<!-- dcode-release-notes-content-start -->/);
+  assert.match(calls.createComment[0].body, /<!-- dcode-release-notes-content-end -->\n---/);
+  assert.match(calls.createComment[0].body, /```\n@dcode-release-bot apply\n```/);
+  assert.match(calls.createComment[0].body, /```\n@dcode-release-bot draft\n```/);
+  assert.match(calls.createComment[0].body, /only way to skip the curated-notes merge gate/);
 
   const stale = makeGithub({ pr: releasePr({ head: { ...releasePr().head, sha: 'c'.repeat(40) } }) });
   await assert.rejects(
@@ -756,6 +760,10 @@ test('required check waits for the first automatic draft before validating', asy
     sleep: async () => {},
   });
   assert.equal(result.status, 'unapplied');
+  assert.equal(
+    result.draftCommentUrl,
+    `https://github.com/langchain-ai/deepagents/pull/123#issuecomment-${comments[0].id}`,
+  );
   assert.match(core.failed, /Review the curated release-note draft.*apply/);
   assert.ok(core.infos.some(message => /Waiting for the automatic/.test(message)));
   assert.equal(run.calls.getContent.length, 1);

--- a/.github/scripts/test_check_sdk_pin.py
+++ b/.github/scripts/test_check_sdk_pin.py
@@ -263,7 +263,7 @@ def test_workflow_warning_comments_link_pin_release() -> None:
 
 
 def test_workflow_prerelease_warning_requires_release_deps_acknowledgement() -> None:
-    """Prerelease warnings require the release-deps acknowledgement label."""
+    """Prerelease pins fail closed until `release-deps: acknowledged` is present."""
     workflow = Path(__file__).parents[1] / "workflows" / "check_sdk_pin.yml"
     text = workflow.read_text()
 
@@ -271,6 +271,9 @@ def test_workflow_prerelease_warning_requires_release_deps_acknowledgement() -> 
     assert "${releaseDepsBypassLabel}" in text
     assert "This is allowed" not in text
     assert "Required:** add the" in text
-    assert "${releaseDepsBypassLabel}" in text
     assert "explicit merge acknowledgement" in text
     assert "label before merging to acknowledge this pin" in text
+    assert "types: [opened, synchronize, reopened, labeled, unlabeled]" in text
+    assert "prereleaseAcknowledged" in text
+    assert "core.setFailed(warning)" in text
+    assert "else if (prerelease && !prereleaseAcknowledged)" in text

--- a/.github/scripts/test_check_sdk_pin.py
+++ b/.github/scripts/test_check_sdk_pin.py
@@ -262,11 +262,15 @@ def test_workflow_warning_comments_link_pin_release() -> None:
     )
 
 
-def test_workflow_prerelease_warning_has_release_dependency_tip() -> None:
-    """Prerelease warnings explain how to acknowledge intentional release ordering."""
+def test_workflow_prerelease_warning_requires_release_deps_acknowledgement() -> None:
+    """Prerelease warnings require the release-deps acknowledgement label."""
     workflow = Path(__file__).parents[1] / "workflows" / "check_sdk_pin.yml"
     text = workflow.read_text()
 
     assert 'RELEASE_DEPS_BYPASS_LABEL: "release-deps: acknowledged"' in text
     assert "${releaseDepsBypassLabel}" in text
-    assert "release dependency check fails" in text
+    assert "This is allowed" not in text
+    assert "Required:** add the" in text
+    assert "${releaseDepsBypassLabel}" in text
+    assert "explicit merge acknowledgement" in text
+    assert "label before merging to acknowledge this pin" in text

--- a/.github/workflows/check_sdk_pin.yml
+++ b/.github/workflows/check_sdk_pin.yml
@@ -159,11 +159,11 @@ jobs:
                 '> [!WARNING]',
                 `> **Prerelease SDK pin** — ${pkgLabel} currently pins ${pkgPinLink}, which is a prerelease.`,
                 '>',
-                '> This is allowed and does not block the release workflow as long as the pin is not older than the workspace SDK. Please verify this prerelease pin is intentional before merging.',
+                '> A prerelease pin is valid only when it is not older than the workspace SDK, but it still needs an explicit merge acknowledgement.',
                 '>',
-                `> **Tip:** if this pin is part of an intentional cross-package release sequence and the release dependency check fails because the SDK prerelease is not on PyPI yet, add the \`${releaseDepsBypassLabel}\` label to acknowledge and skip that check.`,
+                `> **Required:** add the \`${releaseDepsBypassLabel}\` label before merging to acknowledge this pin. That label records the review decision and skips the release dependency / freshness checks that commonly fail when the pinned SDK is not on PyPI yet (for example during an intentional cross-package release sequence).`,
               ].join('\n');
-              warning = `${pkgLabel} pins prerelease SDK deepagents==${pkgPin}; verify this is intentional.`;
+              warning = `${pkgLabel} pins prerelease SDK deepagents==${pkgPin}; add ${releaseDepsBypassLabel} to acknowledge before merging.`;
             }
 
             if (body === null && existing) {

--- a/.github/workflows/check_sdk_pin.yml
+++ b/.github/workflows/check_sdk_pin.yml
@@ -1,14 +1,18 @@
-# Advisory check: posts a comment on Code release PRs when the deepagents
-# SDK pin is older than the actual SDK version. Does not block merge — the
-# release workflow enforces the pin at publish time. Removes the comment
-# once resolved.
+# SDK pin check for Code release PRs.
+#
+# - Stale pin: posts an advisory comment/warning only. The release workflow
+#   enforces the pin at publish time.
+# - Prerelease pin: posts a warning and fails until the PR carries the
+#   `release-deps: acknowledged` label (re-runs on labeled/unlabeled).
+# Removes the comment once the pin no longer needs attention.
 # See also: release.yml "Verify package pins SDK at or ahead of workspace
-# version" step (hard gate).
+# version" step (hard gate for stale pins at publish).
 
 name: "🔗 Check SDK Pin"
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - "libs/deepagents/pyproject.toml"
       - "libs/code/pyproject.toml"
@@ -133,8 +137,14 @@ jobs:
               return;
             }
 
+            const labels = (context.payload.pull_request.labels ?? [])
+              .map(label => (typeof label === 'string' ? label : label.name))
+              .filter(Boolean);
+            const prereleaseAcknowledged = labels.includes(releaseDepsBypassLabel);
+
             let body = null;
             let warning = null;
+            let fail = false;
             if (stale) {
               body = [
                 marker,
@@ -153,7 +163,7 @@ jobs:
                 '> See [`.github/RELEASING.md`](https://github.com/langchain-ai/deepagents/blob/main/.github/RELEASING.md#release-failed-code-sdk-pin-is-older-than-sdk) for the full recovery procedure.',
               ].join('\n');
               warning = `${pkgLabel} has a stale SDK pin: deepagents==${pkgPin} but SDK is ${sdkVersion}`;
-            } else if (prerelease) {
+            } else if (prerelease && !prereleaseAcknowledged) {
               body = [
                 marker,
                 '> [!WARNING]',
@@ -164,6 +174,12 @@ jobs:
                 `> **Required:** add the \`${releaseDepsBypassLabel}\` label before merging to acknowledge this pin. That label records the review decision and skips the release dependency / freshness checks that commonly fail when the pinned SDK is not on PyPI yet (for example during an intentional cross-package release sequence).`,
               ].join('\n');
               warning = `${pkgLabel} pins prerelease SDK deepagents==${pkgPin}; add ${releaseDepsBypassLabel} to acknowledge before merging.`;
+              fail = true;
+            } else if (prerelease) {
+              core.info(
+                `${pkgLabel} pins prerelease SDK deepagents==${pkgPin}; ` +
+                `\`${releaseDepsBypassLabel}\` is present so the pin is acknowledged.`
+              );
             }
 
             if (body === null && existing) {
@@ -185,7 +201,9 @@ jobs:
                 }
               }
             } else if (body === null) {
-              core.info(`${pkgLabel} SDK pin is stable and at or ahead of workspace SDK (${pkgPin} >= ${sdkVersion}). No action needed.`);
+              if (!prerelease) {
+                core.info(`${pkgLabel} SDK pin is stable and at or ahead of workspace SDK (${pkgPin} >= ${sdkVersion}). No action needed.`);
+              }
             } else {
               try {
                 // Update silently (no workflow annotation) to avoid repeated warnings on re-pushes.
@@ -209,6 +227,10 @@ jobs:
                   warning
                 );
               }
-              // Always emit annotation regardless of comment success.
-              core.warning(warning);
+              // Fail unacknowledged prerelease pins; stale pins stay advisory.
+              if (fail) {
+                core.setFailed(warning);
+              } else {
+                core.warning(warning);
+              }
             }

--- a/.github/workflows/dcode_release_notes_check.yml
+++ b/.github/workflows/dcode_release_notes_check.yml
@@ -111,7 +111,15 @@ jobs:
                         ? 'Curated release notes are ready for review'
                         : 'Curated release notes need attention',
                     summary: result.status === 'unapplied'
-                      ? 'Review the bot-authored draft, then run `@dcode-release-bot apply`.'
+                      ? [
+                          result.draftCommentUrl
+                            ? `Review the [bot-authored draft](${result.draftCommentUrl}), then run:`
+                            : 'Review the bot-authored draft, then run:',
+                          '',
+                          '```',
+                          '@dcode-release-bot apply',
+                          '```',
+                        ].join('\n')
                       : `Validation result: ${result.status}.`,
                   },
                 });

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -52,7 +52,7 @@
   ],
   "pull-request-title-pattern": "release(${component}): ${version}",
   "component-no-space": true,
-  "pull-request-header": "> [!CAUTION]\n> Merging this PR will automatically publish to **PyPI** and create a **GitHub release**.\n\nFor the full release process, see [`.github/RELEASING.md`](https://github.com/langchain-ai/deepagents/blob/main/.github/RELEASING.md).\n\n---\n\n_Release notes preview: keep this section in sync with the package `CHANGELOG.md`. The published GitHub release body is extracted from the merged `CHANGELOG.md` by `release.yml`, not from this PR description._\n",
+  "pull-request-header": "> [!CAUTION]\n> Merging this PR will automatically publish to **PyPI** and create a **GitHub release**.\n\nFor the full release process, see [`.github/RELEASING.md`](https://github.com/langchain-ai/deepagents/blob/main/.github/RELEASING.md).\n\n---\n\n_Release notes preview: keep this section in sync with the package `CHANGELOG.md`. Publish reads the merged CHANGELOG via `release.yml`, not this PR description — keep them aligned anyway so the PR stays an accurate historical record for reviewers and anyone returning later._\n",
   "pull-request-footer": "\n_End release notes preview._\n\n---\n\n> [!NOTE]\n> A **New Contributors** section is appended to the GitHub release notes automatically at publish time (see [Release Pipeline](https://github.com/langchain-ai/deepagents/blob/main/.github/RELEASING.md#release-pipeline), step 2).",
   "packages": {
     "libs/cli": {


### PR DESCRIPTION
Clarify release PR and release-bot copy so maintainers get clearer guidance on note hygiene, prerelease SDK pins, and next steps.

---

Makes release PR surface copy more actionable:

- **Release-please PR header** — explain *why* the notes preview should stay in sync with `CHANGELOG.md` even though publish uses the merged changelog: the PR body remains the historical record for reviewers and later readers.
- **Curated notes draft comment** — visible horizontal rules around the editable content markers, prefer copyable fenced code blocks for `@dcode-release-bot apply` / `draft`, and clearer wording for the curated-notes gate bypass label.
- **Curated notes check** — when notes are ready for review, link the bot draft comment and put the apply command in a code block.
- **Prerelease SDK pin warning** — drop the misleading “this is allowed” framing; treat `release-deps: acknowledged` as an explicit acknowledgement before merge (and note that it also covers deps/freshness failures common for unpublished prerelease SDK pins).

Affects future release PR automation/text only; does not change an already-open release PR body/comments until they are regenerated.