### PR TITLE
feat(code): show changelog link before install-script update prompt

### DIFF
--- a/libs/code/scripts/install.sh
+++ b/libs/code/scripts/install.sh
@@ -833,6 +833,12 @@ esac
 # tell whether an existing install is out of date before upgrading it.
 PYPI_JSON_URL="https://pypi.org/pypi/deepagents-code/json"
 
+# Base URL for a version-specific GitHub release, surfaced before the update
+# prompt so users can review what changed before agreeing to upgrade. Release
+# tags are `deepagents-code==X.Y.Z`; the `==` must be percent-encoded (%3D%3D)
+# for the tag URL to resolve.
+RELEASE_TAG_URL_BASE="https://github.com/langchain-ai/deepagents/releases/tag/deepagents-code%3D%3D"
+
 # Validate and normalize extras: accept bare CSV, wrap in brackets for pip
 if [[ -n "$EXTRAS" ]]; then
   # Strip brackets if the user passed them anyway
@@ -1257,6 +1263,7 @@ elif [ -n "$PRE_VERSION" ] && [ -z "$VERSION" ] && [ -z "$PRERELEASE_REQUESTED" 
   elif [ "$ASSUME_YES" = "1" ]; then
     log_info "Updating deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}..."
   elif can_prompt; then
+    log_info "What's new: ${RELEASE_TAG_URL_BASE}${LATEST_VERSION}"
     if prompt_yn "Update deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}?"; then
       log_info "Updating deepagents-code ${PRE_VERSION} → ${LATEST_VERSION}..."
     else

--- a/libs/code/tests/unit_tests/test_install_script.py
+++ b/libs/code/tests/unit_tests/test_install_script.py
@@ -726,6 +726,10 @@ def test_install_script_interactive_decline_keeps_current(tmp_path: Path) -> Non
     assert code == 0
     assert not args_path.exists()
     assert "0.1.0 → 0.2.0" in output
+    assert (
+        "What's new: https://github.com/langchain-ai/deepagents/releases/tag/"
+        "deepagents-code%3D%3D0.2.0" in output
+    )
     assert "Keeping deepagents-code 0.1.0" in output
 
 
@@ -740,6 +744,10 @@ def test_install_script_interactive_accept_updates(tmp_path: Path) -> None:
     # paths, so assert the "Updating ..." line to prove the prompt was shown and
     # answered yes rather than bypassed.
     assert "Updating deepagents-code 0.1.0 → 0.2.0" in output
+    assert (
+        "What's new: https://github.com/langchain-ai/deepagents/releases/tag/"
+        "deepagents-code%3D%3D0.2.0" in output
+    )
     args = args_path.read_text().splitlines()
     assert args[:3] == ["tool", "install", "-U"]
     assert args[-1] == "deepagents-code"
@@ -764,6 +772,7 @@ def test_install_script_pinned_version_skips_prompt_over_existing_install(
 
     assert code == 0
     assert "→" not in output
+    assert "What's new:" not in output
     assert "Keeping deepagents-code" not in output
     args = args_path.read_text().splitlines()
     assert args[:3] == ["tool", "install", "-U"]


### PR DESCRIPTION
The `deepagents-code` install script now shows a "What's new" changelog link before prompting to update.

---

When the `deepagents-code` installer detects a newer version, the interactive `curl … | bash` path now prints a `What's new: <release URL>` line just before the `Update … → …? [y/N]` prompt, so users can review what changed before agreeing to upgrade.

The link points at the version-specific GitHub release tag (`deepagents-code==X.Y.Z`, with `==` percent-encoded so the tag URL resolves). It is shown only on the interactive prompt path — the auto-update/no-TTY, assume-yes, and pinned-version paths are unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/7ce89a24-4597-59c8-d31e-2031bd2f90ed)