### PR TITLE
feat(code): include `yolo` mode in `Shift+Tab` approval cycle

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -401,6 +401,17 @@ THEME = "DEEPAGENTS_CODE_THEME"
 USER_ID = "DEEPAGENTS_CODE_USER_ID"
 """Attach a user identifier to LangSmith trace metadata."""
 
+YOLO_SWITCHER = "DEEPAGENTS_CODE_YOLO_SWITCHER"
+"""Include YOLO in the Shift+Tab approval-mode cycle.
+
+Enabled by default so an interactive session can cycle Manual → Auto → YOLO
+without restarting with `--yolo`. Set to a falsy value (`0`, `false`, `no`,
+`off`, or empty) to leave Shift+Tab limited to Manual/Auto. Also settable via
+`[startup].yolo_switcher` in config.toml so orgs can distribute the opt-out.
+Parsed by `classify_env_bool` through the config resolver (unrecognized values
+fall through rather than forcing the default).
+"""
+
 _TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
 _FALSY_VALUES = frozenset({"0", "false", "no", "off", ""})
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3105,6 +3105,7 @@ class DeepAgentsApp(App):
             self._auto_approve = False
         self._approval_mode_blocked = False
         self._auto_mode_notice_pending = False
+        self._yolo_mode_notice_pending = False
 
         if sub_title is None and self._sandbox_type is not None:
             display = _SANDBOX_DISPLAY_NAMES.get(
@@ -16912,10 +16913,12 @@ class DeepAgentsApp(App):
             panel.toggle()
 
     async def action_toggle_auto_approve(self) -> None:
-        """Toggle between Manual and Auto after Store acknowledgement.
+        """Cycle Manual → Auto → YOLO (when enabled) after Store acknowledgement.
 
-        A session launched in YOLO moves to Manual; normal key navigation never
-        enters unrestricted mode.
+        YOLO is included by default (`startup.yolo_switcher` / env). Auto is
+        skipped when a sandbox makes classifier-backed Auto ineligible. The
+        first Shift+Tab into YOLO prompts for the same install-local
+        acknowledgement used by `--yolo` before unrestricted mode becomes active.
         """
         from deepagents_code.tui.modals.plugin_manager import PluginManagerScreen
         from deepagents_code.tui.widgets.agent_selector import AgentSelectorScreen
@@ -16969,17 +16972,49 @@ class DeepAgentsApp(App):
         if self._pending_ask_user_widget is not None:
             self._pending_ask_user_widget.action_previous_question()
             return
-        from deepagents_code.approval_mode import ApprovalMode
+        from deepagents_code.approval_mode import (
+            ApprovalMode,
+            has_yolo_acknowledgement,
+            next_approval_mode,
+        )
+        from deepagents_code.config import is_yolo_switcher_enabled
 
-        if self._approval_mode is ApprovalMode.MANUAL:
-            if not self._auto_mode_eligible:
+        yolo_switcher_enabled = is_yolo_switcher_enabled()
+        target = next_approval_mode(
+            self._approval_mode,
+            auto_eligible=self._auto_mode_eligible,
+            yolo_switcher_enabled=yolo_switcher_enabled,
+        )
+        if target is None:
+            if not self._auto_mode_eligible and not yolo_switcher_enabled:
                 self._warn_live_approval_mode_unavailable(
-                    "Auto is unavailable with a sandbox."
+                    "Auto is unavailable with a sandbox, and YOLO is disabled "
+                    "in the approval switcher."
                 )
-                return
-            target = ApprovalMode.AUTO
-        else:
-            target = ApprovalMode.MANUAL
+            else:
+                self._warn_live_approval_mode_unavailable(
+                    "No other approval mode is available in this session."
+                )
+            return
+
+        # Gate the first YOLO switcher entry on the same policy acknowledgement
+        # as `--yolo`. Do not activate YOLO until the user continues.
+        if target is ApprovalMode.YOLO and not has_yolo_acknowledgement():
+            self._prompt_yolo_switcher_acknowledgement()
+            return
+
+        await self._set_approval_mode(target)
+
+    async def _set_approval_mode(self, target: ApprovalMode) -> bool:
+        """Apply an approval-mode change after optional live Store acknowledgement.
+
+        Args:
+            target: Mode to select.
+
+        Returns:
+            `True` when local UI state was updated to `target`.
+        """
+        from deepagents_code.approval_mode import ApprovalMode
 
         # With no usable agent/session pair there is no running graph to update.
         # Stage the selection locally; `execute_task_textual` persists it before
@@ -16993,7 +17028,12 @@ class DeepAgentsApp(App):
                 self._warn_live_approval_mode_unavailable(
                     "Auto could not be persisted; remaining in Manual."
                 )
-                return
+                return False
+            if target is ApprovalMode.YOLO:
+                self._warn_live_approval_mode_unavailable(
+                    "YOLO could not be persisted; remaining in the previous mode."
+                )
+                return False
             self._approval_mode_blocked = True
             self._warn_live_approval_mode_unavailable(
                 "Manual could not be persisted; active work was cancelled and "
@@ -17001,7 +17041,7 @@ class DeepAgentsApp(App):
             )
             if self._agent_running:
                 self._force_interrupt_active_work()
-            return
+            return False
 
         self._approval_mode_blocked = False
         self._approval_mode = target
@@ -17014,6 +17054,63 @@ class DeepAgentsApp(App):
             self._notify_auto_mode_enabled_once()
             if should_persist_live:
                 await self._auto_accept_pending_goal_rubric()
+        elif target is ApprovalMode.YOLO:
+            if should_persist_live:
+                await self._auto_accept_pending_goal_rubric()
+            self.notify(
+                "YOLO is active: gated actions run without review.",
+                severity="warning",
+                timeout=8,
+                markup=False,
+            )
+        return True
+
+    def _prompt_yolo_switcher_acknowledgement(self) -> None:
+        """Show the first-run YOLO acknowledgement before entering unrestricted mode.
+
+        YOLO stays inactive until Enter persists the acknowledgement and the
+        follow-up mode write succeeds. Esc (or a non-true dismiss) leaves the
+        current mode untouched and does not store the acknowledgement.
+        """
+        from deepagents_code.approval_mode import (
+            ApprovalMode,
+            save_yolo_acknowledgement,
+        )
+        from deepagents_code.tui.widgets.yolo_mode_notice import YoloModeNoticeScreen
+
+        if getattr(self, "_yolo_mode_notice_pending", False):
+            return
+
+        def handle_result(accepted: bool | None) -> None:
+            self._yolo_mode_notice_pending = False
+            if accepted is not True:
+                self.notify(
+                    "Stayed in the current approval mode.",
+                    severity="information",
+                    markup=False,
+                )
+                return
+            if not save_yolo_acknowledgement():
+                self._warn_live_approval_mode_unavailable(
+                    "YOLO acknowledgement could not be saved; staying in the "
+                    "current mode."
+                )
+                return
+            task = asyncio.create_task(self._set_approval_mode(ApprovalMode.YOLO))
+            task.add_done_callback(_log_task_exception)
+
+        try:
+            self.push_screen(YoloModeNoticeScreen(), handle_result)
+        except Exception:
+            # Cosmetically missing notice must not strand a pending enable.
+            logger.warning(
+                "Could not show YOLO switcher acknowledgement", exc_info=True
+            )
+            return
+
+        # Mark pending only after the push succeeds so a failed push cannot
+        # suppress a later try for the whole session.
+        self._yolo_mode_notice_pending = True
 
     def action_toggle_tool_output(self) -> None:
         """Toggle the most recent collapsible transcript unit."""

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -16986,15 +16986,13 @@ class DeepAgentsApp(App):
             yolo_switcher_enabled=yolo_switcher_enabled,
         )
         if target is None:
-            if not self._auto_mode_eligible and not yolo_switcher_enabled:
-                self._warn_live_approval_mode_unavailable(
-                    "Auto is unavailable with a sandbox, and YOLO is disabled "
-                    "in the approval switcher."
-                )
-            else:
-                self._warn_live_approval_mode_unavailable(
-                    "No other approval mode is available in this session."
-                )
+            # `next_approval_mode` returns None only from Manual when neither
+            # Auto (sandbox-ineligible) nor the YOLO switcher entry is available,
+            # so this is the only reachable case.
+            self._warn_live_approval_mode_unavailable(
+                "Auto is unavailable with a sandbox, and YOLO is disabled "
+                "in the approval switcher."
+            )
             return
 
         # Gate the first YOLO switcher entry on the same policy acknowledgement
@@ -17055,14 +17053,18 @@ class DeepAgentsApp(App):
             if should_persist_live:
                 await self._auto_accept_pending_goal_rubric()
         elif target is ApprovalMode.YOLO:
-            if should_persist_live:
-                await self._auto_accept_pending_goal_rubric()
+            # Warn before the await below. State is already committed above, so
+            # if goal-rubric auto-accept raises, YOLO is active and the "no
+            # review" warning must have fired first. AUTO notifies before its
+            # await for the same reason.
             self.notify(
                 "YOLO is active: gated actions run without review.",
                 severity="warning",
                 timeout=8,
                 markup=False,
             )
+            if should_persist_live:
+                await self._auto_accept_pending_goal_rubric()
         return True
 
     def _prompt_yolo_switcher_acknowledgement(self) -> None:
@@ -17102,9 +17104,15 @@ class DeepAgentsApp(App):
         try:
             self.push_screen(YoloModeNoticeScreen(), handle_result)
         except Exception:
-            # Cosmetically missing notice must not strand a pending enable.
+            # This modal *is* the YOLO gate (unlike Auto's post-hoc notice), so
+            # a failed push leaves the mode unchanged. Surface it, or Shift+Tab
+            # looks dead. Leaving `_yolo_mode_notice_pending` unset (it is set
+            # only below, after a successful push) lets a later Shift+Tab retry.
             logger.warning(
                 "Could not show YOLO switcher acknowledgement", exc_info=True
+            )
+            self._warn_live_approval_mode_unavailable(
+                "Could not open the YOLO confirmation; approval mode unchanged."
             )
             return
 

--- a/libs/code/deepagents_code/approval_mode.py
+++ b/libs/code/deepagents_code/approval_mode.py
@@ -98,7 +98,8 @@ def next_approval_mode(
         if yolo_switcher_enabled:
             return ApprovalMode.YOLO
         return ApprovalMode.MANUAL
-    # YOLO and any fail-closed unknown value leave unrestricted mode.
+    # Only genuine YOLO reaches here; unknown/invalid values were normalized to
+    # Manual above and took that branch. Exiting YOLO always returns to Manual.
     return ApprovalMode.MANUAL
 
 

--- a/libs/code/deepagents_code/approval_mode.py
+++ b/libs/code/deepagents_code/approval_mode.py
@@ -63,6 +63,45 @@ def coerce_approval_mode(value: object) -> ApprovalMode:
         return ApprovalMode.MANUAL
 
 
+def next_approval_mode(
+    current: ApprovalMode | str | object,
+    *,
+    auto_eligible: bool,
+    yolo_switcher_enabled: bool,
+) -> ApprovalMode | None:
+    """Return the next Shift+Tab approval mode for the active session.
+
+    The cycle is Manual → Auto → YOLO → Manual when both Auto and the YOLO
+    switcher entry are available. Auto is omitted when `auto_eligible` is false
+    (for example a remote sandbox). YOLO is omitted when orgs/users disable
+    `startup.yolo_switcher`. Launching with `--yolo` still leaves unrestricted
+    mode when the switcher entry is disabled; Shift+Tab only exits YOLO then.
+
+    Args:
+        current: Active approval mode (mode enum or raw value).
+        auto_eligible: Whether classifier-backed Auto can be selected.
+        yolo_switcher_enabled: Whether unrestricted YOLO appears in the cycle.
+
+    Returns:
+        The next mode, or `None` when no alternate mode is available.
+    """
+    mode = (
+        current if isinstance(current, ApprovalMode) else coerce_approval_mode(current)
+    )
+    if mode is ApprovalMode.MANUAL:
+        if auto_eligible:
+            return ApprovalMode.AUTO
+        if yolo_switcher_enabled:
+            return ApprovalMode.YOLO
+        return None
+    if mode is ApprovalMode.AUTO:
+        if yolo_switcher_enabled:
+            return ApprovalMode.YOLO
+        return ApprovalMode.MANUAL
+    # YOLO and any fail-closed unknown value leave unrestricted mode.
+    return ApprovalMode.MANUAL
+
+
 def approval_mode_key(thread_id: str) -> str:
     """Return the store key for a thread's live approval mode.
 

--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -3255,6 +3255,27 @@ def is_memory_auto_save_enabled() -> bool:
     return bool(value)
 
 
+def is_yolo_switcher_enabled() -> bool:
+    """Return whether Shift+Tab may enter unrestricted YOLO mode.
+
+    Resolves the `startup.yolo_switcher` option from env/`config.toml`,
+    defaulting to enabled. When disabled, the interactive cycle stays Manual /
+    Auto only (or Manual alone when Auto is ineligible). Sessions already in
+    YOLO (for example via `--yolo`) can still leave it with Shift+Tab.
+    """
+    from deepagents_code.config_manifest import (
+        get_option,
+        load_config_toml,
+        resolve_scalar,
+    )
+
+    option = get_option("startup.yolo_switcher")
+    if option is None:
+        return True
+    value, _ = resolve_scalar(option, toml_data=load_config_toml())
+    return bool(value)
+
+
 def is_openai_prompt_cache_key_enabled() -> bool:
     """Return whether OpenAI model calls should carry a per-thread cache key.
 

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -1464,6 +1464,19 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         toml_keys=("startup", "mode"),
         cli_flag="--auto-approve",
     ),
+    ConfigOption(
+        key="startup.yolo_switcher",
+        group="Startup",
+        summary=(
+            "Include YOLO in the Shift+Tab approval-mode cycle "
+            "(Manual → Auto → YOLO); disable to keep the cycle Manual/Auto only."
+        ),
+        kind=OptionKind.BOOL,
+        default=True,
+        env_var=_env_vars.YOLO_SWITCHER,
+        empty_env_is_false=True,
+        toml_keys=("startup", "yolo_switcher"),
+    ),
     # --- Debug / Development -------------------------------------------
     ConfigOption(
         key="debug.enabled",

--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -10,6 +10,12 @@ from textual.widgets import Static
 
 from deepagents_code._env_vars import HIDE_SPLASH_TIPS, is_env_truthy
 
+_TIP_SHIFT_TAB_WITH_YOLO = "Press Shift+Tab to cycle Manual, Auto, and YOLO modes"
+"""Tip used when `startup.yolo_switcher` keeps YOLO in the approval cycle."""
+
+_TIP_SHIFT_TAB_WITHOUT_YOLO = "Press Shift+Tab to toggle Manual and Auto modes"
+"""Tip used when orgs/users disable YOLO entry via the approval switcher."""
+
 _TIPS: dict[str, int] = {
     "Use @ to reference files and / for commands": 3,
     "Try /threads to resume a previous conversation": 2,
@@ -27,12 +33,16 @@ _TIPS: dict[str, int] = {
     "Ask for a workflow to fan work out to subagents in parallel": 3,
     "Use /timestamps to show or hide message timestamp footers": 1,
     "Use /agents to browse and switch between your available agents": 2,
-    "Press Shift+Tab to cycle Manual, Auto, and YOLO modes": 2,
+    _TIP_SHIFT_TAB_WITH_YOLO: 2,
     "Use !! for incognito shell commands that stay out of model context": 1,
     "Deep Agents can explain its own features and look up its docs. Ask it how to use.": 3,  # noqa: E501
 }
 """Tips shown above the chat input. One is chosen at random per launch,
-weighted by these relative selection weights."""
+weighted by these relative selection weights.
+
+The Shift+Tab tip is varied at pick time via `_active_tips` so disabled-YOLO
+installs do not advertise a switcher path that policy has removed.
+"""
 
 # Fail fast at import if the registry is ever emptied or given a non-positive
 # weight: `random.choices` would otherwise raise a cryptic error at widget
@@ -46,15 +56,45 @@ if any(weight <= 0 for weight in _TIPS.values()):
     raise ValueError(msg)
 
 
-def _pick_tip() -> str:
-    """Pick one startup tip using the configured relative weights.
+def _active_tips(*, yolo_switcher_enabled: bool | None = None) -> dict[str, int]:
+    """Return the weighted tip registry for the current switcher policy.
+
+    Args:
+        yolo_switcher_enabled: Override for whether YOLO appears in the
+            Shift+Tab cycle. When omitted, resolves `startup.yolo_switcher`.
 
     Returns:
-        Tip text selected from `_TIPS`.
+        Weighted tip map appropriate for the active YOLO switcher setting.
     """
-    tips = list(_TIPS.keys())
-    weights = list(_TIPS.values())
-    return random.choices(tips, weights=weights, k=1)[0]  # noqa: S311
+    if yolo_switcher_enabled is None:
+        from deepagents_code.config import is_yolo_switcher_enabled
+
+        yolo_switcher_enabled = is_yolo_switcher_enabled()
+
+    tips = dict(_TIPS)
+    if yolo_switcher_enabled:
+        return tips
+
+    # Replace the YOLO cycle tip with the Manual/Auto-only wording so the
+    # splash never claims Shift+Tab can enter unrestricted mode when policy
+    # has removed that entry from the switcher.
+    weight = tips.pop(_TIP_SHIFT_TAB_WITH_YOLO, None)
+    if weight is not None:
+        tips[_TIP_SHIFT_TAB_WITHOUT_YOLO] = weight
+    return tips
+
+
+def _pick_tip(*, yolo_switcher_enabled: bool | None = None) -> str:
+    """Pick one startup tip using the configured relative weights.
+
+    Args:
+        yolo_switcher_enabled: Optional override forwarded to `_active_tips`.
+
+    Returns:
+        Tip text selected from the active tip registry.
+    """
+    tips = _active_tips(yolo_switcher_enabled=yolo_switcher_enabled)
+    return random.choices(list(tips.keys()), weights=list(tips.values()), k=1)[0]  # noqa: S311
 
 
 def show_startup_tip() -> bool:

--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -27,7 +27,7 @@ _TIPS: dict[str, int] = {
     "Ask for a workflow to fan work out to subagents in parallel": 3,
     "Use /timestamps to show or hide message timestamp footers": 1,
     "Use /agents to browse and switch between your available agents": 2,
-    "Press Shift+Tab to toggle Manual and Auto modes": 2,
+    "Press Shift+Tab to cycle Manual, Auto, and YOLO modes": 2,
     "Use !! for incognito shell commands that stay out of model context": 1,
     "Deep Agents can explain its own features and look up its docs. Ask it how to use.": 3,  # noqa: E501
 }

--- a/libs/code/deepagents_code/tui/widgets/yolo_mode_notice.py
+++ b/libs/code/deepagents_code/tui/widgets/yolo_mode_notice.py
@@ -1,0 +1,160 @@
+"""First-enable confirmation modal before Shift+Tab enters YOLO.
+
+Shown when the user cycles into unrestricted YOLO without a persisted
+acknowledgement. Enter acknowledges YOLO and records the policy version; Esc
+keeps the previous approval mode and leaves the acknowledgement unsaved.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Markdown, Static
+
+from deepagents_code.tui.widgets._links import open_checked_url_async
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+YOLO_MODE_DOCS_URL = (
+    "https://docs.langchain.com/oss/python/deepagents/code/approval-modes"
+)
+"""Canonical docs page for Manual / Auto / YOLO behavior."""
+
+YOLO_MODE_NOTICE_BODY = (
+    "You are about to enable **YOLO**. The agent will run **gated actions "
+    "without asking first** — shell commands, file edits, network calls, and "
+    "other tools on this machine.\n\n"
+    "This is **not Auto**. There is **no classifier review** and **no approval "
+    "prompt** while YOLO is active. Prefer Auto unless you intend full "
+    "unrestricted execution.\n\n"
+    "This notice appears **once** on this machine after you continue. You can "
+    "leave YOLO any time with **Shift+Tab**.\n\n"
+    f"[Learn more about approval modes]({YOLO_MODE_DOCS_URL})"
+)
+"""Default Markdown body shown before the first YOLO switcher enable."""
+
+
+class YoloModeNoticeScreen(ModalScreen[bool]):
+    """In-TUI acknowledgement shown before unrestricted YOLO becomes active.
+
+    Dismisses with `True` on Enter (acknowledge and enable) and `False` on Esc
+    (keep the previous mode). Programmatic dismiss may yield `None`; callers
+    treat that like cancel so YOLO is never left active without an explicit
+    acknowledge.
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("enter", "confirm", "Enable YOLO", show=False, priority=True),
+        Binding("escape", "cancel", "Keep previous", show=False, priority=True),
+    ]
+
+    CSS = """
+    YoloModeNoticeScreen {
+        align: center middle;
+    }
+
+    YoloModeNoticeScreen > Vertical {
+        width: 72;
+        max-width: 90%;
+        height: auto;
+        background: $surface;
+        border: solid $error;
+        padding: 1 2;
+    }
+
+    YoloModeNoticeScreen .yolo-mode-notice-title {
+        text-style: bold;
+        color: $error;
+        text-align: center;
+        margin-bottom: 1;
+    }
+
+    YoloModeNoticeScreen .yolo-mode-notice-body {
+        height: auto;
+        color: $text;
+        margin-bottom: 1;
+        padding: 0;
+    }
+
+    YoloModeNoticeScreen .yolo-mode-notice-body > * {
+        margin: 0 0 1 0;
+    }
+
+    YoloModeNoticeScreen .yolo-mode-notice-body > *:last-child {
+        margin-bottom: 0;
+    }
+
+    YoloModeNoticeScreen .yolo-mode-notice-help {
+        height: 1;
+        color: $text-muted;
+        text-style: italic;
+        text-align: center;
+        margin-top: 1;
+    }
+    """
+
+    # The screen must be the focus target for its own priority Enter/Esc
+    # bindings to fire (see `on_mount`); without this the keys reach no handler.
+    can_focus = True
+
+    def __init__(self, body: str | None = None) -> None:
+        """Initialize the notice.
+
+        Args:
+            body: Optional Markdown body under the title. Defaults to
+                `YOLO_MODE_NOTICE_BODY`. Links open in a browser.
+        """
+        super().__init__()
+        self._body = YOLO_MODE_NOTICE_BODY if body is None else body
+
+    def on_mount(self) -> None:
+        """Take focus so priority bindings receive Enter/Esc."""
+        self.focus()
+
+    def compose(self) -> ComposeResult:
+        """Compose the YOLO acknowledgement notice.
+
+        Yields:
+            Title, body, and help-row widgets parented inside a `Vertical`.
+        """
+        with Vertical():
+            yield Static(
+                "YOLO mode",
+                classes="yolo-mode-notice-title",
+                markup=False,
+            )
+            # open_links=False so we own the click path (toast feedback + shared
+            # URL safety). Assistant message widgets use the same pattern.
+            yield Markdown(
+                self._body,
+                classes="yolo-mode-notice-body",
+                open_links=False,
+            )
+            yield Static(
+                "Enter to acknowledge and enable YOLO · Esc to keep current mode",
+                classes="yolo-mode-notice-help",
+                markup=False,
+            )
+
+    async def on_markdown_link_clicked(self, event: Markdown.LinkClicked) -> None:
+        """Open docs (or any body link) with the shared URL helper."""
+        event.stop()
+        await open_checked_url_async(event.href, app=self.app, notify_on_success=True)
+
+    def action_confirm(self) -> None:
+        """Acknowledge YOLO and mark the notice dismissed without re-showing."""
+        self.dismiss(True)
+
+    def action_cancel(self) -> None:
+        """Keep the previous approval mode without persisting acknowledgement.
+
+        The method name must stay `cancel`: the app owns a priority `escape`
+        binding that, for an active `ModalScreen`, dispatches to
+        `action_cancel` if present and otherwise falls through to
+        `dismiss(None)`. Renaming this would silently regress Esc handling.
+        """
+        self.dismiss(False)

--- a/libs/code/deepagents_code/tui/widgets/yolo_mode_notice.py
+++ b/libs/code/deepagents_code/tui/widgets/yolo_mode_notice.py
@@ -97,8 +97,9 @@ class YoloModeNoticeScreen(ModalScreen[bool]):
     }
     """
 
-    # The screen must be the focus target for its own priority Enter/Esc
-    # bindings to fire (see `on_mount`); without this the keys reach no handler.
+    # The screen must be the focus target for its own priority Enter binding to
+    # fire (see `on_mount`). Esc does not depend on focus: the app owns a global
+    # priority `escape` binding that routes to `action_cancel` for active modals.
     can_focus = True
 
     def __init__(self, body: str | None = None) -> None:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -25959,6 +25959,12 @@ class TestLiveApprovalModeWrites:
                 patch(
                     "deepagents_code.approval_mode.save_auto_mode_notice"
                 ) as save_notice,
+                # Keep Manual ↔ Auto for this Auto-notice sequence; YOLO coverage
+                # lives in dedicated switcher tests below.
+                patch(
+                    "deepagents_code.config.is_yolo_switcher_enabled",
+                    return_value=False,
+                ),
             ):
                 # Manual -> Auto
                 await app.action_toggle_auto_approve()
@@ -25972,6 +25978,190 @@ class TestLiveApprovalModeWrites:
                 assert not isinstance(app.screen, AutoModeNoticeScreen)
 
         save_notice.assert_not_called()
+
+    async def test_toggle_cycles_manual_auto_yolo_when_acknowledged(self) -> None:
+        """Shift+Tab visits YOLO once the install-local YOLO ack exists."""
+        from deepagents_code.approval_mode import ApprovalMode
+        from deepagents_code.tui.widgets.auto_mode_notice import AutoModeNoticeScreen
+        from deepagents_code.tui.widgets.yolo_mode_notice import YoloModeNoticeScreen
+
+        app = DeepAgentsApp()
+        app._auto_mode_eligible = True
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = object()
+            with (
+                patch.object(
+                    app,
+                    "_write_live_approval_mode",
+                    new=AsyncMock(return_value=True),
+                ),
+                patch.object(
+                    app,
+                    "_auto_accept_pending_goal_rubric",
+                    new=AsyncMock(),
+                ),
+                patch(
+                    "deepagents_code.approval_mode.has_auto_mode_notice",
+                    return_value=True,
+                ),
+                patch(
+                    "deepagents_code.approval_mode.has_yolo_acknowledgement",
+                    return_value=True,
+                ),
+                patch(
+                    "deepagents_code.config.is_yolo_switcher_enabled",
+                    return_value=True,
+                ),
+                patch.object(app, "notify"),
+            ):
+                await app.action_toggle_auto_approve()
+                assert app._approval_mode is ApprovalMode.AUTO
+                await app.action_toggle_auto_approve()
+                assert app._approval_mode is ApprovalMode.YOLO
+                assert app._auto_approve is True
+                assert not isinstance(app.screen, AutoModeNoticeScreen)
+                assert not isinstance(app.screen, YoloModeNoticeScreen)
+                await app.action_toggle_auto_approve()
+                assert app._approval_mode is ApprovalMode.MANUAL
+                assert app._auto_approve is False
+
+    async def test_toggle_into_yolo_prompts_for_acknowledgement(self) -> None:
+        """First switcher entry into YOLO waits for acknowledge before enabling."""
+        from deepagents_code.approval_mode import ApprovalMode
+        from deepagents_code.tui.widgets.yolo_mode_notice import (
+            YOLO_MODE_NOTICE_BODY,
+            YoloModeNoticeScreen,
+        )
+
+        app = DeepAgentsApp()
+        app._auto_mode_eligible = True
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = object()
+            app._approval_mode = ApprovalMode.AUTO
+            if app._session_state is not None:
+                app._session_state.approval_mode = ApprovalMode.AUTO
+            with (
+                patch.object(
+                    app,
+                    "_write_live_approval_mode",
+                    new=AsyncMock(return_value=True),
+                ) as write_mode,
+                patch.object(
+                    app,
+                    "_auto_accept_pending_goal_rubric",
+                    new=AsyncMock(),
+                ) as accept_goal,
+                patch(
+                    "deepagents_code.approval_mode.has_yolo_acknowledgement",
+                    return_value=False,
+                ),
+                patch(
+                    "deepagents_code.approval_mode.save_yolo_acknowledgement",
+                    return_value=True,
+                ) as save_ack,
+                patch(
+                    "deepagents_code.config.is_yolo_switcher_enabled",
+                    return_value=True,
+                ),
+                patch.object(app, "notify"),
+            ):
+                await app.action_toggle_auto_approve()
+                await pilot.pause()
+                assert app._approval_mode is ApprovalMode.AUTO
+                assert isinstance(app.screen, YoloModeNoticeScreen)
+                assert app.screen._body == YOLO_MODE_NOTICE_BODY
+                write_mode.assert_not_awaited()
+                save_ack.assert_not_called()
+
+                await pilot.press("enter")
+                await pilot.pause()
+                save_ack.assert_called_once_with()
+                assert app._approval_mode is ApprovalMode.YOLO
+                assert app._auto_approve is True
+                write_mode.assert_awaited_with(ApprovalMode.YOLO)
+                accept_goal.assert_awaited_once_with()
+
+    async def test_toggle_into_yolo_escape_keeps_current_mode(self) -> None:
+        """Esc on the switcher YOLO notice leaves Auto active and unsaved."""
+        from deepagents_code.approval_mode import ApprovalMode
+        from deepagents_code.tui.widgets.yolo_mode_notice import YoloModeNoticeScreen
+
+        app = DeepAgentsApp()
+        app._auto_mode_eligible = True
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = object()
+            app._approval_mode = ApprovalMode.AUTO
+            if app._session_state is not None:
+                app._session_state.approval_mode = ApprovalMode.AUTO
+            with (
+                patch.object(
+                    app,
+                    "_write_live_approval_mode",
+                    new=AsyncMock(return_value=True),
+                ) as write_mode,
+                patch(
+                    "deepagents_code.approval_mode.has_yolo_acknowledgement",
+                    return_value=False,
+                ),
+                patch(
+                    "deepagents_code.approval_mode.save_yolo_acknowledgement"
+                ) as save_ack,
+                patch(
+                    "deepagents_code.config.is_yolo_switcher_enabled",
+                    return_value=True,
+                ),
+                patch.object(app, "notify") as notify,
+            ):
+                await app.action_toggle_auto_approve()
+                await pilot.pause()
+                assert isinstance(app.screen, YoloModeNoticeScreen)
+                await pilot.press("escape")
+                await pilot.pause()
+                save_ack.assert_not_called()
+                write_mode.assert_not_awaited()
+                assert app._approval_mode is ApprovalMode.AUTO
+                assert app._auto_approve is False
+                assert any(
+                    "Stayed in the current approval mode" in str(call.args[0])
+                    for call in notify.call_args_list
+                )
+
+    async def test_toggle_skips_yolo_when_switcher_disabled(self) -> None:
+        """Disabling the switcher restores Manual ↔ Auto only."""
+        from deepagents_code.approval_mode import ApprovalMode
+
+        app = DeepAgentsApp()
+        app._auto_mode_eligible = True
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = object()
+            with (
+                patch.object(
+                    app,
+                    "_write_live_approval_mode",
+                    new=AsyncMock(return_value=True),
+                ),
+                patch.object(
+                    app,
+                    "_auto_accept_pending_goal_rubric",
+                    new=AsyncMock(),
+                ),
+                patch(
+                    "deepagents_code.approval_mode.has_auto_mode_notice",
+                    return_value=True,
+                ),
+                patch(
+                    "deepagents_code.config.is_yolo_switcher_enabled",
+                    return_value=False,
+                ),
+            ):
+                await app.action_toggle_auto_approve()
+                assert app._approval_mode is ApprovalMode.AUTO
+                await app.action_toggle_auto_approve()
+                assert app._approval_mode is ApprovalMode.MANUAL
 
     async def test_on_auto_approve_enabled_first_modal_and_save(self) -> None:
         from deepagents_code.approval_mode import ApprovalMode

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -26163,6 +26163,150 @@ class TestLiveApprovalModeWrites:
                 await app.action_toggle_auto_approve()
                 assert app._approval_mode is ApprovalMode.MANUAL
 
+    async def test_toggle_into_yolo_ack_save_failure_keeps_mode(self) -> None:
+        """A failed acknowledgement write must not enter YOLO."""
+        from deepagents_code.approval_mode import ApprovalMode
+        from deepagents_code.tui.widgets.yolo_mode_notice import YoloModeNoticeScreen
+
+        app = DeepAgentsApp()
+        app._auto_mode_eligible = True
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = object()
+            app._approval_mode = ApprovalMode.AUTO
+            if app._session_state is not None:
+                app._session_state.approval_mode = ApprovalMode.AUTO
+            with (
+                patch.object(
+                    app,
+                    "_write_live_approval_mode",
+                    new=AsyncMock(return_value=True),
+                ) as write_mode,
+                patch(
+                    "deepagents_code.approval_mode.has_yolo_acknowledgement",
+                    return_value=False,
+                ),
+                patch(
+                    "deepagents_code.approval_mode.save_yolo_acknowledgement",
+                    return_value=False,
+                ) as save_ack,
+                patch(
+                    "deepagents_code.config.is_yolo_switcher_enabled",
+                    return_value=True,
+                ),
+                patch.object(app, "_warn_live_approval_mode_unavailable") as warn,
+            ):
+                await app.action_toggle_auto_approve()
+                await pilot.pause()
+                assert isinstance(app.screen, YoloModeNoticeScreen)
+                await pilot.press("enter")
+                await pilot.pause()
+                save_ack.assert_called_once_with()
+                # Ack failed: never persist the mode, stay in the previous one.
+                write_mode.assert_not_awaited()
+                assert app._approval_mode is ApprovalMode.AUTO
+                assert app._auto_approve is False
+                warn.assert_called_once()
+                assert "acknowledgement could not be saved" in str(
+                    warn.call_args.args[0]
+                )
+
+    async def test_set_approval_mode_yolo_persist_failure_returns_false(self) -> None:
+        """A failed live write for YOLO returns False without escalating."""
+        from deepagents_code.approval_mode import ApprovalMode
+
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = object()
+            app._approval_mode = ApprovalMode.AUTO
+            app._auto_approve = False
+            if app._session_state is not None:
+                app._session_state.approval_mode = ApprovalMode.AUTO
+            with (
+                patch.object(
+                    app,
+                    "_write_live_approval_mode",
+                    new=AsyncMock(return_value=False),
+                ),
+                patch.object(
+                    app,
+                    "_auto_accept_pending_goal_rubric",
+                    new=AsyncMock(),
+                ) as accept_goal,
+                patch.object(app, "_warn_live_approval_mode_unavailable") as warn,
+            ):
+                result = await app._set_approval_mode(ApprovalMode.YOLO)
+                assert result is False
+                # No partial escalation: mode/flag/goal-rubric all untouched.
+                assert app._approval_mode is ApprovalMode.AUTO
+                assert app._auto_approve is False
+                accept_goal.assert_not_awaited()
+                warn.assert_called_once()
+                assert "YOLO could not be persisted" in str(warn.call_args.args[0])
+
+    async def test_prompt_yolo_push_failure_surfaces_and_allows_retry(self) -> None:
+        """A push_screen failure warns the user and never latches the guard."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = object()
+            with (
+                patch.object(
+                    app, "push_screen", side_effect=RuntimeError("boom")
+                ) as push,
+                patch(
+                    "deepagents_code.approval_mode.save_yolo_acknowledgement",
+                    return_value=True,
+                ),
+                patch.object(app, "_warn_live_approval_mode_unavailable") as warn,
+            ):
+                app._prompt_yolo_switcher_acknowledgement()
+                push.assert_called_once()
+                # Guard stays unset so a later Shift+Tab can retry the prompt.
+                assert app._yolo_mode_notice_pending is False
+                warn.assert_called_once()
+                assert "Could not open the YOLO confirmation" in str(
+                    warn.call_args.args[0]
+                )
+
+    async def test_prompt_yolo_reentrancy_guard_blocks_second_push(self) -> None:
+        """A pending notice makes a second prompt a no-op (no stacked modals)."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = object()
+            app._yolo_mode_notice_pending = True
+            with patch.object(app, "push_screen") as push:
+                app._prompt_yolo_switcher_acknowledgement()
+                push.assert_not_called()
+
+    async def test_toggle_warns_when_auto_ineligible_and_switcher_disabled(
+        self,
+    ) -> None:
+        """Manual with no Auto and no YOLO leaves the mode and warns once."""
+        from deepagents_code.approval_mode import ApprovalMode
+
+        app = DeepAgentsApp()
+        app._auto_mode_eligible = False
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = object()
+            assert app._approval_mode is ApprovalMode.MANUAL
+            with (
+                patch(
+                    "deepagents_code.config.is_yolo_switcher_enabled",
+                    return_value=False,
+                ),
+                patch.object(app, "_warn_live_approval_mode_unavailable") as warn,
+            ):
+                await app.action_toggle_auto_approve()
+                assert app._approval_mode is ApprovalMode.MANUAL
+                warn.assert_called_once()
+                assert "Auto is unavailable with a sandbox" in str(
+                    warn.call_args.args[0]
+                )
+
     async def test_on_auto_approve_enabled_first_modal_and_save(self) -> None:
         from deepagents_code.approval_mode import ApprovalMode
         from deepagents_code.tui.widgets.auto_mode_notice import (

--- a/libs/code/tests/unit_tests/test_approval_mode.py
+++ b/libs/code/tests/unit_tests/test_approval_mode.py
@@ -21,6 +21,7 @@ from deepagents_code.approval_mode import (
     awrite_approval_mode,
     has_auto_mode_notice,
     has_yolo_acknowledgement,
+    next_approval_mode,
     read_approval_mode_from_store,
     save_auto_mode_notice,
     save_yolo_acknowledgement,
@@ -90,6 +91,38 @@ def test_approval_mode_payload_shape(mode: ApprovalMode) -> None:
 
     assert payload == {"mode": mode.value}
     assert "auto_approve" not in payload
+
+
+@pytest.mark.parametrize(
+    ("current", "auto_eligible", "yolo_switcher_enabled", "expected"),
+    [
+        (ApprovalMode.MANUAL, True, True, ApprovalMode.AUTO),
+        (ApprovalMode.AUTO, True, True, ApprovalMode.YOLO),
+        (ApprovalMode.YOLO, True, True, ApprovalMode.MANUAL),
+        (ApprovalMode.MANUAL, True, False, ApprovalMode.AUTO),
+        (ApprovalMode.AUTO, True, False, ApprovalMode.MANUAL),
+        (ApprovalMode.YOLO, True, False, ApprovalMode.MANUAL),
+        (ApprovalMode.MANUAL, False, True, ApprovalMode.YOLO),
+        (ApprovalMode.YOLO, False, True, ApprovalMode.MANUAL),
+        (ApprovalMode.MANUAL, False, False, None),
+        ("auto", True, True, ApprovalMode.YOLO),
+        ("not-a-mode", True, True, ApprovalMode.AUTO),
+    ],
+)
+def test_next_approval_mode_cycle(
+    current: ApprovalMode | str,
+    auto_eligible: bool,
+    yolo_switcher_enabled: bool,
+    expected: ApprovalMode | None,
+) -> None:
+    assert (
+        next_approval_mode(
+            current,
+            auto_eligible=auto_eligible,
+            yolo_switcher_enabled=yolo_switcher_enabled,
+        )
+        is expected
+    )
 
 
 def test_read_approval_mode_from_store_accepts_mapping_item() -> None:

--- a/libs/code/tests/unit_tests/test_config_manifest.py
+++ b/libs/code/tests/unit_tests/test_config_manifest.py
@@ -1788,6 +1788,74 @@ def test_startup_mode_option_definition() -> None:
     assert opt.env_var is None
 
 
+def test_startup_yolo_switcher_defaults_enabled(monkeypatch) -> None:
+    """`startup.yolo_switcher` resolves to enabled when nothing overrides it."""
+    option = get_option("startup.yolo_switcher")
+    assert option is not None
+    assert option.group == "Startup"
+    assert option.default is True
+    assert option.env_var == _env_vars.YOLO_SWITCHER
+    assert option.toml_keys == ("startup", "yolo_switcher")
+    monkeypatch.delenv(_env_vars.YOLO_SWITCHER, raising=False)
+    assert resolve_scalar(option, toml_data={}) == (True, "default")
+
+
+def test_startup_yolo_switcher_env_disables(monkeypatch) -> None:
+    """A falsy `DEEPAGENTS_CODE_YOLO_SWITCHER` removes YOLO from the switcher."""
+    option = get_option("startup.yolo_switcher")
+    assert option is not None
+    monkeypatch.setenv(_env_vars.YOLO_SWITCHER, "0")
+    value, _ = resolve_scalar(option, toml_data={})
+    assert value is False
+
+
+def test_startup_yolo_switcher_empty_env_disables(monkeypatch) -> None:
+    """An explicitly empty env override disables the YOLO switcher entry."""
+    option = get_option("startup.yolo_switcher")
+    assert option is not None
+    monkeypatch.setenv(_env_vars.YOLO_SWITCHER, "")
+    assert resolve_scalar(option, toml_data={}) == (
+        False,
+        f"env ({_env_vars.YOLO_SWITCHER})",
+    )
+
+
+def test_startup_yolo_switcher_toml_disables(monkeypatch) -> None:
+    """`[startup].yolo_switcher = false` disables the YOLO switcher entry."""
+    option = get_option("startup.yolo_switcher")
+    assert option is not None
+    monkeypatch.delenv(_env_vars.YOLO_SWITCHER, raising=False)
+    value, _ = resolve_scalar(option, toml_data={"startup": {"yolo_switcher": False}})
+    assert value is False
+
+
+def test_is_yolo_switcher_enabled_reads_env(monkeypatch) -> None:
+    """The `config.is_yolo_switcher_enabled` helper honors the env override."""
+    from deepagents_code import config_manifest
+    from deepagents_code.config import is_yolo_switcher_enabled
+
+    monkeypatch.setattr(config_manifest, "load_config_toml", dict)
+    monkeypatch.delenv(_env_vars.YOLO_SWITCHER, raising=False)
+    assert is_yolo_switcher_enabled() is True
+
+    monkeypatch.setenv(_env_vars.YOLO_SWITCHER, "false")
+    assert is_yolo_switcher_enabled() is False
+
+
+def test_is_yolo_switcher_enabled_reads_toml(monkeypatch) -> None:
+    """The helper honors `[startup].yolo_switcher` when env is unset."""
+    from deepagents_code import config_manifest
+    from deepagents_code.config import is_yolo_switcher_enabled
+
+    monkeypatch.delenv(_env_vars.YOLO_SWITCHER, raising=False)
+    monkeypatch.setattr(
+        config_manifest,
+        "load_config_toml",
+        lambda: {"startup": {"yolo_switcher": False}},
+    )
+    assert is_yolo_switcher_enabled() is False
+
+
 def test_resolve_startup_mode_from_toml(caplog) -> None:
     """`startup.mode` resolves only valid runtime modes from config.toml."""
     import logging

--- a/libs/code/tests/unit_tests/tui/widgets/test_startup_tip.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_startup_tip.py
@@ -7,14 +7,18 @@ from textual.content import Content
 
 from deepagents_code._env_vars import HIDE_SPLASH_TIPS
 from deepagents_code.tui.widgets.startup_tip import (
+    _TIP_SHIFT_TAB_WITH_YOLO,
+    _TIP_SHIFT_TAB_WITHOUT_YOLO,
     _TIPS,
     StartupTip,
+    _active_tips,
     _pick_tip,
     show_startup_tip,
 )
 
 _PICK_TIP = "deepagents_code.tui.widgets.startup_tip._pick_tip"
 _CHOICES = "deepagents_code.tui.widgets.startup_tip.random.choices"
+_IS_YOLO_SWITCHER = "deepagents_code.config.is_yolo_switcher_enabled"
 
 
 class TestStartupTip:
@@ -42,18 +46,55 @@ class TestStartupTip:
         pick_tip.assert_called_once()
 
     def test_pick_tip_returns_registered_tip(self) -> None:
-        """`_pick_tip` only ever returns a tip drawn from the registry."""
-        for _ in range(100):
-            assert _pick_tip() in _TIPS
+        """`_pick_tip` only ever returns a tip drawn from the active registry."""
+        with patch(_IS_YOLO_SWITCHER, return_value=True):
+            for _ in range(100):
+                assert _pick_tip() in _TIPS
 
     def test_pick_tip_weights_by_registry_values(self) -> None:
-        """`_pick_tip` passes the registry's relative weights to the draw."""
-        with patch(_CHOICES, return_value=["Use /copy"]) as choices:
+        """`_pick_tip` passes the active registry's relative weights to the draw."""
+        with (
+            patch(_IS_YOLO_SWITCHER, return_value=True),
+            patch(_CHOICES, return_value=["Use /copy"]) as choices,
+        ):
             assert _pick_tip() == "Use /copy"
 
         choices.assert_called_once()
-        _, kwargs = choices.call_args
+        args, kwargs = choices.call_args
+        assert args[0] == list(_TIPS.keys())
         assert kwargs["weights"] == list(_TIPS.values())
+
+    def test_active_tips_includes_yolo_when_switcher_enabled(self) -> None:
+        """Enabled YOLO switcher keeps the three-mode Shift+Tab tip."""
+        tips = _active_tips(yolo_switcher_enabled=True)
+
+        assert _TIP_SHIFT_TAB_WITH_YOLO in tips
+        assert _TIP_SHIFT_TAB_WITHOUT_YOLO not in tips
+        assert tips[_TIP_SHIFT_TAB_WITH_YOLO] == _TIPS[_TIP_SHIFT_TAB_WITH_YOLO]
+
+    def test_active_tips_hides_yolo_when_switcher_disabled(self) -> None:
+        """Disabled YOLO switcher advertises Manual/Auto only."""
+        tips = _active_tips(yolo_switcher_enabled=False)
+
+        assert _TIP_SHIFT_TAB_WITH_YOLO not in tips
+        assert tips[_TIP_SHIFT_TAB_WITHOUT_YOLO] == _TIPS[_TIP_SHIFT_TAB_WITH_YOLO]
+
+    def test_pick_tip_uses_resolved_yolo_switcher_setting(self) -> None:
+        """`_pick_tip` resolves the live switcher setting when choosing tips."""
+        with (
+            patch(_IS_YOLO_SWITCHER, return_value=False) as resolved,
+            patch(
+                _CHOICES,
+                return_value=[_TIP_SHIFT_TAB_WITHOUT_YOLO],
+            ) as choices,
+        ):
+            assert _pick_tip() == _TIP_SHIFT_TAB_WITHOUT_YOLO
+
+        resolved.assert_called_once_with()
+        args, kwargs = choices.call_args
+        assert _TIP_SHIFT_TAB_WITHOUT_YOLO in args[0]
+        assert _TIP_SHIFT_TAB_WITH_YOLO not in args[0]
+        assert kwargs["weights"][args[0].index(_TIP_SHIFT_TAB_WITHOUT_YOLO)] == 2
 
     def test_show_startup_tip_defaults_to_true(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Make YOLO reachable from the interactive approval switcher so you do not need to restart with `--yolo`.

Shift+Tab now cycles **Manual → Auto → YOLO → Manual** by default. Organizations and cautious installs can remove YOLO from that cycle with `DEEPAGENTS_CODE_YOLO_SWITCHER=false` or `[startup].yolo_switcher = false` in a distributed `config.toml`. The first switcher entry into YOLO still requires the existing install-local acknowledgement used by `--yolo`; Esc keeps the current mode and does not enable unrestricted execution.

Auto remains skipped under sandboxes. Disabling the switcher keeps Manual/Auto only, while a session already started with `--yolo` can still leave YOLO with Shift+Tab.