### PR TITLE
feat(code): add Claude Opus 5 support

### DIFF
--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -4854,6 +4854,8 @@ def create_model(
         reasoning_effort_override,
         reasoning_override,
     )
+    if provider == "anthropic" and model_name == "claude-opus-5":
+        kwargs.setdefault("max_tokens", 128000)
 
     # `--max-retries` outranks everything: fold it under the provider's resolved
     # retry-param name (honoring `[retries.<provider>].param`) so a custom

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -1029,7 +1029,9 @@ def get_available_models() -> dict[str, list[str]]:
             )
             continue
         try:
-            profiles = _load_provider_profiles(module_path)
+            profiles = _with_builtin_profiles(
+                provider, _load_provider_profiles(module_path)
+            )
         except ImportError:
             logger.debug(
                 "Could not import profiles from %s (package may not be installed)",
@@ -1171,6 +1173,36 @@ def get_available_models() -> dict[str, list[str]]:
     return available
 
 
+_BUILTIN_MODEL_PROFILES: dict[str, dict[str, dict[str, Any]]] = {
+    "anthropic": {
+        "claude-opus-5": {
+            "tool_calling": True,
+            "text_inputs": True,
+            "text_outputs": True,
+            "reasoning_output": True,
+            "reasoning_effort_levels": ["low", "medium", "high", "xhigh", "max"],
+            "reasoning_effort_default": "high",
+        }
+    }
+}
+
+
+def _with_builtin_profiles(
+    provider: str, profiles: dict[str, dict[str, Any]]
+) -> dict[str, dict[str, Any]]:
+    """Add missing profiles required by the current Deep Agents model catalog.
+
+    Args:
+        provider: Provider whose profiles are being loaded.
+        profiles: Profiles loaded from the provider integration.
+
+    Returns:
+        Provider profiles supplemented by built-in fallbacks.
+    """
+    builtins = _BUILTIN_MODEL_PROFILES.get(provider, {})
+    return {**builtins, **profiles}
+
+
 def _build_entry(
     base: dict[str, Any],
     overrides: dict[str, Any],
@@ -1251,7 +1283,9 @@ def get_model_profiles(
             )
             continue
         try:
-            profiles = _load_provider_profiles(module_path)
+            profiles = _with_builtin_profiles(
+                provider, _load_provider_profiles(module_path)
+            )
         except ImportError:
             logger.debug(
                 "Could not import profiles from %s for provider '%s'",

--- a/libs/code/deepagents_code/tui/widgets/model_selector.py
+++ b/libs/code/deepagents_code/tui/widgets/model_selector.py
@@ -67,6 +67,7 @@ from the per-provider sections below.
 _RECOMMENDED_MODELS: dict[str, str] = {
     "anthropic:claude-opus-4-7": "Claude Opus 4.7",
     "anthropic:claude-opus-4-8": "Claude Opus 4.8",
+    "anthropic:claude-opus-5": "Claude Opus 5",
     "anthropic:claude-sonnet-5": "Claude Sonnet 5",
     "baseten:deepseek-ai/DeepSeek-V4-Pro": "DeepSeek V4 Pro",
     "baseten:moonshotai/Kimi-K2.7-Code": "Kimi K2.7 Code",

--- a/libs/code/tests/unit_tests/test_config.py
+++ b/libs/code/tests/unit_tests/test_config.py
@@ -5013,6 +5013,27 @@ max_tokens = 1024
         # Config kwarg preserved when not overridden
         assert call_kwargs["max_tokens"] == 1024
 
+    @pytest.mark.parametrize(
+        ("extra_kwargs", "expected"),
+        [(None, 128000), ({"max_tokens": 64000}, 64000)],
+    )
+    @patch("langchain.chat_models.init_chat_model")
+    def test_opus_5_max_tokens_default_preserves_override(
+        self,
+        mock_init_chat_model: Mock,
+        extra_kwargs: dict[str, int] | None,
+        expected: int,
+    ) -> None:
+        """Opus 5 uses its documented limit unless the user overrides it."""
+        mock_model = Mock()
+        mock_model.profile = None
+        mock_init_chat_model.return_value = mock_model
+
+        create_model("anthropic:claude-opus-5", extra_kwargs=extra_kwargs)
+
+        _, call_kwargs = mock_init_chat_model.call_args
+        assert call_kwargs["max_tokens"] == expected
+
     @patch("langchain.chat_models.init_chat_model")
     def test_none_extra_kwargs_is_noop(self, mock_init_chat_model: Mock) -> None:
         """extra_kwargs=None does not affect behavior."""

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -7285,6 +7285,32 @@ class TestGetModelProfiles:
         assert entry["profile"]["tool_calling"] is True
         assert entry["overridden_keys"] == frozenset()
 
+    def test_adds_opus_5_fallback_when_upstream_profile_is_missing(self) -> None:
+        """Opus 5 remains available before LangChain publishes its profile."""
+
+        def mock_load(module_path: str) -> dict[str, Any]:
+            if module_path == "langchain_anthropic.data._profiles":
+                return {}
+            msg = "not installed"
+            raise ImportError(msg)
+
+        with patch(
+            "deepagents_code.model_config._load_provider_profiles",
+            side_effect=mock_load,
+        ):
+            profiles = get_model_profiles()
+
+        profile = profiles["anthropic:claude-opus-5"]["profile"]
+        assert profile["reasoning_output"] is True
+        assert profile["reasoning_effort_levels"] == [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
+        ]
+        assert profile["reasoning_effort_default"] == "high"
+
     def test_merges_config_overrides(self, tmp_path: Path) -> None:
         """Config.toml profile overrides are merged and tracked."""
         config_path = tmp_path / "config.toml"

--- a/libs/code/tests/unit_tests/test_reasoning_effort.py
+++ b/libs/code/tests/unit_tests/test_reasoning_effort.py
@@ -360,12 +360,14 @@ def test_openai_and_codex_use_mirrored_profile_contract() -> None:
 
 
 def test_anthropic_profile_contract() -> None:
-    assert supported_efforts_for_model("anthropic:claude-opus-4-5") == (
+    assert supported_efforts_for_model("anthropic:claude-opus-5") == (
         "low",
         "medium",
         "high",
+        "xhigh",
+        "max",
     )
-    assert default_effort_for_model("anthropic:claude-opus-4-5") == "high"
+    assert default_effort_for_model("anthropic:claude-opus-5") == "high"
 
 
 def test_openai_integration_translates_standard_effort_without_summary() -> None:
@@ -393,16 +395,16 @@ def test_anthropic_integration_translates_standard_effort() -> None:
     from langchain_core.messages import HumanMessage
 
     model = ChatAnthropic(
-        model="claude-opus-4-5",
+        model="claude-opus-5",
         api_key="test",
-        reasoning_effort="high",
+        reasoning_effort="xhigh",
         output_config={"format": {"type": "json_schema", "schema": {}}},
     )
     payload = model._get_request_payload([HumanMessage("hello")])
 
     assert payload["output_config"] == {
         "format": {"type": "json_schema", "schema": {}},
-        "effort": "high",
+        "effort": "xhigh",
     }
     assert "reasoning_effort" not in payload
 

--- a/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_model_selector.py
@@ -2004,6 +2004,22 @@ class TestAvailabilityOrdering:
 class TestCuratedModelSelection:
     """Tests for onboarding curated model selection."""
 
+    def test_opus_5_is_recommended(self) -> None:
+        """Opus 5 should be discoverable in the frontier picker subset."""
+        from deepagents_code.tui.widgets import model_selector
+
+        all_models = [
+            ("anthropic:claude-opus-5", "anthropic"),
+            ("anthropic:claude-opus-4-5", "anthropic"),
+        ]
+
+        curated = ModelSelectorScreen._curate_models(all_models)
+
+        assert model_selector._RECOMMENDED_MODELS["anthropic:claude-opus-5"] == (
+            "Claude Opus 5"
+        )
+        assert curated == all_models[:1]
+
     def test_sonnet_5_is_recommended(self) -> None:
         """Sonnet 5 should be part of the frontier picker subset."""
         from deepagents_code.tui.widgets import model_selector


### PR DESCRIPTION
Claude Opus 5 is now available in the curated model selector with its complete Anthropic effort configuration.

---

Adds a local profile fallback so users can select `claude-opus-5` before installed LangChain profile data catches up, while preferring upstream metadata when present. Covers discovery, display, effort levels/default, and native `output_config.effort` request shaping.

Made by [Open SWE](https://openswe.vercel.app/agents/019f9535-a4fd-73b9-92ac-49f6ab6ab454)

## References
- Plan: https://openswe.vercel.app/agents/019f9535-a4fd-73b9-92ac-49f6ab6ab454/plan