### PR TITLE
perf(langsmith-sandbox): run LangSmith sandbox commands over the async client

### DIFF
--- a/libs/deepagents/deepagents/backends/langsmith.py
+++ b/libs/deepagents/deepagents/backends/langsmith.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import logging
 from typing import TYPE_CHECKING
@@ -23,9 +24,17 @@ from deepagents.backends.sandbox import (
 from deepagents.backends.utils import _get_backend_read_file_type
 
 if TYPE_CHECKING:
-    from langsmith.sandbox import Sandbox
+    from langsmith.sandbox import AsyncSandbox, AsyncSandboxClient, ExecutionResult, Sandbox
 
 logger = logging.getLogger(__name__)
+
+
+def _execute_response(result: ExecutionResult) -> ExecuteResponse:
+    """Build an `ExecuteResponse` from a LangSmith SDK execution result."""
+    output = result.stdout or ""
+    if result.stderr:
+        output += "\n" + result.stderr if output else result.stderr
+    return ExecuteResponse(output=output, exit_code=result.exit_code, truncated=False)
 
 
 def _binary_read_result(file_path: str, raw: bytes) -> ReadResult:
@@ -60,6 +69,9 @@ class LangSmithSandbox(BaseSandbox):
         """
         self._sandbox = sandbox
         self._default_timeout: int = 30 * 60
+        self._async_sandbox: AsyncSandbox | None = None
+        self._async_client: AsyncSandboxClient | None = None
+        self._async_loop: asyncio.AbstractEventLoop | None = None
 
     @property
     def id(self) -> str:
@@ -82,17 +94,53 @@ class LangSmithSandbox(BaseSandbox):
             `ExecuteResponse` containing output, exit code, and truncation flag.
         """
         effective_timeout = timeout if timeout is not None else self._default_timeout
-        result = self._sandbox.run(command, timeout=effective_timeout)
+        return _execute_response(self._sandbox.run(command, timeout=effective_timeout))
 
-        output = result.stdout or ""
-        if result.stderr:
-            output += "\n" + result.stderr if output else result.stderr
+    def _aget_sandbox(self) -> AsyncSandbox:
+        """Return a cached `AsyncSandbox` bound to the running event loop.
 
-        return ExecuteResponse(
-            output=output,
-            exit_code=result.exit_code,
-            truncated=False,
-        )
+        `Sandbox.to_async()` builds a fresh client with its own connection pool
+        on every call, so it is cached: rebuilding per command would add a TCP
+        and TLS handshake to each one. The cache is keyed on the running loop
+        because the underlying httpx client is bound to the loop that created
+        it.
+        """
+        loop = asyncio.get_running_loop()
+        if self._async_sandbox is None or self._async_loop is not loop:
+            # The SDK exposes no public accessor for a sandbox's client, and
+            # the async client is held here so `aclose()` can reach its pool.
+            self._async_client = self._sandbox._client.to_async()
+            self._async_sandbox = self._sandbox.to_async(client=self._async_client)
+            self._async_loop = loop
+        return self._async_sandbox
+
+    async def aexecute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:  # noqa: ASYNC109
+        """Execute a shell command inside the sandbox.
+
+        Overrides the protocol default, which offloads the blocking `execute()`
+        to a worker thread. `BaseSandbox` routes every async filesystem
+        operation through `aexecute`, so using the SDK's async client here keeps
+        all of them off the sync transport.
+
+        Args:
+            command: Shell command string to execute.
+            timeout: Maximum time in seconds to wait for the command to complete.
+
+                If `None`, uses the backend's default timeout.
+
+        Returns:
+            `ExecuteResponse` containing output, exit code, and truncation flag.
+        """
+        effective_timeout = timeout if timeout is not None else self._default_timeout
+        sandbox = self._aget_sandbox()
+        return _execute_response(await sandbox.run(command, timeout=effective_timeout))
+
+    async def aclose(self) -> None:
+        """Close the cached async client's connection pool, if one was created."""
+        client = self._async_client
+        self._async_sandbox = self._async_client = self._async_loop = None
+        if client is not None:
+            await client.aclose()
 
     def write(self, file_path: str, content: str) -> WriteResult:
         """Write content using the LangSmith SDK to avoid ARG_MAX.

--- a/libs/deepagents/deepagents/backends/langsmith.py
+++ b/libs/deepagents/deepagents/backends/langsmith.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import logging
 from typing import TYPE_CHECKING
@@ -71,7 +70,6 @@ class LangSmithSandbox(BaseSandbox):
         self._default_timeout: int = 30 * 60
         self._async_sandbox: AsyncSandbox | None = None
         self._async_client: AsyncSandboxClient | None = None
-        self._async_loop: asyncio.AbstractEventLoop | None = None
 
     @property
     def id(self) -> str:
@@ -97,21 +95,19 @@ class LangSmithSandbox(BaseSandbox):
         return _execute_response(self._sandbox.run(command, timeout=effective_timeout))
 
     def _aget_sandbox(self) -> AsyncSandbox:
-        """Return a cached `AsyncSandbox` bound to the running event loop.
+        """Return the cached `AsyncSandbox`, creating it on first async use.
 
         `Sandbox.to_async()` builds a fresh client with its own connection pool
         on every call, so it is cached: rebuilding per command would add a TCP
-        and TLS handshake to each one. The cache is keyed on the running loop
-        because the underlying httpx client is bound to the loop that created
-        it.
+        and TLS handshake to each one. The client belongs to the event loop that
+        created it, as does this backend — reusing one instance across loops is
+        not supported.
         """
-        loop = asyncio.get_running_loop()
-        if self._async_sandbox is None or self._async_loop is not loop:
+        if self._async_sandbox is None:
             # The SDK exposes no public accessor for a sandbox's client, and
             # the async client is held here so `aclose()` can reach its pool.
             self._async_client = self._sandbox._client.to_async()
             self._async_sandbox = self._sandbox.to_async(client=self._async_client)
-            self._async_loop = loop
         return self._async_sandbox
 
     async def aexecute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:  # noqa: ASYNC109
@@ -138,7 +134,7 @@ class LangSmithSandbox(BaseSandbox):
     async def aclose(self) -> None:
         """Close the cached async client's connection pool, if one was created."""
         client = self._async_client
-        self._async_sandbox = self._async_client = self._async_loop = None
+        self._async_sandbox = self._async_client = None
         if client is not None:
             await client.aclose()
 

--- a/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from langsmith.sandbox import ResourceNotFoundError, SandboxClientError
 
@@ -517,3 +517,67 @@ def test_max_binary_bytes_constant_matches_template() -> None:
 def test_max_output_bytes_constant_matches_template() -> None:
     assert "MAX_OUTPUT_BYTES = 500 * 1024" in base_sandbox._READ_COMMAND_TEMPLATE
     assert MAX_OUTPUT_BYTES == 500 * 1024
+
+
+def _make_async_sandbox() -> tuple[LangSmithSandbox, MagicMock, MagicMock]:
+    sb, mock_sdk = _make_sandbox()
+    async_sdk = MagicMock()
+    async_sdk.run = AsyncMock(return_value=SimpleNamespace(stdout="out", stderr="", exit_code=0))
+    async_client = MagicMock()
+    async_client.aclose = AsyncMock()
+    mock_sdk._client.to_async.return_value = async_client
+    mock_sdk.to_async.return_value = async_sdk
+    return sb, async_sdk, async_client
+
+
+async def test_aexecute_uses_async_client_not_sync_run() -> None:
+    """`aexecute` must not fall through to the protocol's `to_thread(execute)`."""
+    sb, async_sdk, _ = _make_async_sandbox()
+
+    result = await sb.aexecute("echo hi", timeout=30)
+
+    assert result.output == "out"
+    assert result.exit_code == 0
+    async_sdk.run.assert_awaited_once_with("echo hi", timeout=30)
+    sb._sandbox.run.assert_not_called()
+
+
+async def test_aexecute_combines_stdout_and_stderr() -> None:
+    sb, async_sdk, _ = _make_async_sandbox()
+    async_sdk.run.return_value = SimpleNamespace(stdout="out", stderr="err", exit_code=1)
+
+    result = await sb.aexecute("failing-cmd")
+
+    assert result.output == "out\nerr"
+    assert result.exit_code == 1
+    async_sdk.run.assert_awaited_once_with("failing-cmd", timeout=30 * 60)
+
+
+async def test_aexecute_reuses_one_async_client() -> None:
+    """A client per command would add a TCP + TLS handshake to every call."""
+    sb, _, _ = _make_async_sandbox()
+
+    await sb.aexecute("true")
+    await sb.aexecute("true")
+    await sb.aexecute("true")
+
+    assert sb._sandbox.to_async.call_count == 1
+
+
+async def test_aclose_closes_pool_and_allows_rebuild() -> None:
+    sb, _, async_client = _make_async_sandbox()
+    await sb.aexecute("true")
+
+    await sb.aclose()
+    async_client.aclose.assert_awaited_once()
+
+    await sb.aexecute("true")
+    assert sb._sandbox.to_async.call_count == 2
+
+
+async def test_aclose_without_async_use_is_a_noop() -> None:
+    sb, _, async_client = _make_async_sandbox()
+
+    await sb.aclose()
+
+    async_client.aclose.assert_not_awaited()


### PR DESCRIPTION
`LangSmithSandbox` never overrode `aexecute`, so async commands fell through to `SandboxBackendProtocol.aexecute`, which offloads the blocking SDK client to a worker thread. This implements it against the SDK's async client instead.

---

`BaseSandbox` routes `als`/`aread`/`awrite`/`aedit`/`agrep`/`aglob` through `aexecute`, so this covers every async filesystem operation, not just `execute`.

`Sandbox.to_async()` builds a fresh client with its own connection pool on every call, so it is cached per event loop — otherwise every file read, write, glob, and grep would pay a TCP and TLS handshake. Construction stays lazy, so a purely synchronous caller never builds one, and `aclose()` releases the pool.

It is also much faster, for an unsatisfying reason: the sync client blocks the caller on the WebSocket teardown, which sits behind a 1s `delayed_close_timeout` on the gateway fronting the sandbox. Same command, same box: **1274ms → 188ms**. The async client returns as soon as the command's `exit` frame arrives and lets the teardown finish on its own. Both paths use `_run_ws`, so this is not a WebSocket-to-HTTP downgrade — same protocol, same frames.

## Test plan

- [x] `make test TEST_FILE=tests/unit_tests/backends/test_langsmith_sandbox.py` — 45 pass, including new cases for the async path, stdout/stderr combining, single-client reuse, `aclose` + rebuild, and the no-op close when async was never used
- [x] `make lint` clean (ruff, format, `ty`)
- [x] Verified end to end against a real sandbox
