### PR TITLE
fix(runloop): return per-file errors from file transfers instead of raising

### DIFF
--- a/libs/partners/runloop/langchain_runloop/sandbox.py
+++ b/libs/partners/runloop/langchain_runloop/sandbox.py
@@ -8,8 +8,13 @@ if TYPE_CHECKING:
     from runloop_api_client.sdk import Devbox
 
 from deepagents.backends.protocol import (
+    FILE_NOT_FOUND,
+    INVALID_PATH,
+    IS_DIRECTORY,
+    PERMISSION_DENIED,
     ExecuteResponse,
     FileDownloadResponse,
+    FileOperationError,
     FileUploadResponse,
 )
 from deepagents.backends.sandbox import BaseSandbox
@@ -63,7 +68,22 @@ class RunloopSandbox(BaseSandbox):
         """Download files from the devbox."""
         responses: list[FileDownloadResponse] = []
         for path in paths:
-            content = self._devbox.file.download(path=path)
+            if not path.startswith("/"):
+                responses.append(
+                    FileDownloadResponse(path=path, content=None, error=INVALID_PATH)
+                )
+                continue
+            try:
+                content = self._devbox.file.download(path=path)
+            except Exception as exc:  # noqa: BLE001  # Provider exceptions vary by SDK version
+                responses.append(
+                    FileDownloadResponse(
+                        path=path,
+                        content=None,
+                        error=_map_file_error(exc),
+                    )
+                )
+                continue
             responses.append(
                 FileDownloadResponse(path=path, content=content, error=None)
             )
@@ -73,6 +93,43 @@ class RunloopSandbox(BaseSandbox):
         """Upload files into the devbox."""
         responses: list[FileUploadResponse] = []
         for path, content in files:
-            self._devbox.file.upload(path=path, file=content)
+            if not path.startswith("/"):
+                responses.append(FileUploadResponse(path=path, error=INVALID_PATH))
+                continue
+            try:
+                self._devbox.file.upload(path=path, file=content)
+            except Exception as exc:  # noqa: BLE001  # Provider exceptions vary by SDK version
+                responses.append(
+                    FileUploadResponse(path=path, error=_map_file_error(exc))
+                )
+                continue
             responses.append(FileUploadResponse(path=path, error=None))
         return responses
+
+
+def _map_file_error(exc: Exception) -> FileOperationError | str:
+    """Map a provider filesystem failure to a Deep Agents file error.
+
+    Recognized failures map to a ``FileOperationError`` literal. Unrecognized
+    exceptions return their string representation rather than defaulting to
+    ``FILE_NOT_FOUND``, so that auth, network, or transient SDK failures are
+    surfaced to the agent instead of masquerading as a missing file.
+    """
+    if isinstance(exc, PermissionError):
+        return PERMISSION_DENIED
+    if isinstance(exc, IsADirectoryError):
+        return IS_DIRECTORY
+    if isinstance(exc, FileNotFoundError):
+        return FILE_NOT_FOUND
+
+    message = str(exc).lower()
+    substring_errors: tuple[tuple[tuple[str, ...], FileOperationError], ...] = (
+        (("permission", "forbidden", "access denied"), PERMISSION_DENIED),
+        (("is a directory",), IS_DIRECTORY),
+        (("invalid path",), INVALID_PATH),
+        (("no such file",), FILE_NOT_FOUND),
+    )
+    for needles, error in substring_errors:
+        if any(needle in message for needle in needles):
+            return error
+    return str(exc) or FILE_NOT_FOUND

--- a/libs/partners/runloop/tests/unit_tests/test_sandbox.py
+++ b/libs/partners/runloop/tests/unit_tests/test_sandbox.py
@@ -1,0 +1,105 @@
+"""Unit tests for RunloopSandbox file transfer error handling.
+
+These tests verify that ``download_files`` and ``upload_files`` correctly
+implement the partial-success contract documented on
+``SandboxBackendProtocol``: per-file errors are returned in the response
+objects rather than raised.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from langchain_runloop.sandbox import RunloopSandbox
+
+
+def _make_sandbox() -> RunloopSandbox:
+    """Create a sandbox with a mocked devbox."""
+    devbox = MagicMock()
+    devbox.id = "test-devbox"
+    return RunloopSandbox(devbox=devbox)
+
+
+# ---------------------------------------------------------------------------
+# download_files
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadFilesPartialSuccess:
+    """download_files must return per-file errors, never raise on one failure."""
+
+    def test_single_failure_does_not_discard_batch(self) -> None:
+        """A provider exception on one path must not crash the remaining downloads."""
+        sandbox = _make_sandbox()
+        sandbox._devbox.file.download.side_effect = [  # noqa: SLF001
+            b"good content",
+            RuntimeError("no such file"),
+            b"also good",
+        ]
+        paths = ["/a.txt", "/missing.txt", "/b.txt"]
+        results = sandbox.download_files(paths)
+        assert len(results) == len(paths)
+        assert results[0].error is None
+        assert results[0].content == b"good content"
+        assert results[1].error is not None
+        assert results[1].content is None
+        assert results[2].error is None
+        assert results[2].content == b"also good"
+
+    def test_relative_path_rejected_with_invalid_path(self) -> None:
+        """Paths without a leading ``/`` must be rejected as ``invalid_path``."""
+        sandbox = _make_sandbox()
+        results = sandbox.download_files(["relative/path.txt"])
+        assert len(results) == 1
+        assert results[0].error == "invalid_path"
+        assert results[0].content is None
+        sandbox._devbox.file.download.assert_not_called()  # noqa: SLF001
+
+    def test_happy_path_batch(self) -> None:
+        """All valid absolute paths succeed without error."""
+        sandbox = _make_sandbox()
+        sandbox._devbox.file.download.side_effect = [b"one", b"two"]  # noqa: SLF001
+        results = sandbox.download_files(["/one.txt", "/two.txt"])
+        assert all(r.error is None for r in results)
+        assert results[0].content == b"one"
+        assert results[1].content == b"two"
+
+
+# ---------------------------------------------------------------------------
+# upload_files
+# ---------------------------------------------------------------------------
+
+
+class TestUploadFilesPartialSuccess:
+    """upload_files must return per-file errors, never raise on one failure."""
+
+    def test_single_failure_does_not_discard_batch(self) -> None:
+        """A provider exception on one path must not crash the remaining uploads."""
+        sandbox = _make_sandbox()
+        sandbox._devbox.file.upload.side_effect = [  # noqa: SLF001
+            None,
+            RuntimeError("disk full"),
+            None,
+        ]
+        files = [("/a.txt", b"a"), ("/b.txt", b"b"), ("/c.txt", b"c")]
+        results = sandbox.upload_files(files)
+        assert len(results) == len(files)
+        assert results[0].error is None
+        assert results[1].error is not None
+        assert results[2].error is None
+
+    def test_relative_path_rejected_with_invalid_path(self) -> None:
+        """Paths without a leading ``/`` must be rejected as ``invalid_path``."""
+        sandbox = _make_sandbox()
+        results = sandbox.upload_files([("relative/path.txt", b"data")])
+        assert len(results) == 1
+        assert results[0].error == "invalid_path"
+        sandbox._devbox.file.upload.assert_not_called()  # noqa: SLF001
+
+    def test_happy_path_batch(self) -> None:
+        """All valid absolute paths succeed without error."""
+        sandbox = _make_sandbox()
+        files = [("/a.txt", b"a"), ("/b.txt", b"b")]
+        results = sandbox.upload_files(files)
+        assert all(r.error is None for r in results)
+        assert len(results) == len(files)


### PR DESCRIPTION
Fixes #2507

`RunloopSandbox` file transfers now return per-file errors instead of raising.
A failed path in a batch no longer discards the results for the other files,
and relative paths are rejected with `invalid_path` rather than being passed
through to the provider.

---

`download_files`/`upload_files` called the provider SDK unguarded, which broke
the partial-success contract documented on the `SandboxBackendProtocol` abstract
methods. This follows the existing `VercelSandbox` pattern for consistency —
happy to hoist `_map_file_error` into shared `deepagents.backends` code instead
if you'd prefer, since this makes it the second copy.

**Test plan**
- 6 new unit tests in `test_sandbox.py` (mocked devbox, no network needed)
- `make format`, `make lint`, `make test` all pass locally (34/34 tests)

This contribution was drafted with AI assistance. I have reviewed every change,
verified the behavior against the documented contract, and run the package's
format, lint, and test targets locally.