### PR TITLE
fix(talon): handle empty text in telegram/whatsapp send_message

### DIFF
--- a/libs/talon/deepagents_talon/channels/telegram.py
+++ b/libs/talon/deepagents_talon/channels/telegram.py
@@ -375,7 +375,10 @@ class TelegramChannel:
         Returns:
             Result indicating whether the send succeeded.
         """
-        for chunk in chunk_text(text, limit=MAX_TEXT_CHARS):
+        chunks = chunk_text(text, limit=MAX_TEXT_CHARS)
+        if not chunks:
+            return SendResult(success=True)
+        for chunk in chunks:
             payload = await self._transport.call(
                 "sendMessage",
                 chat_id=conversation_id,

--- a/libs/talon/deepagents_talon/channels/whatsapp.py
+++ b/libs/talon/deepagents_talon/channels/whatsapp.py
@@ -318,7 +318,10 @@ class WhatsAppChannel:
         Returns:
             Result indicating whether the send succeeded.
         """
-        for chunk in _chunk_with_bot_header(text, bot_header=self.config.bot_header):
+        chunks = _chunk_with_bot_header(text, bot_header=self.config.bot_header)
+        if not chunks:
+            return SendResult(success=True)
+        for chunk in chunks:
             response = await self._post_result("/send", {"chatId": conversation_id, "text": chunk})
         return SendResult(success=True, message_id=_extract_message_id(response))
 

--- a/libs/talon/tests/channels/test_send_empty.py
+++ b/libs/talon/tests/channels/test_send_empty.py
@@ -1,0 +1,69 @@
+"""Unit tests for Telegram and WhatsApp send_message on empty text.
+
+These tests verify that ``send_message("")`` does not raise
+``UnboundLocalError`` when ``chunk_text`` returns an empty list.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from deepagents_talon.channels.telegram import TelegramChannel, TelegramChannelConfig
+from deepagents_talon.channels.whatsapp import WhatsAppChannel, WhatsAppChannelConfig
+from deepagents_talon.interfaces import SendResult
+
+# ---------------------------------------------------------------------------
+# Telegram
+# ---------------------------------------------------------------------------
+
+
+def _make_telegram_channel() -> TelegramChannel:
+    """Create a TelegramChannel with a mocked transport."""
+    config = TelegramChannelConfig(
+        bot_token="fake-token",  # noqa: S106  # Test-only dummy value
+        session_dir=MagicMock(),
+    )
+    transport = MagicMock()
+    transport.call = AsyncMock(return_value={"result": {"message_id": 1}})
+    return TelegramChannel(config, transport=transport)
+
+
+class TestTelegramSendMessageEmpty:
+    """Telegram send_message must not crash on empty text."""
+
+    @pytest.mark.asyncio
+    async def test_empty_text_does_not_raise(self) -> None:
+        """send_message('') must not raise UnboundLocalError."""
+        channel = _make_telegram_channel()
+        result = await channel.send_message("chat-1", "")
+        assert isinstance(result, SendResult)
+        assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# WhatsApp
+# ---------------------------------------------------------------------------
+
+
+def _make_whatsapp_channel() -> WhatsAppChannel:
+    """Create a WhatsAppChannel with a mocked transport."""
+    config = WhatsAppChannelConfig(
+        session_dir=MagicMock(),
+    )
+    transport = MagicMock()
+    transport.post = AsyncMock(return_value={"success": True, "message_id": "m1"})
+    return WhatsAppChannel(config, transport=transport)
+
+
+class TestWhatsAppSendMessageEmpty:
+    """WhatsApp send_message must not crash on empty text."""
+
+    @pytest.mark.asyncio
+    async def test_empty_text_does_not_raise(self) -> None:
+        """send_message('') must not raise UnboundLocalError."""
+        channel = _make_whatsapp_channel()
+        result = await channel.send_message("chat-1", "")
+        assert isinstance(result, SendResult)
+        assert result.success is True


### PR DESCRIPTION
Fixes #5063

`TelegramChannel.send_message` and `WhatsAppChannel.send_message` no longer
raise `UnboundLocalError` when called with empty text. Empty text now returns a
no-op `SendResult(success=True)`.

---

Both methods assigned the transport response only inside a `for chunk in
chunk_text(text)` loop, then referenced the variable in the return. Since
`chunk_text("")` returns `[]`, the loop body never ran and the return raised
`UnboundLocalError`. This is reachable via `deliver_scheduled_result` when a
cron job produces empty text.

The fix materializes chunks into a list and returns `SendResult(success=True)`
early when the list is empty. This matches the `ChannelAdapter` protocol return
type and avoids `success=False` which would cause `send_with_retry` to retry
forever.

**Test plan**
- 2 new unit tests in `test_send_empty.py` (mocked transport, no network needed)
- `make format`, `make lint`, `make test` all pass locally (217/217 tests)

This contribution was drafted with AI assistance. I have reviewed every change,
verified the behavior against the documented contract, and run the package's
format, lint, and test targets locally.