### PR TITLE
fix(ci): preserve dependency bounds in Dependabot uv updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,19 @@ updates:
       - "/examples/text-to-sql-agent"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "deepagents"
+      - dependency-name: "deepagents-cli"
+      - dependency-name: "deepagents-code"
+      - dependency-name: "deepagents-evals"
+      - dependency-name: "deepagents-acp"
+      - dependency-name: "deepagents-talon"
+      - dependency-name: "langchain-daytona"
+      - dependency-name: "langchain-modal"
+      - dependency-name: "langchain-quickjs"
+      - dependency-name: "langchain-runloop"
+      - dependency-name: "langchain-vercel-sandbox"
     groups:
       minor-and-patch:
         patterns: ["*"]


### PR DESCRIPTION
- Configure the maintained multi-directory `uv` Dependabot entry to increase compatible manifest bounds while updating lockfiles.
- Ignore coordinated same-repository Deep Agents and partner packages so Dependabot does not separate their release updates.
- Keep the existing dependency roots, monthly schedule, and update groups unchanged.