### PR TITLE
fix(code): toast model no-op notice instead of inline message

### DIFF
--- a/libs/code/AGENTS.md
+++ b/libs/code/AGENTS.md
@@ -32,7 +32,7 @@ IMPORTANT: `Content` requires **Textual's** `Style` (`textual.style.Style`) for 
 
 ### `App.notify()` defaults to `markup=True`
 
-Textual's `App.notify(message)` parses the message string as Rich markup by default. Any dynamic content (exception messages, file paths, user input, command strings) containing brackets `[]`, ANSI escape codes, or `=` will cause a `MarkupError` crash in Textual's Toast renderer. Always pass `markup=False` when the message contains f-string interpolated variables. Hardcoded string literals are safe with the default.
+Textual's `App.notify(message)` parses the message string as Rich markup by default. Any dynamic content (exception messages, file paths, user input, command strings) containing square brackets is unsafe: tag-shaped text like `[bold]` is silently swallowed, and closing-tag-shaped text like `[/tmp/x]` raises a `MarkupError` crash in Textual's Toast renderer. Always pass `markup=False` when the message contains f-string interpolated variables. Hardcoded string literals are safe with the default.
 
 ### Rich `console.print()` and number highlighting
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3161,8 +3161,14 @@ class DeepAgentsApp(App):
         )
         """Per-turn model params override set via startup or `/model` params."""
 
-        self._last_model_unchanged_message: str | None = None
-        """Most recent same-model notice, used to suppress duplicates."""
+        self._last_model_unchanged: tuple[str, float] | None = None
+        """Most recent same-model toast, as `(text, monotonic timestamp)`.
+
+        Used to suppress duplicates. Suppression only lasts for the toast
+        lifetime (`NOTIFICATION_TIMEOUT`); after expiry, a later identical
+        no-op selection can toast again. Text and timestamp are one field so
+        they cannot drift out of sync.
+        """
 
         self._model_install_switching = False
         """True while a provider extra install-then-switch flow is active."""
@@ -22263,7 +22269,7 @@ class DeepAgentsApp(App):
                 (e.g., `'anthropic:claude-sonnet-4-5'`) or just the model name
                 for auto-detection.
             extra_kwargs: Extra constructor kwargs from `--model-params`.
-            announce_unchanged: Whether to mount a message when the requested
+            announce_unchanged: Whether to toast a notice when the requested
                 model is already active.
             persist: Whether to write the model to the user's recent/default
                 config.
@@ -22390,14 +22396,21 @@ class DeepAgentsApp(App):
                 params_suffix = _format_model_params(extra_kwargs)
                 if announce_unchanged:
                     message = f"Already using {current}{params_suffix}"
-                    if message != self._last_model_unchanged_message:
+                    # Suppress only while the previous identical toast is
+                    # presumed still on-screen. Once it expires, a later
+                    # intentional no-op selection must be able to toast again.
+                    now = _monotonic()
+                    last = self._last_model_unchanged
+                    if (
+                        last is None
+                        or last[0] != message
+                        or (now - last[1]) >= self.NOTIFICATION_TIMEOUT
+                    ):
                         # A no-op re-selection is transient feedback, not part
                         # of the conversation, so surface it as a toast rather
-                        # than an inline chat message. `markup=False` because
-                        # the model spec and params suffix contain `:` / `=`
-                        # that Textual would otherwise parse as Rich markup.
+                        # than an inline chat message.
                         self.notify(message, markup=False)
-                        self._last_model_unchanged_message = message
+                        self._last_model_unchanged = (message, now)
                 logger.info(
                     "Model unchanged (%s); model_params=%s",
                     current,
@@ -22449,7 +22462,7 @@ class DeepAgentsApp(App):
 
             self._sync_status_model()
 
-            self._last_model_unchanged_message = None
+            self._last_model_unchanged = None
             params_suffix = _format_model_params(extra_kwargs)
             if not persist:
                 # Session-only switch (e.g. adopting a resumed thread's model):

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -22426,7 +22426,12 @@ class DeepAgentsApp(App):
                 if announce_unchanged:
                     message = f"Already using {current}{params_suffix}"
                     if message != self._last_model_unchanged_message:
-                        await self._mount_message(AppMessage(message))
+                        # A no-op re-selection is transient feedback, not part
+                        # of the conversation, so surface it as a toast rather
+                        # than an inline chat message. `markup=False` because
+                        # the model spec and params suffix contain `:` / `=`
+                        # that Textual would otherwise parse as Rich markup.
+                        self.notify(message, markup=False)
                         self._last_model_unchanged_message = message
                 logger.info(
                     "Model unchanged (%s); model_params=%s",

--- a/libs/code/tests/unit_tests/test_model_switch.py
+++ b/libs/code/tests/unit_tests/test_model_switch.py
@@ -160,7 +160,7 @@ class TestFormatModelParams:
 class TestModelSwitchNoOp:
     """Tests for no-op when switching to the same model."""
 
-    async def test_no_message_when_switching_to_same_model(self) -> None:
+    async def test_same_model_toasts_instead_of_inline_message(self) -> None:
         """Switching to the already-active model should toast 'Already using'.
 
         This is a regression test for the bug where selecting the same model
@@ -169,9 +169,11 @@ class TestModelSwitchNoOp:
         toast rather than an inline chat message.
         """
         app = DeepAgentsApp()
-        # Replace methods with mocks to track calls (hence ignore)
-        app._mount_message = AsyncMock()  # ty: ignore
-        app.notify = Mock()  # ty: ignore
+        mount_mock = AsyncMock()
+        notify_mock = Mock()
+        # Type checker doesn't track that the methods were replaced with mocks
+        app._mount_message = mount_mock  # ty: ignore
+        app.notify = notify_mock  # ty: ignore
         app._agent = _make_remote_agent()
 
         # Set current model
@@ -186,44 +188,130 @@ class TestModelSwitchNoOp:
             await app._switch_model("anthropic:claude-opus-4-5")
 
         # Should toast "Already using", not mount an inline "Switched to" message.
-        # Type checker doesn't track that the methods were replaced with mocks
-        app._mount_message.assert_not_called()  # ty: ignore
-        app.notify.assert_called_once()  # ty: ignore
-        message = app.notify.call_args.args[0]  # ty: ignore
+        mount_mock.assert_not_called()
+        notify_mock.assert_called_once()
+        message = notify_mock.call_args.args[0]
         assert "Already using" in message
         assert "Switched to" not in message
-        assert app.notify.call_args.kwargs["markup"] is False  # ty: ignore
+        # Model specs and `--model-params` values can contain square brackets,
+        # which Textual's markup parser would swallow or reject.
+        assert notify_mock.call_args.kwargs["markup"] is False
         assert app._model_switching is False
 
-    async def test_duplicate_same_model_message_is_suppressed(self) -> None:
-        """Repeated same-model switches should only toast one unchanged notice."""
+    async def test_duplicate_same_model_toast_is_suppressed(self) -> None:
+        """Repeated no-ops within the toast lifetime should toast only once."""
         app = DeepAgentsApp()
-        app._mount_message = AsyncMock()  # ty: ignore
-        app.notify = Mock()  # ty: ignore
+        mount_mock = AsyncMock()
+        notify_mock = Mock()
+        app._mount_message = mount_mock  # ty: ignore
+        app.notify = notify_mock  # ty: ignore
         app._agent = _make_remote_agent()
 
         settings.model_name = "claude-opus-4-5"
         settings.model_provider = "anthropic"
 
-        with patch(
-            "deepagents_code.model_config.get_provider_auth_status",
-            return_value=_CONFIGURED_AUTH_STATUS,
+        # Pin the clock inside the toast lifetime so suppression is asserted
+        # deterministically rather than relying on real elapsed time.
+        clock = {"now": 100.0}
+
+        with (
+            patch(
+                "deepagents_code.model_config.get_provider_auth_status",
+                return_value=_CONFIGURED_AUTH_STATUS,
+            ),
+            patch(
+                "deepagents_code.app._monotonic",
+                side_effect=lambda: clock["now"],
+            ),
         ):
             await app._switch_model("anthropic:claude-opus-4-5")
+            clock["now"] = 100.0 + app.NOTIFICATION_TIMEOUT / 2
             await app._switch_model("anthropic:claude-opus-4-5")
 
-        app.notify.assert_called_once()  # ty: ignore
+        notify_mock.assert_called_once()
         assert (
-            app.notify.call_args.args[0]  # ty: ignore
-            == "Already using anthropic:claude-opus-4-5"
+            notify_mock.call_args.args[0] == "Already using anthropic:claude-opus-4-5"
         )
+        mount_mock.assert_not_called()
         assert app._model_switching is False
 
-    async def test_same_model_changed_params_emit_new_message(self) -> None:
+    async def test_expired_same_model_toast_can_reemit(self) -> None:
+        """After the toast lifetime elapses, identical no-ops toast again."""
+        app = DeepAgentsApp()
+        mount_mock = AsyncMock()
+        notify_mock = Mock()
+        app._mount_message = mount_mock  # ty: ignore
+        app.notify = notify_mock  # ty: ignore
+        app._agent = _make_remote_agent()
+
+        settings.model_name = "claude-opus-4-5"
+        settings.model_provider = "anthropic"
+
+        # Advance past NOTIFICATION_TIMEOUT between the two no-ops so the
+        # second selection re-toasts instead of staying suppressed forever.
+        clock = {"now": 100.0}
+
+        with (
+            patch(
+                "deepagents_code.model_config.get_provider_auth_status",
+                return_value=_CONFIGURED_AUTH_STATUS,
+            ),
+            patch(
+                "deepagents_code.app._monotonic",
+                side_effect=lambda: clock["now"],
+            ),
+        ):
+            await app._switch_model("anthropic:claude-opus-4-5")
+            clock["now"] = 100.0 + app.NOTIFICATION_TIMEOUT + 0.1
+            await app._switch_model("anthropic:claude-opus-4-5")
+
+        assert [call.args[0] for call in notify_mock.call_args_list] == [
+            "Already using anthropic:claude-opus-4-5",
+            "Already using anthropic:claude-opus-4-5",
+        ]
+        assert app._model_switching is False
+
+    async def test_same_model_toast_reemits_at_exact_lifetime_boundary(self) -> None:
+        """At exactly `NOTIFICATION_TIMEOUT`, the previous toast has expired.
+
+        Pins the boundary comparison: the elapsed check is `>=`, so a no-op
+        landing exactly on the timeout must re-toast rather than stay
+        suppressed.
+        """
+        app = DeepAgentsApp()
+        notify_mock = Mock()
+        app._mount_message = AsyncMock()  # ty: ignore
+        app.notify = notify_mock  # ty: ignore
+        app._agent = _make_remote_agent()
+
+        settings.model_name = "claude-opus-4-5"
+        settings.model_provider = "anthropic"
+
+        clock = {"now": 100.0}
+
+        with (
+            patch(
+                "deepagents_code.model_config.get_provider_auth_status",
+                return_value=_CONFIGURED_AUTH_STATUS,
+            ),
+            patch(
+                "deepagents_code.app._monotonic",
+                side_effect=lambda: clock["now"],
+            ),
+        ):
+            await app._switch_model("anthropic:claude-opus-4-5")
+            clock["now"] = 100.0 + app.NOTIFICATION_TIMEOUT
+            await app._switch_model("anthropic:claude-opus-4-5")
+
+        assert notify_mock.call_count == 2
+
+    async def test_same_model_changed_params_emit_new_toast(self) -> None:
         """A changed same-model notice should still be shown to the user."""
         app = DeepAgentsApp()
-        app._mount_message = AsyncMock()  # ty: ignore
-        app.notify = Mock()  # ty: ignore
+        mount_mock = AsyncMock()
+        notify_mock = Mock()
+        app._mount_message = mount_mock  # ty: ignore
+        app.notify = notify_mock  # ty: ignore
         app._agent = _make_remote_agent()
 
         settings.model_name = "claude-opus-4-5"
@@ -239,23 +327,68 @@ class TestModelSwitchNoOp:
                 extra_kwargs={"temperature": 0.2},
             )
 
-        assert app.notify.call_count == 2  # ty: ignore
-        assert [
-            call.args[0]  # ty: ignore
-            for call in app.notify.call_args_list  # ty: ignore
-        ] == [
+        assert [call.args[0] for call in notify_mock.call_args_list] == [
             "Already using anthropic:claude-opus-4-5",
             (
                 "Already using anthropic:claude-opus-4-5 "
                 'with model params {"temperature": 0.2}'
             ),
         ]
+        mount_mock.assert_not_called()
         assert app._model_switching is False
 
-    async def test_same_model_can_skip_unchanged_message(self) -> None:
-        """Onboarding can re-select the active model without adding chat noise."""
+    async def test_real_switch_resets_unchanged_toast_suppression(self) -> None:
+        """A real switch clears suppression so the next no-op toasts again.
+
+        Without the reset, re-selecting A after an A -> B -> A round trip
+        would be swallowed by the stale suppression entry left by the first
+        no-op.
+        """
         app = DeepAgentsApp()
+        notify_mock = Mock()
         app._mount_message = AsyncMock()  # ty: ignore
+        app.notify = notify_mock  # ty: ignore
+        app._agent = _make_remote_agent()
+
+        settings.model_name = "claude-opus-4-5"
+        settings.model_provider = "anthropic"
+
+        # Hold the clock still so a second toast is attributable to the reset
+        # rather than to the toast lifetime quietly expiring.
+        with (
+            patch(
+                "deepagents_code.model_config.get_provider_auth_status",
+                return_value=_CONFIGURED_AUTH_STATUS,
+            ),
+            patch("deepagents_code.model_config.save_recent_model", return_value=True),
+            patch("deepagents_code.app._monotonic", return_value=100.0),
+        ):
+            # No-op records the suppression entry.
+            await app._switch_model("anthropic:claude-opus-4-5")
+            # Real switches away and back must clear it.
+            await app._switch_model("anthropic:claude-sonnet-4-5")
+            await app._switch_model("anthropic:claude-opus-4-5")
+            # Identical message, same instant on the clock: only the reset can
+            # let this through.
+            await app._switch_model("anthropic:claude-opus-4-5")
+
+        unchanged_toasts = [
+            call.args[0]
+            for call in notify_mock.call_args_list
+            if call.args[0].startswith("Already using")
+        ]
+        assert unchanged_toasts == [
+            "Already using anthropic:claude-opus-4-5",
+            "Already using anthropic:claude-opus-4-5",
+        ]
+
+    async def test_same_model_can_skip_unchanged_message(self) -> None:
+        """Onboarding can re-select the active model without any notice."""
+        app = DeepAgentsApp()
+        mount_mock = AsyncMock()
+        notify_mock = Mock()
+        app._mount_message = mount_mock  # ty: ignore
+        app.notify = notify_mock  # ty: ignore
         app._agent = _make_remote_agent()
 
         settings.model_name = "claude-opus-4-5"
@@ -271,7 +404,10 @@ class TestModelSwitchNoOp:
 
         assert app._model_override == "anthropic:claude-opus-4-5"
         assert app._model_params_override is None
-        app._mount_message.assert_not_called()  # ty: ignore
+        # `announce_unchanged=False` must suppress the toast, not just the
+        # inline message the notice used to use.
+        mount_mock.assert_not_called()
+        notify_mock.assert_not_called()
         assert app._model_switching is False
 
     async def test_same_model_with_new_params_applies_overrides(self) -> None:
@@ -282,8 +418,9 @@ class TestModelSwitchNoOp:
         leaving `_model_params_override` unset.
         """
         app = DeepAgentsApp()
+        notify_mock = Mock()
         app._mount_message = AsyncMock()  # ty: ignore
-        app.notify = Mock()  # ty: ignore
+        app.notify = notify_mock  # ty: ignore
         app._agent = _make_remote_agent()
 
         settings.model_name = "claude-opus-4-5"
@@ -303,8 +440,8 @@ class TestModelSwitchNoOp:
             "num_ctx": 16384,
             "temperature": 0.2,
         }
-        app.notify.assert_called_once()  # ty: ignore
-        message = app.notify.call_args.args[0]  # ty: ignore
+        notify_mock.assert_called_once()
+        message = notify_mock.call_args.args[0]
         assert message.startswith("Already using anthropic:claude-opus-4-5")
         # Stable, key-sorted JSON in the echoed suffix.
         assert 'with model params {"num_ctx": 16384, "temperature": 0.2}' in message
@@ -1127,8 +1264,10 @@ class TestModelSwitchBareModelName:
     async def test_bare_model_name_already_using(self) -> None:
         """Bare model name matching current model toasts 'Already using'."""
         app = DeepAgentsApp()
-        app._mount_message = AsyncMock()  # ty: ignore
-        app.notify = Mock()  # ty: ignore
+        mount_mock = AsyncMock()
+        notify_mock = Mock()
+        app._mount_message = mount_mock  # ty: ignore
+        app.notify = notify_mock  # ty: ignore
         app._agent = _make_remote_agent()
 
         settings.model_name = "gpt-5.5"
@@ -1143,9 +1282,9 @@ class TestModelSwitchBareModelName:
         ):
             await app._switch_model("gpt-5.5")
 
-        app._mount_message.assert_not_called()  # ty: ignore
-        app.notify.assert_called_once()  # ty: ignore
-        assert "Already using" in app.notify.call_args.args[0]  # ty: ignore
+        mount_mock.assert_not_called()
+        notify_mock.assert_called_once()
+        assert "Already using" in notify_mock.call_args.args[0]
 
 
 class TestExtractModelParamsFlag:

--- a/libs/code/tests/unit_tests/test_model_switch.py
+++ b/libs/code/tests/unit_tests/test_model_switch.py
@@ -161,98 +161,77 @@ class TestModelSwitchNoOp:
     """Tests for no-op when switching to the same model."""
 
     async def test_no_message_when_switching_to_same_model(self) -> None:
-        """Switching to the already-active model should not print 'Switched to'.
+        """Switching to the already-active model should toast 'Already using'.
 
         This is a regression test for the bug where selecting the same model
         from the model selector would print "Switched to X" even though no
-        actual switch occurred.
+        actual switch occurred. The no-op notice is surfaced as a transient
+        toast rather than an inline chat message.
         """
         app = DeepAgentsApp()
-        # Replace method with mock to track calls (hence ignore)
+        # Replace methods with mocks to track calls (hence ignore)
         app._mount_message = AsyncMock()  # ty: ignore
+        app.notify = Mock()  # ty: ignore
         app._agent = _make_remote_agent()
 
         # Set current model
         settings.model_name = "claude-opus-4-5"
         settings.model_provider = "anthropic"
 
-        captured_messages: list[str] = []
-        original_init = AppMessage.__init__
-
-        def capture_init(self: AppMessage, message: str, **kwargs: Any) -> None:
-            captured_messages.append(message)
-            original_init(self, message, **kwargs)
-
-        with (
-            patch(
-                "deepagents_code.model_config.get_provider_auth_status",
-                return_value=_CONFIGURED_AUTH_STATUS,
-            ),
-            patch.object(AppMessage, "__init__", capture_init),
+        with patch(
+            "deepagents_code.model_config.get_provider_auth_status",
+            return_value=_CONFIGURED_AUTH_STATUS,
         ):
             # Attempt to switch to the same model
             await app._switch_model("anthropic:claude-opus-4-5")
 
-        # Should show "Already using" message, not "Switched to"
-        # Type checker doesn't track that _mount_message was replaced with mock
-        app._mount_message.assert_called_once()  # ty: ignore
-        assert len(captured_messages) == 1
-        assert "Already using" in captured_messages[0]
-        assert "Switched to" not in captured_messages[0]
+        # Should toast "Already using", not mount an inline "Switched to" message.
+        # Type checker doesn't track that the methods were replaced with mocks
+        app._mount_message.assert_not_called()  # ty: ignore
+        app.notify.assert_called_once()  # ty: ignore
+        message = app.notify.call_args.args[0]  # ty: ignore
+        assert "Already using" in message
+        assert "Switched to" not in message
+        assert app.notify.call_args.kwargs["markup"] is False  # ty: ignore
         assert app._model_switching is False
 
     async def test_duplicate_same_model_message_is_suppressed(self) -> None:
-        """Repeated same-model switches should only emit one unchanged notice."""
+        """Repeated same-model switches should only toast one unchanged notice."""
         app = DeepAgentsApp()
         app._mount_message = AsyncMock()  # ty: ignore
+        app.notify = Mock()  # ty: ignore
         app._agent = _make_remote_agent()
 
         settings.model_name = "claude-opus-4-5"
         settings.model_provider = "anthropic"
 
-        captured_messages: list[str] = []
-        original_init = AppMessage.__init__
-
-        def capture_init(self: AppMessage, message: str, **kwargs: Any) -> None:
-            captured_messages.append(message)
-            original_init(self, message, **kwargs)
-
-        with (
-            patch(
-                "deepagents_code.model_config.get_provider_auth_status",
-                return_value=_CONFIGURED_AUTH_STATUS,
-            ),
-            patch.object(AppMessage, "__init__", capture_init),
+        with patch(
+            "deepagents_code.model_config.get_provider_auth_status",
+            return_value=_CONFIGURED_AUTH_STATUS,
         ):
             await app._switch_model("anthropic:claude-opus-4-5")
             await app._switch_model("anthropic:claude-opus-4-5")
 
-        app._mount_message.assert_called_once()  # ty: ignore
-        assert captured_messages == ["Already using anthropic:claude-opus-4-5"]
+        app.notify.assert_called_once()  # ty: ignore
+        assert (
+            app.notify.call_args.args[0]  # ty: ignore
+            == "Already using anthropic:claude-opus-4-5"
+        )
         assert app._model_switching is False
 
     async def test_same_model_changed_params_emit_new_message(self) -> None:
         """A changed same-model notice should still be shown to the user."""
         app = DeepAgentsApp()
         app._mount_message = AsyncMock()  # ty: ignore
+        app.notify = Mock()  # ty: ignore
         app._agent = _make_remote_agent()
 
         settings.model_name = "claude-opus-4-5"
         settings.model_provider = "anthropic"
 
-        captured_messages: list[str] = []
-        original_init = AppMessage.__init__
-
-        def capture_init(self: AppMessage, message: str, **kwargs: Any) -> None:
-            captured_messages.append(message)
-            original_init(self, message, **kwargs)
-
-        with (
-            patch(
-                "deepagents_code.model_config.get_provider_auth_status",
-                return_value=_CONFIGURED_AUTH_STATUS,
-            ),
-            patch.object(AppMessage, "__init__", capture_init),
+        with patch(
+            "deepagents_code.model_config.get_provider_auth_status",
+            return_value=_CONFIGURED_AUTH_STATUS,
         ):
             await app._switch_model("anthropic:claude-opus-4-5")
             await app._switch_model(
@@ -260,8 +239,11 @@ class TestModelSwitchNoOp:
                 extra_kwargs={"temperature": 0.2},
             )
 
-        assert app._mount_message.call_count == 2  # ty: ignore
-        assert captured_messages == [
+        assert app.notify.call_count == 2  # ty: ignore
+        assert [
+            call.args[0]  # ty: ignore
+            for call in app.notify.call_args_list  # ty: ignore
+        ] == [
             "Already using anthropic:claude-opus-4-5",
             (
                 "Already using anthropic:claude-opus-4-5 "
@@ -301,24 +283,15 @@ class TestModelSwitchNoOp:
         """
         app = DeepAgentsApp()
         app._mount_message = AsyncMock()  # ty: ignore
+        app.notify = Mock()  # ty: ignore
         app._agent = _make_remote_agent()
 
         settings.model_name = "claude-opus-4-5"
         settings.model_provider = "anthropic"
 
-        captured_messages: list[str] = []
-        original_init = AppMessage.__init__
-
-        def capture_init(self: AppMessage, message: str, **kwargs: Any) -> None:
-            captured_messages.append(message)
-            original_init(self, message, **kwargs)
-
-        with (
-            patch(
-                "deepagents_code.model_config.get_provider_auth_status",
-                return_value=_CONFIGURED_AUTH_STATUS,
-            ),
-            patch.object(AppMessage, "__init__", capture_init),
+        with patch(
+            "deepagents_code.model_config.get_provider_auth_status",
+            return_value=_CONFIGURED_AUTH_STATUS,
         ):
             await app._switch_model(
                 "anthropic:claude-opus-4-5",
@@ -330,8 +303,8 @@ class TestModelSwitchNoOp:
             "num_ctx": 16384,
             "temperature": 0.2,
         }
-        assert len(captured_messages) == 1
-        message = captured_messages[0]
+        app.notify.assert_called_once()  # ty: ignore
+        message = app.notify.call_args.args[0]  # ty: ignore
         assert message.startswith("Already using anthropic:claude-opus-4-5")
         # Stable, key-sorted JSON in the echoed suffix.
         assert 'with model params {"num_ctx": 16384, "temperature": 0.2}' in message
@@ -1152,20 +1125,14 @@ class TestModelSwitchBareModelName:
         assert "OPENAI_API_KEY" in captured_errors[0]
 
     async def test_bare_model_name_already_using(self) -> None:
-        """Bare model name matching current model shows 'Already using'."""
+        """Bare model name matching current model toasts 'Already using'."""
         app = DeepAgentsApp()
         app._mount_message = AsyncMock()  # ty: ignore
+        app.notify = Mock()  # ty: ignore
         app._agent = _make_remote_agent()
 
         settings.model_name = "gpt-5.5"
         settings.model_provider = "openai"
-
-        captured_messages: list[str] = []
-        original_init = AppMessage.__init__
-
-        def capture_init(self: AppMessage, message: str, **kwargs: Any) -> None:
-            captured_messages.append(message)
-            original_init(self, message, **kwargs)
 
         with (
             patch("deepagents_code.config.detect_provider", return_value="openai"),
@@ -1173,13 +1140,12 @@ class TestModelSwitchBareModelName:
                 "deepagents_code.model_config.get_provider_auth_status",
                 return_value=_CONFIGURED_AUTH_STATUS,
             ),
-            patch.object(AppMessage, "__init__", capture_init),
         ):
             await app._switch_model("gpt-5.5")
 
-        app._mount_message.assert_called_once()  # ty: ignore
-        assert len(captured_messages) == 1
-        assert "Already using" in captured_messages[0]
+        app._mount_message.assert_not_called()  # ty: ignore
+        app.notify.assert_called_once()  # ty: ignore
+        assert "Already using" in app.notify.call_args.args[0]  # ty: ignore
 
 
 class TestExtractModelParamsFlag:


### PR DESCRIPTION
Selecting a model that is already active now shows the "Already using provider:model" notice as a transient toast instead of an inline chat message.

---

Re-selecting the already-active model is a no-op — transient feedback, not part of the conversation — so an inline `AppMessage` was the wrong surface and left permanent chat noise. This moves the notice to `App.notify()` (with `markup=False`, since the model spec and any `--model-params` suffix contain `:` / `=` that Textual would otherwise parse as Rich markup). The existing duplicate-suppression guard is preserved so a repeated identical selection doesn't stack toasts, and `--model-params` still emits an updated toast. Actual switches and error cases keep their inline messages.

Made by [Open SWE](https://openswe.vercel.app/agents/cde4ba2c-12aa-891d-2822-dd6bf3235ab2)