### PR TITLE
feat(code): make collapsed long user messages visible and expandable

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -13856,6 +13856,18 @@ class DeepAgentsApp(App):
         user_message = UserMessage(
             message, media_snapshot=media_snapshot, detect_mode=False
         )
+        # Long messages are collapsed to a head+tail preview in the transcript.
+        # Announce it once at submit time so the collapse isn't silent, and
+        # point at the expand affordance. The full text still went to the model.
+        if UserMessage.will_truncate(message):
+            self.notify(
+                "Long message collapsed in the transcript. Click "
+                "'show full message' or press Ctrl+O to expand it — the full "
+                "text was still sent to the model.",
+                severity="information",
+                markup=False,
+                timeout=6,
+            )
         await self._mount_message(user_message)
         self._active_user_message = user_message
         await self._send_to_agent(message)
@@ -17151,6 +17163,9 @@ class DeepAgentsApp(App):
                 return
             if isinstance(child, SkillMessage) and child._stripped_body.strip():
                 child.toggle_body()
+                return
+            if isinstance(child, UserMessage) and child.has_expandable_body:
+                child.toggle_expanded()
                 return
             if isinstance(child, ToolCallMessage) and (
                 not child.has_class("-grouped") or child.display

--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -241,8 +241,26 @@ def _select_prompt_body(widget: Static) -> None:
     }
 
 
-def _truncate_for_display(text: str) -> str:
-    """Truncate very long user message text for display in the conversation.
+@dataclass(frozen=True, slots=True)
+class _CollapsedMessage:
+    """Result of collapsing a long user message for display.
+
+    Attributes:
+        text: The display text — head+tail elision when truncated, otherwise
+            the original content unchanged.
+        truncated: Whether the content exceeded the display threshold and was
+            collapsed.
+        hidden_lines: Number of newlines hidden in the elided middle region
+            (0 when not truncated).
+    """
+
+    text: str
+    truncated: bool
+    hidden_lines: int
+
+
+def _collapse_user_message(text: str) -> _CollapsedMessage:
+    """Collapse very long user message text for display in the conversation.
 
     Keeps the first and last portions and replaces the middle with an elision
     marker showing the number of newlines in the hidden region.  This mirrors
@@ -253,20 +271,48 @@ def _truncate_for_display(text: str) -> str:
         text: Full message content.
 
     Returns:
-        Truncated text with an elision marker, or the original text when
-        it does not exceed the display threshold.
+        A `_CollapsedMessage` carrying the display text plus whether truncation
+        occurred and how many newlines were hidden.
     """
     if len(text) <= _USER_MSG_MAX_DISPLAY_CHARS:
-        return text
+        return _CollapsedMessage(text=text, truncated=False, hidden_lines=0)
     head = text[:_USER_MSG_TRUNCATE_HEAD_CHARS]
     tail = text[-_USER_MSG_TRUNCATE_TAIL_CHARS:]
     hidden_text = text[_USER_MSG_TRUNCATE_HEAD_CHARS:-_USER_MSG_TRUNCATE_TAIL_CHARS]
     hidden_lines = hidden_text.count("\n")
-    return f"{head}\n… +{hidden_lines} lines …\n{tail}"
+    return _CollapsedMessage(
+        text=f"{head}\n… +{hidden_lines} lines …\n{tail}",
+        truncated=True,
+        hidden_lines=hidden_lines,
+    )
+
+
+def _truncate_for_display(text: str) -> str:
+    """Return the collapsed display text for a long user message.
+
+    Thin string-returning wrapper over `_collapse_user_message` for callers
+    (e.g. `QueuedUserMessage`) that only need the display string.
+
+    Args:
+        text: Full message content.
+
+    Returns:
+        Truncated text with an elision marker, or the original text when
+        it does not exceed the display threshold.
+    """
+    return _collapse_user_message(text).text
 
 
 class UserMessage(Static):
-    """Widget displaying a user message."""
+    """Widget displaying a user message.
+
+    Very long messages are collapsed to a head+tail preview at render time so
+    huge pastes don't flood the transcript. The collapse is reversible: a dim
+    `… +N lines — click or Ctrl+O to show full message` affordance toggles the
+    full body inline (click via a Textual `@click` action span, or Ctrl+O via
+    `App.action_toggle_tool_output`). The full untruncated text is always kept
+    for copy/select regardless of the visible state.
+    """
 
     DEFAULT_CSS = """
     UserMessage {
@@ -283,6 +329,24 @@ class UserMessage(Static):
     }
     """
     """`-cancelled` dims a prompt whose turn was interrupted by the user."""
+
+    _expanded: var[bool] = var(False)
+    """Whether the full body is shown instead of the head+tail preview."""
+
+    @staticmethod
+    def will_truncate(content: str) -> bool:
+        """Return whether `content` would be collapsed at render time.
+
+        Lets the app decide (before mounting) whether to announce the collapse,
+        without duplicating the threshold logic.
+
+        Args:
+            content: The message content that would be submitted.
+
+        Returns:
+            `True` when the content exceeds the display threshold.
+        """
+        return _collapse_user_message(content).truncated
 
     def __init__(
         self,
@@ -328,6 +392,31 @@ class UserMessage(Static):
     def set_cancelled(self) -> None:
         """Dim the message to mark its turn as interrupted by the user."""
         self.add_class("-cancelled")
+
+    @property
+    def is_truncated(self) -> bool:
+        """Whether the body is long enough to be collapsed at render time."""
+        _prefix, body = self._prefix_and_body()
+        return _collapse_user_message(body).truncated
+
+    @property
+    def has_expandable_body(self) -> bool:
+        """Whether Ctrl+O / click can toggle a collapsed body on this message."""
+        return self.is_truncated
+
+    def toggle_expanded(self) -> None:
+        """Toggle between the collapsed preview and the full body."""
+        if not self.is_truncated:
+            return
+        self._expanded = not self._expanded
+
+    def action_toggle_expand(self) -> None:
+        """Toggle expansion from the clickable `@click` hint affordance."""
+        self.toggle_expanded()
+
+    def watch__expanded(self, expanded: bool) -> None:  # noqa: ARG002  # reactive watcher repaints on state change
+        """Repaint when the expanded state changes."""
+        self.refresh(layout=True)
 
     def get_selection(self, selection: Selection) -> tuple[str, str] | None:
         """Return selected text, preferring the full content over the render.
@@ -394,7 +483,9 @@ class UserMessage(Static):
         """Render the styled user message.
 
         Returns:
-            Styled Content with mode prefix and highlighted mentions.
+            Styled Content with mode prefix and highlighted mentions. When the
+            body is long it is collapsed to a head+tail preview with a dim,
+            clickable expand affordance (unless already expanded).
         """
         colors = theme.get_theme_colors(self)
 
@@ -404,9 +495,11 @@ class UserMessage(Static):
         prefix, content = self._prefix_and_body()
         parts: list[str | tuple[str, str]] = [prefix]
 
-        # Truncate very long content for display so large pastes don't flood
-        # the conversation.  The full text is still available for copy/select.
-        content = _truncate_for_display(content)
+        # Collapse very long content for display so large pastes don't flood
+        # the conversation, unless the user expanded it.  The full text is
+        # always available for copy/select and was sent to the model verbatim.
+        collapsed = _collapse_user_message(content)
+        content = content if self._expanded else collapsed.text
 
         # Highlight @mentions and /commands in the content
         last_end = 0
@@ -442,7 +535,34 @@ class UserMessage(Static):
         if last_end < len(content):
             parts.append(content[last_end:])
 
-        return Content.assemble(*parts)
+        body = Content.assemble(*parts)
+        if not collapsed.truncated:
+            return body
+        return Content.assemble(body, "\n", self._expand_hint(collapsed.hidden_lines))
+
+    def _expand_hint(self, hidden_lines: int) -> Content:
+        """Build the dim, clickable expand/collapse affordance.
+
+        The hint carries a Textual `@click` action span so clicking it toggles
+        the body via `action_toggle_expand`, while ordinary clicks on the body
+        text still select/copy.  User content never reaches the markup parser:
+        the hint text is static and interpolated with `$var` auto-escaping.
+
+        Args:
+            hidden_lines: Number of newlines hidden in the collapsed middle.
+
+        Returns:
+            A dim `Content` affordance with an attached click action.
+        """
+        if self._expanded:
+            hint = "click or Ctrl+O to collapse"
+        else:
+            ellipsis = get_glyphs().ellipsis
+            hint = (
+                f"{ellipsis} +{hidden_lines} lines"
+                " — click or Ctrl+O to show full message"
+            )
+        return Content.from_markup("[dim][@click=toggle_expand]$hint[/][/]", hint=hint)
 
 
 class QueuedUserMessage(Static):

--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -34,6 +34,7 @@ _TIPS: dict[str, int] = {
     "Use /timestamps to show or hide message timestamp footers": 1,
     "Use /agents to browse and switch between your available agents": 2,
     _TIP_SHIFT_TAB_WITH_YOLO: 2,
+    "Click a collapsed message or press Ctrl+O to expand it": 1,
     "Use !! for incognito shell commands that stay out of model context": 1,
     "Deep Agents can explain its own features and look up its docs. Ask it how to use.": 3,  # noqa: E501
 }

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -5516,6 +5516,67 @@ class TestAskUserLifecycle:
         rubric.toggle_details.assert_not_called()
         group.toggle.assert_called_once_with()
 
+    def test_ctrl_o_toggles_recent_expandable_user_message(self) -> None:
+        """Ctrl+O expands the most-recent collapsed user message."""
+        from deepagents_code.tui.widgets.messages import UserMessage
+
+        app = DeepAgentsApp(agent=MagicMock())
+        app._pending_ask_user_widget = None
+        user_msg = MagicMock(spec=UserMessage)
+        user_msg.has_expandable_body = True
+        container = MagicMock()
+        container.children = [user_msg]
+
+        with patch.object(app, "query_one", return_value=container):
+            app.action_toggle_tool_output()
+
+        user_msg.toggle_expanded.assert_called_once_with()
+
+    def test_ctrl_o_skips_user_message_without_expandable_body(self) -> None:
+        """A short user message is not toggleable, so Ctrl+O leaves it alone."""
+        from deepagents_code.tui.widgets.messages import UserMessage
+
+        app = DeepAgentsApp(agent=MagicMock())
+        app._pending_ask_user_widget = None
+        user_msg = MagicMock(spec=UserMessage)
+        user_msg.has_expandable_body = False
+        container = MagicMock()
+        container.children = [user_msg]
+
+        with patch.object(app, "query_one", return_value=container):
+            app.action_toggle_tool_output()
+
+        user_msg.toggle_expanded.assert_not_called()
+
+    async def test_long_user_message_posts_collapse_toast(self) -> None:
+        """Submitting a message past the display threshold announces the collapse."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with (
+                patch.object(app, "_send_to_agent", new_callable=AsyncMock),
+                patch.object(app, "notify") as mock_notify,
+            ):
+                await app._handle_user_message("L" * 12_000)
+
+            assert mock_notify.call_count == 1
+            _args, kwargs = mock_notify.call_args
+            assert kwargs["severity"] == "information"
+            assert kwargs["markup"] is False
+
+    async def test_short_user_message_posts_no_collapse_toast(self) -> None:
+        """A short message must not trigger the collapse toast."""
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with (
+                patch.object(app, "_send_to_agent", new_callable=AsyncMock),
+                patch.object(app, "notify") as mock_notify,
+            ):
+                await app._handle_user_message("short and sweet")
+
+            mock_notify.assert_not_called()
+
     async def test_request_ask_user_timeout_cleans_old_widget(self) -> None:
         """Timeout cleanup should cancel then remove the previous widget."""
         app = DeepAgentsApp()

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -14,6 +14,7 @@ from rich.style import Style
 from textual.app import App, ComposeResult
 from textual.containers import VerticalScroll
 from textual.content import Content
+from textual.geometry import Offset
 from textual.widgets import Markdown, Static
 
 from deepagents_code import theme
@@ -4951,6 +4952,105 @@ class TestUserMessageTruncation:
             assert result == expected
             assert result is not None
             assert result[0] != big
+
+    def test_will_truncate_boundary(self) -> None:
+        """`will_truncate` is false at the threshold and true just past it."""
+        assert UserMessage.will_truncate("C" * 10_000) is False
+        assert UserMessage.will_truncate("C" * 10_001) is True
+
+    def test_collapsed_render_has_clickable_expand_hint(self) -> None:
+        """A collapsed message renders a dim, clickable expand affordance."""
+        content = _render_content(UserMessage("Z" * 12_000))
+        assert "show full message" in content.plain
+        # The hint carries a Textual @click action span so a click toggles it.
+        assert any("@click=toggle_expand" in str(span.style) for span in content.spans)
+
+    def test_short_message_has_no_expand_hint(self) -> None:
+        """A short message renders no affordance and no click action span."""
+        content = _render_content(UserMessage("hello world"))
+        assert "show full message" not in content.plain
+        assert not any(
+            "@click=toggle_expand" in str(span.style) for span in content.spans
+        )
+
+    async def test_toggle_expands_to_full_body_and_flips_hint(self) -> None:
+        """Toggling shows the full body and swaps the hint to a collapse label."""
+        big = "H" * 6000 + "\n" * 40 + "T" * 6000
+        msg = UserMessage(big)
+
+        class _TestApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield msg
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert msg.is_truncated is True
+            assert msg.has_expandable_body is True
+            collapsed = _render_content(msg)
+            assert "show full message" in collapsed.plain
+            assert len(collapsed.plain) < len(big)
+
+            msg.toggle_expanded()
+            await pilot.pause()
+            expanded = _render_content(msg)
+            assert "to collapse" in expanded.plain
+            assert big in expanded.plain
+
+            msg.toggle_expanded()
+            await pilot.pause()
+            assert "show full message" in _render_content(msg).plain
+
+    async def test_short_message_toggle_is_a_noop(self) -> None:
+        """A message that never collapses cannot be toggled."""
+        msg = UserMessage("tiny")
+
+        class _TestApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield msg
+
+        app = _TestApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert msg.has_expandable_body is False
+            msg.toggle_expanded()
+            await pilot.pause()
+            assert msg._expanded is False
+
+    async def test_click_hint_toggles_but_body_click_does_not(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Clicking the hint span expands; clicking body text leaves it collapsed."""
+        import deepagents_code.tui.widgets.messages as messages_module
+
+        # Shrink thresholds so the whole widget (body + hint) fits on screen and
+        # the hint row is reachable by a click at a stable coordinate.
+        monkeypatch.setattr(messages_module, "_USER_MSG_MAX_DISPLAY_CHARS", 20)
+        monkeypatch.setattr(messages_module, "_USER_MSG_TRUNCATE_HEAD_CHARS", 6)
+        monkeypatch.setattr(messages_module, "_USER_MSG_TRUNCATE_TAIL_CHARS", 6)
+
+        content = "AAAAAA" + "X" * 10 + "\n\n" + "Y" * 10 + "BBBBBB"
+        msg = UserMessage(content)
+
+        class _TestApp(App[None]):
+            def compose(self) -> ComposeResult:
+                yield msg
+
+        app = _TestApp()
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            assert msg.is_truncated is True
+            assert msg._expanded is False
+
+            # Body text sits on the first row; a click there must not toggle.
+            await pilot.click(UserMessage, offset=Offset(4, 0))
+            await pilot.pause()
+            assert msg._expanded is False
+
+            # The hint renders on the last content row (head, marker, tail, hint).
+            await pilot.click(UserMessage, offset=Offset(4, 3))
+            await pilot.pause()
+            assert msg._expanded is True
 
     def test_queued_message_render_truncates(self) -> None:
         """QueuedUserMessage render truncates long content with an elision marker."""


### PR DESCRIPTION
Very long prompts are no longer silently shortened in the transcript: submitting one now shows a toast explaining that the message was collapsed for display (and that the full text still reached the model), and the collapsed message can be expanded in place by clicking its `… +N lines — click or Ctrl+O to show full message` hint or pressing Ctrl+O.

---

`UserMessage` collapses bodies over the display threshold to a head+tail preview so huge pastes don't flood the scrollback. That behavior was invisible and one-way: the rendered message matched neither the draft nor the full text, there was no indication the collapse had happened, and the hidden middle could only be recovered via select-all copy. The `+N` in the elision marker counts hidden *middle* newlines, which also reads confusingly next to the chat input's paste-collapse `+M lines` placeholder.

Rather than change what is rendered by default (the scrollback-performance win is worth keeping), this makes the collapse *announced* and *reversible*:

- `_collapse_user_message` replaces the bare string helper and reports whether truncation occurred plus the hidden line count, so callers no longer have to re-parse the marker. `_truncate_for_display` stays as a thin wrapper for `QueuedUserMessage`.
- `UserMessage` gains an `_expanded` reactive, `toggle_expanded`/`action_toggle_expand`, and `is_truncated`/`has_expandable_body`. The expand affordance is a dim Textual `@click` action span appended to the render, so clicking the hint toggles while ordinary clicks on the body still select and copy. This mirrors the existing `SkillMessage`/`ToolCallMessage` expand idiom and its hint wording.
- The static `will_truncate` predicate lets the app decide whether to toast before mounting, without duplicating threshold logic. The toast fires only at submit time and only when the message actually collapses.
- Ctrl+O routing (`action_toggle_tool_output`) now also reaches a most-recent expandable user message. In practice agent output usually follows a prompt, so click remains the primary affordance — but this keeps the key consistent with the hint text.

Copy/select behavior is unchanged: select-all still extracts the full untruncated body, and the hint span is never part of it.

Worth a careful look: the `@click` span relies on Textual dispatching `@click` meta actions through `broker_event`, and the hint text is interpolated with `$var` auto-escaping so user content never reaches the markup parser.

<details>
<summary>Test plan</summary>

- New unit tests cover the `will_truncate` threshold boundary, presence/absence of the clickable hint span, toggling to the full body and back, no-op toggle on short messages, and a real pilot click proving the hint toggles while a body click does not.
- App-level tests cover the toast firing (and not firing) at submit time and Ctrl+O routing to an expandable user message.
- `make format`, `make lint` (ruff + `ty` + commands-catalog drift), and the touched test modules all pass.

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/ef920b77-632f-3263-eb7c-1a299590393a)

## References
- Plan: https://openswe.vercel.app/agents/ef920b77-632f-3263-eb7c-1a299590393a/plan