### PR TITLE
style(code): simplify Auto classifier unavailable messages

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -16901,7 +16901,9 @@ class DeepAgentsApp(App):
         elif kind == "denial":
             text = f"Auto denied [{event.get('category', 'policy')}]: {reason}"
         elif kind == "unavailable":
-            text = f"Auto classifier unavailable: {reason}"
+            # Reason is a short cause fragment from the server; keep the UI
+            # line outcome-focused so the blocked action is obvious.
+            text = f"Auto classifier unavailable: {reason} (action blocked)"
         else:
             text = f"Auto warning: {reason}"
         await self._mount_message(AppMessage(text))

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -518,7 +518,7 @@ def classifier_unavailable_reason(exc: BaseException, *, timeout_seconds: float)
         Compact single-line reason for tool messages and TUI events.
     """
     if isinstance(exc, _ClassifierDeadlineExceededError):
-        return f"timed out after {timeout_seconds:g}s"
+        return f"no decision within Auto's {timeout_seconds:g}s limit"
     return f"failed ({type(exc).__name__})"
 
 

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -506,9 +506,9 @@ def classifier_unavailable_reason(exc: BaseException, *, timeout_seconds: float)
 
     Provider exception text stays out of the reason (it can carry secrets or
     noisy HTML). Only real local deadline expiry
-    (`_ClassifierDeadlineExceededError`) gets app-timeout wording; a bare
-    provider `TimeoutError` stays type-only so we do not claim dcode
-    cancelled a call the model failed first.
+    (`_ClassifierDeadlineExceededError`) includes the configured wait budget; a
+    bare provider `TimeoutError` stays type-only so we do not claim dcode's
+    deadline fired when the model failed first.
 
     Args:
         exc: Failure raised while invoking or validating the classifier.
@@ -518,11 +518,8 @@ def classifier_unavailable_reason(exc: BaseException, *, timeout_seconds: float)
         Compact single-line reason for tool messages and TUI events.
     """
     if isinstance(exc, _ClassifierDeadlineExceededError):
-        return (
-            "dcode cancelled the authorization classifier after its local "
-            f"{timeout_seconds:g}s timeout (app-imposed, not a provider timeout)."
-        )
-    return f"The authorization classifier was unavailable ({type(exc).__name__})."
+        return f"timed out after {timeout_seconds:g}s"
+    return f"failed ({type(exc).__name__})"
 
 
 def _default_counters(mode: ApprovalMode) -> AutoModeCounters:

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -2898,28 +2898,28 @@ async def test_malformed_classifier_batch_blocks_call_and_increments_unavailable
 
 
 def test_classifier_unavailable_reason_specializes_timeouts() -> None:
-    assert classifier_unavailable_reason(
-        _ClassifierDeadlineExceededError(20.0), timeout_seconds=20.0
-    ) == (
-        "dcode cancelled the authorization classifier after its local "
-        "20s timeout (app-imposed, not a provider timeout)."
+    assert (
+        classifier_unavailable_reason(
+            _ClassifierDeadlineExceededError(20.0), timeout_seconds=20.0
+        )
+        == "timed out after 20s"
     )
-    assert classifier_unavailable_reason(
-        _ClassifierDeadlineExceededError(1.5), timeout_seconds=1.5
-    ) == (
-        "dcode cancelled the authorization classifier after its local "
-        "1.5s timeout (app-imposed, not a provider timeout)."
+    assert (
+        classifier_unavailable_reason(
+            _ClassifierDeadlineExceededError(1.5), timeout_seconds=1.5
+        )
+        == "timed out after 1.5s"
     )
-    # Provider exception type alone must not claim dcode cancelled the call.
+    # Provider exception type alone must not claim dcode's deadline fired.
     assert (
         classifier_unavailable_reason(TimeoutError(), timeout_seconds=20.0)
-        == "The authorization classifier was unavailable (TimeoutError)."
+        == "failed (TimeoutError)"
     )
     assert (
         classifier_unavailable_reason(
             RuntimeError("provider overloaded"), timeout_seconds=20.0
         )
-        == "The authorization classifier was unavailable (RuntimeError)."
+        == "failed (RuntimeError)"
     )
 
 
@@ -2955,10 +2955,7 @@ async def test_classifier_timeout_reports_configured_limit(tmp_path: Path) -> No
     )
 
     assert plan["decisions"][0]["disposition"] == "classifier_unavailable"
-    assert plan["decisions"][0]["reason"] == (
-        "dcode cancelled the authorization classifier after its local "
-        "0.05s timeout (app-imposed, not a provider timeout)."
-    )
+    assert plan["decisions"][0]["reason"] == "timed out after 0.05s"
 
 
 async def test_classifier_provider_timeout_stays_type_only(tmp_path: Path) -> None:
@@ -2979,9 +2976,7 @@ async def test_classifier_provider_timeout_stays_type_only(tmp_path: Path) -> No
     )
 
     assert plan["decisions"][0]["disposition"] == "classifier_unavailable"
-    assert plan["decisions"][0]["reason"] == (
-        "The authorization classifier was unavailable (TimeoutError)."
-    )
+    assert plan["decisions"][0]["reason"] == "failed (TimeoutError)"
 
 
 async def test_classifier_unavailable_logs_underlying_error(
@@ -3007,9 +3002,7 @@ async def test_classifier_unavailable_logs_underlying_error(
 
     assert plan["decisions"][0]["disposition"] == "classifier_unavailable"
     # Provider exception text stays out of agent/UI; logs keep the detail.
-    assert plan["decisions"][0]["reason"] == (
-        "The authorization classifier was unavailable (RuntimeError)."
-    )
+    assert plan["decisions"][0]["reason"] == "failed (RuntimeError)"
     assert "provider overloaded" not in plan["decisions"][0]["reason"]
     records = [
         record
@@ -3497,10 +3490,7 @@ async def test_classifier_unavailable_emits_single_event_for_batch(
         store=store,
         stream_writer=events.append,
     )
-    reason = (
-        "dcode cancelled the authorization classifier after its local "
-        "1s timeout (app-imposed, not a provider timeout)."
-    )
+    reason = "timed out after 1s"
     plan = {
         "batch_id": _batch_id(ai_message.tool_calls),
         "thread_key": key,

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -2902,13 +2902,13 @@ def test_classifier_unavailable_reason_specializes_timeouts() -> None:
         classifier_unavailable_reason(
             _ClassifierDeadlineExceededError(20.0), timeout_seconds=20.0
         )
-        == "timed out after 20s"
+        == "no decision within Auto's 20s limit"
     )
     assert (
         classifier_unavailable_reason(
             _ClassifierDeadlineExceededError(1.5), timeout_seconds=1.5
         )
-        == "timed out after 1.5s"
+        == "no decision within Auto's 1.5s limit"
     )
     # Provider exception type alone must not claim dcode's deadline fired.
     assert (
@@ -2955,7 +2955,7 @@ async def test_classifier_timeout_reports_configured_limit(tmp_path: Path) -> No
     )
 
     assert plan["decisions"][0]["disposition"] == "classifier_unavailable"
-    assert plan["decisions"][0]["reason"] == "timed out after 0.05s"
+    assert plan["decisions"][0]["reason"] == "no decision within Auto's 0.05s limit"
 
 
 async def test_classifier_provider_timeout_stays_type_only(tmp_path: Path) -> None:
@@ -3490,7 +3490,7 @@ async def test_classifier_unavailable_emits_single_event_for_batch(
         store=store,
         stream_writer=events.append,
     )
-    reason = "timed out after 1s"
+    reason = "no decision within Auto's 1s limit"
     plan = {
         "batch_id": _batch_id(ai_message.tool_calls),
         "thread_key": key,


### PR DESCRIPTION
When Auto cannot classify a gated action, the transcript now says so more plainly—and when Auto itself stopped waiting, it names Auto's wait limit instead of sounding like a provider outage.

For example, after Auto's default 20s classifier wait with no decision, the UI shows:

```text
Auto classifier unavailable: no decision within Auto's 20s limit (action blocked)
```

A real classifier call failure still stays type-only, e.g. `failed (TimeoutError)`, so the two cases stay distinct. Underlying provider detail continues to go to logs / Debug Console only.
