### PR TITLE
feat(code): add `install` subcommand

### DIFF
--- a/libs/code/deepagents_code/client/commands/extras.py
+++ b/libs/code/deepagents_code/client/commands/extras.py
@@ -1,18 +1,15 @@
-"""The `dcode extras` command group: manage optional deepagents-code extras.
+"""CLI install path for optional deepagents-code extras.
 
-`dcode extras install <name>` installs a curated optional extra (for example a
-sandbox or model-provider dependency) into the current `dcode` environment. The
-legacy global flags `dcode --install <name>` / `--package` / `--yes` remain as
+`dcode install <name>` installs a curated optional extra (for example a sandbox
+or model-provider dependency) into the current `dcode` environment. The legacy
+global flags `dcode --install <name>` / `--package` / `--yes` remain as
 compatible aliases and call the same implementation.
 
 `tools install` is intentionally separate: that group provisions managed host
-binaries (ripgrep), while `extras` manages Python package extras for dcode.
-Leave room here for later verbs such as `list` / `info` without colliding with
-`tools`.
+binaries (ripgrep), while this command manages Python package extras for dcode.
 
-Help rendering for `dcode extras -h` / `dcode extras install -h` is served by
-`ui.show_extras_help` / `ui.show_extras_install_help`, which do not import this
-module, so the help path stays light.
+Help rendering for `dcode install -h` is served by `ui.show_install_help`, which
+does not import this module, so the help path stays light.
 """
 
 from __future__ import annotations
@@ -35,8 +32,8 @@ def _tail_log_command(log_path: Path | str) -> str:
     return f"tail -f {shlex.quote(str(log_path))}"
 
 
-def run_extras_command(args: argparse.Namespace) -> int:
-    """Dispatch a `dcode extras` subcommand.
+def run_install_command(args: argparse.Namespace) -> int:
+    """Dispatch `dcode install <name>`.
 
     Args:
         args: Parsed CLI namespace.
@@ -44,35 +41,25 @@ def run_extras_command(args: argparse.Namespace) -> int:
     Returns:
         Process exit code.
     """
-    subcommand = getattr(args, "extras_command", None)
-    if subcommand == "install":
-        name = getattr(args, "extras_target", None)
-        if not isinstance(name, str) or not name:
-            from deepagents_code import ui
+    name = getattr(args, "install_target", None)
+    if not isinstance(name, str) or not name:
+        from deepagents_code import ui
 
-            ui.show_extras_install_help()
-            return 2
-        # Accept flag-style modifiers either on the subcommand or (for
-        # compatibility) as global root flags that precede the group name,
-        # e.g. `dcode --yes extras install daytona`.
-        package = bool(
-            getattr(args, "extras_package", False) or getattr(args, "package", False)
-        )
-        yes = bool(getattr(args, "extras_yes", False) or getattr(args, "yes", False))
-        return run_install_request(name=name, package=package, yes=yes)
-
-    # `cli_main`'s bare-group help fast path handles `dcode extras` with no
-    # subcommand, so this is only reached for an unexpected value.
-    from deepagents_code import ui
-
-    ui.show_extras_help()
-    return 0
+        ui.show_install_help()
+        return 2
+    # Accept modifiers on the subcommand or as global root flags that precede
+    # it, e.g. `dcode --yes install daytona`.
+    package = bool(
+        getattr(args, "install_package", False) or getattr(args, "package", False)
+    )
+    yes = bool(getattr(args, "install_yes", False) or getattr(args, "yes", False))
+    return run_install_request(name=name, package=package, yes=yes)
 
 
 def run_install_request(*, name: str, package: bool, yes: bool) -> int:
     """Install an optional extra or an arbitrary package via `uv --with`.
 
-    Shared by `dcode extras install` and the legacy `dcode --install` flag.
+    Shared by `dcode install` and the legacy `dcode --install` flag.
 
     Args:
         name: Extra or package name to install.
@@ -179,7 +166,7 @@ def _run_install_package(*, name: str, yes: bool) -> int:
         console.print("\nAborted.", style="dim")
         return 130
     except Exception as exc:
-        logger.warning("extras install --package failed", exc_info=True)
+        logger.warning("install --package failed", exc_info=True)
         log_line = f"\nLog: {pkg_log_path}" if pkg_log_path else ""
         console.print(
             f"[bold red]Error:[/bold red] "
@@ -295,7 +282,7 @@ def _run_install_extra(*, name: str, yes: bool) -> int:
         console.print("\nAborted.", style="dim")
         return 130
     except Exception as exc:
-        logger.warning("extras install failed", exc_info=True)
+        logger.warning("install failed", exc_info=True)
         log_line = f"\nLog: {log_path}" if log_path else ""
         # Catch-all for any unexpected install failure: never let recovery-hint
         # generation raise a second error over the original one. `manual_cmd`

--- a/libs/code/deepagents_code/client/commands/extras.py
+++ b/libs/code/deepagents_code/client/commands/extras.py
@@ -1,0 +1,317 @@
+"""The `dcode extras` command group: manage optional deepagents-code extras.
+
+`dcode extras install <name>` installs a curated optional extra (for example a
+sandbox or model-provider dependency) into the current `dcode` environment. The
+legacy global flags `dcode --install <name>` / `--package` / `--yes` remain as
+compatible aliases and call the same implementation.
+
+`tools install` is intentionally separate: that group provisions managed host
+binaries (ripgrep), while `extras` manages Python package extras for dcode.
+Leave room here for later verbs such as `list` / `info` without colliding with
+`tools`.
+
+Help rendering for `dcode extras -h` / `dcode extras install -h` is served by
+`ui.show_extras_help` / `ui.show_extras_install_help`, which do not import this
+module, so the help path stays light.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shlex
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _tail_log_command(log_path: Path | str) -> str:
+    """Return a copy-pasteable command for following a log file."""
+    return f"tail -f {shlex.quote(str(log_path))}"
+
+
+def run_extras_command(args: argparse.Namespace) -> int:
+    """Dispatch a `dcode extras` subcommand.
+
+    Args:
+        args: Parsed CLI namespace.
+
+    Returns:
+        Process exit code.
+    """
+    subcommand = getattr(args, "extras_command", None)
+    if subcommand == "install":
+        name = getattr(args, "extras_target", None)
+        if not isinstance(name, str) or not name:
+            from deepagents_code import ui
+
+            ui.show_extras_install_help()
+            return 2
+        # Accept flag-style modifiers either on the subcommand or (for
+        # compatibility) as global root flags that precede the group name,
+        # e.g. `dcode --yes extras install daytona`.
+        package = bool(
+            getattr(args, "extras_package", False) or getattr(args, "package", False)
+        )
+        yes = bool(getattr(args, "extras_yes", False) or getattr(args, "yes", False))
+        return run_install_request(name=name, package=package, yes=yes)
+
+    # `cli_main`'s bare-group help fast path handles `dcode extras` with no
+    # subcommand, so this is only reached for an unexpected value.
+    from deepagents_code import ui
+
+    ui.show_extras_help()
+    return 0
+
+
+def run_install_request(*, name: str, package: bool, yes: bool) -> int:
+    """Install an optional extra or an arbitrary package via `uv --with`.
+
+    Shared by `dcode extras install` and the legacy `dcode --install` flag.
+
+    Args:
+        name: Extra or package name to install.
+        package: When `True`, install `name` as an arbitrary package rather than
+            a `deepagents-code` extra.
+        yes: Skip interactive confirmation prompts.
+
+    Returns:
+        Process exit code.
+    """
+    if package:
+        return _run_install_package(name=name, yes=yes)
+    return _run_install_extra(name=name, yes=yes)
+
+
+def _run_install_package(*, name: str, yes: bool) -> int:
+    """Install an arbitrary package via `uv --with` (custom provider path).
+
+    Returns:
+        Process exit code.
+    """
+    from rich.markup import escape
+
+    from deepagents_code.config import _is_editable_install, console
+    from deepagents_code.update_check import (
+        create_update_log_path,
+        editable_package_hint,
+        is_valid_package_name,
+        perform_install_package,
+    )
+
+    package = name
+    pkg_log_path: Path | None = None
+    try:
+        if not is_valid_package_name(package):
+            # Defense in depth — the package is interpolated into a shell
+            # command. Reject malformed names before any prompt or uv call,
+            # even with --yes.
+            console.print(
+                f"[bold red]Error:[/bold red] "
+                f"Invalid package name '{escape(package)}'. "
+                "Package names must be alphanumeric with `-`, `_`, "
+                "or `.` (PEP 508).",
+                highlight=False,
+            )
+            return 2
+        if _is_editable_install():
+            console.print(
+                "[bold yellow]Warning:[/bold yellow] "
+                "Package install is not supported on editable "
+                "installs.\n" + escape(editable_package_hint(package)),
+                highlight=False,
+            )
+            return 1
+
+        # Arbitrary packages have no curated allowlist to vet against, so
+        # confirm before pulling third-party code into the tool env.
+        console.print(
+            f"This will install the package '{escape(package)}' into "
+            "the dcode environment (this runs third-party "
+            "code).",
+            highlight=False,
+        )
+        if not yes:
+            if not sys.stdin.isatty():
+                console.print(
+                    "[bold red]Error:[/bold red] "
+                    "Refusing package install in non-interactive mode. "
+                    "Pass --yes to proceed."
+                )
+                return 2
+            try:
+                reply = input(f"Install package '{package}'? [y/N] ")
+            except EOFError:
+                console.print("\nAborted.", style="dim")
+                return 130
+            if reply.strip().lower() not in {"y", "yes"}:
+                console.print("Aborted.", style="dim")
+                return 1
+
+        console.print(f"Installing package '{package}'...")
+        pkg_log_path = create_update_log_path()
+        console.print(
+            f"Install log: {_tail_log_command(pkg_log_path)}",
+            style="dim",
+            highlight=False,
+            markup=False,
+        )
+        success, output = asyncio.run(
+            perform_install_package(package, log_path=pkg_log_path)
+        )
+        if success:
+            console.print(f"[green]Installed package '{package}'.[/green]")
+            return 0
+        # Tail the last 200 chars — uv prints the resolved error at the end.
+        # The full output is in the log.
+        detail = f": {output[-200:]}" if output else ""
+        console.print(
+            f"[bold red]Install failed[/bold red]{escape(detail)}\nLog: {pkg_log_path}",
+            markup=True,
+            highlight=False,
+        )
+    except KeyboardInterrupt:
+        console.print("\nAborted.", style="dim")
+        return 130
+    except Exception as exc:
+        logger.warning("extras install --package failed", exc_info=True)
+        log_line = f"\nLog: {pkg_log_path}" if pkg_log_path else ""
+        console.print(
+            f"[bold red]Error:[/bold red] "
+            f"{type(exc).__name__}: {escape(str(exc))}"
+            f"{escape(log_line)}",
+            markup=True,
+            highlight=False,
+        )
+        return 1
+    else:
+        return 1
+
+
+def _run_install_extra(*, name: str, yes: bool) -> int:
+    """Install a deepagents-code optional extra into the current env.
+
+    Returns:
+        Process exit code.
+    """
+    from rich.markup import escape
+
+    from deepagents_code.config import _is_editable_install, console
+    from deepagents_code.extras_info import KNOWN_EXTRAS
+    from deepagents_code.update_check import (
+        create_update_log_path,
+        editable_extra_hint,
+        install_extra_command,
+        install_extras_command,
+        is_valid_extra_name,
+        perform_install_extra,
+        safe_install_extra_recovery_command,
+    )
+
+    extra = name
+    log_path: Path | None = None
+    manual_cmd: str | None = None
+    try:
+        if not is_valid_extra_name(extra):
+            # Defense in depth — the extra is interpolated into a shell
+            # command. Reject malformed names before any confirmation
+            # prompt, even with --yes.
+            console.print(
+                f"[bold red]Error:[/bold red] "
+                f"Invalid extra name '{escape(extra)}'. "
+                "Extra names must be alphanumeric with `-`, `_`, "
+                "or `.` (PEP 508).",
+                highlight=False,
+            )
+            return 2
+        if _is_editable_install():
+            console.print(
+                "[bold yellow]Warning:[/bold yellow] "
+                "Installing extras is not supported on editable installs.\n"
+                + escape(editable_extra_hint(extra)),
+                highlight=False,
+            )
+            return 1
+
+        manual_cmd = install_extra_command(extra)
+        # KNOWN_EXTRAS is a curated "did you mean" list, not the authoritative
+        # set (that's pyproject, resolved by uv): warn and confirm rather than
+        # refuse, since valid-but-unlisted names exist (e.g. all-providers).
+        # Malformed names blocked above.
+        if extra not in KNOWN_EXTRAS:
+            known = ", ".join(sorted(KNOWN_EXTRAS))
+            console.print(
+                f"[bold yellow]Warning:[/bold yellow] "
+                f"'{extra}' is not a known extra.\n"
+                f"Known extras: {known}",
+                highlight=False,
+            )
+            if not yes:
+                if not sys.stdin.isatty():
+                    console.print(
+                        "[bold red]Error:[/bold red] "
+                        "Refusing unknown extra in non-interactive "
+                        "mode. Pass --yes to override."
+                    )
+                    return 2
+                reply = input("Continue anyway? [y/N] ").strip().lower()
+                if reply not in {"y", "yes"}:
+                    console.print("Aborted.", style="dim")
+                    return 1
+
+        console.print(f"Installing extra '{extra}'...")
+        log_path = create_update_log_path()
+        console.print(
+            f"Install log: {_tail_log_command(log_path)}",
+            style="dim",
+            highlight=False,
+            markup=False,
+        )
+        success, output = asyncio.run(perform_install_extra(extra, log_path=log_path))
+        if success:
+            console.print(f"[green]Installed extra '{extra}'.[/green]")
+            return 0
+        # Tail the last 200 chars — uv resolver prints the resolved error at
+        # the end, not the beginning.
+        detail = f": {output[-200:]}" if output else ""
+        # Best-effort upgrade of `manual_cmd` (set above via
+        # `install_extra_command`) to the install-method-specific recovery
+        # command. On failure, keep that already-bound install-script command
+        # so the hint is never empty.
+        manual_cmd = safe_install_extra_recovery_command(extra, fallback=manual_cmd)
+        console.print(
+            f"[bold red]Install failed[/bold red]{escape(detail)}\n"
+            f"Log: {log_path}\n"
+            f"Run manually: [cyan]{escape(manual_cmd)}[/cyan]",
+            markup=True,
+            highlight=False,
+        )
+    except KeyboardInterrupt:
+        console.print("\nAborted.", style="dim")
+        return 130
+    except Exception as exc:
+        logger.warning("extras install failed", exc_info=True)
+        log_line = f"\nLog: {log_path}" if log_path else ""
+        # Catch-all for any unexpected install failure: never let recovery-hint
+        # generation raise a second error over the original one. `manual_cmd`
+        # may still be unset if the failure predated `install_extra_command`,
+        # so fall back to a bare extras command in that case.
+        fallback_cmd = safe_install_extra_recovery_command(
+            extra, fallback=manual_cmd or install_extras_command((extra,))
+        )
+        console.print(
+            f"[bold red]Error:[/bold red] "
+            f"{type(exc).__name__}: {escape(str(exc))}"
+            f"{escape(log_line)}\n"
+            f"Run manually: [cyan]{escape(fallback_cmd)}[/cyan]",
+            markup=True,
+            highlight=False,
+        )
+        return 1
+    else:
+        return 1

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -237,7 +237,7 @@ def _import_provider_module(
         msg = (
             f"The '{provider}' sandbox provider requires the '{package}' package. "
             f"Install it with: /install {provider} (in-app) or "
-            f"dcode --install {provider} (CLI)"
+            f"dcode extras install {provider} (CLI)"
         )
         raise ImportError(msg) from exc
 

--- a/libs/code/deepagents_code/integrations/sandbox_factory.py
+++ b/libs/code/deepagents_code/integrations/sandbox_factory.py
@@ -237,7 +237,7 @@ def _import_provider_module(
         msg = (
             f"The '{provider}' sandbox provider requires the '{package}' package. "
             f"Install it with: /install {provider} (in-app) or "
-            f"dcode extras install {provider} (CLI)"
+            f"dcode install {provider} (CLI)"
         )
         raise ImportError(msg) from exc
 

--- a/libs/code/deepagents_code/integrations/sandbox_provider.py
+++ b/libs/code/deepagents_code/integrations/sandbox_provider.py
@@ -29,12 +29,12 @@ class SandboxInstallHint:
 
         Args:
             in_app: Whether to render the in-app slash command (`/install`)
-                rather than the CLI command (`dcode --install`).
+                rather than the CLI command (`dcode extras install`).
 
         Returns:
             The install command string.
         """
-        prefix = "/install" if in_app else "dcode --install"
+        prefix = "/install" if in_app else "dcode extras install"
         suffix = " --package" if self.kind == "package" else ""
         return f"{prefix} {self.name}{suffix}"
 

--- a/libs/code/deepagents_code/integrations/sandbox_provider.py
+++ b/libs/code/deepagents_code/integrations/sandbox_provider.py
@@ -29,12 +29,12 @@ class SandboxInstallHint:
 
         Args:
             in_app: Whether to render the in-app slash command (`/install`)
-                rather than the CLI command (`dcode extras install`).
+                rather than the CLI command (`dcode install`).
 
         Returns:
             The install command string.
         """
-        prefix = "/install" if in_app else "dcode extras install"
+        prefix = "/install" if in_app else "dcode install"
         suffix = " --package" if self.kind == "package" else ""
         return f"{prefix} {self.name}{suffix}"
 

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1469,6 +1469,7 @@ _HELP_SPECS: dict[str, tuple[str | None, str]] = {
     "mcp": ("mcp_command", "show_mcp_help"),
     "auth": ("auth_command", "show_auth_help"),
     "tools": ("tools_command", "show_tools_help"),
+    "extras": ("extras_command", "show_extras_help"),
 }
 """Maps top-level command names to their startup-fast-path help dispatch.
 
@@ -1807,6 +1808,41 @@ def parse_args() -> argparse.Namespace:
     )
     add_json_output_arg(tools_list)
 
+    extras_parser = subparsers.add_parser(
+        "extras",
+        help="Manage optional deepagents-code extras (providers, sandboxes)",
+        add_help=False,
+        parents=help_parent(_lazy_help("show_extras_help")),
+    )
+    extras_sub = extras_parser.add_subparsers(dest="extras_command")
+
+    extras_install = extras_sub.add_parser(
+        "install",
+        help="Install an optional extra (e.g. daytona, fireworks)",
+        add_help=False,
+        parents=help_parent(_lazy_help("show_extras_install_help")),
+    )
+    extras_install.add_argument(
+        "extras_target",
+        metavar="NAME",
+        help="Extra name, or package name when --package is set",
+    )
+    extras_install.add_argument(
+        "--package",
+        dest="extras_package",
+        action="store_true",
+        help=(
+            "Treat NAME as a package added via `uv --with` "
+            "(for a custom provider package), not a deepagents-code extra"
+        ),
+    )
+    extras_install.add_argument(
+        "--yes",
+        dest="extras_yes",
+        action="store_true",
+        help="Skip interactive confirmation prompts",
+    )
+
     # Default interactive mode — argument order here determines the
     # usage line printed by argparse; keep in sync with ui.show_help().
     parser.add_argument(
@@ -2127,20 +2163,27 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--install",
         metavar="NAME",
-        help="Install an optional extra (e.g. daytona, fireworks), then exit",
+        help=(
+            "Alias for `extras install NAME`. Install an optional extra "
+            "(e.g. daytona, fireworks), then exit"
+        ),
     )
     parser.add_argument(
         "--package",
         action="store_true",
         help=(
-            "With --install, treat NAME as a package added via `uv --with` "
-            "(for a custom provider package), not a deepagents-code extra"
+            "With --install or `extras install`, treat NAME as a package "
+            "added via `uv --with` (for a custom provider package), not a "
+            "deepagents-code extra"
         ),
     )
     parser.add_argument(
         "--yes",
         action="store_true",
-        help="Skip interactive confirmation prompts (e.g., for --install)",
+        help=(
+            "Skip interactive confirmation prompts "
+            "(e.g., for --install / extras install)"
+        ),
     )
     parser.add_argument(
         "--acp",
@@ -3589,6 +3632,11 @@ def cli_main() -> None:
 
             sys.exit(run_tools_command(args))
 
+        if command == "extras":
+            from deepagents_code.client.commands.extras import run_extras_command
+
+            sys.exit(run_extras_command(args))
+
         # Best-effort, idempotent migration. Placed after parse_args and the
         # bare-help fast path so --help / --version / `deepagents <group>`
         # exit before any I/O. Wrapped broadly so an unexpected non-OSError
@@ -4020,234 +4068,24 @@ def cli_main() -> None:
 
         if args.package and not args.install:
             console.print(
-                "[bold red]Error:[/bold red] --package requires --install <package>.",
+                "[bold red]Error:[/bold red] --package requires "
+                "`dcode extras install <package> --package` "
+                "(or the `--install <package>` alias).",
             )
             sys.exit(2)
 
-        # Handle --install <package> --package flag (headless, no session).
-        # Installs an arbitrary package via `uv --with` for a custom provider,
-        # rather than a deepagents-code extra. Always exits.
-        if args.install and args.package:
-            from rich.markup import escape
-
-            from deepagents_code.config import _is_editable_install
-            from deepagents_code.update_check import (
-                create_update_log_path,
-                editable_package_hint,
-                is_valid_package_name,
-                perform_install_package,
-            )
-
-            package: str = args.install
-            pkg_log_path: Path | None = None
-            try:
-                if not is_valid_package_name(package):
-                    # Defense in depth — the package is interpolated into a
-                    # shell command. Reject malformed names before any prompt
-                    # or uv call, even with --yes.
-                    console.print(
-                        f"[bold red]Error:[/bold red] "
-                        f"Invalid package name '{escape(package)}'. "
-                        "Package names must be alphanumeric with `-`, `_`, "
-                        "or `.` (PEP 508).",
-                        highlight=False,
-                    )
-                    sys.exit(2)
-                if _is_editable_install():
-                    console.print(
-                        "[bold yellow]Warning:[/bold yellow] "
-                        "--install --package is not supported on editable "
-                        "installs.\n" + escape(editable_package_hint(package)),
-                        highlight=False,
-                    )
-                    sys.exit(1)
-
-                # Arbitrary packages have no curated allowlist to vet against,
-                # so confirm before pulling third-party code into the tool env.
-                console.print(
-                    f"This will install the package '{escape(package)}' into "
-                    "the dcode environment (this runs third-party "
-                    "code).",
-                    highlight=False,
-                )
-                if not args.yes:
-                    if not sys.stdin.isatty():
-                        console.print(
-                            "[bold red]Error:[/bold red] "
-                            "Refusing package install in non-interactive mode. "
-                            "Pass --yes to proceed."
-                        )
-                        sys.exit(2)
-                    try:
-                        reply = input(f"Install package '{package}'? [y/N] ")
-                    except EOFError:
-                        console.print("\nAborted.", style="dim")
-                        sys.exit(130)
-                    if reply.strip().lower() not in {"y", "yes"}:
-                        console.print("Aborted.", style="dim")
-                        sys.exit(1)
-
-                console.print(f"Installing package '{package}'...")
-                pkg_log_path = create_update_log_path()
-                console.print(
-                    f"Install log: {_tail_log_command(pkg_log_path)}",
-                    style="dim",
-                    highlight=False,
-                    markup=False,
-                )
-                success, output = asyncio.run(
-                    perform_install_package(package, log_path=pkg_log_path)
-                )
-                if success:
-                    console.print(f"[green]Installed package '{package}'.[/green]")
-                    sys.exit(0)
-                # Tail the last 200 chars — uv prints the resolved error at the
-                # end. The full output is in the log.
-                detail = f": {output[-200:]}" if output else ""
-                console.print(
-                    f"[bold red]Install failed[/bold red]{escape(detail)}\n"
-                    f"Log: {pkg_log_path}",
-                    markup=True,
-                    highlight=False,
-                )
-                sys.exit(1)
-            except KeyboardInterrupt:
-                console.print("\nAborted.", style="dim")
-                sys.exit(130)
-            except Exception as exc:
-                logger.warning("--install --package failed", exc_info=True)
-                log_line = f"\nLog: {pkg_log_path}" if pkg_log_path else ""
-                console.print(
-                    f"[bold red]Error:[/bold red] "
-                    f"{type(exc).__name__}: {escape(str(exc))}"
-                    f"{escape(log_line)}",
-                    markup=True,
-                    highlight=False,
-                )
-                sys.exit(1)
-
-        # Handle --install <extra> flag (headless, no session)
+        # Handle --install <name> [--package] flag (headless, no session).
+        # Alias for `dcode extras install`. Always exits.
         if args.install:
-            from rich.markup import escape
+            from deepagents_code.client.commands.extras import run_install_request
 
-            from deepagents_code.config import _is_editable_install
-            from deepagents_code.extras_info import KNOWN_EXTRAS
-            from deepagents_code.update_check import (
-                create_update_log_path,
-                editable_extra_hint,
-                install_extra_command,
-                install_extras_command,
-                is_valid_extra_name,
-                perform_install_extra,
-                safe_install_extra_recovery_command,
+            sys.exit(
+                run_install_request(
+                    name=args.install,
+                    package=bool(args.package),
+                    yes=bool(args.yes),
+                )
             )
-
-            extra: str = args.install
-            log_path: Path | None = None
-            manual_cmd: str | None = None
-            try:
-                if not is_valid_extra_name(extra):
-                    # Defense in depth — the extra is interpolated into a
-                    # shell command. Reject malformed names before any
-                    # confirmation prompt, even with --yes.
-                    console.print(
-                        f"[bold red]Error:[/bold red] "
-                        f"Invalid extra name '{escape(extra)}'. "
-                        "Extra names must be alphanumeric with `-`, `_`, "
-                        "or `.` (PEP 508).",
-                        highlight=False,
-                    )
-                    sys.exit(2)
-                if _is_editable_install():
-                    console.print(
-                        "[bold yellow]Warning:[/bold yellow] "
-                        "--install is not supported on editable installs.\n"
-                        + escape(editable_extra_hint(extra)),
-                        highlight=False,
-                    )
-                    sys.exit(1)
-
-                manual_cmd = install_extra_command(extra)
-                # KNOWN_EXTRAS is a curated "did you mean" list, not the
-                # authoritative set (that's pyproject, resolved by uv): warn and
-                # confirm rather than refuse, since valid-but-unlisted names
-                # exist (e.g. all-providers). Malformed names blocked above.
-                if extra not in KNOWN_EXTRAS:
-                    known = ", ".join(sorted(KNOWN_EXTRAS))
-                    console.print(
-                        f"[bold yellow]Warning:[/bold yellow] "
-                        f"'{extra}' is not a known extra.\n"
-                        f"Known extras: {known}",
-                        highlight=False,
-                    )
-                    if not args.yes:
-                        if not sys.stdin.isatty():
-                            console.print(
-                                "[bold red]Error:[/bold red] "
-                                "Refusing unknown extra in non-interactive "
-                                "mode. Pass --yes to override."
-                            )
-                            sys.exit(2)
-                        reply = input("Continue anyway? [y/N] ").strip().lower()
-                        if reply not in {"y", "yes"}:
-                            console.print("Aborted.", style="dim")
-                            sys.exit(1)
-
-                console.print(f"Installing extra '{extra}'...")
-                log_path = create_update_log_path()
-                console.print(
-                    f"Install log: {_tail_log_command(log_path)}",
-                    style="dim",
-                    highlight=False,
-                    markup=False,
-                )
-                success, output = asyncio.run(
-                    perform_install_extra(extra, log_path=log_path)
-                )
-                if success:
-                    console.print(f"[green]Installed extra '{extra}'.[/green]")
-                    sys.exit(0)
-                # Tail the last 200 chars — uv resolver prints the resolved
-                # error at the end, not the beginning.
-                detail = f": {output[-200:]}" if output else ""
-                # Best-effort upgrade of `manual_cmd` (set above via
-                # `install_extra_command`) to the install-method-specific
-                # recovery command. On failure, keep that already-bound
-                # install-script command so the hint is never empty.
-                manual_cmd = safe_install_extra_recovery_command(
-                    extra, fallback=manual_cmd
-                )
-                console.print(
-                    f"[bold red]Install failed[/bold red]{escape(detail)}\n"
-                    f"Log: {log_path}\n"
-                    f"Run manually: [cyan]{escape(manual_cmd)}[/cyan]",
-                    markup=True,
-                    highlight=False,
-                )
-                sys.exit(1)
-            except KeyboardInterrupt:
-                console.print("\nAborted.", style="dim")
-                sys.exit(130)
-            except Exception as exc:
-                logger.warning("--install failed", exc_info=True)
-                log_line = f"\nLog: {log_path}" if log_path else ""
-                # Catch-all for any unexpected install failure: never let
-                # recovery-hint generation raise a second error over the
-                # original one. `manual_cmd` may still be unset if the failure
-                # predated `install_extra_command`, so fall back to a bare
-                # extras command in that case.
-                fallback_cmd = safe_install_extra_recovery_command(
-                    extra, fallback=manual_cmd or install_extras_command((extra,))
-                )
-                console.print(
-                    f"[bold red]Error:[/bold red] "
-                    f"{type(exc).__name__}: {escape(str(exc))}"
-                    f"{escape(log_line)}\n"
-                    f"Run manually: [cyan]{escape(fallback_cmd)}[/cyan]",
-                    markup=True,
-                    highlight=False,
-                )
-                sys.exit(1)
 
         # Handle --auto-update flag (headless toggle: reads current state
         # and inverts it, no session)

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -1469,7 +1469,6 @@ _HELP_SPECS: dict[str, tuple[str | None, str]] = {
     "mcp": ("mcp_command", "show_mcp_help"),
     "auth": ("auth_command", "show_auth_help"),
     "tools": ("tools_command", "show_tools_help"),
-    "extras": ("extras_command", "show_extras_help"),
 }
 """Maps top-level command names to their startup-fast-path help dispatch.
 
@@ -1808,37 +1807,31 @@ def parse_args() -> argparse.Namespace:
     )
     add_json_output_arg(tools_list)
 
-    extras_parser = subparsers.add_parser(
-        "extras",
-        help="Manage optional deepagents-code extras (providers, sandboxes)",
-        add_help=False,
-        parents=help_parent(_lazy_help("show_extras_help")),
-    )
-    extras_sub = extras_parser.add_subparsers(dest="extras_command")
-
-    extras_install = extras_sub.add_parser(
+    install_parser = subparsers.add_parser(
         "install",
         help="Install an optional extra (e.g. daytona, fireworks)",
         add_help=False,
-        parents=help_parent(_lazy_help("show_extras_install_help")),
+        parents=help_parent(_lazy_help("show_install_help")),
     )
-    extras_install.add_argument(
-        "extras_target",
+    install_parser.add_argument(
+        "install_target",
+        nargs="?",
+        default=None,
         metavar="NAME",
         help="Extra name, or package name when --package is set",
     )
-    extras_install.add_argument(
+    install_parser.add_argument(
         "--package",
-        dest="extras_package",
+        dest="install_package",
         action="store_true",
         help=(
             "Treat NAME as a package added via `uv --with` "
             "(for a custom provider package), not a deepagents-code extra"
         ),
     )
-    extras_install.add_argument(
+    install_parser.add_argument(
         "--yes",
-        dest="extras_yes",
+        dest="install_yes",
         action="store_true",
         help="Skip interactive confirmation prompts",
     )
@@ -2164,7 +2157,7 @@ def parse_args() -> argparse.Namespace:
         "--install",
         metavar="NAME",
         help=(
-            "Alias for `extras install NAME`. Install an optional extra "
+            "Alias for `install NAME`. Install an optional extra "
             "(e.g. daytona, fireworks), then exit"
         ),
     )
@@ -2172,18 +2165,15 @@ def parse_args() -> argparse.Namespace:
         "--package",
         action="store_true",
         help=(
-            "With --install or `extras install`, treat NAME as a package "
-            "added via `uv --with` (for a custom provider package), not a "
+            "With --install or `install`, treat NAME as a package added via "
+            "`uv --with` (for a custom provider package), not a "
             "deepagents-code extra"
         ),
     )
     parser.add_argument(
         "--yes",
         action="store_true",
-        help=(
-            "Skip interactive confirmation prompts "
-            "(e.g., for --install / extras install)"
-        ),
+        help=("Skip interactive confirmation prompts (e.g., for --install / install)"),
     )
     parser.add_argument(
         "--acp",
@@ -3632,10 +3622,10 @@ def cli_main() -> None:
 
             sys.exit(run_tools_command(args))
 
-        if command == "extras":
-            from deepagents_code.client.commands.extras import run_extras_command
+        if command == "install":
+            from deepagents_code.client.commands.extras import run_install_command
 
-            sys.exit(run_extras_command(args))
+            sys.exit(run_install_command(args))
 
         # Best-effort, idempotent migration. Placed after parse_args and the
         # bare-help fast path so --help / --version / `deepagents <group>`
@@ -4069,13 +4059,13 @@ def cli_main() -> None:
         if args.package and not args.install:
             console.print(
                 "[bold red]Error:[/bold red] --package requires "
-                "`dcode extras install <package> --package` "
+                "`dcode install <package> --package` "
                 "(or the `--install <package>` alias).",
             )
             sys.exit(2)
 
         # Handle --install <name> [--package] flag (headless, no session).
-        # Alias for `dcode extras install`. Always exits.
+        # Alias for `dcode install`. Always exits.
         if args.install:
             from deepagents_code.client.commands.extras import run_install_request
 

--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -22,6 +22,7 @@ _TIPS: dict[str, int] = {
     "Use /offload when your conversation gets long": 2,
     "Use /copy to copy the latest message": 3,
     "Use /tools to list the tools available to the agent": 1,
+    "Use dcode extras install <name> for optional providers": 1,
     "Use /mcp login <server> to authenticate MCP servers": 1,
     "Use /remember to save learnings from this conversation": 1,
     "Use /model to switch models mid-conversation": 2,

--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -22,7 +22,7 @@ _TIPS: dict[str, int] = {
     "Use /offload when your conversation gets long": 2,
     "Use /copy to copy the latest message": 3,
     "Use /tools to list the tools available to the agent": 1,
-    "Use dcode extras install <name> for optional providers": 1,
+    "Use dcode install <name> for optional providers": 1,
     "Use /mcp login <server> to authenticate MCP servers": 1,
     "Use /remember to save learnings from this conversation": 1,
     "Use /model to switch models mid-conversation": 2,

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -122,7 +122,7 @@ def show_help() -> None:
     console.print(
         "  dcode tools <install|list>                Manage managed tools (ripgrep)"
     )
-    console.print("  dcode extras install NAME                 Install optional extras")
+    console.print("  dcode install NAME                        Install optional extras")
     console.print()
 
     console.print("[bold]Options:[/bold]", style=theme.PRIMARY)
@@ -236,14 +236,12 @@ def show_help() -> None:
     console.print(
         "  --auto-update              Toggle automatic updates on or off, then exit"
     )
+    console.print("  --install NAME             Alias for `install NAME`")
     console.print(
-        "  --install NAME             Install an optional extra (e.g. daytona)"
+        "  --package                  With install/--install, treat NAME as a "
+        "package (uv --with), not an extra"
     )
-    console.print(
-        "  --package                  With --install, treat NAME as a package "
-        "(uv --with), not an extra"
-    )
-    console.print("  --yes                      Skip --install confirmation prompts")
+    console.print("  --yes                      Skip install confirmation prompts")
     console.print("  --acp                      Run as an ACP server over stdio")
     console.print("  -v, --version              Show dcode and SDK versions")
     console.print("  -h, --help                 Show this help message and exit")
@@ -651,49 +649,23 @@ def show_tools_install_help() -> None:
     console.print()
 
 
-def show_extras_help() -> None:
-    """Show help information for the `extras` subcommand."""
+def show_install_help() -> None:
+    """Show help information for the `install` subcommand."""
     console.print()
     console.print("[bold]Usage:[/bold]", style=theme.PRIMARY)
-    console.print("  dcode extras <command> [options]")
-    console.print()
-    console.print(
-        "Manage optional deepagents-code extras (sandbox providers, model",
-    )
-    console.print(
-        "providers, and other opt-in dependencies). Distinct from "
-        "`dcode tools`, which provisions managed host binaries such as ripgrep.",
-    )
-    console.print()
-    console.print("[bold]Commands:[/bold]", style=theme.PRIMARY)
-    console.print(
-        "  install NAME       Install an optional extra (or package with --package)"
-    )
-    console.print()
-    console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
-    console.print("  dcode extras install daytona")
-    console.print("  dcode extras install fireworks")
-    console.print("  dcode extras install langchain-custom --package --yes")
-    console.print()
-    console.print(
-        "Legacy alias: `dcode --install NAME` still works.",
-        style=theme.MUTED,
-        highlight=False,
-    )
-    console.print()
-
-
-def show_extras_install_help() -> None:
-    """Show help information for the `extras install` subcommand."""
-    console.print()
-    console.print("[bold]Usage:[/bold]", style=theme.PRIMARY)
-    console.print("  dcode extras install NAME [options]")
+    console.print("  dcode install NAME [options]")
     console.print()
     console.print(
         "Install an optional deepagents-code extra into the current dcode",
     )
     console.print(
         "environment (for example a sandbox provider or model provider).",
+    )
+    console.print(
+        "Distinct from `dcode tools install`, which provisions managed host",
+    )
+    console.print(
+        "binaries such as ripgrep.",
     )
     console.print()
     _print_option_section(
@@ -702,10 +674,10 @@ def show_extras_install_help() -> None:
     )
     console.print()
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
-    console.print("  dcode extras install daytona")
-    console.print("  dcode extras install fireworks")
-    console.print("  dcode extras install not-listed-yet --yes")
-    console.print("  dcode extras install langchain-custom --package --yes")
+    console.print("  dcode install daytona")
+    console.print("  dcode install fireworks")
+    console.print("  dcode install not-listed-yet --yes")
+    console.print("  dcode install langchain-custom --package --yes")
     console.print()
     console.print(
         "In-session equivalent: `/install NAME`. Legacy CLI alias:",

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -668,10 +668,14 @@ def show_install_help() -> None:
         "binaries such as ripgrep.",
     )
     console.print()
-    _print_option_section(
-        "  --package               Treat NAME as a package added via `uv --with`",
-        "  --yes                   Skip interactive confirmation prompts",
+    # Do not use `_print_option_section` here: it appends the shared `--json`
+    # line, and `dcode install` does not accept that flag.
+    console.print("[bold]Options:[/bold]", style=theme.PRIMARY)
+    console.print(
+        "  --package               Treat NAME as a package added via `uv --with`"
     )
+    console.print("  --yes                   Skip interactive confirmation prompts")
+    console.print(_HELP_OPTION_LINE)
     console.print()
     console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
     console.print("  dcode install daytona")

--- a/libs/code/deepagents_code/ui.py
+++ b/libs/code/deepagents_code/ui.py
@@ -120,8 +120,9 @@ def show_help() -> None:
         "  dcode doctor                              Print install diagnostics"
     )
     console.print(
-        "  dcode tools <install>                     Manage managed tools (ripgrep)"
+        "  dcode tools <install|list>                Manage managed tools (ripgrep)"
     )
+    console.print("  dcode extras install NAME                 Install optional extras")
     console.print()
 
     console.print("[bold]Options:[/bold]", style=theme.PRIMARY)
@@ -644,6 +645,75 @@ def show_tools_install_help() -> None:
     )
     console.print(
         "DEEPAGENTS_CODE_RIPGREP_INSTALLER=system to use your package manager.",
+        style=theme.MUTED,
+        highlight=False,
+    )
+    console.print()
+
+
+def show_extras_help() -> None:
+    """Show help information for the `extras` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=theme.PRIMARY)
+    console.print("  dcode extras <command> [options]")
+    console.print()
+    console.print(
+        "Manage optional deepagents-code extras (sandbox providers, model",
+    )
+    console.print(
+        "providers, and other opt-in dependencies). Distinct from "
+        "`dcode tools`, which provisions managed host binaries such as ripgrep.",
+    )
+    console.print()
+    console.print("[bold]Commands:[/bold]", style=theme.PRIMARY)
+    console.print(
+        "  install NAME       Install an optional extra (or package with --package)"
+    )
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
+    console.print("  dcode extras install daytona")
+    console.print("  dcode extras install fireworks")
+    console.print("  dcode extras install langchain-custom --package --yes")
+    console.print()
+    console.print(
+        "Legacy alias: `dcode --install NAME` still works.",
+        style=theme.MUTED,
+        highlight=False,
+    )
+    console.print()
+
+
+def show_extras_install_help() -> None:
+    """Show help information for the `extras install` subcommand."""
+    console.print()
+    console.print("[bold]Usage:[/bold]", style=theme.PRIMARY)
+    console.print("  dcode extras install NAME [options]")
+    console.print()
+    console.print(
+        "Install an optional deepagents-code extra into the current dcode",
+    )
+    console.print(
+        "environment (for example a sandbox provider or model provider).",
+    )
+    console.print()
+    _print_option_section(
+        "  --package               Treat NAME as a package added via `uv --with`",
+        "  --yes                   Skip interactive confirmation prompts",
+    )
+    console.print()
+    console.print("[bold]Examples:[/bold]", style=theme.PRIMARY)
+    console.print("  dcode extras install daytona")
+    console.print("  dcode extras install fireworks")
+    console.print("  dcode extras install not-listed-yet --yes")
+    console.print("  dcode extras install langchain-custom --package --yes")
+    console.print()
+    console.print(
+        "In-session equivalent: `/install NAME`. Legacy CLI alias:",
+        style=theme.MUTED,
+        highlight=False,
+    )
+    console.print(
+        "`dcode --install NAME`.",
         style=theme.MUTED,
         highlight=False,
     )

--- a/libs/code/tests/unit_tests/client/commands/test_extras.py
+++ b/libs/code/tests/unit_tests/client/commands/test_extras.py
@@ -1,0 +1,175 @@
+"""Tests for the `dcode extras` command group."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deepagents_code.client.commands.extras import (
+    run_extras_command,
+    run_install_request,
+)
+
+
+class TestExtrasInstallDispatch:
+    """Tests for `dcode extras install` dispatch and shared install helpers."""
+
+    def test_no_subcommand_shows_help(self) -> None:
+        args = argparse.Namespace(extras_command=None)
+        with patch("deepagents_code.ui.show_extras_help") as show_help:
+            code = run_extras_command(args)
+        assert code == 0
+        show_help.assert_called_once()
+
+    def test_install_dispatches_to_shared_helper(self) -> None:
+        args = argparse.Namespace(
+            extras_command="install",
+            extras_target="daytona",
+            extras_package=False,
+            extras_yes=True,
+            package=False,
+            yes=False,
+        )
+        with patch(
+            "deepagents_code.client.commands.extras.run_install_request",
+            return_value=0,
+        ) as install:
+            code = run_extras_command(args)
+        assert code == 0
+        install.assert_called_once_with(name="daytona", package=False, yes=True)
+
+    def test_install_accepts_global_yes_and_package_flags(self) -> None:
+        """Root flags preceding the group (e.g. `dcode --yes extras install`) work."""
+        args = argparse.Namespace(
+            extras_command="install",
+            extras_target="langchain-custom",
+            extras_package=False,
+            extras_yes=False,
+            package=True,
+            yes=True,
+        )
+        with patch(
+            "deepagents_code.client.commands.extras.run_install_request",
+            return_value=0,
+        ) as install:
+            code = run_extras_command(args)
+        assert code == 0
+        install.assert_called_once_with(name="langchain-custom", package=True, yes=True)
+
+    def test_known_extra_runs_install(self) -> None:
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.config.console", MagicMock(), create=True
+            ) as console_mock,
+            patch(
+                "deepagents_code.update_check.create_update_log_path",
+                return_value=Path("/tmp/deepagents-install.log"),
+            ),
+            patch(
+                "deepagents_code.update_check.install_extra_command",
+                return_value="script",
+            ),
+            patch(
+                "deepagents_code.update_check.perform_install_extra",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as perform,
+        ):
+            code = run_install_request(name="quickjs", package=False, yes=True)
+        assert code == 0
+        perform.assert_awaited_once()
+        printed = " ".join(
+            str(arg) for call in console_mock.print.call_args_list for arg in call.args
+        )
+        assert "Installed extra 'quickjs'" in printed
+
+    def test_package_path_runs_package_install(self) -> None:
+        with (
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch("deepagents_code.config.console", MagicMock(), create=True),
+            patch(
+                "deepagents_code.update_check.create_update_log_path",
+                return_value=Path("/tmp/deepagents-install.log"),
+            ),
+            patch(
+                "deepagents_code.update_check.perform_install_package",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as perform,
+        ):
+            code = run_install_request(name="langchain-custom", package=True, yes=True)
+        assert code == 0
+        perform.assert_awaited_once()
+
+
+class TestExtrasCliParsing:
+    """Parse-level coverage for the extras group."""
+
+    def test_parse_extras_install(self) -> None:
+        from deepagents_code.main import parse_args
+
+        with patch.object(
+            sys, "argv", ["dcode", "extras", "install", "daytona", "--yes"]
+        ):
+            args = parse_args()
+        assert args.command == "extras"
+        assert args.extras_command == "install"
+        assert args.extras_target == "daytona"
+        assert args.extras_yes is True
+        assert args.extras_package is False
+
+    def test_parse_extras_install_package(self) -> None:
+        from deepagents_code.main import parse_args
+
+        with patch.object(
+            sys,
+            "argv",
+            ["dcode", "extras", "install", "langchain-custom", "--package", "--yes"],
+        ):
+            args = parse_args()
+        assert args.command == "extras"
+        assert args.extras_target == "langchain-custom"
+        assert args.extras_package is True
+        assert args.extras_yes is True
+
+
+class TestExtrasCliMain:
+    """End-to-end control flow through `cli_main` for the new subcommand."""
+
+    def test_extras_install_via_cli_main(self) -> None:
+        from deepagents_code.main import cli_main
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = False
+        mock_stdin.read.return_value = ""
+        with (
+            patch.object(
+                sys, "argv", ["dcode", "extras", "install", "quickjs", "--yes"]
+            ),
+            patch.object(sys, "stdin", mock_stdin),
+            patch("deepagents_code.main.check_cli_dependencies"),
+            patch("deepagents_code.config.console", MagicMock(), create=True),
+            patch("deepagents_code.config._is_editable_install", return_value=False),
+            patch(
+                "deepagents_code.update_check.create_update_log_path",
+                return_value=Path("/tmp/deepagents-install.log"),
+            ),
+            patch(
+                "deepagents_code.update_check.install_extra_command",
+                return_value="script",
+            ),
+            patch(
+                "deepagents_code.update_check.perform_install_extra",
+                new_callable=AsyncMock,
+                return_value=(True, ""),
+            ) as perform,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_main()
+        assert int(exc_info.value.code or 0) == 0
+        perform.assert_awaited_once()

--- a/libs/code/tests/unit_tests/client/commands/test_extras.py
+++ b/libs/code/tests/unit_tests/client/commands/test_extras.py
@@ -1,4 +1,4 @@
-"""Tests for the `dcode extras` command group."""
+"""Tests for the `dcode install` command and shared install helpers."""
 
 from __future__ import annotations
 
@@ -10,27 +10,26 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from deepagents_code.client.commands.extras import (
-    run_extras_command,
+    run_install_command,
     run_install_request,
 )
 
 
-class TestExtrasInstallDispatch:
-    """Tests for `dcode extras install` dispatch and shared install helpers."""
+class TestInstallCommandDispatch:
+    """Tests for `dcode install` dispatch and shared install helpers."""
 
-    def test_no_subcommand_shows_help(self) -> None:
-        args = argparse.Namespace(extras_command=None)
-        with patch("deepagents_code.ui.show_extras_help") as show_help:
-            code = run_extras_command(args)
-        assert code == 0
+    def test_missing_name_shows_help(self) -> None:
+        args = argparse.Namespace(install_target=None)
+        with patch("deepagents_code.ui.show_install_help") as show_help:
+            code = run_install_command(args)
+        assert code == 2
         show_help.assert_called_once()
 
     def test_install_dispatches_to_shared_helper(self) -> None:
         args = argparse.Namespace(
-            extras_command="install",
-            extras_target="daytona",
-            extras_package=False,
-            extras_yes=True,
+            install_target="daytona",
+            install_package=False,
+            install_yes=True,
             package=False,
             yes=False,
         )
@@ -38,17 +37,16 @@ class TestExtrasInstallDispatch:
             "deepagents_code.client.commands.extras.run_install_request",
             return_value=0,
         ) as install:
-            code = run_extras_command(args)
+            code = run_install_command(args)
         assert code == 0
         install.assert_called_once_with(name="daytona", package=False, yes=True)
 
     def test_install_accepts_global_yes_and_package_flags(self) -> None:
-        """Root flags preceding the group (e.g. `dcode --yes extras install`) work."""
+        """Root flags preceding the command (e.g. `dcode --yes install`) work."""
         args = argparse.Namespace(
-            extras_command="install",
-            extras_target="langchain-custom",
-            extras_package=False,
-            extras_yes=False,
+            install_target="langchain-custom",
+            install_package=False,
+            install_yes=False,
             package=True,
             yes=True,
         )
@@ -56,7 +54,7 @@ class TestExtrasInstallDispatch:
             "deepagents_code.client.commands.extras.run_install_request",
             return_value=0,
         ) as install:
-            code = run_extras_command(args)
+            code = run_install_command(args)
         assert code == 0
         install.assert_called_once_with(name="langchain-custom", package=True, yes=True)
 
@@ -107,50 +105,45 @@ class TestExtrasInstallDispatch:
         perform.assert_awaited_once()
 
 
-class TestExtrasCliParsing:
-    """Parse-level coverage for the extras group."""
+class TestInstallCliParsing:
+    """Parse-level coverage for the install command."""
 
-    def test_parse_extras_install(self) -> None:
+    def test_parse_install(self) -> None:
         from deepagents_code.main import parse_args
 
-        with patch.object(
-            sys, "argv", ["dcode", "extras", "install", "daytona", "--yes"]
-        ):
+        with patch.object(sys, "argv", ["dcode", "install", "daytona", "--yes"]):
             args = parse_args()
-        assert args.command == "extras"
-        assert args.extras_command == "install"
-        assert args.extras_target == "daytona"
-        assert args.extras_yes is True
-        assert args.extras_package is False
+        assert args.command == "install"
+        assert args.install_target == "daytona"
+        assert args.install_yes is True
+        assert args.install_package is False
 
-    def test_parse_extras_install_package(self) -> None:
+    def test_parse_install_package(self) -> None:
         from deepagents_code.main import parse_args
 
         with patch.object(
             sys,
             "argv",
-            ["dcode", "extras", "install", "langchain-custom", "--package", "--yes"],
+            ["dcode", "install", "langchain-custom", "--package", "--yes"],
         ):
             args = parse_args()
-        assert args.command == "extras"
-        assert args.extras_target == "langchain-custom"
-        assert args.extras_package is True
-        assert args.extras_yes is True
+        assert args.command == "install"
+        assert args.install_target == "langchain-custom"
+        assert args.install_package is True
+        assert args.install_yes is True
 
 
-class TestExtrasCliMain:
-    """End-to-end control flow through `cli_main` for the new subcommand."""
+class TestInstallCliMain:
+    """End-to-end control flow through `cli_main` for the install command."""
 
-    def test_extras_install_via_cli_main(self) -> None:
+    def test_install_via_cli_main(self) -> None:
         from deepagents_code.main import cli_main
 
         mock_stdin = MagicMock()
         mock_stdin.isatty.return_value = False
         mock_stdin.read.return_value = ""
         with (
-            patch.object(
-                sys, "argv", ["dcode", "extras", "install", "quickjs", "--yes"]
-            ),
+            patch.object(sys, "argv", ["dcode", "install", "quickjs", "--yes"]),
             patch.object(sys, "stdin", mock_stdin),
             patch("deepagents_code.main.check_cli_dependencies"),
             patch("deepagents_code.config.console", MagicMock(), create=True),

--- a/libs/code/tests/unit_tests/test_agent_friendly.py
+++ b/libs/code/tests/unit_tests/test_agent_friendly.py
@@ -577,13 +577,13 @@ class TestHelpScreenDriftExtended:
             show_help()
         assert "dcode tools" in buf.getvalue()
 
-    def test_show_help_includes_extras_subcommand(self) -> None:
-        """show_help should mention the extras subcommand."""
+    def test_show_help_includes_install_subcommand(self) -> None:
+        """show_help should mention the install subcommand."""
         buf = io.StringIO()
         test_console = Console(file=buf, highlight=False, width=200)
         with patch("deepagents_code.ui.console", test_console):
             show_help()
-        assert "dcode extras" in buf.getvalue()
+        assert "dcode install" in buf.getvalue()
 
     def test_show_help_includes_stdin(self) -> None:
         """show_help should mention --stdin."""

--- a/libs/code/tests/unit_tests/test_agent_friendly.py
+++ b/libs/code/tests/unit_tests/test_agent_friendly.py
@@ -577,6 +577,14 @@ class TestHelpScreenDriftExtended:
             show_help()
         assert "dcode tools" in buf.getvalue()
 
+    def test_show_help_includes_extras_subcommand(self) -> None:
+        """show_help should mention the extras subcommand."""
+        buf = io.StringIO()
+        test_console = Console(file=buf, highlight=False, width=200)
+        with patch("deepagents_code.ui.console", test_console):
+            show_help()
+        assert "dcode extras" in buf.getvalue()
+
     def test_show_help_includes_stdin(self) -> None:
         """show_help should mention --stdin."""
         buf = io.StringIO()

--- a/libs/code/tests/unit_tests/test_extras_info.py
+++ b/libs/code/tests/unit_tests/test_extras_info.py
@@ -335,7 +335,7 @@ def test_extras_taxonomy_covers_pyproject() -> None:
 def test_known_extras_is_union_of_categories() -> None:
     """`KNOWN_EXTRAS` must be the union of the three category frozensets.
 
-    `dcode extras install <extra>` and `/install <extra>` consult `KNOWN_EXTRAS`
+    `dcode install <extra>` and `/install <extra>` consult `KNOWN_EXTRAS`
     to decide whether to prompt for confirmation on unknown values, so this
     set has to stay aligned with the taxonomy or callers will see spurious
     prompts for real extras.

--- a/libs/code/tests/unit_tests/test_extras_info.py
+++ b/libs/code/tests/unit_tests/test_extras_info.py
@@ -335,7 +335,7 @@ def test_extras_taxonomy_covers_pyproject() -> None:
 def test_known_extras_is_union_of_categories() -> None:
     """`KNOWN_EXTRAS` must be the union of the three category frozensets.
 
-    `dcode --install <extra>` and `/install <extra>` consult `KNOWN_EXTRAS`
+    `dcode extras install <extra>` and `/install <extra>` consult `KNOWN_EXTRAS`
     to decide whether to prompt for confirmation on unknown values, so this
     set has to stay aligned with the taxonomy or callers will see spurious
     prompts for real extras.

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -485,7 +485,7 @@ class TestVerifySandboxDeps:
             pytest.raises(
                 ImportError,
                 match=rf"Missing dependencies for '{provider}' sandbox.*"
-                rf"/install {provider}.*dcode --install {provider}",
+                rf"/install {provider}.*dcode extras install {provider}",
             ),
         ):
             verify_sandbox_deps(provider)

--- a/libs/code/tests/unit_tests/test_sandbox_factory.py
+++ b/libs/code/tests/unit_tests/test_sandbox_factory.py
@@ -485,7 +485,7 @@ class TestVerifySandboxDeps:
             pytest.raises(
                 ImportError,
                 match=rf"Missing dependencies for '{provider}' sandbox.*"
-                rf"/install {provider}.*dcode extras install {provider}",
+                rf"/install {provider}.*dcode install {provider}",
             ),
         ):
             verify_sandbox_deps(provider)

--- a/libs/code/tests/unit_tests/test_sandbox_provider.py
+++ b/libs/code/tests/unit_tests/test_sandbox_provider.py
@@ -19,9 +19,9 @@ if TYPE_CHECKING:
     ("kind", "in_app", "expected"),
     [
         ("extra", True, "/install daytona"),
-        ("extra", False, "dcode extras install daytona"),
+        ("extra", False, "dcode install daytona"),
         ("package", True, "/install daytona --package"),
-        ("package", False, "dcode extras install daytona --package"),
+        ("package", False, "dcode install daytona --package"),
     ],
 )
 def test_install_hint_command(

--- a/libs/code/tests/unit_tests/test_sandbox_provider.py
+++ b/libs/code/tests/unit_tests/test_sandbox_provider.py
@@ -19,9 +19,9 @@ if TYPE_CHECKING:
     ("kind", "in_app", "expected"),
     [
         ("extra", True, "/install daytona"),
-        ("extra", False, "dcode --install daytona"),
+        ("extra", False, "dcode extras install daytona"),
         ("package", True, "/install daytona --package"),
-        ("package", False, "dcode --install daytona --package"),
+        ("package", False, "dcode extras install daytona --package"),
     ],
 )
 def test_install_hint_command(

--- a/libs/code/tests/unit_tests/test_sandbox_registry.py
+++ b/libs/code/tests/unit_tests/test_sandbox_registry.py
@@ -123,7 +123,7 @@ def test_builtin_metadata_working_dir() -> None:
     assert vercel.supports_sandbox_id is True
     assert vercel.supports_snapshot_name is False
     assert vercel.install is not None
-    assert vercel.install.command(in_app=False) == "dcode extras install vercel"
+    assert vercel.install.command(in_app=False) == "dcode install vercel"
 
 
 def test_unknown_provider_metadata_is_none() -> None:

--- a/libs/code/tests/unit_tests/test_sandbox_registry.py
+++ b/libs/code/tests/unit_tests/test_sandbox_registry.py
@@ -123,7 +123,7 @@ def test_builtin_metadata_working_dir() -> None:
     assert vercel.supports_sandbox_id is True
     assert vercel.supports_snapshot_name is False
     assert vercel.install is not None
-    assert vercel.install.command(in_app=False) == "dcode --install vercel"
+    assert vercel.install.command(in_app=False) == "dcode extras install vercel"
 
 
 def test_unknown_provider_metadata_is_none() -> None:


### PR DESCRIPTION
You can install optional Deep Agents Code extras with a short CLI path that matches the in-session command:

```bash
dcode install daytona
dcode install fireworks
dcode install langchain-custom --package --yes
```

Previously this was only available as a global action flag (`dcode --install …`), which diverged from how management actions are normally expressed as subcommands and from the in-session `/install` muscle memory.

`dcode --install` remains as a compatible alias. Recovery hints and help now promote `dcode install`.

---

Adds `dcode install NAME` as the preferred way to add optional providers/sandbox extras. The install implementation is shared so the legacy flag path and new subcommand stay behaviorally identical. Distinct from `dcode tools install`, which provisions managed host binaries such as ripgrep.
