### PR TITLE
fix(code): offload server graph bootstrap cwd calls off the event loop

### DIFF
--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -196,19 +196,50 @@ async def _make_graph() -> Any:  # noqa: ANN401
         Compiled LangGraph agent graph.
     """
     config = ServerConfig.from_env()
-    project_context = get_server_project_context()
 
-    from deepagents_code.agent import create_cli_agent, load_async_subagents
-    from deepagents_code.config import (
-        configure_langsmith_secret_redaction,
+    # Offload cwd/path resolution and the lazy settings bootstrap off the event
+    # loop. On Windows, `Path.resolve()` / `Path.cwd()` call `os.getcwd()`, which
+    # `blockbuster` rejects when invoked directly from the server loop (see
+    # issue #5043). Importing `deepagents_code.agent` / first `settings` access
+    # can also trigger `find_project_root()` -> `Path.cwd()`.
+    def _resolve_project_context_and_settings() -> tuple[
+        ProjectContext | None,
+        Any,
+        Any,
+        Any,
+        Any,
+        Any,
+    ]:
+        project_context = get_server_project_context()
+
+        from deepagents_code.agent import create_cli_agent, load_async_subagents
+        from deepagents_code.config import (
+            configure_langsmith_secret_redaction,
+            create_model,
+            is_memory_auto_save_enabled,
+            settings,
+        )
+
+        if project_context is not None:
+            settings.reload_from_environment(start_path=project_context.user_cwd)
+        configure_langsmith_secret_redaction()
+        return (
+            project_context,
+            create_cli_agent,
+            load_async_subagents,
+            create_model,
+            is_memory_auto_save_enabled,
+            settings,
+        )
+
+    (
+        project_context,
+        create_cli_agent,
+        load_async_subagents,
         create_model,
         is_memory_auto_save_enabled,
         settings,
-    )
-
-    if project_context is not None:
-        settings.reload_from_environment(start_path=project_context.user_cwd)
-    configure_langsmith_secret_redaction()
+    ) = await asyncio.to_thread(_resolve_project_context_and_settings)
 
     # Offload to a worker thread: `create_model` does blocking disk IO for some
     # providers (e.g. the `openai_codex` token store currently acquires a file

--- a/libs/code/deepagents_code/server_graph.py
+++ b/libs/code/deepagents_code/server_graph.py
@@ -202,8 +202,16 @@ async def _make_graph() -> Any:  # noqa: ANN401
     # `blockbuster` rejects when invoked directly from the server loop (see
     # issue #5043). Importing `deepagents_code.agent` / first `settings` access
     # can also trigger `find_project_root()` -> `Path.cwd()`.
+    #
+    # Keep LangSmith redaction configuration on the server task: its fail-closed
+    # path calls `langsmith.configure(enabled=False)`, which sets both a global
+    # fallback and the current `_TRACING_ENABLED` ContextVar. `asyncio.to_thread`
+    # only updates a copied worker context, so a ContextVar disable there would
+    # not reach a parent tracing context that already has `enabled=True` (ContextVar
+    # wins over the global flag).
     def _resolve_project_context_and_settings() -> tuple[
         ProjectContext | None,
+        Any,
         Any,
         Any,
         Any,
@@ -222,7 +230,6 @@ async def _make_graph() -> Any:  # noqa: ANN401
 
         if project_context is not None:
             settings.reload_from_environment(start_path=project_context.user_cwd)
-        configure_langsmith_secret_redaction()
         return (
             project_context,
             create_cli_agent,
@@ -230,6 +237,7 @@ async def _make_graph() -> Any:  # noqa: ANN401
             create_model,
             is_memory_auto_save_enabled,
             settings,
+            configure_langsmith_secret_redaction,
         )
 
     (
@@ -239,7 +247,9 @@ async def _make_graph() -> Any:  # noqa: ANN401
         create_model,
         is_memory_auto_save_enabled,
         settings,
+        configure_langsmith_secret_redaction,
     ) = await asyncio.to_thread(_resolve_project_context_and_settings)
+    configure_langsmith_secret_redaction()
 
     # Offload to a worker thread: `create_model` does blocking disk IO for some
     # providers (e.g. the `openai_codex` token store currently acquires a file

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -146,6 +146,7 @@ class TestServerGraph:
         create_cli_agent_thread_ids: list[int] = []
         create_model_thread_ids: list[int] = []
         setup_thread_ids: list[int] = []
+        redaction_thread_ids: list[int] = []
         repository_backend = object()
         user_cwd = object()
         project_context = SimpleNamespace(user_cwd=user_cwd, project_root=object())
@@ -170,6 +171,9 @@ class TestServerGraph:
             assert kwargs.get("start_path") is user_cwd
             return []
 
+        def configure_redaction_side_effect() -> None:
+            redaction_thread_ids.append(threading.get_ident())
+
         reload_from_environment.side_effect = reload_from_environment_side_effect
 
         create_cli_agent = MagicMock(side_effect=create_cli_agent_side_effect)
@@ -184,9 +188,7 @@ class TestServerGraph:
             model=model_obj,
             apply_to_settings=MagicMock(),
         )
-        configure_redaction = MagicMock(
-            side_effect=lambda: setup_thread_ids.append(threading.get_ident())
-        )
+        configure_redaction = MagicMock(side_effect=configure_redaction_side_effect)
         create_model = MagicMock(side_effect=create_model_side_effect)
         config_module = _module_with_attrs(
             "deepagents_code.config",
@@ -274,6 +276,10 @@ class TestServerGraph:
         # `Path.cwd()`, which `blockbuster` rejects on the server event loop.
         assert setup_thread_ids
         assert all(thread_id != loop_thread_id for thread_id in setup_thread_ids)
+        # Redaction fail-closed must run on the server task so
+        # `configure(enabled=False)` updates this task's tracing ContextVar,
+        # not only a worker-thread copy left behind by `asyncio.to_thread`.
+        assert redaction_thread_ids == [loop_thread_id]
         # `create_model` must run off the loop thread: it does blocking disk IO
         # for some providers (e.g. the `openai_codex` token store calls
         # `os.mkdir`), which `blockbuster` rejects on the server event loop.

--- a/libs/code/tests/unit_tests/test_server_graph.py
+++ b/libs/code/tests/unit_tests/test_server_graph.py
@@ -145,7 +145,11 @@ class TestServerGraph:
         loop_thread_id = threading.get_ident()
         create_cli_agent_thread_ids: list[int] = []
         create_model_thread_ids: list[int] = []
+        setup_thread_ids: list[int] = []
         repository_backend = object()
+        user_cwd = object()
+        project_context = SimpleNamespace(user_cwd=user_cwd, project_root=object())
+        reload_from_environment = MagicMock()
 
         def create_cli_agent_side_effect(**_: object) -> tuple[object, object]:
             create_cli_agent_thread_ids.append(threading.get_ident())
@@ -154,6 +158,19 @@ class TestServerGraph:
         def create_model_side_effect(*_: object, **__: object) -> object:
             create_model_thread_ids.append(threading.get_ident())
             return model_result
+
+        def get_server_project_context_side_effect(*_: object, **__: object) -> object:
+            setup_thread_ids.append(threading.get_ident())
+            return project_context
+
+        def reload_from_environment_side_effect(
+            *_: object, **kwargs: object
+        ) -> list[str]:
+            setup_thread_ids.append(threading.get_ident())
+            assert kwargs.get("start_path") is user_cwd
+            return []
+
+        reload_from_environment.side_effect = reload_from_environment_side_effect
 
         create_cli_agent = MagicMock(side_effect=create_cli_agent_side_effect)
         agent_module = _module_with_attrs(
@@ -167,7 +184,9 @@ class TestServerGraph:
             model=model_obj,
             apply_to_settings=MagicMock(),
         )
-        configure_redaction = MagicMock()
+        configure_redaction = MagicMock(
+            side_effect=lambda: setup_thread_ids.append(threading.get_ident())
+        )
         create_model = MagicMock(side_effect=create_model_side_effect)
         config_module = _module_with_attrs(
             "deepagents_code.config",
@@ -176,7 +195,7 @@ class TestServerGraph:
             is_memory_auto_save_enabled=MagicMock(return_value=True),
             settings=SimpleNamespace(
                 has_tavily=True,
-                reload_from_environment=MagicMock(),
+                reload_from_environment=reload_from_environment,
             ),
         )
 
@@ -226,7 +245,11 @@ class TestServerGraph:
             ),
             patch(
                 "deepagents_code.project_utils.get_server_project_context",
-                return_value=None,
+                side_effect=get_server_project_context_side_effect,
+            ),
+            patch(
+                "deepagents_code.plugins.adapters.mcp.discover_plugin_mcp_configs",
+                return_value=(),
             ),
         ):
             for suffix in (
@@ -242,9 +265,15 @@ class TestServerGraph:
             assert await module.make_graph() is graph_obj
 
         configure_redaction.assert_called_once_with()
+        reload_from_environment.assert_called_once_with(start_path=user_cwd)
         resolve_mcp_tools.assert_awaited_once()
         assert create_cli_agent_thread_ids
         assert create_cli_agent_thread_ids[0] != loop_thread_id
+        # Project-context resolution and the settings bootstrap must run off the
+        # loop: on Windows they call `os.getcwd()` via `Path.resolve()` /
+        # `Path.cwd()`, which `blockbuster` rejects on the server event loop.
+        assert setup_thread_ids
+        assert all(thread_id != loop_thread_id for thread_id in setup_thread_ids)
         # `create_model` must run off the loop thread: it does blocking disk IO
         # for some providers (e.g. the `openai_codex` token store calls
         # `os.mkdir`), which `blockbuster` rejects on the server event loop.
@@ -257,7 +286,7 @@ class TestServerGraph:
         assert kwargs["explicit_config_path"] is None
         assert kwargs["no_mcp"] is False
         assert kwargs["trust_project_mcp"] is None
-        assert kwargs["project_context"] is None
+        assert kwargs["project_context"] is project_context
         assert kwargs["stateless"] is True
         assert isinstance(kwargs["session_manager"], FakeSessionManager)
         create_cli_agent.assert_called_once_with(
@@ -284,8 +313,8 @@ class TestServerGraph:
             rubric_max_iterations=None,
             recursion_limit=None,
             mcp_server_info=mcp_server_info,
-            cwd=None,
-            project_context=None,
+            cwd=user_cwd,
+            project_context=project_context,
             async_subagents=None,
             goal_criteria_tools=[fetch_tool, web_tool, mcp_tool],
             rubric_grader_tools=[fetch_tool, web_tool, mcp_tool],


### PR DESCRIPTION
Closes #5043

On Windows, starting `dcode` after credentials resolve no longer aborts with `BlockingError: Blocking call to os.getcwd` during server graph readiness. Graph bootstrap now finishes and the agent run continues normally.

---

Once a provider key is available, the server graph factory was still doing path/cwd work directly on LangGraph's async loop: resolving the project context, importing settings (which can walk for a project root), and reloading dotenv from that path. On Windows those paths call `os.getcwd()` inside `Path.resolve()` / `Path.cwd()`, and blockbuster rejects that on the server loop, so readiness fails with 500 before the model can run.

This is separate from the earlier `filelock` 3.30 cwd issue — same error class, different call chain after credentials succeed.

The bootstrap setup now follows the same off-loop pattern already used for `create_model` and `create_cli_agent`. Unit coverage asserts the project-context / settings steps run on a worker thread.