### PR TITLE
fix(code): drop redundant `/restart` hint from restart prompt

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/restart_prompt.py
+++ b/libs/code/deepagents_code/tui/widgets/restart_prompt.py
@@ -80,7 +80,7 @@ class RestartPromptScreen(ModalScreen[RestartChoice]):
     }
     """
 
-    _DEFAULT_BODY = "Restart the server to load it now, or defer with `/restart`."
+    _DEFAULT_BODY = "Restart the server to load it now."
 
     def __init__(
         self,


### PR DESCRIPTION
The post-install restart prompt already tells the user "Enter to restart, Esc to defer", so the body line's ", or defer with `/restart`" was redundant/confusing. This trims the default body to just "Restart the server to load it now."

Made by [Open SWE](https://openswe.vercel.app/agents/06c3fe48-99a5-50e8-eeba-ae3b65ab8949)