### PR TITLE
ci(infra): emphasize required SDK pin acknowledgement

### DIFF
--- a/.github/workflows/check_sdk_pin.yml
+++ b/.github/workflows/check_sdk_pin.yml
@@ -171,7 +171,7 @@ jobs:
                 '>',
                 '> A prerelease pin is valid only when it is not older than the workspace SDK, but it still needs an explicit merge acknowledgement.',
                 '>',
-                `> **Required:** add the \`${releaseDepsBypassLabel}\` label before merging to acknowledge this pin. That label records the review decision and skips the release dependency / freshness checks that commonly fail when the pinned SDK is not on PyPI yet (for example during an intentional cross-package release sequence).`,
+                `> 🚨 **Required:** add the \`${releaseDepsBypassLabel}\` label before merging to acknowledge this pin. That label records the review decision and skips the release dependency / freshness checks that commonly fail when the pinned SDK is not on PyPI yet (for example during an intentional cross-package release sequence).`,
               ].join('\n');
               warning = `${pkgLabel} pins prerelease SDK deepagents==${pkgPin}; add ${releaseDepsBypassLabel} to acknowledge before merging.`;
               fail = true;


### PR DESCRIPTION
Make the prerelease SDK pin acknowledgement requirement stand out more clearly in the sticky PR comment by prefixing the required-label line with 🚨.

---

When `check_sdk_pin` warns that a package pins a prerelease SDK, reviewers still need to add the bypass label before merge. The required step was easy to miss in the existing notice copy.