### PR TITLE
style(code): render collapsed expand hints as dim italic

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/messages.py
+++ b/libs/code/deepagents_code/tui/widgets/messages.py
@@ -1016,7 +1016,7 @@ class SkillMessage(Vertical):
                     Content.styled(
                         f"{ellipsis} {remaining} more lines"
                         " — click or Ctrl+O to expand",
-                        "dim",
+                        "dim italic",
                     )
                 )
         else:
@@ -1083,7 +1083,7 @@ class SkillMessage(Vertical):
             self._hint_widget.update(
                 Content.styled(
                     f"{ellipsis} {remaining} more lines — click or Ctrl+O to expand",
-                    "dim",
+                    "dim italic",
                 )
             )
 
@@ -3021,7 +3021,7 @@ class ToolCallMessage(Vertical):
                 ellipsis = get_glyphs().ellipsis
                 self._hint_widget.update(
                     Content.styled(
-                        f"{ellipsis} {self._output_hint_keys()} to expand", "dim"
+                        f"{ellipsis} {self._output_hint_keys()} to expand", "dim italic"
                     )
                 )
                 self._hint_widget.display = True
@@ -3048,7 +3048,7 @@ class ToolCallMessage(Vertical):
                     Content.styled(
                         f"{ellipsis} {result.truncation} — "
                         f"{self._output_hint_keys()} to expand",
-                        "dim",
+                        "dim italic",
                     )
                 )
                 self._hint_widget.display = True

--- a/libs/code/tests/unit_tests/tui/widgets/test_messages.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_messages.py
@@ -1577,6 +1577,37 @@ class TestToolCallMessageExpandHint:
             collapsed = app.msg._hint_widget._Static__content
             assert "collapse" in collapsed.plain
 
+    async def test_expand_and_collapse_hints_share_dim_italic_style(self) -> None:
+        """Expand and collapse hints must both render dim italic.
+
+        Every "click or Ctrl+O" affordance in this module is dim italic; the
+        collapsed expand hint must not drop the italic the collapse hint uses.
+        """
+        output = "\n".join(f"file.py:{index}:hit {index}" for index in range(8))
+        assert output.count("\n") + 1 > ToolCallMessage._PREVIEW_LINES
+
+        app = _tool_msg_app("grep", {"pattern": "hit"})
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.msg.set_success(output)
+            await pilot.pause()
+
+            assert app.msg._hint_widget is not None
+            expand_hint = app.msg._hint_widget._Static__content  # ty: ignore[unresolved-attribute]
+            assert "expand" in expand_hint.plain
+            expand_style = str(expand_hint._spans[0].style)
+            assert "italic" in expand_style
+            assert "dim" in expand_style
+
+            app.msg.toggle_output()
+            await pilot.pause()
+
+            collapse_hint = app.msg._hint_widget._Static__content  # ty: ignore[unresolved-attribute]
+            assert "collapse" in collapse_hint.plain
+            collapse_style = str(collapse_hint._spans[0].style)
+            assert "italic" in collapse_style
+            assert "dim" in collapse_style
+
     async def test_short_non_todo_output_renders_full_without_hint(self) -> None:
         """Short non-todo output uses non-preview formatting and shows no hint.
 


### PR DESCRIPTION
Collapsed "click or Ctrl+O to expand" hints in the `deepagents-code` transcript now render as dim italic, matching the collapse, command/code-block, task-description, and user-message hints.

---

In the `messages` TUI module every "click or Ctrl+O" affordance is meant to be dim italic (see `_hint_style()` and the `UserMessage` CSS comment), but four collapsed-state expand hints — the tool-output "expand" hint (count-free and truncated variants) and the skill-body "N more lines" hint — were styled plain `dim`, dropping the italic. That left a grep/output expand hint visually inconsistent with the italic command hint shown right next to it. This makes all four dim italic and adds a unit test asserting the expand and collapse hints share the dim italic style.

Made by [Open SWE](https://openswe.vercel.app/agents/6f3a21a4-0606-98ac-3b69-d334582bde7b)