### PR TITLE
style(code): clarify Auto classifier timeout messaging

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -16921,8 +16921,8 @@ class DeepAgentsApp(App):
             text = f"Auto denied [{event.get('category', 'policy')}]: {reason}"
         elif kind == "unavailable":
             # Reason is a short cause fragment from the server; keep the UI
-            # line outcome-focused so the blocked action is obvious.
-            text = f"Auto classifier unavailable: {reason} (action blocked)"
+            # line outcome-focused so fail-closed denial is obvious.
+            text = f"Auto classifier unavailable: {reason} — tool not executed"
         else:
             text = f"Auto warning: {reason}"
         await self._mount_message(AppMessage(text))

--- a/libs/code/deepagents_code/auto_mode.py
+++ b/libs/code/deepagents_code/auto_mode.py
@@ -506,9 +506,10 @@ def classifier_unavailable_reason(exc: BaseException, *, timeout_seconds: float)
 
     Provider exception text stays out of the reason (it can carry secrets or
     noisy HTML). Only real local deadline expiry
-    (`_ClassifierDeadlineExceededError`) includes the configured wait budget; a
-    bare provider `TimeoutError` stays type-only so we do not claim dcode's
-    deadline fired when the model failed first.
+    (`_ClassifierDeadlineExceededError`) says the classifier did not respond
+    within the configured wait budget; a bare provider `TimeoutError` stays
+    type-only so we do not claim dcode's deadline fired when the model failed
+    first.
 
     Args:
         exc: Failure raised while invoking or validating the classifier.
@@ -518,7 +519,7 @@ def classifier_unavailable_reason(exc: BaseException, *, timeout_seconds: float)
         Compact single-line reason for tool messages and TUI events.
     """
     if isinstance(exc, _ClassifierDeadlineExceededError):
-        return f"no decision within Auto's {timeout_seconds:g}s limit"
+        return f"classifier did not respond within {timeout_seconds:g}s"
     return f"failed ({type(exc).__name__})"
 
 

--- a/libs/code/tests/unit_tests/test_auto_mode.py
+++ b/libs/code/tests/unit_tests/test_auto_mode.py
@@ -2902,13 +2902,13 @@ def test_classifier_unavailable_reason_specializes_timeouts() -> None:
         classifier_unavailable_reason(
             _ClassifierDeadlineExceededError(20.0), timeout_seconds=20.0
         )
-        == "no decision within Auto's 20s limit"
+        == "classifier did not respond within 20s"
     )
     assert (
         classifier_unavailable_reason(
             _ClassifierDeadlineExceededError(1.5), timeout_seconds=1.5
         )
-        == "no decision within Auto's 1.5s limit"
+        == "classifier did not respond within 1.5s"
     )
     # Provider exception type alone must not claim dcode's deadline fired.
     assert (
@@ -2955,7 +2955,7 @@ async def test_classifier_timeout_reports_configured_limit(tmp_path: Path) -> No
     )
 
     assert plan["decisions"][0]["disposition"] == "classifier_unavailable"
-    assert plan["decisions"][0]["reason"] == "no decision within Auto's 0.05s limit"
+    assert plan["decisions"][0]["reason"] == "classifier did not respond within 0.05s"
 
 
 async def test_classifier_provider_timeout_stays_type_only(tmp_path: Path) -> None:
@@ -3490,7 +3490,7 @@ async def test_classifier_unavailable_emits_single_event_for_batch(
         store=store,
         stream_writer=events.append,
     )
-    reason = "no decision within Auto's 1s limit"
+    reason = "classifier did not respond within 1s"
     plan = {
         "batch_id": _batch_id(ai_message.tool_calls),
         "thread_key": key,


### PR DESCRIPTION
When Auto times out waiting on its classifier, the transcript now says the classifier did not respond within the limit and that the tool was not executed, instead of the vaguer "no decision" / "action blocked" wording.

---

Only the local Auto deadline path gets the specific "did not respond" reason. Other classifier failures stay type-only (`failed (TimeoutError)`), so we still do not imply dcode's budget fired when the provider failed first.