### PR TITLE
chore(code): raise dependency minimums

### DIFF
--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
     # Core model providers - others are added as optional
     "langchain-anthropic>=1.5.2,<2.0.0",
-    "langchain-google-genai>=4.3.1,<5.0.0",
+    "langchain-google-genai>=4.3.2,<5.0.0",
     "langchain-openai>=1.4.1,<2.0.0",
     "pydantic>=2.12.5,<2.14.0a0",
 
@@ -49,7 +49,7 @@ dependencies = [
     "textual>=8.2.8,<9.0.0",
     "textual-autocomplete>=4.0.6,<5.0.0",
     "textual-speedups>=0.2.1,<1.0.0",
-    "prompt-toolkit>=3.0.52,<4.0.0",
+    "prompt-toolkit>=3.0.53,<4.0.0",
     "rich>=15.0.0,<16.0.0",
     "markdownify>=1.2.3,<2.0.0",
 
@@ -58,7 +58,7 @@ dependencies = [
 
     # Tools
     "tavily-python>=0.7.26,<1.0.0",
-    "langchain-quickjs>=0.3.3,<0.4.0",
+    "langchain-quickjs>=0.3.4,<0.4.0",
 
     # Clipboard
     "pyperclip>=1.11.0,<2.0.0",
@@ -95,12 +95,12 @@ dependencies = [
 [project.optional-dependencies]
 # Model providers
 anthropic = ["langchain-anthropic>=1.5.2,<2.0.0"]
-baseten = ["langchain-baseten>=0.2.1,<1.0.0"]
+baseten = ["langchain-baseten>=0.2.3,<1.0.0"]
 bedrock = ["langchain-aws>=1.6.3,<2.0.0"]
 cohere = ["langchain-cohere>=0.6.0,<1.0.0"]
 deepseek = ["langchain-deepseek>=1.1.0,<2.0.0"]
-fireworks = ["langchain-fireworks>=1.5.1,<2.0.0"]
-google-genai = ["langchain-google-genai>=4.3.1,<5.0.0"]
+fireworks = ["langchain-fireworks>=1.5.2,<2.0.0"]
+google-genai = ["langchain-google-genai>=4.3.2,<5.0.0"]
 groq = ["langchain-groq>=1.1.3,<2.0.0"]
 huggingface = ["langchain-huggingface>=1.2.2,<2.0.0"]
 ibm = ["langchain-ibm>=1.1.0,<2.0.0"]

--- a/libs/code/uv.lock
+++ b/libs/code/uv.lock
@@ -1306,13 +1306,13 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.5.2,<2.0.0" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'", specifier = ">=1.5.2,<2.0.0" },
     { name = "langchain-aws", marker = "extra == 'bedrock'", specifier = ">=1.6.3,<2.0.0" },
-    { name = "langchain-baseten", marker = "extra == 'baseten'", specifier = ">=0.2.1,<1.0.0" },
+    { name = "langchain-baseten", marker = "extra == 'baseten'", specifier = ">=0.2.3,<1.0.0" },
     { name = "langchain-cohere", marker = "extra == 'cohere'", specifier = ">=0.6.0,<1.0.0" },
     { name = "langchain-daytona", marker = "extra == 'daytona'", editable = "../partners/daytona" },
     { name = "langchain-deepseek", marker = "extra == 'deepseek'", specifier = ">=1.1.0,<2.0.0" },
-    { name = "langchain-fireworks", marker = "extra == 'fireworks'", specifier = ">=1.5.1,<2.0.0" },
-    { name = "langchain-google-genai", specifier = ">=4.3.1,<5.0.0" },
-    { name = "langchain-google-genai", marker = "extra == 'google-genai'", specifier = ">=4.3.1,<5.0.0" },
+    { name = "langchain-fireworks", marker = "extra == 'fireworks'", specifier = ">=1.5.2,<2.0.0" },
+    { name = "langchain-google-genai", specifier = ">=4.3.2,<5.0.0" },
+    { name = "langchain-google-genai", marker = "extra == 'google-genai'", specifier = ">=4.3.2,<5.0.0" },
     { name = "langchain-google-vertexai", marker = "extra == 'vertex'", specifier = ">=3.2.4,<4.0.0" },
     { name = "langchain-groq", marker = "extra == 'groq'", specifier = ">=1.1.3,<2.0.0" },
     { name = "langchain-huggingface", marker = "extra == 'huggingface'", specifier = ">=1.2.2,<2.0.0" },
@@ -1343,7 +1343,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=26.2" },
     { name = "pillow", specifier = ">=12.3.0,<13.0.0" },
     { name = "pillow", marker = "extra == 'media'", specifier = ">=12.3.0,<13.0.0" },
-    { name = "prompt-toolkit", specifier = ">=3.0.52,<4.0.0" },
+    { name = "prompt-toolkit", specifier = ">=3.0.53,<4.0.0" },
     { name = "pydantic", specifier = ">=2.12.5,<2.14.0a0" },
     { name = "pyperclip", specifier = ">=1.11.0,<2.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.2,<2.0.0" },
@@ -2719,16 +2719,16 @@ wheels = [
 
 [[package]]
 name = "langchain-baseten"
-version = "0.2.1"
+version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "baseten-performance-client" },
     { name = "langchain-core" },
     { name = "langchain-openai" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/bc/2936168d7152835a00cd42d31115983e3390b99f5c18a0c53d1eb8122666/langchain_baseten-0.2.1.tar.gz", hash = "sha256:03175a26df9e91d49cbef4e9559be11918c56a4fda83fcef9fb2168b30279e59", size = 150249, upload-time = "2026-06-26T20:22:31.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/6b/e18045117bd59d055bcb5b9586009dfc6d03974511ae567f2133c25d92c1/langchain_baseten-0.2.3.tar.gz", hash = "sha256:3d15f3ba78e294ddc027c45aa841683418d52c3f1e59a08bde0b33e45ab2cdc4", size = 156745, upload-time = "2026-07-27T16:33:30.277Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/43/5c109d82a130c8409c13923ad06c57155d2acdc14c8540edf6dab94fb3a1/langchain_baseten-0.2.1-py3-none-any.whl", hash = "sha256:8524da321e2d142577e7ddadd1fdb06605952df2c31930344e6fc67232173d1f", size = 14156, upload-time = "2026-06-26T20:22:30.525Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9b/a794392ec17b4e4f96d25e4b1f003408bc42d447e69562b3f800d15ac107/langchain_baseten-0.2.3-py3-none-any.whl", hash = "sha256:7bc64ed9f08bf5d0ccbb0d89ccb6c552241fc478ed35e701d07dec836936dcbc", size = 14349, upload-time = "2026-07-27T16:33:29.38Z" },
 ]
 
 [[package]]
@@ -2809,7 +2809,7 @@ wheels = [
 
 [[package]]
 name = "langchain-fireworks"
-version = "1.5.1"
+version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2818,14 +2818,14 @@ dependencies = [
     { name = "openai" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/43/5240a1609427c6258f4fcabac58cf5aafc87d8ebed56158326fa6e80b415/langchain_fireworks-1.5.1.tar.gz", hash = "sha256:669857834d33c665f4c8aa4e5ffaa7ef6abd5c1860aaca15fabeb617b4e00144", size = 220136, upload-time = "2026-07-23T20:28:31.783Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/e3/a74d812d0bad28c247dae65a7494a1afaad4045f70c3ac5bc228a92776d9/langchain_fireworks-1.5.2.tar.gz", hash = "sha256:3b3c75d612269a211d5beb393d4e2be15154d05968576b22165e11aaaab202d7", size = 220256, upload-time = "2026-07-27T16:59:32.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/58/dd0f3b799baa923aca946fcb1b85a75a9b0828fa3dfedc315444fa3177b2/langchain_fireworks-1.5.1-py3-none-any.whl", hash = "sha256:58e501cc0215323a9c449ba1fbb5885ce950044f9bf0a46ef36852e4f501e2e6", size = 26863, upload-time = "2026-07-23T20:28:30.759Z" },
+    { url = "https://files.pythonhosted.org/packages/66/5f/56391a9a9cdfa162abb5972680b2e2a62bbf760f8bfd4089cea9658d2ce5/langchain_fireworks-1.5.2-py3-none-any.whl", hash = "sha256:26cdaa0966ab952f7fb5f2b66ae0f91a81d8966870aaa151250db97841ecd91b", size = 26903, upload-time = "2026-07-27T16:59:31.966Z" },
 ]
 
 [[package]]
 name = "langchain-google-genai"
-version = "4.3.1"
+version = "4.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filetype" },
@@ -2833,9 +2833,9 @@ dependencies = [
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/b7/793ef6c8894f6c6e6946fcf95c59644341e0307f21490b33645fec0ac56d/langchain_google_genai-4.3.1.tar.gz", hash = "sha256:623cd4329f6a3e4e0397ccacc6fa355728362572688ff9a8e522bf21519e9964", size = 285426, upload-time = "2026-07-21T22:14:43.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/2f/e03b63ad3a61fd1aa479bbc0f3df5d27abb8f9159d111cba96629df844ef/langchain_google_genai-4.3.2.tar.gz", hash = "sha256:6471769a4463fedb10d2d19a9b56c31de1cde505edf7fffd8cdbf98af8c1d7da", size = 286018, upload-time = "2026-07-27T16:27:39.214Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/cf/d6c81ba35c27c24af754f36943100b78ddc922594d23d82a9bd8d1334bad/langchain_google_genai-4.3.1-py3-none-any.whl", hash = "sha256:0ebec25bfa62e75a65561b92fde5bdf8d87618bdda9371afe57d6b86bbb9cda8", size = 72170, upload-time = "2026-07-21T22:14:42.032Z" },
+    { url = "https://files.pythonhosted.org/packages/01/cb/4a2eb187b108a240d57cf8dcf67e818ca75365f769444bf5716e2823cd98/langchain_google_genai-4.3.2-py3-none-any.whl", hash = "sha256:f3b1c09b264612fd1735a9590987bfa0cccca0bc0111691543decb5a03b8667d", size = 72770, upload-time = "2026-07-27T16:27:38.052Z" },
 ]
 
 [[package]]
@@ -4674,14 +4674,14 @@ wheels = [
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.52"
+version = "3.0.53"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Raise minimum versions for Deep Agents Code dependencies that have newer stable releases inside their existing upper bounds, and refresh the lockfile.

---

Scanned every direct dependency in `libs/code` against PyPI stable releases and raised mins only where a newer stable version still satisfies the current upper bound:

- `langchain-google-genai` `>=4.3.1` → `>=4.3.2`
- `prompt-toolkit` `>=3.0.52` → `>=3.0.53`
- `langchain-quickjs` `>=0.3.3` → `>=0.3.4`
- `langchain-baseten` `>=0.2.1` → `>=0.2.3`
- `langchain-fireworks` `>=1.5.1` → `>=1.5.2`

Everything else was already at the latest stable lower bound.

Left intentionally alone:
- `deepagents==0.7.0b2` exact pin
- `pydantic>=2.12.5` — `fireworks-ai` still requires `pydantic<2.13`, so `>=2.13` breaks the `all-providers` extra
- intentional caps (`filelock<3.30`, `ty<0.0.62`, `twine<7`)

Lockfile updated with targeted `--upgrade-package` only (no global prerelease allow).
