### PR TITLE
feat(code): escape to manual mode in YOLO notice, mode slash commands

### DIFF
--- a/libs/code/COMMANDS.md
+++ b/libs/code/COMMANDS.md
@@ -8,12 +8,13 @@ Regenerate this file with `make commands-catalog` after changing command names,
 aliases, descriptions, visibility, or hidden-command metadata.
 
 
-## Public (34)
+## Public (37)
 
 | Command | Aliases | Description |
 | --- | --- | --- |
 | `/agents` |  | Browse and switch between available agents |
 | `/auth` | `/connect` | Connect and manage provider and service credentials |
+| `/auto` |  | Switch to Auto approval mode |
 | `/auto-update` |  | Turn automatic updates on or off |
 | `/changelog` |  | Open the changelog in a browser |
 | `/clear` |  | Clear the chat and start a new thread |
@@ -26,6 +27,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/goal` |  | Set and manage a persistent objective with acceptance criteria |
 | `/help` |  | Show help and available commands |
 | `/install` |  | Install an optional integration |
+| `/manual` |  | Switch to Manual approval mode |
 | `/mcp` |  | Manage MCP servers and authentication |
 | `/model` |  | Switch models or edit model settings |
 | `/notifications` |  | Configure startup warnings |
@@ -46,6 +48,7 @@ aliases, descriptions, visibility, or hidden-command metadata.
 | `/trace` |  | Open this thread in LangSmith |
 | `/update` |  | Check for and install updates |
 | `/version` | `/about` | Show version information |
+| `/yolo` |  | Switch to YOLO approval mode (no review) |
 
 ## Hidden (2)
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -17159,6 +17159,11 @@ class DeepAgentsApp(App):
         def handle_result(result: YoloModeNoticeResult | None) -> None:
             self._yolo_mode_notice_pending = False
             if result is YoloModeNoticeResult.MANUAL:
+                # Already-Manual is a no-op: skip the live store write so a
+                # failed redundant write cannot flip `_approval_mode_blocked`
+                # and cancel an active run after the user declined YOLO.
+                if self._approval_mode is ApprovalMode.MANUAL:
+                    return
                 task = asyncio.create_task(self._set_approval_mode(ApprovalMode.MANUAL))
                 task.add_done_callback(_log_task_exception)
                 return

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -12400,6 +12400,10 @@ class DeepAgentsApp(App):
             await self._handle_version_command()
         elif cmd == "/agents":
             await self._show_agent_selector()
+        elif cmd in {"/manual", "/auto", "/yolo"}:
+            from deepagents_code.approval_mode import ApprovalMode
+
+            await self._handle_approval_mode_command(ApprovalMode(cmd.lstrip("/")))
         elif cmd == "/goal" or cmd.startswith("/goal "):
             await self._handle_goal_command(command)
         elif cmd in {"/rubric", "/criteria"} or cmd.startswith(
@@ -17088,25 +17092,77 @@ class DeepAgentsApp(App):
                 await self._auto_accept_pending_goal_rubric()
         return True
 
+    async def _handle_approval_mode_command(self, target: ApprovalMode) -> None:
+        """Switch approval mode from a slash command (`/manual`, `/auto`, `/yolo`).
+
+        Mirrors the Shift+Tab switcher: Auto is refused with a sandbox, YOLO
+        honors the `startup.yolo_switcher` policy and prompts the first-run
+        acknowledgement modal before unrestricted mode becomes active. Feedback
+        is delivered via toasts and the status bar, not chat messages, so the
+        command stays quiet like the keybinding.
+
+        Args:
+            target: The approval mode requested by the command.
+        """
+        from deepagents_code.approval_mode import (
+            ApprovalMode,
+            has_yolo_acknowledgement,
+        )
+        from deepagents_code.config import is_yolo_switcher_enabled
+
+        if self._approval_mode is target:
+            self.notify(
+                f"Already in {target.value.capitalize()} mode.",
+                severity="information",
+                markup=False,
+            )
+            return
+
+        if target is ApprovalMode.AUTO and not self._auto_mode_eligible:
+            self._warn_live_approval_mode_unavailable(
+                "Auto is unavailable with a sandbox."
+            )
+            return
+
+        if target is ApprovalMode.YOLO:
+            if not is_yolo_switcher_enabled():
+                self._warn_live_approval_mode_unavailable(
+                    "YOLO is disabled in the approval switcher."
+                )
+                return
+            if not has_yolo_acknowledgement():
+                self._prompt_yolo_switcher_acknowledgement()
+                return
+
+        await self._set_approval_mode(target)
+
     def _prompt_yolo_switcher_acknowledgement(self) -> None:
         """Show the first-run YOLO acknowledgement before entering unrestricted mode.
 
         YOLO stays inactive until Enter persists the acknowledgement and the
-        follow-up mode write succeeds. Esc (or a non-true dismiss) leaves the
-        current mode untouched and does not store the acknowledgement.
+        follow-up mode write succeeds. `m` switches to Manual instead. Esc (or a
+        non-acknowledge dismiss) leaves the current mode untouched and does not
+        store the acknowledgement.
         """
         from deepagents_code.approval_mode import (
             ApprovalMode,
             save_yolo_acknowledgement,
         )
-        from deepagents_code.tui.widgets.yolo_mode_notice import YoloModeNoticeScreen
+        from deepagents_code.tui.widgets.yolo_mode_notice import (
+            YoloModeNoticeResult,
+            YoloModeNoticeScreen,
+        )
 
         if getattr(self, "_yolo_mode_notice_pending", False):
             return
 
-        def handle_result(accepted: bool | None) -> None:
+        def handle_result(result: YoloModeNoticeResult | None) -> None:
             self._yolo_mode_notice_pending = False
-            if accepted is not True:
+            if result is YoloModeNoticeResult.MANUAL:
+                task = asyncio.create_task(self._set_approval_mode(ApprovalMode.MANUAL))
+                task.add_done_callback(_log_task_exception)
+                return
+            if result is not YoloModeNoticeResult.ACKNOWLEDGE:
                 self.notify(
                     "Stayed in the current approval mode.",
                     severity="information",

--- a/libs/code/deepagents_code/command_registry.py
+++ b/libs/code/deepagents_code/command_registry.py
@@ -79,6 +79,24 @@ COMMANDS: tuple[SlashCommand, ...] = (
         hidden_keywords="switch profile persona",
     ),
     SlashCommand(
+        name="/auto",
+        description="Switch to Auto approval mode",
+        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
+        hidden_keywords="approval mode classifier automatic auto-approve shift+tab",
+    ),
+    SlashCommand(
+        name="/manual",
+        description="Switch to Manual approval mode",
+        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
+        hidden_keywords="approval mode approve prompt review shift+tab",
+    ),
+    SlashCommand(
+        name="/yolo",
+        description="Switch to YOLO approval mode (no review)",
+        bypass_tier=BypassTier.SIDE_EFFECT_FREE,
+        hidden_keywords="approval mode unrestricted auto-approve dangerous shift+tab",
+    ),
+    SlashCommand(
         name="/auth",
         description="Connect and manage provider and service credentials",
         bypass_tier=BypassTier.IMMEDIATE_UI,

--- a/libs/code/deepagents_code/tui/widgets/yolo_mode_notice.py
+++ b/libs/code/deepagents_code/tui/widgets/yolo_mode_notice.py
@@ -1,12 +1,14 @@
 """First-enable confirmation modal before Shift+Tab enters YOLO.
 
 Shown when the user cycles into unrestricted YOLO without a persisted
-acknowledgement. Enter acknowledges YOLO and records the policy version; Esc
-keeps the previous approval mode and leaves the acknowledgement unsaved.
+acknowledgement. Enter acknowledges YOLO and records the policy version; `m`
+switches to Manual instead; Esc keeps the previous approval mode. Only Enter
+persists the acknowledgement.
 """
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import TYPE_CHECKING, ClassVar
 
 from textual.binding import Binding, BindingType
@@ -18,6 +20,21 @@ from deepagents_code.tui.widgets._links import open_checked_url_async
 
 if TYPE_CHECKING:
     from textual.app import ComposeResult
+
+
+class YoloModeNoticeResult(StrEnum):
+    """Outcome of the YOLO first-enable notice.
+
+    `ACKNOWLEDGE` enables YOLO (and records the acknowledgement); `MANUAL`
+    switches to Manual instead; `CANCEL` keeps the previous mode. A
+    programmatic dismiss may still yield `None`, which callers treat like
+    `CANCEL` so YOLO is never left active without an explicit acknowledge.
+    """
+
+    ACKNOWLEDGE = "acknowledge"
+    MANUAL = "manual"
+    CANCEL = "cancel"
+
 
 YOLO_MODE_DOCS_URL = (
     "https://docs.langchain.com/oss/python/deepagents/code/approval-modes"
@@ -31,24 +48,27 @@ YOLO_MODE_NOTICE_BODY = (
     "This is **not Auto**. There is **no classifier review** and **no approval "
     "prompt** while YOLO is active. Prefer Auto unless you intend full "
     "unrestricted execution.\n\n"
-    "This notice appears **once** on this machine after you continue. You can "
-    "leave YOLO any time with **Shift+Tab**.\n\n"
+    "This notice appears **once** on this machine after you continue. Press "
+    "**m** to switch to Manual instead, and you can leave YOLO any time with "
+    "**Shift+Tab**.\n\n"
     f"[Learn more about approval modes]({YOLO_MODE_DOCS_URL})"
 )
 """Default Markdown body shown before the first YOLO switcher enable."""
 
 
-class YoloModeNoticeScreen(ModalScreen[bool]):
+class YoloModeNoticeScreen(ModalScreen[YoloModeNoticeResult]):
     """In-TUI acknowledgement shown before unrestricted YOLO becomes active.
 
-    Dismisses with `True` on Enter (acknowledge and enable) and `False` on Esc
-    (keep the previous mode). Programmatic dismiss may yield `None`; callers
-    treat that like cancel so YOLO is never left active without an explicit
-    acknowledge.
+    Dismisses with `YoloModeNoticeResult.ACKNOWLEDGE` on Enter (acknowledge and
+    enable), `YoloModeNoticeResult.MANUAL` on `m` (switch to Manual), and
+    `YoloModeNoticeResult.CANCEL` on Esc (keep the previous mode). Programmatic
+    dismiss may yield `None`; callers treat that like cancel so YOLO is never
+    left active without an explicit acknowledge.
     """
 
     BINDINGS: ClassVar[list[BindingType]] = [
         Binding("enter", "confirm", "Enable YOLO", show=False, priority=True),
+        Binding("m", "switch_to_manual", "Switch to Manual", show=False, priority=True),
         Binding("escape", "cancel", "Keep previous", show=False, priority=True),
     ]
 
@@ -136,7 +156,7 @@ class YoloModeNoticeScreen(ModalScreen[bool]):
                 open_links=False,
             )
             yield Static(
-                "Enter to acknowledge and enable YOLO · Esc to keep current mode",
+                "Enter to enable YOLO · m for Manual · Esc to keep current mode",
                 classes="yolo-mode-notice-help",
                 markup=False,
             )
@@ -148,7 +168,11 @@ class YoloModeNoticeScreen(ModalScreen[bool]):
 
     def action_confirm(self) -> None:
         """Acknowledge YOLO and mark the notice dismissed without re-showing."""
-        self.dismiss(True)
+        self.dismiss(YoloModeNoticeResult.ACKNOWLEDGE)
+
+    def action_switch_to_manual(self) -> None:
+        """Switch to Manual instead of YOLO, without persisting acknowledgement."""
+        self.dismiss(YoloModeNoticeResult.MANUAL)
 
     def action_cancel(self) -> None:
         """Keep the previous approval mode without persisting acknowledgement.
@@ -158,4 +182,4 @@ class YoloModeNoticeScreen(ModalScreen[bool]):
         `action_cancel` if present and otherwise falls through to
         `dismiss(None)`. Renaming this would silently regress Esc handling.
         """
-        self.dismiss(False)
+        self.dismiss(YoloModeNoticeResult.CANCEL)

--- a/libs/code/deepagents_code/tui/widgets/yolo_mode_notice.py
+++ b/libs/code/deepagents_code/tui/widgets/yolo_mode_notice.py
@@ -45,9 +45,8 @@ YOLO_MODE_NOTICE_BODY = (
     "You are about to enable **YOLO mode**. The agent may run shell commands, "
     "edit files, make network calls, and use other tools on this machine "
     "**without asking you first**.\n\n"
-    "Only continue if you're comfortable letting it act unsupervised. Press "
-    "**m** to switch to Manual instead, or leave YOLO any time with "
-    "**Shift+Tab**.\n\n"
+    "Only continue if you're comfortable letting it act unsupervised. Leave "
+    "YOLO any time with **Shift+Tab**.\n\n"
     "This notice appears **once** on this machine.\n\n"
     f"[Learn more about approval modes]({YOLO_MODE_DOCS_URL})"
 )

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -16614,6 +16614,125 @@ class TestEditorSlashCommand:
         mock.assert_awaited_once()
 
 
+class TestApprovalModeSlashCommands:
+    """Tests for the `/manual`, `/auto`, and `/yolo` slash commands."""
+
+    async def test_auto_command_sets_auto_when_eligible(self) -> None:
+        from deepagents_code.approval_mode import ApprovalMode
+
+        app = DeepAgentsApp(agent=MagicMock())
+        app._auto_mode_eligible = True
+        app._approval_mode = ApprovalMode.MANUAL
+        with patch.object(
+            app, "_set_approval_mode", new_callable=AsyncMock
+        ) as set_mode:
+            await app._handle_command("/auto")
+        set_mode.assert_awaited_once_with(ApprovalMode.AUTO)
+
+    async def test_manual_command_sets_manual(self) -> None:
+        from deepagents_code.approval_mode import ApprovalMode
+
+        app = DeepAgentsApp(agent=MagicMock())
+        app._auto_mode_eligible = True
+        app._approval_mode = ApprovalMode.AUTO
+        with patch.object(
+            app, "_set_approval_mode", new_callable=AsyncMock
+        ) as set_mode:
+            await app._handle_command("/manual")
+        set_mode.assert_awaited_once_with(ApprovalMode.MANUAL)
+
+    async def test_auto_command_warns_when_ineligible(self) -> None:
+        from deepagents_code.approval_mode import ApprovalMode
+
+        app = DeepAgentsApp(agent=MagicMock())
+        app._auto_mode_eligible = False
+        app._approval_mode = ApprovalMode.MANUAL
+        with (
+            patch.object(app, "_set_approval_mode", new_callable=AsyncMock) as set_mode,
+            patch.object(app, "_warn_live_approval_mode_unavailable") as warn,
+        ):
+            await app._handle_command("/auto")
+        set_mode.assert_not_awaited()
+        warn.assert_called_once()
+        assert "Auto is unavailable" in str(warn.call_args.args[0])
+
+    async def test_already_in_mode_notifies_and_skips(self) -> None:
+        from deepagents_code.approval_mode import ApprovalMode
+
+        app = DeepAgentsApp(agent=MagicMock())
+        app._auto_mode_eligible = True
+        app._approval_mode = ApprovalMode.MANUAL
+        with (
+            patch.object(app, "_set_approval_mode", new_callable=AsyncMock) as set_mode,
+            patch.object(app, "notify") as notify,
+        ):
+            await app._handle_command("/manual")
+        set_mode.assert_not_awaited()
+        notify.assert_called_once()
+        assert "Already in Manual mode" in str(notify.call_args.args[0])
+
+    async def test_yolo_command_sets_yolo_when_acknowledged(self) -> None:
+        from deepagents_code.approval_mode import ApprovalMode
+
+        app = DeepAgentsApp(agent=MagicMock())
+        app._auto_mode_eligible = True
+        app._approval_mode = ApprovalMode.AUTO
+        with (
+            patch.object(app, "_set_approval_mode", new_callable=AsyncMock) as set_mode,
+            patch(
+                "deepagents_code.config.is_yolo_switcher_enabled",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.approval_mode.has_yolo_acknowledgement",
+                return_value=True,
+            ),
+        ):
+            await app._handle_command("/yolo")
+        set_mode.assert_awaited_once_with(ApprovalMode.YOLO)
+
+    async def test_yolo_command_prompts_when_not_acknowledged(self) -> None:
+        from deepagents_code.approval_mode import ApprovalMode
+
+        app = DeepAgentsApp(agent=MagicMock())
+        app._auto_mode_eligible = True
+        app._approval_mode = ApprovalMode.AUTO
+        with (
+            patch.object(app, "_set_approval_mode", new_callable=AsyncMock) as set_mode,
+            patch.object(app, "_prompt_yolo_switcher_acknowledgement") as prompt,
+            patch(
+                "deepagents_code.config.is_yolo_switcher_enabled",
+                return_value=True,
+            ),
+            patch(
+                "deepagents_code.approval_mode.has_yolo_acknowledgement",
+                return_value=False,
+            ),
+        ):
+            await app._handle_command("/yolo")
+        set_mode.assert_not_awaited()
+        prompt.assert_called_once_with()
+
+    async def test_yolo_command_warns_when_switcher_disabled(self) -> None:
+        from deepagents_code.approval_mode import ApprovalMode
+
+        app = DeepAgentsApp(agent=MagicMock())
+        app._auto_mode_eligible = True
+        app._approval_mode = ApprovalMode.AUTO
+        with (
+            patch.object(app, "_set_approval_mode", new_callable=AsyncMock) as set_mode,
+            patch.object(app, "_warn_live_approval_mode_unavailable") as warn,
+            patch(
+                "deepagents_code.config.is_yolo_switcher_enabled",
+                return_value=False,
+            ),
+        ):
+            await app._handle_command("/yolo")
+        set_mode.assert_not_awaited()
+        warn.assert_called_once()
+        assert "YOLO is disabled" in str(warn.call_args.args[0])
+
+
 class TestToolsSlashCommand:
     """Tests for the `/tools` slash command."""
 
@@ -26257,6 +26376,49 @@ class TestLiveApprovalModeWrites:
                     "Stayed in the current approval mode" in str(call.args[0])
                     for call in notify.call_args_list
                 )
+
+    async def test_toggle_into_yolo_m_switches_to_manual(self) -> None:
+        """`m` on the switcher YOLO notice switches to Manual without ack."""
+        from deepagents_code.approval_mode import ApprovalMode
+        from deepagents_code.tui.widgets.yolo_mode_notice import YoloModeNoticeScreen
+
+        app = DeepAgentsApp()
+        app._auto_mode_eligible = True
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = object()
+            app._approval_mode = ApprovalMode.AUTO
+            if app._session_state is not None:
+                app._session_state.approval_mode = ApprovalMode.AUTO
+            with (
+                patch.object(
+                    app,
+                    "_write_live_approval_mode",
+                    new=AsyncMock(return_value=True),
+                ) as write_mode,
+                patch(
+                    "deepagents_code.approval_mode.has_yolo_acknowledgement",
+                    return_value=False,
+                ),
+                patch(
+                    "deepagents_code.approval_mode.save_yolo_acknowledgement"
+                ) as save_ack,
+                patch(
+                    "deepagents_code.config.is_yolo_switcher_enabled",
+                    return_value=True,
+                ),
+                patch.object(app, "notify"),
+            ):
+                await app.action_toggle_auto_approve()
+                await pilot.pause()
+                assert isinstance(app.screen, YoloModeNoticeScreen)
+                await pilot.press("m")
+                await pilot.pause()
+                # Manual chosen: never persist the YOLO ack, land in Manual.
+                save_ack.assert_not_called()
+                assert app._approval_mode is ApprovalMode.MANUAL
+                assert app._auto_approve is False
+                write_mode.assert_awaited_with(ApprovalMode.MANUAL)
 
     async def test_toggle_skips_yolo_when_switcher_disabled(self) -> None:
         """Disabling the switcher restores Manual ↔ Auto only."""

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -26420,6 +26420,59 @@ class TestLiveApprovalModeWrites:
                 assert app._auto_approve is False
                 write_mode.assert_awaited_with(ApprovalMode.MANUAL)
 
+    async def test_yolo_notice_m_skips_write_when_already_manual(self) -> None:
+        """`m` from Manual (via `/yolo`) does not rewrite Manual on the live store.
+
+        A failed redundant Manual write would set `_approval_mode_blocked` and
+        could cancel active work even though the user only declined YOLO.
+        """
+        from deepagents_code.approval_mode import ApprovalMode
+        from deepagents_code.tui.widgets.yolo_mode_notice import YoloModeNoticeScreen
+
+        app = DeepAgentsApp()
+        app._auto_mode_eligible = True
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent = object()
+            app._approval_mode = ApprovalMode.MANUAL
+            app._approval_mode_blocked = False
+            if app._session_state is not None:
+                app._session_state.approval_mode = ApprovalMode.MANUAL
+            with (
+                patch.object(
+                    app,
+                    "_write_live_approval_mode",
+                    new=AsyncMock(return_value=False),
+                ) as write_mode,
+                patch.object(
+                    app, "_set_approval_mode", wraps=app._set_approval_mode
+                ) as set_mode,
+                patch(
+                    "deepagents_code.approval_mode.has_yolo_acknowledgement",
+                    return_value=False,
+                ),
+                patch(
+                    "deepagents_code.approval_mode.save_yolo_acknowledgement"
+                ) as save_ack,
+                patch(
+                    "deepagents_code.config.is_yolo_switcher_enabled",
+                    return_value=True,
+                ),
+                patch.object(app, "_warn_live_approval_mode_unavailable") as warn,
+                patch.object(app, "notify"),
+            ):
+                await app._handle_approval_mode_command(ApprovalMode.YOLO)
+                await pilot.pause()
+                assert isinstance(app.screen, YoloModeNoticeScreen)
+                await pilot.press("m")
+                await pilot.pause()
+                save_ack.assert_not_called()
+                set_mode.assert_not_awaited()
+                write_mode.assert_not_awaited()
+                warn.assert_not_called()
+                assert app._approval_mode is ApprovalMode.MANUAL
+                assert app._approval_mode_blocked is False
+
     async def test_toggle_skips_yolo_when_switcher_disabled(self) -> None:
         """Disabling the switcher restores Manual ↔ Auto only."""
         from deepagents_code.approval_mode import ApprovalMode


### PR DESCRIPTION
Add an `m` shortcut on the YOLO notice to switch to Manual, plus `/manual`, `/auto`, and `/yolo` slash commands for switching approval modes.

---

Shift+Tab in Auto mode only offered "enable YOLO" or "stay in Auto", with no way to reach Manual. This adds an `m` binding to the YOLO first-enable notice that switches to Manual (without persisting a YOLO acknowledgement), and adds `/manual`, `/auto`, `/yolo` slash commands that mirror the switcher's eligibility and acknowledgement gating (Auto refused with a sandbox; YOLO honors `startup.yolo_switcher` and prompts the first-run notice). The modal now returns a tri-state `YoloModeNoticeResult` instead of a bool.

Made by [Open SWE](https://openswe.vercel.app/agents/8d096fda-a174-38d0-dfca-f5ac92b6020a)