### PR TITLE
style(code): toast when submitting empty required `ask_user` answer

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/ask_user.py
+++ b/libs/code/deepagents_code/tui/widgets/ask_user.py
@@ -34,7 +34,7 @@ from deepagents_code.tui.widgets._inline_prompt import (
 )
 
 OTHER_CHOICE_LABEL = "Other (type your answer)"
-MISSING_ANSWER_TOAST = "Please provide an answer before continuing."
+MISSING_ANSWER_TOAST = "Please provide an answer to all questions before continuing."
 logger = logging.getLogger(__name__)
 
 _TRAILING_ANNOTATION_RE = re.compile(

--- a/libs/code/deepagents_code/tui/widgets/ask_user.py
+++ b/libs/code/deepagents_code/tui/widgets/ask_user.py
@@ -34,6 +34,7 @@ from deepagents_code.tui.widgets._inline_prompt import (
 )
 
 OTHER_CHOICE_LABEL = "Other (type your answer)"
+MISSING_ANSWER_TOAST = "This question is required. Type an answer before continuing."
 logger = logging.getLogger(__name__)
 
 _TRAILING_ANNOTATION_RE = re.compile(
@@ -203,6 +204,12 @@ class AskUserMenu(Container):
                 answer = qw.get_answer()
                 if answer.strip() or not qw._required:
                     self.confirm_and_advance(qw._index)
+                else:
+                    self.app.notify(
+                        MISSING_ANSWER_TOAST,
+                        severity="warning",
+                        markup=False,
+                    )
                 return
 
     def confirm_and_advance(self, index: int) -> None:

--- a/libs/code/deepagents_code/tui/widgets/ask_user.py
+++ b/libs/code/deepagents_code/tui/widgets/ask_user.py
@@ -34,7 +34,7 @@ from deepagents_code.tui.widgets._inline_prompt import (
 )
 
 OTHER_CHOICE_LABEL = "Other (type your answer)"
-MISSING_ANSWER_TOAST = "This question is required. Type an answer before continuing."
+MISSING_ANSWER_TOAST = "Please provide an answer before continuing."
 logger = logging.getLogger(__name__)
 
 _TRAILING_ANNOTATION_RE = re.compile(

--- a/libs/code/tests/unit_tests/tui/widgets/test_ask_user.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_ask_user.py
@@ -15,6 +15,7 @@ import deepagents_code
 from deepagents_code.tool_display import format_tool_display
 from deepagents_code.tui.widgets.ask_user import (
     _TRAILING_ANNOTATION_RE,
+    MISSING_ANSWER_TOAST,
     AskUserMenu,
     AskUserTextArea,
     _QuestionWidget,
@@ -1002,6 +1003,25 @@ class TestAskUserMenu:
             await pilot.pause()
 
             assert not future.done()
+
+    async def test_required_empty_submit_shows_toast(self) -> None:
+        """Blocked empty submit surfaces a warning toast to the user."""
+        app = _AskUserTestApp([{"question": "Name?", "type": "text", "required": True}])
+
+        async with app.run_test() as pilot:
+            menu = app.query_one("#ask-user-menu", AskUserMenu)
+            future: asyncio.Future[AskUserWidgetResult] = (
+                asyncio.get_running_loop().create_future()
+            )
+            menu.set_future(future)
+
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert not future.done()
+            messages = [n.message for n in app._notifications]
+            assert MISSING_ANSWER_TOAST in messages
 
     async def test_up_from_other_input_selects_last_choice_directly(self) -> None:
         """Pressing up while Other input is focused jumps to last real choice."""


### PR DESCRIPTION
`ask_user` now shows a warning toast when you press Enter on a required question without an answer.

---

Pressing Enter on a required `ask_user` question with an empty answer previously did nothing and gave no feedback. This surfaces a warning toast prompting the user to type an answer before continuing, so the blocked submit is no longer silent.

BEGIN_COMMIT_OVERRIDE
style(code): toast when submitting empty required `ask_user` answer
END_COMMIT_OVERRIDE

Made by [Open SWE](https://openswe.vercel.app/agents/0137f4f3-a001-2eb9-5cac-2616cfa197df)