### PR TITLE
fix(code): anchor toasts above the chat input

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2519,12 +2519,13 @@ class _ChatScroll(VerticalScroll):
 
 
 _MIN_TOAST_ROWS = 6
-"""Rows kept clear above the bottom chrome so a toast is never pushed offscreen.
+"""Rows the toast rack keeps for itself above the bottom chrome.
 
-A toast is at most a few rows tall (1 row of margin, 1 of padding either side,
-and the wrapped body). On a short terminal — or with a tall composed message in
-the chat input — anchoring above the chrome would otherwise leave the rack no
-room at all, which is worse than overlapping the input.
+On a short terminal — or with a tall composed message in the chat input — the
+chrome can claim the whole screen, and anchoring above it would leave the rack
+no room at all. The anchor stops at this floor, and `_anchor_toast_rack` caps
+the rack's height to whatever space is left so a taller toast scrolls inside the
+rack instead of being docked off the top of the screen.
 """
 
 
@@ -6608,9 +6609,14 @@ class DeepAgentsApp(App):
         screen_height = screen.size.height
         headroom = max(screen_height - _MIN_TOAST_ROWS, 0)
         margin_bottom = min(max(screen_height - region.y, 0), headroom)
-        if rack.styles.margin.bottom == margin_bottom:
-            return
+        # Inline style writes already no-op when the value is unchanged, so
+        # re-running this on every resize costs nothing.
         rack.styles.margin = (0, 0, margin_bottom, 0)
+        # `ToastRack` is `height: auto` with no maximum, so a tall (or heavily
+        # wrapped) toast would be docked past the top of the screen and lose its
+        # first lines. Bound the rack to the space this anchor leaves it; the
+        # rack already scrolls to its end, keeping the newest toast in view.
+        rack.styles.max_height = screen_height - margin_bottom
 
     def _update_status(self, message: str) -> None:
         """Update the status bar with a message."""

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -35,6 +35,7 @@ from textual.binding import Binding, BindingType
 from textual.containers import Container, VerticalScroll
 from textual.content import Content
 from textual.css.query import NoMatches
+from textual.dom import NoScreen
 from textual.events import Click
 from textual.message import Message
 from textual.notifications import Notification as _Notification, Notify as _Notify
@@ -2517,6 +2518,34 @@ class _ChatScroll(VerticalScroll):
         return self.max_scroll_y > 0
 
 
+_MIN_TOAST_ROWS = 6
+"""Rows kept clear above the bottom chrome so a toast is never pushed offscreen.
+
+A toast is at most a few rows tall (1 row of margin, 1 of padding either side,
+and the wrapped body). On a short terminal — or with a tall composed message in
+the chat input — anchoring above the chrome would otherwise leave the rack no
+room at all, which is worse than overlapping the input.
+"""
+
+
+class _BottomChrome(Container):
+    """Bottom container the toast rack is anchored above.
+
+    Textual docks `ToastRack` to the bottom of the screen, where it covers the
+    chat input. This container's height changes whenever the chat input grows,
+    or the startup tip / goal status / subagent panels appear, so it announces
+    its own resizes and lets the app re-anchor the rack (see
+    `DeepAgentsApp._anchor_toast_rack`).
+    """
+
+    class Resized(Message, namespace="bottom_chrome"):
+        """Posted whenever the bottom chrome's geometry changes."""
+
+    def on_resize(self, _event: Resize) -> None:
+        """Announce the new geometry so the app can re-anchor toasts."""
+        self.post_message(self.Resized())
+
+
 class _MainScreen(Screen[None]):
     """Default screen containing the main chat interface.
 
@@ -3787,7 +3816,7 @@ class DeepAgentsApp(App):
                 id="welcome-banner",
             )
             yield Container(id="messages")
-        with Container(id="bottom-app-container"):
+        with _BottomChrome(id="bottom-app-container"):
             # Live fan-out panel for subagents spawned from js_eval. Hidden
             # until the first spawn event; sits at the top of the bottom
             # container, above the startup tip and input.
@@ -6534,6 +6563,9 @@ class DeepAgentsApp(App):
 
     def on_resize(self, _event: Resize) -> None:
         """Scale cached message heights when terminal width changes."""
+        # A terminal resize moves the bottom chrome even when its height is
+        # unchanged, so re-anchor before the early returns below.
+        self._anchor_toast_rack()
         try:
             chat = self.query_one("#chat", VerticalScroll)
         except NoMatches:
@@ -6548,6 +6580,37 @@ class DeepAgentsApp(App):
         self._message_store.invalidate_height_hints(scale=previous / width)
         self._message_measure_width = width
         self._sync_transcript_spacers()
+
+    def on_bottom_chrome_resized(self, _event: _BottomChrome.Resized) -> None:
+        """Re-anchor toasts when the chat input (or a bottom panel) resizes."""
+        self._anchor_toast_rack()
+
+    def _anchor_toast_rack(self) -> None:
+        """Float toasts above the chat input instead of on top of it.
+
+        Textual docks its `ToastRack` to the bottom of the screen, so toasts
+        cover the chat input the user is typing into. Growing the rack's bottom
+        margin to the height of the bottom chrome (panels, chat input, and
+        status bar) lifts toasts to just above the input box.
+        """
+        try:
+            chrome = self.query_one("#bottom-app-container", _BottomChrome)
+            # Resolve the rack from the chrome's own screen: every screen
+            # composes its own rack, and modals must not retune the main one.
+            screen = chrome.screen
+            rack = screen.get_child_by_id("textual-toastrack")
+        except (NoMatches, NoScreen):
+            return
+        region = chrome.region
+        if not region:
+            # Not laid out yet; the chrome's first resize re-anchors.
+            return
+        screen_height = screen.size.height
+        headroom = max(screen_height - _MIN_TOAST_ROWS, 0)
+        margin_bottom = min(max(screen_height - region.y, 0), headroom)
+        if rack.styles.margin.bottom == margin_bottom:
+            return
+        rack.styles.margin = (0, 0, margin_bottom, 0)
 
     def _update_status(self, message: str) -> None:
         """Update the status bar with a message."""

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -24809,16 +24809,28 @@ class TestToastAnchoring:
             assert after > before
             assert after == app.screen.size.height - self._chrome(app).region.y
 
-    async def test_short_terminal_keeps_the_rack_onscreen(self) -> None:
-        """A chrome taller than the terminal must not push toasts offscreen."""
+    async def test_short_terminal_keeps_toasts_onscreen(self) -> None:
+        """A chrome taller than the terminal must not dock toasts off the top.
+
+        The anchor stops at `_MIN_TOAST_ROWS`, and the rack is capped to the
+        space that leaves, so even a heavily wrapped toast stays on screen
+        instead of losing its opening lines above row zero.
+        """
+        from textual.widgets._toast import Toast as _Toast
+
         app = DeepAgentsApp()
         async with app.run_test(notifications=True, size=(80, 12)) as pilot:
             await pilot.pause()
             app.query_one("#input-area", ChatInput).styles.height = 20
             await pilot.pause()
+            app.notify("word " * 60, timeout=60)
+            await pilot.pause()
 
             margin_bottom = self._rack(app).styles.margin.bottom
             assert 0 <= margin_bottom <= 12 - _MIN_TOAST_ROWS
+            toasts = list(app.screen.query(_Toast))
+            assert toasts
+            assert all(toast.region.y >= 0 for toast in toasts)
 
 
 class TestFatalErrorRedaction:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -52,6 +52,7 @@ from deepagents_code._session_stats import SessionStats
 from deepagents_code._version import CHANGELOG_URL, __version__
 from deepagents_code.app import (
     _DEEPAGENTS_IMPORT_LOCK,
+    _MIN_TOAST_ROWS,
     _TYPING_IDLE_THRESHOLD_SECONDS,
     DeepAgentsApp,
     DeferredAction,
@@ -24754,6 +24755,70 @@ class TestNotificationCenterIntegration:
             await pilot.pause()
 
             assert isinstance(app.screen, NotificationCenterScreen)
+
+
+class TestToastAnchoring:
+    """Toasts float above the chat input instead of covering it."""
+
+    @staticmethod
+    def _rack(app: DeepAgentsApp) -> Widget:
+        """Return the toast rack composed into the app's main screen."""
+        return app.screen.get_child_by_id("textual-toastrack")
+
+    @staticmethod
+    def _chrome(app: DeepAgentsApp) -> Widget:
+        """Return the bottom chrome (panels + chat input) container."""
+        return app.query_one("#bottom-app-container", Widget)
+
+    async def test_rack_margin_clears_the_bottom_chrome(self) -> None:
+        """The rack's bottom margin reaches the top of the bottom chrome."""
+        app = DeepAgentsApp()
+        async with app.run_test(notifications=True) as pilot:
+            await pilot.pause()
+            expected = app.screen.size.height - self._chrome(app).region.y
+            assert expected > 1
+            assert self._rack(app).styles.margin.bottom == expected
+
+    async def test_toasts_do_not_cover_the_chat_input(self) -> None:
+        """Displayed toasts stack directly above the bottom chrome."""
+        from textual.widgets._toast import Toast as _Toast
+
+        app = DeepAgentsApp()
+        async with app.run_test(notifications=True) as pilot:
+            await pilot.pause()
+            app.notify("first", timeout=60)
+            app.notify("second", timeout=60)
+            await pilot.pause()
+
+            toasts = list(app.screen.query(_Toast))
+            assert toasts
+            chrome_top = self._chrome(app).region.y
+            assert max(toast.region.bottom for toast in toasts) == chrome_top
+
+    async def test_growing_chat_input_lifts_the_rack(self) -> None:
+        """A taller chat input pushes toasts further up the screen."""
+        app = DeepAgentsApp()
+        async with app.run_test(notifications=True) as pilot:
+            await pilot.pause()
+            before = self._rack(app).styles.margin.bottom
+
+            app.query_one("#input-area", ChatInput).styles.height = 12
+            await pilot.pause()
+
+            after = self._rack(app).styles.margin.bottom
+            assert after > before
+            assert after == app.screen.size.height - self._chrome(app).region.y
+
+    async def test_short_terminal_keeps_the_rack_onscreen(self) -> None:
+        """A chrome taller than the terminal must not push toasts offscreen."""
+        app = DeepAgentsApp()
+        async with app.run_test(notifications=True, size=(80, 12)) as pilot:
+            await pilot.pause()
+            app.query_one("#input-area", ChatInput).styles.height = 20
+            await pilot.pause()
+
+            margin_bottom = self._rack(app).styles.margin.bottom
+            assert 0 <= margin_bottom <= 12 - _MIN_TOAST_ROWS
 
 
 class TestFatalErrorRedaction:


### PR DESCRIPTION
Toasts no longer cover the chat input — they now float directly above the input box.

---

Textual docks its `ToastRack` to the bottom of the screen, which puts every toast on top of the composer the user is typing into. Rather than restyling individual toasts, the app now tracks the bottom chrome (subagent panel, startup tip, goal status, chat input, and status bar) and widens the rack's bottom margin so the stack ends exactly at the top edge of that chrome.

The bottom container announces its own resizes, so the anchor follows the chat input as it grows with a multi-line message and as the bottom panels come and go; terminal resizes re-anchor too. On a terminal too short to fit both, the offset is clamped so a toast is never pushed off screen. Modal screens compose their own rack and are deliberately left alone.

Worth a careful look: the anchoring math lives in `_anchor_toast_rack`, and `_BottomChrome` is a thin `Container` subclass that exists only to surface `Resize` (which does not bubble) to the app.

## Screenshots
<img width="586" height="224" alt="Screenshot 2026-07-27 at 4 35 45 PM" src="https://github.com/user-attachments/assets/d9c5d4a2-a4d9-410e-ad85-a8aacef89bf6" />


<details>
<summary>Test plan</summary>

- New pilot-driven tests cover the resting offset, that stacked toasts end flush above the chrome, that growing the chat input lifts the rack, and the short-terminal clamp. Three of the four fail without the change.

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/40b5babe-cea3-6b01-d998-fc3b980ad406)