### PR TITLE
feat(code): add project hooks workspace trust

### DIFF
--- a/libs/code/THREAT_MODEL.md
+++ b/libs/code/THREAT_MODEL.md
@@ -17,7 +17,7 @@
 - Agent creation (`agent.py`)
 - Built-in tools (`tools.py`: `http_request`, `web_search`, `fetch_url`)
 - MCP config loader and per-server allow/deny lists (`mcp_tools.py`, `model_config.py`)
-- Hook dispatcher (`hooks.py`)
+- Hook runtimes (`hooks/`)
 - Sandbox integration factory (`integrations/sandbox_factory.py`, `integrations/sandbox_provider.py`)
 - Session persistence (`sessions.py`)
 - Configuration system (`config.py`, `model_config.py`)
@@ -126,7 +126,7 @@
 | C3  | Agent Engine                | LangGraph agent graph running inside `langgraph dev` server, assembled by `create_cli_agent`                        | framework-controlled | Yes      | `agent.create_cli_agent`, `agent._add_interrupt_on`, `server_graph.make_graph`                    |
 | C4  | Built-in Tools              | `http_request`, `web_search` (Tavily), `fetch_url` (HTML→markdown)                                                 | framework-controlled | Partial¹ | `tools.http_request`, `tools.web_search`, `tools.fetch_url`                                       |
 | C5  | MCP Loader & Trust          | Discovers/loads `.mcp.json`, validates server configs, applies per-server allow/deny lists + interactive approval    | framework-controlled | No²      | `mcp_tools.resolve_and_load_mcp_tools`, `model_config.load_mcp_server_trust_lists`, `main._check_mcp_project_trust` |
-| C6  | Hook Dispatcher             | Fires subprocess commands on agent lifecycle events                                                                 | framework-controlled | No³      | `hooks.dispatch_hook`, `hooks._run_single_hook`                                                   |
+| C6  | Hook Runtime                | Fires subprocess commands on agent lifecycle events                                                                 | framework-controlled | No³      | `hooks.runtime.HooksRuntime`, `hooks.runner.run_command_handler`                                  |
 | C7  | Sandbox Integration         | Creates/destroys remote sandboxes (Daytona, LangSmith, Modal, Runloop, AgentCore)                                  | framework-controlled | No⁴      | `integrations.sandbox_factory.create_sandbox`                                                     |
 | C8  | Session Persistence         | SQLite checkpoint store for LangGraph thread state                                                                  | framework-controlled | Yes      | `sessions.get_db_path`, `sessions.generate_thread_id`                                             |
 | C9  | Configuration System        | TOML config, env vars, `AGENTS.md` system prompts, model config                                                    | user-controlled      | N/A      | `config.settings`, `model_config.ModelConfig`, `~/.deepagents/config.toml`                        |
@@ -142,7 +142,7 @@
 **Notes:**
 1. `http_request` and `fetch_url` enabled by default; `web_search` requires `TAVILY_API_KEY`.
 2. MCP servers only load if `.mcp.json` config files are present.
-3. Hooks only execute if `~/.deepagents/hooks.json` exists.
+3. User hooks load from `~/.deepagents/hooks.json`. Project hooks load from `.deepagents/hooks.json` only after interactive workspace trust or the headless `--trust-project-hooks` opt-in.
 4. Sandbox mode requires explicit `--sandbox` CLI flag.
 5. Both TUI and non-interactive modes now always spawn a local LangGraph dev server and connect via `RemoteAgent`.
 6. `LocalContextMiddleware` is added whenever `LocalShellBackend` or an `_AsyncExecutableBackend` is in use (`agent.py:create_cli_agent`).
@@ -200,7 +200,7 @@
 | TB2  | LLM Decision → Tool Execution         | HITL gate on all side-effecting tool calls                                 | Interrupt map, allow-list check, auto-approve toggle                            | LLM reasoning; what user approves                             |
 | TB3  | Tool Result → LLM Context             | Tool outputs re-enter the context window                                   | Unicode warnings on URLs in args; markdownify HTML conversion                   | Content of fetched web pages, MCP responses, search results   |
 | TB4  | MCP Config → Process / Network        | `.mcp.json` triggers subprocess spawn or network connection                | Schema validation; per-server allow/deny lists + interactive approval prompt    | What the MCP process does once trusted and running            |
-| TB5  | Hooks Config → Subprocess             | `hooks.json` commands execute as local subprocesses                        | JSON structure validation, 5-second timeout                                     | Command content (user-authored); env vars available to child  |
+| TB5  | Hooks Config → Subprocess             | `hooks.json` commands execute as local subprocesses                        | Workspace trust for project hooks, schema validation, bounded execution, sanitized environment | Command content (user-authored) |
 | TB6  | Setup Script → Sandbox Execution      | User-supplied script runs inside sandbox at startup                        | `shlex.quote()` wrapping; `string.Template.safe_substitute`                     | Script content (user-authored); sandbox network access        |
 | TB7  | External LLM API → Agent State        | LLM API responses drive tool call decisions                                | LLM client configuration, model selection, request params                       | LLM output content; provider-side safety                      |
 | TB8  | CLI → Server Subprocess IPC           | Config passed from CLI to `langgraph dev` subprocess via `DA_SERVER_*` env vars | `ServerConfig.to_env()` serialization; env var scoping to parent+child process | Subprocess environment post-fork; /proc visibility to same-uid processes |

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -2777,6 +2777,7 @@ class DeepAgentsApp(App):
         model_explicitly_set: bool = False,
         interpreter_arg: bool | None = None,
         defer_server_start: bool = False,
+        trust_project_hooks: bool = False,
         title: str | None = None,
         sub_title: str | None = None,
         **kwargs: Any,
@@ -2844,6 +2845,7 @@ class DeepAgentsApp(App):
                 `server_kwargs`.
             defer_server_start: Whether to keep app-owned server startup paused
                 until the user configures credentials or explicitly picks a model.
+            trust_project_hooks: Whether project-scoped hook commands may run.
             title: Override the Textual `App.title` shown in the optional
                 header bar (shown when `DEEPAGENTS_CODE_SHOW_HEADER` is set or
                 the installation is stale).
@@ -2867,6 +2869,7 @@ class DeepAgentsApp(App):
             self.sub_title = sub_title
 
         self._register_custom_themes()
+        self._trust_project_hooks = trust_project_hooks
 
         self.theme = _load_theme_preference()
         """Active Textual theme name.
@@ -4385,12 +4388,12 @@ class DeepAgentsApp(App):
             return
         # Loading stays on the event loop deliberately: it is a cheap config
         # read, and `to_thread` races server-ready startup tests that only
-        # yield a few event-loop turns. Interactive sessions keep project hooks
-        # off until a dedicated workspace-trust prompt lands.
+        # yield a few event-loop turns.
         session_state.hooks = HooksManager.create(
             cwd=Path(self._cwd),
             identity=session_state.hook_identity,
             notice=lambda message: self.notify(message, markup=False),
+            workspace_trusted=self._trust_project_hooks,
         )
         # Re-read the app-owned selection last so a mode change during
         # construction cannot be overwritten by the freshly built state.
@@ -4426,7 +4429,10 @@ class DeepAgentsApp(App):
         """Reload hook configuration after the session working directory moves."""
         from pathlib import Path
 
-        await self._hooks.reload(cwd=Path(self._cwd))
+        await self._hooks.reload(
+            cwd=Path(self._cwd),
+            workspace_trusted=self._trust_project_hooks,
+        )
 
     async def _run_session_start_hook(self, cause: SessionStartCause) -> bool:
         """Run `SessionStart`, surfacing a stop as a chat message.
@@ -23208,6 +23214,7 @@ async def run_textual_app(
     model_explicitly_set: bool = False,
     interpreter_arg: bool | None = None,
     defer_server_start: bool = False,
+    trust_project_hooks: bool = False,
     title: str | None = None,
     sub_title: str | None = None,
 ) -> AppResult:
@@ -23266,6 +23273,7 @@ async def run_textual_app(
             explicit opt-out from a sandbox-suppressed default.
         defer_server_start: Whether to keep app-owned server startup paused
             until credentials or a model are configured from inside the TUI.
+        trust_project_hooks: Whether project-scoped hook commands may run.
         title: Override the Textual `App.title` shown in the optional header
             bar (gated on `DEEPAGENTS_CODE_SHOW_HEADER`, or shown automatically
             when the installation is stale). When `None`, the default
@@ -23299,6 +23307,7 @@ async def run_textual_app(
         model_explicitly_set=model_explicitly_set,
         interpreter_arg=interpreter_arg,
         defer_server_start=defer_server_start,
+        trust_project_hooks=trust_project_hooks,
         title=title,
         sub_title=sub_title,
     )

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -605,6 +605,7 @@ if TYPE_CHECKING:
     from deepagents_code.hooks.models.domain import (
         SessionStartCause,
     )
+    from deepagents_code.hooks.trust import WorkspaceTrust
     from deepagents_code.mcp_tools import MCPServerInfo
     from deepagents_code.model_config import MissingProviderPackageError
     from deepagents_code.plugins.models import (
@@ -2777,7 +2778,7 @@ class DeepAgentsApp(App):
         model_explicitly_set: bool = False,
         interpreter_arg: bool | None = None,
         defer_server_start: bool = False,
-        trust_project_hooks: bool = False,
+        hook_trust: WorkspaceTrust | None = None,
         title: str | None = None,
         sub_title: str | None = None,
         **kwargs: Any,
@@ -2845,7 +2846,10 @@ class DeepAgentsApp(App):
                 `server_kwargs`.
             defer_server_start: Whether to keep app-owned server startup paused
                 until the user configures credentials or explicitly picks a model.
-            trust_project_hooks: Whether project-scoped hook commands may run.
+            hook_trust: Policy deciding which workspaces may run project-scoped
+                hook commands. Handed to the hooks coordinator, the only
+                component that resolves it. `None` consults just the persisted
+                trust store.
             title: Override the Textual `App.title` shown in the optional
                 header bar (shown when `DEEPAGENTS_CODE_SHOW_HEADER` is set or
                 the installation is stale).
@@ -2869,7 +2873,13 @@ class DeepAgentsApp(App):
             self.sub_title = sub_title
 
         self._register_custom_themes()
-        self._trust_project_hooks = trust_project_hooks
+        self._hook_trust: WorkspaceTrust | None = hook_trust
+        """Project-hook trust policy, forwarded verbatim to `HooksManager`.
+
+        Carried rather than applied: session state — and therefore the hooks
+        coordinator that owns and resolves this policy — cannot be built until
+        after construction. The app never inspects it.
+        """
 
         self.theme = _load_theme_preference()
         """Active Textual theme name.
@@ -4393,7 +4403,7 @@ class DeepAgentsApp(App):
             cwd=Path(self._cwd),
             identity=session_state.hook_identity,
             notice=lambda message: self.notify(message, markup=False),
-            workspace_trusted=self._trust_project_hooks,
+            trust=self._hook_trust,
         )
         # Re-read the app-owned selection last so a mode change during
         # construction cannot be overwritten by the freshly built state.
@@ -4426,13 +4436,14 @@ class DeepAgentsApp(App):
         )
 
     async def _reload_hooks(self) -> None:
-        """Reload hook configuration after the session working directory moves."""
+        """Reload hook configuration after the session working directory moves.
+
+        Trust is re-resolved by the coordinator for the new directory, so hooks
+        from an untrusted project are never picked up on the old grant.
+        """
         from pathlib import Path
 
-        await self._hooks.reload(
-            cwd=Path(self._cwd),
-            workspace_trusted=self._trust_project_hooks,
-        )
+        await self._hooks.reload(cwd=Path(self._cwd))
 
     async def _run_session_start_hook(self, cause: SessionStartCause) -> bool:
         """Run `SessionStart`, surfacing a stop as a chat message.
@@ -23214,7 +23225,7 @@ async def run_textual_app(
     model_explicitly_set: bool = False,
     interpreter_arg: bool | None = None,
     defer_server_start: bool = False,
-    trust_project_hooks: bool = False,
+    hook_trust: WorkspaceTrust | None = None,
     title: str | None = None,
     sub_title: str | None = None,
 ) -> AppResult:
@@ -23273,7 +23284,9 @@ async def run_textual_app(
             explicit opt-out from a sandbox-suppressed default.
         defer_server_start: Whether to keep app-owned server startup paused
             until credentials or a model are configured from inside the TUI.
-        trust_project_hooks: Whether project-scoped hook commands may run.
+        hook_trust: Policy deciding which workspaces may run project-scoped hook
+            commands. Forwarded to the app's hooks coordinator, which resolves it
+            on load and on every working-directory change.
         title: Override the Textual `App.title` shown in the optional header
             bar (gated on `DEEPAGENTS_CODE_SHOW_HEADER`, or shown automatically
             when the installation is stale). When `None`, the default
@@ -23307,7 +23320,7 @@ async def run_textual_app(
         model_explicitly_set=model_explicitly_set,
         interpreter_arg=interpreter_arg,
         defer_server_start=defer_server_start,
-        trust_project_hooks=trust_project_hooks,
+        hook_trust=hook_trust,
         title=title,
         sub_title=sub_title,
     )

--- a/libs/code/deepagents_code/client/commands/config.py
+++ b/libs/code/deepagents_code/client/commands/config.py
@@ -704,20 +704,26 @@ def _config_paths() -> list[tuple[str, Any, bool]]:
     from pathlib import Path
 
     from deepagents_code.config import _GLOBAL_DOTENV_PATH, _find_dotenv_from_start_path
+    from deepagents_code.hooks.loading import project_hooks_path
     from deepagents_code.model_config import (
         DEFAULT_CONFIG_PATH,
         DEFAULT_STATE_DIR,
         RECENT_MODELS_FILENAME,
     )
+    from deepagents_code.project_utils import ProjectContext
 
     base = DEFAULT_CONFIG_PATH.parent
     project_dotenv = _find_dotenv_from_start_path(Path.cwd())
+    project_context = ProjectContext.from_user_cwd(Path.cwd())
+    project_root = project_context.project_root or project_context.user_cwd
 
     candidates: list[tuple[str, Path | None]] = [
         ("config.toml", DEFAULT_CONFIG_PATH),
         ("project .env", project_dotenv),
         ("global .env", _GLOBAL_DOTENV_PATH),
-        ("hooks.json", base / "hooks.json"),
+        ("project hooks.json", project_hooks_path(project_root)),
+        ("user hooks.json", base / "hooks.json"),
+        ("hooks trust", DEFAULT_STATE_DIR / "hooks_trust.json"),
         ("auth.json", DEFAULT_STATE_DIR / "auth.json"),
         ("recent models", DEFAULT_STATE_DIR / RECENT_MODELS_FILENAME),
     ]

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -1342,6 +1342,7 @@ async def _run_agent_loop(
         SessionEndCause,
         SessionStartCause,
     )
+    from deepagents_code.hooks.trust import WorkspaceTrust
 
     resolved_approval_mode = approval_mode or ApprovalMode.MANUAL
     # One headless turn per process, so identity is fixed for the whole run.
@@ -1355,7 +1356,7 @@ async def _run_agent_loop(
         identity=lambda: identity,
         notice=lambda notice: console.print(Text(notice), highlight=False),
         # Project hooks require an explicit opt-in, matching `--trust-project-mcp`.
-        workspace_trusted=trust_project_hooks,
+        trust=WorkspaceTrust.for_session(Path.cwd(), granted=trust_project_hooks),
     )
     state.hooks.apply_graph_context(context)
     context["approval_mode"] = resolved_approval_mode.value
@@ -1931,6 +1932,7 @@ async def run_non_interactive(
         from deepagents_code.approval_mode import ApprovalMode
         from deepagents_code.hooks.manager import HookSessionIdentity, HooksManager
         from deepagents_code.hooks.models.domain import HookEvent
+        from deepagents_code.hooks.trust import WorkspaceTrust
 
         enable_shell = bool(settings.shell_allow_list)
         shell_is_unrestricted = isinstance(
@@ -1960,7 +1962,7 @@ async def run_non_interactive(
             cwd=Path.cwd(),
             identity=lambda: identity,
             notice=lambda notice: console.print(Text(notice), highlight=False),
-            workspace_trusted=trust_project_hooks,
+            trust=WorkspaceTrust.for_session(Path.cwd(), granted=trust_project_hooks),
         )
         # Permission hooks need every gated call to reach the client, so they
         # override both middleware shortcuts that would skip HITL entirely.

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -1356,7 +1356,9 @@ async def _run_agent_loop(
         identity=lambda: identity,
         notice=lambda notice: console.print(Text(notice), highlight=False),
         # Project hooks require an explicit opt-in, matching `--trust-project-mcp`.
-        trust=WorkspaceTrust.for_session(Path.cwd(), granted=trust_project_hooks),
+        # Persisted interactive trust deliberately does not carry into headless
+        # runs, so CI never inherits a grant made at someone's terminal.
+        trust=WorkspaceTrust.explicit_only(Path.cwd(), granted=trust_project_hooks),
     )
     state.hooks.apply_graph_context(context)
     context["approval_mode"] = resolved_approval_mode.value
@@ -1962,7 +1964,8 @@ async def run_non_interactive(
             cwd=Path.cwd(),
             identity=lambda: identity,
             notice=lambda notice: console.print(Text(notice), highlight=False),
-            trust=WorkspaceTrust.for_session(Path.cwd(), granted=trust_project_hooks),
+            # Explicit opt-in only; see `_run_agent_loop` for the rationale.
+            trust=WorkspaceTrust.explicit_only(Path.cwd(), granted=trust_project_hooks),
         )
         # Permission hooks need every gated call to reach the client, so they
         # override both middleware shortcuts that would skip HITL entirely.

--- a/libs/code/deepagents_code/hooks/loading.py
+++ b/libs/code/deepagents_code/hooks/loading.py
@@ -49,6 +49,13 @@ class LoadedHooksConfig:
     diagnostics: tuple[HookDiagnostic, ...]
     sources: tuple[Path, ...]
     snapshot_id: str
+    project_source_loaded: bool = False
+    """Whether the project-scoped source was selected and successfully loaded.
+
+    Set only when workspace trust allowed the project source and that file
+    contributed configuration. Never inferred from path membership after
+    canonical deduplication (symlinks / shared config dirs can alias paths).
+    """
 
 
 def project_hooks_path(project_root: Path) -> Path:
@@ -93,34 +100,42 @@ def load_hooks_config(
             followed by user hooks.
 
     Returns:
-        Frozen load result with canonical `snapshot_id`.
+        Frozen load result with canonical `snapshot_id` and explicit project
+        source provenance.
     """
-    configured_sources = (
-        tuple(paths)
-        if paths is not None
-        else (
-            (project_hooks_path(project_root), user_hooks_path(config_dir))
-            if workspace_trusted
-            else (user_hooks_path(config_dir),)
-        )
-    )
-    sources = tuple(
-        dict.fromkeys(
-            path.expanduser().resolve(strict=False) for path in configured_sources
-        )
-    )
     diagnostics: list[HookDiagnostic] = []
     merged: dict[HookEvent, list[MatcherGroup]] = {}
     loaded_paths: list[Path] = []
+    project_source_loaded = False
 
-    for path in sources:
-        document, file_diagnostics = _read_hooks_document(path)
+    def _ingest(path: Path, *, as_project: bool) -> None:
+        nonlocal project_source_loaded
+        resolved = path.expanduser().resolve(strict=False)
+        document, file_diagnostics = _read_hooks_document(resolved)
         diagnostics.extend(file_diagnostics)
         if document is None:
-            continue
-        loaded_paths.append(path)
+            return
+        if as_project:
+            project_source_loaded = True
+        loaded_paths.append(resolved)
         for event, groups in document.hooks.items():
             merged.setdefault(event, []).extend(groups)
+
+    if paths is not None:
+        for path in dict.fromkeys(
+            path.expanduser().resolve(strict=False) for path in paths
+        ):
+            _ingest(path, as_project=False)
+    elif workspace_trusted:
+        project_path = (
+            project_hooks_path(project_root).expanduser().resolve(strict=False)
+        )
+        user_path = user_hooks_path(config_dir).expanduser().resolve(strict=False)
+        _ingest(project_path, as_project=True)
+        if user_path != project_path:
+            _ingest(user_path, as_project=False)
+    else:
+        _ingest(user_hooks_path(config_dir), as_project=False)
 
     config = HooksConfig(hooks=merged)
     return LoadedHooksConfig(
@@ -128,6 +143,7 @@ def load_hooks_config(
         diagnostics=tuple(diagnostics),
         sources=tuple(loaded_paths),
         snapshot_id=compute_snapshot_id(config),
+        project_source_loaded=project_source_loaded,
     )
 
 

--- a/libs/code/deepagents_code/hooks/manager.py
+++ b/libs/code/deepagents_code/hooks/manager.py
@@ -27,6 +27,7 @@ from deepagents_code.hooks.permissions import (
     PermissionPlan,
     permission_hook_outcome,
 )
+from deepagents_code.hooks.trust import WorkspaceTrust
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -103,6 +104,9 @@ class HooksManager:
     identity: SessionIdentityProvider
     notice: Callable[[str], None]
     _runtime: HooksRuntime | None = None
+    trust: WorkspaceTrust = field(default_factory=WorkspaceTrust)
+    """Policy re-resolved on every reload; the manager is its only interpreter."""
+
     _service: ClientHookService | None = field(default=None, init=False)
 
     def __post_init__(self) -> None:
@@ -116,7 +120,7 @@ class HooksManager:
         cwd: Path,
         identity: SessionIdentityProvider,
         notice: Callable[[str], None],
-        workspace_trusted: bool = False,
+        trust: WorkspaceTrust | None = None,
     ) -> HooksManager:
         """Load hook configuration and return a ready manager.
 
@@ -127,12 +131,14 @@ class HooksManager:
             cwd: Session working directory used to resolve hook configuration.
             identity: Reads current thread, approval mode, and prompt id.
             notice: Surfaces hook `systemMessage` notices to the user.
-            workspace_trusted: Whether project-scoped hooks may be loaded.
+            trust: Project-hook trust policy. Defaults to trusting nothing
+                beyond what the persisted trust store already records.
 
         Returns:
             A manager owning the loaded runtime, or an inert one on failure.
         """
-        return cls(identity, notice, _load_runtime(cwd, trusted=workspace_trusted))
+        policy = trust if trust is not None else WorkspaceTrust.none()
+        return cls(identity, notice, _load_runtime(cwd, trust=policy), policy)
 
     @classmethod
     def adopting(
@@ -186,22 +192,25 @@ class HooksManager:
         service = self._service
         return service is not None and service.has_handlers(event)
 
-    async def reload(self, *, cwd: Path, workspace_trusted: bool = False) -> None:
+    async def reload(self, *, cwd: Path) -> None:
         """Rebuild the runtime after the session working directory changes.
+
+        Workspace trust is re-resolved for `cwd`, so moving from a trusted
+        project into an untrusted one drops project hooks instead of carrying
+        the previous grant forward.
 
         Pending `SessionStart` context is dropped with the old runtime, matching
         the lifecycle boundary that triggers a reload.
 
         Args:
             cwd: New session working directory.
-            workspace_trusted: Whether project-scoped hooks may be loaded.
         """
         import asyncio
 
         self._runtime = await asyncio.to_thread(
             _load_runtime,
             cwd,
-            trusted=workspace_trusted,
+            trust=self.trust,
         )
         self._service = self._build_service()
 
@@ -523,11 +532,23 @@ class HooksManager:
         )
 
 
-def _load_runtime(cwd: Path, *, trusted: bool) -> HooksRuntime | None:
+def _load_runtime(cwd: Path, *, trust: WorkspaceTrust) -> HooksRuntime | None:
+    """Resolve workspace trust for `cwd` and load a runtime under it.
+
+    Trust is resolved here rather than by the caller so that a reload after a
+    working-directory change re-reads the trust store for the new directory.
+
+    Args:
+        cwd: Session working directory.
+        trust: Policy deciding whether project hooks may load.
+
+    Returns:
+        The loaded runtime, or `None` when configuration could not be loaded.
+    """
     from deepagents_code.hooks.runtime import HooksRuntime
 
     try:
-        return HooksRuntime.create(cwd=cwd, workspace_trusted=trusted)
+        return HooksRuntime.create(cwd=cwd, workspace_trusted=trust.allows(cwd))
     except Exception:
         logger.exception("Failed to load hook configuration; hooks disabled")
         return None

--- a/libs/code/deepagents_code/hooks/runtime.py
+++ b/libs/code/deepagents_code/hooks/runtime.py
@@ -54,6 +54,13 @@ class HooksRuntime:
     engine: HookEngine
     cwd: Path
     workspace_trusted: bool
+    """Trust decision resolved for `cwd` when this runtime was frozen.
+
+    Scoped to `cwd` by construction: a runtime is never reused across working
+    directories, so `HooksManager` discards it and re-resolves trust whenever the
+    session moves.
+    """
+
     project_hooks_loaded: bool
     fulfillments: HookFulfillmentLedger
 
@@ -70,7 +77,9 @@ class HooksRuntime:
 
         Args:
             cwd: Session working directory.
-            workspace_trusted: Whether project-scoped hooks may be loaded.
+            workspace_trusted: Whether project-scoped hooks may be loaded for
+                `cwd`, already resolved by the caller from `WorkspaceTrust`. The
+                runtime treats it as fixed for its lifetime.
             config_dir: Alternate user config directory for tests.
             transcript_root: Alternate transcript store root for tests.
                 Defaults to `~/.deepagents/transcripts` regardless of

--- a/libs/code/deepagents_code/hooks/runtime.py
+++ b/libs/code/deepagents_code/hooks/runtime.py
@@ -21,6 +21,7 @@ from deepagents_code.hooks.models.domain import (
 from deepagents_code.hooks.snapshot import HooksSnapshot
 from deepagents_code.hooks.transcript import TranscriptStore
 from deepagents_code.model_config import DEFAULT_CONFIG_DIR
+from deepagents_code.project_utils import ProjectContext
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -52,6 +53,8 @@ class HooksRuntime:
     transcripts: TranscriptStore
     engine: HookEngine
     cwd: Path
+    workspace_trusted: bool
+    project_hooks_loaded: bool
     fulfillments: HookFulfillmentLedger
 
     @classmethod
@@ -77,8 +80,10 @@ class HooksRuntime:
         Returns:
             A runtime ready to execute invocations for this session.
         """
+        project_context = ProjectContext.from_user_cwd(cwd)
+        project_root = project_context.project_root or project_context.user_cwd
         loaded = load_hooks_config(
-            project_root=cwd,
+            project_root=project_root,
             workspace_trusted=workspace_trusted,
             config_dir=config_dir,
         )
@@ -97,7 +102,9 @@ class HooksRuntime:
             snapshot=snapshot,
             transcripts=store,
             engine=engine,
-            cwd=cwd,
+            cwd=project_context.user_cwd,
+            workspace_trusted=workspace_trusted,
+            project_hooks_loaded=loaded.project_source_loaded,
             fulfillments=HookFulfillmentLedger(),
         )
 
@@ -148,7 +155,13 @@ class HooksRuntime:
 
         Returns:
             Event-specific decision with notices, sequences, and diagnostics.
+
+        Raises:
+            PermissionError: If project handlers were loaded without workspace trust.
         """
+        if self.project_hooks_loaded and not self.workspace_trusted:
+            msg = "Project hooks cannot execute before workspace trust is granted"
+            raise PermissionError(msg)
         prepared = self.prepare_invocation(invocation)
         return await self.engine.run(
             prepared.invocation,

--- a/libs/code/deepagents_code/hooks/trust.py
+++ b/libs/code/deepagents_code/hooks/trust.py
@@ -1,0 +1,331 @@
+"""Persistent workspace trust for project-scoped hooks."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+from contextlib import contextmanager, suppress
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from filelock import FileLock, Timeout
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+logger = logging.getLogger(__name__)
+
+_STORE_VERSION: Literal[1] = 1
+_TRUST_STORE_LOCK_TIMEOUT_SECONDS = 5.0
+_TRUST_STORE_THREAD_LOCKS_GUARD = threading.Lock()
+_TRUST_STORE_THREAD_LOCKS: dict[str, threading.Lock] = {}
+
+
+class HooksTrustEntry(BaseModel):
+    """Persisted trust record for one canonical workspace root."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    trusted_at: str
+    """UTC ISO-8601 timestamp when the workspace was trusted."""
+
+
+class HooksTrustStore(BaseModel):
+    """Versioned on-disk trust store for project-scoped hooks."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    version: Literal[1] = _STORE_VERSION
+    """Schema version; unsupported versions are ignored on read."""
+
+    projects: dict[str, HooksTrustEntry] = {}
+    """Map of canonical workspace roots to trust entries."""
+
+
+def _default_store_path() -> Path:
+    from deepagents_code.model_config import DEFAULT_STATE_DIR
+
+    return DEFAULT_STATE_DIR / "hooks_trust.json"
+
+
+def _project_key(project_root: Path | str) -> str:
+    return str(Path(project_root).expanduser().resolve())
+
+
+def _trust_store_lock_path(path: Path) -> Path:
+    return path.with_name(f"{path.name}.lock")
+
+
+def _trust_store_thread_lock(path: Path) -> threading.Lock:
+    """Return the process-local mutation lock for a trust-store path.
+
+    Args:
+        path: Path to `hooks_trust.json`.
+
+    Returns:
+        Process-lifetime lock keyed by the normalized path string.
+    """
+    key = str(path)
+    with _TRUST_STORE_THREAD_LOCKS_GUARD:
+        lock = _TRUST_STORE_THREAD_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _TRUST_STORE_THREAD_LOCKS[key] = lock
+        return lock
+
+
+@contextmanager
+def _trust_store_lock(path: Path) -> Iterator[None]:
+    """Serialize read-merge-write updates to the hooks trust store.
+
+    Combines a process-local threading lock with a cross-process `FileLock` on a
+    sibling `.lock` file so concurrent `dcode` processes cannot drop each
+    other's workspace entries.
+
+    Args:
+        path: Path to `hooks_trust.json`.
+
+    Yields:
+        Control while the caller exclusively holds the mutation lock.
+
+    Callers should handle `filelock.Timeout` (lock wait expired) and `OSError`
+    (lock directory creation failure).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if os.name != "nt":
+        path.parent.chmod(0o700)
+    file_lock = FileLock(
+        str(_trust_store_lock_path(path)),
+        timeout=_TRUST_STORE_LOCK_TIMEOUT_SECONDS,
+        thread_local=False,
+    )
+    with _trust_store_thread_lock(path), file_lock:
+        yield
+
+
+def _parse_projects(
+    raw_projects: object,
+    *,
+    path: Path,
+) -> dict[str, HooksTrustEntry]:
+    """Parse trust entries, skipping structurally invalid ones.
+
+    Args:
+        raw_projects: Raw `projects` value from JSON.
+        path: Store path used in warning messages.
+
+    Returns:
+        Validated project map. Empty when `raw_projects` is missing or not a
+        mapping.
+
+    Raises:
+        TypeError: When `raw_projects` is present but not a mapping (strict
+            callers refuse to overwrite such stores).
+    """
+    if raw_projects is None:
+        return {}
+    if not isinstance(raw_projects, dict):
+        msg = f"hooks trust store projects must be an object: {path}"
+        raise TypeError(msg)
+
+    projects: dict[str, HooksTrustEntry] = {}
+    for key, value in raw_projects.items():
+        if not isinstance(key, str):
+            logger.warning(
+                "Skipping non-string hooks trust project key in %s: %r",
+                path,
+                key,
+            )
+            continue
+        try:
+            projects[key] = HooksTrustEntry.model_validate(value)
+        except ValidationError as exc:
+            logger.warning(
+                "Skipping invalid hooks trust entry for %s in %s: %s",
+                key,
+                path,
+                exc,
+            )
+    return projects
+
+
+def _load_store(path: Path, *, strict: bool = False) -> HooksTrustStore:
+    """Load and validate the hooks trust store.
+
+    Args:
+        path: Trust store path.
+        strict: When `True`, raise on unreadable or structurally invalid stores
+            so writers refuse to overwrite them.
+
+    Returns:
+        Validated store. Missing files yield an empty store. Unsupported versions
+        and unreadable files yield an empty store when not `strict`.
+
+    Raises:
+        OSError: When `strict` and the file cannot be read.
+        TypeError: When `strict` and `projects` is not a mapping.
+        ValueError: When `strict` and the version or top-level shape is invalid.
+        json.JSONDecodeError: When `strict` and the file is not valid JSON.
+        UnicodeDecodeError: When `strict` and the file is not UTF-8 text.
+    """
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return HooksTrustStore()
+    except OSError as exc:
+        if strict:
+            raise
+        logger.warning("Could not read hooks trust store %s: %s", path, exc)
+        return HooksTrustStore()
+
+    try:
+        data: object = json.loads(raw_text)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        if strict:
+            raise
+        logger.warning("Could not parse hooks trust store %s: %s", path, exc)
+        return HooksTrustStore()
+
+    if not isinstance(data, dict):
+        msg = f"hooks trust store must be a JSON object: {path}"
+        if strict:
+            raise TypeError(msg)
+        logger.warning(msg)
+        return HooksTrustStore()
+
+    version = data.get("version")
+    if version != _STORE_VERSION:
+        msg = f"Unsupported hooks trust store version: {version!r}"
+        if strict:
+            raise ValueError(msg)
+        logger.warning(
+            "Ignoring hooks trust store with unsupported version %r", version
+        )
+        return HooksTrustStore()
+
+    try:
+        projects = _parse_projects(data.get("projects"), path=path)
+    except TypeError:
+        if strict:
+            raise
+        logger.warning(
+            "Ignoring hooks trust store with invalid projects field at %s",
+            path,
+        )
+        return HooksTrustStore()
+
+    # Tolerate unknown top-level fields via HooksTrustStore.extra="ignore".
+    return HooksTrustStore(version=_STORE_VERSION, projects=projects)
+
+
+def _write_store(path: Path, store: HooksTrustStore) -> None:
+    """Atomically write the trust store with restrictive permissions.
+
+    Args:
+        path: Destination path.
+        store: Validated store payload.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if os.name != "nt":
+        path.parent.chmod(0o700)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(
+                store.model_dump(mode="json"),
+                handle,
+                sort_keys=True,
+            )
+            handle.write("\n")
+        if os.name != "nt":
+            tmp_path.chmod(0o600)
+        tmp_path.replace(path)
+        if os.name != "nt":
+            path.chmod(0o600)
+    except BaseException:
+        with suppress(OSError):
+            tmp_path.unlink()
+        raise
+
+
+def is_project_hooks_trusted(
+    project_root: Path | str,
+    *,
+    store_path: Path | None = None,
+) -> bool:
+    """Return whether project hooks are trusted for a canonical workspace root.
+
+    Args:
+        project_root: Workspace root to inspect.
+        store_path: Alternate trust store path for tests.
+
+    Returns:
+        `True` when the canonical workspace root is trusted.
+    """
+    path = store_path or _default_store_path()
+    store = _load_store(path)
+    return _project_key(project_root) in store.projects
+
+
+def trust_project_hooks(
+    project_root: Path | str,
+    *,
+    store_path: Path | None = None,
+) -> bool:
+    """Persist project-hook trust for a workspace root.
+
+    Args:
+        project_root: Workspace root to trust.
+        store_path: Alternate trust store path for tests.
+
+    Returns:
+        `True` when trust was saved.
+
+    Note:
+        Failures (unreadable store, lock timeout, I/O errors) return `False`
+        without mutating the on-disk store. Callers must treat `False` as a
+        real persistence failure, not as an implicit session grant.
+    """
+    path = store_path or _default_store_path()
+    try:
+        with _trust_store_lock(path):
+            try:
+                store = _load_store(path, strict=True)
+            except (
+                OSError,
+                UnicodeDecodeError,
+                json.JSONDecodeError,
+                TypeError,
+                ValueError,
+            ):
+                logger.exception(
+                    "Refusing to overwrite unreadable hooks trust store %s",
+                    path,
+                )
+                return False
+
+            projects = dict(store.projects)
+            projects[_project_key(project_root)] = HooksTrustEntry(
+                trusted_at=datetime.now(UTC).isoformat()
+            )
+            _write_store(
+                path,
+                HooksTrustStore(version=_STORE_VERSION, projects=projects),
+            )
+    except Timeout:
+        logger.exception("Timed out waiting to persist hooks trust store %s", path)
+        return False
+    except OSError:
+        logger.exception("Could not save hooks trust store %s", path)
+        return False
+    return True

--- a/libs/code/deepagents_code/hooks/trust.py
+++ b/libs/code/deepagents_code/hooks/trust.py
@@ -8,12 +8,15 @@ import os
 import tempfile
 import threading
 from contextlib import contextmanager, suppress
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from filelock import FileLock, Timeout
 from pydantic import BaseModel, ConfigDict, ValidationError
+
+from deepagents_code.project_utils import ProjectContext
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -22,8 +25,13 @@ logger = logging.getLogger(__name__)
 
 _STORE_VERSION: Literal[1] = 1
 _TRUST_STORE_LOCK_TIMEOUT_SECONDS = 5.0
-_TRUST_STORE_THREAD_LOCKS_GUARD = threading.Lock()
-_TRUST_STORE_THREAD_LOCKS: dict[str, threading.Lock] = {}
+_TRUST_STORE_THREAD_LOCK = threading.Lock()
+"""Process-local guard for trust-store mutations.
+
+A single lock is sufficient: one store backs the process, and the alternate
+paths tests pass only ever serialize against each other harmlessly. Contention
+across distinct stores is not worth per-path lock bookkeeping.
+"""
 
 
 class HooksTrustEntry(BaseModel):
@@ -61,31 +69,13 @@ def _trust_store_lock_path(path: Path) -> Path:
     return path.with_name(f"{path.name}.lock")
 
 
-def _trust_store_thread_lock(path: Path) -> threading.Lock:
-    """Return the process-local mutation lock for a trust-store path.
-
-    Args:
-        path: Path to `hooks_trust.json`.
-
-    Returns:
-        Process-lifetime lock keyed by the normalized path string.
-    """
-    key = str(path)
-    with _TRUST_STORE_THREAD_LOCKS_GUARD:
-        lock = _TRUST_STORE_THREAD_LOCKS.get(key)
-        if lock is None:
-            lock = threading.Lock()
-            _TRUST_STORE_THREAD_LOCKS[key] = lock
-        return lock
-
-
 @contextmanager
 def _trust_store_lock(path: Path) -> Iterator[None]:
     """Serialize read-merge-write updates to the hooks trust store.
 
-    Combines a process-local threading lock with a cross-process `FileLock` on a
-    sibling `.lock` file so concurrent `dcode` processes cannot drop each
-    other's workspace entries.
+    Combines a single process-local threading lock with a cross-process
+    `FileLock` on a sibling `.lock` file so concurrent `dcode` processes cannot
+    drop each other's workspace entries.
 
     Args:
         path: Path to `hooks_trust.json`.
@@ -104,7 +94,7 @@ def _trust_store_lock(path: Path) -> Iterator[None]:
         timeout=_TRUST_STORE_LOCK_TIMEOUT_SECONDS,
         thread_local=False,
     )
-    with _trust_store_thread_lock(path), file_lock:
+    with _TRUST_STORE_THREAD_LOCK, file_lock:
         yield
 
 
@@ -329,3 +319,106 @@ def trust_project_hooks(
         logger.exception("Could not save hooks trust store %s", path)
         return False
     return True
+
+
+def project_root_for(cwd: Path | str) -> Path:
+    """Resolve the workspace root that governs hook trust for a directory.
+
+    Args:
+        cwd: Session working directory.
+
+    Returns:
+        The enclosing project root, or the directory itself when it is not
+        inside a project.
+    """
+    context = ProjectContext.from_user_cwd(Path(cwd))
+    return context.project_root or context.user_cwd
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceTrust:
+    """Decides whether project-scoped hooks may run in a given directory.
+
+    Trust is a property of the workspace, not of the session, so it must be
+    re-resolved every time the working directory moves. A session that starts in
+    a trusted project and later moves into an untrusted one must not carry the
+    original grant forward.
+
+    Callers hand this policy to `HooksManager`, which resolves it on load and on
+    every reload; nothing upstream needs to hold or reinterpret the decision.
+    """
+
+    session_grants: frozenset[str] = frozenset()
+    """Canonical workspace roots trusted for this session only.
+
+    Populated from an explicit CLI grant or an in-session `allow once` choice,
+    neither of which is persisted to the trust store.
+    """
+
+    store_path: Path | None = None
+    """Alternate trust store path for tests."""
+
+    @classmethod
+    def none(cls) -> WorkspaceTrust:
+        """Return a policy that trusts no workspace.
+
+        Returns:
+            A policy that consults only the persisted trust store.
+        """
+        return cls()
+
+    @classmethod
+    def for_session(
+        cls,
+        cwd: Path | str,
+        *,
+        granted: bool,
+        store_path: Path | None = None,
+    ) -> WorkspaceTrust:
+        """Build a policy from a launch-time trust decision.
+
+        Args:
+            cwd: Directory the trust decision was made for.
+            granted: Whether the user trusted project hooks for this session
+                without persisting that choice.
+            store_path: Alternate trust store path for tests.
+
+        Returns:
+            A policy that grants `cwd`'s workspace root for this session and
+            defers to the persisted store everywhere else.
+        """
+        grants: frozenset[str] = frozenset()
+        if granted:
+            try:
+                grants = frozenset({_project_key(project_root_for(cwd))})
+            except (OSError, ValueError):
+                logger.warning(
+                    "Could not resolve workspace root for session hook trust",
+                    exc_info=True,
+                )
+        return cls(session_grants=grants, store_path=store_path)
+
+    def allows(self, cwd: Path | str) -> bool:
+        """Return whether project hooks may run for a working directory.
+
+        Args:
+            cwd: Directory to resolve trust for.
+
+        Returns:
+            `True` when the enclosing workspace root was granted for this
+            session or is recorded in the trust store. Unresolvable directories
+            fail closed.
+        """
+        try:
+            root = project_root_for(cwd)
+        except (OSError, ValueError):
+            logger.warning(
+                "Could not resolve workspace root for %s; treating project "
+                "hooks as untrusted",
+                cwd,
+                exc_info=True,
+            )
+            return False
+        if _project_key(root) in self.session_grants:
+            return True
+        return is_project_hooks_trusted(root, store_path=self.store_path)

--- a/libs/code/deepagents_code/hooks/trust.py
+++ b/libs/code/deepagents_code/hooks/trust.py
@@ -167,7 +167,9 @@ def _load_store(path: Path, *, strict: bool = False) -> HooksTrustStore:
         raw_text = path.read_text(encoding="utf-8")
     except FileNotFoundError:
         return HooksTrustStore()
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
+        # Decoding happens during the read, so non-UTF-8 stores surface here
+        # rather than at `json.loads` below.
         if strict:
             raise
         logger.warning("Could not read hooks trust store %s: %s", path, exc)
@@ -175,7 +177,7 @@ def _load_store(path: Path, *, strict: bool = False) -> HooksTrustStore:
 
     try:
         data: object = json.loads(raw_text)
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+    except json.JSONDecodeError as exc:
         if strict:
             raise
         logger.warning("Could not parse hooks trust store %s: %s", path, exc)
@@ -355,6 +357,14 @@ class WorkspaceTrust:
     neither of which is persisted to the trust store.
     """
 
+    consult_store: bool = True
+    """Whether persisted trust may satisfy the policy.
+
+    Headless runs set this to `False`: executing repository hooks there requires
+    an explicit opt-in, so a workspace remembered during an interactive session
+    must not silently qualify a later `dcode -n` invocation.
+    """
+
     store_path: Path | None = None
     """Alternate trust store path for tests."""
 
@@ -387,16 +397,51 @@ class WorkspaceTrust:
             A policy that grants `cwd`'s workspace root for this session and
             defers to the persisted store everywhere else.
         """
-        grants: frozenset[str] = frozenset()
-        if granted:
-            try:
-                grants = frozenset({_project_key(project_root_for(cwd))})
-            except (OSError, ValueError):
-                logger.warning(
-                    "Could not resolve workspace root for session hook trust",
-                    exc_info=True,
-                )
-        return cls(session_grants=grants, store_path=store_path)
+        return cls(
+            session_grants=cls._grants_for(cwd) if granted else frozenset(),
+            store_path=store_path,
+        )
+
+    @classmethod
+    def explicit_only(
+        cls,
+        cwd: Path | str,
+        *,
+        granted: bool,
+        store_path: Path | None = None,
+    ) -> WorkspaceTrust:
+        """Build a policy that ignores persisted trust entirely.
+
+        For contexts where running repository hooks must be an explicit opt-in
+        rather than something a previous interactive session can enable —
+        notably headless runs, where the operator may never have seen the
+        interactive trust prompt.
+
+        Args:
+            cwd: Directory the trust decision was made for.
+            granted: Whether project hooks were explicitly opted into.
+            store_path: Alternate trust store path for tests.
+
+        Returns:
+            A policy that allows `cwd`'s workspace root only when `granted`, and
+            allows nothing otherwise.
+        """
+        return cls(
+            session_grants=cls._grants_for(cwd) if granted else frozenset(),
+            consult_store=False,
+            store_path=store_path,
+        )
+
+    @staticmethod
+    def _grants_for(cwd: Path | str) -> frozenset[str]:
+        try:
+            return frozenset({_project_key(project_root_for(cwd))})
+        except (OSError, ValueError):
+            logger.warning(
+                "Could not resolve workspace root for session hook trust",
+                exc_info=True,
+            )
+            return frozenset()
 
     def allows(self, cwd: Path | str) -> bool:
         """Return whether project hooks may run for a working directory.
@@ -406,19 +451,20 @@ class WorkspaceTrust:
 
         Returns:
             `True` when the enclosing workspace root was granted for this
-            session or is recorded in the trust store. Unresolvable directories
-            fail closed.
+            session, or is recorded in the trust store and `consult_store` is
+            set. Unresolvable directories fail closed.
         """
         try:
             root = project_root_for(cwd)
         except (OSError, ValueError):
+            # The raised exception carries the offending path; don't restate it.
             logger.warning(
-                "Could not resolve workspace root for %s; treating project "
-                "hooks as untrusted",
-                cwd,
+                "Could not resolve workspace root; treating project hooks as untrusted",
                 exc_info=True,
             )
             return False
         if _project_key(root) in self.session_grants:
             return True
+        if not self.consult_store:
+            return False
         return is_project_hooks_trusted(root, store_path=self.store_path)

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -2318,6 +2318,7 @@ async def run_textual_cli_async(
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool | None = None,
+    trust_project_hooks: bool = False,
     enable_interpreter: bool | None = None,
     interpreter_arg: bool | None = None,
     interpreter_ptc: str | list[str] | None = None,
@@ -2376,6 +2377,7 @@ async def run_textual_cli_async(
             `True` to allow, `False` to deny, `None` to fall back to the
             user's per-server scoped approvals (equivalent to `False` for the
             whole-config decision).
+        trust_project_hooks: Whether project-scoped hook commands may run.
         enable_interpreter: Enable `CodeInterpreterMiddleware` (`js_eval`) on
             the main agent. `None` defers to the sandbox-aware/config default.
         interpreter_arg: The raw `--interpreter`/`--no-interpreter` tri-state,
@@ -2507,6 +2509,7 @@ async def run_textual_cli_async(
             model_explicitly_set=model_name is not None,
             interpreter_arg=interpreter_arg,
             defer_server_start=defer_server_start,
+            trust_project_hooks=trust_project_hooks,
         )
     except Exception as e:
         logger.debug("App error", exc_info=True)
@@ -2941,11 +2944,16 @@ def _project_mcp_picker_has_terminal() -> bool:
 
 def _run_project_mcp_trust_action_picker(
     console: "Console",
+    *,
+    remember_label: str = "Allow for this project — until changed",
 ) -> _ProjectMcpTrustAction | _ProjectMcpTrustPromptOutcome | None:
     """Show the inline project MCP trust action picker.
 
     Args:
         console: Console to print fallback notices to (stderr).
+        remember_label: Label for the persistent-trust option. Callers that
+            remember broader or narrower scope than MCP should override this so
+            the UI matches what is actually persisted.
 
     Returns:
         The chosen action, `CANCELLED` for Esc or Ctrl+D, `INTERRUPTED` for
@@ -2978,7 +2986,7 @@ def _run_project_mcp_trust_action_picker(
     glyphs = get_glyphs()
     actions = [
         (_ProjectMcpTrustAction.ALLOW_ONCE, "Allow once"),
-        (_ProjectMcpTrustAction.REMEMBER, "Allow for this project — until changed"),
+        (_ProjectMcpTrustAction.REMEMBER, remember_label),
         (_ProjectMcpTrustAction.DENY, "Deny"),
     ]
     selected_index = len(actions) - 1
@@ -3068,17 +3076,24 @@ def _run_project_mcp_trust_action_picker(
 
 def _select_project_mcp_trust_action(
     console: "Console",
+    *,
+    remember_label: str = "Allow for this project — until changed",
 ) -> _ProjectMcpTrustAction | _ProjectMcpTrustPromptOutcome:
     """Choose whether to allow once, remember selected servers, or deny.
 
     Args:
         console: Console used by the text fallback.
+        remember_label: Label for the persistent-trust option forwarded to the
+            inline picker.
 
     Returns:
         The selected trust action, `CANCELLED` when the user presses Esc or
         Ctrl+D, or `INTERRUPTED` when the user presses Ctrl+C.
     """
-    selected = _run_project_mcp_trust_action_picker(console)
+    selected = _run_project_mcp_trust_action_picker(
+        console,
+        remember_label=remember_label,
+    )
     if selected is not None:
         return selected
 
@@ -3539,6 +3554,97 @@ def _check_mcp_project_trust(
         highlight=False,
     )
     return True
+
+
+_PROJECT_HOOKS_REMEMBER_LABEL = "Always allow hooks in this workspace"
+
+
+def _check_project_hooks_trust(
+    *,
+    trust_flag: bool = False,
+) -> (
+    bool
+    | Literal[
+        _ProjectMcpTrustPromptOutcome.INTERRUPTED,
+        _ProjectMcpTrustPromptOutcome.CANCELLED,
+    ]
+):
+    """Resolve interactive trust for project-scoped hook commands.
+
+    Args:
+        trust_flag: Whether the CLI explicitly trusted project hooks.
+
+    Returns:
+        Whether project hooks may run, `INTERRUPTED` when the user presses
+        Ctrl+C, or `CANCELLED` when the user presses Esc or Ctrl+D to abort
+        startup.
+    """
+    from rich.console import Console
+    from rich.text import Text
+
+    from deepagents_code.hooks.loading import project_hooks_path
+    from deepagents_code.hooks.trust import (
+        is_project_hooks_trusted,
+        trust_project_hooks,
+    )
+    from deepagents_code.project_utils import ProjectContext
+
+    try:
+        context = ProjectContext.from_user_cwd(Path.cwd())
+        project_root = context.project_root or context.user_cwd
+        config_path = project_hooks_path(project_root)
+        if not config_path.is_file():
+            return False
+    except OSError:
+        logger.warning("Could not inspect project hooks configuration", exc_info=True)
+        return False
+
+    if trust_flag or is_project_hooks_trusted(project_root):
+        return True
+
+    prompt_console = Console(stderr=True)
+    prompt_console.print()
+    title = Text("Project hooks can execute commands from ", style="bold yellow")
+    title.append(str(config_path))
+    prompt_console.print(title, highlight=False)
+    prompt_console.print(
+        "Only allow hooks for projects you trust. Future edits to this file "
+        "will run without asking again if you always allow.",
+        style="yellow",
+        highlight=False,
+    )
+    action = _select_project_mcp_trust_action(
+        prompt_console,
+        remember_label=_PROJECT_HOOKS_REMEMBER_LABEL,
+    )
+    if action is _ProjectMcpTrustPromptOutcome.INTERRUPTED:
+        return action
+    if action is _ProjectMcpTrustPromptOutcome.CANCELLED:
+        return action
+    if action is _ProjectMcpTrustAction.ALLOW_ONCE:
+        prompt_console.print(
+            "[dim]Allowing project hooks for this session.[/dim]",
+            highlight=False,
+        )
+        return True
+    if action is _ProjectMcpTrustAction.REMEMBER:
+        if not trust_project_hooks(project_root):
+            prompt_console.print(
+                "[yellow]Project hook trust could not be remembered; "
+                "allowing this session only.[/yellow]",
+                highlight=False,
+            )
+        else:
+            prompt_console.print(
+                "[dim]Project hooks trusted for this workspace.[/dim]",
+                highlight=False,
+            )
+        return True
+    prompt_console.print(
+        "[dim]Project hooks skipped.[/dim]",
+        highlight=False,
+    )
+    return False
 
 
 def _verify_interpreter_or_exit() -> None:
@@ -4473,6 +4579,20 @@ def cli_main() -> None:
                 )
                 return
 
+            hooks_trust_decision = _check_project_hooks_trust(
+                trust_flag=getattr(args, "trust_project_hooks", False),
+            )
+            if hooks_trust_decision is _ProjectMcpTrustPromptOutcome.INTERRUPTED:
+                sys.exit(130)
+            if hooks_trust_decision is _ProjectMcpTrustPromptOutcome.CANCELLED:
+                from rich.console import Console as _Console
+
+                _Console(stderr=True).print(
+                    "[dim]Aborted; project hooks not loaded.[/dim]",
+                    highlight=False,
+                )
+                return
+
             # Run Textual TUI
             return_code = 0
             try:
@@ -4525,6 +4645,7 @@ def cli_main() -> None:
                         mcp_config_path=getattr(args, "mcp_config", None),
                         no_mcp=getattr(args, "no_mcp", False),
                         trust_project_mcp=mcp_trust_decision,
+                        trust_project_hooks=hooks_trust_decision,
                         enable_interpreter=enable_interpreter,
                         interpreter_arg=args.interpreter,
                         interpreter_ptc=interpreter_ptc,

--- a/libs/code/deepagents_code/main.py
+++ b/libs/code/deepagents_code/main.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from deepagents_code.app import AppResult
     from deepagents_code.approval_mode import ApprovalMode
     from deepagents_code.config import Glyphs
+    from deepagents_code.hooks.trust import WorkspaceTrust
     from deepagents_code.mcp_tools import MCPServerInfo, ProjectServerSummary
     from deepagents_code.notifications import PendingNotification
 
@@ -51,16 +52,23 @@ _UNPERSISTED_AUTO_UPDATE_FAILURE_NOTE = (
 )
 
 
-class _ProjectMcpTrustAction(Enum):
-    """Actions available in the project MCP trust prompt."""
+class _TrustAction(Enum):
+    """Actions available in any project-scope trust prompt.
+
+    Shared by the project MCP server and project hook prompts; both offer the
+    same allow-once / remember / deny choice over a different subject.
+    """
 
     ALLOW_ONCE = "allow_once"
     REMEMBER = "remember"
     DENY = "deny"
 
 
-class _ProjectMcpTrustPromptOutcome(Enum):
-    """Internal outcomes that are not project MCP trust decisions."""
+class _TrustPromptOutcome(Enum):
+    """Trust-prompt results that are not decisions about the subject.
+
+    Subject-neutral so hook and MCP prompts can report the same abort paths.
+    """
 
     INTERRUPTED = "interrupted"
     """The user pressed Ctrl+C; the caller aborts the run (exit 130)."""
@@ -2318,7 +2326,7 @@ async def run_textual_cli_async(
     mcp_config_path: str | None = None,
     no_mcp: bool = False,
     trust_project_mcp: bool | None = None,
-    trust_project_hooks: bool = False,
+    hook_trust: "WorkspaceTrust | None" = None,
     enable_interpreter: bool | None = None,
     interpreter_arg: bool | None = None,
     interpreter_ptc: str | list[str] | None = None,
@@ -2377,7 +2385,8 @@ async def run_textual_cli_async(
             `True` to allow, `False` to deny, `None` to fall back to the
             user's per-server scoped approvals (equivalent to `False` for the
             whole-config decision).
-        trust_project_hooks: Whether project-scoped hook commands may run.
+        hook_trust: Policy deciding which workspaces may run project-scoped hook
+            commands. `None` consults only the persisted trust store.
         enable_interpreter: Enable `CodeInterpreterMiddleware` (`js_eval`) on
             the main agent. `None` defers to the sandbox-aware/config default.
         interpreter_arg: The raw `--interpreter`/`--no-interpreter` tri-state,
@@ -2509,7 +2518,7 @@ async def run_textual_cli_async(
             model_explicitly_set=model_name is not None,
             interpreter_arg=interpreter_arg,
             defer_server_start=defer_server_start,
-            trust_project_hooks=trust_project_hooks,
+            hook_trust=hook_trust,
         )
     except Exception as e:
         logger.debug("App error", exc_info=True)
@@ -2937,30 +2946,32 @@ def _format_project_mcp_checkbox_rows(
     return rows
 
 
-def _project_mcp_picker_has_terminal() -> bool:
-    """Return whether the inline MCP pickers have interactive input and output."""
+def _trust_picker_has_terminal() -> bool:
+    """Return whether the inline trust pickers have interactive input and output."""
     return sys.stdin.isatty() and sys.stderr.isatty()
 
 
-def _run_project_mcp_trust_action_picker(
+def _run_trust_action_picker(
     console: "Console",
     *,
     remember_label: str = "Allow for this project — until changed",
-) -> _ProjectMcpTrustAction | _ProjectMcpTrustPromptOutcome | None:
-    """Show the inline project MCP trust action picker.
+) -> _TrustAction | _TrustPromptOutcome | None:
+    """Show the inline allow-once / remember / deny picker for a trust prompt.
+
+    Subject-agnostic: callers describe what is being trusted before calling and
+    supply the label for the persistent option.
 
     Args:
         console: Console to print fallback notices to (stderr).
-        remember_label: Label for the persistent-trust option. Callers that
-            remember broader or narrower scope than MCP should override this so
-            the UI matches what is actually persisted.
+        remember_label: Label for the persistent-trust option. Set this to match
+            what the caller actually persists, since scope differs by subject.
 
     Returns:
         The chosen action, `CANCELLED` for Esc or Ctrl+D, `INTERRUPTED` for
         Ctrl+C, or `None` when the inline picker cannot run and the caller should
         use the text fallback.
     """
-    if not _project_mcp_picker_has_terminal():
+    if not _trust_picker_has_terminal():
         return None
 
     try:
@@ -2974,7 +2985,7 @@ def _run_project_mcp_trust_action_picker(
         from prompt_toolkit.output.defaults import create_output
         from prompt_toolkit.styles import Style
     except ImportError:
-        logger.debug("Project MCP action picker unavailable", exc_info=True)
+        logger.debug("Trust action picker unavailable", exc_info=True)
         console.print(
             "[dim]Interactive selector unavailable; falling back to text input.[/dim]",
             highlight=False,
@@ -2985,9 +2996,9 @@ def _run_project_mcp_trust_action_picker(
 
     glyphs = get_glyphs()
     actions = [
-        (_ProjectMcpTrustAction.ALLOW_ONCE, "Allow once"),
-        (_ProjectMcpTrustAction.REMEMBER, remember_label),
-        (_ProjectMcpTrustAction.DENY, "Deny"),
+        (_TrustAction.ALLOW_ONCE, "Allow once"),
+        (_TrustAction.REMEMBER, remember_label),
+        (_TrustAction.DENY, "Deny"),
     ]
     selected_index = len(actions) - 1
 
@@ -3032,54 +3043,58 @@ def _run_project_mcp_trust_action_picker(
     @key_bindings.add("escape")
     @key_bindings.add("c-d")
     def _abort(event: KeyPressEvent) -> None:
-        event.app.exit(result=_ProjectMcpTrustPromptOutcome.CANCELLED)
+        event.app.exit(result=_TrustPromptOutcome.CANCELLED)
 
     @key_bindings.add("c-c")
     def _interrupt(event: KeyPressEvent) -> None:
-        event.app.exit(result=_ProjectMcpTrustPromptOutcome.INTERRUPTED)
+        event.app.exit(result=_TrustPromptOutcome.INTERRUPTED)
 
-    app: Application[_ProjectMcpTrustAction | _ProjectMcpTrustPromptOutcome] = (
-        Application(
-            layout=Layout(
-                Window(
-                    FormattedTextControl(_rows, show_cursor=False),
-                    height=len(actions) + 1,
-                    dont_extend_height=True,
-                )
-            ),
-            key_bindings=key_bindings,
-            style=Style.from_dict(
-                {
-                    "prompt.help": "ansibrightblack",
-                    "item.current": "reverse",
-                }
-            ),
-            full_screen=False,
-            erase_when_done=True,
-            output=create_output(stdout=sys.stderr),
-        )
+    app: Application[_TrustAction | _TrustPromptOutcome] = Application(
+        layout=Layout(
+            Window(
+                FormattedTextControl(_rows, show_cursor=False),
+                height=len(actions) + 1,
+                dont_extend_height=True,
+            )
+        ),
+        key_bindings=key_bindings,
+        style=Style.from_dict(
+            {
+                "prompt.help": "ansibrightblack",
+                "item.current": "reverse",
+            }
+        ),
+        full_screen=False,
+        erase_when_done=True,
+        output=create_output(stdout=sys.stderr),
     )
     try:
         return app.run()
     except (RuntimeError, OSError):
-        logger.debug("Project MCP action picker failed", exc_info=True)
+        logger.debug("Trust action picker failed", exc_info=True)
         console.print(
             "[dim]Interactive selector unavailable; falling back to text input.[/dim]",
             highlight=False,
         )
         return None
     except KeyboardInterrupt:
-        return _ProjectMcpTrustPromptOutcome.INTERRUPTED
+        return _TrustPromptOutcome.INTERRUPTED
     except EOFError:
         return None
 
 
-def _select_project_mcp_trust_action(
+def _select_trust_action(
     console: "Console",
     *,
     remember_label: str = "Allow for this project — until changed",
-) -> _ProjectMcpTrustAction | _ProjectMcpTrustPromptOutcome:
-    """Choose whether to allow once, remember selected servers, or deny.
+) -> _TrustAction | _TrustPromptOutcome:
+    """Choose whether to allow once, remember, or deny a project-scoped subject.
+
+    Falls back to a text prompt when the inline picker cannot run. Every failure
+    mode resolves to a decision the caller can act on without knowing which
+    input path produced it: an unavailable picker degrades to text, and EOF on
+    the text prompt denies rather than aborting, so a non-interactive launch
+    fails closed instead of hanging.
 
     Args:
         console: Console used by the text fallback.
@@ -3090,7 +3105,7 @@ def _select_project_mcp_trust_action(
         The selected trust action, `CANCELLED` when the user presses Esc or
         Ctrl+D, or `INTERRUPTED` when the user presses Ctrl+C.
     """
-    selected = _run_project_mcp_trust_action_picker(
+    selected = _run_trust_action_picker(
         console,
         remember_label=remember_label,
     )
@@ -3102,19 +3117,19 @@ def _select_project_mcp_trust_action(
             input("Choose [y] allow once / [r] remember / [N] deny: ").strip().lower()
         )
     except KeyboardInterrupt:
-        return _ProjectMcpTrustPromptOutcome.INTERRUPTED
+        return _TrustPromptOutcome.INTERRUPTED
     except EOFError:
-        return _ProjectMcpTrustAction.DENY
+        return _TrustAction.DENY
     if answer in {"y", "yes"}:
-        return _ProjectMcpTrustAction.ALLOW_ONCE
+        return _TrustAction.ALLOW_ONCE
     if answer in {"r", "remember", "a", "always"}:
-        return _ProjectMcpTrustAction.REMEMBER
-    return _ProjectMcpTrustAction.DENY
+        return _TrustAction.REMEMBER
+    return _TrustAction.DENY
 
 
 def _run_project_mcp_server_checkbox_picker(
     prompt_servers: Sequence["ProjectServerSummary"], console: "Console"
-) -> list[str] | _ProjectMcpTrustPromptOutcome | None:
+) -> list[str] | _TrustPromptOutcome | None:
     """Show an inline checkbox picker for project MCP servers to remember.
 
     Args:
@@ -3127,7 +3142,7 @@ def _run_project_mcp_server_checkbox_picker(
         `INTERRUPTED` means the user pressed Ctrl+C; `None` means the checkbox UI
         could not run and the caller should fall back to a simpler prompt.
     """
-    if not _project_mcp_picker_has_terminal():
+    if not _trust_picker_has_terminal():
         return None
 
     try:
@@ -3231,13 +3246,13 @@ def _run_project_mcp_server_checkbox_picker(
 
     @key_bindings.add("escape")
     def _cancel(event: KeyPressEvent) -> None:
-        event.app.exit(result=_ProjectMcpTrustPromptOutcome.CANCELLED)
+        event.app.exit(result=_TrustPromptOutcome.CANCELLED)
 
     @key_bindings.add("c-c")
     def _interrupt(event: KeyPressEvent) -> None:
-        event.app.exit(result=_ProjectMcpTrustPromptOutcome.INTERRUPTED)
+        event.app.exit(result=_TrustPromptOutcome.INTERRUPTED)
 
-    app: Application[list[str] | _ProjectMcpTrustPromptOutcome] = Application(
+    app: Application[list[str] | _TrustPromptOutcome] = Application(
         layout=Layout(
             HSplit(
                 [
@@ -3276,16 +3291,16 @@ def _run_project_mcp_server_checkbox_picker(
         )
         return None
     except KeyboardInterrupt:
-        return _ProjectMcpTrustPromptOutcome.INTERRUPTED
+        return _TrustPromptOutcome.INTERRUPTED
     except EOFError:
         # Ctrl+D backs out of the picker, same as Esc: cancel rather than
         # silently confirm an empty selection.
-        return _ProjectMcpTrustPromptOutcome.CANCELLED
+        return _TrustPromptOutcome.CANCELLED
 
 
 def _select_project_servers_with_numbers(
     prompt_servers: Sequence["ProjectServerSummary"], console: "Console"
-) -> list[str] | _ProjectMcpTrustPromptOutcome:
+) -> list[str] | _TrustPromptOutcome:
     """Ask which prompted project MCP servers to remember with a text fallback.
 
     Args:
@@ -3310,11 +3325,11 @@ def _select_project_servers_with_numbers(
     try:
         raw = input("Enter numbers to remember (e.g. 1,3), 'all', or blank to abort: ")
     except KeyboardInterrupt:
-        return _ProjectMcpTrustPromptOutcome.INTERRUPTED
+        return _TrustPromptOutcome.INTERRUPTED
     except EOFError:
-        return _ProjectMcpTrustPromptOutcome.CANCELLED
+        return _TrustPromptOutcome.CANCELLED
     if not raw.strip():
-        return _ProjectMcpTrustPromptOutcome.CANCELLED
+        return _TrustPromptOutcome.CANCELLED
     if raw.strip().lower() in {"a", "all"}:
         return names
     return [
@@ -3324,7 +3339,7 @@ def _select_project_servers_with_numbers(
 
 def _select_project_servers_to_persist(
     prompt_servers: Sequence["ProjectServerSummary"], console: "Console"
-) -> list[str] | _ProjectMcpTrustPromptOutcome:
+) -> list[str] | _TrustPromptOutcome:
     """Ask which prompted project MCP servers to remember for this project.
 
     Multiple prompted servers use an arrow-key checkbox picker. A single
@@ -3355,8 +3370,8 @@ def _check_mcp_project_trust(
 ) -> (
     bool
     | Literal[
-        _ProjectMcpTrustPromptOutcome.INTERRUPTED,
-        _ProjectMcpTrustPromptOutcome.CANCELLED,
+        _TrustPromptOutcome.INTERRUPTED,
+        _TrustPromptOutcome.CANCELLED,
     ]
     | None
 ):
@@ -3502,18 +3517,18 @@ def _check_mcp_project_trust(
 
     server_count = len(prompt_servers)
     noun = "server" if server_count == 1 else "servers"
-    action = _select_project_mcp_trust_action(prompt_console)
-    if action is _ProjectMcpTrustPromptOutcome.INTERRUPTED:
-        return _ProjectMcpTrustPromptOutcome.INTERRUPTED
-    if action is _ProjectMcpTrustPromptOutcome.CANCELLED:
-        return _ProjectMcpTrustPromptOutcome.CANCELLED
-    if action is _ProjectMcpTrustAction.DENY:
+    action = _select_trust_action(prompt_console)
+    if action is _TrustPromptOutcome.INTERRUPTED:
+        return _TrustPromptOutcome.INTERRUPTED
+    if action is _TrustPromptOutcome.CANCELLED:
+        return _TrustPromptOutcome.CANCELLED
+    if action is _TrustAction.DENY:
         prompt_console.print(
             f"[dim]Denied {server_count} project MCP {noun}.[/dim]",
             highlight=False,
         )
         return False
-    if action is _ProjectMcpTrustAction.ALLOW_ONCE:
+    if action is _TrustAction.ALLOW_ONCE:
         prompt_console.print(
             f"[dim]Allowing {server_count} project MCP {noun} for this "
             "session; remembering 0.[/dim]",
@@ -3524,10 +3539,10 @@ def _check_mcp_project_trust(
     from deepagents_code.model_config import add_enabled_project_mcp_servers
 
     names = _select_project_servers_to_persist(prompt_servers, prompt_console)
-    if names is _ProjectMcpTrustPromptOutcome.INTERRUPTED:
-        return _ProjectMcpTrustPromptOutcome.INTERRUPTED
-    if names is _ProjectMcpTrustPromptOutcome.CANCELLED:
-        return _ProjectMcpTrustPromptOutcome.CANCELLED
+    if names is _TrustPromptOutcome.INTERRUPTED:
+        return _TrustPromptOutcome.INTERRUPTED
+    if names is _TrustPromptOutcome.CANCELLED:
+        return _TrustPromptOutcome.CANCELLED
     if not names:
         prompt_console.print(
             f"[dim]No servers selected; denied {server_count} project MCP "
@@ -3562,28 +3577,27 @@ _PROJECT_HOOKS_REMEMBER_LABEL = "Always allow hooks in this workspace"
 def _check_project_hooks_trust(
     *,
     trust_flag: bool = False,
-) -> (
-    bool
-    | Literal[
-        _ProjectMcpTrustPromptOutcome.INTERRUPTED,
-        _ProjectMcpTrustPromptOutcome.CANCELLED,
-    ]
-):
+) -> "WorkspaceTrust | _TrustPromptOutcome":
     """Resolve interactive trust for project-scoped hook commands.
+
+    Returns a policy rather than a Boolean so the decision keeps its scope: the
+    grant applies to the launch workspace, and directories the session later
+    moves into are re-resolved against the persisted trust store.
 
     Args:
         trust_flag: Whether the CLI explicitly trusted project hooks.
 
     Returns:
-        Whether project hooks may run, `INTERRUPTED` when the user presses
-        Ctrl+C, or `CANCELLED` when the user presses Esc or Ctrl+D to abort
-        startup.
+        The trust policy to run the session under, `INTERRUPTED` when the user
+        presses Ctrl+C, or `CANCELLED` when the user presses Esc or Ctrl+D to
+        abort startup.
     """
     from rich.console import Console
     from rich.text import Text
 
     from deepagents_code.hooks.loading import project_hooks_path
     from deepagents_code.hooks.trust import (
+        WorkspaceTrust,
         is_project_hooks_trusted,
         trust_project_hooks,
     )
@@ -3594,13 +3608,14 @@ def _check_project_hooks_trust(
         project_root = context.project_root or context.user_cwd
         config_path = project_hooks_path(project_root)
         if not config_path.is_file():
-            return False
+            return WorkspaceTrust.none()
     except OSError:
         logger.warning("Could not inspect project hooks configuration", exc_info=True)
-        return False
+        return WorkspaceTrust.none()
 
+    granted = WorkspaceTrust.for_session(project_root, granted=True)
     if trust_flag or is_project_hooks_trusted(project_root):
-        return True
+        return granted
 
     prompt_console = Console(stderr=True)
     prompt_console.print()
@@ -3613,21 +3628,21 @@ def _check_project_hooks_trust(
         style="yellow",
         highlight=False,
     )
-    action = _select_project_mcp_trust_action(
+    action = _select_trust_action(
         prompt_console,
         remember_label=_PROJECT_HOOKS_REMEMBER_LABEL,
     )
-    if action is _ProjectMcpTrustPromptOutcome.INTERRUPTED:
+    if action is _TrustPromptOutcome.INTERRUPTED:
         return action
-    if action is _ProjectMcpTrustPromptOutcome.CANCELLED:
+    if action is _TrustPromptOutcome.CANCELLED:
         return action
-    if action is _ProjectMcpTrustAction.ALLOW_ONCE:
+    if action is _TrustAction.ALLOW_ONCE:
         prompt_console.print(
             "[dim]Allowing project hooks for this session.[/dim]",
             highlight=False,
         )
-        return True
-    if action is _ProjectMcpTrustAction.REMEMBER:
+        return granted
+    if action is _TrustAction.REMEMBER:
         if not trust_project_hooks(project_root):
             prompt_console.print(
                 "[yellow]Project hook trust could not be remembered; "
@@ -3639,12 +3654,12 @@ def _check_project_hooks_trust(
                 "[dim]Project hooks trusted for this workspace.[/dim]",
                 highlight=False,
             )
-        return True
+        return granted
     prompt_console.print(
         "[dim]Project hooks skipped.[/dim]",
         highlight=False,
     )
-    return False
+    return WorkspaceTrust.none()
 
 
 def _verify_interpreter_or_exit() -> None:
@@ -4568,9 +4583,9 @@ def cli_main() -> None:
             )
             if _debug_mcp_project_trust_enabled():
                 sys.exit(0)
-            if mcp_trust_decision is _ProjectMcpTrustPromptOutcome.INTERRUPTED:
+            if mcp_trust_decision is _TrustPromptOutcome.INTERRUPTED:
                 sys.exit(130)
-            if mcp_trust_decision is _ProjectMcpTrustPromptOutcome.CANCELLED:
+            if mcp_trust_decision is _TrustPromptOutcome.CANCELLED:
                 from rich.console import Console as _Console
 
                 _Console(stderr=True).print(
@@ -4579,12 +4594,12 @@ def cli_main() -> None:
                 )
                 return
 
-            hooks_trust_decision = _check_project_hooks_trust(
+            hook_trust = _check_project_hooks_trust(
                 trust_flag=getattr(args, "trust_project_hooks", False),
             )
-            if hooks_trust_decision is _ProjectMcpTrustPromptOutcome.INTERRUPTED:
+            if hook_trust is _TrustPromptOutcome.INTERRUPTED:
                 sys.exit(130)
-            if hooks_trust_decision is _ProjectMcpTrustPromptOutcome.CANCELLED:
+            if hook_trust is _TrustPromptOutcome.CANCELLED:
                 from rich.console import Console as _Console
 
                 _Console(stderr=True).print(
@@ -4645,7 +4660,7 @@ def cli_main() -> None:
                         mcp_config_path=getattr(args, "mcp_config", None),
                         no_mcp=getattr(args, "no_mcp", False),
                         trust_project_mcp=mcp_trust_decision,
-                        trust_project_hooks=hooks_trust_decision,
+                        hook_trust=hook_trust,
                         enable_interpreter=enable_interpreter,
                         interpreter_arg=args.interpreter,
                         interpreter_ptc=interpreter_ptc,

--- a/libs/code/tests/unit_tests/hooks/test_configuration.py
+++ b/libs/code/tests/unit_tests/hooks/test_configuration.py
@@ -87,6 +87,7 @@ def test_load_hooks_config_precedence_and_snapshot_hash(tmp_path: Path) -> None:
         for group in untrusted.config.hooks[HookEvent.SESSION_START]
     ] == ["user-hook"]
     assert untrusted.sources == (user_dir / "hooks.json",)
+    assert not untrusted.project_source_loaded
 
     loaded = load_hooks_config(
         project_root=project_dir,
@@ -99,6 +100,7 @@ def test_load_hooks_config_precedence_and_snapshot_hash(tmp_path: Path) -> None:
         "project-hook",
         "user-hook",
     ]
+    assert loaded.project_source_loaded
     assert loaded.snapshot_id == compute_snapshot_id(loaded.config)
     assert loaded.snapshot_id == compute_snapshot_id(
         HooksConfig.model_validate(

--- a/libs/code/tests/unit_tests/hooks/test_trust.py
+++ b/libs/code/tests/unit_tests/hooks/test_trust.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
@@ -11,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from deepagents_code.approval_mode import ApprovalMode
+from deepagents_code.hooks.manager import HookSessionIdentity, HooksManager
 from deepagents_code.hooks.models.domain import (
     HookContext,
     HookEvent,
@@ -18,7 +20,11 @@ from deepagents_code.hooks.models.domain import (
     StopEvent,
 )
 from deepagents_code.hooks.runtime import HooksRuntime
-from deepagents_code.hooks.trust import is_project_hooks_trusted, trust_project_hooks
+from deepagents_code.hooks.trust import (
+    WorkspaceTrust,
+    is_project_hooks_trusted,
+    trust_project_hooks,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -56,6 +62,65 @@ def test_corrupt_store_fails_closed_without_overwrite(tmp_path: Path) -> None:
     assert not is_project_hooks_trusted(root, store_path=store)
     assert not trust_project_hooks(root, store_path=store)
     assert store.read_text(encoding="utf-8") == "{invalid"
+
+
+def test_concurrent_writes_across_stores_preserve_every_entry(tmp_path: Path) -> None:
+    """A single process-wide lock must not drop entries under contention."""
+    roots = [_write_project_hooks(tmp_path / f"project-{index}") for index in range(8)]
+    stores = [tmp_path / "state-a" / "trust.json", tmp_path / "state-b" / "trust.json"]
+
+    with ThreadPoolExecutor(max_workers=len(roots)) as pool:
+        results = list(
+            pool.map(
+                lambda pair: trust_project_hooks(pair[1], store_path=pair[0]),
+                [
+                    (stores[index % len(stores)], root)
+                    for index, root in enumerate(roots)
+                ],
+            )
+        )
+
+    assert all(results)
+    for index, root in enumerate(roots):
+        assert is_project_hooks_trusted(root, store_path=stores[index % len(stores)])
+
+
+def test_trust_is_resolved_per_workspace(tmp_path: Path) -> None:
+    """Trust follows the workspace, so each directory resolves independently."""
+    trusted = _write_project_hooks(tmp_path / "trusted")
+    untrusted = _write_project_hooks(tmp_path / "untrusted")
+    store = tmp_path / "state" / "hooks_trust.json"
+    assert trust_project_hooks(trusted, store_path=store)
+
+    nested = trusted / "src"
+    nested.mkdir()
+    policy = WorkspaceTrust(store_path=store)
+
+    assert policy.allows(trusted)
+    assert policy.allows(nested)
+    assert not policy.allows(untrusted)
+
+
+def test_session_grant_does_not_extend_to_other_workspaces(tmp_path: Path) -> None:
+    """An unpersisted `allow once` grant covers only the workspace it was made in."""
+    granted = _write_project_hooks(tmp_path / "granted")
+    other = _write_project_hooks(tmp_path / "other")
+    store = tmp_path / "state" / "hooks_trust.json"
+
+    policy = WorkspaceTrust.for_session(granted, granted=True, store_path=store)
+
+    assert policy.allows(granted)
+    assert not policy.allows(other)
+    assert not is_project_hooks_trusted(granted, store_path=store)
+
+
+def test_declined_trust_resolves_to_untrusted_everywhere(tmp_path: Path) -> None:
+    root = _write_project_hooks(tmp_path / "project")
+    store = tmp_path / "state" / "hooks_trust.json"
+
+    policy = WorkspaceTrust.for_session(root, granted=False, store_path=store)
+
+    assert not policy.allows(root)
 
 
 def test_runtime_loads_project_hooks_only_when_trusted(tmp_path: Path) -> None:
@@ -123,18 +188,20 @@ def test_interactive_prompt_applies_selected_action(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from deepagents_code.hooks import trust
-    from deepagents_code.main import _check_project_hooks_trust, _ProjectMcpTrustAction
+    from deepagents_code.main import _check_project_hooks_trust, _TrustAction
 
     root = _write_project_hooks(tmp_path / "project")
     store = tmp_path / "state" / "hooks_trust.json"
     monkeypatch.chdir(root)
     monkeypatch.setattr(trust, "_default_store_path", lambda: store)
     monkeypatch.setattr(
-        "deepagents_code.main._select_project_mcp_trust_action",
-        lambda _console, **_kwargs: _ProjectMcpTrustAction[action],
+        "deepagents_code.main._select_trust_action",
+        lambda _console, **_kwargs: _TrustAction[action],
     )
 
-    assert _check_project_hooks_trust() is allowed
+    decision = _check_project_hooks_trust()
+    assert isinstance(decision, WorkspaceTrust)
+    assert decision.allows(root) is allowed
     assert is_project_hooks_trusted(root, store_path=store) is persisted
 
 
@@ -151,17 +218,28 @@ def test_persisted_trust_skips_prompt(
     monkeypatch.setattr(trust, "_default_store_path", lambda: store)
     assert trust_project_hooks(root, store_path=store)
     monkeypatch.setattr(
-        "deepagents_code.main._select_project_mcp_trust_action",
+        "deepagents_code.main._select_trust_action",
         lambda *_args, **_kwargs: pytest.fail("prompt ran despite persisted trust"),
     )
 
-    assert _check_project_hooks_trust() is True
+    decision = _check_project_hooks_trust()
+    assert isinstance(decision, WorkspaceTrust)
+    assert decision.allows(root)
 
 
-async def test_textual_app_forwards_project_trust() -> None:
+async def test_textual_app_forwards_hook_trust(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from deepagents_code.app import DeepAgentsApp
 
-    app = DeepAgentsApp(agent=MagicMock(), thread_id="thread", trust_project_hooks=True)
+    root = _write_project_hooks(tmp_path / "project")
+    monkeypatch.chdir(root)
+    app = DeepAgentsApp(
+        agent=MagicMock(),
+        thread_id="thread",
+        hook_trust=WorkspaceTrust.for_session(root, granted=True),
+    )
     with patch(
         "deepagents_code.hooks.runtime.HooksRuntime.create",
         return_value=MagicMock(),
@@ -169,3 +247,83 @@ async def test_textual_app_forwards_project_trust() -> None:
         await app._init_session_state()
 
     assert create.call_args.kwargs["workspace_trusted"] is True
+
+
+async def test_textual_app_defaults_to_untrusted_without_a_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deepagents_code.app import DeepAgentsApp
+    from deepagents_code.hooks import trust
+
+    root = _write_project_hooks(tmp_path / "project")
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(
+        trust, "_default_store_path", lambda: tmp_path / "state" / "hooks_trust.json"
+    )
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="thread")
+    with patch(
+        "deepagents_code.hooks.runtime.HooksRuntime.create",
+        return_value=MagicMock(),
+    ) as create:
+        await app._init_session_state()
+
+    assert create.call_args.kwargs["workspace_trusted"] is False
+
+
+def _isolate_hook_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point user hooks and transcripts at `tmp_path` instead of the real home."""
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    monkeypatch.setattr("deepagents_code.hooks.loading.DEFAULT_CONFIG_DIR", user_dir)
+    monkeypatch.setattr(
+        "deepagents_code.hooks.runtime.DEFAULT_CONFIG_DIR", tmp_path / "state"
+    )
+
+
+def _manager(cwd: Path, trust: WorkspaceTrust) -> HooksManager:
+    return HooksManager.create(
+        cwd=cwd,
+        identity=lambda: HookSessionIdentity("thread", ApprovalMode.MANUAL),
+        notice=lambda _message: None,
+        trust=trust,
+    )
+
+
+async def test_reload_drops_project_hooks_when_leaving_trusted_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A grant for one workspace must not survive a move into an untrusted one."""
+    _isolate_hook_config(tmp_path, monkeypatch)
+    trusted = _write_project_hooks(tmp_path / "trusted")
+    untrusted = _write_project_hooks(tmp_path / "untrusted")
+    store = tmp_path / "state" / "hooks_trust.json"
+
+    manager = _manager(
+        trusted, WorkspaceTrust.for_session(trusted, granted=True, store_path=store)
+    )
+    assert manager.has_handlers(HookEvent.STOP)
+
+    await manager.reload(cwd=untrusted)
+
+    assert not manager.has_handlers(HookEvent.STOP)
+
+
+async def test_reload_picks_up_trust_when_entering_trusted_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Moving into a workspace the store already trusts loads its hooks."""
+    _isolate_hook_config(tmp_path, monkeypatch)
+    untrusted = _write_project_hooks(tmp_path / "untrusted")
+    trusted = _write_project_hooks(tmp_path / "trusted")
+    store = tmp_path / "state" / "hooks_trust.json"
+    assert trust_project_hooks(trusted, store_path=store)
+
+    manager = _manager(untrusted, WorkspaceTrust(store_path=store))
+    assert not manager.has_handlers(HookEvent.STOP)
+
+    await manager.reload(cwd=trusted)
+
+    assert manager.has_handlers(HookEvent.STOP)

--- a/libs/code/tests/unit_tests/hooks/test_trust.py
+++ b/libs/code/tests/unit_tests/hooks/test_trust.py
@@ -1,0 +1,553 @@
+"""Tests for project-hook workspace trust."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deepagents_code.approval_mode import ApprovalMode
+from deepagents_code.hooks.loading import load_hooks_config
+from deepagents_code.hooks.models.domain import (
+    HookContext,
+    HookEvent,
+    HookInvocation,
+    StopEvent,
+)
+from deepagents_code.hooks.runtime import HooksRuntime
+from deepagents_code.hooks.trust import (
+    HooksTrustStore,
+    is_project_hooks_trusted,
+    trust_project_hooks,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_project_hooks(root: Path, command: str = "true") -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / ".git").mkdir(exist_ok=True)
+    hooks_dir = root / ".deepagents"
+    hooks_dir.mkdir(exist_ok=True)
+    (hooks_dir / "hooks.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "Stop": [
+                        {
+                            "hooks": [
+                                {"type": "command", "command": command},
+                            ]
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_trust_store_persists_canonical_project_root(tmp_path: Path) -> None:
+    root = _write_project_hooks(tmp_path / "project")
+    store = tmp_path / "state" / "hooks_trust.json"
+
+    assert trust_project_hooks(root / ".", store_path=store)
+    assert is_project_hooks_trusted(root, store_path=store)
+
+
+def test_symlink_alias_shares_persisted_trust(tmp_path: Path) -> None:
+    root = _write_project_hooks(tmp_path / "project")
+    alias = tmp_path / "alias"
+    alias.symlink_to(root)
+    store = tmp_path / "hooks_trust.json"
+
+    assert trust_project_hooks(root, store_path=store)
+    assert is_project_hooks_trusted(alias, store_path=store)
+
+
+def test_linked_worktree_style_roots_are_trusted_independently(
+    tmp_path: Path,
+) -> None:
+    primary = _write_project_hooks(tmp_path / "main-worktree")
+    linked = _write_project_hooks(tmp_path / "linked-worktree")
+    store = tmp_path / "hooks_trust.json"
+
+    assert trust_project_hooks(primary, store_path=store)
+    assert is_project_hooks_trusted(primary, store_path=store)
+    assert not is_project_hooks_trusted(linked, store_path=store)
+
+
+def test_corrupt_trust_store_fails_closed_without_overwrite(tmp_path: Path) -> None:
+    root = _write_project_hooks(tmp_path / "project")
+    store = tmp_path / "hooks_trust.json"
+    store.write_text("{invalid", encoding="utf-8")
+
+    assert not is_project_hooks_trusted(root, store_path=store)
+    assert not trust_project_hooks(root, store_path=store)
+    assert store.read_text(encoding="utf-8") == "{invalid"
+
+
+def test_partially_invalid_trust_store_keeps_valid_entries(tmp_path: Path) -> None:
+    root = _write_project_hooks(tmp_path / "project")
+    other = _write_project_hooks(tmp_path / "other")
+    store = tmp_path / "hooks_trust.json"
+    store.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "projects": {
+                    str(root.resolve()): {"trusted_at": "2026-01-01T00:00:00+00:00"},
+                    str(other.resolve()): "not-an-object",
+                    str(tmp_path / "missing-fields"): {"unexpected": True},
+                },
+                "future_field": {"ignored": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert is_project_hooks_trusted(root, store_path=store)
+    assert not is_project_hooks_trusted(other, store_path=store)
+    assert not is_project_hooks_trusted(tmp_path / "missing-fields", store_path=store)
+
+    third = _write_project_hooks(tmp_path / "third")
+    assert trust_project_hooks(third, store_path=store)
+    payload = json.loads(store.read_text(encoding="utf-8"))
+    assert str(root.resolve()) in payload["projects"]
+    assert str(third.resolve()) in payload["projects"]
+    assert str(other.resolve()) not in payload["projects"]
+
+
+def test_malformed_projects_field_refuses_overwrite(tmp_path: Path) -> None:
+    root = _write_project_hooks(tmp_path / "project")
+    store = tmp_path / "hooks_trust.json"
+    original = json.dumps({"version": 1, "projects": ["not", "a", "mapping"]})
+    store.write_text(original, encoding="utf-8")
+
+    assert not is_project_hooks_trusted(root, store_path=store)
+    assert not trust_project_hooks(root, store_path=store)
+    assert store.read_text(encoding="utf-8") == original
+
+
+def test_concurrent_writers_preserve_all_entries(tmp_path: Path) -> None:
+    store = tmp_path / "hooks_trust.json"
+    roots = [_write_project_hooks(tmp_path / f"project-{index}") for index in range(8)]
+
+    def _trust(root: Path) -> bool:
+        return trust_project_hooks(root, store_path=store)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(_trust, roots))
+
+    assert all(results)
+    for root in roots:
+        assert is_project_hooks_trusted(root, store_path=store)
+
+
+def test_trust_write_failure_surfaces_without_mutating_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deepagents_code.hooks import trust as trust_mod
+
+    root = _write_project_hooks(tmp_path / "project")
+    store = tmp_path / "hooks_trust.json"
+    store.write_text(
+        json.dumps({"version": 1, "projects": {}}),
+        encoding="utf-8",
+    )
+
+    def _boom(_path: object, _store: object) -> None:
+        msg = "disk full"
+        raise OSError(msg)
+
+    monkeypatch.setattr(trust_mod, "_write_store", _boom)
+
+    assert not trust_project_hooks(root, store_path=store)
+    assert json.loads(store.read_text(encoding="utf-8")) == {
+        "version": 1,
+        "projects": {},
+    }
+    assert not is_project_hooks_trusted(root, store_path=store)
+
+
+def test_loader_path_alias_does_not_misclassify_user_hooks_as_project(
+    tmp_path: Path,
+) -> None:
+    """When user and project hooks paths alias, provenance must stay explicit."""
+    shared = tmp_path / "shared-config"
+    shared.mkdir()
+    (shared / "hooks.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "Stop": [{"hooks": [{"type": "command", "command": "shared-hook"}]}]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".git").mkdir()
+    (project / ".deepagents").symlink_to(shared)
+
+    untrusted = load_hooks_config(
+        project_root=project,
+        workspace_trusted=False,
+        config_dir=shared,
+    )
+    assert not untrusted.project_source_loaded
+    assert HookEvent.STOP in untrusted.config.hooks
+    assert [
+        group.hooks[0].command for group in untrusted.config.hooks[HookEvent.STOP]
+    ] == ["shared-hook"]
+
+    trusted = load_hooks_config(
+        project_root=project,
+        workspace_trusted=True,
+        config_dir=shared,
+    )
+    assert trusted.project_source_loaded
+    assert [
+        group.hooks[0].command for group in trusted.config.hooks[HookEvent.STOP]
+    ] == ["shared-hook"]
+
+
+def test_runtime_home_as_git_alias_keeps_user_hooks_when_untrusted(
+    tmp_path: Path,
+) -> None:
+    home_project = _write_project_hooks(tmp_path / "home-as-git", command="home-hook")
+    config_dir = home_project / ".deepagents"
+
+    untrusted = HooksRuntime.create(
+        cwd=home_project,
+        workspace_trusted=False,
+        config_dir=config_dir,
+        transcript_root=tmp_path / "untrusted-transcripts",
+    )
+    assert not untrusted.project_hooks_loaded
+    assert HookEvent.STOP in untrusted.configured_events()
+
+    trusted = HooksRuntime.create(
+        cwd=home_project,
+        workspace_trusted=True,
+        config_dir=config_dir,
+        transcript_root=tmp_path / "trusted-transcripts",
+    )
+    assert trusted.project_hooks_loaded
+    assert HookEvent.STOP in trusted.configured_events()
+
+
+def test_runtime_discovers_project_hooks_from_repository_root(tmp_path: Path) -> None:
+    root = _write_project_hooks(tmp_path / "project")
+    cwd = root / "src"
+    cwd.mkdir()
+    config_dir = tmp_path / "user"
+    config_dir.mkdir()
+
+    trusted = HooksRuntime.create(
+        cwd=cwd,
+        workspace_trusted=True,
+        config_dir=config_dir,
+        transcript_root=tmp_path / "trusted-transcripts",
+    )
+    untrusted = HooksRuntime.create(
+        cwd=cwd,
+        workspace_trusted=False,
+        config_dir=config_dir,
+        transcript_root=tmp_path / "untrusted-transcripts",
+    )
+
+    assert HookEvent.STOP in trusted.configured_events()
+    assert trusted.project_hooks_loaded
+    assert HookEvent.STOP not in untrusted.configured_events()
+    assert not untrusted.project_hooks_loaded
+
+
+async def test_runtime_guard_blocks_loaded_project_hooks_without_trust(
+    tmp_path: Path,
+) -> None:
+    root = _write_project_hooks(tmp_path / "project")
+    runtime = HooksRuntime.create(
+        cwd=root,
+        workspace_trusted=True,
+        config_dir=tmp_path / "user",
+        transcript_root=tmp_path / "transcripts",
+    )
+    runtime = replace(runtime, workspace_trusted=False)
+    invocation = HookInvocation(
+        context=HookContext(
+            thread_id="thread",
+            cwd=root,
+            approval_mode=ApprovalMode.MANUAL,
+        ),
+        event=StopEvent(
+            event=HookEvent.STOP,
+            continuation_count=0,
+            last_assistant_message="done",
+        ),
+    )
+
+    with pytest.raises(PermissionError, match="workspace trust"):
+        await runtime.invoke(invocation)
+
+
+def test_interactive_prompt_remembers_project_hooks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deepagents_code.hooks import trust
+    from deepagents_code.main import (
+        _PROJECT_HOOKS_REMEMBER_LABEL,
+        _check_project_hooks_trust,
+        _ProjectMcpTrustAction,
+    )
+
+    root = _write_project_hooks(tmp_path / "project")
+    store = tmp_path / "state" / "hooks_trust.json"
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(trust, "_default_store_path", lambda: store)
+    captured: dict[str, str] = {}
+
+    def _select(_console: object, *, remember_label: str) -> _ProjectMcpTrustAction:
+        captured["remember_label"] = remember_label
+        return _ProjectMcpTrustAction.REMEMBER
+
+    monkeypatch.setattr(
+        "deepagents_code.main._select_project_mcp_trust_action",
+        _select,
+    )
+
+    assert _check_project_hooks_trust() is True
+    assert is_project_hooks_trusted(root, store_path=store)
+    assert captured["remember_label"] == _PROJECT_HOOKS_REMEMBER_LABEL
+    assert captured["remember_label"] != "Allow for this project — until changed"
+
+
+def test_interactive_prompt_allow_once_does_not_persist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deepagents_code.hooks import trust
+    from deepagents_code.main import (
+        _check_project_hooks_trust,
+        _ProjectMcpTrustAction,
+    )
+
+    root = _write_project_hooks(tmp_path / "project")
+    store = tmp_path / "state" / "hooks_trust.json"
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(trust, "_default_store_path", lambda: store)
+    monkeypatch.setattr(
+        "deepagents_code.main._select_project_mcp_trust_action",
+        lambda _console, **_kwargs: _ProjectMcpTrustAction.ALLOW_ONCE,
+    )
+
+    assert _check_project_hooks_trust() is True
+    assert not is_project_hooks_trusted(root, store_path=store)
+
+
+def test_interactive_prompt_skips_untrusted_project_hooks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deepagents_code.main import (
+        _check_project_hooks_trust,
+        _ProjectMcpTrustAction,
+    )
+
+    root = _write_project_hooks(tmp_path / "project")
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(
+        "deepagents_code.main._select_project_mcp_trust_action",
+        lambda _console, **_kwargs: _ProjectMcpTrustAction.DENY,
+    )
+
+    assert _check_project_hooks_trust() is False
+
+
+def test_interactive_prompt_cancelled_aborts_startup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deepagents_code.main import (
+        _check_project_hooks_trust,
+        _ProjectMcpTrustPromptOutcome,
+    )
+
+    root = _write_project_hooks(tmp_path / "project")
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(
+        "deepagents_code.main._select_project_mcp_trust_action",
+        lambda _console, **_kwargs: _ProjectMcpTrustPromptOutcome.CANCELLED,
+    )
+
+    assert _check_project_hooks_trust() is _ProjectMcpTrustPromptOutcome.CANCELLED
+
+
+def test_persisted_trust_reused_on_later_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deepagents_code.hooks import trust
+    from deepagents_code.main import _check_project_hooks_trust
+
+    root = _write_project_hooks(tmp_path / "project")
+    store = tmp_path / "state" / "hooks_trust.json"
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(trust, "_default_store_path", lambda: store)
+    assert trust_project_hooks(root, store_path=store)
+
+    called = False
+
+    def _should_not_prompt(_console: object, **_kwargs: object) -> object:
+        nonlocal called
+        called = True
+        msg = "prompt should not run when trust is persisted"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(
+        "deepagents_code.main._select_project_mcp_trust_action",
+        _should_not_prompt,
+    )
+
+    assert _check_project_hooks_trust() is True
+    assert called is False
+
+
+def test_headless_requires_explicit_opt_in_even_with_persisted_trust(
+    tmp_path: Path,
+) -> None:
+    root = _write_project_hooks(tmp_path / "project")
+    store = tmp_path / "hooks_trust.json"
+    assert trust_project_hooks(root, store_path=store)
+    assert is_project_hooks_trusted(root, store_path=store)
+
+    # Headless/non-interactive paths pass workspace_trusted only from the
+    # explicit CLI flag, never from the interactive trust store.
+    runtime = HooksRuntime.create(
+        cwd=root,
+        workspace_trusted=False,
+        config_dir=tmp_path / "user",
+        transcript_root=tmp_path / "transcripts",
+    )
+    assert not runtime.project_hooks_loaded
+    assert HookEvent.STOP not in runtime.configured_events()
+
+    opted_in = HooksRuntime.create(
+        cwd=root,
+        workspace_trusted=True,
+        config_dir=tmp_path / "user",
+        transcript_root=tmp_path / "opted-in-transcripts",
+    )
+    assert opted_in.project_hooks_loaded
+
+
+def test_interactive_remember_write_failure_surfaces(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from deepagents_code.hooks import trust
+    from deepagents_code.main import (
+        _check_project_hooks_trust,
+        _ProjectMcpTrustAction,
+    )
+
+    root = _write_project_hooks(tmp_path / "project")
+    store = tmp_path / "state" / "hooks_trust.json"
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(trust, "_default_store_path", lambda: store)
+    monkeypatch.setattr(trust, "trust_project_hooks", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        "deepagents_code.main._select_project_mcp_trust_action",
+        lambda _console, **_kwargs: _ProjectMcpTrustAction.REMEMBER,
+    )
+
+    assert _check_project_hooks_trust() is True
+    captured = capsys.readouterr()
+    assert "could not be remembered" in captured.err
+    assert not is_project_hooks_trusted(root, store_path=store)
+
+
+async def test_textual_session_initialization_uses_project_trust() -> None:
+    from deepagents_code.app import DeepAgentsApp
+
+    app = DeepAgentsApp(
+        agent=MagicMock(),
+        thread_id="thread",
+        trust_project_hooks=True,
+    )
+    runtime = MagicMock()
+    with patch(
+        "deepagents_code.hooks.runtime.HooksRuntime.create",
+        return_value=runtime,
+    ) as create:
+        await app._init_session_state()
+
+    assert app._session_state is not None
+    assert app._session_state.hooks_runtime is runtime
+    assert create.call_args.kwargs["workspace_trusted"] is True
+
+
+def test_trust_store_lock_serializes_in_process_mutations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from deepagents_code.hooks import trust as trust_mod
+
+    store = tmp_path / "hooks_trust.json"
+    root_a = _write_project_hooks(tmp_path / "a")
+    root_b = _write_project_hooks(tmp_path / "b")
+    hold = threading.Event()
+    release = threading.Event()
+    original_write = trust_mod._write_store
+
+    def _gated_write(path: Path, store_model: HooksTrustStore) -> None:
+        if not hold.is_set():
+            hold.set()
+            assert release.wait(timeout=5)
+        original_write(path, store_model)
+
+    monkeypatch.setattr(trust_mod, "_write_store", _gated_write)
+    first = threading.Thread(
+        target=trust_project_hooks,
+        kwargs={"project_root": root_a, "store_path": store},
+    )
+    first.start()
+    assert hold.wait(timeout=5)
+    second_done = threading.Event()
+    second_result: list[bool] = []
+
+    def _second() -> None:
+        second_result.append(trust_project_hooks(root_b, store_path=store))
+        second_done.set()
+
+    second = threading.Thread(target=_second)
+    second.start()
+    # Second writer should block on the in-process lock until first finishes.
+    assert not second_done.wait(timeout=0.2)
+    release.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+    assert second_result == [True]
+    assert is_project_hooks_trusted(root_a, store_path=store)
+    assert is_project_hooks_trusted(root_b, store_path=store)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits only")
+def test_trust_store_written_with_restrictive_permissions(tmp_path: Path) -> None:
+    root = _write_project_hooks(tmp_path / "project")
+    store = tmp_path / "state" / "hooks_trust.json"
+    assert trust_project_hooks(root, store_path=store)
+    assert (store.stat().st_mode & 0o777) == 0o600
+    assert (store.parent.stat().st_mode & 0o777) == 0o700

--- a/libs/code/tests/unit_tests/hooks/test_trust.py
+++ b/libs/code/tests/unit_tests/hooks/test_trust.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import threading
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
@@ -13,7 +11,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from deepagents_code.approval_mode import ApprovalMode
-from deepagents_code.hooks.loading import load_hooks_config
 from deepagents_code.hooks.models.domain import (
     HookContext,
     HookEvent,
@@ -21,71 +18,37 @@ from deepagents_code.hooks.models.domain import (
     StopEvent,
 )
 from deepagents_code.hooks.runtime import HooksRuntime
-from deepagents_code.hooks.trust import (
-    HooksTrustStore,
-    is_project_hooks_trusted,
-    trust_project_hooks,
-)
+from deepagents_code.hooks.trust import is_project_hooks_trusted, trust_project_hooks
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-def _write_project_hooks(root: Path, command: str = "true") -> Path:
-    root.mkdir(parents=True, exist_ok=True)
-    (root / ".git").mkdir(exist_ok=True)
+def _write_project_hooks(root: Path) -> Path:
+    (root / ".git").mkdir(parents=True)
     hooks_dir = root / ".deepagents"
-    hooks_dir.mkdir(exist_ok=True)
+    hooks_dir.mkdir()
     (hooks_dir / "hooks.json").write_text(
         json.dumps(
-            {
-                "hooks": {
-                    "Stop": [
-                        {
-                            "hooks": [
-                                {"type": "command", "command": command},
-                            ]
-                        }
-                    ]
-                }
-            }
+            {"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "true"}]}]}}
         ),
         encoding="utf-8",
     )
     return root
 
 
-def test_trust_store_persists_canonical_project_root(tmp_path: Path) -> None:
+def test_trust_persists_under_canonical_key(tmp_path: Path) -> None:
     root = _write_project_hooks(tmp_path / "project")
     store = tmp_path / "state" / "hooks_trust.json"
 
     assert trust_project_hooks(root / ".", store_path=store)
     assert is_project_hooks_trusted(root, store_path=store)
+    assert not is_project_hooks_trusted(tmp_path / "other", store_path=store)
+    if os.name != "nt":
+        assert (store.stat().st_mode & 0o777) == 0o600
 
 
-def test_symlink_alias_shares_persisted_trust(tmp_path: Path) -> None:
-    root = _write_project_hooks(tmp_path / "project")
-    alias = tmp_path / "alias"
-    alias.symlink_to(root)
-    store = tmp_path / "hooks_trust.json"
-
-    assert trust_project_hooks(root, store_path=store)
-    assert is_project_hooks_trusted(alias, store_path=store)
-
-
-def test_linked_worktree_style_roots_are_trusted_independently(
-    tmp_path: Path,
-) -> None:
-    primary = _write_project_hooks(tmp_path / "main-worktree")
-    linked = _write_project_hooks(tmp_path / "linked-worktree")
-    store = tmp_path / "hooks_trust.json"
-
-    assert trust_project_hooks(primary, store_path=store)
-    assert is_project_hooks_trusted(primary, store_path=store)
-    assert not is_project_hooks_trusted(linked, store_path=store)
-
-
-def test_corrupt_trust_store_fails_closed_without_overwrite(tmp_path: Path) -> None:
+def test_corrupt_store_fails_closed_without_overwrite(tmp_path: Path) -> None:
     root = _write_project_hooks(tmp_path / "project")
     store = tmp_path / "hooks_trust.json"
     store.write_text("{invalid", encoding="utf-8")
@@ -95,195 +58,42 @@ def test_corrupt_trust_store_fails_closed_without_overwrite(tmp_path: Path) -> N
     assert store.read_text(encoding="utf-8") == "{invalid"
 
 
-def test_partially_invalid_trust_store_keeps_valid_entries(tmp_path: Path) -> None:
-    root = _write_project_hooks(tmp_path / "project")
-    other = _write_project_hooks(tmp_path / "other")
-    store = tmp_path / "hooks_trust.json"
-    store.write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "projects": {
-                    str(root.resolve()): {"trusted_at": "2026-01-01T00:00:00+00:00"},
-                    str(other.resolve()): "not-an-object",
-                    str(tmp_path / "missing-fields"): {"unexpected": True},
-                },
-                "future_field": {"ignored": True},
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    assert is_project_hooks_trusted(root, store_path=store)
-    assert not is_project_hooks_trusted(other, store_path=store)
-    assert not is_project_hooks_trusted(tmp_path / "missing-fields", store_path=store)
-
-    third = _write_project_hooks(tmp_path / "third")
-    assert trust_project_hooks(third, store_path=store)
-    payload = json.loads(store.read_text(encoding="utf-8"))
-    assert str(root.resolve()) in payload["projects"]
-    assert str(third.resolve()) in payload["projects"]
-    assert str(other.resolve()) not in payload["projects"]
-
-
-def test_malformed_projects_field_refuses_overwrite(tmp_path: Path) -> None:
-    root = _write_project_hooks(tmp_path / "project")
-    store = tmp_path / "hooks_trust.json"
-    original = json.dumps({"version": 1, "projects": ["not", "a", "mapping"]})
-    store.write_text(original, encoding="utf-8")
-
-    assert not is_project_hooks_trusted(root, store_path=store)
-    assert not trust_project_hooks(root, store_path=store)
-    assert store.read_text(encoding="utf-8") == original
-
-
-def test_concurrent_writers_preserve_all_entries(tmp_path: Path) -> None:
-    store = tmp_path / "hooks_trust.json"
-    roots = [_write_project_hooks(tmp_path / f"project-{index}") for index in range(8)]
-
-    def _trust(root: Path) -> bool:
-        return trust_project_hooks(root, store_path=store)
-
-    with ThreadPoolExecutor(max_workers=8) as pool:
-        results = list(pool.map(_trust, roots))
-
-    assert all(results)
-    for root in roots:
-        assert is_project_hooks_trusted(root, store_path=store)
-
-
-def test_trust_write_failure_surfaces_without_mutating_store(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from deepagents_code.hooks import trust as trust_mod
-
-    root = _write_project_hooks(tmp_path / "project")
-    store = tmp_path / "hooks_trust.json"
-    store.write_text(
-        json.dumps({"version": 1, "projects": {}}),
-        encoding="utf-8",
-    )
-
-    def _boom(_path: object, _store: object) -> None:
-        msg = "disk full"
-        raise OSError(msg)
-
-    monkeypatch.setattr(trust_mod, "_write_store", _boom)
-
-    assert not trust_project_hooks(root, store_path=store)
-    assert json.loads(store.read_text(encoding="utf-8")) == {
-        "version": 1,
-        "projects": {},
-    }
-    assert not is_project_hooks_trusted(root, store_path=store)
-
-
-def test_loader_path_alias_does_not_misclassify_user_hooks_as_project(
-    tmp_path: Path,
-) -> None:
-    """When user and project hooks paths alias, provenance must stay explicit."""
-    shared = tmp_path / "shared-config"
-    shared.mkdir()
-    (shared / "hooks.json").write_text(
-        json.dumps(
-            {
-                "hooks": {
-                    "Stop": [{"hooks": [{"type": "command", "command": "shared-hook"}]}]
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
-    project = tmp_path / "project"
-    project.mkdir()
-    (project / ".git").mkdir()
-    (project / ".deepagents").symlink_to(shared)
-
-    untrusted = load_hooks_config(
-        project_root=project,
-        workspace_trusted=False,
-        config_dir=shared,
-    )
-    assert not untrusted.project_source_loaded
-    assert HookEvent.STOP in untrusted.config.hooks
-    assert [
-        group.hooks[0].command for group in untrusted.config.hooks[HookEvent.STOP]
-    ] == ["shared-hook"]
-
-    trusted = load_hooks_config(
-        project_root=project,
-        workspace_trusted=True,
-        config_dir=shared,
-    )
-    assert trusted.project_source_loaded
-    assert [
-        group.hooks[0].command for group in trusted.config.hooks[HookEvent.STOP]
-    ] == ["shared-hook"]
-
-
-def test_runtime_home_as_git_alias_keeps_user_hooks_when_untrusted(
-    tmp_path: Path,
-) -> None:
-    home_project = _write_project_hooks(tmp_path / "home-as-git", command="home-hook")
-    config_dir = home_project / ".deepagents"
-
-    untrusted = HooksRuntime.create(
-        cwd=home_project,
-        workspace_trusted=False,
-        config_dir=config_dir,
-        transcript_root=tmp_path / "untrusted-transcripts",
-    )
-    assert not untrusted.project_hooks_loaded
-    assert HookEvent.STOP in untrusted.configured_events()
-
-    trusted = HooksRuntime.create(
-        cwd=home_project,
-        workspace_trusted=True,
-        config_dir=config_dir,
-        transcript_root=tmp_path / "trusted-transcripts",
-    )
-    assert trusted.project_hooks_loaded
-    assert HookEvent.STOP in trusted.configured_events()
-
-
-def test_runtime_discovers_project_hooks_from_repository_root(tmp_path: Path) -> None:
-    root = _write_project_hooks(tmp_path / "project")
-    cwd = root / "src"
+def test_runtime_loads_project_hooks_only_when_trusted(tmp_path: Path) -> None:
+    cwd = _write_project_hooks(tmp_path / "project") / "src"
     cwd.mkdir()
     config_dir = tmp_path / "user"
     config_dir.mkdir()
 
-    trusted = HooksRuntime.create(
-        cwd=cwd,
-        workspace_trusted=True,
-        config_dir=config_dir,
-        transcript_root=tmp_path / "trusted-transcripts",
-    )
-    untrusted = HooksRuntime.create(
-        cwd=cwd,
-        workspace_trusted=False,
-        config_dir=config_dir,
-        transcript_root=tmp_path / "untrusted-transcripts",
-    )
+    def _create(*, trusted: bool) -> HooksRuntime:
+        return HooksRuntime.create(
+            cwd=cwd,
+            workspace_trusted=trusted,
+            config_dir=config_dir,
+            transcript_root=tmp_path / f"transcripts-{trusted}",
+        )
 
-    assert HookEvent.STOP in trusted.configured_events()
+    trusted = _create(trusted=True)
+    untrusted = _create(trusted=False)
+
     assert trusted.project_hooks_loaded
-    assert HookEvent.STOP not in untrusted.configured_events()
+    assert HookEvent.STOP in trusted.configured_events()
     assert not untrusted.project_hooks_loaded
+    assert HookEvent.STOP not in untrusted.configured_events()
 
 
-async def test_runtime_guard_blocks_loaded_project_hooks_without_trust(
+async def test_runtime_refuses_loaded_project_hooks_without_trust(
     tmp_path: Path,
 ) -> None:
     root = _write_project_hooks(tmp_path / "project")
-    runtime = HooksRuntime.create(
-        cwd=root,
-        workspace_trusted=True,
-        config_dir=tmp_path / "user",
-        transcript_root=tmp_path / "transcripts",
+    runtime = replace(
+        HooksRuntime.create(
+            cwd=root,
+            workspace_trusted=True,
+            config_dir=tmp_path / "user",
+            transcript_root=tmp_path / "transcripts",
+        ),
+        workspace_trusted=False,
     )
-    runtime = replace(runtime, workspace_trusted=False)
     invocation = HookInvocation(
         context=HookContext(
             thread_id="thread",
@@ -301,47 +111,19 @@ async def test_runtime_guard_blocks_loaded_project_hooks_without_trust(
         await runtime.invoke(invocation)
 
 
-def test_interactive_prompt_remembers_project_hooks(
+@pytest.mark.parametrize(
+    ("action", "allowed", "persisted"),
+    [("REMEMBER", True, True), ("ALLOW_ONCE", True, False), ("DENY", False, False)],
+)
+def test_interactive_prompt_applies_selected_action(
+    action: str,
+    allowed: bool,
+    persisted: bool,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from deepagents_code.hooks import trust
-    from deepagents_code.main import (
-        _PROJECT_HOOKS_REMEMBER_LABEL,
-        _check_project_hooks_trust,
-        _ProjectMcpTrustAction,
-    )
-
-    root = _write_project_hooks(tmp_path / "project")
-    store = tmp_path / "state" / "hooks_trust.json"
-    monkeypatch.chdir(root)
-    monkeypatch.setattr(trust, "_default_store_path", lambda: store)
-    captured: dict[str, str] = {}
-
-    def _select(_console: object, *, remember_label: str) -> _ProjectMcpTrustAction:
-        captured["remember_label"] = remember_label
-        return _ProjectMcpTrustAction.REMEMBER
-
-    monkeypatch.setattr(
-        "deepagents_code.main._select_project_mcp_trust_action",
-        _select,
-    )
-
-    assert _check_project_hooks_trust() is True
-    assert is_project_hooks_trusted(root, store_path=store)
-    assert captured["remember_label"] == _PROJECT_HOOKS_REMEMBER_LABEL
-    assert captured["remember_label"] != "Allow for this project — until changed"
-
-
-def test_interactive_prompt_allow_once_does_not_persist(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from deepagents_code.hooks import trust
-    from deepagents_code.main import (
-        _check_project_hooks_trust,
-        _ProjectMcpTrustAction,
-    )
+    from deepagents_code.main import _check_project_hooks_trust, _ProjectMcpTrustAction
 
     root = _write_project_hooks(tmp_path / "project")
     store = tmp_path / "state" / "hooks_trust.json"
@@ -349,52 +131,14 @@ def test_interactive_prompt_allow_once_does_not_persist(
     monkeypatch.setattr(trust, "_default_store_path", lambda: store)
     monkeypatch.setattr(
         "deepagents_code.main._select_project_mcp_trust_action",
-        lambda _console, **_kwargs: _ProjectMcpTrustAction.ALLOW_ONCE,
+        lambda _console, **_kwargs: _ProjectMcpTrustAction[action],
     )
 
-    assert _check_project_hooks_trust() is True
-    assert not is_project_hooks_trusted(root, store_path=store)
+    assert _check_project_hooks_trust() is allowed
+    assert is_project_hooks_trusted(root, store_path=store) is persisted
 
 
-def test_interactive_prompt_skips_untrusted_project_hooks(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from deepagents_code.main import (
-        _check_project_hooks_trust,
-        _ProjectMcpTrustAction,
-    )
-
-    root = _write_project_hooks(tmp_path / "project")
-    monkeypatch.chdir(root)
-    monkeypatch.setattr(
-        "deepagents_code.main._select_project_mcp_trust_action",
-        lambda _console, **_kwargs: _ProjectMcpTrustAction.DENY,
-    )
-
-    assert _check_project_hooks_trust() is False
-
-
-def test_interactive_prompt_cancelled_aborts_startup(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from deepagents_code.main import (
-        _check_project_hooks_trust,
-        _ProjectMcpTrustPromptOutcome,
-    )
-
-    root = _write_project_hooks(tmp_path / "project")
-    monkeypatch.chdir(root)
-    monkeypatch.setattr(
-        "deepagents_code.main._select_project_mcp_trust_action",
-        lambda _console, **_kwargs: _ProjectMcpTrustPromptOutcome.CANCELLED,
-    )
-
-    assert _check_project_hooks_trust() is _ProjectMcpTrustPromptOutcome.CANCELLED
-
-
-def test_persisted_trust_reused_on_later_run(
+def test_persisted_trust_skips_prompt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -406,148 +150,22 @@ def test_persisted_trust_reused_on_later_run(
     monkeypatch.chdir(root)
     monkeypatch.setattr(trust, "_default_store_path", lambda: store)
     assert trust_project_hooks(root, store_path=store)
-
-    called = False
-
-    def _should_not_prompt(_console: object, **_kwargs: object) -> object:
-        nonlocal called
-        called = True
-        msg = "prompt should not run when trust is persisted"
-        raise AssertionError(msg)
-
     monkeypatch.setattr(
         "deepagents_code.main._select_project_mcp_trust_action",
-        _should_not_prompt,
+        lambda *_args, **_kwargs: pytest.fail("prompt ran despite persisted trust"),
     )
 
     assert _check_project_hooks_trust() is True
-    assert called is False
 
 
-def test_headless_requires_explicit_opt_in_even_with_persisted_trust(
-    tmp_path: Path,
-) -> None:
-    root = _write_project_hooks(tmp_path / "project")
-    store = tmp_path / "hooks_trust.json"
-    assert trust_project_hooks(root, store_path=store)
-    assert is_project_hooks_trusted(root, store_path=store)
-
-    # Headless/non-interactive paths pass workspace_trusted only from the
-    # explicit CLI flag, never from the interactive trust store.
-    runtime = HooksRuntime.create(
-        cwd=root,
-        workspace_trusted=False,
-        config_dir=tmp_path / "user",
-        transcript_root=tmp_path / "transcripts",
-    )
-    assert not runtime.project_hooks_loaded
-    assert HookEvent.STOP not in runtime.configured_events()
-
-    opted_in = HooksRuntime.create(
-        cwd=root,
-        workspace_trusted=True,
-        config_dir=tmp_path / "user",
-        transcript_root=tmp_path / "opted-in-transcripts",
-    )
-    assert opted_in.project_hooks_loaded
-
-
-def test_interactive_remember_write_failure_surfaces(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    from deepagents_code.hooks import trust
-    from deepagents_code.main import (
-        _check_project_hooks_trust,
-        _ProjectMcpTrustAction,
-    )
-
-    root = _write_project_hooks(tmp_path / "project")
-    store = tmp_path / "state" / "hooks_trust.json"
-    monkeypatch.chdir(root)
-    monkeypatch.setattr(trust, "_default_store_path", lambda: store)
-    monkeypatch.setattr(trust, "trust_project_hooks", lambda *_args, **_kwargs: False)
-    monkeypatch.setattr(
-        "deepagents_code.main._select_project_mcp_trust_action",
-        lambda _console, **_kwargs: _ProjectMcpTrustAction.REMEMBER,
-    )
-
-    assert _check_project_hooks_trust() is True
-    captured = capsys.readouterr()
-    assert "could not be remembered" in captured.err
-    assert not is_project_hooks_trusted(root, store_path=store)
-
-
-async def test_textual_session_initialization_uses_project_trust() -> None:
+async def test_textual_app_forwards_project_trust() -> None:
     from deepagents_code.app import DeepAgentsApp
 
-    app = DeepAgentsApp(
-        agent=MagicMock(),
-        thread_id="thread",
-        trust_project_hooks=True,
-    )
-    runtime = MagicMock()
+    app = DeepAgentsApp(agent=MagicMock(), thread_id="thread", trust_project_hooks=True)
     with patch(
         "deepagents_code.hooks.runtime.HooksRuntime.create",
-        return_value=runtime,
+        return_value=MagicMock(),
     ) as create:
         await app._init_session_state()
 
-    assert app._session_state is not None
-    assert app._session_state.hooks_runtime is runtime
     assert create.call_args.kwargs["workspace_trusted"] is True
-
-
-def test_trust_store_lock_serializes_in_process_mutations(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from deepagents_code.hooks import trust as trust_mod
-
-    store = tmp_path / "hooks_trust.json"
-    root_a = _write_project_hooks(tmp_path / "a")
-    root_b = _write_project_hooks(tmp_path / "b")
-    hold = threading.Event()
-    release = threading.Event()
-    original_write = trust_mod._write_store
-
-    def _gated_write(path: Path, store_model: HooksTrustStore) -> None:
-        if not hold.is_set():
-            hold.set()
-            assert release.wait(timeout=5)
-        original_write(path, store_model)
-
-    monkeypatch.setattr(trust_mod, "_write_store", _gated_write)
-    first = threading.Thread(
-        target=trust_project_hooks,
-        kwargs={"project_root": root_a, "store_path": store},
-    )
-    first.start()
-    assert hold.wait(timeout=5)
-    second_done = threading.Event()
-    second_result: list[bool] = []
-
-    def _second() -> None:
-        second_result.append(trust_project_hooks(root_b, store_path=store))
-        second_done.set()
-
-    second = threading.Thread(target=_second)
-    second.start()
-    # Second writer should block on the in-process lock until first finishes.
-    assert not second_done.wait(timeout=0.2)
-    release.set()
-    first.join(timeout=5)
-    second.join(timeout=5)
-    assert second_result == [True]
-    assert is_project_hooks_trusted(root_a, store_path=store)
-    assert is_project_hooks_trusted(root_b, store_path=store)
-
-
-@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits only")
-def test_trust_store_written_with_restrictive_permissions(tmp_path: Path) -> None:
-    root = _write_project_hooks(tmp_path / "project")
-    store = tmp_path / "state" / "hooks_trust.json"
-    assert trust_project_hooks(root, store_path=store)
-    assert (store.stat().st_mode & 0o777) == 0o600
-    assert (store.parent.stat().st_mode & 0o777) == 0o700

--- a/libs/code/tests/unit_tests/hooks/test_trust.py
+++ b/libs/code/tests/unit_tests/hooks/test_trust.py
@@ -64,6 +64,18 @@ def test_corrupt_store_fails_closed_without_overwrite(tmp_path: Path) -> None:
     assert store.read_text(encoding="utf-8") == "{invalid"
 
 
+def test_non_utf8_store_fails_closed_without_overwrite(tmp_path: Path) -> None:
+    """Decoding happens during the read, so it must fail closed like other I/O."""
+    root = _write_project_hooks(tmp_path / "project")
+    store = tmp_path / "hooks_trust.json"
+    raw = b'{"version": 1, "projects": {"\xff\xfe": {}}}'
+    store.write_bytes(raw)
+
+    assert not is_project_hooks_trusted(root, store_path=store)
+    assert not trust_project_hooks(root, store_path=store)
+    assert store.read_bytes() == raw
+
+
 def test_concurrent_writes_across_stores_preserve_every_entry(tmp_path: Path) -> None:
     """A single process-wide lock must not drop entries under contention."""
     roots = [_write_project_hooks(tmp_path / f"project-{index}") for index in range(8)]
@@ -112,6 +124,21 @@ def test_session_grant_does_not_extend_to_other_workspaces(tmp_path: Path) -> No
     assert policy.allows(granted)
     assert not policy.allows(other)
     assert not is_project_hooks_trusted(granted, store_path=store)
+
+
+def test_explicit_only_policy_ignores_persisted_trust(tmp_path: Path) -> None:
+    """Headless runs must not inherit a grant made in an interactive session."""
+    root = _write_project_hooks(tmp_path / "project")
+    store = tmp_path / "state" / "hooks_trust.json"
+    assert trust_project_hooks(root, store_path=store)
+
+    opted_out = WorkspaceTrust.explicit_only(root, granted=False, store_path=store)
+    opted_in = WorkspaceTrust.explicit_only(root, granted=True, store_path=store)
+
+    assert not opted_out.allows(root)
+    assert opted_in.allows(root)
+    # The interactive policy still honors the same persisted grant.
+    assert WorkspaceTrust(store_path=store).allows(root)
 
 
 def test_declined_trust_resolves_to_untrusted_everywhere(tmp_path: Path) -> None:
@@ -327,3 +354,24 @@ async def test_reload_picks_up_trust_when_entering_trusted_workspace(
     await manager.reload(cwd=trusted)
 
     assert manager.has_handlers(HookEvent.STOP)
+
+
+def test_headless_manager_ignores_persisted_trust(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The policy the headless runner builds must not load remembered hooks."""
+    _isolate_hook_config(tmp_path, monkeypatch)
+    root = _write_project_hooks(tmp_path / "project")
+    store = tmp_path / "state" / "hooks_trust.json"
+    assert trust_project_hooks(root, store_path=store)
+
+    opted_out = _manager(
+        root, WorkspaceTrust.explicit_only(root, granted=False, store_path=store)
+    )
+    opted_in = _manager(
+        root, WorkspaceTrust.explicit_only(root, granted=True, store_path=store)
+    )
+
+    assert not opted_out.has_handlers(HookEvent.STOP)
+    assert opted_in.has_handlers(HookEvent.STOP)

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -26245,11 +26245,8 @@ class TestLiveApprovalModeWrites:
 
         app = DeepAgentsApp(approval_mode=ApprovalMode.MANUAL)
 
-        def change_mode_during_construction(
-            *_args: object, **_kwargs: object
-        ) -> MagicMock:
+        def change_mode_during_construction(**_kwargs: object) -> None:
             app._approval_mode = ApprovalMode.AUTO
-            return MagicMock()
 
         with patch(
             "deepagents_code.hooks.runtime.HooksRuntime.create",

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -26245,8 +26245,11 @@ class TestLiveApprovalModeWrites:
 
         app = DeepAgentsApp(approval_mode=ApprovalMode.MANUAL)
 
-        def change_mode_during_construction(**_kwargs: object) -> None:
+        def change_mode_during_construction(
+            *_args: object, **_kwargs: object
+        ) -> MagicMock:
             app._approval_mode = ApprovalMode.AUTO
+            return MagicMock()
 
         with patch(
             "deepagents_code.hooks.runtime.HooksRuntime.create",

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -976,7 +976,7 @@ class TestStartupAutoUpdate:
 
     def test_project_mcp_prompt_interrupt_aborts_before_tui(self) -> None:
         """Ctrl+C at the project MCP prompt exits before launching Textual."""
-        from deepagents_code.main import _ProjectMcpTrustPromptOutcome
+        from deepagents_code.main import _TrustPromptOutcome
 
         launch = AsyncMock(return_value=AppResult(return_code=0, thread_id="thread"))
         with (
@@ -989,7 +989,7 @@ class TestStartupAutoUpdate:
             ),
             patch(
                 "deepagents_code.main._check_mcp_project_trust",
-                return_value=_ProjectMcpTrustPromptOutcome.INTERRUPTED,
+                return_value=_TrustPromptOutcome.INTERRUPTED,
             ),
             patch("deepagents_code.main.run_textual_cli_async", launch),
             pytest.raises(SystemExit) as exc_info,
@@ -1037,7 +1037,7 @@ class TestStartupAutoUpdate:
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """Esc in the server selector cancels launch before Textual starts."""
-        from deepagents_code.main import _ProjectMcpTrustPromptOutcome
+        from deepagents_code.main import _TrustPromptOutcome
 
         launch = AsyncMock(return_value=AppResult(return_code=0, thread_id="thread"))
         with (
@@ -1050,7 +1050,7 @@ class TestStartupAutoUpdate:
             ),
             patch(
                 "deepagents_code.main._check_mcp_project_trust",
-                return_value=_ProjectMcpTrustPromptOutcome.CANCELLED,
+                return_value=_TrustPromptOutcome.CANCELLED,
             ),
             patch("deepagents_code.main.run_textual_cli_async", launch),
         ):
@@ -2631,7 +2631,7 @@ class TestCheckMcpProjectTrustPrompt:
         from deepagents_code._env_vars import DEBUG_MCP_PROJECT_TRUST
         from deepagents_code.main import (
             _check_mcp_project_trust,
-            _ProjectMcpTrustPromptOutcome,
+            _TrustPromptOutcome,
         )
 
         project_context = SimpleNamespace(project_root=tmp_path, user_cwd=tmp_path)
@@ -2653,13 +2653,13 @@ class TestCheckMcpProjectTrustPrompt:
                 return_value=([], []),
             ),
             patch(
-                "deepagents_code.main._select_project_mcp_trust_action",
-                return_value=_ProjectMcpTrustPromptOutcome.CANCELLED,
+                "deepagents_code.main._select_trust_action",
+                return_value=_TrustPromptOutcome.CANCELLED,
             ),
         ):
             decision = _check_mcp_project_trust(trust_flag=False)
 
-        assert decision is _ProjectMcpTrustPromptOutcome.CANCELLED
+        assert decision is _TrustPromptOutcome.CANCELLED
         assert "denied" not in capsys.readouterr().err.lower()
         assert not user_config.exists()
 
@@ -2677,7 +2677,7 @@ class TestCheckMcpProjectTrustPrompt:
         from deepagents_code._env_vars import DEBUG_MCP_PROJECT_TRUST
         from deepagents_code.main import (
             _check_mcp_project_trust,
-            _ProjectMcpTrustAction,
+            _TrustAction,
         )
 
         project_context = SimpleNamespace(project_root=tmp_path, user_cwd=tmp_path)
@@ -2697,8 +2697,8 @@ class TestCheckMcpProjectTrustPrompt:
                 return_value=([], []),
             ),
             patch(
-                "deepagents_code.main._select_project_mcp_trust_action",
-                return_value=_ProjectMcpTrustAction.DENY,
+                "deepagents_code.main._select_trust_action",
+                return_value=_TrustAction.DENY,
             ),
         ):
             decision = _check_mcp_project_trust(trust_flag=False)
@@ -3170,7 +3170,7 @@ class TestCheckMcpProjectTrustPrompt:
         from deepagents_code import model_config
         from deepagents_code.main import (
             _check_mcp_project_trust,
-            _ProjectMcpTrustPromptOutcome,
+            _TrustPromptOutcome,
         )
 
         project_root = tmp_path / "proj"
@@ -3216,12 +3216,12 @@ class TestCheckMcpProjectTrustPrompt:
             patch("builtins.input", return_value="a"),
             patch(
                 "deepagents_code.main._run_project_mcp_server_checkbox_picker",
-                return_value=_ProjectMcpTrustPromptOutcome.CANCELLED,
+                return_value=_TrustPromptOutcome.CANCELLED,
             ),
         ):
             decision = _check_mcp_project_trust(trust_flag=False)
 
-        assert decision is _ProjectMcpTrustPromptOutcome.CANCELLED
+        assert decision is _TrustPromptOutcome.CANCELLED
         assert not user_config.exists()
         assert "denied" not in capsys.readouterr().err.lower()
 
@@ -3555,7 +3555,7 @@ class TestCheckMcpProjectTrustPrompt:
         """Ctrl+C at the approval prompt cancels launch instead of denying MCP."""
         from deepagents_code.main import (
             _check_mcp_project_trust,
-            _ProjectMcpTrustPromptOutcome,
+            _TrustPromptOutcome,
         )
 
         project_root = tmp_path / "proj"
@@ -3591,7 +3591,7 @@ class TestCheckMcpProjectTrustPrompt:
         ):
             decision = _check_mcp_project_trust(trust_flag=False)
 
-        assert decision is _ProjectMcpTrustPromptOutcome.INTERRUPTED
+        assert decision is _TrustPromptOutcome.INTERRUPTED
 
     def test_eof_at_prompt_denies(self, tmp_path: Path) -> None:
         """EOF (closed stdin) at the approval prompt fails safe to deny.
@@ -3822,7 +3822,7 @@ class TestSelectProjectServersToPersist:
     def _interactive_picker_terminal(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Allow picker tests to run independently of pytest's captured streams."""
         monkeypatch.setattr(
-            "deepagents_code.main._project_mcp_picker_has_terminal",
+            "deepagents_code.main._trust_picker_has_terminal",
             lambda: True,
         )
 
@@ -3897,8 +3897,8 @@ class TestSelectProjectServersToPersist:
         from rich.console import Console
 
         from deepagents_code.main import (
-            _ProjectMcpTrustAction,
-            _run_project_mcp_trust_action_picker,
+            _run_trust_action_picker,
+            _TrustAction,
         )
 
         captured: dict[str, Any] = {}
@@ -3910,9 +3910,9 @@ class TestSelectProjectServersToPersist:
             def __init__(self, **kwargs: Any) -> None:
                 captured.update(kwargs)
 
-            def run(self) -> _ProjectMcpTrustAction:
+            def run(self) -> _TrustAction:
                 bindings = captured["key_bindings"].bindings
-                holder: dict[str, _ProjectMcpTrustAction] = {}
+                holder: dict[str, _TrustAction] = {}
                 event = SimpleNamespace(
                     app=SimpleNamespace(
                         exit=lambda *, result: holder.update(value=result)
@@ -3927,9 +3927,9 @@ class TestSelectProjectServersToPersist:
                 return holder["value"]
 
         monkeypatch.setattr("prompt_toolkit.Application", _FakeApplication)
-        result = _run_project_mcp_trust_action_picker(Console(stderr=True))
+        result = _run_trust_action_picker(Console(stderr=True))
 
-        assert result is _ProjectMcpTrustAction.DENY
+        assert result is _TrustAction.DENY
         assert captured["full_screen"] is False
         rendered = "".join(
             text for _style, text in captured["layout"].container.content.text()
@@ -3948,8 +3948,8 @@ class TestSelectProjectServersToPersist:
         from rich.console import Console
 
         from deepagents_code.main import (
-            _ProjectMcpTrustAction,
-            _run_project_mcp_trust_action_picker,
+            _run_trust_action_picker,
+            _TrustAction,
         )
 
         captured: dict[str, Any] = {}
@@ -3961,11 +3961,11 @@ class TestSelectProjectServersToPersist:
             def __init__(self, **kwargs: Any) -> None:
                 captured.update(kwargs)
 
-            def run(self) -> _ProjectMcpTrustAction:
-                return _ProjectMcpTrustAction.DENY
+            def run(self) -> _TrustAction:
+                return _TrustAction.DENY
 
         monkeypatch.setattr("prompt_toolkit.Application", _FakeApplication)
-        _run_project_mcp_trust_action_picker(Console(stderr=True))
+        _run_trust_action_picker(Console(stderr=True))
 
         _assert_all_controls_hide_cursor(captured["layout"])
 
@@ -3980,8 +3980,8 @@ class TestSelectProjectServersToPersist:
         from rich.console import Console
 
         from deepagents_code.main import (
-            _ProjectMcpTrustPromptOutcome,
-            _run_project_mcp_trust_action_picker,
+            _run_trust_action_picker,
+            _TrustPromptOutcome,
         )
 
         captured: dict[str, Any] = {}
@@ -3993,9 +3993,9 @@ class TestSelectProjectServersToPersist:
             def __init__(self, **kwargs: Any) -> None:
                 captured.update(kwargs)
 
-            def run(self) -> _ProjectMcpTrustPromptOutcome:
+            def run(self) -> _TrustPromptOutcome:
                 bindings = captured["key_bindings"].bindings
-                holder: dict[str, _ProjectMcpTrustPromptOutcome] = {}
+                holder: dict[str, _TrustPromptOutcome] = {}
                 event = SimpleNamespace(
                     app=SimpleNamespace(
                         exit=lambda *, result: holder.update(value=result)
@@ -4013,9 +4013,9 @@ class TestSelectProjectServersToPersist:
                 return holder["value"]
 
         monkeypatch.setattr("prompt_toolkit.Application", _FakeApplication)
-        result = _run_project_mcp_trust_action_picker(Console(stderr=True))
+        result = _run_trust_action_picker(Console(stderr=True))
 
-        assert result is _ProjectMcpTrustPromptOutcome.CANCELLED
+        assert result is _TrustPromptOutcome.CANCELLED
         rendered = "".join(
             text for _style, text in captured["layout"].container.content.text()
         )
@@ -4030,18 +4030,18 @@ class TestSelectProjectServersToPersist:
         from rich.console import Console
 
         from deepagents_code.main import (
-            _ProjectMcpTrustPromptOutcome,
-            _select_project_mcp_trust_action,
+            _select_trust_action,
+            _TrustPromptOutcome,
         )
 
         monkeypatch.setattr(
-            "deepagents_code.main._run_project_mcp_trust_action_picker",
-            lambda _console, **_kwargs: _ProjectMcpTrustPromptOutcome.CANCELLED,
+            "deepagents_code.main._run_trust_action_picker",
+            lambda _console, **_kwargs: _TrustPromptOutcome.CANCELLED,
         )
 
-        result = _select_project_mcp_trust_action(Console(stderr=True))
+        result = _select_trust_action(Console(stderr=True))
 
-        assert result is _ProjectMcpTrustPromptOutcome.CANCELLED
+        assert result is _TrustPromptOutcome.CANCELLED
 
     def test_action_picker_falls_back_when_stderr_is_redirected(
         self, monkeypatch: pytest.MonkeyPatch
@@ -4049,7 +4049,7 @@ class TestSelectProjectServersToPersist:
         """A hidden selector is not launched when stderr is not a terminal."""
         from rich.console import Console
 
-        from deepagents_code.main import _run_project_mcp_trust_action_picker
+        from deepagents_code.main import _run_trust_action_picker
 
         monkeypatch.setattr(
             "deepagents_code.main.sys.stdin", SimpleNamespace(isatty=lambda: True)
@@ -4058,7 +4058,7 @@ class TestSelectProjectServersToPersist:
             "deepagents_code.main.sys.stderr", SimpleNamespace(isatty=lambda: False)
         )
 
-        result = _run_project_mcp_trust_action_picker(Console(stderr=True))
+        result = _run_trust_action_picker(Console(stderr=True))
 
         assert result is None
 
@@ -4371,8 +4371,8 @@ class TestSelectProjectServersToPersist:
         from rich.console import Console
 
         from deepagents_code.main import (
-            _ProjectMcpTrustPromptOutcome,
             _run_project_mcp_server_checkbox_picker,
+            _TrustPromptOutcome,
         )
 
         captured: dict[str, Any] = {}
@@ -4410,7 +4410,7 @@ class TestSelectProjectServersToPersist:
         ]
         result = _run_project_mcp_server_checkbox_picker(servers, Console(stderr=True))
 
-        assert result is _ProjectMcpTrustPromptOutcome.CANCELLED
+        assert result is _TrustPromptOutcome.CANCELLED
         help_control = captured["layout"].container.children[0].content
         rendered = "".join(text for _style, text in help_control.text())
         assert "Esc abort" in rendered
@@ -4425,8 +4425,8 @@ class TestSelectProjectServersToPersist:
         from rich.console import Console
 
         from deepagents_code.main import (
-            _ProjectMcpTrustPromptOutcome,
             _run_project_mcp_server_checkbox_picker,
+            _TrustPromptOutcome,
         )
 
         captured: dict[str, Any] = {}
@@ -4438,9 +4438,9 @@ class TestSelectProjectServersToPersist:
             def __init__(self, **kwargs: Any) -> None:
                 captured.update(kwargs)
 
-            def run(self) -> _ProjectMcpTrustPromptOutcome:
+            def run(self) -> _TrustPromptOutcome:
                 bindings = captured["key_bindings"].bindings
-                holder: dict[str, _ProjectMcpTrustPromptOutcome] = {}
+                holder: dict[str, _TrustPromptOutcome] = {}
                 event = SimpleNamespace(
                     app=SimpleNamespace(
                         exit=lambda *, result: holder.update(value=result)
@@ -4462,7 +4462,7 @@ class TestSelectProjectServersToPersist:
         ]
         result = _run_project_mcp_server_checkbox_picker(servers, Console(stderr=True))
 
-        assert result is _ProjectMcpTrustPromptOutcome.INTERRUPTED
+        assert result is _TrustPromptOutcome.INTERRUPTED
 
     @pytest.mark.usefixtures("_interactive_picker_terminal")
     def test_checkbox_picker_eof_cancels(
@@ -4473,8 +4473,8 @@ class TestSelectProjectServersToPersist:
         from rich.console import Console
 
         from deepagents_code.main import (
-            _ProjectMcpTrustPromptOutcome,
             _run_project_mcp_server_checkbox_picker,
+            _TrustPromptOutcome,
         )
 
         class _FakeApplication:
@@ -4495,7 +4495,7 @@ class TestSelectProjectServersToPersist:
         ]
         result = _run_project_mcp_server_checkbox_picker(servers, Console(stderr=True))
 
-        assert result is _ProjectMcpTrustPromptOutcome.CANCELLED
+        assert result is _TrustPromptOutcome.CANCELLED
 
     @pytest.mark.usefixtures("_interactive_picker_terminal")
     def test_checkbox_picker_falls_back_when_app_run_fails(
@@ -4538,7 +4538,7 @@ class TestSelectProjectServersToPersist:
         """A runtime failure launching the action picker falls back to text input."""
         from rich.console import Console
 
-        from deepagents_code.main import _run_project_mcp_trust_action_picker
+        from deepagents_code.main import _run_trust_action_picker
 
         class _FakeApplication:
             def __class_getitem__(cls, _item: object) -> type["_FakeApplication"]:
@@ -4552,7 +4552,7 @@ class TestSelectProjectServersToPersist:
 
         monkeypatch.setattr("prompt_toolkit.Application", _FakeApplication)
 
-        result = _run_project_mcp_trust_action_picker(Console(stderr=True))
+        result = _run_trust_action_picker(Console(stderr=True))
 
         assert result is None
 
@@ -4639,8 +4639,8 @@ class TestSelectProjectServersToPersist:
         from rich.console import Console
 
         from deepagents_code.main import (
-            _ProjectMcpTrustPromptOutcome,
             _select_project_servers_to_persist,
+            _TrustPromptOutcome,
         )
 
         servers = [
@@ -4656,15 +4656,15 @@ class TestSelectProjectServersToPersist:
         ):
             names = _select_project_servers_to_persist(servers, Console(stderr=True))
 
-        assert names is _ProjectMcpTrustPromptOutcome.INTERRUPTED
+        assert names is _TrustPromptOutcome.INTERRUPTED
 
     def test_fallback_blank_cancels(self) -> None:
         """Blank fallback input cancels (deny) rather than confirming nothing."""
         from rich.console import Console
 
         from deepagents_code.main import (
-            _ProjectMcpTrustPromptOutcome,
             _select_project_servers_to_persist,
+            _TrustPromptOutcome,
         )
 
         servers = [
@@ -4680,15 +4680,15 @@ class TestSelectProjectServersToPersist:
         ):
             names = _select_project_servers_to_persist(servers, Console(stderr=True))
 
-        assert names is _ProjectMcpTrustPromptOutcome.CANCELLED
+        assert names is _TrustPromptOutcome.CANCELLED
 
     def test_fallback_eof_cancels(self) -> None:
         """EOF (Ctrl+D) at the fallback prompt cancels, not an empty confirm."""
         from rich.console import Console
 
         from deepagents_code.main import (
-            _ProjectMcpTrustPromptOutcome,
             _select_project_servers_to_persist,
+            _TrustPromptOutcome,
         )
 
         servers = [
@@ -4704,7 +4704,7 @@ class TestSelectProjectServersToPersist:
         ):
             names = _select_project_servers_to_persist(servers, Console(stderr=True))
 
-        assert names is _ProjectMcpTrustPromptOutcome.CANCELLED
+        assert names is _TrustPromptOutcome.CANCELLED
 
 
 class TestSelectProjectMcpTrustAction:
@@ -4735,20 +4735,20 @@ class TestSelectProjectMcpTrustAction:
         from rich.console import Console
 
         from deepagents_code.main import (
-            _ProjectMcpTrustAction,
-            _select_project_mcp_trust_action,
+            _select_trust_action,
+            _TrustAction,
         )
 
         # Force the inline picker to defer to the text prompt.
         monkeypatch.setattr(
-            "deepagents_code.main._run_project_mcp_trust_action_picker",
+            "deepagents_code.main._run_trust_action_picker",
             lambda *_args, **_kwargs: None,
         )
         monkeypatch.setattr("builtins.input", lambda _prompt="": token)
 
-        result = _select_project_mcp_trust_action(Console(stderr=True))
+        result = _select_trust_action(Console(stderr=True))
 
-        assert result is _ProjectMcpTrustAction[expected_name]
+        assert result is _TrustAction[expected_name]
 
 
 class TestCheckMcpProjectTrustDedupe:

--- a/libs/code/tests/unit_tests/test_main.py
+++ b/libs/code/tests/unit_tests/test_main.py
@@ -4036,7 +4036,7 @@ class TestSelectProjectServersToPersist:
 
         monkeypatch.setattr(
             "deepagents_code.main._run_project_mcp_trust_action_picker",
-            lambda _console: _ProjectMcpTrustPromptOutcome.CANCELLED,
+            lambda _console, **_kwargs: _ProjectMcpTrustPromptOutcome.CANCELLED,
         )
 
         result = _select_project_mcp_trust_action(Console(stderr=True))

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -1706,6 +1706,47 @@ class TestMaxTurns:
         _, kwargs = agent.astream.call_args
         assert "Stop" in (kwargs["context"].get("hooks_server_events") or [])
 
+    async def test_run_agent_loop_ignores_persisted_project_hook_trust(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Trust remembered interactively must not opt a headless run in.
+
+        The operator of a `dcode -n` run may never have seen the interactive
+        prompt, so only the explicit flag may enable repository hooks.
+        """
+        from deepagents_code.hooks import trust as trust_module
+
+        monkeypatch.chdir(tmp_path)
+        project_hooks = tmp_path / ".deepagents"
+        project_hooks.mkdir()
+        (project_hooks / "hooks.json").write_text(
+            '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"echo x"}]}]}}',
+            encoding="utf-8",
+        )
+        store = tmp_path / "state" / "hooks_trust.json"
+        monkeypatch.setattr(trust_module, "_default_store_path", lambda: store)
+        assert trust_module.trust_project_hooks(tmp_path, store_path=store)
+
+        agent = MagicMock()
+        agent.astream = MagicMock(return_value=_async_iter([]))
+        config: RunnableConfig = {"configurable": {"thread_id": "t1"}}
+
+        with patch(
+            "deepagents_code.client.non_interactive.dispatch_hook",
+            new_callable=AsyncMock,
+        ):
+            await _run_agent_loop(
+                agent,
+                "task",
+                config,
+                Console(quiet=True),
+                MagicMock(),
+                quiet=True,
+            )
+
+        _, kwargs = agent.astream.call_args
+        assert "Stop" not in (kwargs["context"].get("hooks_server_events") or [])
+
     async def test_raises_after_user_limit(self) -> None:
         """HITLIterationLimitError is raised after max_turns HITL iterations."""
         agent = _make_looping_agent()


### PR DESCRIPTION
Supersedes #5044 (auto-closed when #4997 squash-merged; GitHub seals force-pushed closed PRs).

Project-level hooks now require an explicit workspace trust decision before their commands run. Interactive users can allow once, remember the workspace, or skip project hooks; headless runs remain opt-in through `--trust-project-hooks`.

---

This closes the execution gap that left interactive project hooks permanently disabled while preserving fail-closed behavior. Trust is keyed to the canonical repository root, saved atomically, and enforced again at runtime if a snapshot is ever constructed inconsistently. `config path` and the threat model now expose the relevant project, user, and trust locations.

Re-anchored onto `main` after #5104 squash-merged, so the PR diff contains only this branch's commits.

## Review Guide

1. `hooks/trust.py` — store, keys, atomic write, trust APIs
2. `hooks/loading.py` — project source ingest vs skip
3. `hooks/runtime.py` — fail-closed runtime guard
4. `main.py` — `--trust-project-hooks` + interactive prompt
5. Skim: `app.py`, `client/commands/config.py`, `THREAT_MODEL.md`
6. Tests: `test_trust.py`, then config/app/main touches

<details>
<summary>Test plan</summary>

- Full hooks suite passes on the rebuilt stack tip. `test_trust.py` keeps one case per regressable behavior: canonical persistence, fail-closed corrupt-store handling, project-source provenance, the runtime trust guard, the three prompt outcomes, prompt suppression on persisted trust, and Textual wiring.

</details>


<!-- branch-stack-start -->

-------------------------
- main
  - **feat(code): add project hooks workspace trust** :point_left:
    - https://github.com/langchain-ai/deepagents/pull/5045

<sup>[Stack](https://www.git-town.com/how-to/proposal-breadcrumb.html) generated by [Git Town](https://github.com/git-town/git-town)</sup>

<!-- branch-stack-end -->