### PR TITLE
fix(code): ignore mouse hits on detached widgets

### DIFF
--- a/libs/code/deepagents_code/_textual_patches.py
+++ b/libs/code/deepagents_code/_textual_patches.py
@@ -1,6 +1,6 @@
 r"""Runtime patches over Textual internals, imported for side effect.
 
-This module hosts three independent best-effort patches over private Textual
+This module hosts four independent best-effort patches over private Textual
 APIs. Each guards its own import/assignment and degrades to stock Textual
 behavior (logging a warning) if the targeted internals move, so they have
 separate lifecycles — do not delete the whole file when only one lands
@@ -41,6 +41,15 @@ upstream.
     a click chain; these patches narrow a double-click (and double-click
     drag) to word boundaries. No upstream issue tracks this yet, so it has
     no removal criterion — it stays until Textual grows native word select.
+
+4. Detached-widget hit filtering. The compositor keeps reporting a widget as
+    visible for a few event-loop iterations after it leaves the DOM, which
+    `Markdown.update` (and therefore the `MarkdownStream` that drives every
+    streaming assistant message) does constantly. `Screen._forward_event`
+    starts a text selection from `content_widget.parent`, which is `None` for
+    such a widget, so a mouse press landing on freshly replaced markdown
+    crashes the app with `AttributeError: 'NoneType' object has no attribute
+    'region'`. Tracked in Textualize/textual#6643; remove when that lands.
 
 Imported for side effect from `app.py` before any `App()` is created.
 """
@@ -417,6 +426,49 @@ else:
     except (AttributeError, TypeError) as exc:  # pragma: no cover - defensive
         logger.warning(
             "Textual word-selection patch assignment rejected (textual %s): %s",
+            _textual_version,
+            exc,
+        )
+
+
+try:
+    from textual.screen import Screen as _HitScreen
+
+    _original_get_widget_and_offset_at = _HitScreen.get_widget_and_offset_at
+except (ImportError, AttributeError) as exc:  # pragma: no cover - defensive
+    logger.warning(
+        "Textual detached-hit patch skipped (textual %s): %s",
+        _textual_version,
+        exc,
+    )
+else:
+
+    def _get_widget_and_offset_at_attached(
+        self: Screen,
+        x: int,
+        y: int,
+    ) -> tuple[Widget | None, Offset | None]:
+        """Ignore compositor hits on widgets that already left the DOM.
+
+        Returns:
+            The stock result, or `(None, None)` when the hit widget is
+            detached, which sends Textual down its existing "nothing
+            selectable here" branch instead of dereferencing a `None` parent.
+        """
+        widget, offset = _original_get_widget_and_offset_at(self, x, y)
+        if (
+            widget is not None
+            and not isinstance(widget, _HitScreen)
+            and (widget.parent is None or not widget.is_attached)
+        ):
+            return None, None
+        return widget, offset
+
+    try:
+        _HitScreen.get_widget_and_offset_at = _get_widget_and_offset_at_attached  # ty: ignore[invalid-assignment]
+    except (AttributeError, TypeError) as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "Textual detached-hit patch assignment rejected (textual %s): %s",
             _textual_version,
             exc,
         )

--- a/libs/code/tests/unit_tests/test_textual_patches.py
+++ b/libs/code/tests/unit_tests/test_textual_patches.py
@@ -10,6 +10,7 @@ import importlib.util
 from pathlib import Path
 
 import pytest
+from textual import events
 from textual._time import get_time
 from textual._xterm_parser import XTermParser
 from textual.app import App, ComposeResult
@@ -75,6 +76,53 @@ class TestPatchedWordSelection:
             await pilot.triple_click("#second", offset=(1, 0))
 
             assert pilot.app.screen.get_selected_text() == "second message"
+
+
+class TestDetachedHitGuard:
+    """Coverage of the Textualize/textual#6643 crash guard."""
+
+    async def test_mouse_down_on_detached_widget_does_not_crash(self) -> None:
+        """A press on a widget pruned since the last repaint must be ignored.
+
+        `Markdown.update` — which `MarkdownStream` runs on every streaming
+        assistant message — detaches its old blocks while the compositor still
+        reports them as visible. `_detach` is exactly what Textual calls during
+        that prune, so calling it directly pins the race window deterministically
+        instead of spinning the event loop until it happens to be observed.
+        Without the guard, `Screen._forward_event` raises `AttributeError` on the
+        detached widget's `None` parent and takes the whole app down.
+        """
+        async with SelectableMarkdownApp().run_test() as pilot:
+            screen = pilot.app.screen
+            document = pilot.app.query_one("#msg", Markdown)
+            paragraph = document.query("*").first()
+            x = paragraph.region.x + 1
+            y = paragraph.region.y
+            assert screen._compositor.get_widget_and_offset_at(x, y)[0] is paragraph
+
+            paragraph._detach()
+            try:
+                assert screen.get_widget_and_offset_at(x, y) == (None, None)
+                screen._forward_event(
+                    events.MouseDown(None, x, y, 0, 0, 1, False, False, False)
+                )
+
+                assert screen._select_state is None
+            finally:
+                # Textual's own teardown asserts every widget still has a
+                # parent, so hand the simulated prune victim back to the DOM.
+                paragraph._attach(document)
+
+    async def test_attached_widget_hit_is_still_reported(self) -> None:
+        """The guard must only drop detached hits, not live ones."""
+        async with SelectableTextApp().run_test() as pilot:
+            widget = pilot.app.query_one("#msg", Static)
+            offset = widget.content_region.offset + Offset(2, 0)
+
+            hit, hit_offset = pilot.app.screen.get_widget_and_offset_at(*offset)
+
+            assert hit is widget
+            assert hit_offset == Offset(2, 0)
 
 
 class TestPatchedSequenceToKeyEvents:


### PR DESCRIPTION
Related Textualize/textual#6643

Clicking or starting a text selection in the transcript while the agent was streaming a response could take the whole app down with `AttributeError: 'NoneType' object has no attribute 'region'`. Mouse presses on markdown that is being replaced mid-stream are now ignored instead of crashing.

---

Textual's compositor keeps reporting a widget as visible for a few event-loop iterations after it leaves the DOM. `Markdown.update` — which `MarkdownStream` runs on every flush of a streaming assistant message — detaches and remounts its blocks constantly, so that stale window is open more or less continuously while output streams. When a mouse press lands in it, `Screen._forward_event` starts a text selection from the hit widget's parent, which is `None` for a detached widget, and dereferences `container.region`.

Reproduced against the pinned Textual with upstream's minimal example (no `deepagents` code involved), so this is fixed here only as a stopgap: it joins the other version-scoped shims in the Textual patch module as a fourth independent, separately guarded patch, with Textualize/textual#6643 as its removal criterion.

The guard wraps the public `Screen.get_widget_and_offset_at` — the single funnel for all three hit lookups in `_forward_event` (selection start, drag update, and drag-in-progress) — and returns no hit when the widget is detached. Textual then takes its existing "nothing selectable here" branch, so a press on a just-pruned paragraph starts no selection rather than killing the process. This mirrors Textual's own `is_attached` guarding of live selections.

Worth a careful look: the patch is on a public Textual method rather than a private one, so it changes hit-testing for every mouse event, not just selection. Live widgets are unaffected, and there is a test pinning that.

Made by [Open SWE](https://openswe.vercel.app/agents/a1475bad-bf2c-b5aa-716f-6d5e0cdbc40b)

## References
- Plan: https://openswe.vercel.app/agents/a1475bad-bf2c-b5aa-716f-6d5e0cdbc40b/plan