### PR TITLE
docs(repo): clarify PR body is release note without heading

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,11 +2,11 @@ Fixes #
 
 <!-- Update the relationship and number above, or remove the line when none applies. Only `Closes`, `Fixes`, and `Resolves` auto-close the referenced GitHub issue on merge. -->
 
-<!-- For a net new feature or behavior-changing bugfix, replace this comment with a high-level, plain-English summary of the user-visible change. Do not add a heading or label. Remove this comment for chores, refactors, or test-only changes. -->
+<!-- For a net new feature or behavior-changing bugfix, replace this comment with a high-level, plain-English summary of the user-visible change. That paragraph is the release note — no heading or label, and do not repeat it later. Remove this comment for chores, refactors, or test-only changes. -->
 
 ---
 
-<!-- Explain the motivation and why this solution is the right one. Do not add a `# Summary` or `## Release note` heading. -->
+<!-- Explain the motivation and why this solution is the right one. Do not add a `# Summary`, `## Release note`, or `## Release Note` heading; the plain summary above `---` already is the release note. -->
 
 Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview
 
@@ -28,7 +28,7 @@ Thank you for contributing to Deep Agents! Follow these steps to have your pull 
 2. PR description:
 
   - Keep an optional issue or PR relationship and, when required, the user-facing summary above the `---`; put the rest of the body below it.
-  - For net new features or behavior-changing bugfixes, write a high-level, plain-English summary of the user-visible change without a heading or label.
+  - For net new features or behavior-changing bugfixes, write a high-level, plain-English summary of the user-visible change above `---` without a heading or label. That summary is the release note — do not also add a `## Release note` / `## Release Note` section.
   - If this PR addresses a specific issue, use `Fixes #ISSUE_NUMBER`, `Closes #ISSUE_NUMBER`, or `Resolves #ISSUE_NUMBER` to automatically close it when the PR is merged.
   - If there are any breaking changes, please clearly describe them.
   - If this PR depends on another PR being merged first, please include `Depends on #PR_NUMBER` in the description.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,23 @@
-Fixes #
+<!-- Optional: Replace this comment with `Fixes #` / `Closes#` / or `Resolves #` with the issue number to auto-close the issue when this PR is merged. If applicable, add separate `Depends on #` or `Related: #` lines. -->
 
-<!-- Optional: `Fixes` / `Closes` / `Resolves` auto-close the issue on merge. Use `Depends on` or `Related` otherwise. -->
-
-<!-- For a net new feature or behavior-changing bugfix: one plain-English sentence on the user-visible change (this is the release note — no heading, don't repeat it). Remove for chores/refactors/tests-only. -->
+<!-- For a net new feature or behavior-changing bugfix: replace this comment with one plain-English sentence on the user-visible change. Usually not needed for chores/refactors/test-only PRs. -->
 
 ---
 
-<!-- Why this change, and why this approach. No `# Summary` or `## Release note` heading. -->
+<!-- Why this change, and why this approach. No `# Summary` or `## Release note` headings, please. -->
 
-Thanks for contributing! A few essentials:
+Thanks for contributing! A few essentials below. Remove these instructions before submission.
 
 1. **Title:** `type(scope): description` — e.g. `fix(sdk): ...`, `feat(cli): ...`. Allowed values: [pr_lint.yml](https://github.com/langchain-ai/deepagents/blob/main/.github/workflows/pr_lint.yml).
-2. **Body:** optional issue link + user-facing summary above `---`; motivation below. Call out breaking changes.
-3. **Checks:** `make format`, `make lint`, and `make test` from the package(s) you changed (CI must pass).
-
-Also:
-- One package per PR unless a maintainer says otherwise
-- Don't change `uv.lock` / add deps without maintainer OK
-- AI-assisted? Say so. Large pasted AI descriptions may be ignored or closed
-- English only — [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
+2. One package per PR unless a maintainer says otherwise
+3. External contributors: don't change `uv.lock` / add deps without maintainer approval
+4. Large pasted AI descriptions may be ignored or closed
+5. English only — [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
 
 Full guide: https://docs.langchain.com/oss/python/contributing/overview
+Remove the above instructions before submission!
 
 ## Social handles (optional)
-<!-- Shoutout on release -->
-Twitter: @
-LinkedIn: https://linkedin.com/in/
+<!-- For external contributors: get a shoutout on release -->
+Twitter: @YOUR_USERNAME
+LinkedIn: https://linkedin.com/in/YOUR_USERNAME

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,60 +1,28 @@
 Fixes #
 
-<!-- Update the relationship and number above, or remove the line when none applies. Only `Closes`, `Fixes`, and `Resolves` auto-close the referenced GitHub issue on merge. -->
+<!-- Optional: `Fixes` / `Closes` / `Resolves` auto-close the issue on merge. Use `Depends on` or `Related` otherwise. -->
 
-<!-- For a net new feature or behavior-changing bugfix, replace this comment with a high-level, plain-English summary of the user-visible change. That paragraph is the release note — no heading or label, and do not repeat it later. Remove this comment for chores, refactors, or test-only changes. -->
+<!-- For a net new feature or behavior-changing bugfix: one plain-English sentence on the user-visible change (this is the release note — no heading, don't repeat it). Remove for chores/refactors/tests-only. -->
 
 ---
 
-<!-- Explain the motivation and why this solution is the right one. Do not add a `# Summary`, `## Release note`, or `## Release Note` heading; the plain summary above `---` already is the release note. -->
+<!-- Why this change, and why this approach. No `# Summary` or `## Release note` heading. -->
 
-Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview
+Thanks for contributing! A few essentials:
 
-> **All contributions must be in English.** See the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy).
+1. **Title:** `type(scope): description` — e.g. `fix(sdk): ...`, `feat(cli): ...`. Allowed values: [pr_lint.yml](https://github.com/langchain-ai/deepagents/blob/main/.github/workflows/pr_lint.yml).
+2. **Body:** optional issue link + user-facing summary above `---`; motivation below. Call out breaking changes.
+3. **Checks:** `make format`, `make lint`, and `make test` from the package(s) you changed (CI must pass).
 
-If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!
+Also:
+- One package per PR unless a maintainer says otherwise
+- Don't change `uv.lock` / add deps without maintainer OK
+- AI-assisted? Say so. Large pasted AI descriptions may be ignored or closed
+- English only — [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
 
-Thank you for contributing to Deep Agents! Follow these steps to have your pull request considered as ready for review.
-
-1. PR title: Should follow the format: TYPE(SCOPE): DESCRIPTION
-
-  - Examples:
-    - fix(sdk): resolve flag parsing error
-    - feat(cli): add multi-tenant support
-    - test(acp): update API usage tests
-  - Do not include Linear issue-closing markers such as `[closes DCD-52]` in the title. Put issue references and closing metadata in the PR description instead.
-  - Allowed TYPE and SCOPE values: https://github.com/langchain-ai/deepagents/blob/main/.github/workflows/pr_lint.yml
-
-2. PR description:
-
-  - Keep an optional issue or PR relationship and, when required, the user-facing summary above the `---`; put the rest of the body below it.
-  - For net new features or behavior-changing bugfixes, write a high-level, plain-English summary of the user-visible change above `---` without a heading or label. That summary is the release note — do not also add a `## Release note` / `## Release Note` section.
-  - If this PR addresses a specific issue, use `Fixes #ISSUE_NUMBER`, `Closes #ISSUE_NUMBER`, or `Resolves #ISSUE_NUMBER` to automatically close it when the PR is merged.
-  - If there are any breaking changes, please clearly describe them.
-  - If this PR depends on another PR being merged first, please include `Depends on #PR_NUMBER` in the description.
-
-<!--
-Do not add a dedicated "Test plan" or "Testing" section unless this PR is large or the changes are highly consequential. When one is warranted, keep it collapsed:
-
-<details>
-<summary>Test plan</summary>
-
-- Describe the verification performed.
-
-</details>
--->
-
-3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.
-
-  - We will not consider a PR unless these three are passing in CI.
-
-Additional guidelines:
-
-  - We ask that if you use generative AI for your contribution, you include a disclaimer.
-  - PRs should not touch more than one package unless absolutely necessary.
-  - Do not update the `uv.lock` files or add dependencies to `pyproject.toml` files (even optional ones) unless you have explicit permission to do so by a maintainer.
+Full guide: https://docs.langchain.com/oss/python/contributing/overview
 
 ## Social handles (optional)
-<!-- If you'd like a shoutout on release, add your socials below -->
+<!-- Shoutout on release -->
 Twitter: @
 LinkedIn: https://linkedin.com/in/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ mdrxy/cli/startup-cmd-flag
 
 #### PR descriptions
 
-Do not add a `# Summary` or `## Release note` heading. Use an opening block ("frontmatter") in this order:
+Do not add a `# Summary`, `## Release note`, or `## Release Note` heading. The plain paragraph above `---` *is* the release note — never restate that same idea later under a heading. Use an opening block ("frontmatter") in this order:
 
 ```md
 Closes #123
@@ -132,9 +132,23 @@ A high-level, plain-English summary of the user-visible change.
 <rest of PR body>
 ```
 
+Bad example (do not do this — the opening paragraph already covers the user-visible change):
+
+```md
+Resume hints now echo the launched command name instead of always printing `dcode`.
+
+---
+
+<details about motivation>
+
+## Release Note
+
+Resume hints now echo the launched command name instead of always printing `dcode`.
+```
+
 - The issue or PR relationship line is optional. Use the appropriate keyword, such as `Fixes`, `Closes`, `Resolves`, `Supersedes`, `Depends on`, or `Related`. Only `Closes`, `Fixes`, and `Resolves` auto-close the referenced GitHub issue on merge.
-- For net new features or behavior-changing bugfixes, include the high-level user-facing summary in this opening block. Write it in release-note-ready plain English without a label or heading. Omit it for chores, refactors, or test-only changes.
-- Explain the *why* in the rest of the body: the motivation and why this solution is the right one. Limit prose.
+- For net new features or behavior-changing bugfixes, put one high-level plain-English summary of the user-visible change in the opening block only (no label or heading). That text is the release note; do not duplicate it below `---` or under any `Release note` / `Release Note` heading. Omit the opening summary for chores, refactors, or test-only changes.
+- Below `---`, explain the *why*: the motivation and why this solution is the right one. Limit prose. Do not repeat the opening summary.
 - Write for readers who may be unfamiliar with this area of the codebase. Avoid insider shorthand and prefer language that is friendly to public viewers — this aids interpretability.
 - Do **not** cite line numbers; they go stale as soon as the file changes.
 - Rarely include full file paths or filenames. Reference the affected symbol, class, or subsystem by name instead.


### PR DESCRIPTION
PR descriptions that mention `release-note-ready` text still led agents to append a separate `## Release Note` section that duplicated the frontmatter summary. Clarifies that the plain paragraph above `---` is the release note, bans both heading casings, and shows the anti-pattern.

---

The release-note content already belongs in the unlabeled opening summary. Agents were treating "release-note-ready" as a cue to add a second section. Tightens the wording in contributor agent guidance and the GitHub PR template so the rule is positive ("that paragraph is the release note") and includes a concrete bad example.

Related #5119
