### PR TITLE
feat(code): steer queued messages into the running turn

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -381,6 +381,17 @@ Off by default; the model is always visible in the status bar, so the banner
 row is opt-in to avoid duplicating it.
 """
 
+STEERING = "DEEPAGENTS_CODE_STEERING"
+"""Allow queued messages to be steered into a running turn (defaults to on).
+
+When enabled, pressing Enter on an empty chat input while the agent is working
+hands every queued message to the server-side steering inbox, and the agent
+picks them up at its next model call instead of after the turn ends. Set to a
+falsy value (`0`, `false`, `no`, `off`) to keep queued messages strictly
+post-turn, which also stops the agent server from reading the inbox at all.
+Parsed by `is_env_truthy`.
+"""
+
 SUPPRESS_ENV_OVERRIDE_WARNING = "DEEPAGENTS_CODE_SUPPRESS_ENV_OVERRIDE_WARNING"
 """Silence the startup warning emitted when a `DEEPAGENTS_CODE_`-prefixed
 LangSmith variable overrides its canonical counterpart (e.g. both

--- a/libs/code/deepagents_code/agent.py
+++ b/libs/code/deepagents_code/agent.py
@@ -2559,6 +2559,18 @@ def create_cli_agent(
 
     agent_middleware.extend([ResumeStateMiddleware(), GoalToolsMiddleware()])
 
+    # Mid-turn steering: drains the client's Store inbox before each model call so
+    # a queued message can reach the turn that is already running instead of
+    # waiting for it to finish. Interactive only (the headless surface has no
+    # queue to steer from), and skipped entirely when steering is disabled so the
+    # per-boundary Store read never happens.
+    from deepagents_code.steering import steering_enabled
+
+    if interactive and steering_enabled():
+        from deepagents_code.steering_middleware import SteeringMiddleware
+
+        agent_middleware.append(SteeringMiddleware())
+
     # Add ask_user middleware (must be early so its tool is available)
     trusted_ask_user_tool: BaseTool | None = None
     if enable_ask_user:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -9114,6 +9114,117 @@ class DeepAgentsApp(App):
 
         await self._submit_input(value, mode)
 
+    async def on_chat_input_steer_requested(
+        self,
+        event: ChatInput.SteerRequested,  # noqa: ARG002  # Textual event handler signature
+    ) -> None:
+        """Steer queued messages into the running turn on an empty-draft Enter."""
+        if self._exiting:
+            return
+        await self._steer_pending_messages()
+
+    async def _steer_pending_messages(self) -> None:
+        """Hand queued messages to the running turn instead of waiting for it.
+
+        Writes each steerable queued message into the thread's steering inbox,
+        where `SteeringMiddleware` picks it up before the agent's next model
+        call. The queued placeholder is replaced with a normal user message so
+        the transcript shows it as sent, matching how the injected message is
+        rendered when the thread is later resumed.
+
+        No-ops (silently, since Enter on an empty draft has always been a no-op)
+        unless steering is enabled, an agent turn is actually running, and the
+        session has a server-backed agent with a thread id. Slash and shell
+        entries stay queued: they execute in the client, not in the graph.
+        """
+        from deepagents_code.steering import awrite_steer, steering_enabled
+
+        if not steering_enabled() or not self._pending_messages:
+            return
+        if not self._agent_running:
+            return
+        agent = self._remote_agent()
+        thread_id = self._lc_thread_id
+        if agent is None or not thread_id:
+            return
+
+        steerable = [msg for msg in self._pending_messages if msg.mode == "normal"]
+        if not steerable:
+            return
+
+        turn_id = self._session_state.turn_id if self._session_state else None
+        delivered: list[QueuedMessage] = []
+        for queued in steerable:
+            try:
+                await awrite_steer(
+                    agent,
+                    thread_id,
+                    text=queued.text,
+                    turn_id=turn_id,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to write a steering message to the inbox", exc_info=True
+                )
+                break
+            delivered.append(queued)
+
+        if not delivered:
+            self.notify(
+                "Could not steer the agent; the message stays queued",
+                severity="warning",
+                timeout=4,
+            )
+            return
+
+        await self._promote_steered_messages(delivered)
+        count = len(delivered)
+        noun = "message" if count == 1 else "messages"
+        self.notify(
+            f"Steering the agent with {count} queued {noun}; it lands at the next step",
+            timeout=4,
+            markup=False,
+        )
+
+    async def _promote_steered_messages(self, delivered: list[QueuedMessage]) -> None:
+        """Move steered entries out of the queue and into the transcript.
+
+        `_pending_messages` and `_queued_widgets` are positionally aligned, so
+        both are rebuilt in one pass to keep them in step even when the steered
+        entries are not contiguous.
+
+        Args:
+            delivered: Queue entries already written to the steering inbox,
+                identified by object identity so duplicate text is not dropped
+                twice.
+        """
+        delivered_ids = {id(queued) for queued in delivered}
+        widgets = list(self._queued_widgets)
+        remaining_messages: list[QueuedMessage] = []
+        remaining_widgets: list[QueuedUserMessage] = []
+        detached: list[QueuedUserMessage] = []
+
+        for index, queued in enumerate(self._pending_messages):
+            widget = widgets[index] if index < len(widgets) else None
+            if id(queued) in delivered_ids:
+                if widget is not None:
+                    detached.append(widget)
+                continue
+            remaining_messages.append(queued)
+            if widget is not None:
+                remaining_widgets.append(widget)
+
+        self._pending_messages.clear()
+        self._pending_messages.extend(remaining_messages)
+        self._queued_widgets.clear()
+        self._queued_widgets.extend(remaining_widgets)
+
+        for widget in detached:
+            await widget.remove()
+        for queued in delivered:
+            await self._mount_message(UserMessage(queued.text))
+        self._sync_status_queued()
+
     async def _dismiss_startup_tip(self) -> None:
         """Remove the startup tip once the first prompt is submitted.
 

--- a/libs/code/deepagents_code/client/remote_client.py
+++ b/libs/code/deepagents_code/client/remote_client.py
@@ -395,6 +395,8 @@ class RemoteAgent:
         namespace: tuple[str, ...],
         key: str,
         value: dict[str, Any],
+        *,
+        ttl: int | None = None,
     ) -> None:
         """Write an item to the server-side LangGraph Store.
 
@@ -402,6 +404,10 @@ class RemoteAgent:
             namespace: Store namespace.
             key: Item key within `namespace`.
             value: JSON-serializable item value.
+            ttl: Optional expiry in minutes. Control records that must outlive
+                the session (approval mode) omit it; transient records (the
+                steering inbox) set it so an abandoned session cannot strand
+                them.
 
         Notes:
             A failed write is logged at debug and re-raised. The re-raise is
@@ -415,7 +421,7 @@ class RemoteAgent:
         graph = self._get_graph()
         try:
             client = graph._validate_client()
-            await client.store.put_item(namespace, key, value, index=False)
+            await client.store.put_item(namespace, key, value, index=False, ttl=ttl)
         except Exception:
             logger.debug(
                 "Failed to write store item %s/%s",

--- a/libs/code/deepagents_code/steering.py
+++ b/libs/code/deepagents_code/steering.py
@@ -1,0 +1,344 @@
+"""Mid-turn steering inbox shared by the Textual client and agent server.
+
+Queued chat input normally waits for the running turn to end. *Steering* hands a
+queued message to the agent **during** the turn: the client writes it into a
+per-thread LangGraph Store namespace, and `SteeringMiddleware` drains that inbox
+at the agent's next model call, so the message arrives as a `HumanMessage` in the
+live run instead of the run having to be cancelled and restarted.
+
+The Store is the only live client-to-running-run channel the platform offers
+today (`POST /threads/{id}/state` is rejected with `409` while a run is in
+flight), and it is the same channel `AsyncApprovalHITLMiddleware` already uses to
+read the live approval mode mid-run.
+
+Item layout, one item per steered message:
+
+- namespace: `("deepagents_code", "steer", <sha256 of thread id>)`
+- key: the zero-padded `seq`, so lexical order matches delivery order
+- value: `SteerPayload`
+
+`seq` is a wall-clock millisecond stamp, which keeps increasing across client
+restarts on the same thread. Consumption is tracked by a checkpointed watermark
+in agent state rather than by deleting items, so a run that dies before its
+checkpoint is written redelivers the message instead of dropping it.
+
+This module deliberately imports no LangChain/LangGraph module at import time:
+the Textual client writes the inbox and must stay off the slow-import path. The
+middleware that consumes the inbox lives in `steering_middleware`.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from hashlib import sha256
+from inspect import isawaitable
+from typing import TYPE_CHECKING, NotRequired, TypedDict
+
+from deepagents_code._env_vars import STEERING, is_env_truthy
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+logger = logging.getLogger(__name__)
+
+STEER_NAMESPACE_ROOT: tuple[str, str] = ("deepagents_code", "steer")
+"""Store namespace prefix for per-thread steering inboxes."""
+
+STEER_ITEM_TTL_MINUTES = 120
+"""Expiry for inbox items, so an abandoned session cannot strand them forever."""
+
+MAX_PENDING_STEERS = 20
+"""Largest number of inbox items read (and delivered) in one model boundary."""
+
+_SEQ_KEY_WIDTH = 20
+"""Zero-padding width for keys, so lexical key order equals numeric seq order."""
+
+
+class SteerPayload(TypedDict):
+    """Stored steering item written by the client and read by the server."""
+
+    seq: int
+    text: str
+    literal_user_text: str
+    turn_id: NotRequired[str | None]
+
+
+@dataclass(frozen=True)
+class SteerItem:
+    """A validated inbox item ready to be injected into the running turn."""
+
+    seq: int
+    key: str
+    text: str
+    literal_user_text: str
+    turn_id: str | None
+
+
+class _SeqCounter:
+    """Monotonic millisecond sequence source shared by one client process."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._last = 0
+
+    def next(self) -> int:
+        """Return a strictly increasing millisecond-resolution sequence number.
+
+        Returns:
+            The current wall clock in milliseconds, bumped past the previously
+            issued value so two steers submitted in the same millisecond still
+            order deterministically.
+        """
+        with self._lock:
+            seq = max(time.time_ns() // 1_000_000, self._last + 1)
+            self._last = seq
+            return seq
+
+
+_SEQ = _SeqCounter()
+
+
+def steering_enabled() -> bool:
+    """Whether queued messages may be steered into a running turn.
+
+    Returns:
+        `True` unless `DEEPAGENTS_CODE_STEERING` is set to a falsy value.
+    """
+    return is_env_truthy(STEERING, default=True)
+
+
+def steer_namespace(thread_id: str) -> tuple[str, ...]:
+    """Return the Store namespace holding a thread's steering inbox.
+
+    The thread id is hashed (matching `approval_mode_key`) so raw thread ids are
+    not exposed in Store namespaces.
+
+    Args:
+        thread_id: LangGraph thread id for the active session.
+
+    Returns:
+        Namespace tuple scoped to exactly this thread.
+    """
+    digest = sha256(thread_id.encode("utf-8")).hexdigest()
+    return (*STEER_NAMESPACE_ROOT, digest)
+
+
+def steer_key(seq: int) -> str:
+    """Return the Store key for a sequence number.
+
+    Args:
+        seq: Sequence number from `next_steer_seq`.
+
+    Returns:
+        Zero-padded key so lexical ordering matches delivery order.
+    """
+    return f"{seq:0{_SEQ_KEY_WIDTH}d}"
+
+
+def next_steer_seq() -> int:
+    """Return the next steering sequence number for this client process.
+
+    Returns:
+        Strictly increasing millisecond stamp.
+    """
+    return _SEQ.next()
+
+
+def steer_payload(
+    text: str,
+    *,
+    seq: int,
+    literal_user_text: str | None = None,
+    turn_id: str | None = None,
+) -> SteerPayload:
+    """Build the stored payload for one steered message.
+
+    Args:
+        text: Message text delivered to the agent.
+        seq: Sequence number from `next_steer_seq`.
+        literal_user_text: Text as typed, when it differs from `text`. Used for
+            the trusted prompt metadata the Auto-approval classifier reads.
+        turn_id: Id of the turn being steered, when one is active.
+
+    Returns:
+        JSON-serializable Store value.
+    """
+    return SteerPayload(
+        seq=seq,
+        text=text,
+        literal_user_text=literal_user_text if literal_user_text is not None else text,
+        turn_id=turn_id,
+    )
+
+
+def parse_steer_item(key: object, value: object) -> SteerItem | None:
+    """Validate one raw Store item, or reject it.
+
+    Every field is type-checked before use: a malformed item is dropped rather
+    than partially trusted, since the inbox is consumed inside a live graph run
+    where raising would fail the user's turn.
+
+    Args:
+        key: Raw Store key.
+        value: Raw Store value.
+
+    Returns:
+        The validated item, or `None` when it cannot be trusted.
+    """
+    if not isinstance(key, str) or not key:
+        return None
+    if not isinstance(value, Mapping):
+        return None
+    seq = value.get("seq")
+    text = value.get("text")
+    if not isinstance(seq, int) or isinstance(seq, bool) or seq <= 0:
+        return None
+    if not isinstance(text, str) or not text.strip():
+        return None
+    literal = value.get("literal_user_text")
+    turn_id = value.get("turn_id")
+    return SteerItem(
+        seq=seq,
+        key=key,
+        text=text,
+        literal_user_text=literal if isinstance(literal, str) and literal else text,
+        turn_id=turn_id if isinstance(turn_id, str) and turn_id else None,
+    )
+
+
+def coerce_consumed_seq(value: object) -> int:
+    """Narrow a checkpointed consumption watermark to a usable integer.
+
+    Args:
+        value: Raw watermark read back from agent state.
+
+    Returns:
+        The watermark, or `0` when it is missing or not a positive integer.
+    """
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return 0
+
+
+async def awrite_steer(
+    agent: object,
+    thread_id: str,
+    *,
+    text: str,
+    literal_user_text: str | None = None,
+    turn_id: str | None = None,
+) -> int | None:
+    """Write one steering message into a thread's inbox.
+
+    Args:
+        agent: Agent object. Remote agents expose `aput_store_item`.
+        thread_id: LangGraph thread id for the active session.
+        text: Message text to deliver to the running turn.
+        literal_user_text: Text as typed, when it differs from `text`.
+        turn_id: Id of the turn being steered, when one is active.
+
+    Returns:
+        The written sequence number, or `None` when the agent has no Store
+        writer (for example a local in-process graph).
+    """
+    put = getattr(agent, "aput_store_item", None)
+    if put is None:
+        return None
+    seq = next_steer_seq()
+    await put(
+        steer_namespace(thread_id),
+        steer_key(seq),
+        steer_payload(
+            text,
+            seq=seq,
+            literal_user_text=literal_user_text,
+            turn_id=turn_id,
+        ),
+        ttl=STEER_ITEM_TTL_MINUTES,
+    )
+    return seq
+
+
+async def aread_pending_steers(
+    store: object,
+    thread_id: str,
+    *,
+    after_seq: int,
+) -> list[SteerItem]:
+    """Read a thread's undelivered inbox items in delivery order.
+
+    Reads only the namespace belonging to `thread_id`, so one thread's run can
+    never observe another thread's steering messages. Store failures are logged
+    and reported as an empty inbox: a steer that cannot be read is delivered on
+    a later boundary (or, at worst, after the turn) rather than failing the run.
+
+    Args:
+        store: `runtime.store` from the graph server.
+        thread_id: Thread whose inbox is being drained.
+        after_seq: Watermark; only items with a greater `seq` are returned.
+
+    Returns:
+        Validated items ordered by `seq`, capped at `MAX_PENDING_STEERS`.
+    """
+    if store is None:
+        return []
+    search = getattr(store, "asearch", None) or getattr(store, "search", None)
+    if not callable(search):
+        logger.debug("Steering store exposes neither asearch() nor search()")
+        return []
+
+    namespace = steer_namespace(thread_id)
+    try:
+        result = search(namespace, limit=MAX_PENDING_STEERS)
+        raw_items = await result if isawaitable(result) else result
+    except Exception:
+        logger.warning("Could not read the steering inbox", exc_info=True)
+        return []
+
+    items: list[SteerItem] = []
+    for raw in raw_items or []:
+        if tuple(getattr(raw, "namespace", ()) or ()) != namespace:
+            # Defensive: a store that widened the prefix must not leak another
+            # thread's inbox into this run.
+            continue
+        item = parse_steer_item(getattr(raw, "key", None), getattr(raw, "value", None))
+        if item is None:
+            logger.warning("Discarding malformed steering item")
+            continue
+        if item.seq <= after_seq:
+            continue
+        items.append(item)
+    items.sort(key=lambda item: item.seq)
+    return items[:MAX_PENDING_STEERS]
+
+
+async def adelete_steers(
+    store: object,
+    thread_id: str,
+    keys: Sequence[str],
+) -> None:
+    """Remove delivered items from a thread's inbox, best effort.
+
+    Deletion only keeps the namespace tidy. Redelivery is prevented by the
+    checkpointed watermark, so a failed delete is safe to ignore.
+
+    Args:
+        store: `runtime.store` from the graph server.
+        thread_id: Thread whose inbox was drained.
+        keys: Keys of the items already delivered.
+    """
+    delete = getattr(store, "adelete", None) or getattr(store, "delete", None)
+    if not callable(delete) or not keys:
+        return
+    namespace = steer_namespace(thread_id)
+    for key in keys:
+        try:
+            result = delete(namespace, key)
+            if isawaitable(result):
+                await result
+        except Exception:
+            logger.debug("Could not delete steering item %s", key, exc_info=True)

--- a/libs/code/deepagents_code/steering_middleware.py
+++ b/libs/code/deepagents_code/steering_middleware.py
@@ -1,0 +1,159 @@
+"""Middleware that delivers steered messages into a running agent turn.
+
+Runs in the agent server process. See `steering` for the inbox layout and why the
+Store is the delivery channel. The inbox is drained in `abefore_model`, which is
+the only boundary where appending a `HumanMessage` is both timely (the model sees
+it on its very next call) and structurally valid (tool results for the previous
+`AIMessage` are already complete).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Annotated, Any, NotRequired
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ContextT,
+    PrivateStateAttr,
+)
+from langchain_core.messages import HumanMessage
+
+from deepagents_code.auto_mode import USER_PROMPT_METADATA_KEY, user_prompt_metadata
+from deepagents_code.steering import (
+    SteerItem,
+    adelete_steers,
+    aread_pending_steers,
+    coerce_consumed_seq,
+    steering_enabled,
+)
+
+if TYPE_CHECKING:
+    from langgraph.runtime import Runtime
+
+logger = logging.getLogger(__name__)
+
+
+class SteerState(AgentState):
+    """Agent state extended with the steering consumption watermark."""
+
+    _steer_consumed_seq: Annotated[NotRequired[int], PrivateStateAttr]
+    """Highest steering `seq` already delivered on this thread."""
+
+
+def _context_value(context: object, name: str) -> object:
+    """Read a context field from either a mapping or an attribute holder.
+
+    Args:
+        context: Run context supplied by the graph server.
+        name: Field to read.
+
+    Returns:
+        The field value, or `None` when the context does not carry it.
+    """
+    if isinstance(context, Mapping):
+        return context.get(name)
+    return getattr(context, name, None)
+
+
+def _resolve_thread_id(runtime: object) -> str | None:
+    """Return the thread whose inbox this run may drain.
+
+    The run's own `execution_info.thread_id` is authoritative; the context copy
+    is cross-checked so a mismatched context can never point the drain at
+    another thread's namespace.
+
+    Args:
+        runtime: LangGraph runtime for the current step.
+
+    Returns:
+        The thread id, or `None` when it is missing or inconsistent.
+    """
+    execution = getattr(runtime, "execution_info", None)
+    execution_id = getattr(execution, "thread_id", None)
+    context_id = _context_value(getattr(runtime, "context", None), "thread_id")
+    candidates = [
+        value
+        for value in (execution_id, context_id)
+        if isinstance(value, str) and value
+    ]
+    if not candidates:
+        return None
+    if len(candidates) == 2 and candidates[0] != candidates[1]:  # noqa: PLR2004  # both ids present
+        logger.warning("Steering thread id mismatch; skipping inbox drain")
+        return None
+    return candidates[0]
+
+
+def _steer_message(item: SteerItem) -> HumanMessage:
+    """Build the injected user message for one inbox item.
+
+    The trusted prompt metadata is rebuilt here from validated fields only, and
+    never carries referenced paths: steered text is delivered verbatim (no `@`
+    file expansion), so an inbox item cannot assert that the user referenced a
+    path they never referenced.
+
+    Args:
+        item: Validated inbox item.
+
+    Returns:
+        The `HumanMessage` appended to agent state.
+    """
+    return HumanMessage(
+        content=item.text,
+        additional_kwargs={
+            USER_PROMPT_METADATA_KEY: user_prompt_metadata(
+                item.literal_user_text,
+                [],
+                turn_id=item.turn_id,
+            )
+        },
+    )
+
+
+class SteeringMiddleware(AgentMiddleware[SteerState, ContextT]):
+    """Injects client-steered messages at the next model call.
+
+    Only the async hook is implemented: the agent server always drives the graph
+    asynchronously, and the Store it supplies rejects synchronous reads from the
+    event-loop thread. A synchronous run simply does not steer, which degrades to
+    today's behavior (queued messages run after the turn).
+    """
+
+    state_schema = SteerState
+
+    async def abefore_model(  # noqa: PLR6301  # AgentMiddleware hook must be an instance method.
+        self,
+        state: SteerState,
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Append any undelivered steering messages before the model runs.
+
+        Args:
+            state: Current agent state, read for the consumption watermark.
+            runtime: Runtime carrying the run context and Store.
+
+        Returns:
+            State update with the injected messages and the advanced watermark,
+            or `None` when there is nothing to deliver.
+        """
+        if not steering_enabled():
+            return None
+        thread_id = _resolve_thread_id(runtime)
+        if thread_id is None:
+            return None
+
+        consumed = coerce_consumed_seq(state.get("_steer_consumed_seq"))
+        store = getattr(runtime, "store", None)
+        items = await aread_pending_steers(store, thread_id, after_seq=consumed)
+        if not items:
+            return None
+
+        logger.info("Delivering %d steering message(s) mid-turn", len(items))
+        await adelete_steers(store, thread_id, [item.key for item in items])
+        return {
+            "messages": [_steer_message(item) for item in items],
+            "_steer_consumed_seq": items[-1].seq,
+        }

--- a/libs/code/deepagents_code/tui/widgets/chat_input.py
+++ b/libs/code/deepagents_code/tui/widgets/chat_input.py
@@ -466,6 +466,13 @@ class ChatTextArea(PasteBurstTextArea):
             self.value = value
             super().__init__()
 
+    class SteerRequested(Message):
+        """Enter was pressed with an empty draft.
+
+        The app layer decides what this means: with messages queued behind a
+        running turn it steers them into that turn, and otherwise it is a no-op.
+        """
+
     class HistoryPrevious(Message):
         """Request previous history entry."""
 
@@ -1026,6 +1033,11 @@ class ChatTextArea(PasteBurstTextArea):
             value = self.text.strip()
             if value:
                 self.post_message(self.Submitted(value))
+            else:
+                # An empty draft has nothing to submit, but the keypress is still
+                # a deliberate "send it now" for anything queued behind a running
+                # turn. The app layer owns that decision.
+                self.post_message(self.SteerRequested())
             return
 
         await super()._on_key(event)
@@ -1428,6 +1440,9 @@ class ChatInput(Vertical):
             super().__init__()
             self.value = value
             self.mode = mode
+
+    class SteerRequested(Message):
+        """Relayed from the chat text area when Enter is pressed on an empty draft."""
 
     class ModeChanged(Message):
         """Message sent when input mode changes."""
@@ -2208,6 +2223,13 @@ class ChatInput(Vertical):
         process immediately or queue based on agent status.
         """
         self._submit_value(event.value)
+
+    def on_chat_text_area_steer_requested(
+        self,
+        event: ChatTextArea.SteerRequested,  # noqa: ARG002  # Textual event handler signature
+    ) -> None:
+        """Relay an empty-draft Enter to the app as `ChatInput.SteerRequested`."""
+        self.post_message(self.SteerRequested())
 
     def on_chat_text_area_history_previous(
         self, event: ChatTextArea.HistoryPrevious

--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -28,6 +28,7 @@ _TIPS: dict[str, int] = {
     "Use /model to switch models mid-conversation": 2,
     "Use /effort to change the current model's reasoning effort": 1,
     "Press ctrl+x to compose prompts in your external editor": 1,
+    "Queue a message while the agent works, then press Enter to steer it mid-turn": 2,
     "Use /skill:<name> to invoke a skill directly": 1,
     "Use /theme to customize the TUI's colors": 1,
     "Use /skill-creator to build reusable agent skills": 1,

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -4030,6 +4030,132 @@ class TestQueuedMessage:
         assert msg.mode == "shell"
 
 
+class TestSteerQueuedMessages:
+    """Enter on an empty chat input steers queued messages into a running turn."""
+
+    @staticmethod
+    def _recording_agent(*, fail: bool = False) -> Any:  # noqa: ANN401  # concrete RemoteAgent subclass defined inline
+        """Return a real `RemoteAgent` whose Store write is captured locally."""
+        from deepagents_code.client.remote_client import RemoteAgent
+
+        class _RecordingRemoteAgent(RemoteAgent):
+            """Captures inbox writes instead of sending them to a server."""
+
+            def __init__(self) -> None:
+                super().__init__("http://localhost:0")
+                self.writes: list[dict[str, Any]] = []
+
+            async def aput_store_item(
+                self,
+                namespace: tuple[str, ...],
+                key: str,
+                value: dict[str, Any],
+                *,
+                ttl: int | None = None,
+            ) -> None:
+                del namespace, key, ttl
+                if fail:
+                    msg = "store unavailable"
+                    raise RuntimeError(msg)
+                self.writes.append(value)
+
+        return _RecordingRemoteAgent()
+
+    async def test_empty_enter_steers_every_queued_message(self) -> None:
+        """Queued prompts are handed to the running turn in submission order."""
+        agent = self._recording_agent()
+        app = DeepAgentsApp(agent=agent, thread_id="thread-steer")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+            await app._submit_input("first", "normal")
+            await app._submit_input("second", "normal")
+            await pilot.pause()
+
+            app.post_message(ChatInput.SteerRequested())
+            await pilot.pause()
+
+            assert [write["text"] for write in agent.writes] == ["first", "second"]
+            assert not app._pending_messages
+            assert not app._queued_widgets
+            assert not app.query(QueuedUserMessage)
+            mounted = [widget.raw_text for widget in app.query(UserMessage)]
+            assert mounted == ["first", "second"]
+
+    async def test_steer_leaves_client_side_entries_queued(self) -> None:
+        """Shell and slash entries must still run in the client after the turn."""
+        agent = self._recording_agent()
+        app = DeepAgentsApp(agent=agent, thread_id="thread-steer")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+            await app._submit_input("!ls", "shell")
+            await app._submit_input("steer me", "normal")
+            await pilot.pause()
+
+            app.post_message(ChatInput.SteerRequested())
+            await pilot.pause()
+
+            assert [write["text"] for write in agent.writes] == ["steer me"]
+            assert [message.text for message in app._pending_messages] == ["!ls"]
+            assert len(app._queued_widgets) == 1
+            assert len(app.query(QueuedUserMessage)) == 1
+
+    async def test_steer_is_a_noop_while_idle(self) -> None:
+        """With no turn running there is nothing to steer into."""
+        agent = self._recording_agent()
+        app = DeepAgentsApp(agent=agent, thread_id="thread-steer")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+            await app._submit_input("later", "normal")
+            # Hold the normal drain so the queue state reflects steering alone.
+            drain = AsyncMock()
+            app._process_next_from_queue = drain  # ty: ignore
+            app._agent_running = False
+
+            app.post_message(ChatInput.SteerRequested())
+            await pilot.pause()
+
+            assert agent.writes == []
+            assert [message.text for message in app._pending_messages] == ["later"]
+
+    async def test_steer_respects_the_disable_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Opting out keeps queued messages strictly post-turn."""
+        from deepagents_code._env_vars import STEERING
+
+        monkeypatch.setenv(STEERING, "0")
+        agent = self._recording_agent()
+        app = DeepAgentsApp(agent=agent, thread_id="thread-steer")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+            await app._submit_input("queued", "normal")
+
+            app.post_message(ChatInput.SteerRequested())
+            await pilot.pause()
+
+            assert agent.writes == []
+            assert [message.text for message in app._pending_messages] == ["queued"]
+
+    async def test_failed_write_keeps_the_message_queued(self) -> None:
+        """A Store failure must not lose the prompt the user typed."""
+        agent = self._recording_agent(fail=True)
+        app = DeepAgentsApp(agent=agent, thread_id="thread-steer")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._agent_running = True
+            await app._submit_input("keep me", "normal")
+
+            app.post_message(ChatInput.SteerRequested())
+            await pilot.pause()
+
+            assert [message.text for message in app._pending_messages] == ["keep me"]
+            assert len(app._queued_widgets) == 1
+
+
 class TestMessageQueue:
     """Test message queue behavior in DeepAgentsApp."""
 

--- a/libs/code/tests/unit_tests/test_steering.py
+++ b/libs/code/tests/unit_tests/test_steering.py
@@ -1,0 +1,467 @@
+"""Tests for the mid-turn steering inbox and its delivery middleware."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langgraph.runtime import ExecutionInfo, Runtime
+from langgraph.store.memory import InMemoryStore
+
+from deepagents_code._env_vars import STEERING
+from deepagents_code._fake_models import _ToolBindingFakeModel
+from deepagents_code.auto_mode import USER_PROMPT_METADATA_KEY
+from deepagents_code.steering import (
+    STEER_NAMESPACE_ROOT,
+    adelete_steers,
+    aread_pending_steers,
+    awrite_steer,
+    coerce_consumed_seq,
+    next_steer_seq,
+    parse_steer_item,
+    steer_key,
+    steer_namespace,
+    steering_enabled,
+)
+from deepagents_code.steering_middleware import SteeringMiddleware
+
+if TYPE_CHECKING:
+    from langchain_core.callbacks import CallbackManagerForLLMRun
+    from langgraph.store.base import BaseStore
+
+THREAD = "thread-steer-1"
+OTHER_THREAD = "thread-steer-2"
+
+
+@dataclass
+class _Context:
+    """Minimal stand-in for the run context field the middleware reads."""
+
+    thread_id: str | None = None
+
+
+class _StoreWritingAgent:
+    """Client-side agent double that writes to a real Store like the server would.
+
+    `RemoteAgent.aput_store_item` posts to the server's Store over HTTP; this
+    performs the same write locally so the client write path and the server read
+    path can be exercised against one another without a server.
+    """
+
+    def __init__(self, store: BaseStore) -> None:
+        self.store = store
+        self.ttls: list[int | None] = []
+
+    async def aput_store_item(
+        self,
+        namespace: tuple[str, ...],
+        key: str,
+        value: dict[str, Any],
+        *,
+        ttl: int | None = None,
+    ) -> None:
+        """Record the TTL and write the item into the backing Store."""
+        self.ttls.append(ttl)
+        await self.store.aput(namespace, key, value)
+
+
+class _ExplodingStore:
+    """Store whose search always fails, to prove reads degrade to an empty inbox."""
+
+    async def asearch(
+        self,
+        *args: Any,  # noqa: ARG002  # signature mirrors `BaseStore.asearch`
+        **kwargs: Any,  # noqa: ARG002  # signature mirrors `BaseStore.asearch`
+    ) -> list[Any]:
+        """Raise as a failing Store would.
+
+        Returns:
+            Never returns; the call always raises.
+        """
+        msg = "store unavailable"
+        raise RuntimeError(msg)
+
+
+def _runtime(
+    store: BaseStore | None,
+    *,
+    thread_id: str | None = THREAD,
+    execution_thread_id: str | None = THREAD,
+) -> Runtime[Any]:
+    """Build a runtime carrying the context, Store, and execution thread id."""
+    execution = (
+        ExecutionInfo(
+            checkpoint_id="cp",
+            checkpoint_ns="",
+            task_id="task",
+            thread_id=execution_thread_id,
+        )
+        if execution_thread_id is not None
+        else None
+    )
+    return Runtime(
+        context=_Context(thread_id=thread_id),
+        store=store,
+        execution_info=execution,
+    )
+
+
+async def _write(store: BaseStore, thread_id: str, seq: int, text: str) -> None:
+    """Write one raw inbox item, bypassing the client helper's sequencing."""
+    await store.aput(
+        steer_namespace(thread_id),
+        steer_key(seq),
+        {"seq": seq, "text": text, "literal_user_text": text, "turn_id": "turn-1"},
+    )
+
+
+class TestInboxAddressing:
+    """Namespace and key derivation."""
+
+    def test_namespace_is_scoped_per_thread(self) -> None:
+        """Each thread gets its own namespace under the shared root."""
+        namespace = steer_namespace(THREAD)
+        assert namespace[:2] == STEER_NAMESPACE_ROOT
+        assert namespace != steer_namespace(OTHER_THREAD)
+
+    def test_namespace_does_not_expose_thread_id(self) -> None:
+        """The thread id is hashed, matching the approval-mode key convention."""
+        assert THREAD not in steer_namespace(THREAD)[-1]
+
+    def test_keys_sort_in_delivery_order(self) -> None:
+        """Zero-padded keys keep lexical order aligned with numeric order."""
+        assert sorted([steer_key(2), steer_key(10)]) == [steer_key(2), steer_key(10)]
+
+    def test_sequence_numbers_strictly_increase(self) -> None:
+        """Two steers submitted in the same millisecond still order."""
+        seqs = [next_steer_seq() for _ in range(5)]
+        assert seqs == sorted(set(seqs))
+
+
+class TestPayloadValidation:
+    """`parse_steer_item` must reject anything it cannot fully trust."""
+
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("k", None),
+            ("k", "not-a-mapping"),
+            ("k", {"text": "hi"}),
+            ("k", {"seq": 0, "text": "hi"}),
+            ("k", {"seq": -1, "text": "hi"}),
+            ("k", {"seq": True, "text": "hi"}),
+            ("k", {"seq": "1", "text": "hi"}),
+            ("k", {"seq": 1, "text": "   "}),
+            ("k", {"seq": 1, "text": 5}),
+            ("", {"seq": 1, "text": "hi"}),
+            (None, {"seq": 1, "text": "hi"}),
+        ],
+    )
+    def test_malformed_items_are_rejected(self, key: object, value: object) -> None:
+        """A malformed item is dropped rather than partially trusted."""
+        assert parse_steer_item(key, value) is None
+
+    def test_valid_item_is_parsed(self) -> None:
+        """A well-formed item keeps every validated field."""
+        item = parse_steer_item(
+            "k",
+            {
+                "seq": 7,
+                "text": "use async",
+                "literal_user_text": "use async instead",
+                "turn_id": "turn-9",
+            },
+        )
+        assert item is not None
+        assert (item.seq, item.text, item.turn_id) == (7, "use async", "turn-9")
+        assert item.literal_user_text == "use async instead"
+
+    def test_literal_text_falls_back_to_delivered_text(self) -> None:
+        """A missing or non-string literal text falls back to the message text."""
+        item = parse_steer_item("k", {"seq": 1, "text": "hi", "literal_user_text": 3})
+        assert item is not None
+        assert item.literal_user_text == "hi"
+
+    def test_non_string_turn_id_becomes_none(self) -> None:
+        """An unusable turn id is dropped instead of reaching prompt metadata."""
+        item = parse_steer_item("k", {"seq": 1, "text": "hi", "turn_id": 12})
+        assert item is not None
+        assert item.turn_id is None
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [(5, 5), (0, 0), (-3, 0), (None, 0), ("4", 0), (True, 0)],
+    )
+    def test_consumed_watermark_coercion(self, value: object, expected: int) -> None:
+        """Only positive integers survive as a watermark."""
+        assert coerce_consumed_seq(value) == expected
+
+
+class TestInboxReads:
+    """Reading a thread's pending items."""
+
+    async def test_returns_items_after_watermark_in_order(self) -> None:
+        """Only newer items are returned, ordered by sequence."""
+        store = InMemoryStore()
+        await _write(store, THREAD, 1, "first")
+        await _write(store, THREAD, 2, "second")
+        await _write(store, THREAD, 3, "third")
+
+        items = await aread_pending_steers(store, THREAD, after_seq=1)
+
+        assert [item.text for item in items] == ["second", "third"]
+
+    async def test_other_threads_are_never_read(self) -> None:
+        """A run may only observe its own thread's inbox."""
+        store = InMemoryStore()
+        await _write(store, OTHER_THREAD, 1, "not mine")
+
+        assert await aread_pending_steers(store, THREAD, after_seq=0) == []
+
+    async def test_malformed_items_are_skipped(self) -> None:
+        """A corrupt item cannot block a valid one behind it."""
+        store = InMemoryStore()
+        await store.aput(steer_namespace(THREAD), steer_key(1), {"text": "no seq"})
+        await _write(store, THREAD, 2, "valid")
+
+        items = await aread_pending_steers(store, THREAD, after_seq=0)
+
+        assert [item.text for item in items] == ["valid"]
+
+    async def test_missing_store_reads_empty(self) -> None:
+        """No Store means no steering, not an exception."""
+        assert await aread_pending_steers(None, THREAD, after_seq=0) == []
+
+    async def test_store_failure_reads_empty(self) -> None:
+        """A failing Store degrades to an empty inbox instead of failing the run."""
+        assert await aread_pending_steers(_ExplodingStore(), THREAD, after_seq=0) == []
+
+    async def test_delete_removes_delivered_items(self) -> None:
+        """Delivered keys are cleaned up so the namespace does not grow."""
+        store = InMemoryStore()
+        await _write(store, THREAD, 1, "first")
+
+        await adelete_steers(store, THREAD, [steer_key(1)])
+
+        assert await aread_pending_steers(store, THREAD, after_seq=0) == []
+
+
+class TestClientWritePath:
+    """The client write helper must produce items the server can read."""
+
+    async def test_write_then_read_round_trip(self) -> None:
+        """Text written by the client is readable by the server-side reader."""
+        store = InMemoryStore()
+        agent = _StoreWritingAgent(store)
+
+        seq = await awrite_steer(agent, THREAD, text="use async", turn_id="turn-3")
+
+        assert seq is not None
+        items = await aread_pending_steers(store, THREAD, after_seq=0)
+        assert [(item.text, item.turn_id) for item in items] == [
+            ("use async", "turn-3")
+        ]
+        assert agent.ttls == [pytest.approx(120)]
+
+    async def test_write_is_skipped_without_a_store_writer(self) -> None:
+        """A local in-process agent has no Store, so the write is a no-op."""
+        assert await awrite_steer(object(), THREAD, text="hi") is None
+
+    async def test_written_items_preserve_submission_order(self) -> None:
+        """Successive writes are delivered in the order they were queued."""
+        store = InMemoryStore()
+        agent = _StoreWritingAgent(store)
+
+        await awrite_steer(agent, THREAD, text="first")
+        await awrite_steer(agent, THREAD, text="second")
+
+        items = await aread_pending_steers(store, THREAD, after_seq=0)
+        assert [item.text for item in items] == ["first", "second"]
+
+
+class TestSteeringMiddleware:
+    """Delivery at the model boundary."""
+
+    async def test_injects_pending_messages_and_advances_watermark(self) -> None:
+        """Pending items become user messages and bump the consumed watermark."""
+        store = InMemoryStore()
+        await _write(store, THREAD, 4, "use async instead")
+        middleware = SteeringMiddleware()
+
+        update = await middleware.abefore_model({"messages": []}, _runtime(store))
+
+        assert update is not None
+        assert update["_steer_consumed_seq"] == 4
+        (message,) = update["messages"]
+        assert isinstance(message, HumanMessage)
+        assert message.content == "use async instead"
+        metadata = message.additional_kwargs[USER_PROMPT_METADATA_KEY]
+        assert metadata["literal_user_text"] == "use async instead"
+        assert metadata["turn_id"] == "turn-1"
+        assert metadata["referenced_paths"] == []
+
+    async def test_delivered_message_is_not_delivered_twice(self) -> None:
+        """The checkpointed watermark makes a second boundary a no-op."""
+        store = InMemoryStore()
+        await _write(store, THREAD, 4, "use async instead")
+        middleware = SteeringMiddleware()
+        runtime = _runtime(store)
+
+        first = await middleware.abefore_model({"messages": []}, runtime)
+        assert first is not None
+        second = await middleware.abefore_model(
+            {"messages": [], "_steer_consumed_seq": first["_steer_consumed_seq"]},
+            runtime,
+        )
+
+        assert second is None
+
+    async def test_uncheckpointed_delivery_is_redelivered(self) -> None:
+        """Without the watermark persisted, the message is delivered again.
+
+        This is the deliberate trade: a run that dies before its checkpoint is
+        written redelivers rather than silently dropping user input.
+        """
+        store = InMemoryStore()
+        await store.aput(
+            steer_namespace(THREAD),
+            steer_key(4),
+            {"seq": 4, "text": "retry me", "literal_user_text": "retry me"},
+        )
+        middleware = SteeringMiddleware()
+
+        await middleware.abefore_model({"messages": []}, _runtime(store))
+        await store.aput(
+            steer_namespace(THREAD),
+            steer_key(4),
+            {"seq": 4, "text": "retry me", "literal_user_text": "retry me"},
+        )
+        again = await middleware.abefore_model({"messages": []}, _runtime(store))
+
+        assert again is not None
+
+    async def test_empty_inbox_returns_no_update(self) -> None:
+        """Nothing queued means no state update at all."""
+        middleware = SteeringMiddleware()
+
+        assert (
+            await middleware.abefore_model({"messages": []}, _runtime(InMemoryStore()))
+            is None
+        )
+
+    async def test_disabled_flag_skips_the_store_entirely(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Opting out stops delivery even with items waiting."""
+        monkeypatch.setenv(STEERING, "0")
+        store = InMemoryStore()
+        await _write(store, THREAD, 1, "ignored")
+
+        assert not steering_enabled()
+        assert (
+            await SteeringMiddleware().abefore_model({"messages": []}, _runtime(store))
+            is None
+        )
+
+    async def test_thread_id_mismatch_skips_delivery(self) -> None:
+        """A context/execution thread disagreement must not pick a namespace."""
+        store = InMemoryStore()
+        await _write(store, THREAD, 1, "mine")
+        runtime = _runtime(store, thread_id=OTHER_THREAD, execution_thread_id=THREAD)
+
+        assert (
+            await SteeringMiddleware().abefore_model({"messages": []}, runtime) is None
+        )
+
+    async def test_missing_thread_id_skips_delivery(self) -> None:
+        """With no thread id there is no inbox to read."""
+        store = InMemoryStore()
+        await _write(store, THREAD, 1, "mine")
+        runtime = _runtime(store, thread_id=None, execution_thread_id=None)
+
+        assert (
+            await SteeringMiddleware().abefore_model({"messages": []}, runtime) is None
+        )
+
+
+class TestSteeringInRealAgent:
+    """The middleware inside a real `create_agent` loop."""
+
+    async def test_steered_message_reaches_the_next_model_call(self) -> None:
+        """A steer written mid-run is visible to the model's next call."""
+        from langchain.agents import create_agent
+        from langchain_core.tools import tool
+
+        store = InMemoryStore()
+        seen_prompts: list[list[str]] = []
+
+        @tool
+        def slow_tool(query: str) -> str:
+            """Record the call, then steer the still-running turn."""
+            store.put(
+                steer_namespace(THREAD),
+                steer_key(9),
+                {"seq": 9, "text": "actually, use async", "turn_id": "turn-1"},
+            )
+            return f"looked up {query}"
+
+        class _TwoStepModel(_ToolBindingFakeModel):
+            """Calls `slow_tool` once, then answers."""
+
+            disable_streaming: bool = True
+
+            def _generate(
+                self,
+                messages: list[BaseMessage],
+                stop: list[str] | None = None,
+                run_manager: CallbackManagerForLLMRun | None = None,
+                **kwargs: Any,
+            ) -> ChatResult:
+                del stop, run_manager, kwargs
+                seen_prompts.append(
+                    [
+                        str(message.content)
+                        for message in messages
+                        if isinstance(message, HumanMessage)
+                    ]
+                )
+                if any(isinstance(message, ToolMessage) for message in messages):
+                    response = AIMessage(content="done")
+                else:
+                    response = AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "slow_tool",
+                                "args": {"query": "steering"},
+                                "id": "call-1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    )
+                return ChatResult(generations=[ChatGeneration(message=response)])
+
+        agent = create_agent(
+            model=_TwoStepModel(),
+            tools=[slow_tool],
+            middleware=[SteeringMiddleware()],
+            context_schema=_Context,
+            store=store,
+        )
+        result = await agent.ainvoke(
+            {"messages": [HumanMessage(content="look something up")]},
+            context=_Context(thread_id=THREAD),
+        )
+
+        assert seen_prompts[0] == ["look something up"]
+        assert "actually, use async" in seen_prompts[1]
+        steered = [
+            message
+            for message in result["messages"]
+            if isinstance(message, HumanMessage)
+            and message.content == "actually, use async"
+        ]
+        assert len(steered) == 1

--- a/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_chat_input.py
@@ -480,6 +480,58 @@ class TestChatTextAreaKeybindings:
         assert "alt+backspace" in word_delete_keys
 
 
+class TestEmptyEnterSteerRequest:
+    """Enter on an empty draft asks the app to steer, instead of doing nothing."""
+
+    class _SteerRecordingApp(App[None]):
+        """App that records `ChatInput.SteerRequested` for assertion."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.steer_requests = 0
+            self.submitted: list[ChatInput.Submitted] = []
+
+        def compose(self) -> ComposeResult:
+            yield ChatInput(id="chat-input")
+
+        def on_chat_input_steer_requested(
+            self,
+            event: ChatInput.SteerRequested,  # noqa: ARG002  # Textual event handler signature
+        ) -> None:
+            self.steer_requests += 1
+
+        def on_chat_input_submitted(self, event: ChatInput.Submitted) -> None:
+            self.submitted.append(event)
+
+    async def test_empty_draft_requests_a_steer(self) -> None:
+        """An empty Enter reaches the app as a steer request."""
+        app = self._SteerRecordingApp()
+        async with app.run_test() as pilot:
+            app.query_one(ChatInput).focus_input()
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert app.steer_requests == 1
+            assert app.submitted == []
+
+    async def test_draft_still_submits(self) -> None:
+        """A non-empty Enter submits as before and never requests a steer."""
+        app = self._SteerRecordingApp()
+        async with app.run_test() as pilot:
+            chat_input = app.query_one(ChatInput)
+            chat_input.focus_input()
+            text_area = chat_input.input_widget
+            assert text_area is not None
+            text_area.insert("do the thing")
+            await pilot.pause()
+
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert [event.value for event in app.submitted] == ["do the thing"]
+            assert app.steer_requests == 0
+
+
 class TestDiscardText:
     """Tests for the undoable draft clear behind esc+esc and the `[ X ]` button."""
 


### PR DESCRIPTION
Related #1390

While the agent is working, pressing Enter on an empty chat input now hands every queued prompt to the turn that is already running: the agent picks it up at its next model call instead of after the turn finishes, and the run is never cancelled. Previously the only way to redirect the agent mid-turn was `Esc`, which stops the run and throws away the work it had done.

---

Draft for local evaluation of the "Store-backed steer inbox + `before_model` middleware" option from the steering scope-out. Try it with `dcode`, send a prompt, queue a second one while it works, then press Enter on the empty chat input.

## Why this shape

`POST /threads/{id}/state` is rejected with `409 "Thread is busy with a running job"` while a run is in flight, and nothing in Pregel or the platform API accepts input for a live run, so a `HumanMessage` cannot simply be appended to a running turn. The Store *is* reachable mid-run in both directions — the client writes it over HTTP and node/middleware code reads it through `runtime.store` — and `AsyncApprovalHITLMiddleware` already relies on exactly that to observe live approval-mode changes during a turn. This change reuses that channel:

- `steering` owns the inbox contract (per-thread namespace keyed by a hashed thread id, one item per steered message, millisecond sequence numbers) and the client write path. It intentionally imports nothing from LangChain/LangGraph so the TUI stays off the slow-import path.
- `SteeringMiddleware` (server side, interactive graphs only) drains the inbox in `abefore_model`. That is the only boundary where injecting a user message is both timely and structurally valid — tool results for the previous `AIMessage` are already complete, so no provider sees a `HumanMessage` wedged between a tool call and its result.
- Idempotency comes from `_steer_consumed_seq`, a private checkpointed channel, not from deleting the inbox item. A run that dies before its checkpoint is written therefore **redelivers** the message rather than silently dropping what the user typed; the delete is only housekeeping.

Slash and shell entries stay queued — they execute in the client, not in the graph — and a failed Store write leaves the prompt queued instead of losing it.

## Review focus

- **Trust boundary.** Steered text is injected server-side as a `HumanMessage` carrying `USER_PROMPT_METADATA_KEY`, which the Auto-approval classifier reads as user intent. The metadata is rebuilt from validated fields only, and `referenced_paths` is always empty (steered text gets no `@` expansion), so an inbox item cannot claim the user referenced a path they did not. The inbox is client-written, i.e. the same trust level as the existing approval-mode control record.
- **Thread scoping.** The drain resolves its thread from `execution_info.thread_id`, cross-checks the context copy, and reads only that thread's namespace; a mismatch skips the drain entirely.
- **Fail-closed reads.** Every field is type-validated and malformed or unreadable items are skipped, since this runs inside a live turn where raising would fail the user's request.
- **Cost.** One Store search per model call in interactive graphs, comparable to the approval-mode read already done per `after_model`. `DEEPAGENTS_CODE_STEERING=0` removes both the middleware and the client write.
- **Signature change:** `RemoteAgent.aput_store_item` gains a keyword-only `ttl` (default `None`, so existing callers are unaffected); the inbox sets it so an abandoned session cannot strand items.

## Known limitation

If the turn ends before the agent reaches another model call, the steer stays in the inbox and is delivered at the start of the next turn, even though the transcript already shows it as sent. Closing that needs a delivery-confirmation event from the middleware (the `custom` stream mode the adapter already consumes) so the client can reconcile — deliberately left out of this draft.

<details>
<summary>Test plan</summary>

- New unit suite covers inbox addressing, payload validation, watermark filtering, cross-thread isolation, Store-failure degradation, the client write/server read round trip, the disable flag, thread-id mismatch, and redelivery when the watermark was not persisted.
- One test runs the middleware inside a real `create_agent` loop with a real Store and asserts the steered text is visible to the model's *second* call and lands once in final state.
- App-level tests cover empty-Enter steering of multiple queued prompts, client-side entries staying queued, no-op while idle, the disable flag, and a failed write keeping the prompt queued.

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/86e13d3d-7304-1c41-f35c-54c1cd6f7e57)

## References
- Plan: https://openswe.vercel.app/agents/86e13d3d-7304-1c41-f35c-54c1cd6f7e57/plan