### PR TITLE
hotfix(infra): add missing space in PR template Closes keyword

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Optional: Replace this comment with `Fixes #` / `Closes#` / or `Resolves #` with the issue number to auto-close the issue when this PR is merged. If applicable, add separate `Depends on #` or `Related: #` lines. -->
+<!-- Optional: Replace this comment with `Fixes #` / `Closes #` / or `Resolves #` with the issue number to auto-close the issue when this PR is merged. If applicable, add separate `Depends on #` or `Related: #` lines. -->
 
 <!-- For a net new feature or behavior-changing bugfix: replace this comment with one plain-English sentence on the user-visible change. Usually not needed for chores/refactors/test-only PRs. -->
 


### PR DESCRIPTION
fix missing space in the PR template `Closes #` keyword example.

---

The template comment said `Closes#` instead of `Closes #`, which could confuse authors copying the auto-close keyword form.
