### PR TITLE
style(code): document `Enter` toggle in `/notifications` footer

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/notification_settings.py
+++ b/libs/code/deepagents_code/tui/widgets/notification_settings.py
@@ -114,7 +114,7 @@ class NotificationSettingsScreen(ModalScreen[None]):
                 )
             help_text = (
                 f"{glyphs.arrow_up}/{glyphs.arrow_down} or Tab navigate"
-                f" {glyphs.bullet} Space toggle"
+                f" {glyphs.bullet} Space/Enter toggle"
                 f" {glyphs.bullet} Esc close"
             )
             yield Static(help_text, classes="ns-help")

--- a/libs/code/tests/unit_tests/tui/widgets/test_notification_settings.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_notification_settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from textual.app import App
+from textual.widgets import Checkbox, Static
 
 from deepagents_code.tui.widgets.notification_settings import (
     NotificationSettingsScreen,
@@ -27,3 +28,40 @@ async def test_notification_settings_dims_underlying_content() -> None:
         await app.push_screen(NotificationSettingsScreen(suppressed=set()))
         await pilot.pause()
         assert 0 < app.screen.styles.background.a < 1
+
+
+async def test_enter_toggles_focused_warning_without_closing() -> None:
+    """Enter must toggle the focused warning, matching the footer hint.
+
+    Textual's `ToggleButton` binds `enter,space` to its toggle action, so Enter
+    is a documented second toggle key here. A screen-level `enter` binding
+    would silently steal it, so assert the real keypress path.
+    """
+    app = _NotificationSettingsHost()
+    async with app.run_test() as pilot:
+        screen = NotificationSettingsScreen(suppressed=set())
+        await app.push_screen(screen)
+        await pilot.pause()
+        focused = screen.query(Checkbox).first()
+        assert app.focused is focused
+        assert focused.value is True
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert focused.value is False
+        assert app.screen is screen
+
+
+async def test_help_footer_documents_both_toggle_keys() -> None:
+    """The footer advertises Enter alongside Space so the hint is complete."""
+    app = _NotificationSettingsHost()
+    async with app.run_test() as pilot:
+        screen = NotificationSettingsScreen(suppressed=set())
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        help_text = str(screen.query_one(".ns-help", Static).content)
+
+        assert "Space/Enter toggle" in help_text
+        assert "Esc close" in help_text


### PR DESCRIPTION
The `/notifications` settings modal footer advertised `Space toggle`, but Enter toggles the focused warning too — Textual's `ToggleButton` binds `enter,space` to its toggle action. The hint now reads `Space/Enter toggle` so the advertised keys match real behavior.

---

Added coverage pins both the Enter keypress path (via `pilot`) and the footer text, so a future screen-level `enter` binding on `NotificationSettingsScreen` can't silently steal the toggle key without a failing test.

Adding an Enter-to-close binding here was considered and rejected: every `enter` binding in the TUI means *activate/confirm the highlighted item* and `escape` means *close* — no modal closes on Enter, and the sibling notification center and detail modals both use Enter to drill in. A priority Enter-to-close would also have silently removed the working toggle key.

Made by [Open SWE](https://openswe.vercel.app/agents/c41fc23f-fbb9-6978-fcc3-eb95fc6d203f)