### PR TITLE
ci(infra): annotate uv bump workflow with PR links

### DIFF
--- a/.github/workflows/bump_uv_pin.yml
+++ b/.github/workflows/bump_uv_pin.yml
@@ -74,10 +74,13 @@ jobs:
           BRANCH: ${{ steps.versions.outputs.branch }}
         run: |
           set -euo pipefail
-          count=$(gh pr list --head "$BRANCH" --state open --json number --jq 'length')
+          existing_json=$(gh pr list --head "$BRANCH" --state open --json number,url)
+          count=$(printf '%s' "$existing_json" | jq 'length')
           echo "count=$count" >> "$GITHUB_OUTPUT"
           if [ "$count" -gt 0 ]; then
+            pr_url=$(printf '%s' "$existing_json" | jq -r '.[0].url')
             echo "Open PR already exists for $BRANCH; skipping."
+            echo "::notice::Open uv bump PR already exists: $pr_url"
           fi
 
       - name: Wait for astral mirror to replicate
@@ -197,8 +200,10 @@ jobs:
             printf 'Opened automatically by `bump_uv_pin.yml`. Mirror availability on `releases.astral.sh` was verified before this PR was created, so CI should not race the fallback.\n'
           } > "$body_file"
 
-          gh pr create \
+          pr_url=$(gh pr create \
             --head "$BRANCH" \
             --base "$DEFAULT_BRANCH" \
             --title "chore(deps): bump uv to $LATEST" \
-            --body-file "$body_file"
+            --body-file "$body_file")
+          echo "Opened uv bump PR: $pr_url"
+          echo "::notice::Opened uv bump PR: $pr_url"


### PR DESCRIPTION
Bump uv pin workflow runs now surface a clickable PR link as a GitHub Actions notice annotation when a pull request is opened or already exists.

---

`gh pr create` only prints the URL in the step log. Successful open and already-open paths now emit `::notice::` so the run Annotations panel links straight to the PR.