### PR TITLE
fix(sdk): make task subagents readable from checkpoint history

### DIFF
--- a/libs/deepagents/deepagents/graph.py
+++ b/libs/deepagents/deepagents/graph.py
@@ -26,6 +26,7 @@ from langchain_core.tools import BaseTool
 from langgraph.cache.base import BaseCache
 from langgraph.channels.delta import DeltaChannel
 from langgraph.graph.state import CompiledStateGraph
+from langgraph.pregel import Pregel
 from langgraph.store.base import BaseStore
 from langgraph.types import Checkpointer
 from langgraph.typing import ContextT
@@ -263,6 +264,27 @@ _REQUIRED_MIDDLEWARE_NAMES: frozenset[str] = frozenset(name for cls, aliases in 
 
 Derived from `_REQUIRED_MIDDLEWARE` and used for quick membership testing.
 """
+
+
+def _declare_subagent_subgraphs(agent: Pregel, middleware: Sequence[AgentMiddleware]) -> None:
+    """Declare `task` subagents on the tools node so history can find them.
+
+    `Pregel.get_subgraphs()` — which `get_state_history` uses to resolve a
+    namespace — reads `node.subgraphs`, auto-detected by scanning the node's
+    bound runnable. A subagent lives in the `task` tool's *closure*, so that
+    scan cannot see it: the tools node ends up with no subgraphs and reading a
+    subagent's own namespace raises `Subgraph tools not found`, even though its
+    checkpoints were written.
+
+    Declaring the graphs here makes them addressable. Note `get_subgraphs`
+    yields only the first, so with several subagent types the "wrong" one may
+    resolve; shared channels (notably `messages`) still read correctly, which is
+    what a history/inspection UI needs.
+    """
+    graphs = [g for m in middleware for g in getattr(m, "subagent_graphs", {}).values()]
+    node = agent.nodes.get("tools") if hasattr(agent, "nodes") else None
+    if graphs and node is not None and not getattr(node, "subgraphs", None):
+        node.subgraphs = graphs
 
 
 def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly logic with many conditional branches
@@ -919,7 +941,7 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
     else:
         final_system_prompt = system_prompt + (f"\n\n{base_prompt}" if base_prompt else "")
 
-    return create_agent(
+    agent = create_agent(
         model,
         system_prompt=final_system_prompt,
         tools=_tools,
@@ -932,7 +954,10 @@ def create_deep_agent(  # noqa: C901, PLR0912, PLR0915  # Complex graph assembly
         name=name,
         cache=cache,
         state_schema=state_schema if state_schema is not None else DeepAgentState,
-    ).with_config(
+    )
+    # Before `.with_config()`, which copies the graph.
+    _declare_subagent_subgraphs(agent, deepagent_middleware)
+    return agent.with_config(
         {
             "recursion_limit": 9_999,
             "metadata": {

--- a/libs/deepagents/deepagents/middleware/subagents.py
+++ b/libs/deepagents/deepagents/middleware/subagents.py
@@ -405,7 +405,7 @@ def _build_task_tool(  # noqa: C901, PLR0915
     *,
     private_state_keys: frozenset[str] = frozenset(),
     state_schema: type | None = None,
-) -> BaseTool:
+) -> tuple[BaseTool, dict[str, Runnable]]:
     """Create a task tool from subagent specs.
 
     Args:
@@ -595,13 +595,16 @@ def _build_task_tool(  # noqa: C901, PLR0915
             result = await subagent.ainvoke(subagent_state, subagent_config)
         return _return_command_with_state_update(result, runtime.tool_call_id)
 
-    return StructuredTool.from_function(
-        name="task",
-        func=task,
-        coroutine=atask,
-        description=description,
-        infer_schema=False,
-        args_schema=TaskToolSchema,
+    return (
+        StructuredTool.from_function(
+            name="task",
+            func=task,
+            coroutine=atask,
+            description=description,
+            infer_schema=False,
+            args_schema=TaskToolSchema,
+        ),
+        subagent_graphs,
     )
 
 
@@ -687,12 +690,19 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         """Declared subagent names. Public so streamers can discover them
         without introspecting the `task` tool's closure."""
 
-        task_tool = _build_task_tool(
+        task_tool, subagent_graphs = _build_task_tool(
             self._subagents,
             task_description,
             private_state_keys=self._private_state_keys,
             state_schema=self._state_schema,
         )
+
+        self.subagent_graphs: dict[str, Runnable] = subagent_graphs
+        """Compiled subagent graphs, keyed by name. Public for the same reason
+        as `subagent_names`: a subagent lives in the `task` tool's closure, so
+        nothing outside can find it by introspection. `create_deep_agent`
+        declares these on the tools node, which is what makes a subagent's
+        checkpoints addressable in history."""
 
         # Build system prompt with available agents
         if system_prompt and subagents:
@@ -711,7 +721,7 @@ class SubAgentMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
     @private_state_keys.setter
     def private_state_keys(self, value: frozenset[str]) -> None:
         self._private_state_keys = value
-        task_tool = _build_task_tool(
+        task_tool, self.subagent_graphs = _build_task_tool(
             self._subagents,
             task_description=self._task_description,
             private_state_keys=value,

--- a/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
+++ b/libs/deepagents/tests/unit_tests/middleware/test_subagent_middleware_init.py
@@ -197,7 +197,7 @@ class TestSubagentMiddlewareInit:
 
         runnable = RunnableLambda(lambda _state, _config: (_ for _ in ()).throw(AssertionError("compiled runnable should not be invoked")))
 
-        task_tool = _build_task_tool(
+        task_tool, _ = _build_task_tool(
             [
                 {
                     "name": "worker",

--- a/libs/deepagents/tests/unit_tests/test_subagent_history.py
+++ b/libs/deepagents/tests/unit_tests/test_subagent_history.py
@@ -1,0 +1,119 @@
+"""A `task` subagent's own state must be readable back from checkpoint history.
+
+`Pregel.get_subgraphs()` — which `get_state_history` uses to resolve a namespace
+— reads `node.subgraphs`, auto-detected by scanning the node's bound runnable. A
+subagent lives in the `task` tool's *closure*, so that scan cannot see it: the
+tools node ends up with no subgraphs and reading a subagent's namespace raises
+`Subgraph tools not found`, even though its checkpoints were written.
+
+`create_deep_agent` therefore declares the compiled subagent graphs on the tools
+node. Without that, a history/inspection UI can see that a subagent ran and what
+it returned (both are in the parent's transcript) but never what it did.
+"""
+
+from types import SimpleNamespace
+from typing import Annotated
+
+import pytest
+from langchain_core.messages import AIMessage
+from langgraph.channels.delta import DeltaChannel
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import _messages_delta_reducer
+from typing_extensions import TypedDict
+
+from deepagents.graph import _declare_subagent_subgraphs, create_deep_agent
+from tests.unit_tests.chat_model import GenericFakeChatModel
+
+
+class _SubState(TypedDict, total=False):
+    messages: Annotated[list, DeltaChannel(_messages_delta_reducer)]
+
+
+def _subagent():
+    graph = StateGraph(_SubState)
+    graph.add_node("work", lambda _state: {"messages": [AIMessage("sub worked")]})
+    graph.add_edge(START, "work")
+    graph.add_edge("work", END)
+    return graph.compile()
+
+
+def _agent(checkpointer):
+    model = GenericFakeChatModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "id": "c1",
+                            "name": "task",
+                            "args": {
+                                "description": "do it",
+                                "subagent_type": "helper",
+                            },
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                AIMessage(content="all done"),
+            ]
+        )
+    )
+    return create_deep_agent(
+        model=model,
+        subagents=[
+            {
+                "name": "helper",
+                "description": "Does things.",
+                "runnable": _subagent(),
+            }
+        ],
+        checkpointer=checkpointer,
+    )
+
+
+def test_tools_node_declares_subagent_graphs() -> None:
+    """The declaration itself — what makes the namespace resolvable."""
+    agent = _agent(InMemorySaver())
+    assert agent.nodes["tools"].subgraphs, "tools node has no subgraphs, so `get_state_history` cannot resolve a `tools:<id>` namespace"
+
+
+def test_subagent_state_is_readable_from_history() -> None:
+    saver = InMemorySaver()
+    agent = _agent(saver)
+    config = {"configurable": {"thread_id": "1"}}
+    agent.invoke({"messages": [{"role": "user", "content": "go"}]}, config)
+
+    namespaces = sorted({tup.config["configurable"]["checkpoint_ns"] for tup in saver.list({"configurable": {"thread_id": "1"}})} - {""})
+    assert namespaces, "the subagent did not checkpoint under its own namespace"
+
+    for namespace in namespaces:
+        snapshots = list(agent.get_state_history({"configurable": {"thread_id": "1", "checkpoint_ns": namespace}}))
+        assert snapshots, f"no snapshots for {namespace}"
+
+
+@pytest.mark.parametrize("subagents", [None, []])
+def test_builtin_general_purpose_subagent_is_declared_too(subagents) -> None:
+    """Even with no user subagents, deepagents registers `general-purpose`.
+
+    Its checkpoints are just as unreadable without the declaration, so it must
+    be covered by the same mechanism.
+    """
+    agent = create_deep_agent(
+        model=GenericFakeChatModel(messages=iter([AIMessage(content="done")])),
+        subagents=subagents,
+    )
+    assert agent.nodes["tools"].subgraphs
+
+
+def test_declaration_does_not_clobber_existing_subgraphs() -> None:
+    """Only fills the gap; never overwrites what auto-detection already found."""
+    sentinel = object()
+
+    node = SimpleNamespace(subgraphs=[sentinel])
+    agent = SimpleNamespace(nodes={"tools": node})
+    middleware = SimpleNamespace(subagent_graphs={"helper": _subagent()})
+
+    _declare_subagent_subgraphs(agent, [middleware])
+    assert node.subgraphs == [sentinel]


### PR DESCRIPTION
Fixes #5131

A `task` subagent's checkpoints are written, but reading them back fails:

```
ValueError: Subgraph tools not found
```

`Pregel.get_subgraphs()` — which `get_state_history` uses to resolve a namespace — reads `node.subgraphs`, auto-detected by scanning the node's bound runnable. A subagent lives in the `task` tool's *closure*, so that scan can't see it and the tools node ends up with none. The practical effect: an inspection UI can show that a subagent ran and what it returned, but never what it did.

`SubAgentMiddleware` now exposes its compiled graphs — mirroring the existing `subagent_names`, which is public for exactly this reason ("so streamers can discover them without introspecting the `task` tool's closure") — and `create_deep_agent` declares them on the tools node before `.with_config()` copies the graph. Existing subgraphs are never overwritten.

One caveat, tested rather than assumed: `get_subgraphs` yields only `subgraphs[0]`, so with several subagent types the "wrong" one can resolve. Two subagents with different state schemas under one ToolNode both returned **correct** `messages`; only a subagent-specific extra channel was dropped. Still a large improvement over unreadable.

`_build_task_tool` now returns `(tool, graphs)`. It's private with one test caller, updated here.

**Tests** — `tests/unit_tests/test_subagent_history.py`: the declaration, an end-to-end read of a subagent's namespace, the built-in `general-purpose` subagent, and non-clobbering. Four of the five fail without the change.

Full `tests/unit_tests` before/after on the same machine: identical set of 4 pre-existing failures, 2299 → 2304 passed (the new tests). `ruff check` adds no new findings versus baseline; `ruff format` clean.