### PR TITLE
fix(code): scope selection copy to the clicked screen

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -17663,14 +17663,20 @@ class DeepAgentsApp(App):
     def on_mouse_up(self, event: MouseUp) -> None:  # noqa: ARG002  # Textual event handler signature
         """Copy selection to clipboard after click-chain selection updates.
 
-        The scan is pinned to the screen the release landed on, so a selection
-        left behind on the transcript underneath a modal cannot race that
-        modal's own copy action (e.g. clicking the Debug Console thread id).
+        The scan is pinned to the active screen captured here, not resolved
+        inside the deferred callback. Textual routes mouse events only to the
+        top of the screen stack (`App.on_event` forwards to `self.screen`), so
+        that is necessarily where the release landed. Without pinning, a
+        selection left behind on the screen below a modal would be scanned too
+        and emit a spurious "copied" toast alongside whatever the user actually
+        clicked (e.g. the Debug Console thread id, which copies itself).
+
+        `self.screen` needs no empty-stack guard: `App.on_event` already
+        dereferenced it to forward this `MouseUp`, and the only code that
+        empties the stack runs after the message loop has stopped.
         """
         from deepagents_code.clipboard import copy_selection_to_clipboard
 
-        if not self.screen_stack:
-            return
         self.call_after_refresh(
             copy_selection_to_clipboard,
             self,

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -17661,10 +17661,21 @@ class DeepAgentsApp(App):
         self.call_after_refresh(self._chat_input.focus_input)
 
     def on_mouse_up(self, event: MouseUp) -> None:  # noqa: ARG002  # Textual event handler signature
-        """Copy selection to clipboard after click-chain selection updates."""
+        """Copy selection to clipboard after click-chain selection updates.
+
+        The scan is pinned to the screen the release landed on, so a selection
+        left behind on the transcript underneath a modal cannot race that
+        modal's own copy action (e.g. clicking the Debug Console thread id).
+        """
         from deepagents_code.clipboard import copy_selection_to_clipboard
 
-        self.call_after_refresh(copy_selection_to_clipboard, self)
+        if not self.screen_stack:
+            return
+        self.call_after_refresh(
+            copy_selection_to_clipboard,
+            self,
+            screen=self.screen,
+        )
 
     # =========================================================================
     # Model Switching

--- a/libs/code/deepagents_code/clipboard.py
+++ b/libs/code/deepagents_code/clipboard.py
@@ -142,25 +142,19 @@ def copy_text_with_feedback(
     return success
 
 
-def copy_selection_to_clipboard(app: App, *, screen: Screen | None = None) -> None:
+def copy_selection_to_clipboard(app: App, *, screen: Screen) -> None:
     """Copy selected text from one screen's widgets to the clipboard.
 
-    Scanning is scoped to a single screen because selections are per-screen and
-    survive a modal being pushed on top: `App.query` is rooted at the app's
-    default (compose) screen, so an unscoped scan would copy a stale transcript
-    selection when the click actually landed inside a modal — racing that
-    modal's own copy action for the clipboard.
+    Selections live on the screen that owns them (`Screen.selections`) and
+    survive a modal being pushed on top, so a scan has to target exactly one
+    screen. `screen` is required rather than defaulting to the active screen
+    because this runs deferred, by which point the active screen may no longer
+    be the one the caller meant — the caller pins it at event time instead.
 
     Args:
         app: The active Textual app, used for the clipboard backend and toasts.
-        screen: Screen whose widgets are scanned for selections. Defaults to the
-            app's active screen.
+        screen: Screen whose widgets are scanned for selections.
     """
-    if screen is None:
-        if not app.screen_stack:
-            return
-        screen = app.screen
-
     selected_texts = []
 
     for widget in screen.query("*"):

--- a/libs/code/deepagents_code/clipboard.py
+++ b/libs/code/deepagents_code/clipboard.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from textual.app import App
+    from textual.screen import Screen
 
 _PREVIEW_MAX_LENGTH = 40
 
@@ -141,15 +142,28 @@ def copy_text_with_feedback(
     return success
 
 
-def copy_selection_to_clipboard(app: App) -> None:
-    """Copy selected text from app widgets to clipboard.
+def copy_selection_to_clipboard(app: App, *, screen: Screen | None = None) -> None:
+    """Copy selected text from one screen's widgets to the clipboard.
 
-    This queries all widgets for their text_selection and copies
-    any selected text to the system clipboard.
+    Scanning is scoped to a single screen because selections are per-screen and
+    survive a modal being pushed on top: `App.query` is rooted at the app's
+    default (compose) screen, so an unscoped scan would copy a stale transcript
+    selection when the click actually landed inside a modal — racing that
+    modal's own copy action for the clipboard.
+
+    Args:
+        app: The active Textual app, used for the clipboard backend and toasts.
+        screen: Screen whose widgets are scanned for selections. Defaults to the
+            app's active screen.
     """
+    if screen is None:
+        if not app.screen_stack:
+            return
+        screen = app.screen
+
     selected_texts = []
 
-    for widget in app.query("*"):
+    for widget in screen.query("*"):
         # Skip detached widgets before touching `text_selection` — the
         # property reads `widget.screen.selections`, which raises `NoScreen`
         # for transient toasts mid-mount. `hasattr` is not a safe precheck

--- a/libs/code/tests/unit_tests/test_clipboard.py
+++ b/libs/code/tests/unit_tests/test_clipboard.py
@@ -360,12 +360,18 @@ class TestCopySelectionToClipboard:
         widget.text_selection = selection
         widget.get_selection.return_value = ("selected text", None)
         mock_app.screen.query.return_value = [widget]
+        # The scan must be screen-scoped. Without this, a regression to
+        # `app.query` would fail below with the opaque "copy not called"
+        # (a `MagicMock` query yields nothing) rather than naming the cause.
+        mock_app.query.side_effect = AssertionError(
+            "selection scan must query the screen, not the app",
+        )
 
         with patch(
             "deepagents_code.clipboard.copy_text_to_clipboard",
             return_value=(True, None),
         ) as copy:
-            copy_selection_to_clipboard(mock_app)
+            copy_selection_to_clipboard(mock_app, screen=mock_app.screen)
 
         copy.assert_called_once_with(mock_app, "selected text")
         mock_app.notify.assert_called_once()
@@ -385,7 +391,7 @@ class TestCopySelectionToClipboard:
             "deepagents_code.clipboard.copy_text_to_clipboard",
             return_value=(False, "no clipboard mechanism"),
         ):
-            copy_selection_to_clipboard(mock_app)
+            copy_selection_to_clipboard(mock_app, screen=mock_app.screen)
 
         mock_app.notify.assert_called_once_with(
             "Failed to copy - no clipboard method available",
@@ -409,7 +415,7 @@ class TestCopySelectionToClipboard:
             "deepagents_code.clipboard.copy_text_to_clipboard",
             return_value=(True, None),
         ) as copy:
-            copy_selection_to_clipboard(mock_app)
+            copy_selection_to_clipboard(mock_app, screen=mock_app.screen)
 
         copy.assert_called_once_with(mock_app, "full widget text")
 
@@ -422,7 +428,7 @@ class TestCopySelectionToClipboard:
         mock_app.screen.query.return_value = [mock_widget]
 
         with caplog.at_level(logging.DEBUG, logger="deepagents_code"):
-            copy_selection_to_clipboard(mock_app)
+            copy_selection_to_clipboard(mock_app, screen=mock_app.screen)
 
         assert "Failed to get selection from widget" in caplog.text
         assert "No selection" in caplog.text
@@ -449,7 +455,7 @@ class TestCopySelectionToClipboard:
             "deepagents_code.clipboard.copy_text_to_clipboard",
             return_value=(True, None),
         ) as copy:
-            copy_selection_to_clipboard(mock_app)
+            copy_selection_to_clipboard(mock_app, screen=mock_app.screen)
 
         copy.assert_not_called()
 
@@ -481,16 +487,50 @@ class TestCopySelectionToClipboard:
                 return_value=(True, None),
             ) as copy,
         ):
-            copy_selection_to_clipboard(mock_app)
+            copy_selection_to_clipboard(mock_app, screen=mock_app.screen)
 
         copy.assert_called_once_with(mock_app, "sibling text")
         assert "Skipping widget" in caplog.text
 
 
 class TestSelectionCopyScreenScope:
-    """A modal must not copy the selection left behind on the screen below it."""
+    """The scan copies the passed screen's selection and no other screen's."""
+
+    async def test_copies_only_the_active_screens_selection(self) -> None:
+        """Scanning the modal copies its own selection, not the one below it.
+
+        Covers both directions at once, so an over-correction that skips modal
+        screens entirely fails here instead of passing a suite that only ever
+        asserts the negative case.
+        """
+        app = _SelectionApp()
+        async with app.run_test() as pilot:
+            base_static = await _select_base_text(pilot)
+            app.push_screen(_SelectableModal())
+            await pilot.pause()
+            await pilot.triple_click("#modal-static")
+            await pilot.pause()
+
+            with patch(
+                "deepagents_code.clipboard.copy_text_to_clipboard",
+                return_value=(True, None),
+            ) as copy:
+                copy_selection_to_clipboard(app, screen=app.screen)
+
+            # The base-screen selection survives the modal, it just isn't copied.
+            assert base_static.text_selection is not None
+            assert copy.call_count == 1
+            copied = copy.call_args.args[1]
+            assert "modal text" in copied
+            assert _BASE_TEXT not in copied
 
     async def test_skips_selection_on_screen_below_active_modal(self) -> None:
+        """A selection stranded under the modal is left alone, not copied.
+
+        The original defect: `App.query` is rooted at the app's default screen,
+        so an unscoped scan reached this selection even though the click landed
+        in the modal.
+        """
         app = _SelectionApp()
         async with app.run_test() as pilot:
             base_static = await _select_base_text(pilot)
@@ -503,17 +543,22 @@ class TestSelectionCopyScreenScope:
             ) as copy:
                 copy_selection_to_clipboard(app, screen=app.screen)
 
-            # The transcript selection survives the modal, it just isn't copied.
             assert base_static.text_selection is not None
+            copy.assert_not_called()
 
-        copy.assert_not_called()
+    async def test_honors_a_screen_that_is_not_the_active_one(self) -> None:
+        """The passed screen wins even when another screen is on top.
 
-    async def test_copies_selection_from_the_requested_screen(self) -> None:
+        Pins the contract that makes pinning-at-event-time work: the caller's
+        screen is used verbatim, never re-resolved to whatever is active now.
+        """
         app = _SelectionApp()
         async with app.run_test() as pilot:
             await _select_base_text(pilot)
             base_screen = app.screen
             app.push_screen(_SelectableModal())
+            await pilot.pause()
+            await pilot.triple_click("#modal-static")
             await pilot.pause()
 
             with patch(
@@ -522,23 +567,10 @@ class TestSelectionCopyScreenScope:
             ) as copy:
                 copy_selection_to_clipboard(app, screen=base_screen)
 
-        assert copy.call_count == 1
-        assert _BASE_TEXT in copy.call_args.args[1]
-
-    async def test_defaults_to_the_active_screen(self) -> None:
-        app = _SelectionApp()
-        async with app.run_test() as pilot:
-            await _select_base_text(pilot)
-            app.push_screen(_SelectableModal())
-            await pilot.pause()
-
-            with patch(
-                "deepagents_code.clipboard.copy_text_to_clipboard",
-                return_value=(True, None),
-            ) as copy:
-                copy_selection_to_clipboard(app)
-
-        copy.assert_not_called()
+            assert copy.call_count == 1
+            copied = copy.call_args.args[1]
+            assert _BASE_TEXT in copied
+            assert "modal text" not in copied
 
 
 class TestAppSelectionCopy:

--- a/libs/code/tests/unit_tests/test_clipboard.py
+++ b/libs/code/tests/unit_tests/test_clipboard.py
@@ -11,8 +11,12 @@ import base64
 import io
 import logging
 import sys
-from typing import Self
+from typing import TYPE_CHECKING, Self
 from unittest.mock import MagicMock, patch
+
+from textual.app import App, ComposeResult
+from textual.screen import ModalScreen
+from textual.widgets import Static
 
 from deepagents_code.clipboard import (
     _copy_osc52,
@@ -21,6 +25,38 @@ from deepagents_code.clipboard import (
     copy_text_with_feedback,
     logger as clipboard_logger,
 )
+
+if TYPE_CHECKING:
+    from textual.pilot import Pilot
+
+_BASE_TEXT = "hello base world"
+
+
+class _SelectionApp(App[None]):
+    """App whose base screen holds selectable text."""
+
+    def compose(self) -> ComposeResult:
+        yield Static(_BASE_TEXT, id="base-static")
+
+
+class _SelectableModal(ModalScreen[None]):
+    """Modal pushed over `_SelectionApp`, with its own selectable text."""
+
+    def compose(self) -> ComposeResult:
+        yield Static("modal text", id="modal-static")
+
+
+async def _select_base_text(pilot: Pilot[None]) -> Static:
+    """Select text on the base screen the way a user would, and return its widget.
+
+    Returns:
+        The base-screen widget left holding a live text selection.
+    """
+    await pilot.triple_click("#base-static")
+    await pilot.pause()
+    base_static = pilot.app.query_one("#base-static", Static)
+    assert base_static.text_selection is not None
+    return base_static
 
 
 class TestCopyTextToClipboard:
@@ -323,7 +359,7 @@ class TestCopySelectionToClipboard:
         widget = MagicMock()
         widget.text_selection = selection
         widget.get_selection.return_value = ("selected text", None)
-        mock_app.query.return_value = [widget]
+        mock_app.screen.query.return_value = [widget]
 
         with patch(
             "deepagents_code.clipboard.copy_text_to_clipboard",
@@ -343,7 +379,7 @@ class TestCopySelectionToClipboard:
         widget = MagicMock()
         widget.text_selection = selection
         widget.get_selection.return_value = ("selected text", None)
-        mock_app.query.return_value = [widget]
+        mock_app.screen.query.return_value = [widget]
 
         with patch(
             "deepagents_code.clipboard.copy_text_to_clipboard",
@@ -367,7 +403,7 @@ class TestCopySelectionToClipboard:
         widget.is_attached = True
         widget.text_selection = SELECT_ALL
         widget.get_selection.return_value = ("full widget text", None)
-        mock_app.query.return_value = [widget]
+        mock_app.screen.query.return_value = [widget]
 
         with patch(
             "deepagents_code.clipboard.copy_text_to_clipboard",
@@ -383,7 +419,7 @@ class TestCopySelectionToClipboard:
         mock_widget = MagicMock()
         mock_widget.text_selection = MagicMock()
         mock_widget.get_selection.side_effect = AttributeError("No selection")
-        mock_app.query.return_value = [mock_widget]
+        mock_app.screen.query.return_value = [mock_widget]
 
         with caplog.at_level(logging.DEBUG, logger="deepagents_code"):
             copy_selection_to_clipboard(mock_app)
@@ -407,7 +443,7 @@ class TestCopySelectionToClipboard:
         type(detached).text_selection = PropertyMock(
             side_effect=AssertionError("text_selection must not be read"),
         )
-        mock_app.query.return_value = [detached]
+        mock_app.screen.query.return_value = [detached]
 
         with patch(
             "deepagents_code.clipboard.copy_text_to_clipboard",
@@ -436,7 +472,7 @@ class TestCopySelectionToClipboard:
         sibling.text_selection = MagicMock(end=1)
         sibling.get_selection.return_value = ("sibling text", None)
 
-        mock_app.query.return_value = [racy, sibling]
+        mock_app.screen.query.return_value = [racy, sibling]
 
         with (
             caplog.at_level(logging.DEBUG, logger="deepagents_code"),
@@ -451,6 +487,60 @@ class TestCopySelectionToClipboard:
         assert "Skipping widget" in caplog.text
 
 
+class TestSelectionCopyScreenScope:
+    """A modal must not copy the selection left behind on the screen below it."""
+
+    async def test_skips_selection_on_screen_below_active_modal(self) -> None:
+        app = _SelectionApp()
+        async with app.run_test() as pilot:
+            base_static = await _select_base_text(pilot)
+            app.push_screen(_SelectableModal())
+            await pilot.pause()
+
+            with patch(
+                "deepagents_code.clipboard.copy_text_to_clipboard",
+                return_value=(True, None),
+            ) as copy:
+                copy_selection_to_clipboard(app, screen=app.screen)
+
+            # The transcript selection survives the modal, it just isn't copied.
+            assert base_static.text_selection is not None
+
+        copy.assert_not_called()
+
+    async def test_copies_selection_from_the_requested_screen(self) -> None:
+        app = _SelectionApp()
+        async with app.run_test() as pilot:
+            await _select_base_text(pilot)
+            base_screen = app.screen
+            app.push_screen(_SelectableModal())
+            await pilot.pause()
+
+            with patch(
+                "deepagents_code.clipboard.copy_text_to_clipboard",
+                return_value=(True, None),
+            ) as copy:
+                copy_selection_to_clipboard(app, screen=base_screen)
+
+        assert copy.call_count == 1
+        assert _BASE_TEXT in copy.call_args.args[1]
+
+    async def test_defaults_to_the_active_screen(self) -> None:
+        app = _SelectionApp()
+        async with app.run_test() as pilot:
+            await _select_base_text(pilot)
+            app.push_screen(_SelectableModal())
+            await pilot.pause()
+
+            with patch(
+                "deepagents_code.clipboard.copy_text_to_clipboard",
+                return_value=(True, None),
+            ) as copy:
+                copy_selection_to_clipboard(app)
+
+        copy.assert_not_called()
+
+
 class TestAppSelectionCopy:
     """Regression coverage for click-chain selection copy timing."""
 
@@ -463,7 +553,11 @@ class TestAppSelectionCopy:
             DeepAgentsApp.on_mouse_up(mock_app, event)
 
         copy.assert_not_called()
-        mock_app.call_after_refresh.assert_called_once_with(copy, mock_app)
+        mock_app.call_after_refresh.assert_called_once_with(
+            copy,
+            mock_app,
+            screen=mock_app.screen,
+        )
 
 
 class TestClipboardLogger:


### PR DESCRIPTION
Clicking a copyable value in a modal (for example the thread id in the Debug Console) no longer fights with text still selected in the conversation behind it — only the value you clicked lands on the clipboard.

---

Text selected with the mouse is auto-copied on mouse release, and that scan walked `App.query("*")`. Textual roots `App.query` at the app's *default* (compose) screen rather than the active one, so a selection left behind in the transcript stayed in scope even while a modal was on top. Any click inside the modal then produced two clipboard writes — the modal's own copy plus the stale transcript selection — and whichever landed last won.

Selections are per-screen state, so the scan is now scoped to a single screen: `copy_selection_to_clipboard` takes an optional keyword-only `screen` (defaulting to the app's active screen), and the mouse-up handler pins it to the screen the release actually landed on. Background selections are left untouched and visible, matching the current behavior; they simply aren't copied by clicks that happened somewhere else. As a side effect, selections made *inside* a modal are now copyable, which the app-rooted scan never reached.

The new regression tests drive a real selection through Textual's event path (triple-click via `Pilot`) with a modal pushed on top, and fail against the previous implementation.

Made by [Open SWE](https://openswe.vercel.app/agents/bde43330-a625-d287-611f-af90f64dac82)