### PR TITLE
style(code): clarify debug console trace link as `(open in langsmith)`

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/debug_console.py
+++ b/libs/code/deepagents_code/tui/widgets/debug_console.py
@@ -61,7 +61,8 @@ class SnapshotField(NamedTuple):
 
     The four named fields keep the display strings and their interaction metadata
     explicit at construction sites. `copyable` opts a row into click-to-copy, and
-    `thread_id` enables a resolvable `(langsmith)` trace link for the thread row.
+    `thread_id` enables a resolvable `(open in langsmith)` trace link for the
+    thread row.
     """
 
     label: str
@@ -69,8 +70,8 @@ class SnapshotField(NamedTuple):
     copyable: bool = False
     """Whether `value` can be clicked to copy it to the clipboard."""
     thread_id: str | None = None
-    """A LangSmith thread id whose ``(langsmith)`` trace link is appended to the
-    row once the URL resolves. `None` disables the link."""
+    """A LangSmith thread id whose ``(open in langsmith)`` trace link is appended
+    to the row once the URL resolves. `None` disables the link."""
 
 
 _SNAPSHOT_COPY_META = "snapshot_copy"
@@ -916,7 +917,7 @@ class DebugConsoleScreen(ModalScreen[None]):
         self._resolve_langsmith_links()
 
     def _resolve_langsmith_links(self) -> None:
-        """Kick off background resolution of `(langsmith)` links for the snapshot.
+        """Kick off background resolution of `(open in langsmith)` snapshot links.
 
         Each thread id gets at most one lookup per console open. The refresh tick
         calls this on every snapshot change, and a resolved URL is only recorded
@@ -1112,7 +1113,7 @@ class DebugConsoleScreen(ModalScreen[None]):
             parts.append(field.value)
         url = self._langsmith_urls.get(field.thread_id) if field.thread_id else None
         if url:
-            parts.extend(("  ", ("(langsmith)", TStyle(link=url))))
+            parts.extend(("  ", ("(open in langsmith)", TStyle(link=url))))
         return Content.assemble(*parts)
 
     @staticmethod

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -1086,7 +1086,7 @@ class TestDebugConsoleScreen:
             await pilot.pause()
 
             snapshot_widget = screen.query_one(".debug-console-snapshot", Static)
-            assert "(langsmith)" not in _widget_text(snapshot_widget)
+            assert "(open in langsmith)" not in _widget_text(snapshot_widget)
 
             screen._langsmith_urls["thread-abc"] = (
                 "https://smith.langchain.com/o/org/projects/p/proj/t/thread-abc"
@@ -1094,7 +1094,7 @@ class TestDebugConsoleScreen:
             screen._refresh_snapshot()
             await pilot.pause()
 
-            assert "(langsmith)" in _widget_text(snapshot_widget)
+            assert "(open in langsmith)" in _widget_text(snapshot_widget)
 
     async def test_cached_langsmith_link_renders_on_first_frame_without_lookup(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1117,7 +1117,7 @@ class TestDebugConsoleScreen:
             await pilot.pause()
 
             snapshot_widget = screen.query_one(".debug-console-snapshot", Static)
-            assert "(langsmith)" in _widget_text(snapshot_widget)
+            assert "(open in langsmith)" in _widget_text(snapshot_widget)
 
         lookup.assert_not_called()
 
@@ -1476,9 +1476,10 @@ class TestDebugConsoleScreen:
             await pilot.pause()
 
             snapshot_widget = screen.query_one(".debug-console-snapshot", Static)
-            # Row renders "Thread  thread-abc  (langsmith)": label (6) + 2-space
-            # gutter = col 8, value (10 chars) spans 8-17, 2-space gap, then
-            # "(langsmith)" starts at col 20. An x offset of 22 is inside it.
+            # Row renders "Thread  thread-abc  (open in langsmith)": label (6)
+            # + 2-space gutter = col 8, value (10 chars) spans 8-17, 2-space gap,
+            # then "(open in langsmith)" starts at col 20. An x offset of 22 is
+            # inside it.
             await pilot.click(snapshot_widget, offset=(22, 0))
             await pilot.pause()
 
@@ -1520,8 +1521,8 @@ class TestDebugConsoleScreen:
             await pilot.pause()
 
             snapshot_widget = screen.query_one(".debug-console-snapshot", Static)
-            # "(langsmith)" starts at col 20 (see the toggle-off test); x=22 is
-            # inside it.
+            # "(open in langsmith)" starts at col 20 (see the toggle-off test);
+            # x=22 is inside it.
             await pilot.click(snapshot_widget, offset=(22, 0))
             await pilot.pause()
 


### PR DESCRIPTION
Debug console thread trace link now reads `(open in langsmith)`.

Made by [Open SWE](https://openswe.vercel.app/agents/ab11afb9-e839-c104-b9ce-d2c0f5fa2e42)