### PR TITLE
docs(repo): add Windows AppLocker workaround

### DIFF
--- a/libs/DEVELOPMENT.md
+++ b/libs/DEVELOPMENT.md
@@ -60,6 +60,18 @@ uv sync --all-groups      # install the package + all dependency groups
 
 Prefer the package's `make` targets for standard workflows; use `uv run ...` for direct one-off commands.
 
+### Windows & AppLocker / WDAC Troubleshooting
+
+If `uv` fails to execute on Windows with `WinError 4551` (`An Application Control policy has blocked this file`), your system may be enforcing Application Control policies (AppLocker or Windows Defender Application Control) that restrict standalone executable binaries running outside approved directories.
+
+In this environment, you can install the package in editable mode and run tests directly using standard `pip` and `pytest`:
+
+```bash
+cd libs/deepagents
+python -m pip install -e .[test]
+python -m pytest tests/unit_tests
+```
+
 ## Common commands
 
 Run these from inside a package directory (e.g. `libs/deepagents`). They are consistent across the core SDK packages (`deepagents`, `code`); run `make help` to see what a given package supports:


### PR DESCRIPTION
## Summary
Adds a troubleshooting section to `libs/DEVELOPMENT.md` for Windows environments where Application Control policies (e.g., AppLocker, WDAC) block `uv.exe` standalone binaries with `WinError 4551`.

```text
OSError: [WinError 4551] An Application Control policy has blocked this file
```

## Motivation
When setting up Deep Agents locally on restricted Windows corporate or enterprise environments, `uv` installation succeeds, but executing `uv sync` or `uv run` fails. This happens because OS-level security policies restrict standalone executables from running inside `%USERPROFILE%\.local\bin`.

Adding explicit fallback instructions for standard `pip` editable installations and `pytest` invocations helps Windows contributors bypass these security roadblocks smoothly.

## Changes Made
* **Documentation Update**: Added a `### Windows & AppLocker / WDAC Troubleshooting` subsection under the Setup section in `libs/DEVELOPMENT.md`.
* **Fallback Commands**: Documented the standard alternative workflow:
  ```bash
  cd libs/deepagents
  python -m pip install -e .[test]
  python -m pytest tests/unit_tests
  ```

## Test Plan
* [x] Verified local installation and editable setup via `pip install -e .[test]` on Windows 11.
* [x] Successfully ran the unit test suite using `python -m pytest tests/unit_tests` (2,280+ tests passed).
* [x] Formatted and validated markdown rendering.
