### PR TITLE
chore(code): bump deepagents pin to 0.7.0

### DIFF
--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     # Framework
-    "deepagents==0.7.0b2",
+    "deepagents==0.7.0",
     "langchain>=1.3.14,<2.0.0",
     "langgraph-checkpoint-sqlite>=3.1.0,<4.0.0",
 


### PR DESCRIPTION
Deep Agents Code now pins the stable `deepagents` 0.7.0 SDK release instead of the 0.7.0b2 beta.

---

The SDK 0.7.0 release landed on main. Keep the exact dcode pin aligned so installs and the SDK pin check track the GA package rather than an older beta.
