### PR TITLE
fix(modal): require deepagents 0.7.x

### DIFF
--- a/libs/partners/modal/pyproject.toml
+++ b/libs/partners/modal/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 version = "0.0.5"
 requires-python = ">=3.11,<4.0"
 dependencies = [
-    "deepagents>=0.6.12,<0.7.0",
+    "deepagents>=0.6.12,<0.8.0",
     "modal",
 ]
 

--- a/libs/partners/modal/pyproject.toml
+++ b/libs/partners/modal/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 version = "0.0.5"
 requires-python = ">=3.11,<4.0"
 dependencies = [
-    "deepagents>=0.6.12,<0.8.0",
+    "deepagents>=0.7.0,<0.8.0",
     "modal",
 ]
 


### PR DESCRIPTION
Require deepagents 0.7.x by narrowing the dependency range from `>=0.6.12,<0.7.0` to `>=0.7.0,<0.8.0`.

---

No code changes; publish metadata only after the release-please patch PR merges.
