### PR TITLE
fix(runloop): require deepagents 0.7.x

### DIFF
--- a/libs/partners/runloop/pyproject.toml
+++ b/libs/partners/runloop/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 version = "0.0.6"
 requires-python = ">=3.11,<4.0"
 dependencies = [
-    "deepagents>=0.6.12,<0.8.0",
+    "deepagents>=0.7.0,<0.8.0",
     "runloop-api-client",
 ]
 

--- a/libs/partners/runloop/pyproject.toml
+++ b/libs/partners/runloop/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 version = "0.0.6"
 requires-python = ">=3.11,<4.0"
 dependencies = [
-    "deepagents>=0.6.12,<0.7.0",
+    "deepagents>=0.6.12,<0.8.0",
     "runloop-api-client",
 ]
 


### PR DESCRIPTION
Require deepagents 0.7.x by narrowing the dependency range from `>=0.6.12,<0.7.0` to `>=0.7.0,<0.8.0`.

---

No code changes; publish metadata only after the release-please patch PR merges.
