### PR TITLE
fix(quickjs): require deepagents 0.7.x

### DIFF
--- a/libs/partners/quickjs/pyproject.toml
+++ b/libs/partners/quickjs/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.11,<4.0"
 keywords = ["deepagents", "langchain", "langgraph", "repl", "javascript", "quickjs", "middleware"]
 
 dependencies = [
-    "deepagents>=0.6.12,<0.8.0",
+    "deepagents>=0.7.0,<0.8.0",
     "quickjs-rs>=0.2.5,<0.3.0",
     "langchain>=1.3.14,<2.0.0",
     "langchain-core>=1.4.9,<2.0.0",


### PR DESCRIPTION
Require deepagents 0.7.x by raising the dependency floor from `>=0.6.12` to `>=0.7.0` (upper bound `<0.8.0` unchanged).

---

No code changes; publish metadata only after the release-please patch PR merges.
