### PR TITLE
ci(infra): require the release-notes helper by its current path

### DIFF
--- a/.github/scripts/tests/release/test_release_notes.py
+++ b/.github/scripts/tests/release/test_release_notes.py
@@ -1,6 +1,7 @@
 """Pytest shim for the curated release-notes Node.js tests."""
 
 import json
+import re
 import subprocess
 from pathlib import Path
 
@@ -90,18 +91,24 @@ def test_required_check_is_attached_to_the_validated_pr_head() -> None:
     release_please = RELEASE_PLEASE_WORKFLOW.read_text()
     assert "--ref main" in release_please
     assert "needs.update-lockfiles.result == 'success'" not in release_please
-    # The helper is checked out from main while this YAML comes from the PR, so a
-    # rename must keep older names as fallbacks or the required check breaks for one
-    # merge. Current name has to be tried first.
-    candidates = [
-        line.strip().strip("',")
-        for line in check_workflow.splitlines()
-        if "trusted-source/.github/scripts" in line and line.strip().startswith("'")
-    ]
-    assert candidates[0] == (
-        "./trusted-source/.github/scripts/release/release-notes.js"
-    )
-    assert len(candidates) > 1
+
+
+def test_workflows_reference_helper_scripts_that_exist() -> None:
+    """Catch a helper rename that misses a workflow reference.
+
+    Both workflows load their helpers from a `trusted-source` checkout of `main`,
+    so a path that does not exist fails at runtime rather than at lint time. The
+    check workflow is the worst case: a bad path there breaks a required check.
+    """
+    referenced = set()
+    for workflow in (AUTOMATION_WORKFLOW, CHECK_WORKFLOW):
+        for match in re.finditer(
+            r"\./trusted-source/(\.github/scripts/\S+?\.js)\b", workflow.read_text()
+        ):
+            referenced.add(match.group(1))
+    assert referenced, "expected the workflows to reference helper scripts"
+    missing = sorted(path for path in referenced if not (ROOT / path).is_file())
+    assert not missing, f"workflows reference helper scripts that do not exist: {missing}"
 
 
 def test_release_notes_cover_every_release_please_component() -> None:

--- a/.github/workflows/release_notes_check.yml
+++ b/.github/workflows/release_notes_check.yml
@@ -52,21 +52,12 @@ jobs:
         with:
           script: |
             // This workflow's YAML comes from the PR, but the helper is checked out
-            // from main, so a rename lands here one merge before it lands there.
-            // Try the current name first and fall back to the older ones, newest
-            // first, so the required check keeps working across the rename.
-            const fs = require('fs');
-            const candidates = [
-              './trusted-source/.github/scripts/release/release-notes.js',
-              './trusted-source/.github/scripts/release/dcode-release-notes.js',
-              './trusted-source/.github/scripts/dcode-release-notes.js',
-            ];
-            const helperPath = candidates.find(candidate => fs.existsSync(candidate));
-            if (!helperPath) {
-              core.setFailed(`No curated release-notes helper found on main; looked for: ${candidates.join(', ')}`);
-              return;
-            }
-            const { checkCuratedState, isReleaseBranchPr } = require(helperPath);
+            // from main. Renaming or moving the helper therefore breaks this require
+            // for exactly one merge — the new path does not exist on main until the
+            // renaming PR lands, and that PR needs this required check to pass. If
+            // you rename it, temporarily accept the old path here too and drop the
+            // fallback in a follow-up.
+            const { checkCuratedState, isReleaseBranchPr } = require('./trusted-source/.github/scripts/release/release-notes.js');
             const number = Number(process.env.PR_NUMBER);
             if (!Number.isSafeInteger(number) || number <= 0) {
               core.setFailed(`Invalid PR number: ${process.env.PR_NUMBER}`);


### PR DESCRIPTION
Follow-up to #5159.

---

The curated release-notes check resolved its helper through a list of candidate paths, trying the current filename first and falling back to the pre-rename ones. That existed for a single reason: this workflow takes its YAML from the pull request but checks the helper itself out of `main`, so during #5159 the new filename did not exist on `main` yet — and that PR needed this required check to pass. The fallback bridged exactly one merge.

`main` now carries the helper at its current path and neither old path exists anywhere, so those entries are unreachable. This replaces the candidate list with a direct `require`, and leaves a comment explaining why a future rename will need the same temporary fallback — the trap is not obvious from reading the workflow.

The test that pinned the fallback ordering is replaced with a stronger invariant: every helper script either workflow loads out of its `trusted-source` checkout must exist in the repository. A wrong path there is invisible to YAML linting and only surfaces when the workflow runs, which in the check workflow means a broken required check. The new assertion covers both the automation and check workflows, and both the `require` and `run:` call sites.
