### PR TITLE
ci(infra): refresh open release PRs after sibling merges

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -228,7 +228,20 @@ The [release-please workflow (`.github/workflows/release-please.yml`)](https://g
 Both must be true. release-please always satisfies both when merging a release PR — a manual `CHANGELOG.md` edit alone will not trigger a release.
 
 > [!NOTE]
-> Merged release PRs dispatch the publish workflow directly and skip the release-please PR-maintenance step for that push. The dispatch job comments on the merged release PR with a direct link to each package's release workflow run. This intentionally keeps publishing from being blocked behind normal release-please updates while another package is publishing. If any next release PR needs to be refreshed after the merge, the next normal push to `main` will handle it.
+> Merging a release PR uses a publish-first dependency chain. `trigger-releases`
+> runs immediately after the release commit is detected and does not wait for the
+> pending-release guard or serialized release-please maintenance. The dispatch job
+> comments on the merged release PR with a direct link to each package's release
+> workflow run. After required `release.yml` dispatches succeed, the same workflow
+> run enters `guard-pending-release`, waits until no merged release PR remains
+> labeled `autorelease: pending`, and only an explicit `skip=false` allows
+> release-please to refresh remaining open release PRs (shared files such as
+> `.release-please-manifest.json` and lockfiles). `update-lockfiles` then runs for
+> PRs returned by that maintenance step.
+>
+> Residual: if the pending guard times out, fails closed, or GitHub state is
+> unreadably stuck, maintenance may still need a later ordinary push / recovery
+> once publish state is consistent.
 
 ### Lockfile Updates
 
@@ -778,7 +791,9 @@ gh pr list --state merged --search "release(<PACKAGE>)" --limit 5
 gh pr edit <PR_NUMBER> --remove-label "autorelease: pending" --add-label "autorelease: tagged"
 ```
 
-The label update is non-fatal in the workflow (`|| true`), so the release itself succeeded—only the label needs fixing.
+On the normal mainline publish path, a failed label swap fails `mark-release`
+after the tag and GitHub release already exist. Treat the package release as
+done and fix only the stuck label so later release-please maintenance can run.
 
 ### Release Failed: Pre-release Checks
 

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -257,14 +257,14 @@ In the normal case you do not need to think about any of this. Step 3 is the onl
 <details>
 <summary><b>If the other release PRs were not refreshed</b></summary>
 
-Step 3 is skipped in the situations below. In every case your own package still published normally, and the refresh happens on the next push to `main`.
+Step 3 can be skipped in the situations below. Skipping it holds up only the refresh of the *other* open release PRs — with one exception: a red `release.yml` means that package did not publish and has to be re-dispatched.
 
-| Situation | What you will see | What to do |
-| --- | --- | --- |
-| A publish is still in flight after 45 min | `release-please.yml` green, with a `deferred` step summary | Nothing, unless the publish is genuinely stuck — then clear the label per [Release PR Stuck with "autorelease: pending"](#release-pr-stuck-with-autorelease-pending-label) |
-| A publish failed (yours, or a package left stuck earlier) | `release.yml` red; `release-please.yml` green, with a `deferred (release commit)` summary naming the failed run | Fix and re-dispatch the failed package release |
-| GitHub's release state is unreadable | `release-please.yml` **red** at `guard-pending-release` | Re-run the job. It refuses to guess whether a publish is in flight rather than recompute against unverified state |
-| You merged several release PRs at once | Some `release-please` jobs show as **cancelled** | Nothing — this is expected. Only one job may queue per concurrency group, and the surviving (newest) run recomputes every component, so it covers the cancelled jobs' work |
+| Situation | What you will see | What to do | When the refresh happens |
+| --- | --- | --- | --- |
+| A publish is still in flight after 45 min | `release-please.yml` green, with a `deferred` step summary | Nothing, unless the publish is genuinely stuck — then clear the label per [Release PR Stuck with "autorelease: pending"](#release-pr-stuck-with-autorelease-pending-label) | Next push to `main` |
+| A publish failed (yours, or a package left stuck earlier) | `release.yml` red; `release-please.yml` green, with a `deferred (release commit)` summary naming the failed run | Fix and re-dispatch the failed package release — this package has **not** published | Next push to `main`, once the failed release is recovered |
+| GitHub's release state is unreadable | `release-please.yml` **red** at `guard-pending-release` | Re-run the job. It refuses to guess whether a publish is in flight rather than recompute against unverified state | When the re-run succeeds |
+| You merged several release PRs at once | Some `release-please` jobs show as **cancelled** | Nothing — this is expected. Only one job may queue per concurrency group | Already done: the surviving (newest) run recomputes every component, covering the cancelled jobs' work |
 
 </details>
 

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -236,16 +236,26 @@ Both must be true. release-please always satisfies both when merging a release P
 > runs immediately after the release commit is detected and does not wait for the
 > pending-release guard or serialized release-please maintenance. The dispatch job
 > comments on the merged release PR with a direct link to each package's release
-> workflow run. After required `release.yml` dispatches succeed, the same workflow
-> run enters `guard-pending-release`, waits until no merged release PR remains
-> labeled `autorelease: pending`, and only an explicit `skip=false` allows
+> workflow run. Once every matched `release.yml` dispatch succeeds, the same
+> workflow run enters `guard-pending-release`, waits until no merged release PR
+> remains labeled `autorelease: pending`, and only an explicit `skip=false` allows
 > release-please to refresh remaining open release PRs (shared files such as
-> `.release-please-manifest.json` and lockfiles). `update-lockfiles` then runs for
-> PRs returned by that maintenance step.
+> `.release-please-manifest.json`). `update-lockfiles` then regenerates lockfiles
+> on the PRs that maintenance step returned.
 >
-> Residual: if the pending guard times out, fails closed, or GitHub state is
-> unreadably stuck, maintenance may still need a later ordinary push / recovery
-> once publish state is consistent.
+> The wait covers every pending release PR in the repo, not just the one you
+> merged: release-please recomputes all components on each run, so any single
+> component sitting between "version bumped" and "tag created" is enough to
+> trigger a bootstrap downgrade.
+>
+> When maintenance does **not** run, here is what you will see and what to do:
+>
+> | Situation | Signal | Action |
+> | --- | --- | --- |
+> | A publish is still in flight after 45 min | `release-please.yml` is green; the guard logs a `deferred` step summary | Nothing, unless the publish is genuinely stuck — then clear the label per [Release PR Stuck with "autorelease: pending"](#release-pr-stuck-with-autorelease-pending-label). The next push runs maintenance. |
+> | The publish failed | `release.yml` is red; `release-please.yml` stays green with a `deferred (release commit)` summary | Fix and re-dispatch the failed package release. Maintenance runs on the next push. |
+> | GitHub state is unreadable | `release-please.yml` is **red** at `guard-pending-release` | Re-run the job. It refuses to guess whether a publish is in flight rather than recompute against unverified state. |
+> | You merged several release PRs at once | Some `release-please` jobs show as **cancelled** | Expected. Only one job may queue per concurrency group; the surviving (newest) run recomputes every component, so it does the cancelled jobs' work. |
 
 ### Lockfile Updates
 
@@ -783,7 +793,7 @@ Edit `.release-please-manifest.json` to the last good version for the affected p
 
 ### Release PR Stuck with "autorelease: pending" Label
 
-If a release PR shows `autorelease: pending` after the release workflow completed, the label update step may have failed. This can block release-please from creating new release PRs.
+If a release PR shows `autorelease: pending` after the release workflow ran, the label update step may have failed — on the mainline path `mark-release` will be red. This can block release-please from creating new release PRs.
 
 **To fix manually:**
 

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -89,9 +89,9 @@ Create the `release-bot` environment without required reviewers or other approva
 
 | `RELEASE_BOT_MODEL` provider | Environment secret name |
 | ------------------------------ | ----------------------- |
-| `openai`                       | `OPENAI_API_KEY`        |
-| `anthropic`                    | `ANTHROPIC_API_KEY`     |
-| `google_genai`                 | `GOOGLE_API_KEY`        |
+| `openai` | `OPENAI_API_KEY` |
+| `anthropic` | `ANTHROPIC_API_KEY` |
+| `google_genai` | `GOOGLE_API_KEY` |
 
 A mismatched secret name resolves to an empty key and fails the draft run with "The selected release-note model API key is not configured."
 
@@ -231,31 +231,40 @@ The [release-please workflow (`.github/workflows/release-please.yml`)](https://g
 
 Both must be true. release-please always satisfies both when merging a release PR — a manual `CHANGELOG.md` edit alone will not trigger a release.
 
-> [!NOTE]
-> Merging a release PR uses a publish-first dependency chain. `trigger-releases`
-> runs immediately after the release commit is detected and does not wait for the
-> pending-release guard or serialized release-please maintenance. The dispatch job
-> comments on the merged release PR with a direct link to each package's release
-> workflow run. Once every matched `release.yml` dispatch succeeds, the same
-> workflow run enters `guard-pending-release`, waits until no merged release PR
-> remains labeled `autorelease: pending`, and only an explicit `skip=false` allows
-> release-please to refresh remaining open release PRs (shared files such as
-> `.release-please-manifest.json`). `update-lockfiles` then regenerates lockfiles
-> on the PRs that maintenance step returned.
->
-> The wait covers every pending release PR in the repo, not just the one you
-> merged: release-please recomputes all components on each run, so any single
-> component sitting between "version bumped" and "tag created" is enough to
-> trigger a bootstrap downgrade.
->
-> When maintenance does **not** run, here is what you will see and what to do:
->
-> | Situation | Signal | Action |
-> | --- | --- | --- |
-> | A publish is still in flight after 45 min | `release-please.yml` is green; the guard logs a `deferred` step summary | Nothing, unless the publish is genuinely stuck — then clear the label per [Release PR Stuck with "autorelease: pending"](#release-pr-stuck-with-autorelease-pending-label). The next push runs maintenance. |
-> | The publish failed | `release.yml` is red; `release-please.yml` stays green with a `deferred (release commit)` summary | Fix and re-dispatch the failed package release. Maintenance runs on the next push. |
-> | GitHub state is unreadable | `release-please.yml` is **red** at `guard-pending-release` | Re-run the job. It refuses to guess whether a publish is in flight rather than recompute against unverified state. |
-> | You merged several release PRs at once | Some `release-please` jobs show as **cancelled** | Expected. Only one job may queue per concurrency group; the surviving (newest) run recomputes every component, so it does the cancelled jobs' work. |
+### What Happens When You Merge a Release PR
+
+Publishing starts immediately. Housekeeping on the *other* open release PRs happens afterwards, in the same workflow run:
+
+1. **Your package publishes first.** `trigger-releases` fires as soon as the release commit is detected and never waits on anything else. It comments on the merged PR with a direct link to each package's release run — that link is where you watch the actual publish.
+2. **The run waits for publishing to settle.** `guard-pending-release` polls until no merged release PR is still labeled `autorelease: pending`.
+3. **Then the remaining release PRs are refreshed.** release-please updates shared files (notably `.release-please-manifest.json`) on the still-open release PRs, and `update-lockfiles` regenerates their lockfiles.
+
+In the normal case you do not need to think about any of this. Step 3 is the only part that can be quietly skipped — if the other release PRs look stale afterwards, expand *If the other release PRs were not refreshed* below.
+
+<details>
+<summary><b>Why publishing never waits, and why the wait covers the whole repo</b></summary>
+
+**Publishing goes first** so that a publish is never blocked behind housekeeping for some *other* package. Only step 3 is serialized (release-please mutates shared release branches, so two copies must not run at once); steps 1 and 2 are deliberately outside that serialization.
+
+**Step 3 requires an explicit all-clear.** The guard has to positively report "nothing in flight" (`skip=false`) for release-please to run. If the guard crashes, times out, or is skipped, release-please does *not* run — an unknown state is treated as unsafe rather than assumed fine.
+
+**The wait covers every pending release PR in the repo, not just the one you merged.** This looks over-broad but is required: release-please recomputes *all* components on every run, so any single component sitting between "version bumped" and "tag created" is enough to trigger a bootstrap downgrade — it sees no tag, concludes the package was never released, and proposes resetting it to `0.1.0` with the full history. Scoping the wait to your own PR would not be safe.
+
+</details>
+
+<details>
+<summary><b>If the other release PRs were not refreshed</b></summary>
+
+Step 3 is skipped in the situations below. In every case your own package still published normally, and the refresh happens on the next push to `main`.
+
+| Situation | What you will see | What to do |
+| --- | --- | --- |
+| A publish is still in flight after 45 min | `release-please.yml` green, with a `deferred` step summary | Nothing, unless the publish is genuinely stuck — then clear the label per [Release PR Stuck with "autorelease: pending"](#release-pr-stuck-with-autorelease-pending-label) |
+| A publish failed (yours, or a package left stuck earlier) | `release.yml` red; `release-please.yml` green, with a `deferred (release commit)` summary naming the failed run | Fix and re-dispatch the failed package release |
+| GitHub's release state is unreadable | `release-please.yml` **red** at `guard-pending-release` | Re-run the job. It refuses to guess whether a publish is in flight rather than recompute against unverified state |
+| You merged several release PRs at once | Some `release-please` jobs show as **cancelled** | Nothing — this is expected. Only one job may queue per concurrency group, and the surviving (newest) run recomputes every component, so it covers the cancelled jobs' work |
+
+</details>
 
 ### Lockfile Updates
 

--- a/.github/scripts/tests/release/test_release_please_workflow.py
+++ b/.github/scripts/tests/release/test_release_please_workflow.py
@@ -9,12 +9,68 @@ ROOT = Path(__file__).resolve().parents[4]
 WORKFLOW = ROOT / ".github/workflows/release-please.yml"
 
 
+def _load_workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def _needs(job: dict) -> set[str]:
+    needs = job.get("needs", [])
+    if isinstance(needs, str):
+        return {needs}
+    return set(needs)
+
+
+def _condition(job: dict) -> str:
+    return " ".join(str(job.get("if", "")).split())
+
+
 def test_trigger_releases_can_comment_on_release_pr() -> None:
     """Grant only the permissions needed to dispatch and report releases."""
-    workflow = yaml.safe_load(WORKFLOW.read_text())
+    workflow = _load_workflow()
 
     assert workflow["jobs"]["trigger-releases"]["permissions"] == {
         "actions": "write",
         "issues": "read",
         "pull-requests": "write",
     }
+
+
+def test_release_dispatch_precedes_release_please_maintenance() -> None:
+    """Publish dispatch stays first; maintenance waits after successful dispatch."""
+    workflow = _load_workflow()
+    jobs = workflow["jobs"]
+
+    assert "concurrency" not in workflow
+
+    trigger = jobs["trigger-releases"]
+    assert _needs(trigger) == {"detect-release-commit"}
+
+    guard = jobs["guard-pending-release"]
+    assert _needs(guard) == {
+        "guard-empty-commit",
+        "detect-release-commit",
+        "trigger-releases",
+    }
+
+    guard_if = _condition(guard)
+    assert "!cancelled()" in guard_if
+    assert "needs.guard-empty-commit.result == 'success'" in guard_if
+    assert "needs.detect-release-commit.result == 'success'" in guard_if
+    assert "needs.detect-release-commit.outputs.release-commit == 'false'" in guard_if
+    assert "needs.detect-release-commit.outputs.release-commit == 'true'" in guard_if
+    assert "needs.trigger-releases.result == 'success'" in guard_if
+    # Malformed detector output must fail closed (no loose != 'true').
+    assert "release-commit != 'true'" not in guard_if
+
+    release_please = jobs["release-please"]
+    assert "guard-pending-release" in _needs(release_please)
+    assert "trigger-releases" not in _needs(release_please)
+    assert _condition(release_please) == (
+        "needs.guard-pending-release.outputs.skip == 'false'"
+    )
+    # Maintenance may run after release commits once the guard authorizes it.
+    assert "release-commit" not in _condition(release_please)
+    assert "skip != 'true'" not in _condition(release_please)
+    assert "||" not in _condition(release_please)
+
+    assert "release-please" in _needs(jobs["update-lockfiles"])

--- a/.github/scripts/tests/release/test_release_please_workflow.py
+++ b/.github/scripts/tests/release/test_release_please_workflow.py
@@ -1,5 +1,7 @@
 """Tests for the release-please workflow."""
 
+import json
+import re
 from pathlib import Path
 
 import yaml
@@ -7,6 +9,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[4]
 WORKFLOW = ROOT / ".github/workflows/release-please.yml"
+CONFIG = ROOT / "release-please-config.json"
 
 
 def _load_workflow() -> dict:
@@ -22,6 +25,33 @@ def _needs(job: dict) -> set[str]:
 
 def _condition(job: dict) -> str:
     return " ".join(str(job.get("if", "")).split())
+
+
+def _step(job: dict, step_id: str) -> dict:
+    return next(step for step in job["steps"] if step.get("id") == step_id)
+
+
+def _evaluate(
+    condition: str, values: dict[str, str], *, cancelled: bool = False
+) -> bool:
+    """Evaluate an Actions `if:` expression against concrete `needs` values.
+
+    Substring assertions cannot tell correct nesting from no nesting: flattening
+    the parentheses, or swapping `||` for `&&`, leaves every clause present while
+    inverting the meaning. Only the boolean structure catches that, so evaluate it.
+
+    Supports just the subset the workflow uses — `!cancelled()`, `&&`, `||`,
+    parentheses, and `needs.<job>.result` / `needs.<job>.outputs.<name>` compared
+    against single-quoted literals.
+    """
+    expr = condition
+    for ref, value in values.items():
+        expr = expr.replace(ref, repr(value))
+    expr = expr.replace("!cancelled()", repr(not cancelled))
+    expr = expr.replace("&&", " and ").replace("||", " or ")
+    leftover = re.findall(r"needs\.[\w.-]+", expr)
+    assert not leftover, f"unsubstituted references (update the test): {leftover}"
+    return bool(eval(expr))  # noqa: S307 - workflow-derived, no external input
 
 
 def test_trigger_releases_can_comment_on_release_pr() -> None:
@@ -52,25 +82,154 @@ def test_release_dispatch_precedes_release_please_maintenance() -> None:
         "trigger-releases",
     }
 
+    # `!cancelled()` is required: `trigger-releases` is legitimately skipped on
+    # normal pushes, so the implicit success() gate on `needs` cannot be used.
+    # Because it also disables that gate, every upstream result is checked by
+    # hand — see test_guard_condition_fails_closed for the resulting truth table.
     guard_if = _condition(guard)
     assert "!cancelled()" in guard_if
-    assert "needs.guard-empty-commit.result == 'success'" in guard_if
-    assert "needs.detect-release-commit.result == 'success'" in guard_if
-    assert "needs.detect-release-commit.outputs.release-commit == 'false'" in guard_if
-    assert "needs.detect-release-commit.outputs.release-commit == 'true'" in guard_if
-    assert "needs.trigger-releases.result == 'success'" in guard_if
     # Malformed detector output must fail closed (no loose != 'true').
     assert "release-commit != 'true'" not in guard_if
 
     release_please = jobs["release-please"]
     assert "guard-pending-release" in _needs(release_please)
     assert "trigger-releases" not in _needs(release_please)
+    # Exact match, so no status function sneaks in: without one, the implicit
+    # success() gate on `needs` is retained and a red/skipped guard blocks
+    # maintenance. Maintenance may run after release commits, so this must not
+    # re-test `release-commit` either.
     assert _condition(release_please) == (
         "needs.guard-pending-release.outputs.skip == 'false'"
     )
-    # Maintenance may run after release commits once the guard authorizes it.
-    assert "release-commit" not in _condition(release_please)
-    assert "skip != 'true'" not in _condition(release_please)
-    assert "||" not in _condition(release_please)
 
     assert "release-please" in _needs(jobs["update-lockfiles"])
+
+
+def test_guard_condition_fails_closed() -> None:
+    """Pin the guard's boolean structure, not just the presence of its clauses."""
+    guard_if = _condition(_load_workflow()["jobs"]["guard-pending-release"])
+
+    def runs(
+        release_commit: str,
+        trigger: str,
+        *,
+        empty_commit: str = "success",
+        detect: str = "success",
+        cancelled: bool = False,
+    ) -> bool:
+        return _evaluate(
+            guard_if,
+            {
+                "needs.guard-empty-commit.result": empty_commit,
+                "needs.detect-release-commit.result": detect,
+                "needs.detect-release-commit.outputs.release-commit": release_commit,
+                "needs.trigger-releases.result": trigger,
+            },
+            cancelled=cancelled,
+        )
+
+    # Normal push: `trigger-releases` is skipped and must be ignored, not awaited.
+    assert runs("false", "skipped")
+    assert runs("false", "success")
+    # Release commit: maintenance only after the publish actually dispatched.
+    assert runs("true", "success")
+    assert not runs("true", "failure")
+    assert not runs("true", "skipped")
+    assert not runs("true", "cancelled")
+    # Malformed/unset detector output must not pass as a normal push.
+    assert not runs("", "skipped")
+    assert not runs("garbage", "success")
+    # A cancelled workflow must not start a poll that runs for up to MAX_WAIT.
+    assert not runs("false", "skipped", cancelled=True)
+    # `!cancelled()` disables implicit needs-gating, so upstream failures have to
+    # be rejected explicitly or a red dependency would be silently tolerated.
+    assert not runs("false", "skipped", empty_commit="failure")
+    assert not runs("false", "skipped", empty_commit="skipped")
+    assert not runs("false", "skipped", detect="failure")
+    assert not runs("true", "success", detect="failure")
+
+
+def test_guard_wait_is_not_serialized_and_outlives_its_poll() -> None:
+    """Two invariants the guard's comments call deliberate."""
+    guard = _load_workflow()["jobs"]["guard-pending-release"]
+
+    # A poll of up to MAX_WAIT must not hold the `release-please` slot that every
+    # other push queues on.
+    assert "concurrency" not in guard
+
+    # The job timeout has to sit well above MAX_WAIT so the graceful skip=true
+    # fallback wins the race. A hard timeout leaves `skip` unset, which blocks
+    # maintenance until the next push instead of deferring cleanly.
+    script = _step(guard, "check")["run"]
+    max_wait = int(re.search(r"^\s*MAX_WAIT=(\d+)", script, re.MULTILINE).group(1))
+    assert guard["timeout-minutes"] * 60 - max_wait >= 600
+
+
+def test_release_please_maintenance_stays_serialized() -> None:
+    """Only the release-please action is serialized, and it is never cancelled."""
+    release_please = _load_workflow()["jobs"]["release-please"]
+
+    # Job-scoped, not workflow-scoped: workflow-level concurrency would let
+    # GitHub coalesce away a pending release-commit run before it can dispatch.
+    assert release_please["concurrency"] == {
+        "group": "release-please",
+        "cancel-in-progress": False,
+    }
+
+
+def test_every_component_is_wired_for_detection_and_dispatch() -> None:
+    """A component missing from either list publishes nothing, silently.
+
+    `trigger-releases` is gated on the per-package outputs, so an unwired
+    component skips the dispatch — and since the guard requires a successful
+    dispatch on release commits, maintenance skips too. Every job would be green
+    while the release did not happen. The detector now fails loudly in that case;
+    this keeps the two hand-maintained lists from drifting in the first place.
+    """
+    jobs = _load_workflow()["jobs"]
+    detect_job = jobs["detect-release-commit"]
+    detect = _step(detect_job, "check-releases")["run"]
+    trigger_if = _condition(jobs["trigger-releases"])
+    packages = json.loads(CONFIG.read_text())["packages"]
+
+    for path, meta in packages.items():
+        component = meta["component"]
+        assert f"release\\({component}\\)" in detect, (
+            f"detect-release-commit does not match release({component})"
+        )
+        changelog = f"^{path}/{meta['changelog-path']}$"
+        assert changelog in detect, (
+            f"detect-release-commit does not watch {changelog}"
+        )
+
+    flags = [name for name in detect_job["outputs"] if name.endswith("-release")]
+    assert len(flags) == len(packages), (
+        f"{len(flags)} per-package outputs for {len(packages)} configured packages"
+    )
+    for flag in flags:
+        assert f"needs.detect-release-commit.outputs.{flag} == 'true'" in trigger_if, (
+            f"{flag} does not gate trigger-releases; that package would never publish"
+        )
+
+
+def test_unmatched_release_commit_fails_loudly() -> None:
+    """A release commit matching no package must not conclude green."""
+    detect = _step(
+        _load_workflow()["jobs"]["detect-release-commit"], "check-releases"
+    )["run"]
+
+    assert 'ANY_PACKAGE=false' in detect
+    assert detect.count("ANY_PACKAGE=true") == len(
+        json.loads(CONFIG.read_text())["packages"]
+    )
+    # YAML block scalars strip the common indentation, so the closing `fi` of a
+    # top-level `if` sits at column 0 in the parsed script.
+    guard = re.search(
+        r'^if \[ -n "\$RELEASE_VERSION" \] && \[ "\$ANY_PACKAGE" = false \]; then\n'
+        r"(.*?)^fi$",
+        detect,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert guard, "missing the unmatched-release-commit guard"
+    assert "::error::" in guard.group(1)
+    assert "exit 1" in guard.group(1)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -260,11 +260,11 @@ jobs:
   # PR's `autorelease: pending` -> `autorelease: tagged` label minutes *after*
   # the release PR merges, in a separate dispatched run. In that window the
   # manifest already names the new version but the tag does not exist yet. A
-  # normal (non-release) push landing in that window re-runs release-please
-  # against this half-updated state: it finds no tag, and if the label has just
-  # flipped, release-please's own "untagged outstanding -> abort" guard appears
-  # not to fire — so it treats the component as never-released and proposes a
-  # bootstrap downgrade (observed once: 0.1.8 -> 0.1.0 with the full history).
+  # push that runs release-please against this half-updated state finds no tag,
+  # and if the label has just flipped, release-please's own "untagged
+  # outstanding -> abort" guard appears not to fire — so it treats the
+  # component as never-released and proposes a bootstrap downgrade (observed
+  # once: 0.1.8 -> 0.1.0 with the full history).
   #
   # Crucially, completing a publish does NOT push to main (it only creates a tag
   # + GitHub release), so nothing re-triggers release-please.yml afterwards. An
@@ -274,10 +274,16 @@ jobs:
   # defer. So instead we *wait*: poll the label until the publish finishes (or a
   # bounded timeout), then let release-please run in this same run against the
   # now-consistent state. This job is deliberately outside the `release-please`
-  # concurrency group so release-commit runs can still dispatch publishing.
+  # concurrency group so `trigger-releases` can still dispatch publishing first.
   #
-  # Release commits bypass this wait entirely: their run must reach
-  # `trigger-releases` to dispatch the publish.
+  # Path by push kind:
+  #   * Normal pushes: enter this wait when detect/empty-commit succeeded
+  #     (`trigger-releases` is skipped and ignored).
+  #   * Release commits: still dispatch publish first via `trigger-releases`
+  #     (not blocked by this wait). After that job succeeds, this guard runs
+  #     so the same workflow can refresh remaining open sibling release PRs
+  #     once half-updated tag/label state clears. A failed or skipped trigger
+  #     fails closed and leaves maintenance off.
   #
   # Three fallbacks if the wait can't resolve cleanly:
   #   * Publish genuinely *stuck* past MAX_WAIT (label never flips, but GitHub is
@@ -291,9 +297,27 @@ jobs:
   #     then skipped via `needs`, and a red guard is the honest signal — better
   #     than silently guessing "in flight" for 45 min and stranding commits.
   guard-pending-release:
-    needs: [guard-empty-commit, detect-release-commit]
+    needs:
+      - guard-empty-commit
+      - detect-release-commit
+      - trigger-releases
     name: Check for in-flight publish
-    if: needs.detect-release-commit.outputs.release-commit != 'true'
+    # `trigger-releases` is skipped on normal pushes, so do not rely on the
+    # implicit success() gate for needs. Prefer !cancelled() over always() so
+    # a cancelled workflow does not keep polling for up to ~45m.
+    # Strict `== 'true'` / `== 'false'` on release-commit: malformed/unset
+    # detector output fails closed rather than looking like a normal push.
+    if: |
+      !cancelled() &&
+      needs.guard-empty-commit.result == 'success' &&
+      needs.detect-release-commit.result == 'success' &&
+      (
+        needs.detect-release-commit.outputs.release-commit == 'false' ||
+        (
+          needs.detect-release-commit.outputs.release-commit == 'true' &&
+          needs.trigger-releases.result == 'success'
+        )
+      )
     runs-on: ubuntu-latest
     # Backstops the poll loop at the job level (covers checkout + every `gh`
     # round-trip, not just the sleeps). Sits ~10 min above MAX_WAIT (45 min) so
@@ -539,16 +563,16 @@ jobs:
   release-please:
     needs: [guard-empty-commit, detect-release-commit, guard-pending-release]
     # Fail closed: run only on an explicit `skip=false`. An unset value (guard
-    # crashed or hit its job timeout before writing the output) blocks
-    # release-please rather than letting it recompute against unverified state.
-    if: |
-      needs.detect-release-commit.outputs.release-commit != 'true' &&
-      needs.guard-pending-release.outputs.skip == 'false'
+    # crashed, was skipped, or hit its job timeout before writing the output)
+    # blocks release-please rather than letting it recompute against unverified
+    # state. Release commits reach this job only after successful publish
+    # dispatch and a cleared/authorized pending-label wait above.
+    if: needs.guard-pending-release.outputs.skip == 'false'
     runs-on: ubuntu-latest
     # Serialize only the release-please action, which mutates shared release
     # branches and reads in-flight release state. Keeping this at job scope lets
-    # release-commit runs dispatch publishing without queueing behind long guard
-    # waits from ordinary pushes.
+    # release-commit runs dispatch publishing immediately via `trigger-releases`
+    # without queueing behind long guard waits from ordinary pushes.
     concurrency:
       group: release-please
       cancel-in-progress: false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -184,8 +184,14 @@ jobs:
           # grep -q in an `if` conditional is safe under set -eo pipefail;
           # bash suppresses errexit inside `if` compound commands.
 
+          # Tracks whether any package matched, so a release commit that matches
+          # none can fail loudly instead of producing a green no-op run (see the
+          # check after the last package below).
+          ANY_PACKAGE=false
+
           if echo "$CHANGED" | grep -q "^libs/cli/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(deepagents-cli\):"; then
             echo "cli-release=true" >> "$GITHUB_OUTPUT"
+            ANY_PACKAGE=true
             echo "CLI release detected: $COMMIT_MSG"
           else
             echo "cli-release=false" >> "$GITHUB_OUTPUT"
@@ -193,6 +199,7 @@ jobs:
 
           if echo "$CHANGED" | grep -q "^libs/deepagents/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(deepagents\):"; then
             echo "sdk-release=true" >> "$GITHUB_OUTPUT"
+            ANY_PACKAGE=true
             echo "SDK release detected: $COMMIT_MSG"
           else
             echo "sdk-release=false" >> "$GITHUB_OUTPUT"
@@ -200,6 +207,7 @@ jobs:
 
           if echo "$CHANGED" | grep -q "^libs/acp/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(deepagents-acp\):"; then
             echo "acp-release=true" >> "$GITHUB_OUTPUT"
+            ANY_PACKAGE=true
             echo "ACP release detected: $COMMIT_MSG"
           else
             echo "acp-release=false" >> "$GITHUB_OUTPUT"
@@ -207,6 +215,7 @@ jobs:
 
           if echo "$CHANGED" | grep -q "^libs/code/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(deepagents-code\):"; then
             echo "code-release=true" >> "$GITHUB_OUTPUT"
+            ANY_PACKAGE=true
             echo "Deep Agents Code release detected: $COMMIT_MSG"
           else
             echo "code-release=false" >> "$GITHUB_OUTPUT"
@@ -214,6 +223,7 @@ jobs:
 
           if echo "$CHANGED" | grep -q "^libs/talon/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(deepagents-talon\):"; then
             echo "talon-release=true" >> "$GITHUB_OUTPUT"
+            ANY_PACKAGE=true
             echo "Deep Agents Talon release detected: $COMMIT_MSG"
           else
             echo "talon-release=false" >> "$GITHUB_OUTPUT"
@@ -221,6 +231,7 @@ jobs:
 
           if echo "$CHANGED" | grep -q "^libs/partners/daytona/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-daytona\):"; then
             echo "daytona-release=true" >> "$GITHUB_OUTPUT"
+            ANY_PACKAGE=true
             echo "Daytona release detected: $COMMIT_MSG"
           else
             echo "daytona-release=false" >> "$GITHUB_OUTPUT"
@@ -228,6 +239,7 @@ jobs:
 
           if echo "$CHANGED" | grep -q "^libs/partners/modal/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-modal\):"; then
             echo "modal-release=true" >> "$GITHUB_OUTPUT"
+            ANY_PACKAGE=true
             echo "Modal release detected: $COMMIT_MSG"
           else
             echo "modal-release=false" >> "$GITHUB_OUTPUT"
@@ -235,6 +247,7 @@ jobs:
 
           if echo "$CHANGED" | grep -q "^libs/partners/runloop/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-runloop\):"; then
             echo "runloop-release=true" >> "$GITHUB_OUTPUT"
+            ANY_PACKAGE=true
             echo "Runloop release detected: $COMMIT_MSG"
           else
             echo "runloop-release=false" >> "$GITHUB_OUTPUT"
@@ -242,6 +255,7 @@ jobs:
 
           if echo "$CHANGED" | grep -q "^libs/partners/vercel/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-vercel-sandbox\):"; then
             echo "vercel-release=true" >> "$GITHUB_OUTPUT"
+            ANY_PACKAGE=true
             echo "Vercel release detected: $COMMIT_MSG"
           else
             echo "vercel-release=false" >> "$GITHUB_OUTPUT"
@@ -249,9 +263,23 @@ jobs:
 
           if echo "$CHANGED" | grep -q "^libs/partners/quickjs/CHANGELOG.md$" && echo "$COMMIT_MSG" | grep -qE "^release\(langchain-quickjs\):"; then
             echo "quickjs-release=true" >> "$GITHUB_OUTPUT"
+            ANY_PACKAGE=true
             echo "QuickJS release detected: $COMMIT_MSG"
           else
             echo "quickjs-release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # A release commit that matches no package is a wiring bug, not a no-op:
+          # `trigger-releases` is gated on the per-package outputs, so it skips and
+          # nothing publishes — and because `guard-pending-release` requires a
+          # successful dispatch on release commits, maintenance skips too. Every
+          # job would be green while the release silently did not happen. The usual
+          # cause is a package added to release-please-config.json and to this list
+          # but missed in `trigger-releases`, or a changed changelog-path.
+          if [ -n "$RELEASE_VERSION" ] && [ "$ANY_PACKAGE" = false ]; then
+            echo "::error::Release commit matched no known package: $COMMIT_MSG"
+            echo "::error::Add the component to this job's detection list and to trigger-releases' \`if:\`, or check its changelog-path in release-please-config.json."
+            exit 1
           fi
 
   # Wait out an in-flight publish instead of recomputing against half-updated state.
@@ -273,29 +301,47 @@ jobs:
   # push happened to re-run release-please, which looks like a cancel, not a
   # defer. So instead we *wait*: poll the label until the publish finishes (or a
   # bounded timeout), then let release-please run in this same run against the
-  # now-consistent state. This job is deliberately outside the `release-please`
-  # concurrency group so `trigger-releases` can still dispatch publishing first.
+  # now-consistent state.
+  #
+  # This job is deliberately outside the `release-please` concurrency group: a
+  # poll of up to MAX_WAIT must not hold the serialization slot that every other
+  # push's `release-please` job queues on. Dispatch-before-maintenance ordering
+  # comes from `needs: trigger-releases` below, not from concurrency — those two
+  # jobs are otherwise independent.
+  #
+  # The wait is deliberately repo-wide (every merged PR still labeled
+  # `autorelease: pending`, not just this run's). release-please recomputes *all*
+  # components on every run, so any one component sitting in the half-updated
+  # state above is enough to trigger the downgrade — scoping the wait to the PR
+  # this run merged would not be safe.
   #
   # Path by push kind:
-  #   * Normal pushes: enter this wait when detect/empty-commit succeeded
-  #     (`trigger-releases` is skipped and ignored).
-  #   * Release commits: still dispatch publish first via `trigger-releases`
-  #     (not blocked by this wait). After that job succeeds, this guard runs
-  #     so the same workflow can refresh remaining open sibling release PRs
-  #     once half-updated tag/label state clears. A failed or skipped trigger
-  #     fails closed and leaves maintenance off.
+  #   * Normal pushes (`release-commit == 'false'`): enter this wait;
+  #     `trigger-releases` is skipped and ignored.
+  #   * Release commits (`release-commit == 'true'`): dispatch publish first via
+  #     `trigger-releases` (not blocked by this wait). After that job succeeds,
+  #     this guard runs so the same workflow can refresh remaining open sibling
+  #     release PRs once half-updated tag/label state clears. A failed or skipped
+  #     trigger fails closed and leaves maintenance off.
+  #   * Anything else (unset/malformed `release-commit`): fails closed — the
+  #     guard is skipped, so maintenance is too.
   #
-  # Three fallbacks if the wait can't resolve cleanly:
+  # Four outcomes if the wait can't resolve cleanly:
   #   * Publish genuinely *stuck* past MAX_WAIT (label never flips, but GitHub is
   #     answering): skip=true, deferring to the next push, so a hung publish
   #     outside this run's control never paints main red.
-  #   * The matching release run already failed/cancelled/timed out: fail the job
-  #     loudly (exit 1), because the pending label now means operator action is
-  #     needed rather than an in-flight publish.
-  #   * GitHub itself unreadable (gh keeps erroring so we can't tell whether a
-  #     publish is in flight): fail the job loudly (exit 1). release-please is
-  #     then skipped via `needs`, and a red guard is the honest signal — better
-  #     than silently guessing "in flight" for 45 min and stranding commits.
+  #   * The matching release run already failed/cancelled/timed out, on an
+  #     *ordinary* push: fail the job loudly (exit 1), because the pending label
+  #     now means operator action is needed rather than an in-flight publish.
+  #   * The same, on a *hotfix push or release commit*: skip=true with notices
+  #     instead of exit 1 — the operator already has the signal from the failed
+  #     publish's own run, and an unrelated stuck package must not redden a
+  #     release that dispatched fine. See fail_failed_releases.
+  #   * GitHub itself unreadable (gh keeps erroring, or answers with something we
+  #     cannot parse, so we can't tell whether a publish is in flight): fail the
+  #     job loudly (exit 1). release-please is then skipped via `needs`, and a red
+  #     guard is the honest signal — better than silently guessing "in flight"
+  #     for 45 min and stranding commits.
   guard-pending-release:
     needs:
       - guard-empty-commit
@@ -341,15 +387,26 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          RELEASE_COMMIT: ${{ needs.detect-release-commit.outputs.release-commit }}
         run: |
           # No `-e`: the poll loop handles transient `gh` failures itself rather
           # than aborting the job, which would skip the wait entirely.
           set -uo pipefail
-          HEAD_SUBJECT=$(git log -1 --format=%s HEAD)
+          # Checked explicitly: without `-e`, a failure here would leave the
+          # subject empty, silently classify the push as neither hotfix nor
+          # release commit, and route a failed release down the wrong branch.
+          if ! HEAD_SUBJECT=$(git log -1 --format=%s HEAD); then
+            echo "::error::Could not read the HEAD commit subject; cannot classify this push."
+            exit 1
+          fi
           IS_HOTFIX=false
           case "$HEAD_SUBJECT" in
             hotfix\(*|hotfix:*|hotfix!*) IS_HOTFIX=true ;;
           esac
+          IS_RELEASE_COMMIT=false
+          if [ "${RELEASE_COMMIT:-}" = "true" ]; then
+            IS_RELEASE_COMMIT=true
+          fi
 
           # `autorelease: pending` is release-please-action's built-in label,
           # applied to release PRs and cleared to `autorelease: tagged` by
@@ -364,8 +421,18 @@ jobs:
               --label "autorelease: pending" --limit 100 --json number,title
           }
 
+          # Exits non-zero on anything that is not the expected array of PRs, so
+          # the caller can tell "no pending PRs" (empty output, status 0) apart
+          # from "could not read the response". Without the type guard a
+          # valid-JSON body of the wrong shape (an API error object, an HTML
+          # error page) renders as empty output and reads as "nothing pending" —
+          # which would wave release-please through against half-updated state.
+          # `-e` is safe here: an empty string is neither null nor false.
           format_pending() {
-            jq -r '[.[] | "#\(.number) \(.title)"] | join("; ")'
+            jq -er '
+              if type != "array" then error("expected an array of PRs") else . end
+              | [.[] | "#\(.number) \(.title)"] | join("; ")
+            '
           }
 
           # Echoes a line per merged pending PR whose matching release.yml run has
@@ -404,11 +471,13 @@ jobs:
             # an outright error. Runs merely *awaiting* approval have status !=
             # "completed" and are excluded by the status check below.
             #
-            # Any single failed pending release makes this emit a line, and the
-            # caller fails the whole guard closed — even if a sibling PR's publish
-            # is still legitimately in flight. That is intentional: once a human
-            # must intervene, release-please must not run against half-updated
-            # state regardless of what else is mid-publish.
+            # Any single failed pending release makes this emit a line — even if a
+            # sibling PR's publish is still legitimately in flight. That is
+            # intentional: once a human must intervene, release-please must not run
+            # against half-updated state regardless of what else is mid-publish. The
+            # caller decides how loudly to stop: ordinary pushes fail closed, while
+            # hotfix pushes and release commits defer with skip=true (see
+            # fail_failed_releases).
             jq -r --argjson prs "$pending_json" '
               def failed_conclusion:
                 . == "failure" or . == "cancelled" or . == "timed_out" or
@@ -420,17 +489,37 @@ jobs:
             ' <<< "$runs_json"
           }
 
+          # Defer (skip=true, green) rather than fail when a red guard adds no
+          # signal the operator does not already have:
+          #   * Hotfix pushes: the operator is already recovering the failed
+          #     release; this push is the recovery.
+          #   * Release commits: the failed publish's own `release.yml` run is
+          #     already red, so failing here only duplicates it — and because the
+          #     pending set is repo-wide, an unrelated package left stuck days ago
+          #     would otherwise redden a release that dispatched perfectly.
+          # Ordinary pushes still fail loudly: there, a red guard is the only
+          # signal that a stuck pending label needs a human.
           fail_failed_releases() {
+            local defer_reason=""
+            local defer_detail=""
             if [ "$IS_HOTFIX" = true ]; then
-              echo "::notice::Hotfix push detected; release-please is deferred while the failed package release is recovered:"
+              defer_reason="hotfix recovery"
+              defer_detail="The push that triggered this run is a hotfix commit (\`$HEAD_SUBJECT\`)."
+            elif [ "$IS_RELEASE_COMMIT" = true ]; then
+              defer_reason="release commit"
+              defer_detail="This run is a release commit (\`$HEAD_SUBJECT\`); the failed package release is already reported by its own \`release.yml\` run."
+            fi
+
+            if [ -n "$defer_reason" ]; then
+              echo "::notice::Deferring release-please ($defer_reason) while the failed package release is recovered:"
               printf '%s\n' "$FAILED_RELEASES" | while IFS= read -r line; do
                 [ -n "$line" ] && echo "::notice::$line"
               done
               echo "::notice::Fix the failed package release, then manually re-dispatch it before running release-please again."
               {
-                echo "## release-please deferred for hotfix recovery"
+                echo "## release-please deferred ($defer_reason)"
                 echo ""
-                echo "The push that triggered this run is a hotfix commit (\`$HEAD_SUBJECT\`). The following merged release PR(s) are still labeled \`autorelease: pending\`, and their matching \`release.yml\` run has already completed unsuccessfully:"
+                echo "$defer_detail The following merged release PR(s) are still labeled \`autorelease: pending\`, and their matching \`release.yml\` run has already completed unsuccessfully:"
                 echo ""
                 printf '%s\n' "$FAILED_RELEASES"
                 echo ""
@@ -479,7 +568,17 @@ jobs:
               return
             fi
 
-            next_pending=$(printf '%s\n' "$next_pending_json" | format_pending)
+            # Status checked explicitly: `-e` is off, so an unparseable payload
+            # would otherwise yield empty output and be indistinguishable from
+            # "nothing pending". Treat it as a query failure so a sustained one
+            # trips MAX_QUERY_FAILS below instead of proceeding on a guess.
+            if ! next_pending=$(printf '%s\n' "$next_pending_json" | format_pending); then
+              QUERY_FAILS=$((QUERY_FAILS + 1))
+              PENDING="(unreadable GitHub response)"
+              FAILED_RELEASES=""
+              echo "::warning::Could not parse the pending release PR response (${QUERY_FAILS} consecutive)."
+              return
+            fi
             if [ -n "$next_pending" ]; then
               if ! next_failed=$(describe_failed_pending_releases "$next_pending_json"); then
                 QUERY_FAILS=$((QUERY_FAILS + 1))
@@ -573,6 +672,13 @@ jobs:
     # branches and reads in-flight release state. Keeping this at job scope lets
     # release-commit runs dispatch publishing immediately via `trigger-releases`
     # without queueing behind long guard waits from ordinary pushes.
+    #
+    # Batch-merging release PRs will cancel jobs here, and that is the designed
+    # outcome, not a bug to fix by removing the group: GitHub allows only one
+    # *pending* member per group, so a third arrival cancels the waiting one. The
+    # survivor is always the newest, it sees the most up-to-date main, and
+    # release-please recomputes every component — so it does the cancelled jobs'
+    # work too. Expect cancelled runs on main after a release burst.
     concurrency:
       group: release-please
       cancel-in-progress: false


### PR DESCRIPTION
## The situation before

This repo releases ten packages independently, so it is normal to have several open release PRs at once. Those PRs all touch shared files — most importantly `.release-please-manifest.json`. When one of them merges, the others are instantly stale, and release-please is what normally rewrites them.

But release commits deliberately skipped release-please entirely, for a good reason: running it while a publish is mid-flight is dangerous. Merging a release PR bumps the manifest immediately, while the git tag is only created minutes later by `release.yml`. In that window release-please sees a version with no matching tag, concludes the package was never released, and proposes resetting it to `0.1.0` with the full history. That is not hypothetical — it happened once (`0.1.8` → `0.1.0`).

So the workflow chose the safe option: on a release commit, dispatch the publish and do nothing else.

## Why that was a problem

**Completing a publish does not push to `main`.** It creates a tag and a GitHub release, and neither re-triggers `release-please.yml`.

So after a release merge there was no follow-up run — ever. The remaining open release PRs stayed stale until some unrelated push happened to land, which could be days. This made other release PRs sit with merge conflicts "forever" on shared files.

## What this changes

Publishing still goes first and is never blocked. The difference is that the *same run* now sticks around, waits for publishing to settle, and then does the maintenance it used to skip:

1. `detect-release-commit`
2. `trigger-releases` — fires immediately, `needs` unchanged, still not blocked by anything
3. `guard-pending-release` — new: also runs on release commits, after a successful dispatch. Polls until no merged release PR is still labeled `autorelease: pending`
4. `release-please` — runs only on an explicit `skip=false` from the guard
5. `update-lockfiles` — unchanged

Normal (non-release) pushes are unaffected: same wait, same fail-closed maintenance gate as before.

<details>
<summary><b>Why this ordering is safe</b></summary>

**Publishing cannot be delayed by the wait.** `trigger-releases` depends only on `detect-release-commit`, and the guard is deliberately outside the `release-please` concurrency group — a poll of up to 45 minutes must not hold the serialization slot other pushes queue on. Only step 4 is serialized, since release-please mutates shared release branches.

**Maintenance requires a positive all-clear.** `release-please` runs only on `skip == 'false'`. A guard that crashes, times out, or is skipped leaves that output unset, which blocks maintenance rather than letting it recompute against unverified state. `trigger-releases` is intentionally *not* in `release-please.needs`, so its skipped status on normal pushes can't loosen that gate.

**The wait is repo-wide by design.** It covers every pending release PR, not just the merged one, because release-please recomputes *all* components on every run — any single package sitting between "version bumped" and "tag created" is enough to trigger the downgrade above. Scoping the wait to your own PR would not be safe.

</details>

<details>
<summary><b>Hardening added after review</b></summary>

Routing release commits through the guard exposed three paths that previously could not be reached, plus one latent bug:

- **A release commit matching no package used to be a silent no-op.** The package list is hardcoded in both `detect-release-commit` and `trigger-releases`. If a future package is wired into one but not the other, nothing publishes, nothing refreshes, and every job reports success. The detector now fails loudly, and a config-derived test keeps the two lists from drifting.
- **The guard treated an unreadable API response as "nothing pending."** `format_pending` swallowed its own parse failures, so a successful-but-unparseable `gh` response was indistinguishable from an empty result — which would wave release-please through during exactly the dangerous window. Parse failures now feed the existing retry/fail-closed path.
- **A failed publish reddened two workflows.** Since the pending set is repo-wide, a package left stuck days earlier would also fail an unrelated release that dispatched perfectly. Release commits now defer with `skip=true` and a step summary naming the failed run, extending the mechanism hotfix pushes already used. Ordinary pushes still fail loudly, where a red guard is the only signal a human would see. Maintenance is skipped either way — this only changes red vs. green and whether the message is actionable.
- **`git log` was unchecked**, so a failure would silently misclassify the push and route a failed release down the wrong branch.

</details>

<details>
<summary><b>Cases that still need a later push</b></summary>

These are documented in `RELEASING.md` with the signal to look for and what to do:

| Situation | Signal |
| --- | --- |
| Publish still in flight after 45 min | `release-please.yml` green, `deferred` step summary |
| Publish failed (yours, or one stuck earlier) | `release.yml` red; `release-please.yml` green with a `deferred (release commit)` summary |
| GitHub release state unreadable | `release-please.yml` **red** at `guard-pending-release` |
| Several release PRs merged at once | Some `release-please` jobs show **cancelled** — expected; the surviving newest run recomputes every component |

Cross-run sibling merges can still race around the pending-label window. This intentionally does not add a hard global cross-run barrier.

</details>

<details>
<summary><b>Testing</b></summary>

`.github/scripts/tests` passes (681 tests). The guard's `if:` condition is now pinned by a truth table over a small expression evaluator rather than substring checks — mutation-tested against five broken variants (flattened parens, `||`↔`&&` swap, negated trigger check, `always()` for `!cancelled()`), all of which are caught and four of which passed the previous assertions.

Also verified directly: every `run:` block passes `bash -n`; `format_pending` correctly separates "empty" from "unreadable" across six payloads; and the guard's three exit paths behave as intended when driven with stubbed `gh`/`git` (ordinary push → exit 1 with `skip` unset; release commit and hotfix → exit 0 with `skip=true`).

</details>
