### PR TITLE
fix(code): keep hooks state private to each graph

### DIFF
--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Literal,
     NotRequired,
@@ -35,6 +36,7 @@ from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,
     ContextT,
+    PrivateStateAttr,
     ResponseT,
     hook_config,
 )
@@ -102,10 +104,17 @@ class _PreToolState(TypedDict):
 
 
 class ServerHooksState(AgentState[Any]):
-    """Agent state extensions for server-owned hook middleware."""
+    """Agent state extensions for server-owned hook middleware.
 
-    _hooks_stop_continuation_count: NotRequired[int]
-    _hooks_pre_tool_outcomes: NotRequired[dict[str, _PreToolState]]
+    Both keys are marked `PrivateStateAttr`: they are per-graph bookkeeping with
+    no meaning in a parent agent, and reducer-less keys returned by parallel
+    subagents collide on a `LastValue` channel.
+    """
+
+    _hooks_stop_continuation_count: NotRequired[Annotated[int, PrivateStateAttr]]
+    _hooks_pre_tool_outcomes: NotRequired[
+        Annotated[dict[str, _PreToolState], PrivateStateAttr]
+    ]
 
 
 class _SessionHookGate(TypedDict):

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -753,6 +753,24 @@ def test_emit_stop_false_skips_after_agent(
     invoke.assert_not_called()
 
 
+def test_hook_state_keys_are_private_to_each_graph() -> None:
+    from deepagents.middleware._state import private_state_field_names
+
+    private = private_state_field_names(ServerHooksState)
+    assert "_hooks_stop_continuation_count" in private
+    assert "_hooks_pre_tool_outcomes" in private
+
+
+def test_after_model_update_keys_are_private() -> None:
+    from deepagents.middleware._state import private_state_field_names
+
+    middleware = ServerHooksMiddleware(cwd=Path("/tmp"))
+    runtime = MagicMock()
+    runtime.context = {"thread_id": "t1", "approval_mode": "manual"}
+    update = middleware._after_model({"messages": []}, runtime)
+    assert set(update) <= private_state_field_names(ServerHooksState)
+
+
 def test_subagent_start_deny_returns_error_tool_message(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -753,24 +753,6 @@ def test_emit_stop_false_skips_after_agent(
     invoke.assert_not_called()
 
 
-def test_hook_state_keys_are_private_to_each_graph() -> None:
-    from deepagents.middleware._state import private_state_field_names
-
-    private = private_state_field_names(ServerHooksState)
-    assert "_hooks_stop_continuation_count" in private
-    assert "_hooks_pre_tool_outcomes" in private
-
-
-def test_after_model_update_keys_are_private() -> None:
-    from deepagents.middleware._state import private_state_field_names
-
-    middleware = ServerHooksMiddleware(cwd=Path("/tmp"))
-    runtime = MagicMock()
-    runtime.context = {"thread_id": "t1", "approval_mode": "manual"}
-    update = middleware._after_model({"messages": []}, runtime)
-    assert set(update) <= private_state_field_names(ServerHooksState)
-
-
 def test_subagent_start_deny_returns_error_tool_message(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Launching two subagents in parallel no longer crashes with `InvalidUpdateError` when server-owned hooks are active.

---

`ServerHooksState` declared `_hooks_pre_tool_outcomes` and `_hooks_stop_continuation_count` as plain, reducer-less keys. Because `ServerHooksMiddleware` also wraps the subagent stack (so `PreToolUse`/`PostToolUse` fire inside subagents), every subagent returned those keys in its state update to the parent. When the model issued two `task` calls in one turn, both updates landed in the same superstep and LangGraph rejected the second write to a `LastValue` channel.

Marking both keys with `PrivateStateAttr` — the same mechanism `skills_metadata`, `memory_contents`, and the rubric keys already use — keeps them out of both the inbound copy into subagent state and the outbound merge back to the parent. Neither key has any meaning in a parent agent: pre-tool outcomes are consumed by `wrap_tool_call` within the same graph, and the stop counter is unused in subagents since they run with `emit_stop=False`.

Note that the stop counter would fail the same way even when its value is unchanged, since `LastValue` rejects multiple writes regardless of equality, so both keys are covered here.

Made by [Open SWE](https://openswe.vercel.app/agents/019faf33-27fd-70cc-8444-772034898668)