### PR TITLE
fix(sdk): warn instead of silently skipping unresolved state schemas

### DIFF
--- a/libs/deepagents/deepagents/middleware/_state.py
+++ b/libs/deepagents/deepagents/middleware/_state.py
@@ -2,21 +2,40 @@
 
 from __future__ import annotations
 
-import contextlib
+import logging
 from typing import Annotated, get_args, get_origin, get_type_hints
 
 from langchain.agents.middleware.types import PrivateStateAttr
 
+logger = logging.getLogger(__name__)
+
 
 def private_state_field_names(*state_schemas: type[object]) -> frozenset[str]:
-    """Return fields annotated with `PrivateStateAttr` across state schemas."""
+    """Return fields annotated with `PrivateStateAttr` across state schemas.
+
+    Annotations are resolved at runtime, so a schema whose `PrivateStateAttr`
+    annotation references a `TYPE_CHECKING`-only name cannot be inspected. That
+    schema is skipped with a warning rather than failing the whole agent, because
+    the caller may own several unrelated schemas -- but the warning matters: a
+    skipped schema keeps none of its private fields, so they will be forwarded to
+    and merged back from subagents.
+    """
     names: set[str] = set()
     for state_schema in state_schemas:
-        with contextlib.suppress(Exception):
+        try:
             hints = get_type_hints(state_schema, include_extras=True)
-            for name, annotation in hints.items():
-                if _has_marker(annotation, PrivateStateAttr):
-                    names.add(name)
+        except (NameError, TypeError, AttributeError):
+            logger.warning(
+                "Could not resolve annotations for state schema %s; its "
+                "PrivateStateAttr fields will NOT be kept private. Ensure every "
+                "name used in those annotations is imported at runtime rather "
+                "than only under TYPE_CHECKING.",
+                getattr(state_schema, "__qualname__", state_schema),
+            )
+            continue
+        for name, annotation in hints.items():
+            if _has_marker(annotation, PrivateStateAttr):
+                names.add(name)
     return frozenset(names)
 
 


### PR DESCRIPTION
`private_state_field_names` resolved annotations under a blanket `contextlib.suppress(Exception)`.

A schema whose `PrivateStateAttr` annotation references a `TYPE_CHECKING`-only name raises `NameError` from `get_type_hints`, so the function returned an empty set with no diagnostic. Every private field on that schema is then forwarded to, and merged back from, subagents — the exact leak the marker exists to prevent, with nothing in the logs to explain it.

This catches only the annotation-resolution errors (`NameError`, `TypeError`, `AttributeError`), logs which schema failed and what the consequence is, and still skips that schema rather than failing the whole agent — a caller may own several unrelated schemas.

Split out of #5164.