### PR TITLE
fix(infra): run release-please after skipped trigger-releases

### DIFF
--- a/.github/scripts/tests/release/test_release_please_workflow.py
+++ b/.github/scripts/tests/release/test_release_please_workflow.py
@@ -93,16 +93,61 @@ def test_release_dispatch_precedes_release_please_maintenance() -> None:
 
     release_please = jobs["release-please"]
     assert "guard-pending-release" in _needs(release_please)
+    # Must stay off this job: `trigger-releases` is skipped on ordinary pushes.
+    # The guard already sequences dispatch-before-maintenance; listing the
+    # skipped job here would reintroduce the #5161 skip poison that left main
+    # green while never refreshing release PRs.
     assert "trigger-releases" not in _needs(release_please)
-    # Exact match, so no status function sneaks in: without one, the implicit
-    # success() gate on `needs` is retained and a red/skipped guard blocks
-    # maintenance. Maintenance may run after release commits, so this must not
-    # re-test `release-commit` either.
-    assert _condition(release_please) == (
-        "needs.guard-pending-release.outputs.skip == 'false'"
-    )
+    # `!cancelled()` is required for the same reason as on the guard: an
+    # upstream-skipped `trigger-releases` would otherwise trip the implicit
+    # success() gate on this job even after a successful `skip=false` guard.
+    # Maintenance may (and should) run after release commits, so this must not
+    # re-test `release-commit`.
+    release_please_if = _condition(release_please)
+    assert "!cancelled()" in release_please_if
+    # Soft-reject only the detector's release-commit *output* gate — job ids may
+    # contain the words "release-commit" (e.g. detect-release-commit).
+    assert "outputs.release-commit" not in release_please_if
+    assert "needs.guard-pending-release.outputs.skip == 'false'" in release_please_if
 
     assert "release-please" in _needs(jobs["update-lockfiles"])
+
+
+def test_release_please_condition_fails_closed() -> None:
+    """Pin maintenance's boolean structure after the #5161 skip-gate fix."""
+    release_please_if = _condition(_load_workflow()["jobs"]["release-please"])
+
+    def runs(
+        skip: str,
+        *,
+        empty_commit: str = "success",
+        detect: str = "success",
+        guard: str = "success",
+        cancelled: bool = False,
+    ) -> bool:
+        return _evaluate(
+            release_please_if,
+            {
+                "needs.guard-empty-commit.result": empty_commit,
+                "needs.detect-release-commit.result": detect,
+                "needs.guard-pending-release.result": guard,
+                "needs.guard-pending-release.outputs.skip": skip,
+            },
+            cancelled=cancelled,
+        )
+
+    # Guard cleared the path — the normal push and post-dispatch release path.
+    assert runs("false")
+    # Guard deferred (in-flight / stuck publish / operator recovery).
+    assert not runs("true")
+    # Unset/empty skip (crash, hard timeout) must not look like all-clear.
+    assert not runs("")
+    # Direct deps: any red/skipped guardian job fails closed.
+    assert not runs("false", empty_commit="failure")
+    assert not runs("false", detect="failure")
+    assert not runs("false", guard="failure")
+    assert not runs("false", guard="skipped")
+    assert not runs("false", cancelled=True)
 
 
 def test_guard_condition_fails_closed() -> None:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -661,12 +661,21 @@ jobs:
 
   release-please:
     needs: [guard-empty-commit, detect-release-commit, guard-pending-release]
-    # Fail closed: run only on an explicit `skip=false`. An unset value (guard
-    # crashed, was skipped, or hit its job timeout before writing the output)
-    # blocks release-please rather than letting it recompute against unverified
-    # state. Release commits reach this job only after successful publish
-    # dispatch and a cleared/authorized pending-label wait above.
-    if: needs.guard-pending-release.outputs.skip == 'false'
+    # #5161 put `trigger-releases` behind the guard so release commits can refresh
+    # sibling release PRs after dispatch. On ordinary pushes `trigger-releases` is
+    # legitimately skipped, and Actions' default `success()` gate on this job then
+    # fails closed even when the guard ran and wrote `skip=false` — observed as a
+    # green workflow with an empty-step `release-please` skip (runs 30487226539 /
+    # 30487483156). Same pattern as the guard: override with `!cancelled()` and
+    # check every direct dependency by hand. Fail closed unless the guard both
+    # succeeded and positively reported `skip=false` (unset/empty after crash or
+    # hard timeout stays blocked).
+    if: |
+      !cancelled() &&
+      needs.guard-empty-commit.result == 'success' &&
+      needs.detect-release-commit.result == 'success' &&
+      needs.guard-pending-release.result == 'success' &&
+      needs.guard-pending-release.outputs.skip == 'false'
     runs-on: ubuntu-latest
     # Serialize only the release-please action, which mutates shared release
     # branches and reads in-flight release state. Keeping this at job scope lets


### PR DESCRIPTION
After #5161, ordinary pushes to `main` skipped the `release-please` maintenance job even when the in-flight-publish guard had already written `skip=false`, so release PRs stopped refreshing.

---

## Why

#5161 made `guard-pending-release` depend on `trigger-releases` so a merged release commit can dispatch publish first, then refresh sibling release PRs. On a normal non-release push, `trigger-releases` is **skipped**.

The guard itself already overrode Actions' default `success()` gate with `!cancelled()` and explicit `needs.*.result` checks, so it still ran and correctly reported `skip=false`.

`release-please` only had:

```yaml
if: needs.guard-pending-release.outputs.skip == 'false'
```

Without a status-check function, Actions still applies the implicit `success()` gate. With a skipped ancestor behind the successful guard, that gate failed closed and `release-please` was skipped with empty steps — leaving the whole workflow green. Observed on:

- https://github.com/langchain-ai/deepagents/actions/runs/30487226539 (#5161 merge)
- https://github.com/langchain-ai/deepagents/actions/runs/30487483156 (`fix(sdk)` follow-up)

## Fix

Give `release-please` the same pattern as the guard:

- `!cancelled()` so the upstream-skipped dispatch job does not poison maintenance
- explicit success checks on every direct dependency
- still require `outputs.skip == 'false'` so crash / hard-timeout / deferred paths stay fail-closed

Tests now pin this truth table (and stop asserting the old bare `skip == 'false'` condition, which is exactly what broke main).
