### PR TITLE
feat(code): click the splash `thread` ID to copy it

### DIFF
--- a/libs/code/deepagents_code/tui/widgets/_copy_spans.py
+++ b/libs/code/deepagents_code/tui/widgets/_copy_spans.py
@@ -1,0 +1,52 @@
+"""Shared click-to-copy span metadata for Textual widgets.
+
+Widgets that render `label: value` rows (the debug console snapshot, the welcome
+banner) mark individual value spans as copyable by embedding the copy text and a
+toast label in the span's style meta. Keeping the meta keys and the
+build/extract pair here means the two ends of the protocol cannot drift apart.
+"""
+
+from __future__ import annotations
+
+from textual.style import Style as TStyle
+
+COPY_TEXT_META = "copy_text"
+"""Meta key marking a span whose text is copied on click."""
+
+COPY_LABEL_META = "copy_label"
+"""Meta key carrying the field label used in the copy toast."""
+
+
+def copy_span_style(text: str, label: str) -> TStyle:
+    """Build the style that marks a span as click-to-copy.
+
+    Args:
+        text: The text copied to the clipboard when the span is clicked.
+        label: The field label used to word the success toast.
+
+    Returns:
+        A style carrying only the copy metadata, so it can be combined with a
+            visual style (e.g. `TStyle(dim=True) + copy_span_style(...)`).
+    """
+    return TStyle.from_meta({COPY_TEXT_META: text, COPY_LABEL_META: label})
+
+
+def copy_span_target(style: object) -> tuple[str, str] | None:
+    """Return the copy text and field label from a span style, if any.
+
+    Args:
+        style: The Textual event style under the pointer/click.
+
+    Returns:
+        `(text, label)` when the span carries a copy marker, else `None`.
+    """
+    meta = getattr(style, "meta", None)
+    if not isinstance(meta, dict):
+        return None
+    text = meta.get(COPY_TEXT_META)
+    if not isinstance(text, str) or not text:
+        return None
+    label = meta.get(COPY_LABEL_META)
+    if not isinstance(label, str) or not label:
+        return None
+    return text, label

--- a/libs/code/deepagents_code/tui/widgets/debug_console.py
+++ b/libs/code/deepagents_code/tui/widgets/debug_console.py
@@ -41,6 +41,7 @@ from deepagents_code._debug_buffer import (
     retention_bucket_for_level,
 )
 from deepagents_code.clipboard import copy_text_to_clipboard
+from deepagents_code.tui.widgets._copy_spans import copy_span_style, copy_span_target
 from deepagents_code.tui.widgets._links import open_style_link
 from deepagents_code.unicode_security import sanitize_control_chars
 
@@ -72,13 +73,6 @@ class SnapshotField(NamedTuple):
     thread_id: str | None = None
     """A LangSmith thread id whose ``(open in langsmith)`` trace link is appended
     to the row once the URL resolves. `None` disables the link."""
-
-
-_SNAPSHOT_COPY_META = "snapshot_copy"
-"""Meta key marking a snapshot span whose text is copied on click."""
-
-_SNAPSHOT_COPY_LABEL_META = "snapshot_copy_label"
-"""Meta key carrying the snapshot field label used in the copy toast."""
 
 
 _REFRESH_INTERVAL = 0.5
@@ -583,27 +577,6 @@ class _DebugLogView(ScrollView, can_focus=True):
             self._on_copy_record(record)
 
 
-def _snapshot_copy_target(style: object) -> tuple[str, str] | None:
-    """Return the copy text and field label from a snapshot span style, if any.
-
-    Args:
-        style: The Textual event style under the pointer/click.
-
-    Returns:
-        `(text, label)` when the span carries a copy marker, else `None`.
-    """
-    meta = getattr(style, "meta", None)
-    if not isinstance(meta, dict):
-        return None
-    text = meta.get(_SNAPSHOT_COPY_META)
-    if not isinstance(text, str) or not text:
-        return None
-    label = meta.get(_SNAPSHOT_COPY_LABEL_META)
-    if not isinstance(label, str) or not label:
-        return None
-    return text, label
-
-
 def _snapshot_copy_success_message(label: str) -> str:
     """Build the toast shown after copying a snapshot field value.
 
@@ -652,7 +625,7 @@ class _SnapshotView(Static):
         if getattr(event.style, "link", None):
             open_style_link(event)
             return
-        target = _snapshot_copy_target(event.style)
+        target = copy_span_target(event.style)
         if target is not None:
             event.stop()
             text, label = target
@@ -661,7 +634,7 @@ class _SnapshotView(Static):
     def on_mouse_move(self, event: events.MouseMove) -> None:
         """Show a hand pointer over clickable spans and reset it elsewhere."""
         clickable = bool(getattr(event.style, "link", None)) or (
-            _snapshot_copy_target(event.style) is not None
+            copy_span_target(event.style) is not None
         )
         self.styles.pointer = "pointer" if clickable else "default"
 
@@ -1098,17 +1071,7 @@ class DebugConsoleScreen(ModalScreen[None]):
             (f"{field.label:>{width}}  ", "bold")
         ]
         if field.copyable and field.value:
-            parts.append(
-                (
-                    field.value,
-                    TStyle.from_meta(
-                        {
-                            _SNAPSHOT_COPY_META: field.value,
-                            _SNAPSHOT_COPY_LABEL_META: field.label,
-                        }
-                    ),
-                )
-            )
+            parts.append((field.value, copy_span_style(field.value, field.label)))
         else:
             parts.append(field.value)
         url = self._langsmith_urls.get(field.thread_id) if field.thread_id else None

--- a/libs/code/deepagents_code/tui/widgets/welcome.py
+++ b/libs/code/deepagents_code/tui/widgets/welcome.py
@@ -29,6 +29,7 @@ from deepagents_code._env_vars import (
 )
 from deepagents_code._version import __version__
 from deepagents_code.config import (
+    _assemble_langsmith_thread_url,
     _get_editable_install_path,
     _is_editable_install,
     fetch_langsmith_project_url,
@@ -36,6 +37,7 @@ from deepagents_code.config import (
     get_langsmith_project_name,
     get_langsmith_replica_project,
 )
+from deepagents_code.tui.widgets._copy_spans import copy_span_style, copy_span_target
 from deepagents_code.tui.widgets._links import open_style_link
 
 logger = logging.getLogger(__name__)
@@ -46,6 +48,9 @@ rather than by the app, so link styles use bold instead of a parsed color."""
 
 _LANGSMITH_UTM_SOURCE: Final[str] = "deepagents-code"
 """UTM source tag appended to LangSmith project URLs in the welcome banner."""
+
+_THREAD_COPY_LABEL: Final[str] = "Thread ID"
+"""Label used to word the toast shown after copying the thread ID."""
 
 
 def _langsmith_project_link(project_url: str) -> str:
@@ -170,8 +175,9 @@ class WelcomeBanner(Static):
     active model
     (`SPLASH_SHOW_MODEL`, opt-in), working directory (`SPLASH_SHOW_CWD`,
     opt-in), LangSmith tracing project and its replica (each clickable once its
-    URL resolves), thread ID (debug mode only), and the MCP tool count. MCP
-    server warnings and the editable-install path follow.
+    URL resolves), thread ID (debug mode only; click to copy, with an
+    `(open in langsmith)` trace link once the project URL resolves), and the MCP
+    tool count. MCP server warnings and the editable-install path follow.
     """
 
     # Disable Textual's auto_links to prevent a flicker cycle: Style.__add__
@@ -301,6 +307,23 @@ class WelcomeBanner(Static):
             return None
         return self._project_urls.get(project)
 
+    def _thread_url(self) -> str | None:
+        """Return the LangSmith trace URL for the current thread.
+
+        Reuses the project URL already resolved for the tracing row, so no extra
+        lookup is made.
+
+        Returns:
+            Thread trace URL, or `None` when the thread ID or project URL is
+                unavailable.
+        """
+        if not self._cli_thread_id:
+            return None
+        project_url = self._project_url(self._project_name)
+        if not project_url:
+            return None
+        return _assemble_langsmith_thread_url(project_url, self._cli_thread_id)
+
     def update_model(self, *, provider: str, model: str) -> None:
         """Track a new model and re-render when it is displayed.
 
@@ -355,13 +378,42 @@ class WelcomeBanner(Static):
         self._mcp_awaiting_reconnect = mcp_awaiting_reconnect
         self.update(self._build_banner())
 
-    def on_click(self, event: Click) -> None:  # noqa: PLR6301  # Textual event handler
-        """Open style-embedded hyperlinks on single click."""
+    def on_click(self, event: Click) -> None:
+        """Copy a marked span (e.g. the thread ID), else open a link span.
+
+        Copy spans never carry a link, so the two branches cannot both apply.
+        """
+        target = copy_span_target(event.style)
+        if target is not None:
+            event.stop()
+            self._copy_span_text(*target)
+            return
         open_style_link(event)
 
+    def _copy_span_text(self, text: str, label: str) -> None:
+        """Copy a clicked span's text to the clipboard with a toast.
+
+        Args:
+            text: The span text to copy.
+            label: The field label used to word the success toast.
+        """
+        from deepagents_code.clipboard import copy_text_to_clipboard
+
+        success, error = copy_text_to_clipboard(self.app, text)
+        if success:
+            self.app.notify(
+                f"{label} copied", severity="information", timeout=2, markup=False
+            )
+            return
+        suffix = f": {error}" if error else ""
+        self.app.notify(
+            f"Failed to copy{suffix}", severity="warning", timeout=3, markup=False
+        )
+
     def on_mouse_move(self, event: MouseMove) -> None:
-        """Show a hand pointer over link spans and reset it elsewhere."""
-        self.styles.pointer = "pointer" if event.style.link else "default"
+        """Show a hand pointer over clickable spans and reset it elsewhere."""
+        clickable = bool(event.style.link) or copy_span_target(event.style) is not None
+        self.styles.pointer = "pointer" if clickable else "default"
 
     def on_leave(self) -> None:
         """Reset the pointer shape when the mouse leaves the banner."""
@@ -377,7 +429,8 @@ class WelcomeBanner(Static):
             installs when the version is shown), followed by any applicable rows
             in order: model (when `SPLASH_SHOW_MODEL`), directory (when
             `SPLASH_SHOW_CWD`), tracing and replica (each clickable once its URL
-            resolves), thread ID (debug only), MCP tool count, MCP server
+            resolves), thread ID (debug only; click-to-copy plus a trace link
+            once the project URL resolves), MCP tool count, MCP server
             warnings, and the editable-install path.
         """
         colors = theme.get_theme_colors(self)
@@ -466,7 +519,20 @@ class WelcomeBanner(Static):
                     [("replica:   ", "dim"), (f"'{self._replica_project}'", accent)]
                 )
         if self._show_thread_id and self._cli_thread_id:
-            rows.append([("thread:    ", "dim"), (self._cli_thread_id, "dim")])
+            thread_row: list[tuple[str, str | TStyle]] = [
+                ("thread:    ", "dim"),
+                (
+                    self._cli_thread_id,
+                    TStyle(dim=True)
+                    + copy_span_style(self._cli_thread_id, _THREAD_COPY_LABEL),
+                ),
+            ]
+            thread_url = self._thread_url()
+            if thread_url:
+                thread_row.extend(
+                    [("  ", "dim"), ("(open in langsmith)", TStyle(link=thread_url))]
+                )
+            rows.append(thread_row)
         if self._mcp_tool_count > 0:
             label = "tool" if self._mcp_tool_count == 1 else "tools"
             rows.append(

--- a/libs/code/tests/unit_tests/test_debug_console.py
+++ b/libs/code/tests/unit_tests/test_debug_console.py
@@ -15,6 +15,7 @@ from textual.widgets._select import SelectOverlay
 import deepagents_code.tui.widgets.debug_console as debug_console_mod
 from deepagents_code._debug_buffer import InMemoryLogRecord, get_log_buffer
 from deepagents_code.app import DeepAgentsApp
+from deepagents_code.tui.widgets._copy_spans import COPY_LABEL_META, COPY_TEXT_META
 from deepagents_code.tui.widgets.debug_console import (
     DebugConsoleScreen,
     SnapshotField,
@@ -1310,10 +1311,8 @@ class TestDebugConsoleScreen:
                 span
                 for span in content.spans
                 if isinstance(span.style, debug_console_mod.TStyle)
-                and span.style.meta.get(debug_console_mod._SNAPSHOT_COPY_META)
-                == "thread-abc"
-                and span.style.meta.get(debug_console_mod._SNAPSHOT_COPY_LABEL_META)
-                == "Thread"
+                and span.style.meta.get(COPY_TEXT_META) == "thread-abc"
+                and span.style.meta.get(COPY_LABEL_META) == "Thread"
             ]
             assert any(
                 content.plain[span.start : span.end] == "thread-abc"

--- a/libs/code/tests/unit_tests/tui/widgets/test_copy_spans.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_copy_spans.py
@@ -1,0 +1,43 @@
+"""Unit tests for the shared click-to-copy span metadata helpers."""
+
+from __future__ import annotations
+
+from textual.style import Style as TStyle
+
+from deepagents_code.tui.widgets._copy_spans import copy_span_style, copy_span_target
+
+
+class TestCopySpanRoundTrip:
+    """`copy_span_style` output is readable by `copy_span_target`."""
+
+    def test_round_trip(self) -> None:
+        style = copy_span_style("abc-123", "Thread ID")
+
+        assert copy_span_target(style) == ("abc-123", "Thread ID")
+
+    def test_combines_with_a_visual_style(self) -> None:
+        style = TStyle(dim=True) + copy_span_style("abc-123", "Thread ID")
+
+        assert style.dim is True
+        assert copy_span_target(style) == ("abc-123", "Thread ID")
+
+
+class TestCopySpanTargetRejects:
+    """Styles without usable copy metadata resolve to `None`."""
+
+    def test_style_without_meta(self) -> None:
+        assert copy_span_target(TStyle(dim=True)) is None
+
+    def test_style_string(self) -> None:
+        assert copy_span_target("dim") is None
+
+    def test_empty_text(self) -> None:
+        assert copy_span_target(copy_span_style("", "Thread ID")) is None
+
+    def test_empty_label(self) -> None:
+        assert copy_span_target(copy_span_style("abc-123", "")) is None
+
+    def test_non_string_values(self) -> None:
+        style = TStyle.from_meta({"copy_text": 1, "copy_label": 2})
+
+        assert copy_span_target(style) is None

--- a/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_welcome.py
@@ -4,9 +4,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from textual.app import App, ComposeResult
 from textual.content import Content
 from textual.style import Style as TStyle
 
+from deepagents_code import clipboard as clipboard_module
 from deepagents_code._env_vars import (
     DEBUG,
     EXPERIMENTAL,
@@ -18,6 +20,8 @@ from deepagents_code._env_vars import (
     SPLASH_SHOW_MODEL,
 )
 from deepagents_code._version import __version__
+from deepagents_code.tui.widgets import welcome as welcome_module
+from deepagents_code.tui.widgets._copy_spans import copy_span_target
 from deepagents_code.tui.widgets.welcome import (
     WelcomeBanner,
     _debug_tag_style,
@@ -789,6 +793,156 @@ class TestThreadLine:
         """No thread row in debug mode when the thread ID is unset."""
         plain = _make_banner(thread_id=None, env={DEBUG: "1"})._build_banner().plain
         assert "thread:" not in plain
+
+    def test_thread_id_span_is_marked_copyable(self) -> None:
+        """The thread ID span carries the click-to-copy metadata."""
+        content = _make_banner(thread_id="abc-123", env={DEBUG: "1"})._build_banner()
+        style = _style_covering(content, "abc-123")
+        assert copy_span_target(style) == ("abc-123", "Thread ID")
+        assert style.dim is True
+
+    def test_langsmith_link_appended_once_project_url_resolves(self) -> None:
+        """A resolved project URL adds a thread trace link to the row."""
+        content = _make_banner(
+            thread_id="abc-123",
+            project_name="proj",
+            project_urls={"proj": "https://smith.langchain.com/o/org/projects/p/p1"},
+            env={DEBUG: "1"},
+        )._build_banner()
+        assert "(open in langsmith)" in content.plain
+        link = _style_covering(content, "(open in langsmith)").link
+        assert link == (
+            "https://smith.langchain.com/o/org/projects/p/p1/t/abc-123"
+            "?utm_source=deepagents-code"
+        )
+
+    def test_no_langsmith_link_before_project_url_resolves(self) -> None:
+        """The row stays link-free while the project URL is unresolved."""
+        plain = (
+            _make_banner(thread_id="abc-123", project_name="proj", env={DEBUG: "1"})
+            ._build_banner()
+            .plain
+        )
+        assert "(open in langsmith)" not in plain
+
+    def test_no_langsmith_link_without_tracing(self) -> None:
+        """No trace link when LangSmith tracing is not configured."""
+        plain = (
+            _make_banner(thread_id="abc-123", env={DEBUG: "1"})._build_banner().plain
+        )
+        assert "(open in langsmith)" not in plain
+
+
+class _BannerApp(App[None]):
+    """Minimal app that mounts a prebuilt `WelcomeBanner` for click tests."""
+
+    def __init__(self, banner: WelcomeBanner) -> None:
+        super().__init__()
+        self._banner = banner
+
+    def compose(self) -> ComposeResult:
+        yield self._banner
+
+
+def _click_offset(banner: WelcomeBanner, needle: str) -> tuple[int, int]:
+    """Return a click offset inside the rendered span containing `needle`.
+
+    Derives the offset from the rendered text instead of hardcoding columns, then
+    shifts it by the banner's border (1 column, 1 row) and horizontal padding
+    (2 columns) so it addresses the widget's own coordinate space.
+
+    Args:
+        banner: The banner whose content is measured.
+        needle: Substring identifying the target span.
+
+    Returns:
+        The `(x, y)` offset to click.
+    """
+    border_x, border_y, padding_x = 1, 1, 2
+    for y, line in enumerate(banner._build_banner().plain.split("\n")):
+        column = line.find(needle)
+        if column != -1:
+            return border_x + padding_x + column, border_y + y
+    msg = f"{needle!r} not found in the rendered banner"
+    raise AssertionError(msg)
+
+
+class TestThreadIdClickToCopy:
+    """Clicking the thread ID copies it; the trace link still opens."""
+
+    async def test_click_copies_thread_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Clicking the thread ID copies it and reports success."""
+        copied: list[str] = []
+
+        def fake_copy(_app: App[None], text: str) -> tuple[bool, str | None]:
+            copied.append(text)
+            return True, None
+
+        monkeypatch.setattr(clipboard_module, "copy_text_to_clipboard", fake_copy)
+        banner = _make_banner(thread_id="abc-123", show_model=False, env={DEBUG: "1"})
+        app = _BannerApp(banner)
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.click(banner, offset=_click_offset(banner, "abc-123"))
+            await pilot.pause()
+
+            assert copied == ["abc-123"]
+            latest = list(app._notifications)[-1]
+            assert latest.message == "Thread ID copied"
+
+    async def test_copy_failure_notifies_warning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A clipboard failure surfaces the backend error in a warning toast."""
+
+        def fake_copy(_app: App[None], _text: str) -> tuple[bool, str | None]:
+            return False, "clipboard unavailable"
+
+        monkeypatch.setattr(clipboard_module, "copy_text_to_clipboard", fake_copy)
+        banner = _make_banner(thread_id="abc-123", show_model=False, env={DEBUG: "1"})
+        app = _BannerApp(banner)
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.click(banner, offset=_click_offset(banner, "abc-123"))
+            await pilot.pause()
+
+            latest = list(app._notifications)[-1]
+            assert latest.severity == "warning"
+            assert "clipboard unavailable" in latest.message
+
+    async def test_clicking_trace_link_opens_it_without_copying(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The trace link opens in the browser and never copies."""
+        copied: list[str] = []
+
+        def fake_copy(_app: App[None], text: str) -> tuple[bool, str | None]:
+            copied.append(text)
+            return True, None
+
+        monkeypatch.setattr(clipboard_module, "copy_text_to_clipboard", fake_copy)
+        opened: list[object] = []
+        monkeypatch.setattr(
+            welcome_module, "open_style_link", lambda event: opened.append(event)
+        )
+        banner = _make_banner(
+            thread_id="abc-123", show_model=False, project_name="proj", env={DEBUG: "1"}
+        )
+        app = _BannerApp(banner)
+        project_url = "https://smith.langchain.com/o/org/projects/p/p1"
+        # The mounted banner renders the link only after its startup worker
+        # resolves the project URL, so patch the fetch and let the worker run.
+        with patch(_FETCH_URL, return_value=project_url):
+            async with app.run_test(size=(80, 24)) as pilot:
+                await pilot.pause()
+                assert banner._project_urls == {"proj": project_url}
+                await pilot.click(
+                    banner, offset=_click_offset(banner, "(open in langsmith)")
+                )
+                await pilot.pause()
+
+                assert len(opened) == 1
+                assert copied == []
 
 
 class TestMcpToolLine:


### PR DESCRIPTION
Clicking the thread ID on the startup splash now copies it, and the row links to the thread's LangSmith trace.

---

The Debug Console already lets you click a thread ID to copy it and shows an `(open in langsmith)` trace link, but the startup splash rendered the same ID as inert text. The splash thread ID is now a click-to-copy span (toast: "Thread ID copied"), and the row gains the same `(open in langsmith)` link built from the project URL the banner already resolves in the background — no extra lookup. The copy-span meta protocol moved to a shared `tui/widgets/_copy_spans.py` so the banner and the console can't drift apart.

Note: the splash `thread:` row only renders in debug mode (`DEEPAGENTS_CODE_DEBUG`), unchanged by this PR.

Made by [Open SWE](https://openswe.vercel.app/agents/3168ee95-5a3e-fe72-c36f-f5ba194e42d4)