### PR TITLE
feat(code): warn on expensive conversations

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -252,6 +252,47 @@ def _coerce_session_cost_usd(value: object) -> float:
     return cost_usd if math.isfinite(cost_usd) and cost_usd >= 0 else 0.0
 
 
+def _load_cost_warning_threshold_usd() -> float | None:
+    """Load the optional non-negative conversation cost warning threshold.
+
+    Returns:
+        The configured threshold, or `None` when warnings are disabled.
+    """
+    from deepagents_code.config_manifest import (
+        get_option,
+        load_config_toml,
+        resolve_scalar,
+    )
+
+    option = get_option("warnings.cost_threshold_usd")
+    if option is None:
+        logger.warning("Cost warning config option is missing; warning is disabled")
+        return None
+
+    value, source = resolve_scalar(option, toml_data=load_config_toml())
+    if value is None:
+        return None
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        logger.warning(
+            "Ignoring %s=%r from %s (expected a finite number >= 0)",
+            option.key,
+            value,
+            source,
+        )
+        return None
+
+    threshold_usd = float(value)
+    if not math.isfinite(threshold_usd) or threshold_usd < 0:
+        logger.warning(
+            "Ignoring %s=%r from %s (expected a finite number >= 0)",
+            option.key,
+            value,
+            source,
+        )
+        return None
+    return threshold_usd
+
+
 def _warn_discarded_goal_channels(state_values: dict[str, Any]) -> list[str]:
     """Report persisted goal/rubric channels that are present but malformed.
 
@@ -3630,6 +3671,14 @@ class DeepAgentsApp(App):
         self._thread_restored_cost_usd: float = 0.0
         """Checkpoint cost without a local per-model breakdown."""
 
+        self._cost_warning_threshold_usd: float | None = (
+            _load_cost_warning_threshold_usd()
+        )
+        """Configured USD threshold, or `None` when cost warnings are disabled."""
+
+        self._cost_warning_shown: bool = False
+        """Whether the active conversation already crossed its warning threshold."""
+
         # Session lazy state & startup
         self._session_state: TextualSessionState | None = None
         """Auto-approve + thread state shared with `execute_task_textual`.
@@ -6825,6 +6874,31 @@ class DeepAgentsApp(App):
         """Show the server total plus any spend it has not accounted for yet."""
         if self._status_bar:
             self._status_bar.set_cost(self._displayed_cost_usd)
+        self._maybe_warn_session_cost()
+
+    def _maybe_warn_session_cost(self) -> None:
+        """Warn once when the active conversation exceeds its cost threshold."""
+        threshold_usd = self._cost_warning_threshold_usd
+        displayed_cost_usd = self._displayed_cost_usd
+        if (
+            threshold_usd is None
+            or self._cost_warning_shown
+            or displayed_cost_usd <= threshold_usd
+        ):
+            return
+
+        self._cost_warning_shown = True
+        self.notify(
+            (
+                f"Estimated conversation cost is {format_cost(displayed_cost_usd)}, "
+                f"above your {format_cost(threshold_usd)} warning threshold. "
+                "Use /cost for details."
+            ),
+            title="Cost warning",
+            severity="warning",
+            timeout=8,
+            markup=False,
+        )
 
     def _reset_thread_usage(self, cost_usd: float = 0.0) -> None:
         """Start local usage details for a newly activated thread.
@@ -6833,6 +6907,7 @@ class DeepAgentsApp(App):
             cost_usd: Cumulative cost restored from that thread's checkpoint.
         """
         self._thread_stats = SessionStats()
+        self._cost_warning_shown = False
         self._thread_restored_cost_usd = _coerce_session_cost_usd(cost_usd)
         self._set_session_cost(self._thread_restored_cost_usd)
 

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -6864,6 +6864,7 @@ class DeepAgentsApp(App):
         self._session_cost_usd = _coerce_session_cost_usd(cost_usd)
         self._provisional_cost_usd = 0.0
         self._refresh_session_cost_display()
+        self._maybe_warn_session_cost()
 
     @property
     def _displayed_cost_usd(self) -> float:
@@ -6874,23 +6875,22 @@ class DeepAgentsApp(App):
         """Show the server total plus any spend it has not accounted for yet."""
         if self._status_bar:
             self._status_bar.set_cost(self._displayed_cost_usd)
-        self._maybe_warn_session_cost()
 
     def _maybe_warn_session_cost(self) -> None:
-        """Warn once when the active conversation exceeds its cost threshold."""
+        """Warn once when authoritative conversation cost exceeds its threshold."""
         threshold_usd = self._cost_warning_threshold_usd
-        displayed_cost_usd = self._displayed_cost_usd
+        session_cost_usd = self._session_cost_usd
         if (
             threshold_usd is None
             or self._cost_warning_shown
-            or displayed_cost_usd <= threshold_usd
+            or session_cost_usd <= threshold_usd
         ):
             return
 
         self._cost_warning_shown = True
         self.notify(
             (
-                f"Estimated conversation cost is {format_cost(displayed_cost_usd)}, "
+                f"Estimated conversation cost is {format_cost(session_cost_usd)}, "
                 f"above your {format_cost(threshold_usd)} warning threshold. "
                 "Use /cost for details."
             ),

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -1340,6 +1340,13 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
     ),
     # --- Warnings ------------------------------------------------------
     ConfigOption(
+        key="warnings.cost_threshold_usd",
+        group="Warnings",
+        summary="Warn when a conversation's estimated USD cost exceeds this value.",
+        kind=OptionKind.FLOAT,
+        toml_keys=("warnings", "cost_threshold_usd"),
+    ),
+    ConfigOption(
         key="warnings.suppress",
         group="Warnings",
         summary=(

--- a/libs/code/tests/unit_tests/test_cost_warning.py
+++ b/libs/code/tests/unit_tests/test_cost_warning.py
@@ -1,0 +1,110 @@
+"""Tests for configurable conversation cost warnings."""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import patch
+
+import pytest
+
+from deepagents_code.app import DeepAgentsApp, _load_cost_warning_threshold_usd
+from deepagents_code.config_manifest import OptionKind, get_option, resolve_scalar
+
+
+def test_cost_warning_manifest_option() -> None:
+    """The threshold is discoverable and resolves config-file numbers."""
+    option = get_option("warnings.cost_threshold_usd")
+
+    assert option is not None
+    assert option.kind is OptionKind.FLOAT
+    assert option.default is None
+    assert option.toml_keys == ("warnings", "cost_threshold_usd")
+    assert resolve_scalar(option, toml_data={}) == (None, "default")
+    assert resolve_scalar(
+        option,
+        toml_data={"warnings": {"cost_threshold_usd": 2.5}},
+    ) == (2.5, "config.toml")
+
+
+@pytest.mark.parametrize("value", [-0.01, math.inf, -math.inf, math.nan])
+def test_cost_warning_loader_rejects_invalid_values(
+    monkeypatch: pytest.MonkeyPatch,
+    value: float,
+) -> None:
+    """Negative and non-finite thresholds disable the warning."""
+    monkeypatch.setattr(
+        "deepagents_code.config_manifest.load_config_toml",
+        lambda: {"warnings": {"cost_threshold_usd": value}},
+    )
+
+    assert _load_cost_warning_threshold_usd() is None
+
+
+def test_cost_warning_loader_accepts_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A zero threshold warns on the first positive estimated cost."""
+    monkeypatch.setattr(
+        "deepagents_code.config_manifest.load_config_toml",
+        lambda: {"warnings": {"cost_threshold_usd": 0}},
+    )
+
+    assert _load_cost_warning_threshold_usd() == pytest.approx(0.0)
+
+
+def test_cost_warning_is_strict_and_shown_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only cost above the threshold warns, including provisional spend."""
+    monkeypatch.setattr(
+        "deepagents_code.app._load_cost_warning_threshold_usd",
+        lambda: 1.0,
+    )
+    app = DeepAgentsApp()
+
+    with patch.object(app, "notify") as notify:
+        app._set_session_cost(1.0)
+        notify.assert_not_called()
+
+        app._add_provisional_cost(0.01)
+        notify.assert_called_once_with(
+            (
+                "Estimated conversation cost is $1.01, above your $1.00 "
+                "warning threshold. Use /cost for details."
+            ),
+            title="Cost warning",
+            severity="warning",
+            timeout=8,
+            markup=False,
+        )
+
+        app._set_session_cost(1.01)
+        app._add_provisional_cost(0.5)
+        assert notify.call_count == 1
+
+
+def test_cost_warning_disabled_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No notification is shown when the threshold is not configured."""
+    monkeypatch.setattr(
+        "deepagents_code.app._load_cost_warning_threshold_usd",
+        lambda: None,
+    )
+    app = DeepAgentsApp()
+
+    with patch.object(app, "notify") as notify:
+        app._set_session_cost(100.0)
+
+    notify.assert_not_called()
+
+
+def test_cost_warning_resets_for_loaded_conversation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resetting usage lets a restored over-threshold conversation warn."""
+    monkeypatch.setattr(
+        "deepagents_code.app._load_cost_warning_threshold_usd",
+        lambda: 1.0,
+    )
+    app = DeepAgentsApp()
+
+    with patch.object(app, "notify") as notify:
+        app._set_session_cost(1.25)
+        app._reset_thread_usage(1.5)
+
+    assert notify.call_count == 2

--- a/libs/code/tests/unit_tests/test_cost_warning.py
+++ b/libs/code/tests/unit_tests/test_cost_warning.py
@@ -51,7 +51,7 @@ def test_cost_warning_loader_accepts_zero(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_cost_warning_is_strict_and_shown_once(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Only cost above the threshold warns, including provisional spend."""
+    """Only authoritative cost above the threshold warns once."""
     monkeypatch.setattr(
         "deepagents_code.app._load_cost_warning_threshold_usd",
         lambda: 1.0,
@@ -63,6 +63,9 @@ def test_cost_warning_is_strict_and_shown_once(monkeypatch: pytest.MonkeyPatch) 
         notify.assert_not_called()
 
         app._add_provisional_cost(0.01)
+        notify.assert_not_called()
+
+        app._set_session_cost(1.01)
         notify.assert_called_once_with(
             (
                 "Estimated conversation cost is $1.01, above your $1.00 "
@@ -74,8 +77,8 @@ def test_cost_warning_is_strict_and_shown_once(monkeypatch: pytest.MonkeyPatch) 
             markup=False,
         )
 
-        app._set_session_cost(1.01)
         app._add_provisional_cost(0.5)
+        app._set_session_cost(1.51)
         assert notify.call_count == 1
 
 


### PR DESCRIPTION
Deep Agents Code can now warn once per conversation when estimated model spend exceeds `[warnings].cost_threshold_usd`.

---

The threshold is config-only and disabled when unset. Notifications use the graph-owned cumulative total so transient provisional display estimates cannot trigger false warnings.

<details><summary>Test plan</summary>

- `pytest tests/unit_tests/test_cost_warning.py tests/unit_tests/test_config_manifest.py tests/unit_tests/test_resume_state.py`
- `make lint`

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/7c80f920-fa8a-0382-1a18-8aa8aaa38f57)