### PR TITLE
fix(code): stabilize hook resumes across identity and Command tool results

### DIFF
--- a/libs/code/deepagents_code/hooks/models/domain.py
+++ b/libs/code/deepagents_code/hooks/models/domain.py
@@ -11,12 +11,6 @@ from uuid import (
     UUID,  # ruff:ignore[typing-only-standard-library-import] - Pydantic resolves model annotations at runtime.
 )
 
-from langchain_core.messages import (  # ruff:ignore[typing-only-third-party-import] - Pydantic runtime annotation.
-    ToolMessage,
-)
-from langgraph.types import (
-    Command,  # ruff:ignore[typing-only-third-party-import] - Pydantic runtime annotation.
-)
 from pydantic import BaseModel, ConfigDict, Field
 
 from deepagents_code.approval_mode import (  # ruff:ignore[typing-only-first-party-import] - Pydantic runtime annotation.
@@ -24,6 +18,7 @@ from deepagents_code.approval_mode import (  # ruff:ignore[typing-only-first-par
 )
 from deepagents_code.json_types import (  # ruff:ignore[typing-only-first-party-import] - Pydantic runtime annotation.
     JsonObject,
+    JsonValue,
 )
 
 
@@ -205,11 +200,17 @@ class PreToolUseEvent(_DomainModel):
 
 
 class PostToolUseEvent(_DomainModel):
-    """Domain payload for `PostToolUse`."""
+    """Domain payload for `PostToolUse`.
+
+    `result` is the JSON projection of the native tool return value
+    (`to_wire_tool_result`), not a live `Command` / `ToolMessage`. The live
+    value stays in the tool wrapper for decision application; only JSON crosses
+    the interrupt boundary to the client.
+    """
 
     event: Literal[HookEvent.POST_TOOL_USE]
     call: ToolCallData
-    result: Command[str] | ToolMessage
+    result: JsonValue
     duration_ms: int | None = None
 
 

--- a/libs/code/deepagents_code/hooks/models/domain.py
+++ b/libs/code/deepagents_code/hooks/models/domain.py
@@ -6,20 +6,25 @@ from enum import StrEnum
 from pathlib import (
     Path,  # ruff:ignore[typing-only-standard-library-import] - Pydantic resolves model annotations at runtime.
 )
-from typing import Annotated, Literal, TypeAlias
+from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeAlias
 from uuid import (
     UUID,  # ruff:ignore[typing-only-standard-library-import] - Pydantic resolves model annotations at runtime.
 )
 
+from langchain_core.messages import ToolMessage
 from pydantic import BaseModel, ConfigDict, Field
 
 from deepagents_code.approval_mode import (  # ruff:ignore[typing-only-first-party-import] - Pydantic runtime annotation.
     ApprovalMode,
 )
-from deepagents_code.json_types import (  # ruff:ignore[typing-only-first-party-import] - Pydantic runtime annotation.
+from deepagents_code.json_types import (
+    JSON_VALUE_ADAPTER,
     JsonObject,
     JsonValue,
 )
+
+if TYPE_CHECKING:
+    from langgraph.types import Command
 
 
 class _DomainModel(BaseModel):
@@ -202,16 +207,50 @@ class PreToolUseEvent(_DomainModel):
 class PostToolUseEvent(_DomainModel):
     """Domain payload for `PostToolUse`.
 
-    `result` is the JSON projection of the native tool return value
-    (`to_wire_tool_result`), not a live `Command` / `ToolMessage`. The live
-    value stays in the tool wrapper for decision application; only JSON crosses
-    the interrupt boundary to the client.
+    `result` is the JSON projection of the native tool return value, not a
+    live `Command` / `ToolMessage`. The live value stays in the tool wrapper
+    for decision application; only JSON crosses the interrupt boundary to the
+    client.
     """
 
     event: Literal[HookEvent.POST_TOOL_USE]
     call: ToolCallData
     result: JsonValue
     duration_ms: int | None = None
+
+    @classmethod
+    def from_tool_result(
+        cls,
+        result: ToolMessage | Command[Any],
+        *,
+        call: ToolCallData,
+        duration_ms: int | None = None,
+    ) -> PostToolUseEvent:
+        """Build a `PostToolUseEvent` from a native tool return value.
+
+        `PostToolUse` crosses a LangGraph interrupt boundary, so the domain
+        event must carry JSON — not a live `Command` / `ToolMessage`.
+        Re-validating a dumped `Command` as `ToolMessage` raises
+        `KeyError: 'tool_call_id'` in LangChain's message coercion.
+
+        Args:
+            result: Native tool return value from the tool wrapper.
+            call: Tool-call data for the hook payload.
+            duration_ms: Tool execution duration in milliseconds.
+
+        Returns:
+            A `PostToolUseEvent` with a JSON-projected `result`.
+        """
+        if isinstance(result, ToolMessage):
+            value: object = result.model_dump(mode="json")
+        else:
+            value = JSON_VALUE_ADAPTER.dump_python(result, mode="json", warnings=False)
+        return cls(
+            event=HookEvent.POST_TOOL_USE,
+            call=call,
+            result=JSON_VALUE_ADAPTER.validate_python(value),
+            duration_ms=duration_ms,
+        )
 
 
 class PreCompactEvent(_DomainModel):

--- a/libs/code/deepagents_code/hooks/projection.py
+++ b/libs/code/deepagents_code/hooks/projection.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from functools import singledispatch
 from typing import TYPE_CHECKING, NotRequired, TypedDict
 
-from langchain_core.messages import ToolMessage
-
 from deepagents_code.approval_mode import ApprovalMode
 from deepagents_code.hooks.models.adapters import HOOK_WIRE_INPUT_ADAPTER
 from deepagents_code.hooks.models.domain import (
@@ -43,13 +41,10 @@ from deepagents_code.hooks.models.wire import (
     WirePermissionMode,
 )
 from deepagents_code.hooks.tools import to_wire_call
-from deepagents_code.json_types import JSON_VALUE_ADAPTER, JsonValue
 
 if TYPE_CHECKING:
     from pathlib import Path
     from uuid import UUID
-
-    from langgraph.types import Command
 
     from deepagents_code.hooks.models.domain import (
         AgentIdentity,
@@ -218,7 +213,7 @@ def _project_post_tool_use(
         hook_event_name=HookEvent.POST_TOOL_USE,
         tool_name=tool_name,
         tool_input=tool_input,
-        tool_response=_tool_result(event.result),
+        tool_response=event.result,
         tool_use_id=event.call.id,
         duration_ms=event.duration_ms,
     )
@@ -386,11 +381,3 @@ def to_wire_notification_type(value: str) -> WireNotificationType:
     except KeyError as exc:
         msg = f"Unsupported notification type: {value}"
         raise ValueError(msg) from exc
-
-
-def _tool_result(result: ToolMessage | Command[str]) -> JsonValue:
-    if isinstance(result, ToolMessage):
-        value: object = result.model_dump(mode="json")
-    else:
-        value = JSON_VALUE_ADAPTER.dump_python(result, mode="json", warnings=False)
-    return JSON_VALUE_ADAPTER.validate_python(value)

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -715,13 +715,18 @@ def _invocation_id(
     # starts a new run. Mixing `run_id` in made the id differ across the very
     # boundary it guards, so any event re-derived after a resume (`PostToolUse`
     # and the subagent events, which run inside the replayed tool wrapper)
-    # always mismatched. The remaining fields identify the event uniquely.
+    # always mismatched.
+    #
+    # `prompt_id` takes its place as the per-turn discriminator: the client
+    # advances it once per user prompt and holds it across every resume of that
+    # turn, so tool-call ids reused by a later turn cannot collide with this
+    # one and replay its cached decision from the fulfillment ledger.
     identity = {
         "thread_id": context.thread_id,
         "snapshot_id": snapshot_id,
+        "prompt_id": str(context.prompt_id) if context.prompt_id is not None else "",
         "event": event.event.value,
         "logical_event": _logical_event_identity(
-            context,
             event,
             logical_event_id=logical_event_id,
         ),
@@ -733,7 +738,6 @@ def _invocation_id(
 
 
 def _logical_event_identity(
-    context: HookContext,
     event: (
         PreToolUseEvent
         | PostToolUseEvent
@@ -754,11 +758,10 @@ def _logical_event_identity(
         raise ValueError(msg)
     if isinstance(event, SubagentStartEvent):
         return event.agent.id
-    prompt_id = str(context.prompt_id) if context.prompt_id is not None else ""
     if isinstance(event, SubagentStopEvent):
-        return f"{event.agent.id}:{event.continuation_count}:{prompt_id}"
+        return f"{event.agent.id}:{event.continuation_count}"
     message_hash = hashlib.sha256(event.last_assistant_message.encode()).hexdigest()
-    return f"{event.continuation_count}:{prompt_id}:{message_hash}"
+    return f"{event.continuation_count}:{message_hash}"
 
 
 def _config_thread_id(config: Mapping[str, Any] | None) -> str | None:

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -710,17 +710,6 @@ def _invocation_id(
     ),
     logical_event_id: str | None = None,
 ) -> UUID:
-    # Deliberately excludes `run_id`: this id is echoed by the client and
-    # re-derived here to validate the resume, but every `Command(resume=...)`
-    # starts a new run. Mixing `run_id` in made the id differ across the very
-    # boundary it guards, so any event re-derived after a resume (`PostToolUse`
-    # and the subagent events, which run inside the replayed tool wrapper)
-    # always mismatched.
-    #
-    # `prompt_id` takes its place as the per-turn discriminator: the client
-    # advances it once per user prompt and holds it across every resume of that
-    # turn, so tool-call ids reused by a later turn cannot collide with this
-    # one and replay its cached decision from the fulfillment ledger.
     identity = {
         "thread_id": context.thread_id,
         "snapshot_id": snapshot_id,

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -612,7 +612,6 @@ def _invoke_hook(
         raise RuntimeError(msg)
     run_id = _run_id(config, context.thread_id)
     invocation_id = _invocation_id(
-        run_id=run_id,
         snapshot_id=gate["snapshot_id"],
         context=context,
         event=event,
@@ -699,7 +698,6 @@ def _run_id(config: Mapping[str, Any] | None, thread_id: str) -> str:
 
 def _invocation_id(
     *,
-    run_id: str,
     snapshot_id: str,
     context: HookContext,
     event: (
@@ -712,8 +710,13 @@ def _invocation_id(
     ),
     logical_event_id: str | None = None,
 ) -> UUID:
+    # Deliberately excludes `run_id`: this id is echoed by the client and
+    # re-derived here to validate the resume, but every `Command(resume=...)`
+    # starts a new run. Mixing `run_id` in made the id differ across the very
+    # boundary it guards, so any event re-derived after a resume (`PostToolUse`
+    # and the subagent events, which run inside the replayed tool wrapper)
+    # always mismatched. The remaining fields identify the event uniquely.
     identity = {
-        "run_id": run_id,
         "thread_id": context.thread_id,
         "snapshot_id": snapshot_id,
         "event": event.event.value,

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -71,7 +71,7 @@ from deepagents_code.hooks.models.domain import (
     ToolCallData,
 )
 from deepagents_code.hooks.models.transport import HookInvocationRequest
-from deepagents_code.hooks.tools import to_wire_tool_name, to_wire_tool_result
+from deepagents_code.hooks.tools import to_wire_tool_name
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterator
@@ -430,10 +430,9 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
             return result
         decision = _invoke_hook(
             context,
-            PostToolUseEvent(
-                event=HookEvent.POST_TOOL_USE,
+            PostToolUseEvent.from_tool_result(
+                result,
                 call=call,
-                result=to_wire_tool_result(result),
                 duration_ms=duration_ms,
             ),
             gate=gate,

--- a/libs/code/deepagents_code/hooks/server_middleware.py
+++ b/libs/code/deepagents_code/hooks/server_middleware.py
@@ -71,7 +71,7 @@ from deepagents_code.hooks.models.domain import (
     ToolCallData,
 )
 from deepagents_code.hooks.models.transport import HookInvocationRequest
-from deepagents_code.hooks.tools import to_wire_tool_name
+from deepagents_code.hooks.tools import to_wire_tool_name, to_wire_tool_result
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterator
@@ -433,7 +433,7 @@ class ServerHooksMiddleware(AgentMiddleware[ServerHooksState, ContextT, Response
             PostToolUseEvent(
                 event=HookEvent.POST_TOOL_USE,
                 call=call,
-                result=result,
+                result=to_wire_tool_result(result),
                 duration_ms=duration_ms,
             ),
             gate=gate,

--- a/libs/code/deepagents_code/hooks/tools.py
+++ b/libs/code/deepagents_code/hooks/tools.py
@@ -3,19 +3,13 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any
-
-from langchain_core.messages import ToolMessage
-
-from deepagents_code.json_types import JSON_VALUE_ADAPTER
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from langgraph.types import Command
-
     from deepagents_code.hooks.models.domain import ToolCallData
-    from deepagents_code.json_types import JsonObject, JsonValue
+    from deepagents_code.json_types import JsonObject
 
 
 def _select(args: JsonObject, *fields: str) -> JsonObject:
@@ -151,25 +145,3 @@ def to_wire_call(
     if call.mcp_server is not None or _MCP_WIRE_RE.fullmatch(call.name) is not None:
         return name, dict(call.args)
     return name, to_wire_tool_input(call.name, call.args)
-
-
-def to_wire_tool_result(result: ToolMessage | Command[Any]) -> JsonValue:
-    """Project a native tool result into JSON for hook transport and wire input.
-
-    `PostToolUse` crosses a LangGraph interrupt boundary, so the domain event must
-    carry JSON — not a live `Command` / `ToolMessage`. Re-validating a dumped
-    `Command` as `ToolMessage` raises `KeyError: 'tool_call_id'` in LangChain's
-    message coercion.
-
-    Args:
-        result: Native tool return value from the tool wrapper.
-
-    Returns:
-        JSON-compatible tool response for `PostToolUseEvent.result` / wire
-        `tool_response`.
-    """
-    if isinstance(result, ToolMessage):
-        value: object = result.model_dump(mode="json")
-    else:
-        value = JSON_VALUE_ADAPTER.dump_python(result, mode="json", warnings=False)
-    return JSON_VALUE_ADAPTER.validate_python(value)

--- a/libs/code/deepagents_code/hooks/tools.py
+++ b/libs/code/deepagents_code/hooks/tools.py
@@ -3,13 +3,19 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.messages import ToolMessage
+
+from deepagents_code.json_types import JSON_VALUE_ADAPTER
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from langgraph.types import Command
+
     from deepagents_code.hooks.models.domain import ToolCallData
-    from deepagents_code.json_types import JsonObject
+    from deepagents_code.json_types import JsonObject, JsonValue
 
 
 def _select(args: JsonObject, *fields: str) -> JsonObject:
@@ -145,3 +151,25 @@ def to_wire_call(
     if call.mcp_server is not None or _MCP_WIRE_RE.fullmatch(call.name) is not None:
         return name, dict(call.args)
     return name, to_wire_tool_input(call.name, call.args)
+
+
+def to_wire_tool_result(result: ToolMessage | Command[Any]) -> JsonValue:
+    """Project a native tool result into JSON for hook transport and wire input.
+
+    `PostToolUse` crosses a LangGraph interrupt boundary, so the domain event must
+    carry JSON — not a live `Command` / `ToolMessage`. Re-validating a dumped
+    `Command` as `ToolMessage` raises `KeyError: 'tool_call_id'` in LangChain's
+    message coercion.
+
+    Args:
+        result: Native tool return value from the tool wrapper.
+
+    Returns:
+        JSON-compatible tool response for `PostToolUseEvent.result` / wire
+        `tool_response`.
+    """
+    if isinstance(result, ToolMessage):
+        value: object = result.model_dump(mode="json")
+    else:
+        value = JSON_VALUE_ADAPTER.dump_python(result, mode="json", warnings=False)
+    return JSON_VALUE_ADAPTER.validate_python(value)

--- a/libs/code/tests/unit_tests/hooks/models/test_models.py
+++ b/libs/code/tests/unit_tests/hooks/models/test_models.py
@@ -33,6 +33,7 @@ from deepagents_code.hooks.models.transport import (
     HookInvocationRequest,
     HookInvocationResponse,
 )
+from deepagents_code.hooks.tools import to_wire_tool_result
 
 _COMMON_WIRE_INPUT = {
     "session_id": "thread-1",
@@ -287,8 +288,8 @@ def test_domain_event_union_selects_event_model() -> None:
     assert event.event is HookEvent.NOTIFICATION
 
 
-def test_post_tool_use_accepts_native_tool_message() -> None:
-    result = ToolMessage(content="done", tool_call_id="call-1")
+def test_post_tool_use_accepts_json_tool_result() -> None:
+    result = to_wire_tool_result(ToolMessage(content="done", tool_call_id="call-1"))
 
     event = PostToolUseEvent(
         event=HookEvent.POST_TOOL_USE,
@@ -296,7 +297,7 @@ def test_post_tool_use_accepts_native_tool_message() -> None:
         result=result,
     )
 
-    assert event.result is result
+    assert event.result == result
 
 
 def test_domain_models_reject_unknown_fields() -> None:

--- a/libs/code/tests/unit_tests/hooks/models/test_models.py
+++ b/libs/code/tests/unit_tests/hooks/models/test_models.py
@@ -33,7 +33,6 @@ from deepagents_code.hooks.models.transport import (
     HookInvocationRequest,
     HookInvocationResponse,
 )
-from deepagents_code.hooks.tools import to_wire_tool_result
 
 _COMMON_WIRE_INPUT = {
     "session_id": "thread-1",
@@ -289,15 +288,13 @@ def test_domain_event_union_selects_event_model() -> None:
 
 
 def test_post_tool_use_accepts_json_tool_result() -> None:
-    result = to_wire_tool_result(ToolMessage(content="done", tool_call_id="call-1"))
-
-    event = PostToolUseEvent(
-        event=HookEvent.POST_TOOL_USE,
+    event = PostToolUseEvent.from_tool_result(
+        ToolMessage(content="done", tool_call_id="call-1"),
         call=ToolCallData(id="call-1", name="write_file", args={}),
-        result=result,
     )
 
-    assert event.result == result
+    assert isinstance(event.result, dict)
+    assert event.result.get("content") == "done"
 
 
 def test_domain_models_reject_unknown_fields() -> None:

--- a/libs/code/tests/unit_tests/hooks/test_engine.py
+++ b/libs/code/tests/unit_tests/hooks/test_engine.py
@@ -57,7 +57,7 @@ from deepagents_code.hooks.projection import project_hook_input, serialize_hook_
 from deepagents_code.hooks.reducer import reduce_hook_results
 from deepagents_code.hooks.runner import HandlerResult, run_command_handler
 from deepagents_code.hooks.snapshot import HookHandler, HooksSnapshot
-from deepagents_code.hooks.tools import to_wire_call
+from deepagents_code.hooks.tools import to_wire_call, to_wire_tool_result
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -449,7 +449,9 @@ def test_snapshot_rejects_matcher_for_unmatchable_event() -> None:
             PostToolUseEvent(
                 event=HookEvent.POST_TOOL_USE,
                 call=ToolCallData(id="call-2", name="Bash", args={}),
-                result=ToolMessage(content="done", tool_call_id="call-2"),
+                result=to_wire_tool_result(
+                    ToolMessage(content="done", tool_call_id="call-2")
+                ),
             ),
             {"hook_event_name": "PostToolUse", "tool_use_id": "call-2"},
         ),
@@ -568,10 +570,10 @@ def test_projects_native_tool_names_to_wire(tmp_path: Path) -> None:
 
     invocation = _invocation(
         tmp_path,
-        PostToolUseEvent.model_construct(
+        PostToolUseEvent(
             event=HookEvent.POST_TOOL_USE,
             call=ToolCallData(id="call-1", name="Bash", args={}),
-            result=Command(update={"result": "done"}),
+            result=to_wire_tool_result(Command(update={"result": "done"})),
         ),
     )
 
@@ -737,9 +739,11 @@ def test_serializes_native_tool_message_as_json(tmp_path: Path) -> None:
         PostToolUseEvent(
             event=HookEvent.POST_TOOL_USE,
             call=ToolCallData(id="call-1", name="Bash", args={}),
-            result=ToolMessage(
-                content=[{"type": "text", "text": "done"}],
-                tool_call_id="call-1",
+            result=to_wire_tool_result(
+                ToolMessage(
+                    content=[{"type": "text", "text": "done"}],
+                    tool_call_id="call-1",
+                )
             ),
         ),
     )
@@ -1197,7 +1201,9 @@ def test_reducer_covers_event_decision_shapes_and_loop_guards(tmp_path: Path) ->
             PostToolUseEvent(
                 event=HookEvent.POST_TOOL_USE,
                 call=ToolCallData(id="call", name="Bash", args={}),
-                result=ToolMessage(content="done", tool_call_id="call"),
+                result=to_wire_tool_result(
+                    ToolMessage(content="done", tool_call_id="call")
+                ),
             ),
             {
                 "decision": "block",

--- a/libs/code/tests/unit_tests/hooks/test_engine.py
+++ b/libs/code/tests/unit_tests/hooks/test_engine.py
@@ -57,7 +57,7 @@ from deepagents_code.hooks.projection import project_hook_input, serialize_hook_
 from deepagents_code.hooks.reducer import reduce_hook_results
 from deepagents_code.hooks.runner import HandlerResult, run_command_handler
 from deepagents_code.hooks.snapshot import HookHandler, HooksSnapshot
-from deepagents_code.hooks.tools import to_wire_call, to_wire_tool_result
+from deepagents_code.hooks.tools import to_wire_call
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -446,12 +446,9 @@ def test_snapshot_rejects_matcher_for_unmatchable_event() -> None:
             {"hook_event_name": "PreToolUse", "tool_use_id": "call-1"},
         ),
         (
-            PostToolUseEvent(
-                event=HookEvent.POST_TOOL_USE,
+            PostToolUseEvent.from_tool_result(
+                ToolMessage(content="done", tool_call_id="call-2"),
                 call=ToolCallData(id="call-2", name="Bash", args={}),
-                result=to_wire_tool_result(
-                    ToolMessage(content="done", tool_call_id="call-2")
-                ),
             ),
             {"hook_event_name": "PostToolUse", "tool_use_id": "call-2"},
         ),
@@ -570,10 +567,9 @@ def test_projects_native_tool_names_to_wire(tmp_path: Path) -> None:
 
     invocation = _invocation(
         tmp_path,
-        PostToolUseEvent(
-            event=HookEvent.POST_TOOL_USE,
+        PostToolUseEvent.from_tool_result(
+            Command(update={"result": "done"}),
             call=ToolCallData(id="call-1", name="Bash", args={}),
-            result=to_wire_tool_result(Command(update={"result": "done"})),
         ),
     )
 
@@ -736,15 +732,12 @@ def test_adapts_native_tool_calls_to_wire(
 def test_serializes_native_tool_message_as_json(tmp_path: Path) -> None:
     invocation = _invocation(
         tmp_path,
-        PostToolUseEvent(
-            event=HookEvent.POST_TOOL_USE,
-            call=ToolCallData(id="call-1", name="Bash", args={}),
-            result=to_wire_tool_result(
-                ToolMessage(
-                    content=[{"type": "text", "text": "done"}],
-                    tool_call_id="call-1",
-                )
+        PostToolUseEvent.from_tool_result(
+            ToolMessage(
+                content=[{"type": "text", "text": "done"}],
+                tool_call_id="call-1",
             ),
+            call=ToolCallData(id="call-1", name="Bash", args={}),
         ),
     )
 
@@ -1198,12 +1191,9 @@ def test_reducer_covers_event_decision_shapes_and_loop_guards(tmp_path: Path) ->
             },
         ),
         (
-            PostToolUseEvent(
-                event=HookEvent.POST_TOOL_USE,
+            PostToolUseEvent.from_tool_result(
+                ToolMessage(content="done", tool_call_id="call"),
                 call=ToolCallData(id="call", name="Bash", args={}),
-                result=to_wire_tool_result(
-                    ToolMessage(content="done", tool_call_id="call")
-                ),
             ),
             {
                 "decision": "block",

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -40,6 +40,7 @@ from deepagents_code.hooks.models.domain import (
     HookInvocation,
     PermissionEffect,
     PostToolUseDecision,
+    PostToolUseEvent,
     PreCompactDecision,
     PreCompactEvent,
     PreToolUseDecision,
@@ -70,6 +71,7 @@ from deepagents_code.hooks.server_middleware import (
     _tool_result_text,
 )
 from deepagents_code.hooks.snapshot import HooksSnapshot
+from deepagents_code.hooks.tools import to_wire_tool_result
 from deepagents_code.hooks.transcript import SUBAGENT_TRANSCRIPT_ID_METADATA_KEY
 
 if TYPE_CHECKING:
@@ -82,7 +84,9 @@ class _ReplayState(BaseModel):
     completed: bool
 
 
-def _request(event: PreToolUseEvent | None = None) -> HookInvocationRequest:
+def _request(
+    event: PreToolUseEvent | PostToolUseEvent | None = None,
+) -> HookInvocationRequest:
     invocation = HookInvocation(
         context=HookContext(
             thread_id="thread-1",
@@ -113,6 +117,43 @@ def test_hook_interrupt_payload_round_trip() -> None:
     assert is_hook_interrupt_payload(payload)
     assert parse_hook_interrupt_payload(payload) == request
     assert parse_hook_interrupt_payload({"type": "ask_user"}) is None
+
+
+def test_post_tool_use_command_result_round_trips_interrupt() -> None:
+    """`task` returns `Command`; that JSON must parse without ToolMessage coercion."""
+    result = Command(
+        update={
+            "messages": [
+                ToolMessage(
+                    content="subagent done",
+                    name="task",
+                    tool_call_id="call-task",
+                    status="success",
+                )
+            ]
+        }
+    )
+    request = _request(
+        PostToolUseEvent(
+            event=HookEvent.POST_TOOL_USE,
+            call=ToolCallData(
+                id="call-task",
+                name="task",
+                args={"subagent_type": "general-purpose"},
+            ),
+            result=to_wire_tool_result(result),
+            duration_ms=10,
+        )
+    )
+    payload = build_hook_interrupt_payload(request)
+    parsed = parse_hook_interrupt_payload(payload)
+
+    assert parsed is not None
+    assert parsed == request
+    assert isinstance(parsed.invocation.event, PostToolUseEvent)
+    assert parsed.invocation.event.result["update"]["messages"][0]["tool_call_id"] == (
+        "call-task"
+    )
 
 
 def test_hook_resume_value_validates_identity() -> None:

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -40,7 +40,6 @@ from deepagents_code.hooks.models.domain import (
     HookInvocation,
     PermissionEffect,
     PostToolUseDecision,
-    PostToolUseEvent,
     PreCompactDecision,
     PreCompactEvent,
     PreToolUseDecision,
@@ -71,7 +70,6 @@ from deepagents_code.hooks.server_middleware import (
     _tool_result_text,
 )
 from deepagents_code.hooks.snapshot import HooksSnapshot
-from deepagents_code.hooks.tools import to_wire_tool_result
 from deepagents_code.hooks.transcript import SUBAGENT_TRANSCRIPT_ID_METADATA_KEY
 
 if TYPE_CHECKING:
@@ -84,9 +82,7 @@ class _ReplayState(BaseModel):
     completed: bool
 
 
-def _request(
-    event: PreToolUseEvent | PostToolUseEvent | None = None,
-) -> HookInvocationRequest:
+def _request(event: PreToolUseEvent | None = None) -> HookInvocationRequest:
     invocation = HookInvocation(
         context=HookContext(
             thread_id="thread-1",
@@ -117,43 +113,6 @@ def test_hook_interrupt_payload_round_trip() -> None:
     assert is_hook_interrupt_payload(payload)
     assert parse_hook_interrupt_payload(payload) == request
     assert parse_hook_interrupt_payload({"type": "ask_user"}) is None
-
-
-def test_post_tool_use_command_result_round_trips_interrupt() -> None:
-    """`task` returns `Command`; that JSON must parse without ToolMessage coercion."""
-    result = Command(
-        update={
-            "messages": [
-                ToolMessage(
-                    content="subagent done",
-                    name="task",
-                    tool_call_id="call-task",
-                    status="success",
-                )
-            ]
-        }
-    )
-    request = _request(
-        PostToolUseEvent(
-            event=HookEvent.POST_TOOL_USE,
-            call=ToolCallData(
-                id="call-task",
-                name="task",
-                args={"subagent_type": "general-purpose"},
-            ),
-            result=to_wire_tool_result(result),
-            duration_ms=10,
-        )
-    )
-    payload = build_hook_interrupt_payload(request)
-    parsed = parse_hook_interrupt_payload(payload)
-
-    assert parsed is not None
-    assert parsed == request
-    assert isinstance(parsed.invocation.event, PostToolUseEvent)
-    assert parsed.invocation.event.result["update"]["messages"][0]["tool_call_id"] == (
-        "call-task"
-    )
 
 
 def test_hook_resume_value_validates_identity() -> None:

--- a/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
+++ b/libs/code/tests/unit_tests/hooks/test_server_lifecycle.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
@@ -63,6 +63,7 @@ from deepagents_code.hooks.server_middleware import (
     _apply_subagent_stop,
     _ask_permission_via_hitl,
     _denied_tool_message,
+    _invocation_id,
     _invoke_hook,
     _merge_tool_message_content,
     _session_gate,
@@ -147,6 +148,7 @@ def test_real_checkpointer_resume_replays_stable_hook_identity() -> None:
         thread_id="thread-1",
         cwd=Path("/tmp"),
         approval_mode=ApprovalMode.MANUAL,
+        prompt_id=uuid4(),
     )
     event = PreToolUseEvent(
         event=HookEvent.PRE_TOOL_USE,
@@ -195,6 +197,37 @@ def test_real_checkpointer_resume_replays_stable_hook_identity() -> None:
     resumed = graph.invoke(Command(resume=build_hook_resume_value(response)), config)
 
     assert resumed["completed"] is True
+
+
+def test_invocation_id_separates_turns_that_reuse_a_tool_call_id() -> None:
+    """A tool-call id reused by a later turn must not inherit its decision.
+
+    The fulfillment ledger caches completed responses by
+    `(snapshot_id, invocation_id)`, so colliding ids would replay the earlier
+    allow/block without running the hook.
+    """
+    event = PreToolUseEvent(
+        event=HookEvent.PRE_TOOL_USE,
+        call=ToolCallData(id="call-1", name="execute", args={"command": "ls"}),
+    )
+
+    def context_for_turn(prompt_id: UUID | None) -> HookContext:
+        return HookContext(
+            thread_id="thread-1",
+            cwd=Path("/tmp"),
+            approval_mode=ApprovalMode.MANUAL,
+            prompt_id=prompt_id,
+        )
+
+    first_turn = context_for_turn(uuid4())
+    second_turn = context_for_turn(uuid4())
+
+    first = _invocation_id(snapshot_id="snapshot-1", context=first_turn, event=event)
+    replayed = _invocation_id(snapshot_id="snapshot-1", context=first_turn, event=event)
+    second = _invocation_id(snapshot_id="snapshot-1", context=second_turn, event=event)
+
+    assert replayed == first
+    assert second != first
 
 
 def test_apply_hooks_context_sets_server_events(tmp_path: Path) -> None:


### PR DESCRIPTION
Server-owned hooks now survive resume, so `PostToolUse`, `SubagentStart`, `SubagentStop`, and `Stop` can complete a turn — including for `Command`-returning tools like `task`.

---

Two defects aborted server-owned hook resumes:

1. `_invocation_id` hashed `run_id`, which changes on every `Command(resume=...)`, so the id the client echoed back never matched the one the server re-derived. Fixed by swapping `run_id` for `prompt_id`, which is per-turn but stable across every resume within that turn.
2. `PostToolUseEvent.result` was typed as a live `Command | ToolMessage`, and client re-validation of a dumped `Command` raised `KeyError: 'tool_call_id'`. Fixed by projecting the tool return through `to_wire_tool_result` into `JsonValue` before building the interrupt.

`PreToolUse` was unaffected by (1) because its outcome is replayed from state rather than re-invoked, and (2) only hit `Command`-returning tools — so `task` failed where `execute` worked.

Keeping a per-turn value in the identity matters: `HookFulfillmentLedger` caches completed responses by `(snapshot_id, invocation_id)`, so if two turns reusing a tool-call id derived the same id, the later one would replay the earlier allow/block without running its hook.

<details>
<summary>Test plan</summary>

Verified non-interactively with handlers for every event: `SessionStart`, `UserPromptSubmit`, `PreToolUse`/`PostToolUse` for Bash and `task`, `SubagentStart`, `SubagentStop`, `Stop`, and `SessionEnd` all fire, and the turn completes without error.

</details>