### PR TITLE
feat(code): prompt before resuming large threads

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -8374,6 +8374,27 @@ class DeepAgentsApp(App):
         try:
             from deepagents_code.hooks.models.domain import SessionStartCause
 
+            resume_payload: _ThreadHistoryPayload | None = None
+            resume_choice: Literal["compact", "continue", "cancel"] = "continue"
+            if self._initial_resume_requested and self._lc_thread_id and self._agent:
+                try:
+                    resume_payload = await self._fetch_thread_history_data(
+                        self._lc_thread_id
+                    )
+                except Exception:
+                    logger.warning(
+                        "Could not prefetch resumed thread %s for context-size check",
+                        self._lc_thread_id,
+                        exc_info=True,
+                    )
+                if resume_payload is not None:
+                    resume_choice = await self._offer_resume_compaction(
+                        resume_payload.context_tokens
+                    )
+                    if resume_choice == "cancel":
+                        self._cancel_initial_thread_resume()
+                        resume_payload = None
+
             start_cause = (
                 SessionStartCause.RESUME
                 if self._initial_resume_requested
@@ -8384,11 +8405,24 @@ class DeepAgentsApp(App):
                 or not self._has_initial_submission()
             )
             if should_load_history:
-                await self._load_thread_history(resolve_pending_goal=False)
+                await self._load_thread_history(
+                    preloaded_payload=resume_payload,
+                    resolve_pending_goal=False,
+                )
             elif self._has_initial_submission():
                 try:
                     await self._adopt_resumed_model_if_needed(
-                        thread_id=self._lc_thread_id
+                        model_spec=(
+                            resume_payload.model_spec
+                            if resume_payload is not None
+                            else None
+                        ),
+                        model_params=(
+                            resume_payload.model_params
+                            if resume_payload is not None
+                            else None
+                        ),
+                        thread_id=self._lc_thread_id,
                     )
                 except Exception:
                     logger.exception(
@@ -8408,6 +8442,9 @@ class DeepAgentsApp(App):
                 self._initial_session_start_stopped = True
                 return
             self._initial_session_started = True
+
+            if resume_choice == "compact":
+                await self._handle_offload()
 
             if self._startup_cmd:
                 cmd = self._startup_cmd
@@ -15289,6 +15326,50 @@ class DeepAgentsApp(App):
         if state and state.values:
             return dict(state.values)
         return {}
+
+    async def _offer_resume_compaction(
+        self, context_tokens: int
+    ) -> Literal["compact", "continue", "cancel"]:
+        """Prompt for compaction when a resumed thread exceeds its threshold.
+
+        Returns:
+            The selected resume behavior, defaulting to cancellation when the
+            modal is dismissed without a result.
+        """
+        from deepagents_code.model_config import load_resume_compaction_threshold
+        from deepagents_code.tui.widgets.resume_compaction import (
+            ResumeCompactionPromptScreen,
+        )
+
+        threshold = await asyncio.to_thread(load_resume_compaction_threshold)
+        if context_tokens <= threshold:
+            return "continue"
+        choice = await self._push_screen_wait(
+            ResumeCompactionPromptScreen(
+                context_tokens=context_tokens,
+                threshold=threshold,
+            )
+        )
+        return choice or "cancel"
+
+    def _cancel_initial_thread_resume(self) -> None:
+        """Replace a cancelled launch-time resume with a fresh thread."""
+        from deepagents_code.sessions import generate_thread_id
+
+        thread_id = generate_thread_id()
+        self._lc_thread_id = thread_id
+        if self._session_state is not None:
+            self._session_state.thread_id = thread_id
+        self._initial_resume_requested = False
+        self._should_adopt_resumed_model = False
+        self._resuming = False
+        self._sync_status_connection()
+        self._update_welcome_banner(
+            thread_id,
+            missing_message="Welcome banner not found after cancelling resume to %s",
+            warn_if_missing=False,
+        )
+        self.notify("Resume cancelled. Starting a new session.", markup=False)
 
     async def _fetch_thread_history_data(self, thread_id: str) -> _ThreadHistoryPayload:
         """Fetch and convert stored messages for a thread.
@@ -22760,11 +22841,21 @@ class DeepAgentsApp(App):
             self._chat_input.set_cursor_active(active=False)
 
         prefetched_payload: _ThreadHistoryPayload | None = None
+        compact_after_switch = False
         outgoing_ended = False
         try:
             self._update_status(f"Loading thread: {thread_id}")
             await self._set_spinner("Loading thread")
             prefetched_payload = await self._fetch_thread_history_data(thread_id)
+            await self._set_spinner(None)
+            resume_choice = await self._offer_resume_compaction(
+                prefetched_payload.context_tokens
+            )
+            if resume_choice == "cancel":
+                await self._restore_cwd_after_failed_thread_switch(prev_cwd)
+                return
+            compact_after_switch = resume_choice == "compact"
+            await self._set_spinner("Loading thread")
             from deepagents_code.hooks.models.domain import (
                 SessionEndCause,
                 SessionStartCause,
@@ -22824,6 +22915,8 @@ class DeepAgentsApp(App):
             self._last_thread_unchanged = None
             if not await self._run_session_start_hook(SessionStartCause.RESUME):
                 return
+            if compact_after_switch:
+                await self._handle_offload()
         except Exception as exc:
             if prefetched_payload is None:
                 logger.exception("Failed to prefetch history for thread %s", thread_id)

--- a/libs/code/deepagents_code/model_config.py
+++ b/libs/code/deepagents_code/model_config.py
@@ -4424,6 +4424,75 @@ def add_enabled_project_mcp_servers(
     return True
 
 
+DEFAULT_RESUME_COMPACTION_THRESHOLD = 300_000
+"""Context size that triggers the resume compaction prompt by default."""
+
+
+def _validate_resume_compaction_threshold(value: object) -> int:
+    """Validate a configured resume-compaction token threshold.
+
+    Args:
+        value: Parsed TOML value.
+
+    Returns:
+        The validated non-negative integer.
+
+    Raises:
+        ValueError: If the value is not a non-negative integer.
+    """
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        msg = "[threads].resume_compaction_threshold must be a non-negative integer"
+        raise ValueError(msg)
+    return value
+
+
+def load_resume_compaction_threshold(config_path: Path | None = None) -> int:
+    """Load the context size that prompts for compaction on thread resume.
+
+    Args:
+        config_path: Path to config file.
+
+    Returns:
+        A non-negative token threshold from
+        `[threads].resume_compaction_threshold`, or the default when unset or
+        invalid.
+    """
+    if config_path is None:
+        config_path = DEFAULT_CONFIG_PATH
+    try:
+        if not config_path.exists():
+            return DEFAULT_RESUME_COMPACTION_THRESHOLD
+        with config_path.open("rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.warning(
+            "Could not read resume compaction threshold; using %d",
+            DEFAULT_RESUME_COMPACTION_THRESHOLD,
+            exc_info=True,
+        )
+        return DEFAULT_RESUME_COMPACTION_THRESHOLD
+
+    threads = data.get("threads")
+    value = (
+        threads.get("resume_compaction_threshold")
+        if isinstance(threads, dict)
+        else None
+    )
+    if value is None:
+        return DEFAULT_RESUME_COMPACTION_THRESHOLD
+    try:
+        threshold = _validate_resume_compaction_threshold(value)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid [threads].resume_compaction_threshold; using %d",
+            DEFAULT_RESUME_COMPACTION_THRESHOLD,
+            exc_info=True,
+        )
+        return DEFAULT_RESUME_COMPACTION_THRESHOLD
+    else:
+        return threshold
+
+
 THREAD_COLUMN_DEFAULTS: dict[str, bool] = {
     "thread_id": False,
     "messages": True,

--- a/libs/code/deepagents_code/tui/widgets/resume_compaction.py
+++ b/libs/code/deepagents_code/tui/widgets/resume_compaction.py
@@ -1,0 +1,146 @@
+"""Prompt for compaction when resuming a thread with a large context."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, Literal, cast
+
+from textual.binding import Binding, BindingType
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+from deepagents_code._session_stats import format_token_count
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+    from deepagents_code.app import DeepAgentsApp
+
+
+ResumeCompactionChoice = Literal["compact", "continue", "cancel"]
+"""Outcome of the large-context resume prompt."""
+
+
+class ResumeCompactionPromptScreen(ModalScreen[ResumeCompactionChoice]):
+    """Ask how to resume a thread whose saved context exceeds the threshold."""
+
+    can_focus = True
+    can_focus_children = False
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("enter,c", "compact", "Compact", show=False, priority=True),
+        Binding("w", "continue_without_compaction", "Without compaction", show=False),
+        Binding("escape", "cancel_resume", "Cancel", show=False, priority=True),
+        Binding(
+            "ctrl+c",
+            "quit_or_interrupt",
+            "Quit/Interrupt",
+            show=False,
+            priority=True,
+        ),
+        Binding("ctrl+d", "quit_app", "Quit", show=False, priority=True),
+    ]
+
+    CSS = """
+    ResumeCompactionPromptScreen {
+        align: center middle;
+    }
+
+    ResumeCompactionPromptScreen > Vertical {
+        width: 72;
+        max-width: 90%;
+        height: auto;
+        background: $surface;
+        border: solid $warning;
+        padding: 1 2;
+    }
+
+    ResumeCompactionPromptScreen .resume-compaction-title {
+        text-style: bold;
+        color: $warning;
+        text-align: center;
+        margin-bottom: 1;
+    }
+
+    ResumeCompactionPromptScreen .resume-compaction-body {
+        height: auto;
+        color: $text;
+        margin-bottom: 1;
+    }
+
+    ResumeCompactionPromptScreen .resume-compaction-help {
+        height: 1;
+        color: $text-muted;
+        text-style: italic;
+        text-align: center;
+    }
+    """
+
+    def __init__(self, *, context_tokens: int, threshold: int) -> None:
+        """Initialize the prompt with the saved context size and threshold."""
+        super().__init__()
+        self._context_tokens = context_tokens
+        self._threshold = threshold
+
+    def _body_text(self) -> str:
+        """Return the prompt body."""
+        context = format_token_count(self._context_tokens)
+        threshold = format_token_count(self._threshold)
+        return (
+            f"This thread has {context} context tokens, above your {threshold}-token "
+            "resume threshold.\n\n"
+            "Enter/C — Continue conversation with compaction\n"
+            "W — Continue without compaction\n"
+            "Esc — Cancel"
+        )
+
+    def compose(self) -> ComposeResult:
+        """Compose the prompt.
+
+        Yields:
+            The prompt title, choices, and keyboard help.
+        """
+        with Vertical():
+            yield Static(
+                "Large conversation context",
+                classes="resume-compaction-title",
+                markup=False,
+            )
+            yield Static(
+                self._body_text(),
+                classes="resume-compaction-body",
+                markup=False,
+            )
+            yield Static(
+                "Enter/C: compact · W: without compaction · Esc: cancel",
+                classes="resume-compaction-help",
+                markup=False,
+            )
+
+    def on_mount(self) -> None:
+        """Focus the modal so its bindings receive input."""
+        self.focus()
+
+    def action_compact(self) -> None:
+        """Resume after compacting the thread."""
+        self.dismiss("compact")
+
+    def action_continue_without_compaction(self) -> None:
+        """Resume without changing the saved context."""
+        self.dismiss("continue")
+
+    def action_cancel_resume(self) -> None:
+        """Cancel the resume operation."""
+        self.dismiss("cancel")
+
+    def action_cancel(self) -> None:
+        """Treat the app-level cancel action as cancelling resume."""
+        self.action_cancel_resume()
+
+    def action_quit_or_interrupt(self) -> None:
+        """Delegate Ctrl+C to the app-level quit handler."""
+        cast("DeepAgentsApp", self.app).action_quit_or_interrupt()
+
+    def action_quit_app(self) -> None:
+        """Delegate Ctrl+D to the app-level quit handler."""
+        cast("DeepAgentsApp", self.app).action_quit_app()

--- a/libs/code/deepagents_code/tui/widgets/startup_tip.py
+++ b/libs/code/deepagents_code/tui/widgets/startup_tip.py
@@ -19,6 +19,7 @@ _TIP_SHIFT_TAB_WITHOUT_YOLO = "Press Shift+Tab to toggle Manual and Auto modes"
 _TIPS: dict[str, int] = {
     "Use @ to reference files and / for commands": 3,
     "Try /threads to resume a previous conversation": 2,
+    "Choose compaction when resuming a large conversation": 1,
     "Use /offload when your conversation gets long": 2,
     "Use /copy to copy the latest message": 3,
     "Use /tools to list the tools available to the agent": 1,

--- a/libs/code/tests/unit_tests/test_model_config.py
+++ b/libs/code/tests/unit_tests/test_model_config.py
@@ -1287,6 +1287,51 @@ class TestThreadScopePersistence:
         assert data["threads"]["scope"] == "all"
 
 
+class TestResumeCompactionThreshold:
+    """Tests for the configurable large-context resume threshold."""
+
+    def test_defaults_to_300k(self, tmp_path: Path) -> None:
+        from deepagents_code.model_config import load_resume_compaction_threshold
+
+        assert load_resume_compaction_threshold(tmp_path / "missing.toml") == 300_000
+
+    def test_reads_threads_override(self, tmp_path: Path) -> None:
+        from deepagents_code.model_config import load_resume_compaction_threshold
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            "[threads]\nresume_compaction_threshold = 125000\n",
+            encoding="utf-8",
+        )
+
+        assert load_resume_compaction_threshold(config_path) == 125_000
+
+    @pytest.mark.parametrize("value", ["-1", '"300000"', "true"])
+    def test_invalid_override_uses_default(self, tmp_path: Path, value: str) -> None:
+        from deepagents_code.model_config import load_resume_compaction_threshold
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            f"[threads]\nresume_compaction_threshold = {value}\n",
+            encoding="utf-8",
+        )
+
+        assert load_resume_compaction_threshold(config_path) == 300_000
+
+    def test_zero_allows_prompting_for_any_nonempty_context(
+        self, tmp_path: Path
+    ) -> None:
+        from deepagents_code.model_config import load_resume_compaction_threshold
+
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            "[threads]\nresume_compaction_threshold = 0\n",
+            encoding="utf-8",
+        )
+
+        assert load_resume_compaction_threshold(config_path) == 0
+
+
 class TestThreadConfigCoalesced:
     """Tests for the coalesced `load_thread_config()` helper."""
 

--- a/libs/code/tests/unit_tests/test_threads_resume.py
+++ b/libs/code/tests/unit_tests/test_threads_resume.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from deepagents_code.app import DeepAgentsApp, TextualSessionState
+from deepagents_code.app import (
+    DeepAgentsApp,
+    TextualSessionState,
+    _ThreadHistoryPayload,
+)
 
 
 class TestSessionStatePreviousThread:
@@ -36,6 +40,178 @@ def _make_app() -> DeepAgentsApp:
     app._show_thread_selector = AsyncMock()  # ty: ignore
     app._resume_thread = AsyncMock()  # ty: ignore
     return app
+
+
+class TestResumeCompactionChoice:
+    """Large saved contexts should gate both resume paths."""
+
+    async def test_below_threshold_continues_without_modal(self) -> None:
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-1")
+        push_wait = AsyncMock(return_value="compact")
+        app._push_screen_wait = push_wait
+
+        with patch(
+            "deepagents_code.model_config.load_resume_compaction_threshold",
+            return_value=300_000,
+        ):
+            choice = await app._offer_resume_compaction(300_000)
+
+        assert choice == "continue"
+        push_wait.assert_not_awaited()
+
+    async def test_above_threshold_uses_modal_choice(self) -> None:
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-1")
+        push_wait = AsyncMock(return_value="compact")
+        app._push_screen_wait = push_wait
+
+        with patch(
+            "deepagents_code.model_config.load_resume_compaction_threshold",
+            return_value=300_000,
+        ):
+            choice = await app._offer_resume_compaction(300_001)
+
+        assert choice == "compact"
+        assert push_wait.await_args is not None
+        screen = push_wait.await_args.args[0]
+        assert screen._context_tokens == 300_001
+        assert screen._threshold == 300_000
+
+    async def test_modal_dismissal_cancels_resume(self) -> None:
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-1")
+        app._push_screen_wait = AsyncMock(return_value=None)
+
+        with patch(
+            "deepagents_code.model_config.load_resume_compaction_threshold",
+            return_value=300_000,
+        ):
+            choice = await app._offer_resume_compaction(300_001)
+
+        assert choice == "cancel"
+
+    async def test_initial_resume_compacts_before_startup_finishes(self) -> None:
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-1")
+        app._session_state = TextualSessionState(thread_id="thread-1")
+        app._initial_resume_requested = True
+        payload = _ThreadHistoryPayload(
+            messages=[],
+            context_tokens=350_000,
+            model_spec="",
+        )
+        app._fetch_thread_history_data = AsyncMock(return_value=payload)
+        app._offer_resume_compaction = AsyncMock(return_value="compact")
+        load_history = AsyncMock()
+        app._load_thread_history = load_history
+        app._run_session_start_hook = AsyncMock(return_value=True)
+        compact = AsyncMock()
+        app._handle_offload = compact
+        app._remount_pending_goal_rubric_review = AsyncMock()
+        app._drain_startup_backlog = AsyncMock()
+
+        await app._run_session_start_sequence()
+
+        load_history.assert_awaited_once_with(
+            preloaded_payload=payload,
+            resolve_pending_goal=False,
+        )
+        compact.assert_awaited_once_with()
+        assert app._initial_session_started is True
+
+    async def test_initial_resume_cancel_starts_fresh_thread(self) -> None:
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-1")
+        app._session_state = TextualSessionState(thread_id="thread-1")
+        app._initial_resume_requested = True
+        payload = _ThreadHistoryPayload(
+            messages=[],
+            context_tokens=350_000,
+            model_spec="",
+        )
+        app._fetch_thread_history_data = AsyncMock(return_value=payload)
+        app._offer_resume_compaction = AsyncMock(return_value="cancel")
+        load_history = AsyncMock()
+        app._load_thread_history = load_history
+        app._run_session_start_hook = AsyncMock(return_value=True)
+        app._drain_startup_backlog = AsyncMock()
+        app.notify = MagicMock()
+        app._update_welcome_banner = MagicMock()
+
+        with patch(
+            "deepagents_code.sessions.generate_thread_id",
+            return_value="fresh-thread",
+        ):
+            await app._run_session_start_sequence()
+
+        assert app._lc_thread_id == "fresh-thread"
+        assert app._session_state.thread_id == "fresh-thread"
+        assert app._initial_resume_requested is False
+        load_history.assert_awaited_once_with(
+            preloaded_payload=None,
+            resolve_pending_goal=False,
+        )
+
+    async def test_thread_switch_cancel_keeps_current_thread(self) -> None:
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-1")
+        app._session_state = TextualSessionState(thread_id="thread-1")
+        app._lc_thread_id = "thread-1"
+        payload = _ThreadHistoryPayload(
+            messages=[],
+            context_tokens=350_000,
+            model_spec="",
+        )
+        app._offer_thread_cwd_switch = AsyncMock(return_value="continue")
+        app._fetch_thread_history_data = AsyncMock(return_value=payload)
+        app._offer_resume_compaction = AsyncMock(return_value="cancel")
+        restore = AsyncMock()
+        app._restore_cwd_after_failed_thread_switch = restore
+        clear = AsyncMock()
+        app._clear_messages = clear
+        app._set_spinner = AsyncMock()
+        app._update_status = MagicMock()
+
+        await app._resume_thread("thread-2")
+
+        assert app._session_state.thread_id == "thread-1"
+        assert app._lc_thread_id == "thread-1"
+        restore.assert_awaited_once()
+        clear.assert_not_awaited()
+
+    async def test_thread_switch_compacts_after_resume(self) -> None:
+        app = DeepAgentsApp(agent=MagicMock(), thread_id="thread-1")
+        app._session_state = TextualSessionState(thread_id="thread-1")
+        app._lc_thread_id = "thread-1"
+        payload = _ThreadHistoryPayload(
+            messages=[],
+            context_tokens=350_000,
+            model_spec="",
+        )
+        app._offer_thread_cwd_switch = AsyncMock(return_value="continue")
+        app._fetch_thread_history_data = AsyncMock(return_value=payload)
+        app._offer_resume_compaction = AsyncMock(return_value="compact")
+        app._clear_messages = AsyncMock()
+        app._set_spinner = AsyncMock()
+        load_history = AsyncMock()
+        app._load_thread_history = load_history
+        app._reload_hooks = AsyncMock()
+        app._run_session_start_hook = AsyncMock(return_value=True)
+        compact = AsyncMock()
+        app._handle_offload = compact
+        app._sync_status_queued = MagicMock()
+        app._update_tokens = MagicMock()
+        app._update_status = MagicMock()
+        app._update_welcome_banner = MagicMock()
+
+        with patch(
+            "deepagents_code.hooks.manager.HooksManager.on_session_end",
+            AsyncMock(),
+        ):
+            await app._resume_thread("thread-2")
+
+        assert app._session_state.thread_id == "thread-2"
+        assert app._lc_thread_id == "thread-2"
+        load_history.assert_awaited_once_with(
+            thread_id="thread-2",
+            preloaded_payload=payload,
+        )
+        compact.assert_awaited_once_with()
 
 
 class TestHandleThreadsCommand:

--- a/libs/code/tests/unit_tests/tui/widgets/test_resume_compaction.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_resume_compaction.py
@@ -1,0 +1,93 @@
+"""Tests for the large-context resume compaction prompt."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.widgets import Static
+
+from deepagents_code.tui.widgets.resume_compaction import (
+    ResumeCompactionChoice,
+    ResumeCompactionPromptScreen,
+)
+
+
+class _ResumeCompactionTestApp(App[None]):
+    def compose(self) -> ComposeResult:
+        yield Static("base")
+
+
+class TestResumeCompactionPromptScreen:
+    """Verify the three explicit resume outcomes."""
+
+    @staticmethod
+    def _screen() -> tuple[ResumeCompactionPromptScreen, MagicMock]:
+        screen = ResumeCompactionPromptScreen(
+            context_tokens=350_000,
+            threshold=300_000,
+        )
+        dismiss = MagicMock()
+        screen.dismiss = dismiss
+        return screen, dismiss
+
+    def test_body_reports_context_and_threshold(self) -> None:
+        screen, _ = self._screen()
+
+        assert "350.0K context tokens" in screen._body_text()
+        assert "300.0K-token resume threshold" in screen._body_text()
+        assert "Continue conversation with compaction" in screen._body_text()
+        assert "Continue without compaction" in screen._body_text()
+        assert "Esc — Cancel" in screen._body_text()
+
+    def test_bindings_expose_all_choices(self) -> None:
+        bindings = [
+            binding
+            for binding in ResumeCompactionPromptScreen.BINDINGS
+            if isinstance(binding, Binding)
+        ]
+        actions = {binding.action for binding in bindings}
+
+        assert "compact" in actions
+        assert "continue_without_compaction" in actions
+        assert "cancel_resume" in actions
+
+    def test_compact_action_dismisses_compact(self) -> None:
+        screen, dismiss = self._screen()
+
+        screen.action_compact()
+
+        dismiss.assert_called_once_with("compact")
+
+    def test_continue_action_dismisses_continue(self) -> None:
+        screen, dismiss = self._screen()
+
+        screen.action_continue_without_compaction()
+
+        dismiss.assert_called_once_with("continue")
+
+    def test_cancel_action_dismisses_cancel(self) -> None:
+        screen, dismiss = self._screen()
+
+        screen.action_cancel()
+
+        dismiss.assert_called_once_with("cancel")
+
+    async def test_keyboard_choices_resolve_modal(self) -> None:
+        app = _ResumeCompactionTestApp()
+        outcomes: list[ResumeCompactionChoice | None] = []
+
+        async with app.run_test() as pilot:
+            app.push_screen(
+                ResumeCompactionPromptScreen(
+                    context_tokens=350_000,
+                    threshold=300_000,
+                ),
+                outcomes.append,
+            )
+            await pilot.pause()
+            await pilot.press("w")
+            await pilot.pause()
+
+        assert outcomes == ["continue"]


### PR DESCRIPTION
Large resumed conversations now prompt users to compact, continue unchanged, or cancel once their saved context exceeds 300K tokens.

---

The threshold is configurable with `[threads].resume_compaction_threshold`; the prompt reuses checkpointed token usage and the existing trusted server-side compaction path for both `-r` and `/threads` resumes.

Verified with `make lint` and focused resume, startup, offload, configuration, and Textual modal tests.

Made by [Open SWE](https://openswe.vercel.app/agents/01052c6e-4a57-6ee8-6aa9-fc33e8a22b16)