### PR TITLE
feat(code): warn before expensive uncached requests

### DIFF
--- a/libs/code/deepagents_code/_expensive_request.py
+++ b/libs/code/deepagents_code/_expensive_request.py
@@ -1,0 +1,74 @@
+"""Shared event contract for expensive uncached model requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, cast
+
+_SECONDS_PER_HOUR = 3600
+
+EXPENSIVE_REQUEST_EVENT_TYPE = "expensive_model_request"
+EXPENSIVE_REQUEST_TOKEN_THRESHOLD = 500_000
+PROMPT_CACHE_TTL_SECONDS: dict[str, int] = {
+    "anthropic": 5 * 60,
+    "openai": 24 * 60 * 60,
+}
+
+PromptCacheProvider = Literal["anthropic", "openai"]
+
+
+@dataclass(frozen=True)
+class ExpensiveRequestWarning:
+    """Validated warning details shared by interactive and headless clients."""
+
+    provider: PromptCacheProvider
+    input_tokens: int
+
+    @property
+    def cache_ttl_seconds(self) -> int:
+        """Configured prompt-cache TTL for this provider."""
+        return PROMPT_CACHE_TTL_SECONDS[self.provider]
+
+
+def parse_expensive_request_warning(data: object) -> ExpensiveRequestWarning | None:
+    """Validate a custom-stream payload as an expensive-request warning.
+
+    Returns:
+        Validated warning details, or `None` when the payload does not match.
+    """
+    if not isinstance(data, dict) or data.get("type") != EXPENSIVE_REQUEST_EVENT_TYPE:
+        return None
+    provider = data.get("provider")
+    input_tokens = data.get("input_tokens")
+    if provider not in PROMPT_CACHE_TTL_SECONDS:
+        return None
+    if (
+        not isinstance(input_tokens, int)
+        or isinstance(input_tokens, bool)
+        or input_tokens <= EXPENSIVE_REQUEST_TOKEN_THRESHOLD
+    ):
+        return None
+    return ExpensiveRequestWarning(
+        provider=cast("PromptCacheProvider", provider),
+        input_tokens=input_tokens,
+    )
+
+
+def format_expensive_request_warning(warning: ExpensiveRequestWarning) -> str:
+    """Format an expensive-request warning for a user-facing notification.
+
+    Returns:
+        Notification text with the provider, token estimate, and cache TTL.
+    """
+    ttl = warning.cache_ttl_seconds
+    ttl_label = (
+        f"{ttl // _SECONDS_PER_HOUR}-hour"
+        if ttl >= _SECONDS_PER_HOUR
+        else f"{ttl // 60}-minute"
+    )
+    provider = warning.provider.capitalize()
+    return (
+        "Expensive request: about to send approximately "
+        f"{warning.input_tokens:,} input tokens to {provider} outside its "
+        f"{ttl_label} prompt cache TTL."
+    )

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -596,6 +596,7 @@ if TYPE_CHECKING:
     from textual.worker import Worker
 
     from deepagents_code._ask_user_types import AskUserWidgetResult, Question
+    from deepagents_code._expensive_request import ExpensiveRequestWarning
     from deepagents_code.approval_mode import ApprovalMode
     from deepagents_code.client.launch.server import ServerProcess
     from deepagents_code.client.remote_client import RemoteAgent
@@ -4335,6 +4336,7 @@ class DeepAgentsApp(App):
             on_tool_complete=self._schedule_git_branch_refresh,
             on_subagent_event=self._on_subagent_event,
             on_auto_mode_event=self._on_auto_mode_event,
+            on_expensive_request=self._on_expensive_request,
             on_approval_mode_fallback=self._on_approval_mode_fallback,
         )
         # Wire token display callbacks
@@ -17321,6 +17323,17 @@ class DeepAgentsApp(App):
         panel = self._get_subagent_panel()
         if panel is not None:
             panel.on_subagent_event(event)
+
+    def _on_expensive_request(self, warning: ExpensiveRequestWarning) -> None:
+        """Show a warning before an uncached, very large model request."""
+        from deepagents_code._expensive_request import format_expensive_request_warning
+
+        self.notify(
+            format_expensive_request_warning(warning),
+            severity="warning",
+            timeout=10,
+            markup=False,
+        )
 
     async def _on_auto_mode_event(self, event: dict[str, Any]) -> None:
         """Render one compact sanitized Auto event in the transcript.

--- a/libs/code/deepagents_code/client/non_interactive.py
+++ b/libs/code/deepagents_code/client/non_interactive.py
@@ -40,6 +40,10 @@ from rich.style import Style
 from rich.text import Text
 
 from deepagents_code._cli_context import CLIContext
+from deepagents_code._expensive_request import (
+    format_expensive_request_warning,
+    parse_expensive_request_warning,
+)
 from deepagents_code._session_stats import SessionStats, print_usage_table
 from deepagents_code._tool_stream import (
     UNRENDERABLE_TOOL_OUTPUT,
@@ -802,6 +806,30 @@ def _process_message_chunk(
             state.spinner.start()
 
 
+def _process_expensive_request_event(
+    data: object,
+    state: StreamState,
+    console: Console,
+) -> bool:
+    """Render a validated expensive-request custom event when present.
+
+    Returns:
+        `True` when the event was rendered, otherwise `False`.
+    """
+    warning = parse_expensive_request_warning(data)
+    if warning is None:
+        return False
+    if state.spinner:
+        state.spinner.stop()
+    console.print(
+        Text(f"Warning: {format_expensive_request_warning(warning)}", style="yellow"),
+        highlight=False,
+    )
+    if state.spinner:
+        state.spinner.start()
+    return True
+
+
 def _process_rubric_event(
     data: dict[str, Any],
     state: StreamState,
@@ -923,6 +951,11 @@ def _process_stream_chunk(
 
     namespace, stream_mode, data = chunk
     is_main_agent = not namespace
+
+    if stream_mode == "custom" and _process_expensive_request_event(
+        data, state, console
+    ):
+        return
 
     if (
         stream_mode == "messages"

--- a/libs/code/deepagents_code/configurable_model.py
+++ b/libs/code/deepagents_code/configurable_model.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from operator import itemgetter
+from typing import TYPE_CHECKING, Annotated, Any, NotRequired
 
 from deepagents._models import (  # noqa: PLC2701
     get_model_identifier,
@@ -19,13 +22,21 @@ from deepagents._models import (  # noqa: PLC2701
 )
 from langchain.agents.middleware.types import (
     AgentMiddleware,
+    AgentState,
     ExtendedModelResponse,
     ModelRequest,
     ModelResponse,
+    PrivateStateAttr,
 )
+from langchain_core.messages.utils import count_tokens_approximately
 from langgraph.types import Command
 
 from deepagents_code._cli_context import CLIContextSchema
+from deepagents_code._expensive_request import (
+    EXPENSIVE_REQUEST_EVENT_TYPE,
+    EXPENSIVE_REQUEST_TOKEN_THRESHOLD,
+    PROMPT_CACHE_TTL_SECONDS,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -36,6 +47,17 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+_PROMPT_CACHE_REQUEST_TIMES_KEY = "_prompt_cache_request_times"
+_MAX_PROMPT_CACHE_MODELS = 16
+
+
+class PromptCacheState(AgentState):
+    """Private state used to track provider prompt-cache freshness."""
+
+    _prompt_cache_request_times: Annotated[
+        NotRequired[dict[str, float]], PrivateStateAttr
+    ]
 
 
 @dataclass(frozen=True)
@@ -562,17 +584,108 @@ async def _apply_overrides_async(
     )
 
 
-def _checkpoint_command(resolved: _ResolvedModelRequest) -> Command[Any] | None:
-    """Build the private resume-state update for a completed model call.
+def _prompt_cache_request_times(state: Mapping[str, Any]) -> dict[str, float]:
+    """Read a bounded set of valid prompt-cache timestamps from graph state.
 
     Returns:
-        Command with private checkpoint updates, or `None` when nothing is known.
+        Up to `_MAX_PROMPT_CACHE_MODELS` valid model timestamps.
+    """
+    raw = state.get(_PROMPT_CACHE_REQUEST_TIMES_KEY)
+    if not isinstance(raw, Mapping):
+        return {}
+    valid: dict[str, float] = {}
+    for key, value in raw.items():
+        if len(valid) >= _MAX_PROMPT_CACHE_MODELS:
+            break
+        if (
+            isinstance(key, str)
+            and isinstance(value, int | float)
+            and not isinstance(value, bool)
+            and math.isfinite(value)
+            and value >= 0
+        ):
+            valid[key] = float(value)
+    return valid
+
+
+def _prepare_prompt_cache_update(request: ModelRequest) -> dict[str, float] | None:
+    """Emit an expensive-request warning and stage cache freshness state.
+
+    Returns:
+        Updated model timestamps, or `None` for untracked requests.
+    """
+    context = _get_context(request)
+    if context is None or not context.thread_id:
+        return None
+    provider = _get_ls_provider(request.model)
+    ttl = PROMPT_CACHE_TTL_SECONDS.get(provider or "")
+    if provider is None or ttl is None:
+        return None
+
+    model_name = get_model_identifier(request.model)
+    model_key = f"{provider}:{model_name}" if model_name else provider
+    now = time.time()
+    if not math.isfinite(now) or now < 0:
+        logger.warning("Cannot track prompt-cache freshness with invalid wall clock")
+        return None
+
+    request_times = _prompt_cache_request_times(request.state)
+    last_request_at = request_times.get(model_key)
+    cache_is_fresh = last_request_at is not None and 0 <= now - last_request_at < ttl
+    if not cache_is_fresh:
+        messages = [request.system_message, *request.messages]
+        try:
+            input_tokens = count_tokens_approximately(
+                (message for message in messages if message is not None),
+                tools=request.tools,
+                use_usage_metadata_scaling=True,
+            )
+        except Exception:
+            logger.debug("Could not estimate model request tokens", exc_info=True)
+        else:
+            if input_tokens > EXPENSIVE_REQUEST_TOKEN_THRESHOLD:
+                writer = getattr(request.runtime, "stream_writer", None)
+                if callable(writer):
+                    try:
+                        writer(
+                            {
+                                "type": EXPENSIVE_REQUEST_EVENT_TYPE,
+                                "provider": provider,
+                                "input_tokens": input_tokens,
+                            }
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Could not emit expensive model request warning",
+                            exc_info=True,
+                        )
+
+    request_times[model_key] = now
+    if len(request_times) > _MAX_PROMPT_CACHE_MODELS:
+        newest = sorted(request_times.items(), key=itemgetter(1), reverse=True)
+        request_times = dict(newest[:_MAX_PROMPT_CACHE_MODELS])
+    return request_times
+
+
+def _checkpoint_command(
+    resolved: _ResolvedModelRequest,
+    prompt_cache_times: dict[str, float] | None,
+    *,
+    persist_model_state: bool,
+) -> Command[Any] | None:
+    """Build the private state update for a completed model call.
+
+    Returns:
+        Checkpoint command, or `None` when no private state is available.
     """
     update: dict[str, Any] = {}
-    if resolved.model_spec:
-        update["_model_spec"] = resolved.model_spec
-    if resolved.model_params_known:
-        update["_model_params"] = resolved.model_params
+    if persist_model_state:
+        if resolved.model_spec:
+            update["_model_spec"] = resolved.model_spec
+        if resolved.model_params_known:
+            update["_model_params"] = resolved.model_params
+    if prompt_cache_times is not None:
+        update[_PROMPT_CACHE_REQUEST_TIMES_KEY] = prompt_cache_times
     if not update:
         return None
     return Command(update=update)
@@ -594,6 +707,8 @@ class ConfigurableModelMiddleware(AgentMiddleware):
     model call before provider-specific middleware (like
     `AnthropicPromptCachingMiddleware`) runs.
     """
+
+    state_schema = PromptCacheState
 
     def __init__(
         self,
@@ -640,8 +755,13 @@ class ConfigurableModelMiddleware(AgentMiddleware):
         resolved = _apply_overrides(
             request, openai_prompt_cache_key=self._openai_prompt_cache_key
         )
+        prompt_cache_times = _prepare_prompt_cache_update(resolved.request)
         response = handler(resolved.request)
-        command = _checkpoint_command(resolved) if self._persist_model_state else None
+        command = _checkpoint_command(
+            resolved,
+            prompt_cache_times,
+            persist_model_state=self._persist_model_state,
+        )
         if command is None:
             return response
         return ExtendedModelResponse(model_response=response, command=command)
@@ -660,8 +780,13 @@ class ConfigurableModelMiddleware(AgentMiddleware):
         resolved = await _apply_overrides_async(
             request, openai_prompt_cache_key=self._openai_prompt_cache_key
         )
+        prompt_cache_times = _prepare_prompt_cache_update(resolved.request)
         response = await handler(resolved.request)
-        command = _checkpoint_command(resolved) if self._persist_model_state else None
+        command = _checkpoint_command(
+            resolved,
+            prompt_cache_times,
+            persist_model_state=self._persist_model_state,
+        )
         if command is None:
             return response
         return ExtendedModelResponse(model_response=response, command=command)

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -58,6 +58,10 @@ from deepagents_code._ask_user_types import (
 )
 from deepagents_code._cli_context import CLIContext
 from deepagents_code._constants import SYSTEM_MESSAGE_PREFIX
+from deepagents_code._expensive_request import (
+    ExpensiveRequestWarning,
+    parse_expensive_request_warning,
+)
 from deepagents_code._session_stats import (
     ModelStats as ModelStats,
     ModelStatsKey as ModelStatsKey,
@@ -632,6 +636,7 @@ class TextualUIAdapter:
         on_auto_mode_event: (
             Callable[[dict[str, Any]], Awaitable[None] | None] | None
         ) = None,
+        on_expensive_request: Callable[[ExpensiveRequestWarning], None] | None = None,
         on_approval_mode_fallback: Callable[[str], None] | None = None,
     ) -> None:
         """Initialize the adapter."""
@@ -688,6 +693,9 @@ class TextualUIAdapter:
 
         self._on_auto_mode_event = on_auto_mode_event
         """Callback for compact sanitized Auto denial and fallback events."""
+
+        self._on_expensive_request = on_expensive_request
+        """Callback for validated expensive uncached model-request warnings."""
 
         self._on_approval_mode_fallback = on_approval_mode_fallback
         """Callback that synchronizes a fail-closed startup fallback to Manual."""
@@ -1376,6 +1384,17 @@ async def execute_task_textual(
                 # nested custom events never reach the panel; forwarding must
                 # never raise into the stream loop.
                 if current_stream_mode == "custom":
+                    expensive_warning = parse_expensive_request_warning(data)
+                    if expensive_warning is not None:
+                        if adapter._on_expensive_request is not None:
+                            try:
+                                adapter._on_expensive_request(expensive_warning)
+                            except Exception:
+                                logger.warning(
+                                    "Expensive-request warning callback failed",
+                                    exc_info=True,
+                                )
+                        continue
                     rubric_message = data if isinstance(data, dict) else None
                     formatted_rubric_event = (
                         _format_rubric_event(rubric_message) if rubric_message else None

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -27592,6 +27592,23 @@ class TestLiveApprovalModeWrites:
         )
         mount.assert_awaited_once()
 
+    def test_expensive_request_uses_warning_notification_without_markup(self) -> None:
+        from deepagents_code._expensive_request import ExpensiveRequestWarning
+
+        app = DeepAgentsApp()
+        with patch.object(app, "notify") as notify:
+            app._on_expensive_request(
+                ExpensiveRequestWarning(provider="anthropic", input_tokens=750_000)
+            )
+
+        notify.assert_called_once_with(
+            "Expensive request: about to send approximately 750,000 input tokens "
+            "to Anthropic outside its 5-minute prompt cache TTL.",
+            severity="warning",
+            timeout=10,
+            markup=False,
+        )
+
 
 class TestExternalBypassFieldHonored:
     """`event.bypass` overrides queue when set on a prompt event."""

--- a/libs/code/tests/unit_tests/test_configurable_model.py
+++ b/libs/code/tests/unit_tests/test_configurable_model.py
@@ -17,6 +17,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage
 
 from deepagents_code._cli_context import CLIContext, CLIContextSchema
+from deepagents_code._expensive_request import EXPENSIVE_REQUEST_EVENT_TYPE
 from deepagents_code.agent import build_model_identity_section
 from deepagents_code.configurable_model import (
     ConfigurableModelMiddleware,
@@ -42,15 +43,18 @@ def _make_request(
     context: object = None,
     model_settings: dict[str, Any] | None = None,
     system_prompt: str | None = None,
+    state: dict[str, Any] | None = None,
+    stream_writer: Callable[[dict[str, Any]], None] | None = None,
 ) -> ModelRequest:
     """Create a ModelRequest with a runtime that carries CLIContext."""
-    runtime = SimpleNamespace(context=context)
+    runtime = SimpleNamespace(context=context, stream_writer=stream_writer)
     kwargs: dict[str, Any] = {
         "model": model,
         "messages": [HumanMessage(content="hi")],
         "tools": [],
         "runtime": cast("Any", runtime),
         "model_settings": model_settings,
+        "state": state,
     }
     if system_prompt is not None:
         kwargs["system_prompt"] = system_prompt
@@ -97,6 +101,157 @@ _PATCH_CREATE = "deepagents_code.config.create_model"
 # developer's env/config.toml. Tests that exercise flag *resolution* construct
 # their own instances after patching the config lookup.
 _mw = ConfigurableModelMiddleware(openai_prompt_cache_key=True)
+
+
+class TestExpensiveRequestWarning:
+    """Tests for large requests outside provider prompt-cache TTLs."""
+
+    def test_uncached_anthropic_request_emits_warning_and_tracks_timestamp(
+        self,
+    ) -> None:
+        model = _make_model("claude-opus-4-6")
+        model._get_ls_params.return_value = {"ls_provider": "anthropic"}
+        events: list[dict[str, Any]] = []
+        request = _make_request(
+            model,
+            context=CLIContext(thread_id="thread-123"),
+            system_prompt="system instructions",
+            stream_writer=events.append,
+        )
+        captured_messages: list[object] = []
+
+        def count(messages: object, **kwargs: Any) -> int:
+            captured_messages.extend(list(cast("Any", messages)))
+            assert kwargs == {"tools": [], "use_usage_metadata_scaling": True}
+            return 500_001
+
+        with (
+            patch(
+                "deepagents_code.configurable_model.count_tokens_approximately",
+                side_effect=count,
+            ),
+            patch("deepagents_code.configurable_model.time.time", return_value=1_000.0),
+        ):
+            result = _mw.wrap_model_call(request, lambda _request: _make_response())
+
+        assert events == [
+            {
+                "type": EXPENSIVE_REQUEST_EVENT_TYPE,
+                "provider": "anthropic",
+                "input_tokens": 500_001,
+            }
+        ]
+        assert getattr(captured_messages[0], "text", None) == "system instructions"
+        assert getattr(captured_messages[1], "text", None) == "hi"
+        assert _checkpoint_update(result)["_prompt_cache_request_times"] == {
+            "anthropic:claude-opus-4-6": 1_000.0
+        }
+
+    @pytest.mark.parametrize(
+        ("provider", "age", "warns"),
+        [
+            ("anthropic", 299.0, False),
+            ("anthropic", 300.0, True),
+            ("openai", 86_399.0, False),
+            ("openai", 86_400.0, True),
+        ],
+    )
+    def test_provider_cache_ttl_boundary(
+        self, provider: str, age: float, warns: bool
+    ) -> None:
+        model = _make_model("model-1")
+        model._get_ls_params.return_value = {"ls_provider": provider}
+        events: list[dict[str, Any]] = []
+        request = _make_request(
+            model,
+            context=CLIContext(thread_id="thread-123"),
+            state={"_prompt_cache_request_times": {f"{provider}:model-1": 100_000.0}},
+            stream_writer=events.append,
+        )
+        with (
+            patch(
+                "deepagents_code.configurable_model.count_tokens_approximately",
+                return_value=500_001,
+            ) as count_tokens,
+            patch(
+                "deepagents_code.configurable_model.time.time",
+                return_value=100_000.0 + age,
+            ),
+        ):
+            _mw.wrap_model_call(request, lambda _request: _make_response())
+
+        assert bool(events) is warns
+        assert count_tokens.called is warns
+
+    def test_threshold_is_strictly_greater_than_500k(self) -> None:
+        events: list[dict[str, Any]] = []
+        request = _make_request(
+            _make_model("gpt-5.6"),
+            context=CLIContext(thread_id="thread-123"),
+            stream_writer=events.append,
+        )
+        with (
+            patch(
+                "deepagents_code.configurable_model.count_tokens_approximately",
+                return_value=500_000,
+            ),
+            patch("deepagents_code.configurable_model.time.time", return_value=2_000.0),
+        ):
+            result = _mw.wrap_model_call(request, lambda _request: _make_response())
+
+        assert events == []
+        assert _checkpoint_update(result)["_prompt_cache_request_times"] == {
+            "openai:gpt-5.6": 2_000.0
+        }
+
+    def test_cache_freshness_is_model_specific(self) -> None:
+        events: list[dict[str, Any]] = []
+        request = _make_request(
+            _make_model("gpt-5.6"),
+            context=CLIContext(thread_id="thread-123"),
+            state={"_prompt_cache_request_times": {"openai:gpt-5.5": 9_999.0}},
+            stream_writer=events.append,
+        )
+        with (
+            patch(
+                "deepagents_code.configurable_model.count_tokens_approximately",
+                return_value=600_000,
+            ),
+            patch(
+                "deepagents_code.configurable_model.time.time", return_value=10_000.0
+            ),
+        ):
+            _mw.wrap_model_call(request, lambda _request: _make_response())
+
+        assert events[0]["provider"] == "openai"
+
+    async def test_async_request_emits_warning(self) -> None:
+        model = _make_model("claude-opus-4-6")
+        model._get_ls_params.return_value = {"ls_provider": "anthropic"}
+        events: list[dict[str, Any]] = []
+        request = _make_request(
+            model,
+            context=CLIContext(thread_id="thread-123"),
+            stream_writer=events.append,
+        )
+
+        async def handler(_request: ModelRequest) -> ModelResponse[Any]:
+            await asyncio.sleep(0)
+            return _make_response()
+
+        with (
+            patch(
+                "deepagents_code.configurable_model.count_tokens_approximately",
+                return_value=700_000,
+            ),
+            patch("deepagents_code.configurable_model.time.time", return_value=3_000.0),
+        ):
+            result = await _mw.awrap_model_call(request, handler)
+
+        assert events[0]["input_tokens"] == 700_000
+        assert _checkpoint_update(result)["_prompt_cache_request_times"] == {
+            "anthropic:claude-opus-4-6": 3_000.0
+        }
 
 
 class TestCheckpointPersistence:

--- a/libs/code/tests/unit_tests/test_non_interactive.py
+++ b/libs/code/tests/unit_tests/test_non_interactive.py
@@ -41,6 +41,7 @@ from deepagents_code.client.non_interactive import (
     _process_ai_message,
     _process_hitl_interrupts,
     _process_message_chunk,
+    _process_stream_chunk,
     _run_agent_loop,
     _run_startup_command,
     _start_langsmith_thread_url_lookup,
@@ -79,6 +80,31 @@ def test_subagent_summarization_does_not_signal_compaction() -> None:
     )
 
     assert _summarization_stream_status(chunk) is None
+
+
+def test_expensive_request_warning_renders_for_subagent() -> None:
+    output = io.StringIO()
+    warning_console = Console(file=output, color_system=None)
+
+    _process_stream_chunk(
+        (
+            ("subagent",),
+            "custom",
+            {
+                "type": "expensive_model_request",
+                "provider": "openai",
+                "input_tokens": 600_000,
+            },
+        ),
+        StreamState(),
+        warning_console,
+        MagicMock(),
+    )
+
+    rendered = output.getvalue()
+    assert "Expensive request" in rendered
+    assert "600,000 input tokens" in rendered
+    assert "24-hour prompt cache TTL" in rendered
 
 
 def test_compaction_result_id_requires_compact_tool_name() -> None:

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -80,6 +80,7 @@ if TYPE_CHECKING:
 
     from langchain_core.runnables import RunnableConfig
 
+    from deepagents_code._expensive_request import ExpensiveRequestWarning
     from deepagents_code.app import TextualSessionState
 
 
@@ -8991,6 +8992,79 @@ class TestReadMentionedFile:
 
         assert "too large to embed" in snippet
         assert "```" not in snippet
+
+
+# ---------------------------------------------------------------------------
+# Expensive-request custom-stream events
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteTaskTextualExpensiveRequestEvents:
+    """Expensive request events reach the notification callback."""
+
+    async def test_subagent_warning_reaches_callback(self) -> None:
+        warnings: list[ExpensiveRequestWarning] = []
+        adapter = TextualUIAdapter(
+            mount_message=AsyncMock(),
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            on_expensive_request=warnings.append,
+        )
+
+        await execute_task_textual(
+            user_input="hi",
+            agent=_FakeAgent(
+                [
+                    (
+                        ("subagent",),
+                        "custom",
+                        {
+                            "type": "expensive_model_request",
+                            "provider": "anthropic",
+                            "input_tokens": 500_001,
+                        },
+                    )
+                ]
+            ),
+            assistant_id="assistant",
+            session_state=_session_state(auto_approve=False),
+            adapter=adapter,
+        )
+
+        assert len(warnings) == 1
+        assert warnings[0].provider == "anthropic"
+        assert warnings[0].input_tokens == 500_001
+
+    async def test_malformed_warning_is_ignored(self) -> None:
+        callback = MagicMock()
+        adapter = TextualUIAdapter(
+            mount_message=AsyncMock(),
+            update_status=_noop_status,
+            request_approval=_mock_approval,
+            on_expensive_request=callback,
+        )
+
+        await execute_task_textual(
+            user_input="hi",
+            agent=_FakeAgent(
+                [
+                    (
+                        (),
+                        "custom",
+                        {
+                            "type": "expensive_model_request",
+                            "provider": "openai",
+                            "input_tokens": "600000",
+                        },
+                    )
+                ]
+            ),
+            assistant_id="assistant",
+            session_state=_session_state(auto_approve=False),
+            adapter=adapter,
+        )
+
+        callback.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Deep Agents Code now warns before Anthropic or OpenAI requests over 500,000 input tokens when the provider's tracked prompt cache TTL has expired.

---

The model middleware estimates the full request context, checkpoints successful request times per model, and emits a validated event for Textual notifications and headless warnings.

Made by [Open SWE](https://openswe.vercel.app/agents/5fff5873-23aa-d1e2-b7b6-633e713cd7df)