### PR TITLE
feat(code): show context usage percentage

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -14414,6 +14414,7 @@ class DeepAgentsApp(App):
             logger.debug("Screen stack empty during model sync", exc_info=True)
         if self._status_bar is None:
             return
+        self._status_bar.set_context_limit(settings.model_context_limit)
         if not provider or not model:
             logger.warning(
                 "Settings missing model identity at status sync "

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -288,6 +288,14 @@ class StatusBar(Horizontal):
         color: $text-muted;
     }
 
+    StatusBar .status-tokens.warning {
+        color: $warning;
+    }
+
+    StatusBar .status-tokens.error {
+        color: $error;
+    }
+
     StatusBar .status-rubric {
         width: auto;
         padding: 0 1;
@@ -378,6 +386,12 @@ class StatusBar(Horizontal):
 
     _CWD_WIDTH_THRESHOLD = 70
     """Hide cwd display below this terminal width."""
+
+    _TOKEN_WARNING_THRESHOLD = 0.4
+    """Show context usage in yellow at or above 40 percent."""
+
+    _TOKEN_ERROR_THRESHOLD = 0.6
+    """Show context usage in red at or above 60 percent."""
 
     def on_resize(self, event: events.Resize) -> None:
         """Hide the cwd on very narrow terminals.
@@ -729,6 +743,8 @@ class StatusBar(Horizontal):
     """
     _has_token_count: bool = False
     """Whether the status bar has displayed a real token count this session."""
+    _context_limit: int | None = None
+    """Maximum input tokens for the active model, when known."""
 
     def watch_tokens(self, new_value: int) -> None:
         """Update token display when count changes."""
@@ -756,17 +772,30 @@ class StatusBar(Horizontal):
         except NoMatches:
             return
 
-        # Hide when empty so the widget's padding doesn't reserve a blank gap.
+        display.remove_class("warning", "error")
         display.display = count > 0
-        if count > 0:
-            suffix = "+" if approximate else ""
-            # Format with K suffix for thousands
-            if count >= 1000:  # noqa: PLR2004  # Count formatting threshold
-                display.update(f"{count / 1000:.1f}K{suffix} tokens")
-            else:
-                display.update(f"{count}{suffix} tokens")
-        else:
+        if count <= 0:
             display.update("")
+            return
+
+        suffix = "+" if approximate else ""
+        if self._context_limit is not None:
+            ratio = count / self._context_limit
+            percent = int(ratio * 100)
+            display.update(f"{percent}% / {count:,}{suffix} tokens")
+            if ratio >= self._TOKEN_ERROR_THRESHOLD:
+                display.add_class("error")
+            elif ratio >= self._TOKEN_WARNING_THRESHOLD:
+                display.add_class("warning")
+        elif count >= 1000:  # noqa: PLR2004  # Count formatting threshold
+            display.update(f"{count / 1000:.1f}K{suffix} tokens")
+        else:
+            display.update(f"{count}{suffix} tokens")
+
+    def set_context_limit(self, limit: int | None) -> None:
+        """Set the active model's context-window size."""
+        self._context_limit = limit if isinstance(limit, int) and limit > 0 else None
+        self._render_tokens(self.tokens, approximate=self._approximate)
 
     def set_rubric_label(self, label: str) -> None:
         """Set the rubric status label.

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -331,8 +331,10 @@ class TestInitialPromptOnMount:
         ):
             mock_settings.model_provider = "openai"
             mock_settings.model_name = "gpt-5.5"
+            mock_settings.model_context_limit = 200_000
             await app.on_mount()
 
+        status_bar.set_context_limit.assert_called_once_with(200_000)
         status_bar.set_model.assert_called_once_with(
             provider="openai", model="gpt-5.5", effort="medium"
         )

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -389,6 +389,59 @@ class TestTokenDisplay:
             display = pilot.app.query_one("#tokens-display")
             assert "5.0K" in str(display.render())
 
+    async def test_context_usage_shows_percent_and_raw_count(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_context_limit(20_000)
+            bar.set_tokens(5_000)
+            await pilot.pause()
+            display = pilot.app.query_one("#tokens-display")
+            assert str(display.render()) == "25% / 5,000 tokens"
+            assert not display.has_class("warning")
+            assert not display.has_class("error")
+
+    async def test_context_usage_turns_yellow_at_40_percent(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_context_limit(10_000)
+            bar.set_tokens(4_000)
+            await pilot.pause()
+            display = pilot.app.query_one("#tokens-display")
+            assert str(display.render()) == "40% / 4,000 tokens"
+            assert display.has_class("warning")
+            assert not display.has_class("error")
+
+    async def test_context_usage_turns_red_at_60_percent(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_context_limit(10_000)
+            bar.set_tokens(6_000)
+            await pilot.pause()
+            display = pilot.app.query_one("#tokens-display")
+            assert str(display.render()) == "60% / 6,000 tokens"
+            assert display.has_class("error")
+            assert not display.has_class("warning")
+
+    async def test_context_limit_change_reformats_cached_count(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_tokens(5_000, approximate=True)
+            await pilot.pause()
+            bar.set_context_limit(10_000)
+            await pilot.pause()
+            display = pilot.app.query_one("#tokens-display")
+            assert str(display.render()) == "50% / 5,000+ tokens"
+            assert display.has_class("warning")
+
+    async def test_invalid_context_limit_uses_count_only(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_context_limit(0)
+            bar.set_tokens(5_000)
+            await pilot.pause()
+            display = pilot.app.query_one("#tokens-display")
+            assert str(display.render()) == "5.0K tokens"
+
     async def test_show_pending_tokens_shows_unknown_placeholder(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)


### PR DESCRIPTION
Context usage in the status bar now shows the percentage and exact token count, turning yellow at 40% and red at 60%.

---

The active model profile supplies the context-window limit; models without one retain the existing token-only display.

Made by [Open SWE](https://openswe.vercel.app/agents/4776615a-2e38-8771-6c79-ee77525257f4)