### PR TITLE
fix(sdk): empty read for degenerate `read_file` windows

### DIFF
--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -39,12 +39,14 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from deepagents.backends.utils import (
+    EMPTY_READ_WINDOW,
     MAX_VIDEO_INPUT_BYTES,
     _get_backend_read_file_type,
     check_empty_content,
     compile_grep_include_glob,
     compile_recursive_glob,
     perform_string_replacement,
+    resolve_read_window,
 )
 
 logger = logging.getLogger(__name__)
@@ -421,7 +423,12 @@ class FilesystemBackend(BackendProtocol):
         Args:
             file_path: Absolute or relative file path.
             offset: Line offset to start reading from (0-indexed).
+
+                Clamped to the start of the file when negative.
             limit: Maximum number of lines to read.
+
+                A non-positive value returns empty content with no pagination
+                metadata.
 
         Returns:
             `ReadResult` with raw (unformatted) content for the requested window.
@@ -456,10 +463,9 @@ class FilesystemBackend(BackendProtocol):
                 if fd >= 0:
                     os.close(fd)
 
-            total_lines: int | None = None
-            start_line: int | None = None
-            end_line: int | None = None
-            next_offset: int | None = None
+            # Binary reads and empty files carry no line range, so they keep the
+            # metadata-free window.
+            window = EMPTY_READ_WINDOW
             if file_type == "text":
                 empty_msg = check_empty_content(content)
                 if empty_msg:
@@ -470,24 +476,18 @@ class FilesystemBackend(BackendProtocol):
                     # trailing-newline state. Required so `edit()` can detect
                     # EOF-newline mismatches in the model's `old_string`.
                     lines = content.splitlines(keepends=True)
-                    start_idx = offset
-                    end_idx = min(start_idx + limit, len(lines))
-                    total_lines = len(lines)
-
-                    if start_idx >= total_lines:
-                        return ReadResult(error=f"Line offset {offset} exceeds file length ({total_lines} lines)")
-
-                    file_data = FileData(content="".join(lines[start_idx:end_idx]), encoding="utf-8")
-                    start_line = start_idx + 1
-                    end_line = end_idx
-                    next_offset = end_idx if end_idx < total_lines else None
+                    resolved = resolve_read_window(len(lines), offset, limit)
+                    if resolved is None:
+                        return ReadResult(error=f"Line offset {offset} exceeds file length ({len(lines)} lines)")
+                    window = resolved
+                    file_data = FileData(content="".join(lines[window.start_idx : window.end_idx]), encoding="utf-8")
 
             return ReadResult(
                 file_data=file_data,
-                total_lines=total_lines,
-                start_line=start_line,
-                end_line=end_line,
-                next_offset=next_offset,
+                total_lines=window.total_lines,
+                start_line=window.start_line,
+                end_line=window.end_line,
+                next_offset=window.next_offset,
             )
         except (OSError, UnicodeDecodeError) as e:
             return ReadResult(error=f"Error reading file '{file_path}': {e}")

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -423,11 +423,14 @@ class FilesystemBackend(BackendProtocol):
             file_path: Absolute or relative file path.
             offset: Line offset to start reading from (0-indexed).
 
-                Clamped to the start of the file when negative.
+                Only applied to text files, and clamped to the start of the file
+                when negative.
             limit: Maximum number of lines to read.
 
-                A non-positive value returns empty content with no pagination
-                metadata.
+                Only applied to text files with content: a non-positive value
+                returns empty content with no pagination metadata. Empty and
+                whitespace-only files return the empty-file reminder regardless
+                of `limit`, and binary files return their full payload.
 
         Returns:
             `ReadResult` with raw (unformatted) content for the requested window.
@@ -467,8 +470,11 @@ class FilesystemBackend(BackendProtocol):
                 if empty_msg:
                     file_data = FileData(content=empty_msg, encoding="utf-8")
                 else:
-                    # Reuse the shared slicer so local reads paginate exactly
-                    # like the state and store backends.
+                    # Reuse the shared slicer so local reads paginate, clamp
+                    # degenerate bounds, and preserve trailing-newline state
+                    # exactly like the state and store backends. `edit()`
+                    # depends on that last property to detect EOF-newline
+                    # mismatches in the model's `old_string`.
                     return slice_read_response(FileData(content=content, encoding="utf-8"), offset, limit)
 
             return ReadResult(file_data=file_data)

--- a/libs/deepagents/deepagents/backends/filesystem.py
+++ b/libs/deepagents/deepagents/backends/filesystem.py
@@ -39,14 +39,13 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from deepagents.backends.utils import (
-    EMPTY_READ_WINDOW,
     MAX_VIDEO_INPUT_BYTES,
     _get_backend_read_file_type,
     check_empty_content,
     compile_grep_include_glob,
     compile_recursive_glob,
     perform_string_replacement,
-    resolve_read_window,
+    slice_read_response,
 )
 
 logger = logging.getLogger(__name__)
@@ -463,32 +462,16 @@ class FilesystemBackend(BackendProtocol):
                 if fd >= 0:
                     os.close(fd)
 
-            # Binary reads and empty files carry no line range, so they keep the
-            # metadata-free window.
-            window = EMPTY_READ_WINDOW
             if file_type == "text":
                 empty_msg = check_empty_content(content)
                 if empty_msg:
                     file_data = FileData(content=empty_msg, encoding="utf-8")
                 else:
-                    # `splitlines(keepends=True)` preserves whether the final line
-                    # has a terminator; joining with `""` round-trips the file's
-                    # trailing-newline state. Required so `edit()` can detect
-                    # EOF-newline mismatches in the model's `old_string`.
-                    lines = content.splitlines(keepends=True)
-                    resolved = resolve_read_window(len(lines), offset, limit)
-                    if resolved is None:
-                        return ReadResult(error=f"Line offset {offset} exceeds file length ({len(lines)} lines)")
-                    window = resolved
-                    file_data = FileData(content="".join(lines[window.start_idx : window.end_idx]), encoding="utf-8")
+                    # Reuse the shared slicer so local reads paginate exactly
+                    # like the state and store backends.
+                    return slice_read_response(FileData(content=content, encoding="utf-8"), offset, limit)
 
-            return ReadResult(
-                file_data=file_data,
-                total_lines=window.total_lines,
-                start_line=window.start_line,
-                end_line=window.end_line,
-                next_offset=window.next_offset,
-            )
+            return ReadResult(file_data=file_data)
         except (OSError, UnicodeDecodeError) as e:
             return ReadResult(error=f"Error reading file '{file_path}': {e}")
 

--- a/libs/deepagents/deepagents/backends/langsmith.py
+++ b/libs/deepagents/deepagents/backends/langsmith.py
@@ -248,9 +248,11 @@ class LangSmithSandbox(BaseSandbox):
 
         # Nothing was requested: no line range to describe, and nothing for the
         # byte cap below to shorten. Guarded at `<= 0` so this holds even if the
-        # clamp above is ever bypassed or removed.
+        # clamp above is ever bypassed or removed. `no_lines_requested` flags
+        # the window as never inspected so the middleware can tell it apart
+        # from a genuinely empty file.
         if limit <= 0:
-            return ReadResult(file_data=FileData(content="", encoding="utf-8"))
+            return ReadResult(file_data=FileData(content="", encoding="utf-8"), no_lines_requested=True)
 
         total_lines = len(lines)
         if not lines or offset >= total_lines:

--- a/libs/deepagents/deepagents/backends/langsmith.py
+++ b/libs/deepagents/deepagents/backends/langsmith.py
@@ -20,7 +20,7 @@ from deepagents.backends.sandbox import (
     TRUNCATION_MSG,
     BaseSandbox,
 )
-from deepagents.backends.utils import _get_backend_read_file_type, empty_read_result, resolve_read_window
+from deepagents.backends.utils import _get_backend_read_file_type, normalize_read_bounds
 
 if TYPE_CHECKING:
     from langsmith.sandbox import AsyncSandbox, AsyncSandboxClient, ExecutionResult, Sandbox
@@ -244,16 +244,18 @@ class LangSmithSandbox(BaseSandbox):
         if lines and lines[-1] == "":
             lines.pop()
 
-        total_lines = len(lines)
-        window = resolve_read_window(total_lines, offset, limit)
-        if window is None:
-            return ReadResult(error=f"File '{file_path}': Line offset {offset} exceeds file length ({total_lines} lines)")
-        # Nothing was requested, so skip the byte-cap bookkeeping below: it
-        # describes a rendered line range, and there is none.
-        if window.is_empty:
-            return empty_read_result()
+        offset, limit = normalize_read_bounds(offset, limit)
 
-        page = lines[window.start_idx : window.end_idx]
+        # Nothing was requested: no line range to describe, and nothing for the
+        # byte cap below to shorten.
+        if limit == 0:
+            return ReadResult(file_data=FileData(content="", encoding="utf-8"))
+
+        total_lines = len(lines)
+        if not lines or offset >= total_lines:
+            return ReadResult(error=f"File '{file_path}': Line offset {offset} exceeds file length ({total_lines} lines)")
+
+        page = lines[offset : offset + limit]
         content = "\n".join(page)
         returned_lines = len(page)
 
@@ -275,13 +277,13 @@ class LangSmithSandbox(BaseSandbox):
             returned_lines = truncated.count("\n") or 1
             content = truncated + TRUNCATION_MSG
 
-        end_line = window.start_idx + returned_lines
+        end_line = offset + returned_lines
         next_offset = end_line if end_line < total_lines else None
 
         return ReadResult(
             file_data=FileData(content=content, encoding="utf-8"),
             total_lines=total_lines,
-            start_line=window.start_line,
+            start_line=offset + 1,
             end_line=end_line,
             next_offset=next_offset,
         )

--- a/libs/deepagents/deepagents/backends/langsmith.py
+++ b/libs/deepagents/deepagents/backends/langsmith.py
@@ -20,7 +20,7 @@ from deepagents.backends.sandbox import (
     TRUNCATION_MSG,
     BaseSandbox,
 )
-from deepagents.backends.utils import _get_backend_read_file_type
+from deepagents.backends.utils import _get_backend_read_file_type, empty_read_result, resolve_read_window
 
 if TYPE_CHECKING:
     from langsmith.sandbox import AsyncSandbox, AsyncSandboxClient, ExecutionResult, Sandbox
@@ -186,6 +186,9 @@ class LangSmithSandbox(BaseSandbox):
             `\r` collapse to `\n`), split on `\n`, paginated by `offset` /
             `limit`, joined back with `\n`, and capped at `MAX_OUTPUT_BYTES`
             with `TRUNCATION_MSG` appended on overflow.
+        - A negative `offset` is clamped to the start of the file, and a
+            non-positive `limit` returns empty content with no pagination
+            metadata.
 
         Args:
             file_path: Absolute path to the file to read.
@@ -241,14 +244,16 @@ class LangSmithSandbox(BaseSandbox):
         if lines and lines[-1] == "":
             lines.pop()
 
-        offset = int(offset)
-        limit = int(limit)
-
         total_lines = len(lines)
-        if not lines or offset >= total_lines:
+        window = resolve_read_window(total_lines, offset, limit)
+        if window is None:
             return ReadResult(error=f"File '{file_path}': Line offset {offset} exceeds file length ({total_lines} lines)")
+        # Nothing was requested, so skip the byte-cap bookkeeping below: it
+        # describes a rendered line range, and there is none.
+        if window.is_empty:
+            return empty_read_result()
 
-        page = lines[offset : offset + limit]
+        page = lines[window.start_idx : window.end_idx]
         content = "\n".join(page)
         returned_lines = len(page)
 
@@ -270,13 +275,13 @@ class LangSmithSandbox(BaseSandbox):
             returned_lines = truncated.count("\n") or 1
             content = truncated + TRUNCATION_MSG
 
-        end_line = offset + returned_lines
+        end_line = window.start_idx + returned_lines
         next_offset = end_line if end_line < total_lines else None
 
         return ReadResult(
             file_data=FileData(content=content, encoding="utf-8"),
             total_lines=total_lines,
-            start_line=offset + 1,
+            start_line=window.start_line,
             end_line=end_line,
             next_offset=next_offset,
         )

--- a/libs/deepagents/deepagents/backends/langsmith.py
+++ b/libs/deepagents/deepagents/backends/langsmith.py
@@ -247,8 +247,9 @@ class LangSmithSandbox(BaseSandbox):
         offset, limit = normalize_read_bounds(offset, limit)
 
         # Nothing was requested: no line range to describe, and nothing for the
-        # byte cap below to shorten.
-        if limit == 0:
+        # byte cap below to shorten. Guarded at `<= 0` so this holds even if the
+        # clamp above is ever bypassed or removed.
+        if limit <= 0:
             return ReadResult(file_data=FileData(content="", encoding="utf-8"))
 
         total_lines = len(lines)

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -213,6 +213,15 @@ class ReadResult:
     next_offset: int | None = None
     """0-indexed offset for the next unread source line."""
 
+    no_lines_requested: bool = False
+    """The read asked for zero lines and the file was never inspected.
+
+    Set by backends when a non-positive `limit` short-circuits the read, so
+    the middleware can tell a never-inspected window apart from a file that
+    was inspected and is genuinely empty — both otherwise arrive as empty
+    content with no pagination metadata.
+    """
+
     def __post_init__(self) -> None:
         """Reject malformed pagination-field combinations at construction.
 
@@ -229,6 +238,11 @@ class ReadResult:
         """
         if (self.start_line is None) != (self.end_line is None):
             msg = "ReadResult.start_line and end_line must be set together or both left unset"
+            raise ValueError(msg)
+        if self.no_lines_requested and (
+            self.error is not None or self.start_line is not None or self.next_offset is not None or self.total_lines is not None
+        ):
+            msg = "ReadResult.no_lines_requested describes an uninspected window; it cannot be combined with error or pagination fields"
             raise ValueError(msg)
         if self.next_offset is not None and self.start_line is None:
             msg = "ReadResult.next_offset requires start_line and end_line to be set"

--- a/libs/deepagents/deepagents/backends/protocol.py
+++ b/libs/deepagents/deepagents/backends/protocol.py
@@ -419,6 +419,17 @@ class BackendProtocol(abc.ABC):  # noqa: B024
     ) -> ReadResult:
         """Read file content for the requested line range.
 
+        Implementations must tolerate degenerate windows rather than raising:
+        a negative `offset` reads from the first line, and a non-positive
+        `limit` returns empty content with every pagination field unset.
+        `deepagents.backends.utils.normalize_read_bounds` clamps both bounds for
+        implementations that slice in Python.
+
+        Implementations must also set `start_line` whenever they return
+        line-numberable text. The middleware falls back to deriving the gutter
+        from `offset` when `start_line` is unset, which only yields a valid
+        1-indexed gutter for windows the backend actually sliced.
+
         Args:
             file_path: Absolute path to the file to read. Must start with `'/'`.
             offset: Line number to start reading from (0-indexed).

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -144,8 +144,8 @@ for open_path, display_path in targets:
                     match_count += 1
                     # Emit one record past the cap (match_count > max_count, not
                     # >=) so the parser can tell "exactly at the cap" (complete)
-                    # from "capped early" (truncated). Mirrors the `head -n
-                    # max_count+1` route in `_build_grep_cmd`.
+                    # from "capped early" (truncated). Mirrors the head -n
+                    # max_count+1 route in _build_grep_cmd.
                     if max_count is not None and match_count > max_count:
                         sys.exit(0)
     except OSError:

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -432,7 +432,7 @@ try:
     # directory, empty-file, and binary branches, so real failures and the
     # empty-file reminder are still reported first.
     if limit <= 0:
-        print(json.dumps({{'encoding': 'utf-8', 'content': ''}}))
+        print(json.dumps({{'encoding': 'utf-8', 'content': '', 'no_lines_requested': True}}))
         sys.exit(0)
 
     line_count = 0
@@ -556,8 +556,9 @@ unbounded. On success
 (binary): `{{"encoding": "base64", "content": ...}}` without pagination keys.
 An empty file short-circuits to `{{"encoding": "utf-8", "content": <empty-file
 reminder>}}`, and a non-positive `limit` to `{{"encoding": "utf-8", "content":
-""}}`, both also without pagination keys. The empty-file check runs first, so an
-empty file yields the reminder even when `limit` is non-positive. On failure:
+"", "no_lines_requested": true}}`, both also without pagination keys. The
+empty-file check runs first, so an empty file yields the reminder even when
+`limit` is non-positive. On failure:
 `{{"error": ...}}`.
 """
 
@@ -650,6 +651,7 @@ def _parse_read_output(output: str, file_path: str) -> ReadResult:
             start_line=data.get("start_line"),
             end_line=data.get("end_line"),
             next_offset=data.get("next_offset"),
+            no_lines_requested=bool(data.get("no_lines_requested")),
         )
     except (KeyError, TypeError, ValueError) as exc:
         return ReadResult(error=f"File '{file_path}': unexpected server response: {exc}")

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -426,8 +426,8 @@ try:
     limit = {limit}
 
     # No lines requested: no line range to report. Reached whenever a caller
-    # asks for zero lines, including a negative `limit` that `_build_read_cmd`
-    # floored to `0`; without this the empty window would fall through to the
+    # asks for zero lines, including a negative limit that _build_read_cmd
+    # floored to 0; without this the empty window would fall through to the
     # offset-exceeds-length error below. Checked here, after the not-found,
     # directory, empty-file, and binary branches, so real failures and the
     # empty-file reminder are still reported first.

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -425,9 +425,8 @@ try:
     offset = {offset}
     limit = {limit}
 
-    # A non-positive limit asks for no lines. Reported after the checks above so
-    # a missing file, a directory, or a binary payload still wins, and without
-    # pagination keys since there is no line range to describe.
+    # No lines requested: no line range to report. Checked here so a missing
+    # file, a directory, or a binary payload is still reported first.
     if limit <= 0:
         print(json.dumps({{'encoding': 'utf-8', 'content': ''}}))
         sys.exit(0)
@@ -602,11 +601,8 @@ def _parse_ls_output(output: str, path: str) -> LsResult:
 def _build_read_cmd(file_path: str, offset: int, limit: int) -> str:
     file_type = _get_backend_read_file_type(file_path)
     path_b64 = base64.b64encode(file_path.encode("utf-8")).decode("ascii")
-    # Clamp here (defensively coercing to int, in case callers bypass type
-    # checking) so a degenerate window never reaches the script: a negative
-    # offset would otherwise be reported as `start_line=0`, which `ReadResult`
-    # rejects. A non-positive limit survives as `0` and the script short-circuits
-    # to an empty read.
+    # Clamp (and defensively coerce to int, in case callers bypass type
+    # checking) so the script never reports a line range starting before line 1.
     offset, limit = normalize_read_bounds(offset, limit)
     return _READ_COMMAND_TEMPLATE.format(
         path_b64=path_b64,

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -425,8 +425,12 @@ try:
     offset = {offset}
     limit = {limit}
 
-    # No lines requested: no line range to report. Checked here so a missing
-    # file, a directory, or a binary payload is still reported first.
+    # No lines requested: no line range to report. Reached whenever a caller
+    # asks for zero lines, including a negative `limit` that `_build_read_cmd`
+    # floored to `0`; without this the empty window would fall through to the
+    # offset-exceeds-length error below. Checked here, after the not-found,
+    # directory, empty-file, and binary branches, so real failures and the
+    # empty-file reminder are still reported first.
     if limit <= 0:
         print(json.dumps({{'encoding': 'utf-8', 'content': ''}}))
         sys.exit(0)
@@ -537,8 +541,11 @@ except PermissionError:
 
 Runs on the sandbox via `execute()`. Only the requested page is returned,
 avoiding full-file transfer for paginated text reads. The path is
-base64-encoded; `file_type`, `offset`, and `limit` are interpolated directly
-(safe because they come from internal code, not user input).
+base64-encoded; `file_type`, `offset`, and `limit` are interpolated directly.
+`offset` and `limit` are model-supplied tool arguments, so interpolation is
+only safe because `_build_read_cmd` coerces both to `int` via
+`normalize_read_bounds` first — that coercion is what bounds them to integer
+literals, and must not be removed.
 
 Output: single-line JSON. On success (text): `{{"encoding", "content",
 "total_lines", "start_line", "end_line", "next_offset"}}`, where `start_line`
@@ -549,7 +556,9 @@ unbounded. On success
 (binary): `{{"encoding": "base64", "content": ...}}` without pagination keys.
 An empty file short-circuits to `{{"encoding": "utf-8", "content": <empty-file
 reminder>}}`, and a non-positive `limit` to `{{"encoding": "utf-8", "content":
-""}}`, both also without pagination keys. On failure: `{{"error": ...}}`.
+""}}`, both also without pagination keys. The empty-file check runs first, so an
+empty file yields the reminder even when `limit` is non-positive. On failure:
+`{{"error": ...}}`.
 """
 
 
@@ -601,8 +610,12 @@ def _parse_ls_output(output: str, path: str) -> LsResult:
 def _build_read_cmd(file_path: str, offset: int, limit: int) -> str:
     file_type = _get_backend_read_file_type(file_path)
     path_b64 = base64.b64encode(file_path.encode("utf-8")).decode("ascii")
-    # Clamp (and defensively coerce to int, in case callers bypass type
-    # checking) so the script never reports a line range starting before line 1.
+    # The `offset` clamp is load-bearing: the script has no negative-offset
+    # guard of its own and would report `start_line` 0 or lower, which
+    # `ReadResult` rejects. The `limit` clamp only normalizes negatives into the
+    # zero-limit case that the script itself short-circuits. The `int()`
+    # coercion inside the helper is what makes interpolating these
+    # model-supplied values into the script source safe.
     offset, limit = normalize_read_bounds(offset, limit)
     return _READ_COMMAND_TEMPLATE.format(
         path_b64=path_b64,
@@ -1075,8 +1088,9 @@ class BaseSandbox(SandboxBackendProtocol, ABC):
                 when negative.
             limit: Maximum number of lines to return.
 
-                Only applied to text files. A non-positive value returns empty
-                content with no pagination metadata.
+                Only applied to text files with content: a non-positive value
+                returns empty content with no pagination metadata. Empty files
+                return the empty-file reminder regardless of `limit`.
 
         Returns:
             `ReadResult` with `file_data` on success or `error` on failure.

--- a/libs/deepagents/deepagents/backends/sandbox.py
+++ b/libs/deepagents/deepagents/backends/sandbox.py
@@ -42,7 +42,7 @@ from deepagents.backends.protocol import (
     WriteResult,
     execute_accepts_timeout,
 )
-from deepagents.backends.utils import _get_backend_read_file_type
+from deepagents.backends.utils import _get_backend_read_file_type, normalize_read_bounds
 
 logger = logging.getLogger(__name__)
 
@@ -424,6 +424,14 @@ try:
 
     offset = {offset}
     limit = {limit}
+
+    # A non-positive limit asks for no lines. Reported after the checks above so
+    # a missing file, a directory, or a binary payload still wins, and without
+    # pagination keys since there is no line range to describe.
+    if limit <= 0:
+        print(json.dumps({{'encoding': 'utf-8', 'content': ''}}))
+        sys.exit(0)
+
     line_count = 0
     returned_lines = 0
     truncated = False
@@ -541,7 +549,8 @@ when the file is large enough that a full re-scan to count its lines would be
 unbounded. On success
 (binary): `{{"encoding": "base64", "content": ...}}` without pagination keys.
 An empty file short-circuits to `{{"encoding": "utf-8", "content": <empty-file
-reminder>}}`, also without pagination keys. On failure: `{{"error": ...}}`.
+reminder>}}`, and a non-positive `limit` to `{{"encoding": "utf-8", "content":
+""}}`, both also without pagination keys. On failure: `{{"error": ...}}`.
 """
 
 
@@ -593,12 +602,17 @@ def _parse_ls_output(output: str, path: str) -> LsResult:
 def _build_read_cmd(file_path: str, offset: int, limit: int) -> str:
     file_type = _get_backend_read_file_type(file_path)
     path_b64 = base64.b64encode(file_path.encode("utf-8")).decode("ascii")
-    # Defensive int coercion in case callers bypass type checking.
+    # Clamp here (defensively coercing to int, in case callers bypass type
+    # checking) so a degenerate window never reaches the script: a negative
+    # offset would otherwise be reported as `start_line=0`, which `ReadResult`
+    # rejects. A non-positive limit survives as `0` and the script short-circuits
+    # to an empty read.
+    offset, limit = normalize_read_bounds(offset, limit)
     return _READ_COMMAND_TEMPLATE.format(
         path_b64=path_b64,
         file_type=file_type,
-        offset=int(offset),
-        limit=int(limit),
+        offset=offset,
+        limit=limit,
     )
 
 
@@ -1061,10 +1075,12 @@ class BaseSandbox(SandboxBackendProtocol, ABC):
             file_path: Absolute path to the file to read.
             offset: Starting line number (0-indexed).
 
-                Only applied to text files.
+                Only applied to text files, and clamped to the start of the file
+                when negative.
             limit: Maximum number of lines to return.
 
-                Only applied to text files.
+                Only applied to text files. A non-positive value returns empty
+                content with no pagination metadata.
 
         Returns:
             `ReadResult` with `file_data` on success or `error` on failure.

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -11,7 +11,7 @@ import re
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import PurePosixPath
-from typing import Any, Final, Literal, overload
+from typing import Any, Final, Literal, NamedTuple, overload
 
 import wcmatch.glob as wcglob
 
@@ -389,6 +389,105 @@ def _copy_file_data_with_content(file_data: FileData, content: str) -> FileData:
     return sliced_fd
 
 
+def normalize_read_bounds(offset: int, limit: int) -> tuple[int, int]:
+    """Clamp a requested read window to a non-negative offset and line count.
+
+    Models occasionally emit degenerate `read_file` arguments (`offset=-1`,
+    `limit=0`). Clamping them in one place keeps every backend from building a
+    `ReadResult` window that starts before line 1 or runs backward, which
+    `ReadResult.__post_init__` rejects.
+
+    Args:
+        offset: Requested 0-indexed line offset.
+        limit: Requested maximum number of lines.
+
+    Returns:
+        Tuple of `(offset, limit)`, each floored at `0`.
+    """
+    return max(int(offset), 0), max(int(limit), 0)
+
+
+class ReadWindow(NamedTuple):
+    """Resolved bounds for a single page of a paginated text read.
+
+    `start_idx`/`end_idx` are 0-indexed slice bounds into the file's lines; the
+    remaining fields are the pagination metadata `ReadResult` expects, and are
+    all `None` for a window that returns no lines (see `EMPTY_READ_WINDOW`).
+    """
+
+    start_idx: int
+    end_idx: int
+    total_lines: int | None
+    start_line: int | None
+    end_line: int | None
+    next_offset: int | None
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether the window deliberately selects no lines."""
+        return self.start_line is None
+
+
+EMPTY_READ_WINDOW = ReadWindow(
+    start_idx=0,
+    end_idx=0,
+    total_lines=None,
+    start_line=None,
+    end_line=None,
+    next_offset=None,
+)
+"""Window for a read that returns no lines.
+
+A non-positive `limit` asks for nothing, so there is no line range to describe:
+every pagination field stays unset, exactly as it does for an empty file.
+"""
+
+
+def resolve_read_window(total_lines: int, offset: int, limit: int) -> ReadWindow | None:
+    """Resolve which lines a paginated read should return.
+
+    Shared by every built-in text read path so the emitted window always
+    satisfies the `ReadResult` contract: it runs forward from line 1 or later,
+    stays inside the file, and resumes at the first line not shown.
+
+    Args:
+        total_lines: Number of source lines in the file.
+        offset: Requested 0-indexed line offset; clamped at `0`.
+        limit: Requested maximum number of lines; `<= 0` selects no lines.
+
+    Returns:
+        `EMPTY_READ_WINDOW` when nothing was requested, `None` when the offset
+            starts at or past the end of the file (the caller reports that as
+            its own error), otherwise the resolved `ReadWindow`.
+    """
+    offset, limit = normalize_read_bounds(offset, limit)
+    if limit == 0:
+        return EMPTY_READ_WINDOW
+    if offset >= total_lines:
+        return None
+    end_idx = min(offset + limit, total_lines)
+    return ReadWindow(
+        start_idx=offset,
+        end_idx=end_idx,
+        total_lines=total_lines,
+        start_line=offset + 1,
+        end_line=end_idx,
+        next_offset=end_idx if end_idx < total_lines else None,
+    )
+
+
+def empty_read_result(encoding: str = "utf-8") -> ReadResult:
+    """Build the result for a read whose window returns no lines.
+
+    Args:
+        encoding: Encoding recorded on the returned `FileData`.
+
+    Returns:
+        `ReadResult` with empty content and no pagination metadata.
+    """
+    return ReadResult(file_data=FileData(content="", encoding=encoding))
+
+
 def slice_read_response(
     file_data: FileData,
     offset: int,
@@ -409,8 +508,8 @@ def slice_read_response(
         `ReadResult` with the sliced raw content and pagination metadata
             (`total_lines`, `start_line`, `end_line`, `next_offset`). The
             pagination fields are left unset for empty or whitespace-only
-            content. `error` is set instead when the offset exceeds the file
-            length.
+            content, and for a window that returns no lines. `error` is set
+            instead when the offset exceeds the file length.
     """
     content = file_data_to_string(file_data)
 
@@ -424,24 +523,20 @@ def slice_read_response(
     # also splits on CR / CRLF, so line indexing matches the LF-normalized
     # form without first rewriting the whole (potentially huge) string.
     lines = content.splitlines(keepends=True)
-    start_idx = offset
-    end_idx = min(start_idx + limit, len(lines))
-    total_lines = len(lines)
-
-    if start_idx >= total_lines:
-        return ReadResult(error=f"Line offset {offset} exceeds file length ({total_lines} lines)")
+    window = resolve_read_window(len(lines), offset, limit)
+    if window is None:
+        return ReadResult(error=f"Line offset {offset} exceeds file length ({len(lines)} lines)")
 
     # Normalize line endings to LF, but only across the requested window.
     # State/Store backends may carry CRLF or CR content as written;
     # downstream tooling (edit match, grep, format) assumes LF.
-    sliced = "".join(lines[start_idx:end_idx]).replace("\r\n", "\n").replace("\r", "\n")
-    next_offset = end_idx if end_idx < total_lines else None
+    sliced = "".join(lines[window.start_idx : window.end_idx]).replace("\r\n", "\n").replace("\r", "\n")
     return ReadResult(
         file_data=_copy_file_data_with_content(file_data, sliced),
-        total_lines=total_lines,
-        start_line=start_idx + 1,
-        end_line=end_idx,
-        next_offset=next_offset,
+        total_lines=window.total_lines,
+        start_line=window.start_line,
+        end_line=window.end_line,
+        next_offset=window.next_offset,
     )
 
 

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -6,6 +6,7 @@ enable composition without fragile string parsing.
 """
 
 import functools
+import logging
 import os
 import re
 from collections.abc import Callable, Sequence
@@ -16,6 +17,8 @@ from typing import Any, Final, Literal, overload
 import wcmatch.glob as wcglob
 
 from deepagents.backends.protocol import FileData, FileInfo as _FileInfo, GrepMatch as _GrepMatch, GrepResult, ReadResult
+
+logger = logging.getLogger(__name__)
 
 EMPTY_CONTENT_WARNING = "System reminder: File exists but has empty contents"
 MAX_VIDEO_INPUT_BYTES: Final = 1024 * 1024 * 1024
@@ -393,17 +396,37 @@ def normalize_read_bounds(offset: int, limit: int) -> tuple[int, int]:
     """Floor a requested read window at a zero offset and zero lines.
 
     Models occasionally emit degenerate `read_file` arguments (`offset=-1`,
-    `limit=0`). Clamping them keeps backends from reporting a line range that
-    starts before line 1 or runs backward, which `ReadResult` rejects.
+    `limit=0`). Clamping `offset` keeps backends from reporting a line range
+    that starts before line 1, which `ReadResult` rejects.
+
+    Clamping `limit` is *not* sufficient on its own: flooring a negative limit
+    at `0` produces a zero-length window, which still has no valid
+    `start_line`/`end_line` pair. Callers must additionally treat a returned
+    `limit` of `0` as an empty read — see `slice_read_response` below, or the
+    equivalent short-circuits in the sandbox and LangSmith backends.
+
+    The `int()` coercion is deliberate and load-bearing, not redundant with the
+    annotations: `offset` and `limit` originate from model-supplied tool
+    arguments, and the sandbox backend interpolates them into the source of a
+    script it executes (`_READ_COMMAND_TEMPLATE`). Do not remove it.
 
     Args:
         offset: Requested 0-indexed line offset.
         limit: Requested maximum number of lines.
 
     Returns:
-        Tuple of `(offset, limit)`, each floored at `0`.
+        Tuple of `(offset, limit)`, each coerced to `int` and floored at `0`.
     """
-    return max(int(offset), 0), max(int(limit), 0)
+    normalized_offset, normalized_limit = max(int(offset), 0), max(int(limit), 0)
+    if (normalized_offset, normalized_limit) != (offset, limit):
+        logger.debug(
+            "Clamped degenerate read window: offset %r -> %d, limit %r -> %d",
+            offset,
+            normalized_offset,
+            limit,
+            normalized_limit,
+        )
+    return normalized_offset, normalized_limit
 
 
 def slice_read_response(
@@ -422,21 +445,29 @@ def slice_read_response(
         offset: Line offset (0-indexed).
         limit: Maximum number of lines.
 
+    Both bounds are clamped through `normalize_read_bounds` before slicing, so
+    a negative `offset` reads from the first line and a negative `limit` is
+    treated as `0`.
+
     Returns:
         `ReadResult` with the sliced raw content and pagination metadata
             (`total_lines`, `start_line`, `end_line`, `next_offset`). The
             pagination fields are left unset for empty or whitespace-only
-            content, and when `limit` selects no lines. `error` is set instead
+            content, and when the clamped `limit` is `0`. `error` is set instead
             when the offset exceeds the file length.
     """
     content = file_data_to_string(file_data)
     offset, limit = normalize_read_bounds(offset, limit)
 
+    # Ordering note: blank content is reported before the zero-limit check, so a
+    # whitespace-only file returns its content (which the middleware maps to the
+    # empty-file reminder) rather than `""`, regardless of `limit`.
     if not content or content.strip() == "":
         return ReadResult(file_data=_copy_file_data_with_content(file_data, content))
 
-    # Nothing was requested, so there is no line range to report — same shape as
-    # an empty file above.
+    # Nothing was requested, so there is no line range to report — same
+    # pagination shape as the blank-content branch above. The middleware
+    # distinguishes this from a genuinely empty file by re-checking `limit`.
     if limit == 0:
         return ReadResult(file_data=_copy_file_data_with_content(file_data, ""))
 

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -403,7 +403,8 @@ def normalize_read_bounds(offset: int, limit: int) -> tuple[int, int]:
     at `0` produces a zero-length window, which still has no valid
     `start_line`/`end_line` pair. Callers must additionally treat a returned
     `limit` of `0` as an empty read — see `slice_read_response` below, or the
-    equivalent short-circuits in the sandbox and LangSmith backends.
+    equivalent short-circuits in the sandbox and LangSmith backends, which
+    flag the result with `ReadResult.no_lines_requested`.
 
     The `int()` coercion is deliberate and load-bearing, not redundant with the
     annotations: `offset` and `limit` originate from model-supplied tool
@@ -453,8 +454,11 @@ def slice_read_response(
         `ReadResult` with the sliced raw content and pagination metadata
             (`total_lines`, `start_line`, `end_line`, `next_offset`). The
             pagination fields are left unset for empty or whitespace-only
-            content, and when the clamped `limit` is `0`. `error` is set instead
-            when the offset exceeds the file length.
+            content, and when the clamped `limit` is `0`; the zero-`limit`
+            result additionally sets `no_lines_requested` so the middleware
+            can tell the never-inspected window apart from a genuinely empty
+            file. `error` is set instead when the offset exceeds the file
+            length.
     """
     content = file_data_to_string(file_data)
     offset, limit = normalize_read_bounds(offset, limit)
@@ -465,11 +469,12 @@ def slice_read_response(
     if not content or content.strip() == "":
         return ReadResult(file_data=_copy_file_data_with_content(file_data, content))
 
-    # Nothing was requested, so there is no line range to report — same
-    # pagination shape as the blank-content branch above. The middleware
-    # distinguishes this from a genuinely empty file by re-checking `limit`.
+    # Nothing was requested: flag the window as never inspected so the
+    # middleware can tell it apart from a genuinely empty file, which arrives
+    # via the blank-content branch above (its `ReadResult` is otherwise
+    # identical: empty content, no pagination metadata).
     if limit == 0:
-        return ReadResult(file_data=_copy_file_data_with_content(file_data, ""))
+        return ReadResult(file_data=_copy_file_data_with_content(file_data, ""), no_lines_requested=True)
 
     # `splitlines(keepends=True)` retains each line's terminator, including
     # the absence of one on the final line. Joining with `""` therefore

--- a/libs/deepagents/deepagents/backends/utils.py
+++ b/libs/deepagents/deepagents/backends/utils.py
@@ -11,7 +11,7 @@ import re
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import PurePosixPath
-from typing import Any, Final, Literal, NamedTuple, overload
+from typing import Any, Final, Literal, overload
 
 import wcmatch.glob as wcglob
 
@@ -390,12 +390,11 @@ def _copy_file_data_with_content(file_data: FileData, content: str) -> FileData:
 
 
 def normalize_read_bounds(offset: int, limit: int) -> tuple[int, int]:
-    """Clamp a requested read window to a non-negative offset and line count.
+    """Floor a requested read window at a zero offset and zero lines.
 
     Models occasionally emit degenerate `read_file` arguments (`offset=-1`,
-    `limit=0`). Clamping them in one place keeps every backend from building a
-    `ReadResult` window that starts before line 1 or runs backward, which
-    `ReadResult.__post_init__` rejects.
+    `limit=0`). Clamping them keeps backends from reporting a line range that
+    starts before line 1 or runs backward, which `ReadResult` rejects.
 
     Args:
         offset: Requested 0-indexed line offset.
@@ -405,87 +404,6 @@ def normalize_read_bounds(offset: int, limit: int) -> tuple[int, int]:
         Tuple of `(offset, limit)`, each floored at `0`.
     """
     return max(int(offset), 0), max(int(limit), 0)
-
-
-class ReadWindow(NamedTuple):
-    """Resolved bounds for a single page of a paginated text read.
-
-    `start_idx`/`end_idx` are 0-indexed slice bounds into the file's lines; the
-    remaining fields are the pagination metadata `ReadResult` expects, and are
-    all `None` for a window that returns no lines (see `EMPTY_READ_WINDOW`).
-    """
-
-    start_idx: int
-    end_idx: int
-    total_lines: int | None
-    start_line: int | None
-    end_line: int | None
-    next_offset: int | None
-
-    @property
-    def is_empty(self) -> bool:
-        """Whether the window deliberately selects no lines."""
-        return self.start_line is None
-
-
-EMPTY_READ_WINDOW = ReadWindow(
-    start_idx=0,
-    end_idx=0,
-    total_lines=None,
-    start_line=None,
-    end_line=None,
-    next_offset=None,
-)
-"""Window for a read that returns no lines.
-
-A non-positive `limit` asks for nothing, so there is no line range to describe:
-every pagination field stays unset, exactly as it does for an empty file.
-"""
-
-
-def resolve_read_window(total_lines: int, offset: int, limit: int) -> ReadWindow | None:
-    """Resolve which lines a paginated read should return.
-
-    Shared by every built-in text read path so the emitted window always
-    satisfies the `ReadResult` contract: it runs forward from line 1 or later,
-    stays inside the file, and resumes at the first line not shown.
-
-    Args:
-        total_lines: Number of source lines in the file.
-        offset: Requested 0-indexed line offset; clamped at `0`.
-        limit: Requested maximum number of lines; `<= 0` selects no lines.
-
-    Returns:
-        `EMPTY_READ_WINDOW` when nothing was requested, `None` when the offset
-            starts at or past the end of the file (the caller reports that as
-            its own error), otherwise the resolved `ReadWindow`.
-    """
-    offset, limit = normalize_read_bounds(offset, limit)
-    if limit == 0:
-        return EMPTY_READ_WINDOW
-    if offset >= total_lines:
-        return None
-    end_idx = min(offset + limit, total_lines)
-    return ReadWindow(
-        start_idx=offset,
-        end_idx=end_idx,
-        total_lines=total_lines,
-        start_line=offset + 1,
-        end_line=end_idx,
-        next_offset=end_idx if end_idx < total_lines else None,
-    )
-
-
-def empty_read_result(encoding: str = "utf-8") -> ReadResult:
-    """Build the result for a read whose window returns no lines.
-
-    Args:
-        encoding: Encoding recorded on the returned `FileData`.
-
-    Returns:
-        `ReadResult` with empty content and no pagination metadata.
-    """
-    return ReadResult(file_data=FileData(content="", encoding=encoding))
 
 
 def slice_read_response(
@@ -508,13 +426,19 @@ def slice_read_response(
         `ReadResult` with the sliced raw content and pagination metadata
             (`total_lines`, `start_line`, `end_line`, `next_offset`). The
             pagination fields are left unset for empty or whitespace-only
-            content, and for a window that returns no lines. `error` is set
-            instead when the offset exceeds the file length.
+            content, and when `limit` selects no lines. `error` is set instead
+            when the offset exceeds the file length.
     """
     content = file_data_to_string(file_data)
+    offset, limit = normalize_read_bounds(offset, limit)
 
     if not content or content.strip() == "":
         return ReadResult(file_data=_copy_file_data_with_content(file_data, content))
+
+    # Nothing was requested, so there is no line range to report — same shape as
+    # an empty file above.
+    if limit == 0:
+        return ReadResult(file_data=_copy_file_data_with_content(file_data, ""))
 
     # `splitlines(keepends=True)` retains each line's terminator, including
     # the absence of one on the final line. Joining with `""` therefore
@@ -523,20 +447,24 @@ def slice_read_response(
     # also splits on CR / CRLF, so line indexing matches the LF-normalized
     # form without first rewriting the whole (potentially huge) string.
     lines = content.splitlines(keepends=True)
-    window = resolve_read_window(len(lines), offset, limit)
-    if window is None:
-        return ReadResult(error=f"Line offset {offset} exceeds file length ({len(lines)} lines)")
+    start_idx = offset
+    end_idx = min(start_idx + limit, len(lines))
+    total_lines = len(lines)
+
+    if start_idx >= total_lines:
+        return ReadResult(error=f"Line offset {offset} exceeds file length ({total_lines} lines)")
 
     # Normalize line endings to LF, but only across the requested window.
     # State/Store backends may carry CRLF or CR content as written;
     # downstream tooling (edit match, grep, format) assumes LF.
-    sliced = "".join(lines[window.start_idx : window.end_idx]).replace("\r\n", "\n").replace("\r", "\n")
+    sliced = "".join(lines[start_idx:end_idx]).replace("\r\n", "\n").replace("\r", "\n")
+    next_offset = end_idx if end_idx < total_lines else None
     return ReadResult(
         file_data=_copy_file_data_with_content(file_data, sliced),
-        total_lines=window.total_lines,
-        start_line=window.start_line,
-        end_line=window.end_line,
-        next_offset=window.next_offset,
+        total_lines=total_lines,
+        start_line=start_idx + 1,
+        end_line=end_idx,
+        next_offset=next_offset,
     )
 
 

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -624,6 +624,10 @@ Distinct from `EMPTY_CONTENT_WARNING` on purpose: the `read_file` description
 teaches the model that the empty-contents reminder means the file itself is
 empty, so reusing it for a zero-line window would state something false about
 the filesystem that a following `write_file` could act on destructively.
+
+Backends declare the zero-line window with `ReadResult.no_lines_requested`,
+so an inspected-but-empty file (which otherwise arrives identically: empty
+content, no pagination metadata) keeps the empty-file reminder instead.
 """
 GLOB_TIMEOUT = 10.0  # seconds
 GREP_TRUNCATION_NOTE = (
@@ -1630,10 +1634,14 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                 # zero-line window, where the file was never inspected, and a
                 # genuinely empty file. Reporting the former as the latter
                 # states something false about a file that may have contents.
-                # `not content` is required alongside the `limit` check because
-                # binary and video reads ignore `limit` and return a non-empty
-                # payload, so neither cause applies to them.
-                if not content and limit <= 0:
+                # The backend declares which one happened: both arrive as
+                # empty content with no pagination metadata, but only the
+                # never-inspected window sets `no_lines_requested` — a file
+                # that was inspected and is empty (whitespace-only text from
+                # `slice_read_response`'s blank branch, or empty base64 from
+                # a binary read that ignored `limit`) keeps the empty-file
+                # reminder.
+                if not content and read_result.no_lines_requested:
                     empty_msg = NO_LINES_REQUESTED_WARNING.format(limit=limit)
                 return ToolMessage(
                     content=empty_msg,

--- a/libs/deepagents/deepagents/middleware/filesystem.py
+++ b/libs/deepagents/deepagents/middleware/filesystem.py
@@ -592,7 +592,39 @@ def _remaining_lines_notice(read_result: ReadResult) -> str:
     )
 
 
+def _clamped_offset_notice(offset: int) -> str:
+    """Disclose that a negative requested offset was read from the file start.
+
+    Backends clamp a negative `offset` to `0` rather than erroring, so without
+    this the model sees a correct-looking gutter starting at line 1 and no
+    indication its request was reinterpreted. `_remaining_lines_notice` cannot
+    carry the disclosure: it returns an empty string once the window reaches the
+    end of the file, which is exactly the common degenerate case
+    (`offset=-1` with a default `limit`).
+
+    Args:
+        offset: Offset as requested by the caller, before clamping.
+
+    Returns:
+        A model-facing notice when `offset` was negative, else an empty string.
+    """
+    if offset >= 0:
+        return ""
+    return f"\n\n[Requested offset {offset} is before the start of the file; read from line 1 instead.]"
+
+
 EMPTY_CONTENT_WARNING = "System reminder: File exists but has empty contents"
+NO_LINES_REQUESTED_WARNING = (
+    "System reminder: no lines were read because `limit` was {limit}. The file was "
+    "not inspected and may have contents; retry with `limit` >= 1 to read it."
+)
+"""Reported when a read requested zero lines.
+
+Distinct from `EMPTY_CONTENT_WARNING` on purpose: the `read_file` description
+teaches the model that the empty-contents reminder means the file itself is
+empty, so reusing it for a zero-line window would state something false about
+the filesystem that a following `write_file` could act on destructively.
+"""
 GLOB_TIMEOUT = 10.0  # seconds
 GREP_TRUNCATION_NOTE = (
     "Note: the search stopped early (it hit its time limit or the maximum match count). "
@@ -1594,6 +1626,15 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
             # binary reads.
             empty_msg = check_empty_content(content)
             if empty_msg:
+                # Empty content has two causes that must not be conflated: a
+                # zero-line window, where the file was never inspected, and a
+                # genuinely empty file. Reporting the former as the latter
+                # states something false about a file that may have contents.
+                # `not content` is required alongside the `limit` check because
+                # binary and video reads ignore `limit` and return a non-empty
+                # payload, so neither cause applies to them.
+                if not content and limit <= 0:
+                    empty_msg = NO_LINES_REQUESTED_WARNING.format(limit=limit)
                 return ToolMessage(
                     content=empty_msg,
                     name="read_file",
@@ -1629,12 +1670,17 @@ class FilesystemMiddleware(AgentMiddleware[FilesystemState, ContextT, ResponseT]
                     status="success",
                 )
 
-            content = format_content_with_line_numbers(content, start_line=read_result.start_line or offset + 1)
+            # `max(offset, 0)` so the fallback gutter stays 1-indexed: a backend
+            # that returns numberable text without `start_line` would otherwise
+            # render a zero or negative line marker, which the row-marker
+            # parsers downstream assume never happens.
+            content = format_content_with_line_numbers(content, start_line=read_result.start_line or max(offset, 0) + 1)
             # `limit` already bounded raw source lines at the backend; do not
             # re-truncate by row count here, or wrapped continuation rows would
             # push real source lines off the end of the page (#2453).
+            # The clamp notice is appended after truncation so it cannot be cut.
             return ToolMessage(
-                content=_truncate_paginated_read(content, validated_path, read_result, token_limit),
+                content=_truncate_paginated_read(content, validated_path, read_result, token_limit) + _clamped_offset_notice(offset),
                 name="read_file",
                 tool_call_id=tool_call_id,
                 status="success",

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -330,14 +330,13 @@ def test_filesystem_backend_read_empty_file_leaves_pagination_unset(tmp_path: Pa
     assert result.next_offset is None
 
 
-@pytest.mark.parametrize("limit", [0, -5])
-def test_filesystem_backend_read_non_positive_limit_returns_empty_read(tmp_path: Path, limit: int) -> None:
-    """A degenerate `limit` returns an empty read, not a window-validation error."""
+def test_filesystem_backend_read_zero_limit_returns_empty_read(tmp_path: Path) -> None:
+    """A degenerate `limit` returns an empty read, not a line-range error."""
     target = tmp_path / "notes.txt"
     target.write_text("one\ntwo\nthree\n")
     be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
 
-    result = be.read(str(target), offset=0, limit=limit)
+    result = be.read(str(target), offset=0, limit=0)
 
     assert result.error is None
     assert result.file_data is not None

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -330,6 +330,40 @@ def test_filesystem_backend_read_empty_file_leaves_pagination_unset(tmp_path: Pa
     assert result.next_offset is None
 
 
+@pytest.mark.parametrize("limit", [0, -5])
+def test_filesystem_backend_read_non_positive_limit_returns_empty_read(tmp_path: Path, limit: int) -> None:
+    """A degenerate `limit` returns an empty read, not a window-validation error."""
+    target = tmp_path / "notes.txt"
+    target.write_text("one\ntwo\nthree\n")
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+    result = be.read(str(target), offset=0, limit=limit)
+
+    assert result.error is None
+    assert result.file_data is not None
+    assert result.file_data["content"] == ""
+    assert result.total_lines is None
+    assert result.start_line is None
+    assert result.end_line is None
+    assert result.next_offset is None
+
+
+def test_filesystem_backend_read_negative_offset_starts_at_first_line(tmp_path: Path) -> None:
+    """A negative offset is clamped to the start of the file instead of erroring."""
+    target = tmp_path / "notes.txt"
+    target.write_text("one\ntwo\nthree\n")
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+    result = be.read(str(target), offset=-1, limit=2)
+
+    assert result.error is None
+    assert result.file_data is not None
+    assert result.file_data["content"] == "one\ntwo\n"
+    assert result.start_line == 1
+    assert result.end_line == 2
+    assert result.next_offset == 2
+
+
 def test_filesystem_backend_reads_mkv_as_binary(tmp_path: Path) -> None:
     """Local `.mkv` reads must be routed as binary before UTF-8 decoding."""
     target = tmp_path / "clip.mkv"

--- a/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_filesystem_backend.py
@@ -330,13 +330,14 @@ def test_filesystem_backend_read_empty_file_leaves_pagination_unset(tmp_path: Pa
     assert result.next_offset is None
 
 
-def test_filesystem_backend_read_zero_limit_returns_empty_read(tmp_path: Path) -> None:
+@pytest.mark.parametrize("limit", [0, -3])
+def test_filesystem_backend_read_non_positive_limit_returns_empty_read(tmp_path: Path, limit: int) -> None:
     """A degenerate `limit` returns an empty read, not a line-range error."""
     target = tmp_path / "notes.txt"
     target.write_text("one\ntwo\nthree\n")
     be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
 
-    result = be.read(str(target), offset=0, limit=0)
+    result = be.read(str(target), offset=0, limit=limit)
 
     assert result.error is None
     assert result.file_data is not None
@@ -361,6 +362,33 @@ def test_filesystem_backend_read_negative_offset_starts_at_first_line(tmp_path: 
     assert result.start_line == 1
     assert result.end_line == 2
     assert result.next_offset == 2
+
+
+def test_filesystem_backend_read_zero_limit_on_empty_file_reports_empty_file(tmp_path: Path) -> None:
+    """The empty-file check precedes the slice, so the reminder wins over the limit."""
+    target = tmp_path / "blank.txt"
+    target.write_text("")
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+    result = be.read(str(target), offset=0, limit=0)
+
+    assert result.error is None
+    assert result.file_data is not None
+    assert "empty contents" in result.file_data["content"]
+
+
+def test_filesystem_backend_read_zero_limit_on_binary_returns_full_payload(tmp_path: Path) -> None:
+    """`limit` does not apply to binary reads, so a zero limit is not an empty read."""
+    target = tmp_path / "clip.png"
+    target.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+    be = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=False)
+
+    result = be.read(str(target), offset=0, limit=0)
+
+    assert result.error is None
+    assert result.file_data is not None
+    assert result.file_data["encoding"] == "base64"
+    assert result.file_data["content"] != ""
 
 
 def test_filesystem_backend_reads_mkv_as_binary(tmp_path: Path) -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
@@ -6,6 +6,7 @@ import base64
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from langsmith.sandbox import ResourceNotFoundError, SandboxClientError
 
 from deepagents.backends import sandbox as base_sandbox
@@ -317,12 +318,18 @@ def test_read_offset_exceeds_length() -> None:
     assert "offset" in result.error.lower()
 
 
-def test_read_zero_limit_returns_empty_read() -> None:
-    """A degenerate `limit` reads nothing instead of raising on the line range."""
+@pytest.mark.parametrize("limit", [0, -3])
+def test_read_non_positive_limit_returns_empty_read(limit: int) -> None:
+    """A degenerate `limit` reads nothing instead of raising on the line range.
+
+    A negative `limit` is covered separately from `0`: the guard in `read()` is
+    what makes this hold, and a clamp-dependent `== 0` check would pass the
+    zero case while raising on the negative one.
+    """
     sb, mock_sdk = _make_sandbox()
     mock_sdk.read.return_value = b"line1\nline2\nline3"
 
-    result = sb.read("/app/test.txt", limit=0)
+    result = sb.read("/app/test.txt", limit=limit)
 
     assert result.error is None
     assert result.file_data is not None

--- a/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
@@ -6,6 +6,7 @@ import base64
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from langsmith.sandbox import ResourceNotFoundError, SandboxClientError
 
 from deepagents.backends import sandbox as base_sandbox
@@ -315,6 +316,38 @@ def test_read_offset_exceeds_length() -> None:
 
     assert result.error is not None
     assert "offset" in result.error.lower()
+
+
+@pytest.mark.parametrize("limit", [0, -2])
+def test_read_non_positive_limit_returns_empty_read(limit: int) -> None:
+    """A degenerate `limit` reads nothing instead of raising on the window."""
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.read.return_value = b"line1\nline2\nline3"
+
+    result = sb.read("/app/test.txt", limit=limit)
+
+    assert result.error is None
+    assert result.file_data is not None
+    assert result.file_data["content"] == ""
+    assert result.total_lines is None
+    assert result.start_line is None
+    assert result.end_line is None
+    assert result.next_offset is None
+
+
+def test_read_negative_offset_starts_at_first_line() -> None:
+    """A negative offset is clamped to the start of the file instead of erroring."""
+    sb, mock_sdk = _make_sandbox()
+    mock_sdk.read.return_value = b"line1\nline2\nline3"
+
+    result = sb.read("/app/test.txt", offset=-1, limit=2)
+
+    assert result.error is None
+    assert result.file_data is not None
+    assert result.file_data["content"] == "line1\nline2"
+    assert result.start_line == 1
+    assert result.end_line == 2
+    assert result.next_offset == 2
 
 
 def test_read_normalizes_crlf_to_lf() -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_langsmith_sandbox.py
@@ -6,7 +6,6 @@ import base64
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
 from langsmith.sandbox import ResourceNotFoundError, SandboxClientError
 
 from deepagents.backends import sandbox as base_sandbox
@@ -318,13 +317,12 @@ def test_read_offset_exceeds_length() -> None:
     assert "offset" in result.error.lower()
 
 
-@pytest.mark.parametrize("limit", [0, -2])
-def test_read_non_positive_limit_returns_empty_read(limit: int) -> None:
-    """A degenerate `limit` reads nothing instead of raising on the window."""
+def test_read_zero_limit_returns_empty_read() -> None:
+    """A degenerate `limit` reads nothing instead of raising on the line range."""
     sb, mock_sdk = _make_sandbox()
     mock_sdk.read.return_value = b"line1\nline2\nline3"
 
-    result = sb.read("/app/test.txt", limit=limit)
+    result = sb.read("/app/test.txt", limit=0)
 
     assert result.error is None
     assert result.file_data is not None

--- a/libs/deepagents/tests/unit_tests/backends/test_protocol.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_protocol.py
@@ -322,3 +322,22 @@ class TestReadResultPaginationInvariants:
     def test_malformed_combinations_raise(self, kwargs: dict[str, int]) -> None:
         with pytest.raises(ValueError, match="ReadResult"):
             ReadResult(**kwargs)
+
+    def test_no_lines_requested_valid_window(self) -> None:
+        """The zero-line flag is valid on its own with empty file data."""
+        result = ReadResult(file_data={"content": "", "encoding": "utf-8"}, no_lines_requested=True)
+        assert result.no_lines_requested is True
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({"error": "boom"}, id="with_error"),
+            pytest.param({"start_line": 1, "end_line": 1}, id="with_window"),
+            pytest.param({"total_lines": 3, "start_line": 1, "end_line": 1}, id="with_total"),
+            pytest.param({"start_line": 1, "end_line": 1, "next_offset": 1}, id="with_next_offset"),
+        ],
+    )
+    def test_no_lines_requested_rejects_other_dispositions(self, kwargs: dict) -> None:
+        """A never-inspected window cannot also claim an error or a line range."""
+        with pytest.raises(ValueError, match="no_lines_requested"):
+            ReadResult(no_lines_requested=True, **kwargs)

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -1349,13 +1349,13 @@ def test_sandbox_edit_upload_malformed_output_cleans_up() -> None:
 # _FakeSandbox-style tests cannot reach because they stub execute() output.
 
 
-def _run_read_script(target: Path, *, file_type: str = "text", offset: int = 0, limit: int = 2000) -> dict:
-    cmd = _READ_COMMAND_TEMPLATE.format(
-        path_b64=base64.b64encode(str(target).encode("utf-8")).decode("ascii"),
-        file_type=file_type,
-        offset=offset,
-        limit=limit,
-    )
+def _run_read_cmd(cmd: str) -> dict:
+    """Execute the read script embedded in `cmd` and return its parsed JSON.
+
+    Accepts any command string in `_READ_COMMAND_TEMPLATE`'s shape, so callers
+    can pass either a directly-formatted template or the output of
+    `_build_read_cmd` to cover the argument-clamping it performs.
+    """
     _, _, tail = cmd.partition('python3 -c "')
     script, _, _ = tail.rpartition('" 2>&1')
     proc = subprocess.run(  # noqa: S603  # script is the project's own _READ_COMMAND_TEMPLATE, not user input
@@ -1365,6 +1365,17 @@ def _run_read_script(target: Path, *, file_type: str = "text", offset: int = 0, 
         check=True,
     )
     return json.loads(proc.stdout.strip())
+
+
+def _run_read_script(target: Path, *, file_type: str = "text", offset: int = 0, limit: int = 2000) -> dict:
+    return _run_read_cmd(
+        _READ_COMMAND_TEMPLATE.format(
+            path_b64=base64.b64encode(str(target).encode("utf-8")).decode("ascii"),
+            file_type=file_type,
+            offset=offset,
+            limit=limit,
+        )
+    )
 
 
 def test_read_script_cjk_at_prefix_boundary(tmp_path: Path) -> None:
@@ -1480,12 +1491,42 @@ def test_read_script_zero_limit_returns_empty_content(tmp_path: Path) -> None:
     assert result == {"encoding": "utf-8", "content": ""}
 
 
-def test_build_read_cmd_clamps_degenerate_bounds() -> None:
-    """Degenerate arguments are clamped before reaching the sandbox script."""
-    cmd = _build_read_cmd("/notes.txt", -3, -1)
+def test_build_read_cmd_clamps_negative_offset_to_first_line(tmp_path: Path) -> None:
+    """A negative offset is clamped by the builder, which the script relies on.
 
-    assert "offset = 0" in cmd
-    assert "limit = 0" in cmd
+    Asserted through the script's output rather than the generated source: the
+    script has no negative-offset guard of its own, so an unclamped value would
+    reach `_parse_read_output` as `start_line=-2` and surface to the model as an
+    opaque "unexpected server response".
+    """
+    target = tmp_path / "notes.txt"
+    target.write_text("one\ntwo\nthree")
+
+    result = _run_read_cmd(_build_read_cmd(str(target), -3, 2))
+
+    assert result["start_line"] == 1
+    assert result["end_line"] == 2
+    assert result["content"] == "one\ntwo"
+
+
+def test_build_read_cmd_clamps_negative_limit_to_empty_read(tmp_path: Path) -> None:
+    """A negative limit is floored to the zero-limit case the script handles."""
+    target = tmp_path / "notes.txt"
+    target.write_text("one\ntwo\nthree")
+
+    result = _run_read_cmd(_build_read_cmd(str(target), -3, -1))
+
+    assert result == {"encoding": "utf-8", "content": ""}
+
+
+def test_read_script_zero_limit_on_empty_file_reports_empty_file(tmp_path: Path) -> None:
+    """The empty-file check precedes the limit check, so the reminder wins."""
+    target = tmp_path / "blank.txt"
+    target.write_text("")
+
+    result = _run_read_script(target, offset=0, limit=0)
+
+    assert "empty contents" in result["content"]
 
 
 def test_read_script_bounds_total_count_and_does_not_decode_unrequested_bytes(tmp_path: Path) -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -1470,7 +1470,7 @@ def test_read_script_final_window_has_null_next_offset(tmp_path: Path) -> None:
     assert result["next_offset"] is None
 
 
-def test_read_script_non_positive_limit_returns_empty_content(tmp_path: Path) -> None:
+def test_read_script_zero_limit_returns_empty_content(tmp_path: Path) -> None:
     """A degenerate `limit` reads nothing, with no pagination keys to validate."""
     target = tmp_path / "notes.txt"
     target.write_text("one\ntwo\nthree")
@@ -1480,54 +1480,12 @@ def test_read_script_non_positive_limit_returns_empty_content(tmp_path: Path) ->
     assert result == {"encoding": "utf-8", "content": ""}
 
 
-def test_read_script_missing_file_wins_over_non_positive_limit(tmp_path: Path) -> None:
-    """The empty read must not mask a path that cannot be read at all."""
-    result = _run_read_script(tmp_path / "absent.txt", offset=0, limit=0)
-
-    assert result == {"error": "file_not_found"}
-
-
-def test_build_read_cmd_clamps_degenerate_window() -> None:
+def test_build_read_cmd_clamps_degenerate_bounds() -> None:
     """Degenerate arguments are clamped before reaching the sandbox script."""
     cmd = _build_read_cmd("/notes.txt", -3, -1)
 
     assert "offset = 0" in cmd
     assert "limit = 0" in cmd
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="/bin/sh is unavailable on Windows")
-@pytest.mark.parametrize(
-    ("offset", "limit", "expected"),
-    [
-        (-1, 0, {"content": "", "total_lines": None, "start_line": None, "end_line": None, "next_offset": None}),
-        (-1, 2, {"content": "one\ntwo", "total_lines": 3, "start_line": 1, "end_line": 2, "next_offset": 2}),
-    ],
-)
-def test_build_read_cmd_degenerate_window_parses_into_read_result(
-    tmp_path: Path,
-    offset: int,
-    limit: int,
-    expected: dict,
-) -> None:
-    """Degenerate arguments must survive the full script -> `ReadResult` round-trip."""
-    target = tmp_path / "notes.txt"
-    target.write_text("one\ntwo\nthree")
-
-    proc = subprocess.run(  # noqa: S603  # command is built from the project's sandbox template
-        ["/bin/sh", "-c", _build_read_cmd(str(target), offset, limit)],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    result = _parse_read_output(proc.stdout, str(target))
-
-    assert result.error is None
-    assert result.file_data is not None
-    assert result.file_data["content"] == expected["content"]
-    assert result.total_lines == expected["total_lines"]
-    assert result.start_line == expected["start_line"]
-    assert result.end_line == expected["end_line"]
-    assert result.next_offset == expected["next_offset"]
 
 
 def test_read_script_bounds_total_count_and_does_not_decode_unrequested_bytes(tmp_path: Path) -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -1470,6 +1470,66 @@ def test_read_script_final_window_has_null_next_offset(tmp_path: Path) -> None:
     assert result["next_offset"] is None
 
 
+def test_read_script_non_positive_limit_returns_empty_content(tmp_path: Path) -> None:
+    """A degenerate `limit` reads nothing, with no pagination keys to validate."""
+    target = tmp_path / "notes.txt"
+    target.write_text("one\ntwo\nthree")
+
+    result = _run_read_script(target, offset=0, limit=0)
+
+    assert result == {"encoding": "utf-8", "content": ""}
+
+
+def test_read_script_missing_file_wins_over_non_positive_limit(tmp_path: Path) -> None:
+    """The empty read must not mask a path that cannot be read at all."""
+    result = _run_read_script(tmp_path / "absent.txt", offset=0, limit=0)
+
+    assert result == {"error": "file_not_found"}
+
+
+def test_build_read_cmd_clamps_degenerate_window() -> None:
+    """Degenerate arguments are clamped before reaching the sandbox script."""
+    cmd = _build_read_cmd("/notes.txt", -3, -1)
+
+    assert "offset = 0" in cmd
+    assert "limit = 0" in cmd
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="/bin/sh is unavailable on Windows")
+@pytest.mark.parametrize(
+    ("offset", "limit", "expected"),
+    [
+        (-1, 0, {"content": "", "total_lines": None, "start_line": None, "end_line": None, "next_offset": None}),
+        (-1, 2, {"content": "one\ntwo", "total_lines": 3, "start_line": 1, "end_line": 2, "next_offset": 2}),
+    ],
+)
+def test_build_read_cmd_degenerate_window_parses_into_read_result(
+    tmp_path: Path,
+    offset: int,
+    limit: int,
+    expected: dict,
+) -> None:
+    """Degenerate arguments must survive the full script -> `ReadResult` round-trip."""
+    target = tmp_path / "notes.txt"
+    target.write_text("one\ntwo\nthree")
+
+    proc = subprocess.run(  # noqa: S603  # command is built from the project's sandbox template
+        ["/bin/sh", "-c", _build_read_cmd(str(target), offset, limit)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    result = _parse_read_output(proc.stdout, str(target))
+
+    assert result.error is None
+    assert result.file_data is not None
+    assert result.file_data["content"] == expected["content"]
+    assert result.total_lines == expected["total_lines"]
+    assert result.start_line == expected["start_line"]
+    assert result.end_line == expected["end_line"]
+    assert result.next_offset == expected["next_offset"]
+
+
 def test_read_script_bounds_total_count_and_does_not_decode_unrequested_bytes(tmp_path: Path) -> None:
     target = tmp_path / "large.txt"
     target.write_bytes(b"first\n" + (b"a" * (1024 * 1024)) + b"\xff")

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -1482,13 +1482,17 @@ def test_read_script_final_window_has_null_next_offset(tmp_path: Path) -> None:
 
 
 def test_read_script_zero_limit_returns_empty_content(tmp_path: Path) -> None:
-    """A degenerate `limit` reads nothing, with no pagination keys to validate."""
+    """A degenerate `limit` reads nothing, with no pagination keys to validate.
+
+    `no_lines_requested` flags the window as never inspected so the middleware
+    can tell it apart from an inspected-but-empty file.
+    """
     target = tmp_path / "notes.txt"
     target.write_text("one\ntwo\nthree")
 
     result = _run_read_script(target, offset=0, limit=0)
 
-    assert result == {"encoding": "utf-8", "content": ""}
+    assert result == {"encoding": "utf-8", "content": "", "no_lines_requested": True}
 
 
 def test_build_read_cmd_clamps_negative_offset_to_first_line(tmp_path: Path) -> None:
@@ -1516,7 +1520,7 @@ def test_build_read_cmd_clamps_negative_limit_to_empty_read(tmp_path: Path) -> N
 
     result = _run_read_cmd(_build_read_cmd(str(target), -3, -1))
 
-    assert result == {"encoding": "utf-8", "content": ""}
+    assert result == {"encoding": "utf-8", "content": "", "no_lines_requested": True}
 
 
 def test_read_script_zero_limit_on_empty_file_reports_empty_file(tmp_path: Path) -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_sandbox_backend.py
@@ -1068,6 +1068,28 @@ def test_sandbox_edit_upload_partial_upload_failure() -> None:
 # -- remaining template tests --------------------------------------------------
 
 
+def test_shell_templates_have_no_command_substitution() -> None:
+    """Shell templates must not contain backticks or `$(...)` substitutions.
+
+    The templates run through POSIX `sh` inside double-quoted strings, where
+    backticks and `$()` trigger command substitution. A comment with a harmless
+    backticked identifier (like `limit`) gets executed as a shell command, and
+    the resulting "command not found" stderr noise corrupts the JSON stdout
+    consumers parse.
+    """
+    templates = [
+        _READ_COMMAND_TEMPLATE,
+        _EDIT_COMMAND_TEMPLATE,
+        _EDIT_TMPFILE_TEMPLATE,
+        _GLOB_COMMAND_TEMPLATE,
+        _GREP_PATH_GLOB_TEMPLATE,
+        _WRITE_CHECK_TEMPLATE,
+    ]
+    for template in templates:
+        assert "`" not in template
+        assert "$(" not in template
+
+
 def test_read_command_template_format() -> None:
     """Test that _READ_COMMAND_TEMPLATE can be formatted without KeyError."""
     path_b64 = base64.b64encode(b"/test/file.txt").decode("ascii")
@@ -1433,6 +1455,10 @@ def test_build_read_cmd_shell_outputs_single_json_document(tmp_path: Path) -> No
     result = json.loads(proc.stdout.strip())
     assert result["content"] == "one\ntwo\nthree"
     assert result["total_lines"] == 3
+    # Real consumers merge stderr into stdout (the template ends with `2>&1`),
+    # so any stderr noise — e.g. a stray command substitution in the template —
+    # would corrupt the JSON those consumers parse.
+    assert proc.stderr == ""
 
 
 def test_read_script_mid_buffer_invalid_utf8_returns_base64(tmp_path: Path) -> None:

--- a/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_state_backend.py
@@ -21,6 +21,34 @@ def test_upload_files_raises_outside_graph_context():
         be.upload_files([("/hello.txt", b"hello")])
 
 
+@pytest.mark.parametrize(("offset", "limit"), [(0, 0), (0, -3), (-1, 0)])
+def test_state_backend_read_non_positive_limit_returns_empty_read(monkeypatch: pytest.MonkeyPatch, offset: int, limit: int) -> None:
+    """`StateBackend.read` inherits the shared clamp rather than raising."""
+    backend = StateBackend()
+    files = {"/notes.txt": {"content": "one\ntwo\nthree", "encoding": "utf-8"}}
+    monkeypatch.setattr(backend, "_read_files", lambda: files)
+
+    result = backend.read("/notes.txt", offset=offset, limit=limit)
+
+    assert result.error is None
+    assert result.file_data is not None
+    assert result.file_data["content"] == ""
+    assert result.start_line is None
+
+
+def test_state_backend_read_negative_offset_starts_at_first_line(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A negative offset is clamped to the start of the file instead of erroring."""
+    backend = StateBackend()
+    files = {"/notes.txt": {"content": "one\ntwo\nthree", "encoding": "utf-8"}}
+    monkeypatch.setattr(backend, "_read_files", lambda: files)
+
+    result = backend.read("/notes.txt", offset=-1, limit=2)
+
+    assert result.error is None
+    assert result.start_line == 1
+    assert result.end_line == 2
+
+
 def test_state_backend_reads_legacy_list_content(monkeypatch: pytest.MonkeyPatch) -> None:
     backend = StateBackend()
     legacy_content = ["hello", "world", ""]

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend.py
@@ -60,6 +60,34 @@ def test_store_backend_read_surfaces_pagination_metadata():
     assert result.next_offset == 3
 
 
+@pytest.mark.parametrize(("offset", "limit"), [(0, 0), (0, -3), (-1, 0)])
+def test_store_backend_read_non_positive_limit_returns_empty_read(offset: int, limit: int):
+    """`StoreBackend.read` inherits the shared clamp rather than raising."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    be.write("/notes.txt", "one\ntwo\nthree")
+
+    result = be.read("/notes.txt", offset=offset, limit=limit)
+
+    assert result.error is None
+    assert result.file_data is not None
+    assert result.file_data["content"] == ""
+    assert result.start_line is None
+
+
+def test_store_backend_read_negative_offset_starts_at_first_line():
+    """A negative offset is clamped to the start of the file instead of erroring."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    be.write("/notes.txt", "one\ntwo\nthree")
+
+    result = be.read("/notes.txt", offset=-1, limit=2)
+
+    assert result.error is None
+    assert result.start_line == 1
+    assert result.end_line == 2
+
+
 def test_store_backend_reads_mkv_as_binary_without_slicing():
     """`.mkv` reads bypass text line-slicing so binary bytes are returned intact.
 

--- a/libs/deepagents/tests/unit_tests/backends/test_store_backend_async.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_store_backend_async.py
@@ -8,6 +8,33 @@ from deepagents.backends.store import StoreBackend
 from deepagents.middleware.filesystem import FilesystemMiddleware
 
 
+async def test_store_backend_aread_non_positive_limit_returns_empty_read():
+    """`aread` is a separate method body from `read`, so it needs its own case."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    await be.awrite("/notes.txt", "one\ntwo\nthree")
+
+    result = await be.aread("/notes.txt", offset=0, limit=0)
+
+    assert result.error is None
+    assert result.file_data is not None
+    assert result.file_data["content"] == ""
+    assert result.start_line is None
+
+
+async def test_store_backend_aread_negative_offset_starts_at_first_line():
+    """A negative offset is clamped on the async path too."""
+    mem_store = InMemoryStore()
+    be = StoreBackend(store=mem_store, namespace=lambda _rt: ("filesystem",))
+    await be.awrite("/notes.txt", "one\ntwo\nthree")
+
+    result = await be.aread("/notes.txt", offset=-1, limit=2)
+
+    assert result.error is None
+    assert result.start_line == 1
+    assert result.end_line == 2
+
+
 async def test_store_backend_async_crud_and_search():
     """Test async CRUD and search operations."""
     mem_store = InMemoryStore()

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -543,6 +543,35 @@ class TestSliceReadResponse:
         assert result.end_line == 2
         assert result.next_offset == 2
 
+    def test_negative_offset_and_non_positive_limit_combine(self) -> None:
+        """Both bounds degenerate at once still yields an empty read."""
+        result = slice_read_response(self._file("a\nb\nc"), offset=-3, limit=-3)
+        assert result.error is None
+        assert self._content(result) == ""
+        assert result.start_line is None
+
+    def test_zero_limit_takes_precedence_over_offset_past_eof(self) -> None:
+        """The zero-limit check runs before the bounds check, so no error is raised.
+
+        Pins the ordering rather than endorsing it: the offset is also invalid
+        here, and reporting the empty read first costs the caller a round trip
+        to discover that. Reordering would have to change all four read paths.
+        """
+        result = slice_read_response(self._file("a\nb\nc"), offset=99, limit=0)
+        assert result.error is None
+        assert self._content(result) == ""
+
+    def test_blank_content_takes_precedence_over_zero_limit(self) -> None:
+        """Whitespace-only content is returned verbatim even for a zero limit.
+
+        The blank-content branch precedes the zero-limit branch, so the content
+        is the whitespace rather than `""`. The middleware maps either to a
+        reminder, but the two branches must not be reordered silently.
+        """
+        result = slice_read_response(self._file("   \n\t\n"), offset=0, limit=0)
+        assert result.error is None
+        assert self._content(result) == "   \n\t\n"
+
 
 class TestGrepMaxCount:
     """`max_count` total-cap semantics for `grep_matches_from_files`.

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -9,13 +9,16 @@ from pydantic import TypeAdapter
 from deepagents.backends.protocol import FileData, ReadResult
 from deepagents.backends.utils import (
     _EXTENSION_TO_FILE_TYPE,
+    EMPTY_READ_WINDOW,
     _get_backend_read_file_type,
     _get_file_type,
     _glob_search_files,
     _looks_like_regex,
     grep_matches_from_files,
+    normalize_read_bounds,
     perform_string_replacement,
     regex_literal_hint,
+    resolve_read_window,
     slice_read_response,
     to_posix_path,
     validate_path,
@@ -522,6 +525,81 @@ class TestSliceReadResponse:
         result = slice_read_response(self._file("a\nb"), offset=10, limit=5)
         assert result.error is not None
         assert "exceeds file length" in result.error
+
+    @pytest.mark.parametrize("limit", [0, -3])
+    def test_non_positive_limit_returns_empty_read(self, limit: int) -> None:
+        """A degenerate `limit` reads nothing instead of raising on the window."""
+        result = slice_read_response(self._file("a\nb\nc"), offset=0, limit=limit)
+        assert result.error is None
+        assert self._content(result) == ""
+        assert result.total_lines is None
+        assert result.start_line is None
+        assert result.end_line is None
+        assert result.next_offset is None
+
+    def test_negative_offset_reads_from_first_line(self) -> None:
+        """A degenerate `offset` is clamped rather than reported as line 0."""
+        result = slice_read_response(self._file("a\nb\nc"), offset=-1, limit=2)
+        assert result.error is None
+        assert self._content(result) == "a\nb\n"
+        assert result.start_line == 1
+        assert result.end_line == 2
+        assert result.next_offset == 2
+
+
+class TestResolveReadWindow:
+    """`resolve_read_window` is the single window source for built-in text reads.
+
+    Its output feeds `ReadResult`, whose constructor rejects windows that run
+    backward or advertise a resume offset past unshown lines.
+    """
+
+    @pytest.mark.parametrize(
+        ("offset", "limit", "expected"),
+        [
+            (0, 0, (0, 0)),
+            (-1, 10, (0, 10)),
+            (-1, -1, (0, 0)),
+            (2, 5, (2, 5)),
+        ],
+    )
+    def test_normalize_read_bounds_floors_at_zero(self, offset: int, limit: int, expected: tuple[int, int]) -> None:
+        assert normalize_read_bounds(offset, limit) == expected
+
+    def test_partial_window(self) -> None:
+        window = resolve_read_window(5, offset=1, limit=2)
+        assert window is not None
+        assert (window.start_idx, window.end_idx) == (1, 3)
+        assert window.total_lines == 5
+        assert (window.start_line, window.end_line) == (2, 3)
+        assert window.next_offset == 3
+
+    def test_final_window_has_no_next_offset(self) -> None:
+        window = resolve_read_window(5, offset=3, limit=10)
+        assert window is not None
+        assert window.end_idx == 5
+        assert window.next_offset is None
+
+    @pytest.mark.parametrize("limit", [0, -1])
+    def test_non_positive_limit_is_the_empty_window(self, limit: int) -> None:
+        window = resolve_read_window(5, offset=0, limit=limit)
+        assert window == EMPTY_READ_WINDOW
+        assert window.is_empty
+
+    def test_negative_offset_is_clamped(self) -> None:
+        window = resolve_read_window(5, offset=-4, limit=2)
+        assert window is not None
+        assert window.start_idx == 0
+        assert window.start_line == 1
+        assert not window.is_empty
+
+    def test_offset_at_or_past_end_has_no_window(self) -> None:
+        assert resolve_read_window(5, offset=5, limit=2) is None
+        assert resolve_read_window(0, offset=0, limit=2) is None
+
+    def test_empty_window_wins_over_offset_past_end(self) -> None:
+        """Nothing was requested, so there is nothing to report as out of range."""
+        assert resolve_read_window(5, offset=99, limit=0) == EMPTY_READ_WINDOW
 
 
 class TestGrepMaxCount:

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -9,16 +9,13 @@ from pydantic import TypeAdapter
 from deepagents.backends.protocol import FileData, ReadResult
 from deepagents.backends.utils import (
     _EXTENSION_TO_FILE_TYPE,
-    EMPTY_READ_WINDOW,
     _get_backend_read_file_type,
     _get_file_type,
     _glob_search_files,
     _looks_like_regex,
     grep_matches_from_files,
-    normalize_read_bounds,
     perform_string_replacement,
     regex_literal_hint,
-    resolve_read_window,
     slice_read_response,
     to_posix_path,
     validate_path,
@@ -528,7 +525,7 @@ class TestSliceReadResponse:
 
     @pytest.mark.parametrize("limit", [0, -3])
     def test_non_positive_limit_returns_empty_read(self, limit: int) -> None:
-        """A degenerate `limit` reads nothing instead of raising on the window."""
+        """A degenerate `limit` reads nothing instead of raising on the line range."""
         result = slice_read_response(self._file("a\nb\nc"), offset=0, limit=limit)
         assert result.error is None
         assert self._content(result) == ""
@@ -545,61 +542,6 @@ class TestSliceReadResponse:
         assert result.start_line == 1
         assert result.end_line == 2
         assert result.next_offset == 2
-
-
-class TestResolveReadWindow:
-    """`resolve_read_window` is the single window source for built-in text reads.
-
-    Its output feeds `ReadResult`, whose constructor rejects windows that run
-    backward or advertise a resume offset past unshown lines.
-    """
-
-    @pytest.mark.parametrize(
-        ("offset", "limit", "expected"),
-        [
-            (0, 0, (0, 0)),
-            (-1, 10, (0, 10)),
-            (-1, -1, (0, 0)),
-            (2, 5, (2, 5)),
-        ],
-    )
-    def test_normalize_read_bounds_floors_at_zero(self, offset: int, limit: int, expected: tuple[int, int]) -> None:
-        assert normalize_read_bounds(offset, limit) == expected
-
-    def test_partial_window(self) -> None:
-        window = resolve_read_window(5, offset=1, limit=2)
-        assert window is not None
-        assert (window.start_idx, window.end_idx) == (1, 3)
-        assert window.total_lines == 5
-        assert (window.start_line, window.end_line) == (2, 3)
-        assert window.next_offset == 3
-
-    def test_final_window_has_no_next_offset(self) -> None:
-        window = resolve_read_window(5, offset=3, limit=10)
-        assert window is not None
-        assert window.end_idx == 5
-        assert window.next_offset is None
-
-    @pytest.mark.parametrize("limit", [0, -1])
-    def test_non_positive_limit_is_the_empty_window(self, limit: int) -> None:
-        window = resolve_read_window(5, offset=0, limit=limit)
-        assert window == EMPTY_READ_WINDOW
-        assert window.is_empty
-
-    def test_negative_offset_is_clamped(self) -> None:
-        window = resolve_read_window(5, offset=-4, limit=2)
-        assert window is not None
-        assert window.start_idx == 0
-        assert window.start_line == 1
-        assert not window.is_empty
-
-    def test_offset_at_or_past_end_has_no_window(self) -> None:
-        assert resolve_read_window(5, offset=5, limit=2) is None
-        assert resolve_read_window(0, offset=0, limit=2) is None
-
-    def test_empty_window_wins_over_offset_past_end(self) -> None:
-        """Nothing was requested, so there is nothing to report as out of range."""
-        assert resolve_read_window(5, offset=99, limit=0) == EMPTY_READ_WINDOW
 
 
 class TestGrepMaxCount:

--- a/libs/deepagents/tests/unit_tests/backends/test_utils.py
+++ b/libs/deepagents/tests/unit_tests/backends/test_utils.py
@@ -525,10 +525,16 @@ class TestSliceReadResponse:
 
     @pytest.mark.parametrize("limit", [0, -3])
     def test_non_positive_limit_returns_empty_read(self, limit: int) -> None:
-        """A degenerate `limit` reads nothing instead of raising on the line range."""
+        """A degenerate `limit` reads nothing instead of raising on the line range.
+
+        `no_lines_requested` flags the window as never inspected so the
+        middleware can tell it apart from an inspected-but-empty file, whose
+        `ReadResult` is otherwise identical.
+        """
         result = slice_read_response(self._file("a\nb\nc"), offset=0, limit=limit)
         assert result.error is None
         assert self._content(result) == ""
+        assert result.no_lines_requested is True
         assert result.total_lines is None
         assert result.start_line is None
         assert result.end_line is None

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1593,9 +1593,9 @@ class TestFilesystemMiddleware:
         assert isinstance(result, ToolMessage)
         assert result.content == ("1  one\n\n[Read 1 line (lines 1-1 of 5 total). 4 lines remaining from offset 1.]")
 
-    @pytest.mark.parametrize(("offset", "limit"), [(0, 0), (-1, 0), (0, -5)])
-    def test_read_file_degenerate_limit_reads_nothing(self, offset, limit):
-        """A model asking for zero (or fewer) lines gets an empty read, not a crash."""
+    @pytest.mark.parametrize(("offset", "limit"), [(0, 0), (-1, 100)])
+    def test_read_file_degenerate_arguments_do_not_error(self, offset, limit):
+        """Degenerate tool arguments read nothing or clamp, but never fail the tool."""
         files = {
             "/notes.txt": FileData(
                 content="one\ntwo\nthree",
@@ -1610,24 +1610,8 @@ class TestFilesystemMiddleware:
 
         assert isinstance(result, ToolMessage)
         assert result.status == "success"
-        assert result.content == EMPTY_CONTENT_WARNING
-
-    def test_read_file_negative_offset_reads_from_first_line(self):
-        """A negative offset is clamped to the start of the file, not reported as line 0."""
-        files = {
-            "/notes.txt": FileData(
-                content="one\ntwo\nthree",
-                encoding="utf-8",
-            )
-        }
-        backend, _ = _make_backend(files)
-        middleware = FilesystemMiddleware(backend=backend)
-        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
-
-        result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": -1, "limit": 2})
-
-        assert isinstance(result, ToolMessage)
-        assert result.content == ("1  one\n2  two\n\n[Read 2 lines (lines 1-2 of 3 total). 1 line remaining from offset 2.]")
+        expected = EMPTY_CONTENT_WARNING if limit == 0 else "1  one\n2  two\n3  three"
+        assert result.content == expected
 
     def test_read_file_unknown_total_reports_next_offset(self):
         backend, _ = _make_backend()

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -48,6 +48,7 @@ from deepagents.middleware.filesystem import (
     EMPTY_CONTENT_WARNING,
     GLOB_TRUNCATION_NOTE,
     GREP_TRUNCATION_NOTE,
+    NO_LINES_REQUESTED_WARNING,
     FileData,
     FilesystemMiddleware,
     FilesystemPermission,
@@ -1593,9 +1594,8 @@ class TestFilesystemMiddleware:
         assert isinstance(result, ToolMessage)
         assert result.content == ("1  one\n\n[Read 1 line (lines 1-1 of 5 total). 4 lines remaining from offset 1.]")
 
-    @pytest.mark.parametrize(("offset", "limit"), [(0, 0), (-1, 100)])
-    def test_read_file_degenerate_arguments_do_not_error(self, offset, limit):
-        """Degenerate tool arguments read nothing or clamp, but never fail the tool."""
+    def _read_notes(self, *, offset: int, limit: int) -> ToolMessage:
+        """Invoke `read_file` against a fixed 3-line file with the given window."""
         files = {
             "/notes.txt": FileData(
                 content="one\ntwo\nthree",
@@ -1607,11 +1607,41 @@ class TestFilesystemMiddleware:
         read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
 
         result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": offset, "limit": limit})
-
         assert isinstance(result, ToolMessage)
+        return result
+
+    @pytest.mark.parametrize("limit", [0, -3])
+    def test_read_file_non_positive_limit_does_not_claim_the_file_is_empty(self, limit):
+        """A zero-line window must not borrow the empty-file reminder.
+
+        The `read_file` description teaches the model that reminder means the
+        file itself is empty, so reusing it here would state something false
+        about a file that has contents.
+        """
+        result = self._read_notes(offset=0, limit=limit)
+
         assert result.status == "success"
-        expected = EMPTY_CONTENT_WARNING if limit == 0 else "1  one\n2  two\n3  three"
-        assert result.content == expected
+        assert result.content == NO_LINES_REQUESTED_WARNING.format(limit=limit)
+        assert result.content != EMPTY_CONTENT_WARNING
+        assert "empty contents" not in result.content
+
+    def test_read_file_negative_offset_clamps_and_discloses(self):
+        """A clamped offset still reads, and says so.
+
+        The window reaches EOF here, which suppresses the pagination notice, so
+        the disclosure has to come from its own notice or the model gets a
+        gutter starting at line 1 with no sign its request was reinterpreted.
+        """
+        result = self._read_notes(offset=-1, limit=100)
+
+        assert result.status == "success"
+        assert result.content == ("1  one\n2  two\n3  three\n\n[Requested offset -1 is before the start of the file; read from line 1 instead.]")
+
+    def test_read_file_non_negative_offset_has_no_clamp_notice(self):
+        """The clamp notice must not appear on ordinary reads."""
+        result = self._read_notes(offset=0, limit=100)
+
+        assert result.content == "1  one\n2  two\n3  three"
 
     def test_read_file_unknown_total_reports_next_offset(self):
         backend, _ = _make_backend()
@@ -2132,6 +2162,35 @@ class TestFilesystemMiddleware:
         result = middleware._intercept_large_tool_result(tool_message)
 
         assert result == tool_message
+
+    def test_read_file_zero_limit_on_image_still_returns_the_image(self):
+        """A zero limit must not turn a binary read into a no-lines reminder.
+
+        `limit` never applies to binary payloads, so the no-lines guard is
+        conditioned on empty content as well. Guarding on `limit` alone would
+        regress every image read that happens to carry a degenerate limit.
+        """
+
+        class ImageBackend(StateBackend):
+            def read(self, path, *, offset=0, limit=100):
+                return ReadResult(file_data={"content": "<base64_data>", "encoding": "base64"})
+
+        middleware = FilesystemMiddleware(backend=ImageBackend())
+        runtime = ToolRuntime(
+            state=FilesystemState(messages=[], files={}),
+            context=None,
+            tool_call_id="img-zero-limit",
+            store=None,
+            stream_writer=lambda _: None,
+            config={},
+        )
+
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+        result = read_file_tool.invoke({"file_path": "/app/screenshot.png", "runtime": runtime, "limit": 0})
+
+        assert isinstance(result, ToolMessage)
+        assert isinstance(result.content, list)
+        assert result.content[0]["type"] == "image"
 
     def test_read_file_image_returns_standard_image_content_block(self):
         """Test image reads return standard image blocks with base64 + mime_type."""

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1593,6 +1593,42 @@ class TestFilesystemMiddleware:
         assert isinstance(result, ToolMessage)
         assert result.content == ("1  one\n\n[Read 1 line (lines 1-1 of 5 total). 4 lines remaining from offset 1.]")
 
+    @pytest.mark.parametrize(("offset", "limit"), [(0, 0), (-1, 0), (0, -5)])
+    def test_read_file_degenerate_limit_reads_nothing(self, offset, limit):
+        """A model asking for zero (or fewer) lines gets an empty read, not a crash."""
+        files = {
+            "/notes.txt": FileData(
+                content="one\ntwo\nthree",
+                encoding="utf-8",
+            )
+        }
+        backend, _ = _make_backend(files)
+        middleware = FilesystemMiddleware(backend=backend)
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": offset, "limit": limit})
+
+        assert isinstance(result, ToolMessage)
+        assert result.status == "success"
+        assert result.content == EMPTY_CONTENT_WARNING
+
+    def test_read_file_negative_offset_reads_from_first_line(self):
+        """A negative offset is clamped to the start of the file, not reported as line 0."""
+        files = {
+            "/notes.txt": FileData(
+                content="one\ntwo\nthree",
+                encoding="utf-8",
+            )
+        }
+        backend, _ = _make_backend(files)
+        middleware = FilesystemMiddleware(backend=backend)
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": -1, "limit": 2})
+
+        assert isinstance(result, ToolMessage)
+        assert result.content == ("1  one\n2  two\n\n[Read 2 lines (lines 1-2 of 3 total). 1 line remaining from offset 2.]")
+
     def test_read_file_unknown_total_reports_next_offset(self):
         backend, _ = _make_backend()
         read_result = ReadResult(

--- a/libs/deepagents/tests/unit_tests/test_middleware.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware.py
@@ -1625,6 +1625,54 @@ class TestFilesystemMiddleware:
         assert result.content != EMPTY_CONTENT_WARNING
         assert "empty contents" not in result.content
 
+    @pytest.mark.parametrize("limit", [0, -3])
+    def test_read_file_non_positive_limit_empty_binary_keeps_empty_file_reminder(self, limit):
+        """An inspected-but-empty file must not borrow the zero-line-window warning.
+
+        Binary reads ignore `limit`, so a zero-byte binary is fully inspected
+        and comes back as empty base64; claiming it "was not inspected and may
+        have contents" would be false on both counts.
+        """
+        files = {
+            "/image.png": FileData(
+                content="",
+                encoding="base64",
+            )
+        }
+        backend, _ = _make_backend(files)
+        middleware = FilesystemMiddleware(backend=backend)
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/image.png", "offset": 0, "limit": limit})
+
+        assert isinstance(result, ToolMessage)
+        assert result.status == "success"
+        assert result.content == EMPTY_CONTENT_WARNING
+
+    @pytest.mark.parametrize("limit", [0, -3])
+    def test_read_file_non_positive_limit_empty_text_keeps_empty_file_reminder(self, limit):
+        """A genuinely empty text file reports emptiness regardless of `limit`.
+
+        The blank-content branch in `slice_read_response` runs before the
+        zero-`limit` check, so an empty file arrives as whitespace-only text,
+        not as a backend-declared zero-line window.
+        """
+        files = {
+            "/notes.txt": FileData(
+                content="",
+                encoding="utf-8",
+            )
+        }
+        backend, _ = _make_backend(files)
+        middleware = FilesystemMiddleware(backend=backend)
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        result = read_file_tool.invoke({"runtime": _runtime(), "file_path": "/notes.txt", "offset": 0, "limit": limit})
+
+        assert isinstance(result, ToolMessage)
+        assert result.status == "success"
+        assert result.content == EMPTY_CONTENT_WARNING
+
     def test_read_file_negative_offset_clamps_and_discloses(self):
         """A clamped offset still reads, and says so.
 

--- a/libs/deepagents/tests/unit_tests/test_middleware_async.py
+++ b/libs/deepagents/tests/unit_tests/test_middleware_async.py
@@ -655,6 +655,29 @@ class TestFilesystemMiddlewareAsync:
         assert "Line 2" in result.content
         assert "Line 3" in result.content
 
+    async def test_aread_file_degenerate_arguments(self):
+        """The async tool applies the same disclosure and no-lines reminder as the sync one."""
+        files = {
+            "/test.txt": FileData(
+                content="Line 1\nLine 2\nLine 3",
+                modified_at="2021-01-01",
+                created_at="2021-01-01",
+            ),
+        }
+        backend, _ = _make_backend(files)
+        middleware = FilesystemMiddleware(backend=backend)
+        read_file_tool = next(tool for tool in middleware.tools if tool.name == "read_file")
+
+        zero_limit = await read_file_tool.ainvoke({"file_path": "/test.txt", "offset": 0, "limit": 0, "runtime": _runtime()})
+        assert zero_limit.status == "success"
+        assert "empty contents" not in zero_limit.content
+        assert "`limit` was 0" in zero_limit.content
+
+        negative_offset = await read_file_tool.ainvoke({"file_path": "/test.txt", "offset": -1, "limit": 100, "runtime": _runtime()})
+        assert negative_offset.status == "success"
+        assert negative_offset.content.startswith("1  Line 1")
+        assert "before the start of the file" in negative_offset.content
+
     async def test_aread_file_with_offset(self):
         """Test async read_file tool with offset."""
         files = {


### PR DESCRIPTION
Closes #5180

`read_file` no longer fails when a model asks for a window that contains no lines: a `limit` of zero or less now returns an empty read, and a negative `offset` starts from the first line, matching pre-0.7 behavior.

---

0.7 added pagination metadata to read results, and `ReadResult` validates that metadata at construction — a line range has to run forward and the resume offset has to point at the first un-shown line, so a backend can never hand the agent an offset that silently skips source lines. That strictness is deliberate and stays; the bug is that the code paths *producing* those ranges never clamped degenerate tool arguments, so `limit=0` or `offset=-1` reached the constructor and raised instead of reading nothing.

Each read path now floors the requested bounds through one shared helper and returns empty content when no lines were asked for — no line range to describe, which is how empty files already behave. `FilesystemBackend` also drops its own copy of the slicing logic and reuses `slice_read_response`, the same helper the state and store backends already use, so local reads and in-memory reads can no longer disagree. The sandbox read runs as a script inside the sandbox and can't import that helper, so it clamps when the command is built and short-circuits a non-positive `limit` on the sandbox side, after the not-found, directory, and binary checks so real failures still take priority.

Made by [Open SWE](https://openswe.vercel.app/agents/b90d509c-c8fd-c0f2-ed5a-c783be1314ed)
