### PR TITLE
chore(infra): ignore OpenSSH private keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,16 @@ Cookies
 Cookies.db
 cookies.sqlite
 cookies.txt
+# OpenSSH private keys (no extension, so *.key never matches);
+# .pub counterparts are not secrets and stay committable.
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+*_rsa
+*_dsa
+*_ecdsa
+*_ed25519
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
OpenSSH private keys sitting in the working tree (e.g. an `id_rsa` copied in for a deploy) are no longer stageable: the root `.gitignore` now covers the standard private key filenames and the common `<name>_<type>` naming convention.

---

The `.gitignore` "Local credentials and secrets" section already covered `*.key`, `*.pem`, and friends, but OpenSSH private keys have no file extension, so none of those patterns ever matched — an `id_rsa` in the repo root could be `git add`ed and committed without any warning.

Added to the same section:

```
id_rsa
id_dsa
id_ecdsa
id_ed25519
*_rsa
*_dsa
*_ecdsa
*_ed25519
```

No negation is needed for public keys: `id_rsa` matches only the exact name, so `id_rsa.pub` and `deploy_ed25519.pub` stay committable (verified below).

<details>
<summary>Test plan</summary>

`git check-ignore` (authoritative, accounts for all ignore sources):

```
IGNORED      id_rsa
IGNORED      id_dsa
IGNORED      id_ed25519
IGNORED      id_ecdsa
IGNORED      mykey_rsa
IGNORED      mykey_dsa
IGNORED      deploy_ed25519
IGNORED      other_ecdsa
NOT IGNORED  id_rsa.pub
NOT IGNORED  deploy_ed25519.pub
```

`git ls-files | git check-ignore --stdin` prints nothing, so no already-tracked file changes ignore status.

</details>
