### PR TITLE
chore(infra): clarify that release-notes edits are optional

### DIFF
--- a/.github/scripts/release/release-notes.js
+++ b/.github/scripts/release/release-notes.js
@@ -380,7 +380,7 @@ function overrideBody({ component, version, head, headingHash, fingerprint, sect
     `changelog-fingerprint: ${fingerprint}`,
     'state: draft',
     '-->',
-    'Review and edit the release notes between the content markers below. Keep the version heading intact.',
+    'Review and edit the release notes between the content markers below as needed. Keep the version heading intact.',
     '',
     '---',
     CONTENT_START,


### PR DESCRIPTION
Clarify in the curated release-notes draft comment that editing the notes is optional.

---

The draft comment posted on release PRs previously read "Review and edit the release notes between the content markers below." Adding "as needed" makes it clear maintainers don't have to change anything when the generated notes are already fine, rather than implying an edit is always expected.
