### PR TITLE
feat(code): add cache and context status row

### DIFF
--- a/libs/code/deepagents_code/_session_stats.py
+++ b/libs/code/deepagents_code/_session_stats.py
@@ -147,6 +147,12 @@ class SessionStats:
     output_tokens: int = 0
     """Cumulative output tokens across all LLM requests."""
 
+    cache_read_tokens: int = 0
+    """Cumulative prompt tokens served from provider caches."""
+
+    cache_write_tokens: int = 0
+    """Cumulative prompt tokens written to provider caches."""
+
     total_cost_usd: float = 0.0
     """Cumulative estimated USD cost across priceable LLM requests."""
 
@@ -176,6 +182,8 @@ class SessionStats:
         cost_usd: float | None = None,
         *,
         kind: UsageKind = "assistant",
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
     ) -> None:
         """Accumulate usage for one completed LLM request.
 
@@ -193,10 +201,14 @@ class SessionStats:
             cost_usd: Estimated request cost, or `None` when no estimate exists.
                 Missing estimates leave monetary totals unchanged.
             kind: Request class used for `/cost` type breakdowns.
+            cache_read_tokens: Input tokens served from the provider cache.
+            cache_write_tokens: Input tokens written to the provider cache.
         """
         self.request_count += 1
         self.input_tokens += input_toks
         self.output_tokens += output_toks
+        self.cache_read_tokens += max(cache_read_tokens, 0)
+        self.cache_write_tokens += max(cache_write_tokens, 0)
         if cost_usd is not None:
             self.total_cost_usd += cost_usd
             self.priced_request_count += 1
@@ -231,6 +243,8 @@ class SessionStats:
         self.request_count += other.request_count
         self.input_tokens += other.input_tokens
         self.output_tokens += other.output_tokens
+        self.cache_read_tokens += other.cache_read_tokens
+        self.cache_write_tokens += other.cache_write_tokens
         self.total_cost_usd += other.total_cost_usd
         self.priced_request_count += other.priced_request_count
         self.wall_time_seconds += other.wall_time_seconds

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -4272,6 +4272,7 @@ class DeepAgentsApp(App):
         self._ui_adapter._on_tokens_show = self._show_tokens
         self._ui_adapter._on_session_cost = self._set_session_cost
         self._ui_adapter._on_provisional_cost = self._add_provisional_cost
+        self._ui_adapter._on_usage_update = self._refresh_cache_display
 
         if self._server_startup_deferred:
             await self._mount_deferred_start_notice()
@@ -6802,6 +6803,18 @@ class DeepAgentsApp(App):
         if self._status_bar:
             self._status_bar.show_pending_tokens()
 
+    def _refresh_cache_display(self) -> None:
+        """Show active-thread cache totals, including the in-flight turn."""
+        if self._status_bar is None:
+            return
+        reads = self._thread_stats.cache_read_tokens
+        writes = self._thread_stats.cache_write_tokens
+        inflight = self._inflight_turn_stats
+        if inflight is not None and self._inflight_thread_id == self._lc_thread_id:
+            reads += inflight.cache_read_tokens
+            writes += inflight.cache_write_tokens
+        self._status_bar.set_cache_tokens(reads, writes)
+
     def _set_session_cost(self, cost_usd: float) -> None:
         """Set the active thread's cumulative cost from a server-owned value.
 
@@ -6833,6 +6846,7 @@ class DeepAgentsApp(App):
             cost_usd: Cumulative cost restored from that thread's checkpoint.
         """
         self._thread_stats = SessionStats()
+        self._refresh_cache_display()
         self._thread_restored_cost_usd = _coerce_session_cost_usd(cost_usd)
         self._set_session_cost(self._thread_restored_cost_usd)
 
@@ -14343,6 +14357,7 @@ class DeepAgentsApp(App):
             logger.debug("Screen stack empty during model sync", exc_info=True)
         if self._status_bar is None:
             return
+        self._status_bar.set_context_limit(settings.model_context_limit)
         if not provider or not model:
             logger.warning(
                 "Settings missing model identity at status sync "

--- a/libs/code/deepagents_code/cost_tracking.py
+++ b/libs/code/deepagents_code/cost_tracking.py
@@ -116,6 +116,30 @@ def _cache_write_tokens(details: Mapping[str, Any]) -> int:
     return _token_count(details.get("cache_creation") or details.get("cache_write"))
 
 
+def cache_token_counts(
+    usage_metadata: Mapping[str, Any] | None,
+) -> tuple[int, int]:
+    """Return validated cache read and write tokens from usage metadata.
+
+    Args:
+        usage_metadata: A request's LangChain `usage_metadata` mapping.
+
+    Returns:
+        Cache read and write counts, clamped to the inclusive input total.
+    """
+    if not usage_metadata:
+        return 0, 0
+    input_tokens = _token_count(usage_metadata.get("input_tokens"))
+    details = usage_metadata.get("input_token_details")
+    if not isinstance(details, Mapping):
+        return 0, 0
+    cache_read_tokens = min(_token_count(details.get("cache_read")), input_tokens)
+    cache_write_tokens = min(
+        _cache_write_tokens(details), input_tokens - cache_read_tokens
+    )
+    return cache_read_tokens, cache_write_tokens
+
+
 def estimate_cost(
     usage_metadata: Mapping[str, Any] | None,
     model_name: str,
@@ -156,19 +180,7 @@ def estimate_cost(
         # rates. Without the split there is no defensible estimate.
         return None
 
-    details = usage_metadata.get("input_token_details")
-    if isinstance(details, Mapping):
-        cache_read_tokens = _token_count(details.get("cache_read"))
-        cache_write_tokens = _cache_write_tokens(details)
-    else:
-        cache_read_tokens = 0
-        cache_write_tokens = 0
-
-    # Provider metadata can occasionally report cache parts that exceed the
-    # inclusive input total. Clamp the parts so pricing still produces a safe
-    # estimate instead of failing the model turn with negative uncached input.
-    cache_read_tokens = min(cache_read_tokens, input_tokens)
-    cache_write_tokens = min(cache_write_tokens, input_tokens - cache_read_tokens)
+    cache_read_tokens, cache_write_tokens = cache_token_counts(usage_metadata)
 
     provider_id = _PROVIDER_ALIASES.get(provider_key, provider_key) or None
     try:

--- a/libs/code/deepagents_code/tui/textual_adapter.py
+++ b/libs/code/deepagents_code/tui/textual_adapter.py
@@ -60,6 +60,11 @@ if TYPE_CHECKING:
 
         def __call__(self, cost_usd: float) -> None: ...
 
+    class _UsageUpdateCallback(Protocol):
+        """Callback signature for `_on_usage_update`."""
+
+        def __call__(self) -> None: ...
+
 
 from deepagents_code._ask_user_types import AskUserRequest
 from deepagents_code._cli_context import CLIContext
@@ -494,6 +499,9 @@ class TextualUIAdapter:
         checkpointed yet — a long subagent run, say — without making the client
         a second authority: every server total replaces what this accumulated.
         """
+
+        self._on_usage_update: _UsageUpdateCallback | None = None
+        """Called after a request is added to the shared in-flight turn stats."""
 
     def _sync_tool_widget(self, tool_msg: ToolCallMessage) -> None:
         """Sync a tool widget when the app provided a store callback.
@@ -1379,6 +1387,7 @@ async def execute_task_textual(
                             )
                             from deepagents_code.config import settings
                             from deepagents_code.cost_tracking import (
+                                cache_token_counts,
                                 estimate_cost,
                                 resolve_message_model,
                             )
@@ -1388,6 +1397,7 @@ async def execute_task_textual(
                                 fallback_model=settings.model_name or "",
                                 fallback_provider=settings.model_provider or "",
                             )
+                            cache_reads, cache_writes = cache_token_counts(usage)
                             cost_usd = estimate_cost(
                                 usage, active_model, active_provider
                             )
@@ -1407,6 +1417,8 @@ async def execute_task_textual(
                                     active_provider,
                                     cost_usd=cost_usd,
                                     kind=usage_kind,
+                                    cache_read_tokens=cache_reads,
+                                    cache_write_tokens=cache_writes,
                                 )
                                 captured_input_tokens = max(
                                     captured_input_tokens, input_toks + output_toks
@@ -1421,11 +1433,15 @@ async def execute_task_textual(
                                     active_provider,
                                     cost_usd=cost_usd,
                                     kind=usage_kind,
+                                    cache_read_tokens=cache_reads,
+                                    cache_write_tokens=cache_writes,
                                 )
                                 captured_input_tokens = max(
                                     captured_input_tokens, total_toks
                                 )
                                 recorded = True
+                            if recorded and adapter._on_usage_update:
+                                adapter._on_usage_update()
                             if (
                                 recorded
                                 and cost_usd is not None

--- a/libs/code/deepagents_code/tui/widgets/status.py
+++ b/libs/code/deepagents_code/tui/widgets/status.py
@@ -7,7 +7,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
-from textual.containers import Horizontal
+from textual.containers import Horizontal, Vertical
 from textual.content import Content
 from textual.css.query import NoMatches
 from textual.reactive import reactive
@@ -16,7 +16,7 @@ from textual.widgets import Static
 
 from deepagents_code._constants import FIREWORKS_MODEL_ID_PREFIXES
 from deepagents_code._env_vars import HIDE_CWD, HIDE_GIT_BRANCH, is_env_truthy
-from deepagents_code._session_stats import format_cost
+from deepagents_code._session_stats import format_cost, format_token_count
 from deepagents_code.config import get_glyphs
 from deepagents_code.tui.widgets.loading import Spinner
 
@@ -182,14 +182,20 @@ class BranchLabel(Widget):
         return full[: width - len(ellipsis)] + ellipsis
 
 
-class StatusBar(Horizontal):
-    """Status bar showing mode, cwd, tokens with cost, and the active model."""
+class StatusBar(Vertical):
+    """Two-line status bar showing workspace, cache, context, cost, and model."""
 
     DEFAULT_CSS = """
     StatusBar {
-        height: 1;
+        height: 2;
         dock: bottom;
         background: $background;
+    }
+
+    StatusBar .status-top,
+    StatusBar .status-metrics {
+        width: 1fr;
+        height: 1;
     }
 
     StatusBar .status-mode {
@@ -280,10 +286,17 @@ class StatusBar(Horizontal):
         overflow-x: hidden;
     }
 
-    StatusBar .status-tokens {
-        width: auto;
+    StatusBar .status-cache {
+        width: 1fr;
         padding: 0 1;
         color: $text-muted;
+    }
+
+    StatusBar .status-tokens {
+        width: auto;
+        padding: 0 2;
+        color: $text-muted;
+        text-align: right;
     }
 
     StatusBar .status-rubric {
@@ -330,7 +343,10 @@ class StatusBar(Horizontal):
     cwd: reactive[str] = reactive("", init=False)
     branch: reactive[str] = reactive("", init=False)
     tokens: reactive[int] = reactive(0, init=False)
+    context_limit: reactive[int | None] = reactive(None, init=False)
     cost_usd: reactive[float] = reactive(0.0, init=False)
+    cache_read_tokens: reactive[int] = reactive(0, init=False)
+    cache_write_tokens: reactive[int] = reactive(0, init=False)
     rubric_label: reactive[str] = reactive("", init=False)
 
     def __init__(self, cwd: str | Path | None = None, **kwargs: Any) -> None:
@@ -353,23 +369,25 @@ class StatusBar(Horizontal):
         """Compose the status bar layout.
 
         Yields:
-            Widgets for mode, auto-approve, message, cwd, branch, tokens, and
-                model display.
+            Top-row workspace widgets and second-row cache, context, and cost metrics.
         """
-        yield Static("", classes="status-mode normal", id="mode-indicator")
-        yield Static(
-            "manual",
-            classes="status-auto-approve manual",
-            id="auto-approve-indicator",
-        )
-        with Horizontal(classes="status-left-collapsible"):
-            yield Static("", classes="status-connection", id="connection-indicator")
-            yield Static("", classes="status-message", id="status-message")
-            yield Static("", classes="status-cwd", id="cwd-display")
-            yield BranchLabel(classes="status-branch", id="branch-display")
-        yield Static("", classes="status-rubric", id="rubric-display")
-        yield Static("", classes="status-tokens", id="tokens-display")
-        yield ModelLabel(id="model-display")
+        with Horizontal(classes="status-top"):
+            yield Static("", classes="status-mode normal", id="mode-indicator")
+            yield Static(
+                "manual",
+                classes="status-auto-approve manual",
+                id="auto-approve-indicator",
+            )
+            with Horizontal(classes="status-left-collapsible"):
+                yield Static("", classes="status-connection", id="connection-indicator")
+                yield Static("", classes="status-message", id="status-message")
+                yield Static("", classes="status-cwd", id="cwd-display")
+                yield BranchLabel(classes="status-branch", id="branch-display")
+            yield Static("", classes="status-rubric", id="rubric-display")
+            yield ModelLabel(id="model-display")
+        with Horizontal(classes="status-metrics"):
+            yield Static("", classes="status-cache", id="cache-display")
+            yield Static("", classes="status-tokens", id="tokens-display")
 
     _CWD_WIDTH_THRESHOLD = 70
     """Hide cwd display below this terminal width."""
@@ -433,16 +451,14 @@ class StatusBar(Horizontal):
         label = self.query_one("#model-display", ModelLabel)
         label.provider = settings.model_provider or ""
         label.model = settings.model_name or ""
+        self.set_context_limit(settings.model_context_limit)
         with suppress(NoMatches):
             self.query_one("#rubric-display", Static).display = False
-        # Reactives are `init=False`, so the connection watcher never fires on
-        # mount; render once to hide the empty indicator (and its padding).
+        # Reactives are `init=False`, so their watchers never fire on mount.
         self._render_connection()
-        # Same reasoning for the message and token slots: both start empty, so
-        # hide them on mount so their padding doesn't reserve a blank gap.
         self.watch_status_message(self.status_message)
-        with suppress(NoMatches):
-            self.query_one("#tokens-display", Static).display = False
+        self._render_cache_metrics()
+        self._render_tokens(self.tokens, approximate=self._approximate)
 
     def watch_mode(self, mode: str) -> None:
         """Update mode indicator when mode changes."""
@@ -711,12 +727,24 @@ class StatusBar(Horizontal):
     """Whether the status bar has displayed a real token count this session."""
 
     def watch_tokens(self, new_value: int) -> None:
-        """Update the combined token and cost display when tokens change."""
+        """Update the combined context and cost display when tokens change."""
         self._render_tokens(new_value, approximate=self._approximate)
 
-    def watch_cost_usd(self, _new_value: float) -> None:
-        """Update the combined token and cost display when cost changes."""
+    def watch_context_limit(self, _new_value: int | None) -> None:
+        """Update context percentage when the active model limit changes."""
         self._render_tokens(self.tokens, approximate=self._approximate)
+
+    def watch_cost_usd(self, _new_value: float) -> None:
+        """Update the combined context and cost display when cost changes."""
+        self._render_tokens(self.tokens, approximate=self._approximate)
+
+    def watch_cache_read_tokens(self, _new_value: int) -> None:
+        """Update cache metrics when the read count changes."""
+        self._render_cache_metrics()
+
+    def watch_cache_write_tokens(self, _new_value: int) -> None:
+        """Update cache metrics when the write count changes."""
+        self._render_cache_metrics()
 
     def watch_rubric_label(self, new_value: str) -> None:
         """Update rubric display when active rubric state changes."""
@@ -727,30 +755,44 @@ class StatusBar(Horizontal):
         display.display = bool(new_value)
         display.update(new_value)
 
-    @staticmethod
-    def _token_text(count: int, *, approximate: bool = False) -> str:
-        """Format the token portion of the shared status-bar slot.
+    def _context_text(self, count: int, *, approximate: bool = False) -> str:
+        """Format current context usage as percentage and token total.
+
+        Args:
+            count: Current context token total.
+            approximate: Whether the total is stale after an interrupted turn.
 
         Returns:
-            Formatted token count, or an empty string when no count is known.
+            Compact context usage text for the metrics row.
         """
-        if count <= 0:
-            return ""
-        suffix = "+" if approximate else ""
-        if count >= 1000:  # noqa: PLR2004  # Count formatting threshold
-            return f"{count / 1000:.1f}K{suffix} tokens"
-        return f"{count}{suffix} tokens"
+        normalized = max(count, 0)
+        suffix = "+" if approximate and normalized else ""
+        total = f"{format_token_count(normalized)}{suffix} tokens"
+        if self.context_limit is None:
+            return f"Context: {total}"
+        percentage = normalized / self.context_limit * 100
+        return f"Context: {percentage:.0f}% / {total}"
 
     def _cost_text(self) -> str:
-        """Format positive cost, hiding zero and unknown estimates.
+        """Format cumulative cost in US dollars.
 
         Returns:
-            Formatted cost, or an empty string when no positive estimate exists.
+            Compact dollar amount for the metrics row.
         """
-        return format_cost(self.cost_usd) if self.cost_usd > 0 else ""
+        return format_cost(self.cost_usd)
+
+    def _render_cache_metrics(self) -> None:
+        """Render cumulative cache read and write tokens for the active thread."""
+        try:
+            display = self.query_one("#cache-display", Static)
+        except NoMatches:
+            return
+        reads = format_token_count(self.cache_read_tokens)
+        writes = format_token_count(self.cache_write_tokens)
+        display.update(f"Cache: {reads} read / {writes} write")
 
     def _render_tokens(self, count: int, *, approximate: bool = False) -> None:
-        """Render context tokens and cumulative cost in one compact slot.
+        """Render context usage and cumulative cost in one compact slot.
 
         Args:
             count: Total context token count.
@@ -762,17 +804,12 @@ class StatusBar(Horizontal):
         except NoMatches:
             return
 
-        parts = [
-            part
-            for part in (
-                self._token_text(count, approximate=approximate),
-                self._cost_text(),
-            )
-            if part
-        ]
-        display.display = bool(parts)
         separator = f" {get_glyphs().bullet} "
-        display.update(separator.join(parts))
+        display.update(
+            separator.join(
+                (self._context_text(count, approximate=approximate), self._cost_text())
+            )
+        )
 
     def set_rubric_label(self, label: str) -> None:
         """Set the rubric status label.
@@ -804,6 +841,41 @@ class StatusBar(Horizontal):
             # self._approximate for the suffix.
             self.tokens = count
 
+    def set_context_limit(self, limit: int | None) -> None:
+        """Set the active model's maximum input-token count.
+
+        Args:
+            limit: Positive model context limit, or `None` when unavailable.
+        """
+        normalized = (
+            limit if isinstance(limit, int) and not isinstance(limit, bool) else None
+        )
+        if normalized is not None and normalized <= 0:
+            normalized = None
+        if self.context_limit == normalized:
+            self._render_tokens(self.tokens, approximate=self._approximate)
+        else:
+            self.context_limit = normalized
+
+    def set_cache_tokens(self, read_tokens: int, write_tokens: int) -> None:
+        """Set cumulative cache read and write counts for the active thread.
+
+        Args:
+            read_tokens: Tokens served from provider caches.
+            write_tokens: Tokens written to provider caches.
+        """
+        reads = max(read_tokens, 0)
+        writes = max(write_tokens, 0)
+        changed = False
+        if self.cache_read_tokens != reads:
+            self.cache_read_tokens = reads
+            changed = True
+        if self.cache_write_tokens != writes:
+            self.cache_write_tokens = writes
+            changed = True
+        if not changed:
+            self._render_cache_metrics()
+
     def set_cost(self, cost_usd: float) -> None:
         """Set the cumulative thread cost shown beside context tokens.
 
@@ -823,9 +895,8 @@ class StatusBar(Horizontal):
             display = self.query_one("#tokens-display", Static)
         except NoMatches:
             return
-        parts = [part for part in ("... tokens", self._cost_text()) if part]
         separator = f" {get_glyphs().bullet} "
-        display.update(separator.join(parts))
+        display.update(separator.join(("Context: ...", self._cost_text())))
 
     def set_model(self, *, provider: str, model: str, effort: str = "") -> None:
         """Update the model display text.

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -6471,6 +6471,12 @@ class TestClearCommand:
                 10,
                 provider="openai",
                 cost_usd=1.25,
+                cache_read_tokens=80,
+                cache_write_tokens=20,
+            )
+            app._refresh_cache_display()
+            assert "Cache: 80 read / 20 write" in str(
+                app.query_one("#cache-display").render()
             )
 
             with (
@@ -6488,6 +6494,9 @@ class TestClearCommand:
             # thread, where nothing would ever supersede it.
             assert app._displayed_cost_usd == pytest.approx(0.0)
             assert app._thread_stats.request_count == 0
+            assert "Cache: 0 read / 0 write" in str(
+                app.query_one("#cache-display").render()
+            )
 
             app_msgs = list(app.query(AppMessage))
             assert any(

--- a/libs/code/tests/unit_tests/test_cost_tracking.py
+++ b/libs/code/tests/unit_tests/test_cost_tracking.py
@@ -32,6 +32,7 @@ from deepagents_code.cost_tracking import (
     CostTrackingMiddleware,
     _ModelCallRecord,
     _SessionCostRecorder,
+    cache_token_counts,
     estimate_cost,
     resolve_message_model,
 )
@@ -171,6 +172,30 @@ def _collect(
         ),
         run_id=run_id,
     )
+
+
+class TestCacheTokenCounts:
+    """Tests for cache metadata normalization shared by pricing and the UI."""
+
+    def test_reads_and_writes_are_returned(self) -> None:
+        assert cache_token_counts(_usage(cache_read=600, cache_write=300)) == (600, 300)
+
+    def test_counts_are_clamped_to_inclusive_input(self) -> None:
+        assert cache_token_counts(_usage(cache_read=900, cache_write=900)) == (900, 100)
+
+    def test_malformed_details_are_ignored(self) -> None:
+        usage = _usage()
+        usage["input_token_details"] = {"cache_read": True, "cache_creation": -1}
+        assert cache_token_counts(usage) == (0, 0)
+
+    def test_detailed_anthropic_writes_are_summed(self) -> None:
+        usage = _usage()
+        usage["input_token_details"] = {
+            "cache_creation": 0,
+            "ephemeral_5m_input_tokens": 200,
+            "ephemeral_1h_input_tokens": 100,
+        }
+        assert cache_token_counts(usage) == (0, 300)
 
 
 class TestEstimateCost:

--- a/libs/code/tests/unit_tests/test_session_stats.py
+++ b/libs/code/tests/unit_tests/test_session_stats.py
@@ -95,6 +95,8 @@ class TestSessionStats:
         assert stats.request_count == 0
         assert stats.input_tokens == 0
         assert stats.output_tokens == 0
+        assert stats.cache_read_tokens == 0
+        assert stats.cache_write_tokens == 0
         assert stats.total_cost_usd == pytest.approx(0.0)
         assert stats.priced_request_count == 0
         assert stats.wall_time_seconds == pytest.approx(0.0)
@@ -114,6 +116,25 @@ class TestSessionStats:
         assert stats.request_count == 2
         assert stats.input_tokens == 300
         assert stats.output_tokens == 125
+
+    def test_record_request_accumulates_cache_tokens(self) -> None:
+        stats = SessionStats()
+        stats.record_request(
+            "gpt-5.5",
+            100,
+            50,
+            cache_read_tokens=80,
+            cache_write_tokens=20,
+        )
+        stats.record_request(
+            "gpt-5.5",
+            200,
+            75,
+            cache_read_tokens=150,
+            cache_write_tokens=25,
+        )
+        assert stats.cache_read_tokens == 230
+        assert stats.cache_write_tokens == 45
 
     def test_record_request_populates_per_model(self) -> None:
         stats = SessionStats()
@@ -184,18 +205,24 @@ class TestSessionStats:
             request_count=1,
             input_tokens=100,
             output_tokens=50,
+            cache_read_tokens=80,
+            cache_write_tokens=20,
             wall_time_seconds=1.5,
         )
         b = SessionStats(
             request_count=2,
             input_tokens=200,
             output_tokens=75,
+            cache_read_tokens=150,
+            cache_write_tokens=25,
             wall_time_seconds=2.0,
         )
         a.merge(b)
         assert a.request_count == 3
         assert a.input_tokens == 300
         assert a.output_tokens == 125
+        assert a.cache_read_tokens == 230
+        assert a.cache_write_tokens == 45
         assert a.wall_time_seconds == pytest.approx(3.5)
 
     def test_merge_combines_cost(self) -> None:

--- a/libs/code/tests/unit_tests/tui/test_textual_adapter.py
+++ b/libs/code/tests/unit_tests/tui/test_textual_adapter.py
@@ -2068,17 +2068,25 @@ def _usage_chunk(
     input_tokens: int,
     output_tokens: int,
     metadata: dict[str, Any] | None = None,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
 ) -> tuple[Any, ...]:
     """Build a `messages`-stream chunk carrying only `usage_metadata`."""
     from langchain_core.messages import AIMessageChunk
 
+    usage: dict[str, Any] = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+    }
+    if cache_read_tokens or cache_write_tokens:
+        usage["input_token_details"] = {
+            "cache_read": cache_read_tokens,
+            "cache_creation": cache_write_tokens,
+        }
     message = AIMessageChunk(
         content="",
-        usage_metadata={
-            "input_tokens": input_tokens,
-            "output_tokens": output_tokens,
-            "total_tokens": input_tokens + output_tokens,
-        },
+        usage_metadata=usage,
     )
     return ((), "messages", (message, metadata or {}))
 
@@ -2092,16 +2100,22 @@ class TestExecuteTaskTextualUsageStats:
     """
 
     async def test_records_provider_from_settings(self) -> None:
-        """A usage chunk records the configured provider on `turn_stats`."""
+        """A usage chunk records provider and cache totals on `turn_stats`."""
 
         async def mount_message(_: object) -> None:
             await asyncio.sleep(0)
 
         turn_stats = SessionStats()
         cost_updates: list[float] = []
+        cache_updates: list[tuple[int, int]] = []
 
         def record_cost(cost_usd: float) -> None:
             cost_updates.append(cost_usd)
+
+        def record_usage_update() -> None:
+            cache_updates.append(
+                (turn_stats.cache_read_tokens, turn_stats.cache_write_tokens)
+            )
 
         adapter = TextualUIAdapter(
             mount_message=mount_message,
@@ -2109,6 +2123,7 @@ class TestExecuteTaskTextualUsageStats:
             request_approval=_mock_approval,
         )
         adapter._on_provisional_cost = record_cost
+        adapter._on_usage_update = record_usage_update
 
         with (
             patch("deepagents_code.config.settings") as mock_settings,
@@ -2118,7 +2133,16 @@ class TestExecuteTaskTextualUsageStats:
             mock_settings.model_provider = "openai"
             await execute_task_textual(
                 user_input="hello",
-                agent=_FakeAgent([_usage_chunk(input_tokens=100, output_tokens=50)]),
+                agent=_FakeAgent(
+                    [
+                        _usage_chunk(
+                            input_tokens=100,
+                            output_tokens=50,
+                            cache_read_tokens=80,
+                            cache_write_tokens=20,
+                        )
+                    ]
+                ),
                 assistant_id="assistant",
                 session_state=SimpleNamespace(thread_id="thread-1", auto_approve=False),
                 adapter=adapter,
@@ -2130,7 +2154,10 @@ class TestExecuteTaskTextualUsageStats:
         assert model_stats.output_tokens == 50
         assert model_stats.cost_usd == pytest.approx(0.42)
         assert turn_stats.total_cost_usd == pytest.approx(0.42)
+        assert turn_stats.cache_read_tokens == 80
+        assert turn_stats.cache_write_tokens == 20
         assert cost_updates == [0.42]
+        assert cache_updates == [(80, 20)]
 
     async def test_records_hidden_subagent_and_summarization_usage(self) -> None:
         """Subagent and summarization spend still accumulate even when hidden."""

--- a/libs/code/tests/unit_tests/tui/widgets/test_status.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_status.py
@@ -33,6 +33,24 @@ class StatusBarApp(App):
         yield StatusBar(id="status-bar")
 
 
+class TestTwoLineLayout:
+    """Tests for the status bar's fixed two-row layout."""
+
+    async def test_workspace_and_metrics_use_separate_rows(self) -> None:
+        async with StatusBarApp().run_test(size=(120, 24)) as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            top = pilot.app.query_one(".status-top")
+            metrics = pilot.app.query_one(".status-metrics")
+
+            assert bar.size.height == 2
+            assert top.region.y == bar.region.y
+            assert metrics.region.y == bar.region.y + 1
+            for selector in ("#cwd-display", "#branch-display", "#model-display"):
+                assert pilot.app.query_one(selector).region.y == top.region.y
+            for selector in ("#cache-display", "#tokens-display"):
+                assert pilot.app.query_one(selector).region.y == metrics.region.y
+
+
 class TestApprovalModeDisplay:
     """Tests for the three-state approval indicator."""
 
@@ -397,15 +415,19 @@ class TestTokenDisplay:
             bar.show_pending_tokens()
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == "... tokens"
+            rendered = str(display.render())
+            assert "Context: ..." in rendered
+            assert "$0.00" in rendered
 
-    async def test_show_pending_tokens_before_count_leaves_display_empty(self) -> None:
+    async def test_show_pending_tokens_before_count_keeps_zero_display(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.show_pending_tokens()
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == ""
+            rendered = str(display.render())
+            assert "Context: 0 tokens" in rendered
+            assert "$0.00" in rendered
 
     async def test_set_tokens_after_pending_restores_display(self) -> None:
         """Regression: set_tokens must refresh even when value is unchanged.
@@ -440,7 +462,9 @@ class TestTokenDisplay:
             bar.show_pending_tokens()
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == "... tokens"
+            rendered = str(display.render())
+            assert "Context: ..." in rendered
+            assert "$0.00" in rendered
 
     def test_show_pending_tokens_without_mount_is_noop(self) -> None:
         bar = StatusBar()
@@ -483,23 +507,87 @@ class TestTokenDisplay:
             assert "8.0K" in rendered
             assert "+" not in rendered
 
-    async def test_empty_tokens_hidden_on_mount(self) -> None:
-        """An empty token slot is hidden so its padding adds no gap."""
+    async def test_empty_context_shows_zero_on_mount(self) -> None:
+        """The metrics row shows zero context before the first request."""
         async with StatusBarApp().run_test() as pilot:
             display = pilot.app.query_one("#tokens-display")
-            assert display.display is False
+            assert "Context: 0 tokens" in str(display.render())
+            assert display.display is True
 
-    async def test_set_tokens_shows_then_zero_hides(self) -> None:
-        """A positive count reveals the token slot; zeroing hides it again."""
+    async def test_zeroing_tokens_keeps_zero_context_visible(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.set_tokens(5000)
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert display.display is True
             bar.set_tokens(0)
             await pilot.pause()
-            assert display.display is False
+            assert "Context: 0 tokens" in str(display.render())
+            assert display.display is True
+
+
+class TestContextDisplay:
+    """Tests for percentage and token totals on the metrics row."""
+
+    async def test_context_shows_percentage_and_current_total(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_context_limit(200_000)
+            bar.set_tokens(12_500)
+            await pilot.pause()
+
+            rendered = str(pilot.app.query_one("#tokens-display").render())
+            assert "Context: 6% / 12.5K tokens" in rendered
+
+    async def test_context_limit_change_recalculates_percentage(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_tokens(10_000)
+            bar.set_context_limit(100_000)
+            await pilot.pause()
+            assert "Context: 10% / 10.0K tokens" in str(
+                pilot.app.query_one("#tokens-display").render()
+            )
+
+            bar.set_context_limit(200_000)
+            await pilot.pause()
+            assert "Context: 5% / 10.0K tokens" in str(
+                pilot.app.query_one("#tokens-display").render()
+            )
+
+    async def test_invalid_context_limit_falls_back_to_token_total(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_context_limit(0)
+            bar.set_tokens(5000)
+            await pilot.pause()
+            assert "Context: 5.0K tokens" in str(
+                pilot.app.query_one("#tokens-display").render()
+            )
+
+
+class TestCacheDisplay:
+    """Tests for active-thread cache read and write metrics."""
+
+    async def test_cache_counts_render_on_left_metric(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            bar.set_cache_tokens(12_500, 750)
+            await pilot.pause()
+
+            cache = pilot.app.query_one("#cache-display")
+            assert str(cache.render()) == "Cache: 12.5K read / 750 write"
+            assert cache.region.x < pilot.app.query_one("#tokens-display").region.x
+
+    async def test_cache_counts_start_at_zero_and_clamp_negative_values(self) -> None:
+        async with StatusBarApp().run_test() as pilot:
+            bar = pilot.app.query_one("#status-bar", StatusBar)
+            cache = pilot.app.query_one("#cache-display")
+            assert str(cache.render()) == "Cache: 0 read / 0 write"
+
+            bar.set_cache_tokens(-1, -2)
+            await pilot.pause()
+            assert str(cache.render()) == "Cache: 0 read / 0 write"
 
 
 class TestCostDisplay:
@@ -521,25 +609,29 @@ class TestCostDisplay:
             bar.set_cost(1.25)
             await pilot.pause()
             display = pilot.app.query_one("#tokens-display")
-            assert str(display.render()) == "$1.25"
+            rendered = str(display.render())
+            assert "Context: 0 tokens" in rendered
+            assert "$1.25" in rendered
             assert display.display is True
 
-    async def test_zero_cost_is_hidden(self) -> None:
+    async def test_zero_cost_is_shown_in_usd(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.set_tokens(5000)
             bar.set_cost(0.0)
             await pilot.pause()
             rendered = str(pilot.app.query_one("#tokens-display").render())
-            assert rendered == "5.0K tokens"
-            assert "$" not in rendered
+            assert "Context: 5.0K tokens" in rendered
+            assert "$0.00" in rendered
 
     async def test_sub_cent_cost_uses_display_floor(self) -> None:
         async with StatusBarApp().run_test() as pilot:
             bar = pilot.app.query_one("#status-bar", StatusBar)
             bar.set_cost(0.0045)
             await pilot.pause()
-            assert str(pilot.app.query_one("#tokens-display").render()) == "<$0.01"
+            rendered = str(pilot.app.query_one("#tokens-display").render())
+            assert "Context: 0 tokens" in rendered
+            assert "<$0.01" in rendered
 
     async def test_approximate_token_marker_survives_cost_update(self) -> None:
         async with StatusBarApp().run_test() as pilot:
@@ -560,7 +652,7 @@ class TestCostDisplay:
             bar.show_pending_tokens()
             await pilot.pause()
             rendered = str(pilot.app.query_one("#tokens-display").render())
-            assert "... tokens" in rendered
+            assert "Context: ..." in rendered
             assert "$0.42" in rendered
 
 


### PR DESCRIPTION
The status footer now uses a second row for cache reads/writes, context percentage and token totals, and cumulative USD cost.

---

Keeping workspace/model state on the first row prevents live usage metrics from competing with cwd and branch space. Cache metadata is validated through the pricing path and scoped to the active thread.

Verified with focused status, session-stat, cost-tracking, adapter, and thread-reset tests plus package lint/type checks.

Made by [Open SWE](https://openswe.vercel.app/agents/7a831dda-3c65-a0f6-35ce-62af0c34f84f)