### PR TITLE
fix(code): release the turn when an interrupted worker never starts

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3464,6 +3464,16 @@ class DeepAgentsApp(App):
         """Active `_run_agent_task` worker, tracked so it can be cancelled
         on interrupt (`Ctrl+C`) or exit."""
 
+        self._agent_turn_started = False
+        """True once the active worker's `_run_agent_task` coroutine has begun.
+
+        A worker cancelled before its first event-loop step never runs its
+        coroutine, so `_run_agent_task`'s `finally` — and with it
+        `_cleanup_agent_task` — never fires and nothing would release
+        `_agent_running`. The interrupt paths read this to recover instead of
+        leaving the session permanently busy, queueing every later message
+        behind a turn that will never report back."""
+
         self._agent_running = False
         """True while the agent worker is streaming a response."""
 
@@ -14580,48 +14590,56 @@ class DeepAgentsApp(App):
             # Fresh turn: no model text or tool call is visible yet, so an Esc
             # interrupt may still return this prompt to the input.
             self._active_turn_visible_output_started = False
+            self._agent_turn_started = False
+            # The awaited setup below runs while the session already reports
+            # busy but before a worker exists to cancel, so any early exit or
+            # failure in that window must hand the running flag back. Otherwise
+            # the session stays busy forever and every later message is queued
+            # behind a turn that was never started.
+            worker_started = False
+            try:
+                # Flush any buffered non-incognito `!` shell output into thread
+                # state so this turn's model sees commands run since the last turn.
+                await self._flush_pending_shell_messages()
 
-            # Flush any buffered non-incognito `!` shell output into thread
-            # state so this turn's model sees commands run since the last turn.
-            await self._flush_pending_shell_messages()
-
-            # Any send (typed reply or skill invocation) counts as the user
-            # acting on a blocked goal, so reset it before the turn starts.
-            reset = await self._reset_blocked_goal_for_user_turn()
-            if not reset.ready:
-                self._set_agent_running(False)
-                self._active_user_message = None
-                await self._mount_message(
-                    ErrorMessage(
-                        "The blocked goal could not be resumed, so this message was "
-                        "not sent. Retry after the thread state is available."
+                # Any send (typed reply or skill invocation) counts as the user
+                # acting on a blocked goal, so reset it before the turn starts.
+                reset = await self._reset_blocked_goal_for_user_turn()
+                if not reset.ready:
+                    self._active_user_message = None
+                    await self._mount_message(
+                        ErrorMessage(
+                            "The blocked goal could not be resumed, so this message "
+                            "was not sent. Retry after the thread state is available."
+                        )
                     )
+                    return
+                resuming_blocked = reset.did_reset
+
+                if resuming_blocked and self._active_goal:
+                    await self._mount_message(
+                        AppMessage(
+                            f"Resuming previously blocked goal: {self._active_goal}"
+                        )
+                    )
+
+                if self._chat_input:
+                    self._chat_input.set_cursor_active(active=False)
+
+                # Use run_worker to avoid blocking the main event loop
+                # This allows the UI to remain responsive during agent execution
+                self._agent_worker = self.run_worker(
+                    self._run_agent_task(
+                        message,
+                        message_kwargs=message_kwargs,
+                        goal_notice_current=resuming_blocked,
+                    ),
+                    exclusive=False,
                 )
-                # Drain any messages queued behind this turn so they are not
-                # stranded; mirrors the queue handling in `_agent_finished`.
-                if self._pending_messages and not self._agent_running:
-                    await self._process_next_from_queue()
-                return
-            resuming_blocked = reset.did_reset
-
-            if resuming_blocked and self._active_goal:
-                await self._mount_message(
-                    AppMessage(f"Resuming previously blocked goal: {self._active_goal}")
-                )
-
-            if self._chat_input:
-                self._chat_input.set_cursor_active(active=False)
-
-            # Use run_worker to avoid blocking the main event loop
-            # This allows the UI to remain responsive during agent execution
-            self._agent_worker = self.run_worker(
-                self._run_agent_task(
-                    message,
-                    message_kwargs=message_kwargs,
-                    goal_notice_current=resuming_blocked,
-                ),
-                exclusive=False,
-            )
+                worker_started = True
+            finally:
+                if not worker_started:
+                    await self._release_unstarted_turn()
         elif self._server_startup_deferred:
             await self._mount_message(AppMessage(_DEFERRED_START_NOTICE))
         elif not self._server_startup_error:
@@ -14631,6 +14649,27 @@ class DeepAgentsApp(App):
             await self._mount_message(
                 AppMessage("Agent not configured for this session."),
             )
+
+    async def _release_unstarted_turn(self) -> None:
+        """Hand back the running flag for a turn whose worker never started.
+
+        `_send_to_agent` reports busy before its awaited setup so the UI reacts
+        immediately, and `_cleanup_agent_task` normally releases that state from
+        the worker's `finally`. When no worker was started there is nothing to
+        cancel and no `finally` to run, so this releases the state instead and
+        drains anything queued behind the abandoned turn.
+        """
+        self._set_agent_running(False)
+        if self._chat_input:
+            self._chat_input.set_cursor_active(active=True)
+        if not self._pending_messages:
+            return
+        # Best-effort: a failed drain must not mask the error that abandoned
+        # the turn, and the session is already idle again by this point.
+        try:
+            await self._process_next_from_queue()
+        except Exception:
+            logger.exception("Failed to drain queue after abandoned turn")
 
     async def _mount_deferred_start_notice(self) -> None:
         """Tell first-launch users how to configure model credentials."""
@@ -14980,17 +15019,12 @@ class DeepAgentsApp(App):
             graph_input: Prepared non-conversation input for a server operation.
             goal_notice_current: Whether the caller just persisted the current notice.
         """
-        # Caller ensures _ui_adapter is set (checked in _handle_user_message)
-        if self._ui_adapter is None:
-            return
-        if self._approval_mode_blocked:
-            await self._mount_message(
-                ErrorMessage(
-                    "Manual approval mode has not been persisted. Press Ctrl+T "
-                    "to retry before starting another run."
-                )
-            )
-            return
+        # Recorded before anything can fail so the interrupt paths can tell a
+        # turn that started from a worker that was cancelled before its first
+        # event-loop step (whose coroutine — and so the `finally` below — never
+        # runs at all).
+        self._agent_turn_started = True
+
         from deepagents_code.config import settings
         from deepagents_code.resume_state import RUBRIC_RESULT_VALUES
         from deepagents_code.tui.textual_adapter import (
@@ -14999,76 +15033,13 @@ class DeepAgentsApp(App):
         )
 
         criteria_request_id: str | None = None
-        if graph_input is not None:
-            criteria_request = graph_input.get("goal_criteria_request")
-            if isinstance(criteria_request, dict):
-                raw_request_id = criteria_request.get("request_id")
-                if isinstance(raw_request_id, str):
-                    criteria_request_id = raw_request_id
-
-        # Create the stats object up-front and store on the app so
-        # exit() can merge it synchronously if the worker is cancelled
-        # before this method can return (e.g. Ctrl+D during HITL).
+        # Create the stats object up-front so exit() can merge it synchronously
+        # if the worker is cancelled before this method can return (e.g. Ctrl+D
+        # during HITL).
         turn_stats = SessionStats()
-        self._inflight_turn_stats = turn_stats
-        self._inflight_turn_start = time.monotonic()
-
-        # Arm the subagent fan-out panel for this turn, seeding the session
-        # model that labels each row. The panel persists across turns and only
-        # clears when this turn's first subagent actually starts, so a turn that
-        # spawns none leaves the previous workflow's results on screen.
-        panel = self._get_subagent_panel()
-        if panel is not None:
-            spec = self._effective_model_spec()
-            panel.prepare_turn(model_label=_display_model_label(spec))
-
-        # A paused or completed goal withholds its rubric so the grader does not
-        # run this turn (mirrors the persisted-state suppression in
-        # `_goal_state_update`). A one-shot `_next_rubric` still applies, but is
-        # deliberately not treated as a goal-backed grade even when its text matches.
-        rubric = None
-        goal_backed_grading = False
-        goal_notice_ready = True
-        goal_notice_written = goal_notice_current
-        if graph_input is None:
-            if self._last_consumed_next_rubric is not None:
-                state_update = self._goal_state_update()
-                goal_notice_ready = await self._persist_goal_rubric_state(
-                    notice=build_goal_state_notice(state_update),
-                    state_update=state_update,
-                )
-                goal_notice_written = goal_notice_ready
-                if goal_notice_ready:
-                    self._last_consumed_next_rubric = None
-                    self._last_consumed_next_previous_rubric = None
-            rubric = self._next_rubric
-            if rubric is None and not (
-                self._active_goal and self._goal_status in {"paused", "complete"}
-            ):
-                rubric = self._active_rubric
-                goal_backed_grading = bool(
-                    rubric and self._active_goal and self._goal_status == "active"
-                )
-            if self._next_rubric is not None:
-                previous_state = self._goal_state_update()
-                state_update = dict(previous_state)
-                state_update["rubric"] = self._next_rubric
-                notice = _goal_state_change_notice(previous_state, state_update)
-                goal_notice_ready = await self._persist_goal_rubric_state(
-                    notice=notice,
-                    state_update=state_update,
-                )
-                goal_notice_written = goal_notice_ready and notice is not None
-                if goal_notice_ready:
-                    self._last_consumed_next_rubric = self._next_rubric
-                    self._last_consumed_next_previous_rubric = self._active_rubric
-                    self._next_rubric = None
-                    self._sync_status_rubric()
-        if graph_input is None and goal_notice_ready and not goal_notice_written:
-            goal_notice_ready = await self._ensure_goal_state_notice()
-
         latest_goal_grade: RubricEvaluationEnd | None = None
         turn_completed = False
+        task_succeeded = False
 
         def _record_goal_grading_run(event: RubricEvaluationEnd) -> None:
             nonlocal latest_goal_grade
@@ -15085,8 +15056,89 @@ class DeepAgentsApp(App):
                     event.result,
                 )
 
-        task_succeeded = False
+        # Turn setup runs inside this `try` as well as the stream itself:
+        # `_cleanup_agent_task` in the `finally` is the only thing that releases
+        # `_agent_running`, so an early return or an interrupt landing during
+        # setup must not slip past it. Otherwise the session stays busy forever
+        # and every later message is queued behind a turn that already ended.
         try:
+            # Caller ensures _ui_adapter is set (checked in _handle_user_message)
+            if self._ui_adapter is None:
+                return
+            if self._approval_mode_blocked:
+                await self._mount_message(
+                    ErrorMessage(
+                        "Manual approval mode has not been persisted. Press Ctrl+T "
+                        "to retry before starting another run."
+                    )
+                )
+                return
+
+            if graph_input is not None:
+                criteria_request = graph_input.get("goal_criteria_request")
+                if isinstance(criteria_request, dict):
+                    raw_request_id = criteria_request.get("request_id")
+                    if isinstance(raw_request_id, str):
+                        criteria_request_id = raw_request_id
+
+            self._inflight_turn_stats = turn_stats
+            self._inflight_turn_start = time.monotonic()
+
+            # Arm the subagent fan-out panel for this turn, seeding the session
+            # model that labels each row. The panel persists across turns and only
+            # clears when this turn's first subagent actually starts, so a turn that
+            # spawns none leaves the previous workflow's results on screen.
+            panel = self._get_subagent_panel()
+            if panel is not None:
+                spec = self._effective_model_spec()
+                panel.prepare_turn(model_label=_display_model_label(spec))
+
+            # A paused or completed goal withholds its rubric so the grader does not
+            # run this turn (mirrors the persisted-state suppression in
+            # `_goal_state_update`). A one-shot `_next_rubric` still applies, but is
+            # deliberately not treated as a goal-backed grade even when its text
+            # matches.
+            rubric = None
+            goal_backed_grading = False
+            goal_notice_ready = True
+            goal_notice_written = goal_notice_current
+            if graph_input is None:
+                if self._last_consumed_next_rubric is not None:
+                    state_update = self._goal_state_update()
+                    goal_notice_ready = await self._persist_goal_rubric_state(
+                        notice=build_goal_state_notice(state_update),
+                        state_update=state_update,
+                    )
+                    goal_notice_written = goal_notice_ready
+                    if goal_notice_ready:
+                        self._last_consumed_next_rubric = None
+                        self._last_consumed_next_previous_rubric = None
+                rubric = self._next_rubric
+                if rubric is None and not (
+                    self._active_goal and self._goal_status in {"paused", "complete"}
+                ):
+                    rubric = self._active_rubric
+                    goal_backed_grading = bool(
+                        rubric and self._active_goal and self._goal_status == "active"
+                    )
+                if self._next_rubric is not None:
+                    previous_state = self._goal_state_update()
+                    state_update = dict(previous_state)
+                    state_update["rubric"] = self._next_rubric
+                    notice = _goal_state_change_notice(previous_state, state_update)
+                    goal_notice_ready = await self._persist_goal_rubric_state(
+                        notice=notice,
+                        state_update=state_update,
+                    )
+                    goal_notice_written = goal_notice_ready and notice is not None
+                    if goal_notice_ready:
+                        self._last_consumed_next_rubric = self._next_rubric
+                        self._last_consumed_next_previous_rubric = self._active_rubric
+                        self._next_rubric = None
+                        self._sync_status_rubric()
+            if graph_input is None and goal_notice_ready and not goal_notice_written:
+                goal_notice_ready = await self._ensure_goal_state_notice()
+
             if not goal_notice_ready:
                 # A goal/rubric state write failed (not a deferral — deferrals
                 # now let the turn run so recovery middleware can repair it), so
@@ -16684,7 +16736,9 @@ class DeepAgentsApp(App):
         if self._shell_running and self._shell_worker:
             self._shell_worker.cancel()
         if self._agent_running and self._agent_worker:
-            self._agent_worker.cancel()
+            agent_worker = self._agent_worker
+            agent_worker.cancel()
+            self._recover_unstarted_agent_worker(agent_worker)
         self._warn_dropped_mcp_reconnect()
         self._discard_queue()
 
@@ -16772,6 +16826,41 @@ class DeepAgentsApp(App):
         self._discard_queue()
         if worker is not None:
             worker.cancel()
+            self._recover_unstarted_agent_worker(worker)
+
+    def _recover_unstarted_agent_worker(self, worker: Worker[None]) -> None:
+        """Release the turn when a cancelled agent worker never started.
+
+        A worker cancelled before its first event-loop step never runs its
+        coroutine, so `_run_agent_task` — and the `_cleanup_agent_task` call in
+        its `finally` — never happens and Textual leaves the worker's state as
+        `RUNNING`. Nothing else would ever clear `_agent_running`, so the
+        session would look busy for the rest of its life: new messages would
+        queue instead of sending, `Esc` would only pop them back into the chat
+        input, and not even `/force-clear` would recover.
+
+        Args:
+            worker: The worker that was just cancelled.
+        """
+        if worker is not self._agent_worker or self._agent_turn_started:
+            return
+
+        async def _release() -> None:
+            # Re-check on the callback: the worker may have taken its first step
+            # between the cancel and this callback, in which case its own
+            # `finally` owns cleanup.
+            if (
+                worker is not self._agent_worker
+                or self._agent_turn_started
+                or not self._agent_running
+            ):
+                return
+            logger.warning(
+                "Agent worker was cancelled before it started; releasing the turn"
+            )
+            await self._cleanup_agent_task()
+
+        self.call_after_refresh(_release)
 
     def action_quit_or_interrupt(self) -> None:
         """Handle Ctrl+C - interrupt agent, reject approval, or quit on double press.

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3465,14 +3465,27 @@ class DeepAgentsApp(App):
         on interrupt (`Ctrl+C`) or exit."""
 
         self._agent_turn_started = False
-        """True once the active worker's `_run_agent_task` coroutine has begun.
+        """True once the current `_run_agent_task` invocation has begun.
+
+        This is the canonical explanation of the wedge the interrupt-recovery
+        machinery exists to prevent; other sites describe only their local
+        mechanism and point here.
 
         A worker cancelled before its first event-loop step never runs its
         coroutine, so `_run_agent_task`'s `finally` — and with it
-        `_cleanup_agent_task` — never fires and nothing would release
-        `_agent_running`. The interrupt paths read this to recover instead of
-        leaving the session permanently busy, queueing every later message
-        behind a turn that will never report back."""
+        `_cleanup_agent_task` — never fires and nothing releases
+        `_agent_running`. The session then looks busy for the rest of its life:
+        new messages queue instead of sending, `Esc` only pops them back into
+        the chat input, and `/force-clear` does not recover. The interrupt paths
+        read this flag to tell that case apart from a worker that really ran,
+        and release the turn themselves.
+
+        Lifetime: set by `_run_agent_task` (which is also awaited directly,
+        without a worker, from `_run_goal_criteria_request`); cleared by
+        `_send_to_agent` before it spawns a worker and by `_cleanup_agent_task`
+        at turn end. Any new path that starts an agent worker must leave this
+        `False`, or `_recover_unstarted_agent_worker` will skip that worker and
+        the wedge returns."""
 
         self._agent_running = False
         """True while the agent worker is streaming a response."""
@@ -13552,7 +13565,10 @@ class DeepAgentsApp(App):
                 if self._server_proc is not None and self._server_kwargs is not None:
                     if self._agent_running and self._agent_worker:
                         self._cancel_worker(self._agent_worker)
-                        self._agent_running = False
+                        # Via `_set_agent_running` so the quiescence event is
+                        # released with the flag; a bare assignment leaves
+                        # `_agent_quiescent` cleared.
+                        self._set_agent_running(False)
                     else:
                         self._discard_queue()
                     restarted = await self._restart_server_manual()
@@ -14592,10 +14608,10 @@ class DeepAgentsApp(App):
             self._active_turn_visible_output_started = False
             self._agent_turn_started = False
             # The awaited setup below runs while the session already reports
-            # busy but before a worker exists to cancel, so any early exit or
-            # failure in that window must hand the running flag back. Otherwise
-            # the session stays busy forever and every later message is queued
-            # behind a turn that was never started.
+            # busy but before a worker exists to cancel, so nothing here can be
+            # released by an interrupt or by a worker `finally`. This window
+            # owns the release itself; see `_agent_turn_started` for what a
+            # missed release costs.
             worker_started = False
             try:
                 # Flush any buffered non-incognito `!` shell output into thread
@@ -14606,7 +14622,6 @@ class DeepAgentsApp(App):
                 # acting on a blocked goal, so reset it before the turn starts.
                 reset = await self._reset_blocked_goal_for_user_turn()
                 if not reset.ready:
-                    self._active_user_message = None
                     await self._mount_message(
                         ErrorMessage(
                             "The blocked goal could not be resumed, so this message "
@@ -14658,18 +14673,39 @@ class DeepAgentsApp(App):
         the worker's `finally`. When no worker was started there is nothing to
         cancel and no `finally` to run, so this releases the state instead and
         drains anything queued behind the abandoned turn.
+
+        Deliberately not a full `_cleanup_agent_task`: no turn ran, so there is
+        no spinner, stats, tool group, or goal state to reconcile.
+
+        Runs from a `finally`, so every step is best-effort — raising here would
+        replace the exception that abandoned the turn with a teardown error.
         """
         self._set_agent_running(False)
+        self._active_user_message = None
+        self._active_turn_visible_output_started = False
         if self._chat_input:
-            self._chat_input.set_cursor_active(active=True)
+            # Widget calls can fail against a torn-down DOM; the running flag is
+            # the part that wedges the session, and it is already handed back.
+            with suppress(Exception):
+                self._chat_input.set_cursor_active(active=True)
         if not self._pending_messages:
             return
-        # Best-effort: a failed drain must not mask the error that abandoned
-        # the turn, and the session is already idle again by this point.
         try:
             await self._process_next_from_queue()
         except Exception:
+            # `_process_next_from_queue` handles its own failures, so reaching
+            # here means its error reporting failed too — the queued message has
+            # already been popped and the user would otherwise see nothing at
+            # all about its disappearance.
             logger.exception("Failed to drain queue after abandoned turn")
+            with suppress(Exception):
+                await self._mount_message(
+                    ErrorMessage(
+                        "A queued message could not be sent after the previous "
+                        "turn was abandoned. Resend it, or run `/force-clear` "
+                        "if the session looks stuck."
+                    )
+                )
 
     async def _mount_deferred_start_notice(self) -> None:
         """Tell first-launch users how to configure model credentials."""
@@ -15019,10 +15055,9 @@ class DeepAgentsApp(App):
             graph_input: Prepared non-conversation input for a server operation.
             goal_notice_current: Whether the caller just persisted the current notice.
         """
-        # Recorded before anything can fail so the interrupt paths can tell a
-        # turn that started from a worker that was cancelled before its first
-        # event-loop step (whose coroutine — and so the `finally` below — never
-        # runs at all).
+        # Set before anything can fail, so a cancel arriving later cannot leave
+        # this `False` and be mistaken for a worker that never ran. See
+        # `_agent_turn_started`.
         self._agent_turn_started = True
 
         from deepagents_code.config import settings
@@ -15032,14 +15067,23 @@ class DeepAgentsApp(App):
             execute_task_textual,
         )
 
+        # Read before the guard clauses below so an early return still clears
+        # the submitted request during cleanup instead of stranding it.
         criteria_request_id: str | None = None
-        # Create the stats object up-front so exit() can merge it synchronously
-        # if the worker is cancelled before this method can return (e.g. Ctrl+D
-        # during HITL).
+        if graph_input is not None:
+            criteria_request = graph_input.get("goal_criteria_request")
+            if isinstance(criteria_request, dict):
+                raw_request_id = criteria_request.get("request_id")
+                if isinstance(raw_request_id, str):
+                    criteria_request_id = raw_request_id
+
         turn_stats = SessionStats()
         latest_goal_grade: RubricEvaluationEnd | None = None
         turn_completed = False
         task_succeeded = False
+        # Distinguishes a local setup fault from a real agent failure in the
+        # handler below; they get very different messages.
+        streaming_started = False
 
         def _record_goal_grading_run(event: RubricEvaluationEnd) -> None:
             nonlocal latest_goal_grade
@@ -15056,14 +15100,25 @@ class DeepAgentsApp(App):
                     event.result,
                 )
 
-        # Turn setup runs inside this `try` as well as the stream itself:
-        # `_cleanup_agent_task` in the `finally` is the only thing that releases
-        # `_agent_running`, so an early return or an interrupt landing during
-        # setup must not slip past it. Otherwise the session stays busy forever
-        # and every later message is queued behind a turn that already ended.
+        # Turn setup runs inside this `try` as well as the stream itself: for a
+        # turn that reached this coroutine, `_cleanup_agent_task` in the
+        # `finally` below is the only release path, so an early return or an
+        # interrupt landing during setup must not slip past it. See
+        # `_agent_turn_started` for what a missed release costs.
         try:
-            # Caller ensures _ui_adapter is set (checked in _handle_user_message)
+            # Both entry points (`_send_to_agent`, `_run_goal_criteria_request`)
+            # gate on `_ui_adapter`, but a `/restart` or server teardown can
+            # clear it between that check and this worker's first step.
             if self._ui_adapter is None:
+                logger.error(
+                    "Agent turn started with no UI adapter; message was not sent"
+                )
+                await self._mount_message(
+                    ErrorMessage(
+                        "The session is not ready, so this message was not sent. "
+                        "Retry, or run `/restart` if the problem persists."
+                    )
+                )
                 return
             if self._approval_mode_blocked:
                 await self._mount_message(
@@ -15074,13 +15129,9 @@ class DeepAgentsApp(App):
                 )
                 return
 
-            if graph_input is not None:
-                criteria_request = graph_input.get("goal_criteria_request")
-                if isinstance(criteria_request, dict):
-                    raw_request_id = criteria_request.get("request_id")
-                    if isinstance(raw_request_id, str):
-                        criteria_request_id = raw_request_id
-
+            # Published on the app so exit() can merge the stats synchronously
+            # if the worker is cancelled before this method can return (e.g.
+            # Ctrl+D during HITL).
             self._inflight_turn_stats = turn_stats
             self._inflight_turn_start = time.monotonic()
 
@@ -15150,6 +15201,7 @@ class DeepAgentsApp(App):
                     )
                 )
                 return
+            streaming_started = True
             await execute_task_textual(
                 user_input=message,
                 agent=self._agent,
@@ -15187,6 +15239,21 @@ class DeepAgentsApp(App):
                 logger.exception("Failed to close/regroup tool group at turn end")
             task_succeeded = True
         except Exception as e:  # Resilient tool rendering
+            if not streaming_started:
+                # Nothing was ever sent to the agent, so this is a local TUI or
+                # state fault. Routing it through the agent-error path below
+                # would blame the model or the backend for a bug in this file —
+                # and run credential-mismatch detection that cannot apply.
+                logger.exception("Agent turn setup failed before streaming began")
+                with suppress(Exception):
+                    await self._mount_message(
+                        ErrorMessage(
+                            "Internal error preparing this turn, so the message "
+                            f"was not sent: {e!r}. Retry, or run `/restart` if "
+                            "it persists."
+                        )
+                    )
+                return
             logger.exception("Agent execution failed")
             try:
                 from deepagents_code.client.remote_client import format_agent_exception
@@ -15364,6 +15431,9 @@ class DeepAgentsApp(App):
         self._agent_reconciling = True
         self._set_agent_running(False)
         self._agent_worker = None
+        # Tie the flag's lifetime to the worker's: left `True` across turns it
+        # would disable `_recover_unstarted_agent_worker` for every later turn.
+        self._agent_turn_started = False
         self._active_user_message = None
         self._active_turn_visible_output_started = False
         queued_result: _GoalApplicationResult | None = None
@@ -16833,22 +16903,27 @@ class DeepAgentsApp(App):
 
         A worker cancelled before its first event-loop step never runs its
         coroutine, so `_run_agent_task` — and the `_cleanup_agent_task` call in
-        its `finally` — never happens and Textual leaves the worker's state as
-        `RUNNING`. Nothing else would ever clear `_agent_running`, so the
-        session would look busy for the rest of its life: new messages would
-        queue instead of sending, `Esc` would only pop them back into the chat
-        input, and not even `/force-clear` would recover.
+        its `finally` — never happens. Textual also leaves such a worker's state
+        as `RUNNING` (`Worker._start` sets it before creating the task, and only
+        `Worker._run` moves it to `CANCELLED`), which is why this keys off
+        `_agent_turn_started` rather than the worker's own state. See
+        `_agent_turn_started` for what goes wrong when nothing releases the turn.
 
         Args:
-            worker: The worker that was just cancelled.
+            worker: The worker that was just cancelled. Callers may pass any
+                worker — `_cancel_worker` also handles the shell worker —
+                so anything that is not the current `_agent_worker` is ignored.
         """
         if worker is not self._agent_worker or self._agent_turn_started:
             return
 
         async def _release() -> None:
             # Re-check on the callback: the worker may have taken its first step
-            # between the cancel and this callback, in which case its own
-            # `finally` owns cleanup.
+            # between the cancel and this callback, or a new turn may have
+            # started, in which case cleanup is not ours to run. A caller that
+            # already cleared `_agent_running` (the plugin-reload path) has also
+            # taken ownership — running a full cleanup there would drive goal
+            # sync against a server that is mid-restart.
             if (
                 worker is not self._agent_worker
                 or self._agent_turn_started
@@ -16858,9 +16933,29 @@ class DeepAgentsApp(App):
             logger.warning(
                 "Agent worker was cancelled before it started; releasing the turn"
             )
-            await self._cleanup_agent_task()
+            try:
+                await self._cleanup_agent_task()
+            except Exception:
+                # This is the recovery path for an already-wedged session, so a
+                # teardown failure must not escalate into a crash: an exception
+                # from a refresh callback reaches Textual's handler and exits
+                # the app. The state that wedges the session is cleared before
+                # `_cleanup_agent_task`'s own `try`, so the session is usable
+                # even when the reconciliation after it fails.
+                logger.exception("Cleanup failed while releasing an unstarted turn")
+                with suppress(Exception):
+                    await self._mount_message(
+                        ErrorMessage(
+                            "Cleanup after the interrupt did not finish. The "
+                            "session is usable; run `/force-clear` if anything "
+                            "looks stale."
+                        )
+                    )
 
-        self.call_after_refresh(_release)
+        if not self.call_after_refresh(_release):
+            logger.warning(
+                "Could not schedule unstarted-turn recovery; message pump is closing"
+            )
 
     def action_quit_or_interrupt(self) -> None:
         """Handle Ctrl+C - interrupt agent, reject approval, or quit on double press.

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -5325,9 +5325,9 @@ class TestTurnStateRelease:
         """An interrupt landing before the worker's first step ends the turn.
 
         Textual never runs the coroutine of a worker cancelled before its first
-        event-loop step (and leaves its state as `RUNNING`), so
-        `_run_agent_task`'s `finally` — the only caller of
-        `_cleanup_agent_task` — never fires on its own.
+        event-loop step (and leaves its state as `RUNNING`), so the
+        `_cleanup_agent_task` call in `_run_agent_task`'s `finally` never fires
+        on its own.
         """
         app = self._configured_app()
         async with app.run_test() as pilot:
@@ -5335,16 +5335,114 @@ class TestTurnStateRelease:
 
             await app._send_to_agent("hello")
             # No await between worker creation and the interrupt, so the worker
-            # task cannot have started yet.
+            # task cannot have started yet. Asserted rather than assumed: any
+            # future await added after `run_worker` would let the worker run and
+            # clean up after itself, and this test would pass without exercising
+            # the recovery path at all.
+            assert app._agent_turn_started is False
             app.action_interrupt()
-            for _ in range(3):
-                await pilot.pause()
+            await pilot.pause()
 
             assert app._agent_running is False
 
             app.post_message(ChatInput.Submitted("next message", "normal"))
             await pilot.pause()
             assert not app._pending_messages
+
+    async def test_later_turns_can_still_recover(self) -> None:
+        """The started-marker resets at turn end, so turn 2 recovers as well.
+
+        `_recover_unstarted_agent_worker` bails when the marker is set, so a
+        marker left `True` by a completed turn would silently disable recovery
+        for the rest of the session — the original wedge, one turn later.
+        """
+        app = self._configured_app()
+        app._approval_mode_blocked = True
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            # Turn 1 reaches `_run_agent_task` (setting the marker) and is then
+            # rejected, so it runs the cleanup that must clear the marker again.
+            await app._send_to_agent("first")
+            for _ in range(3):
+                await pilot.pause()
+            assert app._agent_turn_started is False
+
+            app._approval_mode_blocked = False
+            await app._send_to_agent("second")
+            app.action_interrupt()
+            await pilot.pause()
+
+            assert app._agent_running is False
+
+    async def test_force_clear_releases_unstarted_turn(self) -> None:
+        """`/force-clear` recovers a worker that never started.
+
+        It cancels the worker inline rather than through `_cancel_worker`, so it
+        needs its own coverage.
+        """
+        app = self._configured_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            await app._send_to_agent("hello")
+            assert app._agent_turn_started is False
+            app._force_interrupt_active_work()
+            await pilot.pause()
+
+            assert app._agent_running is False
+
+    async def test_restart_releases_unstarted_turn(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`/restart` recovers a worker cancelled before its first step."""
+        app = self._configured_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._server_proc = MagicMock()
+            app._server_kwargs = {}
+
+            async def _noop_restart() -> bool:  # noqa: RUF029  # awaited by handler
+                return False
+
+            monkeypatch.setattr(app, "_restart_server_manual", _noop_restart)
+
+            await app._send_to_agent("hello")
+            assert app._agent_turn_started is False
+            await app._handle_command("/restart")
+            for _ in range(3):
+                await pilot.pause()
+
+            assert app._agent_running is False
+
+    async def test_recovery_skips_a_worker_from_a_newer_turn(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A turn started after the interrupt is not torn down by the callback.
+
+        Recovery is deferred to a refresh callback, so a new turn can install
+        its own worker in between. Without the re-check the stale callback would
+        clean up the live turn instead.
+        """
+        app = self._configured_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            await app._send_to_agent("hello")
+            app.action_interrupt()
+
+            # Stand in for a turn that started between the cancel and the
+            # callback: a different worker, and the marker cleared the way
+            # `_send_to_agent` clears it before spawning one. Only the identity
+            # check distinguishes this from the worker that was cancelled.
+            app._agent_worker = MagicMock()
+            app._agent_turn_started = False
+            with caplog.at_level(logging.WARNING):
+                await pilot.pause()
+
+            assert "cancelled before it started" not in caplog.text
+            # The stand-in turn is still live rather than torn down.
+            assert app._agent_running is True
 
     async def test_early_return_in_run_agent_task_releases_turn(self) -> None:
         """A turn rejected before streaming still releases the running flag."""
@@ -5388,22 +5486,90 @@ class TestTurnStateRelease:
             assert app._agent_worker is None
 
     async def test_queued_message_drains_after_abandoned_turn(self) -> None:
-        """Messages queued behind an abandoned turn are not stranded."""
+        """A message queued behind an abandoned turn is sent, not just dropped."""
         app = self._configured_app()
         async with app.run_test() as pilot:
             await pilot.pause()
             app._pending_messages.append(QueuedMessage(text="queued", mode="normal"))
 
+            # Fail only the abandoned turn's setup. If the drained message hit
+            # the same failure it would be popped and swallowed, and an
+            # emptied-queue assertion alone could not tell that apart from
+            # delivery.
             with patch.object(
                 app,
                 "_flush_pending_shell_messages",
-                AsyncMock(side_effect=RuntimeError("boom")),
+                AsyncMock(side_effect=[RuntimeError("boom"), None]),
             ):
                 with pytest.raises(RuntimeError):
                     await app._send_to_agent("hello")
-                await pilot.pause()
+                for _ in range(3):
+                    await pilot.pause()
 
             assert not app._pending_messages
+            assert any(w._content == "queued" for w in app.query(UserMessage))
+
+    async def test_failed_drain_after_abandoned_turn_is_reported(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A drain that cannot even report its own failure still tells the user.
+
+        `_process_next_from_queue` handles its own errors, so an exception
+        escaping it means its error reporting failed too — and by then the
+        queued message has already been popped.
+        """
+        app = self._configured_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._pending_messages.append(QueuedMessage(text="queued", mode="normal"))
+
+            with (
+                patch.object(
+                    app,
+                    "_flush_pending_shell_messages",
+                    AsyncMock(side_effect=RuntimeError("boom")),
+                ),
+                patch.object(
+                    app,
+                    "_process_next_from_queue",
+                    AsyncMock(side_effect=RuntimeError("drain exploded")),
+                ),
+                caplog.at_level(logging.ERROR),
+            ):
+                with pytest.raises(RuntimeError, match="boom"):
+                    await app._send_to_agent("hello")
+                await pilot.pause()
+
+            assert app._agent_running is False
+            assert "Failed to drain queue after abandoned turn" in caplog.text
+            errors = [str(w._content) for w in app.query(ErrorMessage)]
+            assert any("queued message could not be sent" in m for m in errors)
+
+    async def test_setup_failure_is_not_reported_as_an_agent_error(self) -> None:
+        """A local fault during turn setup is not blamed on the agent.
+
+        Setup runs inside the same `try` as the stream so cleanup cannot be
+        skipped, which puts local TUI faults in reach of the agent-error
+        handler. They must not be rendered as though the model or backend
+        failed.
+        """
+        app = self._configured_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            with patch.object(
+                app,
+                "_ensure_goal_state_notice",
+                AsyncMock(side_effect=RuntimeError("notice exploded")),
+            ):
+                await app._send_to_agent("hello")
+                for _ in range(3):
+                    await pilot.pause()
+
+            errors = [str(w._content) for w in app.query(ErrorMessage)]
+            assert any("Internal error preparing this turn" in m for m in errors)
+            assert not any(m.startswith("Agent error") for m in errors)
+            assert app._agent_running is False
 
 
 class TestAskUserLifecycle:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -5301,6 +5301,111 @@ class TestMessageQueue:
             assert any(w._content == "hello agent" for w in user_msgs)
 
 
+class TestTurnStateRelease:
+    """Tests that every abandoned turn hands `_agent_running` back.
+
+    A turn that ends without releasing that flag wedges the session: the app
+    still believes the agent is streaming, so later messages are queued instead
+    of sent, `Esc` only pops them back into the chat input, and even
+    `/force-clear` cannot recover.
+    """
+
+    @staticmethod
+    def _configured_app() -> DeepAgentsApp:
+        """Build an app with the collaborators `_send_to_agent` requires."""
+        app = DeepAgentsApp()
+        app._agent = MagicMock()
+        app._agent.aupdate_state = AsyncMock()
+        app._ui_adapter = MagicMock()
+        app._session_state = MagicMock()
+        app._session_state.hooks = HooksManager.inert()
+        return app
+
+    async def test_interrupt_before_worker_starts_releases_turn(self) -> None:
+        """An interrupt landing before the worker's first step ends the turn.
+
+        Textual never runs the coroutine of a worker cancelled before its first
+        event-loop step (and leaves its state as `RUNNING`), so
+        `_run_agent_task`'s `finally` — the only caller of
+        `_cleanup_agent_task` — never fires on its own.
+        """
+        app = self._configured_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            await app._send_to_agent("hello")
+            # No await between worker creation and the interrupt, so the worker
+            # task cannot have started yet.
+            app.action_interrupt()
+            for _ in range(3):
+                await pilot.pause()
+
+            assert app._agent_running is False
+
+            app.post_message(ChatInput.Submitted("next message", "normal"))
+            await pilot.pause()
+            assert not app._pending_messages
+
+    async def test_early_return_in_run_agent_task_releases_turn(self) -> None:
+        """A turn rejected before streaming still releases the running flag."""
+        app = self._configured_app()
+        app._approval_mode_blocked = True
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            await app._send_to_agent("hello")
+            for _ in range(3):
+                await pilot.pause()
+
+            assert app._agent_running is False
+
+            app.post_message(ChatInput.Submitted("next message", "normal"))
+            await pilot.pause()
+            assert not app._pending_messages
+
+    async def test_failed_turn_setup_releases_turn(self) -> None:
+        """A failure before the worker exists releases the running flag.
+
+        `_send_to_agent` reports busy before its awaited setup, and there is no
+        worker to cancel yet, so the setup path owns the release itself.
+        """
+        app = self._configured_app()
+        msg = "shell flush failed"
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            with (
+                patch.object(
+                    app,
+                    "_flush_pending_shell_messages",
+                    AsyncMock(side_effect=RuntimeError(msg)),
+                ),
+                pytest.raises(RuntimeError, match=msg),
+            ):
+                await app._send_to_agent("hello")
+
+            assert app._agent_running is False
+            assert app._agent_worker is None
+
+    async def test_queued_message_drains_after_abandoned_turn(self) -> None:
+        """Messages queued behind an abandoned turn are not stranded."""
+        app = self._configured_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._pending_messages.append(QueuedMessage(text="queued", mode="normal"))
+
+            with patch.object(
+                app,
+                "_flush_pending_shell_messages",
+                AsyncMock(side_effect=RuntimeError("boom")),
+            ):
+                with pytest.raises(RuntimeError):
+                    await app._send_to_agent("hello")
+                await pilot.pause()
+
+            assert not app._pending_messages
+
+
 class TestAskUserLifecycle:
     """Tests for ask_user widget cleanup flows."""
 
@@ -30035,6 +30140,7 @@ class TestRestartCommand:
             worker = MagicMock()
             app._agent_worker = worker
             app._set_agent_running(True)
+            app._agent_turn_started = True
             app._pending_messages.append(QueuedMessage(text="hi", mode="normal"))
 
             from deepagents_code.config import settings


### PR DESCRIPTION
Pressing `Esc` to interrupt the agent could leave the session permanently stuck, unable to accept any new work.

## What users saw

You interrupt a turn, then try to send a follow-up message. Instead of going to the agent, it shows up dimmed — queued behind a turn that already ended and will never finish. From there:

- `Esc` just pops the text back into the input box ("Queued message moved to input"), and re-submitting queues it again.
- `/force-clear` doesn't help.
- The only way out is relaunching the TUI.

## Why it happened

The session tracks whether the agent is busy with a single flag. While that flag is set, typed messages are queued instead of sent. Only one piece of code clears it: the cleanup that runs when a turn finishes.

The bug is that a turn can end without ever reaching its cleanup. Three ways that happened:

- **The turn was cancelled before it started running.** Textual marks a background worker as `RUNNING` the moment it's created, before its code actually begins. Interrupting inside that window throws the whole turn away without running any of it — including the cleanup — while the worker still looks alive from the outside. Later interrupts just re-cancel something already dead.
- **Turn setup ran outside the block cleanup is attached to.** `_run_agent_task` had two early-return guard clauses, and it persisted goal/rubric state before entering its `try`. A rejected turn, or an interrupt landing during that setup, skipped cleanup entirely.
- **The busy flag was set before a worker existed.** `_send_to_agent` sets it first so the UI reacts immediately, then does some `await`ed setup before starting the worker. Bailing out during that setup left the session busy with no worker at all.

## The fix

Make it explicit who is responsible for releasing the flag in each case:

- Turn setup moves inside the `try` whose `finally` does the cleanup, so any early exit still releases the turn.
- `_send_to_agent` releases the flag itself when it never got as far as starting a worker.
- A new `_agent_turn_started` marker lets the interrupt paths tell "cancelled before it ran" apart from a live turn, and release it directly.

A message queued behind an abandoned turn is now drained rather than stranded.

Made by [Open SWE](https://openswe.vercel.app/agents/038692df-2613-b315-330e-00ce0e0d82a2)
