### PR TITLE
test(code): stop unit tests from tripping the socket guard

### DIFF
--- a/libs/code/tests/unit_tests/conftest.py
+++ b/libs/code/tests/unit_tests/conftest.py
@@ -325,6 +325,26 @@ def _disable_app_startup_update_checks(
 
 
 @pytest.fixture(autouse=True)
+def _skip_managed_tool_downloads(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep app startup from downloading the managed `rg` binary.
+
+    `_ensure_managed_ripgrep` runs on app mount and fetches a ripgrep release
+    from GitHub whenever no current binary is on `PATH` -- the norm on CI and
+    in containers. The download happens in a worker thread and its failure is
+    swallowed, but pytest-socket still warns for every blocked `getaddrinfo`
+    (hundreds per run), and the "auto-install failed" toast it posts perturbs
+    tests that assert on toast layout or the notification registry.
+
+    Set the production opt-out env var so the install short-circuits before
+    touching the network, and so subprocess tests inherit the same no-network
+    behavior. Tests that cover the installer clear it themselves.
+    """
+    from deepagents_code._env_vars import OFFLINE
+
+    monkeypatch.setenv(OFFLINE, "1")
+
+
+@pytest.fixture(autouse=True)
 def _clear_behavior_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent developer behavior overrides from changing default-path tests."""
     for key in (

--- a/libs/code/tests/unit_tests/test_reasoning_effort.py
+++ b/libs/code/tests/unit_tests/test_reasoning_effort.py
@@ -387,6 +387,7 @@ def test_openai_integration_translates_standard_effort_without_summary() -> None
             api_key="test",
             reasoning_effort="high",
             use_responses_api=True,
+            http_socket_options=[],
         )
     payload = model._get_request_payload([HumanMessage("hello")])
 


### PR DESCRIPTION
The unit suite runs under `--disable-socket`, and pytest-socket emits a `UserWarning` from `SocketBlockedError.__init__` itself — so a blocked socket attempt warns even when the calling code catches the error and degrades gracefully. That produced hundreds of `A test tried to use socket.getaddrinfo` / `socket.socket` warnings per run, which is exactly the noise that hides a genuinely new warning.

Two paths were reaching the guard:

- **Managed ripgrep install.** `_ensure_managed_ripgrep` runs on app mount, and with no current `rg` on `PATH` (the norm on CI and in containers) it downloads a release from GitHub in a worker thread. The failure is swallowed, but every blocked DNS lookup warns, and the "auto-install failed" toast it posts is stray state for tests that assert on toast layout or the notification registry. An autouse fixture now sets the existing production opt-out env var so the install short-circuits before any network work — the same approach already used for the startup update check. Tests that exercise the installer already clear that variable themselves.
- **`ChatOpenAI` construction.** langchain-openai probes a throwaway socket to filter unsupported TCP keepalive options on every construction. The reasoning-effort integration test now passes explicit empty socket options, matching what the Codex-model tests already do.

Test-only; no production behavior changes.

Made by [Open SWE](https://openswe.vercel.app/agents/160421ef-a69f-9f10-986a-9833c6e9ad39)