### PR TITLE
chore(deps): sync lockfiles after SDK packaging dep addition

### DIFF
--- a/examples/async-subagent-server/uv.lock
+++ b/examples/async-subagent-server/uv.lock
@@ -354,6 +354,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
     { name = "langsmith" },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
 
@@ -367,6 +368,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.3.1,<5.0.0" },
     { name = "langchain-quickjs", marker = "extra == 'quickjs'", specifier = ">=0.3.3" },
     { name = "langsmith", specifier = ">=0.10.9" },
+    { name = "packaging", specifier = ">=23.2" },
     { name = "pillow", marker = "extra == 'video'", specifier = ">=12.3.0,<13.0.0" },
     { name = "wcmatch", specifier = ">=11.0" },
 ]

--- a/examples/llm-wiki/uv.lock
+++ b/examples/llm-wiki/uv.lock
@@ -289,6 +289,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
     { name = "langsmith" },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
 
@@ -302,6 +303,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.3.1,<5.0.0" },
     { name = "langchain-quickjs", marker = "extra == 'quickjs'", specifier = ">=0.3.3" },
     { name = "langsmith", specifier = ">=0.10.9" },
+    { name = "packaging", specifier = ">=23.2" },
     { name = "pillow", marker = "extra == 'video'", specifier = ">=12.3.0,<13.0.0" },
     { name = "wcmatch", specifier = ">=11.0" },
 ]

--- a/libs/acp/uv.lock
+++ b/libs/acp/uv.lock
@@ -438,6 +438,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
     { name = "langsmith" },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
 
@@ -451,6 +452,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.3.1,<5.0.0" },
     { name = "langchain-quickjs", marker = "extra == 'quickjs'", specifier = ">=0.3.3" },
     { name = "langsmith", specifier = ">=0.10.9" },
+    { name = "packaging", specifier = ">=23.2" },
     { name = "pillow", marker = "extra == 'video'", specifier = ">=12.3.0,<13.0.0" },
     { name = "wcmatch", specifier = ">=11.0" },
 ]

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -415,6 +415,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
     { name = "langsmith" },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
 
@@ -428,6 +429,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.3.1,<5.0.0" },
     { name = "langchain-quickjs", marker = "extra == 'quickjs'", specifier = ">=0.3.3" },
     { name = "langsmith", specifier = ">=0.10.9" },
+    { name = "packaging", specifier = ">=23.2" },
     { name = "pillow", marker = "extra == 'video'", specifier = ">=12.3.0,<13.0.0" },
     { name = "wcmatch", specifier = ">=11.0" },
 ]

--- a/libs/evals/uv.lock
+++ b/libs/evals/uv.lock
@@ -407,6 +407,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
     { name = "langsmith" },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
 
@@ -420,6 +421,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.3.1,<5.0.0" },
     { name = "langchain-quickjs", marker = "extra == 'quickjs'", specifier = ">=0.3.3" },
     { name = "langsmith", specifier = ">=0.10.9" },
+    { name = "packaging", specifier = ">=23.2" },
     { name = "pillow", marker = "extra == 'video'", specifier = ">=12.3.0,<13.0.0" },
     { name = "wcmatch", specifier = ">=11.0" },
 ]
@@ -462,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "deepagents-code"
-version = "0.1.49"
+version = "0.1.50"
 source = { directory = "../code" }
 dependencies = [
     { name = "aiosqlite" },

--- a/libs/partners/daytona/uv.lock
+++ b/libs/partners/daytona/uv.lock
@@ -652,6 +652,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
     { name = "langsmith" },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
 
@@ -665,6 +666,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.3.1,<5.0.0" },
     { name = "langchain-quickjs", marker = "extra == 'quickjs'", specifier = ">=0.3.3" },
     { name = "langsmith", specifier = ">=0.10.9" },
+    { name = "packaging", specifier = ">=23.2" },
     { name = "pillow", marker = "extra == 'video'", specifier = ">=12.3.0,<13.0.0" },
     { name = "wcmatch", specifier = ">=11.0" },
 ]

--- a/libs/partners/modal/uv.lock
+++ b/libs/partners/modal/uv.lock
@@ -598,6 +598,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
     { name = "langsmith" },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
 
@@ -611,6 +612,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.3.1,<5.0.0" },
     { name = "langchain-quickjs", marker = "extra == 'quickjs'", specifier = ">=0.3.3" },
     { name = "langsmith", specifier = ">=0.10.9" },
+    { name = "packaging", specifier = ">=23.2" },
     { name = "pillow", marker = "extra == 'video'", specifier = ">=12.3.0,<13.0.0" },
     { name = "wcmatch", specifier = ">=11.0" },
 ]

--- a/libs/partners/quickjs/uv.lock
+++ b/libs/partners/quickjs/uv.lock
@@ -475,6 +475,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
     { name = "langsmith" },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
 
@@ -488,6 +489,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.3.1,<5.0.0" },
     { name = "langchain-quickjs", marker = "extra == 'quickjs'", specifier = ">=0.3.3" },
     { name = "langsmith", specifier = ">=0.10.9" },
+    { name = "packaging", specifier = ">=23.2" },
     { name = "pillow", marker = "extra == 'video'", specifier = ">=12.3.0,<13.0.0" },
     { name = "wcmatch", specifier = ">=11.0" },
 ]

--- a/libs/partners/runloop/uv.lock
+++ b/libs/partners/runloop/uv.lock
@@ -390,6 +390,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
     { name = "langsmith" },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
 
@@ -403,6 +404,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.3.1,<5.0.0" },
     { name = "langchain-quickjs", marker = "extra == 'quickjs'", specifier = ">=0.3.3" },
     { name = "langsmith", specifier = ">=0.10.9" },
+    { name = "packaging", specifier = ">=23.2" },
     { name = "pillow", marker = "extra == 'video'", specifier = ">=12.3.0,<13.0.0" },
     { name = "wcmatch", specifier = ">=11.0" },
 ]

--- a/libs/partners/vercel/uv.lock
+++ b/libs/partners/vercel/uv.lock
@@ -447,6 +447,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
     { name = "langsmith" },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
 
@@ -460,6 +461,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.3.1,<5.0.0" },
     { name = "langchain-quickjs", marker = "extra == 'quickjs'", specifier = ">=0.3.3" },
     { name = "langsmith", specifier = ">=0.10.9" },
+    { name = "packaging", specifier = ">=23.2" },
     { name = "pillow", marker = "extra == 'video'", specifier = ">=12.3.0,<13.0.0" },
     { name = "wcmatch", specifier = ">=11.0" },
 ]

--- a/libs/talon/uv.lock
+++ b/libs/talon/uv.lock
@@ -767,6 +767,7 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
     { name = "langsmith" },
+    { name = "packaging" },
     { name = "wcmatch" },
 ]
 
@@ -780,6 +781,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.3.1,<5.0.0" },
     { name = "langchain-quickjs", marker = "extra == 'quickjs'", specifier = ">=0.3.3" },
     { name = "langsmith", specifier = ">=0.10.9" },
+    { name = "packaging", specifier = ">=23.2" },
     { name = "pillow", marker = "extra == 'video'", specifier = ">=12.3.0,<13.0.0" },
     { name = "wcmatch", specifier = ">=11.0" },
 ]
@@ -822,7 +824,7 @@ wheels = [
 
 [[package]]
 name = "deepagents-code"
-version = "0.1.49"
+version = "0.1.50"
 source = { editable = "../code" }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Regenerates the per-package `uv.lock` files after `packaging` (>=23.2) was added as a runtime dependency of the `deepagents` SDK.

---

Two lockfile-only categories of change, no source edits:

- Every package/example lockfile that depends on the local `deepagents` SDK now records `packaging` in the SDK's `dependencies` / `requires-dist` entries, matching the SDK's `pyproject.toml`.
- The `evals` and `talon` lockfiles pick up the `deepagents-code` 0.1.49 → 0.1.50 version stamp from the latest release.

This is the standard post-release lockfile sync so the "check lockfiles are up-to-date" pre-commit hook stays green on `main`.
