### PR TITLE
fix(infra): run `update-`lockfiles after skipped `trigger-releases`

### DIFF
--- a/.github/scripts/tests/release/test_release_please_workflow.py
+++ b/.github/scripts/tests/release/test_release_please_workflow.py
@@ -40,14 +40,17 @@ def _evaluate(
     the parentheses, or swapping `||` for `&&`, leaves every clause present while
     inverting the meaning. Only the boolean structure catches that, so evaluate it.
 
-    Supports just the subset the workflow uses — `!cancelled()`, `&&`, `||`,
-    parentheses, and `needs.<job>.result` / `needs.<job>.outputs.<name>` compared
-    against single-quoted literals.
+    Supports just the subset the workflow uses — `!cancelled()`, `always()`,
+    `&&`, `||`, parentheses, and `needs.<job>.result` /
+    `needs.<job>.outputs.<name>` compared against single-quoted literals.
     """
     expr = condition
     for ref, value in values.items():
         expr = expr.replace(ref, repr(value))
     expr = expr.replace("!cancelled()", repr(not cancelled))
+    # always() unconditionally disables the implicit success() gate; the
+    # hand-checked needs.*.result clauses beside it carry the fail-closed load.
+    expr = expr.replace("always()", repr(True))
     expr = expr.replace("&&", " and ").replace("||", " or ")
     leftover = re.findall(r"needs\.[\w.-]+", expr)
     assert not leftover, f"unsubstituted references (update the test): {leftover}"
@@ -110,7 +113,31 @@ def test_release_dispatch_precedes_release_please_maintenance() -> None:
     assert "outputs.release-commit" not in release_please_if
     assert "needs.guard-pending-release.outputs.skip == 'false'" in release_please_if
 
-    assert "release-please" in _needs(jobs["update-lockfiles"])
+    update_lockfiles = jobs["update-lockfiles"]
+    assert "release-please" in _needs(update_lockfiles)
+    # Same skip poison as on `release-please`: this job's needs chain also ends
+    # at a legitimately-skipped `trigger-releases`, so a bare outputs-only `if:`
+    # keeps the implicit success() gate and the job silently skips even when
+    # release-please produced PRs. It must override the gate and hand-check
+    # every dependency in the chain instead.
+    update_lockfiles_if = _condition(update_lockfiles)
+    assert "!cancelled()" in update_lockfiles_if
+    assert "needs.release-please.result == 'success'" in update_lockfiles_if
+    assert "needs.release-please.outputs.prs != '[]'" in update_lockfiles_if
+    # `release-please` succeeding already implies the guard saw the dispatch
+    # succeed on release commits, so re-checking the skipped job is unnecessary
+    # — and a `'skipped'` comparison would wrongly block this job on them.
+    assert "trigger-releases" not in update_lockfiles_if
+
+    # The notes-check dispatch sits behind the same chain (and `always()` alone
+    # would tolerate red ancestors), so it must pin the same hand-checked
+    # dependency results — except `update-lockfiles` itself, which is a
+    # sequencing-only need whose own failure must not block the check.
+    dispatch_if = _condition(jobs["dispatch-release-notes-check"])
+    assert "always()" in dispatch_if
+    assert "!cancelled()" in dispatch_if
+    assert "needs.release-please.result == 'success'" in dispatch_if
+    assert "update-lockfiles" not in dispatch_if
 
 
 def test_release_please_condition_fails_closed() -> None:
@@ -148,6 +175,105 @@ def test_release_please_condition_fails_closed() -> None:
     assert not runs("false", guard="failure")
     assert not runs("false", guard="skipped")
     assert not runs("false", cancelled=True)
+
+
+def test_update_lockfiles_condition_fails_closed() -> None:
+    """Pin lockfile regeneration's boolean structure after the #5161 skip-gate fix.
+
+    `update-lockfiles` needs `release-please`, which transitively needs a
+    legitimately-skipped `trigger-releases` on ordinary pushes — the same
+    implicit-success() poison #5169 fixed for `release-please`. Without
+    `!cancelled()` and hand-checked dependency results, this job silently
+    skipped on a green workflow and release PR lockfiles went stale.
+    """
+    update_lockfiles_if = _condition(
+        _load_workflow()["jobs"]["update-lockfiles"]
+    )
+
+    def runs(
+        prs: str,
+        *,
+        empty_commit: str = "success",
+        detect: str = "success",
+        guard: str = "success",
+        release_please: str = "success",
+        cancelled: bool = False,
+    ) -> bool:
+        return _evaluate(
+            update_lockfiles_if,
+            {
+                "needs.guard-empty-commit.result": empty_commit,
+                "needs.detect-release-commit.result": detect,
+                "needs.guard-pending-release.result": guard,
+                "needs.release-please.result": release_please,
+                "needs.release-please.outputs.prs": prs,
+            },
+            cancelled=cancelled,
+        )
+
+    # release-please opened/updated release PRs — the normal refresh path.
+    assert runs(
+        '[{"headBranchName": "release-please--branches--main--components--deepagents"}]'
+    )
+    # No PRs produced (empty output or the empty-array literal) — nothing to do.
+    assert not runs("[]")
+    # Unset/empty prs (release-please crashed before writing outputs) must not
+    # look like work to do.
+    assert not runs("")
+    # Direct deps: any red guardian job fails closed.
+    assert not runs("[1]", empty_commit="failure")
+    assert not runs("[1]", detect="failure")
+    assert not runs("[1]", guard="failure")
+    assert not runs("[1]", guard="skipped")
+    assert not runs("[1]", release_please="failure")
+    assert not runs("[1]", release_please="skipped")
+    assert not runs("[1]", cancelled=True)
+
+
+def test_dispatch_release_notes_check_condition_fails_closed() -> None:
+    """Pin the notes-check dispatch gate: `always()` plus hand-checked deps.
+
+    `update-lockfiles` is a sequencing-only need whose own failure must not
+    block the dispatch (its comment says so), but every other ancestor in the
+    chain must be checked by hand — bare `always()` would also tolerate red
+    guardians and a cancelled workflow.
+    """
+    dispatch_if = _condition(_load_workflow()["jobs"]["dispatch-release-notes-check"])
+
+    def runs(
+        prs: str,
+        *,
+        empty_commit: str = "success",
+        detect: str = "success",
+        guard: str = "success",
+        release_please: str = "success",
+        cancelled: bool = False,
+    ) -> bool:
+        return _evaluate(
+            dispatch_if,
+            {
+                "needs.guard-empty-commit.result": empty_commit,
+                "needs.detect-release-commit.result": detect,
+                "needs.guard-pending-release.result": guard,
+                "needs.release-please.result": release_please,
+                "needs.release-please.outputs.prs": prs,
+            },
+            cancelled=cancelled,
+        )
+
+    # Release PRs exist and every guardian succeeded — dispatch the check.
+    assert runs("[1]")
+    # No PRs / unset prs — nothing to validate.
+    assert not runs("[]")
+    assert not runs("")
+    # Red ancestors fail closed even though the condition starts with always().
+    assert not runs("[1]", empty_commit="failure")
+    assert not runs("[1]", detect="failure")
+    assert not runs("[1]", guard="failure")
+    assert not runs("[1]", guard="skipped")
+    assert not runs("[1]", release_please="failure")
+    assert not runs("[1]", release_please="skipped")
+    assert not runs("[1]", cancelled=True)
 
 
 def test_guard_condition_fails_closed() -> None:

--- a/.github/scripts/tests/release/test_release_please_workflow.py
+++ b/.github/scripts/tests/release/test_release_please_workflow.py
@@ -57,6 +57,28 @@ def _evaluate(
     return bool(eval(expr))  # noqa: S307 - workflow-derived, no external input
 
 
+def test_condition_references_only_declared_needs() -> None:
+    """Every job referenced in a job-level `if:` must appear in its `needs:`.
+
+    The Actions `needs` context only contains declared dependencies: a
+    reference to an undeclared job evaluates to an empty string instead of
+    erroring, so a `result == 'success'` clause silently fails and the job
+    skips even when its real dependency succeeded. This is what let the
+    `update-lockfiles` fix reference the guard jobs without depending on
+    them. Checking for undeclared references in `env:`/`run:` steps is out of
+    scope — there it is a runtime bug, not an always-skip gate.
+    """
+    for job_name, job in _load_workflow()["jobs"].items():
+        condition = str(job.get("if", ""))
+        declared = _needs(job)
+        undeclared = {
+            ref.split(".")[1]
+            for ref in re.findall(r"needs\.[\w-]+(?=\.(?:result|outputs)\b)", condition)
+            if ref.split(".")[1] not in declared
+        }
+        assert not undeclared, f"{job_name} if: references undeclared needs: {undeclared}"
+
+
 def test_trigger_releases_can_comment_on_release_pr() -> None:
     """Grant only the permissions needed to dispatch and report releases."""
     workflow = _load_workflow()
@@ -115,6 +137,15 @@ def test_release_dispatch_precedes_release_please_maintenance() -> None:
 
     update_lockfiles = jobs["update-lockfiles"]
     assert "release-please" in _needs(update_lockfiles)
+    # The `needs` context only carries declared dependencies, so every
+    # ancestor whose result the `if:` hand-checks must be listed — an
+    # undeclared reference compares an empty string against 'success' and
+    # the job skips even when release-please opened PRs.
+    assert {
+        "guard-empty-commit",
+        "detect-release-commit",
+        "guard-pending-release",
+    } <= _needs(update_lockfiles)
     # Same skip poison as on `release-please`: this job's needs chain also ends
     # at a legitimately-skipped `trigger-releases`, so a bare outputs-only `if:`
     # keeps the implicit success() gate and the job silently skips even when
@@ -133,6 +164,15 @@ def test_release_dispatch_precedes_release_please_maintenance() -> None:
     # would tolerate red ancestors), so it must pin the same hand-checked
     # dependency results — except `update-lockfiles` itself, which is a
     # sequencing-only need whose own failure must not block the check.
+    # Same declared-needs requirement as update-lockfiles: the hand-checked
+    # ancestors must be listed, while `update-lockfiles` itself stays a
+    # sequencing-only need whose result the `if:` does not check.
+    assert {
+        "guard-empty-commit",
+        "detect-release-commit",
+        "guard-pending-release",
+        "update-lockfiles",
+    } <= _needs(jobs["dispatch-release-notes-check"])
     dispatch_if = _condition(jobs["dispatch-release-notes-check"])
     assert "always()" in dispatch_if
     assert "!cancelled()" in dispatch_if

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -741,8 +741,25 @@ jobs:
   # https://github.com/googleapis/release-please/issues/2561
   update-lockfiles:
     needs: release-please
-    if: needs.release-please.outputs.prs != '[]' && needs.release-please.outputs.prs
-      != ''
+    # Same skip poison as #5161/#5169: `release-please` transitively needs
+    # `trigger-releases` (via the guard), which is legitimately skipped on
+    # ordinary pushes, and this job's bare `if:` kept Actions' implicit
+    # success() gate — so a successful `release-please` that opened PRs still
+    # left this job skipped on a green workflow, and the release PR's
+    # lockfiles went stale until fixed by hand. Override the gate with
+    # `!cancelled()` plus explicit result checks on every dependency in the
+    # direct needs chain, and still require a positively non-empty `prs` (unset
+    # after a crash stays blocked). `trigger-releases` itself is deliberately
+    # NOT re-checked: on release-commit pushes, `release-please` succeeding
+    # already implies the guard saw a successful dispatch.
+    if: |
+      !cancelled() &&
+      needs.guard-empty-commit.result == 'success' &&
+      needs.detect-release-commit.result == 'success' &&
+      needs.guard-pending-release.result == 'success' &&
+      needs.release-please.result == 'success' &&
+      needs.release-please.outputs.prs != '[]' &&
+      needs.release-please.outputs.prs != ''
     name: Update lockfiles
     runs-on: ubuntu-latest
     permissions:
@@ -855,10 +872,21 @@ jobs:
   # deliberately does NOT gate on `needs.update-lockfiles.result` — combined with
   # `always()`, a lockfile-update failure (which is loud on its own: that job goes red)
   # still lets the gate fire against the current head rather than silently skipping it.
+  #
+  # `always()` alone would also run this job after a cancelled workflow and would
+  # tolerate red ancestors, so the same explicit checks as `update-lockfiles`
+  # are pinned alongside it: every guard in the needs chain above `release-please`
+  # must have succeeded, and `prs` must be positively non-empty. Skipped
+  # `trigger-releases` is not re-checked — on release commits, a successful
+  # `release-please` already implies the guard saw the dispatch succeed.
   dispatch-release-notes-check:
     needs: [release-please, update-lockfiles]
     if: |
       always() &&
+      !cancelled() &&
+      needs.guard-empty-commit.result == 'success' &&
+      needs.detect-release-commit.result == 'success' &&
+      needs.guard-pending-release.result == 'success' &&
       needs.release-please.result == 'success' &&
       needs.release-please.outputs.prs != '[]' &&
       needs.release-please.outputs.prs != ''

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -740,7 +740,11 @@ jobs:
   # release-please updates pyproject.toml versions but doesn't regenerate lockfiles
   # https://github.com/googleapis/release-please/issues/2561
   update-lockfiles:
-    needs: release-please
+    # The `needs` list must cover every job the `if:` references: the `needs`
+    # context only carries direct dependencies, so checking an undeclared
+    # ancestor's result compares an empty string against 'success' and the
+    # condition always fails.
+    needs: [guard-empty-commit, detect-release-commit, guard-pending-release, release-please]
     # Same skip poison as #5161/#5169: `release-please` transitively needs
     # `trigger-releases` (via the guard), which is legitimately skipped on
     # ordinary pushes, and this job's bare `if:` kept Actions' implicit
@@ -750,8 +754,10 @@ jobs:
     # `!cancelled()` plus explicit result checks on every dependency in the
     # direct needs chain, and still require a positively non-empty `prs` (unset
     # after a crash stays blocked). `trigger-releases` itself is deliberately
-    # NOT re-checked: on release-commit pushes, `release-please` succeeding
-    # already implies the guard saw a successful dispatch.
+    # NOT re-checked (and deliberately NOT in `needs`): it is skipped on
+    # release-commit pushes, where `release-please` succeeding already implies
+    # the guard saw a successful dispatch — depending on it would reintroduce
+    # the poison.
     if: |
       !cancelled() &&
       needs.guard-empty-commit.result == 'success' &&
@@ -880,7 +886,9 @@ jobs:
   # `trigger-releases` is not re-checked — on release commits, a successful
   # `release-please` already implies the guard saw the dispatch succeed.
   dispatch-release-notes-check:
-    needs: [release-please, update-lockfiles]
+    # `needs` must list every job the `if:` references (see update-lockfiles);
+    # `update-lockfiles` is sequencing-only, so its result is not checked.
+    needs: [guard-empty-commit, detect-release-commit, guard-pending-release, release-please, update-lockfiles]
     if: |
       always() &&
       !cancelled() &&


### PR DESCRIPTION
Release PRs opened or updated by release-please get their `uv.lock` files regenerated again. The `update-lockfiles` job was silently skipping on every push to `main` — the workflow showed green while release PR lockfiles went stale and the "🔒 Check Lockfiles" workflow failed on them — because #5161 put the legitimately-skipped `trigger-releases` job in its upstream `needs` chain and the job's bare `if:` kept GitHub Actions' implicit `success()` gate. #5169 fixed this for the `release-please` job; this applies the same gating to `update-lockfiles` (and audits the remaining downstream jobs).

---

## Why

`update-lockfiles` needs `release-please`, which (after #5161) transitively needs `trigger-releases` via `guard-pending-release`. On ordinary pushes to `main`, `trigger-releases` is skipped — and without a status-check function in the job's `if:`, Actions' implicit `success()` gate on the whole `needs` chain fails closed. The job was skipped with an all-green workflow; observed on release PR #5170, where lockfiles had to be regenerated by hand.

## Fix

- `update-lockfiles`: `!cancelled()` plus explicit `result == 'success'` checks on every dependency in the chain (`guard-empty-commit`, `detect-release-commit`, `guard-pending-release`, `release-please`), keeping the existing `prs != '[]' && prs != ''` requirement. Fail-closed semantics preserved: a crashed guard or unset `prs` still blocks the job. `trigger-releases` is deliberately not re-checked — on release commits, `release-please` succeeding already implies the guard saw the dispatch succeed.
- `dispatch-release-notes-check`: audit found its `always()` gate already survived the skipped-`trigger-releases` case, but would also run after a cancelled workflow or red guardians. Added `!cancelled()` and the same hand-checked ancestor results; `update-lockfiles` stays a sequencing-only need whose own failure does not block the dispatch.
- `guard-empty-commit`, `detect-release-commit`, and `trigger-releases` need no changes — their `needs` chains never contain a legitimately-skipped job.

Tests pin the new truth tables for both jobs, mirroring the style #5169 used for `release-please`, and `_evaluate` now handles `always()`.
