### PR TITLE
feat(code): prompt to reconnect when leaving `/mcp` with pending toggles

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3151,6 +3151,14 @@ class DeepAgentsApp(App):
         self._active_mcp_viewer: Any = None
         """Handle to the `/mcp` modal so server-ready events can refresh it."""
 
+        self._mcp_viewer_disable_toggled = False
+        """Whether the current/last `/mcp` viewer session toggled a disable state.
+
+        Scoped to one viewer session (reset each time the viewer opens) so
+        closing the viewer only offers a reconnect when the user actually
+        changed something while it was open.
+        """
+
         self._restart_respawn_task: asyncio.Task[None] | None = None
         """Strong reference to the detached `/restart` respawn task.
 
@@ -5167,6 +5175,7 @@ class DeepAgentsApp(App):
         self._mcp_optimistic_original_server_info.clear()
         self._pending_mcp_login_reconnect = False
         self._pending_mcp_disable_reconnect_servers.clear()
+        self._mcp_viewer_disable_toggled = False
         self._sync_pending_mcp_reconnect()
 
         # Drop transient failure-state widgets — banner state and the agent
@@ -21258,7 +21267,9 @@ class DeepAgentsApp(App):
 
         The viewer may dismiss with a server name (when the user activates
         an `unauthenticated` header row to start in-TUI OAuth login) or
-        with `None` (close without action).
+        with `None` (close without action). A plain close after `F2`
+        disable toggles offers a reconnect so the changes are not left
+        silently unapplied.
         """
         from deepagents_code.tui.widgets.mcp_viewer import (
             MCP_VIEWER_RECONNECT_REQUEST,
@@ -21272,6 +21283,7 @@ class DeepAgentsApp(App):
             on_toggle_disable=self._toggle_mcp_server_disabled,
         )
         self._active_mcp_viewer = screen
+        self._mcp_viewer_disable_toggled = False
 
         def handle_result(result: str | None) -> None:
             self._active_mcp_viewer = None
@@ -21296,17 +21308,89 @@ class DeepAgentsApp(App):
             if result:
                 # User picked an unauthenticated server — start login.
                 self._start_mcp_login(result)
-            elif self._chat_input:
+                return
+            if self._mcp_viewer_disable_toggled and self._pending_mcp_reconnect:
+                # Disable toggles only take effect after a restart, and the
+                # user closed the viewer without pressing Ctrl+R. Offer the
+                # reconnect instead of leaving the change unapplied. The
+                # follow-up modal is scheduled (not pushed here) so this
+                # dismiss fully unwinds first.
+                self.call_after_refresh(self._prompt_mcp_disable_reconnect)
+                return
+            if self._chat_input:
                 self._chat_input.focus_input()
 
         self.push_screen(screen, handle_result)
+
+    def _prompt_mcp_disable_reconnect(self) -> None:
+        """Offer a reconnect for `/mcp` disable toggles left unapplied.
+
+        Scheduled from `_show_mcp_viewer`'s dismiss callback when the user
+        closed the viewer after an `F2` toggle without pressing `Ctrl+R`.
+        Re-checks pending state so a reconnect that landed in the meantime
+        (or an undone toggle) skips the prompt.
+        """
+        self._mcp_viewer_disable_toggled = False
+        if not self._pending_mcp_reconnect:
+            if self._chat_input:
+                self._chat_input.focus_input()
+            return
+
+        from deepagents_code.tui.widgets.mcp_reconnect import (
+            MCPDisableReconnectPromptScreen,
+            ReconnectChoice,
+        )
+
+        def handle_choice(choice: ReconnectChoice | None) -> None:
+            if choice == "reconnect":
+                # Detached task, not `call_later`: the restart takes seconds
+                # and awaiting it on the message pump freezes the chat input
+                # (same rationale as the Ctrl+R path in `_show_mcp_viewer`).
+                task = asyncio.create_task(self._reconnect_from_viewer_safe())
+                self._track_server_restart_task(task)
+                task.add_done_callback(_log_task_exception)
+                return
+            # `later` (explicit defer) and `None` (programmatic dismiss) both
+            # keep the current server; only the explicit choice gets a toast.
+            if choice == "later":
+                self.notify(
+                    "MCP server changes are still pending. Run `/mcp reconnect` "
+                    "when ready to apply them.",
+                    severity="information",
+                    timeout=8,
+                    markup=False,
+                )
+            if self._chat_input:
+                self._chat_input.focus_input()
+
+        try:
+            self.push_screen(
+                MCPDisableReconnectPromptScreen(
+                    sorted(self._pending_mcp_disable_reconnect_servers),
+                ),
+                handle_choice,
+            )
+        except Exception:
+            # Modal could not be mounted (e.g. another modal hijacked the
+            # stack). The toggle is already persisted, so surface the recovery
+            # path rather than silently dropping the prompt.
+            logger.exception("Failed to mount MCP disable-reconnect prompt")
+            self.notify(
+                "Couldn't open the reconnect prompt. Run `/mcp reconnect` to "
+                "apply the MCP server changes.",
+                severity="warning",
+                markup=False,
+            )
+            if self._chat_input:
+                self._chat_input.focus_input()
 
     async def _reconnect_from_viewer_safe(self) -> None:
         """Run the post-viewer reconnect and surface unexpected failures.
 
         Scheduled via `asyncio.create_task` from `_show_mcp_viewer`'s
-        dismiss callback so the reconnect runs detached from the message
-        pump; `_log_task_exception` logs any escaped error, and this
+        dismiss callback and from `_prompt_mcp_disable_reconnect` so the
+        reconnect runs detached from the message pump;
+        `_log_task_exception` logs any escaped error, and this
         wrapper additionally catches failures to display an `ErrorMessage`.
         Re-checks pending state so a flip between the viewer dismiss and
         this task starting silently no-ops instead of degrading to the
@@ -21383,6 +21467,7 @@ class DeepAgentsApp(App):
             return
 
         had_original = server_name in self._mcp_optimistic_original_server_info
+        self._mcp_viewer_disable_toggled = True
         verb = "disabled" if new_state else "enabled"
         self._apply_optimistic_disabled_state(server_name, disabled=new_state)
         if new_state:

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -3154,9 +3154,10 @@ class DeepAgentsApp(App):
         self._mcp_viewer_disable_toggled = False
         """Whether the current/last `/mcp` viewer session toggled a disable state.
 
-        Scoped to one viewer session (reset each time the viewer opens) so
-        closing the viewer only offers a reconnect when the user actually
-        changed something while it was open.
+        Scoped to one viewer session — cleared when the viewer opens, when
+        the close prompt fires, and on `ServerReady` — so closing the
+        viewer only offers a reconnect when the user actually changed
+        something while it was open.
         """
 
         self._restart_respawn_task: asyncio.Task[None] | None = None
@@ -21268,8 +21269,8 @@ class DeepAgentsApp(App):
         The viewer may dismiss with a server name (when the user activates
         an `unauthenticated` header row to start in-TUI OAuth login) or
         with `None` (close without action). A plain close after `F2`
-        disable toggles offers a reconnect so the changes are not left
-        silently unapplied.
+        disable/enable toggles offers a reconnect so the changes are not
+        left silently unapplied.
         """
         from deepagents_code.tui.widgets.mcp_viewer import (
             MCP_VIEWER_RECONNECT_REQUEST,
@@ -21305,17 +21306,32 @@ class DeepAgentsApp(App):
                 self._track_server_restart_task(task)
                 task.add_done_callback(_log_task_exception)
                 return
-            if result:
-                # User picked an unauthenticated server — start login.
-                self._start_mcp_login(result)
+            if result and self._start_mcp_login(result):
+                # User picked an unauthenticated server and login started.
+                # Any pending disable toggle rides along on the post-login
+                # reconnect prompt, so this path never prompts twice.
                 return
-            if self._mcp_viewer_disable_toggled and self._pending_mcp_reconnect:
-                # Disable toggles only take effect after a restart, and the
-                # user closed the viewer without pressing Ctrl+R. Offer the
-                # reconnect instead of leaving the change unapplied. The
-                # follow-up modal is scheduled (not pushed here) so this
-                # dismiss fully unwinds first.
-                self.call_after_refresh(self._prompt_mcp_disable_reconnect)
+            # A rejected login (MCP off, remote server, agent switching)
+            # already dismissed the viewer, so fall through: without this a
+            # toggle made in the same session would sit unapplied with no
+            # further nudge until the next `/mcp` open reset the flag.
+            if (
+                self._mcp_viewer_disable_toggled
+                and self._pending_mcp_disable_reconnect_servers
+            ):
+                # Disable/enable toggles only take effect after a restart,
+                # and the user closed the viewer without pressing Ctrl+R.
+                # Offer the reconnect instead of leaving the change
+                # unapplied. The follow-up modal is scheduled (not pushed
+                # here) so this dismiss fully unwinds first.
+                if not self.call_after_refresh(self._prompt_mcp_disable_reconnect):
+                    # Pump is closing, so the prompt will never run. The
+                    # toggle is already on disk and applies on next launch;
+                    # log rather than leaving no trace of the dropped prompt.
+                    logger.warning(
+                        "Could not schedule MCP disable-reconnect prompt; "
+                        "message pump is closing"
+                    )
                 return
             if self._chat_input:
                 self._chat_input.focus_input()
@@ -21327,13 +21343,22 @@ class DeepAgentsApp(App):
 
         Scheduled from `_show_mcp_viewer`'s dismiss callback when the user
         closed the viewer after an `F2` toggle without pressing `Ctrl+R`.
-        Re-checks pending state so a reconnect that landed in the meantime
-        (or an undone toggle) skips the prompt.
+        Re-checks pending disable changes so a reconnect that landed
+        between the dismiss and this callback skips the prompt.
+
+        Runs a refresh after the viewer's dismiss, so an unrelated modal
+        (tool approval, `/auth`) can own the screen by now. `push_screen`
+        would happily stack on top of it and steal Enter/Esc, so defer to
+        the toast instead — same trade-off as `_open_update_available_modal`.
         """
         self._mcp_viewer_disable_toggled = False
-        if not self._pending_mcp_reconnect:
+        if not self._pending_mcp_disable_reconnect_servers:
             if self._chat_input:
                 self._chat_input.focus_input()
+            return
+
+        if isinstance(self.screen, ModalScreen):
+            self._notify_mcp_disable_reconnect_recovery()
             return
 
         from deepagents_code.tui.widgets.mcp_reconnect import (
@@ -21350,8 +21375,10 @@ class DeepAgentsApp(App):
                 self._track_server_restart_task(task)
                 task.add_done_callback(_log_task_exception)
                 return
-            # `later` (explicit defer) and `None` (programmatic dismiss) both
-            # keep the current server; only the explicit choice gets a toast.
+            # `later` (explicit defer) and `None` (programmatic dismiss)
+            # both keep the current server. Only an explicit `later` emits
+            # the pending-changes toast — `None` stays quiet so we don't
+            # narrate an action the user didn't take.
             if choice == "later":
                 self.notify(
                     "MCP server changes are still pending. Run `/mcp reconnect` "
@@ -21371,18 +21398,30 @@ class DeepAgentsApp(App):
                 handle_choice,
             )
         except Exception:
-            # Modal could not be mounted (e.g. another modal hijacked the
-            # stack). The toggle is already persisted, so surface the recovery
-            # path rather than silently dropping the prompt.
+            # Last-resort net for an unexpected fault while building or
+            # pushing the screen — a stacking conflict is handled above,
+            # since `push_screen` stacks rather than raising. The toggle is
+            # already persisted, so surface the recovery path rather than
+            # silently dropping the prompt.
             logger.exception("Failed to mount MCP disable-reconnect prompt")
-            self.notify(
-                "Couldn't open the reconnect prompt. Run `/mcp reconnect` to "
-                "apply the MCP server changes.",
-                severity="warning",
-                markup=False,
-            )
-            if self._chat_input:
-                self._chat_input.focus_input()
+            self._notify_mcp_disable_reconnect_recovery()
+
+    def _notify_mcp_disable_reconnect_recovery(self) -> None:
+        """Point the user at `/mcp reconnect` when the prompt can't open.
+
+        Shared by the modal-already-open guard and the mount-failure
+        fallback in `_prompt_mcp_disable_reconnect`. The toggle is already
+        persisted either way, so the change is not lost — it just needs a
+        reconnect the user now has to trigger themselves.
+        """
+        self.notify(
+            "Couldn't open the reconnect prompt. Run `/mcp reconnect` to "
+            "apply the MCP server changes.",
+            severity="warning",
+            markup=False,
+        )
+        if self._chat_input:
+            self._chat_input.focus_input()
 
     async def _reconnect_from_viewer_safe(self) -> None:
         """Run the post-viewer reconnect and surface unexpected failures.
@@ -21392,11 +21431,20 @@ class DeepAgentsApp(App):
         reconnect runs detached from the message pump;
         `_log_task_exception` logs any escaped error, and this
         wrapper additionally catches failures to display an `ErrorMessage`.
-        Re-checks pending state so a flip between the viewer dismiss and
+        Re-checks pending state so a flip between the caller's dismiss and
         this task starting silently no-ops instead of degrading to the
-        CLI no-op notice.
+        CLI no-op notice. Via `_prompt_mcp_disable_reconnect` that window
+        is much wider than the Ctrl+R path's — it spans the modal mount
+        and however long the user leaves the prompt open.
         """
         if not self._pending_mcp_reconnect:
+            # Almost always a `ServerReady` that already loaded the new
+            # config from disk, so the user's intent is satisfied and a
+            # toast would be noise. Log so an unexpected clear is traceable.
+            logger.debug(
+                "Skipping post-viewer MCP reconnect; nothing pending by the "
+                "time the task started"
+            )
             return
         try:
             await self._handle_mcp_reconnect_command()
@@ -21684,7 +21732,7 @@ class DeepAgentsApp(App):
                 ),
             )
 
-    def _start_mcp_login(self, server_name: str) -> None:
+    def _start_mcp_login(self, server_name: str) -> bool:
         """Begin in-TUI OAuth login for `server_name`.
 
         Rejects when MCP is disabled, in remote-server mode (no owned server
@@ -21699,6 +21747,12 @@ class DeepAgentsApp(App):
 
         Args:
             server_name: MCP server name from `mcpServers`.
+
+        Returns:
+            `True` when the login started or was queued, `False` when it was
+            rejected outright (already reported to the user via a toast).
+            Callers that dismissed a screen to get here use this to decide
+            whether a follow-up prompt of their own still needs to run.
         """
         if self._mcp_preload_kwargs is None:
             self.notify(
@@ -21706,7 +21760,7 @@ class DeepAgentsApp(App):
                 severity="warning",
                 markup=False,
             )
-            return
+            return False
 
         if self._server_kwargs is None:
             # Remote-server mode: we cannot restart the server, so the new
@@ -21717,7 +21771,7 @@ class DeepAgentsApp(App):
                 severity="warning",
                 markup=False,
             )
-            return
+            return False
 
         if self._agent_switching:
             self.notify(
@@ -21725,7 +21779,7 @@ class DeepAgentsApp(App):
                 severity="warning",
                 markup=False,
             )
-            return
+            return False
 
         if self._connecting or self._server_proc is None:
             # The server is still coming up (initial connect, a reconnect,
@@ -21745,7 +21799,7 @@ class DeepAgentsApp(App):
                     execute=lambda: self._run_mcp_login_worker(server_name),
                 ),
             )
-            return
+            return True
 
         # An active agent/shell run is intentionally not a defer gate: the
         # OAuth handshake and on-disk token write are independent of the
@@ -21756,6 +21810,7 @@ class DeepAgentsApp(App):
             exclusive=False,
             group=f"mcp-login-{server_name}",
         )
+        return True
 
     async def _run_mcp_login_worker(self, server_name: str) -> None:
         """Resolve config, run the login modal, and refresh on success.

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -630,6 +630,7 @@ if TYPE_CHECKING:
         GoalReviewResult,
         GoalReviewTextArea,
     )
+    from deepagents_code.tui.widgets.mcp_reconnect import ReconnectChoice
     from deepagents_code.tui.widgets.model_selector import ModelSelectorScreen
     from deepagents_code.tui.widgets.notification_center import (
         NotificationActionRequested,
@@ -21282,6 +21283,7 @@ class DeepAgentsApp(App):
             connecting=self._connecting,
             pending_reconnect=self._pending_mcp_reconnect,
             on_toggle_disable=self._toggle_mcp_server_disabled,
+            on_close=self._replace_mcp_viewer_with_disable_reconnect_prompt,
         )
         self._active_mcp_viewer = screen
         self._mcp_viewer_disable_toggled = False
@@ -21311,10 +21313,12 @@ class DeepAgentsApp(App):
                 # Any pending disable toggle rides along on the post-login
                 # reconnect prompt, so this path never prompts twice.
                 return
-            # A rejected login (MCP off, remote server, agent switching)
-            # already dismissed the viewer, so fall through: without this a
-            # toggle made in the same session would sit unapplied with no
-            # further nudge until the next `/mcp` open reset the flag.
+            # Normal Escape is intercepted by the viewer's `on_close` callback
+            # and atomically switches to the prompt. This is the fallback for
+            # a rejected login (MCP off, remote server, agent switching) or a
+            # programmatic dismiss: without it, a toggle made in the same
+            # session would sit unapplied with no further nudge until the next
+            # `/mcp` open reset the flag.
             if (
                 self._mcp_viewer_disable_toggled
                 and self._pending_mcp_disable_reconnect_servers
@@ -21338,13 +21342,54 @@ class DeepAgentsApp(App):
 
         self.push_screen(screen, handle_result)
 
+    def _replace_mcp_viewer_with_disable_reconnect_prompt(self) -> bool:
+        """Atomically replace a closing MCP viewer with its apply prompt.
+
+        `MCPViewerScreen.action_cancel` calls this before dismissing. Using
+        `switch_screen` keeps a modal screen active throughout the transition;
+        dismissing the viewer and pushing after a refresh exposes the chat
+        screen for one frame.
+
+        Returns:
+            `True` when the viewer was replaced and must not dismiss itself,
+            otherwise `False` so the viewer closes normally.
+        """
+        if not (
+            self._mcp_viewer_disable_toggled
+            and self._pending_mcp_disable_reconnect_servers
+        ):
+            return False
+
+        from deepagents_code.tui.widgets.mcp_reconnect import (
+            MCPDisableReconnectPromptScreen,
+        )
+
+        prompt = MCPDisableReconnectPromptScreen(
+            sorted(self._pending_mcp_disable_reconnect_servers),
+            on_choice=self._handle_mcp_disable_reconnect_choice,
+        )
+        try:
+            self.switch_screen(prompt)
+        except Exception:
+            # Leave the viewer's normal dismiss path intact. Its result
+            # callback will schedule the existing recovery prompt after the
+            # stack unwinds, so an unexpected switch failure remains usable.
+            logger.exception(
+                "Failed to replace MCP viewer with disable-reconnect prompt"
+            )
+            return False
+
+        self._active_mcp_viewer = None
+        self._mcp_viewer_disable_toggled = False
+        return True
+
     def _prompt_mcp_disable_reconnect(self) -> None:
         """Offer a reconnect for `/mcp` disable toggles left unapplied.
 
-        Scheduled from `_show_mcp_viewer`'s dismiss callback when the user
-        closed the viewer after an `F2` toggle without pressing `Ctrl+R`.
-        Re-checks pending disable changes so a reconnect that landed
-        between the dismiss and this callback skips the prompt.
+        Fallback scheduled from `_show_mcp_viewer`'s dismiss callback when a
+        rejected login or programmatic dismiss bypasses the atomic Escape
+        transition. Re-checks pending disable changes so a reconnect that
+        landed between the dismiss and this callback skips the prompt.
 
         Runs a refresh after the viewer's dismiss, so an unrelated modal
         (tool approval, `/auth`) can own the screen by now. `push_screen`
@@ -21363,39 +21408,14 @@ class DeepAgentsApp(App):
 
         from deepagents_code.tui.widgets.mcp_reconnect import (
             MCPDisableReconnectPromptScreen,
-            ReconnectChoice,
         )
-
-        def handle_choice(choice: ReconnectChoice | None) -> None:
-            if choice == "reconnect":
-                # Detached task, not `call_later`: the restart takes seconds
-                # and awaiting it on the message pump freezes the chat input
-                # (same rationale as the Ctrl+R path in `_show_mcp_viewer`).
-                task = asyncio.create_task(self._reconnect_from_viewer_safe())
-                self._track_server_restart_task(task)
-                task.add_done_callback(_log_task_exception)
-                return
-            # `later` (explicit defer) and `None` (programmatic dismiss)
-            # both keep the current server. Only an explicit `later` emits
-            # the pending-changes toast — `None` stays quiet so we don't
-            # narrate an action the user didn't take.
-            if choice == "later":
-                self.notify(
-                    "MCP server changes are still pending. Run `/mcp reconnect` "
-                    "when ready to apply them.",
-                    severity="information",
-                    timeout=8,
-                    markup=False,
-                )
-            if self._chat_input:
-                self._chat_input.focus_input()
 
         try:
             self.push_screen(
                 MCPDisableReconnectPromptScreen(
                     sorted(self._pending_mcp_disable_reconnect_servers),
                 ),
-                handle_choice,
+                self._handle_mcp_disable_reconnect_choice,
             )
         except Exception:
             # Last-resort net for an unexpected fault while building or
@@ -21405,6 +21425,36 @@ class DeepAgentsApp(App):
             # silently dropping the prompt.
             logger.exception("Failed to mount MCP disable-reconnect prompt")
             self._notify_mcp_disable_reconnect_recovery()
+
+    def _handle_mcp_disable_reconnect_choice(
+        self, choice: ReconnectChoice | None
+    ) -> None:
+        """Apply an explicit choice from either disable-reconnect prompt path.
+
+        Args:
+            choice: Reconnect now, defer, or `None` for a programmatic dismiss.
+        """
+        if choice == "reconnect":
+            # Detached task, not `call_later`: the restart takes seconds and
+            # awaiting it on the message pump freezes the chat input (same
+            # rationale as the Ctrl+R path in `_show_mcp_viewer`).
+            task = asyncio.create_task(self._reconnect_from_viewer_safe())
+            self._track_server_restart_task(task)
+            task.add_done_callback(_log_task_exception)
+            return
+        # `later` (explicit defer) and `None` (programmatic dismiss) both keep
+        # the current server. Only an explicit `later` emits the pending-change
+        # toast; `None` stays quiet so we don't narrate an action the user did
+        # not take.
+        if choice == "later":
+            self.notify(
+                "MCP server changes are still pending. Run `/mcp reconnect` "
+                "when ready to apply them.",
+                severity="information",
+                timeout=8,
+                markup=False,
+            )
+        self._focus_chat_input_after_refresh()
 
     def _notify_mcp_disable_reconnect_recovery(self) -> None:
         """Point the user at `/mcp reconnect` when the prompt can't open.
@@ -21972,7 +22022,6 @@ class DeepAgentsApp(App):
         """
         from deepagents_code.tui.widgets.mcp_reconnect import (
             MCPReconnectPromptScreen,
-            ReconnectChoice,
         )
 
         choice_future: asyncio.Future[ReconnectChoice | None] = (

--- a/libs/code/deepagents_code/tui/widgets/mcp_reconnect.py
+++ b/libs/code/deepagents_code/tui/widgets/mcp_reconnect.py
@@ -1,9 +1,10 @@
-"""Confirmation modal shown after a successful MCP login.
+"""Confirmation modals for MCP changes that need a server restart.
 
 Restarting the LangGraph server is required for newly minted MCP tokens
-to take effect, but auto-restarting interrupts users who want to
-authenticate against several MCP servers back-to-back. This modal lets
-the user choose between restarting now and deferring until later.
+and for `/mcp` disable/enable toggles to take effect, but auto-restarting
+interrupts users who want to make several MCP changes back-to-back. These
+modals let the user choose between restarting now and deferring until
+later.
 """
 
 from __future__ import annotations
@@ -19,6 +20,8 @@ from textual.widgets import Static
 from deepagents_code.config import get_glyphs
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from textual.app import ComposeResult
 
 
@@ -128,6 +131,111 @@ class MCPReconnectPromptScreen(ModalScreen[ReconnectChoice]):
         present, else falls through to `dismiss(None)`. Without this
         alias, Esc would dismiss with `None`, which the caller treats as
         a programmatic dismiss (no toast, no reopen) instead of an
+        explicit defer.
+        """
+        self.action_later()
+
+
+class MCPDisableReconnectPromptScreen(ModalScreen[ReconnectChoice]):
+    """Modal asking whether to reconnect after `/mcp` disable/enable toggles.
+
+    Shown when the user closes the `/mcp` viewer with pending `F2`
+    disable-state changes but without pressing `Ctrl+R`, so the toggles
+    do not silently sit unapplied. Dismisses with `"reconnect"` when the
+    user accepts the restart and `"later"` when the user defers; Esc is
+    treated as "later".
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("enter", "reconnect", "Reconnect", show=False, priority=True),
+        Binding("escape", "later", "Later", show=False, priority=True),
+    ]
+
+    CSS = """
+    MCPDisableReconnectPromptScreen {
+        align: center middle;
+    }
+
+    MCPDisableReconnectPromptScreen > Vertical {
+        width: 64;
+        max-width: 90%;
+        height: auto;
+        background: $surface;
+        border: solid $primary;
+        padding: 1 2;
+    }
+
+    MCPDisableReconnectPromptScreen .mcp-reconnect-title {
+        text-style: bold;
+        color: $primary;
+        text-align: center;
+        margin-bottom: 1;
+    }
+
+    MCPDisableReconnectPromptScreen .mcp-reconnect-body {
+        height: auto;
+        color: $text;
+        margin-bottom: 1;
+    }
+
+    MCPDisableReconnectPromptScreen .mcp-reconnect-help {
+        height: 1;
+        color: $text-muted;
+        text-style: italic;
+        text-align: center;
+    }
+    """
+
+    def __init__(self, server_names: Sequence[str]) -> None:
+        """Initialize the prompt.
+
+        Args:
+            server_names: Servers whose disabled state changed and is
+                waiting on a reconnect.
+        """
+        super().__init__()
+        self._server_names = tuple(server_names)
+
+    def compose(self) -> ComposeResult:
+        """Compose the confirmation dialog.
+
+        Yields:
+            Title, body, and help-row widgets parented inside a `Vertical`.
+        """
+        with Vertical():
+            yield Static(
+                "Apply MCP server changes?",
+                classes="mcp-reconnect-title",
+                markup=False,
+            )
+            yield Static(
+                Content.from_markup(
+                    "Reconnect to apply the changes to $names.",
+                    names=", ".join(self._server_names) or "the MCP servers",
+                ),
+                classes="mcp-reconnect-body",
+                markup=False,
+            )
+            yield Static(
+                "Enter to reconnect, Esc to defer",
+                classes="mcp-reconnect-help",
+                markup=False,
+            )
+
+    def action_reconnect(self) -> None:
+        """Dismiss with `"reconnect"`."""
+        self.dismiss("reconnect")
+
+    def action_later(self) -> None:
+        """Dismiss with `"later"`."""
+        self.dismiss("later")
+
+    def action_cancel(self) -> None:
+        """Alias for `action_later` so the app-level Esc handler defers.
+
+        Same rationale as `MCPReconnectPromptScreen.action_cancel`: the
+        app's priority `escape` binding dispatches to `action_cancel`, so
+        without this alias Esc would dismiss with `None` instead of an
         explicit defer.
         """
         self.action_later()

--- a/libs/code/deepagents_code/tui/widgets/mcp_reconnect.py
+++ b/libs/code/deepagents_code/tui/widgets/mcp_reconnect.py
@@ -2,9 +2,13 @@
 
 Restarting the LangGraph server is required for newly minted MCP tokens
 and for `/mcp` disable/enable toggles to take effect, but auto-restarting
-interrupts users who want to make several MCP changes back-to-back. These
-modals let the user choose between restarting now and deferring until
-later.
+interrupts users who want to make several MCP changes back-to-back. The
+two `_ReconnectPromptScreen` subclasses let the user choose between
+restarting now and deferring until later.
+
+`MCPReconnectForceConfirmScreen` is the exception: it guards
+`/mcp reconnect --force` when nothing is queued, so its Esc cancels the
+restart outright rather than deferring it.
 """
 
 from __future__ import annotations
@@ -26,15 +30,22 @@ if TYPE_CHECKING:
 
 
 ReconnectChoice = Literal["reconnect", "later"]
-"""Outcome of the prompt: restart the server now or keep the current one."""
+"""Outcome of the prompt: restart the server now or keep the current one.
+
+Callers must also handle `None`, which Textual passes when a screen is
+dismissed programmatically rather than by a user keypress. That is not a
+choice, and callers deliberately stay quiet for it rather than narrating
+an action the user did not take.
+"""
 
 
-class MCPReconnectPromptScreen(ModalScreen[ReconnectChoice]):
-    """Modal asking whether to restart the server after an MCP login.
+class _ReconnectPromptScreen(ModalScreen[ReconnectChoice]):
+    """Shared base for the reconnect-or-defer MCP modals.
 
-    Dismisses with `"reconnect"` when the user accepts the restart and
-    `"later"` when the user defers. Esc is treated as "later" so the
-    user is never forced into a reconnect they did not explicitly choose.
+    Subclasses supply only their title and body copy; the base owns the
+    bindings, layout, styling, and the `"reconnect"`/`"later"` dismissal
+    contract. The `DEFAULT_CSS` type selector matches subclasses because
+    Textual resolves type selectors against every class name in the MRO.
     """
 
     BINDINGS: ClassVar[list[BindingType]] = [
@@ -42,12 +53,12 @@ class MCPReconnectPromptScreen(ModalScreen[ReconnectChoice]):
         Binding("escape", "later", "Later", show=False, priority=True),
     ]
 
-    CSS = """
-    MCPReconnectPromptScreen {
+    DEFAULT_CSS = """
+    _ReconnectPromptScreen {
         align: center middle;
     }
 
-    MCPReconnectPromptScreen > Vertical {
+    _ReconnectPromptScreen > Vertical {
         width: 64;
         max-width: 90%;
         height: auto;
@@ -56,20 +67,20 @@ class MCPReconnectPromptScreen(ModalScreen[ReconnectChoice]):
         padding: 1 2;
     }
 
-    MCPReconnectPromptScreen .mcp-reconnect-title {
+    _ReconnectPromptScreen .mcp-reconnect-title {
         text-style: bold;
         color: $primary;
         text-align: center;
         margin-bottom: 1;
     }
 
-    MCPReconnectPromptScreen .mcp-reconnect-body {
+    _ReconnectPromptScreen .mcp-reconnect-body {
         height: auto;
         color: $text;
         margin-bottom: 1;
     }
 
-    MCPReconnectPromptScreen .mcp-reconnect-help {
+    _ReconnectPromptScreen .mcp-reconnect-help {
         height: 1;
         color: $text-muted;
         text-style: italic;
@@ -77,14 +88,16 @@ class MCPReconnectPromptScreen(ModalScreen[ReconnectChoice]):
     }
     """
 
-    def __init__(self, server_name: str) -> None:
-        """Initialize the prompt.
+    def __init__(self, *, title: str | Content, body: str | Content) -> None:
+        """Store the dialog copy for `compose`.
 
         Args:
-            server_name: Server whose login just succeeded.
+            title: Bold heading shown at the top of the dialog.
+            body: Explanatory paragraph beneath the title.
         """
         super().__init__()
-        self._server_name = server_name
+        self._title = title
+        self._body = body
 
     def compose(self) -> ComposeResult:
         """Compose the confirmation dialog.
@@ -92,19 +105,14 @@ class MCPReconnectPromptScreen(ModalScreen[ReconnectChoice]):
         Yields:
             Title, body, and help-row widgets parented inside a `Vertical`.
         """
-        glyphs = get_glyphs()
         with Vertical():
             yield Static(
-                Content.from_markup(
-                    "$check Connected to [bold]$name[/bold]",
-                    check=glyphs.checkmark,
-                    name=self._server_name,
-                ),
+                self._title,
                 classes="mcp-reconnect-title",
                 markup=False,
             )
             yield Static(
-                "Reconnect to load new tools.",
+                self._body,
                 classes="mcp-reconnect-body",
                 markup=False,
             )
@@ -136,7 +144,31 @@ class MCPReconnectPromptScreen(ModalScreen[ReconnectChoice]):
         self.action_later()
 
 
-class MCPDisableReconnectPromptScreen(ModalScreen[ReconnectChoice]):
+class MCPReconnectPromptScreen(_ReconnectPromptScreen):
+    """Modal asking whether to restart the server after an MCP login.
+
+    Dismisses with `"reconnect"` when the user accepts the restart and
+    `"later"` when the user defers. Esc is treated as "later" so the
+    user is never forced into a reconnect they did not explicitly choose.
+    """
+
+    def __init__(self, server_name: str) -> None:
+        """Initialize the prompt.
+
+        Args:
+            server_name: Server whose login just succeeded.
+        """
+        super().__init__(
+            title=Content.from_markup(
+                "$check Connected to [bold]$name[/bold]",
+                check=get_glyphs().checkmark,
+                name=server_name,
+            ),
+            body="Reconnect to load new tools.",
+        )
+
+
+class MCPDisableReconnectPromptScreen(_ReconnectPromptScreen):
     """Modal asking whether to reconnect after `/mcp` disable/enable toggles.
 
     Shown when the user closes the `/mcp` viewer with pending `F2`
@@ -146,99 +178,22 @@ class MCPDisableReconnectPromptScreen(ModalScreen[ReconnectChoice]):
     treated as "later".
     """
 
-    BINDINGS: ClassVar[list[BindingType]] = [
-        Binding("enter", "reconnect", "Reconnect", show=False, priority=True),
-        Binding("escape", "later", "Later", show=False, priority=True),
-    ]
-
-    CSS = """
-    MCPDisableReconnectPromptScreen {
-        align: center middle;
-    }
-
-    MCPDisableReconnectPromptScreen > Vertical {
-        width: 64;
-        max-width: 90%;
-        height: auto;
-        background: $surface;
-        border: solid $primary;
-        padding: 1 2;
-    }
-
-    MCPDisableReconnectPromptScreen .mcp-reconnect-title {
-        text-style: bold;
-        color: $primary;
-        text-align: center;
-        margin-bottom: 1;
-    }
-
-    MCPDisableReconnectPromptScreen .mcp-reconnect-body {
-        height: auto;
-        color: $text;
-        margin-bottom: 1;
-    }
-
-    MCPDisableReconnectPromptScreen .mcp-reconnect-help {
-        height: 1;
-        color: $text-muted;
-        text-style: italic;
-        text-align: center;
-    }
-    """
-
     def __init__(self, server_names: Sequence[str]) -> None:
         """Initialize the prompt.
 
         Args:
-            server_names: Servers whose disabled state changed and is
-                waiting on a reconnect.
+            server_names: Servers whose disabled state changed and are
+                waiting on a reconnect. Must be non-empty — the caller
+                only opens this modal when at least one toggle is
+                pending, and the body would otherwise name no server.
         """
-        super().__init__()
-        self._server_names = tuple(server_names)
-
-    def compose(self) -> ComposeResult:
-        """Compose the confirmation dialog.
-
-        Yields:
-            Title, body, and help-row widgets parented inside a `Vertical`.
-        """
-        with Vertical():
-            yield Static(
-                "Apply MCP server changes?",
-                classes="mcp-reconnect-title",
-                markup=False,
-            )
-            yield Static(
-                Content.from_markup(
-                    "Reconnect to apply the changes to $names.",
-                    names=", ".join(self._server_names) or "the MCP servers",
-                ),
-                classes="mcp-reconnect-body",
-                markup=False,
-            )
-            yield Static(
-                "Enter to reconnect, Esc to defer",
-                classes="mcp-reconnect-help",
-                markup=False,
-            )
-
-    def action_reconnect(self) -> None:
-        """Dismiss with `"reconnect"`."""
-        self.dismiss("reconnect")
-
-    def action_later(self) -> None:
-        """Dismiss with `"later"`."""
-        self.dismiss("later")
-
-    def action_cancel(self) -> None:
-        """Alias for `action_later` so the app-level Esc handler defers.
-
-        Same rationale as `MCPReconnectPromptScreen.action_cancel`: the
-        app's priority `escape` binding dispatches to `action_cancel`, so
-        without this alias Esc would dismiss with `None` instead of an
-        explicit defer.
-        """
-        self.action_later()
+        super().__init__(
+            title="Apply MCP server changes?",
+            body=Content.from_markup(
+                "Reconnect to apply the changes to $names.",
+                names=", ".join(server_names),
+            ),
+        )
 
 
 class MCPReconnectForceConfirmScreen(ModalScreen[bool]):

--- a/libs/code/deepagents_code/tui/widgets/mcp_reconnect.py
+++ b/libs/code/deepagents_code/tui/widgets/mcp_reconnect.py
@@ -24,7 +24,7 @@ from textual.widgets import Static
 from deepagents_code.config import get_glyphs
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     from textual.app import ComposeResult
 
@@ -178,7 +178,12 @@ class MCPDisableReconnectPromptScreen(_ReconnectPromptScreen):
     treated as "later".
     """
 
-    def __init__(self, server_names: Sequence[str]) -> None:
+    def __init__(
+        self,
+        server_names: Sequence[str],
+        *,
+        on_choice: Callable[[ReconnectChoice], None] | None = None,
+    ) -> None:
         """Initialize the prompt.
 
         Args:
@@ -186,6 +191,10 @@ class MCPDisableReconnectPromptScreen(_ReconnectPromptScreen):
                 waiting on a reconnect. Must be non-empty — the caller
                 only opens this modal when at least one toggle is
                 pending, and the body would otherwise name no server.
+            on_choice: Optional callback invoked for an explicit reconnect
+                or defer choice before the screen dismisses. This supports
+                an atomic `switch_screen` transition from the MCP viewer,
+                whose original result callback is removed by the switch.
         """
         super().__init__(
             title="Apply MCP server changes?",
@@ -194,6 +203,19 @@ class MCPDisableReconnectPromptScreen(_ReconnectPromptScreen):
                 names=", ".join(server_names),
             ),
         )
+        self._on_choice = on_choice
+
+    def action_reconnect(self) -> None:
+        """Report and dismiss with `"reconnect"`."""
+        if self._on_choice is not None:
+            self._on_choice("reconnect")
+        super().action_reconnect()
+
+    def action_later(self) -> None:
+        """Report and dismiss with `"later"`."""
+        if self._on_choice is not None:
+            self._on_choice("later")
+        super().action_later()
 
 
 class MCPReconnectForceConfirmScreen(ModalScreen[bool]):

--- a/libs/code/deepagents_code/tui/widgets/mcp_viewer.py
+++ b/libs/code/deepagents_code/tui/widgets/mcp_viewer.py
@@ -902,6 +902,7 @@ class MCPViewerScreen(ModalScreen[str | None]):
         connecting: bool = False,
         pending_reconnect: bool = False,
         on_toggle_disable: Callable[[str], Awaitable[None]] | None = None,
+        on_close: Callable[[], bool] | None = None,
     ) -> None:
         """Initialize the MCP viewer screen.
 
@@ -921,12 +922,17 @@ class MCPViewerScreen(ModalScreen[str | None]):
                 expected to call `refresh_server_info` on this screen so
                 the user sees the updated status without a screen swap.
                 When `None`, `F2` is a no-op.
+            on_close: Callback invoked before Escape dismisses the viewer.
+                Return `True` when the callback replaced the viewer with a
+                follow-up screen and dismissal should be skipped. `None`
+                keeps the normal close behavior.
         """
         super().__init__()
         self._server_info = server_info
         self._connecting = connecting
         self._pending_reconnect = pending_reconnect
         self._on_toggle_disable = on_toggle_disable
+        self._on_close = on_close
         # All cursor-navigable rows in render order: server headers + tool
         # items intermixed. `_selected_index` indexes into this list.
         self._row_widgets: list[MCPToolItem | MCPServerHeaderItem] = []
@@ -1603,6 +1609,8 @@ class MCPViewerScreen(ModalScreen[str | None]):
 
     def action_cancel(self) -> None:
         """Close the viewer without selecting a server to log into."""
+        if self._on_close is not None and self._on_close():
+            return
         self.dismiss(None)
 
     def action_reconnect(self) -> None:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -29926,6 +29926,162 @@ class TestMCPLoginCommand:
             await app._restart_server_for_mcp_refresh("notion")
             assert app._pending_mcp_reconnect is False
 
+    async def test_viewer_close_after_disable_toggle_prompts_reconnect(self) -> None:
+        """Leaving `/mcp` after an F2 toggle offers the reconnect.
+
+        End-to-end through the real widgets: F2 disables a server, Esc
+        closes the viewer without `Ctrl+R`, and the follow-up prompt
+        accepts Enter to apply the change. Without the prompt the toggle
+        would sit unapplied with no further nudge.
+        """
+        from deepagents_code.mcp_tools import MCPServerInfo, MCPToolInfo
+        from deepagents_code.tui.widgets.mcp_reconnect import (
+            MCPDisableReconnectPromptScreen,
+        )
+
+        original = MCPServerInfo(
+            name="filesystem",
+            transport="stdio",
+            tools=(MCPToolInfo(name="read_file", description="Read a file"),),
+        )
+        app = DeepAgentsApp(agent=MagicMock(), mcp_server_info=[original])
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with (
+                patch(
+                    "deepagents_code.mcp_disabled.is_server_disabled",
+                    return_value=False,
+                ),
+                patch(
+                    "deepagents_code.mcp_disabled.set_server_disabled",
+                    return_value=(True, None),
+                ),
+                patch.object(
+                    app, "_restart_server_for_mcp_refresh", new=AsyncMock()
+                ) as restart,
+                patch.object(app, "notify"),
+            ):
+                await app._show_mcp_viewer()
+                await pilot.pause()
+                await pilot.press("f2")
+                await pilot.pause()
+                assert app._pending_mcp_reconnect is True
+
+                await pilot.press("escape")
+                for _ in range(3):
+                    await pilot.pause()
+                assert isinstance(app.screen, MCPDisableReconnectPromptScreen)
+
+                await pilot.press("enter")
+                for _ in range(3):
+                    await pilot.pause()
+            restart.assert_awaited_once()
+
+    async def test_viewer_close_after_disable_toggle_esc_defers(self) -> None:
+        """Deferring the post-viewer prompt keeps the pending state intact."""
+        from deepagents_code.mcp_tools import MCPServerInfo, MCPToolInfo
+        from deepagents_code.tui.widgets.mcp_reconnect import (
+            MCPDisableReconnectPromptScreen,
+        )
+
+        original = MCPServerInfo(
+            name="filesystem",
+            transport="stdio",
+            tools=(MCPToolInfo(name="read_file", description="Read a file"),),
+        )
+        app = DeepAgentsApp(agent=MagicMock(), mcp_server_info=[original])
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with (
+                patch(
+                    "deepagents_code.mcp_disabled.is_server_disabled",
+                    return_value=False,
+                ),
+                patch(
+                    "deepagents_code.mcp_disabled.set_server_disabled",
+                    return_value=(True, None),
+                ),
+                patch.object(
+                    app, "_restart_server_for_mcp_refresh", new=AsyncMock()
+                ) as restart,
+                patch.object(app, "notify") as notify,
+            ):
+                await app._show_mcp_viewer()
+                await pilot.pause()
+                await pilot.press("f2")
+                await pilot.pause()
+                await pilot.press("escape")
+                for _ in range(3):
+                    await pilot.pause()
+                assert isinstance(app.screen, MCPDisableReconnectPromptScreen)
+
+                await pilot.press("escape")
+                for _ in range(3):
+                    await pilot.pause()
+
+            restart.assert_not_called()
+            assert app._pending_mcp_reconnect is True
+            messages = [call.args[0] for call in notify.call_args_list]
+            assert any("still pending" in m for m in messages)
+
+    async def test_viewer_close_without_toggle_does_not_prompt(self) -> None:
+        """A plain `/mcp` close never asks about a reconnect."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # A login-pending reconnect alone must not trigger the prompt —
+            # that flow has its own post-login modal.
+            app._pending_mcp_reconnect = True
+            with patch.object(
+                app, "_prompt_mcp_disable_reconnect"
+            ) as prompt_disable_reconnect:
+                await app._show_mcp_viewer()
+                await pilot.pause()
+                await app.screen.dismiss(None)
+                for _ in range(3):
+                    await pilot.pause()
+            prompt_disable_reconnect.assert_not_called()
+
+    async def test_prompt_disable_reconnect_skips_when_nothing_pending(self) -> None:
+        """An undone toggle (nothing pending) skips the prompt entirely."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._mcp_viewer_disable_toggled = True
+            app._pending_mcp_reconnect = False
+            with patch.object(app, "push_screen") as push_screen:
+                app._prompt_mcp_disable_reconnect()
+                await pilot.pause()
+            push_screen.assert_not_called()
+            assert app._mcp_viewer_disable_toggled is False
+
+    async def test_prompt_disable_reconnect_survives_push_failure(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A modal that can't mount still points the user at `/mcp reconnect`."""
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._mcp_viewer_disable_toggled = True
+            app._pending_mcp_reconnect = True
+            with (
+                patch.object(
+                    app,
+                    "push_screen",
+                    side_effect=RuntimeError("modal mount failed"),
+                ),
+                patch.object(app, "notify") as notify,
+                caplog.at_level("ERROR", logger="deepagents_code.app"),
+            ):
+                app._prompt_mcp_disable_reconnect()
+                await pilot.pause()
+            assert any(
+                "Failed to mount MCP disable-reconnect prompt" in record.getMessage()
+                for record in caplog.records
+            )
+            notify.assert_called_once()
+            assert "/mcp reconnect" in notify.call_args.args[0]
+
 
 class TestParseReconnectArgs:
     """Pure-function tests for `/mcp reconnect` argument parsing."""

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -30025,35 +30025,90 @@ class TestMCPLoginCommand:
             assert any("still pending" in m for m in messages)
 
     async def test_viewer_close_without_toggle_does_not_prompt(self) -> None:
-        """A plain `/mcp` close never asks about a reconnect."""
+        """A plain `/mcp` close never asks about a reconnect.
+
+        Asserts on the screen stack rather than on a patched
+        `_prompt_mcp_disable_reconnect` so the test still means something
+        if that helper is renamed or inlined.
+        """
+        from deepagents_code.tui.widgets.mcp_reconnect import (
+            MCPDisableReconnectPromptScreen,
+        )
+
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
             # A login-pending reconnect alone must not trigger the prompt —
             # that flow has its own post-login modal.
-            app._pending_mcp_reconnect = True
-            with patch.object(
-                app, "_prompt_mcp_disable_reconnect"
-            ) as prompt_disable_reconnect:
+            app._pending_mcp_login_reconnect = True
+            app._sync_pending_mcp_reconnect()
+            await app._show_mcp_viewer()
+            await pilot.pause()
+            await app.screen.dismiss(None)
+            for _ in range(3):
+                await pilot.pause()
+            assert not isinstance(app.screen, MCPDisableReconnectPromptScreen)
+
+    async def test_viewer_close_after_undone_toggle_ignores_pending_login(
+        self,
+    ) -> None:
+        """An undone disable does not borrow pending state from an MCP login."""
+        from deepagents_code.mcp_tools import MCPServerInfo, MCPToolInfo
+
+        original = MCPServerInfo(
+            name="filesystem",
+            transport="stdio",
+            tools=(MCPToolInfo(name="read_file", description="Read a file"),),
+        )
+        app = DeepAgentsApp(agent=MagicMock(), mcp_server_info=[original])
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._pending_mcp_login_reconnect = True
+            app._sync_pending_mcp_reconnect()
+            with (
+                patch(
+                    "deepagents_code.mcp_disabled.is_server_disabled",
+                    side_effect=[False, True],
+                ),
+                patch(
+                    "deepagents_code.mcp_disabled.set_server_disabled",
+                    return_value=(True, None),
+                ),
+                patch.object(app, "_prompt_mcp_disable_reconnect") as prompt,
+                patch.object(app, "notify"),
+            ):
                 await app._show_mcp_viewer()
                 await pilot.pause()
-                await app.screen.dismiss(None)
+                await pilot.press("f2")
+                await pilot.pause()
+                await pilot.press("f2")
+                await pilot.pause()
+
+                assert app._pending_mcp_reconnect is True
+                assert not app._pending_mcp_disable_reconnect_servers
+
+                await pilot.press("escape")
                 for _ in range(3):
                     await pilot.pause()
-            prompt_disable_reconnect.assert_not_called()
 
-    async def test_prompt_disable_reconnect_skips_when_nothing_pending(self) -> None:
-        """An undone toggle (nothing pending) skips the prompt entirely."""
+            prompt.assert_not_called()
+
+    async def test_prompt_disable_reconnect_skips_when_only_login_pending(
+        self,
+    ) -> None:
+        """A delayed prompt recheck ignores unrelated pending login state."""
         app = DeepAgentsApp(agent=MagicMock())
         async with app.run_test() as pilot:
             await pilot.pause()
             app._mcp_viewer_disable_toggled = True
-            app._pending_mcp_reconnect = False
+            app._pending_mcp_login_reconnect = True
+            app._sync_pending_mcp_reconnect()
             with patch.object(app, "push_screen") as push_screen:
                 app._prompt_mcp_disable_reconnect()
                 await pilot.pause()
             push_screen.assert_not_called()
             assert app._mcp_viewer_disable_toggled is False
+            assert app._pending_mcp_reconnect is True
 
     async def test_prompt_disable_reconnect_survives_push_failure(
         self, caplog: pytest.LogCaptureFixture
@@ -30063,7 +30118,8 @@ class TestMCPLoginCommand:
         async with app.run_test() as pilot:
             await pilot.pause()
             app._mcp_viewer_disable_toggled = True
-            app._pending_mcp_reconnect = True
+            app._pending_mcp_disable_reconnect_servers.add("notion")
+            app._sync_pending_mcp_reconnect()
             with (
                 patch.object(
                     app,
@@ -30081,6 +30137,209 @@ class TestMCPLoginCommand:
             )
             notify.assert_called_once()
             assert "/mcp reconnect" in notify.call_args.args[0]
+
+    @pytest.mark.timeout(15)
+    async def test_disable_prompt_reconnect_keeps_chat_input_responsive(
+        self,
+    ) -> None:
+        """Accepting the close prompt must not freeze the chat input.
+
+        Regression guard mirroring `test_viewer_ctrl_r_keeps_chat_input_
+        responsive` for the second entry point. Scheduling the reconnect
+        with `call_later` awaits the multi-second restart inside the app
+        message pump, which stops forwarding key events. Without the
+        detached task this test times out (pump stalled on the gated
+        coroutine).
+        """
+        from deepagents_code.tui.widgets.mcp_reconnect import (
+            MCPDisableReconnectPromptScreen,
+        )
+
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._chat_input is not None
+            app._chat_input.focus_input()
+            await pilot.pause()
+
+            gate = asyncio.Event()
+
+            async def _blocked_reconnect() -> None:
+                await gate.wait()
+
+            app._mcp_viewer_disable_toggled = True
+            app._pending_mcp_disable_reconnect_servers.add("filesystem")
+            app._sync_pending_mcp_reconnect()
+            with patch.object(
+                app, "_reconnect_from_viewer_safe", new=_blocked_reconnect
+            ):
+                app._prompt_mcp_disable_reconnect()
+                await pilot.pause()
+                assert isinstance(app.screen, MCPDisableReconnectPromptScreen)
+
+                await pilot.press("enter")
+                await pilot.pause()
+                # The reconnect is in-flight and gated open; the pump must
+                # still deliver keystrokes to the chat input.
+                await pilot.press("h", "i")
+                await pilot.pause()
+                typed = app._chat_input.value
+                gate.set()
+                await pilot.pause()
+
+            assert typed == "hi"
+
+    async def test_viewer_close_after_enable_toggle_prompts_reconnect(self) -> None:
+        """Re-enabling a server disabled in a prior session also prompts.
+
+        `F2` toggles both directions. Enabling a server that started the
+        session disabled has no optimistic original to restore, so it adds
+        to the pending set rather than discarding from it — the branch that
+        makes the prompt reachable in the enable direction.
+        """
+        from deepagents_code.mcp_tools import MCPServerInfo
+        from deepagents_code.tui.widgets.mcp_reconnect import (
+            MCPDisableReconnectPromptScreen,
+        )
+
+        original = MCPServerInfo(
+            name="filesystem",
+            transport="stdio",
+            status="disabled",
+            error="Disabled by user.",
+        )
+        app = DeepAgentsApp(agent=MagicMock(), mcp_server_info=[original])
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            with (
+                patch(
+                    "deepagents_code.mcp_disabled.is_server_disabled",
+                    return_value=True,
+                ),
+                patch(
+                    "deepagents_code.mcp_disabled.set_server_disabled",
+                    return_value=(True, None),
+                ),
+                patch.object(app, "notify"),
+            ):
+                await app._show_mcp_viewer()
+                await pilot.pause()
+                await pilot.press("f2")
+                await pilot.pause()
+
+                assert app._pending_mcp_disable_reconnect_servers == {"filesystem"}
+
+                await pilot.press("escape")
+                for _ in range(3):
+                    await pilot.pause()
+
+                assert isinstance(app.screen, MCPDisableReconnectPromptScreen)
+
+    async def test_prompt_lists_every_pending_server_in_sorted_order(self) -> None:
+        """Multiple pending servers render deterministically, not set order.
+
+        Set iteration order varies with per-process string hash seeding, so
+        without the explicit sort the modal body would name the servers in a
+        different order on different runs.
+        """
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._mcp_viewer_disable_toggled = True
+            app._pending_mcp_disable_reconnect_servers.update(
+                {"notion", "filesystem", "atlassian"}
+            )
+            app._sync_pending_mcp_reconnect()
+
+            app._prompt_mcp_disable_reconnect()
+            await pilot.pause()
+
+            bodies = app.screen.query(".mcp-reconnect-body")
+            assert "atlassian, filesystem, notion" in str(bodies.first().render())
+
+    async def test_prompt_disable_reconnect_none_dismiss_silent(self) -> None:
+        """A programmatic dismiss stays quiet — the user didn't pick `later`."""
+        from deepagents_code.tui.widgets.mcp_reconnect import (
+            MCPDisableReconnectPromptScreen,
+        )
+
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._mcp_viewer_disable_toggled = True
+            app._pending_mcp_disable_reconnect_servers.add("filesystem")
+            app._sync_pending_mcp_reconnect()
+            with patch.object(app, "notify") as notify:
+                app._prompt_mcp_disable_reconnect()
+                await pilot.pause()
+                assert isinstance(app.screen, MCPDisableReconnectPromptScreen)
+
+                await app.screen.dismiss(None)
+                for _ in range(3):
+                    await pilot.pause()
+
+            notify.assert_not_called()
+            assert app._pending_mcp_disable_reconnect_servers == {"filesystem"}
+
+    async def test_prompt_disable_reconnect_defers_to_an_open_modal(self) -> None:
+        """A modal already on the stack gets the toast, not a stacked prompt.
+
+        `push_screen` stacks rather than raising, so without the guard the
+        prompt would mount on top of an unrelated modal and steal Enter/Esc.
+        """
+        from deepagents_code.tui.widgets.mcp_reconnect import (
+            MCPReconnectForceConfirmScreen,
+        )
+
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._mcp_viewer_disable_toggled = True
+            app._pending_mcp_disable_reconnect_servers.add("filesystem")
+            app._sync_pending_mcp_reconnect()
+
+            app.push_screen(MCPReconnectForceConfirmScreen())
+            await pilot.pause()
+
+            with patch.object(app, "notify") as notify:
+                app._prompt_mcp_disable_reconnect()
+                for _ in range(3):
+                    await pilot.pause()
+
+            assert isinstance(app.screen, MCPReconnectForceConfirmScreen)
+            notify.assert_called_once()
+            assert "/mcp reconnect" in notify.call_args.args[0]
+
+    async def test_viewer_close_prompts_when_login_is_rejected(self) -> None:
+        """A rejected login still surfaces the pending disable toggle.
+
+        Activating an unauthenticated row dismisses the viewer before
+        `_start_mcp_login` runs its guards. When login is refused outright
+        (here: MCP disabled for the session), the toggle made in the same
+        viewer session would otherwise sit unapplied with no further nudge.
+        """
+        from deepagents_code.tui.widgets.mcp_reconnect import (
+            MCPDisableReconnectPromptScreen,
+        )
+
+        app = DeepAgentsApp(agent=MagicMock())
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._mcp_preload_kwargs = None
+            with patch.object(app, "notify"):
+                await app._show_mcp_viewer()
+                await pilot.pause()
+                # Set after opening: `_show_mcp_viewer` resets the flag so
+                # each viewer session starts clean.
+                app._mcp_viewer_disable_toggled = True
+                app._pending_mcp_disable_reconnect_servers.add("filesystem")
+                app._sync_pending_mcp_reconnect()
+
+                await app.screen.dismiss("notion")
+                for _ in range(3):
+                    await pilot.pause()
+
+            assert isinstance(app.screen, MCPDisableReconnectPromptScreen)
 
 
 class TestParseReconnectArgs:

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -29967,10 +29967,17 @@ class TestMCPLoginCommand:
                 await pilot.pause()
                 assert app._pending_mcp_reconnect is True
 
+                screen_changes: list[object] = []
+                app.screen_change_signal.subscribe(
+                    app,
+                    screen_changes.append,
+                    immediate=True,
+                )
                 await pilot.press("escape")
                 for _ in range(3):
                     await pilot.pause()
                 assert isinstance(app.screen, MCPDisableReconnectPromptScreen)
+                assert screen_changes == [app.screen]
 
                 await pilot.press("enter")
                 for _ in range(3):

--- a/libs/code/tests/unit_tests/tui/widgets/test_mcp_reconnect.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_mcp_reconnect.py
@@ -1,8 +1,9 @@
-"""Tests for the MCP reconnect confirmation modal."""
+"""Tests for the MCP reconnect confirmation modals."""
 
 from __future__ import annotations
 
 from textual.app import App, ComposeResult
+from textual.containers import Vertical
 from textual.widgets import Static
 
 from deepagents_code.tui.widgets.mcp_reconnect import (
@@ -97,7 +98,7 @@ class TestMCPDisableReconnectPromptScreen:
     """Behavior tests for `MCPDisableReconnectPromptScreen`."""
 
     async def test_enter_dismisses_with_reconnect(self) -> None:
-        """Pressing Enter applies the pending disable toggles."""
+        """Pressing Enter chooses `reconnect`."""
         app = _ReconnectTestApp()
         async with app.run_test() as pilot:
             outcomes: list[str | None] = []
@@ -114,7 +115,7 @@ class TestMCPDisableReconnectPromptScreen:
             assert outcomes == ["reconnect"]
 
     async def test_escape_dismisses_with_later(self) -> None:
-        """Pressing Esc defers the reconnect."""
+        """Pressing Esc chooses `later` (no implicit reconnect)."""
         app = _ReconnectTestApp()
         async with app.run_test() as pilot:
             outcomes: list[str | None] = []
@@ -163,15 +164,33 @@ class TestMCPDisableReconnectPromptScreen:
             assert "filesystem" in rendered
             assert "notion" in rendered
 
-    async def test_renders_fallback_without_server_names(self) -> None:
-        """An empty name list still renders a sensible body."""
+    async def test_shares_styling_with_login_prompt(self) -> None:
+        """Both prompts inherit one style contract from the shared base.
+
+        The two screens used to duplicate a 34-line CSS block, so a tweak
+        to one silently diverged the other. They now share `DEFAULT_CSS`
+        via `_ReconnectPromptScreen`, which Textual resolves through the
+        MRO — this pins that the shared rules actually reach both.
+        """
         app = _ReconnectTestApp()
         async with app.run_test() as pilot:
-            app.push_screen(MCPDisableReconnectPromptScreen([]))
-            await pilot.pause()
+            for screen in (
+                MCPDisableReconnectPromptScreen(["filesystem"]),
+                MCPReconnectPromptScreen("notion"),
+            ):
+                app.push_screen(screen)
+                await pilot.pause()
 
-            bodies = app.screen.query(".mcp-reconnect-body")
-            assert "the MCP servers" in str(bodies.first().render())
+                dialog = app.screen.query_one(Vertical)
+                assert dialog.styles.width is not None
+                assert dialog.styles.width.value == 64
+                help_rows = app.screen.query(".mcp-reconnect-help")
+                assert str(help_rows.first().render()) == (
+                    "Enter to reconnect, Esc to defer"
+                )
+
+                app.pop_screen()
+                await pilot.pause()
 
 
 class TestMCPReconnectForceConfirmScreen:

--- a/libs/code/tests/unit_tests/tui/widgets/test_mcp_reconnect.py
+++ b/libs/code/tests/unit_tests/tui/widgets/test_mcp_reconnect.py
@@ -6,6 +6,7 @@ from textual.app import App, ComposeResult
 from textual.widgets import Static
 
 from deepagents_code.tui.widgets.mcp_reconnect import (
+    MCPDisableReconnectPromptScreen,
     MCPReconnectForceConfirmScreen,
     MCPReconnectPromptScreen,
 )
@@ -90,6 +91,87 @@ class TestMCPReconnectPromptScreen:
             titles = app.screen.query(".mcp-reconnect-title")
             assert len(titles) == 1
             assert "notion" in str(titles.first().render())
+
+
+class TestMCPDisableReconnectPromptScreen:
+    """Behavior tests for `MCPDisableReconnectPromptScreen`."""
+
+    async def test_enter_dismisses_with_reconnect(self) -> None:
+        """Pressing Enter applies the pending disable toggles."""
+        app = _ReconnectTestApp()
+        async with app.run_test() as pilot:
+            outcomes: list[str | None] = []
+
+            def on_dismiss(result: str | None) -> None:
+                outcomes.append(result)
+
+            app.push_screen(MCPDisableReconnectPromptScreen(["filesystem"]), on_dismiss)
+            await pilot.pause()
+
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert outcomes == ["reconnect"]
+
+    async def test_escape_dismisses_with_later(self) -> None:
+        """Pressing Esc defers the reconnect."""
+        app = _ReconnectTestApp()
+        async with app.run_test() as pilot:
+            outcomes: list[str | None] = []
+
+            def on_dismiss(result: str | None) -> None:
+                outcomes.append(result)
+
+            app.push_screen(MCPDisableReconnectPromptScreen(["filesystem"]), on_dismiss)
+            await pilot.pause()
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert outcomes == ["later"]
+
+    async def test_action_cancel_dismisses_with_later(self) -> None:
+        """`action_cancel` defers — the path taken by the app's Esc handler."""
+        app = _ReconnectTestApp()
+        async with app.run_test() as pilot:
+            outcomes: list[str | None] = []
+
+            def on_dismiss(result: str | None) -> None:
+                outcomes.append(result)
+
+            screen = MCPDisableReconnectPromptScreen(["filesystem"])
+            app.push_screen(screen, on_dismiss)
+            await pilot.pause()
+
+            screen.action_cancel()
+            await pilot.pause()
+
+            assert outcomes == ["later"]
+
+    async def test_renders_server_names(self) -> None:
+        """Every pending server name appears in the body."""
+        app = _ReconnectTestApp()
+        async with app.run_test() as pilot:
+            app.push_screen(
+                MCPDisableReconnectPromptScreen(["filesystem", "notion"]),
+            )
+            await pilot.pause()
+
+            bodies = app.screen.query(".mcp-reconnect-body")
+            assert len(bodies) == 1
+            rendered = str(bodies.first().render())
+            assert "filesystem" in rendered
+            assert "notion" in rendered
+
+    async def test_renders_fallback_without_server_names(self) -> None:
+        """An empty name list still renders a sensible body."""
+        app = _ReconnectTestApp()
+        async with app.run_test() as pilot:
+            app.push_screen(MCPDisableReconnectPromptScreen([]))
+            await pilot.pause()
+
+            bodies = app.screen.query(".mcp-reconnect-body")
+            assert "the MCP servers" in str(bodies.first().render())
 
 
 class TestMCPReconnectForceConfirmScreen:


### PR DESCRIPTION
`/mcp`: closing the viewer after disabling/enabling servers now offers to reconnect so the change takes effect.

---

`F2` disable/enable toggles in the `/mcp` viewer only take effect after a server restart, but closing the viewer with Esc left them silently unapplied unless the user remembered `Ctrl+R`. Closing the viewer after a toggle now schedules a `MCPDisableReconnectPromptScreen` action modal: Enter reconnects via the same detached-task path as `Ctrl+R`, Esc defers with a reminder toast.

The prompt is scoped to toggles that are actually still pending, so it stays quiet on a plain close, on a toggle that was undone, and on a pending login (that flow has its own post-login modal). If another modal already owns the screen by the time it fires, it degrades to a toast pointing at `/mcp reconnect` rather than stacking on top and stealing Enter/Esc. Toggles are persisted to `config.toml` either way, so they apply on next launch even when the reconnect never happens.

Both prompts in `mcp_reconnect.py` now share a `_ReconnectPromptScreen` base holding the bindings, layout, styling, and the reconnect/defer dismissal contract, following the existing `update_confirm.py` pattern. Subclasses supply only their title and body copy, so the two dialogs cannot drift apart visually or behaviorally.

Made by [Open SWE](https://openswe.vercel.app/agents/47e3ff8c-9f5c-f8a3-15cc-6476a4a187de)
