### PR TITLE
feat(code): drop redundant `shell` and `web_search` prompt guidance

### DIFF
--- a/libs/code/deepagents_code/system_prompt.md
+++ b/libs/code/deepagents_code/system_prompt.md
@@ -77,23 +77,7 @@ Reading sequentially when parallel is possible:
 read_file("/path/a.py") → wait → read_file("/path/b.py") → wait
 </bad-example>
 
-### shell
-
-Execute shell commands. Always quote paths with spaces. The bash command will be run from your current working directory. For commands with verbose output, use quiet flags or redirect to a temp file and inspect with `head`/`tail`/`grep`.
-
-<good-example>
-pytest /foo/bar/tests
-</good-example>
-
-<bad-example>
-cd /foo/bar && pytest tests
-</bad-example>
-
 When a single tool call in a parallel fanout fails with a schema error like `Unknown JSON field`, do NOT submit additional parallel calls with the same invalid field — drop the offending field and retry as a single corrected call before fanning out again.
-
-### web_search
-
-Search for documentation, error solutions, and code examples.
 
 ## File Reading Best Practices
 

--- a/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
+++ b/libs/code/tests/unit_tests/smoke_tests/snapshots/system_prompt_interactive_local.md
@@ -81,23 +81,7 @@ Reading sequentially when parallel is possible:
 read_file("/path/a.py") → wait → read_file("/path/b.py") → wait
 </bad-example>
 
-### shell
-
-Execute shell commands. Always quote paths with spaces. The bash command will be run from your current working directory. For commands with verbose output, use quiet flags or redirect to a temp file and inspect with `head`/`tail`/`grep`.
-
-<good-example>
-pytest /foo/bar/tests
-</good-example>
-
-<bad-example>
-cd /foo/bar && pytest tests
-</bad-example>
-
 When a single tool call in a parallel fanout fails with a schema error like `Unknown JSON field`, do NOT submit additional parallel calls with the same invalid field — drop the offending field and retry as a single corrected call before fanning out again.
-
-### web_search
-
-Search for documentation, error solutions, and code examples.
 
 ## File Reading Best Practices
 


### PR DESCRIPTION
Trims two subsections from the `## Tool Usage` section of the `deepagents-code` system prompt.

---

The `### shell` subsection repeated guidance the `execute` tool already carries in its own model-facing description (quoting paths with spaces, avoiding `cd` in favor of absolute paths), and its suggestion to inspect verbose output with `head`/`tail`/`grep` directly contradicted that description, which tells the model to prefer `read_file`. Static, per-tool advice belongs with the tool, not duplicated in the prompt where the two copies can drift.

The `### web_search` subsection was a one-line stub fully subsumed by the dedicated web-search section later in the same file.

Retained in `## Tool Usage`: the dynamic filesystem-guidance placeholder (conditional on the filesystem tool allowlist, so it cannot live in a static tool description) and the parallel tool-call guidance plus the parallel-fanout schema-error recovery note, which describe cross-tool orchestration that no single tool description covers and that is not reliably injected for non-Anthropic models.

The system-prompt smoke-test snapshot is regenerated accordingly.

Made by [Open SWE](https://openswe.vercel.app/agents/f28cbb41-5b4f-31c7-6ec1-5268ecca4864)