### PR TITLE
hotfix(code): mark editable SDK installs in `dcode_client_deepagents_version`

### DIFF
--- a/libs/code/deepagents_code/config.py
+++ b/libs/code/deepagents_code/config.py
@@ -1248,9 +1248,9 @@ def _get_deepagents_version() -> str | None:
     """Resolve the installed Deep Agents SDK version for diagnostics.
 
     Editable installs can leave package metadata behind the source checkout, so
-    this uses the shared resolver that prefers the editable source marker. A
-    sibling monorepo workspace whose marker trails dcode's exact pin reports the
-    pinned release baseline with a `+editable` suffix.
+    this uses the shared resolver that prefers the editable source marker and
+    appends an `+editable` suffix. A sibling monorepo workspace whose marker
+    trails dcode's exact pin reports the pinned release baseline instead.
 
     Returns:
         The resolved Deep Agents SDK version, or `None` when unavailable.
@@ -1738,9 +1738,10 @@ def build_stream_config(
 
     Also records `dcode_client_deepagents_version` as a dcode-client diagnostic.
     This describes the Deep Agents package installed alongside the TUI, which
-    can differ from a remote graph's Deep Agents runtime version. For sibling
-    monorepo packages, a `+editable` suffix identifies workspace HEAD relative
-    to the pinned published SDK baseline.
+    can differ from a remote graph's Deep Agents runtime version. Editable
+    installs carry an `+editable` suffix, matching how the SDK stamps
+    `lc_versions["deepagents"]`; for sibling monorepo packages that suffix
+    identifies workspace HEAD relative to the pinned published SDK baseline.
 
     Also records `dcode_experimental=True` when `DEEPAGENTS_CODE_EXPERIMENTAL`
     is enabled, so experimental runs are filterable in trace metadata.

--- a/libs/code/deepagents_code/extras_info.py
+++ b/libs/code/deepagents_code/extras_info.py
@@ -798,6 +798,27 @@ def _display_sdk_version(
     return _with_editable_local_version(version)
 
 
+def _trace_sdk_version(
+    cli: DistributionVersion, sdk: DistributionVersion, requirement: Requirement | None
+) -> str | None:
+    """Return the SDK version string for LangSmith trace metadata.
+
+    Every editable SDK install gets the `editable` local segment, not just the
+    sibling workspace HEAD case that `_display_sdk_version` marks. A trace
+    carries the version string alone, with no room for the `(editable)`
+    annotation the human-facing surfaces render alongside it, and the SDK stamps
+    `lc_versions["deepagents"]` for any editable install — so suffixing only the
+    workspace HEAD case left the two entries in a single trace disagreeing.
+
+    Returns:
+        The version string, or `None` when it cannot be resolved.
+    """
+    version = _effective_sdk_version(cli, sdk, requirement)
+    if version is None or not sdk.editable:
+        return version
+    return _with_editable_local_version(version)
+
+
 def _sdk_requirement_comparison_version(
     cli: DistributionVersion, sdk: DistributionVersion, requirement: Requirement | None
 ) -> str | None:
@@ -951,9 +972,10 @@ def resolve_sdk_version() -> tuple[str | None, DistributionMetadataStatus]:
     """Resolve the diagnostic `deepagents` SDK version.
 
     Compatibility wrapper for callers that only need one SDK version string and
-    lookup status. For sibling monorepo packages whose stable source marker trails
-    dcode's exact SDK pin, the pin identifies the nearest published baseline and
-    an `+editable` local segment identifies the running workspace HEAD.
+    lookup status. Every editable install carries an `+editable` local segment,
+    matching how the SDK stamps `lc_versions["deepagents"]`. For sibling monorepo
+    packages whose stable source marker trails dcode's exact SDK pin, the pin
+    identifies the nearest published baseline the workspace HEAD represents.
 
     Returns:
         `(version, status)`. `version` is the resolved version string when
@@ -964,7 +986,7 @@ def resolve_sdk_version() -> tuple[str | None, DistributionMetadataStatus]:
     if sdk.status != "resolved":
         return None, sdk.status
     requirement = _sdk_requirement_for_cli(cli)
-    return _display_sdk_version(cli, sdk, requirement), "resolved"
+    return _trace_sdk_version(cli, sdk, requirement), "resolved"
 
 
 _EXTRA_MARKER_RE = re.compile(r"""extra\s*==\s*["']([^"']+)["']""")

--- a/libs/code/tests/unit_tests/test_extras_info.py
+++ b/libs/code/tests/unit_tests/test_extras_info.py
@@ -510,7 +510,7 @@ class TestResolveSdkVersion:
             patch("deepagents_code.extras_info.distributions", return_value=[editable]),
         ):
             version, status = resolve_sdk_version()
-        assert (version, status) == ("1.2.4", "resolved")
+        assert (version, status) == ("1.2.4+editable", "resolved")
 
     def test_resolved_uses_newer_exact_requirement_for_editable_install(
         self, sdk_root: Path
@@ -541,6 +541,43 @@ class TestResolveSdkVersion:
             version_value, status = resolve_sdk_version()
         assert (version_value, status) == ("0.7.0a8+editable", "resolved")
 
+    def test_resolved_marks_editable_sibling_matching_its_pin(
+        self, sdk_root: Path
+    ) -> None:
+        """A workspace SDK level with dcode's pin still reports `+editable`.
+
+        This is the everyday monorepo checkout: nothing about the pin is ahead
+        of the sibling SDK, so no workspace-HEAD inference applies, yet the SDK
+        stamps `lc_versions["deepagents"]` as `0.7.1+editable`. Reporting a bare
+        `0.7.1` here left the two version entries in one trace disagreeing.
+        """
+        cli_path = sdk_root.parent / "code"
+        version_file = sdk_root / "deepagents" / "_version.py"
+        _write_cli_pyproject(cli_path, "deepagents==0.7.1")
+        version_file.write_text('__version__ = "0.7.1"\n', encoding="utf-8")
+        sdk_dist = _sdk_dist(
+            raw=f'{{"url":"{sdk_root.as_uri()}","dir_info":{{"editable":true}}}}'
+        )
+
+        def version(name: str) -> str:
+            return {"deepagents": "0.7.1", "deepagents-code": "0.1.50"}[name]
+
+        with (
+            patch("deepagents_code.extras_info.pkg_version", side_effect=version),
+            patch("deepagents_code.extras_info.distributions", return_value=[sdk_dist]),
+            patch(
+                "deepagents_code.extras_info._cli_editable_info",
+                return_value=(True, str(cli_path)),
+            ),
+        ):
+            version_value, status = resolve_sdk_version()
+            report = collect_version_report()
+        assert (version_value, status) == ("0.7.1+editable", "resolved")
+        # The human-facing surfaces render `(editable)` beside the version, so
+        # they keep the unsuffixed string.
+        assert report.display_sdk_version == "0.7.1"
+        assert format_sdk_version_annotation(report) == " (editable)"
+
     def test_resolved_keeps_source_for_unrelated_editable_sdk(
         self, tmp_path: Path, sdk_root: Path
     ) -> None:
@@ -567,7 +604,7 @@ class TestResolveSdkVersion:
             ),
         ):
             version_value, status = resolve_sdk_version()
-        assert (version_value, status) == ("0.6.12", "resolved")
+        assert (version_value, status) == ("0.6.12+editable", "resolved")
 
     def test_resolve_source_path_returns_none_for_unusable_path(self) -> None:
         """Malformed editable paths should not crash version diagnostics."""
@@ -599,7 +636,7 @@ class TestResolveSdkVersion:
             patch("deepagents_code.extras_info.distributions", return_value=[editable]),
         ):
             version, status = resolve_sdk_version()
-        assert (version, status) == ("1.2.3", "resolved")
+        assert (version, status) == ("1.2.3+editable", "resolved")
 
     def test_resolved_ignores_egg_info_shadowing_editable_install(
         self, sdk_root: Path
@@ -625,7 +662,7 @@ class TestResolveSdkVersion:
             ),
         ):
             version, status = resolve_sdk_version()
-        assert (version, status) == ("1.2.4", "resolved")
+        assert (version, status) == ("1.2.4+editable", "resolved")
 
     def test_resolved_ignores_unrelated_editable_checkout(self, tmp_path: Path) -> None:
         """An editable record must not be credited when it does not supply the code.
@@ -751,7 +788,7 @@ class TestResolveSdkVersion:
             patch("deepagents_code.extras_info.distributions", return_value=[editable]),
         ):
             version, status = resolve_sdk_version()
-        assert (version, status) == ("1.2.3", "resolved")
+        assert (version, status) == ("1.2.3+editable", "resolved")
 
     @pytest.mark.parametrize("source_version", ["", None, 123])
     def test_resolved_falls_back_to_metadata_when_source_version_unusable(
@@ -768,7 +805,7 @@ class TestResolveSdkVersion:
             patch("deepagents_code.extras_info.distributions", return_value=[editable]),
         ):
             version, status = resolve_sdk_version()
-        assert (version, status) == ("1.2.3", "resolved")
+        assert (version, status) == ("1.2.3+editable", "resolved")
 
     def test_resolved_uses_metadata_for_editable_non_file_url(self) -> None:
         """An editable install with a non-`file` source URL prefers metadata."""
@@ -813,7 +850,7 @@ class TestResolveSdkVersion:
             patch("deepagents_code.extras_info.distributions", return_value=[editable]),
         ):
             version, status = resolve_sdk_version()
-        assert (version, status) == ("1.2.3", "resolved")
+        assert (version, status) == ("1.2.3+editable", "resolved")
 
     def test_resolved_falls_back_to_metadata_when_version_is_non_literal(
         self, sdk_root: Path
@@ -834,7 +871,7 @@ class TestResolveSdkVersion:
             patch("deepagents_code.extras_info.distributions", return_value=[editable]),
         ):
             version, status = resolve_sdk_version()
-        assert (version, status) == ("1.2.3", "resolved")
+        assert (version, status) == ("1.2.3+editable", "resolved")
 
     @pytest.mark.parametrize(
         ("url", "expected"),


### PR DESCRIPTION
Trace metadata now reports editable `deepagents` installs as `X.Y.Z+editable` under `dcode_client_deepagents_version`, matching the encoding the SDK already uses for `lc_versions.deepagents`.

---

Running `dcode` from a monorepo checkout produced a trace where `lc_versions` read `deepagents 0.7.1+editable` (stamped by the SDK) but `dcode_client_deepagents_version` read `0.7.1`. Same install, two encodings — which makes it look like the client and the graph are on different builds.

The client-side resolver was reusing `_display_sdk_version`, the string built for the human-facing `--version` / `/version` / `doctor` surfaces. That string only appends the `editable` PEP 440 local segment for the "workspace HEAD" case, where the pin `deepagents-code` declares is newer than the sibling SDK's own marker, because those surfaces render a separate `(editable)` annotation next to the version. Trace metadata has no such annotation, so the marker has to live in the version string itself.

Trace metadata now goes through its own resolver that appends the segment for any editable SDK install. The human surfaces are unchanged and keep their unsuffixed version plus `(editable)` annotation; the pin-ahead workspace HEAD case is also unchanged, since it already carried the segment.

Made by [Open SWE](https://openswe.vercel.app/agents/414781f9-ad36-05cc-386a-6cc13fc267d5)