### PR TITLE
fix(infra): tolerate unpublished tags in fan-out watch

### DIFF
--- a/.github/scripts/release/check_open_release_fanout.py
+++ b/.github/scripts/release/check_open_release_fanout.py
@@ -87,6 +87,16 @@ def _ref_exists(ref: str, *, repo_root: Path) -> bool:
     Uses `rev-parse --verify` so a missing release tag is distinguishable from
     a `git diff` that failed for some other reason (see the caller in
     `find_lockfile_only_components`).
+
+    Args:
+        ref: Git ref to resolve.
+        repo_root: Repository root used as the git cwd.
+
+    Returns:
+        `True` when the ref resolves and `False` when it is absent.
+
+    Raises:
+        RuntimeError: If git fails for a reason other than an absent ref.
     """
     completed = subprocess.run(  # fixed argv, no shell
         ["git", "rev-parse", "--verify", "--quiet", ref],
@@ -95,7 +105,16 @@ def _ref_exists(ref: str, *, repo_root: Path) -> bool:
         capture_output=True,
         text=True,
     )
-    return completed.returncode == 0
+    if completed.returncode == 0:
+        return True
+    if completed.returncode == 1:
+        return False
+    msg = (
+        f"git 'rev-parse --verify --quiet {ref}' failed "
+        f"(rc={completed.returncode}): "
+        f"{completed.stderr.strip() or completed.stdout.strip()}"
+    )
+    raise RuntimeError(msg)
 
 
 def package_unreleased_files(

--- a/.github/scripts/release/check_open_release_fanout.py
+++ b/.github/scripts/release/check_open_release_fanout.py
@@ -81,6 +81,23 @@ def release_tag(component: str, version: str, *, separator: str = DEFAULT_TAG_SE
     return f"{component}{separator}{version}"
 
 
+def _ref_exists(ref: str, *, repo_root: Path) -> bool:
+    """Return whether `ref` resolves to a git object.
+
+    Uses `rev-parse --verify` so a missing release tag is distinguishable from
+    a `git diff` that failed for some other reason (see the caller in
+    `find_lockfile_only_components`).
+    """
+    completed = subprocess.run(  # fixed argv, no shell
+        ["git", "rev-parse", "--verify", "--quiet", ref],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return completed.returncode == 0
+
+
 def package_unreleased_files(
     path: str,
     baseline_ref: str,
@@ -133,10 +150,12 @@ def find_lockfile_only_components(
 
     Returns:
         Sorted list of dicts with `component`, `path`, `version`, `baseline`
-        (resolved release tag), and `files`.
+        (resolved release tag), and `files`. Components whose manifest version
+        has no published release tag yet are skipped (with a stderr warning)
+        rather than treated as offenders.
 
     Raises:
-        RuntimeError: If a release tag cannot be resolved or git fails.
+        RuntimeError: If a git diff fails for an existing release tag.
     """
     packages = config.get("packages", {})
     sep = tag_separator(config)
@@ -151,8 +170,22 @@ def find_lockfile_only_components(
         if not isinstance(component, str) or not component:
             continue
         baseline = release_tag(component, version, separator=sep)
-        # Missing tags (never published, deleted, shallow-without-tags) raise so
-        # CI fails closed rather than silently skipping a package.
+        if not _ref_exists(baseline, repo_root=repo_root):
+            # The manifest was bumped (release PR merged) but the tag is not
+            # published yet — pre-release checks may still be running or have
+            # failed. There is no released baseline to diff against, so skip
+            # this component for this run instead of failing closed; the watch
+            # re-checks on the next release-please run / hourly cron, by which
+            # point the tag exists. A genuinely deleted tag still surfaces here
+            # on every run until restored.
+            print(
+                f"::warning::Skipping {component}: release tag '{baseline}' "
+                f"(manifest {version}) not found; release likely unpublished.",
+                file=sys.stderr,
+            )
+            continue
+        # A diff failure for an existing tag (shallow clone without history,
+        # corrupt ref) still raises so CI fails closed.
         files = package_unreleased_files(
             path, baseline, repo_root=repo_root, head=head
         )

--- a/.github/scripts/tests/release/test_check_open_release_fanout.py
+++ b/.github/scripts/tests/release/test_check_open_release_fanout.py
@@ -56,6 +56,9 @@ def test_find_lockfile_only_components_resolves_version_to_tag(
         return []
 
     monkeypatch.setattr(
+        "check_open_release_fanout._ref_exists", lambda *_a, **_k: True
+    )
+    monkeypatch.setattr(
         "check_open_release_fanout.package_unreleased_files", fake_diff
     )
     offenders = find_lockfile_only_components(config, manifest, repo_root=tmp_path)
@@ -93,6 +96,9 @@ def test_main_happy_path(capsys, tmp_path: Path, monkeypatch) -> None:
     )
     manifest_path.write_text(json.dumps({"libs/cli": "0.2.2"}), encoding="utf-8")
     monkeypatch.setattr(
+        "check_open_release_fanout._ref_exists", lambda *_a, **_k: True
+    )
+    monkeypatch.setattr(
         "check_open_release_fanout.package_unreleased_files",
         lambda *a, **k: ["libs/cli/uv.lock"],
     )
@@ -104,8 +110,43 @@ def test_main_happy_path(capsys, tmp_path: Path, monkeypatch) -> None:
     assert payload[0]["baseline"] == "deepagents-cli==0.2.2"
 
 
-def test_main_missing_tag_fails_closed(capsys, tmp_path: Path, monkeypatch) -> None:
-    """Unresolved release tags fail closed rather than skipping packages."""
+def test_main_unpublished_tag_is_skipped_not_fatal(
+    capsys, tmp_path: Path, monkeypatch
+) -> None:
+    """A manifest version with no published tag yet is skipped, not an error.
+
+    Covers the release-in-flight window: the release PR merged (manifest
+    bumped) but pre-release checks have not created the tag. The watch must
+    not hard-crash the whole job on this transient state.
+    """
+    config_path = tmp_path / "release-please-config.json"
+    manifest_path = tmp_path / ".release-please-manifest.json"
+    config_path.write_text(
+        json.dumps({"packages": {"libs/code": {"component": "deepagents-code"}}}),
+        encoding="utf-8",
+    )
+    manifest_path.write_text(json.dumps({"libs/code": "0.1.51"}), encoding="utf-8")
+    # Tag does not resolve -> component skipped before any diff is attempted.
+    monkeypatch.setattr(
+        "check_open_release_fanout._ref_exists", lambda *_a, **_k: False
+    )
+    monkeypatch.setattr(
+        "check_open_release_fanout.package_unreleased_files",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AssertionError("diff must not run for an unpublished tag")
+        ),
+    )
+    rc = main(config_path=config_path, manifest_path=manifest_path, repo_root=tmp_path)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert json.loads(captured.out) == []
+    assert "deepagents-code==0.1.51" in captured.err
+
+
+def test_main_diff_failure_for_existing_tag_fails_closed(
+    capsys, tmp_path: Path, monkeypatch
+) -> None:
+    """A git diff failure for an existing tag still fails closed (exit 2)."""
     config_path = tmp_path / "release-please-config.json"
     manifest_path = tmp_path / ".release-please-manifest.json"
     config_path.write_text(
@@ -113,14 +154,17 @@ def test_main_missing_tag_fails_closed(capsys, tmp_path: Path, monkeypatch) -> N
         encoding="utf-8",
     )
     manifest_path.write_text(json.dumps({"libs/cli": "0.2.2"}), encoding="utf-8")
+    monkeypatch.setattr(
+        "check_open_release_fanout._ref_exists", lambda *_a, **_k: True
+    )
 
     def boom(*_a, **_k):
         raise RuntimeError(
             "git 'diff --name-only deepagents-cli==0.2.2..HEAD -- libs/cli/' "
-            "failed (rc=128): fatal: bad revision"
+            "failed (rc=128): fatal: bad object"
         )
 
     monkeypatch.setattr("check_open_release_fanout.package_unreleased_files", boom)
     rc = main(config_path=config_path, manifest_path=manifest_path, repo_root=tmp_path)
     assert rc == 2
-    assert "bad revision" in capsys.readouterr().err
+    assert "bad object" in capsys.readouterr().err

--- a/.github/scripts/tests/release/test_check_open_release_fanout.py
+++ b/.github/scripts/tests/release/test_check_open_release_fanout.py
@@ -1,9 +1,12 @@
 """Tests for check_open_release_fanout (post-merge lockfile release safety net)."""
 
 import json
+import subprocess
 from pathlib import Path
 
+import pytest
 from check_open_release_fanout import (
+    _ref_exists,
     find_lockfile_only_components,
     is_lockfile_only,
     main,
@@ -27,6 +30,47 @@ def test_release_tag_matches_repo_convention() -> None:
     assert release_tag("deepagents", "0.6.12", separator="==") == "deepagents==0.6.12"
     assert tag_separator({"tag-separator": "=="}) == "=="
     assert tag_separator({}) == "=="
+
+
+def test_ref_exists_returns_false_for_missing_ref(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Git return code 1 means the requested ref does not exist."""
+    completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+    monkeypatch.setattr(
+        "check_open_release_fanout.subprocess.run", lambda *_args, **_kwargs: completed
+    )
+    assert not _ref_exists("deepagents-code==0.1.51", repo_root=tmp_path)
+
+
+def test_main_ref_lookup_failure_fails_closed(
+    capsys, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Operational git failures propagate through `main` as exit code 2."""
+    config_path = tmp_path / "release-please-config.json"
+    manifest_path = tmp_path / ".release-please-manifest.json"
+    config_path.write_text(
+        json.dumps({"packages": {"libs/code": {"component": "deepagents-code"}}}),
+        encoding="utf-8",
+    )
+    manifest_path.write_text(json.dumps({"libs/code": "0.1.51"}), encoding="utf-8")
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=128,
+        stdout="",
+        stderr="fatal: not a git repository",
+    )
+    monkeypatch.setattr(
+        "check_open_release_fanout.subprocess.run", lambda *_args, **_kwargs: completed
+    )
+
+    rc = main(config_path=config_path, manifest_path=manifest_path, repo_root=tmp_path)
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert captured.out == ""
+    assert "rc=128" in captured.err
+    assert "not a git repository" in captured.err
 
 
 def test_find_lockfile_only_components_resolves_version_to_tag(


### PR DESCRIPTION
The release-please fan-out watch no longer crashes while a merged release is waiting to publish its tag. It skips that component with a visible warning and continues checking the remaining packages.

---

Release-please updates the manifest when its release PR merges, but the package tag is created later, after pre-release checks pass. If those checks fail, as they did for `deepagents-code` 0.1.51, the manifest points to a tag that does not yet exist. The fan-out detector currently passes that tag directly to `git diff`, which exits with `fatal: bad revision` and prevents the watch from examining any other package.

The detector now verifies each baseline ref before diffing. `git rev-parse` return code 1 means the release tag is absent, so the component is skipped with a warning and checked again on the next release-please run or hourly backstop. Any other git failure raises and makes `main()` exit 2, preserving the advisory's fail-closed behavior. Diff failures for an existing tag also remain fatal.

<details>
<summary>Test plan</summary>

- `.github/scripts/tests/release/test_check_open_release_fanout.py` — 9 passed, covering ref found, ref absent, operational lookup failure, and existing-ref diff failure.
- Full workflow-helper suite — 891 passed.
- Ruff checks pass for the detector and its tests.

</details>
