### PR TITLE
hotfix(code): deflake toast anchoring test

### DIFF
--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -25962,17 +25962,27 @@ class TestToastAnchoring:
         app = DeepAgentsApp()
         async with app.run_test(notifications=True) as pilot:
             await pilot.pause()
+            expected_messages = {"first", "second"}
             app.notify("first", timeout=60)
             app.notify("second", timeout=60)
-            # Two pauses: the first lets both toasts mount, the second lets the
-            # rack re-anchor to the chrome before we assert exact layout. A
-            # single pause races toast mount against `_anchor_toast_rack` under
-            # xdist load (the CI release run failed this assertion 29 != 19).
-            await pilot.pause()
-            await pilot.pause()
+
+            async def wait_for_anchored_toasts() -> None:
+                while True:
+                    toasts = list(app.screen.query(_Toast))
+                    messages = {toast._notification.message for toast in toasts}
+                    chrome_top = self._chrome(app).region.y
+                    if (
+                        expected_messages <= messages
+                        and max(toast.region.bottom for toast in toasts) == chrome_top
+                    ):
+                        return
+                    await pilot.pause()
+
+            await asyncio.wait_for(wait_for_anchored_toasts(), timeout=5)
 
             toasts = list(app.screen.query(_Toast))
-            assert toasts
+            messages = {toast._notification.message for toast in toasts}
+            assert expected_messages <= messages
             chrome_top = self._chrome(app).region.y
             assert max(toast.region.bottom for toast in toasts) == chrome_top
 

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -25964,6 +25964,11 @@ class TestToastAnchoring:
             await pilot.pause()
             app.notify("first", timeout=60)
             app.notify("second", timeout=60)
+            # Two pauses: the first lets both toasts mount, the second lets the
+            # rack re-anchor to the chrome before we assert exact layout. A
+            # single pause races toast mount against `_anchor_toast_rack` under
+            # xdist load (the CI release run failed this assertion 29 != 19).
+            await pilot.pause()
             await pilot.pause()
 
             toasts = list(app.screen.query(_Toast))


### PR DESCRIPTION
A flaky unit test blocked the `deepagents-code` 0.1.51 release: pre-release checks failed `TestToastAnchoring::test_toasts_do_not_cover_the_chat_input` with `assert 29 == 19`, so publishing and GitHub release creation were skipped. This makes the test deterministic so the release can be dispatched again.

---

The test sends two notifications and immediately asserts exact toast layout after one `pilot.pause()`. Under pytest-xdist load, the assertion can run before those notifications are mounted and their rack layout is current.

The test now waits for observable rendered state: both named notifications must be mounted and the complete toast stack must end at the top of the bottom chrome. The wait is bounded to five seconds. Matching the named notifications avoids returning early when startup has already mounted an unrelated toast; checking the full stack still verifies that no displayed toast overlaps the chat input.

<details>
<summary>Test plan</summary>

- Python 3.11 (the release runner): exact formerly failing test passed 20/20.
- `uv run --python 3.11 --group test pytest tests/unit_tests/test_app.py::TestToastAnchoring -q` — 4 passed.
- Ruff lint and formatting checks pass.
- Confirmed the test fails when `_anchor_toast_rack` is temporarily disabled.

</details>
