### PR TITLE
fix(code): stop leaking turn coroutines and sqlite handles

### DIFF
--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -15254,15 +15254,29 @@ class DeepAgentsApp(App):
                 if self._chat_input:
                     self._chat_input.set_cursor_active(active=False)
 
+                from functools import partial
+
                 # Use run_worker to avoid blocking the main event loop
                 # This allows the UI to remain responsive during agent execution
-                self._agent_worker = self.run_worker(
-                    self._run_agent_task(
-                        message,
-                        message_kwargs=message_kwargs,
-                        goal_notice_current=resuming_blocked,
-                    ),
-                    exclusive=False,
+                #
+                # Passed as a callable rather than a coroutine: a worker
+                # cancelled before its first event-loop step never runs its
+                # work, and an already-built coroutine would then be finalized
+                # unawaited (`RuntimeWarning`, plus an unraisable exception when
+                # the interpreter is far enough into teardown). Building it
+                # inside the worker means nothing exists to strand.
+                turn: Callable[[], Coroutine[None, None, None]] = partial(
+                    self._run_agent_task,
+                    message,
+                    message_kwargs=message_kwargs,
+                    goal_notice_current=resuming_blocked,
+                )
+                # Cast because Textual's `WorkType` alias admits both a
+                # coroutine factory and a plain callable, so the result type
+                # infers as the union rather than the `None` the turn returns.
+                self._agent_worker = cast(
+                    "Worker[None]",
+                    self.run_worker(turn, name="_run_agent_task", exclusive=False),
                 )
                 worker_started = True
             finally:

--- a/libs/code/deepagents_code/sessions.py
+++ b/libs/code/deepagents_code/sessions.py
@@ -105,10 +105,10 @@ def _guard_sqlite_handle(conn: aiosqlite.Connection) -> None:
     window leaves the handle unreachable from the cleanup that follows:
 
     - Cancelled while the worker is still opening, the library has no handle
-      recorded yet, so the cleanup it queues closes nothing.
+        recorded yet, so the cleanup it queues closes nothing.
     - Cancelled after the handle is delivered but before the coroutine resumes,
-      the library clears its own record before that queued cleanup can run, so
-      again it closes nothing.
+        the library clears its own record before that queued cleanup can run, so
+        again it closes nothing.
 
     Either way the garbage collector is left to report `ResourceWarning:
     unclosed database`. Recording the handle from the worker thread covers the

--- a/libs/code/deepagents_code/sessions.py
+++ b/libs/code/deepagents_code/sessions.py
@@ -32,6 +32,8 @@ _initial_prompt_cache: dict[str, tuple[str | None, str | None]] = {}
 _MAX_INITIAL_PROMPT_CACHE = 4096
 _recent_threads_cache: dict[tuple[str | None, int], list[ThreadInfo]] = {}
 _MAX_RECENT_THREADS_CACHE_KEYS = 16
+_DEFAULT_SQLITE_TIMEOUT = 5.0
+"""Seconds to wait out a locked database; matches the `sqlite3` default."""
 
 
 def _patch_aiosqlite() -> None:
@@ -93,6 +95,59 @@ async def _drain_aiosqlite_worker(conn: aiosqlite.Connection) -> None:
         await asyncio.to_thread(worker.join, 5.0)
 
 
+def _record_handle_on_open(conn: aiosqlite.Connection) -> None:
+    """Record the sqlite handle on `conn` the moment its worker opens it.
+
+    `aiosqlite` opens the database on its worker thread and delivers the raw
+    `sqlite3.Connection` back through a future, so the handle only reaches the
+    `Connection` when the awaiting coroutine resumes. A task cancelled in that
+    window — background workers are routinely cancelled at app exit — leaves
+    the handle reachable from nothing but the worker thread: the library's own
+    cancellation cleanup finds no connection to close, and the garbage
+    collector reports `ResourceWarning: unclosed database` instead.
+
+    Storing the handle from the worker thread, ahead of the cleanup that
+    cancellation queues behind it, closes that window so an interrupted connect
+    is torn down like any other.
+
+    Args:
+        conn: A connection that has not been opened yet.
+    """
+    # No public hook for the connector, so tolerate it moving: the leak this
+    # avoids is a warning at teardown, not something worth failing a query for.
+    connector = getattr(conn, "_connector", None)
+    if connector is None:
+        logger.debug("aiosqlite connector is unavailable; cannot guard the handle")
+        return
+
+    def open_and_record() -> sqlite3.Connection:
+        handle = connector()
+        # The same assignment aiosqlite makes once the awaiting coroutine
+        # resumes, made early enough that a cancel cannot get in front of it.
+        conn._connection = handle
+        return handle
+
+    conn._connector = open_and_record
+
+
+def _new_connection(timeout: float = _DEFAULT_SQLITE_TIMEOUT) -> aiosqlite.Connection:
+    """Build an unopened connection to the sessions database.
+
+    Args:
+        timeout: Seconds to wait out a locked database before giving up.
+
+    Returns:
+        A connection that closes its sqlite handle even when interrupted.
+    """
+    import aiosqlite as _aiosqlite
+
+    _patch_aiosqlite()
+
+    conn = _aiosqlite.connect(str(get_db_path()), timeout=timeout)
+    _record_handle_on_open(conn)
+    return conn
+
+
 @asynccontextmanager
 async def _connect() -> AsyncIterator[aiosqlite.Connection]:
     """Import aiosqlite, apply the compatibility patch, and connect.
@@ -103,18 +158,12 @@ async def _connect() -> AsyncIterator[aiosqlite.Connection]:
     Yields:
         An open aiosqlite connection to the sessions database.
     """
-    import aiosqlite as _aiosqlite
-
-    _patch_aiosqlite()
-
-    conn: aiosqlite.Connection | None = None
+    conn = _new_connection(timeout=30.0)
     try:
-        async with _aiosqlite.connect(str(get_db_path()), timeout=30.0) as opened:
-            conn = opened
+        async with conn as opened:
             yield opened
     finally:
-        if conn is not None:
-            await _drain_aiosqlite_worker(conn)
+        await _drain_aiosqlite_worker(conn)
 
 
 class ThreadInfo(TypedDict):
@@ -1468,20 +1517,15 @@ async def get_checkpointer() -> AsyncIterator[AsyncSqliteSaver]:
     """
     from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
-    _patch_aiosqlite()
-
-    saver: AsyncSqliteSaver | None = None
+    # Built here rather than through `AsyncSqliteSaver.from_conn_string` so the
+    # connection is one this module owns and can clean up after an interrupted
+    # connect; see `_record_handle_on_open`.
+    conn = _new_connection()
     try:
-        async with AsyncSqliteSaver.from_conn_string(
-            str(get_db_path())
-        ) as checkpointer:
-            saver = checkpointer
-            yield checkpointer
+        async with conn as opened:
+            yield AsyncSqliteSaver(opened)
     finally:
-        if saver is not None:
-            conn = getattr(saver, "conn", None)
-            if conn is not None:
-                await _drain_aiosqlite_worker(conn)
+        await _drain_aiosqlite_worker(conn)
 
 
 _DEFAULT_THREAD_LIMIT = 20

--- a/libs/code/deepagents_code/sessions.py
+++ b/libs/code/deepagents_code/sessions.py
@@ -95,39 +95,60 @@ async def _drain_aiosqlite_worker(conn: aiosqlite.Connection) -> None:
         await asyncio.to_thread(worker.join, 5.0)
 
 
-def _record_handle_on_open(conn: aiosqlite.Connection) -> None:
-    """Record the sqlite handle on `conn` the moment its worker opens it.
+def _guard_sqlite_handle(conn: aiosqlite.Connection) -> None:
+    """Keep the sqlite handle closable when the opening task is cancelled.
 
     `aiosqlite` opens the database on its worker thread and delivers the raw
-    `sqlite3.Connection` back through a future, so the handle only reaches the
-    `Connection` when the awaiting coroutine resumes. A task cancelled in that
-    window — background workers are routinely cancelled at app exit — leaves
-    the handle reachable from nothing but the worker thread: the library's own
-    cancellation cleanup finds no connection to close, and the garbage
-    collector reports `ResourceWarning: unclosed database` instead.
+    `sqlite3.Connection` back through a future, recording it on the
+    `Connection` only once the awaiting coroutine resumes. Background workers
+    are routinely cancelled at app exit, and a cancel landing anywhere in that
+    window leaves the handle unreachable from the cleanup that follows:
 
-    Storing the handle from the worker thread, ahead of the cleanup that
-    cancellation queues behind it, closes that window so an interrupted connect
-    is torn down like any other.
+    - Cancelled while the worker is still opening, the library has no handle
+      recorded yet, so the cleanup it queues closes nothing.
+    - Cancelled after the handle is delivered but before the coroutine resumes,
+      the library clears its own record before that queued cleanup can run, so
+      again it closes nothing.
+
+    Either way the garbage collector is left to report `ResourceWarning:
+    unclosed database`. Recording the handle from the worker thread covers the
+    first case; queueing an explicit close ahead of the library's own cleanup
+    covers the second. Both run on the thread that opened the handle, and
+    closing twice is a no-op, so neither disturbs a normal shutdown.
 
     Args:
         conn: A connection that has not been opened yet.
     """
-    # No public hook for the connector, so tolerate it moving: the leak this
-    # avoids is a warning at teardown, not something worth failing a query for.
+    # No public hooks for any of this, so tolerate it moving: the leak avoided
+    # here is a warning at teardown, not something worth failing a query for.
     connector = getattr(conn, "_connector", None)
-    if connector is None:
-        logger.debug("aiosqlite connector is unavailable; cannot guard the handle")
+    queue = getattr(conn, "_tx", None)
+    stop = getattr(conn, "stop", None)
+    if connector is None or queue is None or stop is None:
+        logger.debug("aiosqlite internals moved; cannot guard the sqlite handle")
         return
 
     def open_and_record() -> sqlite3.Connection:
         handle = connector()
-        # The same assignment aiosqlite makes once the awaiting coroutine
-        # resumes, made early enough that a cancel cannot get in front of it.
+        # The assignment aiosqlite makes once the awaiting coroutine resumes,
+        # made early enough that a cancel cannot get in front of it.
         conn._connection = handle
         return handle
 
+    def stop_and_close() -> asyncio.Future[Any] | None:
+        # Runs before aiosqlite drops its own reference, so the handle is still
+        # here to queue a close for -- ahead of the stop sentinel, which ends
+        # the worker loop. A `None` future keeps the worker from reaching for an
+        # event loop that may already be gone.
+        handle = conn._connection
+        if handle is not None:
+            queue.put_nowait((None, handle.close))
+        return stop()
+
     conn._connector = open_and_record
+    # Shadows the bound method on this one instance; the declared type is the
+    # unbound `stop(self)`, which a zero-argument replacement cannot match.
+    conn.stop = stop_and_close  # ty: ignore[invalid-assignment]
 
 
 def _new_connection(timeout: float = _DEFAULT_SQLITE_TIMEOUT) -> aiosqlite.Connection:
@@ -144,7 +165,7 @@ def _new_connection(timeout: float = _DEFAULT_SQLITE_TIMEOUT) -> aiosqlite.Conne
     _patch_aiosqlite()
 
     conn = _aiosqlite.connect(str(get_db_path()), timeout=timeout)
-    _record_handle_on_open(conn)
+    _guard_sqlite_handle(conn)
     return conn
 
 
@@ -1519,7 +1540,7 @@ async def get_checkpointer() -> AsyncIterator[AsyncSqliteSaver]:
 
     # Built here rather than through `AsyncSqliteSaver.from_conn_string` so the
     # connection is one this module owns and can clean up after an interrupted
-    # connect; see `_record_handle_on_open`.
+    # connect; see `_guard_sqlite_handle`.
     conn = _new_connection()
     try:
         async with conn as opened:

--- a/libs/code/pyproject.toml
+++ b/libs/code/pyproject.toml
@@ -341,6 +341,10 @@ filterwarnings = [
     # uses `stacklevel=2`, so it is attributed to this package, not to the
     # module that raised it.
     "error:Unsupported usage key for standard pricing:UserWarning",
+    # `google.genai.types` builds a union alias out of `typing._UnionGenericAlias`
+    # at import time, which Python 3.14 deprecates. Nothing here can act on it --
+    # it fires before any of our code runs and is fixed by upgrading the SDK.
+    "ignore:'_UnionGenericAlias' is deprecated:DeprecationWarning:google\\.genai\\.types",
 ]
 
 addopts = "--strict-markers --strict-config --durations=5"

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -5290,8 +5290,8 @@ class TestMessageQueue:
 
         Without this reset the gate would be sticky: once any turn produced
         output, every later turn's Esc-interrupt would stop restoring the
-        prompt. Closing the worker coroutine leaves the flag as `_send_to_agent`
-        set it, without running the turn.
+        prompt. Stubbing the worker leaves the flag as `_send_to_agent` set it,
+        without running the turn.
         """
         app = DeepAgentsApp()
         app._agent = MagicMock()
@@ -5308,8 +5308,6 @@ class TestMessageQueue:
             with patch.object(app, "run_worker") as mock_rw:
                 mock_rw.return_value = MagicMock()
                 await app._send_to_agent("next question")
-                coro = mock_rw.call_args[0][0]
-                coro.close()
 
             assert app._active_turn_visible_output_started is False
 
@@ -5552,6 +5550,27 @@ class TestTurnStateRelease:
             app.post_message(ChatInput.Submitted("next message", "normal"))
             await pilot.pause()
             assert not app._pending_messages
+
+    async def test_turn_is_spawned_as_a_callable(self) -> None:
+        """The worker is handed a callable, not an already-built coroutine.
+
+        Textual never runs the work of a worker cancelled before its first
+        event-loop step, so a pre-built coroutine would be left to be finalized
+        unawaited — a `RuntimeWarning`, and an unraisable exception once
+        interpreter teardown has gone far enough to break the import machinery
+        the coroutine's cleanup relies on.
+        """
+        app = self._configured_app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            with patch.object(app, "run_worker") as mock_run_worker:
+                mock_run_worker.return_value = MagicMock()
+                await app._send_to_agent("hello")
+
+            work = mock_run_worker.call_args[0][0]
+            assert not inspect.iscoroutine(work)
+            assert callable(work)
 
     async def test_later_turns_can_still_recover(self) -> None:
         """The started-marker resets at turn end, so turn 2 recovers as well.
@@ -15604,8 +15623,6 @@ class TestShellCommandInterrupt:
             with patch.object(app, "run_worker") as mock_rw:
                 mock_rw.return_value = MagicMock()
                 await app._send_to_agent("what did that print?")
-                coro = mock_rw.call_args[0][0]
-                coro.close()
 
         app._agent.aupdate_state.assert_awaited_once()
         call = app._agent.aupdate_state.await_args
@@ -15635,8 +15652,6 @@ class TestShellCommandInterrupt:
             with patch.object(app, "run_worker") as mock_rw:
                 mock_rw.return_value = MagicMock()
                 await app._send_to_agent("what did that print?")
-                coro = mock_rw.call_args[0][0]
-                coro.close()
 
         app._agent.aupdate_state.assert_awaited_once()
         call = app._agent.aupdate_state.await_args
@@ -15853,8 +15868,6 @@ class TestShellCommandInterrupt:
                 manager.attach_mock(app._agent.aupdate_state, "flush")
                 manager.attach_mock(mock_rw, "spawn")
                 await app._send_to_agent("what did that print?")
-                coro = mock_rw.call_args[0][0]
-                coro.close()
 
         # Flush the `!` pair into state before spawning the turn, so the model
         # sees the shell output ahead of this turn's user message.

--- a/libs/code/tests/unit_tests/test_sessions.py
+++ b/libs/code/tests/unit_tests/test_sessions.py
@@ -1,12 +1,15 @@
 """Tests for session/thread management."""
 
 import asyncio
+import gc
 import json
 import sqlite3
+import threading
 import uuid
+import warnings
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -471,6 +474,60 @@ class TestConnectHelper:
         assert not worker.is_alive(), (
             "aiosqlite worker thread should be joined after _connect exit"
         )
+
+    def test_cancelled_open_closes_the_sqlite_handle(self, tmp_path, monkeypatch):
+        """A connect cancelled mid-open still closes the sqlite handle.
+
+        Background workers are routinely cancelled at app exit, and aiosqlite
+        opens the database on a worker thread. Without the handle being
+        recorded as soon as it exists, a cancel landing in that window strands
+        it for the garbage collector to report as an unclosed database.
+        """
+        db_path = tmp_path / "cancelled.db"
+        opening = threading.Event()
+        finish_open = threading.Event()
+        handles: list[sqlite3.Connection] = []
+        connections: list[aiosqlite.Connection] = []
+        real_sqlite_connect = sqlite3.connect
+        real_new_connection = sessions._new_connection
+
+        def blocking_connect(database: str, **kwargs: Any) -> sqlite3.Connection:
+            opening.set()
+            finish_open.wait(10)
+            handle = real_sqlite_connect(database, **kwargs)
+            handles.append(handle)
+            return handle
+
+        def capturing_new_connection(timeout: float) -> "aiosqlite.Connection":
+            conn = real_new_connection(timeout)
+            connections.append(conn)
+            return conn
+
+        async def _test() -> None:
+            async def use_connection() -> None:
+                async with sessions._connect():
+                    pass
+
+            task = asyncio.create_task(use_connection())
+            await asyncio.to_thread(opening.wait, 10)
+            task.cancel()
+            finish_open.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        monkeypatch.setattr(sessions, "get_db_path", lambda: db_path)
+        monkeypatch.setattr(sessions, "_new_connection", capturing_new_connection)
+        monkeypatch.setattr(sqlite3, "connect", blocking_connect)
+        asyncio.run(_test())
+
+        assert handles, "the worker thread should have opened a handle"
+        assert not connections[0]._thread.is_alive()
+        handles.clear()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            gc.collect()
+        unclosed = [w for w in caught if "unclosed database" in str(w.message)]
+        assert not unclosed, [str(w.message) for w in unclosed]
 
 
 class TestFormatTimestamp:

--- a/libs/code/tests/unit_tests/test_sessions.py
+++ b/libs/code/tests/unit_tests/test_sessions.py
@@ -529,6 +529,59 @@ class TestConnectHelper:
         unclosed = [w for w in caught if "unclosed database" in str(w.message)]
         assert not unclosed, [str(w.message) for w in unclosed]
 
+    def test_cancel_after_open_closes_the_sqlite_handle(self, tmp_path, monkeypatch):
+        """A cancel landing after the open, before the resume, also closes it.
+
+        The other half of the same window: aiosqlite has the handle by now, but
+        its cancellation path drops that reference before the cleanup it queued
+        gets a chance to run, so the handle would again be left to the garbage
+        collector.
+        """
+        db_path = tmp_path / "raced.db"
+        handles: list[sqlite3.Connection] = []
+        connections: list[aiosqlite.Connection] = []
+        pending: dict[str, Any] = {}
+        real_sqlite_connect = sqlite3.connect
+        real_new_connection = sessions._new_connection
+
+        def cancelling_connect(database: str, **kwargs: Any) -> sqlite3.Connection:
+            handle = real_sqlite_connect(database, **kwargs)
+            handles.append(handle)
+            # Queued from the worker thread before aiosqlite delivers the
+            # handle to the awaiting coroutine, so the cancel deterministically
+            # lands in the gap between the open and the resume.
+            pending["loop"].call_soon_threadsafe(pending["task"].cancel)
+            return handle
+
+        def capturing_new_connection(timeout: float) -> "aiosqlite.Connection":
+            conn = real_new_connection(timeout)
+            connections.append(conn)
+            return conn
+
+        async def _test() -> None:
+            async def use_connection() -> None:
+                async with sessions._connect():
+                    pass
+
+            pending["loop"] = asyncio.get_running_loop()
+            pending["task"] = asyncio.create_task(use_connection())
+            with pytest.raises(asyncio.CancelledError):
+                await pending["task"]
+
+        monkeypatch.setattr(sessions, "get_db_path", lambda: db_path)
+        monkeypatch.setattr(sessions, "_new_connection", capturing_new_connection)
+        monkeypatch.setattr(sqlite3, "connect", cancelling_connect)
+        asyncio.run(_test())
+
+        assert handles, "the worker thread should have opened a handle"
+        assert not connections[0]._thread.is_alive()
+        handles.clear()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            gc.collect()
+        unclosed = [w for w in caught if "unclosed database" in str(w.message)]
+        assert not unclosed, [str(w.message) for w in unclosed]
+
 
 class TestFormatTimestamp:
     """Tests for format_timestamp helper."""


### PR DESCRIPTION
Interrupting a turn, or exiting while a background thread-cache refresh is in flight, no longer strands an unawaited coroutine or an open SQLite handle.

---

The unit suite emitted three families of warnings, all at teardown. Two are ours and are fixed here; the third is upstream and is filtered.

### An unawaited turn coroutine

`_send_to_agent` handed `run_worker` an already-built `_run_agent_task` coroutine. Textual never runs the work of a worker cancelled before its first event-loop step, so that coroutine was finalized unawaited — a `RuntimeWarning`, and (once interpreter teardown had gone far enough to break the import machinery its cleanup relies on) an unraisable `KeyError: '__import__'`. Passing a callable means the coroutine only exists if the worker actually runs, so there is nothing to strand. Several tests were closing that coroutine by hand purely to silence the warning; those workarounds are gone, and a new test pins the callable contract.

**Where it started:** #5196. Handing `run_worker` a coroutine dates all the way back to the original Textual REPL (#686), but it was harmless until something cancelled a worker before its first step. #5196 added the recovery path for exactly that situation along with the tests that exercise it. Its parent commit runs the app test module with zero `never awaited` warnings; #5196 itself produces three.

### An unclosed SQLite handle

`aiosqlite` opens the database on its worker thread and hands the raw `sqlite3.Connection` back through a future, recording it on the connection only when the awaiting coroutine resumes. A cancel landing anywhere in that window left the handle unreachable from the cleanup that follows, so the garbage collector reported `ResourceWarning: unclosed database`. There are two halves to the window, and both are now covered:

- Cancelled while the worker is still opening, the library has no handle recorded yet, so the cleanup it queues closes nothing. The session module now records the handle from the worker thread the moment the connector returns.
- Cancelled after the handle is delivered but before the coroutine resumes, the library clears its own reference before that queued cleanup can run — so it again closes nothing. The guard now also queues an explicit close ahead of the library's cleanup, while the handle is still reachable.

Both closes run on the thread that opened the handle, and closing twice is a no-op, so neither disturbs a normal shutdown. `get_checkpointer` builds its connection through the same helper rather than `AsyncSqliteSaver.from_conn_string`, so it gets the same guard.

**Where it started:** #5174. The prewarm that reads the session database has existed since #1481, but it ran once at startup, so it had normally finished before anything cancelled it. #5174 re-fires it after every turn, which reliably leaves a session-DB read in flight when a test app exits. Counting handles that `aiosqlite` opened and never closed across the goal-command tests: zero on the parent commit, fourteen on #5174.

### A `typing` deprecation from `google-genai`

`google.genai.types` builds a union alias out of `typing._UnionGenericAlias`, which CPython 3.14 deprecates, and it fires at import before any of this package's code runs. This one is not a regression from any change here — `deepagents-code` has been tested on the 3.14 leg since the package was created in #3027, and the warning appears wherever a test imports the Google integration. It is tracked upstream as [googleapis/python-genai#1640](https://github.com/googleapis/python-genai/issues/1640) and still unfixed as of `google-genai` 2.13.0, so it is filtered narrowly (message, category, and module) rather than worked around.

Made by [Open SWE](https://openswe.vercel.app/agents/f42590ef-0fe4-0b9f-6880-1c48b28446d5)
