### PR TITLE
fix(code): surface `cursor_blink` and `terminal_progress` in `dcode config`

### DIFF
--- a/libs/code/deepagents_code/_env_vars.py
+++ b/libs/code/deepagents_code/_env_vars.py
@@ -44,6 +44,15 @@ rather than forcing the default). Also settable via `[ui].collapse_pastes` in
 config.toml.
 """
 
+CURSOR_BLINK = "DEEPAGENTS_CODE_CURSOR_BLINK"
+"""Blink the chat input cursor.
+
+Enabled by default; set to a falsy value (`0`, `false`, `no`, `off`, or empty)
+for a steady cursor. Parsed by `classify_env_bool` (an unrecognized value falls
+through to the config value rather than forcing the default). Also settable via
+`[ui].cursor_blink` in config.toml.
+"""
+
 CURSOR_STYLE = "DEEPAGENTS_CODE_CURSOR_STYLE"
 """Chat input cursor style (`block` or `underline`).
 
@@ -404,6 +413,16 @@ only reads canonical names, picks it up). The value you exported in your own
 shell is unaffected, since a process cannot change its parent's environment.
 Off by default; set to a truthy value (`1`, `true`, `yes`, `on`) to suppress
 the warning when this coexistence is expected. Parsed by `is_env_truthy`.
+"""
+
+TERMINAL_PROGRESS = "DEEPAGENTS_CODE_TERMINAL_PROGRESS"
+"""Report agent activity as `OSC 9;4` taskbar/dock/tab progress.
+
+Enabled by default; set to a falsy value (`0`, `false`, `no`, `off`, or empty)
+to stop emitting the sequence on terminals that render it poorly. Parsed by
+`classify_env_bool` (an unrecognized value falls through to the config value
+rather than forcing the default). Also settable via `[ui].terminal_progress` in
+config.toml. `NO_TERMINAL_ESCAPE` suppresses the sequence regardless.
 """
 
 THEME = "DEEPAGENTS_CODE_THEME"

--- a/libs/code/deepagents_code/app.py
+++ b/libs/code/deepagents_code/app.py
@@ -1239,68 +1239,46 @@ def save_theme_preference(name: str) -> bool:
     return _save_theme_preference_result(name).ok
 
 
-def _load_bool_ui_preference(key: str, *, log_label: str) -> bool:
-    """Load a boolean `[ui]` preference from `~/.deepagents/config.toml`.
+def _load_bool_display_preference(key: str) -> bool:
+    """Resolve a boolean `Display` option that defaults to on.
 
-    These preferences have no in-app command; the file is edited manually. The
-    loader is intentionally forgiving: any problem reading or parsing the config
-    falls back to `True` (the feature stays on) after logging a warning, so a
-    typo in a cosmetic setting never breaks startup.
+    Precedence follows `resolve_scalar`: the option's `DEEPAGENTS_CODE_*` env
+    var wins, then its `[ui]` key in `~/.deepagents/config.toml`. Resolution is
+    intentionally forgiving — an unreadable config, a non-table `[ui]`, or a
+    wrong-typed value is logged by the resolver and falls back to `True` (the
+    feature stays on), so a typo in a cosmetic setting never breaks startup.
 
     Args:
-        key: The key to read from the `[ui]` table.
-        log_label: Human-readable name of the preference, used in warning logs.
+        key: Manifest key of the option, e.g. `"display.cursor_blink"`.
 
     Returns:
-        The saved `[ui].<key>` value, or `True` when unset, unreadable,
-            or malformed.
+        The resolved value, or `True` when unset, unreadable, or malformed.
     """
-    import tomllib
+    from deepagents_code.config_manifest import (
+        get_option,
+        load_config_toml,
+        resolve_scalar,
+    )
 
-    from deepagents_code.model_config import DEFAULT_CONFIG_PATH
-
-    if not DEFAULT_CONFIG_PATH.exists():
+    option = get_option(key)
+    if option is None:
+        logger.warning("Unknown config option %r; leaving it enabled", key)
         return True
-    try:
-        with DEFAULT_CONFIG_PATH.open("rb") as f:
-            data = tomllib.load(f)
-    except (tomllib.TOMLDecodeError, PermissionError, OSError) as exc:
-        logger.warning("Could not read config for %s preference: %s", log_label, exc)
-        return True
-
-    ui = data.get("ui", {})
-    if not isinstance(ui, dict):
-        logger.warning(
-            "[ui] should be a table; got %s while loading %s preference",
-            type(ui).__name__,
-            log_label,
-        )
-        return True
-
-    value = ui.get(key)
-    if isinstance(value, bool):
-        return value
-    if value is not None:
-        logger.warning(
-            "[ui].%s should be a boolean; got %s",
-            key,
-            type(value).__name__,
-        )
-    return True
+    value, _ = resolve_scalar(option, toml_data=load_config_toml())
+    return bool(value)
 
 
 def _load_cursor_blink_preference() -> bool:
-    """Load the saved cursor-blink preference from `~/.deepagents/config.toml`.
+    """Resolve whether the chat input cursor should blink.
 
-    The chat input cursor blink can be turned off by setting
-    `[ui].cursor_blink = false` in the config file. There is no in-app command
-    for this; the file is edited manually.
+    The blink can be turned off with `DEEPAGENTS_CODE_CURSOR_BLINK=0` or
+    `[ui].cursor_blink = false`. There is no in-app command for this.
 
     Returns:
-        The saved `[ui].cursor_blink` value, or `True` (blink on) when unset,
+        The resolved cursor-blink preference, or `True` (blink on) when unset,
         unreadable, or malformed.
     """
-    return _load_bool_ui_preference("cursor_blink", log_label="cursor blink")
+    return _load_bool_display_preference("display.cursor_blink")
 
 
 def _load_cursor_style_preference() -> CursorStyle:
@@ -1331,19 +1309,19 @@ def _load_cursor_style_preference() -> CursorStyle:
 
 
 def _load_terminal_progress_preference() -> bool:
-    """Load the `OSC 9;4` progress preference from `~/.deepagents/config.toml`.
+    """Resolve whether to emit `OSC 9;4` terminal progress.
 
-    The terminal taskbar/dock/tab progress indicator (where supported) can be
-    turned off by setting `[ui].terminal_progress = false` in the config file.
-    There is no in-app command for this; the file is edited manually. The
+    The taskbar/dock/tab progress indicator (where supported) can be turned off
+    with `DEEPAGENTS_CODE_TERMINAL_PROGRESS=0` or
+    `[ui].terminal_progress = false`. There is no in-app command for this. The
     `DEEPAGENTS_CODE_NO_TERMINAL_ESCAPE` environment variable still disables all
     terminal escapes regardless of this value.
 
     Returns:
-        The saved `[ui].terminal_progress` value, or `True` (progress on) when
+        The resolved terminal-progress preference, or `True` (progress on) when
         unset, unreadable, or malformed.
     """
-    return _load_bool_ui_preference("terminal_progress", log_label="terminal progress")
+    return _load_bool_display_preference("display.terminal_progress")
 
 
 def _save_terminal_theme_mapping_result(
@@ -19235,9 +19213,16 @@ class DeepAgentsApp(App):
     def on_app_blur(self) -> None:
         """Pause the chat input cursor blink when the terminal loses OS focus.
 
-        `TextArea` pauses its own blink when its `has_focus` flips, but
-        `AppBlur` does not change widget focus, so we toggle `cursor_blink`
-        manually.
+        Textual's own `AppBlur` handling already drops screen focus, which stops
+        the blink via `has_focus`; pausing `cursor_blink` here keeps the cursor
+        hidden even in the paths that restore widget focus while the app itself
+        stays blurred.
+
+        Either way this only runs when the terminal reports focus changes. tmux
+        withholds them from its panes unless `focus-events` is on, so an
+        unfocused pane keeps showing a blinking cursor until the user sets
+        `set -g focus-events on`; `[ui].cursor_blink = false` is the in-app
+        workaround.
         """
         if self._chat_input is None:
             return

--- a/libs/code/deepagents_code/config_manifest.py
+++ b/libs/code/deepagents_code/config_manifest.py
@@ -969,6 +969,27 @@ _STATIC_OPTIONS: tuple[ConfigOption, ...] = (
         toml_keys=("ui", "cursor_style"),
     ),
     ConfigOption(
+        key="display.cursor_blink",
+        group="Display",
+        summary=(
+            "Blink the chat input cursor (tmux needs 'focus-events on' to hide "
+            "it in unfocused panes)."
+        ),
+        kind=OptionKind.BOOL,
+        default=True,
+        env_var=_env_vars.CURSOR_BLINK,
+        toml_keys=("ui", "cursor_blink"),
+    ),
+    ConfigOption(
+        key="display.terminal_progress",
+        group="Display",
+        summary="Report agent activity as terminal taskbar/dock/tab progress.",
+        kind=OptionKind.BOOL,
+        default=True,
+        env_var=_env_vars.TERMINAL_PROGRESS,
+        toml_keys=("ui", "terminal_progress"),
+    ),
+    ConfigOption(
         key="display.show_header",
         group="Display",
         summary="Show Textual's native header bar at the top of the TUI.",

--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -14783,7 +14783,7 @@ class TestDebugConsoleClickToCopyPreference:
 
 
 class TestAppBlurPausesCursorBlink:
-    """Test `on_app_blur` pauses cursor blink without changing widget focus."""
+    """Test the chat input cursor stops drawing when the terminal is blurred."""
 
     async def test_app_blur_pauses_blink(self) -> None:
         """Losing terminal focus should pause the chat input cursor blink."""
@@ -14799,8 +14799,8 @@ class TestAppBlurPausesCursorBlink:
 
             assert app._chat_input._text_area.cursor_blink is False
 
-    async def test_app_blur_preserves_widget_focus(self) -> None:
-        """Pausing blink must not blur the chat input widget."""
+    async def test_handler_alone_preserves_widget_focus(self) -> None:
+        """Pausing blink must not itself blur the chat input widget."""
         app = DeepAgentsApp()
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -14813,6 +14813,36 @@ class TestAppBlurPausesCursorBlink:
             await pilot.pause()
 
             assert app._chat_input._text_area.has_focus is True
+
+    async def test_blur_event_hides_cursor_and_focus_restores_it(self) -> None:
+        """A real `AppBlur` must stop drawing the cursor; `AppFocus` restores it.
+
+        This is the symptom users see in an unfocused tmux pane, so drive the
+        real events rather than calling the handlers: Textual's own `AppBlur`
+        handling drops screen focus, and only the combination of that and our
+        handler decides whether a cursor is painted.
+        """
+        app = DeepAgentsApp()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._chat_input is not None
+            text_area = app._chat_input._text_area
+            assert text_area is not None
+            text_area.focus()
+            await pilot.pause()
+            assert text_area._draw_cursor is True
+
+            app.post_message(events.AppBlur())
+            await pilot.pause()
+            await pilot.pause()
+
+            assert text_area._draw_cursor is False
+
+            app.post_message(events.AppFocus())
+            await pilot.pause()
+            await pilot.pause()
+
+            assert text_area._draw_cursor is True
 
     async def test_app_blur_noop_before_mount(self) -> None:
         """`on_app_blur` should silently ignore blur events before mount."""
@@ -28305,18 +28335,20 @@ class TestSetSpinnerTerminalProgress:
 
     @pytest.fixture(autouse=True)
     def _isolate_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Point the config path at an empty temp dir.
+        """Point the config path at an empty temp dir and clear the env override.
 
         Without this, `_load_terminal_progress_preference` reads the developer's
         real `~/.deepagents/config.toml` during `DeepAgentsApp.__init__`, so a
-        local `[ui].terminal_progress = false` would silently flip the
-        positive-path tests below to failing. Tests that need a specific config
-        write to and re-point at this same path.
+        local `[ui].terminal_progress = false` — or an exported
+        `DEEPAGENTS_CODE_TERMINAL_PROGRESS`, which outranks it — would silently
+        flip the positive-path tests below to failing. Tests that need a
+        specific config write to and re-point at this same path.
         """
         monkeypatch.setattr(
             "deepagents_code.model_config.DEFAULT_CONFIG_PATH",
             tmp_path / "config.toml",
         )
+        monkeypatch.delenv("DEEPAGENTS_CODE_TERMINAL_PROGRESS", raising=False)
 
     async def test_status_triggers_indeterminate_progress(
         self, monkeypatch: pytest.MonkeyPatch

--- a/libs/code/tests/unit_tests/test_cursor_blink.py
+++ b/libs/code/tests/unit_tests/test_cursor_blink.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
+from deepagents_code._env_vars import CURSOR_BLINK
 from deepagents_code.app import (
     _load_cursor_blink_preference,
 )
@@ -11,11 +14,14 @@ from deepagents_code.app import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
-
 
 class TestLoadCursorBlinkPreference:
-    """_load_cursor_blink_preference reads config.toml correctly."""
+    """_load_cursor_blink_preference resolves env then config.toml."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Drop a developer's exported override so config tests stay honest."""
+        monkeypatch.delenv(CURSOR_BLINK, raising=False)
 
     def test_default_true_when_no_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -57,3 +63,23 @@ class TestLoadCursorBlinkPreference:
         config.write_text('ui = "not a table"\n', encoding="utf-8")
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
         assert _load_cursor_blink_preference() is True
+
+    def test_env_var_wins_over_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The env var overrides an enabling `config.toml` value."""
+        config = tmp_path / "config.toml"
+        config.write_text("[ui]\ncursor_blink = true\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(CURSOR_BLINK, "0")
+        assert _load_cursor_blink_preference() is False
+
+    def test_unrecognized_env_falls_through_to_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-boolean env token is ignored in favor of `config.toml`."""
+        config = tmp_path / "config.toml"
+        config.write_text("[ui]\ncursor_blink = false\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(CURSOR_BLINK, "maybe")
+        assert _load_cursor_blink_preference() is False

--- a/libs/code/tests/unit_tests/test_terminal_progress_preference.py
+++ b/libs/code/tests/unit_tests/test_terminal_progress_preference.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
+from deepagents_code._env_vars import TERMINAL_PROGRESS
 from deepagents_code.app import (
     _load_terminal_progress_preference,
 )
@@ -11,11 +14,14 @@ from deepagents_code.app import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
-
 
 class TestLoadTerminalProgressPreference:
-    """_load_terminal_progress_preference reads config.toml correctly."""
+    """_load_terminal_progress_preference resolves env then config.toml."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Drop a developer's exported override so config tests stay honest."""
+        monkeypatch.delenv(TERMINAL_PROGRESS, raising=False)
 
     def test_default_true_when_no_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -66,3 +72,23 @@ class TestLoadTerminalProgressPreference:
         config.write_text('ui = "not a table"\n', encoding="utf-8")
         monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
         assert _load_terminal_progress_preference() is True
+
+    def test_env_var_wins_over_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The env var overrides an enabling `config.toml` value."""
+        config = tmp_path / "config.toml"
+        config.write_text("[ui]\nterminal_progress = true\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(TERMINAL_PROGRESS, "0")
+        assert _load_terminal_progress_preference() is False
+
+    def test_unrecognized_env_falls_through_to_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-boolean env token is ignored in favor of `config.toml`."""
+        config = tmp_path / "config.toml"
+        config.write_text("[ui]\nterminal_progress = false\n", encoding="utf-8")
+        monkeypatch.setattr("deepagents_code.model_config.DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setenv(TERMINAL_PROGRESS, "maybe")
+        assert _load_terminal_progress_preference() is False


### PR DESCRIPTION
The chat-input cursor blink and the terminal progress indicator can now be found in `dcode config` and toggled with `DEEPAGENTS_CODE_CURSOR_BLINK` / `DEEPAGENTS_CODE_TERMINAL_PROGRESS`, alongside the existing `[ui]` config keys.

---

This came out of a report that the cursor keeps blinking in unfocused tmux panes, making it impossible to tell which pane has focus.

That symptom is not ours: tmux's `focus-events` option is off by default, so it never forwards `FocusOut` to a pane, Textual never posts `AppBlur`, and nothing in the app can know it is unfocused. Reproduced side by side with two Textual panes under tmux 3.5a — with `set -g focus-events on` the inactive pane receives `AppBlur`, Textual drops screen focus, and the cursor stops being painted, exactly as intended.

What the report *did* expose is that the escape hatch was undiscoverable. `[ui].cursor_blink` (and its sibling `[ui].terminal_progress`) were read by a bespoke loader that predates the config manifest, so neither showed up in `dcode config`, neither had an env-var override, and their malformed-value handling was a second, hand-maintained copy of what the shared resolver already does. Registering both as `Display` options removes that duplication and makes them behave like every other display setting.

Two things worth a careful look:

- The `on_app_blur` docstring claimed `AppBlur` does not change widget focus. That has not been true for a while — Textual's own handler calls `screen.set_focus(None)` — and a unit test encoded the same belief, passing only because it invoked the handler directly instead of dispatching the event. The docstring is corrected and a test now posts real `AppBlur`/`AppFocus` events and asserts the cursor stops and resumes being drawn.
- Because these options now accept env vars, an exported value outranks `config.toml`. The existing terminal-progress test fixture clears the new variable so a developer's shell cannot flip those assertions.

Made by [Open SWE](https://openswe.vercel.app/agents/1c22682d-7700-26b5-b84e-a99ca14124e7)