### PR TITLE
hotfix(code): check rendered toast bounds

### DIFF
--- a/libs/code/tests/unit_tests/test_app.py
+++ b/libs/code/tests/unit_tests/test_app.py
@@ -25966,14 +25966,26 @@ class TestToastAnchoring:
             app.notify("first", timeout=60)
             app.notify("second", timeout=60)
 
+            def painted_toast_bottoms(toasts: list[_Toast]) -> list[int]:
+                """Return bottom rows of toast regions the compositor will paint."""
+                bottoms: list[int] = []
+                for toast in toasts:
+                    geometry = app.screen.find_widget(toast)
+                    painted = geometry.region.intersection(geometry.clip)
+                    if painted:
+                        bottoms.append(painted.bottom)
+                return bottoms
+
             async def wait_for_anchored_toasts() -> None:
                 while True:
                     toasts = list(app.screen.query(_Toast))
                     messages = {toast._notification.message for toast in toasts}
+                    bottoms = painted_toast_bottoms(toasts)
                     chrome_top = self._chrome(app).region.y
                     if (
                         expected_messages <= messages
-                        and max(toast.region.bottom for toast in toasts) == chrome_top
+                        and bottoms
+                        and max(bottoms) == chrome_top
                     ):
                         return
                     await pilot.pause()
@@ -25983,8 +25995,10 @@ class TestToastAnchoring:
             toasts = list(app.screen.query(_Toast))
             messages = {toast._notification.message for toast in toasts}
             assert expected_messages <= messages
+            bottoms = painted_toast_bottoms(toasts)
+            assert bottoms
             chrome_top = self._chrome(app).region.y
-            assert max(toast.region.bottom for toast in toasts) == chrome_top
+            assert max(bottoms) == chrome_top
 
     async def test_growing_chat_input_lifts_the_rack(self) -> None:
         """A taller chat input pushes toasts further up the screen."""


### PR DESCRIPTION
Unblocks the `deepagents-code` 0.1.51 release recovery after the second manual release run timed out in `TestToastAnchoring::test_toasts_do_not_cover_the_chat_input`.

---

Textual lays out every toast in an overflowing `ToastRack`, including off-screen toasts, then clips the rack before painting it. When an unrelated startup toast makes the rack overflow, a toast's raw `region.bottom` can extend below the chat input even though its compositor-clipped region does not render there. The previous hotfix waited for every raw region to end at the chrome boundary, so that condition could never converge on the Linux release runner.

The test now waits for and asserts the compositor-clipped toast bottoms. It still requires both named test notifications to mount, checks the complete painted toast stack, and fails when `_anchor_toast_rack` is disabled.

Failed recovery run: https://github.com/langchain-ai/deepagents/actions/runs/30606795001

<details>
<summary>Test plan</summary>

- `uv run --python 3.11 --group test pytest tests/unit_tests/test_app.py::TestToastAnchoring -q` — 4 passed.
- Ruff lint and formatting checks pass via pre-commit.
- Temporarily disabled `_anchor_toast_rack`; the target test failed as expected.
- The full local xdist run was interrupted before completion; PR CI will run the release-equivalent suite.

</details>
