### PR TITLE
fix(code): don't claim kitty-keyboard support inside tmux

### DIFF
--- a/libs/code/deepagents_code/terminal_capabilities.py
+++ b/libs/code/deepagents_code/terminal_capabilities.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 _FALSE_VALUES = frozenset({"0", "false", "no", "off"})
 _KNOWN_KITTY_KEYBOARD_TERMS = frozenset({"xterm-ghostty", "xterm-kitty"})
+_MULTIPLEXER_TERM_PREFIXES = ("screen", "tmux")
 
 
 def _override_supports_kitty_keyboard_protocol(
@@ -59,6 +60,17 @@ def _override_supports_kitty_keyboard_protocol(
     return None
 
 
+def _inside_terminal_multiplexer(env: Mapping[str, str]) -> bool:
+    """Return whether `env` describes a pane inside tmux or GNU Screen.
+
+    A multiplexer owns the pty, so the outer terminal's identity says nothing
+    about which key encodings actually reach the app.
+    """
+    if env.get("TMUX"):
+        return True
+    return env.get("TERM", "").startswith(_MULTIPLEXER_TERM_PREFIXES)
+
+
 def _terminal_identity_supports_kitty_keyboard_protocol(
     env: Mapping[str, str],
 ) -> bool:
@@ -68,7 +80,16 @@ def _terminal_identity_supports_kitty_keyboard_protocol(
     imply kitty-keyboard support is part of the terminal's default identity.
     Configurable terminals such as iTerm2 and WezTerm are intentionally not
     auto-detected because protocol support can be disabled in user settings.
+
+    A multiplexer disqualifies the terminal outright. tmux rewrites `TERM` for
+    its panes but leaves markers like `KITTY_WINDOW_ID` in the inherited
+    environment, and it swallows the protocol enable rather than forwarding it
+    to the outer terminal, so a pane under kitty looks kitty-capable while
+    behaving like a legacy terminal.
     """
+    if _inside_terminal_multiplexer(env):
+        return False
+
     if env.get("KITTY_WINDOW_ID"):
         return True
 
@@ -83,6 +104,9 @@ def supports_kitty_keyboard_protocol() -> bool:
     Detection is side-effect free: it never writes escape sequences or reads
     queued input bytes. That means it may under-detect some configurable
     terminals, but it will not interfere with Textual's input stream.
+
+    Detection also refuses to trust the terminal identity inside tmux or GNU
+    Screen, which do not forward the protocol.
 
     Set `DEEPAGENTS_CODE_KITTY_KEYBOARD` to an accepted truthy value (`1`,
     `true`, `yes`, `on`) to force-enable the label, a falsy value (`0`,
@@ -107,9 +131,11 @@ def supports_kitty_keyboard_protocol() -> bool:
 
     detected = _terminal_identity_supports_kitty_keyboard_protocol(os.environ)
     logger.debug(
-        "kitty kbd detection: %s (terminal identity TERM=%r KITTY_WINDOW_ID=%r)",
+        "kitty kbd detection: %s "
+        "(terminal identity TERM=%r KITTY_WINDOW_ID=%r multiplexer=%s)",
         detected,
         os.environ.get("TERM", ""),
         os.environ.get("KITTY_WINDOW_ID"),
+        _inside_terminal_multiplexer(os.environ),
     )
     return detected

--- a/libs/code/deepagents_code/terminal_capabilities.py
+++ b/libs/code/deepagents_code/terminal_capabilities.py
@@ -66,7 +66,7 @@ def _inside_terminal_multiplexer(env: Mapping[str, str]) -> bool:
     A multiplexer owns the pty, so the outer terminal's identity says nothing
     about which key encodings actually reach the app.
     """
-    if env.get("TMUX"):
+    if env.get("TMUX") or env.get("STY"):
         return True
     return env.get("TERM", "").startswith(_MULTIPLEXER_TERM_PREFIXES)
 

--- a/libs/code/tests/unit_tests/test_terminal_capabilities.py
+++ b/libs/code/tests/unit_tests/test_terminal_capabilities.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 from deepagents_code import terminal_capabilities
 from deepagents_code._env_vars import KITTY_KEYBOARD
 from deepagents_code.terminal_capabilities import (
+    _inside_terminal_multiplexer,
     _override_supports_kitty_keyboard_protocol,
     _terminal_identity_supports_kitty_keyboard_protocol,
     supports_kitty_keyboard_protocol,
@@ -78,6 +79,26 @@ class TestOverrideSupportsKittyKeyboardProtocol:
         )
 
 
+class TestInsideTerminalMultiplexer:
+    """Tests for multiplexer detection."""
+
+    def test_detects_tmux_via_socket_var(self) -> None:
+        """Tmux exports `TMUX` into every pane it owns."""
+        assert _inside_terminal_multiplexer({"TMUX": "/tmp/tmux-0/default,1,0"}) is True
+
+    def test_detects_tmux_via_term(self) -> None:
+        """A pane's `TERM` is rewritten even when `TMUX` is stripped."""
+        assert _inside_terminal_multiplexer({"TERM": "tmux-256color"}) is True
+
+    def test_detects_screen_via_term(self) -> None:
+        """GNU Screen (and tmux's compatibility default) use a `screen` TERM."""
+        assert _inside_terminal_multiplexer({"TERM": "screen-256color"}) is True
+
+    def test_bare_terminal_is_not_a_multiplexer(self) -> None:
+        """A terminal owning its own pty should not be flagged."""
+        assert _inside_terminal_multiplexer({"TERM": "xterm-kitty"}) is False
+
+
 class TestTerminalIdentitySupportsKittyKeyboardProtocol:
     """Tests for the conservative terminal-identity heuristic."""
 
@@ -104,6 +125,28 @@ class TestTerminalIdentitySupportsKittyKeyboardProtocol:
                 {"TERM": "xterm-ghostty"}
             )
             is True
+        )
+
+    def test_ignores_kitty_window_id_inherited_by_a_tmux_pane(self) -> None:
+        """Tmux inherits `KITTY_WINDOW_ID` but never forwards the protocol."""
+        assert (
+            _terminal_identity_supports_kitty_keyboard_protocol(
+                {
+                    "KITTY_WINDOW_ID": "17",
+                    "TERM": "tmux-256color",
+                    "TMUX": "/tmp/tmux-0/default,1,0",
+                }
+            )
+            is False
+        )
+
+    def test_ignores_kitty_term_under_screen(self) -> None:
+        """A `screen` TERM outranks a stale kitty marker in the environment."""
+        assert (
+            _terminal_identity_supports_kitty_keyboard_protocol(
+                {"KITTY_WINDOW_ID": "17", "TERM": "screen-256color"}
+            )
+            is False
         )
 
     def test_does_not_auto_detect_wezterm(self) -> None:
@@ -189,6 +232,38 @@ class TestSupportsKittyKeyboardProtocolDetection:
             ),
         ):
             assert supports_kitty_keyboard_protocol() is True
+
+    def test_override_can_force_true_inside_tmux(self) -> None:
+        """Tmux 3.6 users who know their setup works can still opt in."""
+        with (
+            _fake_tty(),
+            patch.dict(
+                os.environ,
+                {
+                    KITTY_KEYBOARD: "1",
+                    "TERM": "tmux-256color",
+                    "TMUX": "/tmp/tmux-0/default,1,0",
+                },
+                clear=True,
+            ),
+        ):
+            assert supports_kitty_keyboard_protocol() is True
+
+    def test_tmux_pane_under_kitty_falls_back_to_legacy_hint(self) -> None:
+        """Without an override, a kitty-hosted tmux pane must not claim support."""
+        with (
+            _fake_tty(),
+            patch.dict(
+                os.environ,
+                {
+                    "KITTY_WINDOW_ID": "17",
+                    "TERM": "tmux-256color",
+                    "TMUX": "/tmp/tmux-0/default,1,0",
+                },
+                clear=True,
+            ),
+        ):
+            assert supports_kitty_keyboard_protocol() is False
 
     def test_returns_false_for_unrecognized_terminal(self) -> None:
         """Unknown terminals should keep the legacy newline hint."""

--- a/libs/code/tests/unit_tests/test_terminal_capabilities.py
+++ b/libs/code/tests/unit_tests/test_terminal_capabilities.py
@@ -94,6 +94,10 @@ class TestInsideTerminalMultiplexer:
         """GNU Screen (and tmux's compatibility default) use a `screen` TERM."""
         assert _inside_terminal_multiplexer({"TERM": "screen-256color"}) is True
 
+    def test_detects_screen_via_sty_var(self) -> None:
+        """GNU Screen exports `STY` even when `TERM` is overridden."""
+        assert _inside_terminal_multiplexer({"STY": "12345.pts-0.host"}) is True
+
     def test_bare_terminal_is_not_a_multiplexer(self) -> None:
         """A terminal owning its own pty should not be flagged."""
         assert _inside_terminal_multiplexer({"TERM": "xterm-kitty"}) is False
@@ -259,6 +263,22 @@ class TestSupportsKittyKeyboardProtocolDetection:
                     "KITTY_WINDOW_ID": "17",
                     "TERM": "tmux-256color",
                     "TMUX": "/tmp/tmux-0/default,1,0",
+                },
+                clear=True,
+            ),
+        ):
+            assert supports_kitty_keyboard_protocol() is False
+
+    def test_screen_pane_under_kitty_falls_back_to_legacy_hint(self) -> None:
+        """A Screen window that overrode `TERM` still must not claim support."""
+        with (
+            _fake_tty(),
+            patch.dict(
+                os.environ,
+                {
+                    "KITTY_WINDOW_ID": "17",
+                    "TERM": "xterm-kitty",
+                    "STY": "12345.pts-0.host",
                 },
                 clear=True,
             ),


### PR DESCRIPTION
Inside tmux or GNU Screen the composer now advertises the newline shortcut that actually works (`Ctrl+J`, or `Option+Enter` on macOS) instead of a `Shift+Enter` the multiplexer never delivers.

---

Kitty-keyboard detection trusted `KITTY_WINDOW_ID`. That variable is inherited by every tmux pane from the tmux server's environment, while `TERM` is correctly rewritten to `tmux-256color` — so a pane running under kitty looked kitty-capable. It is not: tmux swallows the app's protocol-enable sequence rather than forwarding it to the outer terminal, verified on tmux 3.5a by capturing exactly what an attached client receives.

`newline_shortcut()` is the only consumer, so the blast radius was a wrong hint — but on the most-used keybinding in the composer, which is worse than it sounds for anyone who tries it and concludes the app is broken.

The new `_inside_terminal_multiplexer` check disqualifies the terminal identity outright rather than special-casing `KITTY_WINDOW_ID`, since no environment marker inherited from the outer terminal can speak for what a pane actually receives. It sits after the `DEEPAGENTS_CODE_KITTY_KEYBOARD` override, so anyone on a tmux build that does forward the protocol can still force the hint back on.

Made by [Open SWE](https://openswe.vercel.app/agents/1c22682d-7700-26b5-b84e-a99ca14124e7)

## References
- Plan: https://openswe.vercel.app/agents/1c22682d-7700-26b5-b84e-a99ca14124e7/plan