### PR TITLE
feat(code): report tmux setup in `dcode doctor`

### DIFF
--- a/libs/code/README.md
+++ b/libs/code/README.md
@@ -48,6 +48,22 @@ By default, `dcode` trusts the directory you run it in. Human-in-the-loop approv
 
 Do not run `dcode` in a directory you do not trust without a sandbox backend. For untrusted repositories, use a [remote sandbox](https://docs.langchain.com/oss/python/deepagents/code/remote-sandboxes) so execution is isolated from your machine. Running `dcode` in a directory lets that directory's files shape execution. See [`THREAT_MODEL.md`](https://github.com/langchain-ai/deepagents/blob/main/libs/code/THREAT_MODEL.md) for details.
 
+## 🪟 Running under tmux
+
+A tmux pane is not the terminal you are looking at: tmux owns the pty and decides which escape sequences reach the outer terminal. Four options are off by default and each disables something in `dcode`. Run `dcode doctor` to see which ones apply to your setup.
+
+```tmux
+# ~/.tmux.conf
+set -g focus-events on              # otherwise unfocused panes keep a blinking cursor
+set -g allow-passthrough on         # otherwise terminal progress and OSC 52 are dropped
+set -g set-clipboard on             # otherwise /copy cannot reach the outer clipboard
+set -ga update-environment COLORTERM # otherwise themes are quantized to 256 colors
+```
+
+Reload with `tmux source-file ~/.tmux.conf` (a new server is needed for `update-environment` to reach existing panes).
+
+Note that tmux does not forward the kitty keyboard protocol, so `Shift+Enter` is unavailable inside a pane — use `Ctrl+J` (or `Option+Enter` on macOS) for a newline.
+
 ## 📖 Resources
 
 - **[Documentation](https://docs.langchain.com/deepagents-code)**

--- a/libs/code/deepagents_code/doctor.py
+++ b/libs/code/deepagents_code/doctor.py
@@ -22,11 +22,19 @@ from deepagents_code.output import write_json
 
 if TYPE_CHECKING:
     import argparse
+    from collections.abc import Mapping
 
     from deepagents_code.config import TracingStatus
     from deepagents_code.extras_info import VersionReport
+    from deepagents_code.multiplexer import TmuxStatus
 
 logger = logging.getLogger(__name__)
+
+TMUX_DOCS_URL = (
+    "https://github.com/langchain-ai/deepagents/blob/main/libs/code/README.md"
+    "#-running-under-tmux"
+)
+"""Where the tmux options reported by the `Terminal` section are explained."""
 
 
 @dataclass
@@ -510,6 +518,163 @@ def _path_status(label: str, path: object) -> DiagnosticItem:
     )
 
 
+def _color_system() -> str:
+    """Return the console's detected color depth, or `not detected`."""
+    from deepagents_code.config import console
+
+    return console.color_system or "not detected"
+
+
+def _kitty_keyboard_item() -> DiagnosticItem:
+    """Build the row describing kitty-keyboard support and the newline key.
+
+    Returns:
+        A diagnostic item naming the shortcut the composer will actually honor.
+    """
+    from deepagents_code.config import newline_shortcut
+    from deepagents_code.terminal_capabilities import supports_kitty_keyboard_protocol
+
+    supported = supports_kitty_keyboard_protocol()
+    state = "available" if supported else "unavailable"
+    return DiagnosticItem(
+        "Kitty keyboard", f"{state} - newline is {newline_shortcut()}"
+    )
+
+
+def _annotated_item(
+    label: str,
+    value: str,
+    *,
+    healthy: str,
+    consequence: str,
+    remedy: str,
+) -> DiagnosticItem:
+    """Build a row that explains itself when `value` is not `healthy`.
+
+    Args:
+        label: Row label.
+        value: Current value.
+        healthy: Value at which the dependent feature works.
+        consequence: What breaks while the value differs from `healthy`.
+        remedy: The `~/.tmux.conf` line that fixes it.
+
+    Returns:
+        A diagnostic item. Always healthy: these are opt-in suggestions, not
+        faults, and must not change the `doctor` exit code.
+    """
+    if value == healthy:
+        return DiagnosticItem(label, value)
+    return DiagnosticItem(label, f"{value} - {consequence}; {remedy}")
+
+
+def _tmux_option_item(
+    label: str,
+    options: Mapping[str, str] | None,
+    name: str,
+    *,
+    consequence: str,
+    remedy: str,
+) -> DiagnosticItem:
+    """Build a row for one tmux option, annotated when it is not `on`.
+
+    Args:
+        label: Row label.
+        options: Options tmux reported, or `None` when the probe failed.
+        name: tmux option name to look up.
+        consequence: What breaks while the option is not `on`.
+        remedy: The `~/.tmux.conf` line that fixes it.
+
+    Returns:
+        A diagnostic item, distinguishing a failed probe from a tmux too old
+        to know the option.
+    """
+    if options is None:
+        return DiagnosticItem(label, "could not query tmux")
+    value = options.get(name)
+    if value is None:
+        return DiagnosticItem(label, "unsupported by this tmux")
+    return _annotated_item(
+        label, value, healthy="on", consequence=consequence, remedy=remedy
+    )
+
+
+def _tmux_items(status: TmuxStatus) -> list[DiagnosticItem]:
+    """Build the tmux-specific rows of the `Terminal` section.
+
+    Args:
+        status: Facts probed from the tmux server hosting this pane.
+
+    Returns:
+        One row per option that changes how the app behaves under tmux.
+    """
+    from deepagents_code.multiplexer import (
+        ALLOW_PASSTHROUGH,
+        FOCUS_EVENTS,
+        SET_CLIPBOARD,
+    )
+
+    options = status.options
+    return [
+        DiagnosticItem("Multiplexer", status.version or "tmux (version unknown)"),
+        _tmux_option_item(
+            "Focus events",
+            options,
+            FOCUS_EVENTS,
+            consequence="unfocused panes keep a blinking cursor",
+            remedy="set -g focus-events on",
+        ),
+        _tmux_option_item(
+            "Passthrough",
+            options,
+            ALLOW_PASSTHROUGH,
+            consequence="terminal progress and OSC 52 are dropped",
+            remedy="set -g allow-passthrough on",
+        ),
+        _tmux_option_item(
+            "Clipboard",
+            options,
+            SET_CLIPBOARD,
+            consequence="`/copy` cannot reach the outer clipboard",
+            remedy="set -g set-clipboard on",
+        ),
+        _annotated_item(
+            "Color",
+            _color_system(),
+            healthy="truecolor",
+            consequence="themes are quantized",
+            remedy="set -ga update-environment COLORTERM",
+        ),
+        _kitty_keyboard_item(),
+    ]
+
+
+def _collect_terminal() -> DiagnosticSection:
+    """Collect terminal and multiplexer facts that shape the TUI.
+
+    Returns:
+        The `Terminal` section. Inside tmux it reports the options that gate
+        focus handling, escape passthrough, and clipboard writes; elsewhere it
+        collapses to the terminal identity and color depth.
+    """
+    import os
+
+    from deepagents_code.multiplexer import query_tmux_status
+
+    status = query_tmux_status()
+    if status is not None:
+        return DiagnosticSection(title="Terminal", items=_tmux_items(status))
+
+    identity = os.environ.get("TERM_PROGRAM") or os.environ.get("TERM") or "unknown"
+    return DiagnosticSection(
+        title="Terminal",
+        items=[
+            DiagnosticItem("Terminal", identity),
+            DiagnosticItem("Color", _color_system()),
+            _kitty_keyboard_item(),
+        ],
+    )
+
+
 def _collect_configuration() -> DiagnosticSection:
     """Collect on-disk configuration and data locations.
 
@@ -538,6 +703,7 @@ def collect_sections() -> list[DiagnosticSection]:
     """
     return [
         _collect_diagnostics(),
+        _collect_terminal(),
         _collect_updates(),
         _collect_tracing(),
         _collect_configuration(),
@@ -559,6 +725,7 @@ def _render_text(sections: list[DiagnosticSection]) -> None:
 
     from deepagents_code import theme
     from deepagents_code.config import console, get_glyphs
+    from deepagents_code.multiplexer import inside_tmux
 
     glyphs = get_glyphs()
     tee, corner = _tree_connectors()
@@ -592,6 +759,12 @@ def _render_text(sections: list[DiagnosticSection]) -> None:
         style=theme.MUTED,
         highlight=False,
     )
+    if inside_tmux():
+        console.print(
+            f"       tmux setup is documented at {TMUX_DOCS_URL}",
+            style=theme.MUTED,
+            highlight=False,
+        )
     console.print()
 
 

--- a/libs/code/deepagents_code/multiplexer.py
+++ b/libs/code/deepagents_code/multiplexer.py
@@ -1,0 +1,155 @@
+"""Terminal multiplexer detection and option probing.
+
+A tmux pane is not the terminal the user is looking at. tmux owns the pty,
+rewrites `TERM`, and decides on its own which escape sequences reach the outer
+terminal — so several `deepagents-code` features depend on tmux options the
+user has to opt into. This module reads those options so `dcode doctor` can
+report them.
+
+Probing shells out to `tmux`, so it is deliberately kept out of the startup
+path: nothing here runs unless the user invokes `dcode doctor`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+logger = logging.getLogger(__name__)
+
+TMUX_QUERY_TIMEOUT_SECONDS = 2.0
+"""Ceiling on each `tmux` invocation so a wedged server cannot hang `doctor`."""
+
+FOCUS_EVENTS = "focus-events"
+ALLOW_PASSTHROUGH = "allow-passthrough"
+SET_CLIPBOARD = "set-clipboard"
+
+REPORTED_OPTIONS: tuple[str, ...] = (FOCUS_EVENTS, ALLOW_PASSTHROUGH, SET_CLIPBOARD)
+"""tmux options that change how `deepagents-code` behaves.
+
+- `focus-events` gates `FocusIn`/`FocusOut` delivery, without which an
+  unfocused pane keeps drawing a blinking cursor.
+- `allow-passthrough` gates the `DCS tmux;` wrapper, without which terminal
+  progress and OSC 52 clipboard writes are dropped.
+- `set-clipboard` must be `on` for an application's OSC 52 to reach the
+  outer terminal's clipboard.
+"""
+
+_SHOW_OPTIONS_ARGS: tuple[str, ...] = ("show-options", "-s", ";", "show-options", "-gw")
+"""Read both scopes in one invocation.
+
+`focus-events` and `set-clipboard` are server options while
+`allow-passthrough` is a window option, so a single `show-options -g` (session
+scope) returns none of them. `;` is passed as its own argument, which tmux
+reads as a command separator.
+"""
+
+
+@dataclass(frozen=True)
+class TmuxStatus:
+    """Facts about the tmux server hosting the current pane."""
+
+    version: str | None
+    """Reported `tmux -V` string, or `None` when the query failed."""
+
+    options: Mapping[str, str] | None
+    """Values of `REPORTED_OPTIONS`, or `None` when the query failed.
+
+    A present mapping missing a key means tmux answered but does not know that
+    option — an older server without `allow-passthrough`, say. That is a
+    different fact from a failed probe, so the two must not collapse.
+    """
+
+
+def inside_tmux(env: Mapping[str, str] | None = None) -> bool:
+    """Return whether the process is running inside a tmux pane.
+
+    Args:
+        env: Environment mapping to read. Defaults to the process environment.
+
+    Returns:
+        `True` when tmux exported its socket path into this process.
+    """
+    return bool((env if env is not None else os.environ).get("TMUX"))
+
+
+def _run_tmux(args: Sequence[str]) -> str | None:
+    """Run `tmux` with a fixed argument list and return its stdout.
+
+    Args:
+        args: Arguments appended after the `tmux` executable.
+
+    Returns:
+        Captured stdout, or `None` when tmux is missing, times out, fails, or
+        cannot be executed. Callers treat `None` as "unknown", never as an
+        error worth surfacing.
+    """
+    import subprocess  # noqa: S404  # fixed argv, no shell
+
+    try:
+        result = subprocess.run(  # noqa: S603  # fixed argv, no shell, no user input
+            ["tmux", *args],  # noqa: S607  # resolved from PATH like `git`
+            capture_output=True,
+            text=True,
+            timeout=TMUX_QUERY_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except FileNotFoundError:
+        logger.debug("tmux not on PATH; skipping multiplexer probe")
+        return None
+    except subprocess.TimeoutExpired:
+        logger.debug("tmux %s timed out", " ".join(args))
+        return None
+    except OSError:
+        logger.debug("tmux %s failed", " ".join(args), exc_info=True)
+        return None
+
+    if result.returncode != 0:
+        logger.debug("tmux %s exited %d", " ".join(args), result.returncode)
+        return None
+    return result.stdout
+
+
+def parse_tmux_options(output: str) -> dict[str, str]:
+    """Extract the reported options from `tmux show-options` output.
+
+    Args:
+        output: Raw stdout, one `<name> <value>` pair per line.
+
+    Returns:
+        Values for the `REPORTED_OPTIONS` present in `output`. Options tmux
+        does not recognize are simply absent, which is how an older tmux
+        without `allow-passthrough` is distinguished from one that has it off.
+    """
+    options: dict[str, str] = {}
+    for line in output.splitlines():
+        name, separator, value = line.partition(" ")
+        if separator and name in REPORTED_OPTIONS:
+            options[name] = value.strip()
+    return options
+
+
+def query_tmux_status() -> TmuxStatus | None:
+    """Probe the tmux server hosting this pane.
+
+    Returns:
+        The server's version and relevant options, or `None` when not running
+        inside tmux. Individual facts degrade to `None` rather than failing the
+        whole probe, so a partially answering server still reports what it can.
+    """
+    if not inside_tmux():
+        return None
+
+    version_output = _run_tmux(["-V"])
+    options_output = _run_tmux(_SHOW_OPTIONS_ARGS)
+    return TmuxStatus(
+        version=version_output.strip() if version_output else None,
+        options=parse_tmux_options(options_output)
+        if options_output is not None
+        else None,
+    )

--- a/libs/code/tests/unit_tests/test_doctor.py
+++ b/libs/code/tests/unit_tests/test_doctor.py
@@ -68,6 +68,7 @@ class TestCollectSections:
         sections = collect_sections()
         assert [s.title for s in sections] == [
             "Diagnostics",
+            "Terminal",
             "Updates",
             "Tracing",
             "Configuration",
@@ -238,6 +239,100 @@ class TestDiagnosticsVersionReport:
         sdk = items["deepagents (SDK)"]
         assert sdk.ok is False
         assert sdk.value == "not installed"
+
+
+class TestCollectTerminal:
+    """Tests for the Terminal diagnostic section."""
+
+    def _section(self, status: object) -> DiagnosticSection:
+        from deepagents_code.doctor import _collect_terminal
+
+        with patch(
+            "deepagents_code.multiplexer.query_tmux_status", return_value=status
+        ):
+            return _collect_terminal()
+
+    def _labels(self, status: object) -> dict[str, str]:
+        return {item.label: item.value for item in self._section(status).items}
+
+    def _tmux_status(self, **options: str) -> object:
+        from deepagents_code.multiplexer import TmuxStatus
+
+        return TmuxStatus(version="tmux 3.5a", options=options)
+
+    def test_outside_tmux_reports_terminal_identity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without a multiplexer the section collapses to the terminal itself."""
+        monkeypatch.setenv("TERM_PROGRAM", "Ghostty")
+        labels = self._labels(None)
+        assert labels["Terminal"] == "Ghostty"
+        assert "Multiplexer" not in labels
+        assert "Color" in labels
+
+    def test_healthy_tmux_options_render_bare(self) -> None:
+        """An already-correct option needs no explanation."""
+        from deepagents_code.multiplexer import (
+            ALLOW_PASSTHROUGH,
+            FOCUS_EVENTS,
+            SET_CLIPBOARD,
+        )
+
+        labels = self._labels(
+            self._tmux_status(
+                **{FOCUS_EVENTS: "on", ALLOW_PASSTHROUGH: "on", SET_CLIPBOARD: "on"}
+            )
+        )
+        assert labels["Multiplexer"] == "tmux 3.5a"
+        assert labels["Focus events"] == "on"
+        assert labels["Passthrough"] == "on"
+        assert labels["Clipboard"] == "on"
+
+    def test_disabled_option_carries_consequence_and_remedy(self) -> None:
+        """A user must be able to act on the row without leaving the terminal."""
+        from deepagents_code.multiplexer import FOCUS_EVENTS
+
+        value = self._labels(self._tmux_status(**{FOCUS_EVENTS: "off"}))["Focus events"]
+        assert value.startswith("off - ")
+        assert "blinking cursor" in value
+        assert "set -g focus-events on" in value
+
+    def test_unknown_option_is_distinct_from_failed_probe(self) -> None:
+        """An old tmux and an unreachable one are different problems."""
+        from deepagents_code.multiplexer import TmuxStatus
+
+        old = self._labels(self._tmux_status())["Passthrough"]
+        unreachable = self._labels(TmuxStatus(version=None, options=None))[
+            "Passthrough"
+        ]
+        assert old == "unsupported by this tmux"
+        assert unreachable == "could not query tmux"
+
+    def test_missing_version_is_reported(self) -> None:
+        """A server that will not answer `-V` is still worth listing."""
+        from deepagents_code.multiplexer import TmuxStatus
+
+        labels = self._labels(TmuxStatus(version=None, options={}))
+        assert labels["Multiplexer"] == "tmux (version unknown)"
+
+    def test_section_stays_healthy_when_options_are_off(self) -> None:
+        """Tmux suggestions must not flip the `doctor` exit code."""
+        from deepagents_code.multiplexer import (
+            ALLOW_PASSTHROUGH,
+            FOCUS_EVENTS,
+            SET_CLIPBOARD,
+        )
+
+        section = self._section(
+            self._tmux_status(
+                **{
+                    FOCUS_EVENTS: "off",
+                    ALLOW_PASSTHROUGH: "off",
+                    SET_CLIPBOARD: "external",
+                }
+            )
+        )
+        assert section.ok is True
 
 
 class TestCollectTracing:
@@ -759,7 +854,13 @@ class TestRunDoctorCommand:
         data = envelope["data"]
         assert data["healthy"] is True
         titles = [section["title"] for section in data["sections"]]
-        assert titles == ["Diagnostics", "Updates", "Tracing", "Configuration"]
+        assert titles == [
+            "Diagnostics",
+            "Terminal",
+            "Updates",
+            "Tracing",
+            "Configuration",
+        ]
 
     def test_unhealthy_returns_nonzero(self) -> None:
         """An unhealthy section yields a non-zero exit code."""

--- a/libs/code/tests/unit_tests/test_multiplexer.py
+++ b/libs/code/tests/unit_tests/test_multiplexer.py
@@ -1,0 +1,145 @@
+"""Unit tests for terminal multiplexer detection and option probing."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+from deepagents_code import multiplexer
+from deepagents_code.multiplexer import (
+    ALLOW_PASSTHROUGH,
+    FOCUS_EVENTS,
+    SET_CLIPBOARD,
+    inside_tmux,
+    parse_tmux_options,
+    query_tmux_status,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+_SHOW_OPTIONS_OUTPUT = """\
+activity-action other
+focus-events off
+set-clipboard external
+default-command ''
+allow-passthrough off
+"""
+
+
+class TestInsideTmux:
+    """Tests for tmux pane detection."""
+
+    def test_true_when_socket_exported(self) -> None:
+        """Tmux exports `TMUX` into every pane it owns."""
+        assert inside_tmux({"TMUX": "/tmp/tmux-0/default,1,0"}) is True
+
+    def test_false_when_absent(self) -> None:
+        """A bare terminal has no `TMUX`."""
+        assert inside_tmux({"TERM": "xterm-256color"}) is False
+
+    def test_false_when_empty(self) -> None:
+        """An exported-but-empty `TMUX` does not indicate a pane."""
+        assert inside_tmux({"TMUX": ""}) is False
+
+
+class TestParseTmuxOptions:
+    """Tests for `show-options` output parsing."""
+
+    def test_extracts_reported_options(self) -> None:
+        """Only the options that change app behavior are kept."""
+        assert parse_tmux_options(_SHOW_OPTIONS_OUTPUT) == {
+            FOCUS_EVENTS: "off",
+            SET_CLIPBOARD: "external",
+            ALLOW_PASSTHROUGH: "off",
+        }
+
+    def test_omits_options_tmux_does_not_know(self) -> None:
+        """An older tmux without `allow-passthrough` simply omits the line."""
+        parsed = parse_tmux_options("focus-events on\nset-clipboard on\n")
+        assert ALLOW_PASSTHROUGH not in parsed
+
+    def test_ignores_valueless_lines(self) -> None:
+        """A line with no separator is not an option assignment."""
+        assert parse_tmux_options("focus-events\n") == {}
+
+    def test_empty_output_yields_no_options(self) -> None:
+        """An empty answer is a valid answer with nothing in it."""
+        assert parse_tmux_options("") == {}
+
+
+class TestQueryTmuxStatus:
+    """Tests for the end-to-end probe."""
+
+    def test_returns_none_outside_tmux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The probe must not shell out when there is no pane to ask about."""
+        monkeypatch.delenv("TMUX", raising=False)
+        assert query_tmux_status() is None
+
+    def test_reports_version_and_options(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A cooperative server yields both facts."""
+        monkeypatch.setenv("TMUX", "/tmp/tmux-0/default,1,0")
+
+        def fake_run(args: list[str]) -> str:
+            return "tmux 3.5a\n" if tuple(args) == ("-V",) else _SHOW_OPTIONS_OUTPUT
+
+        monkeypatch.setattr(multiplexer, "_run_tmux", fake_run)
+
+        status = query_tmux_status()
+        assert status is not None
+        assert status.version == "tmux 3.5a"
+        assert status.options == {
+            FOCUS_EVENTS: "off",
+            SET_CLIPBOARD: "external",
+            ALLOW_PASSTHROUGH: "off",
+        }
+
+    def test_failed_probe_reports_none_options(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed query must stay distinguishable from an empty answer."""
+        monkeypatch.setenv("TMUX", "/tmp/tmux-0/default,1,0")
+        monkeypatch.setattr(multiplexer, "_run_tmux", lambda _args: None)
+
+        status = query_tmux_status()
+        assert status is not None
+        assert status.version is None
+        assert status.options is None
+
+
+class TestRunTmux:
+    """Tests for the subprocess wrapper's failure handling."""
+
+    def test_missing_binary_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A machine without tmux on `PATH` should not raise."""
+
+        def raise_missing(*_args: object, **_kwargs: object) -> None:
+            raise FileNotFoundError
+
+        monkeypatch.setattr(subprocess, "run", raise_missing)
+        assert multiplexer._run_tmux(["-V"]) is None
+
+    def test_timeout_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A wedged server must not hang `doctor`."""
+
+        def raise_timeout(*_args: object, **_kwargs: object) -> None:
+            raise subprocess.TimeoutExpired(cmd="tmux", timeout=1)
+
+        monkeypatch.setattr(subprocess, "run", raise_timeout)
+        assert multiplexer._run_tmux(["-V"]) is None
+
+    def test_nonzero_exit_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A rejected command yields no facts rather than partial output."""
+        completed = subprocess.CompletedProcess(
+            args=["tmux"], returncode=1, stdout="usage: tmux\n", stderr=""
+        )
+        monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: completed)
+        assert multiplexer._run_tmux(["show-options", "-s"]) is None
+
+    def test_success_returns_stdout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A successful call hands back raw stdout for the caller to parse."""
+        completed = subprocess.CompletedProcess(
+            args=["tmux"], returncode=0, stdout="tmux 3.5a\n", stderr=""
+        )
+        monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: completed)
+        assert multiplexer._run_tmux(["-V"]) == "tmux 3.5a\n"


### PR DESCRIPTION
`dcode doctor` gains a `Terminal` section. Inside tmux it reports the options that gate focus handling, escape passthrough, clipboard writes, and color depth, each with the consequence and the `~/.tmux.conf` line that fixes it; elsewhere it reports the terminal identity, color depth, and newline shortcut.

---

A tmux pane is not the terminal the user is looking at. tmux owns the pty and decides which escape sequences reach the outer terminal, and four of the relevant options are off by default — so a tmux user silently loses the unfocused-pane cursor behavior, terminal progress, OSC 52 clipboard writes, and truecolor themes, with nothing in the app to explain why. Making these diagnosable is worth more than any single one of them, because the remaining fixes all live in the user's `~/.tmux.conf` rather than in our code.

`doctor` is the right home: it is explicitly user-invoked, so probing tmux costs nothing at startup and runs no shell command behind anyone's back. A one-time in-app notice was the alternative and was rejected as nagging.

Points worth a careful look:

- **Option scopes are not obvious.** `focus-events` and `set-clipboard` are *server* options while `allow-passthrough` is a *window* option, so the natural `show-options -g` (session scope) returns none of the three. The probe reads both scopes in a single invocation using `;` as a separate argv element. This was caught only by running it under a real tmux; a unit test alone would have happily passed against fixture text.
- **"Old tmux" and "unreachable tmux" are different facts** and are reported differently. Collapsing them is what hid the scope bug above during development, so the distinction is now load-bearing and tested.
- **Every row is healthy.** These are opt-in suggestions; marking them as failures would flip the `doctor` exit code and break its use as a health check.
- The `tmux` subprocess uses a fixed argument list with no shell, is timeout-bounded, and degrades to an informational row on any failure.

Made by [Open SWE](https://openswe.vercel.app/agents/1c22682d-7700-26b5-b84e-a99ca14124e7)

## References
- Plan: https://openswe.vercel.app/agents/1c22682d-7700-26b5-b84e-a99ca14124e7/plan